### PR TITLE
api+openwrt: log + fix POST /api/router/events deserialization (fixes #215)

### DIFF
--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -46,18 +46,30 @@ object RouterIngestRoutes {
         },
       Method.POST / "api" / "router" / "events" ->
         handler { (req: Request) =>
-          for {
+          val handle = for {
             router <- auth.authenticate(req)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             rep    <- ZIO
               .fromEither(body.fromJson[RouterEventsRequest])
+              .tapError(e =>
+                ZIO.logWarning(
+                  s"router events: deserialization failed for router=${router.id} bodyLen=${body.length} err=$e",
+                ),
+              )
               .mapError(e => Response.badRequest(e))
             _      <- ZIO
-              .fail(Response.badRequest("router_id mismatch"))
+              .logWarning(
+                s"router events: routerId mismatch token=${router.id} body=${rep.routerId}",
+              )
+              .zipRight(ZIO.fail(Response.badRequest("router_id mismatch")))
               .when(rep.routerId != router.id)
+            _      <- ZIO.logInfo(
+              s"router events: router=${router.id} batchSize=${rep.events.size}",
+            )
             _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo)
             _      <- routerRepo.touch(router.id, None).orElseFail(Response.internalServerError(""))
           } yield Response.ok
+          handle.tapError(r => ZIO.logInfo(s"router events: returning status=${r.status.code}"))
         },
     )
 

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -374,6 +374,31 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(kp.timeUsedToday.totalMinutes >= kp.dailyMinutes.get) &&
         assertTrue(d.exists(_.lastSeenIp.contains("192.168.1.42")))
     },
+    test("events: accepts the raw JSON shape the OpenWRT Lua agent emits (regression for #215)") {
+      // Verbatim payload shape produced by openwrt/files/usr/lib/lua/familydns/conntrack.lua
+      // build_event + jsonc.stringify({ routerId, events }). Hand-rolled rather than going
+      // through RouterEventsRequest.toJson so that any drift in case-class field names
+      // (snake_case → camelCase regressions etc.) is caught by deserialization here.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        rawBody = s"""{
+          "routerId":"$id",
+          "events":[
+            {"type":"connection_attempt","mac":"$knownMac","hostname":"youtube.com",
+             "destIp":"1.2.3.4","allowed":false,"reason":"category:adult",
+             "ts":"2026-05-07T14:01:14Z"}
+          ]
+        }"""
+        resp <- post(routes, "/api/router/events", rawBody, Some(tk))
+        rows <- cRepo.listForRouter(id, 100)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(rows.exists(r => r.hostname == "youtube.com" && !r.allowed))
+    },
     test("events: first_seen_mac creates an unknown-device row when missing") {
       for {
         _        <- cleanDb

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -56,27 +56,43 @@ local function http_post(url, body, headers)
   for k, v in pairs(headers or {}) do
     hdr_args = hdr_args .. string.format(" -H %q", k .. ": " .. v)
   end
-  -- Capture body to a tmp file, status code on stdout, curl stderr to another tmp file.
-  -- This lets us surface the response body and connection-failure messages
-  -- (curl exit codes / "Connection refused" / TLS errors) on failure.
+  -- Write the request body to a tmp file and have curl read it with
+  -- `--data-binary @file`.  An earlier version piped the body via
+  -- `printf '%%s' "..."` — but that string was built with `..` concatenation,
+  -- not `string.format`, so `%%s` was passed *literally* to printf, which
+  -- emitted just `%s` (the body argument was ignored).  Every POST request
+  -- was sending the two-character body `%s`, so the server returned 400 on
+  -- every batch.  The file-based approach also sidesteps shell-quoting
+  -- pitfalls for arbitrary body contents (`$`, backticks, newlines).
   local body_tmp = os.tmpname()
+  local resp_tmp = os.tmpname()
   local err_tmp  = os.tmpname()
+
+  local bf, werr = io.open(body_tmp, "w")
+  if not bf then
+    os.remove(body_tmp); os.remove(resp_tmp); os.remove(err_tmp)
+    return nil, "", werr or "could not write request body tmp file"
+  end
+  bf:write(body)
+  bf:close()
+
   local cmd = string.format(
-    "curl -sS -o %q -w '%%{http_code}' -X POST%s --data-binary @- %q 2>%q",
-    body_tmp, hdr_args, url, err_tmp)
-  local pipe = io.popen("printf '%%s' " .. string.format("%q", body) .. " | " .. cmd, "r")
+    "curl -sS -o %q -w '%%{http_code}' -X POST%s --data-binary @%q %q 2>%q",
+    resp_tmp, hdr_args, body_tmp, url, err_tmp)
+  local pipe = io.popen(cmd, "r")
   if not pipe then
-    os.remove(body_tmp); os.remove(err_tmp)
-    return nil, nil, "io.popen failed"
+    os.remove(body_tmp); os.remove(resp_tmp); os.remove(err_tmp)
+    return nil, "", "io.popen failed"
   end
   local code_str = pipe:read("*a") or ""
   pipe:close()
+  os.remove(body_tmp)
   local code = tonumber((code_str:gsub("%s+$", "")))
 
   local resp_body = ""
-  local bf = io.open(body_tmp, "r")
-  if bf then resp_body = bf:read("*a") or ""; bf:close() end
-  os.remove(body_tmp)
+  local rf = io.open(resp_tmp, "r")
+  if rf then resp_body = rf:read("*a") or ""; rf:close() end
+  os.remove(resp_tmp)
 
   local err_str
   local ef = io.open(err_tmp, "r")
@@ -89,7 +105,6 @@ local function http_post(url, body, headers)
   os.remove(err_tmp)
 
   if not code then
-    -- Connection error (no HTTP status). Prefer curl's stderr; fall back generic.
     return nil, resp_body, err_str or "curl: connection error"
   end
   return code, resp_body, err_str


### PR DESCRIPTION
## Summary

- The OpenWRT agent's `http_post` was sending the literal two-character string `%s` as the request body, so the API returned 400 on every batch. Fix: write body to a tmp file and use `curl --data-binary @file`.
- Add structured logging on `POST /api/router/events` (router id, batch size, deserialization error, returned status) so this is diagnosable next time.
- Add a regression test that feeds the verbatim camelCase JSON the Lua agent emits, hand-rolled rather than round-tripped through the case class.

## Root cause (Part B)

In `openwrt/files/usr/sbin/familydns-agent`:

```lua
local pipe = io.popen(
  "printf '%%s' " .. string.format("%q", body) .. " | " .. cmd, "r")
```

The leading string is plain Lua `..` concatenation, **not** `string.format` — so `%%` is two literal `%` characters, not a percent-escape. The shell ran `printf '%%s' "<body>"`, printf interpreted `%%` → `%` and `s` → `s`, emitted `%s`, and ignored the body argument entirely. Every POST request (events *and* usage) has been sending the body `%s` since this file was first written.

Rewriting the helper to spool the body to a tmp file and pass `--data-binary @file` is the simpler, less foot-gun-y fix and also avoids shell-quoting issues for bodies containing `$`, backticks, or newlines.

## Test plan

- [x] `mill api.test.testOnly familydns.api.feature.RouterIngestSpec` — 15/15 pass, including the new `#215` regression test
- [x] `sh openwrt/test/run_tests.sh` — no new failures (2 pre-existing render_spec failures untouched)
- [x] New log lines visible in test output, e.g. `router events: router=… batchSize=1`
- [ ] Deploy to a real router and confirm event batches stop returning 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)