### PR TITLE
openwrt: URL-encode policy etag in ?since= query (fixes #213)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -15,13 +15,26 @@ local M = {}
 
 local render = require("familydns.render")
 
+-- Percent-encode characters that would break a query-string value:
+-- the canonical HTTP etag is wrapped in literal `"` characters, which a raw
+-- concatenation would emit into the URL and break server-side routing.
+-- Encodes `"`, space, `?`, `#`, `&`, `=`, `+`, `%`, control bytes, and any
+-- non-ASCII byte. Leaves `:` and other pchars (e.g. in `sha256:abc`) alone.
+local function urlencode(s)
+  return (s:gsub("[%c%z\"%%%+%&%=%?%# ]", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end):gsub("[\128-\255]", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
 -- ---------------------------------------------------------------------------
 -- policy.fetch
 -- ---------------------------------------------------------------------------
 function M.fetch(api_url, router_token, etag, http_get_fn)
   local url = api_url .. "/api/router/policy"
   if etag then
-    url = url .. "?since=" .. etag
+    url = url .. "?since=" .. urlencode(etag)
   end
 
   local hdrs = { ["Authorization"] = "Bearer " .. router_token }

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -81,6 +81,22 @@ describe("policy.fetch", function()
     assert.truthy(called_url:find("sha256:prev", 1, true))
   end)
 
+  it("URL-encodes the etag in the ?since= param so quotes are not literal", function()
+    local called_url
+    local function get_fn(url, _hdrs)
+      called_url = url
+      return 304, "", {}
+    end
+    -- Canonical HTTP etag includes surrounding double quotes.
+    policy.fetch("http://api:8080", "rt_tok", '"sha256:abc123"', get_fn)
+    assert.truthy(called_url)
+    assert.is_nil(called_url:find('"', 1, true),
+      "URL must not contain literal double-quote characters: " .. tostring(called_url))
+    -- Sanity: the encoded form should appear.
+    assert.truthy(called_url:find("%22", 1, true),
+      "expected percent-encoded quote (%22) in URL: " .. tostring(called_url))
+  end)
+
   it("returns nil, nil on a 5xx error", function()
     local function get_fn(_url, _hdrs) return 503, "unavailable", {} end
     local snap, etag = policy.fetch("http://api:8080", "rt_tok", nil, get_fn)


### PR DESCRIPTION
## Summary

Fixes #213. The router agent's policy fetcher was concatenating the canonical HTTP etag (which includes literal `"` characters, e.g. `"sha256:abc..."`) directly into the request URL. The resulting URL had unencoded quotes and broke server-side routing — the agent ended up parsing the SPA's `index.html` as JSON.

## Fix

Percent-encode the etag before appending it to `?since=`. A small inline helper in [policy.lua](openwrt/files/usr/lib/lua/familydns/policy.lua) encodes `"`, space, `?`, `#`, `&`, `=`, `+`, `%`, control bytes, and non-ASCII — leaving common safe pchars like `:` alone. The `If-None-Match: <etag>` header (lines 28-30) is unchanged, so the server still gets the etag via the header path.

## Test plan

- [x] New unit test in [policy_spec.lua](openwrt/test/policy_spec.lua) passes an etag containing `"` and asserts the captured URL has no literal `"` (and does contain `%22`).
- [x] Existing policy tests still pass (the `:` in `sha256:prev` is preserved by the encoder).
- [x] Pre-existing render_spec failures are unrelated to this change.