### PR TITLE
openwrt: depend on libuci-lua (fixes module 'uci' not found)

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -13,7 +13,7 @@ define Package/familydns
   SECTION:=net
   CATEGORY:=Network
   TITLE:=FamilyDNS router agent
-  DEPENDS:=+lua +luci-lib-jsonc +conntrack-tools +curl
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack-tools +curl
   PKGARCH:=all
 endef
 

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -46,6 +46,7 @@ nftables — no round-trip to the API per request.
 Installed automatically by opkg when you install the package:
 
 - `lua` — Lua 5.1 interpreter
+- `libuci-lua` — Lua bindings for UCI (`require("uci")`)
 - `luci-lib-jsonc` — provides `cjson` for JSON encoding
 - `conntrack-tools` — provides `conntrack -E -e NEW`
 - `curl` — HTTP client used by the agent

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -92,7 +92,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/sameerparekh/familydns" \
     --info "maintainer:FamilyDNS <noreply@example.com>" \
-    --info "depends:lua luci-lib-jsonc conntrack curl" \
+    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl" \
     --script "post-install:$WORK/post-install" \
     --files "$WORK/data" \
     --output "$OUT_APK"

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -25,7 +25,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: familydns
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, luci-lib-jsonc, conntrack-tools, curl
+Depends: lua, libuci-lua, luci-lib-jsonc, conntrack-tools, curl
 Architecture: all
 Maintainer: FamilyDNS <noreply@example.com>
 Description: Agent daemon for FamilyDNS. Enforces per-device DNS filtering


### PR DESCRIPTION
## Summary

- Add `libuci-lua` to the dependency list for the OpenWrt package in all three places: `openwrt/build-apk.sh`, `openwrt/build-ipk.sh`, and `openwrt/Makefile`.
- Document `libuci-lua` in `openwrt/README.md`.

## Why

After v0.1.2 fixed the `conntrack-tools` → `conntrack` rename, fresh installs on apk-based OpenWrt 24.10 still crashloop:

```
/usr/bin/lua: /usr/sbin/familydns-agent:15: module 'uci' not found
```

`familydns-agent` calls `require("uci")` at startup. The Lua UCI bindings live in the `libuci-lua` package, which we never declared as a dependency. On opkg-based OpenWrt (23.x), `luci-lib-jsonc` pulled it in transitively, so we never noticed. On apk-based 24.10 that transitive pull-in doesn't happen, so the module is missing and the agent fails to start.

Fixes #200.

## Test plan

- [ ] Fresh install on apk-based OpenWrt 24.10: `apk add --allow-untrusted` + enroll + `/etc/init.d/familydns start` → agent runs without `module 'uci' not found`
- [ ] Regression check on 23.05 router: `.ipk` install still works, agent starts
- [ ] openwrt-build.yml CI passes (.apk and .ipk both build with new dep)