### PR TITLE
Fix Docker hang in Claude Code agents: document daemon-restart fix (closes #92)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-  "env": {
-    "DOCKER_HOST": "tcp://localhost:2375"
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "DOCKER_HOST": "tcp://localhost:2375"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,28 +75,24 @@ All three share a single PostgreSQL database.
 
 ## Docker inside Claude Code agents (worktrees)
 
-The Claude Code bash sandbox blocks Unix domain socket connections. Docker CLI
-uses a Unix socket by default, so every `docker` or `docker compose` command
-hangs indefinitely unless Docker is configured to use TCP instead.
+Docker commands (`docker info`, `docker compose`, etc.) will **hang
+indefinitely** if Docker Desktop is not running or is in a degraded state.
+The Claude Code bash sandbox does not block Unix socket connections — Docker
+simply must be healthy.
 
-**Required one-time setup** (Docker Desktop on macOS):
-
-1. Open Docker Desktop → Settings → General.
-2. Enable **"Expose daemon on tcp://localhost:2375 without TLS"**.
-3. Click Apply & restart.
-
-`.claude/settings.json` sets `DOCKER_HOST=tcp://localhost:2375` so all agent
-sessions (including worktrees) automatically use the TCP endpoint.
-
-**Verify it works** — from any agent bash command, this should return within 2 s:
+**Before running any docker command**, verify the daemon responds:
 
 ```bash
-curl -s http://localhost:2375/version | python3 -m json.tool
+docker info 2>&1 | grep "Server Version"
 ```
 
-If Docker Desktop is not running, docker commands fail fast with
-`connection refused` (exit 7) instead of hanging — start Docker Desktop and
-try again.
+This should return within 2 seconds. If it hangs, restart Docker Desktop
+(quit from the menu bar, then reopen) and wait for the whale icon to become
+steady before retrying.
+
+Common symptom: Docker Desktop appears "running" (process exists, socket
+files exist) but the daemon inside the VM has crashed or frozen — this happens
+after long uptimes. Restarting Docker Desktop is the fix.
 
 ## Running locally
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,31 @@ All three share a single PostgreSQL database.
 - **Formatting**: `scalafmt` enforced in CI. Run `mill __.reformat` before committing.
 - **Imports**: managed by `scalafix OrganizeImports`. Run `mill __.fix` before committing.
 
+## Docker inside Claude Code agents (worktrees)
+
+The Claude Code bash sandbox blocks Unix domain socket connections. Docker CLI
+uses a Unix socket by default, so every `docker` or `docker compose` command
+hangs indefinitely unless Docker is configured to use TCP instead.
+
+**Required one-time setup** (Docker Desktop on macOS):
+
+1. Open Docker Desktop → Settings → General.
+2. Enable **"Expose daemon on tcp://localhost:2375 without TLS"**.
+3. Click Apply & restart.
+
+`.claude/settings.json` sets `DOCKER_HOST=tcp://localhost:2375` so all agent
+sessions (including worktrees) automatically use the TCP endpoint.
+
+**Verify it works** — from any agent bash command, this should return within 2 s:
+
+```bash
+curl -s http://localhost:2375/version | python3 -m json.tool
+```
+
+If Docker Desktop is not running, docker commands fail fast with
+`connection refused` (exit 7) instead of hanging — start Docker Desktop and
+try again.
+
 ## Running locally
 
 ```bash


### PR DESCRIPTION
## Summary

- **Root cause**: Docker Desktop's daemon becomes unresponsive after extended uptime. The process is still running and socket files exist, but the VM-internal daemon freezes and stops processing API requests. This causes every `docker`/`docker compose` command to hang indefinitely — in Claude Code agents and in regular terminals alike.
- **Not a sandbox issue**: The Claude Code bash sandbox does not block Unix socket connections. `docker info` works fine from within a worktree agent once Docker Desktop is healthy.
- **Fix**: Document the symptom and the restart procedure in `AGENTS.md` so future agents don't waste time debugging environment configuration.

## What was investigated

1. Confirmed `docker info` hangs inside a worktree — and in a regular terminal on the same machine.
2. Ruled out socket path issues (`~/.docker/run/docker.sock` was bound and accepting connections).
3. Ruled out sandbox Unix socket restrictions (Python test from a LaunchAgent also timed out, same behavior; after Docker Desktop restart, `docker info` works normally from the bash tool).
4. Root cause: Docker Desktop daemon frozen after ~1 week uptime. Restart fixed everything.

## Test plan

- [ ] Ensure Docker Desktop is running and healthy.
- [ ] From a worktree agent session: `docker info 2>&1 | grep "Server Version"` returns within 2 s.
- [ ] If Docker hangs: quit Docker Desktop from the menu bar, reopen, wait for whale icon, retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)