### PR TITLE
Respect -Dconfig.file and namespace HOCON under familydns

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -39,10 +39,11 @@ case class DnsClientConfig(
 object AppConfig:
   val layer: ZLayer[Any, Config.Error, AppConfig] =
     ZLayer.fromZIO:
+      val path = sys.props.getOrElse("config.file", "config/application.conf")
       read(
-        deriveConfig[AppConfig].from(
-          TypesafeConfigProvider.fromHoconFile(
-            new java.io.File("config/application.conf"),
+        deriveConfig[AppConfig]
+          .nested("familydns")
+          .from(
+            TypesafeConfigProvider.fromHoconFile(new java.io.File(path)),
           ),
-        ),
       )

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -17,25 +17,27 @@ set -euo pipefail
 
 mkdir -p /app/config
 cat > /app/config/application.conf <<EOF
-db {
-  host     = "${FAMILYDNS_DB_HOST}"
-  port     = ${FAMILYDNS_DB_PORT}
-  database = "${FAMILYDNS_DB_NAME}"
-  user     = "${FAMILYDNS_DB_USER}"
-  password = "${FAMILYDNS_DB_PASSWORD}"
-  poolSize = 5
-}
-http {
-  host      = "${FAMILYDNS_HTTP_HOST}"
-  port      = ${FAMILYDNS_HTTP_PORT}
-  staticDir = "${FAMILYDNS_STATIC_DIR}"
-}
-jwt {
-  secret      = "${FAMILYDNS_JWT_SECRET}"
-  expiryHours = ${FAMILYDNS_JWT_HOURS}
-}
-dns {
-  cacheRefreshSeconds = ${FAMILYDNS_DNS_REFRESH}
+familydns {
+  db {
+    host     = "${FAMILYDNS_DB_HOST}"
+    port     = ${FAMILYDNS_DB_PORT}
+    database = "${FAMILYDNS_DB_NAME}"
+    user     = "${FAMILYDNS_DB_USER}"
+    password = "${FAMILYDNS_DB_PASSWORD}"
+    poolSize = 5
+  }
+  http {
+    host      = "${FAMILYDNS_HTTP_HOST}"
+    port      = ${FAMILYDNS_HTTP_PORT}
+    staticDir = "${FAMILYDNS_STATIC_DIR}"
+  }
+  jwt {
+    secret      = "${FAMILYDNS_JWT_SECRET}"
+    expiryHours = ${FAMILYDNS_JWT_HOURS}
+  }
+  dns {
+    cacheRefreshSeconds = ${FAMILYDNS_DNS_REFRESH}
+  }
 }
 EOF
 
@@ -52,4 +54,4 @@ if [ "${WAIT_FOR_POSTGRES:-1}" = "1" ]; then
 fi
 
 cd /app
-exec java -Xms256m -Xmx512m -jar /app/api.jar
+exec java -Xms256m -Xmx512m -Dconfig.file=/app/config/application.conf -jar /app/api.jar


### PR DESCRIPTION
## Summary

Fixes #3.

- `api/src/Config.scala` no longer hard-codes `config/application.conf` relative to CWD. It now reads `sys.props("config.file")` (with the old path as fallback), so the `-Dconfig.file=/etc/familydns/application.conf` set by the systemd unit is actually honored.
- `AppConfig` is derived under `.nested(\"familydns\")` so it matches `config/application.conf.example` (and the systemd/prod conventions). Copy-pasting the example no longer crashes startup with `Missing data at db.host`.
- `docker/entrypoint.sh` wraps the generated HOCON in `familydns { … }` and passes `-Dconfig.file` to the JVM, removing the comment-free hack of emitting flat HOCON.

## Test plan

- [x] mill api.compile
- [x] mill api.test (8 tests pass)
- [ ] Verify staging stack still boots with new wrapped HOCON
- [ ] Verify systemd unit picks up `/etc/familydns/application.conf` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)