### PR TITLE
Cancel older paused e2e runs when a newer one starts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,10 +9,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Only one publish can run at a time.
+# Only one publish can run at a time. If a new run kicks off while an older
+# run is still paused waiting on the production environment approval, cancel
+# the older one — we always want the latest commit's run to take precedence.
 concurrency:
   group: e2e-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

`cancel-in-progress: false` meant that when a run on `main` paused at the production environment approval gate, a later push to `main` would queue behind it instead of taking over. Flip to `true` so the newest commit's run always wins.

This matches the intent of CD: we want to ship the latest green commit, not whichever one happened to reach the gate first.

## Test plan

- [ ] Push commit A to `main`; it reaches the publish job and pauses on approval.
- [ ] Push commit B to `main` before approving A.
- [ ] Observe: A's run is cancelled; B's run proceeds through e2e and pauses on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)