### PR TITLE
web: fix copy-to-clipboard on new router enrollment (fixes #196)

### DIFF
--- a/web/src/pages/RoutersPage.test.tsx
+++ b/web/src/pages/RoutersPage.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { CreateRouterResponse, RouterSummary } from '@/types/api'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    routers: {
+      list: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import { RoutersPage } from './RoutersPage'
+
+const existing: RouterSummary = {
+  id: 'r1', name: 'home-gw', enrolled: false,
+  lastSeenAt: null, lastEtag: null, createdAt: '2026-05-11T00:00:00Z',
+}
+
+const createResp: CreateRouterResponse = {
+  routerId: 'r2',
+  name: 'new-gw',
+  enrollmentToken: 'tok_ABCDEFG_1234567890',
+}
+
+// Force the execCommand fallback path — that's what runs in the user's real deploy
+// scenario (HTTP on a LAN IP, where navigator.clipboard is undefined and
+// window.isSecureContext is false). Stubbing jsdom's real Clipboard instance
+// from a test is brittle; testing the fallback path is what matters anyway,
+// since it's the one that was silently failing before this fix.
+function forceInsecureContext() {
+  Object.defineProperty(globalThis, 'isSecureContext', {
+    get: () => false, configurable: true,
+  })
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(api.routers.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([existing])
+  ;(api.routers.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(createResp)
+  forceInsecureContext()
+})
+
+async function openTokenDialog() {
+  const user = userEvent.setup()
+  render(<RoutersPage />)
+  await screen.findByText('home-gw')
+  await user.click(screen.getByRole('button', { name: /enroll router/i }))
+  await user.type(screen.getByPlaceholderText('home-gw'), 'new-gw')
+  await user.click(screen.getByRole('button', { name: /generate token/i }))
+  await screen.findByText(/Save this token now/i)
+  return user
+}
+
+describe('RoutersPage — copy to clipboard', () => {
+  it('copies the enrollment token via execCommand fallback on HTTP/LAN deploys', async () => {
+    const execCommand = vi.fn().mockReturnValue(true)
+    Object.defineProperty(document, 'execCommand', {
+      value: execCommand, configurable: true, writable: true,
+    })
+
+    const user = await openTokenDialog()
+    await user.click(screen.getByRole('button', { name: /copy enrollment token/i }))
+
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copy enrollment token/i }))
+        .toHaveTextContent(/copied/i)
+    })
+  })
+
+  it('shows a failure message when the copy fails so the user can fall back to manual select', async () => {
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn().mockReturnValue(false),
+      configurable: true, writable: true,
+    })
+
+    const user = await openTokenDialog()
+    await user.click(screen.getByRole('button', { name: /copy enrollment token/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copy enrollment token/i }))
+        .toHaveTextContent(/copy failed/i)
+    })
+  })
+
+  it('renders the token in a selectable readonly input as a manual-copy fallback', async () => {
+    await openTokenDialog()
+    const input = screen.getByDisplayValue(createResp.enrollmentToken) as HTMLInputElement
+    expect(input.tagName).toBe('INPUT')
+    expect(input.readOnly).toBe(true)
+  })
+})

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -11,6 +11,30 @@ export function RoutersPage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showToken, setShowToken] = useState<CreateRouterResponse | null>(null)
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  async function copyToken(text: string) {
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text)
+      } else {
+        const ta = document.createElement('textarea')
+        ta.value = text
+        ta.setAttribute('readonly', '')
+        ta.style.position = 'fixed'
+        ta.style.opacity = '0'
+        document.body.appendChild(ta)
+        ta.select()
+        const ok = document.execCommand('copy')
+        document.body.removeChild(ta)
+        if (!ok) throw new Error('execCommand copy failed')
+      }
+      setCopyState('copied')
+    } catch {
+      setCopyState('failed')
+    }
+    setTimeout(() => setCopyState('idle'), 2000)
+  }
 
   async function reload() {
     const list = await api.routers.list()
@@ -132,15 +156,30 @@ export function RoutersPage() {
             <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
               Enrollment token for {showToken.name}
             </label>
-            <code className="block w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-emerald-300 font-mono text-sm break-all">
-              {showToken.enrollmentToken}
-            </code>
+            <input
+              type="text"
+              readOnly
+              value={showToken.enrollmentToken}
+              onFocus={e => e.currentTarget.select()}
+              className="block w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-emerald-300 font-mono text-sm break-all"
+            />
           </div>
           <button
-            onClick={() => navigator.clipboard?.writeText(showToken.enrollmentToken)}
-            className="w-full py-2 rounded-xl bg-gray-800 text-gray-200 text-sm font-medium hover:bg-gray-700"
+            onClick={() => copyToken(showToken.enrollmentToken)}
+            aria-label="Copy enrollment token to clipboard"
+            className={`w-full py-2 rounded-xl text-sm font-medium transition-colors ${
+              copyState === 'copied'
+                ? 'bg-emerald-500/20 text-emerald-300'
+                : copyState === 'failed'
+                ? 'bg-red-500/20 text-red-300'
+                : 'bg-gray-800 text-gray-200 hover:bg-gray-700'
+            }`}
           >
-            Copy to clipboard
+            {copyState === 'copied'
+              ? 'Copied!'
+              : copyState === 'failed'
+              ? 'Copy failed — select the token above and copy manually'
+              : 'Copy to clipboard'}
           </button>
           <button
             onClick={() => setShowToken(null)}


### PR DESCRIPTION
## Summary
- The `Copy to clipboard` button in the new-router enrollment dialog used `navigator.clipboard?.writeText(...)` with optional chaining. Over plain HTTP on a LAN IP (the actual deploy scenario), `navigator.clipboard` is `undefined` and the click silently no-ops.
- Add an `execCommand('copy')` fallback for insecure contexts, plus visible `Copied!` / `Copy failed` button feedback for 2s.
- Render the token as a readonly `<input>` (auto-selects on focus) so the user can always select-and-copy manually if both paths fail.

Closes #196. Context for [#227](https://github.com/sameerparekh/familydns/issues/227) install-path UX audit.

## Test plan
- [x] `npx vitest run` — 69 tests pass, including 3 new ones in `web/src/pages/RoutersPage.test.tsx` covering the fallback path, the failure feedback, and the manual-select input.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: open the API over HTTP on LAN, enroll a router, click "Copy to clipboard", verify the button flashes "Copied!" and the token is on the clipboard.
- [ ] Manual: open over HTTPS / localhost, verify the secure-context branch still uses `navigator.clipboard.writeText`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)