### PR TITLE
Stop double-running CI on PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop, "claude/**"]
   pull_request:
     # Run on PRs targeting any branch
+  push:
+    # Only run on main post-merge — feature/claude branches get coverage via
+    # the PR's pull_request trigger. Avoids double-runs (issue #53).
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Closes #53
- CI was firing twice for every PR from a `claude/**` branch: once via `push` (branch listed in trigger) and once via `pull_request`.
- Restrict `push` to `main` only — keeps post-merge coverage on the default branch — and let `pull_request` handle everything else.
- E2E workflow ([e2e.yml](.github/workflows/e2e.yml)) is unchanged: it's a deploy/promotion workflow that's correctly push-only on main.

## Trigger matrix after this change
| Event | Runs CI? |
|---|---|
| Push to feature branch (no PR) | No |
| Open PR from feature branch | Yes (once, via `pull_request`) |
| Push more commits to PR branch | Yes (once, via `pull_request` synchronize) |
| Merge to main | Yes (via `push` to main) |

## Test plan
- [ ] After merge, push a follow-up commit to a feature branch and confirm CI does not run
- [ ] Open a PR and confirm exactly one CI run appears in the Checks tab
- [ ] Confirm post-merge run on `main` still occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)