### PR TITLE
Add openwrt/ package skeleton with conntrack connection_attempt event watcher (closes #93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,27 @@ jobs:
           done
           exit $fail
 
+  # ── OpenWrt agent: Lua unit tests ───────────────────────────────────────
+  lua-tests:
+    name: OpenWrt Lua Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Lua + luarocks + lua-cjson
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y lua5.4 luarocks lua-cjson
+
+      - name: Install busted
+        run: luarocks install busted
+
+      - name: Run openwrt agent tests
+        working-directory: openwrt
+        run: |
+          LUA_PATH="./files/usr/lib/familydns/?.lua;$(lua5.4 -e 'print(package.path)')" \
+            busted test/conntrack_spec.lua
+
   # ── Frontend: type-check, lint, build ────────────────────────────────────
   frontend:
     name: Frontend Build & Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,18 +128,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Lua + luarocks + lua-cjson
+      - name: Install Lua + busted + lua-cjson
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y lua5.4 luarocks lua-cjson
-
-      - name: Install busted
-        run: luarocks install busted
+          # lua5.1 matches OpenWrt 23.x (LuaJIT is 5.1-compatible).
+          # liblua5.1-dev is needed for luarocks to compile C modules.
+          sudo apt-get install -y lua5.1 liblua5.1-dev luarocks
+          sudo luarocks install busted
+          sudo luarocks install lua-cjson
 
       - name: Run openwrt agent tests
         working-directory: openwrt
         run: |
-          LUA_PATH="./files/usr/lib/familydns/?.lua;$(lua5.4 -e 'print(package.path)')" \
+          LUA_PATH="./files/usr/lib/familydns/?.lua;$(lua -e 'print(package.path)')" \
             busted test/conntrack_spec.lua
 
   # ── Frontend: type-check, lint, build ────────────────────────────────────

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=familydns
+PKG_VERSION:=0.1.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=FamilyDNS <noreply@example.com>
+PKG_LICENSE:=MIT
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/familydns
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=FamilyDNS router agent
+  DEPENDS:=+lua +luci-lib-jsonc +conntrack-tools +curl
+  PKGARCH:=all
+endef
+
+define Package/familydns/description
+  Agent daemon that enforces per-device DNS filtering and time limits,
+  accounts traffic, and reports connection events to the FamilyDNS API.
+endef
+
+define Build/Compile
+endef
+
+define Package/familydns/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/familydns-agent $(1)/usr/sbin/
+
+	$(INSTALL_DIR) $(1)/usr/lib/familydns
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/usr/lib/familydns/*.lua $(1)/usr/lib/familydns/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/familydns $(1)/etc/init.d/
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/config/familydns $(1)/etc/config/
+endef
+
+define Package/familydns/postinst
+#!/bin/sh
+[ -n "$${IPKG_INSTROOT}" ] && exit 0
+/etc/init.d/familydns enable
+endef
+
+$(eval $(call BuildPackage,familydns))

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,0 +1,89 @@
+# familydns OpenWrt package
+
+OpenWrt 23.x agent for FamilyDNS. Enforces per-device DNS filtering via dnsmasq + nftables and reports traffic to the FamilyDNS API.
+
+## Package contents
+
+```
+openwrt/
+├── Makefile                               opkg metadata (OpenWrt SDK)
+├── files/
+│   ├── etc/init.d/familydns               procd init script
+│   ├── etc/config/familydns               UCI config (api_url, router_token, …)
+│   ├── usr/sbin/familydns-agent           main daemon entry point (Lua)
+│   └── usr/lib/familydns/
+│       └── conntrack.lua                  conntrack new-flow watcher + event batcher
+└── test/
+    └── conntrack_spec.lua                 busted unit tests for conntrack.lua
+```
+
+`policy.lua`, `usage.lua`, and `render.lua` land in #72.
+
+## Dependencies
+
+Installed automatically by opkg when you install the package:
+
+- `lua` — Lua 5.1 interpreter
+- `luci-lib-jsonc` — provides `cjson` for JSON encoding
+- `conntrack-tools` — provides `conntrack -E -e NEW`
+- `curl` — used by the agent for HTTP POSTs
+
+## Build (OpenWrt SDK)
+
+```sh
+# From inside an OpenWrt SDK checkout
+cp -r /path/to/familydns/openwrt package/familydns
+make package/familydns/compile V=s
+# .ipk appears in bin/packages/<arch>/base/
+```
+
+## Flash
+
+```sh
+scp bin/packages/.../familydns_*.ipk root@192.168.1.1:/tmp/
+ssh root@192.168.1.1 opkg install /tmp/familydns_*.ipk
+```
+
+## Enrollment
+
+1. In the FamilyDNS admin UI → Routers → **Add router**. Copy the enrollment token.
+2. On the router:
+
+```sh
+curl -s -X POST http://<api-host>:8080/api/router/register \
+  -H 'Content-Type: application/json' \
+  -d '{"enrollment_token":"et_...","router_name":"home-gw","openwrt_version":"23.05.3","agent_version":"0.1.0"}'
+# → {"router_id":"...","router_token":"rt_..."}
+```
+
+3. Write the returned values to UCI:
+
+```sh
+uci set familydns.@familydns[0].api_url='http://<api-host>:8080'
+uci set familydns.@familydns[0].router_id='<router_id>'
+uci set familydns.@familydns[0].router_token='<router_token>'
+uci commit familydns
+/etc/init.d/familydns restart
+```
+
+## Running tests
+
+Tests require [busted](https://olivinelabs.com/busted/) and `lua-cjson`:
+
+```sh
+luarocks install busted
+luarocks install lua-cjson
+busted openwrt/test/conntrack_spec.lua
+```
+
+## conntrack hook: design rationale
+
+`conntrack -E -e NEW` is used rather than nftables `meta nftrace` because:
+
+- Available on stock OpenWrt 23.x via the `conntrack-tools` package without enabling per-rule tracing.
+- Produces line-oriented output that can be consumed with a simple `io.popen` loop in Lua.
+- `meta nftrace` requires a matching `nftrace` rule on every chain and produces verbose output that is harder to parse safely.
+
+Hostname attribution uses the `nft_sets` table populated by `render.lua` from dnsmasq `--ipset=` callbacks (§6.2 of `docs/architecture-openwrt.md`). Reverse DNS is intentionally avoided because CDN PTR records do not reflect what the user resolved.
+
+Both allowed and blocked flows are reported so the admin UI shows a complete connection timeline, not just block events.

--- a/openwrt/files/etc/config/familydns
+++ b/openwrt/files/etc/config/familydns
@@ -1,0 +1,24 @@
+config familydns 'familydns'
+	# Base URL of the familydns API server (HTTP, no trailing slash)
+	option api_url 'http://192.168.1.1:8080'
+
+	# Long-lived router bearer token obtained during enrollment
+	option router_token ''
+
+	# Router UUID returned during enrollment
+	option router_id ''
+
+	# LAN subnet prefix used to identify outbound (egress) flows
+	option lan_prefix '192.168.1.'
+
+	# How many connection_attempt events to accumulate before flushing
+	option event_batch_size '50'
+
+	# Force-flush the event batch after this many seconds even if not full
+	option event_flush_interval '10'
+
+	# How often (seconds) to poll for a new policy snapshot
+	option policy_poll_interval '60'
+
+	# How often (seconds) to POST usage counters
+	option usage_report_interval '300'

--- a/openwrt/files/etc/init.d/familydns
+++ b/openwrt/files/etc/init.d/familydns
@@ -1,0 +1,18 @@
+#!/bin/sh /etc/rc.common
+# procd init script for familydns-agent
+
+USE_PROCD=1
+START=95
+STOP=10
+
+start_service() {
+    procd_open_instance
+    procd_set_param command /usr/sbin/familydns-agent
+    procd_set_param respawn 3600 5 5
+    procd_set_param stderr 1
+    procd_close_instance
+}
+
+service_triggers() {
+    procd_add_reload_trigger "familydns"
+}

--- a/openwrt/files/usr/lib/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/familydns/conntrack.lua
@@ -1,0 +1,286 @@
+-- conntrack.lua — conntrack new-flow watcher + event batcher for familydns-agent
+--
+-- Design notes:
+--   * conntrack -E -e NEW (conntrack-tools package) is used rather than nftables
+--     meta nftrace because it is available on stock OpenWrt 23.x without enabling
+--     per-rule tracing and produces structured, line-oriented output suitable for
+--     a Lua io.popen loop.
+--   * Hostname attribution uses the in-memory nft_sets table that render.lua
+--     populates from dnsmasq --ipset= callbacks.  We look up dest_ip against that
+--     table to recover the hostname the client resolved, NOT reverse DNS.
+--   * Both allowed and blocked flows are batched.  Blocking state comes from the
+--     same nft_sets/policy tables that render.lua writes; we read them but never
+--     modify them here.
+
+local M = {}
+
+-- ---------------------------------------------------------------------------
+-- ipset_lookup_hostname(dest_ip, nft_sets) -> string | nil
+--
+-- nft_sets: { hostname -> { ip -> true } }  (maintained by render.lua)
+-- Returns the hostname whose set contains dest_ip, or nil.
+-- ---------------------------------------------------------------------------
+function M.ipset_lookup_hostname(dest_ip, nft_sets)
+  for hostname, ips in pairs(nft_sets) do
+    if ips[dest_ip] then
+      return hostname
+    end
+  end
+  return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- arp_lookup_mac(src_ip, arp_table) -> string | nil
+--
+-- arp_table: { ip -> mac }  (populated by parse_arp_table())
+-- ---------------------------------------------------------------------------
+function M.arp_lookup_mac(src_ip, arp_table)
+  return arp_table[src_ip]
+end
+
+-- ---------------------------------------------------------------------------
+-- parse_arp_table() -> { ip -> mac }
+--
+-- Reads /proc/net/arp at call time.  Called per-event so the MAC table stays
+-- fresh without a background refresh loop.
+-- ---------------------------------------------------------------------------
+function M.parse_arp_table()
+  local result = {}
+  local f = io.open("/proc/net/arp", "r")
+  if not f then return result end
+  f:read("*l")  -- skip header
+  for line in f:lines() do
+    local ip, _, _, mac = line:match("^(%S+)%s+%S+%s+%S+%s+(%S+)%s+")
+    -- mac field is 4th column; re-match properly
+    local parts = {}
+    for w in line:gmatch("%S+") do parts[#parts + 1] = w end
+    -- /proc/net/arp columns: IP, HWtype, Flags, HWaddr, Mask, Device
+    if #parts >= 4 and parts[4] ~= "00:00:00:00:00:00" then
+      result[parts[1]] = parts[4]
+    end
+  end
+  f:close()
+  return result
+end
+
+-- ---------------------------------------------------------------------------
+-- build_event(opts) -> table
+--
+-- opts: { mac, hostname, dest_ip, allowed, reason, ts }
+-- hostname nil → falls back to dest_ip.
+-- reason nil → "allow" when allowed=true, "blocked" when false.
+-- Returns a Lua table ready for JSON encoding.
+-- ---------------------------------------------------------------------------
+function M.build_event(opts)
+  local hostname = opts.hostname or opts.dest_ip
+  local reason
+  if opts.reason then
+    reason = opts.reason
+  elseif opts.allowed then
+    reason = "allow"
+  else
+    reason = "blocked"
+  end
+  return {
+    ["type"]    = "connection_attempt",
+    mac         = opts.mac,
+    hostname    = hostname,
+    dest_ip     = opts.dest_ip,
+    allowed     = opts.allowed,
+    reason      = reason,
+    ts          = opts.ts,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- new_batcher(max_size, flush_interval_sec, flush_fn) -> batcher
+--
+-- Returns an object with:
+--   batcher.add(event)   — append event; auto-flush when buffer hits max_size
+--   batcher.flush()      — flush whatever is pending (no-op if empty)
+--   batcher.tick(now)    — call periodically; flushes if interval has elapsed
+--
+-- flush_fn(events) is called with the list of accumulated events.
+-- ---------------------------------------------------------------------------
+function M.new_batcher(max_size, flush_interval_sec, flush_fn)
+  local buf          = {}
+  local last_flush   = os.time()
+
+  local self = {}
+
+  function self.flush()
+    if #buf == 0 then return end
+    local to_send = buf
+    buf = {}
+    flush_fn(to_send)
+  end
+
+  function self.add(event)
+    buf[#buf + 1] = event
+    if #buf >= max_size then
+      self.flush()
+    end
+  end
+
+  function self.tick(now)
+    now = now or os.time()
+    if (now - last_flush) >= flush_interval_sec then
+      last_flush = now
+      self.flush()
+    end
+  end
+
+  return self
+end
+
+-- ---------------------------------------------------------------------------
+-- post_with_retry(url, body, max_retries, base_delay, post_fn, sleep_fn) -> bool
+--
+-- post_fn(url, body) -> status_code, body_str
+-- sleep_fn(seconds)  — injectable for tests (defaults to os.execute("sleep N"))
+--
+-- Retries on 5xx / connection errors with exponential back-off.
+-- Does NOT retry on 4xx (client errors are not transient).
+-- Returns true on success, false after max_retries are exhausted.
+-- Never blocks a caller waiting longer than necessary; callers should run this
+-- in a coroutine or dedicate a goroutine-equivalent (Lua co-routine) if needed.
+-- ---------------------------------------------------------------------------
+function M.post_with_retry(url, body, max_retries, base_delay, post_fn, sleep_fn)
+  sleep_fn = sleep_fn or function(s)
+    os.execute("sleep " .. tostring(math.floor(s)))
+  end
+
+  local delay = base_delay
+  for attempt = 1, max_retries do
+    local status, _ = post_fn(url, body)
+    if status and status >= 200 and status < 300 then
+      return true
+    end
+    if status and status >= 400 and status < 500 then
+      -- Client error: no point retrying.
+      return false
+    end
+    -- 5xx or nil (connection failure): retry with back-off.
+    if attempt < max_retries then
+      sleep_fn(delay)
+      delay = delay * 2
+    end
+  end
+  return false
+end
+
+-- ---------------------------------------------------------------------------
+-- parse_conntrack_line(line) -> { src_ip, dst_ip, proto, dport } | nil
+--
+-- Parses a line from `conntrack -E -e NEW`.  Example input:
+--   [NEW] tcp 6 120 SYN_SENT src=192.168.1.42 dst=1.2.3.4 sport=54321 dport=443 ...
+-- ---------------------------------------------------------------------------
+function M.parse_conntrack_line(line)
+  if not line:find("%[NEW%]") then return nil end
+  local proto  = line:match("%[NEW%]%s+(%a+)")
+  local src_ip = line:match("src=(%S+)")
+  local dst_ip = line:match("dst=(%S+)")
+  local dport  = line:match("dport=(%d+)")
+  if not (src_ip and dst_ip) then return nil end
+  return { src_ip = src_ip, dst_ip = dst_ip, proto = proto, dport = tonumber(dport) }
+end
+
+-- ---------------------------------------------------------------------------
+-- is_outbound(flow, lan_prefix) -> bool
+--
+-- Returns true when the source IP is on the LAN (egress flow).
+-- lan_prefix example: "192.168.1."
+-- ---------------------------------------------------------------------------
+function M.is_outbound(flow, lan_prefix)
+  return flow.src_ip:sub(1, #lan_prefix) == lan_prefix
+end
+
+-- ---------------------------------------------------------------------------
+-- watch(cfg) — blocking event loop; called from the main agent daemon
+--
+-- cfg: {
+--   router_id      string    UUID of this router
+--   api_url        string    base URL, e.g. "http://192.168.1.1:8080"
+--   router_token   string    bearer token
+--   nft_sets       table     shared ref: { hostname -> { ip -> true } }
+--   blocked_ips    table     shared ref: { ip -> true }  (filled by render.lua)
+--   blocked_reason table     shared ref: { ip -> reason_string }
+--   lan_prefix     string    default "192.168.1."
+--   max_batch      int       default 50
+--   flush_interval int       default 10  (seconds)
+--   max_retries    int       default 3
+--   base_delay     int       default 2   (seconds, doubles each retry)
+--   http_post      function  injectable: post_fn(url, body) -> status, body
+--   sleep_fn       function  injectable for tests
+-- }
+-- ---------------------------------------------------------------------------
+function M.watch(cfg)
+  local json       = require("cjson")
+  local lan_prefix = cfg.lan_prefix     or "192.168.1."
+  local max_batch  = cfg.max_batch      or 50
+  local flush_int  = cfg.flush_interval or 10
+  local max_retry  = cfg.max_retries    or 3
+  local base_delay = cfg.base_delay     or 2
+
+  local events_url = cfg.api_url .. "/api/router/events"
+
+  local function do_post(url, body)
+    return cfg.http_post(url, body, {
+      ["Authorization"] = "Bearer " .. cfg.router_token,
+      ["Content-Type"]  = "application/json",
+    })
+  end
+
+  local batcher = M.new_batcher(max_batch, flush_int, function(events)
+    local payload = json.encode({
+      router_id = cfg.router_id,
+      events    = events,
+    })
+    local ok = M.post_with_retry(events_url, payload, max_retry, base_delay, do_post, cfg.sleep_fn)
+    if not ok then
+      -- best-effort: log and continue; never block a flow waiting for the API
+      io.stderr:write("[familydns] conntrack: failed to POST events batch after retries, dropping\n")
+    end
+  end)
+
+  local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
+  if not handle then
+    io.stderr:write("[familydns] conntrack: cannot start conntrack -E -e NEW\n")
+    return
+  end
+
+  while true do
+    local line = handle:read("*l")
+    if not line then break end
+
+    local flow = M.parse_conntrack_line(line)
+    if flow and M.is_outbound(flow, lan_prefix) then
+      local arp   = M.parse_arp_table()
+      local mac   = M.arp_lookup_mac(flow.src_ip, arp)
+      local hname = M.ipset_lookup_hostname(flow.dst_ip, cfg.nft_sets or {})
+
+      local allowed = not (cfg.blocked_ips and cfg.blocked_ips[flow.dst_ip])
+      local reason
+      if not allowed and cfg.blocked_reason then
+        reason = cfg.blocked_reason[flow.dst_ip]
+      end
+
+      local ev = M.build_event({
+        mac      = mac,
+        hostname = hname,
+        dest_ip  = flow.dst_ip,
+        allowed  = allowed,
+        reason   = reason,
+        ts       = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+      })
+      batcher.add(ev)
+    end
+
+    batcher.tick()
+  end
+
+  handle:close()
+  batcher.flush()
+end
+
+return M

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -1,0 +1,81 @@
+#!/usr/bin/lua
+-- familydns-agent — main daemon for the familydns OpenWrt package
+--
+-- Three concurrent responsibilities (run in co-operative timer loop):
+--   1. Policy timer  (60 s)  — GET /api/router/policy; rewrite dnsmasq + nft config
+--   2. Usage timer   (5 min) — scrape nft counters; POST /api/router/usage
+--   3. Event watcher (async) — watch conntrack NEW flows; POST /api/router/events
+--
+-- This file wires them together and reads UCI config.  The actual logic lives in
+-- the usr/lib/familydns/*.lua modules so they can be unit-tested independently.
+--
+-- Modules #72 will add: policy.lua, usage.lua, render.lua.
+-- This commit adds: conntrack.lua (event watcher) and the agent skeleton.
+
+local uci      = require("uci")
+local conntrack = require("familydns.conntrack")
+
+-- ── Read UCI config ─────────────────────────────────────────────────────────
+
+local cursor = uci.cursor()
+local cfg_section = "familydns"
+
+local function uci_get(opt, default)
+  return cursor:get(cfg_section, "@familydns[0]", opt) or default
+end
+
+local api_url      = uci_get("api_url",      "http://192.168.1.1:8080")
+local router_token = uci_get("router_token", "")
+local router_id    = uci_get("router_id",    "")
+local lan_prefix   = uci_get("lan_prefix",   "192.168.1.")
+local max_batch    = tonumber(uci_get("event_batch_size", "50"))
+local flush_int    = tonumber(uci_get("event_flush_interval", "10"))
+
+if router_token == "" then
+  io.stderr:write("[familydns] router_token not set — run enrollment first\n")
+  os.exit(1)
+end
+if router_id == "" then
+  io.stderr:write("[familydns] router_id not set — run enrollment first\n")
+  os.exit(1)
+end
+
+-- ── Shared state (populated by render.lua on each policy reload) ─────────────
+-- Other modules write into these tables; conntrack.lua reads them.
+
+local nft_sets     = {}   -- { hostname -> { ip -> true } }
+local blocked_ips  = {}   -- { ip -> true }
+local blocked_reason = {} -- { ip -> reason_string }
+
+-- ── HTTP helper (uses curl, available on all OpenWrt builds) ─────────────────
+
+local function http_post(url, body, headers)
+  local header_args = ""
+  for k, v in pairs(headers or {}) do
+    header_args = header_args .. string.format(" -H '%s: %s'", k, v)
+  end
+  local cmd = string.format(
+    "curl -s -o /dev/null -w '%%{http_code}' -X POST%s --data-binary @- '%s'",
+    header_args, url
+  )
+  local pipe = io.popen("echo " .. string.format("%q", body) .. " | " .. cmd, "r")
+  if not pipe then return nil, "" end
+  local code = pipe:read("*l")
+  pipe:close()
+  return tonumber(code), ""
+end
+
+-- ── Start event watcher ───────────────────────────────────────────────────────
+
+conntrack.watch({
+  router_id      = router_id,
+  api_url        = api_url,
+  router_token   = router_token,
+  nft_sets       = nft_sets,
+  blocked_ips    = blocked_ips,
+  blocked_reason = blocked_reason,
+  lan_prefix     = lan_prefix,
+  max_batch      = max_batch,
+  flush_interval = flush_int,
+  http_post      = http_post,
+})

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -1,0 +1,249 @@
+-- Tests for openwrt/files/usr/lib/familydns/conntrack.lua
+-- Run with: busted openwrt/test/conntrack_spec.lua
+-- Requires: busted (luarocks install busted)
+
+local conntrack = require("conntrack")
+
+-- ---------------------------------------------------------------------------
+-- 1. ipset attribution: dest_ip → hostname
+-- ---------------------------------------------------------------------------
+
+describe("ipset_lookup_hostname", function()
+  it("returns the hostname whose nftables set contains dest_ip", function()
+    -- nft_sets is a table mapping hostname → {ip, ...} (populated by dnsmasq --ipset)
+    local nft_sets = {
+      ["youtube.com"]  = { ["1.2.3.4"] = true, ["1.2.3.5"] = true },
+      ["google.com"]   = { ["8.8.8.8"] = true },
+    }
+    assert.equal("youtube.com", conntrack.ipset_lookup_hostname("1.2.3.4", nft_sets))
+    assert.equal("google.com",  conntrack.ipset_lookup_hostname("8.8.8.8",  nft_sets))
+  end)
+
+  it("returns nil when no set contains the ip", function()
+    local nft_sets = { ["youtube.com"] = { ["1.2.3.4"] = true } }
+    assert.is_nil(conntrack.ipset_lookup_hostname("9.9.9.9", nft_sets))
+  end)
+
+  it("returns nil for empty nft_sets", function()
+    assert.is_nil(conntrack.ipset_lookup_hostname("1.2.3.4", {}))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 2. MAC lookup: src_ip → mac via ARP table
+-- ---------------------------------------------------------------------------
+
+describe("arp_lookup_mac", function()
+  it("returns the MAC for a known IP", function()
+    local arp_table = {
+      ["192.168.1.42"] = "aa:bb:cc:11:22:33",
+      ["192.168.1.10"] = "de:ad:be:ef:00:01",
+    }
+    assert.equal("aa:bb:cc:11:22:33", conntrack.arp_lookup_mac("192.168.1.42", arp_table))
+  end)
+
+  it("returns nil for an unknown IP", function()
+    local arp_table = { ["192.168.1.42"] = "aa:bb:cc:11:22:33" }
+    assert.is_nil(conntrack.arp_lookup_mac("10.0.0.1", arp_table))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 3. Event serialization
+-- ---------------------------------------------------------------------------
+
+describe("build_event", function()
+  it("serializes a full connection_attempt to the correct JSON shape", function()
+    local ev = conntrack.build_event({
+      mac      = "aa:bb:cc:11:22:33",
+      hostname = "youtube.com",
+      dest_ip  = "1.2.3.4",
+      allowed  = false,
+      reason   = "category:adult",
+      ts       = "2026-05-07T14:01:14Z",
+    })
+    assert.equal("connection_attempt", ev["type"])
+    assert.equal("aa:bb:cc:11:22:33", ev.mac)
+    assert.equal("youtube.com",        ev.hostname)
+    assert.equal("1.2.3.4",            ev.dest_ip)
+    assert.equal(false,                ev.allowed)
+    assert.equal("category:adult",     ev.reason)
+    assert.equal("2026-05-07T14:01:14Z", ev.ts)
+  end)
+
+  it("uses dest_ip as hostname fallback when hostname is nil", function()
+    local ev = conntrack.build_event({
+      mac      = "aa:bb:cc:11:22:33",
+      hostname = nil,
+      dest_ip  = "9.9.9.9",
+      allowed  = true,
+      reason   = nil,
+      ts       = "2026-05-07T14:01:14Z",
+    })
+    assert.equal("9.9.9.9", ev.hostname)
+    assert.equal("allow",   ev.reason)
+  end)
+
+  it("JSON-encodes the event with correct field names", function()
+    local json = require("cjson")
+    local ev = conntrack.build_event({
+      mac = "aa:bb:cc:11:22:33", hostname = "example.com",
+      dest_ip = "1.1.1.1", allowed = true, reason = "allow",
+      ts = "2026-05-07T00:00:00Z",
+    })
+    local encoded = json.encode(ev)
+    local decoded = json.decode(encoded)
+    assert.equal("connection_attempt", decoded["type"])
+    assert.equal("example.com",        decoded.hostname)
+    assert.equal("1.1.1.1",            decoded.dest_ip)   -- snake_case, not camelCase
+    assert.is_boolean(decoded.allowed)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 4. Batching
+-- ---------------------------------------------------------------------------
+
+describe("batcher", function()
+  local MAX_BATCH = 50
+  local FLUSH_INTERVAL = 10  -- seconds
+
+  it("flushes when batch reaches MAX_BATCH size", function()
+    local flushed = {}
+    local batch = conntrack.new_batcher(MAX_BATCH, FLUSH_INTERVAL, function(events)
+      table.insert(flushed, events)
+    end)
+
+    for i = 1, MAX_BATCH do
+      batch.add({ type = "connection_attempt", ts = tostring(i) })
+    end
+
+    assert.equal(1, #flushed)
+    assert.equal(MAX_BATCH, #flushed[1])
+  end)
+
+  it("does not flush before MAX_BATCH is reached", function()
+    local flushed = {}
+    local batch = conntrack.new_batcher(MAX_BATCH, FLUSH_INTERVAL, function(events)
+      table.insert(flushed, events)
+    end)
+
+    for i = 1, MAX_BATCH - 1 do
+      batch.add({ type = "connection_attempt", ts = tostring(i) })
+    end
+
+    assert.equal(0, #flushed)
+  end)
+
+  it("flush() drains whatever is pending regardless of size", function()
+    local flushed = {}
+    local batch = conntrack.new_batcher(MAX_BATCH, FLUSH_INTERVAL, function(events)
+      table.insert(flushed, events)
+    end)
+
+    batch.add({ type = "connection_attempt", ts = "t1" })
+    batch.add({ type = "connection_attempt", ts = "t2" })
+    batch.flush()
+
+    assert.equal(1, #flushed)
+    assert.equal(2, #flushed[1])
+  end)
+
+  it("flush() is a no-op when the buffer is empty", function()
+    local flushed = {}
+    local batch = conntrack.new_batcher(MAX_BATCH, FLUSH_INTERVAL, function(events)
+      table.insert(flushed, events)
+    end)
+    batch.flush()
+    assert.equal(0, #flushed)
+  end)
+
+  it("resets buffer after a flush", function()
+    local flushed = {}
+    local batch = conntrack.new_batcher(MAX_BATCH, FLUSH_INTERVAL, function(events)
+      table.insert(flushed, events)
+    end)
+
+    for i = 1, MAX_BATCH do
+      batch.add({ type = "connection_attempt", ts = tostring(i) })
+    end
+    -- One full batch flushed; add one more and manually flush.
+    batch.add({ type = "connection_attempt", ts = "extra" })
+    batch.flush()
+
+    assert.equal(2, #flushed)
+    assert.equal(1, #flushed[2])
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 5. Retry logic
+-- ---------------------------------------------------------------------------
+
+describe("post_with_retry", function()
+  local MAX_RETRIES    = 3
+  local BASE_DELAY_SEC = 0  -- set to 0 in tests so they don't sleep
+
+  it("succeeds on first attempt and returns true", function()
+    local calls = 0
+    local function post_fn(_url, _body)
+      calls = calls + 1
+      return 200, ""
+    end
+    local ok = conntrack.post_with_retry("http://api/events", "{}", MAX_RETRIES, 0, post_fn)
+    assert.is_true(ok)
+    assert.equal(1, calls)
+  end)
+
+  it("retries on 5xx and succeeds on second attempt", function()
+    local calls = 0
+    local function post_fn(_url, _body)
+      calls = calls + 1
+      if calls < 2 then return 500, "err" end
+      return 200, ""
+    end
+    local ok = conntrack.post_with_retry("http://api/events", "{}", MAX_RETRIES, 0, post_fn)
+    assert.is_true(ok)
+    assert.equal(2, calls)
+  end)
+
+  it("drops and returns false after max retries are exhausted", function()
+    local calls = 0
+    local function post_fn(_url, _body)
+      calls = calls + 1
+      return 503, "unavailable"
+    end
+    local ok = conntrack.post_with_retry("http://api/events", "{}", MAX_RETRIES, 0, post_fn)
+    assert.is_false(ok)
+    assert.equal(MAX_RETRIES, calls)
+  end)
+
+  it("does not retry on 4xx (client error)", function()
+    local calls = 0
+    local function post_fn(_url, _body)
+      calls = calls + 1
+      return 401, "unauthorized"
+    end
+    local ok = conntrack.post_with_retry("http://api/events", "{}", MAX_RETRIES, 0, post_fn)
+    assert.is_false(ok)
+    assert.equal(1, calls)   -- no retry on 4xx
+  end)
+
+  it("uses exponential back-off delays (doubles each retry)", function()
+    local delays_used = {}
+    local calls = 0
+    local function post_fn(_url, _body)
+      calls = calls + 1
+      return 500, "err"
+    end
+    local function sleep_fn(secs)
+      table.insert(delays_used, secs)
+    end
+    conntrack.post_with_retry("http://api/events", "{}", 4, 1, post_fn, sleep_fn)
+    -- delays should be 1, 2, 4 (3 sleeps for 4 attempts)
+    assert.equal(3, #delays_used)
+    assert.equal(1, delays_used[1])
+    assert.equal(2, delays_used[2])
+    assert.equal(4, delays_used[3])
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run the familydns OpenWrt agent unit tests.
+# Requires: luarocks install busted lua-cjson
+set -e
+cd "$(dirname "$0")/.."
+LUA_PATH="./files/usr/lib/familydns/?.lua;$(lua -e 'print(package.path)')" \
+  busted test/conntrack_spec.lua "$@"


### PR DESCRIPTION
## Summary

- Initialises the `openwrt/` package directory in **Lua** as specified in #72 (architecture-openwrt.md §6.3).
- Adds `conntrack.lua` — subscribes to `conntrack -E -e NEW` (more reliable on OpenWrt 23.x than `meta nftrace`; no per-rule tracing setup required) and emits `connection_attempt` events to `POST /api/router/events` (#69).
- Hostname attribution uses the dnsmasq `--ipset` nft_sets table (populated by the render module in #72), not reverse DNS (per architecture-openwrt.md §6.2).
- Both allowed and blocked flows are reported.
- Events are batched (default 50 events or 10 s, whichever comes first) and posted with exponential-backoff retry; 4xx is not retried; after `max_retries` the batch is dropped with a log line — the endpoint is best-effort and no flow is ever blocked waiting for the API.
- Also adds: procd init script, UCI config template, opkg `Makefile`, `README.md`, and 18 busted unit tests (all passing).

## References

- Closes #93
- Depends on #69 (events endpoint — already merged)
- Part of #72 (full agent package — this PR creates the `openwrt/` skeleton #72 will layer policy + usage on top of)
- Architecture: #87 (`docs/architecture-openwrt.md` §6.2 hostname attribution, §6.3 package layout)

## Test plan

- [x] `busted openwrt/test/conntrack_spec.lua` — 18/18 pass (run locally)
- [ ] Flash to OpenWrt 23.x router and verify `conntrack -E -e NEW` events appear in `/api/router/events` for both allowed and blocked flows
- [ ] Verify hostname field matches the dnsmasq-resolved name, not a CDN PTR record
- [ ] Simulate API downtime; confirm agent keeps running and drops with a log line after retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)