### PR TITLE
install.sh: drop helper scripts (start/stop/restart/logs/status/update) into install dir

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -33,9 +33,10 @@ case "${1:-}" in
     ;;
 esac
 
-REPO_RAW="https://raw.githubusercontent.com/sameerparekh/familydns/main"
+REPO_RAW="${FAMILYDNS_REPO_RAW:-https://raw.githubusercontent.com/sameerparekh/familydns/main}"
 COMPOSE_URL="${REPO_RAW}/deploy/docker-compose.prod.yml"
 ENV_EXAMPLE_URL="${REPO_RAW}/deploy/.env.example"
+HELPER_SCRIPTS=(start stop restart logs status update)
 
 c_red()    { printf '\033[31m%s\033[0m\n' "$*"; }
 c_green()  { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -186,7 +187,11 @@ step "Fetching deploy files"
 
 curl -fsSL "$COMPOSE_URL"     -o docker-compose.prod.yml
 curl -fsSL "$ENV_EXAMPLE_URL" -o .env.example
-ok "docker-compose.prod.yml + .env.example downloaded"
+for s in "${HELPER_SCRIPTS[@]}"; do
+  curl -fsSL "${REPO_RAW}/deploy/scripts/${s}.sh" -o "${s}.sh"
+  chmod +x "${s}.sh"
+done
+ok "docker-compose.prod.yml + .env.example + ${#HELPER_SCRIPTS[@]} helper scripts downloaded"
 
 # ── 5. Refuse to clobber an existing install ──────────────────────────────
 #
@@ -201,17 +206,21 @@ if [ -f .env ]; then
   like an existing install. install.sh only handles first-install and will
   not overwrite an existing one.
 
-  To manage an existing install, use the update/relaunch tooling instead:
+  To manage an existing install, use the helper scripts in the install
+  dir:
 
-    docker compose -f ${FAMILYDNS_INSTALL_DIR}/docker-compose.prod.yml \\
-      --env-file ${FAMILYDNS_INSTALL_DIR}/.env <pull|up -d|restart|down>
+    ${FAMILYDNS_INSTALL_DIR}/update.sh    # pull latest images and restart
+    ${FAMILYDNS_INSTALL_DIR}/restart.sh   # restart in place
+    ${FAMILYDNS_INSTALL_DIR}/stop.sh      # stop (data preserved)
+    ${FAMILYDNS_INSTALL_DIR}/start.sh     # bring back up
+    ${FAMILYDNS_INSTALL_DIR}/logs.sh      # tail api logs
+    ${FAMILYDNS_INSTALL_DIR}/status.sh    # container status
 
   ⚠  DANGER — only run the next block if you intend to PERMANENTLY DELETE
      all FamilyDNS data on this host (devices, profiles, query logs,
      admin user, everything). There is no undo.
 
-    docker compose -f ${FAMILYDNS_INSTALL_DIR}/docker-compose.prod.yml \\
-      --env-file ${FAMILYDNS_INSTALL_DIR}/.env down -v
+    ${FAMILYDNS_INSTALL_DIR}/stop.sh -v
     rm ${FAMILYDNS_INSTALL_DIR}/.env
     # then re-run install.sh
 EOF
@@ -244,8 +253,6 @@ if [ -n "$proj" ] && docker volume inspect "${proj}_pgdata" >/dev/null 2>&1; the
      contains nothing you care about. This PERMANENTLY DELETES all data
      in it. There is no undo.
 
-    docker compose -f ${FAMILYDNS_INSTALL_DIR}/docker-compose.prod.yml \\
-      --env-file ${FAMILYDNS_INSTALL_DIR}/.env down -v 2>/dev/null || true
     docker volume rm ${proj}_pgdata
     # then re-run install.sh
 EOF
@@ -468,9 +475,12 @@ c_green "═══════════════════════�
 cat <<EOF
 
   Install dir : ${FAMILYDNS_INSTALL_DIR}
-  Compose     : docker compose -f docker-compose.prod.yml --env-file .env <cmd>
-  Logs        : docker compose -f docker-compose.prod.yml --env-file .env logs -f api
-  Stop        : docker compose -f docker-compose.prod.yml --env-file .env down
+  Update      : ${FAMILYDNS_INSTALL_DIR}/update.sh    # pull latest images and restart
+  Restart     : ${FAMILYDNS_INSTALL_DIR}/restart.sh
+  Stop        : ${FAMILYDNS_INSTALL_DIR}/stop.sh      # data preserved
+  Start       : ${FAMILYDNS_INSTALL_DIR}/start.sh
+  Logs        : ${FAMILYDNS_INSTALL_DIR}/logs.sh      # tail api logs
+  Status      : ${FAMILYDNS_INSTALL_DIR}/status.sh
 
 Next steps:
   1. (optional) Put a TLS-terminating reverse proxy (Caddy / nginx) in

--- a/deploy/scripts/logs.sh
+++ b/deploy/scripts/logs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Tail logs. Defaults to the api container; pass a service name to switch:
+#   ./logs.sh             # api
+#   ./logs.sh postgres
+#   ./logs.sh api postgres
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+if [ "$#" -eq 0 ]; then
+  set -- api
+fi
+exec docker compose -f docker-compose.prod.yml --env-file .env logs -f "$@"

--- a/deploy/scripts/restart.sh
+++ b/deploy/scripts/restart.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Restart the FamilyDNS stack in place (without recreating containers).
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+exec docker compose -f docker-compose.prod.yml --env-file .env restart "$@"

--- a/deploy/scripts/start.sh
+++ b/deploy/scripts/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Start the FamilyDNS stack (idempotent — safe to re-run).
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+exec docker compose -f docker-compose.prod.yml --env-file .env up -d "$@"

--- a/deploy/scripts/status.sh
+++ b/deploy/scripts/status.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Show container status (containers, ports, health).
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+exec docker compose -f docker-compose.prod.yml --env-file .env ps "$@"

--- a/deploy/scripts/stop.sh
+++ b/deploy/scripts/stop.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Stop the FamilyDNS stack. Containers are removed; the postgres data
+# volume is preserved (use `docker volume rm` to wipe it explicitly).
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+exec docker compose -f docker-compose.prod.yml --env-file .env down "$@"

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Pull the latest images from ghcr.io and restart the stack with them.
+# Safe to re-run; data is preserved across the restart.
+#
+# `compose up -d` only recreates containers whose image changed, so
+# postgres stays put unless its image was bumped, and the api restarts
+# only when there's actually a new build to roll out.
+set -euo pipefail
+cd "$(dirname "$(readlink -f "$0")")"
+docker compose -f docker-compose.prod.yml --env-file .env pull
+docker compose -f docker-compose.prod.yml --env-file .env up -d


### PR DESCRIPTION
## Summary

Adds `deploy/scripts/{start,stop,restart,logs,status,update}.sh` — thin wrappers around the equivalent `docker compose` commands. install.sh fetches them into the install dir during first install (alongside `docker-compose.prod.yml`) and `chmod +x`s them. Updates the success summary and the existing-install error message to point at the scripts instead of the long `docker compose -f … --env-file …` invocations.

`update.sh` does `pull` then `up -d`. Since `compose up -d` only recreates containers whose image changed, it's safe to re-run and only restarts the api when there's actually a new image.

`REPO_RAW` in install.sh is now overridable via `FAMILYDNS_REPO_RAW` so a fresh install can be exercised against a feature branch end-to-end.

Follow-up to #171.

## Test plan

- [x] `bash deploy/install.test.sh` — 12/12 pass
- [x] End-to-end against this branch (`FAMILYDNS_REPO_RAW=…/claude/install-helper-scripts`): clean install drops 6 helper scripts in the install dir, all executable; `status.sh` shows the running stack; `update.sh` pulls + reconciles; existing-install error path references the scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)