### PR TITLE
Fix install.sh sudo prompt failure under curl | bash

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -13,7 +13,11 @@
 # .env and offers to keep it, and `docker compose up -d` is idempotent.
 #
 # Env vars to skip prompts (useful for unattended installs):
-#   FAMILYDNS_INSTALL_DIR    install path                (default: /opt/familydns)
+#   FAMILYDNS_PREFIX         install path. Default: $HOME/.familydns when run
+#                            as a normal user (no sudo needed), /opt/familydns
+#                            when run as root. Set to /opt/familydns explicitly
+#                            for a system-wide install (requires sudo/root).
+#   FAMILYDNS_INSTALL_DIR    legacy alias for FAMILYDNS_PREFIX.
 #   FAMILYDNS_API_HOST_PORT  host port to bind           (default: 8080)
 #   FAMILYDNS_API_BIND       host interface to bind on   (default: 0.0.0.0)
 #   FAMILYDNS_DNS_LOCATION   free-form location label    (default: home)
@@ -97,7 +101,20 @@ ok "docker $(docker --version | awk '{print $3}' | tr -d ',') / compose $(docker
 
 step "Configuration"
 
-prompt FAMILYDNS_INSTALL_DIR    "Install directory"                           "/opt/familydns"
+# FAMILYDNS_PREFIX is the preferred name; FAMILYDNS_INSTALL_DIR is the legacy alias.
+if [ -n "${FAMILYDNS_PREFIX:-}" ] && [ -z "${FAMILYDNS_INSTALL_DIR:-}" ]; then
+  FAMILYDNS_INSTALL_DIR="$FAMILYDNS_PREFIX"
+fi
+
+# Default prefix: user-writable when not root (so `curl|bash` works without
+# sudo), /opt/familydns when running as root.
+if [ "$(id -u)" -eq 0 ]; then
+  DEFAULT_PREFIX="/opt/familydns"
+else
+  DEFAULT_PREFIX="${HOME}/.familydns"
+fi
+
+prompt FAMILYDNS_INSTALL_DIR    "Install directory"                           "$DEFAULT_PREFIX"
 prompt FAMILYDNS_API_HOST_PORT  "Host port for the API"                       "8080"
 prompt FAMILYDNS_API_BIND       "Bind address (0.0.0.0 or 127.0.0.1)"         "0.0.0.0"
 prompt FAMILYDNS_DNS_LOCATION   "Location label for query logs"               "home"
@@ -107,9 +124,36 @@ prompt FAMILYDNS_DNS_LOCATION   "Location label for query logs"               "h
 step "Preparing $FAMILYDNS_INSTALL_DIR"
 
 if [ ! -d "$FAMILYDNS_INSTALL_DIR" ]; then
-  if [ -w "$(dirname "$FAMILYDNS_INSTALL_DIR")" ]; then
+  parent_dir="$(dirname "$FAMILYDNS_INSTALL_DIR")"
+  if [ -w "$parent_dir" ]; then
+    mkdir -p "$FAMILYDNS_INSTALL_DIR"
+  elif [ "$(id -u)" -eq 0 ]; then
     mkdir -p "$FAMILYDNS_INSTALL_DIR"
   else
+    # Need sudo to create the install dir. If stdin is not a tty (e.g.
+    # `curl … | bash`), sudo can't prompt for a password and will fail
+    # silently with "a password is required". Detect that up front and
+    # tell the user how to recover.
+    if ! [ -t 0 ]; then
+      die "$(cat <<EOF
+
+  This install needs root to write to ${FAMILYDNS_INSTALL_DIR}, but stdin is
+  not a tty (curl|bash detected) so sudo cannot prompt for a password. Run
+  one of:
+
+    # 1. User-mode install (no sudo needed):
+    curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh \\
+      | FAMILYDNS_PREFIX=\$HOME/.familydns bash
+
+    # 2. Save and run with sudo:
+    curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
+    sudo bash install.sh
+
+    # 3. Warm up sudo first, then pipe:
+    sudo -v && curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+EOF
+)"
+    fi
     sudo mkdir -p "$FAMILYDNS_INSTALL_DIR"
     sudo chown "$USER" "$FAMILYDNS_INSTALL_DIR"
   fi

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -37,9 +37,25 @@ The script:
 Re-running it on an existing install is safe — it offers to keep your
 existing `.env` and `docker compose up -d` is idempotent.
 
+By default the one-liner installs into `$HOME/.familydns` (user-writable, no
+sudo required) — this is the recommended path for first-time users and is
+what the `curl | bash` invocation above will do. For a system-wide install
+under `/opt/familydns` (recommended for production hosts), set
+`FAMILYDNS_PREFIX` explicitly and run the script with `sudo`:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
+sudo FAMILYDNS_PREFIX=/opt/familydns bash install.sh
+```
+
+Piping `curl … | sudo bash` works too, but only if sudo is already warmed up
+(`sudo -v` first) — otherwise sudo can't prompt for a password through the
+pipe. The script detects this case and prints a recovery hint.
+
 For unattended installs, set `FAMILYDNS_NONINTERACTIVE=1` and any of
-`FAMILYDNS_INSTALL_DIR`, `FAMILYDNS_API_HOST_PORT`, `FAMILYDNS_API_BIND`,
-`FAMILYDNS_DNS_LOCATION`, `FAMILYDNS_NEW_ADMIN_PW` to skip prompts.
+`FAMILYDNS_PREFIX` (or its legacy alias `FAMILYDNS_INSTALL_DIR`),
+`FAMILYDNS_API_HOST_PORT`, `FAMILYDNS_API_BIND`, `FAMILYDNS_DNS_LOCATION`,
+`FAMILYDNS_NEW_ADMIN_PW` to skip prompts.
 
 The rest of this document is the manual walkthrough — read it if you'd
 rather understand each step, or if the script doesn't fit your environment


### PR DESCRIPTION
## Summary
- Default install prefix is now `$HOME/.familydns` (user-writable, no sudo) when run as a normal user; `/opt/familydns` only when running as root or when `FAMILYDNS_PREFIX` is set explicitly.
- Accepts `FAMILYDNS_PREFIX` (preferred) and keeps `FAMILYDNS_INSTALL_DIR` as a legacy alias.
- When sudo is still needed and stdin is not a tty, fail fast with an actionable error message that lists three recovery paths (user-mode install, save-and-sudo, `sudo -v` warmup) instead of letting sudo silently bail with `a password is required`.
- Docs (`docs/install-api.md`) updated to recommend the user-mode default for first-time users and document the `/opt/familydns` + sudo path for production.

Closes #161. Refs #160.

## Test plan
- [ ] `curl -fsSL …/install.sh | bash` as a normal user installs into `$HOME/.familydns` with no sudo prompt.
- [ ] `FAMILYDNS_PREFIX=/opt/familydns` + `curl … | bash` without a tty exits with the new actionable error (no silent sudo failure).
- [ ] `sudo bash install.sh` (saved file) installs into `/opt/familydns` as before.
- [ ] `FAMILYDNS_INSTALL_DIR=/tmp/fdns-test bash install.sh` still works (legacy alias).

Note: a dedicated bash test harness for install.sh is tracked separately by #154; this PR doesn't add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)