### PR TITLE
Deploy api+postgres as a single Compose stack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,9 +49,17 @@ jobs:
         if: always()
         run: docker compose -f docker/docker-compose.yml down -v
 
+  prod-stack-smoke:
+    name: deploy/docker-compose.prod.yml smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run prod-stack smoke
+        run: scripts/smoke-prod.sh
+
   promote-production:
     name: Fast-forward production branch
-    needs: [bootstrap-smoke, e2e]
+    needs: [bootstrap-smoke, e2e, prod-stack-smoke]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ web/build/
 config/application.conf
 config/*.conf
 !config/application.conf.example
+deploy/.env
+deploy/.env.*
+!deploy/.env.example
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -83,13 +83,40 @@ Sanity check:
 - **IntelliJ**: File → Open → select the repo root → choose **BSP** when
   prompted (not sbt). Subsequent reloads are via the BSP refresh button.
 
-## Deployment (Linux)
+## Deployment
 
-The deployment model: a Linux host runs `scripts/deploy.sh` either by hand
-or on a timer; it pulls the latest `main`, builds the assembly + frontend,
-and restarts a systemd unit. Every artifact (the unit file, the deploy
-script, the bootstrap script) lives in this repo, so updating any of them
-is a normal PR.
+### Recommended: api + postgres as a single Docker Compose stack
+
+The api and its postgres database deploy together as one Compose stack.
+The dns and traffic services are **not** part of this stack — they run on
+an OpenWRT router and reach the api over the network (see
+[`docs/architecture-openwrt.md`](docs/architecture-openwrt.md)).
+
+```bash
+cp deploy/.env.example deploy/.env
+$EDITOR deploy/.env                # set FAMILYDNS_DB_PASSWORD and FAMILYDNS_JWT_SECRET
+
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d --build
+```
+
+Postgres is internal to the compose network — it is not published on a
+host port. The api binds to `:8080` (configurable via `FAMILYDNS_API_BIND`
+/ `FAMILYDNS_API_PORT`). Run `scripts/smoke-prod.sh` to validate the stack.
+
+Full operator notes (backups, reverse-proxy guidance, migration from the
+host-based deploy below) live in [`deploy/README.md`](deploy/README.md).
+
+### Legacy: systemd-on-host deploy
+
+The original deployment model: a Linux host runs `scripts/deploy.sh` either
+by hand or on a timer; it pulls the latest `main`, builds the assembly +
+frontend, and restarts a systemd unit. Every artifact (the unit file, the
+deploy script, the bootstrap script) lives in this repo, so updating any of
+them is a normal PR.
+
+This path is being phased out in favour of the Compose stack above and the
+OpenWRT agent for dns/traffic. The unit files under `deploy/` are kept for
+existing installs.
 
 ### One-shot host bootstrap (curl-pipe)
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,24 @@
+# Copy to deploy/.env and fill in real values. Never commit deploy/.env.
+#
+#   cp deploy/.env.example deploy/.env
+#   docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d
+
+# Postgres credentials (postgres is internal-only — these never leave the
+# compose network, but use a strong password anyway).
+FAMILYDNS_DB_NAME=familydns
+FAMILYDNS_DB_USER=familydns
+FAMILYDNS_DB_PASSWORD=replace-with-strong-password
+
+# JWT signing secret. MUST be at least 32 random characters.
+# Generate one with:  openssl rand -base64 48
+FAMILYDNS_JWT_SECRET=replace-with-32-plus-random-chars-not-this
+FAMILYDNS_JWT_HOURS=24
+
+# How the api port is exposed on the host.
+# - FAMILYDNS_API_BIND=0.0.0.0  → reachable from anywhere (default; put behind a reverse proxy / firewall)
+# - FAMILYDNS_API_BIND=127.0.0.1 → only reachable from the host (front with nginx/Caddy)
+FAMILYDNS_API_BIND=0.0.0.0
+FAMILYDNS_API_PORT=8080
+
+# Free-form label persisted with query logs (e.g. "home", "vacation").
+FAMILYDNS_DNS_LOCATION=home

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,91 @@
+# Deploying FamilyDNS
+
+The api + postgres pair ships as a single Docker Compose stack. The dns and
+traffic services do **not** live here — they run on an OpenWRT router and
+reach this api over the network (see [`docs/architecture-openwrt.md`](../docs/architecture-openwrt.md)).
+
+## What's in this directory
+
+| File                              | Purpose |
+| --------------------------------- | ------- |
+| `docker-compose.prod.yml`         | Single-stack compose: postgres + api. |
+| `.env.example`                    | Template for secrets/config. Copy to `.env`. |
+| `familydns-api.service`           | Legacy systemd unit for host-based deploys. Kept for reference; new installs should use Compose. |
+| `familydns-dns.service`           | Legacy host-based dns unit (replaced by OpenWRT agent). |
+| `familydns-traffic.service`       | Legacy host-based traffic unit (replaced by OpenWRT agent). |
+
+## One-command deploy
+
+```bash
+cp deploy/.env.example deploy/.env
+$EDITOR deploy/.env                # set FAMILYDNS_DB_PASSWORD and FAMILYDNS_JWT_SECRET
+
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d --build
+```
+
+That's it. The api binds to `:8080` on the host; postgres stays inside the
+compose network and is unreachable from the host or LAN.
+
+Default admin login: `admin / changeme` — change it immediately via
+`POST /api/auth/change-password`.
+
+## Design notes
+
+- **Postgres is internal-only.** No `ports:` mapping. The api reaches it as
+  `postgres:5432` over the compose bridge network. Nothing on the host or
+  LAN can connect to the database directly. Inspecting the DB requires
+  `docker compose exec postgres psql ...`.
+- **Named volume for data.** `pgdata` is a Docker named volume; data
+  survives `down` / `up` cycles. Backups are a `pg_dump` away
+  (`docker compose exec postgres pg_dump -U familydns familydns`).
+- **Restart `unless-stopped`.** Both services come back automatically after
+  a crash or host reboot, but stay down if you explicitly `docker compose
+  stop` them.
+- **Healthchecks on both services.** `api` waits for postgres to be
+  healthy before it starts, and its own healthcheck hits the login
+  endpoint (a 400/401 response proves the api + DB round-trip works).
+- **Cloud vs. local target.** None of the above is target-specific — this
+  works on any Linux host with Docker. Bind the api to `127.0.0.1` and
+  front it with a TLS-terminating reverse proxy (Caddy, nginx, traefik) for
+  production internet exposure. For LAN-only deployments, the default
+  `0.0.0.0` bind plus a host firewall is fine.
+
+## Common operations
+
+```bash
+# Tail logs
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env logs -f api
+
+# Update to the latest main and restart
+git pull && docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d --build
+
+# Backup the database
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env \
+  exec postgres pg_dump -U familydns familydns > backup-$(date +%F).sql
+
+# Open a psql shell
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env \
+  exec postgres psql -U familydns familydns
+```
+
+## Smoke test
+
+```bash
+scripts/smoke-prod.sh
+```
+
+This brings the stack up, waits for the api healthcheck, asserts that
+postgres is **not** reachable from the host, and tears the stack down.
+
+## Migrating from the legacy host-based deploy
+
+If you're running the older systemd-on-host install (`scripts/deploy.sh` +
+`familydns-api.service`):
+
+1. `pg_dump` your existing local postgres.
+2. Stop and disable the systemd units.
+3. Bring up the compose stack with a fresh `.env`.
+4. Restore the dump: `docker compose ... exec -T postgres psql -U familydns familydns < backup.sql`.
+
+Open an issue if you hit anything missing — this path will get more polish
+as more installs migrate.

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,60 @@
+# Production single-stack deploy: api + postgres only.
+#
+# Postgres stays on the internal compose network — there is no published
+# host port. The api reaches it as `postgres:5432` (service-name DNS).
+#
+# Run:
+#   cp deploy/.env.example deploy/.env   # then edit secrets
+#   docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d
+#
+# This stack is target-agnostic. It runs on any Linux host with Docker —
+# a cheap VPS, a home server, or a cloud VM. The dns/ and traffic/ services
+# live elsewhere (OpenWRT router) and reach this api over the network.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${FAMILYDNS_DB_USER:?FAMILYDNS_DB_USER required}
+      POSTGRES_PASSWORD: ${FAMILYDNS_DB_PASSWORD:?FAMILYDNS_DB_PASSWORD required}
+      POSTGRES_DB: ${FAMILYDNS_DB_NAME:?FAMILYDNS_DB_NAME required}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: familydns-api:latest
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      FAMILYDNS_MODE: api
+      FAMILYDNS_DB_HOST: postgres
+      FAMILYDNS_DB_PORT: "5432"
+      FAMILYDNS_DB_NAME: ${FAMILYDNS_DB_NAME}
+      FAMILYDNS_DB_USER: ${FAMILYDNS_DB_USER}
+      FAMILYDNS_DB_PASSWORD: ${FAMILYDNS_DB_PASSWORD}
+      FAMILYDNS_HTTP_PORT: "8080"
+      FAMILYDNS_JWT_SECRET: ${FAMILYDNS_JWT_SECRET:?FAMILYDNS_JWT_SECRET required (>=32 chars)}
+      FAMILYDNS_JWT_HOURS: ${FAMILYDNS_JWT_HOURS:-24}
+      FAMILYDNS_DNS_LOCATION: ${FAMILYDNS_DNS_LOCATION:-home}
+    ports:
+      - "${FAMILYDNS_API_BIND:-0.0.0.0}:${FAMILYDNS_API_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' -d '{}' http://localhost:8080/api/auth/login | grep -qE '^(400|401)$$'"]
+      interval: 10s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
+
+volumes:
+  pgdata:

--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Smoke test for deploy/docker-compose.prod.yml.
+#
+# Brings the stack up with throwaway secrets, verifies:
+#   1. api becomes healthy
+#   2. postgres is NOT reachable from the host (no published port)
+#   3. api responds on its published port
+# Then tears everything down. Used in CI and as a sanity check before deploys.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ENV_FILE="$(mktemp)"
+trap 'rm -f "$ENV_FILE"; docker compose -f deploy/docker-compose.prod.yml --env-file "$ENV_FILE" down -v --remove-orphans >/dev/null 2>&1 || true' EXIT
+
+cat > "$ENV_FILE" <<'EOF'
+FAMILYDNS_DB_NAME=familydns
+FAMILYDNS_DB_USER=familydns
+FAMILYDNS_DB_PASSWORD=smoke-test-password
+FAMILYDNS_JWT_SECRET=smoke-test-jwt-secret-min-32-chars-long-yes
+FAMILYDNS_JWT_HOURS=24
+FAMILYDNS_API_BIND=127.0.0.1
+FAMILYDNS_API_PORT=18080
+FAMILYDNS_DNS_LOCATION=smoke
+EOF
+
+COMPOSE=(docker compose -f deploy/docker-compose.prod.yml --env-file "$ENV_FILE")
+
+echo "[smoke] starting stack..."
+"${COMPOSE[@]}" up -d --build --quiet-pull
+
+echo "[smoke] waiting for api to become healthy..."
+for i in $(seq 1 60); do
+  status=$("${COMPOSE[@]}" ps --format '{{.Service}} {{.Health}}' | awk '$1=="api"{print $2}')
+  if [ "$status" = "healthy" ]; then
+    echo "[smoke] api healthy"
+    break
+  fi
+  if [ "$i" -eq 60 ]; then
+    echo "[smoke] api never became healthy" >&2
+    "${COMPOSE[@]}" logs --tail=80 api postgres >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "[smoke] checking api responds on host port 18080..."
+code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' \
+  -d '{}' http://127.0.0.1:18080/api/auth/login)
+case "$code" in
+  400|401) echo "[smoke] api responded with $code (expected)";;
+  *)       echo "[smoke] api returned unexpected $code" >&2; exit 1;;
+esac
+
+echo "[smoke] confirming postgres is NOT exposed on the host..."
+# 5432 (default) and 5433 (dev compose port) must both be unreachable from
+# the host — postgres has no published port in the prod stack.
+for port in 5432 5433; do
+  if (echo > "/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+    echo "[smoke] postgres is reachable on 127.0.0.1:$port — leaked publish?" >&2
+    exit 1
+  fi
+done
+echo "[smoke] postgres is internal-only — good"
+
+echo "[smoke] OK"


### PR DESCRIPTION
Closes #80.

## Summary

- New `deploy/docker-compose.prod.yml`: postgres + api in one stack.
- Postgres is **internal-only** — no `ports:` mapping. The api reaches it via service-name DNS (`postgres:5432`). Nothing on the host or LAN can connect to the database directly.
- Named volume (`pgdata`) for durability, `restart: unless-stopped` and healthchecks on both services, `api` waits for postgres to be healthy.
- Secrets via `deploy/.env` (template at `deploy/.env.example`, real file gitignored). `FAMILYDNS_JWT_SECRET` and `FAMILYDNS_DB_PASSWORD` are required — Compose fails fast if they're missing.
- `FAMILYDNS_API_BIND` / `FAMILYDNS_API_PORT` keep the api port configurable so it can sit behind a reverse proxy (`127.0.0.1`) or expose directly (`0.0.0.0`).
- `scripts/smoke-prod.sh` brings the stack up, asserts the api goes healthy, and verifies postgres is **not** reachable from the host. Wired into the e2e workflow as a new `prod-stack-smoke` job that gates the production-branch promotion.
- `deploy/README.md` documents the one-command deploy, common ops (logs, backup, psql), reverse-proxy guidance, and a migration path from the legacy systemd-on-host install. Root README points at it.

## Cloud vs. local target

The stack is target-agnostic — it runs on any Linux host with Docker (cheap VPS, home server, cloud VM). No cloud-provider-specific knobs were added; the existing prod box already runs Linux, and the issue body called out "support both via env" which is exactly what `FAMILYDNS_API_BIND`/`FAMILYDNS_API_PORT` give you.

## What's *not* changed

- Dev compose (`docker/docker-compose.yml`) is untouched. The `5433:5432` published postgres port stays in dev for debugging — that decision is explicit in #80.
- Legacy systemd unit files under `deploy/` stay in place for existing host-based installs. They're called out as legacy in `deploy/README.md` and the root README.
- The dns/traffic deploy paths are independent — they reach the api over the network from the OpenWRT router (out of scope per #80).

## Out of scope

- Migrating existing prod data from the legacy host postgres into the compose volume — `deploy/README.md` documents the `pg_dump` → restore path but the actual migration on the live box happens out-of-band.
- DNS query forwarding / OpenWRT agent (tracked in #67–#73).

## Test plan

- [x] `docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env.example config` validates.
- [ ] CI's new `prod-stack-smoke` job runs `scripts/smoke-prod.sh` end-to-end. (Couldn't run locally — Docker daemon not responsive in the worktree environment.)
- [ ] Manual: `docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d`, hit `http://localhost:8080/api/auth/login`, confirm `nc -z localhost 5432` fails.