### PR TITLE
Add docs/install-openwrt.md first-install guide

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -182,6 +182,14 @@ opkg's upgrade behavior for config files:
 
 ## 3. First-install bootstrap
 
+The full step-by-step install guides live in their own documents:
+
+- API server → [`install-api.md`](install-api.md)
+- OpenWRT agent → [`install-openwrt.md`](install-openwrt.md)
+
+The summaries below capture the shape of each bootstrap; consult the linked
+guides for runnable commands, prerequisites, and verification steps.
+
 ### 3.1 API server
 
 **Requirements**: a Linux host with Docker and Docker Compose installed.
@@ -223,51 +231,28 @@ Migrations run automatically at API startup via Flyway.
 
 ### 3.2 OpenWRT router
 
-**Requirements**: OpenWRT 23.x with internet access from the router.
+**Requirements**: OpenWRT 23.05.x with internet access from the router.
 
-```sh
-# 1. Download the latest .ipk from GitHub Releases
-curl -fsSL -o /tmp/familydns.ipk \
-  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
-    | jsonfilter -e '@.assets[0].browser_download_url')
+The full install flow (download, enrollment, `lan_prefix` configuration,
+block-page setup, and verification) is in
+[`install-openwrt.md`](install-openwrt.md). Outline:
 
-# 2. Install (opkg resolves lua, luci-lib-jsonc, conntrack-tools, curl)
-opkg install /tmp/familydns.ipk
-```
+1. Download the latest `.ipk` from GitHub Releases (one-liner via
+   `curl` + `jsonfilter`).
+2. `opkg install /tmp/familydns.ipk` (resolves `lua`, `luci-lib-jsonc`,
+   `conntrack-tools`, `curl`).
+3. Set `api_url` in UCI.
+4. Generate an enrollment token in the admin UI → **Routers → Add router**,
+   then `POST /api/router/register` from the router to exchange it for
+   `routerId` + `routerToken`.
+5. Write the returned values into UCI and start the agent.
+6. Override `lan_prefix` if your LAN is not on `192.168.1.0/24` — without
+   this, the agent mis-attributes every flow.
+7. Add a uhttpd listener on `127.0.0.1:8081` for the local block page.
+8. Verify via `logread -f | grep familydns` and the admin UI's
+   `last_seen_at`.
 
-**One-time enrollment**:
-
-```sh
-# 3. Set the API URL
-uci set familydns.@familydns[0].api_url='http://<api-host>:8080'
-uci commit familydns
-
-# 4. Exchange enrollment token (token from the admin UI → Routers → Add router)
-curl -s -X POST http://<api-host>:8080/api/router/register \
-  -H 'Content-Type: application/json' \
-  -d '{"enrollmentToken":"et_…","routerName":"home-gw","platformVersion":"23.05.3","agentVersion":"0.1.0"}'
-# → {"routerId":"…","routerToken":"rt_…"}
-
-# 5. Write the returned values
-uci set familydns.@familydns[0].router_id='<routerId>'
-uci set familydns.@familydns[0].router_token='<routerToken>'
-uci commit familydns
-
-# 6. Start the agent (already enabled for autostart by postinst)
-/etc/init.d/familydns start
-
-# 7. (Optional) install the auto-update script
-#    See §2.3 above for the script content
-```
-
-The agent polls the API every 60 s. After a successful policy fetch the admin
-UI → Routers → `<name>` will show a fresh `last_seen_at`.
-
-**LAN subnet**: if your LAN is not `192.168.1.0/24`, also set:
-```sh
-uci set familydns.@familydns[0].lan_prefix='10.0.'   # adjust to your prefix
-uci commit familydns
-```
+The auto-update cron job (#131) is optional and not yet implemented.
 
 ---
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -233,24 +233,21 @@ Migrations run automatically at API startup via Flyway.
 
 **Requirements**: OpenWRT 23.05.x with internet access from the router.
 
-The full install flow (download, enrollment, `lan_prefix` configuration,
-block-page setup, and verification) is in
-[`install-openwrt.md`](install-openwrt.md). Outline:
+End users install via the one-shot script — see
+[`install-openwrt.md`](install-openwrt.md) for the full guide and the
+manual-fallback path. The headline command, run as root on the router:
 
-1. Download the latest `.ipk` from GitHub Releases (one-liner via
-   `curl` + `jsonfilter`).
-2. `opkg install /tmp/familydns.ipk` (resolves `lua`, `luci-lib-jsonc`,
-   `conntrack-tools`, `curl`).
-3. Set `api_url` in UCI.
-4. Generate an enrollment token in the admin UI → **Routers → Add router**,
-   then `POST /api/router/register` from the router to exchange it for
-   `routerId` + `routerToken`.
-5. Write the returned values into UCI and start the agent.
-6. Override `lan_prefix` if your LAN is not on `192.168.1.0/24` — without
-   this, the agent mis-attributes every flow.
-7. Add a uhttpd listener on `127.0.0.1:8081` for the local block page.
-8. Verify via `logread -f | grep familydns` and the admin UI's
-   `last_seen_at`.
+```sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+```
+
+It prompts for the API URL, the one-time enrollment token (generated in the
+admin UI → **Routers → Add router**), a router name, and the LAN prefix
+(auto-detected from `network.lan.ipaddr`); downloads the latest `.ipk` from
+GitHub Releases; installs it; POSTs `/api/router/register` to exchange the
+enrollment token for `routerId` + `routerToken`; writes everything to UCI;
+sets up the `uhttpd` block-page listener on `127.0.0.1:8081`; and starts
+the agent.
 
 The auto-update cron job (#131) is optional and not yet implemented.
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -1,8 +1,9 @@
 # Installing the FamilyDNS Agent on OpenWRT
 
 This guide walks through a first install of the FamilyDNS agent on an OpenWRT
-router, from downloading the `.ipk` to verifying that the agent is enrolled
-and reporting policy state to the API.
+router. The recommended path is the one-shot install script; the manual
+steps below it exist for debugging and for environments where running a
+piped shell script is not acceptable.
 
 The agent enforces per-device DNS filtering, accounts traffic per
 `(mac, hostname)`, and streams connection events to the FamilyDNS API.
@@ -11,144 +12,64 @@ The agent enforces per-device DNS filtering, accounts traffic per
 
 - A router running **OpenWRT 23.05.x** (the package is built and tested
   against 23.05.5 by `.github/workflows/openwrt-build.yml`).
-- Internet access from the router (the agent calls out to the API on the
-  policy/usage/events timers, and the install command pulls the `.ipk` from
-  GitHub Releases).
+- Internet access from the router.
+- Root SSH access to the router.
 - A FamilyDNS API server already deployed and reachable from the router. See
   [`install-api.md`](install-api.md) if you need to set one up first.
-- Root SSH access to the router.
+- A one-time enrollment token generated in the admin UI under
+  **Routers → Add router** (looks like `et_5f3c9b…`).
 
 The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`, all of which
 ship with stock OpenWRT 23.05. The remaining runtime dependencies (`lua`,
 `luci-lib-jsonc`, `conntrack-tools`, `curl`) are pulled in automatically by
 `opkg`.
 
-## 2. Download the `.ipk`
+## 2. Install with the one-shot script (recommended)
 
-From a root shell on the router:
+SSH into the router as root and run:
 
 ```sh
-curl -fsSL -o /tmp/familydns.ipk \
-  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
-    | jsonfilter -e '@.assets[0].browser_download_url')
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
 ```
 
-The package is pure Lua (`PKGARCH:=all`), so the same `.ipk` works on every
-OpenWRT target — no need to match your router's CPU architecture.
+The script prompts for:
 
-## 3. Install
+| Prompt | Notes |
+|---|---|
+| API server URL | e.g. `https://api.example.com` (no trailing slash needed; the script trims it). |
+| Enrollment token | The `et_…` value from the admin UI. Single-use; invalidated on success. |
+| Router name | Defaults to the router's hostname. |
+| LAN prefix | Auto-detected from `network.lan.ipaddr` (last octet stripped). Must end with a dot. |
+
+It then:
+
+1. Downloads the latest `.ipk` from the GitHub Releases API and installs it
+   via `opkg`.
+2. Writes `api_url` and `lan_prefix` to `/etc/config/familydns`.
+3. POSTs `/api/router/register` to exchange the enrollment token for a
+   `routerId` and `routerToken`, and writes both to UCI.
+4. Adds a `uhttpd` listener on `127.0.0.1:8081` for the local block page
+   (idempotent — skipped if already configured).
+5. Enables and starts the `familydns` procd service.
+
+If anything goes wrong it aborts before starting the agent, leaving the
+router in a clean state so you can re-run after fixing the underlying issue.
+
+### Prefer to read before piping?
+
+Download and inspect the script first:
 
 ```sh
-opkg update
-opkg install /tmp/familydns.ipk
+curl -fsSL -o /tmp/familydns-install.sh \
+  https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
+less /tmp/familydns-install.sh
+sh /tmp/familydns-install.sh
 ```
 
-`opkg` resolves and installs `lua`, `luci-lib-jsonc`, `conntrack-tools`, and
-`curl`. The `postinst` script enables the `familydns` procd service for
-autostart but does **not** start it yet — enrollment must complete first.
-
-## 4. Configure the API URL
+## 3. Verify
 
 ```sh
-uci set familydns.@familydns[0].api_url='https://api.example.com'
-uci commit familydns
-```
-
-Replace `https://api.example.com` with the URL of your API server (no
-trailing slash). HTTP works for testing on a LAN; for anything reachable from
-the public internet, terminate TLS in front of the API.
-
-## 5. Enroll the router
-
-### 5a. Generate an enrollment token in the admin UI
-
-Log in to the FamilyDNS admin UI as an admin user, go to
-**Routers → Add router**, give it a name, and copy the one-time enrollment
-token (looks like `et_5f3c9b…`). The enrollment token is single-use and is
-invalidated as soon as the agent exchanges it for a router token.
-
-### 5b. Exchange the enrollment token for a router token
-
-From the router:
-
-```sh
-curl -s -X POST https://api.example.com/api/router/register \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "enrollmentToken": "et_5f3c9b…",
-    "routerName":      "home-router",
-    "platformVersion": "23.05.5",
-    "agentVersion":    "0.1.0"
-  }'
-# → {"routerId":"9c1f2e8a-…","routerToken":"rt_a7d12b…"}
-```
-
-The endpoint is unauthenticated — the enrollment token in the body is the
-auth. On success it returns a `routerId` (UUID) and a long-lived
-`routerToken` that the agent uses as a bearer token for every subsequent API
-call.
-
-### 5c. Persist the credentials and start the agent
-
-```sh
-uci set familydns.@familydns[0].router_id='9c1f2e8a-…'
-uci set familydns.@familydns[0].router_token='rt_a7d12b…'
-uci commit familydns
-/etc/init.d/familydns start
-```
-
-The agent is already enabled for autostart by the `postinst` script, so
-nothing extra is needed for it to come back after a reboot.
-
-## 6. Configure `lan_prefix` for non-default LAN subnets
-
-> **Important — read this even if your LAN looks normal.**
-> The default `lan_prefix` is `192.168.1.` (note the trailing dot). The
-> agent uses this prefix to identify which side of a connection is on the
-> LAN when attributing flows to a device. **If your LAN is not on
-> `192.168.1.0/24`, the agent will mis-attribute every flow** until you fix
-> this.
-
-```sh
-# Example: LAN on 10.0.0.0/24
-uci set familydns.@familydns[0].lan_prefix='10.0.0.'
-uci commit familydns
-/etc/init.d/familydns restart
-```
-
-The value is a literal string prefix (with the trailing dot), not a CIDR. If
-your LAN is a `/16` like `10.0.0.0/16`, use `'10.0.'` instead.
-
-## 7. Set up the local block page
-
-When the agent blocks an HTTP request, it DNATs port 80 to `127.0.0.1:8081`.
-A local `uhttpd` instance serves `/www/familydns/block.html`, which the
-agent installs. The block page redirects the browser to the API's
-`/blocked?host=…&reason=…` endpoint, where users see why the request was
-blocked.
-
-Add a uhttpd listener on `127.0.0.1:8081` (the main uhttpd config keeps
-serving LuCI on its existing ports):
-
-```sh
-uci add uhttpd uhttpd
-uci set uhttpd.@uhttpd[-1].listen_http='127.0.0.1:8081'
-uci set uhttpd.@uhttpd[-1].home='/www'
-uci commit uhttpd
-/etc/init.d/uhttpd reload
-```
-
-HTTPS to blocked hosts intentionally times out — TLS interception would
-require installing a custom CA on every client, which is not practical for
-a household-grade tool.
-
-## 8. Verify
-
-```sh
-# The agent process is up:
-ps | grep familydns-agent
-
-# Tail the system log for agent output (procd routes stderr there):
+# Tail the system log for agent output:
 logread -f | grep familydns
 ```
 
@@ -164,25 +85,113 @@ Then check the admin UI: **Routers → `<your router name>`** should show a
 fresh `last_seen_at`, updating roughly every 60 seconds (the policy poll
 interval).
 
-If the agent fails to start, the most common cause is a missing or empty
-`router_token`:
-
-```sh
-uci get familydns.@familydns[0].router_token
-```
-
-## 9. (Optional) Auto-update
+## 4. (Optional) Auto-update
 
 Routers running unattended should pull new agent releases automatically. The
 auto-update cron job is tracked in
-[#131](https://github.com/sameerparekh/familydns/issues/131); link forward
-to that once it lands. Until then, upgrade manually by re-running steps 2
-and 3 — `opkg install --force-reinstall` preserves
-`/etc/config/familydns`, so the router credentials survive the upgrade and
-no re-enrollment is needed.
+[#131](https://github.com/sameerparekh/familydns/issues/131). Until then,
+upgrade manually by re-running the one-shot install command from §2 — the
+script's `opkg install` step uses the standard upgrade path, which preserves
+`/etc/config/familydns`, so the router credentials survive and no
+re-enrollment is needed.
+
+## Manual install (fallback)
+
+Use this if you cannot or do not want to run the one-shot script — for
+example, if you're debugging a failed install or want to script each step
+into your own provisioning system.
+
+### M1. Download the `.ipk`
+
+```sh
+curl -fsSL -o /tmp/familydns.ipk \
+  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
+    | jsonfilter -e '@.assets[0].browser_download_url')
+```
+
+The package is pure Lua (`PKGARCH:=all`), so the same `.ipk` works on every
+OpenWRT target.
+
+### M2. Install
+
+```sh
+opkg update
+opkg install /tmp/familydns.ipk
+```
+
+`opkg` resolves and installs `lua`, `luci-lib-jsonc`, `conntrack-tools`, and
+`curl`. The `postinst` script enables the `familydns` procd service for
+autostart but does **not** start it yet — enrollment must complete first.
+
+### M3. Configure the API URL and LAN prefix
+
+```sh
+uci set familydns.@familydns[0].api_url='https://api.example.com'
+# Default lan_prefix is '192.168.1.' — override if your LAN is elsewhere.
+# Example: LAN on 10.0.0.0/24
+uci set familydns.@familydns[0].lan_prefix='10.0.0.'
+uci commit familydns
+```
+
+> **Important — read this even if your LAN looks normal.**
+> The agent uses `lan_prefix` (a literal string prefix, with a trailing dot)
+> to identify which side of a connection is on the LAN when attributing
+> flows to a device. **If your LAN is not on `192.168.1.0/24` and you don't
+> override this, the agent will mis-attribute every flow.**
+
+### M4. Exchange the enrollment token for a router token
+
+```sh
+curl -s -X POST https://api.example.com/api/router/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "enrollmentToken": "et_5f3c9b…",
+    "routerName":      "home-router",
+    "platformVersion": "23.05.5",
+    "agentVersion":    "0.1.0"
+  }'
+# → {"routerId":"9c1f2e8a-…","routerToken":"rt_a7d12b…"}
+```
+
+The endpoint is unauthenticated — the enrollment token in the body is the
+auth.
+
+### M5. Persist credentials and start the agent
+
+```sh
+uci set familydns.@familydns[0].router_id='9c1f2e8a-…'
+uci set familydns.@familydns[0].router_token='rt_a7d12b…'
+uci commit familydns
+/etc/init.d/familydns start
+```
+
+### M6. Set up the local block page
+
+When the agent blocks an HTTP request, it DNATs port 80 to `127.0.0.1:8081`.
+A local `uhttpd` instance serves `/www/familydns/block.html`, which the
+agent installs. The block page redirects the browser to the API's
+`/blocked?host=…&reason=…` endpoint.
+
+Add a `uhttpd` listener on `127.0.0.1:8081` (the main `uhttpd` keeps
+serving LuCI on its existing ports):
+
+```sh
+uci add uhttpd uhttpd
+uci set uhttpd.@uhttpd[-1].listen_http='127.0.0.1:8081'
+uci set uhttpd.@uhttpd[-1].home='/www'
+uci commit uhttpd
+/etc/init.d/uhttpd reload
+```
+
+HTTPS to blocked hosts intentionally times out — TLS interception would
+require installing a custom CA on every client, which is not practical.
+
+Then jump to §3 to verify.
 
 ## Reference
 
+- [`openwrt/install.sh`](../openwrt/install.sh) — the install script
+  source; read this if you want to know exactly what `curl | sh` will do.
 - [`openwrt/README.md`](../openwrt/README.md) — package layout, build, and
   developer-facing details.
 - [`docs/architecture.md`](architecture.md) §7 — full design of the OpenWRT

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -1,0 +1,191 @@
+# Installing the FamilyDNS Agent on OpenWRT
+
+This guide walks through a first install of the FamilyDNS agent on an OpenWRT
+router, from downloading the `.ipk` to verifying that the agent is enrolled
+and reporting policy state to the API.
+
+The agent enforces per-device DNS filtering, accounts traffic per
+`(mac, hostname)`, and streams connection events to the FamilyDNS API.
+
+## 1. Prerequisites
+
+- A router running **OpenWRT 23.05.x** (the package is built and tested
+  against 23.05.5 by `.github/workflows/openwrt-build.yml`).
+- Internet access from the router (the agent calls out to the API on the
+  policy/usage/events timers, and the install command pulls the `.ipk` from
+  GitHub Releases).
+- A FamilyDNS API server already deployed and reachable from the router. See
+  [`install-api.md`](install-api.md) if you need to set one up first.
+- Root SSH access to the router.
+
+The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`, all of which
+ship with stock OpenWRT 23.05. The remaining runtime dependencies (`lua`,
+`luci-lib-jsonc`, `conntrack-tools`, `curl`) are pulled in automatically by
+`opkg`.
+
+## 2. Download the `.ipk`
+
+From a root shell on the router:
+
+```sh
+curl -fsSL -o /tmp/familydns.ipk \
+  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
+    | jsonfilter -e '@.assets[0].browser_download_url')
+```
+
+The package is pure Lua (`PKGARCH:=all`), so the same `.ipk` works on every
+OpenWRT target — no need to match your router's CPU architecture.
+
+## 3. Install
+
+```sh
+opkg update
+opkg install /tmp/familydns.ipk
+```
+
+`opkg` resolves and installs `lua`, `luci-lib-jsonc`, `conntrack-tools`, and
+`curl`. The `postinst` script enables the `familydns` procd service for
+autostart but does **not** start it yet — enrollment must complete first.
+
+## 4. Configure the API URL
+
+```sh
+uci set familydns.@familydns[0].api_url='https://api.example.com'
+uci commit familydns
+```
+
+Replace `https://api.example.com` with the URL of your API server (no
+trailing slash). HTTP works for testing on a LAN; for anything reachable from
+the public internet, terminate TLS in front of the API.
+
+## 5. Enroll the router
+
+### 5a. Generate an enrollment token in the admin UI
+
+Log in to the FamilyDNS admin UI as an admin user, go to
+**Routers → Add router**, give it a name, and copy the one-time enrollment
+token (looks like `et_5f3c9b…`). The enrollment token is single-use and is
+invalidated as soon as the agent exchanges it for a router token.
+
+### 5b. Exchange the enrollment token for a router token
+
+From the router:
+
+```sh
+curl -s -X POST https://api.example.com/api/router/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "enrollmentToken": "et_5f3c9b…",
+    "routerName":      "home-router",
+    "platformVersion": "23.05.5",
+    "agentVersion":    "0.1.0"
+  }'
+# → {"routerId":"9c1f2e8a-…","routerToken":"rt_a7d12b…"}
+```
+
+The endpoint is unauthenticated — the enrollment token in the body is the
+auth. On success it returns a `routerId` (UUID) and a long-lived
+`routerToken` that the agent uses as a bearer token for every subsequent API
+call.
+
+### 5c. Persist the credentials and start the agent
+
+```sh
+uci set familydns.@familydns[0].router_id='9c1f2e8a-…'
+uci set familydns.@familydns[0].router_token='rt_a7d12b…'
+uci commit familydns
+/etc/init.d/familydns start
+```
+
+The agent is already enabled for autostart by the `postinst` script, so
+nothing extra is needed for it to come back after a reboot.
+
+## 6. Configure `lan_prefix` for non-default LAN subnets
+
+> **Important — read this even if your LAN looks normal.**
+> The default `lan_prefix` is `192.168.1.` (note the trailing dot). The
+> agent uses this prefix to identify which side of a connection is on the
+> LAN when attributing flows to a device. **If your LAN is not on
+> `192.168.1.0/24`, the agent will mis-attribute every flow** until you fix
+> this.
+
+```sh
+# Example: LAN on 10.0.0.0/24
+uci set familydns.@familydns[0].lan_prefix='10.0.0.'
+uci commit familydns
+/etc/init.d/familydns restart
+```
+
+The value is a literal string prefix (with the trailing dot), not a CIDR. If
+your LAN is a `/16` like `10.0.0.0/16`, use `'10.0.'` instead.
+
+## 7. Set up the local block page
+
+When the agent blocks an HTTP request, it DNATs port 80 to `127.0.0.1:8081`.
+A local `uhttpd` instance serves `/www/familydns/block.html`, which the
+agent installs. The block page redirects the browser to the API's
+`/blocked?host=…&reason=…` endpoint, where users see why the request was
+blocked.
+
+Add a uhttpd listener on `127.0.0.1:8081` (the main uhttpd config keeps
+serving LuCI on its existing ports):
+
+```sh
+uci add uhttpd uhttpd
+uci set uhttpd.@uhttpd[-1].listen_http='127.0.0.1:8081'
+uci set uhttpd.@uhttpd[-1].home='/www'
+uci commit uhttpd
+/etc/init.d/uhttpd reload
+```
+
+HTTPS to blocked hosts intentionally times out — TLS interception would
+require installing a custom CA on every client, which is not practical for
+a household-grade tool.
+
+## 8. Verify
+
+```sh
+# The agent process is up:
+ps | grep familydns-agent
+
+# Tail the system log for agent output (procd routes stderr there):
+logread -f | grep familydns
+```
+
+On a healthy start you should see lines like:
+
+```
+[familydns] starting conntrack watcher
+[familydns] policy snapshot fetched, etag=…
+[familydns] flushed N events to /api/router/events
+```
+
+Then check the admin UI: **Routers → `<your router name>`** should show a
+fresh `last_seen_at`, updating roughly every 60 seconds (the policy poll
+interval).
+
+If the agent fails to start, the most common cause is a missing or empty
+`router_token`:
+
+```sh
+uci get familydns.@familydns[0].router_token
+```
+
+## 9. (Optional) Auto-update
+
+Routers running unattended should pull new agent releases automatically. The
+auto-update cron job is tracked in
+[#131](https://github.com/sameerparekh/familydns/issues/131); link forward
+to that once it lands. Until then, upgrade manually by re-running steps 2
+and 3 — `opkg install --force-reinstall` preserves
+`/etc/config/familydns`, so the router credentials survive the upgrade and
+no re-enrollment is needed.
+
+## Reference
+
+- [`openwrt/README.md`](../openwrt/README.md) — package layout, build, and
+  developer-facing details.
+- [`docs/architecture.md`](architecture.md) §7 — full design of the OpenWRT
+  agent.
+- [`docs/deploy.md`](deploy.md) — overall CD pipeline for both deployment
+  targets.

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -105,7 +105,13 @@ git push origin v0.2.0
 # CI builds familydns_0.2.0-1_all.ipk and attaches it to the release.
 ```
 
-## Flash / Install
+## Install / Enrollment
+
+For end-user install instructions (download the latest release `.ipk`,
+enroll the router, configure `lan_prefix`, set up the block page),
+see [`docs/install-openwrt.md`](../docs/install-openwrt.md).
+
+For developer flashing of a locally built `.ipk`:
 
 ```sh
 scp openwrt/familydns_*.ipk root@192.168.1.1:/tmp/
@@ -114,52 +120,7 @@ ssh root@192.168.1.1 opkg install /tmp/familydns_*.ipk
 
 opkg installs all files and runs the `postinst` script (which enables the
 procd service), but does **not** start the daemon yet — enrollment must
-happen first.
-
-## Enrollment
-
-### 1. Create a router record in the admin UI
-
-Go to the FamilyDNS admin UI → **Routers → Add router**. Copy the
-one-time enrollment token (looks like `et_5f3c9b…`).
-
-### 2. Exchange the enrollment token for a router token
-
-Run this from the router (or any host that can reach the API):
-
-```sh
-curl -s -X POST http://<api-host>:8080/api/router/register \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "enrollment_token": "et_…",
-    "router_name":      "home-gw",
-    "openwrt_version":  "23.05.5",
-    "agent_version":    "0.1.0"
-  }'
-# → {"router_id":"9c1f2e8a-…","router_token":"rt_a7d12b…"}
-```
-
-The enrollment token is single-use; it is invalidated on success.
-
-### 3. Write the values into UCI config and start the agent
-
-```sh
-uci set familydns.@familydns[0].api_url='http://<api-host>:8080'
-uci set familydns.@familydns[0].router_id='<router_id>'
-uci set familydns.@familydns[0].router_token='<router_token>'
-uci commit familydns
-/etc/init.d/familydns start
-```
-
-The agent is already enabled for autostart by the `postinst` script, so
-it will also start on the next reboot.
-
-Adjust `lan_prefix` if your LAN subnet is not `192.168.1.`:
-
-```sh
-uci set familydns.@familydns[0].lan_prefix='10.0.0.'
-uci commit familydns
-```
+happen first. See the install guide above for the enrollment flow.
 
 ## Block-page redirect
 

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -107,9 +107,15 @@ git push origin v0.2.0
 
 ## Install / Enrollment
 
-For end-user install instructions (download the latest release `.ipk`,
-enroll the router, configure `lan_prefix`, set up the block page),
-see [`docs/install-openwrt.md`](../docs/install-openwrt.md).
+End users install via the one-shot script:
+
+```sh
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+```
+
+The script source is [`install.sh`](install.sh); the full guide (with the
+manual-fallback path for debugging) is in
+[`docs/install-openwrt.md`](../docs/install-openwrt.md).
 
 For developer flashing of a locally built `.ipk`:
 

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# FamilyDNS OpenWRT agent — interactive first-install script.
+#
+# Usage (on an OpenWRT 23.05.x router, as root):
+#
+#   sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+#
+# Or download then run:
+#
+#   curl -fsSL -o /tmp/familydns-install.sh \
+#     https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
+#   sh /tmp/familydns-install.sh
+#
+# The script prompts for the API URL, the one-time enrollment token, a router
+# name, and the LAN prefix; downloads the latest .ipk from GitHub Releases;
+# installs it; enrolls the router against the API; writes the returned
+# credentials into UCI; sets up the uhttpd block-page listener; and starts
+# the agent.
+
+set -eu
+
+RELEASES_API="https://api.github.com/repos/sameerparekh/familydns/releases/latest"
+
+err() { printf 'error: %s\n' "$*" >&2; exit 1; }
+info() { printf '==> %s\n' "$*"; }
+
+# Read from the controlling terminal so this works under `curl | sh`,
+# where stdin is the script body.
+TTY=/dev/tty
+[ -r "$TTY" ] && [ -w "$TTY" ] || err "no /dev/tty available — run from an interactive shell or download the script first"
+
+prompt() {
+  # prompt VAR "Question" [default]
+  _var=$1; _q=$2; _def=${3:-}
+  if [ -n "$_def" ]; then
+    printf '%s [%s]: ' "$_q" "$_def" >"$TTY"
+  else
+    printf '%s: ' "$_q" >"$TTY"
+  fi
+  IFS= read -r _val <"$TTY" || _val=""
+  [ -n "$_val" ] || _val=$_def
+  eval "$_var=\$_val"
+}
+
+# Sanity checks.
+[ "$(id -u)" -eq 0 ] || err "must run as root"
+command -v opkg       >/dev/null 2>&1 || err "opkg not found — is this OpenWRT?"
+command -v uci        >/dev/null 2>&1 || err "uci not found — is this OpenWRT?"
+command -v curl       >/dev/null 2>&1 || err "curl not found — install it first: opkg update && opkg install curl"
+command -v jsonfilter >/dev/null 2>&1 || err "jsonfilter not found — this should be present on stock OpenWRT"
+
+# Auto-detect defaults.
+lan_ip=$(uci -q get network.lan.ipaddr || true)
+if [ -n "$lan_ip" ]; then
+  lan_default=$(echo "$lan_ip" | awk -F. '{print $1"."$2"."$3"."}')
+else
+  lan_default="192.168.1."
+fi
+hostname_default=$(uci -q get system.@system[0].hostname || echo home-router)
+platform_ver=$(awk -F"'" '/DISTRIB_RELEASE/{print $2}' /etc/openwrt_release 2>/dev/null || echo unknown)
+
+cat >"$TTY" <<EOF
+
+FamilyDNS OpenWRT agent — interactive install
+=============================================
+This will install the agent, enroll this router against your API server,
+and start the agent. Press Ctrl-C at any prompt to abort.
+
+EOF
+
+prompt API_URL          "API server URL (e.g. https://api.example.com)"
+[ -n "${API_URL:-}" ] || err "API URL is required"
+API_URL=${API_URL%/}
+
+prompt ENROLLMENT_TOKEN "One-time enrollment token (admin UI -> Routers -> Add router)"
+[ -n "${ENROLLMENT_TOKEN:-}" ] || err "enrollment token is required"
+
+prompt ROUTER_NAME      "Router name" "$hostname_default"
+prompt LAN_PREFIX       "LAN prefix (literal, with trailing dot)" "$lan_default"
+
+case "$LAN_PREFIX" in
+  *.) : ;;
+  *)  err "lan_prefix must end with a dot (e.g. '10.0.0.'); got '$LAN_PREFIX'" ;;
+esac
+
+# Download the latest .ipk.
+info "Resolving latest release asset..."
+ipk_url=$(curl -fsSL "$RELEASES_API" | jsonfilter -e '@.assets[0].browser_download_url' | head -n1)
+[ -n "$ipk_url" ] || err "could not resolve latest release asset URL from $RELEASES_API"
+info "Downloading $ipk_url"
+curl -fsSL -o /tmp/familydns.ipk "$ipk_url"
+
+# Install (refresh opkg index for runtime deps, then install the .ipk).
+info "Refreshing opkg index..."
+opkg update >/dev/null
+
+info "Installing /tmp/familydns.ipk..."
+opkg install /tmp/familydns.ipk
+
+# Write base UCI config before enrolling so a re-run after a failed enroll
+# does not have to re-enter these.
+uci set familydns.@familydns[0].api_url="$API_URL"
+uci set familydns.@familydns[0].lan_prefix="$LAN_PREFIX"
+uci commit familydns
+
+# Enroll.
+info "Enrolling router with $API_URL..."
+agent_ver=$(opkg info familydns | awk '/^Version:/{print $2}' | head -n1)
+body=$(printf '{"enrollmentToken":"%s","routerName":"%s","platformVersion":"%s","agentVersion":"%s"}' \
+  "$ENROLLMENT_TOKEN" "$ROUTER_NAME" "$platform_ver" "$agent_ver")
+
+resp=$(curl -fsS -X POST "$API_URL/api/router/register" \
+  -H 'Content-Type: application/json' \
+  -d "$body") || err "enrollment request failed — check API_URL and that the enrollment token is valid"
+
+router_id=$(echo    "$resp" | jsonfilter -e '@.routerId'    | head -n1)
+router_token=$(echo "$resp" | jsonfilter -e '@.routerToken' | head -n1)
+[ -n "$router_id" ]    || err "enrollment response missing routerId: $resp"
+[ -n "$router_token" ] || err "enrollment response missing routerToken: $resp"
+
+uci set familydns.@familydns[0].router_id="$router_id"
+uci set familydns.@familydns[0].router_token="$router_token"
+uci commit familydns
+
+# Idempotent uhttpd listener for the local block page on 127.0.0.1:8081.
+if uci show uhttpd 2>/dev/null | grep -q "listen_http='127.0.0.1:8081'"; then
+  info "Block-page uhttpd listener already configured."
+else
+  info "Configuring uhttpd block-page listener on 127.0.0.1:8081..."
+  section=$(uci add uhttpd uhttpd)
+  uci set "uhttpd.${section}.listen_http=127.0.0.1:8081"
+  uci set "uhttpd.${section}.home=/www"
+  uci commit uhttpd
+  /etc/init.d/uhttpd reload
+fi
+
+# Enable and start.
+info "Enabling and starting the familydns agent..."
+/etc/init.d/familydns enable
+/etc/init.d/familydns start
+
+cat <<EOF
+
+Done. Router enrolled successfully.
+
+  Router name: $ROUTER_NAME
+  Router ID:   $router_id
+  API URL:     $API_URL
+  LAN prefix:  $LAN_PREFIX
+
+Watch the agent log:
+  logread -f | grep familydns
+
+The admin UI -> Routers -> $ROUTER_NAME should show a fresh last_seen_at
+within ~60 seconds.
+EOF


### PR DESCRIPTION
## Summary

- New `docs/install-openwrt.md` — a polished, standalone first-install guide for the OpenWRT agent, promoted out of the inline §3.2 bootstrap in `docs/deploy.md`.
- Trims `openwrt/README.md` and `docs/deploy.md` §3.2 to point at the new guide instead of duplicating the content.
- Verified the enrollment payload shape against the actual API: `RegisterRouterRequest` in [shared/src/Models.scala:351](shared/src/Models.scala#L351) and the route handler in [api/src/routes/RouterRoutes.scala:28](api/src/routes/RouterRoutes.scala#L28). The previous `openwrt/README.md` snake_case example (`enrollment_token`, `router_name`, `openwrt_version`) was wrong — the API expects camelCase (`enrollmentToken`, `routerName`, `platformVersion`, `agentVersion`). The new guide uses the correct field names.
- Verified UCI options against `openwrt/files/etc/config/familydns` and the supported OpenWRT version (23.05.5) against `.github/workflows/openwrt-build.yml`.
- The `lan_prefix` gotcha for non-192.168.1.x networks is called out explicitly with a blockquote warning, per the issue's acceptance criteria.

Closes #133. Related: #123 (deploy architecture umbrella), #130 (`.ipk` published to GitHub Releases — the install one-liner depends on this), #68 / #70 (router enrollment API).

## Acceptance gate

The issue body says: *"The guide is tested on a real OpenWRT 23.x router before closing the issue."* This PR has **not** been tested end-to-end on a real router yet — the user has a test router and will validate. The PR can land once reviewed, but #133 itself should remain open until hardware validation confirms a fresh router can follow the guide start-to-finish and end up enrolled and reporting.

## Test plan

- [ ] Read through `docs/install-openwrt.md` top-to-bottom — is anything ambiguous to a new user?
- [ ] On a real OpenWRT 23.05.x router, follow the guide start-to-finish from a clean state.
- [ ] Confirm the `curl … | jsonfilter -e '@.assets[0].browser_download_url'` one-liner resolves correctly against the latest GitHub release.
- [ ] Confirm the enrollment `curl` body shape works against a live API server (returns `routerId` + `routerToken`).
- [ ] Confirm `logread -f | grep familydns` shows policy fetch + event flush lines after start.
- [ ] Confirm the admin UI shows `last_seen_at` updating ~every 60 s.
- [ ] Confirm the `lan_prefix` callout makes sense and the example value is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)