### PR TITLE
openwrt: emit first_seen_mac events for new MACs (fixes #221)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -64,6 +64,49 @@ function M.parse_arp_table()
 end
 
 -- ---------------------------------------------------------------------------
+-- parse_dhcp_leases(path) -> { mac -> { ip = string, hostname = string|nil } }
+--
+-- Reads a dnsmasq lease file (default /tmp/dhcp.leases).  Each line is:
+--   <expiry-epoch> <mac> <ip> <hostname-or-*> <client-id-or-*>
+-- A hostname of "*" is treated as absent (nil).
+-- Returns an empty table if the file can't be opened.
+-- ---------------------------------------------------------------------------
+function M.parse_dhcp_leases(path)
+  local result = {}
+  local f = io.open(path or "/tmp/dhcp.leases", "r")
+  if not f then return result end
+  for line in f:lines() do
+    local parts = {}
+    for w in line:gmatch("%S+") do parts[#parts + 1] = w end
+    if #parts >= 3 then
+      local mac      = parts[2]
+      local ip       = parts[3]
+      local hostname = parts[4]
+      if hostname == "*" or hostname == "" then hostname = nil end
+      result[mac] = { ip = ip, hostname = hostname }
+    end
+  end
+  f:close()
+  return result
+end
+
+-- ---------------------------------------------------------------------------
+-- build_first_seen_mac_event(opts) -> table
+--
+-- opts: { mac, ip, hostname, ts }
+-- ip / hostname may be nil (e.g. MAC has no DHCP lease — static IP client).
+-- ---------------------------------------------------------------------------
+function M.build_first_seen_mac_event(opts)
+  return {
+    ["type"] = "first_seen_mac",
+    mac      = opts.mac,
+    ip       = opts.ip,
+    hostname = opts.hostname,
+    ts       = opts.ts,
+  }
+end
+
+-- ---------------------------------------------------------------------------
 -- build_event(opts) -> table
 --
 -- opts: { mac, hostname, dest_ip, allowed, reason, ts }
@@ -173,6 +216,51 @@ function M.post_with_retry(url, body, max_retries, base_delay, post_fn, sleep_fn
 end
 
 -- ---------------------------------------------------------------------------
+-- handle_flow(flow, ctx, batcher)
+--
+-- Processes a single outbound flow: emits a first_seen_mac event the first
+-- time we observe a given MAC, then always emits a connection_attempt event.
+--
+-- ctx: {
+--   arp_table      table   { ip -> mac }
+--   nft_sets       table   { hostname -> { ip -> true } }
+--   blocked_ips    table   { ip -> true }
+--   blocked_reason table   { ip -> reason }
+--   reported_macs  table   { mac -> true }  (mutated)
+--   leases         table   { mac -> { ip, hostname } } (may be nil/empty)
+--   ts             string  ISO8601 timestamp to attach to the events
+-- }
+-- ---------------------------------------------------------------------------
+function M.handle_flow(flow, ctx, batcher)
+  local mac = M.arp_lookup_mac(flow.src_ip, ctx.arp_table or {})
+
+  if mac and not (ctx.reported_macs or {})[mac] then
+    local lease = (ctx.leases or {})[mac]
+    local ip, hostname
+    if lease then ip = lease.ip; hostname = lease.hostname end
+    batcher.add(M.build_first_seen_mac_event({
+      mac = mac, ip = ip, hostname = hostname, ts = ctx.ts,
+    }))
+    if ctx.reported_macs then ctx.reported_macs[mac] = true end
+  end
+
+  local hname = M.ipset_lookup_hostname(flow.dst_ip, ctx.nft_sets or {})
+  local allowed = not (ctx.blocked_ips and ctx.blocked_ips[flow.dst_ip])
+  local reason
+  if not allowed and ctx.blocked_reason then
+    reason = ctx.blocked_reason[flow.dst_ip]
+  end
+  batcher.add(M.build_event({
+    mac      = mac,
+    hostname = hname,
+    dest_ip  = flow.dst_ip,
+    allowed  = allowed,
+    reason   = reason,
+    ts       = ctx.ts,
+  }))
+end
+
+-- ---------------------------------------------------------------------------
 -- parse_conntrack_line(line) -> { src_ip, dst_ip, proto, dport } | nil
 --
 -- Parses a line from `conntrack -E -e NEW`.  Example input:
@@ -257,31 +345,32 @@ function M.watch(cfg)
     return
   end
 
+  local reported_macs = {}
+  local leases_path   = cfg.leases_path or "/tmp/dhcp.leases"
+
   while true do
     local line = handle:read("*l")
     if not line then break end
 
     local flow = M.parse_conntrack_line(line)
     if flow and M.is_outbound(flow, lan_prefix) then
-      local arp   = M.parse_arp_table()
-      local mac   = M.arp_lookup_mac(flow.src_ip, arp)
-      local hname = M.ipset_lookup_hostname(flow.dst_ip, cfg.nft_sets or {})
-
-      local allowed = not (cfg.blocked_ips and cfg.blocked_ips[flow.dst_ip])
-      local reason
-      if not allowed and cfg.blocked_reason then
-        reason = cfg.blocked_reason[flow.dst_ip]
+      local arp = M.parse_arp_table()
+      local mac_candidate = M.arp_lookup_mac(flow.src_ip, arp)
+      -- Only parse the lease file when we actually need it (new MAC).
+      local leases
+      if mac_candidate and not reported_macs[mac_candidate] then
+        leases = M.parse_dhcp_leases(leases_path)
       end
 
-      local ev = M.build_event({
-        mac      = mac,
-        hostname = hname,
-        dest_ip  = flow.dst_ip,
-        allowed  = allowed,
-        reason   = reason,
-        ts       = os.date("!%Y-%m-%dT%H:%M:%SZ"),
-      })
-      batcher.add(ev)
+      M.handle_flow(flow, {
+        arp_table      = arp,
+        nft_sets       = cfg.nft_sets or {},
+        blocked_ips    = cfg.blocked_ips,
+        blocked_reason = cfg.blocked_reason,
+        reported_macs  = reported_macs,
+        leases         = leases or {},
+        ts             = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+      }, batcher)
     end
 
     batcher.tick()

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -177,6 +177,139 @@ describe("batcher", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 4b. parse_dhcp_leases
+-- ---------------------------------------------------------------------------
+
+describe("parse_dhcp_leases", function()
+  local function write_tmp(contents)
+    local path = os.tmpname()
+    local f = assert(io.open(path, "w"))
+    f:write(contents)
+    f:close()
+    return path
+  end
+
+  it("returns an empty table when the file doesn't exist", function()
+    local leases = conntrack.parse_dhcp_leases("/tmp/__does_not_exist_familydns__")
+    assert.same({}, leases)
+  end)
+
+  it("parses mac -> {ip, hostname} entries", function()
+    local path = write_tmp(
+      "1715000000 aa:bb:cc:11:22:33 192.168.1.42 laptop 01:aa:bb:cc:11:22:33\n" ..
+      "1715000001 de:ad:be:ef:00:01 192.168.1.99 phone *\n")
+    local leases = conntrack.parse_dhcp_leases(path)
+    os.remove(path)
+    assert.equal("192.168.1.42", leases["aa:bb:cc:11:22:33"].ip)
+    assert.equal("laptop",       leases["aa:bb:cc:11:22:33"].hostname)
+    assert.equal("192.168.1.99", leases["de:ad:be:ef:00:01"].ip)
+    assert.equal("phone",        leases["de:ad:be:ef:00:01"].hostname)
+  end)
+
+  it("treats a hostname of '*' as nil", function()
+    local path = write_tmp("1715000000 aa:bb:cc:11:22:33 192.168.1.42 * *\n")
+    local leases = conntrack.parse_dhcp_leases(path)
+    os.remove(path)
+    assert.equal("192.168.1.42", leases["aa:bb:cc:11:22:33"].ip)
+    assert.is_nil(leases["aa:bb:cc:11:22:33"].hostname)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 4c. handle_flow — first_seen_mac emission semantics
+-- ---------------------------------------------------------------------------
+
+describe("handle_flow", function()
+  local MAC      = "aa:bb:cc:11:22:33"
+  local SRC_IP   = "192.168.1.42"
+  local DST_IP   = "1.2.3.4"
+
+  local function collecting_batcher()
+    local events = {}
+    return {
+      add   = function(ev) table.insert(events, ev) end,
+      flush = function() end,
+      tick  = function() end,
+      events = events,
+    }
+  end
+
+  local function ctx_with(overrides)
+    local base = {
+      arp_table      = { [SRC_IP] = MAC },
+      nft_sets       = {},
+      blocked_ips    = {},
+      blocked_reason = {},
+      reported_macs  = {},
+      leases         = {},
+      ts             = "2026-05-11T00:00:00Z",
+    }
+    for k, v in pairs(overrides or {}) do base[k] = v end
+    return base
+  end
+
+  it("emits first_seen_mac and connection_attempt on first flow from a new MAC", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+
+    assert.equal(2, #b.events)
+    assert.equal("first_seen_mac",     b.events[1]["type"])
+    assert.equal(MAC,                  b.events[1].mac)
+    assert.equal("connection_attempt", b.events[2]["type"])
+    assert.equal(MAC,                  b.events[2].mac)
+    assert.is_true(ctx.reported_macs[MAC])
+  end)
+
+  it("does not re-emit first_seen_mac on subsequent flows from the same MAC", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+    })
+
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "5.6.7.8" }, ctx, b)
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "9.9.9.9" }, ctx, b)
+
+    -- 1 first_seen_mac + 3 connection_attempts
+    assert.equal(4, #b.events)
+    assert.equal("first_seen_mac",     b.events[1]["type"])
+    assert.equal("connection_attempt", b.events[2]["type"])
+    assert.equal("connection_attempt", b.events[3]["type"])
+    assert.equal("connection_attempt", b.events[4]["type"])
+  end)
+
+  it("carries ip and hostname from the lease into the first_seen_mac event", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+
+    local ev = b.events[1]
+    assert.equal("first_seen_mac",  ev["type"])
+    assert.equal(MAC,               ev.mac)
+    assert.equal("192.168.1.42",    ev.ip)
+    assert.equal("laptop",          ev.hostname)
+    assert.equal("2026-05-11T00:00:00Z", ev.ts)
+  end)
+
+  it("emits first_seen_mac with nil ip/hostname when the MAC has no lease entry", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({ leases = {} })  -- no lease for this MAC
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+
+    local ev = b.events[1]
+    assert.equal("first_seen_mac", ev["type"])
+    assert.equal(MAC,              ev.mac)
+    assert.is_nil(ev.ip)
+    assert.is_nil(ev.hostname)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 5. Retry logic
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- The API's `applyDhcpOrFirstSeen` only fires for `dhcp_lease` or `first_seen_mac` events, but the agent never emitted either — so the `devices` table stayed empty and unknown LAN clients were never surfaced as candidates. This implements Option A from #221: emit `first_seen_mac` from conntrack.
- Adds `parse_dhcp_leases`, `build_first_seen_mac_event`, and a `handle_flow` helper extracted from `watch()`. `watch()` now keeps an in-memory `reported_macs` set and emits a `first_seen_mac` event the first time each MAC appears, enriched from `/tmp/dhcp.leases` when an entry exists. The `connection_attempt` event still fires on every flow.
- Lease file is parsed lazily — only when a new MAC is seen — so the common steady-state path is unchanged.

Fixes #221.

## Test plan

- [x] `sh openwrt/test/run_tests.sh` — new `parse_dhcp_leases` and `handle_flow` specs pass (the two `render_spec` failures are pre-existing on `main`).
- [ ] Redeploy to live router; confirm `first_seen_mac` events flow and `SELECT * FROM devices` populates within a minute or two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)