### PR TITLE
install.sh: wait on /api/health with timeout + diagnostics (closes #163)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -243,27 +243,50 @@ ok "Containers started"
 
 # ── 7. Wait for health ────────────────────────────────────────────────────
 
-step "Waiting for API to come up"
-
 API_URL="http://127.0.0.1:${FAMILYDNS_API_HOST_PORT}"
-HEALTHY=0
-for i in $(seq 1 60); do
-  code="$(curl -s -o /dev/null -w '%{http_code}' \
-    -X POST -H 'content-type: application/json' \
-    -d '{}' "${API_URL}/api/auth/login" || true)"
-  if [ "$code" = "400" ] || [ "$code" = "401" ]; then
-    HEALTHY=1
-    break
-  fi
-  sleep 2
-done
 
-if [ "$HEALTHY" -eq 0 ]; then
-  warn "API didn't become healthy within ~120s. Check 'docker compose logs api'."
+# wait_for_api polls GET /api/health until it returns 2xx, or until the
+# timeout (FAMILYDNS_WAIT_TIMEOUT seconds, default 90) elapses. On failure
+# it dumps the last 100 lines of the api container logs plus `compose ps`
+# so the user can diagnose without re-running anything by hand.
+wait_for_api() {
+  local url="${API_URL}/api/health"
+  local timeout="${FAMILYDNS_WAIT_TIMEOUT:-90}"
+  local start elapsed
+  start=$(date +%s)
+  elapsed=0
+  step "Waiting for API to come up"
+  printf "  "
+  while [ "$elapsed" -lt "$timeout" ]; do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      echo
+      ok "API healthy at ${API_URL}"
+      return 0
+    fi
+    printf "."
+    sleep 2
+    elapsed=$(( $(date +%s) - start ))
+  done
+  echo
+  c_red "  ✗ API did not become healthy in ${timeout}s"
+  echo
+  echo "Recent api container logs:"
+  echo "------------------------------------------------------------------"
+  docker compose -f docker-compose.prod.yml --env-file .env logs api --tail=100 || true
+  echo "------------------------------------------------------------------"
+  echo "Container status:"
   docker compose -f docker-compose.prod.yml --env-file .env ps || true
-  exit 1
-fi
-ok "API is healthy at ${API_URL}"
+  echo
+  echo "Common causes:"
+  echo "  - DB credentials in .env don't match what postgres was created with"
+  echo "    (try: docker compose -f docker-compose.prod.yml --env-file .env down -v"
+  echo "     and re-run install.sh)"
+  echo "  - FAMILYDNS_JWT_SECRET missing or empty in .env"
+  echo "  - Postgres still initializing (rare; retry install.sh once)"
+  return 1
+}
+
+wait_for_api || exit 1
 
 # ── 8. Rotate admin password ──────────────────────────────────────────────
 

--- a/deploy/install.test.sh
+++ b/deploy/install.test.sh
@@ -138,6 +138,61 @@ else
   fail "--help should print FAMILYDNS_PREFIX and FAMILYDNS_NONINTERACTIVE"
 fi
 
+# ── 8. wait_for_api: success path. Mock curl to return 0 immediately.
+#      Should print "API healthy" and exit 0 well under the timeout.
+WAIT_FN="$(mktemp)"
+trap 'rm -f "${HELPERS}" "${WAIT_FN}"' EXIT
+awk '/^wait_for_api\(\) \{/{f=1} f; /^\}$/{if(f){f=0; exit}}' "${SCRIPT}" > "${WAIT_FN}"
+[[ -s "${WAIT_FN}" ]] || { echo "FAIL: could not extract wait_for_api from install.sh"; exit 1; }
+
+start_ts=$(date +%s)
+out="$(bash -c "
+  source '${HELPERS}'
+  step() { :; }
+  ok()   { echo \"OK: \$*\"; }
+  API_URL='http://127.0.0.1:8080'
+  curl() { return 0; }
+  $(cat "${WAIT_FN}")
+  wait_for_api
+" 2>&1)"
+rc=$?
+end_ts=$(date +%s)
+duration=$((end_ts - start_ts))
+if [[ ${rc} -eq 0 ]] && grep -q "API healthy" <<<"${out}" && [[ ${duration} -lt 10 ]]; then
+  pass "wait_for_api succeeds quickly when curl returns 0 (${duration}s)"
+else
+  fail "wait_for_api success path (rc=${rc}, duration=${duration}s, out=${out})"
+fi
+
+# ── 9. wait_for_api: timeout path. Mock curl to always fail and docker to
+#      noop. Use a short FAMILYDNS_WAIT_TIMEOUT so the test runs fast. The
+#      function should return non-zero and print diagnostics.
+start_ts=$(date +%s)
+set +e
+out="$(FAMILYDNS_WAIT_TIMEOUT=3 bash -c "
+  source '${HELPERS}'
+  step() { :; }
+  ok()   { echo \"OK: \$*\"; }
+  API_URL='http://127.0.0.1:8080'
+  curl()   { return 7; }
+  docker() { echo \"(mocked docker \$*)\"; }
+  $(cat "${WAIT_FN}")
+  wait_for_api
+" 2>&1)"
+rc=$?
+set -e
+end_ts=$(date +%s)
+duration=$((end_ts - start_ts))
+if [[ ${rc} -ne 0 ]] \
+   && grep -q "did not become healthy" <<<"${out}" \
+   && grep -q "Recent api container logs" <<<"${out}" \
+   && grep -q "Common causes" <<<"${out}" \
+   && [[ ${duration} -ge 3 ]] && [[ ${duration} -lt 15 ]]; then
+  pass "wait_for_api times out, prints diagnostics, exits non-zero (${duration}s)"
+else
+  fail "wait_for_api timeout path (rc=${rc}, duration=${duration}s, out=${out})"
+fi
+
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ ${FAIL} -eq 0 ]]


### PR DESCRIPTION
## Summary

- Replace the legacy `POST /api/auth/login`-based wait loop with `GET /api/health` (added in #152).
- 90s timeout (configurable via `FAMILYDNS_WAIT_TIMEOUT`), dot-spinner progress, clear failure message.
- On timeout: dump the last 100 lines of api container logs + `docker compose ps`, plus a short "common causes" list (DB credential mismatch, missing JWT secret, postgres still initializing).
- Exits non-zero on failure so CI / scripted installs notice.
- All diagnostic commands are `|| true`-guarded so `set -euo pipefail` can't mask the output.

## Test plan

Automated (`deploy/install.test.sh`, run by the `shell-tests` CI job):

- [x] Existing 10 tty/can_prompt/prompt tests still pass.
- [x] New: `wait_for_api` succeeds quickly when curl returns 0.
- [x] New: `wait_for_api` times out with `FAMILYDNS_WAIT_TIMEOUT=3`, prints "did not become healthy", "Recent api container logs", "Common causes", and returns non-zero.

Closes #163. Refs #160, #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)