### PR TITLE
CD: confirm Option B (tagged-release-only) for OpenWRT .ipk

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
-    paths: ["openwrt/**"]
   pull_request:
     paths: ["openwrt/**"]
   workflow_dispatch:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -114,14 +114,24 @@ Output: `openwrt/familydns_<version>-<release>_all.ipk`
 
 ### 2.2 Build and publish: `.ipk` → GitHub Releases
 
-Workflow: `.github/workflows/openwrt-build.yml` (already exists, updated in #130).
+Workflow: `.github/workflows/openwrt-build.yml`.
+
+**Release strategy: tagged releases only (Option B from #130).**
+Routers auto-update only when a `vX.Y.Z` tag is pushed. We do *not* publish
+per-commit pre-releases. Rationale: tagged releases are the natural cadence
+for router updates, avoid GitHub Release churn on every commit, and let the
+router's auto-update script target the simple `releases/latest` endpoint
+(which excludes pre-releases by default).
 
 **Trigger**:
-- Push to `main` touching `openwrt/**` → build + upload as a workflow artifact.
+- PR touching `openwrt/**` → build (verify only).
+- Push to `main` → build + upload as a workflow artifact (smoke test only,
+  not published as a release).
 - Push of a `v*` tag → build + attach to a GitHub Release.
 
-On a `v*` tag, `softprops/action-gh-release` creates the release and attaches
-the `.ipk`. The release is the distribution mechanism for the router.
+On a `v*` tag, `softprops/action-gh-release` creates the release named after
+the tag (e.g. `v0.2.0`) and attaches `openwrt/familydns_*.ipk`. The release
+is the distribution mechanism for the router.
 
 To cut a release:
 ```sh
@@ -129,8 +139,13 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-This produces `familydns_0.2.0-1_all.ipk` attached to the `v0.2.0` release on
-GitHub. Routers running the auto-update script pick it up within the next poll.
+This produces `familydns_0.2.0-1_all.ipk` attached to the `v0.2.0` release
+on GitHub. Routers running the auto-update script (§2.3) pick it up on their
+next poll.
+
+**Cadence**: cut a tag whenever a meaningful change to the agent lands on
+`main` — there is no fixed schedule. Typical expectation is at most weekly,
+often less. Trivial doc-only or test-only changes do not need a tag.
 
 ### 2.3 Auto-update on the router
 


### PR DESCRIPTION
## Summary

- Documents the chosen release strategy for the OpenWRT agent auto-update path (closes #130, follow-on to #123).
- Per #130 recommendation, routers auto-update only on `vX.Y.Z` tag pushes — no per-commit pre-releases. The auto-update script in #131 will target `releases/latest` (which excludes pre-releases by default).
- Fixes a latent bug in `.github/workflows/openwrt-build.yml`: the `paths: ["openwrt/**"]` filter was applied at the `on.push` level, which would silently skip a `v*` tag pushed at a commit that happened not to touch `openwrt/**`. The filter now applies only to PRs; `main` and tag pushes always build.

## Acceptance (from #130)

- [x] `v*` tag push creates a GitHub Release with `familydns_<version>-1_all.ipk` attached. (Workflow already does this via `softprops/action-gh-release`; tag-push trigger no longer gated by path filter.)
- [x] `curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest | jsonfilter -e '@.assets[0].browser_download_url'` will return the `.ipk` URL once any tag is published. (Asset filename pattern `familydns_<version>-1_all.ipk` is stable per [openwrt/build-ipk.sh](openwrt/build-ipk.sh) and [openwrt/Makefile](openwrt/Makefile).)
- [x] `docs/deploy.md §2.2` updated to state Option B as the chosen strategy and document the cadence expectation.

## Test plan

- [x] CI: PR pipeline (`OpenWRT Build`) runs and produces a workflow artifact.
- [ ] Post-merge: cut a `v0.0.0-test` tag (can be deleted after verification) and confirm:
  - Workflow runs on the tag push.
  - A GitHub Release named `v0.0.0-test` is created with `familydns_0.0.0-test-1_all.ipk` attached.
  - `curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest | jsonfilter -e '@.assets[0].browser_download_url'` returns the expected URL (after deleting the test tag, the previous "latest" remains in place).
- [ ] #131 (opkg cron job) is the natural follow-on consumer of this URL.

## Related

- Parent: #123
- Follow-on: #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)