### PR TITLE
Allow adult role to read all profiles, devices, and logs

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -145,7 +145,7 @@ object ProfileRoutes:
         handler { (id: Long, req: Request) =>
           for
             claims <- requireAuth(req, auth)
-            _      <- requireProfileAccess(claims, id, userProfileRepo)
+            _      <- requireProfileReadAccess(claims, id, userProfileRepo)
             p      <- profileRepo
               .findById(id)
               .orElseFail(Response.internalServerError(""))
@@ -345,7 +345,7 @@ object TimeRoutes:
               .findByMac(normalizeMac(mac))
               .orElseFail(Response.internalServerError(""))
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileAccess(claims, device.profileId, userProfileRepo)
+            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
             status <- buildDeviceTimeStatus(
               device,
               date,
@@ -387,7 +387,7 @@ object TimeRoutes:
               .findByMac(normalized)
               .orElseFail(Response.internalServerError(""))
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileAccess(claims, device.profileId, userProfileRepo)
+            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
             date   <- clock.today
             exts   <- extRepo
               .listForDevice(normalized, date)
@@ -553,13 +553,13 @@ def requireWriter(req: Request, auth: AuthService): IO[Response, JwtClaims] =
         },
     )
 
-/** Admin sees all profiles. Adult/child only see profiles linked to their user. */
+/** Admin and adult see all profiles. Child only sees profiles linked to their user. */
 def visibleProfiles(
     claims: JwtClaims,
     all: List[Profile],
     upRepo: UserProfileRepo,
 ): IO[Response, List[Profile]] =
-  if claims.role == "admin" then ZIO.succeed(all)
+  if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(all)
   else
     upRepo
       .listProfilesForUsername(claims.sub)
@@ -571,7 +571,7 @@ def filterDevices(
     all: List[Device],
     upRepo: UserProfileRepo,
 ): IO[Response, List[Device]] =
-  if claims.role == "admin" then ZIO.succeed(all)
+  if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(all)
   else
     upRepo
       .listProfilesForUsername(claims.sub)
@@ -583,14 +583,30 @@ def filterLogs(
     all: List[QueryLog],
     upRepo: UserProfileRepo,
 ): IO[Response, List[QueryLog]] =
-  if claims.role == "admin" then ZIO.succeed(all)
+  if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(all)
   else
     upRepo
       .listProfilesForUsername(claims.sub)
       .orElseFail(Response.internalServerError(""))
       .map(pids => all.filter(l => l.profileId.exists(pids.contains)))
 
-/** Allow if admin, or the user is linked to that profile. */
+/** Allow read access if admin or adult (full visibility); child must be linked to the profile. */
+def requireProfileReadAccess(
+    claims: JwtClaims,
+    profileId: Long,
+    upRepo: UserProfileRepo,
+): IO[Response, Unit] =
+  if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(())
+  else
+    upRepo
+      .listProfilesForUsername(claims.sub)
+      .orElseFail(Response.internalServerError(""))
+      .flatMap { pids =>
+        if pids.contains(profileId) then ZIO.succeed(())
+        else ZIO.fail(Response.forbidden("Not authorized for this profile"))
+      }
+
+/** Allow write access if admin or adult linked to the profile. Child is always denied. */
 def requireProfileAccess(
     claims: JwtClaims,
     profileId: Long,

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -326,5 +326,125 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         assertTrue(devices.length == 1) &&
         assertTrue(devices.head.name == "kid-tablet")
     },
+    test("adult sees ALL profiles (not just linked ones)") {
+      for
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        schedRepo   <- ZIO.service[ScheduleRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        auth        <- makeAuth
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
+        token <- auth.login("mom", "pass").map(_.token)
+        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        req    = Request
+          .get(URL.decode("/api/profiles").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp    <- routes.runZIO(req)
+        body    <- resp.body.asString
+        details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
+      yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(details.length == 2)
+    },
+    test("adult can GET any profile by id even if not linked") {
+      for
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        schedRepo   <- ZIO.service[ScheduleRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        auth        <- makeAuth
+        profiles    <- profileRepo.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
+        token <- auth.login("mom", "pass").map(_.token)
+        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        req    = Request
+          .get(URL.decode(s"/api/profiles/$adultsId").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+      yield assertTrue(resp.status == Status.Ok)
+    },
+    test("adult sees ALL devices (not just linked ones)") {
+      for
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        auth        <- makeAuth
+        profiles    <- profileRepo.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        _     <- deviceRepo.upsert("aa:bb:cc:00:00:01", "kid-tablet", kidsId, "")
+        _     <- deviceRepo.upsert("aa:bb:cc:00:00:02", "dad-laptop", adultsId, "")
+        _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
+        token <- auth.login("mom", "pass").map(_.token)
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        req    = Request
+          .get(URL.decode("/api/devices").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp    <- routes.runZIO(req)
+        body    <- resp.body.asString
+        devices <- ZIO.fromEither(body.fromJson[List[Device]])
+      yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(devices.length == 2)
+    },
+    test("adult sees ALL logs (not just linked profiles)") {
+      for
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        logRepo     <- ZIO.service[QueryLogRepo]
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        auth        <- makeAuth
+        profiles    <- profileRepo.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        _     <- logRepo.insertBatch(
+          List(
+            QueryLogInsert(
+              Some("aa:bb:cc:00:00:01"),
+              Some("kid-tablet"),
+              Some(kidsId),
+              Some("Kids"),
+              "youtube.com",
+              1,
+              blocked = false,
+              "allowed",
+              Some("home"),
+            ),
+            QueryLogInsert(
+              Some("aa:bb:cc:00:00:02"),
+              Some("dad-laptop"),
+              Some(adultsId),
+              Some("Adults"),
+              "nytimes.com",
+              1,
+              blocked = false,
+              "allowed",
+              Some("home"),
+            ),
+          ),
+        )
+        _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
+        token <- auth.login("mom", "pass").map(_.token)
+        routes = LogRoutes.routes(auth, logRepo, upRepo)
+        req    = Request
+          .get(URL.decode("/api/logs").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        resp <- routes.runZIO(req)
+        body <- resp.body.asString
+        logs <- ZIO.fromEither(body.fromJson[List[QueryLog]])
+      yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(logs.length == 2)
+    },
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
Closes #99

## Summary

- `visibleProfiles`, `filterDevices`, and `filterLogs` now return all data for the `adult` role (previously only admin received unscoped results; adults were limited to their linked profiles)
- New `requireProfileReadAccess` helper — admin or adult passes unconditionally; child is still restricted to linked profiles
- Four GET routes swapped from `requireProfileAccess` to `requireProfileReadAccess`: `GET /api/profiles/:id`, `GET /api/time/status/:mac`, `GET /api/time/extensions/:mac` (list already used `filterDevices`)
- Write/mutation endpoints (`POST`, `PUT`, `DELETE`) unchanged — adults still limited to profiles they're linked to via `requireProfileAccess`

## Previously over-restricted endpoints now opened to adults

| Route | Was | Now |
|---|---|---|
| `GET /api/profiles` | linked profiles only | all profiles |
| `GET /api/profiles/:id` | 403 for unlinked | 200 for any |
| `GET /api/devices` | linked profiles' devices only | all devices |
| `GET /api/time/status` | linked profiles' devices only | all devices |
| `GET /api/time/status/:mac` | 403 for unlinked device | 200 for any |
| `GET /api/time/extensions/:mac` | 403 for unlinked device | 200 for any |
| `GET /api/logs` | linked profiles' logs only | all logs |

## Test plan

- [x] 4 new feature tests in `RoleAccessSpec` (adult sees all profiles / can GET any profile by id / sees all devices / sees all logs) — all pass
- [x] Existing child-scoping tests unchanged and still pass (children still see only their linked data)
- [x] Full `mill api.test` suite: 0 failures
- [x] scalafmt pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)