### PR TITLE
openwrt: depend on 'conntrack' (not 'conntrack-tools') in .apk

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -92,7 +92,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/sameerparekh/familydns" \
     --info "maintainer:FamilyDNS <noreply@example.com>" \
-    --info "depends:lua luci-lib-jsonc conntrack-tools curl" \
+    --info "depends:lua luci-lib-jsonc conntrack curl" \
     --script "post-install:$WORK/post-install" \
     --files "$WORK/data" \
     --output "$OUT_APK"


### PR DESCRIPTION
## Summary
- The .apk produced by [openwrt/build-apk.sh](openwrt/build-apk.sh) declared a dep on `conntrack-tools`, which doesn't exist as a binary package in the apk-based OpenWRT 24.10+ feeds — that source package is split, and the CLI we use (`conntrack -E -e NEW`) ships as `conntrack`. Installing the .apk on 24.10 fails with `conntrack-tools (no such package)`.
- Switch the apk dep to `conntrack`. The .ipk path (opkg / 23.05) still uses `conntrack-tools`, which is correct there.

Hit during e2e validation for #181.

## Test plan
- [ ] CI builds .apk successfully
- [ ] On a 24.10 router: `apk add --allow-untrusted /tmp/familydns.apk` resolves deps and installs
- [ ] Agent starts and the conntrack watcher runs (`logread -f | grep familydns`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)