### PR TITLE
Add account page for self-service password change

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { DevicesPage } from '@/pages/DevicesPage'
 import { ProfilesPage } from '@/pages/ProfilesPage'
 import { TimePage } from '@/pages/TimePage'
 import { LogsPage } from '@/pages/LogsPage'
+import { AccountPage } from '@/pages/AccountPage'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -29,6 +30,7 @@ function AppRoutes() {
         <Route path="profiles"  element={<ProfilesPage />} />
         <Route path="time"      element={<TimePage />} />
         <Route path="logs"      element={<LogsPage />} />
+        <Route path="account"   element={<AccountPage />} />
       </Route>
     </Routes>
   )

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -61,9 +61,19 @@ export function Layout() {
           </nav>
 
           <div className="flex items-center gap-3">
-            <span className="hidden sm:block text-xs text-gray-500 font-mono">
+            <NavLink
+              to="/account"
+              className={({ isActive }) =>
+                `hidden sm:block text-xs font-mono px-2 py-1 rounded transition-colors ${
+                  isActive
+                    ? 'text-emerald-400'
+                    : 'text-gray-500 hover:text-white'
+                }`
+              }
+              title="Account settings"
+            >
               {username} {isAdmin ? '· admin' : '· readonly'}
-            </span>
+            </NavLink>
             <button
               onClick={handleLogout}
               className="text-xs text-gray-500 hover:text-white transition-colors px-2 py-1 rounded"

--- a/web/src/pages/AccountPage.tsx
+++ b/web/src/pages/AccountPage.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react'
+import { api } from '@/api/client'
+import { useAuth } from '@/hooks/useAuth'
+
+export function AccountPage() {
+  const { username, isAdmin } = useAuth()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword]         = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error,   setError]   = useState('')
+  const [success, setSuccess] = useState(false)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    setSuccess(false)
+
+    if (newPassword !== confirmPassword) {
+      setError('New password and confirmation do not match')
+      return
+    }
+    if (newPassword.length < 8) {
+      setError('New password must be at least 8 characters')
+      return
+    }
+    if (newPassword === currentPassword) {
+      setError('New password must differ from the current password')
+      return
+    }
+
+    setLoading(true)
+    try {
+      await api.auth.changePassword(currentPassword, newPassword)
+      setSuccess(true)
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to change password'
+      setError(msg.includes('401') || msg.toLowerCase().includes('unauth')
+        ? 'Current password is incorrect'
+        : msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6 max-w-xl">
+      <h1 className="text-xl font-bold text-white">Account</h1>
+
+      <section className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+          Profile
+        </h2>
+        <dl className="text-sm space-y-2">
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Username</dt>
+            <dd className="text-white font-mono">{username}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt className="text-gray-500">Role</dt>
+            <dd className="text-white font-mono">{isAdmin ? 'admin' : 'readonly'}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+        <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
+          Change password
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <PasswordField
+            label="Current password"
+            value={currentPassword}
+            onChange={setCurrentPassword}
+            autoComplete="current-password"
+            autoFocus
+          />
+          <PasswordField
+            label="New password"
+            value={newPassword}
+            onChange={setNewPassword}
+            autoComplete="new-password"
+          />
+          <PasswordField
+            label="Confirm new password"
+            value={confirmPassword}
+            onChange={setConfirmPassword}
+            autoComplete="new-password"
+          />
+
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-3 text-red-400 text-sm">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-4 py-3 text-emerald-400 text-sm">
+              Password updated.
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-black font-semibold px-4 py-2 rounded-xl transition-colors"
+          >
+            {loading ? 'Updating…' : 'Update password'}
+          </button>
+        </form>
+      </section>
+    </div>
+  )
+}
+
+function PasswordField({
+  label, value, onChange, autoComplete, autoFocus,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  autoComplete?: string
+  autoFocus?: boolean
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        {label}
+      </label>
+      <input
+        type="password"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        autoComplete={autoComplete}
+        autoFocus={autoFocus}
+        required
+        className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white placeholder-gray-600 focus:outline-none focus:border-emerald-500 transition-colors"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a new `/account` page in the web app with a change-password form, wired to the existing `POST /api/auth/change-password` endpoint.
- Adds a profile section showing username and role.
- Top-bar username is now a link to `/account`.

Closes #11.

## Test plan
- [ ] Sign in, click the username in the top bar, change password to a new value, sign out, sign back in with the new password.
- [ ] Verify error states: wrong current password, mismatched confirmation, password < 8 chars, same as current.
- [ ] Verify the top-bar link highlights when on `/account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)