### PR TITLE
scripts: add dev-push-router.sh for OpenWRT agent debugging

### DIFF
--- a/scripts/dev-push-router.sh
+++ b/scripts/dev-push-router.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Iterative dev loop for the OpenWRT agent: rsync the lua sources to the
+# router, restart the service, and (optionally) tail the system log.
+#
+# Usage:
+#   scripts/dev-push-router.sh                  # push + restart
+#   scripts/dev-push-router.sh tail             # push + restart + follow logread
+#   scripts/dev-push-router.sh logs             # just tail logread (no push)
+#   ROUTER=root@192.168.1.1 scripts/dev-push-router.sh
+#
+# This only syncs the Lua files under openwrt/files/usr/lib/lua/familydns/.
+# If you change init scripts, UCI defaults, or the C/nft side, do a full
+# package rebuild + install instead.
+
+set -euo pipefail
+
+ROUTER="${ROUTER:-root@192.168.1.1}"
+SRC="$(cd "$(dirname "$0")/.." && pwd)/openwrt/files/usr/lib/lua/familydns/"
+DST="/usr/lib/lua/familydns/"
+
+cmd="${1:-push}"
+
+push() {
+  echo "==> tar | ssh $SRC -> $ROUTER:$DST"
+  # BusyBox on OpenWRT has no rsync; pipe a tarball instead.
+  ( cd "$SRC" && tar -cf - --exclude='*.swp' . ) \
+    | ssh "$ROUTER" "mkdir -p '$DST' && tar -xf - -C '$DST'"
+  echo "==> restart familydns"
+  ssh "$ROUTER" '/etc/init.d/familydns restart'
+}
+
+tail_logs() {
+  echo "==> logread -f (Ctrl-C to stop)"
+  ssh -t "$ROUTER" 'logread -f | grep --line-buffered familydns'
+}
+
+case "$cmd" in
+  push)        push ;;
+  tail|watch)  push; tail_logs ;;
+  logs)        tail_logs ;;
+  *)           echo "unknown: $cmd (use: push | tail | logs)" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- Adds `scripts/dev-push-router.sh`, a small helper that syncs the Lua agent sources to a test OpenWRT router and restarts the service, for tight edit→push→observe iteration.
- Uses `tar | ssh` instead of rsync (BusyBox routers have no rsync).
- Supports three modes: `push` (default), `tail` (push + follow `logread`), and `logs` (tail only). `ROUTER=` env var overrides the default `root@192.168.1.1`.

## Why

Debugging Lua agent changes via a full `.ipk` rebuild + reinstall is slow. This gives a one-command loop for iterating on in-progress Lua changes against a real router. Discovered this session while diagnosing #213 / #214 / #215 — was an effective workflow.

Caveat: only syncs `openwrt/files/usr/lib/lua/familydns/`. Changes to init scripts, UCI defaults, or the package layout still need a real package rebuild.

## Test plan

- [x] `scripts/dev-push-router.sh push` syncs and restarts against a live router
- [x] `scripts/dev-push-router.sh tail` follows familydns-filtered logread
- [x] Confirmed BusyBox tar on the receiving end accepts the pipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)