### PR TITLE
Remove location field from devices (closes #12)

### DIFF
--- a/api/resources/db/migration/V3__drop_devices_location.sql
+++ b/api/resources/db/migration/V3__drop_devices_location.sql
@@ -1,0 +1,1 @@
+ALTER TABLE devices DROP COLUMN location;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -85,8 +85,8 @@ trait SiteTimeLimitRepo:
 trait DeviceRepo:
   def listAll: Task[List[Device]]
   def findByMac(mac: String): Task[Option[Device]]
-  def upsert(mac: String, name: String, pid: Long, ip: String, loc: String): Task[Long]
-  def updateLastSeen(mac: String, ip: String, location: String): Task[Unit]
+  def upsert(mac: String, name: String, pid: Long, ip: String): Task[Long]
+  def updateLastSeen(mac: String, ip: String): Task[Unit]
   def updateProfile(mac: String, pid: Long): Task[Unit]
   def delete(mac: String): Task[Unit]
 
@@ -312,8 +312,8 @@ class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo:
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
 
 class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
-  def listAll                                                               =
-    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT,d.location FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id ORDER BY d.name"
+  def listAll                                                  =
+    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id ORDER BY d.name"
       .query[
         (
             Long,
@@ -323,14 +323,13 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
             Option[String],
             Option[String],
             Option[String],
-            Option[String],
         ),
       ]
-      .map(r => Device(r._1, r._2, r._3, r._4.getOrElse(0L), r._5, r._6, r._7, r._8))
+      .map(r => Device(r._1, r._2, r._3, r._4.getOrElse(0L), r._5, r._6, r._7))
       .to[List]
       .transact(xa)
-  def findByMac(mac: String)                                                =
-    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT,d.location FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id WHERE d.mac=$mac"
+  def findByMac(mac: String)                                   =
+    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id WHERE d.mac=$mac"
       .query[
         (
             Long,
@@ -340,22 +339,21 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
             Option[String],
             Option[String],
             Option[String],
-            Option[String],
         ),
       ]
-      .map(r => Device(r._1, r._2, r._3, r._4.getOrElse(0L), r._5, r._6, r._7, r._8))
+      .map(r => Device(r._1, r._2, r._3, r._4.getOrElse(0L), r._5, r._6, r._7))
       .option
       .transact(xa)
-  def upsert(mac: String, name: String, pid: Long, ip: String, loc: String) =
-    sql"INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at,location) VALUES($mac,$name,$pid,$ip,NOW(),$loc) ON CONFLICT(mac) DO UPDATE SET last_seen_ip=EXCLUDED.last_seen_ip,last_seen_at=NOW(),location=EXCLUDED.location RETURNING id"
+  def upsert(mac: String, name: String, pid: Long, ip: String) =
+    sql"INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at) VALUES($mac,$name,$pid,$ip,NOW()) ON CONFLICT(mac) DO UPDATE SET last_seen_ip=EXCLUDED.last_seen_ip,last_seen_at=NOW() RETURNING id"
       .query[Long]
       .unique
       .transact(xa)
-  def updateLastSeen(mac: String, ip: String, location: String)             =
-    sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW(),location=$location WHERE mac=$mac".update.run
+  def updateLastSeen(mac: String, ip: String)                  =
+    sql"UPDATE devices SET last_seen_ip=$ip,last_seen_at=NOW() WHERE mac=$mac".update.run
       .transact(xa)
       .unit
-  def updateProfile(mac: String, pid: Long)                                 =
+  def updateProfile(mac: String, pid: Long)                    =
     sql"UPDATE devices SET profile_id=$pid WHERE mac=$mac".update.run.transact(xa).unit
   def delete(mac: String) = sql"DELETE FROM devices WHERE mac=$mac".update.run.transact(xa).unit
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -276,7 +276,7 @@ object DeviceRoutes:
             _      <- requireProfileAccess(claims, udr.profileId, userProfileRepo)
             mac = normalizeMac(udr.mac)
             id <- deviceRepo
-              .upsert(mac, udr.name, udr.profileId, "", udr.location.getOrElse("home"))
+              .upsert(mac, udr.name, udr.profileId, "")
               .orElseFail(Response.internalServerError(""))
           yield Response.json(s"""{"id":$id}""")
         },

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -117,6 +117,5 @@ object TestLayers:
       mac: String,
       name: String,
       profileId: Long,
-      location: String = "home",
   ): Task[Long] =
-    deviceRepo.upsert(mac, name, profileId, "192.168.1.100", location)
+    deviceRepo.upsert(mac, name, profileId, "192.168.1.100")

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -45,7 +45,6 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
           mac = "aa:bb:cc:dd:ee:ff",
           name = "iPad",
           profileId = kidsId,
-          location = Some("home"),
         ).toJson
         putReq = Request
           .put(URL.decode("/api/devices").toOption.get, Body.fromString(body))
@@ -63,7 +62,8 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(devices.exists(_.name == "iPad")) &&
         assertTrue(
           devices.find(_.mac == "aa:bb:cc:dd:ee:ff").exists(_.profileName.contains("Kids")),
-        )
+        ) &&
+        assertTrue(!body2.contains("\"location\""))
     },
     test("MAC address is normalised (upper → lower, dashes → colons)") {
       for
@@ -76,7 +76,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         kidsId = profiles.find(_.name == "Kids").get.id
         userProfileRepo <- ZIO.service[UserProfileRepo]
         routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
-        body   = UpsertDeviceRequest("AA-BB-CC-DD-EE-FF", "Laptop", kidsId, None).toJson
+        body   = UpsertDeviceRequest("AA-BB-CC-DD-EE-FF", "Laptop", kidsId).toJson
         req    = Request
           .put(URL.decode("/api/devices").toOption.get, Body.fromString(body))
           .addHeader(Header.Authorization.Bearer(token))
@@ -95,7 +95,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         profiles    <- profileRepo.listAll
         kidsId = profiles.find(_.name == "Kids").get.id
         mac    = "11:22:33:44:55:66"
-        _               <- deviceRepo.upsert(mac, "OldDevice", kidsId, "192.168.1.50", "home")
+        _               <- deviceRepo.upsert(mac, "OldDevice", kidsId, "192.168.1.50")
         userProfileRepo <- ZIO.service[UserProfileRepo]
         routes = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
         delReq = Request
@@ -114,8 +114,8 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         profiles    <- profileRepo.listAll
         kidsId = profiles.find(_.name == "Kids").get.id
         mac    = "cc:dd:ee:ff:00:11"
-        _      <- deviceRepo.upsert(mac, "Laptop", kidsId, "192.168.1.5", "home")
-        _      <- deviceRepo.updateLastSeen(mac, "192.168.1.99", "office")
+        _      <- deviceRepo.upsert(mac, "Laptop", kidsId, "192.168.1.5")
+        _      <- deviceRepo.updateLastSeen(mac, "192.168.1.99")
         device <- deviceRepo.findByMac(mac)
       yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.99"))) &&
         assertTrue(device.exists(_.profileId == kidsId))
@@ -130,9 +130,9 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         profiles    <- profileRepo.listAll
         kidsId = profiles.find(_.name == "Kids").get.id
         mac    = "aa:bb:cc:00:00:01"
-        _      <- deviceRepo.upsert(mac, "Phone", kidsId, "192.168.1.10", "home")
+        _      <- deviceRepo.upsert(mac, "Phone", kidsId, "192.168.1.10")
         // Upsert again with different IP (simulating DHCP lease change)
-        _      <- deviceRepo.upsert(mac, "Phone", kidsId, "192.168.1.20", "home")
+        _      <- deviceRepo.upsert(mac, "Phone", kidsId, "192.168.1.20")
         device <- deviceRepo.findByMac(mac)
       yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.20"))) &&
         assertTrue(device.exists(_.profileId == kidsId))

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -311,8 +311,8 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profiles    <- profileRepo.listAll
         kidsId   = profiles.find(_.name == "Kids").get.id
         adultsId = profiles.find(_.name == "Adults").get.id
-        _     <- deviceRepo.upsert("aa:bb:cc:00:00:01", "kid-tablet", kidsId, "", "home")
-        _     <- deviceRepo.upsert("aa:bb:cc:00:00:02", "dad-laptop", adultsId, "", "home")
+        _     <- deviceRepo.upsert("aa:bb:cc:00:00:01", "kid-tablet", kidsId, "")
+        _     <- deviceRepo.upsert("aa:bb:cc:00:00:02", "dad-laptop", adultsId, "")
         _     <- createUser(userRepo, upRepo, auth, "alice", "child", List(kidsId))
         token <- auth.login("alice", "pass").map(_.token)
         routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)

--- a/dns/src/DnsServer.scala
+++ b/dns/src/DnsServer.scala
@@ -92,7 +92,7 @@ class DnsServer(
               for
                 _ <- ZIO.foreachDiscard(mac) { m =>
                   deviceRepo
-                    .updateLastSeen(m, clientIp, config.location)
+                    .updateLastSeen(m, clientIp)
                     .catchAllCause(c => ZIO.logWarningCause("updateLastSeen failed", c))
                     .forkDaemon
                 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -83,7 +83,6 @@ case class Device(
     profileName: Option[String],
     lastSeenIp: Option[String],
     lastSeenAt: Option[String],
-    location: Option[String],
 ) derives JsonCodec
 
 case class QueryLog(
@@ -150,7 +149,6 @@ case class UpsertDeviceRequest(
     mac: String,
     name: String,
     profileId: Long,
-    location: Option[String],
 ) derives JsonCodec
 
 case class GrantExtensionRequest(

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -12,7 +12,7 @@ export function DevicesPage() {
   const [profiles, setProfiles] = useState<ProfileDetail[]>([])
   const [loading,  setLoading]  = useState(true)
   const [editing,  setEditing]  = useState<Device | null>(null)
-  const [form,     setForm]     = useState({ mac: '', name: '', profileId: 0, location: 'home' })
+  const [form,     setForm]     = useState({ mac: '', name: '', profileId: 0 })
 
   useEffect(() => {
     Promise.all([api.devices.list(), api.profiles.list()])
@@ -21,7 +21,7 @@ export function DevicesPage() {
   }, [])
 
   async function save() {
-    await api.devices.upsert({ ...form, location: form.location || null })
+    await api.devices.upsert(form)
     const d = await api.devices.list()
     setDevices(d)
     setEditing(null)
@@ -41,7 +41,7 @@ export function DevicesPage() {
         <h1 className="text-xl font-bold text-white">Devices</h1>
         {isAdmin && (
           <button
-            onClick={() => { setEditing({} as Device); setForm({ mac: '', name: '', profileId: profiles[0]?.profile.id ?? 0, location: 'home' }) }}
+            onClick={() => { setEditing({} as Device); setForm({ mac: '', name: '', profileId: profiles[0]?.profile.id ?? 0 }) }}
             className="bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold px-4 py-2 rounded-xl transition-colors"
           >
             + Add Device
@@ -63,11 +63,10 @@ export function DevicesPage() {
                     {d.profileName ?? 'No profile'}
                   </span>
                 </div>
-                <div className="text-xs text-gray-600 hidden md:block">{d.location ?? 'home'}</div>
                 {isAdmin && (
                   <div className="flex gap-2 shrink-0">
                     <button
-                      onClick={() => { setEditing(d); setForm({ mac: d.mac, name: d.name, profileId: d.profileId, location: d.location ?? 'home' }) }}
+                      onClick={() => { setEditing(d); setForm({ mac: d.mac, name: d.name, profileId: d.profileId }) }}
                       className="text-xs text-gray-400 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors"
                     >Edit</button>
                     <button
@@ -92,14 +91,6 @@ export function DevicesPage() {
               <select value={form.profileId} onChange={e => setForm(f => ({...f, profileId: Number(e.target.value)}))}
                 className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white">
                 {profiles.map(p => <option key={p.profile.id} value={p.profile.id}>{p.profile.name}</option>)}
-              </select>
-            </div>
-            <div>
-              <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Location</label>
-              <select value={form.location} onChange={e => setForm(f => ({...f, location: e.target.value}))}
-                className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white">
-                <option value="home">Home</option>
-                <option value="vacation">Vacation</option>
               </select>
             </div>
             <div className="flex gap-3 pt-2">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -47,7 +47,6 @@ export interface Device {
   profileName: string | null
   lastSeenIp: string | null
   lastSeenAt: string | null
-  location: string | null
 }
 
 export interface QueryLog {
@@ -177,7 +176,6 @@ export interface UpsertDeviceRequest {
   mac: string
   name: string
   profileId: number
-  location: string | null
 }
 
 export interface GrantExtensionRequest {


### PR DESCRIPTION
## Summary
- Devices no longer carry a `location` — they can roam between home/vacation freely.
- Query logs still record location (from DNS server config) so per-house log filtering keeps working.
- Adds `V3__drop_devices_location.sql` per the migration immutability rule (existing migrations untouched).

Removes:
- `Device.location` and `UpsertDeviceRequest.location` from shared models
- `loc`/`location` params from `DeviceRepo.upsert` and `updateLastSeen` (and Live impls)
- `udr.location` from the upsert route
- `config.location` arg from the DNS server's `updateLastSeen` call
- The Location <select> on the device edit modal and the location column on the device list
- `location` from the frontend `Device` and `UpsertDeviceRequest` types

Coordination: PR #84 (frontend test backfill) also touches DevicesPage and references the location toggle — whoever lands second rebases.

Closes #12.

## Test plan
- [x] `mill api.compile`, `mill dns.compile`, `mill api.test.compile` clean
- [x] `mill api.test` — all suites green (DeviceApiSpec, RoleAccessSpec, etc.)
- [x] `npm run build` in `web/` clean
- [x] `npm test` (vitest) — 8/8 passing
- [x] DeviceApiSpec asserts the `location` JSON key is absent from the device list response
- [ ] Manual verification via docker compose (api + UI) — existing devices load, no location anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)