### PR TITLE
Add TrafficMain entrypoint, assembly, systemd unit, deploy hooks

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -122,7 +122,7 @@ object dns extends CommonModule {
 
 // ── Traffic ────────────────────────────────────────────────────────────────
 object traffic extends CommonModule {
-  def moduleDeps = Seq(shared)
+  def moduleDeps = Seq(shared, api)
   def mvnDeps = Seq(
     mvn"dev.zio::zio:$zioVersion",
     mvn"dev.zio::zio-streams:$zioVersion",
@@ -138,6 +138,12 @@ object traffic extends CommonModule {
     mvn"org.tpolecat::doobie-hikari:$doobieVersion",
     mvn"org.postgresql:postgresql:$postgresVersion",
     mvn"ch.qos.logback:logback-classic:$logbackVersion",
+  )
+  // Mirrors api.assemblyRules — api is on the classpath and brings flyway + jdbc
+  // ServiceLoader entries that must be concatenated rather than overwritten.
+  override def assemblyRules = super.assemblyRules ++ Seq(
+    Assembly.Rule.Append("META-INF/services/org.flywaydb.core.extensibility.Plugin", "\n"),
+    Assembly.Rule.Append("META-INF/services/java.sql.Driver", "\n"),
   )
   object test extends ScalaTests with FamilyDnsTestModule {
     def moduleDeps = super.moduleDeps ++ Seq(traffic)

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -22,4 +22,15 @@ familydns {
   dns {
     cacheRefreshSeconds = 60
   }
+
+  traffic {
+    # Network interface to capture packets on. Find with `ip link show`.
+    interface           = "eth0"
+    # Idle seconds before a session is rolled into the time_usage table.
+    sessionTimeoutSecs  = 60
+    # How often to flush rolled-up sessions to postgres.
+    flushIntervalSecs   = 30
+    # Free-form label persisted with usage rows (multi-site deployments).
+    location            = "home"
+  }
 }

--- a/deploy/familydns-traffic.service
+++ b/deploy/familydns-traffic.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=FamilyDNS traffic monitor (pcap-based per-device usage tracker)
+Documentation=https://github.com/sameerparekh/familydns
+After=network-online.target postgresql.service familydns-api.service
+Wants=network-online.target
+# API runs migrations; wait for it so the time_usage table exists.
+Requires=familydns-api.service
+
+[Service]
+Type=simple
+User=familydns
+Group=familydns
+WorkingDirectory=/opt/familydns
+EnvironmentFile=-/etc/familydns/traffic.env
+ExecStart=/usr/bin/java \
+  -Xms128m -Xmx256m \
+  -Dconfig.file=/etc/familydns/application.conf \
+  -jar /opt/familydns/traffic.jar
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=familydns-traffic
+
+# pcap requires raw-socket access. Grant CAP_NET_RAW + CAP_NET_ADMIN to the
+# unprivileged service user via ambient capabilities — no need to run as root.
+AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/log/familydns /var/lib/familydns
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_PACKET
+RestrictNamespaces=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -43,8 +43,10 @@ log() { echo "[bootstrap] $*"; }
 log "Installing system packages (apt)..."
 if command -v apt-get >/dev/null 2>&1; then
   sudo apt-get update -qq
+  # libpcap0.8: pcap4j (traffic monitor) loads it via JNA at runtime.
   sudo apt-get install -y -qq \
-    openjdk-21-jdk-headless ca-certificates curl git gnupg sudo
+    openjdk-21-jdk-headless ca-certificates curl git gnupg sudo \
+    libpcap0.8
   if ! command -v node >/dev/null 2>&1 \
      || ! node --version 2>/dev/null | grep -qE '^v(22|23|24)\.'; then
     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
@@ -127,6 +129,8 @@ log "Installing systemd units..."
 sudo install -d /etc/systemd/system
 sudo ln -sfn "$PREFIX/repo/deploy/familydns-api.service" \
      /etc/systemd/system/familydns-api.service
+sudo ln -sfn "$PREFIX/repo/deploy/familydns-traffic.service" \
+     /etc/systemd/system/familydns-traffic.service
 
 sudo tee /etc/systemd/system/familydns-deploy.service >/dev/null <<EOF
 [Unit]
@@ -166,7 +170,7 @@ fi
 
 # ── 7. Sudoers rule for the deploy user ───────────────────────────────────
 sudo tee /etc/sudoers.d/familydns-deploy >/dev/null <<EOF
-$USER_NAME ALL=(root) NOPASSWD: /bin/systemctl restart familydns-api.service, /usr/bin/install, /bin/mv, /bin/rm, /bin/cp, /usr/bin/tee
+$USER_NAME ALL=(root) NOPASSWD: /bin/systemctl restart familydns-api.service, /bin/systemctl restart familydns-traffic.service, /usr/bin/install, /bin/mv, /bin/rm, /bin/cp, /usr/bin/tee
 EOF
 sudo chmod 0440 /etc/sudoers.d/familydns-deploy
 
@@ -178,6 +182,8 @@ Next steps:
   1. Edit /etc/familydns/application.conf — set jwt.secret + db.password.
   2. (Optional) /etc/familydns/api.env for environment overrides.
   3. sudo systemctl enable --now familydns-api.service
+     # Traffic monitor (optional — needs the right NIC name in application.conf):
+     #   sudo systemctl enable --now familydns-traffic.service
   4. sudo systemctl enable --now familydns-deploy.timer
   5. Initial build/deploy:
        sudo -u $USER_NAME FAMILYDNS_BRANCH=$BRANCH $PREFIX/repo/scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -46,12 +46,14 @@ REV="$(git rev-parse --short HEAD)"
 log "Now at $REV"
 
 # ── Build API assembly ────────────────────────────────────────────────────
-log "Building API assembly (mill api.assembly)..."
+log "Building API + traffic assemblies (mill api.assembly traffic.assembly)..."
 command -v mill >/dev/null 2>&1 || fail "mill not on PATH — run scripts/bootstrap-host.sh"
-mill api.assembly >/tmp/${LOG_TAG}-mill.log 2>&1 \
-  || { tail -50 /tmp/${LOG_TAG}-mill.log; fail "mill api.assembly failed"; }
+mill api.assembly traffic.assembly >/tmp/${LOG_TAG}-mill.log 2>&1 \
+  || { tail -50 /tmp/${LOG_TAG}-mill.log; fail "mill assembly failed"; }
 JAR_SRC="$(ls -t out/api/assembly.dest/out.jar 2>/dev/null | head -1)"
 [ -f "$JAR_SRC" ] || fail "assembly jar not found at out/api/assembly.dest/out.jar"
+TRAFFIC_JAR_SRC="$(ls -t out/traffic/assembly.dest/out.jar 2>/dev/null | head -1)"
+[ -f "$TRAFFIC_JAR_SRC" ] || fail "assembly jar not found at out/traffic/assembly.dest/out.jar"
 
 # ── Build frontend ────────────────────────────────────────────────────────
 if [ "${FAMILYDNS_NO_WEB:-0}" != "1" ]; then
@@ -65,6 +67,8 @@ log "Swapping artifacts into $PREFIX..."
 sudo install -d -o familydns -g familydns "$PREFIX"
 sudo install -m 0644 -o familydns -g familydns "$JAR_SRC" "$PREFIX/api.jar.new"
 sudo mv -f "$PREFIX/api.jar.new" "$PREFIX/api.jar"
+sudo install -m 0644 -o familydns -g familydns "$TRAFFIC_JAR_SRC" "$PREFIX/traffic.jar.new"
+sudo mv -f "$PREFIX/traffic.jar.new" "$PREFIX/traffic.jar"
 
 if [ "${FAMILYDNS_NO_WEB:-0}" != "1" ]; then
   sudo rm -rf "$PREFIX/web.new"
@@ -85,6 +89,20 @@ if [ "${FAMILYDNS_NO_RESTART:-0}" != "1" ]; then
   sleep 2
   systemctl is-active --quiet familydns-api.service \
     || { sudo journalctl -u familydns-api -n 80 --no-pager; fail "service did not come up"; }
+
+  # Traffic monitor restart is best-effort: the service is optional (admin must
+  # enable it explicitly after configuring the right network interface), so a
+  # missing/disabled unit must not fail the deploy.
+  if systemctl list-unit-files familydns-traffic.service >/dev/null 2>&1 \
+     && systemctl is-enabled --quiet familydns-traffic.service 2>/dev/null; then
+    log "Restarting familydns-traffic.service..."
+    sudo systemctl restart familydns-traffic.service
+    sleep 2
+    systemctl is-active --quiet familydns-traffic.service \
+      || { sudo journalctl -u familydns-traffic -n 80 --no-pager; fail "traffic service did not come up"; }
+  else
+    log "familydns-traffic.service not enabled — skipping restart"
+  fi
 fi
 
 log "Deploy OK ($REV)"

--- a/traffic/src/Config.scala
+++ b/traffic/src/Config.scala
@@ -1,0 +1,23 @@
+package familydns.traffic
+
+import familydns.api.DbConfig
+import zio.*
+import zio.config.*
+import zio.config.magnolia.*
+import zio.config.typesafe.*
+
+case class TrafficAppConfig(
+    db: DbConfig,
+    traffic: TrafficConfig,
+)
+
+object TrafficAppConfig:
+  val layer: ZLayer[Any, Config.Error, TrafficAppConfig] =
+    ZLayer.fromZIO:
+      read(
+        deriveConfig[TrafficAppConfig].from(
+          TypesafeConfigProvider.fromHoconFile(
+            new java.io.File("config/application.conf"),
+          ),
+        ),
+      )

--- a/traffic/src/Main.scala
+++ b/traffic/src/Main.scala
@@ -1,0 +1,27 @@
+package familydns.traffic
+
+import familydns.api.db.{Database, TimeUsageRepoLive}
+import familydns.shared.{DnsCache, TimeUsageSnapshot}
+import zio.*
+import zio.logging.backend.SLF4J
+
+object TrafficMain extends ZIOAppDefault:
+
+  override val bootstrap =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+
+  def run =
+    (for
+      cfg <- ZIO.service[TrafficAppConfig]
+      _   <- ZIO.logInfo(
+        s"FamilyDNS traffic monitor starting on interface ${cfg.traffic.interface} " +
+          s"(flush ${cfg.traffic.flushIntervalSecs}s, sessionTimeout ${cfg.traffic.sessionTimeoutSecs}s)",
+      )
+      xa   = Database.makeTransactor(cfg.db)
+      repo = TimeUsageRepoLive(xa)
+      cacheRef <- Ref.make(DnsCache.empty)
+      usageRef <- Ref.make(TimeUsageSnapshot.empty)
+      tracker = SessionTracker(cfg.traffic, cacheRef)
+      monitor = TrafficMonitorLive(cfg.traffic, tracker, usageRef, repo.incrementUsage)
+      _ <- monitor.start
+    yield ()).provide(TrafficAppConfig.layer)


### PR DESCRIPTION
## Summary
Closes #6.

- New `TrafficMain extends ZIOAppDefault` ([traffic/src/Main.scala](../blob/claude/bold-thompson-951e88/traffic/src/Main.scala)) + `TrafficAppConfig` reading HOCON. Wires `SessionTracker` + `TrafficMonitorLive` against the same postgres as the API; `TrafficMonitorLive.start` already runs capture + flush + sweep loops.
- `traffic.assembly` task in [build.mill](../blob/claude/bold-thompson-951e88/build.mill) — `traffic` now depends on `api` (for `DbConfig`/`TimeUsageRepoLive`/`Database`), and the assembly rules concat the flyway + jdbc `META-INF/services` entries the same way `api.assembly` does.
- [deploy/familydns-traffic.service](../blob/claude/bold-thompson-951e88/deploy/familydns-traffic.service) — runs as the unprivileged `familydns` user with `AmbientCapabilities=CAP_NET_RAW CAP_NET_ADMIN` (no root), `Requires=familydns-api.service` so migrations land first, plus the same hardening as the api unit.
- Bootstrap hooks ([scripts/bootstrap-host.sh](../blob/claude/bold-thompson-951e88/scripts/bootstrap-host.sh)): installs `libpcap0.8`, symlinks the new unit, extends the deploy sudoers rule. Service is **not** auto-enabled — admin must set the right NIC name first.
- Deploy hooks ([scripts/deploy.sh](../blob/claude/bold-thompson-951e88/scripts/deploy.sh)): builds + swaps `traffic.jar` alongside `api.jar`; restart is best-effort (only if the unit is enabled), so deploys don't fail on hosts that haven't opted in.
- New `traffic { ... }` section in [config/application.conf.example](../blob/claude/bold-thompson-951e88/config/application.conf.example).

## Why
The traffic library had no runnable Main, so pcap-based per-device usage was never captured on deploy hosts and the `time_usage` tables driving per-device limits stayed empty.

## What's deferred
Docker-compose / e2e wiring is not included — that's most useful once #5 (DNS server Main) also lands so all three services can run together. Will be filed as a follow-up issue.

## Test plan
- [x] `mill traffic.compile`
- [x] `mill traffic.test` (7 passed)
- [x] `mill traffic.assembly` (64 MB jar; verified `TrafficMain`, `org.pcap4j.core.Pcaps`, and `org.postgresql.Driver` are all present)
- [ ] On a Linux host: `scripts/bootstrap-host.sh` then `systemctl enable --now familydns-traffic.service`, confirm pcap capture and `time_usage` rows landing
- [ ] Confirm `deploy.sh` restarts traffic when enabled, skips it when not

🤖 Generated with [Claude Code](https://claude.com/claude-code)