### PR TITLE
openwrt: add build-apk.sh producing APKv3 package

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Build familydns_<version>-<release>_all.apk (OpenWRT APKv3) without the full SDK.
+# The package is pure Lua (PKGARCH:=all → arch=noarch), so no cross-compile.
+# Output: openwrt/familydns_<version>-<release>_all.apk
+#
+# Override version at build time:
+#   PKG_VERSION=0.2.0 PKG_RELEASE=1 ./openwrt/build-apk.sh
+#
+# Approach: build apk-tools v3 from source (alpine/apk-tools, which is the same
+# codebase OpenWRT 24.10+ uses) under "$APK_TOOLS_PREFIX" (default $HOME/.cache/
+# familydns-apk-tools) and invoke `apk mkpkg`. Considered alternatives:
+#   - OpenWRT SDK Docker image: heavy (~1GB), needs Docker, harder for CI.
+#   - Prebuilt apk-tools-static: no first-party static build is published yet
+#     for x86_64 v3; building from source is more reliable.
+# Building from source on a stock Ubuntu runner takes ~30s and only needs
+# meson/ninja/libssl-dev/libzstd-dev (apt-get installable, unprivileged build).
+#
+# Linux-only (build dependencies assume apt/Debian-family). macOS is out of
+# scope for now — run this in CI or a Linux VM/container.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PKG_VERSION="${PKG_VERSION:-$(grep '^PKG_VERSION:=' "$SCRIPT_DIR/Makefile" | cut -d= -f2)}"
+PKG_RELEASE="${PKG_RELEASE:-$(grep '^PKG_RELEASE:=' "$SCRIPT_DIR/Makefile" | cut -d= -f2)}"
+OUT_APK="$SCRIPT_DIR/familydns_${PKG_VERSION}-${PKG_RELEASE}_all.apk"
+
+APK_TOOLS_REPO="${APK_TOOLS_REPO:-https://gitlab.alpinelinux.org/alpine/apk-tools.git}"
+APK_TOOLS_REF="${APK_TOOLS_REF:-v3.0.6}"
+APK_TOOLS_PREFIX="${APK_TOOLS_PREFIX:-$HOME/.cache/familydns-apk-tools}"
+APK_BIN="$APK_TOOLS_PREFIX/build/src/apk"
+
+ensure_apk() {
+    if [ -x "$APK_BIN" ] && "$APK_BIN" version 2>/dev/null | grep -q '^apk-tools 3'; then
+        return 0
+    fi
+    echo "Building apk-tools ($APK_TOOLS_REF) into $APK_TOOLS_PREFIX..."
+    mkdir -p "$APK_TOOLS_PREFIX"
+    if [ ! -d "$APK_TOOLS_PREFIX/src/.git" ]; then
+        rm -rf "$APK_TOOLS_PREFIX/src"
+        git clone --depth 1 --branch "$APK_TOOLS_REF" "$APK_TOOLS_REPO" "$APK_TOOLS_PREFIX/src"
+    fi
+    (
+        cd "$APK_TOOLS_PREFIX/src"
+        # -Durl_backend=wget avoids needing libfetch on Ubuntu.
+        # -Ddocs/help/zstd disabled where not strictly required for `mkpkg`.
+        meson setup --reconfigure \
+            -Dprefix=/usr \
+            -Durl_backend=wget \
+            -Dhelp=disabled \
+            -Ddocs=disabled \
+            -Dlua=disabled \
+            -Dpython=disabled \
+            "$APK_TOOLS_PREFIX/build"
+        ninja -C "$APK_TOOLS_PREFIX/build" src/apk
+    )
+}
+
+ensure_apk
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── stage payload ────────────────────────────────────────────────────────────
+mkdir "$WORK/data"
+cp -r "$SCRIPT_DIR/files/." "$WORK/data/"
+
+find "$WORK/data/usr/sbin"            -type f -exec chmod 0755 {} \;
+find "$WORK/data/etc/init.d"          -type f -exec chmod 0755 {} \;
+find "$WORK/data/usr/lib/familydns"   -type f -exec chmod 0644 {} \; 2>/dev/null || true
+if [ -f "$WORK/data/etc/config/familydns" ]; then
+    chmod 0600 "$WORK/data/etc/config/familydns"
+fi
+
+# ── post-install script ──────────────────────────────────────────────────────
+# Equivalent of the .ipk postinst. The IPKG_INSTROOT guard from build-ipk.sh
+# is dropped: apk runs scripts inside the target root directly, and there is
+# no equivalent offline-install sentinel in apk v3 that we need to skip on.
+cat > "$WORK/post-install" <<'POSTINSTALL'
+#!/bin/sh
+/etc/init.d/familydns enable
+POSTINSTALL
+chmod 0755 "$WORK/post-install"
+
+# ── build .apk ───────────────────────────────────────────────────────────────
+rm -f "$OUT_APK"
+"$APK_BIN" mkpkg \
+    --info "name:familydns" \
+    --info "version:${PKG_VERSION}-r${PKG_RELEASE}" \
+    --info "description:FamilyDNS router agent (per-device DNS filtering + time limits)" \
+    --info "arch:noarch" \
+    --info "license:MIT" \
+    --info "url:https://github.com/sameerparekh/familydns" \
+    --info "maintainer:FamilyDNS <noreply@example.com>" \
+    --info "depends:lua luci-lib-jsonc conntrack-tools curl" \
+    --script "post-install:$WORK/post-install" \
+    --files "$WORK/data" \
+    --output "$OUT_APK"
+
+echo "Built: $OUT_APK"


### PR DESCRIPTION
Closes #178. Part of #176.

Adds `openwrt/build-apk.sh` so we can produce an APKv3 `.apk` for OpenWRT 24.10+/SNAPSHOT routers, alongside the existing `.ipk` for opkg-based routers. CI wiring is intentionally not touched — that's #180.

## Approach

Build `alpine/apk-tools` v3.0.6 from source under `$HOME/.cache/familydns-apk-tools` and invoke `apk mkpkg` against a staged copy of `openwrt/files/`. Chosen for:

- **Simplicity / reproducibility.** Runs on a stock Ubuntu CI runner with `apt-get install meson ninja-build pkg-config libssl-dev zlib1g-dev libzstd-dev git ca-certificates` — no Docker, no privileged container, no SDK download.
- **Cache-friendly.** The script re-uses the cached build; subsequent runs are sub-second.
- **First-party source.** OpenWRT 24.10's apk-tools is the same upstream codebase (the historical "openwrt fork" has been merged back into `alpine/apk-tools` v3); `apk mkpkg` produces the APKv3/ADB packages OpenWRT consumes.

Rejected alternatives:
- OpenWRT 24.10 SDK Docker image — ~1GB pull, requires Docker, heavier than needed.
- Prebuilt `apk-tools-static` — no first-party static v3 binary published; source build is more reliable.

The script mirrors `build-ipk.sh`'s interface: respects `PKG_VERSION` / `PKG_RELEASE` env vars, otherwise greps `openwrt/Makefile`. File permissions are preserved (0755 sbin + init.d, 0644 lua libs, 0600 etc/config/familydns).

### Notes on mapping

- `Architecture: all` → `arch: noarch`.
- `Version: X-Y` → `version: X-rY` (APKv3 version grammar requires `-r<number>` for the build release).
- `postinst` (which ran `[ -n "$IPKG_INSTROOT" ] && exit 0; /etc/init.d/familydns enable`) → APKv3 `post-install` script that just runs `/etc/init.d/familydns enable`. The `IPKG_INSTROOT` guard is dropped: apk has no equivalent offline-staging sentinel, and per the `apk-package(5)` docs the `post-install` script is run in-place after files land.
- Output filename: kept consistent with the `.ipk` — `openwrt/familydns_<version>-<release>_all.apk`.

### Maintenance

If `apk-tools` v3.0.6 stops building or a newer version is needed, override at invocation:

```sh
APK_TOOLS_REF=v3.0.7 ./openwrt/build-apk.sh
```

## Local build output

```
$ ./openwrt/build-apk.sh
Built: /work/openwrt/familydns_0.1.0-1_all.apk

$ ls -l openwrt/familydns_0.1.0-1_all.apk
-rw-r--r-- 1 root root 11135 openwrt/familydns_0.1.0-1_all.apk
```

### `apk adbdump` (metadata + post-install script)

```
info:
  name: familydns
  version: 0.1.0-r1
  description: FamilyDNS router agent (per-device DNS filtering + time limits)
  arch: noarch
  license: MIT
  maintainer: FamilyDNS <noreply@example.com>
  url: https://github.com/sameerparekh/familydns
  installed-size: 34866
  depends:
    - conntrack-tools
    - curl
    - lua
    - luci-lib-jsonc

scripts:
  post-install: |
    #!/bin/sh
    /etc/init.d/familydns enable
```

### Payload listing (.apk)

```
size    path                                  mode
763     etc/config/familydns                  0600
350     etc/init.d/familydns                  0755
10429   usr/lib/familydns/conntrack.lua       0644
2830    usr/lib/familydns/policy.lua          0644
6505    usr/lib/familydns/render.lua          0644
4963    usr/lib/familydns/usage.lua           0644
7545    usr/sbin/familydns-agent              0755
1481    www/familydns/block.html              0644
```

### Diff vs `.ipk` payload (`tar tzf data.tar.gz`)

`diff` between the .ipk and .apk file lists is empty — both packages contain the same 8 files with the same sizes and permissions.

## Test plan

- [x] `./openwrt/build-apk.sh` runs to completion on Ubuntu 24.04 and produces a `.apk`.
- [x] `apk adbdump` shows correct name, version, arch=noarch, depends, post-install script.
- [x] Payload listing matches `.ipk` exactly (paths, sizes, permissions).
- [ ] Install on a real 24.10/SNAPSHOT router via `apk add --allow-untrusted /tmp/familydns.apk` (tracked alongside #176 end-to-end verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)