### PR TITLE
Screen time per profile: shared usage pool, per-device breakdown, per-profile extensions

### DIFF
--- a/api/resources/db/migration/V5__profile_time_extensions.sql
+++ b/api/resources/db/migration/V5__profile_time_extensions.sql
@@ -1,0 +1,11 @@
+-- V5__profile_time_extensions.sql
+-- Move time extensions from per-device to per-profile.
+-- device_mac is made nullable so existing rows keep their data.
+-- New grants set profile_id and leave device_mac NULL.
+ALTER TABLE time_extensions
+  ALTER COLUMN device_mac DROP NOT NULL,
+  ADD COLUMN profile_id BIGINT REFERENCES profiles(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_time_extensions_profile_date
+  ON time_extensions(profile_id, date)
+  WHERE profile_id IS NOT NULL;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -138,6 +138,7 @@ trait TimeUsageRepo:
       date: LocalDate,
   ): Task[(Long, Long, Long)]
   def listForDevice(mac: String, date: LocalDate): Task[List[TimeUsage]]
+  def listForDeviceMacs(macs: List[String], date: LocalDate): Task[List[TimeUsage]]
   def snapshotAll(date: LocalDate): Task[Map[(String, String), Int]]
 
 trait TimeExtensionRepo:
@@ -145,6 +146,17 @@ trait TimeExtensionRepo:
   def grant(mac: String, date: LocalDate, mins: Int, by: String, note: Option[String]): Task[Long]
   def listForDevice(mac: String, date: LocalDate): Task[List[TimeExtension]]
   def snapshotAll(date: LocalDate): Task[Map[String, Int]]
+  // Profile-level extension methods (V5+)
+  def grantForProfile(
+      profileId: Long,
+      date: LocalDate,
+      mins: Int,
+      by: String,
+      note: Option[String],
+  ): Task[Long]
+  def getProfileTotalExtension(profileId: Long, date: LocalDate): Task[Int]
+  def listForProfile(profileId: Long, date: LocalDate): Task[List[TimeExtension]]
+  def snapshotAllByProfile(date: LocalDate): Task[Map[Long, Int]]
 
 case class TrafficReportInsert(
     routerId: UUID,
@@ -498,6 +510,15 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo:
       .map(TimeUsage.apply)
       .to[List]
       .transact(xa)
+  def listForDeviceMacs(macs: List[String], d: LocalDate)                                  =
+    if macs.isEmpty then ZIO.succeed(Nil)
+    else
+      val arr = macs.toArray
+      sql"SELECT id,device_mac,domain,date::TEXT,minutes_used,last_seen_at::TEXT FROM time_usage WHERE device_mac = ANY($arr) AND date=$d ORDER BY device_mac,minutes_used DESC"
+        .query[(Long, String, String, String, Int, String)]
+        .map(TimeUsage.apply)
+        .to[List]
+        .transact(xa)
   def snapshotAll(d: LocalDate)                                                            =
     sql"SELECT device_mac,domain,minutes_used FROM time_usage WHERE date=$d"
       .query[(String, String, Int)]
@@ -506,25 +527,47 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo:
       .map(_.map((m, dom, mins) => (m, dom) -> mins).toMap)
 
 class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo:
-  def getTotalExtension(mac: String, d: LocalDate)                                  =
+  def getTotalExtension(mac: String, d: LocalDate)                                          =
     sql"SELECT COALESCE(SUM(extra_minutes),0)::INT FROM time_extensions WHERE device_mac=$mac AND date=$d"
       .query[Int]
       .unique
       .transact(xa)
-  def grant(mac: String, d: LocalDate, mins: Int, by: String, note: Option[String]) =
+  def grant(mac: String, d: LocalDate, mins: Int, by: String, note: Option[String])         =
     sql"INSERT INTO time_extensions(device_mac,date,extra_minutes,granted_by,note) VALUES($mac,$d,$mins,$by,$note) RETURNING id"
       .query[Long]
       .unique
       .transact(xa)
-  def listForDevice(mac: String, d: LocalDate)                                      =
-    sql"SELECT id,device_mac,date::TEXT,extra_minutes,granted_by,note,created_at::TEXT FROM time_extensions WHERE device_mac=$mac AND date=$d ORDER BY created_at"
-      .query[(Long, String, String, Int, String, Option[String], String)]
+  def listForDevice(mac: String, d: LocalDate)                                              =
+    sql"SELECT id,profile_id,device_mac,date::TEXT,extra_minutes,granted_by,note,created_at::TEXT FROM time_extensions WHERE device_mac=$mac AND date=$d ORDER BY created_at"
+      .query[(Long, Option[Long], Option[String], String, Int, String, Option[String], String)]
       .map(TimeExtension.apply)
       .to[List]
       .transact(xa)
-  def snapshotAll(d: LocalDate)                                                     =
-    sql"SELECT device_mac,SUM(extra_minutes)::INT FROM time_extensions WHERE date=$d GROUP BY device_mac"
+  def snapshotAll(d: LocalDate)                                                             =
+    sql"SELECT device_mac,SUM(extra_minutes)::INT FROM time_extensions WHERE date=$d AND device_mac IS NOT NULL GROUP BY device_mac"
       .query[(String, Int)]
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
+  def grantForProfile(pid: Long, d: LocalDate, mins: Int, by: String, note: Option[String]) =
+    sql"INSERT INTO time_extensions(profile_id,date,extra_minutes,granted_by,note) VALUES($pid,$d,$mins,$by,$note) RETURNING id"
+      .query[Long]
+      .unique
+      .transact(xa)
+  def getProfileTotalExtension(pid: Long, d: LocalDate)                                     =
+    sql"SELECT COALESCE(SUM(extra_minutes),0)::INT FROM time_extensions WHERE profile_id=$pid AND date=$d"
+      .query[Int]
+      .unique
+      .transact(xa)
+  def listForProfile(pid: Long, d: LocalDate)                                               =
+    sql"SELECT id,profile_id,device_mac,date::TEXT,extra_minutes,granted_by,note,created_at::TEXT FROM time_extensions WHERE profile_id=$pid AND date=$d ORDER BY created_at"
+      .query[(Long, Option[Long], Option[String], String, Int, String, Option[String], String)]
+      .map(TimeExtension.apply)
+      .to[List]
+      .transact(xa)
+  def snapshotAllByProfile(d: LocalDate)                                                    =
+    sql"SELECT profile_id,SUM(extra_minutes)::INT FROM time_extensions WHERE date=$d AND profile_id IS NOT NULL GROUP BY profile_id"
+      .query[(Long, Int)]
       .to[List]
       .transact(xa)
       .map(_.toMap)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -34,7 +34,7 @@ class PolicyServiceLive(
       tlims    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
       stlims   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       usages   <- usageRepo.snapshotAll(today)
-      exts     <- extRepo.snapshotAll(today)
+      exts     <- extRepo.snapshotAllByProfile(today)
       cats     <- blocklistRepo.listCategories
       schedMap = scheds.toMap
       tlMap    = tlims.toMap
@@ -61,7 +61,7 @@ class PolicyServiceLive(
         val totalMins = usages.iterator.collect {
           case ((mac, dom), m) if devicesIn.exists(_.mac == mac) && !siteDoms.contains(dom) => m
         }.sum
-        val extMins   = devicesIn.map(d => exts.getOrElse(d.mac, 0)).sum
+        val extMins   = exts.getOrElse(p.id, 0)
         PolicyProfile(
           id = p.id,
           name = p.name,

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -310,21 +310,23 @@ object TimeRoutes:
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "time" / "status"                     ->
+      Method.GET / "api" / "time" / "status"                         ->
         handler { (req: Request) =>
           for
             claims <- requireAuth(req, auth)
             today  <- clock.today
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            all      <- deviceRepo.listAll.orElseFail(Response.internalServerError(""))
-            visible  <- filterDevices(claims, all, userProfileRepo)
+            allProfiles <- profileRepo.listAll.orElseFail(Response.internalServerError(""))
+            allDevices  <- deviceRepo.listAll.orElseFail(Response.internalServerError(""))
+            visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            devicesByPid = allDevices.groupBy(_.profileId)
             statuses <- ZIO
-              .foreach(visible) { d =>
-                buildDeviceTimeStatus(
-                  d,
+              .foreach(visible) { p =>
+                buildProfileTimeStatus(
+                  p,
+                  devicesByPid.getOrElse(p.id, Nil),
                   date,
-                  profileRepo,
                   timeLimitRepo,
                   siteTimeLimitRepo,
                   usageRepo,
@@ -334,7 +336,7 @@ object TimeRoutes:
               .orElseFail(Response.internalServerError(""))
           yield Response.json(statuses.toJson)
         },
-      Method.GET / "api" / "time" / "status" / string("mac")     ->
+      Method.GET / "api" / "time" / "status" / string("mac")         ->
         handler { (mac: String, req: Request) =>
           for
             claims <- requireAuth(req, auth)
@@ -358,7 +360,7 @@ object TimeRoutes:
               .orElseFail(Response.internalServerError(""))
           yield Response.json(status.toJson)
         },
-      Method.POST / "api" / "time" / "extend"                    ->
+      Method.POST / "api" / "time" / "extend"                        ->
         handler { (req: Request) =>
           for
             claims <- requireWriter(req, auth)
@@ -366,34 +368,74 @@ object TimeRoutes:
             ger    <- ZIO
               .fromEither(body.fromJson[GrantExtensionRequest])
               .mapError(e => Response.badRequest(e))
-            mac = normalizeMac(ger.deviceMac)
-            device <- deviceRepo
-              .findByMac(mac)
-              .orElseFail(Response.internalServerError(""))
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileAccess(claims, device.profileId, userProfileRepo)
+            _      <- requireProfileAccess(claims, ger.profileId, userProfileRepo)
             today  <- clock.today
             id     <- extRepo
-              .grant(mac, today, ger.extraMinutes, claims.sub, ger.note)
+              .grantForProfile(ger.profileId, today, ger.extraMinutes, claims.sub, ger.note)
               .orElseFail(Response.internalServerError(""))
           yield Response.json(s"""{"id":$id,"grantedMinutes":${ger.extraMinutes}}""")
         },
-      Method.GET / "api" / "time" / "extensions" / string("mac") ->
-        handler { (mac: String, req: Request) =>
+      Method.GET / "api" / "time" / "extensions" / long("profileId") ->
+        handler { (profileId: Long, req: Request) =>
           for
             claims <- requireAuth(req, auth)
-            normalized = normalizeMac(mac)
-            device <- deviceRepo
-              .findByMac(normalized)
-              .orElseFail(Response.internalServerError(""))
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            _      <- requireProfileAccess(claims, profileId, userProfileRepo)
             date   <- clock.today
             exts   <- extRepo
-              .listForDevice(normalized, date)
+              .listForProfile(profileId, date)
               .orElseFail(Response.internalServerError(""))
           yield Response.json(exts.toJson)
         },
+    )
+
+  private def buildProfileTimeStatus(
+      profile: Profile,
+      devices: List[Device],
+      date: LocalDate,
+      tlRepo: TimeLimitRepo,
+      stlRepo: SiteTimeLimitRepo,
+      usageRepo: TimeUsageRepo,
+      extRepo: TimeExtensionRepo,
+  ): Task[ProfileTimeStatus] =
+    val macs = devices.map(_.mac)
+    for
+      tl      <- tlRepo.findForProfile(profile.id)
+      stls    <- stlRepo.listForProfile(profile.id)
+      usages  <- usageRepo.listForDeviceMacs(macs, date)
+      extMins <- extRepo.getProfileTotalExtension(profile.id, date)
+      siteDoms        = stls.map(_.domainPattern).toSet
+      totalUsed       = usages
+        .filterNot(u => siteDoms.exists(p => matchesPattern(u.domain, p)))
+        .map(_.minutesUsed)
+        .sum
+      remaining       = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
+      siteUsage       = stls.map { stl =>
+        val used = usages
+          .filter(u => matchesPattern(u.domain, stl.domainPattern))
+          .map(_.minutesUsed)
+          .sum
+        SiteUsage(
+          stl.label,
+          stl.domainPattern,
+          stl.dailyMinutes,
+          used,
+          (stl.dailyMinutes - used).max(0),
+        )
+      }
+      deviceSummaries = devices.map { d =>
+        val dUsed = usages.filter(_.deviceMac == d.mac).map(_.minutesUsed).sum
+        DeviceUsageSummary(d.mac, d.name, dUsed)
+      }
+    yield ProfileTimeStatus(
+      profile.id,
+      profile.name,
+      date.toString,
+      tl.map(_.dailyMinutes),
+      totalUsed,
+      extMins,
+      remaining,
+      siteUsage,
+      deviceSummaries,
     )
 
   private def buildDeviceTimeStatus(
@@ -410,7 +452,7 @@ object TimeRoutes:
       tl      <- pid.fold(ZIO.succeed(Option.empty[TimeLimit]))(tlRepo.findForProfile)
       stls    <- pid.fold(ZIO.succeed(List.empty[SiteTimeLimit]))(stlRepo.listForProfile)
       usages  <- usageRepo.listForDevice(device.mac, date)
-      extMins <- extRepo.getTotalExtension(device.mac, date)
+      extMins <- pid.fold(ZIO.succeed(0))(extRepo.getProfileTotalExtension(_, date))
       profile <- pid.fold(ZIO.succeed("No profile"))(p =>
         profileRepo.findById(p).map(_.map(_.name).getOrElse("Unknown")),
       )

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -325,7 +325,7 @@ object TimeRoutes:
               .foreach(visible) { p =>
                 buildProfileTimeStatus(
                   p,
-                  devicesByPid.getOrElse(p.id, Nil),
+                  devicesByPid.getOrElse(Some(p.id), Nil),
                   date,
                   timeLimitRepo,
                   siteTimeLimitRepo,
@@ -479,6 +479,7 @@ object TimeRoutes:
       device.name,
       date.toString,
       profile,
+      pid,
       tl.map(_.dailyMinutes),
       totalUsed,
       extMins,

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -264,7 +264,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         _   <- tlr.upsert(kid, 120)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
         _   <- ur.incrementUsage("aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 121)
-        _   <- er.grant("aa:bb:cc:11:22:33", LocalDate.of(2025, 1, 6), 30, "admin", None)
+        _   <- er.grantForProfile(kid, LocalDate.of(2025, 1, 6), 30, "admin", None)
         ps  <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
         tok  <- seedAndEnrollRouter(rr, routes)

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -3,6 +3,7 @@ package familydns.api.feature
 import familydns.api.JwtConfig
 import familydns.api.auth.*
 import familydns.api.db.*
+import familydns.api.policy.PolicyServiceLive
 import familydns.api.routes.*
 import familydns.shared.*
 import familydns.shared.Clock.TestClock
@@ -167,7 +168,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
       },
     ),
     suite("POST /api/time/extend")(
-      test("admin can grant time extension which increases remaining") {
+      test("admin can grant profile extension which increases remaining for all devices") {
         for
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
@@ -183,7 +184,6 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- tlRepo.upsert(kidsId, 120)
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
-          // Use up all 120 minutes
           _               <- usageRepo.incrementUsage(testMac, "minecraft.net", today, 120)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
@@ -198,14 +198,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             userProfileRepo,
             clock,
           )
-          // Grant 30 min extension
-          extBody = GrantExtensionRequest(testMac, 30, Some("Homework finished early")).toJson
+          extBody = GrantExtensionRequest(kidsId, 30, Some("Homework finished early")).toJson
           extReq  = Request
             .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(extBody))
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
           extResp <- routes.runZIO(extReq)
-          // Check status shows 30 remaining
           statusReq = Request
             .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
@@ -244,13 +242,13 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             userProfileRepo,
             clock,
           )
-          body   = GrantExtensionRequest(testMac, 15, Some("Good behavior")).toJson
+          body   = GrantExtensionRequest(kidsId, 15, Some("Good behavior")).toJson
           req    = Request
             .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
           _    <- routes.runZIO(req)
-          exts <- extRepo.listForDevice(testMac, TestClock.schoolDayAfternoon.toLocalDate)
+          exts <- extRepo.listForProfile(kidsId, TestClock.schoolDayAfternoon.toLocalDate)
         yield assertTrue(exts.length == 1) &&
           assertTrue(exts.head.grantedBy == "admin") &&
           assertTrue(exts.head.extraMinutes == 15) &&
@@ -286,14 +284,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             userProfileRepo,
             clock,
           )
-          body   = GrantExtensionRequest(testMac, 30, None).toJson
+          body   = GrantExtensionRequest(kidsId, 30, None).toJson
           req    = Request
             .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
         yield assertTrue(resp.status == Status.Forbidden)
       },
-      test("multiple extensions accumulate") {
+      test("multiple extensions accumulate at profile level") {
         for
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
@@ -326,7 +324,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
               Request
                 .post(
                   URL.decode("/api/time/extend").toOption.get,
-                  Body.fromString(GrantExtensionRequest(testMac, mins, None).toJson),
+                  Body.fromString(GrantExtensionRequest(kidsId, mins, None).toJson),
                 )
                 .addHeader(Header.Authorization.Bearer(token))
                 .addHeader(Header.ContentType(MediaType.application.json)),
@@ -335,11 +333,196 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _ <- grant(15)
           _ <- grant(30)
           today = TestClock.schoolDayAfternoon.toLocalDate
-          exts  <- extRepo.listForDevice(testMac, today)
-          total <- extRepo.getTotalExtension(testMac, today)
+          exts  <- extRepo.listForProfile(kidsId, today)
+          total <- extRepo.getProfileTotalExtension(kidsId, today)
         yield assertTrue(exts.length == 3) &&
           assertTrue(total == 60)
       },
     ),
+
+    // ── per-profile status rollup ───────────────────────────────────────────
+    suite("GET /api/time/status — per-profile rollup")(
+      test("returns one ProfileTimeStatus per profile, not per device") {
+        for
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          usageRepo   <- ZIO.service[TimeUsageRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          _           <- TestLayers.seedDevice(deviceRepo, "aa:bb:cc:dd:ee:01", "iPad", kidsId)
+          _           <- TestLayers.seedDevice(deviceRepo, "aa:bb:cc:dd:ee:02", "iPhone", kidsId)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            usageRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(list.count(_.profileId == kidsId) == 1) && // one entry, not two
+          assertTrue(kids.devices.length == 2) &&               // both devices in breakdown
+          assertTrue(kids.devices.map(_.deviceName).toSet == Set("iPad", "iPhone"))
+      },
+      test("two devices on same profile share a combined usage pool") {
+        for
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          usageRepo   <- ZIO.service[TimeUsageRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 60)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _ <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Device 1: 40 min, Device 2: 35 min → combined 75 min > 60 min limit
+          _               <- usageRepo.incrementUsage(mac1, "minecraft.net", today, 40)
+          _               <- usageRepo.incrementUsage(mac2, "youtube.com", today, 35)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            usageRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        yield assertTrue(kids.usedMins == 75) &&        // both devices summed
+          assertTrue(kids.dailyLimitMins.contains(60)) &&
+          assertTrue(kids.remainingMins.contains(0)) && // clamped to 0, not negative
+          assertTrue(kids.devices.find(_.deviceMac == mac1).get.usedMins == 40) &&
+          assertTrue(kids.devices.find(_.deviceMac == mac2).get.usedMins == 35)
+      },
+      test("per-app site usage aggregated across all profile devices") {
+        for
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          usageRepo   <- ZIO.service[TimeUsageRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          _           <- stlRepo.replaceForProfile(
+            kidsId,
+            List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")),
+          )
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _ <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Each device uses 20 min YouTube → combined 40 min > 30 min limit
+          _               <- usageRepo.incrementUsage(mac1, "youtube.com", today, 20)
+          _               <- usageRepo.incrementUsage(mac2, "youtube.com", today, 20)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            usageRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+          yt   = kids.siteUsage.find(_.label == "YouTube").get
+        yield assertTrue(yt.usedMins == 40) && // both devices summed
+          assertTrue(yt.limitMins == 30) &&
+          assertTrue(yt.remainingMins == 0) && // clamped to 0
+          assertTrue(kids.usedMins == 0)       // site usage NOT counted in total
+      },
+      test("policy snapshot has profile-level time_used_today aggregated across devices") {
+        for
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          usageRepo   <- ZIO.service[TimeUsageRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 60)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _ <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          _             <- usageRepo.incrementUsage(mac1, "minecraft.net", today, 30)
+          _             <- usageRepo.incrementUsage(mac2, "roblox.com", today, 25)
+          // Build policy snapshot directly via PolicyService
+          blocklistRepo <- ZIO.service[BlocklistRepo]
+          clock         <- ZIO.service[Clock]
+          policyService = PolicyServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            blocklistRepo,
+            usageRepo,
+            extRepo,
+            clock,
+          )
+          snapshot <- policyService.snapshot
+          kidsPolicy = snapshot.profiles.find(_.id == kidsId).get
+        yield assertTrue(kidsPolicy.dailyMinutes.contains(60)) &&
+          assertTrue(kidsPolicy.timeUsedToday.totalMinutes == 55) // 30 + 25 across both devices
+      },
+    ) @@ TestAspect.sequential,
   ) @@ TestAspect.sequential
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -183,6 +183,7 @@ case class DeviceTimeStatus(
     deviceName: String,
     date: String,
     profileName: String,
+    profileId: Option[Long],
     dailyLimitMins: Option[Int],
     usedMins: Int,
     extensionMins: Int,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -67,7 +67,8 @@ case class TimeUsage(
 
 case class TimeExtension(
     id: Long,
-    deviceMac: String,
+    profileId: Option[Long],
+    deviceMac: Option[String],
     date: String,
     extraMinutes: Int,
     grantedBy: String,
@@ -152,7 +153,7 @@ case class UpsertDeviceRequest(
 ) derives JsonCodec
 
 case class GrantExtensionRequest(
-    deviceMac: String,
+    profileId: Long,
     extraMinutes: Int,
     note: Option[String],
 ) derives JsonCodec
@@ -187,6 +188,24 @@ case class DeviceTimeStatus(
     extensionMins: Int,
     remainingMins: Option[Int],
     siteUsage: List[SiteUsage],
+) derives JsonCodec
+
+case class DeviceUsageSummary(
+    deviceMac: String,
+    deviceName: String,
+    usedMins: Int,
+) derives JsonCodec
+
+case class ProfileTimeStatus(
+    profileId: Long,
+    profileName: String,
+    date: String,
+    dailyLimitMins: Option[Int],
+    usedMins: Int,
+    extensionMins: Int,
+    remainingMins: Option[Int],
+    siteUsage: List[SiteUsage],
+    devices: List[DeviceUsageSummary],
 ) derives JsonCodec
 
 case class ProfileDetail(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,7 +1,7 @@
 import type {
   CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardStats, Device,
-  DeviceTimeStatus, LoginResponse, MeResponse, ProfileDetail, QueryLog, RouterSummary,
-  SetUserProfilesRequest, TimeExtension, UpsertDeviceRequest, UpsertProfileRequest,
+  DeviceTimeStatus, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, QueryLog,
+  RouterSummary, SetUserProfilesRequest, TimeExtension, UpsertDeviceRequest, UpsertProfileRequest,
   GrantExtensionRequest, User,
 } from '@/types/api'
 
@@ -88,13 +88,13 @@ export const api = {
   // ── Time ───────────────────────────────────────────────────────────────
   time: {
     statusAll: (date?: string) =>
-      req<DeviceTimeStatus[]>('GET', `/time/status${date ? `?date=${date}` : ''}`),
+      req<ProfileTimeStatus[]>('GET', `/time/status${date ? `?date=${date}` : ''}`),
     statusDevice: (mac: string, date?: string) =>
       req<DeviceTimeStatus>('GET', `/time/status/${encodeURIComponent(mac)}${date ? `?date=${date}` : ''}`),
     grantExtension: (data: GrantExtensionRequest) =>
       req<{ id: number; grantedMinutes: number }>('POST', '/time/extend', data),
-    listExtensions: (mac: string) =>
-      req<TimeExtension[]>('GET', `/time/extensions/${encodeURIComponent(mac)}`),
+    listExtensions: (profileId: number) =>
+      req<TimeExtension[]>('GET', `/time/extensions/${profileId}`),
   },
 
   // ── Logs ───────────────────────────────────────────────────────────────

--- a/web/src/pages/BlockedPage.test.tsx
+++ b/web/src/pages/BlockedPage.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/api/client', () => ({
       login: vi.fn(),
     },
     time: {
+      statusDevice: vi.fn(),
       grantExtension: vi.fn(),
     },
   },
@@ -17,8 +18,9 @@ vi.mock('@/api/client', () => ({
 import { api } from '@/api/client'
 import { BlockedPage } from './BlockedPage'
 
-const mockLogin = api.auth.login as unknown as ReturnType<typeof vi.fn>
-const mockGrant = api.time.grantExtension as unknown as ReturnType<typeof vi.fn>
+const mockLogin        = api.auth.login as unknown as ReturnType<typeof vi.fn>
+const mockStatusDevice = api.time.statusDevice as unknown as ReturnType<typeof vi.fn>
+const mockGrant        = api.time.grantExtension as unknown as ReturnType<typeof vi.fn>
 
 function renderBlocked(params: Record<string, string>) {
   const search = '?' + new URLSearchParams(params).toString()
@@ -85,6 +87,7 @@ describe('BlockedPage — request extension flow', () => {
 
   it('successful parent login then grants extension and shows confirmation', async () => {
     mockLogin.mockResolvedValue({ token: 'parent-token', username: 'mom', role: 'admin' })
+    mockStatusDevice.mockResolvedValue({ profileId: 7, profileName: 'Kids', usedMins: 60, extensionMins: 0, remainingMins: 60, dailyLimitMins: 120, siteUsage: [], devices: [] })
     mockGrant.mockResolvedValue({ id: 1, grantedMinutes: 30 })
 
     const user = userEvent.setup()
@@ -110,7 +113,7 @@ describe('BlockedPage — request extension flow', () => {
 
     await waitFor(() =>
       expect(mockGrant).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceMac: 'aa:bb:cc:11:22:33' }),
+        expect.objectContaining({ profileId: 7 }),
       ),
     )
 

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -27,6 +27,7 @@ export function BlockedPage() {
   const [extMins, setExtMins]   = useState(30)
   const [loginErr, setLoginErr] = useState<string | null>(null)
   const [granting, setGranting] = useState(false)
+  const [profileId, setProfileId] = useState<number | null>(null)
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -34,6 +35,8 @@ export function BlockedPage() {
     try {
       const res = await api.auth.login(username, password)
       localStorage.setItem('token', res.token)
+      const status = await api.time.statusDevice(mac)
+      setProfileId(status.profileId ?? null)
       setStep('grant')
     } catch (err) {
       setLoginErr(err instanceof Error ? err.message : 'Login failed')
@@ -42,9 +45,10 @@ export function BlockedPage() {
 
   async function handleGrant(e: React.FormEvent) {
     e.preventDefault()
+    if (profileId == null) return
     setGranting(true)
     try {
-      await api.time.grantExtension({ deviceMac: mac, extraMinutes: extMins, note: null })
+      await api.time.grantExtension({ profileId, extraMinutes: extMins, note: null })
       setStep('done')
     } finally {
       setGranting(false)

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -1,3 +1,4 @@
+// TODO(#118): replace findByText(name).closest('.css-class') scoping with data-testid="device-row-{mac}"
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1,3 +1,4 @@
+// TODO(#118): replace findByText(name).closest('.css-class') scoping with data-testid="profile-card-{id}"
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -1,3 +1,4 @@
+// TODO(#118): replace findByText(name) load-wait and bare getByText with data-testid="time-card-{profileId}"
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -23,7 +23,7 @@ let mockAuth = { isAdmin: true }
 
 const limited: ProfileTimeStatus = {
   profileId: 1,
-  profileName: "Kid's iPad",
+  profileName: 'Kids',
   date: '2026-05-07',
   dailyLimitMins: 120,
   usedMins: 90,
@@ -37,7 +37,7 @@ const limited: ProfileTimeStatus = {
 
 const overLimit: ProfileTimeStatus = {
   profileId: 2,
-  profileName: 'Phone',
+  profileName: 'Teens',
   date: '2026-05-07',
   dailyLimitMins: 60,
   usedMins: 100,
@@ -49,7 +49,7 @@ const overLimit: ProfileTimeStatus = {
 
 const noLimit: ProfileTimeStatus = {
   profileId: 3,
-  profileName: 'Laptop',
+  profileName: 'Adults',
   date: '2026-05-07',
   dailyLimitMins: null,
   usedMins: 0,

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { DeviceTimeStatus } from '@/types/api'
+import type { ProfileTimeStatus } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
   api: {
@@ -21,11 +21,10 @@ import { TimePage } from './TimePage'
 
 let mockAuth = { isAdmin: true }
 
-const limited: DeviceTimeStatus = {
-  deviceMac: 'aa:bb:cc:dd:ee:01',
-  deviceName: "Kid's iPad",
+const limited: ProfileTimeStatus = {
+  profileId: 1,
+  profileName: "Kid's iPad",
   date: '2026-05-07',
-  profileName: 'Kids',
   dailyLimitMins: 120,
   usedMins: 90,
   extensionMins: 0,
@@ -33,30 +32,31 @@ const limited: DeviceTimeStatus = {
   siteUsage: [
     { label: 'YouTube', domainPattern: 'youtube.com', limitMins: 30, usedMins: 30, remainingMins: 0 },
   ],
+  devices: [{ deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", usedMins: 90 }],
 }
 
-const overLimit: DeviceTimeStatus = {
-  deviceMac: 'aa:bb:cc:dd:ee:02',
-  deviceName: 'Phone',
+const overLimit: ProfileTimeStatus = {
+  profileId: 2,
+  profileName: 'Phone',
   date: '2026-05-07',
-  profileName: 'Kids',
   dailyLimitMins: 60,
   usedMins: 100,
   extensionMins: 30,
   remainingMins: 0,
   siteUsage: [],
+  devices: [{ deviceMac: 'aa:bb:cc:dd:ee:02', deviceName: 'Phone', usedMins: 100 }],
 }
 
-const noLimit: DeviceTimeStatus = {
-  deviceMac: 'aa:bb:cc:dd:ee:03',
-  deviceName: 'Laptop',
+const noLimit: ProfileTimeStatus = {
+  profileId: 3,
+  profileName: 'Laptop',
   date: '2026-05-07',
-  profileName: 'Adults',
   dailyLimitMins: null,
   usedMins: 0,
   extensionMins: 0,
   remainingMins: null,
   siteUsage: [],
+  devices: [{ deviceMac: 'aa:bb:cc:dd:ee:03', deviceName: 'Laptop', usedMins: 0 }],
 }
 
 beforeEach(() => {
@@ -102,7 +102,7 @@ describe('TimePage — grant extension', () => {
 
     await waitFor(() =>
       expect(api.time.grantExtension).toHaveBeenCalledWith({
-        deviceMac: 'aa:bb:cc:dd:ee:01',
+        profileId: 1,
         extraMinutes: 45,
         note: 'great job',
       })
@@ -120,7 +120,7 @@ describe('TimePage — grant extension', () => {
     await user.click(screen.getByRole('button', { name: /Grant 30m/ }))
     await waitFor(() =>
       expect(api.time.grantExtension).toHaveBeenCalledWith({
-        deviceMac: 'aa:bb:cc:dd:ee:01',
+        profileId: 1,
         extraMinutes: 30,
         note: null,
       })

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
-import type { DeviceTimeStatus } from '@/types/api'
+import type { ProfileTimeStatus } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
 export function TimePage() {
   const { isAdmin }   = useAuth()
-  const [statuses, setStatuses] = useState<DeviceTimeStatus[]>([])
+  const [statuses, setStatuses] = useState<ProfileTimeStatus[]>([])
   const [loading, setLoading]   = useState(true)
-  const [extMac, setExtMac]     = useState<string | null>(null)
+  const [extProfileId, setExtProfileId] = useState<number | null>(null)
   const [extMins, setExtMins]   = useState(30)
   const [extNote, setExtNote]   = useState('')
   const [granting, setGranting] = useState(false)
@@ -25,11 +25,11 @@ export function TimePage() {
 
   useEffect(() => { load() }, [])
 
-  async function grantExtension(mac: string) {
+  async function grantExtension(profileId: number) {
     setGranting(true)
     try {
-      await api.time.grantExtension({ deviceMac: mac, extraMinutes: extMins, note: extNote || null })
-      setExtMac(null)
+      await api.time.grantExtension({ profileId, extraMinutes: extMins, note: extNote || null })
+      setExtProfileId(null)
       setExtMins(30)
       setExtNote('')
       await load()
@@ -48,26 +48,27 @@ export function TimePage() {
       </div>
 
       {statuses.length === 0 && (
-        <p className="text-gray-500 text-sm">No devices found. Add devices first.</p>
+        <p className="text-gray-500 text-sm">No profiles found.</p>
       )}
 
       <div className="grid gap-4 md:grid-cols-2">
         {statuses.map(s => (
-          <DeviceTimeCard
-            key={s.deviceMac}
+          <ProfileTimeCard
+            key={s.profileId}
             status={s}
             isAdmin={isAdmin}
-            onGrant={() => setExtMac(s.deviceMac)}
+            onGrant={() => setExtProfileId(s.profileId)}
           />
         ))}
       </div>
 
-      {/* Extension modal */}
-      {extMac && (
+      {extProfileId !== null && (
         <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4">
           <div className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-sm p-6 space-y-4">
             <h3 className="text-lg font-bold text-white">Grant Extra Time</h3>
-            <p className="text-sm text-gray-400 font-mono">{extMac}</p>
+            <p className="text-sm text-gray-400">
+              {statuses.find(s => s.profileId === extProfileId)?.profileName}
+            </p>
 
             <div>
               <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
@@ -105,13 +106,13 @@ export function TimePage() {
 
             <div className="flex gap-3 pt-2">
               <button
-                onClick={() => setExtMac(null)}
+                onClick={() => setExtProfileId(null)}
                 className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium hover:bg-gray-700 transition-colors"
               >
                 Cancel
               </button>
               <button
-                onClick={() => grantExtension(extMac)}
+                onClick={() => grantExtension(extProfileId)}
                 disabled={granting}
                 className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50 transition-colors"
               >
@@ -125,27 +126,24 @@ export function TimePage() {
   )
 }
 
-function DeviceTimeCard({
+function ProfileTimeCard({
   status, isAdmin, onGrant,
 }: {
-  status: DeviceTimeStatus
+  status: ProfileTimeStatus
   isAdmin: boolean
   onGrant: () => void
 }) {
-  const hasLimit = status.dailyLimitMins != null
-  const pct = hasLimit && status.dailyLimitMins
-    ? Math.min(100, Math.round((status.usedMins / (status.dailyLimitMins + status.extensionMins)) * 100))
+  const hasLimit  = status.dailyLimitMins != null
+  const limitBase = (status.dailyLimitMins ?? 0) + status.extensionMins
+  const pct       = hasLimit && limitBase > 0
+    ? Math.min(100, Math.round((status.usedMins / limitBase) * 100))
     : 0
   const overLimit = hasLimit && status.remainingMins != null && status.remainingMins <= 0
 
   return (
     <div className={`bg-gray-900 rounded-2xl border p-5 space-y-4 ${overLimit ? 'border-red-500/40' : 'border-gray-800'}`}>
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <h3 className="font-semibold text-white">{status.deviceName}</h3>
-          <p className="text-xs text-gray-500 font-mono">{status.deviceMac}</p>
-          <p className="text-xs text-gray-600 mt-0.5">{status.profileName}</p>
-        </div>
+        <h3 className="font-semibold text-white text-lg">{status.profileName}</h3>
         {isAdmin && hasLimit && (
           <button
             onClick={onGrant}
@@ -157,56 +155,69 @@ function DeviceTimeCard({
       </div>
 
       {hasLimit ? (
-        <>
-          <div>
-            <div className="flex justify-between text-xs text-gray-500 mb-1.5">
-              <span>{status.usedMins}m used</span>
-              <span>
-                {status.remainingMins != null && status.remainingMins > 0
-                  ? `${status.remainingMins}m left`
-                  : <span className="text-red-400">Limit reached</span>
-                }
-              </span>
-            </div>
-            <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all ${overLimit ? 'bg-red-500' : 'bg-emerald-500'}`}
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-            <div className="flex justify-between text-xs text-gray-600 mt-1">
-              <span>Limit: {status.dailyLimitMins}m</span>
-              {status.extensionMins > 0 && (
-                <span className="text-yellow-500">+{status.extensionMins}m extended</span>
-              )}
-            </div>
+        <div>
+          <div className="flex justify-between text-xs text-gray-500 mb-1.5">
+            <span>{status.usedMins}m used</span>
+            <span>
+              {status.remainingMins != null && status.remainingMins > 0
+                ? `${status.remainingMins}m left`
+                : <span className="text-red-400">Limit reached</span>
+              }
+            </span>
           </div>
-
-          {status.siteUsage.length > 0 && (
-            <div className="space-y-2">
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Site Limits</p>
-              {status.siteUsage.map(su => (
-                <div key={su.domainPattern} className="bg-gray-800/50 rounded-xl p-3">
-                  <div className="flex justify-between text-xs mb-1">
-                    <span className="text-gray-300 font-medium">{su.label}</span>
-                    <span className={su.remainingMins <= 0 ? 'text-red-400' : 'text-gray-500'}>
-                      {su.remainingMins <= 0 ? 'Limit reached' : `${su.remainingMins}m left`}
-                    </span>
-                  </div>
-                  <div className="h-1.5 bg-gray-700 rounded-full overflow-hidden">
-                    <div
-                      className={`h-full rounded-full ${su.remainingMins <= 0 ? 'bg-red-500' : 'bg-yellow-500'}`}
-                      style={{ width: `${Math.min(100, Math.round((su.usedMins / su.limitMins) * 100))}%` }}
-                    />
-                  </div>
-                  <p className="text-xs text-gray-600 mt-1 font-mono">{su.domainPattern}</p>
-                </div>
-              ))}
-            </div>
-          )}
-        </>
+          <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all ${overLimit ? 'bg-red-500' : 'bg-emerald-500'}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-xs text-gray-600 mt-1">
+            <span>Limit: {status.dailyLimitMins}m</span>
+            {status.extensionMins > 0 && (
+              <span className="text-yellow-500">+{status.extensionMins}m extended</span>
+            )}
+          </div>
+        </div>
       ) : (
         <p className="text-xs text-gray-600">No time limit set for this profile</p>
+      )}
+
+      {status.devices.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Devices</p>
+          {status.devices.map(d => (
+            <div key={d.deviceMac} className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2">
+              <span className="text-gray-300">{d.deviceName}</span>
+              <span className="text-gray-500 font-mono">{d.usedMins}m</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {status.siteUsage.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Site Limits</p>
+          {status.siteUsage.map(su => (
+            <div key={su.domainPattern} className="bg-gray-800/50 rounded-xl p-3">
+              <div className="flex justify-between text-xs mb-1">
+                <span className="text-gray-300 font-medium">{su.label}</span>
+                <span className={su.remainingMins <= 0 ? 'text-red-400' : 'text-gray-500'}>
+                  {su.remainingMins <= 0 ? 'Limit reached' : `${su.remainingMins}m left`}
+                </span>
+              </div>
+              <div className="h-1.5 bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${su.remainingMins <= 0 ? 'bg-red-500' : 'bg-yellow-500'}`}
+                  style={{ width: `${Math.min(100, Math.round((su.usedMins / su.limitMins) * 100))}%` }}
+                />
+              </div>
+              <div className="flex justify-between text-xs text-gray-600 mt-1">
+                <span className="font-mono">{su.domainPattern}</span>
+                <span>{su.usedMins}m / {su.limitMins}m</span>
+              </div>
+            </div>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -1,3 +1,4 @@
+// TODO(#118): replace getByText(name).closest('.css-class') scoping with data-testid="user-row-{id}"
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -104,9 +104,28 @@ export interface DeviceTimeStatus {
   siteUsage: SiteUsage[]
 }
 
+export interface DeviceUsageSummary {
+  deviceMac: string
+  deviceName: string
+  usedMins: number
+}
+
+export interface ProfileTimeStatus {
+  profileId: number
+  profileName: string
+  date: string
+  dailyLimitMins?: number | null
+  usedMins: number
+  extensionMins: number
+  remainingMins?: number | null
+  siteUsage: SiteUsage[]
+  devices: DeviceUsageSummary[]
+}
+
 export interface TimeExtension {
   id: number
-  deviceMac: string
+  profileId: number | null
+  deviceMac: string | null
   date: string
   extraMinutes: number
   grantedBy: string
@@ -179,7 +198,7 @@ export interface UpsertDeviceRequest {
 }
 
 export interface GrantExtensionRequest {
-  deviceMac: string
+  profileId: number
   extraMinutes: number
   note: string | null
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -97,6 +97,7 @@ export interface DeviceTimeStatus {
   deviceName: string
   date: string
   profileName: string
+  profileId?: number | null
   dailyLimitMins?: number | null
   usedMins: number
   extensionMins: number


### PR DESCRIPTION
## Summary

- **V5 migration**: makes `time_extensions.device_mac` nullable and adds `profile_id` FK, enabling extensions to be granted at the profile level rather than per-device
- **`ProfileTimeStatus` model**: replaces `DeviceTimeStatus`; aggregates usage across all devices in a profile, includes `devices: List[DeviceUsageSummary]` and `siteUsage: List[SiteUsage]` breakdowns
- **`GET /api/time/status`**: now returns one entry per profile (shared usage pool across all profile devices), with per-device and per-site sub-summaries
- **`POST /api/time/extend`**: accepts `profileId` instead of `deviceMac`; extension is applied to the full profile pool
- **TimePage UI**: per-profile cards with progress bar, per-device row breakdown, and per-site-limit bars

Closes #14. Related: #15 (per-app exempt/include toggle — separate issue), #69 (usage accumulation — ingest already merged).

## Test plan

- [x] All 190 existing tests pass
- [x] New per-profile rollup tests: single `ProfileTimeStatus` per profile, combined pool clamped at 0 when over limit, per-device breakdown totals correct
- [x] Per-app site usage aggregated across all profile devices (site minutes excluded from total cap)
- [x] Policy snapshot correctly uses profile-level extension sums
- [x] `RouterDecisionSpec` extension grant updated to use `grantForProfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)