### PR TITLE
openwrt CI: fix .apk verify step (adbdump + extract)

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -72,10 +72,14 @@ jobs:
           echo "Package: $apk_file"
           ls -lh "$apk_file"
           apk_bin="$HOME/.cache/familydns-apk-tools/build/src/apk"
-          echo "--- apk manifest ---"
-          "$apk_bin" manifest "$apk_file" || true
-          echo "--- payload (tar listing) ---"
-          tar tzf "$apk_file"
+          echo "--- file type ---"
+          file "$apk_file"
+          echo "--- apk adbdump (metadata) ---"
+          "$apk_bin" adbdump "$apk_file"
+          echo "--- payload (extracted listing) ---"
+          extract_dir=$(mktemp -d)
+          "$apk_bin" extract --no-chown --destination "$extract_dir" "$apk_file"
+          ( cd "$extract_dir" && find . -type f -o -type l | sort )
 
       - name: Upload .ipk artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up to #186, which left the `Verify .apk contents` step broken:

```
ERROR: Unable to read database: No such file or directory
gzip: stdin: not in gzip format
```

APKv3 is an ADB container, not a gz tarball. `apk manifest` reads an installed-package DB (not a standalone file), and `tar tzf` fails on the ADB blob.

Replaces both with:
- `apk adbdump <file>` for metadata
- `apk extract --no-chown --destination <tmp> <file>` + `find` for the payload listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)