### PR TITLE
Fix DNS query logging, device tracking, and staging networking

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -85,6 +85,7 @@ trait DeviceRepo:
   def listAll: Task[List[Device]]
   def findByMac(mac: String): Task[Option[Device]]
   def upsert(mac: String, name: String, pid: Long, ip: String, loc: String): Task[Long]
+  def updateLastSeen(mac: String, ip: String, location: String): Task[Unit]
   def updateProfile(mac: String, pid: Long): Task[Unit]
   def delete(mac: String): Task[Unit]
 
@@ -310,6 +311,8 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
       .query[Long]
       .unique
       .transact(xa)
+  def updateLastSeen(mac: String, ip: String, location: String)             =
+    sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW(),location=$location WHERE mac=$mac".update.run.transact(xa).unit
   def updateProfile(mac: String, pid: Long)                                 =
     sql"UPDATE devices SET profile_id=$pid WHERE mac=$mac".update.run.transact(xa).unit
   def delete(mac: String) = sql"DELETE FROM devices WHERE mac=$mac".update.run.transact(xa).unit

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -312,7 +312,9 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
       .unique
       .transact(xa)
   def updateLastSeen(mac: String, ip: String, location: String)             =
-    sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW(),location=$location WHERE mac=$mac".update.run.transact(xa).unit
+    sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW(),location=$location WHERE mac=$mac".update.run
+      .transact(xa)
+      .unit
   def updateProfile(mac: String, pid: Long)                                 =
     sql"UPDATE devices SET profile_id=$pid WHERE mac=$mac".update.run.transact(xa).unit
   def delete(mac: String) = sql"DELETE FROM devices WHERE mac=$mac".update.run.transact(xa).unit

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -102,6 +102,20 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       yield assertTrue(delResp.status == Status.Ok) &&
         assertTrue(after.isEmpty)
     },
+    test("updateLastSeen updates ip without losing profile assignment") {
+      for
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        mac    = "cc:dd:ee:ff:00:11"
+        _      <- deviceRepo.upsert(mac, "Laptop", kidsId, "192.168.1.5", "home")
+        _      <- deviceRepo.updateLastSeen(mac, "192.168.1.99", "office")
+        device <- deviceRepo.findByMac(mac)
+      yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.99"))) &&
+        assertTrue(device.exists(_.profileId == kidsId))
+    },
     test("upsert updates last_seen_ip without losing profile assignment") {
       for
         _           <- cleanDb

--- a/dns/src/DnsMain.scala
+++ b/dns/src/DnsMain.scala
@@ -112,29 +112,30 @@ object DnsMain extends ZIOAppDefault:
     for
       cfg <- ZIO.service[AppConfig]
       dnsCfg = toDnsConfig(cfg.dns)
-      _ <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
-      cacheRef <- Ref.make(DnsCache.empty)
-      usageRef <- Ref.make(TimeUsageSnapshot.empty)
-      logQueue = new ConcurrentLinkedQueue[QueryLogEntry]()
-      _ <- loadCache
+      _          <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
+      cacheRef   <- Ref.make(DnsCache.empty)
+      usageRef   <- Ref.make(TimeUsageSnapshot.empty)
+      logQueue    = new ConcurrentLinkedQueue[QueryLogEntry]()
+      _          <- loadCache
         .flatMap(cacheRef.set)
         .catchAllCause(c => ZIO.logErrorCause("initial cache load failed", c))
-      _ <- loadUsage
+      _          <- loadUsage
         .flatMap(usageRef.set)
         .catchAllCause(c => ZIO.logErrorCause("initial usage load failed", c))
-      _ <- loadCache
+      _          <- loadCache
         .flatMap(cacheRef.set)
         .catchAllCause(c => ZIO.logErrorCause("cache refresh failed", c))
         .repeat(Schedule.spaced(dnsCfg.cacheRefreshSeconds.seconds))
         .forkDaemon
-      _ <- loadUsage
+      _          <- loadUsage
         .flatMap(usageRef.set)
         .catchAllCause(c => ZIO.logErrorCause("usage refresh failed", c))
         .repeat(Schedule.spaced(dnsCfg.cacheRefreshSeconds.seconds))
         .forkDaemon
-      _ <- drainLogs(logQueue, dnsCfg.logBatchSize)
+      _          <- drainLogs(logQueue, dnsCfg.logBatchSize)
         .catchAllCause(c => ZIO.logErrorCause("log drain failed", c))
         .repeat(Schedule.spaced(dnsCfg.logFlushSeconds.seconds))
         .forkDaemon
-      _ <- new DnsServer(dnsCfg, cacheRef, usageRef, logQueue).serve
+      deviceRepo <- ZIO.service[DeviceRepo]
+      _          <- new DnsServer(dnsCfg, cacheRef, usageRef, logQueue, deviceRepo).serve
     yield ()

--- a/dns/src/DnsMain.scala
+++ b/dns/src/DnsMain.scala
@@ -112,10 +112,10 @@ object DnsMain extends ZIOAppDefault:
     for
       cfg <- ZIO.service[AppConfig]
       dnsCfg = toDnsConfig(cfg.dns)
-      _          <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
-      cacheRef   <- Ref.make(DnsCache.empty)
-      usageRef   <- Ref.make(TimeUsageSnapshot.empty)
-      logQueue    = new ConcurrentLinkedQueue[QueryLogEntry]()
+      _ <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
+      cacheRef <- Ref.make(DnsCache.empty)
+      usageRef <- Ref.make(TimeUsageSnapshot.empty)
+      logQueue = new ConcurrentLinkedQueue[QueryLogEntry]()
       _          <- loadCache
         .flatMap(cacheRef.set)
         .catchAllCause(c => ZIO.logErrorCause("initial cache load failed", c))

--- a/dns/src/DnsServer.scala
+++ b/dns/src/DnsServer.scala
@@ -28,6 +28,7 @@ class DnsServer(
     cacheRef: Ref[DnsCache],
     usageRef: Ref[TimeUsageSnapshot],
     logQueue: ConcurrentLinkedQueue[QueryLogEntry],
+    deviceRepo: familydns.api.db.DeviceRepo,
 ):
 
   private val upstreams = List(
@@ -65,40 +66,55 @@ class DnsServer(
       case None        => ZIO.unit
       case Some(query) =>
         for
-          cache <- cacheRef.get
-          usage <- usageRef.get
-          clientIp = addr.getHostAddress
-          mac      = arpLookup(clientIp)
-          profile  = mac
-            .flatMap(m => cache.deviceProfiles.get(m))
-            .orElse(cache.defaultProfile)
+          cache    <- cacheRef.get
+          usage    <- usageRef.get
+          clientIp  = addr.getHostAddress
+          mac       = arpLookup(clientIp)
+          _        <- ZIO.logDebug(s"query from $clientIp mac=${mac.getOrElse("?")} domain=${query.domain} qtype=${query.qtype}")
+          // Only fall back to the default profile when we have a real MAC that isn't registered.
+          // If ARP failed (mac=None) the device is truly unrecognized and we forward+log it.
+          profile   = mac.flatMap(m => cache.deviceProfiles.get(m).orElse(cache.defaultProfile))
+          _        <- ZIO.logDebug(s"profile for mac=${mac.getOrElse("?")} -> ${profile.map(_.profile.name).getOrElse("none (unrecognized)")}")
           response <- profile match
             case None     =>
-              // Unknown device — forward with no filtering
-              forwardUpstream(data)
-                .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
+              // Unknown device — forward with no filtering but log so we can identify & onboard it
+              ZIO.logDebug(s"unrecognized device ip=$clientIp mac=${mac.getOrElse("no-arp-entry")}, forwarding upstream") *>
+                forwardUpstream(data)
+                  .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
+                  .tap(_ => enqueueLog(mac, None, query, blocked = false, ""))
             case Some(cp) =>
-              val now      = LocalTime.now()
-              val today    = LocalDate.now()
-              val decision = BlockingEngine.decide(
-                query.domain,
-                cp,
-                cache.blocklists,
-                usage,
-                mac.getOrElse(""),
-                now,
-                today,
-              )
-              decision match
-                case BlockingEngine.Decision.Allow         =>
-                  forwardUpstream(data).map(_.getOrElse(DnsPacket.buildNxdomain(data)))
-                case BlockingEngine.Decision.Block(reason) =>
-                  val resp =
-                    if reason.startsWith("schedule") || reason == "paused"
-                    then DnsPacket.buildRefused(data)
-                    else DnsPacket.buildNxdomain(data)
-                  ZIO.succeed(resp)
-                    <* enqueueLog(mac, cp, query, blocked = true, reason)
+              for
+                _ <- ZIO.foreachDiscard(mac) { m =>
+                       deviceRepo
+                         .updateLastSeen(m, clientIp, config.location)
+                         .catchAllCause(c => ZIO.logWarningCause("updateLastSeen failed", c))
+                         .forkDaemon
+                     }
+                now      = LocalTime.now()
+                today    = LocalDate.now()
+                decision = BlockingEngine.decide(
+                             query.domain,
+                             cp,
+                             cache.blocklists,
+                             usage,
+                             mac.getOrElse(""),
+                             now,
+                             today,
+                           )
+                _        <- ZIO.logDebug(s"decision for ${query.domain} profile=${cp.profile.name} -> $decision")
+                resp     <- decision match
+                              case BlockingEngine.Decision.Allow         =>
+                                forwardUpstream(data)
+                                  .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
+                                  .tap(_ => enqueueLog(mac, Some(cp), query, blocked = false, ""))
+                              case BlockingEngine.Decision.Block(reason) =>
+                                val r =
+                                  if reason.startsWith("schedule") || reason == "paused"
+                                  then DnsPacket.buildRefused(data)
+                                  else DnsPacket.buildNxdomain(data)
+                                ZIO.succeed(r)
+                                  <* enqueueLog(mac, Some(cp), query, blocked = true, reason)
+              yield resp
           _        <- ZIO.attempt:
             val out = new DatagramPacket(response, response.length, addr, port)
             sock.send(out)
@@ -106,7 +122,7 @@ class DnsServer(
 
   private def enqueueLog(
       mac: Option[String],
-      profile: CachedProfile,
+      profile: Option[CachedProfile],
       query: DnsPacket.Query,
       blocked: Boolean,
       reason: String,
@@ -118,9 +134,9 @@ class DnsServer(
         val _ = logQueue.add(
           QueryLogEntry(
             mac = mac,
-            deviceName = mac.flatMap(m => Some(m)), // DNS doesn't have name; API joins later
-            profileId = Some(profile.profile.id),
-            profileName = Some(profile.profile.name),
+            deviceName = mac, // DNS doesn't have name; API joins later
+            profileId = profile.map(_.profile.id),
+            profileName = profile.map(_.profile.name),
             domain = query.domain,
             qtype = query.qtype,
             blocked = blocked,

--- a/dns/src/DnsServer.scala
+++ b/dns/src/DnsServer.scala
@@ -66,54 +66,62 @@ class DnsServer(
       case None        => ZIO.unit
       case Some(query) =>
         for
-          cache    <- cacheRef.get
-          usage    <- usageRef.get
-          clientIp  = addr.getHostAddress
-          mac       = arpLookup(clientIp)
-          _        <- ZIO.logDebug(s"query from $clientIp mac=${mac.getOrElse("?")} domain=${query.domain} qtype=${query.qtype}")
+          cache <- cacheRef.get
+          usage <- usageRef.get
+          clientIp = addr.getHostAddress
+          mac      = arpLookup(clientIp)
+          _ <- ZIO.logDebug(
+            s"query from $clientIp mac=${mac.getOrElse("?")} domain=${query.domain} qtype=${query.qtype}",
+          )
           // Only fall back to the default profile when we have a real MAC that isn't registered.
           // If ARP failed (mac=None) the device is truly unrecognized and we forward+log it.
-          profile   = mac.flatMap(m => cache.deviceProfiles.get(m).orElse(cache.defaultProfile))
-          _        <- ZIO.logDebug(s"profile for mac=${mac.getOrElse("?")} -> ${profile.map(_.profile.name).getOrElse("none (unrecognized)")}")
+          profile = mac.flatMap(m => cache.deviceProfiles.get(m).orElse(cache.defaultProfile))
+          _        <- ZIO.logDebug(
+            s"profile for mac=${mac.getOrElse("?")} -> ${profile.map(_.profile.name).getOrElse("none (unrecognized)")}",
+          )
           response <- profile match
             case None     =>
               // Unknown device — forward with no filtering but log so we can identify & onboard it
-              ZIO.logDebug(s"unrecognized device ip=$clientIp mac=${mac.getOrElse("no-arp-entry")}, forwarding upstream") *>
+              ZIO.logDebug(
+                s"unrecognized device ip=$clientIp mac=${mac.getOrElse("no-arp-entry")}, forwarding upstream",
+              ) *>
                 forwardUpstream(data)
                   .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
                   .tap(_ => enqueueLog(mac, None, query, blocked = false, ""))
             case Some(cp) =>
               for
                 _ <- ZIO.foreachDiscard(mac) { m =>
-                       deviceRepo
-                         .updateLastSeen(m, clientIp, config.location)
-                         .catchAllCause(c => ZIO.logWarningCause("updateLastSeen failed", c))
-                         .forkDaemon
-                     }
+                  deviceRepo
+                    .updateLastSeen(m, clientIp, config.location)
+                    .catchAllCause(c => ZIO.logWarningCause("updateLastSeen failed", c))
+                    .forkDaemon
+                }
                 now      = LocalTime.now()
                 today    = LocalDate.now()
                 decision = BlockingEngine.decide(
-                             query.domain,
-                             cp,
-                             cache.blocklists,
-                             usage,
-                             mac.getOrElse(""),
-                             now,
-                             today,
-                           )
-                _        <- ZIO.logDebug(s"decision for ${query.domain} profile=${cp.profile.name} -> $decision")
-                resp     <- decision match
-                              case BlockingEngine.Decision.Allow         =>
-                                forwardUpstream(data)
-                                  .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
-                                  .tap(_ => enqueueLog(mac, Some(cp), query, blocked = false, ""))
-                              case BlockingEngine.Decision.Block(reason) =>
-                                val r =
-                                  if reason.startsWith("schedule") || reason == "paused"
-                                  then DnsPacket.buildRefused(data)
-                                  else DnsPacket.buildNxdomain(data)
-                                ZIO.succeed(r)
-                                  <* enqueueLog(mac, Some(cp), query, blocked = true, reason)
+                  query.domain,
+                  cp,
+                  cache.blocklists,
+                  usage,
+                  mac.getOrElse(""),
+                  now,
+                  today,
+                )
+                _    <- ZIO.logDebug(
+                  s"decision for ${query.domain} profile=${cp.profile.name} -> $decision",
+                )
+                resp <- decision match
+                  case BlockingEngine.Decision.Allow         =>
+                    forwardUpstream(data)
+                      .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
+                      .tap(_ => enqueueLog(mac, Some(cp), query, blocked = false, ""))
+                  case BlockingEngine.Decision.Block(reason) =>
+                    val r =
+                      if reason.startsWith("schedule") || reason == "paused"
+                      then DnsPacket.buildRefused(data)
+                      else DnsPacket.buildNxdomain(data)
+                    ZIO.succeed(r)
+                      <* enqueueLog(mac, Some(cp), query, blocked = true, reason)
               yield resp
           _        <- ZIO.attempt:
             val out = new DatagramPacket(response, response.length, addr, port)

--- a/dns/test/src/unit/ProfileResolutionSpec.scala
+++ b/dns/test/src/unit/ProfileResolutionSpec.scala
@@ -1,0 +1,40 @@
+package familydns.dns.unit
+
+import familydns.shared.*
+import zio.test.*
+
+object ProfileResolutionSpec extends ZIOSpecDefault:
+
+  private def mkProfile(name: String): CachedProfile = CachedProfile(
+    profile = Profile(1L, name, Nil, Nil, Nil, false),
+    schedules = Nil,
+    timeLimit = None,
+    siteTimeLimits = Nil,
+  )
+
+  private val defaultProfile = mkProfile("Adults")
+  private val kidsProfile    = mkProfile("Kids")
+  private val testMac        = "aa:bb:cc:dd:ee:ff"
+
+  // Mirror of the resolution expression in DnsServer.handleQuery
+  private def resolve(mac: Option[String], cache: DnsCache): Option[CachedProfile] =
+    mac.flatMap(m => cache.deviceProfiles.get(m).orElse(cache.defaultProfile))
+
+  def spec = suite("Profile resolution")(
+    test("no ARP entry (mac=None) yields no profile even when a default exists") {
+      val cache = DnsCache(Map(testMac -> kidsProfile), Map.empty, Some(defaultProfile))
+      assertTrue(resolve(None, cache).isEmpty)
+    },
+    test("registered MAC resolves to the device's assigned profile") {
+      val cache = DnsCache(Map(testMac -> kidsProfile), Map.empty, Some(defaultProfile))
+      assertTrue(resolve(Some(testMac), cache).contains(kidsProfile))
+    },
+    test("unregistered MAC falls back to the default profile") {
+      val cache = DnsCache(Map.empty, Map.empty, Some(defaultProfile))
+      assertTrue(resolve(Some("11:22:33:44:55:66"), cache).contains(defaultProfile))
+    },
+    test("unregistered MAC with no default profile yields no profile") {
+      val cache = DnsCache(Map.empty, Map.empty, None)
+      assertTrue(resolve(Some("11:22:33:44:55:66"), cache).isEmpty)
+    },
+  )

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       timeout: 2s
       retries: 30
     ports:
-      - "127.0.0.1:5433:5432"
+      - "5433:5432"
 
   api:
     build:
@@ -40,7 +40,7 @@ services:
       FAMILYDNS_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
       FAMILYDNS_DNS_REFRESH: "5"
     ports:
-      - "127.0.0.1:8080:8080"
+      - "0.0.0.0:8080:8080"
     healthcheck:
       # Login endpoint with bad creds → 401, which proves the API + DB are alive.
       # `curl -f` would treat 401 as failure, so we check the body shape instead.
@@ -54,13 +54,18 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    # host networking so /proc/net/arp reflects the real LAN ARP table and
+    # DNS is reachable from other machines without NAT obscuring the source IP.
+    network_mode: host
     depends_on:
       api:
         condition: service_healthy
     environment:
       FAMILYDNS_MODE: dns
-      FAMILYDNS_DB_HOST: postgres
-      FAMILYDNS_DB_PORT: "5432"
+      # With host networking the docker service name "postgres" isn't resolvable;
+      # reach it via the host-mapped port instead.
+      FAMILYDNS_DB_HOST: 127.0.0.1
+      FAMILYDNS_DB_PORT: "5433"
       FAMILYDNS_DB_NAME: familydns
       FAMILYDNS_DB_USER: familydns
       FAMILYDNS_DB_PASSWORD: familydns
@@ -68,8 +73,7 @@ services:
       FAMILYDNS_DNS_REFRESH: "5"
       FAMILYDNS_DNS_PORT: "5354"
       FAMILYDNS_DNS_LOCATION: "staging"
-    ports:
-      - "127.0.0.1:5354:5354/udp"
+    # No ports: mapping — host network mode binds directly to the host NIC.
 
   traffic:
     build:


### PR DESCRIPTION
## Summary

- **Log all queries**: previously only blocked queries were logged; now all queries (allowed, blocked, and unrecognized devices) are written to `query_logs`
- **Fix profile fallback**: a failed ARP lookup (`mac=None`) was incorrectly falling back to the Adults default profile; now only an unregistered-but-known MAC falls back
- **Track last-seen IP**: add `DeviceRepo.updateLastSeen` and call it fire-and-forget on every query from a known device
- **Debug logging**: add `ZIO.logDebug` at each step of query handling (ARP result, profile resolution, blocking decision)
- **Staging host networking**: switch the `dns` compose service to `network_mode: host` so `/proc/net/arp` reflects the real LAN ARP table and client IPs aren't NATed by Docker bridge; update DB connection accordingly
- **Expose API/postgres ports**: bind API on `0.0.0.0:8080` and postgres on `5433` for access from other hosts during staging

## Test plan

- [ ] `ProfileResolutionSpec` — four unit tests covering all MAC/profile combinations
- [ ] `DeviceApiSpec` — new feature test verifying `updateLastSeen` updates IP without clobbering profile
- [ ] Rebuild staging compose stack and point a device at port 5353; confirm MAC appears in query log and `last_seen_ip` updates in the devices table

Closes #50 (filed separately — device name display in query log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)