### PR TITLE
Publish multi-arch (amd64 + arm64) Docker image (closes #162)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for linux/arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -101,6 +106,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds `docker/setup-qemu-action@v3` (arm64) to the publish job in `.github/workflows/e2e.yml`.
- Adds `platforms: linux/amd64,linux/arm64` to the existing `docker/build-push-action@v5` step.
- Existing `cache-to: type=gha,mode=max` covers all platform layers.

The `docker/Dockerfile` base images (`eclipse-temurin:21-jdk`, `eclipse-temurin:21-jre`, `node:22-bookworm-slim`) all publish arm64 variants, and no stage references an arch-specific binary, so the build is portable as-is. The Scala assembly JAR and Vite bundle are arch-neutral.

Unblocks the macOS Apple Silicon install path from #160 as soon as this merges and a new image is published. Builds on the publish job introduced in #128.

Build-time impact: arm64 layers build under QEMU emulation, so expect the publish job to roughly double in wall time. If that becomes painful we can split a follow-up to use GitHub's native arm64 runners.

Closes #162. Refs #160, #128.

## Test plan

- [ ] Workflow YAML parses (GitHub Actions lint on push).
- [ ] After merge, watch the `publish` job on `main` succeed.
- [ ] `docker manifest inspect ghcr.io/sameerparekh/familydns-api:latest` lists both `linux/amd64` and `linux/arm64`.
- [ ] `docker pull` on Apple Silicon succeeds and resolves to arm64.
- [ ] `docker pull` on amd64 Linux still resolves to amd64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)