### PR TITLE
Add DnsMain entrypoint, dns assembly, systemd unit, and e2e dig probe

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -34,6 +34,13 @@ case class JwtConfig(
 
 case class DnsClientConfig(
     cacheRefreshSeconds: Int,
+    port: Int,
+    location: String,
+    upstreamPrimary: String,
+    upstreamSecondary: String,
+    upstreamPort: Int,
+    logBatchSize: Int,
+    logFlushSeconds: Int,
 )
 
 object AppConfig:

--- a/build.mill
+++ b/build.mill
@@ -100,7 +100,7 @@ object api extends CommonModule {
 
 // ── DNS ────────────────────────────────────────────────────────────────────
 object dns extends CommonModule {
-  def moduleDeps = Seq(shared)
+  def moduleDeps = Seq(shared, api)
   def mvnDeps = Seq(
     mvn"dev.zio::zio:$zioVersion",
     mvn"dev.zio::zio-streams:$zioVersion",
@@ -115,8 +115,14 @@ object dns extends CommonModule {
     mvn"org.postgresql:postgresql:$postgresVersion",
     mvn"ch.qos.logback:logback-classic:$logbackVersion",
   )
+  // Same ServiceLoader concat rules as api — flyway-postgres + jdbc drivers
+  // need their META-INF/services entries preserved across the fat jar.
+  override def assemblyRules = super.assemblyRules ++ Seq(
+    Assembly.Rule.Append("META-INF/services/org.flywaydb.core.extensibility.Plugin", "\n"),
+    Assembly.Rule.Append("META-INF/services/java.sql.Driver", "\n"),
+  )
   object test extends ScalaTests with FamilyDnsTestModule {
-    def moduleDeps = super.moduleDeps ++ Seq(dns, api, api.test)
+    def moduleDeps = super.moduleDeps ++ Seq(dns, api.test)
   }
 }
 

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -21,5 +21,12 @@ familydns {
 
   dns {
     cacheRefreshSeconds = 60
+    port                = 53
+    location            = "home"
+    upstreamPrimary     = "1.1.1.1"
+    upstreamSecondary   = "8.8.8.8"
+    upstreamPort        = 53
+    logBatchSize        = 500
+    logFlushSeconds     = 5
   }
 }

--- a/deploy/familydns-dns.service
+++ b/deploy/familydns-dns.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=FamilyDNS DNS server
+Documentation=https://github.com/sameerparekh/familydns
+After=network-online.target postgresql.service familydns-api.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=familydns
+Group=familydns
+WorkingDirectory=/opt/familydns
+EnvironmentFile=-/etc/familydns/dns.env
+ExecStart=/usr/bin/java \
+  -Xms128m -Xmx256m \
+  -Dconfig.file=/etc/familydns/application.conf \
+  -jar /opt/familydns/dns.jar
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=familydns-dns
+
+# Allow binding :53 without running as root
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/log/familydns /var/lib/familydns
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+
+[Install]
+WantedBy=multi-user.target

--- a/dns/src/DnsMain.scala
+++ b/dns/src/DnsMain.scala
@@ -1,0 +1,140 @@
+package familydns.dns
+
+import familydns.api.{AppConfig, DnsClientConfig}
+import familydns.api.db.*
+import familydns.shared.{Schedule as _, *}
+import zio.*
+import zio.logging.backend.SLF4J
+
+import java.time.LocalDate
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters.*
+
+object DnsMain extends ZIOAppDefault:
+
+  override val bootstrap =
+    Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+
+  def run = program.provide(env)
+
+  private val env =
+    AppConfig.layer >+>
+      ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.db)) >+>
+      ZLayer.fromZIO(ZIO.serviceWith[AppConfig](c => Database.makeTransactor(c.db))) >+>
+      Repos.all
+
+  private def toDnsConfig(c: DnsClientConfig): DnsConfig = DnsConfig(
+    port = c.port,
+    location = c.location,
+    upstreamPrimary = c.upstreamPrimary,
+    upstreamSecondary = c.upstreamSecondary,
+    upstreamPort = c.upstreamPort,
+    cacheRefreshSeconds = c.cacheRefreshSeconds,
+    logBatchSize = c.logBatchSize,
+    logFlushSeconds = c.logFlushSeconds,
+  )
+
+  private def loadCache: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo,
+    Throwable,
+    DnsCache,
+  ] =
+    for
+      profileRepo <- ZIO.service[ProfileRepo]
+      schedRepo   <- ZIO.service[ScheduleRepo]
+      tlRepo      <- ZIO.service[TimeLimitRepo]
+      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      blRepo      <- ZIO.service[BlocklistRepo]
+      profiles    <- profileRepo.listAll
+      schedules   <- schedRepo.listAll
+      timeLimits  <- tlRepo.listAll
+      stls        <- stlRepo.listAll
+      devices     <- deviceRepo.listAll
+      blocklists  <- blRepo.loadAll
+      cached    = profiles.map { p =>
+        val sched = schedules.filter(_.profileId == p.id)
+        val tl    = timeLimits.find(_.profileId == p.id).map(_.dailyMinutes)
+        val pstls = stls.filter(_.profileId == p.id)
+        p.id -> CachedProfile(p, sched, tl, pstls)
+      }.toMap
+      deviceMap = devices.flatMap(d => cached.get(d.profileId).map(d.mac -> _)).toMap
+    yield DnsCache(deviceMap, blocklists, cached.values.find(_.profile.name == "Adults"))
+
+  private def loadUsage: ZIO[TimeUsageRepo & TimeExtensionRepo, Throwable, TimeUsageSnapshot] =
+    for
+      usageRepo <- ZIO.service[TimeUsageRepo]
+      extRepo   <- ZIO.service[TimeExtensionRepo]
+      today = LocalDate.now()
+      ts    = today.toString
+      rows <- usageRepo.snapshotAll(today)
+      exts <- extRepo.snapshotAll(today)
+    yield TimeUsageSnapshot(
+      domainUsage = rows.map { case ((mac, dom), m) => (mac, dom, ts) -> m },
+      totalUsage = rows.groupBy(_._1._1).map((m, vs) => (m, ts) -> vs.values.sum),
+      extensions = exts.map((m, v) => (m, ts) -> v),
+    )
+
+  private def drainLogs(
+      queue: ConcurrentLinkedQueue[QueryLogEntry],
+      batchSize: Int,
+  ): ZIO[QueryLogRepo, Throwable, Unit] =
+    for
+      logRepo <- ZIO.service[QueryLogRepo]
+      drained <- ZIO.attempt {
+        val buf = scala.collection.mutable.ListBuffer.empty[QueryLogEntry]
+        var i   = 0
+        var e   = queue.poll()
+        while e != null && i < batchSize do
+          buf += e
+          i += 1
+          e = queue.poll()
+        buf.toList
+      }
+      _       <- ZIO.when(drained.nonEmpty):
+        val inserts = drained.map(e =>
+          QueryLogInsert(
+            e.mac,
+            e.deviceName,
+            e.profileId,
+            e.profileName,
+            e.domain,
+            e.qtype,
+            e.blocked,
+            e.reason,
+            e.location,
+          ),
+        )
+        logRepo.insertBatch(inserts)
+    yield ()
+
+  private def program =
+    for
+      cfg <- ZIO.service[AppConfig]
+      dnsCfg = toDnsConfig(cfg.dns)
+      _ <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
+      cacheRef <- Ref.make(DnsCache.empty)
+      usageRef <- Ref.make(TimeUsageSnapshot.empty)
+      logQueue = new ConcurrentLinkedQueue[QueryLogEntry]()
+      _ <- loadCache
+        .flatMap(cacheRef.set)
+        .catchAllCause(c => ZIO.logErrorCause("initial cache load failed", c))
+      _ <- loadUsage
+        .flatMap(usageRef.set)
+        .catchAllCause(c => ZIO.logErrorCause("initial usage load failed", c))
+      _ <- loadCache
+        .flatMap(cacheRef.set)
+        .catchAllCause(c => ZIO.logErrorCause("cache refresh failed", c))
+        .repeat(Schedule.spaced(dnsCfg.cacheRefreshSeconds.seconds))
+        .forkDaemon
+      _ <- loadUsage
+        .flatMap(usageRef.set)
+        .catchAllCause(c => ZIO.logErrorCause("usage refresh failed", c))
+        .repeat(Schedule.spaced(dnsCfg.cacheRefreshSeconds.seconds))
+        .forkDaemon
+      _ <- drainLogs(logQueue, dnsCfg.logBatchSize)
+        .catchAllCause(c => ZIO.logErrorCause("log drain failed", c))
+        .repeat(Schedule.spaced(dnsCfg.logFlushSeconds.seconds))
+        .forkDaemon
+      _ <- new DnsServer(dnsCfg, cacheRef, usageRef, logQueue).serve
+    yield ()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,9 @@ COPY api api
 COPY dns dns
 COPY traffic traffic
 RUN mill api.assembly \
- && cp out/api/assembly.dest/out.jar /tmp/api.jar
+ && cp out/api/assembly.dest/out.jar /tmp/api.jar \
+ && mill dns.assembly \
+ && cp out/dns/assembly.dest/out.jar /tmp/dns.jar
 
 # ── 2. Web build ──────────────────────────────────────────────────────────
 FROM node:22-bookworm-slim AS web-build
@@ -40,6 +42,7 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=scala-build /tmp/api.jar /app/api.jar
+COPY --from=scala-build /tmp/dns.jar /app/dns.jar
 COPY --from=web-build /web/dist /app/web
 COPY config/application.conf.example /app/application.conf.example
 COPY docker/entrypoint.sh /app/entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,3 +49,24 @@ services:
       timeout: 3s
       retries: 30
       start_period: 20s
+
+  dns:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      FAMILYDNS_MODE: dns
+      FAMILYDNS_DB_HOST: postgres
+      FAMILYDNS_DB_PORT: "5432"
+      FAMILYDNS_DB_NAME: familydns
+      FAMILYDNS_DB_USER: familydns
+      FAMILYDNS_DB_PASSWORD: familydns
+      FAMILYDNS_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
+      FAMILYDNS_DNS_REFRESH: "5"
+      FAMILYDNS_DNS_PORT: "5353"
+      FAMILYDNS_DNS_LOCATION: "staging"
+    ports:
+      - "127.0.0.1:5353:5353/udp"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,14 @@ set -euo pipefail
 : "${FAMILYDNS_JWT_SECRET:=staging-jwt-secret-do-not-use-in-prod-32ch}"
 : "${FAMILYDNS_JWT_HOURS:=24}"
 : "${FAMILYDNS_DNS_REFRESH:=10}"
+: "${FAMILYDNS_DNS_PORT:=5353}"
+: "${FAMILYDNS_DNS_LOCATION:=staging}"
+: "${FAMILYDNS_DNS_UPSTREAM_PRIMARY:=1.1.1.1}"
+: "${FAMILYDNS_DNS_UPSTREAM_SECONDARY:=8.8.8.8}"
+: "${FAMILYDNS_DNS_UPSTREAM_PORT:=53}"
+: "${FAMILYDNS_DNS_LOG_BATCH:=500}"
+: "${FAMILYDNS_DNS_LOG_FLUSH:=5}"
+: "${FAMILYDNS_MODE:=api}"
 
 mkdir -p /app/config
 cat > /app/config/application.conf <<EOF
@@ -36,6 +44,13 @@ jwt {
 }
 dns {
   cacheRefreshSeconds = ${FAMILYDNS_DNS_REFRESH}
+  port                = ${FAMILYDNS_DNS_PORT}
+  location            = "${FAMILYDNS_DNS_LOCATION}"
+  upstreamPrimary     = "${FAMILYDNS_DNS_UPSTREAM_PRIMARY}"
+  upstreamSecondary   = "${FAMILYDNS_DNS_UPSTREAM_SECONDARY}"
+  upstreamPort        = ${FAMILYDNS_DNS_UPSTREAM_PORT}
+  logBatchSize        = ${FAMILYDNS_DNS_LOG_BATCH}
+  logFlushSeconds     = ${FAMILYDNS_DNS_LOG_FLUSH}
 }
 EOF
 
@@ -52,4 +67,8 @@ if [ "${WAIT_FOR_POSTGRES:-1}" = "1" ]; then
 fi
 
 cd /app
-exec java -Xms256m -Xmx512m -jar /app/api.jar
+case "$FAMILYDNS_MODE" in
+  api) exec java -Xms256m -Xmx512m -jar /app/api.jar ;;
+  dns) exec java -Xms128m -Xmx256m -jar /app/dns.jar ;;
+  *)   echo "[entrypoint] unknown FAMILYDNS_MODE=$FAMILYDNS_MODE" >&2; exit 1 ;;
+esac

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -127,6 +127,8 @@ log "Installing systemd units..."
 sudo install -d /etc/systemd/system
 sudo ln -sfn "$PREFIX/repo/deploy/familydns-api.service" \
      /etc/systemd/system/familydns-api.service
+sudo ln -sfn "$PREFIX/repo/deploy/familydns-dns.service" \
+     /etc/systemd/system/familydns-dns.service
 
 sudo tee /etc/systemd/system/familydns-deploy.service >/dev/null <<EOF
 [Unit]
@@ -166,7 +168,7 @@ fi
 
 # ── 7. Sudoers rule for the deploy user ───────────────────────────────────
 sudo tee /etc/sudoers.d/familydns-deploy >/dev/null <<EOF
-$USER_NAME ALL=(root) NOPASSWD: /bin/systemctl restart familydns-api.service, /usr/bin/install, /bin/mv, /bin/rm, /bin/cp, /usr/bin/tee
+$USER_NAME ALL=(root) NOPASSWD: /bin/systemctl restart familydns-api.service, /bin/systemctl restart familydns-dns.service, /usr/bin/install, /bin/mv, /bin/rm, /bin/cp, /usr/bin/tee
 EOF
 sudo chmod 0440 /etc/sudoers.d/familydns-deploy
 
@@ -177,7 +179,7 @@ cat <<MSG
 Next steps:
   1. Edit /etc/familydns/application.conf — set jwt.secret + db.password.
   2. (Optional) /etc/familydns/api.env for environment overrides.
-  3. sudo systemctl enable --now familydns-api.service
+  3. sudo systemctl enable --now familydns-api.service familydns-dns.service
   4. sudo systemctl enable --now familydns-deploy.timer
   5. Initial build/deploy:
        sudo -u $USER_NAME FAMILYDNS_BRANCH=$BRANCH $PREFIX/repo/scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -45,13 +45,15 @@ git reset --hard --quiet "origin/$BRANCH"
 REV="$(git rev-parse --short HEAD)"
 log "Now at $REV"
 
-# ── Build API assembly ────────────────────────────────────────────────────
-log "Building API assembly (mill api.assembly)..."
+# ── Build API + DNS assemblies ────────────────────────────────────────────
+log "Building assemblies (mill api.assembly dns.assembly)..."
 command -v mill >/dev/null 2>&1 || fail "mill not on PATH — run scripts/bootstrap-host.sh"
-mill api.assembly >/tmp/${LOG_TAG}-mill.log 2>&1 \
-  || { tail -50 /tmp/${LOG_TAG}-mill.log; fail "mill api.assembly failed"; }
+mill api.assembly dns.assembly >/tmp/${LOG_TAG}-mill.log 2>&1 \
+  || { tail -50 /tmp/${LOG_TAG}-mill.log; fail "mill assembly build failed"; }
 JAR_SRC="$(ls -t out/api/assembly.dest/out.jar 2>/dev/null | head -1)"
+DNS_JAR_SRC="$(ls -t out/dns/assembly.dest/out.jar 2>/dev/null | head -1)"
 [ -f "$JAR_SRC" ] || fail "assembly jar not found at out/api/assembly.dest/out.jar"
+[ -f "$DNS_JAR_SRC" ] || fail "assembly jar not found at out/dns/assembly.dest/out.jar"
 
 # ── Build frontend ────────────────────────────────────────────────────────
 if [ "${FAMILYDNS_NO_WEB:-0}" != "1" ]; then
@@ -65,6 +67,8 @@ log "Swapping artifacts into $PREFIX..."
 sudo install -d -o familydns -g familydns "$PREFIX"
 sudo install -m 0644 -o familydns -g familydns "$JAR_SRC" "$PREFIX/api.jar.new"
 sudo mv -f "$PREFIX/api.jar.new" "$PREFIX/api.jar"
+sudo install -m 0644 -o familydns -g familydns "$DNS_JAR_SRC" "$PREFIX/dns.jar.new"
+sudo mv -f "$PREFIX/dns.jar.new" "$PREFIX/dns.jar"
 
 if [ "${FAMILYDNS_NO_WEB:-0}" != "1" ]; then
   sudo rm -rf "$PREFIX/web.new"
@@ -84,7 +88,18 @@ if [ "${FAMILYDNS_NO_RESTART:-0}" != "1" ]; then
   sudo systemctl restart familydns-api.service
   sleep 2
   systemctl is-active --quiet familydns-api.service \
-    || { sudo journalctl -u familydns-api -n 80 --no-pager; fail "service did not come up"; }
+    || { sudo journalctl -u familydns-api -n 80 --no-pager; fail "api did not come up"; }
+
+  # familydns-dns.service may not be installed on every host (some deploys run
+  # only the API). Restart it only if the unit is present.
+  if systemctl list-unit-files familydns-dns.service >/dev/null 2>&1 \
+     && [ -n "$(systemctl list-unit-files familydns-dns.service --no-legend 2>/dev/null)" ]; then
+    log "Restarting familydns-dns.service..."
+    sudo systemctl restart familydns-dns.service
+    sleep 2
+    systemctl is-active --quiet familydns-dns.service \
+      || { sudo journalctl -u familydns-dns -n 80 --no-pager; fail "dns did not come up"; }
+  fi
 fi
 
 log "Deploy OK ($REV)"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -74,10 +74,30 @@ step "Blocklists endpoint"
 curl -fsS "${AUTH[@]}" "$BASE/api/blocklists" >/dev/null
 pass "blocklists OK"
 
-# DNS / traffic e2e is currently a TODO: the dns and traffic modules don't yet
-# have runnable Mains, so the staging container only runs the API. Once they
-# do, extend this script with a `dig @127.0.0.1 -p 5353 …` block and a pcap
-# probe.
+step "DNS server responds on UDP :5353"
+DNS_HOST="${E2E_DNS_HOST:-127.0.0.1}"
+DNS_PORT="${E2E_DNS_PORT:-5353}"
+if ! command -v dig >/dev/null 2>&1; then
+  fail "dig not installed — install dnsutils/bind-tools"
+fi
+# Wait for DNS server to bind (may start a moment after the api).
+for i in $(seq 1 30); do
+  if dig +tries=1 +time=2 @"$DNS_HOST" -p "$DNS_PORT" example.com >/dev/null 2>&1; then
+    pass "dns server reachable on $DNS_HOST:$DNS_PORT"
+    break
+  fi
+  if [ "$i" = 30 ]; then fail "dns server never came up on $DNS_HOST:$DNS_PORT"; fi
+  sleep 1
+done
+
+# Unknown client (no profile/device row) should still get an answer — it falls
+# through to the default Adults profile and forwards upstream. We just need a
+# well-formed response (status NOERROR or SERVFAIL is fine — the point is the
+# server is parsing queries and writing replies).
+DIG_OUT=$(dig +tries=1 +time=3 @"$DNS_HOST" -p "$DNS_PORT" example.com || true)
+echo "$DIG_OUT" | grep -qE 'status: (NOERROR|NXDOMAIN|SERVFAIL|REFUSED)' \
+  || fail "dns server did not return a parseable response: $DIG_OUT"
+pass "dns server answered example.com"
 
 echo
 echo "All e2e checks passed."


### PR DESCRIPTION
Closes #5.

## Summary
- The `dns` module previously had no runnable `Main`, so nothing was listening on `:53` in any deploy. This wires it up end-to-end.
- New `DnsMain` (ZIOAppDefault) loads `AppConfig`, builds the `DnsCache` from API repos, periodically refreshes cache + usage, drains the log queue into `query_logs`, and runs `DnsServer.serve`.
- `dns.assembly` now builds a working fat jar (Flyway/JDBC `META-INF/services` append rules added), and the `dns` module reuses `api`'s `Repos`/`Database` instead of growing a parallel db layer.
- New `familydns-dns.service` systemd unit with `AmbientCapabilities=CAP_NET_BIND_SERVICE` so the `familydns` user can bind `:53` without root.
- `scripts/bootstrap-host.sh` symlinks the new unit and adds the dns-restart line to the deploy sudoers rule.
- `scripts/deploy.sh` builds `dns.assembly` alongside `api.assembly`, swaps `dns.jar` atomically, restarts `familydns-dns.service` when installed (still works on hosts that haven't picked it up yet).
- `scripts/e2e-tests.sh` gains a `dig @127.0.0.1 -p 5353` probe that asserts a parseable response — removes the long-standing TODO.
- Docker: `Dockerfile` builds both jars; `entrypoint.sh` switches on `FAMILYDNS_MODE=api|dns` and templates the new `dns.*` config keys; `docker-compose.yml` gains a `dns` service publishing UDP 5353.
- `config/application.conf.example` documents the new `dns.*` fields (`port`, `location`, upstreams, `logBatchSize`, `logFlushSeconds`).

## Notes for reviewers
- `DnsClientConfig` was extended in place rather than split into a separate config record. It's only consumed by `DnsMain` today, so reusing the same `AppConfig` keeps a single config file driving both services.
- The `dns` module now has a moduleDep on `api`. The alternative (a fresh `dns/db` package duplicating the relevant repos) felt like more code and more drift surface than it was worth right now.
- `loadCache` mirrors the test helper in `DnsBlockingSpec`. It picks the default profile by name (`"Adults"`), which matches the existing seed data — happy to make this configurable in a follow-up if needed.
- `deploy.sh` only restarts `familydns-dns.service` if the unit is installed, so older hosts that haven't re-run `bootstrap-host.sh` won't fail mid-deploy.

## Test plan
- [x] `mill dns.compile`
- [x] `mill dns.test` (8/8 pass)
- [x] `mill dns.assembly`
- [x] `mill api.compile`
- [ ] CI e2e workflow: confirm the new `dig` probe passes against the docker staging stack
- [ ] Spot-check `familydns-dns.service` on a real host after a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)