### PR TITLE
Bind api to LAN, keep postgres on loopback (closes #48)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,9 @@ services:
       timeout: 2s
       retries: 30
     ports:
-      - "5433:5432"
+      # Bind to loopback only — postgres must never be reachable from the LAN.
+      # The dns container uses host networking and reaches it via 127.0.0.1.
+      - "127.0.0.1:5433:5432"
 
   api:
     build:


### PR DESCRIPTION
## Summary
- The api port mapping already uses `0.0.0.0:8080:8080` so LAN clients (including the upcoming OpenWRT router agent from #67–#73) can reach it directly — this PR keeps that and adds the missing piece.
- Postgres was previously published as `5433:5432`, which compose binds to `0.0.0.0` by default — i.e. exposed to every device on the LAN. Restrict it to `127.0.0.1:5433:5432` so it stays loopback-only.
- The `dns` container uses `network_mode: host` and connects to postgres via `127.0.0.1:5433`, so it is unaffected by the loopback restriction.

## Security
- Postgres credentials in this compose file are the staging defaults (`familydns`/`familydns`). Even though they are non-prod, exposing the DB port to the LAN is a footgun, so this PR explicitly pins it to loopback.
- No admin/internal endpoints are exposed by other services. The `traffic` service has no host port mapping.

## Test plan
- [x] `docker compose -f docker/docker-compose.yml config` shows `host_ip: 127.0.0.1` for postgres and `host_ip: 0.0.0.0` for api.
- [ ] `docker compose -f docker/docker-compose.yml up --build`, then from another LAN device: `curl http://<host-lan-ip>:8080/api/auth/login` returns 400/401 (api reachable).
- [ ] From another LAN device: `nc -vz <host-lan-ip> 5433` should fail / time out (postgres not reachable from LAN).

Closes #48