### PR TITLE
Per-app time limits: add exemptFromDaily toggle (#15)

### DIFF
--- a/api/resources/db/migration/V6__site_time_exempt_from_daily.sql
+++ b/api/resources/db/migration/V6__site_time_exempt_from_daily.sql
@@ -1,0 +1,11 @@
+-- Issue #15: per-app time limits can be exempt from (default) or included in the
+-- overall daily limit.
+--
+-- exempt_from_daily = true  (default): the app's time does NOT count against the
+--                                      profile's overall daily cap. Burning all of
+--                                      YouTube does not eat into general screen time.
+-- exempt_from_daily = false (included): the app's time DOES count against the daily
+--                                       cap. The per-app limit acts as a sub-cap.
+
+ALTER TABLE site_time_limits
+  ADD COLUMN exempt_from_daily BOOLEAN NOT NULL DEFAULT TRUE;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -375,16 +375,16 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
 }
 
 class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
-  private type R = (Long, Long, String, Int, String)
-  private def toS(r: R)         = SiteTimeLimit(r._1, r._2, r._3, r._4, r._5)
+  private type R = (Long, Long, String, Int, String, Boolean)
+  private def toS(r: R)         = SiteTimeLimit(r._1, r._2, r._3, r._4, r._5, r._6)
   def listForProfile(pid: Long) =
-    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label FROM site_time_limits WHERE profile_id=$pid ORDER BY id"
+    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label,exempt_from_daily FROM site_time_limits WHERE profile_id=$pid ORDER BY id"
       .query[R]
       .map(toS)
       .to[List]
       .transact(xa)
   def listAll                   =
-    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label FROM site_time_limits ORDER BY id"
+    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label,exempt_from_daily FROM site_time_limits ORDER BY id"
       .query[R]
       .map(toS)
       .to[List]
@@ -392,7 +392,7 @@ class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
   def replaceForProfile(pid: Long, ls: List[SiteTimeLimitRequest]) = {
     val del = sql"DELETE FROM site_time_limits WHERE profile_id=$pid".update.run
     val ins = ls.map(l =>
-      sql"INSERT INTO site_time_limits(profile_id,domain_pattern,daily_minutes,label) VALUES($pid,${l.domainPattern},${l.dailyMinutes},${l.label})".update.run,
+      sql"INSERT INTO site_time_limits(profile_id,domain_pattern,daily_minutes,label,exempt_from_daily) VALUES($pid,${l.domainPattern},${l.dailyMinutes},${l.label},${l.exemptFromDaily})".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
   }

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -44,25 +44,28 @@ class PolicyServiceLive(
       val devsByProfile =
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
       val pProfiles     = profiles.map { p =>
-        val pSched    = schedMap
+        val pSched     = schedMap
           .getOrElse(p.id, Nil)
           .map(s => PolicySchedule(s.days, s.blockFrom, s.blockUntil))
-        val pSiteLims = stlMap
+        val pSiteLims  = stlMap
           .getOrElse(p.id, Nil)
-          .map(s => PolicySiteLimit(s.domainPattern, s.dailyMinutes, s.label))
-        val devicesIn = devsByProfile.getOrElse(p.id, Nil)
-        val byDomain  = stlMap
+          .map(s => PolicySiteLimit(s.domainPattern, s.dailyMinutes, s.label, s.exemptFromDaily))
+        val devicesIn  = devsByProfile.getOrElse(p.id, Nil)
+        val byDomain   = stlMap
           .getOrElse(p.id, Nil)
           .foldLeft(Map.empty[String, Int]) { (acc, stl) =>
             val mins =
               devicesIn.iterator.map(d => usages.getOrElse((d.mac, stl.domainPattern), 0)).sum
             if mins == 0 then acc else acc.updated(stl.domainPattern, mins)
           }
-        val siteDoms  = stlMap.getOrElse(p.id, Nil).map(_.domainPattern).toSet
-        val totalMins = usages.iterator.collect {
-          case ((mac, dom), m) if devicesIn.exists(_.mac == mac) && !siteDoms.contains(dom) => m
+        // Only exempt site domains are excluded from the daily total.
+        // Included sites (exemptFromDaily=false) count against the daily cap.
+        val exemptDoms =
+          stlMap.getOrElse(p.id, Nil).filter(_.exemptFromDaily).map(_.domainPattern).toSet
+        val totalMins  = usages.iterator.collect {
+          case ((mac, dom), m) if devicesIn.exists(_.mac == mac) && !exemptDoms.contains(dom) => m
         }.sum
-        val extMins   = exts.getOrElse(p.id, 0)
+        val extMins    = exts.getOrElse(p.id, 0)
         PolicyProfile(
           id = p.id,
           name = p.name,
@@ -184,6 +187,7 @@ class PolicyServiceLive(
       today: LocalDate,
   ): Option[RouterDecisionResponse] = {
     val midnight     = utcString(today.plusDays(1), LocalTime.MIDNIGHT)
+    // Check per-site sub-cap first (applies to both exempt and included sites)
     val siteLimitHit = p.siteLimits.find { sl =>
       matchesDomainPattern(hostname, sl.domain) &&
       p.timeUsedToday.byDomain.getOrElse(sl.domain, 0) >= sl.minutes
@@ -191,13 +195,20 @@ class PolicyServiceLive(
     siteLimitHit
       .map(sl => RouterDecisionResponse("block", s"site_time_limit:${sl.label}", Some(midnight)))
       .orElse {
-        p.dailyMinutes.flatMap { limit =>
-          val used = p.timeUsedToday.totalMinutes
-          val ext  = p.extensionsTodayMinutes
-          Option.when(used >= limit + ext)(
-            RouterDecisionResponse("block", "time_limit", Some(midnight)),
-          )
-        }
+        // Daily total cap: skip entirely if this hostname belongs to an exempt site limit.
+        // Included sites (exemptFromDaily=false) already appear in totalMinutes via the
+        // snapshot calculation, so the check below naturally applies to them.
+        val isExemptSite =
+          p.siteLimits.exists(sl => sl.exemptFromDaily && matchesDomainPattern(hostname, sl.domain))
+        if isExemptSite then None
+        else
+          p.dailyMinutes.flatMap { limit =>
+            val used = p.timeUsedToday.totalMinutes
+            val ext  = p.extensionsTodayMinutes
+            Option.when(used >= limit + ext)(
+              RouterDecisionResponse("block", "time_limit", Some(midnight)),
+            )
+          }
       }
   }
 
@@ -286,7 +297,7 @@ object PolicyService {
         parts += s"  s:${s.days.mkString(",")}|${s.blockFrom}|${s.blockUntil}"
       }
       p.siteLimits.sortBy(_.domain).foreach { sl =>
-        parts += s"  sl:${sl.domain}|${sl.minutes}|${sl.label}"
+        parts += s"  sl:${sl.domain}|${sl.minutes}|${sl.label}|${sl.exemptFromDaily}"
       }
       parts += s"  u:${p.timeUsedToday.totalMinutes}"
       p.timeUsedToday.byDomain.toList.sortBy(_._1).foreach((k, v) => parts += s"    ud:$k=$v")

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -406,9 +406,11 @@ object TimeRoutes {
       stls    <- stlRepo.listForProfile(profile.id)
       usages  <- usageRepo.listForDeviceMacs(macs, date)
       extMins <- extRepo.getProfileTotalExtension(profile.id, date)
-      siteDoms        = stls.map(_.domainPattern).toSet
+      // Only exempt site domains are excluded from the daily total.
+      // Included sites (exemptFromDaily=false) count against the daily cap.
+      exemptDoms      = stls.filter(_.exemptFromDaily).map(_.domainPattern).toSet
       totalUsed       = usages
-        .filterNot(u => siteDoms.exists(p => matchesPattern(u.domain, p)))
+        .filterNot(u => exemptDoms.exists(p => matchesPattern(u.domain, p)))
         .map(_.minutesUsed)
         .sum
       remaining       = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
@@ -460,8 +462,12 @@ object TimeRoutes {
       profile <- pid.fold(ZIO.succeed("No profile"))(p =>
         profileRepo.findById(p).map(_.map(_.name).getOrElse("Unknown")),
       )
+      // Only exempt site domains are excluded from the daily total.
+      // Included sites (exemptFromDaily=false) count against the daily cap.
       totalUsed = usages
-        .filterNot(u => stls.exists(s => matchesPattern(u.domain, s.domainPattern)))
+        .filterNot(u =>
+          stls.exists(s => s.exemptFromDaily && matchesPattern(u.domain, s.domainPattern)),
+        )
         .map(_.minutesUsed)
         .sum
       remaining = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -141,7 +141,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         _     <- tlr.upsert(kid, 120)
         _     <- stlr.replaceForProfile(
           kid,
-          List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")),
+          List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")), // default exemptFromDaily=true
         )
         adult <- TestLayers.seedAdultsProfile(pr)
         _     <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
@@ -170,8 +170,8 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(snap.defaultProfileId.exists(id => snap.profiles.exists(_.id == id))) &&
         assertTrue(kp.dailyMinutes.contains(120)) &&
         assertTrue(kp.schedules.exists(_.blockFrom == "21:00")) &&
-        assertTrue(kp.siteLimits.exists(_.domain == "youtube.com")) &&
-        assertTrue(kp.timeUsedToday.totalMinutes == 47) &&
+        assertTrue(kp.siteLimits.exists(sl => sl.domain == "youtube.com" && sl.exemptFromDaily)) &&
+        assertTrue(kp.timeUsedToday.totalMinutes == 47) && // cnn.com only; exempt youtube excluded
         assertTrue(kp.timeUsedToday.byDomain.get("youtube.com").contains(12)) &&
         assertTrue(snap.blocklists.contains("ads")) &&
         assertTrue(snap.blocklists("ads").url == "/api/blocklists/ads.rpz")

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -378,5 +378,71 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         events <- ber.recent(10)
       } yield assertTrue(events.isEmpty)
     },
+    test(
+      "included site (exemptFromDaily=false): site usage counts toward daily total → block:time_limit",
+    ) {
+      // Site cap is 200 (not hit). Daily cap is 120. 121 min of YouTube usage.
+      // With exemptFromDaily=false the 121 min counts toward the 120 daily cap → time_limit.
+      for
+        _    <- cleanDb
+        rr   <- ZIO.service[RouterRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        stlr <- ZIO.service[SiteTimeLimitRepo]
+        ur   <- ZIO.service[TimeUsageRepo]
+        ber  <- ZIO.service[BlockEventRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 120)
+        _    <- stlr.replaceForProfile(
+          kid,
+          List(SiteTimeLimitRequest("youtube.com", 200, "YouTube", exemptFromDaily = false)),
+        )
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        _    <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 121)
+        ps   <- makePsDefault
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
+        tok  <- seedAndEnrollRouter(rr, routes)
+        resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "youtube.com")
+        body <- resp.body.asString
+        dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
+      yield assertTrue(dr.decision == "block") &&
+        assertTrue(dr.reason == "time_limit")
+    },
+    test(
+      "exempt site (exemptFromDaily=true): site usage does NOT count toward daily total → allow",
+    ) {
+      // Daily cap is 120. 121 min of YouTube usage, but YouTube is exempt from daily cap.
+      // YouTube site cap is 200 (not hit either) → should allow.
+      for
+        _    <- cleanDb
+        rr   <- ZIO.service[RouterRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        stlr <- ZIO.service[SiteTimeLimitRepo]
+        ur   <- ZIO.service[TimeUsageRepo]
+        ber  <- ZIO.service[BlockEventRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 120)
+        _    <- stlr.replaceForProfile(
+          kid,
+          List(
+            // exemptFromDaily=true (default): YouTube time does NOT eat into 120-min daily cap
+            SiteTimeLimitRequest("youtube.com", 200, "YouTube", exemptFromDaily = true),
+          ),
+        )
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        _    <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 121)
+        ps   <- makePsDefault
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
+        tok  <- seedAndEnrollRouter(rr, routes)
+        resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "youtube.com")
+        body <- resp.body.asString
+        dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
+      yield assertTrue(dr.decision == "allow")
+    },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -131,6 +131,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- stlRepo.replaceForProfile(
             kidsId,
             List(
+              // default exemptFromDaily = true → does NOT count toward 120-min cap
               SiteTimeLimitRequest("*.youtube.com", 30, "YouTube"),
             ),
           )
@@ -163,6 +164,58 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(
             status.siteUsage.exists(su =>
               su.label == "YouTube" && su.usedMins == 20 && su.remainingMins == 10,
+            ),
+          )
+      },
+      test("included site (exemptFromDaily=false): usage IS counted in daily total") {
+        for
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          usageRepo   <- ZIO.service[TimeUsageRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          _           <- stlRepo.replaceForProfile(
+            kidsId,
+            List(
+              // exemptFromDaily=false → YouTube minutes count against the 120-min daily cap
+              SiteTimeLimitRequest("*.youtube.com", 60, "YouTube", exemptFromDaily = false),
+            ),
+          )
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // 60 min of YouTube usage; since exemptFromDaily=false it must appear in usedMins
+          _               <- usageRepo.incrementUsage(testMac, "youtube.com", today, 60)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            usageRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode(s"/api/time/status/$testMac").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp   <- routes.runZIO(req)
+          body   <- resp.body.asString
+          status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
+        yield assertTrue(status.usedMins == 60) &&         // YouTube IS counted in total
+          assertTrue(status.remainingMins.contains(60)) && // 120 - 60 = 60
+          assertTrue(
+            status.siteUsage.exists(su =>
+              su.label == "YouTube" && su.usedMins == 60 && su.remainingMins == 0,
             ),
           )
       },

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -58,6 +58,7 @@ case class SiteTimeLimit(
     domainPattern: String,
     dailyMinutes: Int,
     label: String,
+    exemptFromDaily: Boolean = true,
 ) derives JsonCodec
 
 case class TimeUsage(
@@ -148,6 +149,7 @@ case class SiteTimeLimitRequest(
     domainPattern: String,
     dailyMinutes: Int,
     label: String,
+    exemptFromDaily: Boolean = true,
 ) derives JsonCodec
 
 case class UpsertDeviceRequest(
@@ -368,7 +370,12 @@ case class RouterDecisionResponse(
 case class PolicyDevice(mac: String, profileId: Option[Long], name: String) derives JsonCodec
 case class PolicySchedule(days: List[String], blockFrom: String, blockUntil: String)
     derives JsonCodec
-case class PolicySiteLimit(domain: String, minutes: Int, label: String) derives JsonCodec
+case class PolicySiteLimit(
+    domain: String,
+    minutes: Int,
+    label: String,
+    exemptFromDaily: Boolean = true,
+) derives JsonCodec
 case class PolicyTimeUsedToday(totalMinutes: Int, byDomain: Map[String, Int]) derives JsonCodec
 case class PolicyProfile(
     id: Long,

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -41,7 +41,7 @@ const kidsProfile: ProfileDetail = {
   ],
   timeLimit: { id: 5, profileId: 1, dailyMinutes: 120 },
   siteTimeLimits: [
-    { id: 7, profileId: 1, domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube' },
+    { id: 7, profileId: 1, domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },
   ],
 }
 
@@ -176,7 +176,7 @@ describe('ProfilesPage — create', () => {
         { name: 'Bedtime', days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat'], blockFrom: '21:00', blockUntil: '07:00' },
       ],
       siteTimeLimits: [
-        { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30 },
+        { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30, exemptFromDaily: true },
       ],
     })
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
@@ -208,7 +208,7 @@ describe('ProfilesPage — edit', () => {
         { name: 'Bedtime', days: ['mon', 'tue'], blockFrom: '21:00', blockUntil: '07:00' },
       ],
       siteTimeLimits: [
-        { domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube' },
+        { domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },
       ],
     })
   })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -44,7 +44,10 @@ function detailToForm(pd: ProfileDetail): FormState {
       name: s.name, days: s.days, blockFrom: s.blockFrom, blockUntil: s.blockUntil,
     })),
     siteTimeLimits: pd.siteTimeLimits.map(s => ({
-      domainPattern: s.domainPattern, dailyMinutes: s.dailyMinutes, label: s.label,
+      domainPattern: s.domainPattern,
+      dailyMinutes: s.dailyMinutes,
+      label: s.label,
+      exemptFromDaily: s.exemptFromDaily,
     })),
   }
 }
@@ -229,9 +232,18 @@ export function ProfilesPage() {
               <div>
                 <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Site Limits</p>
                 {pd.siteTimeLimits.map(s => (
-                  <div key={s.id} className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
+                  <div key={s.id} className="flex justify-between items-center text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
                     <span className="text-gray-300">{s.label}</span>
-                    <span className="text-emerald-400 text-xs font-mono">{s.dailyMinutes}m · {s.domainPattern}</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-emerald-400 text-xs font-mono">{s.dailyMinutes}m · {s.domainPattern}</span>
+                      <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
+                        s.exemptFromDaily
+                          ? 'bg-gray-700 text-gray-400'
+                          : 'bg-amber-500/20 text-amber-400'
+                      }`}>
+                        {s.exemptFromDaily ? 'exempt' : 'counts'}
+                      </span>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -308,7 +320,10 @@ function ProfileEditor({
   function addSiteLimit() {
     setForm(f => ({
       ...f,
-      siteTimeLimits: [...f.siteTimeLimits, { label: '', domainPattern: '', dailyMinutes: 30 }],
+      siteTimeLimits: [
+        ...f.siteTimeLimits,
+        { label: '', domainPattern: '', dailyMinutes: 30, exemptFromDaily: true },
+      ],
     }))
   }
 
@@ -459,20 +474,36 @@ function ProfileEditor({
           {form.siteTimeLimits.length === 0 && <p className="text-xs text-gray-500">No site-specific limits.</p>}
           <div className="space-y-2">
             {form.siteTimeLimits.map((s, i) => (
-              <div key={i} className="bg-gray-950 border border-gray-700 rounded-xl p-3 grid grid-cols-12 gap-2">
-                <input type="text" value={s.label}
-                  onChange={e => updateSiteLimit(i, { label: e.target.value })}
-                  placeholder="YouTube"
-                  className="col-span-4 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
-                <input type="text" value={s.domainPattern}
-                  onChange={e => updateSiteLimit(i, { domainPattern: e.target.value })}
-                  placeholder="youtube.com"
-                  className="col-span-5 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-                <input type="number" min={0} value={s.dailyMinutes}
-                  onChange={e => updateSiteLimit(i, { dailyMinutes: Number(e.target.value) || 0 })}
-                  className="col-span-2 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
-                <button type="button" onClick={() => removeSiteLimit(i)}
-                  className="col-span-1 text-xs text-red-400 hover:text-red-300 bg-red-500/10 rounded-lg">×</button>
+              <div key={i} className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2">
+                <div className="grid grid-cols-12 gap-2">
+                  <input type="text" value={s.label}
+                    onChange={e => updateSiteLimit(i, { label: e.target.value })}
+                    placeholder="YouTube"
+                    className="col-span-4 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
+                  <input type="text" value={s.domainPattern}
+                    onChange={e => updateSiteLimit(i, { domainPattern: e.target.value })}
+                    placeholder="youtube.com"
+                    className="col-span-5 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
+                  <input type="number" min={0} value={s.dailyMinutes}
+                    onChange={e => updateSiteLimit(i, { dailyMinutes: Number(e.target.value) || 0 })}
+                    className="col-span-2 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
+                  <button type="button" onClick={() => removeSiteLimit(i)}
+                    className="col-span-1 text-xs text-red-400 hover:text-red-300 bg-red-500/10 rounded-lg">×</button>
+                </div>
+                <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={!s.exemptFromDaily}
+                    onChange={e => updateSiteLimit(i, { exemptFromDaily: !e.target.checked })}
+                    className="w-3.5 h-3.5 accent-amber-500"
+                  />
+                  <span>
+                    Counts toward daily limit
+                    {!s.exemptFromDaily && (
+                      <span className="ml-1 text-amber-400">(usage reduces overall remaining time)</span>
+                    )}
+                  </span>
+                </label>
               </div>
             ))}
           </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -30,6 +30,7 @@ export interface SiteTimeLimit {
   domainPattern: string
   dailyMinutes: number
   label: string
+  exemptFromDaily: boolean
 }
 
 export interface ProfileDetail {
@@ -179,6 +180,7 @@ export interface SiteTimeLimitRequest {
   domainPattern: string
   dailyMinutes: number
   label: string
+  exemptFromDaily: boolean
 }
 
 export interface UpsertProfileRequest {


### PR DESCRIPTION
## Summary

Closes #15. Depends on #14 (screen time per-profile) landing first.

Each site/app time limit now carries an **\`exemptFromDaily\`** flag:

| Mode | \`exemptFromDaily\` | Behaviour |
|------|-------------------|-----------|
| **Exempt** (default, existing) | \`true\` | App has its own cap; time does **not** count against the profile daily total. A child can burn all their YouTube budget without eating into general screen time. |
| **Included** | \`false\` | App time **also** counts against the daily cap — acts as a sub-cap. Useful when you want e.g. "no more than 60 min Minecraft, and those 60 min come out of your 120 min/day total." |

## Changes

- **V6 migration** — \`ALTER TABLE site_time_limits ADD COLUMN exempt_from_daily BOOLEAN NOT NULL DEFAULT TRUE\`
- **Models** — \`SiteTimeLimit\`, \`SiteTimeLimitRequest\`, \`PolicySiteLimit\` all gain \`exemptFromDaily: Boolean = true\` (default preserves current behaviour; no existing callers break)
- **Repos** — \`SiteTimeLimitRepoLive\` SELECT/INSERT updated
- **\`PolicyService.snapshot\`** — \`totalMins\` now only excludes *exempt* site domains from the daily total; included domains appear in both \`byDomain\` and \`totalMinutes\`
- **\`PolicyService.timeLimitBlock\`** (router agent) — daily cap check skipped only for exempt sites
- **\`Routes.buildDeviceTimeStatus\` / \`buildProfileTimeStatus\`** — same exemption logic for the time-status API
- **Web** — \`api.ts\` types updated; profile card shows an **exempt** / **counts** badge per site limit; editor gains a **"Counts toward daily limit"** checkbox (default off = exempt)

> Note: the \`dns/\` Scala module was removed in #125 (OpenWRT rearch). The previous commit also updated \`BlockingEngine\` but that file is now gone; all enforcement logic lives in the router agent and \`PolicyService\`.

## Tests (TDD-first, all 267 JVM + 66 web passing, pre-push hooks clean)

- **\`TimeApiSpec\`** +1 — included site: 60 min of app usage shows in \`usedMins\`, reduces \`remainingMins\`
- **\`RouterDecisionSpec\`** +2 — included site usage → \`block:time_limit\`; exempt site with 121 min → \`allow\`
- **\`RouterApiSpec\`** — snapshot assertion updated: \`siteLimits[].exemptFromDaily\` verified in policy JSON

## Test plan

- [ ] Create a kids profile with 120 min/day and a YouTube site limit at 60 min
- [ ] Leave "Counts toward daily limit" **unchecked** (default exempt): confirm YouTube usage shows separately and doesn't reduce remaining general screen time
- [ ] Check "Counts toward daily limit": confirm YouTube usage now reduces both the site counter **and** overall remaining
- [ ] Verify router \`POST /api/router/decision\` returns \`block:time_limit\` for a site domain once its usage pushes the daily total over the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)