### PR TITLE
Add V2 migration and repos for OpenWRT re-architecture (#67)

### DIFF
--- a/api/resources/db/migration/V2__openwrt.sql
+++ b/api/resources/db/migration/V2__openwrt.sql
@@ -1,0 +1,66 @@
+-- V2__openwrt.sql
+-- OpenWRT router enrollment, periodic traffic reports, and block events.
+-- Spec: docs/architecture-openwrt.md (#74), tracking issue #67.
+
+-- Registered OpenWRT gateways. One row per physical router.
+-- enrollment_token_hash is set when an admin creates the row in the UI; it is
+-- consumed once by POST /api/router/register, which writes token_hash and
+-- clears enrollment_token_hash. token_hash is the bearer token used for all
+-- subsequent /api/router/* calls. last_etag is the last policy-snapshot etag
+-- the agent acknowledged, used to short-circuit GET /api/router/policy with
+-- 304 Not Modified.
+CREATE TABLE routers (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name                  TEXT NOT NULL,
+  enrollment_token_hash TEXT,
+  token_hash            TEXT,
+  last_seen_at          TIMESTAMPTZ,
+  last_etag             TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_routers_enrollment_token_hash ON routers(enrollment_token_hash)
+  WHERE enrollment_token_hash IS NOT NULL;
+CREATE INDEX idx_routers_token_hash ON routers(token_hash)
+  WHERE token_hash IS NOT NULL;
+
+-- Raw audit log of POST /api/router/usage payloads. Each row is one
+-- (router, mac, hostname) record from one 5-minute reporting window. The
+-- unique constraint makes router retries idempotent.
+CREATE TABLE traffic_reports (
+  id              BIGSERIAL PRIMARY KEY,
+  router_id       UUID NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  mac             TEXT NOT NULL,
+  ip              TEXT,
+  hostname        TEXT NOT NULL,
+  date            DATE NOT NULL,
+  period_start    TIMESTAMPTZ NOT NULL,
+  period_end      TIMESTAMPTZ NOT NULL,
+  active_seconds  INT NOT NULL DEFAULT 0,
+  bytes_in        BIGINT NOT NULL DEFAULT 0,
+  bytes_out       BIGINT NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(router_id, period_start, mac, hostname)
+);
+CREATE INDEX idx_traffic_reports_router       ON traffic_reports(router_id);
+CREATE INDEX idx_traffic_reports_date         ON traffic_reports(date);
+CREATE INDEX idx_traffic_reports_mac_date     ON traffic_reports(mac, date);
+CREATE INDEX idx_traffic_reports_period_start ON traffic_reports(period_start DESC);
+
+-- Record of block decisions surfaced to the user (router /decision responses
+-- and /blocked redirects). Distinct from query_logs, which tracks every DNS
+-- query; block_events tracks only the moments a user actually saw a block.
+CREATE TABLE block_events (
+  id        BIGSERIAL PRIMARY KEY,
+  mac       TEXT,
+  hostname  TEXT NOT NULL,
+  reason    TEXT NOT NULL,
+  ts        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_block_events_ts  ON block_events(ts DESC);
+CREATE INDEX idx_block_events_mac ON block_events(mac);
+
+-- Add byte counters to time_usage so /api/router/usage can roll bytes up
+-- alongside minutes (existing minutes_used column).
+ALTER TABLE time_usage
+  ADD COLUMN bytes_in  BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN bytes_out BIGINT NOT NULL DEFAULT 0;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -9,6 +9,7 @@ import familydns.shared.Schedule
 import zio.*
 import zio.interop.catz.*
 import java.time.{Instant, LocalDate}
+import java.util.UUID
 
 given Meta[List[String]] = Meta[Array[String]].imap(_.toList)(_.toArray)
 
@@ -109,6 +110,45 @@ trait TimeExtensionRepo:
   def grant(mac: String, date: LocalDate, mins: Int, by: String, note: Option[String]): Task[Long]
   def listForDevice(mac: String, date: LocalDate): Task[List[TimeExtension]]
   def snapshotAll(date: LocalDate): Task[Map[String, Int]]
+
+case class TrafficReportInsert(
+    routerId: UUID,
+    mac: String,
+    ip: Option[String],
+    hostname: String,
+    date: LocalDate,
+    periodStart: Instant,
+    periodEnd: Instant,
+    activeSeconds: Int,
+    bytesIn: Long,
+    bytesOut: Long,
+)
+
+case class BlockEventInsert(
+    mac: Option[String],
+    hostname: String,
+    reason: String,
+)
+
+trait RouterRepo:
+  def listAll: Task[List[Router]]
+  def findById(id: UUID): Task[Option[Router]]
+  def findByEnrollmentTokenHash(h: String): Task[Option[Router]]
+  def findByTokenHash(h: String): Task[Option[Router]]
+  def create(name: String, enrollmentTokenHash: String): Task[UUID]
+  def completeEnrollment(id: UUID, tokenHash: String): Task[Unit]
+  def touch(id: UUID, etag: Option[String]): Task[Unit]
+  def delete(id: UUID): Task[Unit]
+
+trait TrafficReportRepo:
+  def insertBatch(reports: List[TrafficReportInsert]): Task[Int]
+  def listForDevice(mac: String, date: LocalDate): Task[List[TrafficReport]]
+  def listForRouter(routerId: UUID, limit: Int): Task[List[TrafficReport]]
+
+trait BlockEventRepo:
+  def insertBatch(events: List[BlockEventInsert]): Task[Int]
+  def recent(limit: Int): Task[List[BlockEvent]]
+  def listForMac(mac: String, limit: Int): Task[List[BlockEvent]]
 
 trait QueryLogRepo:
   def insertBatch(logs: List[QueryLogInsert]): Task[Unit]
@@ -398,6 +438,101 @@ class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo:
       .transact(xa)
       .map(_.toMap)
 
+class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo:
+  private type R =
+    (UUID, String, Option[String], Option[String], Option[Instant], Option[String], Instant)
+  private def toR(r: R)                                 =
+    Router(
+      r._1,
+      r._2,
+      r._3,
+      r._4,
+      r._5.map(_.toString),
+      r._6,
+      r._7.toString,
+    )
+  def listAll                                           =
+    sql"SELECT id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at FROM routers ORDER BY created_at"
+      .query[R]
+      .map(toR)
+      .to[List]
+      .transact(xa)
+  def findById(id: UUID)                                =
+    sql"SELECT id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at FROM routers WHERE id=$id"
+      .query[R]
+      .map(toR)
+      .option
+      .transact(xa)
+  def findByEnrollmentTokenHash(h: String)              =
+    sql"SELECT id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at FROM routers WHERE enrollment_token_hash=$h"
+      .query[R]
+      .map(toR)
+      .option
+      .transact(xa)
+  def findByTokenHash(h: String)                        =
+    sql"SELECT id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at FROM routers WHERE token_hash=$h"
+      .query[R]
+      .map(toR)
+      .option
+      .transact(xa)
+  def create(name: String, enrollmentTokenHash: String) =
+    sql"INSERT INTO routers(name,enrollment_token_hash) VALUES($name,$enrollmentTokenHash) RETURNING id"
+      .query[UUID]
+      .unique
+      .transact(xa)
+  def completeEnrollment(id: UUID, tokenHash: String)   =
+    sql"UPDATE routers SET token_hash=$tokenHash, enrollment_token_hash=NULL, last_seen_at=NOW() WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def touch(id: UUID, etag: Option[String])             =
+    sql"UPDATE routers SET last_seen_at=NOW(), last_etag=COALESCE($etag,last_etag) WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def delete(id: UUID)                                  =
+    sql"DELETE FROM routers WHERE id=$id".update.run.transact(xa).unit
+
+class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo:
+  private type R =
+    (Long, UUID, String, Option[String], String, String, String, String, Int, Long, Long)
+  private def toT(r: R)                               =
+    TrafficReport(r._1, r._2, r._3, r._4, r._5, r._6, r._7, r._8, r._9, r._10, r._11)
+  def insertBatch(reports: List[TrafficReportInsert]) =
+    Update[TrafficReportInsert](
+      "INSERT INTO traffic_reports(router_id,mac,ip,hostname,date,period_start,period_end,active_seconds,bytes_in,bytes_out) VALUES(?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,hostname) DO NOTHING",
+    ).updateMany(reports).transact(xa)
+  def listForDevice(mac: String, date: LocalDate)     =
+    sql"SELECT id,router_id,mac,ip,hostname,date::TEXT,period_start::TEXT,period_end::TEXT,active_seconds,bytes_in,bytes_out FROM traffic_reports WHERE mac=$mac AND date=$date ORDER BY period_start"
+      .query[R]
+      .map(toT)
+      .to[List]
+      .transact(xa)
+  def listForRouter(routerId: UUID, limit: Int)       =
+    sql"SELECT id,router_id,mac,ip,hostname,date::TEXT,period_start::TEXT,period_end::TEXT,active_seconds,bytes_in,bytes_out FROM traffic_reports WHERE router_id=$routerId ORDER BY period_start DESC LIMIT $limit"
+      .query[R]
+      .map(toT)
+      .to[List]
+      .transact(xa)
+
+class BlockEventRepoLive(xa: Transactor[Task]) extends BlockEventRepo:
+  private type R = (Long, Option[String], String, String, String)
+  private def toB(r: R)                           = BlockEvent(r._1, r._2, r._3, r._4, r._5)
+  def insertBatch(events: List[BlockEventInsert]) =
+    Update[BlockEventInsert](
+      "INSERT INTO block_events(mac,hostname,reason) VALUES(?,?,?)",
+    ).updateMany(events).transact(xa)
+  def recent(limit: Int)                          =
+    sql"SELECT id,mac,hostname,reason,ts::TEXT FROM block_events ORDER BY ts DESC LIMIT $limit"
+      .query[R]
+      .map(toB)
+      .to[List]
+      .transact(xa)
+  def listForMac(mac: String, limit: Int)         =
+    sql"SELECT id,mac,hostname,reason,ts::TEXT FROM block_events WHERE mac=$mac ORDER BY ts DESC LIMIT $limit"
+      .query[R]
+      .map(toB)
+      .to[List]
+      .transact(xa)
+
 class QueryLogRepoLive(xa: Transactor[Task]) extends QueryLogRepo:
   def insertBatch(logs: List[QueryLogInsert]) = Update[QueryLogInsert](
     "INSERT INTO query_logs(mac,device_name,profile_id,profile_name,domain,qtype,blocked,reason,location) VALUES(?,?,?,?,?,?,?,?,?)",
@@ -480,5 +615,8 @@ object Repos:
   val timeUsageRepo     = ZLayer.fromFunction(TimeUsageRepoLive(_))
   val timeExtRepo       = ZLayer.fromFunction(TimeExtensionRepoLive(_))
   val queryLogRepo      = ZLayer.fromFunction(QueryLogRepoLive(_))
+  val routerRepo        = ZLayer.fromFunction(RouterRepoLive(_))
+  val trafficReportRepo = ZLayer.fromFunction(TrafficReportRepoLive(_))
+  val blockEventRepo    = ZLayer.fromFunction(BlockEventRepoLive(_))
   val all               =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ queryLogRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ queryLogRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -77,7 +77,8 @@ object TestDatabase:
   /** All repo types bundled for convenience */
   type AllRepos =
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo &
-      DeviceRepo & BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & QueryLogRepo
+      DeviceRepo & BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & QueryLogRepo & RouterRepo &
+      TrafficReportRepo & BlockEventRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] =
     val pg = embeddedPg

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -1,0 +1,265 @@
+package familydns.api.feature
+
+import familydns.api.db.*
+import familydns.shared.*
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.Transactor
+import zio.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate}
+
+object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  def spec = suite("OpenWRT repos")(
+    suite("RouterRepo")(
+      test("create returns a UUID and stores enrollment_token_hash, no token_hash") {
+        for
+          _        <- cleanDb
+          repo     <- ZIO.service[RouterRepo]
+          id       <- repo.create("home-router", "ENROLL_HASH_1")
+          row      <- repo.findById(id)
+          byEnroll <- repo.findByEnrollmentTokenHash("ENROLL_HASH_1")
+        yield assertTrue(row.exists(_.name == "home-router")) &&
+          assertTrue(row.exists(_.enrollmentTokenHash.contains("ENROLL_HASH_1"))) &&
+          assertTrue(row.exists(_.tokenHash.isEmpty)) &&
+          assertTrue(row.exists(_.lastSeenAt.isEmpty)) &&
+          assertTrue(byEnroll.exists(_.id == id))
+      },
+      test(
+        "completeEnrollment swaps enrollment_token_hash for token_hash and stamps last_seen_at",
+      ) {
+        for
+          _        <- cleanDb
+          repo     <- ZIO.service[RouterRepo]
+          id       <- repo.create("r1", "ENROLL_HASH_2")
+          _        <- repo.completeEnrollment(id, "TOKEN_HASH_2")
+          row      <- repo.findById(id)
+          byEnroll <- repo.findByEnrollmentTokenHash("ENROLL_HASH_2")
+          byTok    <- repo.findByTokenHash("TOKEN_HASH_2")
+        yield assertTrue(row.exists(_.enrollmentTokenHash.isEmpty)) &&
+          assertTrue(row.exists(_.tokenHash.contains("TOKEN_HASH_2"))) &&
+          assertTrue(row.exists(_.lastSeenAt.isDefined)) &&
+          assertTrue(byEnroll.isEmpty) &&
+          assertTrue(byTok.exists(_.id == id))
+      },
+      test("touch updates last_seen_at and last_etag without losing prior etag when None passed") {
+        for
+          _    <- cleanDb
+          repo <- ZIO.service[RouterRepo]
+          id   <- repo.create("r1", "EH")
+          _    <- repo.completeEnrollment(id, "TH")
+          _    <- repo.touch(id, Some("etag-A"))
+          a    <- repo.findById(id)
+          _    <- repo.touch(id, None) // last_etag must remain "etag-A"
+          b    <- repo.findById(id)
+        yield assertTrue(a.flatMap(_.lastEtag).contains("etag-A")) &&
+          assertTrue(b.flatMap(_.lastEtag).contains("etag-A")) &&
+          assertTrue(b.flatMap(_.lastSeenAt).isDefined)
+      },
+      test("delete removes the row and cascades to traffic_reports") {
+        for
+          _     <- cleanDb
+          rRepo <- ZIO.service[RouterRepo]
+          tRepo <- ZIO.service[TrafficReportRepo]
+          id    <- rRepo.create("r1", "EH")
+          start = Instant.parse("2026-05-02T14:00:00Z")
+          end   = Instant.parse("2026-05-02T14:05:00Z")
+          _   <- tRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                id,
+                "aa:bb:cc:dd:ee:ff",
+                Some("192.168.1.10"),
+                "youtube.com",
+                LocalDate.of(2026, 5, 2),
+                start,
+                end,
+                240,
+                1000L,
+                500L,
+              ),
+            ),
+          )
+          _   <- rRepo.delete(id)
+          row <- rRepo.findById(id)
+          rep <- tRepo.listForRouter(id, 10)
+        yield assertTrue(row.isEmpty) && assertTrue(rep.isEmpty)
+      },
+      test("listAll returns rows ordered by created_at") {
+        for
+          _    <- cleanDb
+          repo <- ZIO.service[RouterRepo]
+          a    <- repo.create("a", "h1")
+          b    <- repo.create("b", "h2")
+          all  <- repo.listAll
+        yield assertTrue(all.map(_.id) == List(a, b))
+      },
+    ),
+    suite("TrafficReportRepo")(
+      test("insertBatch is idempotent on (router_id, period_start, mac, hostname)") {
+        for
+          _     <- cleanDb
+          rRepo <- ZIO.service[RouterRepo]
+          tRepo <- ZIO.service[TrafficReportRepo]
+          rid   <- rRepo.create("r1", "EH")
+          start = Instant.parse("2026-05-02T14:00:00Z")
+          end   = Instant.parse("2026-05-02T14:05:00Z")
+          rec   = TrafficReportInsert(
+            rid,
+            "aa:bb:cc:11:22:33",
+            Some("192.168.1.42"),
+            "youtube.com",
+            LocalDate.of(2026, 5, 2),
+            start,
+            end,
+            240,
+            38123412L,
+            921000L,
+          )
+          n1   <- tRepo.insertBatch(List(rec))
+          n2   <- tRepo.insertBatch(List(rec)) // retry
+          rows <- tRepo.listForRouter(rid, 100)
+        yield assertTrue(n1 == 1) && assertTrue(n2 == 0) && assertTrue(rows.size == 1)
+      },
+      test("different hostnames in same period are stored as distinct rows") {
+        for
+          _     <- cleanDb
+          rRepo <- ZIO.service[RouterRepo]
+          tRepo <- ZIO.service[TrafficReportRepo]
+          rid   <- rRepo.create("r1", "EH")
+          start = Instant.parse("2026-05-02T14:00:00Z")
+          end   = Instant.parse("2026-05-02T14:05:00Z")
+          mac   = "aa:bb:cc:11:22:33"
+          batch = List(
+            TrafficReportInsert(
+              rid,
+              mac,
+              None,
+              "youtube.com",
+              LocalDate.of(2026, 5, 2),
+              start,
+              end,
+              60,
+              1L,
+              1L,
+            ),
+            TrafficReportInsert(
+              rid,
+              mac,
+              None,
+              "google.com",
+              LocalDate.of(2026, 5, 2),
+              start,
+              end,
+              30,
+              2L,
+              2L,
+            ),
+          )
+          n    <- tRepo.insertBatch(batch)
+          rows <- tRepo.listForDevice(mac, LocalDate.of(2026, 5, 2))
+        yield assertTrue(n == 2) && assertTrue(rows.size == 2) &&
+          assertTrue(rows.map(_.hostname).toSet == Set("youtube.com", "google.com"))
+      },
+      test("listForDevice filters by mac and date") {
+        for
+          _     <- cleanDb
+          rRepo <- ZIO.service[RouterRepo]
+          tRepo <- ZIO.service[TrafficReportRepo]
+          rid   <- rRepo.create("r1", "EH")
+          mac1 = "aa:bb:cc:11:22:33"
+          mac2 = "aa:bb:cc:99:99:99"
+          d1   = LocalDate.of(2026, 5, 2)
+          d2   = LocalDate.of(2026, 5, 3)
+          mk   = (mac: String, d: LocalDate, h: String) =>
+            TrafficReportInsert(
+              rid,
+              mac,
+              None,
+              h,
+              d,
+              d.atTime(14, 0).toInstant(java.time.ZoneOffset.UTC),
+              d.atTime(14, 5).toInstant(java.time.ZoneOffset.UTC),
+              60,
+              1L,
+              1L,
+            )
+          _    <- tRepo.insertBatch(
+            List(
+              mk(mac1, d1, "a.com"),
+              mk(mac1, d2, "b.com"),
+              mk(mac2, d1, "c.com"),
+            ),
+          )
+          rows <- tRepo.listForDevice(mac1, d1)
+        yield assertTrue(rows.size == 1) && assertTrue(rows.head.hostname == "a.com")
+      },
+    ),
+    suite("BlockEventRepo")(
+      test("insertBatch returns count and records appear in recent() ordered by ts desc") {
+        for
+          _    <- cleanDb
+          repo <- ZIO.service[BlockEventRepo]
+          n    <- repo.insertBatch(
+            List(
+              BlockEventInsert(Some("aa:bb:cc:00:00:01"), "ads.example.com", "category:ads"),
+              BlockEventInsert(
+                Some("aa:bb:cc:00:00:02"),
+                "casino.example.com",
+                "category:gambling",
+              ),
+              BlockEventInsert(None, "unknown.example.com", "category:adult"),
+            ),
+          )
+          rows <- repo.recent(10)
+        yield assertTrue(n == 3) && assertTrue(rows.size == 3) &&
+          assertTrue(rows.exists(_.mac.isEmpty))
+      },
+      test("listForMac returns only events for that mac, newest first") {
+        for
+          _    <- cleanDb
+          repo <- ZIO.service[BlockEventRepo]
+          mac = "aa:bb:cc:00:00:01"
+          _    <- repo.insertBatch(
+            List(
+              BlockEventInsert(Some(mac), "a.com", "r1"),
+              BlockEventInsert(Some("aa:bb:cc:00:00:99"), "b.com", "r1"),
+              BlockEventInsert(Some(mac), "c.com", "r2"),
+            ),
+          )
+          rows <- repo.listForMac(mac, 10)
+        yield assertTrue(rows.size == 2) &&
+          assertTrue(rows.forall(_.mac.contains(mac))) &&
+          assertTrue(rows.map(_.hostname).toSet == Set("a.com", "c.com"))
+      },
+    ),
+    suite("time_usage byte columns")(
+      test("time_usage rows default bytes_in/bytes_out to zero") {
+        import doobie.implicits.*
+        import doobie.postgres.implicits.*
+        import zio.interop.catz.*
+        for
+          _  <- cleanDb
+          tu <- ZIO.service[TimeUsageRepo]
+          xa <- ZIO.service[doobie.Transactor[Task]]
+          mac = "aa:bb:cc:dd:ee:01"
+          d   = LocalDate.of(2026, 5, 2)
+          _   <- tu.incrementUsage(mac, "youtube.com", d, 5)
+          row <-
+            sql"SELECT bytes_in, bytes_out FROM time_usage WHERE device_mac=$mac AND domain='youtube.com' AND date=$d"
+              .query[(Long, Long)]
+              .unique
+              .transact(xa)
+        yield assertTrue(row == ((0L, 0L)))
+      },
+    ),
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -2,6 +2,14 @@ package familydns.shared
 
 import zio.json.*
 
+import java.util.UUID
+
+given JsonCodec[UUID] =
+  JsonCodec[String].transformOrFail(
+    s => scala.util.Try(UUID.fromString(s)).toEither.left.map(_.getMessage),
+    _.toString,
+  )
+
 enum UserRole derives JsonCodec:
   case Admin, Adult, Child
 
@@ -214,3 +222,35 @@ case class TimeUsageSnapshot(
 
 object TimeUsageSnapshot:
   val empty: TimeUsageSnapshot = TimeUsageSnapshot(Map.empty, Map.empty, Map.empty)
+
+case class Router(
+    id: UUID,
+    name: String,
+    enrollmentTokenHash: Option[String],
+    tokenHash: Option[String],
+    lastSeenAt: Option[String],
+    lastEtag: Option[String],
+    createdAt: String,
+) derives JsonCodec
+
+case class TrafficReport(
+    id: Long,
+    routerId: UUID,
+    mac: String,
+    ip: Option[String],
+    hostname: String,
+    date: String,
+    periodStart: String,
+    periodEnd: String,
+    activeSeconds: Int,
+    bytesIn: Long,
+    bytesOut: Long,
+) derives JsonCodec
+
+case class BlockEvent(
+    id: Long,
+    mac: Option[String],
+    hostname: String,
+    reason: String,
+    ts: String,
+) derives JsonCodec


### PR DESCRIPTION
Closes #67. First implementation step in the OpenWRT re-architecture chain (#67 → #68 → #69 → #70 → #71 → #72 → #73). Spec lives in [`docs/architecture-openwrt.md`](docs/architecture-openwrt.md) (#74).

## Summary

- **`V2__openwrt.sql`** — new tables + columns required by the router HTTP API. Strictly additive; V1 is untouched.
  - `routers (id uuid pk, name, enrollment_token_hash, token_hash, last_seen_at, last_etag, created_at)` with partial indexes on the two hash columns.
  - `traffic_reports` — audit log of `POST /api/router/usage`, unique on `(router_id, period_start, mac, hostname)` so router retries are idempotent. FK to `routers` with `ON DELETE CASCADE`. Indexed on `router_id`, `date`, `(mac, date)`, `period_start DESC`.
  - `block_events (id, mac, hostname, reason, ts)` — block decisions surfaced via `/decision` and `/blocked`. Indexed on `ts DESC` and `mac`.
  - `time_usage` gains `bytes_in BIGINT NOT NULL DEFAULT 0` and `bytes_out BIGINT NOT NULL DEFAULT 0` (#67 explicitly).
- **Domain models** in `shared/Models.scala`: `Router`, `TrafficReport`, `BlockEvent` (+ `JsonCodec[UUID]` instance).
- **Repos**: `RouterRepo`, `TrafficReportRepo`, `BlockEventRepo` (traits + `*Live` impls), wired into `Repos.all` and `TestDatabase.AllRepos`.
  - `RouterRepo.touch` uses `COALESCE($etag, last_etag)` so passing `None` preserves the previous etag while still stamping `last_seen_at` (matches the agent heartbeat / 304 path described in §5.2 of the spec).
  - `TrafficReportRepo.insertBatch` uses `ON CONFLICT (router_id, period_start, mac, hostname) DO NOTHING` for idempotent retries.
- **No HTTP routes yet.** Endpoints land in #68 (`/policy`, `/register`, `/blocklists/<cat>.rpz`), #69 (`/usage`, `/events`), #70 (`/decision`, `/blocked`).

## Tests

`api/test/src/feature/RouterRepoSpec.scala` — 11 feature tests, all passing. Each test goes through the real Flyway-migrated embedded Postgres (no mocks), exercising the V2 schema end-to-end:

- RouterRepo: create / completeEnrollment swap / touch etag preservation / delete cascades to traffic_reports / listAll ordering.
- TrafficReportRepo: idempotent inserts on the unique key / distinct hostnames same period / mac+date filter.
- BlockEventRepo: insertBatch returns count, recent ordering, listForMac filter.
- time_usage: new bytes columns default to 0.

`mill api.test` is green (all suites, including pre-existing).

## Test plan

- [x] `mill api.test` passes locally.
- [x] V2 applies cleanly to a fresh DB — verified by every embedded-Postgres test, which `cleanAndMigrate`s (drop schema → run V1+V2 from `classpath:db/migration`) before each test.
- [ ] CI runs the same migrations against postgres:16-alpine in `docker/docker-compose.yml` (Docker daemon was unavailable for a local run; the GH Actions e2e workflow exercises the same path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)