### PR TITLE
Rename workflows to clarify publish purpose

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: E2E + publish
+name: Publish API Server
 
 # Runs e2e and smoke checks on every push to main, then publishes the image
 # to ghcr.io after all checks are green.

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,4 +1,4 @@
-name: OpenWRT Build
+name: Publish OpenWRT Package
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Rename `E2E + publish` workflow → `Publish API Server`
- Rename `OpenWRT Build` workflow → `Publish OpenWRT Package`

Names now describe what each workflow ultimately ships, making the Actions list easier to scan.

## Test plan
- [ ] Verify renamed workflows appear correctly in the Actions tab