### PR TITLE
Inject Clock service for all wall-clock reads in api (closes #47)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -32,8 +32,8 @@ object Main extends ZIOAppDefault:
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](c => Database.makeTransactor(c.db))) >+>
       Repos.all >+>
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.jwt)) >+>
-      AuthService.layer >+>
-      Clock.live
+      Clock.live >+>
+      AuthService.layer
 
   private def allRoutes =
     for
@@ -50,6 +50,7 @@ object Main extends ZIOAppDefault:
       extRepo     <- ZIO.service[TimeExtensionRepo]
       logRepo     <- ZIO.service[QueryLogRepo]
       cfg         <- ZIO.service[AppConfig]
+      clock       <- ZIO.service[Clock]
     yield AuthRoutes.routes(auth, userRepo, upRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
@@ -62,6 +63,7 @@ object Main extends ZIOAppDefault:
         extRepo,
         profileRepo,
         upRepo,
+        clock,
       ) ++
       LogRoutes.routes(auth, logRepo, upRepo) ++
       BlocklistRoutes.routes(auth, blRepo) ++

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -6,10 +6,8 @@ import familydns.api.db.*
 import familydns.shared.*
 import pdi.jwt.*
 import pdi.jwt.algorithms.JwtHmacAlgorithm
-import zio.*
+import zio.{Clock as _, *}
 import zio.json.*
-
-import java.time.Instant
 
 // ── JWT Claims ─────────────────────────────────────────────────────────────
 
@@ -43,6 +41,7 @@ trait AuthService:
 class AuthServiceLive(
     userRepo: UserRepo,
     jwtConfig: JwtConfig,
+    clock: Clock,
 ) extends AuthService:
 
   private val algo: JwtHmacAlgorithm = JwtAlgorithm.HS256
@@ -58,7 +57,7 @@ class AuthServiceLive(
         BCrypt.verifyer().verify(password.toCharArray, user.passwordHash).verified,
       )
       _     <- ZIO.fail(AuthError.InvalidCredentials).when(!valid)
-      now   = Instant.now().getEpochSecond
+      now   <- clock.instant.map(_.getEpochSecond)
       claim = JwtClaim(
         content = s"""{"role":"${user.role}"}""",
         subject = Some(user.username),
@@ -70,9 +69,12 @@ class AuthServiceLive(
         .mapError(e => AuthError.Unexpected(e.getMessage))
     yield LoginResponse(token, user.role, user.username)
 
+  // We delegate expiration/not-before checks to our injected Clock (see below).
+  private val jwtOpts = JwtOptions(expiration = false, notBefore = false)
+
   def verify(token: String): IO[AuthError, JwtClaims] =
     ZIO
-      .fromTry(JwtZIOJson.decode(token, secret, Seq(algo)))
+      .fromTry(JwtZIOJson.decode(token, secret, Seq(algo), jwtOpts))
       .mapError(_ => AuthError.InvalidToken)
       .flatMap { claim =>
         ZIO
@@ -88,8 +90,10 @@ class AuthServiceLive(
           }
       }
       .flatMap { claims =>
-        val now = Instant.now().getEpochSecond
-        ZIO.fail(AuthError.TokenExpired).when(claims.exp < now).as(claims)
+        clock.instant.flatMap { i =>
+          val now = i.getEpochSecond
+          ZIO.fail(AuthError.TokenExpired).when(claims.exp < now).as(claims)
+        }
       }
 
   def requireAdmin(token: String): IO[AuthError, JwtClaims] =
@@ -124,5 +128,5 @@ class AuthServiceLive(
     ZIO.succeed(BCrypt.withDefaults().hashToString(12, password.toCharArray))
 
 object AuthService:
-  val layer: ZLayer[UserRepo & JwtConfig, Nothing, AuthService] =
-    ZLayer.fromFunction(AuthServiceLive(_, _))
+  val layer: ZLayer[UserRepo & JwtConfig & Clock, Nothing, AuthService] =
+    ZLayer.fromFunction(AuthServiceLive(_, _, _))

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -3,7 +3,7 @@ package familydns.api.routes
 import familydns.api.auth.*
 import familydns.api.db.*
 import familydns.shared.*
-import zio.*
+import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
 
@@ -307,13 +307,15 @@ object TimeRoutes:
       extRepo: TimeExtensionRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      clock: Clock,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "time" / "status"                     ->
         handler { (req: Request) =>
           for
             claims <- requireAuth(req, auth)
-            dateStr = req.url.queryParam("date").getOrElse(LocalDate.now().toString)
+            today  <- clock.today
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
             all      <- deviceRepo.listAll.orElseFail(Response.internalServerError(""))
             visible  <- filterDevices(claims, all, userProfileRepo)
@@ -336,7 +338,8 @@ object TimeRoutes:
         handler { (mac: String, req: Request) =>
           for
             claims <- requireAuth(req, auth)
-            dateStr = req.url.queryParam("date").getOrElse(LocalDate.now().toString)
+            today  <- clock.today
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
             device <- deviceRepo
               .findByMac(normalizeMac(mac))
@@ -369,8 +372,8 @@ object TimeRoutes:
               .orElseFail(Response.internalServerError(""))
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _      <- requireProfileAccess(claims, device.profileId, userProfileRepo)
-            today = LocalDate.now()
-            id <- extRepo
+            today  <- clock.today
+            id     <- extRepo
               .grant(mac, today, ger.extraMinutes, claims.sub, ger.note)
               .orElseFail(Response.internalServerError(""))
           yield Response.json(s"""{"id":$id,"grantedMinutes":${ger.extraMinutes}}""")
@@ -385,8 +388,8 @@ object TimeRoutes:
               .orElseFail(Response.internalServerError(""))
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _      <- requireProfileAccess(claims, device.profileId, userProfileRepo)
-            date = LocalDate.now()
-            exts <- extRepo
+            date   <- clock.today
+            exts   <- extRepo
               .listForDevice(normalized, date)
               .orElseFail(Response.internalServerError(""))
           yield Response.json(exts.toJson)

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -20,7 +20,11 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -20,7 +20,11 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
   private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, adminJwt))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, adminJwt, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -20,7 +20,11 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -27,7 +27,11 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
 
   private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
 
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, adminJwt))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, adminJwt, clock)
 
   private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -26,7 +26,11 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -14,15 +14,17 @@ import zio.json.*
 import zio.test.*
 import zio.test.Assertion.*
 
-import java.time.LocalDate
-
 object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
-  private def makeAuth = ZIO.serviceWith[UserRepo](ur => AuthServiceLive(ur, jwtCfg))
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
@@ -47,6 +49,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 120)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -56,6 +59,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           req    = Request
             .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
@@ -84,10 +88,11 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 120)
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          today = LocalDate.now()
+          today = TestClock.schoolDayAfternoon.toLocalDate
           _               <- usageRepo.incrementUsage(testMac, "minecraft.net", today, 45)
           _               <- usageRepo.incrementUsage(testMac, "google.com", today, 30)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -97,6 +102,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           req    = Request
             .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
@@ -128,11 +134,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             ),
           )
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          today = LocalDate.now()
+          today = TestClock.schoolDayAfternoon.toLocalDate
           // 60 min general browsing + 20 min YouTube (site-specific, should NOT count toward 120)
           _               <- usageRepo.incrementUsage(testMac, "google.com", today, 60)
           _               <- usageRepo.incrementUsage(testMac, "youtube.com", today, 20)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -142,6 +149,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           req    = Request
             .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
@@ -174,10 +182,11 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 120)
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          today = LocalDate.now()
+          today = TestClock.schoolDayAfternoon.toLocalDate
           // Use up all 120 minutes
           _               <- usageRepo.incrementUsage(testMac, "minecraft.net", today, 120)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes  = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -187,6 +196,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           // Grant 30 min extension
           extBody = GrantExtensionRequest(testMac, 30, Some("Homework finished early")).toJson
@@ -222,6 +232,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 60)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -231,6 +242,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           body   = GrantExtensionRequest(testMac, 15, Some("Good behavior")).toJson
           req    = Request
@@ -238,7 +250,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
           _    <- routes.runZIO(req)
-          exts <- extRepo.listForDevice(testMac, LocalDate.now())
+          exts <- extRepo.listForDevice(testMac, TestClock.schoolDayAfternoon.toLocalDate)
         yield assertTrue(exts.length == 1) &&
           assertTrue(exts.head.grantedBy == "admin") &&
           assertTrue(exts.head.extraMinutes == 15) &&
@@ -262,6 +274,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           kidsId          <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -271,6 +284,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           body   = GrantExtensionRequest(testMac, 30, None).toJson
           req    = Request
@@ -295,6 +309,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 60)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -304,6 +319,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            clock,
           )
           grant  = (mins: Int) =>
             routes.runZIO(
@@ -315,11 +331,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
                 .addHeader(Header.Authorization.Bearer(token))
                 .addHeader(Header.ContentType(MediaType.application.json)),
             )
-          _     <- grant(15)
-          _     <- grant(15)
-          _     <- grant(30)
-          exts  <- extRepo.listForDevice(testMac, LocalDate.now())
-          total <- extRepo.getTotalExtension(testMac, LocalDate.now())
+          _ <- grant(15)
+          _ <- grant(15)
+          _ <- grant(30)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          exts  <- extRepo.listForDevice(testMac, today)
+          total <- extRepo.getTotalExtension(testMac, today)
         yield assertTrue(exts.length == 3) &&
           assertTrue(total == 60)
       },

--- a/shared/src/Clock.scala
+++ b/shared/src/Clock.scala
@@ -2,13 +2,14 @@ package familydns.shared
 
 import zio.*
 
-import java.time.{LocalDate, LocalDateTime, LocalTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 
 /** Injectable clock — never call java.time directly outside this service. */
 trait Clock:
   def now: UIO[LocalDateTime]
   def today: UIO[LocalDate]
   def currentTime: UIO[LocalTime]
+  def instant: UIO[Instant]
 
 object Clock:
 
@@ -17,6 +18,7 @@ object Clock:
   def now: URIO[Clock, LocalDateTime]     = ZIO.serviceWithZIO(_.now)
   def today: URIO[Clock, LocalDate]       = ZIO.serviceWithZIO(_.today)
   def currentTime: URIO[Clock, LocalTime] = ZIO.serviceWithZIO(_.currentTime)
+  def instant: URIO[Clock, Instant]       = ZIO.serviceWithZIO(_.instant)
 
   // ── Live implementation ──────────────────────────────────────────────────
 
@@ -26,14 +28,20 @@ object Clock:
     def now: UIO[LocalDateTime]     = ZIO.succeed(LocalDateTime.now())
     def today: UIO[LocalDate]       = ZIO.succeed(LocalDate.now())
     def currentTime: UIO[LocalTime] = ZIO.succeed(LocalTime.now())
+    def instant: UIO[Instant]       = ZIO.succeed(Instant.now())
 
   // ── Controllable test implementation ────────────────────────────────────
 
-  /** A clock backed by a Ref — advance time programmatically in tests. */
+  /**
+   * A clock backed by a Ref — advance time programmatically in tests. The simulated wall-clock is
+   * interpreted as UTC when converted to an [[Instant]], so JWT iat/exp values are deterministic
+   * regardless of host timezone.
+   */
   class TestClock(ref: Ref[LocalDateTime]) extends Clock:
     def now: UIO[LocalDateTime]     = ref.get
     def today: UIO[LocalDate]       = ref.get.map(_.toLocalDate)
     def currentTime: UIO[LocalTime] = ref.get.map(_.toLocalTime)
+    def instant: UIO[Instant]       = ref.get.map(_.toInstant(ZoneOffset.UTC))
 
     /** Advance the clock by the given duration. */
     def advance(duration: java.time.Duration): UIO[Unit] =


### PR DESCRIPTION
## Summary
- Replace direct `java.time.{Instant,LocalDate}.now()` calls in `api/` with reads from the existing `familydns.shared.Clock` service so time-dependent behavior is deterministic under `TestClock`.
- `AuthService` now takes a `Clock` for JWT `iat` / `exp` and for verifying expiration. We pass `JwtOptions(expiration = false, notBefore = false)` to pdi-jwt because that library validates `exp` against system time, which would reject tokens minted under a simulated `TestClock`. Our own `Clock`-based check still enforces expiry.
- `TimeRoutes` now takes a `Clock` and derives the default "today" from `clock.today` instead of `LocalDate.now()`.
- `Clock` gains an `instant` accessor; `TestClock` interprets its simulated `LocalDateTime` as UTC so the resulting `Instant` is deterministic regardless of host timezone.
- All API test specs thread the `Clock` through `AuthServiceLive` and `TimeRoutes.routes`. `TimeApiSpec` now pins its dates to `TestClock.schoolDayAfternoon.toLocalDate` so it's no longer flaky around midnight.
- Skipped `dns/` and `traffic/` since they're slated for deletion in #71.

## Why this matters
Unblocks deterministic tests for the time-dependent surfaces that follow:
- #69 (router usage / events ingest)
- #14 (per-profile screen-time semantics)
- #15 (per-app limits inclusion/exclusion from the overall limit)

## Test plan
- [x] `mill __.compile` clean across all modules
- [x] `mill __.test` — full suite green (api auth/device/log/profile/role/time, dns blocking, shared clock, etc.)
- [ ] Manual sanity: log in via the running API and confirm tokens still work end-to-end with `Clock.live`

🤖 Generated with [Claude Code](https://claude.com/claude-code)