### PR TITLE
Fix publish job: set up buildx for gha cache export

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

The `publish` job merged in #142 failed on first run with:

```
ERROR: failed to build: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

The default `docker` build driver doesn't support cache export to GHA. This PR adds `docker/setup-buildx-action@v3` before the build step so buildx uses the `docker-container` driver, which supports `cache-to: type=gha`.

## Test plan

- [ ] Merge → next push to `main` runs `publish` → buildx step succeeds and image is pushed to `ghcr.io/sameerparekh/familydns-api:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)