### PR TITLE
openwrt CI: build .apk in parallel with .ipk, attach both to release

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    name: Build .ipk
+    name: Build .ipk and .apk
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -52,16 +52,50 @@ jobs:
           echo "--- data ---"
           ar p "$ipk" data.tar.gz | tar tz
 
-      - name: Upload artifact
+      - name: Install apk-tools build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            meson ninja-build pkg-config libssl-dev libzstd-dev wget
+
+      - name: Build .apk
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+          PKG_RELEASE: ${{ steps.ver.outputs.release }}
+        run: |
+          chmod +x openwrt/build-apk.sh
+          openwrt/build-apk.sh
+
+      - name: Verify .apk contents
+        run: |
+          apk_file=$(ls openwrt/familydns_*.apk)
+          echo "Package: $apk_file"
+          ls -lh "$apk_file"
+          apk_bin="$HOME/.cache/familydns-apk-tools/build/src/apk"
+          echo "--- apk manifest ---"
+          "$apk_bin" manifest "$apk_file" || true
+          echo "--- payload (tar listing) ---"
+          tar tzf "$apk_file"
+
+      - name: Upload .ipk artifact
         uses: actions/upload-artifact@v4
         with:
           name: familydns-ipk-${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.release }}
           path: openwrt/familydns_*.ipk
           if-no-files-found: error
 
-      - name: Create GitHub release and attach .ipk
+      - name: Upload .apk artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: familydns-apk-${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.release }}
+          path: openwrt/familydns_*.apk
+          if-no-files-found: error
+
+      - name: Create GitHub release and attach packages
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          files: openwrt/familydns_*.ipk
+          files: |
+            openwrt/familydns_*.ipk
+            openwrt/familydns_*.apk
           generate_release_notes: true


### PR DESCRIPTION
Closes #180. Part of #176.

Extends `.github/workflows/openwrt-build.yml` to also build the APKv3 package and attach it to the release alongside the `.ipk`.

## Structure

Kept as a **single job** with sequential build steps rather than splitting into parallel `build-ipk` / `build-apk` jobs joined by `needs:`. `build-apk.sh` compiles apk-tools v3 from source (~30s on a stock Ubuntu runner), which is cheap enough that the extra job startup + checkout overhead and `needs:` plumbing for the release step wasn't worth it.

## Changes

- New `Install apk-tools build deps` step (`meson ninja-build pkg-config libssl-dev libzstd-dev wget`).
- New `Build .apk` step running `openwrt/build-apk.sh` with the same `PKG_VERSION` / `PKG_RELEASE` env from the existing `Derive version` step.
- New `Verify .apk contents` step using `apk manifest` + a `tar tzf` listing (the `.apk` is a gzipped tarball).
- Second `actions/upload-artifact` for `familydns-apk-<version>-<release>`.
- `softprops/action-gh-release@v2` now globs both `openwrt/familydns_*.ipk` and `openwrt/familydns_*.apk`.

## Behavior

- Tag push `v*` → release with both `.ipk` and `.apk` attached.
- Non-tag push / PR touching `openwrt/**` → both artifacts uploaded, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)