### PR TITLE
openwrt: migrate from cjson to luci.jsonc (fixes #203)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Run openwrt agent tests
         working-directory: openwrt
         run: |
-          LUA_PATH="./files/usr/lib/lua/familydns/?.lua;$(lua -e 'print(package.path)')" \
+          LUA_PATH="./files/usr/lib/lua/familydns/?.lua;./test/shim/?.lua;./test/shim/?/init.lua;$(lua -e 'print(package.path)')" \
             busted test/conntrack_spec.lua
 
   # ── OPNsense agent: Python unit tests ───────────────────────────────────

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -47,7 +47,7 @@ Installed automatically by opkg when you install the package:
 
 - `lua` — Lua 5.1 interpreter
 - `libuci-lua` — Lua bindings for UCI (`require("uci")`)
-- `luci-lib-jsonc` — provides `cjson` for JSON encoding
+- `luci-lib-jsonc` — JSON encode/decode (`require("luci.jsonc")`)
 - `conntrack-tools` — provides `conntrack -E -e NEW`
 - `curl` — HTTP client used by the agent
 

--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -215,7 +215,7 @@ end
 -- }
 -- ---------------------------------------------------------------------------
 function M.watch(cfg)
-  local json       = require("cjson")
+  local jsonc      = require("luci.jsonc")
   local lan_prefix = cfg.lan_prefix     or "192.168.1."
   local max_batch  = cfg.max_batch      or 50
   local flush_int  = cfg.flush_interval or 10
@@ -232,7 +232,7 @@ function M.watch(cfg)
   end
 
   local batcher = M.new_batcher(max_batch, flush_int, function(events)
-    local payload = json.encode({
+    local payload = jsonc.stringify({
       routerId = cfg.router_id,
       events   = events,
     })

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -34,15 +34,21 @@ function M.fetch(api_url, router_token, etag, http_get_fn)
   if status == 304 then
     return nil, etag
   elseif status == 200 then
-    local ok, snap = pcall(function()
-      local json = require("cjson")
-      return json.decode(body)
+    local ok, snap_or_err = pcall(function()
+      local jsonc = require("luci.jsonc")
+      local parsed = jsonc.parse(body)
+      if parsed == nil then
+        error("luci.jsonc.parse returned nil (invalid JSON)")
+      end
+      return parsed
     end)
-    if ok and snap then
+    if ok and snap_or_err then
+      local snap = snap_or_err
       local new_etag = (snap.etag ~= nil) and snap.etag or etag
       return snap, new_etag
     end
-    io.stderr:write("[familydns] policy.fetch: JSON decode failed\n")
+    io.stderr:write(string.format(
+      "[familydns] policy.fetch: JSON parse failed: %s\n", tostring(snap_or_err)))
     return nil, nil
   else
     io.stderr:write(string.format(

--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -50,9 +50,11 @@ end
 -- usage.parse_nft_counters(json_str)
 -- ---------------------------------------------------------------------------
 function M.parse_nft_counters(json_str)
-  local json     = require("cjson")
-  local decoded  = json.decode(json_str)
+  local jsonc    = require("luci.jsonc")
+  local decoded  = jsonc.parse(json_str)
   local result   = {}
+
+  if not decoded then return result end
 
   for _, entry in ipairs(decoded.nftables or {}) do
     local c = entry.counter
@@ -117,8 +119,14 @@ end
 -- usage.post(api_url, router_token, report, post_fn)
 -- ---------------------------------------------------------------------------
 function M.post(api_url, router_token, report, post_fn)
-  local json = require("cjson")
-  local body = json.encode(report)
+  local jsonc = require("luci.jsonc")
+  -- luci.jsonc encodes empty Lua tables as `{}` (object). The API requires
+  -- `records` to be a JSON array, so when no usage was observed in this
+  -- window, skip the POST entirely rather than send a malformed payload.
+  if report.records and next(report.records) == nil then
+    return true
+  end
+  local body = jsonc.stringify(report)
   local url  = api_url .. "/api/router/usage"
   local hdrs = {
     ["Authorization"] = "Bearer " .. router_token,

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -8,7 +8,7 @@
 set -e
 cd "$(dirname "$0")/.."
 
-LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/familydns/?.lua;$(lua -e 'print(package.path)')" \
+LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/familydns/?.lua;./test/shim/?.lua;./test/shim/?/init.lua;$(lua -e 'print(package.path)')" \
   busted test/conntrack_spec.lua \
          test/render_spec.lua \
          test/policy_spec.lua \

--- a/openwrt/test/shim/luci/jsonc.lua
+++ b/openwrt/test/shim/luci/jsonc.lua
@@ -1,0 +1,18 @@
+-- Test-only shim: on OpenWrt, the agent uses luci-lib-jsonc (luci.jsonc).
+-- That C module isn't on luarocks, so for local/CI tests we provide a thin
+-- compatibility layer over lua-cjson with the two methods we actually call.
+local cjson = require("cjson")
+
+local M = {}
+
+function M.parse(s)
+  local ok, val = pcall(cjson.decode, s)
+  if not ok then return nil end
+  return val
+end
+
+function M.stringify(v)
+  return cjson.encode(v)
+end
+
+return M

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -185,14 +185,18 @@ end)
 
 describe("usage.post", function()
 
+  local SAMPLE_REC = { mac="aa:bb:cc:11:22:33", hostname="x", activeSeconds=300, bytesIn=1, bytesOut=0 }
+  local function with_records()
+    return { routerId = "r1", periodStart = "t0", periodEnd = "t1", records = { SAMPLE_REC } }
+  end
+
   it("POSTs to /api/router/usage with correct Authorization header", function()
     local got_url, got_hdrs, got_body
     local function post_fn(url, body, hdrs)
       got_url = url; got_body = body; got_hdrs = hdrs
       return 200, ""
     end
-    local report = { routerId = "r1", periodStart = "t0", periodEnd = "t1", records = {} }
-    local ok = usage.post("http://api:8080", "rt_tok", report, post_fn)
+    local ok = usage.post("http://api:8080", "rt_tok", with_records(), post_fn)
     assert.is_true(ok)
     assert.truthy(got_url:find("/api/router/usage", 1, true))
     assert.equal("Bearer rt_tok", got_hdrs["Authorization"])
@@ -202,8 +206,7 @@ describe("usage.post", function()
     local json = require("cjson")
     local got_body
     local function post_fn(_url, body, _hdrs) got_body = body; return 200, "" end
-    local report = { routerId = "r1", periodStart = "t0", periodEnd = "t1", records = {} }
-    usage.post("http://api:8080", "rt_tok", report, post_fn)
+    usage.post("http://api:8080", "rt_tok", with_records(), post_fn)
     local dec = json.decode(got_body)
     assert.equal("r1", dec.routerId)
   end)
@@ -211,18 +214,26 @@ describe("usage.post", function()
   it("sets Content-Type: application/json", function()
     local got_hdrs
     local function post_fn(_url, _body, hdrs) got_hdrs = hdrs; return 200, "" end
-    usage.post("http://api:8080", "rt_tok", {records={}}, post_fn)
+    usage.post("http://api:8080", "rt_tok", with_records(), post_fn)
     assert.equal("application/json", got_hdrs["Content-Type"])
   end)
 
   it("returns false on HTTP 5xx", function()
     local function post_fn(_url, _body, _hdrs) return 500, "error" end
-    assert.is_false(usage.post("http://api:8080", "rt_tok", {records={}}, post_fn))
+    assert.is_false(usage.post("http://api:8080", "rt_tok", with_records(), post_fn))
   end)
 
   it("returns false when post_fn returns nil status (connection failure)", function()
     local function post_fn(_url, _body, _hdrs) return nil, "" end
-    assert.is_false(usage.post("http://api:8080", "rt_tok", {records={}}, post_fn))
+    assert.is_false(usage.post("http://api:8080", "rt_tok", with_records(), post_fn))
+  end)
+
+  it("skips POST and returns true when records is empty", function()
+    local called = false
+    local function post_fn(_url, _body, _hdrs) called = true; return 200, "" end
+    local report = { routerId = "r1", periodStart = "t0", periodEnd = "t1", records = {} }
+    assert.is_true(usage.post("http://api:8080", "rt_tok", report, post_fn))
+    assert.is_false(called)
   end)
 
 end)


### PR DESCRIPTION
## Summary

Fixes #203. The agent was crashing on the first policy fetch / conntrack
flush / usage tick with `module 'cjson' not found` — the OpenWrt package
only declares a dependency on `luci-lib-jsonc` (which exports
`require("luci.jsonc")`), not the separate `lua-cjson` rock.

Rather than add `lua-cjson` as a second JSON library to all three
package-dep locations, this PR migrates the four call sites to the
`luci.jsonc` API we already ship:

- [`policy.lua`](openwrt/files/usr/lib/lua/familydns/policy.lua) — snapshot decode
- [`conntrack.lua`](openwrt/files/usr/lib/lua/familydns/conntrack.lua) — events batch encode
- [`usage.lua`](openwrt/files/usr/lib/lua/familydns/usage.lua) — nft counters decode
- [`usage.lua`](openwrt/files/usr/lib/lua/familydns/usage.lua) — usage report encode

## API differences handled

- `cjson.decode` raises on bad input; `luci.jsonc.parse` returns `nil`.
  Both call sites now check for `nil`. `policy.fetch` additionally
  surfaces the real pcall error in its log line — the old
  `"JSON decode failed"` message was emitted on require() failure too,
  which sent the triage for this very bug down the wrong path.
- `cjson` encodes an empty Lua table as `[]`; `luci.jsonc` encodes it
  as `{}`. The events batch is already guarded (`batcher.flush` is a
  no-op on empty buffer). The usage report wasn't — so `usage.post` now
  skips the POST entirely when `records` is empty, which is the right
  behavior anyway (no traffic in window → nothing to report).

## Tests

Tests still use `lua-cjson` directly as a JSON round-trip utility.
A small shim under `openwrt/test/shim/luci/jsonc.lua` provides the
`luci.jsonc` surface for tests so the production modules load under
the busted runner; `LUA_PATH` in `run_tests.sh` and `ci.yml` is
updated to find it.

77 / 79 specs pass locally (the 2 failures are pre-existing in
`render_spec.lua`, unrelated to this change).

## Test plan

- [ ] CI green
- [ ] After `v0.1.4` (#205) ships, tag this as `v0.1.5` and verify the
      openwrt-build workflow succeeds
- [ ] On a 24.10 router, install the new `.apk` and confirm the agent
      no longer crashes on policy fetch / conntrack events / usage tick
- [ ] Confirm policy snapshot decode still works (router applies a
      remote policy)
- [ ] Confirm events batch POST still works (router posts a connection
      event to `/api/router/events`)
- [ ] Confirm usage POST still works when records is non-empty and is
      correctly skipped when empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)