### PR TITLE
install.sh: use uclient-fetch in bootstrap one-liner (closes #192)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -257,7 +257,7 @@ End users install via the one-shot script — see
 manual-fallback path. The headline command, run as root on the router:
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
 ```
 
 It prompts for the API URL, the one-time enrollment token (generated in the

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -29,7 +29,7 @@ ship with stock OpenWRT 23.05. The remaining runtime dependencies (`lua`,
 SSH into the router as root and run:
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
 ```
 
 The script prompts for:
@@ -60,7 +60,7 @@ router in a clean state so you can re-run after fixing the underlying issue.
 Download and inspect the script first:
 
 ```sh
-curl -fsSL -o /tmp/familydns-install.sh \
+uclient-fetch -qO /tmp/familydns-install.sh \
   https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
 less /tmp/familydns-install.sh
 sh /tmp/familydns-install.sh

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -110,7 +110,7 @@ git push origin v0.2.0
 End users install via the one-shot script:
 
 ```sh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
 ```
 
 The script source is [`install.sh`](install.sh); the full guide (with the

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -3,11 +3,11 @@
 #
 # Usage (on an OpenWRT 23.05.x router, as root):
 #
-#   sh -c "$(curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+#   sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
 #
 # Or download then run:
 #
-#   curl -fsSL -o /tmp/familydns-install.sh \
+#   uclient-fetch -qO /tmp/familydns-install.sh \
 #     https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
 #   sh /tmp/familydns-install.sh
 #


### PR DESCRIPTION
Closes #192.

Stock OpenWRT does not ship with `curl`, so the documented bootstrap one-liner failed immediately on a fresh router. Switched the docs/script-header one-liner to `uclient-fetch` (built into OpenWRT). The script's internal `curl` usage and the L62 "install curl first" check are left in place — they still apply once the script starts running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)