### PR TITLE
Add migrations-immutability check to pre-push hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -35,6 +35,21 @@ else
   echo "pre-push: web/node_modules missing — skipping web checks" >&2
 fi
 
+# ── DB migrations immutability (mirrors CI from #61, #77) ────────────────
+# check-migrations.sh uses `git diff BASE...HEAD` (three-dot = merge-base).
+current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
+if [[ "${current_branch}" == "main" ]]; then
+  : # pushing main itself — nothing to check
+elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "pre-push: origin/main not fetched — skipping migration check (run 'git fetch origin main' to enable)" >&2
+else
+  echo "pre-push: check-migrations.sh origin/main"
+  if ! .github/scripts/check-migrations.sh origin/main; then
+    echo "pre-push: migration immutability check failed (see #61, #78). Bypass with --no-verify if you must." >&2
+    fail=1
+  fi
+fi
+
 end=$(date +%s)
 echo "pre-push: $((end - start))s"
 exit $fail

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tests the migrations-immutability section of .githooks/pre-push.
+# Sets up a tmp repo with a remote so origin/main resolves, then invokes
+# the same logic the hook runs. Does NOT exercise scalafmt/tsc/eslint.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/.github/scripts/check-migrations.sh"
+[[ -x "${SCRIPT}" ]] || chmod +x "${SCRIPT}"
+
+setup() {
+  tmp="$(mktemp -d)"
+  origin="${tmp}/origin.git"
+  work="${tmp}/work"
+  git init -q --bare "${origin}"
+  git init -q "${work}"
+  cd "${work}"
+  git config user.email t@t.io
+  git config user.name tester
+  git config commit.gpgsign false
+  git remote add origin "${origin}"
+  mkdir -p api/resources/db/migration .github/scripts
+  cp "${SCRIPT}" .github/scripts/check-migrations.sh
+  echo "-- v1" > api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m base
+  git branch -M main
+  git push -q origin main
+  git fetch -q origin
+}
+
+cleanup() { rm -rf "${tmp}"; }
+
+# Mirrors the hook's migration section. Returns 0 = pass, 1 = block, 2 = skipped.
+run_hook_section() {
+  local fail=0
+  local current_branch
+  current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo "")"
+  if [[ "${current_branch}" == "main" ]]; then
+    return 0
+  elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
+    echo "skipped: origin/main not fetched" >&2
+    return 2
+  else
+    if ! .github/scripts/check-migrations.sh origin/main; then
+      fail=1
+    fi
+  fi
+  return ${fail}
+}
+
+run_case() {
+  local name="$1"; shift
+  local want_rc="$1"; shift
+  setup
+  "$@"
+  set +e
+  run_hook_section >/tmp/hook.out 2>/tmp/hook.err
+  local rc=$?
+  set -e
+  cleanup
+  if [[ "${rc}" -eq "${want_rc}" ]]; then
+    echo "PASS: ${name}"
+  else
+    echo "FAIL: ${name} (rc=${rc}, wanted ${want_rc})"
+    echo "--- stdout ---"; cat /tmp/hook.out
+    echo "--- stderr ---"; cat /tmp/hook.err
+    exit 1
+  fi
+}
+
+case_branch_modifies_v1() {
+  git checkout -q -b feature
+  echo "-- changed" >> api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m mod
+}
+
+case_branch_adds_v2() {
+  git checkout -q -b feature
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  git add . && git commit -q -m add
+}
+
+case_on_main() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  git add . && git commit -q -m "on main"
+}
+
+case_origin_main_missing() {
+  git checkout -q -b feature
+  git remote remove origin
+  echo "-- changed" >> api/resources/db/migration/V1__init.sql
+  git add . && git commit -q -m mod
+  # Drop the remote-tracking ref too
+  git update-ref -d refs/remotes/origin/main 2>/dev/null || true
+}
+
+run_case "branch modifies V1 → blocked"        1 case_branch_modifies_v1
+run_case "branch only adds V2 → passes"        0 case_branch_adds_v2
+run_case "on main → no-op"                     0 case_on_main
+run_case "origin/main unfetched → skip"        2 case_origin_main_missing
+
+echo "All pre-push hook tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash .github/scripts/check-migrations.sh "$BASE_SHA"
 
+  # ── Hook & script tests ──────────────────────────────────────────────────
+  hook-tests:
+    name: Hook & Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check-migrations.sh tests
+        run: bash .github/scripts/check-migrations.test.sh
+
+      - name: pre-push migration-section tests
+        run: bash .githooks/pre-push.test.sh
+
   # ── Frontend: type-check, lint, build ────────────────────────────────────
   frontend:
     name: Frontend Build & Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,18 +90,34 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash .github/scripts/check-migrations.sh "$BASE_SHA"
 
-  # ── Hook & script tests ──────────────────────────────────────────────────
-  hook-tests:
-    name: Hook & Script Tests
+  # ── Shell test discovery ─────────────────────────────────────────────────
+  # Auto-discovers and runs every *.test.sh in the repo. Add a new test by
+  # dropping a *.test.sh file alongside the script/hook it covers — no CI
+  # change needed. (web/, node_modules, build outputs are excluded.)
+  shell-tests:
+    name: Shell Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: check-migrations.sh tests
-        run: bash .github/scripts/check-migrations.test.sh
-
-      - name: pre-push migration-section tests
-        run: bash .githooks/pre-push.test.sh
+      - name: Discover and run *.test.sh
+        run: |
+          set -euo pipefail
+          mapfile -d '' tests < <(
+            find . \
+              \( -path ./node_modules -o -path ./web -o -path ./out -o -path ./.git \) -prune \
+              -o -type f -name '*.test.sh' -print0
+          )
+          if [[ ${#tests[@]} -eq 0 ]]; then
+            echo "No *.test.sh files found." ; exit 0
+          fi
+          fail=0
+          for t in "${tests[@]}"; do
+            echo "::group::$t"
+            if ! bash "$t"; then fail=1; fi
+            echo "::endgroup::"
+          done
+          exit $fail
 
   # ── Frontend: type-check, lint, build ────────────────────────────────────
   frontend:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,12 @@ Migrations live in `api/resources/db/migration/` as `V{n}__{description}.sql`. T
 
 Tests run the same Flyway migrations from `classpath:db/migration` against the embedded Postgres in `TestDatabase`, so there is one source of truth — never maintain a parallel test schema. To change the schema, add a new `V{n}__...sql` migration; do not edit `V1__init.sql` (or any other already-applied migration).
 
+## Branch-diff checks (CI + pre-push)
+
+CI checks and pre-push checks that compare a branch against `main` MUST diff against the **merge base** with `origin/main`, not `origin/main` directly. Use three-dot syntax (`origin/main...HEAD`) or an explicit `git merge-base origin/main HEAD`. Two-dot (`origin/main..HEAD`) over-reports when `main` has advanced since the branch diverged, producing spurious failures and noise.
+
+Pre-commit checks are different: they operate on staged files (`git diff --cached`), not against `origin/main`.
+
 ## Adding a new API route
 
 1. Add request/response types to `shared/src/Models.scala`


### PR DESCRIPTION
Closes #78.

## Summary
- Adds a new section to `.githooks/pre-push` that invokes `.github/scripts/check-migrations.sh origin/main`, mirroring the CI check from #61/#77 so developers catch modified Flyway migrations before the push round-trip.
- Skips cleanly when pushing `main` itself or when `origin/main` isn't fetched (prints a hint, doesn't fail).
- Bypassable via `git push --no-verify`, consistent with the rest of the hook.
- Adds `.githooks/pre-push.test.sh` covering the four scenarios.
- Adds an AGENTS.md guideline: branch-diff checks must use merge-base (three-dot `origin/main...HEAD`) semantics. Audit follow-up tracked in #81.

## Test plan
- [x] `.githooks/pre-push.test.sh` passes (4/4)
- [x] Existing CI script unchanged; tests in `.github/scripts/check-migrations.test.sh` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)