### PR TITLE
Wire traffic monitor into staging compose stack and e2e

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,9 @@ COPY traffic traffic
 RUN mill api.assembly \
  && cp out/api/assembly.dest/out.jar /tmp/api.jar \
  && mill dns.assembly \
- && cp out/dns/assembly.dest/out.jar /tmp/dns.jar
+ && cp out/dns/assembly.dest/out.jar /tmp/dns.jar \
+ && mill traffic.assembly \
+ && cp out/traffic/assembly.dest/out.jar /tmp/traffic.jar
 
 # ── 2. Web build ──────────────────────────────────────────────────────────
 FROM node:22-bookworm-slim AS web-build
@@ -38,11 +40,12 @@ RUN npm run build
 # ── 3. Runtime ────────────────────────────────────────────────────────────
 FROM eclipse-temurin:21-jre
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
-      curl ca-certificates dnsutils \
+      curl ca-certificates dnsutils libpcap0.8 \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=scala-build /tmp/api.jar /app/api.jar
 COPY --from=scala-build /tmp/dns.jar /app/dns.jar
+COPY --from=scala-build /tmp/traffic.jar /app/traffic.jar
 COPY --from=web-build /web/dist /app/web
 COPY config/application.conf.example /app/application.conf.example
 COPY docker/entrypoint.sh /app/entrypoint.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -70,3 +70,29 @@ services:
       FAMILYDNS_DNS_LOCATION: "staging"
     ports:
       - "127.0.0.1:5353:5353/udp"
+
+  traffic:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      FAMILYDNS_MODE: traffic
+      FAMILYDNS_DB_HOST: postgres
+      FAMILYDNS_DB_PORT: "5432"
+      FAMILYDNS_DB_NAME: familydns
+      FAMILYDNS_DB_USER: familydns
+      FAMILYDNS_DB_PASSWORD: familydns
+      FAMILYDNS_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
+      # eth0 inside the bridge — only sees this container's own packets, which
+      # is enough to verify the service starts up. Real per-device capture
+      # happens on the host via systemd (see deploy/familydns-traffic.service).
+      FAMILYDNS_TRAFFIC_INTERFACE: "eth0"
+      FAMILYDNS_TRAFFIC_FLUSH_INTERVAL: "5"
+      FAMILYDNS_TRAFFIC_SESSION_TIMEOUT: "10"
+      FAMILYDNS_TRAFFIC_LOCATION: "staging"
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,10 @@ set -euo pipefail
 : "${FAMILYDNS_DNS_UPSTREAM_PORT:=53}"
 : "${FAMILYDNS_DNS_LOG_BATCH:=500}"
 : "${FAMILYDNS_DNS_LOG_FLUSH:=5}"
+: "${FAMILYDNS_TRAFFIC_INTERFACE:=eth0}"
+: "${FAMILYDNS_TRAFFIC_SESSION_TIMEOUT:=30}"
+: "${FAMILYDNS_TRAFFIC_FLUSH_INTERVAL:=5}"
+: "${FAMILYDNS_TRAFFIC_LOCATION:=staging}"
 : "${FAMILYDNS_MODE:=api}"
 
 mkdir -p /app/config
@@ -53,6 +57,12 @@ familydns {
     logBatchSize        = ${FAMILYDNS_DNS_LOG_BATCH}
     logFlushSeconds     = ${FAMILYDNS_DNS_LOG_FLUSH}
   }
+  traffic {
+    interface           = "${FAMILYDNS_TRAFFIC_INTERFACE}"
+    sessionTimeoutSecs  = ${FAMILYDNS_TRAFFIC_SESSION_TIMEOUT}
+    flushIntervalSecs   = ${FAMILYDNS_TRAFFIC_FLUSH_INTERVAL}
+    location            = "${FAMILYDNS_TRAFFIC_LOCATION}"
+  }
 }
 EOF
 
@@ -70,7 +80,8 @@ fi
 
 cd /app
 case "$FAMILYDNS_MODE" in
-  api) exec java -Xms256m -Xmx512m -Dconfig.file=/app/config/application.conf -jar /app/api.jar ;;
-  dns) exec java -Xms128m -Xmx256m -Dconfig.file=/app/config/application.conf -jar /app/dns.jar ;;
-  *)   echo "[entrypoint] unknown FAMILYDNS_MODE=$FAMILYDNS_MODE" >&2; exit 1 ;;
+  api)     exec java -Xms256m -Xmx512m -Dconfig.file=/app/config/application.conf -jar /app/api.jar ;;
+  dns)     exec java -Xms128m -Xmx256m -Dconfig.file=/app/config/application.conf -jar /app/dns.jar ;;
+  traffic) exec java -Xms128m -Xmx256m -Dconfig.file=/app/config/application.conf -jar /app/traffic.jar ;;
+  *)       echo "[entrypoint] unknown FAMILYDNS_MODE=$FAMILYDNS_MODE" >&2; exit 1 ;;
 esac

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -99,5 +99,42 @@ echo "$DIG_OUT" | grep -qE 'status: (NOERROR|NXDOMAIN|SERVFAIL|REFUSED)' \
   || fail "dns server did not return a parseable response: $DIG_OUT"
 pass "dns server answered example.com"
 
+step "Traffic monitor running + /api/time/status endpoint"
+# The traffic container captures pcap on its own bridge eth0, which only sees
+# its own packets — enough to verify the service starts and the pcap4j JNA
+# binding works. Real per-device capture happens on the host via systemd.
+if command -v docker >/dev/null 2>&1; then
+  COMPOSE_FILE="${COMPOSE_FILE:-docker/docker-compose.yml}"
+  if [ -f "$COMPOSE_FILE" ]; then
+    for i in $(seq 1 30); do
+      state=$(docker compose -f "$COMPOSE_FILE" ps --format '{{.Service}} {{.State}}' 2>/dev/null \
+        | awk '$1=="traffic"{print $2}')
+      if [ "$state" = "running" ]; then pass "traffic container running"; break; fi
+      if [ "$i" = 30 ]; then fail "traffic container never reached running state (last: $state)"; fi
+      sleep 1
+    done
+    if docker compose -f "$COMPOSE_FILE" logs traffic 2>/dev/null \
+        | grep -q "FamilyDNS traffic monitor starting"; then
+      pass "traffic monitor logged startup"
+    else
+      fail "traffic monitor did not log expected startup line"
+    fi
+  fi
+fi
+
+# Synthetic queries to drive a tiny bit of traffic past the dns server (the
+# traffic container can't see this on its own veth, but if pcap is broken or
+# the upstream resolver is wedged the dns server itself will fail to answer).
+for d in example.com wikipedia.org github.com; do
+  dig +tries=1 +time=2 @"$DNS_HOST" -p "$DNS_PORT" "$d" >/dev/null 2>&1 || true
+done
+
+# Confirm /api/time/status returns a JSON array. Usage rows only appear when
+# the traffic container actually captures matching packets, which the bridge
+# topology can't guarantee — so we don't gate on row content here.
+STATUS=$(curl -fsS "${AUTH[@]}" "$BASE/api/time/status")
+echo "$STATUS" | grep -q '^\[' || fail "time/status did not return a JSON array: $STATUS"
+pass "/api/time/status responded"
+
 echo
 echo "All e2e checks passed."

--- a/traffic/src/Config.scala
+++ b/traffic/src/Config.scala
@@ -14,10 +14,11 @@ case class TrafficAppConfig(
 object TrafficAppConfig:
   val layer: ZLayer[Any, Config.Error, TrafficAppConfig] =
     ZLayer.fromZIO:
+      val path = sys.props.getOrElse("config.file", "config/application.conf")
       read(
-        deriveConfig[TrafficAppConfig].from(
-          TypesafeConfigProvider.fromHoconFile(
-            new java.io.File("config/application.conf"),
+        deriveConfig[TrafficAppConfig]
+          .nested("familydns")
+          .from(
+            TypesafeConfigProvider.fromHoconFile(new java.io.File(path)),
           ),
-        ),
       )


### PR DESCRIPTION
## Summary

Closes #25.

Follows up on #24 (TrafficMain) and #27 (DNS in staging) by adding the third service to the docker staging stack so [scripts/e2e-tests.sh](scripts/e2e-tests.sh) exercises api + dns + traffic together.

- [docker/Dockerfile](docker/Dockerfile): build `traffic.assembly`, install `libpcap0.8` in the runtime stage, copy `traffic.jar`.
- [docker/entrypoint.sh](docker/entrypoint.sh): render the `traffic { ... }` HOCON block from `FAMILYDNS_TRAFFIC_*` env, dispatch on `FAMILYDNS_MODE=traffic`.
- [docker/docker-compose.yml](docker/docker-compose.yml): new `traffic` service, `cap_add: [NET_RAW, NET_ADMIN]`. Bridge-network pcap on `eth0` only sees the container's own packets — enough to validate pcap4j JNA + the ZIO wiring boot cleanly. Real per-device capture happens on the host via [deploy/familydns-traffic.service](deploy/familydns-traffic.service).
- [traffic/src/Config.scala](traffic/src/Config.scala): honor `-Dconfig.file` and `.nested("familydns")`, matching api/dns after #23. Without this the traffic container can't read the rendered `/app/config/application.conf`.
- [scripts/e2e-tests.sh](scripts/e2e-tests.sh): assert the traffic container reaches `running` and logs its startup banner, then `GET /api/time/status`. We don't gate on usage-row content — bridge-network pcap can't observe other containers' traffic, so a positive flow assertion would be flaky.

## Test plan

- [ ] `mill traffic.compile && mill traffic.test` (pass locally)
- [ ] `docker compose -f docker/docker-compose.yml up -d --build && scripts/e2e-tests.sh` (CI e2e workflow)
- [ ] Traffic container logs `FamilyDNS traffic monitor starting` and stays up

🤖 Generated with [Claude Code](https://claude.com/claude-code)