### PR TITLE
openwrt: drop unneeded apk index refresh before local install

### DIFF
--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -113,18 +113,19 @@ pkg_path="/tmp/familydns.${PKG_EXT}"
 info "Downloading $pkg_url"
 curl -fsSL -o "$pkg_path" "$pkg_url"
 
-# Install (refresh package index for runtime deps, then install the package).
-info "Refreshing $PKG_MGR index..."
+# Install the package.
 if [ "$PKG_MGR" = apk ]; then
-  apk update >/dev/null
-else
-  opkg update >/dev/null
-fi
-
-info "Installing $pkg_path..."
-if [ "$PKG_MGR" = apk ]; then
+  # apk installs a local file directly; no repo refresh needed since the .apk
+  # carries its own dependency metadata and the runtime deps are in base.
+  info "Installing $pkg_path..."
   apk add --allow-untrusted "$pkg_path"
 else
+  # opkg needs the package index refreshed before installing a local .ipk so
+  # that runtime deps (e.g. dnsmasq-full bits) can be resolved against the
+  # repos.
+  info "Refreshing opkg index..."
+  opkg update >/dev/null
+  info "Installing $pkg_path..."
   opkg install "$pkg_path"
 fi
 


### PR DESCRIPTION
Refs #179.

Follow-up cleanup on top of #177. The #179 spec explicitly notes "no repo refresh needed for a local file" on the apk path, but #177 added a generic `apk update`/`opkg update` step before install for both managers. This PR drops the refresh from the apk branch and restores a clear opkg-only refresh.

## Branching

- **apk**: `apk add --allow-untrusted /tmp/familydns.apk` directly — the package carries its own manifest and the runtime deps are in base, so no `apk update` round-trip is required.
- **opkg**: unchanged — still runs `opkg update >/dev/null` before `opkg install /tmp/familydns.ipk` so dependency resolution against repos works on 23.05.x.

## Verification

- `sh -n openwrt/install.sh` passes.
- Diff is structural only — no commands run on the opkg path change.
- End-to-end validation on a real apk router is still gated on #181 (publishing the `.apk` asset); this PR is a pure script-side cleanup.