### PR TITLE
Add GET /api/health endpoint (closes #152)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -1,5 +1,7 @@
 package familydns.api
 
+import doobie.*
+import doobie.implicits.*
 import familydns.api.auth.*
 import familydns.api.db.*
 import familydns.api.policy.*
@@ -7,6 +9,7 @@ import familydns.api.routes.*
 import familydns.shared.Clock
 import zio.*
 import zio.http.*
+import zio.interop.catz.*
 import zio.logging.*
 import zio.logging.backend.SLF4J
 
@@ -57,8 +60,11 @@ object Main extends ZIOAppDefault {
       policy      <- ZIO.service[PolicyService]
       cfg         <- ZIO.service[AppConfig]
       clock       <- ZIO.service[Clock]
-      routerAuth = new RouterAuthLive(routerRepo)
-    } yield AuthRoutes.routes(auth, userRepo, upRepo) ++
+      xa          <- ZIO.service[Transactor[Task]]
+      routerAuth    = new RouterAuthLive(routerRepo)
+      dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
+    } yield HealthRoutes.routes(dbHealthCheck) ++
+      AuthRoutes.routes(auth, userRepo, upRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
       TimeRoutes.routes(

--- a/api/src/routes/HealthRoutes.scala
+++ b/api/src/routes/HealthRoutes.scala
@@ -1,0 +1,28 @@
+package familydns.api.routes
+
+import zio.*
+import zio.http.*
+
+/**
+ * Unauthenticated health probe for Docker/uptime monitors/reverse proxies.
+ *
+ * `checkDb` performs a cheap round-trip to Postgres (e.g. `SELECT 1`). Only the failure's class
+ * name is exposed in the response body so SQL details don't leak.
+ */
+object HealthRoutes {
+  def routes(checkDb: Task[Unit]): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "health" ->
+        handler { (_: Request) =>
+          checkDb.fold(
+            err => {
+              val cls = err.getClass.getSimpleName
+              Response
+                .json(s"""{"status":"error","db":"$cls"}""")
+                .status(Status.ServiceUnavailable)
+            },
+            _ => Response.json("""{"status":"ok","db":"ok"}"""),
+          )
+        },
+    )
+}

--- a/api/test/src/feature/HealthApiSpec.scala
+++ b/api/test/src/feature/HealthApiSpec.scala
@@ -1,0 +1,51 @@
+package familydns.api.feature
+
+import familydns.api.routes.HealthRoutes
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+object HealthApiSpec extends ZIOSpecDefault {
+
+  private def get(routes: Routes[Any, Response]): UIO[Response] =
+    routes(Request.get("/api/health")).merge
+
+  def spec = suite("Health API")(
+    test("GET /api/health returns 200 with status=ok,db=ok when DB check succeeds") {
+      val routes = HealthRoutes.routes(ZIO.unit)
+      for {
+        resp <- get(routes)
+        body <- resp.body.asString
+        json <- ZIO.fromEither(body.fromJson[Json])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(json.asObject.flatMap(_.get("status")).flatMap(_.asString).contains("ok")) &&
+        assertTrue(json.asObject.flatMap(_.get("db")).flatMap(_.asString).contains("ok"))
+    },
+    test("GET /api/health returns 503 with status=error when DB check fails") {
+      val routes = HealthRoutes.routes(
+        ZIO.fail(new java.sql.SQLException("connection refused")),
+      )
+      for {
+        resp <- get(routes)
+        body <- resp.body.asString
+        json <- ZIO.fromEither(body.fromJson[Json])
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(json.asObject.flatMap(_.get("status")).flatMap(_.asString).contains("error")) &&
+        assertTrue(
+          json.asObject.flatMap(_.get("db")).flatMap(_.asString).contains("SQLException"),
+        )
+    },
+    test("error response does not leak SQL details") {
+      val secret = "ERROR: relation \"secret_table\" does not exist at line 42"
+      val routes = HealthRoutes.routes(ZIO.fail(new java.sql.SQLException(secret)))
+      for {
+        resp <- get(routes)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(!body.contains("secret_table")) &&
+        assertTrue(!body.contains("line 42"))
+    },
+  )
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -50,11 +50,11 @@ services:
     ports:
       - "${FAMILYDNS_API_BIND:-0.0.0.0}:${FAMILYDNS_API_PORT:-8080}:8080"
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' -d '{}' http://localhost:8080/api/auth/login | grep -qE '^(400|401)$$'"]
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost:8080/api/health"]
       interval: 10s
       timeout: 3s
-      retries: 30
-      start_period: 30s
+      retries: 6
+      start_period: 20s
 
 volumes:
   pgdata:

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -224,17 +224,19 @@ Press `Ctrl-C` to stop tailing — the containers keep running.
 
 ## 5. Verify health
 
-There is no dedicated `/api/health` route. The recommended check (and the
-one the container's own healthcheck uses) is to hit `POST /api/auth/login`
-with an empty JSON body and expect a 400/401 — this proves the HTTP server
-is up *and* its database round-trip is working:
+Hit the unauthenticated `GET /api/health` endpoint. It performs a cheap
+`SELECT 1` against Postgres and returns 200 only if both the HTTP server
+and its database round-trip are working:
 
 ```sh
-curl -s -o /dev/null -w '%{http_code}\n' \
-  -X POST -H 'content-type: application/json' \
-  -d '{}' http://localhost:8080/api/auth/login
-# → 400 (or 401)
+curl -fsS http://localhost:8080/api/health
+# → {"status":"ok","db":"ok"}
 ```
+
+If the DB is unreachable the endpoint returns 503 with
+`{"status":"error","db":"<error class>"}`. This is the same probe used by
+the container's own healthcheck and is safe to point uptime monitors and
+reverse-proxy health checks at.
 
 You can also check the container healthcheck status directly:
 


### PR DESCRIPTION
## Summary

- Adds an unauthenticated `GET /api/health` route that runs a cheap `SELECT 1` and returns `200 {"status":"ok","db":"ok"}` on success, `503 {"status":"error","db":"<exception class>"}` on failure. Only the exception class name is exposed — SQL details don't leak.
- Replaces the auth-endpoint trick in `deploy/docker-compose.prod.yml` (`POST /api/auth/login` + empty body + grep for 400/401) with a clean `curl /api/health` probe.
- Updates `docs/install-api.md §5` to document the new endpoint as the canonical verification step.

## Why

Unblocks #163 (`install.sh` post-up wait loop) which needs a stable URL to poll. Also gives reverse proxies and uptime monitors a proper endpoint to hit, and removes the surprising auth-coupled probe from the install docs.

## Implementation note

`HealthRoutes.routes` takes a `checkDb: Task[Unit]` parameter rather than a `Transactor` directly. Production wires `sql"SELECT 1".query[Int].unique.transact(xa).unit`; tests inject `ZIO.unit` for the happy path and `ZIO.fail(SQLException)` for the failure path. No DB lifecycle gymnastics required.

## Healthcheck command choice

The user prompt suggested `wget`, but the runtime image (`eclipse-temurin:21-jre`, Debian-based) installs `curl` in its apt-get layer and does not ship `wget`. Switched to `curl -fsS -o /dev/null …`.

## Local Docker verification

Skipped — Docker daemon was unavailable in this worktree (per #92). Relying on CI `prod-stack-smoke` to exercise the compose healthcheck end-to-end.

## Test plan

- [x] `GET /api/health` returns 200 + `{"status":"ok","db":"ok"}` when DB check succeeds (unit test)
- [x] `GET /api/health` returns 503 + `{"status":"error","db":"SQLException"}` when DB check fails (unit test)
- [x] Error body does not contain SQL exception messages (unit test)
- [x] `mill api.test` green
- [ ] CI `prod-stack-smoke` shows `api` as `Up (healthy)` against the new compose healthcheck
- [ ] Manual smoke: `curl http://localhost:8080/api/health` against a running stack returns 200

## Follow-on

#163 (install.sh wait loop) is the natural consumer of this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)