### PR TITLE
Switch to braces style: reformat all Scala files, enforce via -no-indent

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,7 +3,6 @@ runner.dialect = scala3
 
 maxColumn = 100
 indent.main = 2
-indent.significant = 2
 
 align.preset = more
 align.multiline = true
@@ -12,11 +11,13 @@ newlines.implicitParamListModifierPrefer = before
 newlines.afterCurlyLambdaParams = squash
 
 rewrite.rules = [
-  RedundantBraces,
   RedundantParens,
   SortImports,
   PreferCurlyFors,
 ]
+
+rewrite.scala3.convertToNewSyntax = false
+rewrite.scala3.removeOptionalBraces = no
 
 docstrings.style = Asterisk
 docstrings.oneline = fold

--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -43,9 +43,9 @@ case class DnsClientConfig(
     logFlushSeconds: Int,
 )
 
-object AppConfig:
+object AppConfig {
   val layer: ZLayer[Any, Config.Error, AppConfig] =
-    ZLayer.fromZIO:
+    ZLayer.fromZIO {
       val path = sys.props.getOrElse("config.file", "config/application.conf")
       read(
         deriveConfig[AppConfig]
@@ -54,3 +54,5 @@ object AppConfig:
             TypesafeConfigProvider.fromHoconFile(new java.io.File(path)),
           ),
       )
+    }
+}

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -10,13 +10,13 @@ import zio.http.*
 import zio.logging.*
 import zio.logging.backend.SLF4J
 
-object Main extends ZIOAppDefault:
+object Main extends ZIOAppDefault {
 
   override val bootstrap =
     Runtime.removeDefaultLoggers >>> SLF4J.slf4j
 
   def run =
-    (for
+    (for {
       cfg    <- ZIO.service[AppConfig]
       _      <- ZIO.logInfo(s"FamilyDNS API starting on ${cfg.http.host}:${cfg.http.port}")
       _      <- Database.runMigrations(cfg.db)
@@ -25,7 +25,7 @@ object Main extends ZIOAppDefault:
       _      <- Server
         .serve(routes)
         .provide(Server.defaultWithPort(cfg.http.port))
-    yield ()).provide(serverEnv)
+    } yield ()).provide(serverEnv)
 
   private val serverEnv =
     AppConfig.layer >+>
@@ -38,7 +38,7 @@ object Main extends ZIOAppDefault:
       PolicyService.layer
 
   private def allRoutes =
-    for
+    for {
       auth        <- ZIO.service[AuthService]
       userRepo    <- ZIO.service[UserRepo]
       upRepo      <- ZIO.service[UserProfileRepo]
@@ -59,7 +59,7 @@ object Main extends ZIOAppDefault:
       cfg         <- ZIO.service[AppConfig]
       clock       <- ZIO.service[Clock]
       routerAuth = new RouterAuthLive(routerRepo)
-    yield AuthRoutes.routes(auth, userRepo, upRepo) ++
+    } yield AuthRoutes.routes(auth, userRepo, upRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
       TimeRoutes.routes(
@@ -86,3 +86,4 @@ object Main extends ZIOAppDefault:
         connRepo,
       ) ++
       StaticRoutes.routes(cfg.http.staticDir)
+}

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -21,34 +21,36 @@ case class JwtClaims(
 // ── Auth errors ────────────────────────────────────────────────────────────
 
 sealed trait AuthError
-object AuthError:
+object AuthError {
   case object InvalidCredentials     extends AuthError
   case object TokenExpired           extends AuthError
   case object InvalidToken           extends AuthError
   case object Forbidden              extends AuthError
   case class Unexpected(msg: String) extends AuthError
+}
 
 // ── Auth service ───────────────────────────────────────────────────────────
 
-trait AuthService:
+trait AuthService {
   def login(username: String, password: String): IO[AuthError, LoginResponse]
   def verify(token: String): IO[AuthError, JwtClaims]
   def requireAdmin(token: String): IO[AuthError, JwtClaims]
   def requireWriter(token: String): IO[AuthError, JwtClaims]
   def changePassword(username: String, current: String, next: String): IO[AuthError, Unit]
   def hashPassword(password: String): UIO[String]
+}
 
 class AuthServiceLive(
     userRepo: UserRepo,
     jwtConfig: JwtConfig,
     clock: Clock,
-) extends AuthService:
+) extends AuthService {
 
   private val algo: JwtHmacAlgorithm = JwtAlgorithm.HS256
   private val secret                 = jwtConfig.secret
 
   def login(username: String, password: String): IO[AuthError, LoginResponse] =
-    for
+    for {
       user  <- userRepo
         .findByUsername(username)
         .mapError(e => AuthError.Unexpected(e.getMessage))
@@ -67,7 +69,7 @@ class AuthServiceLive(
       token <- ZIO
         .attempt(JwtZIOJson.encode(claim, secret, algo))
         .mapError(e => AuthError.Unexpected(e.getMessage))
-    yield LoginResponse(token, user.role, user.username)
+    } yield LoginResponse(token, user.role, user.username)
 
   // We delegate expiration/not-before checks to our injected Clock (see below).
   private val jwtOpts = JwtOptions(expiration = false, notBefore = false)
@@ -109,7 +111,7 @@ class AuthServiceLive(
     }
 
   def changePassword(username: String, current: String, next: String): IO[AuthError, Unit] =
-    for
+    for {
       user  <- userRepo
         .findByUsername(username)
         .mapError(e => AuthError.Unexpected(e.getMessage))
@@ -122,11 +124,13 @@ class AuthServiceLive(
       _     <- userRepo
         .updatePassword(user.id, hash)
         .mapError(e => AuthError.Unexpected(e.getMessage))
-    yield ()
+    } yield ()
 
   def hashPassword(password: String): UIO[String] =
     ZIO.succeed(BCrypt.withDefaults().hashToString(12, password.toCharArray))
+}
 
-object AuthService:
+object AuthService {
   val layer: ZLayer[UserRepo & JwtConfig & Clock, Nothing, AuthService] =
     ZLayer.fromFunction(AuthServiceLive(_, _, _))
+}

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -7,9 +7,9 @@ import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*
 
-object Database:
+object Database {
 
-  def makeTransactor(cfg: DbConfig): Transactor[Task] =
+  def makeTransactor(cfg: DbConfig): Transactor[Task] = {
     val ds = new HikariDataSource()
     ds.setJdbcUrl(s"jdbc:postgresql://${cfg.host}:${cfg.port}/${cfg.database}")
     ds.setUsername(cfg.user)
@@ -20,9 +20,10 @@ object Database:
     ds.setIdleTimeout(600000)
     ds.setMaxLifetime(1800000)
     Transactor.fromDataSource[Task](ds, scala.concurrent.ExecutionContext.global)
+  }
 
   def runMigrations(cfg: DbConfig): Task[Unit] =
-    ZIO.attempt:
+    ZIO.attempt {
       Flyway
         .configure()
         .dataSource(
@@ -35,3 +36,5 @@ object Database:
         .load()
         .migrate()
       ()
+    }
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -41,15 +41,16 @@ case class LogFilter(
     offset: Int = 0,
 )
 
-trait UserRepo:
+trait UserRepo {
   def findByUsername(u: String): Task[Option[DbUser]]
   def findById(id: Long): Task[Option[DbUser]]
   def create(u: String, h: String, r: String): Task[Long]
   def updatePassword(id: Long, h: String): Task[Unit]
   def listAll: Task[List[DbUser]]
   def delete(id: Long): Task[Unit]
+}
 
-trait UserProfileRepo:
+trait UserProfileRepo {
   def listProfilesForUser(userId: Long): Task[List[Long]]
   def listProfilesForUsername(username: String): Task[List[Long]]
   def listAllMappings: Task[List[(Long, Long)]] // (userId, profileId)
@@ -57,32 +58,37 @@ trait UserProfileRepo:
   def addLink(userId: Long, profileId: Long): Task[Unit]
   def removeLink(userId: Long, profileId: Long): Task[Unit]
   def hasAccess(userId: Long, profileId: Long): Task[Boolean]
+}
 
-trait ProfileRepo:
+trait ProfileRepo {
   def listAll: Task[List[Profile]]
   def findById(id: Long): Task[Option[Profile]]
   def create(name: String, cats: List[String]): Task[Long]
   def update(p: Profile): Task[Unit]
   def delete(id: Long): Task[Unit]
   def setPaused(id: Long, paused: Boolean): Task[Unit]
+}
 
-trait ScheduleRepo:
+trait ScheduleRepo {
   def listAll: Task[List[Schedule]]
   def listForProfile(pid: Long): Task[List[Schedule]]
   def replaceForProfile(pid: Long, scheds: List[ScheduleRequest]): Task[Unit]
+}
 
-trait TimeLimitRepo:
+trait TimeLimitRepo {
   def findForProfile(pid: Long): Task[Option[TimeLimit]]
   def upsert(pid: Long, mins: Int): Task[Unit]
   def delete(pid: Long): Task[Unit]
   def listAll: Task[List[TimeLimit]]
+}
 
-trait SiteTimeLimitRepo:
+trait SiteTimeLimitRepo {
   def listForProfile(pid: Long): Task[List[SiteTimeLimit]]
   def listAll: Task[List[SiteTimeLimit]]
   def replaceForProfile(pid: Long, limits: List[SiteTimeLimitRequest]): Task[Unit]
+}
 
-trait DeviceRepo:
+trait DeviceRepo {
   def listAll: Task[List[Device]]
   def findByMac(mac: String): Task[Option[Device]]
   def upsert(mac: String, name: String, pid: Long, ip: String): Task[Long]
@@ -101,16 +107,18 @@ trait DeviceRepo:
   def upsertUnknown(mac: String, name: String, ip: Option[String], at: Instant): Task[Long]
   def updateProfile(mac: String, pid: Long): Task[Unit]
   def delete(mac: String): Task[Unit]
+}
 
-trait BlocklistRepo:
+trait BlocklistRepo {
   def insertBatch(domains: List[(String, String)]): Task[Int]
   def clearCategory(cat: String): Task[Unit]
   def listCategories: Task[List[String]]
   def countByCategory: Task[List[(String, Int)]]
   def loadCategory(cat: String): Task[Set[String]]
   def loadAll: Task[Map[String, Set[String]]]
+}
 
-trait TimeUsageRepo:
+trait TimeUsageRepo {
   def getUsage(mac: String, domain: String, date: LocalDate): Task[Int]
   def getTotalUsage(mac: String, date: LocalDate): Task[Int]
   def incrementUsage(mac: String, domain: String, date: LocalDate, mins: Int): Task[Unit]
@@ -140,8 +148,9 @@ trait TimeUsageRepo:
   def listForDevice(mac: String, date: LocalDate): Task[List[TimeUsage]]
   def listForDeviceMacs(macs: List[String], date: LocalDate): Task[List[TimeUsage]]
   def snapshotAll(date: LocalDate): Task[Map[(String, String), Int]]
+}
 
-trait TimeExtensionRepo:
+trait TimeExtensionRepo {
   def getTotalExtension(mac: String, date: LocalDate): Task[Int]
   def grant(mac: String, date: LocalDate, mins: Int, by: String, note: Option[String]): Task[Long]
   def listForDevice(mac: String, date: LocalDate): Task[List[TimeExtension]]
@@ -157,6 +166,7 @@ trait TimeExtensionRepo:
   def getProfileTotalExtension(profileId: Long, date: LocalDate): Task[Int]
   def listForProfile(profileId: Long, date: LocalDate): Task[List[TimeExtension]]
   def snapshotAllByProfile(date: LocalDate): Task[Map[Long, Int]]
+}
 
 case class TrafficReportInsert(
     routerId: UUID,
@@ -187,7 +197,7 @@ case class ConnectionEventInsert(
     ts: Instant,
 )
 
-trait RouterRepo:
+trait RouterRepo {
   def listAll: Task[List[Router]]
   def findById(id: UUID): Task[Option[Router]]
   def findByEnrollmentTokenHash(h: String): Task[Option[Router]]
@@ -196,30 +206,35 @@ trait RouterRepo:
   def completeEnrollment(id: UUID, tokenHash: String): Task[Unit]
   def touch(id: UUID, etag: Option[String]): Task[Unit]
   def delete(id: UUID): Task[Unit]
+}
 
-trait TrafficReportRepo:
+trait TrafficReportRepo {
   def insertBatch(reports: List[TrafficReportInsert]): Task[Int]
   def listForDevice(mac: String, date: LocalDate): Task[List[TrafficReport]]
   def listForRouter(routerId: UUID, limit: Int): Task[List[TrafficReport]]
+}
 
-trait BlockEventRepo:
+trait BlockEventRepo {
   def insertBatch(events: List[BlockEventInsert]): Task[Int]
   def recent(limit: Int): Task[List[BlockEvent]]
   def listForMac(mac: String, limit: Int): Task[List[BlockEvent]]
+}
 
-trait ConnectionEventRepo:
+trait ConnectionEventRepo {
   def insertBatch(events: List[ConnectionEventInsert]): Task[Int]
   def recent(limit: Int): Task[List[ConnectionEvent]]
   def listForMac(mac: String, limit: Int): Task[List[ConnectionEvent]]
   def listForRouter(routerId: UUID, limit: Int): Task[List[ConnectionEvent]]
+}
 
-trait QueryLogRepo:
+trait QueryLogRepo {
   def insertBatch(logs: List[QueryLogInsert]): Task[Unit]
   def query(f: LogFilter): Task[List[QueryLog]]
   def stats: Task[DashboardStats]
   def topBlocked(hours: Int, limit: Int): Task[List[DomainCount]]
+}
 
-class UserRepoLive(xa: Transactor[Task]) extends UserRepo:
+class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
   def findByUsername(u: String)               =
     sql"SELECT id,username,password_hash,role,created_at FROM users WHERE username=$u"
       .query[(Long, String, String, String, Instant)]
@@ -245,8 +260,9 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo:
     .to[List]
     .transact(xa)
   def delete(id: Long) = sql"DELETE FROM users WHERE id=$id".update.run.transact(xa).unit
+}
 
-class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo:
+class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo {
   def listProfilesForUser(userId: Long)                  =
     sql"SELECT profile_id FROM user_profiles WHERE user_id=$userId ORDER BY profile_id"
       .query[Long]
@@ -262,12 +278,13 @@ class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo:
       .query[(Long, Long)]
       .to[List]
       .transact(xa)
-  def setProfilesForUser(userId: Long, pids: List[Long]) =
+  def setProfilesForUser(userId: Long, pids: List[Long]) = {
     val del = sql"DELETE FROM user_profiles WHERE user_id=$userId".update.run
     val ins = pids.distinct.map(pid =>
       sql"INSERT INTO user_profiles(user_id,profile_id) VALUES($userId,$pid) ON CONFLICT DO NOTHING".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
   def addLink(userId: Long, pid: Long)                   =
     sql"INSERT INTO user_profiles(user_id,profile_id) VALUES($userId,$pid) ON CONFLICT DO NOTHING".update.run
       .transact(xa)
@@ -282,8 +299,9 @@ class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo:
       .option
       .transact(xa)
       .map(_.isDefined)
+}
 
-class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo:
+class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
   private type R = (Long, String, List[String], List[String], List[String], Boolean)
   private def toP(r: R)                        = Profile(r._1, r._2, r._3, r._4, r._5, r._6)
   def listAll                                  =
@@ -310,8 +328,9 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo:
   def delete(id: Long) = sql"DELETE FROM profiles WHERE id=$id".update.run.transact(xa).unit
   def setPaused(id: Long, p: Boolean) =
     sql"UPDATE profiles SET paused=$p WHERE id=$id".update.run.transact(xa).unit
+}
 
-class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo:
+class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
   private type R = (Long, Long, String, List[String], String, String)
   private def toS(r: R)         = Schedule(r._1, r._2, r._3, r._4, r._5, r._6)
   def listAll                   =
@@ -326,14 +345,16 @@ class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo:
       .map(toS)
       .to[List]
       .transact(xa)
-  def replaceForProfile(pid: Long, ss: List[ScheduleRequest]) =
+  def replaceForProfile(pid: Long, ss: List[ScheduleRequest]) = {
     val del = sql"DELETE FROM schedules WHERE profile_id=$pid".update.run
     val ins = ss.map(s =>
       sql"INSERT INTO schedules(profile_id,name,days,block_from,block_until) VALUES($pid,${s.name},${s.days.toArray},${s.blockFrom},${s.blockUntil})".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
+}
 
-class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo:
+class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
   def findForProfile(pid: Long)    =
     sql"SELECT id,profile_id,daily_minutes FROM time_limits WHERE profile_id=$pid"
       .query[(Long, Long, Int)]
@@ -351,8 +372,9 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo:
     .map(TimeLimit.apply)
     .to[List]
     .transact(xa)
+}
 
-class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo:
+class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
   private type R = (Long, Long, String, Int, String)
   private def toS(r: R)         = SiteTimeLimit(r._1, r._2, r._3, r._4, r._5)
   def listForProfile(pid: Long) =
@@ -367,14 +389,16 @@ class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo:
       .map(toS)
       .to[List]
       .transact(xa)
-  def replaceForProfile(pid: Long, ls: List[SiteTimeLimitRequest]) =
+  def replaceForProfile(pid: Long, ls: List[SiteTimeLimitRequest]) = {
     val del = sql"DELETE FROM site_time_limits WHERE profile_id=$pid".update.run
     val ins = ls.map(l =>
       sql"INSERT INTO site_time_limits(profile_id,domain_pattern,daily_minutes,label) VALUES($pid,${l.domainPattern},${l.dailyMinutes},${l.label})".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
+}
 
-class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
+class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
   def listAll                                                                   =
     sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id ORDER BY d.name"
       .query[
@@ -432,8 +456,9 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo:
   def updateProfile(mac: String, pid: Long)                                     =
     sql"UPDATE devices SET profile_id=$pid WHERE mac=$mac".update.run.transact(xa).unit
   def delete(mac: String) = sql"DELETE FROM devices WHERE mac=$mac".update.run.transact(xa).unit
+}
 
-class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo:
+class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo {
   def insertBatch(ds: List[(String, String)]) = Update[(String, String)](
     "INSERT INTO blocklist_domains(domain,category) VALUES(?,?) ON CONFLICT DO NOTHING",
   ).updateMany(ds).transact(xa)
@@ -458,8 +483,9 @@ class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo:
     .to[List]
     .transact(xa)
     .map(_.groupBy(_._1).map((k, vs) => k -> vs.map(_._2).toSet))
+}
 
-class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo:
+class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
   def getUsage(mac: String, dom: String, d: LocalDate)                                     =
     sql"SELECT COALESCE(minutes_used,0) FROM time_usage WHERE device_mac=$mac AND domain=$dom AND date=$d"
       .query[Int]
@@ -512,21 +538,23 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo:
       .transact(xa)
   def listForDeviceMacs(macs: List[String], d: LocalDate)                                  =
     if macs.isEmpty then ZIO.succeed(Nil)
-    else
+    else {
       val arr = macs.toArray
       sql"SELECT id,device_mac,domain,date::TEXT,minutes_used,last_seen_at::TEXT FROM time_usage WHERE device_mac = ANY($arr) AND date=$d ORDER BY device_mac,minutes_used DESC"
         .query[(Long, String, String, String, Int, String)]
         .map(TimeUsage.apply)
         .to[List]
         .transact(xa)
+    }
   def snapshotAll(d: LocalDate)                                                            =
     sql"SELECT device_mac,domain,minutes_used FROM time_usage WHERE date=$d"
       .query[(String, String, Int)]
       .to[List]
       .transact(xa)
       .map(_.map((m, dom, mins) => (m, dom) -> mins).toMap)
+}
 
-class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo:
+class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo {
   def getTotalExtension(mac: String, d: LocalDate)                                          =
     sql"SELECT COALESCE(SUM(extra_minutes),0)::INT FROM time_extensions WHERE device_mac=$mac AND date=$d"
       .query[Int]
@@ -571,8 +599,9 @@ class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo:
       .to[List]
       .transact(xa)
       .map(_.toMap)
+}
 
-class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo:
+class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
   private type R =
     (UUID, String, Option[String], Option[String], Option[Instant], Option[String], Instant)
   private def toR(r: R)                                 =
@@ -624,8 +653,9 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo:
       .unit
   def delete(id: UUID)                                  =
     sql"DELETE FROM routers WHERE id=$id".update.run.transact(xa).unit
+}
 
-class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo:
+class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
   private type R =
     (Long, UUID, String, Option[String], String, String, String, String, Int, Long, Long)
   private def toT(r: R)                               =
@@ -646,8 +676,9 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo:
       .map(toT)
       .to[List]
       .transact(xa)
+}
 
-class BlockEventRepoLive(xa: Transactor[Task]) extends BlockEventRepo:
+class BlockEventRepoLive(xa: Transactor[Task]) extends BlockEventRepo {
   private type R = (Long, Option[String], String, String, String)
   private def toB(r: R)                           = BlockEvent(r._1, r._2, r._3, r._4, r._5)
   def insertBatch(events: List[BlockEventInsert]) =
@@ -666,8 +697,9 @@ class BlockEventRepoLive(xa: Transactor[Task]) extends BlockEventRepo:
       .map(toB)
       .to[List]
       .transact(xa)
+}
 
-class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo:
+class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo {
   private type R =
     (Long, UUID, Option[String], String, Option[String], Boolean, String, String)
   private def toC(r: R)                                =
@@ -694,12 +726,13 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo:
       .map(toC)
       .to[List]
       .transact(xa)
+}
 
-class QueryLogRepoLive(xa: Transactor[Task]) extends QueryLogRepo:
+class QueryLogRepoLive(xa: Transactor[Task]) extends QueryLogRepo {
   def insertBatch(logs: List[QueryLogInsert]) = Update[QueryLogInsert](
     "INSERT INTO query_logs(mac,device_name,profile_id,profile_name,domain,qtype,blocked,reason,location) VALUES(?,?,?,?,?,?,?,?,?)",
   ).updateMany(logs).transact(xa).unit
-  def query(f: LogFilter)                     =
+  def query(f: LogFilter)                     = {
     val base  =
       fr"SELECT id,mac,device_name,profile_id,profile_name,domain,qtype,blocked,reason,location,ts::TEXT FROM query_logs WHERE 1=1"
     val since = fr"AND ts > NOW() - make_interval(hours => ${f.hours})"
@@ -726,8 +759,9 @@ class QueryLogRepoLive(xa: Transactor[Task]) extends QueryLogRepo:
       .map(QueryLog.apply)
       .to[List]
       .transact(xa)
+  }
   def stats                                   =
-    for
+    for {
       tt <- sql"SELECT COUNT(*)::INT FROM query_logs WHERE ts > NOW()-INTERVAL '24 hours'"
         .query[Int]
         .unique
@@ -757,15 +791,16 @@ class QueryLogRepoLive(xa: Transactor[Task]) extends QueryLogRepo:
           .map(DeviceStats.apply)
           .to[List]
           .transact(xa)
-    yield DashboardStats(tt, bt, th, bh, top, dev)
+    } yield DashboardStats(tt, bt, th, bh, top, dev)
   def topBlocked(hours: Int, lim: Int)        =
     sql"SELECT domain,COUNT(*)::INT FROM query_logs WHERE blocked AND ts > NOW() - make_interval(hours => $hours) GROUP BY domain ORDER BY COUNT(*) DESC LIMIT $lim"
       .query[(String, Int)]
       .map(DomainCount.apply)
       .to[List]
       .transact(xa)
+}
 
-object Repos:
+object Repos {
   val userRepo          = ZLayer.fromFunction(UserRepoLive(_))
   val userProfileRepo   = ZLayer.fromFunction(UserProfileRepoLive(_))
   val profileRepo       = ZLayer.fromFunction(ProfileRepoLive(_))
@@ -783,3 +818,4 @@ object Repos:
   val connEventRepo     = ZLayer.fromFunction(ConnectionEventRepoLive(_))
   val all               =
     userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ queryLogRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo
+}

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -7,10 +7,11 @@ import zio.{Clock as _, *}
 import java.security.MessageDigest
 import java.time.{DayOfWeek, LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
 
-trait PolicyService:
+trait PolicyService {
   def snapshot: Task[PolicySnapshot]
   def renderRpz(category: String): Task[Option[(String, String)]]
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse]
+}
 
 class PolicyServiceLive(
     profileRepo: ProfileRepo,
@@ -22,10 +23,10 @@ class PolicyServiceLive(
     usageRepo: TimeUsageRepo,
     extRepo: TimeExtensionRepo,
     clock: Clock,
-) extends PolicyService:
+) extends PolicyService {
 
   def snapshot: Task[PolicySnapshot] =
-    for
+    for {
       today    <- clock.today
       now      <- clock.now
       profiles <- profileRepo.listAll
@@ -39,7 +40,7 @@ class PolicyServiceLive(
       schedMap = scheds.toMap
       tlMap    = tlims.toMap
       stlMap   = stlims.toMap
-    yield
+    } yield {
       val devsByProfile =
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
       val pProfiles     = profiles.map { p =>
@@ -91,14 +92,15 @@ class PolicyServiceLive(
         profiles = pProfiles,
         blocklists = pBlocklists,
       )
+    }
 
   def renderRpz(category: String): Task[Option[(String, String)]] =
-    for
+    for {
       today   <- clock.today
       domains <- blocklistRepo.loadCategory(category)
-    yield
+    } yield
       if domains.isEmpty then None
-      else
+      else {
         val origin = s"$category.rpz."
         val serial = today.toString.replace("-", "")
         val sb     = new StringBuilder
@@ -110,15 +112,16 @@ class PolicyServiceLive(
         val body   = sb.toString
         val etag   = s"\"${PolicyService.sha256Hex(body).take(16)}-$serial\""
         Some((etag, body))
+      }
 
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
-    for
+    for {
       snap  <- snapshot
       now   <- clock.now
       today <- clock.today
       device  = snap.devices.find(_.mac.equalsIgnoreCase(mac))
       profile = device.flatMap(d => d.profileId.flatMap(pid => snap.profiles.find(_.id == pid)))
-      result <- profile match
+      result <- profile match {
         case None    => ZIO.succeed(RouterDecisionResponse("allow", "no_profile", None))
         case Some(p) =>
           val h = hostname.toLowerCase.stripSuffix(".")
@@ -132,21 +135,23 @@ class PolicyServiceLive(
                 else if matchesAny(h, p.extraBlocked) then
                   ZIO.succeed(RouterDecisionResponse("block", "extra_blocked", None))
                 else
-                  timeLimitBlock(p, h, today) match
+                  timeLimitBlock(p, h, today) match {
                     case Some(r) => ZIO.succeed(r)
                     case None    =>
                       categoryBlock(p.blockedCategories, h).map {
                         case Some(cat) => RouterDecisionResponse("block", s"category:$cat", None)
                         case None      => RouterDecisionResponse("allow", "allowed", None)
                       }
+                  }
             }
-    yield result
+      }
+    } yield result
 
   private def scheduleBlock(
       schedules: List[PolicySchedule],
       nowTime: LocalTime,
       today: LocalDate,
-  ): Task[Option[RouterDecisionResponse]] =
+  ): Task[Option[RouterDecisionResponse]] = {
     val todayName = dayName(today)
     val prevName  = dayName(today.minusDays(1))
     val active    = schedules.find { s =>
@@ -171,12 +176,13 @@ class PolicyServiceLive(
           utcString(today, until)
       RouterDecisionResponse("block", "schedule", Some(expiresAt))
     })
+  }
 
   private def timeLimitBlock(
       p: PolicyProfile,
       hostname: String,
       today: LocalDate,
-  ): Option[RouterDecisionResponse] =
+  ): Option[RouterDecisionResponse] = {
     val midnight     = utcString(today.plusDays(1), LocalTime.MIDNIGHT)
     val siteLimitHit = p.siteLimits.find { sl =>
       matchesDomainPattern(hostname, sl.domain) &&
@@ -193,6 +199,7 @@ class PolicyServiceLive(
           )
         }
       }
+  }
 
   private def categoryBlock(
       cats: List[String],
@@ -209,18 +216,20 @@ class PolicyServiceLive(
     patterns.exists(p => matchesDomainPattern(domain, p))
 
   private def matchesDomainPattern(domain: String, pattern: String): Boolean =
-    if pattern.startsWith("*.") then
+    if pattern.startsWith("*.") then {
       val suffix = pattern.drop(1)
       domain.endsWith(suffix) || domain == pattern.drop(2)
-    else domain == pattern || domain.endsWith(s".$pattern")
+    } else domain == pattern || domain.endsWith(s".$pattern")
 
-  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean =
+  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean = {
     val parts = domain.split('.').toList
     (0 until parts.length - 1).exists(i => list.contains(parts.drop(i).mkString(".")))
+  }
 
-  private def parseTime(s: String): LocalTime =
+  private def parseTime(s: String): LocalTime = {
     val Array(h, m) = s.split(':')
     LocalTime.of(h.toInt, m.toInt)
+  }
 
   private val dayNames: Map[DayOfWeek, String] = Map(
     DayOfWeek.MONDAY    -> "mon",
@@ -236,6 +245,7 @@ class PolicyServiceLive(
 
   private def utcString(date: LocalDate, time: LocalTime): String =
     OffsetDateTime.of(date, time, ZoneOffset.UTC).toInstant.toString
+}
 
 private case class SnapshotCore(
     defaultProfileId: Option[Long],
@@ -244,7 +254,7 @@ private case class SnapshotCore(
     blocklists: Map[String, PolicyBlocklist],
 )
 
-object PolicyService:
+object PolicyService {
   val layer: ZLayer[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo &
       TimeUsageRepo & TimeExtensionRepo & Clock,
@@ -252,15 +262,16 @@ object PolicyService:
     PolicyService,
   ] = ZLayer.fromFunction(PolicyServiceLive(_, _, _, _, _, _, _, _, _))
 
-  def sha256Hex(s: String): String =
+  def sha256Hex(s: String): String = {
     val md = MessageDigest.getInstance("SHA-256")
     md.digest(s.getBytes("UTF-8")).map("%02x".format(_)).mkString
+  }
 
   /** Hex SHA-256 of a router/enrollment token, used as the storage key. */
   def hashToken(raw: String): String = sha256Hex(raw)
 
   /** Deterministic ETag over snapshot logical content. */
-  private[policy] def computeEtag(core: SnapshotCore): String =
+  private[policy] def computeEtag(core: SnapshotCore): String = {
     val parts = scala.collection.mutable.ArrayBuffer.empty[String]
     parts += s"d=${core.defaultProfileId.getOrElse("-")}"
     core.devices
@@ -282,3 +293,5 @@ object PolicyService:
     }
     core.blocklists.toList.sortBy(_._1).foreach((k, v) => parts += s"bl:$k=${v.version}")
     "\"sha256:" + sha256Hex(parts.mkString("\n")) + "\""
+  }
+}

--- a/api/src/routes/RouterAuth.scala
+++ b/api/src/routes/RouterAuth.scala
@@ -14,25 +14,29 @@ import java.security.MessageDigest
  *
  * Defined as a trait so #68 (enrollment) can swap implementations without editing every route.
  */
-trait RouterAuth:
+trait RouterAuth {
   def authenticate(req: Request): IO[Response, Router]
+}
 
-object RouterAuth:
+object RouterAuth {
+
   /**
    * Lowercase hex SHA-256 of the input bytes. Must match what `POST /api/router/register` writes to
    * `routers.token_hash` in #68.
    */
-  def sha256Hex(s: String): String =
+  def sha256Hex(s: String): String = {
     val md = MessageDigest.getInstance("SHA-256")
     md.digest(s.getBytes("UTF-8")).map(b => f"$b%02x").mkString
+  }
 
   private[routes] def bearer(req: Request): Option[String] =
     req.header(Header.Authorization).flatMap { h =>
       val v = h.renderedValue
       if v.startsWith("Bearer ") then Some(v.drop(7)) else None
     }
+}
 
-class RouterAuthLive(repo: RouterRepo) extends RouterAuth:
+class RouterAuthLive(repo: RouterRepo) extends RouterAuth {
   def authenticate(req: Request): IO[Response, Router] =
     ZIO
       .fromOption(RouterAuth.bearer(req))
@@ -45,3 +49,4 @@ class RouterAuthLive(repo: RouterRepo) extends RouterAuth:
             ZIO.fromOption(_).orElseFail(Response.unauthorized("Invalid router token")),
           )
       }
+}

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -16,7 +16,7 @@ import java.util.UUID
  *
  * Both require a router bearer token resolved via [[RouterAuth]].
  */
-object RouterIngestRoutes:
+object RouterIngestRoutes {
 
   def routes(
       auth: RouterAuth,
@@ -29,7 +29,7 @@ object RouterIngestRoutes:
     Routes(
       Method.POST / "api" / "router" / "usage"  ->
         handler { (req: Request) =>
-          for
+          for {
             router <- auth.authenticate(req)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             rep    <- ZIO
@@ -42,11 +42,11 @@ object RouterIngestRoutes:
             pe     <- parseInstant(rep.periodEnd)
             _ <- handleUsage(router.id, ps, pe, rep.records, trafficRepo, timeUsageRepo, deviceRepo)
             _ <- routerRepo.touch(router.id, None).orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
       Method.POST / "api" / "router" / "events" ->
         handler { (req: Request) =>
-          for
+          for {
             router <- auth.authenticate(req)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             rep    <- ZIO
@@ -57,7 +57,7 @@ object RouterIngestRoutes:
               .when(rep.routerId != router.id)
             _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo)
             _      <- routerRepo.touch(router.id, None).orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
     )
 
@@ -72,7 +72,7 @@ object RouterIngestRoutes:
       trafficRepo: TrafficReportRepo,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
-  ): IO[Response, Unit] =
+  ): IO[Response, Unit] = {
     val date    = periodStart.atZone(ZoneOffset.UTC).toLocalDate
     val inserts = records.map(r =>
       TrafficReportInsert(
@@ -88,14 +88,15 @@ object RouterIngestRoutes:
         r.bytesOut,
       ),
     )
-    for
+    for {
       // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
       // Only those rows should drive time_usage / device updates; replays return 0.
       newCount <- trafficRepo.insertBatch(inserts).orElseFail(Response.internalServerError(""))
       _        <- ZIO.when(newCount > 0)(
         applyDelta(routerId, periodEnd, records, timeUsageRepo, deviceRepo),
       )
-    yield ()
+    } yield ()
+  }
 
   /**
    * Apply seconds/byte deltas + device last_seen for a freshly-accepted batch. We only enter here
@@ -114,7 +115,7 @@ object RouterIngestRoutes:
       records: List[UsageRecord],
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
-  ): IO[Response, Unit] =
+  ): IO[Response, Unit] = {
     val date = periodEnd.atZone(ZoneOffset.UTC).toLocalDate
     ZIO.foreachDiscard(records) { r =>
       timeUsageRepo
@@ -128,23 +129,24 @@ object RouterIngestRoutes:
           .orElseFail(Response.internalServerError(""))
           .unit
       }
+  }
 
   private def handleEvents(
       routerId: UUID,
       events: List[RouterEvent],
       deviceRepo: DeviceRepo,
       connEventRepo: ConnectionEventRepo,
-  ): IO[Response, Unit] =
+  ): IO[Response, Unit] = {
     val connInserts = events.collect {
       case e if e.`type` == "connection_attempt" =>
-        for
+        for {
           h    <- e.hostname.toRight("connection_attempt missing hostname")
           ts   <- scala.util.Try(Instant.parse(e.ts)).toEither.left.map(_.getMessage)
           allw <- e.allowed.toRight("connection_attempt missing allowed")
           rsn = e.reason.getOrElse(if allw then "allow" else "blocked")
-        yield ConnectionEventInsert(routerId, e.mac, h, e.destIp, allw, rsn, ts)
+        } yield ConnectionEventInsert(routerId, e.mac, h, e.destIp, allw, rsn, ts)
     }
-    for
+    for {
       // Surface JSON validation errors as 400.
       validated <- ZIO.foreach(connInserts)(e =>
         ZIO.fromEither(e).mapError(m => Response.badRequest(m)),
@@ -154,7 +156,8 @@ object RouterIngestRoutes:
         .orElseFail(Response.internalServerError(""))
         .when(validated.nonEmpty)
       _         <- ZIO.foreachDiscard(events)(applyDhcpOrFirstSeen(_, deviceRepo))
-    yield ()
+    } yield ()
+  }
 
   /**
    * DHCP lease + first-seen-MAC: upsert into devices. For a known MAC just refresh last_seen_ip /
@@ -167,15 +170,15 @@ object RouterIngestRoutes:
   ): IO[Response, Unit] =
     if e.`type` != "dhcp_lease" && e.`type` != "first_seen_mac" then ZIO.unit
     else
-      e.mac match
+      e.mac match {
         case None      => ZIO.unit
         case Some(mac) =>
-          for
+          for {
             ts       <- ZIO
               .attempt(Instant.parse(e.ts))
               .orElseFail(Response.badRequest(s"invalid ts: ${e.ts}"))
             existing <- deviceRepo.findByMac(mac).orElseFail(Response.internalServerError(""))
-            _        <- existing match
+            _        <- existing match {
               case Some(_) =>
                 deviceRepo
                   .touchLastSeen(mac, e.ip, ts)
@@ -186,4 +189,7 @@ object RouterIngestRoutes:
                   .upsertUnknown(mac, e.hostname.getOrElse("unknown"), e.ip, ts)
                   .orElseFail(Response.internalServerError(""))
                   .unit
-          yield ()
+            }
+          } yield ()
+      }
+}

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -16,7 +16,7 @@ import java.util.{Base64, UUID}
  * `/register`, which uses a one-time enrollment token. `RouterAuth` lives in
  * [[familydns.api.routes.RouterAuth]].
  */
-object RouterRoutes:
+object RouterRoutes {
 
   def routes(
       routerRepo: RouterRepo,
@@ -27,7 +27,7 @@ object RouterRoutes:
     Routes(
       Method.POST / "api" / "router" / "register"        ->
         handler { (req: Request) =>
-          for
+          for {
             body <- req.body.asString.orElseFail(Response.badRequest(""))
             rr   <- ZIO
               .fromEither(body.fromJson[RegisterRouterRequest])
@@ -46,11 +46,11 @@ object RouterRoutes:
             _ <- routerRepo
               .completeEnrollment(router.id, tokenHash)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(RegisterRouterResponse(router.id, routerToken).toJson)
+          } yield Response.json(RegisterRouterResponse(router.id, routerToken).toJson)
         },
       Method.GET / "api" / "router" / "policy"           ->
         handler { (req: Request) =>
-          for
+          for {
             router <- routerAuth.authenticate(req)
             snap   <- policy.snapshot.orElseFail(Response.internalServerError(""))
             ifNoneMatch = req
@@ -69,11 +69,11 @@ object RouterRoutes:
                 Response
                   .json(snap.toJson)
                   .addHeader(Header.ETag.Strong(stripQuotes(snap.etag)))
-          yield resp
+          } yield resp
         },
       Method.GET / "api" / "blocklists" / string("file") ->
         handler { (file: String, req: Request) =>
-          for
+          for {
             _    <- routerAuth.authenticate(req)
             cat  <- ZIO
               .succeed(file.stripSuffix(".rpz"))
@@ -100,11 +100,11 @@ object RouterRoutes:
                     )
                 },
               )
-          yield resp
+          } yield resp
         },
       Method.POST / "api" / "router" / "decision"        ->
         handler { (req: Request) =>
-          for
+          for {
             router <- routerAuth.authenticate(req)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             dreq   <- ZIO
@@ -123,20 +123,22 @@ object RouterRoutes:
                   )
                   .orElseFail(Response.internalServerError(""))
               }
-          yield Response.json(result.toJson)
+          } yield Response.json(result.toJson)
         },
     )
 
   private def stripQuotes(s: String): String =
     if s.startsWith("\"") && s.endsWith("\"") then s.drop(1).dropRight(1) else s
 
-  private def newToken(prefix: String): String =
+  private def newToken(prefix: String): String = {
     val bytes = new Array[Byte](32)
     new SecureRandom().nextBytes(bytes)
     prefix + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+  }
+}
 
 /** Admin-only routes for managing routers (visible in admin UI). */
-object AdminRouterRoutes:
+object AdminRouterRoutes {
   def routes(
       auth: AuthService,
       routerRepo: RouterRepo,
@@ -144,7 +146,7 @@ object AdminRouterRoutes:
     Routes(
       Method.POST / "api" / "admin" / "routers"                  ->
         handler { (req: Request) =>
-          for
+          for {
             _    <- requireAdmin(req, auth)
             body <- req.body.asString.orElseFail(Response.badRequest(""))
             cr   <- ZIO
@@ -158,24 +160,24 @@ object AdminRouterRoutes:
             id <- routerRepo
               .create(cr.name.trim, etHash)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(CreateRouterResponse(id, cr.name.trim, enrollmentToken).toJson)
+          } yield Response.json(CreateRouterResponse(id, cr.name.trim, enrollmentToken).toJson)
         },
       Method.GET / "api" / "admin" / "routers"                   ->
         handler { (req: Request) =>
-          for
+          for {
             _   <- requireAdmin(req, auth)
             all <- routerRepo.listAll.orElseFail(Response.internalServerError(""))
-          yield Response.json(all.map(toSummary).toJson)
+          } yield Response.json(all.map(toSummary).toJson)
         },
       Method.DELETE / "api" / "admin" / "routers" / string("id") ->
         handler { (id: String, req: Request) =>
-          for
+          for {
             _   <- requireAdmin(req, auth)
             uid <- ZIO
               .attempt(UUID.fromString(id))
               .orElseFail(Response.badRequest("bad uuid"))
             _   <- routerRepo.delete(uid).orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
     )
 
@@ -189,7 +191,9 @@ object AdminRouterRoutes:
       createdAt = r.createdAt,
     )
 
-  private def newEnrollmentToken(): String =
+  private def newEnrollmentToken(): String = {
     val bytes = new Array[Byte](24)
     new SecureRandom().nextBytes(bytes)
     "et_" + Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+  }
+}

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -11,7 +11,7 @@ import java.time.LocalDate
 
 // ── Auth routes ────────────────────────────────────────────────────────────
 
-object AuthRoutes:
+object AuthRoutes {
   def routes(
       auth: AuthService,
       userRepo: UserRepo,
@@ -20,7 +20,7 @@ object AuthRoutes:
     Routes(
       Method.POST / "api" / "auth" / "login"                 ->
         handler { (req: Request) =>
-          for
+          for {
             body <- req.body.asString.mapError(e => Response.internalServerError(e.getMessage))
             lr   <- ZIO
               .fromEither(body.fromJson[LoginRequest])
@@ -31,11 +31,11 @@ object AuthRoutes:
                 case AuthError.InvalidCredentials => Response.unauthorized("Invalid credentials")
                 case e                            => Response.internalServerError(e.toString)
               }
-          yield Response.json(resp.toJson)
+          } yield Response.json(resp.toJson)
         },
       Method.POST / "api" / "auth" / "change-password"       ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             cpr    <- ZIO
@@ -48,20 +48,20 @@ object AuthRoutes:
                   Response.unauthorized("Current password incorrect")
                 case e                            => Response.internalServerError(e.toString)
               }
-          yield Response.ok
+          } yield Response.ok
         },
       Method.GET / "api" / "me"                              ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             pids   <- userProfileRepo
               .listProfilesForUsername(claims.sub)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(MeResponse(claims.sub, claims.role, pids).toJson)
+          } yield Response.json(MeResponse(claims.sub, claims.role, pids).toJson)
         },
       Method.POST / "api" / "users"                          ->
         handler { (req: Request) =>
-          for
+          for {
             _    <- requireAdmin(req, auth)
             body <- req.body.asString.orElseFail(Response.badRequest(""))
             cur  <- ZIO
@@ -77,11 +77,11 @@ object AuthRoutes:
             _    <- userProfileRepo
               .setProfilesForUser(id, cur.profileIds)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(s"""{"id":$id}""")
+          } yield Response.json(s"""{"id":$id}""")
         },
       Method.GET / "api" / "users"                           ->
         handler { (req: Request) =>
-          for
+          for {
             _        <- requireAdmin(req, auth)
             users    <- userRepo.listAll.orElseFail(Response.internalServerError(""))
             mappings <- userProfileRepo.listAllMappings.orElseFail(Response.internalServerError(""))
@@ -89,11 +89,11 @@ object AuthRoutes:
             summaries = users.map(u =>
               UserSummary(u.id, u.username, u.role, byUser.getOrElse(u.id, Nil)),
             )
-          yield Response.json(summaries.toJson)
+          } yield Response.json(summaries.toJson)
         },
       Method.PUT / "api" / "users" / long("id") / "profiles" ->
         handler { (id: Long, req: Request) =>
-          for
+          for {
             _    <- requireAdmin(req, auth)
             body <- req.body.asString.orElseFail(Response.badRequest(""))
             r    <- ZIO
@@ -102,7 +102,7 @@ object AuthRoutes:
             _    <- userProfileRepo
               .setProfilesForUser(id, r.profileIds)
               .orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
       Method.DELETE / "api" / "users" / long("id")           ->
         handler { (id: Long, req: Request) =>
@@ -111,10 +111,11 @@ object AuthRoutes:
             ZIO.succeed(Response.ok)
         },
     )
+}
 
 // ── Profile routes ─────────────────────────────────────────────────────────
 
-object ProfileRoutes:
+object ProfileRoutes {
   def routes(
       auth: AuthService,
       profileRepo: ProfileRepo,
@@ -126,24 +127,24 @@ object ProfileRoutes:
     Routes(
       Method.GET / "api" / "profiles"                         ->
         handler { (req: Request) =>
-          for
+          for {
             claims      <- requireAuth(req, auth)
             allProfiles <- profileRepo.listAll.orElseFail(Response.internalServerError(""))
             visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
             details     <- ZIO
               .foreach(visible) { p =>
-                for
+                for {
                   scheds <- scheduleRepo.listForProfile(p.id)
                   tl     <- timeLimitRepo.findForProfile(p.id)
                   stls   <- siteTimeLimitRepo.listForProfile(p.id)
-                yield ProfileDetail(p, scheds, tl, stls)
+                } yield ProfileDetail(p, scheds, tl, stls)
               }
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(details.toJson)
+          } yield Response.json(details.toJson)
         },
       Method.GET / "api" / "profiles" / long("id")            ->
         handler { (id: Long, req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             _      <- requireProfileReadAccess(claims, id, userProfileRepo)
             p      <- profileRepo
@@ -155,11 +156,11 @@ object ProfileRoutes:
             stls   <- siteTimeLimitRepo
               .listForProfile(id)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(ProfileDetail(p, scheds, tl, stls).toJson)
+          } yield Response.json(ProfileDetail(p, scheds, tl, stls).toJson)
         },
       Method.POST / "api" / "profiles"                        ->
         handler { (req: Request) =>
-          for
+          for {
             _    <- requireAdmin(req, auth)
             body <- req.body.asString.orElseFail(Response.badRequest(""))
             upr  <- ZIO
@@ -189,11 +190,11 @@ object ProfileRoutes:
             _    <- siteTimeLimitRepo
               .replaceForProfile(id, upr.siteTimeLimits)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(s"""{"id":$id}""")
+          } yield Response.json(s"""{"id":$id}""")
         },
       Method.PUT / "api" / "profiles" / long("id")            ->
         handler { (id: Long, req: Request) =>
-          for
+          for {
             claims <- requireWriter(req, auth)
             _      <- requireProfileAccess(claims, id, userProfileRepo)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
@@ -218,14 +219,14 @@ object ProfileRoutes:
             _      <- scheduleRepo
               .replaceForProfile(id, upr.schedules)
               .orElseFail(Response.internalServerError(""))
-            _      <- (upr.timeLimit match
+            _      <- (upr.timeLimit match {
               case Some(mins) => timeLimitRepo.upsert(id, mins)
               case None       => timeLimitRepo.delete(id)
-            ).orElseFail(Response.internalServerError(""))
+            }).orElseFail(Response.internalServerError(""))
             _      <- siteTimeLimitRepo
               .replaceForProfile(id, upr.siteTimeLimits)
               .orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
       Method.DELETE / "api" / "profiles" / long("id")         ->
         handler { (id: Long, req: Request) =>
@@ -235,7 +236,7 @@ object ProfileRoutes:
         },
       Method.POST / "api" / "profiles" / long("id") / "pause" ->
         handler { (id: Long, req: Request) =>
-          for
+          for {
             claims <- requireWriter(req, auth)
             _      <- requireProfileAccess(claims, id, userProfileRepo)
             p      <- profileRepo
@@ -244,13 +245,14 @@ object ProfileRoutes:
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("")))
             _      <-
               profileRepo.setPaused(id, !p.paused).orElseFail(Response.internalServerError(""))
-          yield Response.json(s"""{"paused":${!p.paused}}""")
+          } yield Response.json(s"""{"paused":${!p.paused}}""")
         },
     )
+}
 
 // ── Device routes ──────────────────────────────────────────────────────────
 
-object DeviceRoutes:
+object DeviceRoutes {
   def routes(
       auth: AuthService,
       deviceRepo: DeviceRepo,
@@ -259,15 +261,15 @@ object DeviceRoutes:
     Routes(
       Method.GET / "api" / "devices"                    ->
         handler { (req: Request) =>
-          for
+          for {
             claims  <- requireAuth(req, auth)
             all     <- deviceRepo.listAll.orElseFail(Response.internalServerError(""))
             visible <- filterDevices(claims, all, userProfileRepo)
-          yield Response.json(visible.toJson)
+          } yield Response.json(visible.toJson)
         },
       Method.PUT / "api" / "devices"                    ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireWriter(req, auth)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             udr    <- ZIO
@@ -278,11 +280,11 @@ object DeviceRoutes:
             id <- deviceRepo
               .upsert(mac, udr.name, udr.profileId, "")
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(s"""{"id":$id}""")
+          } yield Response.json(s"""{"id":$id}""")
         },
       Method.DELETE / "api" / "devices" / string("mac") ->
         handler { (mac: String, req: Request) =>
-          for
+          for {
             claims <- requireWriter(req, auth)
             normalized = normalizeMac(mac)
             existing <- deviceRepo
@@ -291,13 +293,14 @@ object DeviceRoutes:
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _        <- requireProfileAccess(claims, existing.profileId, userProfileRepo)
             _        <- deviceRepo.delete(normalized).orElseFail(Response.internalServerError(""))
-          yield Response.ok
+          } yield Response.ok
         },
     )
+}
 
 // ── Time routes ────────────────────────────────────────────────────────────
 
-object TimeRoutes:
+object TimeRoutes {
   def routes(
       auth: AuthService,
       deviceRepo: DeviceRepo,
@@ -312,7 +315,7 @@ object TimeRoutes:
     Routes(
       Method.GET / "api" / "time" / "status"                         ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             today  <- clock.today
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
@@ -334,11 +337,11 @@ object TimeRoutes:
                 )
               }
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(statuses.toJson)
+          } yield Response.json(statuses.toJson)
         },
       Method.GET / "api" / "time" / "status" / string("mac")         ->
         handler { (mac: String, req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             today  <- clock.today
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
@@ -358,11 +361,11 @@ object TimeRoutes:
               extRepo,
             )
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(status.toJson)
+          } yield Response.json(status.toJson)
         },
       Method.POST / "api" / "time" / "extend"                        ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireWriter(req, auth)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             ger    <- ZIO
@@ -373,18 +376,18 @@ object TimeRoutes:
             id     <- extRepo
               .grantForProfile(ger.profileId, today, ger.extraMinutes, claims.sub, ger.note)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(s"""{"id":$id,"grantedMinutes":${ger.extraMinutes}}""")
+          } yield Response.json(s"""{"id":$id,"grantedMinutes":${ger.extraMinutes}}""")
         },
       Method.GET / "api" / "time" / "extensions" / long("profileId") ->
         handler { (profileId: Long, req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             _      <- requireProfileAccess(claims, profileId, userProfileRepo)
             date   <- clock.today
             exts   <- extRepo
               .listForProfile(profileId, date)
               .orElseFail(Response.internalServerError(""))
-          yield Response.json(exts.toJson)
+          } yield Response.json(exts.toJson)
         },
     )
 
@@ -396,9 +399,9 @@ object TimeRoutes:
       stlRepo: SiteTimeLimitRepo,
       usageRepo: TimeUsageRepo,
       extRepo: TimeExtensionRepo,
-  ): Task[ProfileTimeStatus] =
+  ): Task[ProfileTimeStatus] = {
     val macs = devices.map(_.mac)
-    for
+    for {
       tl      <- tlRepo.findForProfile(profile.id)
       stls    <- stlRepo.listForProfile(profile.id)
       usages  <- usageRepo.listForDeviceMacs(macs, date)
@@ -426,7 +429,7 @@ object TimeRoutes:
         val dUsed = usages.filter(_.deviceMac == d.mac).map(_.minutesUsed).sum
         DeviceUsageSummary(d.mac, d.name, dUsed)
       }
-    yield ProfileTimeStatus(
+    } yield ProfileTimeStatus(
       profile.id,
       profile.name,
       date.toString,
@@ -437,6 +440,7 @@ object TimeRoutes:
       siteUsage,
       deviceSummaries,
     )
+  }
 
   private def buildDeviceTimeStatus(
       device: Device,
@@ -446,9 +450,9 @@ object TimeRoutes:
       stlRepo: SiteTimeLimitRepo,
       usageRepo: TimeUsageRepo,
       extRepo: TimeExtensionRepo,
-  ): Task[DeviceTimeStatus] =
+  ): Task[DeviceTimeStatus] = {
     val pid = device.profileId
-    for
+    for {
       tl      <- pid.fold(ZIO.succeed(Option.empty[TimeLimit]))(tlRepo.findForProfile)
       stls    <- pid.fold(ZIO.succeed(List.empty[SiteTimeLimit]))(stlRepo.listForProfile)
       usages  <- usageRepo.listForDevice(device.mac, date)
@@ -474,7 +478,7 @@ object TimeRoutes:
           (stl.dailyMinutes - used).max(0),
         )
       }
-    yield DeviceTimeStatus(
+    } yield DeviceTimeStatus(
       device.mac,
       device.name,
       date.toString,
@@ -486,14 +490,16 @@ object TimeRoutes:
       remaining,
       siteUsage,
     )
+  }
 
   private def matchesPattern(domain: String, pattern: String): Boolean =
     if pattern.startsWith("*.") then domain.endsWith(pattern.drop(1)) || domain == pattern.drop(2)
     else domain == pattern || domain.endsWith(s".$pattern")
+}
 
 // ── Query log routes ───────────────────────────────────────────────────────
 
-object LogRoutes:
+object LogRoutes {
   def routes(
       auth: AuthService,
       logRepo: QueryLogRepo,
@@ -502,7 +508,7 @@ object LogRoutes:
     Routes(
       Method.GET / "api" / "logs"  ->
         handler { (req: Request) =>
-          for
+          for {
             claims <- requireAuth(req, auth)
             filter = LogFilter(
               mac = req.url.queryParam("mac"),
@@ -515,7 +521,7 @@ object LogRoutes:
             )
             logs    <- logRepo.query(filter).orElseFail(Response.internalServerError(""))
             visible <- filterLogs(claims, logs, userProfileRepo)
-          yield Response.json(visible.toJson)
+          } yield Response.json(visible.toJson)
         },
       Method.GET / "api" / "stats" ->
         handler { (req: Request) =>
@@ -525,10 +531,11 @@ object LogRoutes:
               .orElseFail(Response.internalServerError(""))
         },
     )
+}
 
 // ── Blocklist routes ───────────────────────────────────────────────────────
 
-object BlocklistRoutes:
+object BlocklistRoutes {
   def routes(auth: AuthService, blRepo: BlocklistRepo): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "blocklists"                                 ->
@@ -549,6 +556,7 @@ object BlocklistRoutes:
             ZIO.succeed(Response.ok)
         },
     )
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -657,11 +665,12 @@ def requireProfileReadAccess(
     profileId: Option[Long],
     upRepo: UserProfileRepo,
 ): IO[Response, Unit] =
-  profileId match
+  profileId match {
     case None      =>
       if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(())
       else ZIO.fail(Response.forbidden("Device has no assigned profile"))
     case Some(pid) => requireProfileReadAccess(claims, pid, upRepo)
+  }
 
 /** Allow write access if admin or adult linked to the profile. Child is always denied. */
 def requireProfileAccess(
@@ -684,11 +693,12 @@ def requireProfileAccess(
     profileId: Option[Long],
     upRepo: UserProfileRepo,
 ): IO[Response, Unit] =
-  profileId match
+  profileId match {
     case None      =>
       if claims.role == "admin" then ZIO.succeed(())
       else ZIO.fail(Response.forbidden("Device has no assigned profile"))
     case Some(pid) => requireProfileAccess(claims, pid, upRepo)
+  }
 
 def normalizeMac(mac: String): String =
   mac.toLowerCase.replace("-", ":").trim

--- a/api/src/routes/StaticRoutes.scala
+++ b/api/src/routes/StaticRoutes.scala
@@ -4,26 +4,29 @@ import zio.*
 import zio.http.*
 import zio.http.codec.PathCodec.trailing
 
-object StaticRoutes:
-  def routes(staticDir: String): Routes[Any, Response] =
+object StaticRoutes {
+  def routes(staticDir: String): Routes[Any, Response] = {
     val base  = java.io.File(staticDir).getCanonicalFile
     val index = java.io.File(base, "index.html")
 
     def resolve(rel: String): Option[java.io.File] =
       if rel.isEmpty then None
-      else
+      else {
         val candidate = java.io.File(base, rel).getCanonicalFile
         if candidate.getPath == base.getPath || candidate.getPath.startsWith(
             base.getPath + java.io.File.separator,
           )
         then if candidate.isFile then Some(candidate) else None
         else None
+      }
 
-    def mimeFor(name: String): MediaType =
-      val ext = name.lastIndexOf('.') match
+    def mimeFor(name: String): MediaType = {
+      val ext = name.lastIndexOf('.') match {
         case -1 => ""
         case i  => name.substring(i + 1).toLowerCase
+      }
       MediaType.forFileExtension(ext).getOrElse(MediaType.application.`octet-stream`)
+    }
 
     def serve(file: java.io.File): ZIO[Any, Nothing, Response] =
       Body
@@ -41,10 +44,13 @@ object StaticRoutes:
         val rel = path.encode.stripPrefix("/")
         if rel.startsWith("api/") then ZIO.succeed(Response.notFound)
         else
-          resolve(rel) match
+          resolve(rel) match {
             case Some(f) => serve(f)
             case None    =>
               if index.isFile then serve(index)
               else ZIO.succeed(Response.notFound)
+          }
       },
     )
+  }
+}

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -14,7 +14,7 @@ import zio.interop.catz.*
  * initdb failures on ARM Mac (Postgres runs under Rosetta x86 emulation). Each test calls
  * cleanAndMigrate to reset state before running.
  */
-object TestDatabase:
+object TestDatabase {
 
   // JVM-wide singleton: started once, shared across all ZIOSpec bootstrap layers
   // in this JVM. We don't use `lazy val` here — Scala 3 lazy vals can let two
@@ -23,19 +23,22 @@ object TestDatabase:
   // second concurrent call. Explicit double-checked locking serializes init.
   private val pgLock                                 = new Object
   @volatile private var pgInstance: EmbeddedPostgres = null
-  private def sharedPg: EmbeddedPostgres             =
+  private def sharedPg: EmbeddedPostgres             = {
     val cached = pgInstance
     if cached != null then cached
     else
-      pgLock.synchronized:
-        if pgInstance == null then
+      pgLock.synchronized {
+        if pgInstance == null then {
           val pg = EmbeddedPostgres.start()
           runMigrations(pg)
           pgInstance = pg
+        }
         pgInstance
+      }
+  }
 
   /** Run the production Flyway migrations (`classpath:db/migration`) against the embedded PG. */
-  private[testinfra] def runMigrations(pg: EmbeddedPostgres): Unit =
+  private[testinfra] def runMigrations(pg: EmbeddedPostgres): Unit = {
     Flyway
       .configure()
       .dataSource(pg.getPostgresDatabase)
@@ -44,6 +47,7 @@ object TestDatabase:
       .load()
       .migrate()
     ()
+  }
 
   /** Provides the shared EmbeddedPostgres instance (no lifecycle: lives for JVM lifetime). */
   val embeddedPg: ZLayer[Any, Throwable, EmbeddedPostgres] =
@@ -51,28 +55,30 @@ object TestDatabase:
 
   /** Transactor wired to the embedded PG. */
   val transactor: ZLayer[EmbeddedPostgres, Throwable, Transactor[Task]] =
-    ZLayer.fromZIO:
-      for
+    ZLayer.fromZIO {
+      for {
         pg <- ZIO.service[EmbeddedPostgres]
         ds = pg.getPostgresDatabase
         xa = Transactor.fromDataSource[Task](ds, scala.concurrent.ExecutionContext.global)
-      yield xa
+      } yield xa
+    }
 
   /**
    * Drop and recreate the public schema, then re-run migrations. This is faster and more reliable
    * than Flyway's clean() + migrate() in Flyway 10.
    */
   val cleanAndMigrate: ZIO[EmbeddedPostgres, Throwable, Unit] =
-    for
+    for {
       pg <- ZIO.service[EmbeddedPostgres]
-      _  <- ZIO.attempt:
+      _  <- ZIO.attempt {
         val conn = pg.getPostgresDatabase.getConnection
-        try
+        try {
           conn.createStatement().execute("DROP SCHEMA public CASCADE")
           conn.createStatement().execute("CREATE SCHEMA public")
-        finally conn.close()
+        } finally conn.close()
+      }
       _  <- ZIO.attempt(runMigrations(pg))
-    yield ()
+    } yield ()
 
   /** All repo types bundled for convenience */
   type AllRepos =
@@ -80,13 +86,15 @@ object TestDatabase:
       DeviceRepo & BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & QueryLogRepo & RouterRepo &
       TrafficReportRepo & BlockEventRepo & ConnectionEventRepo
 
-  val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] =
+  val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg
     val xa = pg >>> transactor
     pg ++ xa ++ (xa >>> Repos.all)
+  }
+}
 
 /** Helper for building test layers with a controllable clock. */
-object TestLayers:
+object TestLayers {
   import familydns.shared.Clock
 
   def withClock(dt: java.time.LocalDateTime): ULayer[Clock] =
@@ -94,7 +102,7 @@ object TestLayers:
 
   /** Seed helpers */
   def seedKidsProfile(profileRepo: ProfileRepo, scheduleRepo: ScheduleRepo): Task[Long] =
-    for
+    for {
       id <- profileRepo.create("Kids", List("adult", "gambling", "social_media"))
       _  <- scheduleRepo.replaceForProfile(
         id,
@@ -107,7 +115,7 @@ object TestLayers:
           ),
         ),
       )
-    yield id
+    } yield id
 
   def seedAdultsProfile(profileRepo: ProfileRepo): Task[Long] =
     profileRepo.create("Adults", List.empty)
@@ -119,3 +127,4 @@ object TestLayers:
       profileId: Long,
   ): Task[Long] =
     deviceRepo.upsert(mac, name, profileId, "192.168.1.100")
+}

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -21,49 +21,49 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, jwtCfg, clock)
+    } yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
   def spec = suite("Auth API")(
     test("admin can login with seeded credentials") {
-      for
+      for {
         _      <- cleanDb
         auth   <- makeAuth
         result <- auth.login("admin", "changeme")
-      yield assertTrue(result.token.nonEmpty) &&
+      } yield assertTrue(result.token.nonEmpty) &&
         assertTrue(result.role == "admin") &&
         assertTrue(result.username == "admin")
     },
     test("wrong password returns InvalidCredentials") {
-      for
+      for {
         _      <- cleanDb
         auth   <- makeAuth
         result <- auth.login("admin", "wrongpassword").exit
-      yield assertTrue(result.isFailure)
+      } yield assertTrue(result.isFailure)
     },
     test("unknown user returns InvalidCredentials") {
-      for
+      for {
         _      <- cleanDb
         auth   <- makeAuth
         result <- auth.login("nobody", "anything").exit
-      yield assertTrue(result.isFailure)
+      } yield assertTrue(result.isFailure)
     },
     test("issued token is verifiable") {
-      for
+      for {
         _      <- cleanDb
         auth   <- makeAuth
         resp   <- auth.login("admin", "changeme")
         claims <- auth.verify(resp.token)
-      yield assertTrue(claims.sub == "admin") &&
+      } yield assertTrue(claims.sub == "admin") &&
         assertTrue(claims.role == "admin")
     },
     test("admin can create child user who can then login") {
-      for
+      for {
         _        <- cleanDb
         userRepo <- ZIO.service[UserRepo]
         auth     <- makeAuth
@@ -71,11 +71,11 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         _        <- userRepo.create("child1", hash, "child")
         resp     <- auth.login("child1", "childpass")
         claims   <- auth.verify(resp.token)
-      yield assertTrue(resp.role == "child") &&
+      } yield assertTrue(resp.role == "child") &&
         assertTrue(claims.role == "child")
     },
     test("child token fails requireAdmin check") {
-      for
+      for {
         _        <- cleanDb
         userRepo <- ZIO.service[UserRepo]
         auth     <- makeAuth
@@ -83,20 +83,20 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         _        <- userRepo.create("viewer", hash, "child")
         resp     <- auth.login("viewer", "pass")
         result   <- auth.requireAdmin(resp.token).exit
-      yield assertTrue(result.isFailure)
+      } yield assertTrue(result.isFailure)
     },
     test("change password works and old password no longer valid") {
-      for
+      for {
         _    <- cleanDb
         auth <- makeAuth
         _    <- auth.changePassword("admin", "changeme", "newpassword123")
         bad  <- auth.login("admin", "changeme").exit
         good <- auth.login("admin", "newpassword123").exit
-      yield assertTrue(bad.isFailure) &&
+      } yield assertTrue(bad.isFailure) &&
         assertTrue(good.isSuccess)
     },
     test("POST /api/auth/login via HTTP handler") {
-      for
+      for {
         _               <- cleanDb
         userRepo        <- ZIO.service[UserRepo]
         auth            <- makeAuth
@@ -109,7 +109,7 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         resp     <- routes.runZIO(req)
         respBody <- resp.body.asString
         lr       <- ZIO.fromEither(respBody.fromJson[LoginResponse])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(lr.token.nonEmpty) &&
         assertTrue(lr.role == "admin")
     },

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -21,17 +21,17 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
 
   private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, adminJwt, clock)
+    } yield AuthServiceLive(ur, adminJwt, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
   def spec = suite("Device API")(
     test("create and list devices") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -57,7 +57,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         getResp <- routes.runZIO(getReq)
         body2   <- getResp.body.asString
         devices <- ZIO.fromEither(body2.fromJson[List[Device]])
-      yield assertTrue(putResp.status == Status.Ok) &&
+      } yield assertTrue(putResp.status == Status.Ok) &&
         assertTrue(devices.exists(_.mac == "aa:bb:cc:dd:ee:ff")) &&
         assertTrue(devices.exists(_.name == "iPad")) &&
         assertTrue(
@@ -66,7 +66,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(!body2.contains("\"location\""))
     },
     test("MAC address is normalised (upper → lower, dashes → colons)") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -83,10 +83,10 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
           .addHeader(Header.ContentType(MediaType.application.json))
         _      <- routes.runZIO(req)
         device <- deviceRepo.findByMac("aa:bb:cc:dd:ee:ff")
-      yield assertTrue(device.isDefined)
+      } yield assertTrue(device.isDefined)
     },
     test("delete device") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -103,11 +103,11 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
           .addHeader(Header.Authorization.Bearer(token))
         delResp <- routes.runZIO(delReq)
         after   <- deviceRepo.findByMac(mac)
-      yield assertTrue(delResp.status == Status.Ok) &&
+      } yield assertTrue(delResp.status == Status.Ok) &&
         assertTrue(after.isEmpty)
     },
     test("updateLastSeen updates ip without losing profile assignment") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -117,11 +117,11 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         _      <- deviceRepo.upsert(mac, "Laptop", kidsId, "192.168.1.5")
         _      <- deviceRepo.updateLastSeen(mac, "192.168.1.99")
         device <- deviceRepo.findByMac(mac)
-      yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.99"))) &&
+      } yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.99"))) &&
         assertTrue(device.exists(_.profileId.contains(kidsId)))
     },
     test("upsert updates last_seen_ip without losing profile assignment") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -134,7 +134,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         // Upsert again with different IP (simulating DHCP lease change)
         _      <- deviceRepo.upsert(mac, "Phone", kidsId, "192.168.1.20")
         device <- deviceRepo.findByMac(mac)
-      yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.20"))) &&
+      } yield assertTrue(device.exists(_.lastSeenIp.contains("192.168.1.20"))) &&
         assertTrue(device.exists(_.profileId.contains(kidsId)))
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -21,10 +21,10 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, jwtCfg, clock)
+    } yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
@@ -34,7 +34,7 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
 
   def spec = suite("Query Log API")(
     test("GET /api/logs returns inserted logs") {
-      for
+      for {
         _               <- cleanDb
         logRepo         <- ZIO.service[QueryLogRepo]
         auth            <- makeAuth
@@ -85,11 +85,11 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         resp <- routes.runZIO(req)
         body <- resp.body.asString
         logs <- ZIO.fromEither(body.fromJson[List[QueryLog]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(logs.length == 3)
     },
     test("GET /api/logs?blocked=true filters to blocked only") {
-      for
+      for {
         _               <- cleanDb
         logRepo         <- ZIO.service[QueryLogRepo]
         auth            <- makeAuth
@@ -129,12 +129,12 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         resp <- routes.runZIO(req)
         body <- resp.body.asString
         logs <- ZIO.fromEither(body.fromJson[List[QueryLog]])
-      yield assertTrue(logs.length == 1) &&
+      } yield assertTrue(logs.length == 1) &&
         assertTrue(logs.head.domain == "badsite.com") &&
         assertTrue(logs.head.blocked)
     },
     test("GET /api/stats returns correct counts") {
-      for
+      for {
         _               <- cleanDb
         logRepo         <- ZIO.service[QueryLogRepo]
         auth            <- makeAuth
@@ -185,14 +185,14 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         resp  <- routes.runZIO(req)
         body  <- resp.body.asString
         stats <- ZIO.fromEither(body.fromJson[DashboardStats])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(stats.totalToday == 3) &&
         assertTrue(stats.blockedToday == 2) &&
         assertTrue(stats.topBlocked.exists(_.domain == "badsite.com")) &&
         assertTrue(stats.topBlocked.find(_.domain == "badsite.com").exists(_.count == 2))
     },
     test("GET /api/logs?mac=... filters to one device") {
-      for
+      for {
         _               <- cleanDb
         logRepo         <- ZIO.service[QueryLogRepo]
         auth            <- makeAuth
@@ -234,7 +234,7 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         resp <- routes.runZIO(req)
         body <- resp.body.asString
         logs <- ZIO.fromEither(body.fromJson[List[QueryLog]])
-      yield assertTrue(logs.length == 1) &&
+      } yield assertTrue(logs.length == 1) &&
         assertTrue(logs.head.mac.contains("aa:bb:cc:dd:ee:01"))
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -28,10 +28,10 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
 
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, adminJwt, clock)
+    } yield AuthServiceLive(ur, adminJwt, clock)
 
   private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
@@ -40,7 +40,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   def spec = suite("Profile API")(
     suite("GET /api/profiles")(
       test("returns seeded default profiles") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
@@ -64,13 +64,13 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           resp    <- routes.runZIO(req)
           body    <- resp.body.asString
           details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(details.length >= 2) &&
           assertTrue(details.exists(_.profile.name == "Kids")) &&
           assertTrue(details.exists(_.profile.name == "Adults"))
       },
       test("returns 401 without token") {
-        for
+        for {
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
@@ -87,12 +87,12 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           )
           req    = Request.get(URL.decode("/api/profiles").toOption.get)
           resp <- routes.runZIO(req)
-        yield assertTrue(resp.status == Status.Unauthorized)
+        } yield assertTrue(resp.status == Status.Unauthorized)
       },
     ),
     suite("POST /api/profiles")(
       test("admin can create a profile with schedules and time limits") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
@@ -136,7 +136,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           scheds   <- schedRepo.listForProfile(teen.id)
           tl       <- tlRepo.findForProfile(teen.id)
           stls     <- stlRepo.listForProfile(teen.id)
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(teen.blockedCategories.contains("adult")) &&
           assertTrue(teen.extraBlocked.contains("tiktok.com")) &&
           assertTrue(teen.extraAllowed.contains("khanacademy.org")) &&
@@ -148,7 +148,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(stls.head.dailyMinutes == 45)
       },
       test("child user cannot create profiles") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
@@ -173,12 +173,12 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
-        yield assertTrue(resp.status == Status.Forbidden)
+        } yield assertTrue(resp.status == Status.Forbidden)
       },
     ),
     suite("PUT /api/profiles/:id")(
       test("update profile name, categories, and time limit") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -221,7 +221,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           updated <- profileRepo.findById(kidsId)
           tl      <- tlRepo.findForProfile(kidsId)
           scheds  <- schedRepo.listForProfile(kidsId)
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(updated.exists(_.name == "Kids Updated")) &&
           assertTrue(updated.exists(_.extraAllowed.contains("pbs.org"))) &&
           assertTrue(tl.exists(_.dailyMinutes == 120)) &&
@@ -230,7 +230,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     ),
     suite("POST /api/profiles/:id/pause")(
       test("toggles pause state") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -259,7 +259,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           afterPause  <- profileRepo.findById(kidsId)
           resp2       <- routes.runZIO(req)
           afterResume <- profileRepo.findById(kidsId)
-        yield assertTrue(resp1.status == Status.Ok) &&
+        } yield assertTrue(resp1.status == Status.Ok) &&
           assertTrue(afterPause.exists(_.paused)) &&
           assertTrue(resp2.status == Status.Ok) &&
           assertTrue(afterResume.exists(!_.paused))

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -27,10 +27,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, jwtCfg, clock)
+    } yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
@@ -44,15 +44,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       role: String,
       profileIds: List[Long],
   ): Task[Long] =
-    for
+    for {
       hash <- auth.hashPassword("pass")
       id   <- userRepo.create(username, hash, role)
       _    <- upRepo.setProfilesForUser(id, profileIds)
-    yield id
+    } yield id
 
   def spec = suite("Role-based access")(
     test("child sees only profiles linked to them") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -72,12 +72,12 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp    <- routes.runZIO(req)
         body    <- resp.body.asString
         details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(details.length == 1) &&
         assertTrue(details.head.profile.name == "Kids")
     },
     test("child cannot read sibling's profile") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -96,10 +96,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .get(URL.decode(s"/api/profiles/$adultsId").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Forbidden)
+      } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("child cannot edit even their own profile") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -119,10 +119,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .addHeader(Header.Authorization.Bearer(token))
           .addHeader(Header.ContentType(MediaType.application.json))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Forbidden)
+      } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("adult can edit profiles they're linked to") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -160,11 +160,11 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .addHeader(Header.ContentType(MediaType.application.json))
         resp    <- routes.runZIO(req)
         updated <- profileRepo.findById(kidsId)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(updated.exists(_.name == "Kids Renamed"))
     },
     test("adult cannot edit a profile they're not linked to") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -194,10 +194,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .addHeader(Header.Authorization.Bearer(token))
           .addHeader(Header.ContentType(MediaType.application.json))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Forbidden)
+      } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("adult cannot create new profiles (admin only)") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -215,10 +215,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .addHeader(Header.Authorization.Bearer(token))
           .addHeader(Header.ContentType(MediaType.application.json))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Forbidden)
+      } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("adult cannot manage users (admin only)") {
-      for
+      for {
         _        <- cleanDb
         userRepo <- ZIO.service[UserRepo]
         upRepo   <- ZIO.service[UserProfileRepo]
@@ -230,10 +230,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .get(URL.decode("/api/users").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Forbidden)
+      } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("admin can set user-profile links and they take effect") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -273,12 +273,12 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         listResp <- profRoutes.runZIO(listReq)
         body     <- listResp.body.asString
         details  <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
-      yield assertTrue(setResp.status == Status.Ok) &&
+      } yield assertTrue(setResp.status == Status.Ok) &&
         assertTrue(details.length == 1) &&
         assertTrue(details.head.profile.id == kidsId)
     },
     test("GET /api/me returns username, role, and linked profile ids") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         userRepo    <- ZIO.service[UserRepo]
@@ -295,13 +295,13 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp <- routes.runZIO(req)
         body <- resp.body.asString
         me   <- ZIO.fromEither(body.fromJson[MeResponse])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(me.username == "alice") &&
         assertTrue(me.role == "child") &&
         assertTrue(me.profileIds == List(kidsId))
     },
     test("device list scoped to user's profiles for non-admin") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -322,12 +322,12 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp    <- routes.runZIO(req)
         body    <- resp.body.asString
         devices <- ZIO.fromEither(body.fromJson[List[Device]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(devices.length == 1) &&
         assertTrue(devices.head.name == "kid-tablet")
     },
     test("adult sees ALL profiles (not just linked ones)") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -347,11 +347,11 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp    <- routes.runZIO(req)
         body    <- resp.body.asString
         details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(details.length == 2)
     },
     test("adult can GET any profile by id even if not linked") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
@@ -370,10 +370,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .get(URL.decode(s"/api/profiles/$adultsId").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
         resp <- routes.runZIO(req)
-      yield assertTrue(resp.status == Status.Ok)
+      } yield assertTrue(resp.status == Status.Ok)
     },
     test("adult sees ALL devices (not just linked ones)") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
@@ -394,11 +394,11 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp    <- routes.runZIO(req)
         body    <- resp.body.asString
         devices <- ZIO.fromEither(body.fromJson[List[Device]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(devices.length == 2)
     },
     test("adult sees ALL logs (not just linked profiles)") {
-      for
+      for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         logRepo     <- ZIO.service[QueryLogRepo]
@@ -443,7 +443,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         resp <- routes.runZIO(req)
         body <- resp.body.asString
         logs <- ZIO.fromEither(body.fromJson[List[QueryLog]])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(logs.length == 2)
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -29,13 +29,13 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
   )
 
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, jwtCfg, clock)
+    } yield AuthServiceLive(ur, jwtCfg, clock)
 
   private def makePolicyService =
-    for
+    for {
       pr    <- ZIO.service[ProfileRepo]
       sr    <- ZIO.service[ScheduleRepo]
       tlr   <- ZIO.service[TimeLimitRepo]
@@ -45,16 +45,16 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       ur    <- ZIO.service[TimeUsageRepo]
       er    <- ZIO.service[TimeExtensionRepo]
       clock <- ZIO.service[Clock]
-    yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, ur, er, clock)): PolicyService
+    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, ur, er, clock)): PolicyService
 
   /** Seed a router row with a known plain enrollment token, return (id, raw token). */
   private def seedRouter(name: String): ZIO[RouterRepo, Throwable, (UUID, String)] =
-    for
+    for {
       rr <- ZIO.service[RouterRepo]
       token = "et_" + UUID.randomUUID().toString.replace("-", "")
       hash  = PolicyService.hashToken(token)
       id <- rr.create(name, hash)
-    yield (id, token)
+    } yield (id, token)
 
   private def doRegister(routes: Routes[Any, Response], et: String): Task[Response] =
     routes.runZIO(
@@ -66,7 +66,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
 
   def spec = suite("Router API")(
     test("enrollment flow exchanges enrollment_token for router_token; row state updated") {
-      for
+      for {
         _        <- cleanDb
         rr       <- ZIO.service[RouterRepo]
         ber      <- ZIO.service[BlockEventRepo]
@@ -76,14 +76,14 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         body <- resp.body.asString
         out  <- ZIO.fromEither(body.fromJson[RegisterRouterResponse])
         row  <- rr.findById(id).map(_.get)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(out.routerId == id) &&
         assertTrue(out.routerToken.startsWith("rt_")) &&
         assertTrue(row.enrollmentTokenHash.isEmpty) &&
         assertTrue(row.tokenHash.contains(PolicyService.hashToken(out.routerToken)))
     },
     test("enrollment token is single-use: second register returns 401") {
-      for
+      for {
         _       <- cleanDb
         rr      <- ZIO.service[RouterRepo]
         ber     <- ZIO.service[BlockEventRepo]
@@ -91,13 +91,13 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         routes = RouterRoutes.routes(rr, null, RouterAuthLive(rr), ber)
         first  <- doRegister(routes, et)
         second <- doRegister(routes, et)
-      yield assertTrue(first.status == Status.Ok) &&
+      } yield assertTrue(first.status == Status.Ok) &&
         assertTrue(second.status == Status.Unauthorized)
     },
     test(
       "policy without bearer → 401; wrong bearer → 401; right bearer → 200; persists last_etag",
     ) {
-      for
+      for {
         _       <- cleanDb
         rr      <- ZIO.service[RouterRepo]
         ber     <- ZIO.service[BlockEventRepo]
@@ -119,7 +119,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
             .addHeader(Header.Authorization.Bearer(reg.routerToken)),
         )
         row     <- rr.findById(reg.routerId).map(_.get)
-      yield assertTrue(noAuth.status == Status.Unauthorized) &&
+      } yield assertTrue(noAuth.status == Status.Unauthorized) &&
         assertTrue(wrong.status == Status.Unauthorized) &&
         assertTrue(ok.status == Status.Ok) &&
         assertTrue(row.lastEtag.exists(_.startsWith("\"sha256:")))
@@ -127,7 +127,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
     test(
       "policy snapshot composition: devices, profiles, schedules, site_limits, blocklists, time_used",
     ) {
-      for
+      for {
         _     <- cleanDb
         pr    <- ZIO.service[ProfileRepo]
         sr    <- ZIO.service[ScheduleRepo]
@@ -164,7 +164,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         body    <- resp.body.asString
         snap    <- ZIO.fromEither(body.fromJson[PolicySnapshot])
         kp = snap.profiles.find(_.id == kid).get
-      yield assertTrue(snap.devices.size == 2) &&
+      } yield assertTrue(snap.devices.size == 2) &&
         assertTrue(snap.profiles.exists(_.id == kid)) &&
         assertTrue(snap.profiles.exists(_.id == adult)) &&
         assertTrue(snap.defaultProfileId.exists(id => snap.profiles.exists(_.id == id))) &&
@@ -177,7 +177,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(snap.blocklists("ads").url == "/api/blocklists/ads.rpz")
     },
     test("etag deterministic across calls; If-None-Match → 304; mutation → fresh etag") {
-      for
+      for {
         _       <- cleanDb
         pr      <- ZIO.service[ProfileRepo]
         sr      <- ZIO.service[ScheduleRepo]
@@ -211,13 +211,13 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         )
         b3      <- r3.body.asString
         s3      <- ZIO.fromEither(b3.fromJson[PolicySnapshot])
-      yield assertTrue(r1.status == Status.Ok) &&
+      } yield assertTrue(r1.status == Status.Ok) &&
         assertTrue(r2.status == Status.NotModified) &&
         assertTrue(r3.status == Status.Ok) &&
         assertTrue(s1.etag != s3.etag)
     },
     test("RPZ blocklist: 200 with formatted body, 401 unauth, 404 unknown") {
-      for
+      for {
         _       <- cleanDb
         rr      <- ZIO.service[RouterRepo]
         blr     <- ZIO.service[BlocklistRepo]
@@ -241,7 +241,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
             .get(URL.decode("/api/blocklists/nonsense.rpz").toOption.get)
             .addHeader(Header.Authorization.Bearer(reg.routerToken)),
         )
-      yield assertTrue(noAuth.status == Status.Unauthorized) &&
+      } yield assertTrue(noAuth.status == Status.Unauthorized) &&
         assertTrue(ok.status == Status.Ok) &&
         assertTrue(okBody.contains("$ORIGIN ads.rpz.")) &&
         assertTrue(okBody.contains("doubleclick.net CNAME .")) &&
@@ -251,7 +251,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(nf.status == Status.NotFound)
     },
     test("policy snapshot: unknown device (NULL profile_id) appears with profileId=null") {
-      for
+      for {
         _       <- cleanDb
         pr      <- ZIO.service[ProfileRepo]
         sr      <- ZIO.service[ScheduleRepo]
@@ -281,13 +281,13 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         snap    <- ZIO.fromEither(body.fromJson[PolicySnapshot])
         unknown = snap.devices.find(_.mac == "ff:ff:ff:aa:bb:cc")
         known   = snap.devices.find(_.mac == "aa:bb:cc:11:22:33")
-      yield assertTrue(snap.devices.size == 2) &&
+      } yield assertTrue(snap.devices.size == 2) &&
         assertTrue(unknown.isDefined) &&
         assertTrue(unknown.exists(_.profileId.isEmpty)) &&
         assertTrue(known.exists(_.profileId.contains(kid)))
     },
     test("admin can create router; non-admin gets 403; row stores enrollment hash, no token yet") {
-      for
+      for {
         _          <- cleanDb
         auth       <- makeAuth
         rr         <- ZIO.service[RouterRepo]
@@ -316,7 +316,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         okBody   <- ok.body.asString
         out      <- ZIO.fromEither(okBody.fromJson[CreateRouterResponse])
         row      <- rr.findById(out.routerId).map(_.get)
-      yield assertTrue(rejected.status == Status.Forbidden) &&
+      } yield assertTrue(rejected.status == Status.Forbidden) &&
         assertTrue(ok.status == Status.Ok) &&
         assertTrue(out.enrollmentToken.startsWith("et_")) &&
         assertTrue(row.tokenHash.isEmpty) &&

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -25,7 +25,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   )
 
   private def makePsAt(dt: LocalDateTime) =
-    for
+    for {
       pr   <- ZIO.service[ProfileRepo]
       sr   <- ZIO.service[ScheduleRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
@@ -36,7 +36,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       er   <- ZIO.service[TimeExtensionRepo]
       ref  <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, ur, er, clk)): PolicyService
+    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, ur, er, clk)): PolicyService
 
   private def makePsDefault = makePsAt(TestClock.schoolDayAfternoon)
 
@@ -44,10 +44,10 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   private def seedAndEnrollRouter(
       rr: RouterRepo,
       routes: Routes[Any, Response],
-  ): Task[String] =
+  ): Task[String] = {
     val et   = "et_" + UUID.randomUUID().toString.replace("-", "")
     val hash = PolicyService.hashToken(et)
-    for
+    for {
       _    <- rr.create("gw", hash)
       reg  <- routes.runZIO(
         Request.post(
@@ -59,7 +59,8 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       resp <- ZIO
         .fromEither(body.fromJson[RegisterRouterResponse])
         .mapError(new RuntimeException(_))
-    yield resp.routerToken
+    } yield resp.routerToken
+  }
 
   private def callDecide(
       routes: Routes[Any, Response],
@@ -78,7 +79,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
 
   def spec = suite("POST /api/router/decision")(
     test("requires bearer token: missing → 401, wrong → 401") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         ber <- ZIO.service[BlockEventRepo]
@@ -99,11 +100,11 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
             )
             .addHeader(Header.Authorization.Bearer("rt_wrong")),
         )
-      yield assertTrue(noAuth.status == Status.Unauthorized) &&
+      } yield assertTrue(noAuth.status == Status.Unauthorized) &&
         assertTrue(wrong.status == Status.Unauthorized)
     },
     test("unrecognized mac → allow, no_profile, no block_event") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         ber <- ZIO.service[BlockEventRepo]
@@ -114,13 +115,13 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "allow") &&
         assertTrue(dr.reason == "no_profile") &&
         assertTrue(events.isEmpty)
     },
     test("MAC in devices with NULL profile_id → allow, no_profile") {
-      for
+      for {
         _     <- cleanDb
         rr    <- ZIO.service[RouterRepo]
         dRepo <- ZIO.service[DeviceRepo]
@@ -133,12 +134,12 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         resp <- callDecide(routes, tok, mac, "example.com")
         body <- resp.body.asString
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "allow") &&
         assertTrue(dr.reason == "no_profile")
     },
     test("paused profile → block:paused, null expires_at, block_event recorded") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -155,7 +156,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "paused") &&
         assertTrue(dr.expiresAt.isEmpty) &&
@@ -172,7 +173,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     ) {
       // Bedtime = Monday 2025-01-06 21:30; schedule is 21:00–07:00 every day.
       // Overnight schedule started today → ends tomorrow at 07:00.
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -188,7 +189,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "schedule") &&
         assertTrue(dr.expiresAt.exists(s => s.startsWith("2025-01-07T07:00") && s.endsWith("Z"))) &&
@@ -197,7 +198,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     test("early morning during overnight schedule → block:schedule, expires_at = today 07:00") {
       // earlyMorning = Monday 2025-01-06 06:00. Overnight schedule started Sunday 21:00 →
       // ends Monday 07:00.
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -212,13 +213,13 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "example.com")
         body <- resp.body.asString
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
-      yield assertTrue(dr.decision == "block") &&
+      } yield assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "schedule") &&
         assertTrue(dr.expiresAt.exists(s => s.startsWith("2025-01-06T07:00") && s.endsWith("Z")))
     },
     test("daily time limit hit → block:time_limit, expires_at = midnight, block_event recorded") {
       // Kids profile: 120 min/day limit.  Usage = 121 min, no extension.
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -243,14 +244,14 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "time_limit") &&
         assertTrue(dr.expiresAt.exists(s => s.startsWith("2025-01-07T00:00") && s.endsWith("Z"))) &&
         assertTrue(events.exists(_.reason == "time_limit"))
     },
     test("extension grants extra minutes: usage at limit + extension → allow") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -271,10 +272,10 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "cnn.com")
         body <- resp.body.asString
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
-      yield assertTrue(dr.decision == "allow")
+      } yield assertTrue(dr.decision == "allow")
     },
     test("blocked by category blocklist → block:category:ads, block_event recorded") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -292,13 +293,13 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(dr.decision == "block") &&
+      } yield assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "category:ads") &&
         assertTrue(dr.expiresAt.isEmpty) &&
         assertTrue(events.exists(_.reason == "category:ads"))
     },
     test("subdomain matched by blocklist parent → block:category") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -315,11 +316,11 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "sub.doubleclick.net")
         body <- resp.body.asString
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
-      yield assertTrue(dr.decision == "block") &&
+      } yield assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "category:ads")
     },
     test("allowed host: no blocklist match, no limit hit, no schedule → allow, no block_event") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -335,12 +336,12 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         body   <- resp.body.asString
         dr     <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
         events <- ber.recent(10)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(dr.decision == "allow") &&
         assertTrue(events.isEmpty)
     },
     test("extra_blocked domain → block:extra_blocked") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -357,11 +358,11 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "badsite.com")
         body <- resp.body.asString
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
-      yield assertTrue(dr.decision == "block") &&
+      } yield assertTrue(dr.decision == "block") &&
         assertTrue(dr.reason == "extra_blocked")
     },
     test("block_event NOT recorded on allow decision") {
-      for
+      for {
         _   <- cleanDb
         rr  <- ZIO.service[RouterRepo]
         pr  <- ZIO.service[ProfileRepo]
@@ -375,7 +376,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         tok    <- seedAndEnrollRouter(rr, routes)
         _      <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "allowed.example.com")
         events <- ber.recent(10)
-      yield assertTrue(events.isEmpty)
+      } yield assertTrue(events.isEmpty)
     },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -14,16 +14,18 @@ import java.time.{Instant, LocalDate, OffsetDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.UUID
 
-private object SeenParser:
+private object SeenParser {
   // Postgres `::TEXT` on TIMESTAMPTZ produces "2026-05-07 08:05:00-06". Normalize the
   // separator and pad a 2-digit numeric offset to ±HH:00 so OffsetDateTime can parse it.
   private val fmt                   = DateTimeFormatter.ISO_OFFSET_DATE_TIME
-  def toInstant(s: String): Instant =
+  def toInstant(s: String): Instant = {
     val withT  = s.replace(' ', 'T')
     val padded =
       if withT.matches(""".*[+-]\d{2}$""") then withT + ":00"
       else withT
     OffsetDateTime.parse(padded, fmt).toInstant
+  }
+}
 
 object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
 
@@ -33,35 +35,37 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
-  private def seedRouter(rRepo: RouterRepo): Task[(UUID, String)] =
+  private def seedRouter(rRepo: RouterRepo): Task[(UUID, String)] = {
     val token = "ROUTER_TOKEN_PLAIN"
     val hash  = RouterAuth.sha256Hex(token)
-    for
+    for {
       id <- rRepo.create("test-router", "ENROLL_HASH")
       _  <- rRepo.completeEnrollment(id, hash)
-    yield (id, token)
+    } yield (id, token)
+  }
 
   private def buildRoutes =
-    for
+    for {
       rRepo <- ZIO.service[RouterRepo]
       tRepo <- ZIO.service[TrafficReportRepo]
       tu    <- ZIO.service[TimeUsageRepo]
       dRepo <- ZIO.service[DeviceRepo]
       cRepo <- ZIO.service[ConnectionEventRepo]
       auth = new RouterAuthLive(rRepo)
-    yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo)
+    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo)
 
   private def post(
       routes: Routes[Any, Response],
       path: String,
       body: String,
       token: Option[String],
-  ) =
+  ) = {
     val base = Request
       .post(URL.decode(path).toOption.get, Body.fromString(body))
       .addHeader(Header.ContentType(MediaType.application.json))
     val req  = token.fold(base)(t => base.addHeader(Header.Authorization.Bearer(t)))
     routes.runZIO(req)
+  }
 
   // Fixed test instants
   private val periodStart = Instant.parse("2026-05-07T14:00:00Z")
@@ -72,45 +76,45 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
   private val unknownMac = "aa:bb:cc:99:99:99"
 
   private def seedKnownDevice(dRepo: DeviceRepo, profileRepo: ProfileRepo): Task[Unit] =
-    for
+    for {
       pid <- profileRepo.create("Kids", List("adult"))
       _   <- dRepo.upsert(knownMac, "kid-ipad", pid, "192.168.1.10")
-    yield ()
+    } yield ()
 
   def spec = suite("Router ingest /api/router/*")(
     // ── auth ─────────────────────────────────────────────────────────────────
     test("missing bearer returns 401") {
-      for
+      for {
         _      <- cleanDb
         routes <- buildRoutes
         body = UsageReport(UUID.randomUUID(), periodStart.toString, periodEnd.toString, Nil).toJson
         resp <- post(routes, "/api/router/usage", body, None)
-      yield assertTrue(resp.status == Status.Unauthorized)
+      } yield assertTrue(resp.status == Status.Unauthorized)
     },
     test("invalid bearer returns 401") {
-      for
+      for {
         _      <- cleanDb
         routes <- buildRoutes
         body = UsageReport(UUID.randomUUID(), periodStart.toString, periodEnd.toString, Nil).toJson
         resp <- post(routes, "/api/router/usage", body, Some("not-a-real-token"))
-      yield assertTrue(resp.status == Status.Unauthorized)
+      } yield assertTrue(resp.status == Status.Unauthorized)
     },
     test("valid bearer with empty records returns 200") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         routes   <- buildRoutes
         (id, tk) <- seedRouter(rRepo)
         body = UsageReport(id, periodStart.toString, periodEnd.toString, Nil).toJson
         resp <- post(routes, "/api/router/usage", body, Some(tk))
-      yield assertTrue(resp.status == Status.Ok)
+      } yield assertTrue(resp.status == Status.Ok)
     },
 
     // ── usage ────────────────────────────────────────────────────────────────
     test(
       "usage: posting same period+mac+hostname twice does not double-count seconds_used or bytes",
     ) {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         pRepo    <- ZIO.service[ProfileRepo]
@@ -126,7 +130,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         r2   <- post(routes, "/api/router/usage", body, Some(tk))
         sb   <- tu.getSecondsAndBytes(knownMac, "youtube.com", testDate)
         rows <- tRepo.listForRouter(id, 100)
-      yield assertTrue(r1.status == Status.Ok) &&
+      } yield assertTrue(r1.status == Status.Ok) &&
         assertTrue(r2.status == Status.Ok) &&
         assertTrue(sb == ((240L, 1000L, 500L))) &&
         assertTrue(rows.size == 1)
@@ -134,7 +138,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     test(
       "usage: bytes accumulate across multiple records in one POST (different hostnames same mac)",
     ) {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         pRepo    <- ZIO.service[ProfileRepo]
@@ -151,12 +155,12 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         resp <- post(routes, "/api/router/usage", body, Some(tk))
         yt   <- tu.getSecondsAndBytes(knownMac, "youtube.com", testDate)
         gg   <- tu.getSecondsAndBytes(knownMac, "google.com", testDate)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(yt == ((60L, 100L, 50L))) &&
         assertTrue(gg == ((30L, 200L, 10L)))
     },
     test("usage: seconds add across distinct periods for same (mac, hostname)") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         pRepo    <- ZIO.service[ProfileRepo]
@@ -171,10 +175,10 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         _  <- post(routes, "/api/router/usage", b1, Some(tk))
         _  <- post(routes, "/api/router/usage", b2, Some(tk))
         sb <- tu.getSecondsAndBytes(knownMac, "youtube.com", testDate)
-      yield assertTrue(sb == ((240L, 2L, 2L)))
+      } yield assertTrue(sb == ((240L, 2L, 2L)))
     },
     test("usage: known mac last_seen_at is set to period_end and last_seen_ip to record.ip") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         pRepo    <- ZIO.service[ProfileRepo]
@@ -186,11 +190,11 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
         _ <- post(routes, "/api/router/usage", body, Some(tk))
         d <- dRepo.findByMac(knownMac)
-      yield assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.42"))) &&
+      } yield assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.42"))) &&
         assertTrue(d.flatMap(_.lastSeenAt).map(SeenParser.toInstant).contains(periodEnd))
     },
     test("usage: unknown mac in records does NOT create a device row (events does that)") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         dRepo    <- ZIO.service[DeviceRepo]
@@ -200,12 +204,12 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
         resp <- post(routes, "/api/router/usage", body, Some(tk))
         d    <- dRepo.findByMac(unknownMac)
-      yield assertTrue(resp.status == Status.Ok) && assertTrue(d.isEmpty)
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(d.isEmpty)
     },
 
     // ── events ───────────────────────────────────────────────────────────────
     test("events: connection_attempt batch is recorded with allowed/reason") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         cRepo    <- ZIO.service[ConnectionEventRepo]
@@ -234,13 +238,13 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = RouterEventsRequest(id, evs).toJson
         resp <- post(routes, "/api/router/events", body, Some(tk))
         rows <- cRepo.listForRouter(id, 100)
-      yield assertTrue(resp.status == Status.Ok) &&
+      } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(rows.size == 2) &&
         assertTrue(rows.exists(r => r.hostname == "youtube.com" && !r.allowed)) &&
         assertTrue(rows.exists(r => r.hostname == "khanacademy.org" && r.allowed))
     },
     test("events: dhcp_lease for known mac updates devices.last_seen_*") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         pRepo    <- ZIO.service[ProfileRepo]
@@ -258,7 +262,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = RouterEventsRequest(id, List(ev)).toJson
         _ <- post(routes, "/api/router/events", body, Some(tk))
         d <- dRepo.findByMac(knownMac)
-      yield assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.77"))) &&
+      } yield assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.77"))) &&
         assertTrue(
           d.flatMap(_.lastSeenAt)
             .map(SeenParser.toInstant)
@@ -266,7 +270,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         )
     },
     test("events: dhcp_lease for unknown mac upserts a device row with NULL profile_id") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         dRepo    <- ZIO.service[DeviceRepo]
@@ -282,12 +286,12 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = RouterEventsRequest(id, List(ev)).toJson
         _ <- post(routes, "/api/router/events", body, Some(tk))
         d <- dRepo.findByMac(unknownMac)
-      yield assertTrue(d.exists(_.name == "mystery-laptop")) &&
+      } yield assertTrue(d.exists(_.name == "mystery-laptop")) &&
         assertTrue(d.exists(_.profileId.isEmpty)) &&
         assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.55")))
     },
     test("events: dhcp_lease for the same unknown mac twice is idempotent (no duplicate row)") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         dRepo    <- ZIO.service[DeviceRepo]
@@ -304,10 +308,10 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         _   <- post(routes, "/api/router/events", body, Some(tk))
         _   <- post(routes, "/api/router/events", body, Some(tk))
         all <- dRepo.listAll
-      yield assertTrue(all.count(_.mac == unknownMac) == 1)
+      } yield assertTrue(all.count(_.mac == unknownMac) == 1)
     },
     test("events: first_seen_mac creates an unknown-device row when missing") {
-      for
+      for {
         _        <- cleanDb
         rRepo    <- ZIO.service[RouterRepo]
         dRepo    <- ZIO.service[DeviceRepo]
@@ -323,7 +327,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         body = RouterEventsRequest(id, List(ev)).toJson
         _ <- post(routes, "/api/router/events", body, Some(tk))
         d <- dRepo.findByMac("aa:bb:cc:dd:ee:01")
-      yield assertTrue(d.isDefined) &&
+      } yield assertTrue(d.isDefined) &&
         assertTrue(d.exists(_.profileId.isEmpty)) &&
         assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.61")))
     },

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -21,13 +21,13 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   def spec = suite("OpenWRT repos")(
     suite("RouterRepo")(
       test("create returns a UUID and stores enrollment_token_hash, no token_hash") {
-        for
+        for {
           _        <- cleanDb
           repo     <- ZIO.service[RouterRepo]
           id       <- repo.create("home-router", "ENROLL_HASH_1")
           row      <- repo.findById(id)
           byEnroll <- repo.findByEnrollmentTokenHash("ENROLL_HASH_1")
-        yield assertTrue(row.exists(_.name == "home-router")) &&
+        } yield assertTrue(row.exists(_.name == "home-router")) &&
           assertTrue(row.exists(_.enrollmentTokenHash.contains("ENROLL_HASH_1"))) &&
           assertTrue(row.exists(_.tokenHash.isEmpty)) &&
           assertTrue(row.exists(_.lastSeenAt.isEmpty)) &&
@@ -36,7 +36,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       test(
         "completeEnrollment swaps enrollment_token_hash for token_hash and stamps last_seen_at",
       ) {
-        for
+        for {
           _        <- cleanDb
           repo     <- ZIO.service[RouterRepo]
           id       <- repo.create("r1", "ENROLL_HASH_2")
@@ -44,14 +44,14 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           row      <- repo.findById(id)
           byEnroll <- repo.findByEnrollmentTokenHash("ENROLL_HASH_2")
           byTok    <- repo.findByTokenHash("TOKEN_HASH_2")
-        yield assertTrue(row.exists(_.enrollmentTokenHash.isEmpty)) &&
+        } yield assertTrue(row.exists(_.enrollmentTokenHash.isEmpty)) &&
           assertTrue(row.exists(_.tokenHash.contains("TOKEN_HASH_2"))) &&
           assertTrue(row.exists(_.lastSeenAt.isDefined)) &&
           assertTrue(byEnroll.isEmpty) &&
           assertTrue(byTok.exists(_.id == id))
       },
       test("touch updates last_seen_at and last_etag without losing prior etag when None passed") {
-        for
+        for {
           _    <- cleanDb
           repo <- ZIO.service[RouterRepo]
           id   <- repo.create("r1", "EH")
@@ -60,12 +60,12 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           a    <- repo.findById(id)
           _    <- repo.touch(id, None) // last_etag must remain "etag-A"
           b    <- repo.findById(id)
-        yield assertTrue(a.flatMap(_.lastEtag).contains("etag-A")) &&
+        } yield assertTrue(a.flatMap(_.lastEtag).contains("etag-A")) &&
           assertTrue(b.flatMap(_.lastEtag).contains("etag-A")) &&
           assertTrue(b.flatMap(_.lastSeenAt).isDefined)
       },
       test("delete removes the row and cascades to traffic_reports") {
-        for
+        for {
           _     <- cleanDb
           rRepo <- ZIO.service[RouterRepo]
           tRepo <- ZIO.service[TrafficReportRepo]
@@ -91,21 +91,21 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           _   <- rRepo.delete(id)
           row <- rRepo.findById(id)
           rep <- tRepo.listForRouter(id, 10)
-        yield assertTrue(row.isEmpty) && assertTrue(rep.isEmpty)
+        } yield assertTrue(row.isEmpty) && assertTrue(rep.isEmpty)
       },
       test("listAll returns rows ordered by created_at") {
-        for
+        for {
           _    <- cleanDb
           repo <- ZIO.service[RouterRepo]
           a    <- repo.create("a", "h1")
           b    <- repo.create("b", "h2")
           all  <- repo.listAll
-        yield assertTrue(all.map(_.id) == List(a, b))
+        } yield assertTrue(all.map(_.id) == List(a, b))
       },
     ),
     suite("TrafficReportRepo")(
       test("insertBatch is idempotent on (router_id, period_start, mac, hostname)") {
-        for
+        for {
           _     <- cleanDb
           rRepo <- ZIO.service[RouterRepo]
           tRepo <- ZIO.service[TrafficReportRepo]
@@ -127,10 +127,10 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           n1   <- tRepo.insertBatch(List(rec))
           n2   <- tRepo.insertBatch(List(rec)) // retry
           rows <- tRepo.listForRouter(rid, 100)
-        yield assertTrue(n1 == 1) && assertTrue(n2 == 0) && assertTrue(rows.size == 1)
+        } yield assertTrue(n1 == 1) && assertTrue(n2 == 0) && assertTrue(rows.size == 1)
       },
       test("different hostnames in same period are stored as distinct rows") {
-        for
+        for {
           _     <- cleanDb
           rRepo <- ZIO.service[RouterRepo]
           tRepo <- ZIO.service[TrafficReportRepo]
@@ -166,11 +166,11 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           )
           n    <- tRepo.insertBatch(batch)
           rows <- tRepo.listForDevice(mac, LocalDate.of(2026, 5, 2))
-        yield assertTrue(n == 2) && assertTrue(rows.size == 2) &&
+        } yield assertTrue(n == 2) && assertTrue(rows.size == 2) &&
           assertTrue(rows.map(_.hostname).toSet == Set("youtube.com", "google.com"))
       },
       test("listForDevice filters by mac and date") {
-        for
+        for {
           _     <- cleanDb
           rRepo <- ZIO.service[RouterRepo]
           tRepo <- ZIO.service[TrafficReportRepo]
@@ -200,12 +200,12 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             ),
           )
           rows <- tRepo.listForDevice(mac1, d1)
-        yield assertTrue(rows.size == 1) && assertTrue(rows.head.hostname == "a.com")
+        } yield assertTrue(rows.size == 1) && assertTrue(rows.head.hostname == "a.com")
       },
     ),
     suite("BlockEventRepo")(
       test("insertBatch returns count and records appear in recent() ordered by ts desc") {
-        for
+        for {
           _    <- cleanDb
           repo <- ZIO.service[BlockEventRepo]
           n    <- repo.insertBatch(
@@ -220,11 +220,11 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             ),
           )
           rows <- repo.recent(10)
-        yield assertTrue(n == 3) && assertTrue(rows.size == 3) &&
+        } yield assertTrue(n == 3) && assertTrue(rows.size == 3) &&
           assertTrue(rows.exists(_.mac.isEmpty))
       },
       test("listForMac returns only events for that mac, newest first") {
-        for
+        for {
           _    <- cleanDb
           repo <- ZIO.service[BlockEventRepo]
           mac = "aa:bb:cc:00:00:01"
@@ -236,7 +236,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             ),
           )
           rows <- repo.listForMac(mac, 10)
-        yield assertTrue(rows.size == 2) &&
+        } yield assertTrue(rows.size == 2) &&
           assertTrue(rows.forall(_.mac.contains(mac))) &&
           assertTrue(rows.map(_.hostname).toSet == Set("a.com", "c.com"))
       },
@@ -246,7 +246,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         import doobie.implicits.*
         import doobie.postgres.implicits.*
         import zio.interop.catz.*
-        for
+        for {
           _  <- cleanDb
           tu <- ZIO.service[TimeUsageRepo]
           xa <- ZIO.service[doobie.Transactor[Task]]
@@ -258,7 +258,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
               .query[(Long, Long)]
               .unique
               .transact(xa)
-        yield assertTrue(row == ((0L, 0L)))
+        } yield assertTrue(row == ((0L, 0L)))
       },
     ),
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -5,7 +5,7 @@ import zio.*
 import zio.http.*
 import zio.test.*
 
-object StaticRoutesSpec extends ZIOSpecDefault:
+object StaticRoutesSpec extends ZIOSpecDefault {
 
   private def withTempDir[A](f: java.io.File => Task[A]): Task[A] =
     ZIO.acquireReleaseWith(
@@ -15,9 +15,10 @@ object StaticRoutesSpec extends ZIOSpecDefault:
       },
     ) { dir =>
       ZIO.attempt {
-        def del(f: java.io.File): Unit =
+        def del(f: java.io.File): Unit = {
           if f.isDirectory then f.listFiles.foreach(del)
           val _ = f.delete()
+        }
         del(dir)
       }.orDie
     }(f)
@@ -35,55 +36,56 @@ object StaticRoutesSpec extends ZIOSpecDefault:
   def spec = suite("StaticRoutes")(
     test("serves index.html for /") {
       withTempDir { dir =>
-        for
+        for {
           _ <- write(dir, "index.html", "<html>hi</html>")
           rs = StaticRoutes.routes(dir.getAbsolutePath)
           resp <- get(rs, "/")
           body <- resp.body.asString
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(body == "<html>hi</html>")
       }
     },
     test("serves an existing asset") {
       withTempDir { dir =>
-        for
+        for {
           _ <- write(dir, "app.js", "console.log(1)")
           rs = StaticRoutes.routes(dir.getAbsolutePath)
           resp <- get(rs, "/app.js")
           body <- resp.body.asString
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(body == "console.log(1)")
       }
     },
     test("falls back to index.html for unknown non-API path (SPA)") {
       withTempDir { dir =>
-        for
+        for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           rs = StaticRoutes.routes(dir.getAbsolutePath)
           resp <- get(rs, "/devices/some-deep-route")
           body <- resp.body.asString
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(body == "<html>spa</html>")
       }
     },
     test("returns 404 for unknown /api/ path") {
       withTempDir { dir =>
-        for
+        for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           rs = StaticRoutes.routes(dir.getAbsolutePath)
           resp <- get(rs, "/api/unknown")
-        yield assertTrue(resp.status == Status.NotFound)
+        } yield assertTrue(resp.status == Status.NotFound)
       }
     },
     test("rejects path traversal attempts") {
       withTempDir { dir =>
-        for
+        for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           rs = StaticRoutes.routes(dir.getAbsolutePath)
           resp <- get(rs, "/../../etc/passwd")
           body <- resp.body.asString
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(body == "<html>spa</html>")
       }
     },
   )
+}

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -22,10 +22,10 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
 
   private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
-    for
+    for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
-    yield AuthServiceLive(ur, jwtCfg, clock)
+    } yield AuthServiceLive(ur, jwtCfg, clock)
   private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
@@ -35,7 +35,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
   def spec = suite("Time API")(
     suite("GET /api/time/status")(
       test("shows zero usage for a new device") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
@@ -68,14 +68,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           resp   <- routes.runZIO(req)
           body   <- resp.body.asString
           status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(status.dailyLimitMins.contains(120)) &&
           assertTrue(status.usedMins == 0) &&
           assertTrue(status.extensionMins == 0) &&
           assertTrue(status.remainingMins.contains(120))
       },
       test("reflects accumulated usage correctly") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -111,11 +111,11 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           resp   <- routes.runZIO(req)
           body   <- resp.body.asString
           status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
-        yield assertTrue(status.usedMins == 75) &&
+        } yield assertTrue(status.usedMins == 75) &&
           assertTrue(status.remainingMins.contains(45))
       },
       test("site-specific usage shown separately and not counted in total") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -158,7 +158,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           resp   <- routes.runZIO(req)
           body   <- resp.body.asString
           status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
-        yield assertTrue(status.usedMins == 60) && // YouTube NOT counted in total
+        } yield assertTrue(status.usedMins == 60) && // YouTube NOT counted in total
           assertTrue(status.remainingMins.contains(60)) &&
           assertTrue(
             status.siteUsage.exists(su =>
@@ -169,7 +169,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
     ),
     suite("POST /api/time/extend")(
       test("admin can grant profile extension which increases remaining for all devices") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -210,12 +210,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           statusResp <- routes.runZIO(statusReq)
           body       <- statusResp.body.asString
           status     <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
-        yield assertTrue(extResp.status == Status.Ok) &&
+        } yield assertTrue(extResp.status == Status.Ok) &&
           assertTrue(status.extensionMins == 30) &&
           assertTrue(status.remainingMins.contains(30))
       },
       test("extension is logged with granting admin username") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
@@ -249,13 +249,13 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             .addHeader(Header.ContentType(MediaType.application.json))
           _    <- routes.runZIO(req)
           exts <- extRepo.listForProfile(kidsId, TestClock.schoolDayAfternoon.toLocalDate)
-        yield assertTrue(exts.length == 1) &&
+        } yield assertTrue(exts.length == 1) &&
           assertTrue(exts.head.grantedBy == "admin") &&
           assertTrue(exts.head.extraMinutes == 15) &&
           assertTrue(exts.head.note.contains("Good behavior"))
       },
       test("child user cannot grant extensions") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
@@ -289,10 +289,10 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
-        yield assertTrue(resp.status == Status.Forbidden)
+        } yield assertTrue(resp.status == Status.Forbidden)
       },
       test("multiple extensions accumulate at profile level") {
-        for
+        for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
@@ -335,7 +335,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           today = TestClock.schoolDayAfternoon.toLocalDate
           exts  <- extRepo.listForProfile(kidsId, today)
           total <- extRepo.getProfileTotalExtension(kidsId, today)
-        yield assertTrue(exts.length == 3) &&
+        } yield assertTrue(exts.length == 3) &&
           assertTrue(total == 60)
       },
     ),
@@ -343,7 +343,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
     // ── per-profile status rollup ───────────────────────────────────────────
     suite("GET /api/time/status — per-profile rollup")(
       test("returns one ProfileTimeStatus per profile, not per device") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -378,13 +378,13 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
-        yield assertTrue(resp.status == Status.Ok) &&
+        } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(list.count(_.profileId == kidsId) == 1) && // one entry, not two
           assertTrue(kids.devices.length == 2) &&               // both devices in breakdown
           assertTrue(kids.devices.map(_.deviceName).toSet == Set("iPad", "iPhone"))
       },
       test("two devices on same profile share a combined usage pool") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -425,14 +425,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
-        yield assertTrue(kids.usedMins == 75) &&        // both devices summed
+        } yield assertTrue(kids.usedMins == 75) &&      // both devices summed
           assertTrue(kids.dailyLimitMins.contains(60)) &&
           assertTrue(kids.remainingMins.contains(0)) && // clamped to 0, not negative
           assertTrue(kids.devices.find(_.deviceMac == mac1).get.usedMins == 40) &&
           assertTrue(kids.devices.find(_.deviceMac == mac2).get.usedMins == 35)
       },
       test("per-app site usage aggregated across all profile devices") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -478,13 +478,13 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
           yt   = kids.siteUsage.find(_.label == "YouTube").get
-        yield assertTrue(yt.usedMins == 40) && // both devices summed
+        } yield assertTrue(yt.usedMins == 40) && // both devices summed
           assertTrue(yt.limitMins == 30) &&
-          assertTrue(yt.remainingMins == 0) && // clamped to 0
-          assertTrue(kids.usedMins == 0)       // site usage NOT counted in total
+          assertTrue(yt.remainingMins == 0) &&   // clamped to 0
+          assertTrue(kids.usedMins == 0)         // site usage NOT counted in total
       },
       test("policy snapshot has profile-level time_used_today aggregated across devices") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -520,7 +520,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           )
           snapshot <- policyService.snapshot
           kidsPolicy = snapshot.profiles.find(_.id == kidsId).get
-        yield assertTrue(kidsPolicy.dailyMinutes.contains(60)) &&
+        } yield assertTrue(kidsPolicy.dailyMinutes.contains(60)) &&
           assertTrue(kidsPolicy.timeUsedToday.totalMinutes == 55) // 30 + 25 across both devices
       },
     ) @@ TestAspect.sequential,

--- a/build.mill
+++ b/build.mill
@@ -29,6 +29,7 @@ trait CommonModule extends ScalaModule {
     "-Wvalue-discard",
     "-Xfatal-warnings",
     "-source:future",
+    "-no-indent",
   )
 }
 

--- a/dns/src/BlockingEngine.scala
+++ b/dns/src/BlockingEngine.scala
@@ -6,7 +6,7 @@ import familydns.shared.Schedule
 import java.time.{DayOfWeek, LocalDate, LocalTime}
 
 /** Pure blocking logic — no effects, fully testable. */
-object BlockingEngine:
+object BlockingEngine {
 
   private val dayNames: Map[DayOfWeek, String] = Map(
     DayOfWeek.MONDAY    -> "mon",
@@ -19,9 +19,10 @@ object BlockingEngine:
   )
 
   sealed trait Decision
-  object Decision:
+  object Decision {
     case object Allow                extends Decision
     case class Block(reason: String) extends Decision
+  }
 
   /**
    * Full decision including blocklist lookup.
@@ -41,23 +42,23 @@ object BlockingEngine:
       mac: String,
       now: LocalTime,
       today: LocalDate,
-  ): Decision =
+  ): Decision = {
     val d = domain.toLowerCase.stripSuffix(".")
 
     if profile.profile.paused then Decision.Block("paused")
     else if isScheduleActive(profile.schedules, now, today) then Decision.Block("schedule")
     else if matchesAny(d, profile.profile.extraAllowed) then Decision.Allow
     else if matchesAny(d, profile.profile.extraBlocked) then Decision.Block("extra_blocked")
-    else
+    else {
       // Total daily time limit — site-specific domains are exempt
       val timeLimitBlock: Option[Decision] = profile.timeLimit.flatMap { limitMins =>
         val isSiteDomain =
           profile.siteTimeLimits.exists(s => matchesDomainPattern(d, s.domainPattern))
-        if !isSiteDomain then
+        if !isSiteDomain then {
           val usedMins = usage.totalUsage.getOrElse((mac, today.toString), 0)
           val extMins  = usage.extensions.getOrElse((mac, today.toString), 0)
           Option.when(usedMins >= limitMins + extMins)(Decision.Block("time_limit"))
-        else None
+        } else None
       }
 
       // Per-site time limits
@@ -75,38 +76,46 @@ object BlockingEngine:
       }
 
       timeLimitBlock.orElse(siteBlock).orElse(categoryBlock).getOrElse(Decision.Allow)
+    }
+  }
 
-  def isScheduleActive(schedules: List[Schedule], now: LocalTime, today: LocalDate): Boolean =
+  def isScheduleActive(schedules: List[Schedule], now: LocalTime, today: LocalDate): Boolean = {
     val todayName = dayNames(today.getDayOfWeek)
     schedules.exists { s =>
       if !s.days.contains(todayName) then false
-      else
+      else {
         val from  = parseTime(s.blockFrom)
         val until = parseTime(s.blockUntil)
         if from.isAfter(until) then
           // Overnight: e.g. 21:00 → 07:00 (inclusive at from, exclusive at until)
           !now.isBefore(from) || now.isBefore(until)
         else !now.isBefore(from) && now.isBefore(until)
+      }
     }
+  }
 
-  def apexDomain(domain: String): String =
+  def apexDomain(domain: String): String = {
     val parts = domain.split('.')
     if parts.length >= 2 then parts.takeRight(2).mkString(".") else domain
+  }
 
   def matchesDomainPattern(domain: String, pattern: String): Boolean =
-    if pattern.startsWith("*.") then
+    if pattern.startsWith("*.") then {
       val suffix = pattern.drop(1)
       domain.endsWith(suffix) || domain == pattern.drop(2)
-    else domain == pattern || domain.endsWith(s".$pattern")
+    } else domain == pattern || domain.endsWith(s".$pattern")
 
   private def matchesAny(domain: String, patterns: List[String]): Boolean =
     patterns.exists(p => matchesDomainPattern(domain, p))
 
   /** Check domain and all parent labels against blocklist set */
-  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean =
+  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean = {
     val parts = domain.split('.').toList
     (0 until parts.length - 1).exists(i => list.contains(parts.drop(i).mkString(".")))
+  }
 
-  private def parseTime(s: String): LocalTime =
+  private def parseTime(s: String): LocalTime = {
     val Array(h, m) = s.split(':')
     LocalTime.of(h.toInt, m.toInt)
+  }
+}

--- a/dns/src/DnsMain.scala
+++ b/dns/src/DnsMain.scala
@@ -10,7 +10,7 @@ import java.time.LocalDate
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
 
-object DnsMain extends ZIOAppDefault:
+object DnsMain extends ZIOAppDefault {
 
   override val bootstrap =
     Runtime.removeDefaultLoggers >>> SLF4J.slf4j
@@ -39,7 +39,7 @@ object DnsMain extends ZIOAppDefault:
     Throwable,
     DnsCache,
   ] =
-    for
+    for {
       profileRepo <- ZIO.service[ProfileRepo]
       schedRepo   <- ZIO.service[ScheduleRepo]
       tlRepo      <- ZIO.service[TimeLimitRepo]
@@ -59,17 +59,17 @@ object DnsMain extends ZIOAppDefault:
         p.id -> CachedProfile(p, sched, tl, pstls)
       }.toMap
       deviceMap = devices.flatMap(d => d.profileId.flatMap(cached.get).map(d.mac -> _)).toMap
-    yield DnsCache(deviceMap, blocklists, cached.values.find(_.profile.name == "Adults"))
+    } yield DnsCache(deviceMap, blocklists, cached.values.find(_.profile.name == "Adults"))
 
   private def loadUsage: ZIO[TimeUsageRepo & TimeExtensionRepo, Throwable, TimeUsageSnapshot] =
-    for
+    for {
       usageRepo <- ZIO.service[TimeUsageRepo]
       extRepo   <- ZIO.service[TimeExtensionRepo]
       today = LocalDate.now()
       ts    = today.toString
       rows <- usageRepo.snapshotAll(today)
       exts <- extRepo.snapshotAll(today)
-    yield TimeUsageSnapshot(
+    } yield TimeUsageSnapshot(
       domainUsage = rows.map { case ((mac, dom), m) => (mac, dom, ts) -> m },
       totalUsage = rows.groupBy(_._1._1).map((m, vs) => (m, ts) -> vs.values.sum),
       extensions = exts.map((m, v) => (m, ts) -> v),
@@ -79,19 +79,20 @@ object DnsMain extends ZIOAppDefault:
       queue: ConcurrentLinkedQueue[QueryLogEntry],
       batchSize: Int,
   ): ZIO[QueryLogRepo, Throwable, Unit] =
-    for
+    for {
       logRepo <- ZIO.service[QueryLogRepo]
       drained <- ZIO.attempt {
         val buf = scala.collection.mutable.ListBuffer.empty[QueryLogEntry]
         var i   = 0
         var e   = queue.poll()
-        while e != null && i < batchSize do
+        while e != null && i < batchSize do {
           buf += e
           i += 1
           e = queue.poll()
+        }
         buf.toList
       }
-      _       <- ZIO.when(drained.nonEmpty):
+      _       <- ZIO.when(drained.nonEmpty) {
         val inserts = drained.map(e =>
           QueryLogInsert(
             e.mac,
@@ -106,10 +107,11 @@ object DnsMain extends ZIOAppDefault:
           ),
         )
         logRepo.insertBatch(inserts)
-    yield ()
+      }
+    } yield ()
 
   private def program =
-    for
+    for {
       cfg <- ZIO.service[AppConfig]
       dnsCfg = toDnsConfig(cfg.dns)
       _ <- ZIO.logInfo(s"FamilyDNS DNS starting on :${dnsCfg.port} (location=${dnsCfg.location})")
@@ -138,4 +140,5 @@ object DnsMain extends ZIOAppDefault:
         .forkDaemon
       deviceRepo <- ZIO.service[DeviceRepo]
       _          <- new DnsServer(dnsCfg, cacheRef, usageRef, logQueue, deviceRepo).serve
-    yield ()
+    } yield ()
+}

--- a/dns/src/DnsPacket.scala
+++ b/dns/src/DnsPacket.scala
@@ -3,7 +3,7 @@ package familydns.dns
 import java.nio.ByteBuffer
 
 /** Minimal DNS packet parser — enough for filtering, no need for full RFC 1035 */
-object DnsPacket:
+object DnsPacket {
 
   val TYPE_A    = 1
   val TYPE_AAAA = 28
@@ -18,9 +18,9 @@ object DnsPacket:
   )
 
   /** Parse a raw DNS query packet. Returns None if malformed. */
-  def parseQuery(data: Array[Byte]): Option[Query] =
+  def parseQuery(data: Array[Byte]): Option[Query] = {
     if data.length < 12 then return None
-    try
+    try {
       val buf     = ByteBuffer.wrap(data)
       val id      = buf.getShort
       val flags   = buf.getShort & 0xffff
@@ -38,36 +38,40 @@ object DnsPacket:
       // qclass (skip — we only handle IN = 1)
 
       Some(Query(id, domain, qtype, data))
-    catch case _: Exception => None
+    } catch case _: Exception => None
+  }
 
   /** Read a DNS name from current buffer position, handling pointers */
-  private def readDomain(buf: ByteBuffer): String =
+  private def readDomain(buf: ByteBuffer): String = {
     val labels    = scala.collection.mutable.ListBuffer[String]()
     var jumped    = false
     var safeguard = 0
 
-    while safeguard < 128 do
+    while safeguard < 128 do {
       safeguard += 1
       val len = buf.get & 0xff
       if len == 0 then return labels.mkString(".")
-      else if (len & 0xc0) == 0xc0 then
+      else if (len & 0xc0) == 0xc0 then {
         // Pointer
         val lo     = buf.get & 0xff
         val offset = ((len & 0x3f) << 8) | lo
         if !jumped then jumped = true
         val _      = buf.position(offset)
-      else
+      } else {
         val bytes = new Array[Byte](len)
         buf.get(bytes)
         labels += new String(bytes, "ASCII")
+      }
+    }
 
     labels.mkString(".")
+  }
 
   /**
    * Build an NXDOMAIN response for the given query. Sets QR=1, RCODE=3, copies question section,
    * zeroes answer counts.
    */
-  def buildNxdomain(query: Array[Byte]): Array[Byte] =
+  def buildNxdomain(query: Array[Byte]): Array[Byte] = {
     if query.length < 12 then return query
     val response = query.clone()
     // Set QR=1 (response), AA=0, RCODE=3 (NXDOMAIN)
@@ -79,12 +83,13 @@ object DnsPacket:
     response(8) = 0; response(9) = 0
     response(10) = 0; response(11) = 0
     response
+  }
 
   /**
    * Build a REFUSED response (for schedule/pause blocks — cleaner UX than NXDOMAIN which gets
    * cached by the client).
    */
-  def buildRefused(query: Array[Byte]): Array[Byte] =
+  def buildRefused(query: Array[Byte]): Array[Byte] = {
     if query.length < 12 then return query
     val response = query.clone()
     response(2) = (response(2) | 0x80).toByte
@@ -93,3 +98,5 @@ object DnsPacket:
     response(8) = 0; response(9) = 0
     response(10) = 0; response(11) = 0
     response
+  }
+}

--- a/dns/src/DnsServer.scala
+++ b/dns/src/DnsServer.scala
@@ -29,7 +29,7 @@ class DnsServer(
     usageRef: Ref[TimeUsageSnapshot],
     logQueue: ConcurrentLinkedQueue[QueryLogEntry],
     deviceRepo: familydns.api.db.DeviceRepo,
-):
+) {
 
   private val upstreams = List(
     (config.upstreamPrimary, config.upstreamPort),
@@ -43,7 +43,7 @@ class DnsServer(
       ZIO.logInfo(s"DNS server listening on :${config.port}") *>
         ZIO
           .loop(())(Function.const(true), identity) { _ =>
-            for
+            for {
               buf <- ZIO.succeed(new Array[Byte](512))
               pkt <- ZIO.succeed(new DatagramPacket(buf, buf.length))
               _   <- ZIO.attempt(sock.receive(pkt))
@@ -51,7 +51,7 @@ class DnsServer(
               addr = pkt.getAddress
               port = pkt.getPort
               _ <- handleQuery(sock, data, addr, port).forkDaemon
-            yield ()
+            } yield ()
           }
           .unit
     }
@@ -62,10 +62,10 @@ class DnsServer(
       addr: InetAddress,
       port: Int,
   ): Task[Unit] =
-    DnsPacket.parseQuery(data) match
+    DnsPacket.parseQuery(data) match {
       case None        => ZIO.unit
       case Some(query) =>
-        for
+        for {
           cache <- cacheRef.get
           usage <- usageRef.get
           clientIp = addr.getHostAddress
@@ -79,7 +79,7 @@ class DnsServer(
           _        <- ZIO.logDebug(
             s"profile for mac=${mac.getOrElse("?")} -> ${profile.map(_.profile.name).getOrElse("none (unrecognized)")}",
           )
-          response <- profile match
+          response <- profile match {
             case None     =>
               // Unknown device — forward with no filtering but log so we can identify & onboard it
               ZIO.logDebug(
@@ -89,7 +89,7 @@ class DnsServer(
                   .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
                   .tap(_ => enqueueLog(mac, None, query, blocked = false, ""))
             case Some(cp) =>
-              for
+              for {
                 _ <- ZIO.foreachDiscard(mac) { m =>
                   deviceRepo
                     .updateLastSeen(m, clientIp)
@@ -110,7 +110,7 @@ class DnsServer(
                 _    <- ZIO.logDebug(
                   s"decision for ${query.domain} profile=${cp.profile.name} -> $decision",
                 )
-                resp <- decision match
+                resp <- decision match {
                   case BlockingEngine.Decision.Allow         =>
                     forwardUpstream(data)
                       .map(_.getOrElse(DnsPacket.buildNxdomain(data)))
@@ -122,11 +122,15 @@ class DnsServer(
                       else DnsPacket.buildNxdomain(data)
                     ZIO.succeed(r)
                       <* enqueueLog(mac, Some(cp), query, blocked = true, reason)
-              yield resp
-          _        <- ZIO.attempt:
+                }
+              } yield resp
+          }
+          _        <- ZIO.attempt {
             val out = new DatagramPacket(response, response.length, addr, port)
             sock.send(out)
-        yield ()
+          }
+        } yield ()
+    }
 
   private def enqueueLog(
       mac: Option[String],
@@ -138,7 +142,7 @@ class DnsServer(
     // Only log A/AAAA queries to keep noise down
     if !List(DnsPacket.TYPE_A, DnsPacket.TYPE_AAAA).contains(query.qtype) then ZIO.unit
     else
-      ZIO.succeed:
+      ZIO.succeed {
         val _ = logQueue.add(
           QueryLogEntry(
             mac = mac,
@@ -152,13 +156,14 @@ class DnsServer(
             location = Some(config.location),
           ),
         )
+      }
 
   private def forwardUpstream(data: Array[Byte]): Task[Option[Array[Byte]]] =
     ZIO
-      .attemptBlocking:
+      .attemptBlocking {
         upstreams.iterator
           .flatMap { (host, port) =>
-            try
+            try {
               val sock = new DatagramSocket()
               sock.setSoTimeout(3000)
               val addr = InetAddress.getByName(host)
@@ -168,20 +173,22 @@ class DnsServer(
               sock.receive(resp)
               sock.close()
               Some(buf.take(resp.getLength))
-            catch case _: Exception => None
+            } catch case _: Exception => None
           }
           .nextOption()
+      }
       .orElse(ZIO.succeed(None))
 
   /** ARP table lookup: IP → MAC. Returns canonical lowercase MAC or None. */
   private def arpLookup(ip: String): Option[String] =
-    try
+    try {
       val lines = scala.io.Source.fromFile("/proc/net/arp").getLines().drop(1)
       lines.collectFirst {
         case line if line.split("\\s+").headOption.contains(ip) =>
           line.split("\\s+")(3).toLowerCase
       }
-    catch case _: Exception => None
+    } catch case _: Exception => None
+}
 
 case class QueryLogEntry(
     mac: Option[String],

--- a/dns/test/src/feature/DnsBlockingSpec.scala
+++ b/dns/test/src/feature/DnsBlockingSpec.scala
@@ -36,7 +36,7 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
     Throwable,
     DnsCache,
   ] =
-    for
+    for {
       profiles   <- ZIO.service[ProfileRepo].flatMap(_.listAll)
       schedules  <- ZIO.service[ScheduleRepo].flatMap(_.listAll)
       timeLimits <- ZIO.service[TimeLimitRepo].flatMap(_.listAll)
@@ -50,7 +50,7 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
         p.id -> CachedProfile(p, sched, tl, pstls)
       }.toMap
       deviceMap = devices.flatMap(d => d.profileId.flatMap(cached.get).map(d.mac -> _)).toMap
-    yield DnsCache(deviceMap, blocklists, cached.values.find(_.profile.name == "Adults"))
+    } yield DnsCache(deviceMap, blocklists, cached.values.find(_.profile.name == "Adults"))
 
   private def decide(
       domain: String,
@@ -68,7 +68,7 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
   def spec = suite("DNS Blocking — full stack")(
     suite("category blocking loaded from DB")(
       test("blocks adult domain after loading blocklist from DB") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -88,13 +88,13 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
           d2 = decide("xvideos.com", cache)
           d3 = decide("facebook.com", cache)
           d4 = decide("google.com", cache)
-        yield assertTrue(d1 == BlockingEngine.Decision.Block("category:adult")) &&
+        } yield assertTrue(d1 == BlockingEngine.Decision.Block("category:adult")) &&
           assertTrue(d2 == BlockingEngine.Decision.Block("category:adult")) &&
           assertTrue(d3 == BlockingEngine.Decision.Block("category:social_media")) &&
           assertTrue(d4 == BlockingEngine.Decision.Allow)
       },
       test("adult device not blocked by kids blocklist") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -109,13 +109,13 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
           cache <- buildCache
           kidDecision = decide("facebook.com", cache, mac = testMac)
           dadDecision = decide("facebook.com", cache, mac = adultMac)
-        yield assertTrue(kidDecision == BlockingEngine.Decision.Block("category:social_media")) &&
+        } yield assertTrue(kidDecision == BlockingEngine.Decision.Block("category:social_media")) &&
           assertTrue(dadDecision == BlockingEngine.Decision.Allow)
       },
     ),
     suite("schedule blocking with controllable clock")(
       test("kids device is blocked at bedtime") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -125,10 +125,10 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
           cache       <- buildCache
           // 21:30 on a Monday — within bedtime window 21:00–07:00
           d = decide("google.com", cache, time = LocalTime.of(21, 30))
-        yield assertTrue(d == BlockingEngine.Decision.Block("schedule"))
+        } yield assertTrue(d == BlockingEngine.Decision.Block("schedule"))
       },
       test("kids device is allowed during school day") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -137,12 +137,12 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           cache       <- buildCache
           d = decide("google.com", cache, time = LocalTime.of(14, 0))
-        yield assertTrue(d == BlockingEngine.Decision.Allow)
+        } yield assertTrue(d == BlockingEngine.Decision.Allow)
       },
     ),
     suite("time limits loaded from DB")(
       test("blocks device that has hit daily limit") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -159,10 +159,10 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
             extensions = Map.empty,
           )
           d     = decide("minecraft.net", cache, usage = usage, date = today)
-        yield assertTrue(d == BlockingEngine.Decision.Block("time_limit"))
+        } yield assertTrue(d == BlockingEngine.Decision.Block("time_limit"))
       },
       test("allows device with extension after hitting base limit") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -179,12 +179,12 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
             extensions = Map((testMac, today.toString) -> 30),
           )
           d     = decide("minecraft.net", cache, usage = usage, date = today)
-        yield assertTrue(d == BlockingEngine.Decision.Allow)
+        } yield assertTrue(d == BlockingEngine.Decision.Allow)
       },
     ),
     suite("paused profile")(
       test("pausing a profile via DB causes all queries to block") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -194,12 +194,12 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
           _           <- profileRepo.setPaused(kidsId, paused = true)
           cache       <- buildCache
           d = decide("google.com", cache, time = LocalTime.of(14, 0))
-        yield assertTrue(d == BlockingEngine.Decision.Block("paused"))
+        } yield assertTrue(d == BlockingEngine.Decision.Block("paused"))
       },
     ),
     suite("unknown device")(
       test("unknown MAC falls through to default (adults) profile") {
-        for
+        for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
@@ -224,7 +224,7 @@ object DnsBlockingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
               ),
             )
             .getOrElse(BlockingEngine.Decision.Allow)
-        yield assertTrue(d == BlockingEngine.Decision.Allow)
+        } yield assertTrue(d == BlockingEngine.Decision.Allow)
       },
     ),
   ) @@ TestAspect.sequential

--- a/dns/test/src/unit/DnsPacketSpec.scala
+++ b/dns/test/src/unit/DnsPacketSpec.scala
@@ -9,7 +9,7 @@ object DnsPacketSpec extends ZIOSpecDefault {
 
   // A minimal valid DNS query for "google.com" type A
   // Built manually to test parsing without depending on a DNS library
-  private def buildQuery(domain: String, qtype: Int = 1): Array[Byte] =
+  private def buildQuery(domain: String, qtype: Int = 1): Array[Byte] = {
     val header   = Array[Byte](
       0x00, 0x01, // ID = 1
       0x01, 0x00, // Flags: standard query
@@ -30,6 +30,7 @@ object DnsPacketSpec extends ZIOSpecDefault {
       0x01,                // QCLASS IN
     )
     header ++ question
+  }
 
   def spec = suite("DnsPacket")(
     suite("parseQuery")(

--- a/dns/test/src/unit/ProfileResolutionSpec.scala
+++ b/dns/test/src/unit/ProfileResolutionSpec.scala
@@ -3,7 +3,7 @@ package familydns.dns.unit
 import familydns.shared.*
 import zio.test.*
 
-object ProfileResolutionSpec extends ZIOSpecDefault:
+object ProfileResolutionSpec extends ZIOSpecDefault {
 
   private def mkProfile(name: String): CachedProfile = CachedProfile(
     profile = Profile(1L, name, Nil, Nil, Nil, false),
@@ -38,3 +38,4 @@ object ProfileResolutionSpec extends ZIOSpecDefault:
       assertTrue(resolve(Some("11:22:33:44:55:66"), cache).isEmpty)
     },
   )
+}

--- a/shared/src/Clock.scala
+++ b/shared/src/Clock.scala
@@ -5,13 +5,14 @@ import zio.*
 import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 
 /** Injectable clock — never call java.time directly outside this service. */
-trait Clock:
+trait Clock {
   def now: UIO[LocalDateTime]
   def today: UIO[LocalDate]
   def currentTime: UIO[LocalTime]
   def instant: UIO[Instant]
+}
 
-object Clock:
+object Clock {
 
   // ── Accessors (call these everywhere) ───────────────────────────────────
 
@@ -24,11 +25,12 @@ object Clock:
 
   val live: ULayer[Clock] = ZLayer.succeed(LiveClock())
 
-  private class LiveClock extends Clock:
+  private class LiveClock extends Clock {
     def now: UIO[LocalDateTime]     = ZIO.succeed(LocalDateTime.now())
     def today: UIO[LocalDate]       = ZIO.succeed(LocalDate.now())
     def currentTime: UIO[LocalTime] = ZIO.succeed(LocalTime.now())
     def instant: UIO[Instant]       = ZIO.succeed(Instant.now())
+  }
 
   // ── Controllable test implementation ────────────────────────────────────
 
@@ -37,7 +39,7 @@ object Clock:
    * interpreted as UTC when converted to an [[Instant]], so JWT iat/exp values are deterministic
    * regardless of host timezone.
    */
-  class TestClock(ref: Ref[LocalDateTime]) extends Clock:
+  class TestClock(ref: Ref[LocalDateTime]) extends Clock {
     def now: UIO[LocalDateTime]     = ref.get
     def today: UIO[LocalDate]       = ref.get.map(_.toLocalDate)
     def currentTime: UIO[LocalTime] = ref.get.map(_.toLocalTime)
@@ -58,8 +60,10 @@ object Clock:
     /** Set just the date, keeping the time. */
     def setDate(d: LocalDate): UIO[Unit] =
       ref.update(dt => d.atTime(dt.toLocalTime))
+  }
 
-  object TestClock:
+  object TestClock {
+
     /** Create a TestClock starting at the given datetime. */
     def at(dt: LocalDateTime): ULayer[Clock & TestClock] =
       ZLayer.fromZIO(Ref.make(dt).map(new TestClock(_))).flatMap { env =>
@@ -97,3 +101,5 @@ object Clock:
     /** Weekend afternoon: Saturday 15:00 */
     val weekendAfternoon: LocalDateTime =
       LocalDateTime.of(2025, 1, 11, 15, 0, 0)
+  }
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -10,19 +10,23 @@ given JsonCodec[UUID] =
     _.toString,
   )
 
-enum UserRole derives JsonCodec:
+enum UserRole derives JsonCodec {
   case Admin, Adult, Child
+}
 
-object UserRole:
-  def parse(s: String): Option[UserRole] = s.toLowerCase match
+object UserRole {
+  def parse(s: String): Option[UserRole] = s.toLowerCase match {
     case "admin" => Some(Admin)
     case "adult" => Some(Adult)
     case "child" => Some(Child)
     case _       => None
-  def asString(r: UserRole): String      = r match
+  }
+  def asString(r: UserRole): String      = r match {
     case Admin => "admin"
     case Adult => "adult"
     case Child => "child"
+  }
+}
 
 case class Profile(
     id: Long,
@@ -229,8 +233,9 @@ case class DnsCache(
     defaultProfile: Option[CachedProfile],
 )
 
-object DnsCache:
+object DnsCache {
   val empty: DnsCache = DnsCache(Map.empty, Map.empty, None)
+}
 
 case class TimeUsageSnapshot(
     domainUsage: Map[(String, String, String), Int],
@@ -238,8 +243,9 @@ case class TimeUsageSnapshot(
     extensions: Map[(String, String), Int],
 )
 
-object TimeUsageSnapshot:
+object TimeUsageSnapshot {
   val empty: TimeUsageSnapshot = TimeUsageSnapshot(Map.empty, Map.empty, Map.empty)
+}
 
 case class Router(
     id: UUID,

--- a/shared/test/src/ClockSpec.scala
+++ b/shared/test/src/ClockSpec.scala
@@ -11,10 +11,10 @@ object ClockSpec extends ZIOSpecDefault {
   def spec = suite("Clock")(
     suite("LiveClock")(
       test("now returns a datetime close to system time") {
-        for
+        for {
           t1 <- Clock.now.provide(Clock.live)
           t2 = LocalDateTime.now()
-        yield assertTrue(t1.isAfter(t2.minusSeconds(2)) && t1.isBefore(t2.plusSeconds(2)))
+        } yield assertTrue(t1.isAfter(t2.minusSeconds(2)) && t1.isBefore(t2.plusSeconds(2)))
       },
       test("today returns current date") {
         for d <- Clock.today.provide(Clock.live)
@@ -29,41 +29,41 @@ object ClockSpec extends ZIOSpecDefault {
       },
       test("advance moves clock forward") {
         val dt = LocalDateTime.of(2025, 1, 6, 14, 0, 0)
-        for
+        for {
           ref <- Ref.make(dt)
           tc = new Clock.TestClock(ref)
           _   <- tc.advance(java.time.Duration.ofHours(2))
           now <- tc.now
-        yield assertTrue(now == dt.plusHours(2))
+        } yield assertTrue(now == dt.plusHours(2))
       },
       test("setTo replaces datetime") {
         val dt  = LocalDateTime.of(2025, 1, 6, 14, 0, 0)
         val dt2 = LocalDateTime.of(2025, 6, 15, 9, 30, 0)
-        for
+        for {
           ref <- Ref.make(dt)
           tc = new Clock.TestClock(ref)
           _   <- tc.setTo(dt2)
           now <- tc.now
-        yield assertTrue(now == dt2)
+        } yield assertTrue(now == dt2)
       },
       test("setTime preserves date") {
         val dt = LocalDateTime.of(2025, 1, 6, 14, 0, 0)
-        for
+        for {
           ref <- Ref.make(dt)
           tc = new Clock.TestClock(ref)
           _   <- tc.setTime(LocalTime.of(21, 30))
           now <- tc.now
-        yield assertTrue(now.toLocalDate == LocalDate.of(2025, 1, 6)) &&
+        } yield assertTrue(now.toLocalDate == LocalDate.of(2025, 1, 6)) &&
           assertTrue(now.toLocalTime == LocalTime.of(21, 30))
       },
       test("setDate preserves time") {
         val dt = LocalDateTime.of(2025, 1, 6, 14, 0, 0)
-        for
+        for {
           ref <- Ref.make(dt)
           tc = new Clock.TestClock(ref)
           _   <- tc.setDate(LocalDate.of(2025, 6, 15))
           now <- tc.now
-        yield assertTrue(now.toLocalDate == LocalDate.of(2025, 6, 15)) &&
+        } yield assertTrue(now.toLocalDate == LocalDate.of(2025, 6, 15)) &&
           assertTrue(now.toLocalTime == LocalTime.of(14, 0))
       },
       test("today returns date component of current datetime") {
@@ -72,11 +72,11 @@ object ClockSpec extends ZIOSpecDefault {
         yield assertTrue(today == LocalDate.of(2025, 3, 15))
       },
       test("standard test fixtures have expected values") {
-        for
+        for {
           afternoon <- Clock.now.provide(Clock.TestClock.make(Clock.TestClock.schoolDayAfternoon))
           bedtime   <- Clock.now.provide(Clock.TestClock.make(Clock.TestClock.bedtime))
           early     <- Clock.now.provide(Clock.TestClock.make(Clock.TestClock.earlyMorning))
-        yield assertTrue(afternoon.toLocalTime == LocalTime.of(14, 0)) &&
+        } yield assertTrue(afternoon.toLocalTime == LocalTime.of(14, 0)) &&
           assertTrue(bedtime.toLocalTime == LocalTime.of(21, 30)) &&
           assertTrue(early.toLocalTime == LocalTime.of(6, 0))
       },

--- a/traffic/src/Config.scala
+++ b/traffic/src/Config.scala
@@ -11,9 +11,9 @@ case class TrafficAppConfig(
     traffic: TrafficConfig,
 )
 
-object TrafficAppConfig:
+object TrafficAppConfig {
   val layer: ZLayer[Any, Config.Error, TrafficAppConfig] =
-    ZLayer.fromZIO:
+    ZLayer.fromZIO {
       val path = sys.props.getOrElse("config.file", "config/application.conf")
       read(
         deriveConfig[TrafficAppConfig]
@@ -22,3 +22,5 @@ object TrafficAppConfig:
             TypesafeConfigProvider.fromHoconFile(new java.io.File(path)),
           ),
       )
+    }
+}

--- a/traffic/src/Main.scala
+++ b/traffic/src/Main.scala
@@ -5,13 +5,13 @@ import familydns.shared.{DnsCache, TimeUsageSnapshot}
 import zio.*
 import zio.logging.backend.SLF4J
 
-object TrafficMain extends ZIOAppDefault:
+object TrafficMain extends ZIOAppDefault {
 
   override val bootstrap =
     Runtime.removeDefaultLoggers >>> SLF4J.slf4j
 
   def run =
-    (for
+    (for {
       cfg <- ZIO.service[TrafficAppConfig]
       _   <- ZIO.logInfo(
         s"FamilyDNS traffic monitor starting on interface ${cfg.traffic.interface} " +
@@ -24,4 +24,5 @@ object TrafficMain extends ZIOAppDefault:
       tracker = SessionTracker(cfg.traffic, cacheRef)
       monitor = TrafficMonitorLive(cfg.traffic, tracker, usageRef, repo.incrementUsage)
       _ <- monitor.start
-    yield ()).provide(TrafficAppConfig.layer)
+    } yield ()).provide(TrafficAppConfig.layer)
+}

--- a/traffic/src/TrafficMonitor.scala
+++ b/traffic/src/TrafficMonitor.scala
@@ -35,64 +35,73 @@ case class Session(
 class SessionTracker(
     config: TrafficConfig,
     @scala.annotation.unused dnsCacheRef: Ref[DnsCache],
-):
+) {
   // mutable allowed: tight inner loop, single-fiber access
   private val sessions = mutable.HashMap[(String, String), Session]()
   private val pending  = mutable.HashMap[(String, String, String), Int]()
 
-  def recordPacket(srcMac: String, dstIp: String, bytes: Int): Unit =
+  def recordPacket(srcMac: String, dstIp: String, bytes: Int): Unit = {
     val domain = reverseDnsOrIp(dstIp)
     val apex   = apexDomain(domain)
     val key    = (srcMac, apex)
     val now    = java.lang.System.currentTimeMillis()
-    sessions.get(key) match
+    sessions.get(key) match {
       case Some(sess) => sessions(key) = sess.copy(lastSeenAt = now, bytes = sess.bytes + bytes)
       case None       => sessions(key) = Session(srcMac, apex, now, now, bytes)
+    }
+  }
 
-  def sweepExpired(): Unit =
+  def sweepExpired(): Unit = {
     val now     = java.lang.System.currentTimeMillis()
     val timeout = config.sessionTimeoutSecs * 1000L
     val today   = LocalDate.now().toString
     sessions.filterInPlace { case (_, sess) =>
       val expired = now - sess.lastSeenAt > timeout
-      if expired then
+      if expired then {
         val secs = ((sess.lastSeenAt - sess.startedAt) / 1000).toInt.max(1)
         val k    = (sess.mac, sess.domain, today)
         pending(k) = pending.getOrElse(k, 0) + secs
+      }
       !expired
     }
+  }
 
-  def drainPending(): List[(String, String, LocalDate, Int)] =
+  def drainPending(): List[(String, String, LocalDate, Int)] = {
     val result = pending.toList.map { case ((mac, dom, dateStr), secs) =>
       (mac, dom, LocalDate.parse(dateStr), (secs / 60).max(1))
     }
     pending.clear()
     result
+  }
 
   // Test helpers — only used in tests
   private[traffic] def activeSessions: Map[(String, String), Session] = sessions.toMap
-  private[traffic] def forceExpireAll(): Unit                         =
+  private[traffic] def forceExpireAll(): Unit                         = {
     val old = java.lang.System.currentTimeMillis() - (config.sessionTimeoutSecs + 1) * 1000L
     sessions.keys.foreach(k => sessions(k) = sessions(k).copy(lastSeenAt = old))
+  }
 
-  private def apexDomain(host: String): String =
+  private def apexDomain(host: String): String = {
     val parts = host.split('.')
     if parts.length >= 2 then parts.takeRight(2).mkString(".") else host
+  }
 
   private def reverseDnsOrIp(ip: String): String =
     try InetAddress.getByName(ip).getCanonicalHostName
     catch case _: Exception => ip
+}
 
-trait TrafficMonitor:
+trait TrafficMonitor {
   def start: Task[Unit]
   def getSnapshot: UIO[TimeUsageSnapshot]
+}
 
 class TrafficMonitorLive(
     config: TrafficConfig,
     tracker: SessionTracker,
     usageRef: Ref[TimeUsageSnapshot],
     dbFlush: (String, String, LocalDate, Int) => Task[Unit],
-) extends TrafficMonitor:
+) extends TrafficMonitor {
 
   def start: Task[Unit] =
     captureLoop.zipParLeft(flushLoop).zipParLeft(sweepLoop)
@@ -100,21 +109,22 @@ class TrafficMonitorLive(
   def getSnapshot: UIO[TimeUsageSnapshot] = usageRef.get
 
   private def captureLoop: Task[Unit] =
-    ZIO.attemptBlocking:
+    ZIO.attemptBlocking {
       val nif    = Pcaps.getDevByName(config.interface)
       val handle = nif.openLive(65536, PcapNetworkInterface.PromiscuousMode.PROMISCUOUS, 50)
       handle.setFilter("ip", BpfProgram.BpfCompileMode.OPTIMIZE)
       handle.loop(-1, (pkt: Packet) => handlePacket(pkt))
+    }
 
   private def handlePacket(pkt: Packet): Unit =
-    try
+    try {
       val eth    = pkt.get(classOf[EthernetPacket])
       if eth == null then return
       val srcMac = eth.getHeader.getSrcAddr.toString.toLowerCase
       val ip4    = pkt.get(classOf[IpV4Packet])
       if ip4 == null then return
       tracker.recordPacket(srcMac, ip4.getHeader.getDstAddr.getHostAddress, ip4.length())
-    catch case _: Exception => ()
+    } catch case _: Exception => ()
 
   private def sweepLoop: Task[Unit] =
     (ZIO.succeed(tracker.sweepExpired()) *> ZIO.sleep(5.seconds)).forever
@@ -126,3 +136,4 @@ class TrafficMonitorLive(
     ZIO.foreachDiscard(tracker.drainPending()) { (mac, dom, date, mins) =>
       dbFlush(mac, dom, date, mins).orElse(ZIO.unit)
     }
+}

--- a/traffic/test/src/unit/SessionTrackerSpec.scala
+++ b/traffic/test/src/unit/SessionTrackerSpec.scala
@@ -29,41 +29,41 @@ object SessionTrackerSpec extends ZIOSpecDefault {
 
   def spec = suite("SessionTracker")(
     test("new session is created on first packet") {
-      for
+      for {
         tracker <- makeTracker
         _        = tracker.recordPacket("aa:bb:cc:dd:ee:ff", "142.250.80.46", 500)
         sessions = tracker.activeSessions
-      yield assertTrue(sessions.size == 1)
+      } yield assertTrue(sessions.size == 1)
     }.provide(Clock.live),
     test("same mac+domain accumulates in one session") {
-      for
+      for {
         tracker <- makeTracker
         mac      = "aa:bb:cc:dd:ee:ff"
         _        = tracker.recordPacket(mac, "142.250.80.46", 500) // google.com
         _        = tracker.recordPacket(mac, "142.250.80.46", 300)
         _        = tracker.recordPacket(mac, "142.250.80.46", 200)
         sessions = tracker.activeSessions
-      yield assertTrue(sessions.size == 1)
+      } yield assertTrue(sessions.size == 1)
     }.provide(Clock.live),
     test("different MACs create separate sessions for same domain") {
-      for
+      for {
         tracker <- makeTracker
         _        = tracker.recordPacket("aa:bb:cc:dd:ee:01", "142.250.80.46", 500)
         _        = tracker.recordPacket("aa:bb:cc:dd:ee:02", "142.250.80.46", 500)
         sessions = tracker.activeSessions
-      yield assertTrue(sessions.size == 2)
+      } yield assertTrue(sessions.size == 2)
     }.provide(Clock.live),
     test("different domains create separate sessions for same MAC") {
-      for
+      for {
         tracker <- makeTracker
         mac      = "aa:bb:cc:dd:ee:ff"
         _        = tracker.recordPacket(mac, "142.250.80.46", 500) // google.com
         _        = tracker.recordPacket(mac, "31.13.71.36", 500)   // facebook.com
         sessions = tracker.activeSessions
-      yield assertTrue(sessions.size == 2)
+      } yield assertTrue(sessions.size == 2)
     }.provide(Clock.live),
     test("expired sessions are swept and accumulated in pending") {
-      for
+      for {
         tracker <- makeTracker
         mac     = "aa:bb:cc:dd:ee:ff"
         // Record a packet, then manually expire the session by setting lastSeen to past
@@ -71,28 +71,28 @@ object SessionTrackerSpec extends ZIOSpecDefault {
         _       = tracker.forceExpireAll()
         _       = tracker.sweepExpired()
         pending = tracker.drainPending()
-      yield assertTrue(tracker.activeSessions.isEmpty) &&
+      } yield assertTrue(tracker.activeSessions.isEmpty) &&
         assertTrue(pending.nonEmpty)
     }.provide(Clock.live),
     test("drain clears pending after first call") {
-      for
+      for {
         tracker <- makeTracker
         _      = tracker.recordPacket("aa:bb:cc:dd:ee:ff", "142.250.80.46", 1000)
         _      = tracker.forceExpireAll()
         _      = tracker.sweepExpired()
         first  = tracker.drainPending()
         second = tracker.drainPending()
-      yield assertTrue(first.nonEmpty) &&
+      } yield assertTrue(first.nonEmpty) &&
         assertTrue(second.isEmpty)
     }.provide(Clock.live),
     test("pending increments are in minutes (min 1)") {
-      for
+      for {
         tracker <- makeTracker
         _       = tracker.recordPacket("aa:bb:cc:dd:ee:ff", "142.250.80.46", 1000)
         _       = tracker.forceExpireAll()
         _       = tracker.sweepExpired()
         pending = tracker.drainPending()
-      yield assertTrue(pending.forall(_._4 >= 1))
+      } yield assertTrue(pending.forall(_._4 >= 1))
     }.provide(Clock.live),
   )
 }


### PR DESCRIPTION
- Updated .scalafmt.conf: removed RedundantBraces, disabled rewrite.scala3.convertToNewSyntax, added removeOptionalBraces = no
- Added -no-indent to scalacOptions in build.mill to enforce braces style going forward (compiler will reject significant-indentation syntax)
- Used scalac -rewrite -no-indent to convert all 38 source files from braceless/significant-indentation style to explicit braces; no logic changed

Closes #116