### PR TITLE
api: don't serve SPA index.html for /api/* paths (fixes #214)

### DIFF
--- a/api/src/routes/StaticRoutes.scala
+++ b/api/src/routes/StaticRoutes.scala
@@ -40,16 +40,25 @@ object StaticRoutes {
         )
 
     Routes(
-      Method.GET / trailing -> handler { (path: Path, _: Request) =>
-        val rel = path.encode.stripPrefix("/")
-        if rel.startsWith("api/") then ZIO.succeed(Response.notFound)
-        else
-          resolve(rel) match {
-            case Some(f) => serve(f)
-            case None    =>
-              if index.isFile then serve(index)
-              else ZIO.succeed(Response.notFound)
-          }
+      Method.GET / trailing -> handler { (_: Path, req: Request) =>
+        // Use req.url.path rather than the trailing-captured path: zio-http
+        // substitutes URL.empty (encode == "") when netty can't parse the
+        // request URI — e.g. unencoded `"` in a query string (issue #214).
+        // The real "/" gives encode == "/", so this distinguishes them.
+        val encoded = req.url.path.encode
+        if encoded.isEmpty then ZIO.succeed(Response.badRequest("malformed request URI"))
+        else {
+          val rel = encoded.stripPrefix("/")
+          if rel.startsWith("api/") then
+            ZIO.succeed(Response.notFound(s"no such API route: ${req.method} /$rel"))
+          else
+            resolve(rel) match {
+              case Some(f) => serve(f)
+              case None    =>
+                if index.isFile then serve(index)
+                else ZIO.succeed(Response.notFound)
+            }
+        }
       },
     )
   }

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -76,6 +76,32 @@ object StaticRoutesSpec extends ZIOSpecDefault {
         } yield assertTrue(resp.status == Status.NotFound)
       }
     },
+    test("refuses to serve SPA for unparseable request URI (zio-http URL.empty fallback)") {
+      withTempDir { dir =>
+        for {
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          // zio-http substitutes URL.empty when netty can't parse the URI —
+          // e.g. when the agent issued GET /api/router/policy?since="..." with
+          // literal unencoded quotes (see issue #214).
+          resp <- rs(Request.get(URL.empty)).merge
+          ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
+        } yield assertTrue(resp.status.code >= 400 && resp.status.code < 500) &&
+          assertTrue(!ct.startsWith("text/html"))
+      }
+    },
+    test("returns 404 (not SPA) for /api/router/* even with malformed query string") {
+      withTempDir { dir =>
+        for {
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          rs = StaticRoutes.routes(dir.getAbsolutePath)
+          // mimic the agent bug: literal unencoded quotes in the query string
+          resp <- get(rs, "/api/router/policy?since=%22bogus%22")
+          ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
+        } yield assertTrue(resp.status.code >= 400 && resp.status.code < 500) &&
+          assertTrue(!ct.startsWith("text/html"))
+      }
+    },
     test("rejects path traversal attempts") {
       withTempDir { dir =>
         for {


### PR DESCRIPTION
## Summary

Fixes #214 — `GET /api/router/policy?since="bogus"` (or any `/api/*` request with a query string netty can't parse) was returning `200 OK` with `Content-Type: text/html` and the SPA's `index.html`.

**Root cause:** zio-http's netty handler calls `URL.decode(uri).getOrElse(URL.empty)` — when decode fails, the request arrives with `URL.empty` (path encode is `""`). The trailing handler in `StaticRoutes` then ran with an empty path, missed the `if rel.startsWith("api/")` guard, and fell through to `index.html`.

**Fix:** in the trailing handler, use `req.url.path.encode` (not the trailing-captured `path`, which is empty for both `/` and `URL.empty`) and return `400` when the encode is empty — that's the URI-parse-failure signal. Also added a body to the `/api/*` 404 so API misuse is more obvious.

## Test plan

- [x] `mill api.test.testOnly familydns.api.feature.StaticRoutesSpec` — added two new cases (combined-route malformed query, `URL.empty` fallback) plus the existing five all pass
- [x] `mill api.test` — full suite still green