### PR TITLE
Serve web/dist via API with SPA fallback (#2)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -48,9 +48,11 @@ object Main extends ZIOAppDefault:
       usageRepo   <- ZIO.service[TimeUsageRepo]
       extRepo     <- ZIO.service[TimeExtensionRepo]
       logRepo     <- ZIO.service[QueryLogRepo]
+      cfg         <- ZIO.service[AppConfig]
     yield AuthRoutes.routes(auth, userRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo) ++
       DeviceRoutes.routes(auth, deviceRepo) ++
       TimeRoutes.routes(auth, deviceRepo, tlRepo, stlRepo, usageRepo, extRepo, profileRepo) ++
       LogRoutes.routes(auth, logRepo) ++
-      BlocklistRoutes.routes(auth, blRepo)
+      BlocklistRoutes.routes(auth, blRepo) ++
+      StaticRoutes.routes(cfg.http.staticDir)

--- a/api/src/routes/StaticRoutes.scala
+++ b/api/src/routes/StaticRoutes.scala
@@ -1,0 +1,50 @@
+package familydns.api.routes
+
+import zio.*
+import zio.http.*
+import zio.http.codec.PathCodec.trailing
+
+object StaticRoutes:
+  def routes(staticDir: String): Routes[Any, Response] =
+    val base  = java.io.File(staticDir).getCanonicalFile
+    val index = java.io.File(base, "index.html")
+
+    def resolve(rel: String): Option[java.io.File] =
+      if rel.isEmpty then None
+      else
+        val candidate = java.io.File(base, rel).getCanonicalFile
+        if candidate.getPath == base.getPath || candidate.getPath.startsWith(
+            base.getPath + java.io.File.separator,
+          )
+        then if candidate.isFile then Some(candidate) else None
+        else None
+
+    def mimeFor(name: String): MediaType =
+      val ext = name.lastIndexOf('.') match
+        case -1 => ""
+        case i  => name.substring(i + 1).toLowerCase
+      MediaType.forFileExtension(ext).getOrElse(MediaType.application.`octet-stream`)
+
+    def serve(file: java.io.File): ZIO[Any, Nothing, Response] =
+      Body
+        .fromFile(file)
+        .map(b =>
+          Response(
+            status = Status.Ok,
+            headers = Headers(Header.ContentType(mimeFor(file.getName))),
+            body = b,
+          ),
+        )
+
+    Routes(
+      Method.GET / trailing -> handler { (path: Path, _: Request) =>
+        val rel = path.encode.stripPrefix("/")
+        if rel.startsWith("api/") then ZIO.succeed(Response.notFound)
+        else
+          resolve(rel) match
+            case Some(f) => serve(f)
+            case None    =>
+              if index.isFile then serve(index)
+              else ZIO.succeed(Response.notFound)
+      },
+    )

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -1,0 +1,89 @@
+package familydns.api.feature
+
+import familydns.api.routes.StaticRoutes
+import zio.*
+import zio.http.*
+import zio.test.*
+
+object StaticRoutesSpec extends ZIOSpecDefault:
+
+  private def withTempDir[A](f: java.io.File => Task[A]): Task[A] =
+    ZIO.acquireReleaseWith(
+      ZIO.attempt {
+        val d = java.nio.file.Files.createTempDirectory("static-routes-spec").toFile
+        d
+      },
+    ) { dir =>
+      ZIO.attempt {
+        def del(f: java.io.File): Unit =
+          if f.isDirectory then f.listFiles.foreach(del)
+          val _ = f.delete()
+        del(dir)
+      }.orDie
+    }(f)
+
+  private def write(dir: java.io.File, name: String, content: String): Task[Unit] =
+    ZIO.attempt {
+      val f = java.io.File(dir, name)
+      java.nio.file.Files.writeString(f.toPath, content)
+      ()
+    }
+
+  private def get(routes: Routes[Any, Response], path: String): UIO[Response] =
+    routes(Request.get(path)).merge
+
+  def spec = suite("StaticRoutes")(
+    test("serves index.html for /") {
+      withTempDir { dir =>
+        for
+          _ <- write(dir, "index.html", "<html>hi</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          resp <- get(rs, "/")
+          body <- resp.body.asString
+        yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(body == "<html>hi</html>")
+      }
+    },
+    test("serves an existing asset") {
+      withTempDir { dir =>
+        for
+          _ <- write(dir, "app.js", "console.log(1)")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          resp <- get(rs, "/app.js")
+          body <- resp.body.asString
+        yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(body == "console.log(1)")
+      }
+    },
+    test("falls back to index.html for unknown non-API path (SPA)") {
+      withTempDir { dir =>
+        for
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          resp <- get(rs, "/devices/some-deep-route")
+          body <- resp.body.asString
+        yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(body == "<html>spa</html>")
+      }
+    },
+    test("returns 404 for unknown /api/ path") {
+      withTempDir { dir =>
+        for
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          resp <- get(rs, "/api/unknown")
+        yield assertTrue(resp.status == Status.NotFound)
+      }
+    },
+    test("rejects path traversal attempts") {
+      withTempDir { dir =>
+        for
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          resp <- get(rs, "/../../etc/passwd")
+          body <- resp.body.asString
+        yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(body == "<html>spa</html>")
+      }
+    },
+  )


### PR DESCRIPTION
## Summary
- Adds `StaticRoutes` that serves files from `familydns.http.staticDir` with proper content-types, falls back to `index.html` for unknown non-`/api/*` paths so client-side routing works, and returns 404 for unmatched `/api/*` paths.
- Wires it into `Main.allRoutes` after the API routes so API matching wins first.
- Path-traversal protection via canonical-path containment check.

Closes #2.

## Test plan
- [x] `mill api.test` — all 34 tests pass, including 5 new `StaticRoutesSpec` cases (index, asset, SPA fallback, /api 404, traversal).
- [ ] Manual: hit `GET /` against the staging stack and confirm `index.html` is served (staging healthcheck can revert to a static check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)