### PR TITLE
Add OpenWRT router policy snapshot, RPZ blocklists, enrollment + admin UI

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -2,6 +2,7 @@ package familydns.api
 
 import familydns.api.auth.*
 import familydns.api.db.*
+import familydns.api.policy.*
 import familydns.api.routes.*
 import familydns.shared.Clock
 import zio.*
@@ -33,7 +34,8 @@ object Main extends ZIOAppDefault:
       Repos.all >+>
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.jwt)) >+>
       Clock.live >+>
-      AuthService.layer
+      AuthService.layer >+>
+      PolicyService.layer
 
   private def allRoutes =
     for
@@ -49,6 +51,8 @@ object Main extends ZIOAppDefault:
       usageRepo   <- ZIO.service[TimeUsageRepo]
       extRepo     <- ZIO.service[TimeExtensionRepo]
       logRepo     <- ZIO.service[QueryLogRepo]
+      routerRepo  <- ZIO.service[RouterRepo]
+      policy      <- ZIO.service[PolicyService]
       cfg         <- ZIO.service[AppConfig]
       clock       <- ZIO.service[Clock]
     yield AuthRoutes.routes(auth, userRepo, upRepo) ++
@@ -67,4 +71,6 @@ object Main extends ZIOAppDefault:
       ) ++
       LogRoutes.routes(auth, logRepo, upRepo) ++
       BlocklistRoutes.routes(auth, blRepo) ++
+      RouterRoutes.routes(routerRepo, policy, RouterAuthLive(routerRepo)) ++
+      AdminRouterRoutes.routes(auth, routerRepo) ++
       StaticRoutes.routes(cfg.http.staticDir)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -1,0 +1,153 @@
+package familydns.api.policy
+
+import familydns.api.db.*
+import familydns.shared.*
+import zio.{Clock as _, *}
+
+import java.security.MessageDigest
+
+trait PolicyService:
+  def snapshot: Task[PolicySnapshot]
+  def renderRpz(category: String): Task[Option[(String, String)]]
+
+class PolicyServiceLive(
+    profileRepo: ProfileRepo,
+    scheduleRepo: ScheduleRepo,
+    timeLimitRepo: TimeLimitRepo,
+    siteTimeLimitRepo: SiteTimeLimitRepo,
+    deviceRepo: DeviceRepo,
+    blocklistRepo: BlocklistRepo,
+    usageRepo: TimeUsageRepo,
+    extRepo: TimeExtensionRepo,
+    clock: Clock,
+) extends PolicyService:
+
+  def snapshot: Task[PolicySnapshot] =
+    for
+      today    <- clock.today
+      now      <- clock.now
+      profiles <- profileRepo.listAll
+      devices  <- deviceRepo.listAll
+      scheds   <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      tlims    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
+      stlims   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      usages   <- usageRepo.snapshotAll(today)
+      exts     <- extRepo.snapshotAll(today)
+      cats     <- blocklistRepo.listCategories
+      schedMap = scheds.toMap
+      tlMap    = tlims.toMap
+      stlMap   = stlims.toMap
+    yield
+      val devsByProfile = devices.groupBy(_.profileId)
+      val pProfiles     = profiles.map { p =>
+        val pSched    = schedMap
+          .getOrElse(p.id, Nil)
+          .map(s => PolicySchedule(s.days, s.blockFrom, s.blockUntil))
+        val pSiteLims = stlMap
+          .getOrElse(p.id, Nil)
+          .map(s => PolicySiteLimit(s.domainPattern, s.dailyMinutes, s.label))
+        val devicesIn = devsByProfile.getOrElse(p.id, Nil)
+        val byDomain  = stlMap
+          .getOrElse(p.id, Nil)
+          .foldLeft(Map.empty[String, Int]) { (acc, stl) =>
+            val mins =
+              devicesIn.iterator.map(d => usages.getOrElse((d.mac, stl.domainPattern), 0)).sum
+            if mins == 0 then acc else acc.updated(stl.domainPattern, mins)
+          }
+        val siteDoms  = stlMap.getOrElse(p.id, Nil).map(_.domainPattern).toSet
+        val totalMins = usages.iterator.collect {
+          case ((mac, dom), m) if devicesIn.exists(_.mac == mac) && !siteDoms.contains(dom) => m
+        }.sum
+        val extMins   = devicesIn.map(d => exts.getOrElse(d.mac, 0)).sum
+        PolicyProfile(
+          id = p.id,
+          name = p.name,
+          paused = p.paused,
+          blockedCategories = p.blockedCategories,
+          extraBlocked = p.extraBlocked,
+          extraAllowed = p.extraAllowed,
+          schedules = pSched,
+          dailyMinutes = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
+          siteLimits = pSiteLims,
+          timeUsedToday = PolicyTimeUsedToday(totalMins, byDomain),
+          extensionsTodayMinutes = extMins,
+        )
+      }
+      val pDevices      = devices.map(d => PolicyDevice(d.mac, d.profileId, d.name))
+      val pBlocklists   = cats.map { c =>
+        c -> PolicyBlocklist(version = today.toString, url = s"/api/blocklists/$c.rpz")
+      }.toMap
+      val defaultId     = profiles.map(_.id).minOption
+      val core          = SnapshotCore(defaultId, pDevices, pProfiles, pBlocklists)
+      val etag          = PolicyService.computeEtag(core)
+      PolicySnapshot(
+        etag = etag,
+        generatedAt = now.toString,
+        defaultProfileId = defaultId,
+        devices = pDevices,
+        profiles = pProfiles,
+        blocklists = pBlocklists,
+      )
+
+  def renderRpz(category: String): Task[Option[(String, String)]] =
+    for
+      today   <- clock.today
+      domains <- blocklistRepo.loadCategory(category)
+    yield
+      if domains.isEmpty then None
+      else
+        val origin = s"$category.rpz."
+        val serial = today.toString.replace("-", "")
+        val sb     = new StringBuilder
+        sb.append(s"$$ORIGIN $origin\n")
+        sb.append("$TTL 300\n")
+        sb.append(s"@ SOA localhost. admin.localhost. $serial 3600 600 86400 60\n")
+        sb.append("@ NS localhost.\n")
+        domains.toList.sorted.foreach(d => sb.append(s"$d CNAME .\n"))
+        val body   = sb.toString
+        val etag   = s"\"${PolicyService.sha256Hex(body).take(16)}-$serial\""
+        Some((etag, body))
+
+private case class SnapshotCore(
+    defaultProfileId: Option[Long],
+    devices: List[PolicyDevice],
+    profiles: List[PolicyProfile],
+    blocklists: Map[String, PolicyBlocklist],
+)
+
+object PolicyService:
+  val layer: ZLayer[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo &
+      TimeUsageRepo & TimeExtensionRepo & Clock,
+    Nothing,
+    PolicyService,
+  ] = ZLayer.fromFunction(PolicyServiceLive(_, _, _, _, _, _, _, _, _))
+
+  def sha256Hex(s: String): String =
+    val md = MessageDigest.getInstance("SHA-256")
+    md.digest(s.getBytes("UTF-8")).map("%02x".format(_)).mkString
+
+  /** Hex SHA-256 of a router/enrollment token, used as the storage key. */
+  def hashToken(raw: String): String = sha256Hex(raw)
+
+  /** Deterministic ETag over snapshot logical content. */
+  private[policy] def computeEtag(core: SnapshotCore): String =
+    val parts = scala.collection.mutable.ArrayBuffer.empty[String]
+    parts += s"d=${core.defaultProfileId.getOrElse("-")}"
+    core.devices.sortBy(_.mac).foreach(d => parts += s"dev:${d.mac}|${d.profileId}|${d.name}")
+    core.profiles.sortBy(_.id).foreach { p =>
+      parts += s"p:${p.id}|${p.name}|${p.paused}|${p.dailyMinutes.getOrElse(-1)}|${p.extensionsTodayMinutes}"
+      parts += s"  bc:${p.blockedCategories.sorted.mkString(",")}"
+      parts += s"  eb:${p.extraBlocked.sorted.mkString(",")}"
+      parts += s"  ea:${p.extraAllowed.sorted.mkString(",")}"
+      p.schedules.sortBy(s => (s.blockFrom, s.blockUntil)).foreach { s =>
+        parts += s"  s:${s.days.mkString(",")}|${s.blockFrom}|${s.blockUntil}"
+      }
+      p.siteLimits.sortBy(_.domain).foreach { sl =>
+        parts += s"  sl:${sl.domain}|${sl.minutes}|${sl.label}"
+      }
+      parts += s"  u:${p.timeUsedToday.totalMinutes}"
+      p.timeUsedToday.byDomain.toList.sortBy(_._1).foreach((k, v) => parts += s"    ud:$k=$v")
+    }
+    core.blocklists.toList.sortBy(_._1).foreach((k, v) => parts += s"bl:$k=${v.version}")
+    "\"sha256:" + sha256Hex(parts.mkString("\n")) + "\""

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -1,0 +1,196 @@
+package familydns.api.routes
+
+import familydns.api.auth.*
+import familydns.api.db.*
+import familydns.api.policy.*
+import familydns.shared.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+
+import java.security.SecureRandom
+import java.util.{Base64, UUID}
+
+/**
+ * Authentication for the agent-facing `/api/router/` and `/api/blocklists/` endpoints. The agent
+ * sends a per-router bearer token; the API stores only a SHA-256 hash. NOTE: kept here (not in a
+ * separate file) because issue #69 adds its own `RouterAuth.scala`; centralizing in #71 once the
+ * dust settles.
+ */
+trait RouterAuth:
+  def authenticate(req: Request): IO[Response, Router]
+
+class RouterAuthLive(repo: RouterRepo) extends RouterAuth:
+  def authenticate(req: Request): IO[Response, Router] =
+    RouterAuth.bearer(req) match
+      case None    => ZIO.fail(Response.unauthorized("Missing router token"))
+      case Some(t) =>
+        repo
+          .findByTokenHash(PolicyService.hashToken(t))
+          .orElseFail(Response.internalServerError(""))
+          .flatMap(ZIO.fromOption(_).orElseFail(Response.unauthorized("Invalid router token")))
+
+object RouterAuth:
+  private[routes] def bearer(req: Request): Option[String] =
+    req.header(Header.Authorization).flatMap { h =>
+      val v = h.renderedValue
+      if v.startsWith("Bearer ") then Some(v.drop(7)) else None
+    }
+
+/**
+ * Routes the OpenWRT agent calls. Auth: all routes here require the router's bearer token, except
+ * `/register` which uses a one-time enrollment token.
+ */
+object RouterRoutes:
+
+  def routes(
+      routerRepo: RouterRepo,
+      policy: PolicyService,
+      routerAuth: RouterAuth,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.POST / "api" / "router" / "register"        ->
+        handler { (req: Request) =>
+          for
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            rr   <- ZIO
+              .fromEither(body.fromJson[RegisterRouterRequest])
+              .mapError(e => Response.badRequest(e))
+            etHash = PolicyService.hashToken(rr.enrollmentToken)
+            router <- routerRepo
+              .findByEnrollmentTokenHash(etHash)
+              .orElseFail(Response.internalServerError(""))
+              .flatMap(
+                ZIO
+                  .fromOption(_)
+                  .orElseFail(Response.unauthorized("invalid enrollment token")),
+              )
+            routerToken = newToken("rt_")
+            tokenHash   = PolicyService.hashToken(routerToken)
+            _ <- routerRepo
+              .completeEnrollment(router.id, tokenHash)
+              .orElseFail(Response.internalServerError(""))
+          yield Response.json(RegisterRouterResponse(router.id, routerToken).toJson)
+        },
+      Method.GET / "api" / "router" / "policy"           ->
+        handler { (req: Request) =>
+          for
+            router <- routerAuth.authenticate(req)
+            snap   <- policy.snapshot.orElseFail(Response.internalServerError(""))
+            ifNoneMatch = req
+              .header(Header.IfNoneMatch)
+              .map(_.renderedValue)
+              .orElse(req.url.queryParam("since"))
+            _ <- routerRepo
+              .touch(router.id, Some(snap.etag))
+              .orElseFail(Response.internalServerError(""))
+            resp =
+              if ifNoneMatch.contains(snap.etag) then
+                Response
+                  .status(Status.NotModified)
+                  .addHeader(Header.ETag.Strong(stripQuotes(snap.etag)))
+              else
+                Response
+                  .json(snap.toJson)
+                  .addHeader(Header.ETag.Strong(stripQuotes(snap.etag)))
+          yield resp
+        },
+      Method.GET / "api" / "blocklists" / string("file") ->
+        handler { (file: String, req: Request) =>
+          for
+            _    <- routerAuth.authenticate(req)
+            cat  <- ZIO
+              .succeed(file.stripSuffix(".rpz"))
+              .filterOrFail(_ != file)(Response.notFound("expected .rpz suffix"))
+            out  <- policy.renderRpz(cat).orElseFail(Response.internalServerError(""))
+            resp <- ZIO
+              .fromOption(out)
+              .mapBoth(
+                _ => Response.notFound(s"unknown category: $cat"),
+                { case (etag, body) =>
+                  val ifNone = req.header(Header.IfNoneMatch).map(_.renderedValue)
+                  if ifNone.contains(etag) then
+                    Response
+                      .status(Status.NotModified)
+                      .addHeader(Header.ETag.Strong(stripQuotes(etag)))
+                  else
+                    Response(
+                      status = Status.Ok,
+                      headers = Headers(
+                        Header.ContentType(MediaType("text", "dns")),
+                        Header.ETag.Strong(stripQuotes(etag)),
+                      ),
+                      body = Body.fromString(body),
+                    )
+                },
+              )
+          yield resp
+        },
+    )
+
+  private def stripQuotes(s: String): String =
+    if s.startsWith("\"") && s.endsWith("\"") then s.drop(1).dropRight(1) else s
+
+  private def newToken(prefix: String): String =
+    val bytes = new Array[Byte](32)
+    new SecureRandom().nextBytes(bytes)
+    prefix + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+
+/** Admin-only routes for managing routers (visible in admin UI). */
+object AdminRouterRoutes:
+  def routes(
+      auth: AuthService,
+      routerRepo: RouterRepo,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.POST / "api" / "admin" / "routers"                  ->
+        handler { (req: Request) =>
+          for
+            _    <- requireAdmin(req, auth)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            cr   <- ZIO
+              .fromEither(body.fromJson[CreateRouterRequest])
+              .mapError(e => Response.badRequest(e))
+            _    <- ZIO
+              .fail(Response.badRequest("name required"))
+              .when(cr.name.trim.isEmpty)
+            enrollmentToken = newEnrollmentToken()
+            etHash          = PolicyService.hashToken(enrollmentToken)
+            id <- routerRepo
+              .create(cr.name.trim, etHash)
+              .orElseFail(Response.internalServerError(""))
+          yield Response.json(CreateRouterResponse(id, cr.name.trim, enrollmentToken).toJson)
+        },
+      Method.GET / "api" / "admin" / "routers"                   ->
+        handler { (req: Request) =>
+          for
+            _   <- requireAdmin(req, auth)
+            all <- routerRepo.listAll.orElseFail(Response.internalServerError(""))
+          yield Response.json(all.map(toSummary).toJson)
+        },
+      Method.DELETE / "api" / "admin" / "routers" / string("id") ->
+        handler { (id: String, req: Request) =>
+          for
+            _   <- requireAdmin(req, auth)
+            uid <- ZIO
+              .attempt(UUID.fromString(id))
+              .orElseFail(Response.badRequest("bad uuid"))
+            _   <- routerRepo.delete(uid).orElseFail(Response.internalServerError(""))
+          yield Response.ok
+        },
+    )
+
+  private def toSummary(r: Router): RouterSummary =
+    RouterSummary(
+      id = r.id,
+      name = r.name,
+      enrolled = r.tokenHash.isDefined,
+      lastSeenAt = r.lastSeenAt,
+      lastEtag = r.lastEtag,
+      createdAt = r.createdAt,
+    )
+
+  private def newEnrollmentToken(): String =
+    val bytes = new Array[Byte](24)
+    new SecureRandom().nextBytes(bytes)
+    "et_" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -1,0 +1,284 @@
+package familydns.api.feature
+
+import familydns.api.JwtConfig
+import familydns.api.auth.*
+import familydns.api.db.*
+import familydns.api.policy.*
+import familydns.api.routes.*
+import familydns.shared.*
+import familydns.shared.Clock.TestClock
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.time.LocalDate
+import java.util.UUID
+
+object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def makeAuth =
+    for
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def makePolicyService =
+    for
+      pr    <- ZIO.service[ProfileRepo]
+      sr    <- ZIO.service[ScheduleRepo]
+      tlr   <- ZIO.service[TimeLimitRepo]
+      stlr  <- ZIO.service[SiteTimeLimitRepo]
+      dr    <- ZIO.service[DeviceRepo]
+      blr   <- ZIO.service[BlocklistRepo]
+      ur    <- ZIO.service[TimeUsageRepo]
+      er    <- ZIO.service[TimeExtensionRepo]
+      clock <- ZIO.service[Clock]
+    yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, ur, er, clock)): PolicyService
+
+  /** Seed a router row with a known plain enrollment token, return (id, raw token). */
+  private def seedRouter(name: String): ZIO[RouterRepo, Throwable, (UUID, String)] =
+    for
+      rr <- ZIO.service[RouterRepo]
+      token = "et_" + UUID.randomUUID().toString.replace("-", "")
+      hash  = PolicyService.hashToken(token)
+      id <- rr.create(name, hash)
+    yield (id, token)
+
+  private def doRegister(routes: Routes[Any, Response], et: String): Task[Response] =
+    routes.runZIO(
+      Request.post(
+        URL.decode("/api/router/register").toOption.get,
+        Body.fromString(RegisterRouterRequest(et).toJson),
+      ),
+    )
+
+  def spec = suite("Router API")(
+    test("enrollment flow exchanges enrollment_token for router_token; row state updated") {
+      for
+        _        <- cleanDb
+        rr       <- ZIO.service[RouterRepo]
+        (id, et) <- seedRouter("home-gw")
+        routes = RouterRoutes.routes(rr, null, RouterAuthLive(rr))
+        resp <- doRegister(routes, et)
+        body <- resp.body.asString
+        out  <- ZIO.fromEither(body.fromJson[RegisterRouterResponse])
+        row  <- rr.findById(id).map(_.get)
+      yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(out.routerId == id) &&
+        assertTrue(out.routerToken.startsWith("rt_")) &&
+        assertTrue(row.enrollmentTokenHash.isEmpty) &&
+        assertTrue(row.tokenHash.contains(PolicyService.hashToken(out.routerToken)))
+    },
+    test("enrollment token is single-use: second register returns 401") {
+      for
+        _       <- cleanDb
+        rr      <- ZIO.service[RouterRepo]
+        (_, et) <- seedRouter("gw1")
+        routes = RouterRoutes.routes(rr, null, RouterAuthLive(rr))
+        first  <- doRegister(routes, et)
+        second <- doRegister(routes, et)
+      yield assertTrue(first.status == Status.Ok) &&
+        assertTrue(second.status == Status.Unauthorized)
+    },
+    test(
+      "policy without bearer → 401; wrong bearer → 401; right bearer → 200; persists last_etag",
+    ) {
+      for
+        _       <- cleanDb
+        rr      <- ZIO.service[RouterRepo]
+        ps      <- makePolicyService
+        (_, et) <- seedRouter("gw2")
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr))
+        regResp <- doRegister(routes, et)
+        regBody <- regResp.body.asString
+        reg     <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        noAuth  <- routes.runZIO(Request.get(URL.decode("/api/router/policy").toOption.get))
+        wrong   <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer("rt_wrong")),
+        )
+        ok      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+        row     <- rr.findById(reg.routerId).map(_.get)
+      yield assertTrue(noAuth.status == Status.Unauthorized) &&
+        assertTrue(wrong.status == Status.Unauthorized) &&
+        assertTrue(ok.status == Status.Ok) &&
+        assertTrue(row.lastEtag.exists(_.startsWith("\"sha256:")))
+    },
+    test(
+      "policy snapshot composition: devices, profiles, schedules, site_limits, blocklists, time_used",
+    ) {
+      for
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        stlr  <- ZIO.service[SiteTimeLimitRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        ur    <- ZIO.service[TimeUsageRepo]
+        rr    <- ZIO.service[RouterRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- tlr.upsert(kid, 120)
+        _     <- stlr.replaceForProfile(
+          kid,
+          List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")),
+        )
+        adult <- TestLayers.seedAdultsProfile(pr)
+        _     <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        _     <- TestLayers.seedDevice(dr, "11:22:33:44:55:66", "parent-phone", adult)
+        _     <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 12)
+        _     <- ur.incrementUsage("aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 47)
+        _     <- blr.insertBatch(List(("doubleclick.net", "ads"), ("ads.example.com", "ads")))
+        (_, et) <- seedRouter("gw")
+        ps      <- makePolicyService
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr))
+        regResp <- doRegister(routes, et)
+        regBody <- regResp.body.asString
+        reg     <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        resp    <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+        body    <- resp.body.asString
+        snap    <- ZIO.fromEither(body.fromJson[PolicySnapshot])
+        kp = snap.profiles.find(_.id == kid).get
+      yield assertTrue(snap.devices.size == 2) &&
+        assertTrue(snap.profiles.exists(_.id == kid)) &&
+        assertTrue(snap.profiles.exists(_.id == adult)) &&
+        assertTrue(snap.defaultProfileId.exists(id => snap.profiles.exists(_.id == id))) &&
+        assertTrue(kp.dailyMinutes.contains(120)) &&
+        assertTrue(kp.schedules.exists(_.blockFrom == "21:00")) &&
+        assertTrue(kp.siteLimits.exists(_.domain == "youtube.com")) &&
+        assertTrue(kp.timeUsedToday.totalMinutes == 47) &&
+        assertTrue(kp.timeUsedToday.byDomain.get("youtube.com").contains(12)) &&
+        assertTrue(snap.blocklists.contains("ads")) &&
+        assertTrue(snap.blocklists("ads").url == "/api/blocklists/ads.rpz")
+    },
+    test("etag deterministic across calls; If-None-Match → 304; mutation → fresh etag") {
+      for
+        _       <- cleanDb
+        pr      <- ZIO.service[ProfileRepo]
+        sr      <- ZIO.service[ScheduleRepo]
+        rr      <- ZIO.service[RouterRepo]
+        kid     <- TestLayers.seedKidsProfile(pr, sr)
+        ps      <- makePolicyService
+        (_, et) <- seedRouter("gw")
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr))
+        regResp <- doRegister(routes, et)
+        regBody <- regResp.body.asString
+        reg     <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        r1      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+        b1      <- r1.body.asString
+        s1      <- ZIO.fromEither(b1.fromJson[PolicySnapshot])
+        r2      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken))
+            .addHeader(Header.IfNoneMatch.ETags(NonEmptyChunk(s1.etag))),
+        )
+        _       <- pr.setPaused(kid, true)
+        r3      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+        b3      <- r3.body.asString
+        s3      <- ZIO.fromEither(b3.fromJson[PolicySnapshot])
+      yield assertTrue(r1.status == Status.Ok) &&
+        assertTrue(r2.status == Status.NotModified) &&
+        assertTrue(r3.status == Status.Ok) &&
+        assertTrue(s1.etag != s3.etag)
+    },
+    test("RPZ blocklist: 200 with formatted body, 401 unauth, 404 unknown") {
+      for
+        _       <- cleanDb
+        rr      <- ZIO.service[RouterRepo]
+        blr     <- ZIO.service[BlocklistRepo]
+        ps      <- makePolicyService
+        _       <- blr.insertBatch(List(("doubleclick.net", "ads"), ("ads.example.com", "ads")))
+        (_, et) <- seedRouter("gw")
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr))
+        regResp <- doRegister(routes, et)
+        regBody <- regResp.body.asString
+        reg     <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        noAuth  <- routes.runZIO(Request.get(URL.decode("/api/blocklists/ads.rpz").toOption.get))
+        ok      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/blocklists/ads.rpz").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+        okBody  <- ok.body.asString
+        nf      <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/blocklists/nonsense.rpz").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken)),
+        )
+      yield assertTrue(noAuth.status == Status.Unauthorized) &&
+        assertTrue(ok.status == Status.Ok) &&
+        assertTrue(okBody.contains("$ORIGIN ads.rpz.")) &&
+        assertTrue(okBody.contains("doubleclick.net CNAME .")) &&
+        assertTrue(okBody.contains("ads.example.com CNAME .")) &&
+        assertTrue(ok.header(Header.ContentType).exists(_.renderedValue.startsWith("text/dns"))) &&
+        assertTrue(ok.header(Header.ETag).isDefined) &&
+        assertTrue(nf.status == Status.NotFound)
+    },
+    test("admin can create router; non-admin gets 403; row stores enrollment hash, no token yet") {
+      for
+        _          <- cleanDb
+        auth       <- makeAuth
+        rr         <- ZIO.service[RouterRepo]
+        ur         <- ZIO.service[UserRepo]
+        adminLogin <- auth.login("admin", "changeme")
+        h          <- auth.hashPassword("kp")
+        _          <- ur.create("kid", h, "child")
+        kidLogin   <- auth.login("kid", "kp")
+        adminRoutes = AdminRouterRoutes.routes(auth, rr)
+        rejected <- adminRoutes.runZIO(
+          Request
+            .post(
+              URL.decode("/api/admin/routers").toOption.get,
+              Body.fromString(CreateRouterRequest("home").toJson),
+            )
+            .addHeader(Header.Authorization.Bearer(kidLogin.token)),
+        )
+        ok       <- adminRoutes.runZIO(
+          Request
+            .post(
+              URL.decode("/api/admin/routers").toOption.get,
+              Body.fromString(CreateRouterRequest("home").toJson),
+            )
+            .addHeader(Header.Authorization.Bearer(adminLogin.token)),
+        )
+        okBody   <- ok.body.asString
+        out      <- ZIO.fromEither(okBody.fromJson[CreateRouterResponse])
+        row      <- rr.findById(out.routerId).map(_.get)
+      yield assertTrue(rejected.status == Status.Forbidden) &&
+        assertTrue(ok.status == Status.Ok) &&
+        assertTrue(out.enrollmentToken.startsWith("et_")) &&
+        assertTrue(row.tokenHash.isEmpty) &&
+        assertTrue(row.enrollmentTokenHash.contains(PolicyService.hashToken(out.enrollmentToken)))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -254,3 +254,61 @@ case class BlockEvent(
     reason: String,
     ts: String,
 ) derives JsonCodec
+
+// ── Router enrollment & policy snapshot ───────────────────────────────────
+
+case class CreateRouterRequest(name: String) derives JsonCodec
+case class CreateRouterResponse(
+    routerId: UUID,
+    name: String,
+    enrollmentToken: String,
+) derives JsonCodec
+
+case class RouterSummary(
+    id: UUID,
+    name: String,
+    enrolled: Boolean,
+    lastSeenAt: Option[String],
+    lastEtag: Option[String],
+    createdAt: String,
+) derives JsonCodec
+
+case class RegisterRouterRequest(
+    enrollmentToken: String,
+    routerName: Option[String] = None,
+    openwrtVersion: Option[String] = None,
+    agentVersion: Option[String] = None,
+) derives JsonCodec
+
+case class RegisterRouterResponse(
+    routerId: UUID,
+    routerToken: String,
+) derives JsonCodec
+
+case class PolicyDevice(mac: String, profileId: Long, name: String) derives JsonCodec
+case class PolicySchedule(days: List[String], blockFrom: String, blockUntil: String)
+    derives JsonCodec
+case class PolicySiteLimit(domain: String, minutes: Int, label: String) derives JsonCodec
+case class PolicyTimeUsedToday(totalMinutes: Int, byDomain: Map[String, Int]) derives JsonCodec
+case class PolicyProfile(
+    id: Long,
+    name: String,
+    paused: Boolean,
+    blockedCategories: List[String],
+    extraBlocked: List[String],
+    extraAllowed: List[String],
+    schedules: List[PolicySchedule],
+    dailyMinutes: Option[Int],
+    siteLimits: List[PolicySiteLimit],
+    timeUsedToday: PolicyTimeUsedToday,
+    extensionsTodayMinutes: Int,
+) derives JsonCodec
+case class PolicyBlocklist(version: String, url: String) derives JsonCodec
+case class PolicySnapshot(
+    etag: String,
+    generatedAt: String,
+    defaultProfileId: Option[Long],
+    devices: List[PolicyDevice],
+    profiles: List[PolicyProfile],
+    blocklists: Map[String, PolicyBlocklist],
+) derives JsonCodec

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { TimePage } from '@/pages/TimePage'
 import { LogsPage } from '@/pages/LogsPage'
 import { AccountPage } from '@/pages/AccountPage'
 import { UsersPage } from '@/pages/UsersPage'
+import { RoutersPage } from '@/pages/RoutersPage'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -38,6 +39,7 @@ function AppRoutes() {
         <Route path="logs"      element={<LogsPage />} />
         <Route path="account"   element={<AccountPage />} />
         <Route path="users"     element={<RequireAdmin><UsersPage /></RequireAdmin>} />
+        <Route path="routers"   element={<RequireAdmin><RoutersPage /></RequireAdmin>} />
       </Route>
     </Routes>
   )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,7 +1,8 @@
 import type {
-  CreateUserRequest, DashboardStats, Device, DeviceTimeStatus, LoginResponse,
-  MeResponse, ProfileDetail, QueryLog, SetUserProfilesRequest, TimeExtension,
-  UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest, User,
+  CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardStats, Device,
+  DeviceTimeStatus, LoginResponse, MeResponse, ProfileDetail, QueryLog, RouterSummary,
+  SetUserProfilesRequest, TimeExtension, UpsertDeviceRequest, UpsertProfileRequest,
+  GrantExtensionRequest, User,
 } from '@/types/api'
 
 const BASE = '/api'
@@ -124,5 +125,13 @@ export const api = {
   blocklists: {
     counts: () => req<{ category: string; count: number }[]>('GET', '/blocklists'),
     clearCategory: (cat: string) => req<void>('POST', `/blocklists/${cat}/clear`, {}),
+  },
+
+  // ── Routers (admin) ────────────────────────────────────────────────────
+  routers: {
+    list: () => req<RouterSummary[]>('GET', '/admin/routers'),
+    create: (data: CreateRouterRequest) =>
+      req<CreateRouterResponse>('POST', '/admin/routers', data),
+    delete: (id: string) => req<void>('DELETE', `/admin/routers/${id}`),
   },
 }

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -11,6 +11,7 @@ const navItems: NavItem[] = [
   { to: '/time',      label: 'Screen Time', icon: '◷' },
   { to: '/logs',      label: 'Logs',      icon: '≡' },
   { to: '/users',     label: 'Users',     icon: '◐', adminOnly: true },
+  { to: '/routers',   label: 'Routers',   icon: '⬢', adminOnly: true },
 ]
 
 export function Layout() {

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from 'react'
+import { api } from '@/api/client'
+import type { CreateRouterResponse, RouterSummary } from '@/types/api'
+import { PageLoader } from './DashboardPage'
+
+export function RoutersPage() {
+  const [routers, setRouters] = useState<RouterSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [name, setName] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showToken, setShowToken] = useState<CreateRouterResponse | null>(null)
+
+  async function reload() {
+    const list = await api.routers.list()
+    setRouters(list)
+  }
+
+  useEffect(() => {
+    reload().finally(() => setLoading(false))
+  }, [])
+
+  async function saveCreate() {
+    if (!name.trim()) { setError('Name is required'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const out = await api.routers.create({ name: name.trim() })
+      setCreating(false)
+      setName('')
+      setShowToken(out)
+      await reload()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create router')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function del(r: RouterSummary) {
+    if (!confirm(`Delete router "${r.name}"? Its agent will lose access. This cannot be undone.`)) return
+    try {
+      await api.routers.delete(r.id)
+      await reload()
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to delete')
+    }
+  }
+
+  if (loading) return <PageLoader />
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-white">Routers</h1>
+        <button
+          onClick={() => { setCreating(true); setError(null); setName('') }}
+          className="bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold px-4 py-2 rounded-xl transition-colors"
+        >
+          + Enroll Router
+        </button>
+      </div>
+
+      <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        {routers.length === 0
+          ? <p className="p-6 text-gray-500 text-sm">No routers enrolled yet.</p>
+          : routers.map(r => (
+              <div key={r.id} className="flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0">
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-white truncate">{r.name}</p>
+                  <p className="text-xs text-gray-500 mt-0.5 flex items-center gap-2">
+                    <span className={`inline-block px-2 py-0.5 rounded font-mono ${
+                      r.enrolled
+                        ? 'bg-emerald-500/10 text-emerald-400'
+                        : 'bg-yellow-500/10 text-yellow-400'
+                    }`}>{r.enrolled ? 'enrolled' : 'pending'}</span>
+                    {r.lastSeenAt
+                      ? <span>last seen {new Date(r.lastSeenAt).toLocaleString()}</span>
+                      : <span>never seen</span>
+                    }
+                  </p>
+                </div>
+                <button
+                  onClick={() => del(r)}
+                  className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
+                >Delete</button>
+              </div>
+            ))
+        }
+      </div>
+
+      {creating && (
+        <Modal title="Enroll a Router" onClose={() => setCreating(false)}>
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+              {error}
+            </div>
+          )}
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Name</label>
+            <input type="text" value={name} autoFocus
+              onChange={e => setName(e.target.value)}
+              placeholder="home-gw"
+              className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500" />
+          </div>
+          <p className="text-sm text-gray-400">
+            We'll generate a one-time enrollment token. Paste it into the
+            OpenWRT package's UCI config (<code className="font-mono text-gray-300">/etc/config/familydns</code>),
+            then start the agent. The token is single-use.
+          </p>
+          <div className="flex gap-3 pt-2">
+            <button onClick={() => setCreating(false)} disabled={saving}
+              className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
+              Cancel
+            </button>
+            <button onClick={saveCreate} disabled={saving}
+              className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
+              {saving ? 'Generating…' : 'Generate Token'}
+            </button>
+          </div>
+        </Modal>
+      )}
+
+      {showToken && (
+        <Modal title="Save this token now" onClose={() => setShowToken(null)}>
+          <div className="bg-yellow-500/10 border border-yellow-500/30 text-yellow-300 text-sm rounded-xl px-4 py-3">
+            <strong>This token will not be shown again.</strong> Copy it
+            into the router's UCI config before closing this dialog.
+          </div>
+          <div>
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Enrollment token for {showToken.name}
+            </label>
+            <code className="block w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-emerald-300 font-mono text-sm break-all">
+              {showToken.enrollmentToken}
+            </code>
+          </div>
+          <button
+            onClick={() => navigator.clipboard?.writeText(showToken.enrollmentToken)}
+            className="w-full py-2 rounded-xl bg-gray-800 text-gray-200 text-sm font-medium hover:bg-gray-700"
+          >
+            Copy to clipboard
+          </button>
+          <button
+            onClick={() => setShowToken(null)}
+            className="w-full py-3 rounded-xl bg-emerald-500 text-black font-semibold"
+          >
+            I've saved it — close
+          </button>
+        </Modal>
+      )}
+    </div>
+  )
+}
+
+function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto" onClick={onClose}>
+      <div
+        className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-lg my-8 p-6 space-y-5 max-h-[90vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-white">{title}</h3>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -185,3 +185,24 @@ export interface GrantExtensionRequest {
   extraMinutes: number
   note: string | null
 }
+
+// ── Routers ────────────────────────────────────────────────────────────────
+
+export interface RouterSummary {
+  id: string
+  name: string
+  enrolled: boolean
+  lastSeenAt: string | null
+  lastEtag: string | null
+  createdAt: string
+}
+
+export interface CreateRouterRequest {
+  name: string
+}
+
+export interface CreateRouterResponse {
+  routerId: string
+  name: string
+  enrollmentToken: string
+}


### PR DESCRIPTION
## Summary

Implements the gating piece of the OpenWRT re-architecture — the agent-facing policy poll plus RPZ blocklist endpoint plus enrollment flow plus the admin UI page that issues enrollment tokens.

- `POST /api/router/register` — exchange one-time enrollment token for a long-lived router token. Both tokens are stored only as SHA-256 hashes (V2 columns from #67).
- `GET /api/router/policy?since=<etag>` — full enforcement snapshot (devices, profiles + schedules + time limits + `time_used_today`, blocklist versions). Deterministic ETag, 304 on `If-None-Match`. Persists `last_etag`/`last_seen_at`.
- `GET /api/blocklists/<cat>.rpz` — RPZ-formatted (text/dns) blocklist. Versioned ETag.
- `PolicyService` composes the snapshot using the injected `Clock` from #47 against the V2 schema.
- `RouterAuth` bearer middleware on `/api/router/policy` and `/api/blocklists/*`. `/register` is unauthed by design (one-time token consumes itself).
- Admin endpoints `POST/GET/DELETE /api/admin/routers` (admin JWT) and a new `RoutersPage` gated behind `RequireAdmin`. Enrollment token shown **once** with a "save this now" warning; lists enrolled routers + last-seen.

Spec: [docs/architecture-openwrt.md](https://github.com/sameerparekh/familydns/pull/74). Schema: [V2__openwrt.sql](https://github.com/sameerparekh/familydns/pull/67).

## Coordination

- [#69](https://github.com/sameerparekh/familydns/issues/69) (router ingest: `/usage`, `/events`) is being worked in parallel. Both PRs touch `api/src/Main.scala` (route wiring) and `api/src/db/Repos.scala` (`RouterRepo`). `RouterAuth` is currently defined inline at the top of `api/src/routes/RouterRoutes.scala`; #69's separate `RouterAuth.scala` can drop in to replace it on merge — same hash function (`sha256Hex`), same shape.
- #70 (`/decision` + public `/blocked`) and #71 (delete `dns/`, `traffic/`) follow.

## Test plan

- [x] `mill api.test` — 7 new feature tests in `RouterApiSpec` cover: enrollment single-use, bearer auth (missing/wrong/right), snapshot composition, ETag determinism + 304, RPZ formatting, admin gating. All existing api tests still pass.
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 8/8 web tests pass
- [x] `mill api.compile` and pre-commit `scalafmt --check` clean

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)