### PR TITLE
Add CI check forbidding changes to existing migration files

### DIFF
--- a/.github/scripts/check-migrations.sh
+++ b/.github/scripts/check-migrations.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reject modifications, deletions, or renames of existing Flyway migration
+# files. New migrations (added files) are allowed. Editing an applied
+# migration causes a checksum mismatch on production startup (see #60).
+# Enforced by CI on PRs targeting main (see #61).
+set -euo pipefail
+
+BASE="${1:?usage: check-migrations.sh <base-ref>}"
+DIR="api/resources/db/migration"
+
+changes="$(git diff --name-status "${BASE}"...HEAD -- "${DIR}")"
+
+if [[ -z "${changes}" ]]; then
+  echo "No migration changes."
+  exit 0
+fi
+
+bad=0
+while IFS= read -r line; do
+  [[ -z "${line}" ]] && continue
+  status="$(printf '%s' "${line}" | cut -f1)"
+  files="$(printf '%s' "${line}" | cut -f2-)"
+  case "${status}" in
+    A)
+      echo "OK (added):    ${files}"
+      ;;
+    *)
+      echo "BLOCKED (${status}): ${files}" >&2
+      bad=1
+      ;;
+  esac
+done <<< "${changes}"
+
+if [[ ${bad} -ne 0 ]]; then
+  cat >&2 <<'MSG'
+
+Migration files in api/resources/db/migration must not be modified, deleted,
+or renamed once merged to main. Editing an applied migration causes a Flyway
+checksum mismatch on production startup (see issue #60). Add a new
+V{n+1}__... migration instead.
+
+This rule is enforced by .github/scripts/check-migrations.sh (issue #61).
+MSG
+  exit 1
+fi

--- a/.github/scripts/check-migrations.test.sh
+++ b/.github/scripts/check-migrations.test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests for check-migrations.sh. Runs against throwaway git repos in /tmp.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check-migrations.sh"
+[[ -x "${SCRIPT}" ]] || chmod +x "${SCRIPT}"
+
+setup() {
+  tmp="$(mktemp -d)"
+  cd "${tmp}"
+  git init -q
+  git config user.email t@t.io
+  git config user.name tester
+  git config commit.gpgsign false
+  mkdir -p api/resources/db/migration
+  echo "-- v1" > api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m base
+  BASE="$(git rev-parse HEAD)"
+  git checkout -q -b feature
+}
+
+cleanup() { rm -rf "${tmp}"; }
+
+run_case() {
+  local name="$1"; shift
+  local want="$1"; shift  # "pass" or "fail"
+  setup
+  "$@"
+  set +e
+  "${SCRIPT}" "${BASE}" >/tmp/check.out 2>/tmp/check.err
+  local rc=$?
+  set -e
+  cleanup
+  if [[ "${want}" == "pass" && ${rc} -eq 0 ]]; then
+    echo "PASS: ${name}"
+  elif [[ "${want}" == "fail" && ${rc} -ne 0 ]]; then
+    echo "PASS: ${name} (rejected as expected)"
+  else
+    echo "FAIL: ${name} (rc=${rc}, wanted ${want})"
+    echo "--- stdout ---"; cat /tmp/check.out
+    echo "--- stderr ---"; cat /tmp/check.err
+    exit 1
+  fi
+}
+
+case_no_changes() { :; }
+
+case_add_new() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  git add . && git commit -q -m add
+}
+
+case_modify() {
+  echo "-- changed" >> api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m mod
+}
+
+case_delete() {
+  git rm -q api/resources/db/migration/V1__init.sql
+  git commit -q -m del
+}
+
+case_rename() {
+  git mv api/resources/db/migration/V1__init.sql api/resources/db/migration/V1__renamed.sql
+  git commit -q -m rename
+}
+
+case_unrelated_change() {
+  mkdir -p other
+  echo hi > other/file.txt
+  git add . && git commit -q -m unrelated
+}
+
+case_add_plus_modify() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "-- changed" >> api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m mixed
+}
+
+run_case "no migration changes"         pass case_no_changes
+run_case "added new migration"          pass case_add_new
+run_case "unrelated file change"        pass case_unrelated_change
+run_case "modified existing migration"  fail case_modify
+run_case "deleted existing migration"   fail case_delete
+run_case "renamed existing migration"   fail case_rename
+run_case "added new + modified existing" fail case_add_plus_modify
+
+echo "All tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,21 @@ jobs:
           mill api.test
           mill dns.test
 
+  # ── Migrations: forbid changes to existing files on PRs to main ─────────
+  migrations-immutable:
+    name: Migrations Immutability Check
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject changes to existing migration files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash .github/scripts/check-migrations.sh "$BASE_SHA"
+
   # ── Frontend: type-check, lint, build ────────────────────────────────────
   frontend:
     name: Frontend Build & Lint


### PR DESCRIPTION
## Summary
- New CI job `migrations-immutable` runs on PRs targeting `main` and rejects any modification, deletion, or rename of files under `api/resources/db/migration/`. Only newly-added migrations are allowed.
- Logic lives in [.github/scripts/check-migrations.sh](.github/scripts/check-migrations.sh) so it can also be invoked from a local hook later. Bash test suite alongside it covers add / modify / delete / rename / mixed cases.

## Why
Editing an applied Flyway migration causes a checksum mismatch on production startup — see #60. This check prevents that class of regression.

Closes #61. Companion to #60.

## Test plan
- [x] `bash .github/scripts/check-migrations.test.sh` passes locally
- [ ] Confirm the new job runs on this PR (it targets `main`) and stays green since this PR doesn't touch migrations
- [ ] (Manual) Push a throwaway branch that edits `V1__init.sql` and confirm the check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)