### PR TITLE
openwrt: auto-updater script + 6h cron (closes #131)

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -25,9 +25,14 @@ endef
 define Build/Compile
 endef
 
+define Package/familydns/conffiles
+/etc/config/familydns
+endef
+
 define Package/familydns/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/familydns-agent $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/familydns-update $(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/usr/lib/lua/familydns
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/usr/lib/lua/familydns/*.lua $(1)/usr/lib/lua/familydns/
@@ -46,6 +51,13 @@ define Package/familydns/postinst
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
 /etc/init.d/familydns enable
+# Install cron entry for the auto-updater (every 6 hours).
+if ! grep -q familydns-update /etc/crontabs/root 2>/dev/null; then
+	mkdir -p /etc/crontabs
+	echo '0 */6 * * * /usr/sbin/familydns-update' >> /etc/crontabs/root
+	/etc/init.d/cron enable 2>/dev/null || true
+	/etc/init.d/cron restart 2>/dev/null || true
+fi
 endef
 
 $(eval $(call BuildPackage,familydns))

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -195,6 +195,40 @@ If the agent refuses to start, the most common cause is a missing or empty
 
 ## Update
 
+### Auto-update (default)
+
+The package installs `/usr/sbin/familydns-update` and a cron entry that runs
+it every 6 hours:
+
+```
+0 */6 * * * /usr/sbin/familydns-update
+```
+
+Each run hits the GitHub Releases API for the `latest` release, parses the
+`.ipk` asset version, and only invokes `opkg install --force-reinstall` when
+the released version is strictly newer than the installed one (verified via
+`opkg compare-versions`). All output goes to syslog under tag `familydns`
+(`logread | grep familydns`). `/etc/config/familydns` is declared as a
+conffile so the router token survives the upgrade — no re-enrollment.
+
+On OpenWRT 24.10+/SNAPSHOT (apk-only systems) the script exits silently;
+the parallel `.apk` track is in [#176](https://github.com/sameerparekh/familydns/issues/176).
+
+To force an update immediately:
+
+```sh
+/usr/sbin/familydns-update
+```
+
+To disable auto-updates (e.g. on a pinned router), edit the cron table and
+delete the `familydns-update` line:
+
+```sh
+crontab -e
+# remove the "0 */6 * * * /usr/sbin/familydns-update" line, save, exit
+/etc/init.d/cron restart
+```
+
 ### Manual update
 
 ```sh

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -36,8 +36,21 @@ cat > "$WORK/ctrl/postinst" <<'POSTINST'
 #!/bin/sh
 [ -n "$IPKG_INSTROOT" ] && exit 0
 /etc/init.d/familydns enable
+# Install cron entry for the auto-updater (every 6 hours).
+if ! grep -q familydns-update /etc/crontabs/root 2>/dev/null; then
+    mkdir -p /etc/crontabs
+    echo '0 */6 * * * /usr/sbin/familydns-update' >> /etc/crontabs/root
+    /etc/init.d/cron enable 2>/dev/null || true
+    /etc/init.d/cron restart 2>/dev/null || true
+fi
 POSTINST
 chmod 0755 "$WORK/ctrl/postinst"
+
+# Mark UCI config as a conffile so opkg preserves it across upgrades
+# (router_token must survive auto-updates; see #131).
+cat > "$WORK/ctrl/conffiles" <<'CONFFILES'
+/etc/config/familydns
+CONFFILES
 
 (cd "$WORK/ctrl" && tar czf "$WORK/control.tar.gz" .)
 

--- a/openwrt/files/usr/sbin/familydns-update
+++ b/openwrt/files/usr/sbin/familydns-update
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Auto-updater for the familydns package.
+# Checks GitHub Releases for a newer .ipk and upgrades in place.
+# opkg preserves /etc/config/familydns, so the router_token survives upgrades.
+# Safe to run from cron; logs to syslog under tag "familydns".
+set -u
+
+API_URL="https://api.github.com/repos/sameerparekh/familydns/releases/latest"
+
+log() { logger -t familydns "update: $*"; }
+
+# Skip silently on apk-only systems (OpenWRT 24.10+); the .apk track lives
+# elsewhere (see #176).
+command -v opkg >/dev/null 2>&1 || exit 0
+
+CURRENT=$(opkg info familydns 2>/dev/null | awk '/^Version:/{print $2; exit}')
+if [ -z "$CURRENT" ]; then
+  log "familydns not installed via opkg; nothing to update"
+  exit 0
+fi
+
+LATEST_URL=$(curl -sf "$API_URL" \
+  | jsonfilter -e '@.assets[*].browser_download_url' \
+  | grep -E '\.ipk$' \
+  | head -n1)
+if [ -z "$LATEST_URL" ]; then
+  log "could not resolve latest .ipk asset URL; skipping"
+  exit 0
+fi
+
+LATEST_VER=$(echo "$LATEST_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n1)
+if [ -z "$LATEST_VER" ]; then
+  log "could not parse version from $LATEST_URL; skipping"
+  exit 0
+fi
+
+# Prefer opkg's version comparator (handles 1.10.0 > 1.9.0); fall back to
+# string equality.
+if opkg compare-versions "$LATEST_VER" '>' "$CURRENT" 2>/dev/null; then
+  :
+elif [ "$LATEST_VER" = "$CURRENT" ]; then
+  exit 0
+else
+  # compare-versions said not-newer (could be equal or older). Either way no upgrade.
+  exit 0
+fi
+
+log "upgrading $CURRENT -> $LATEST_VER"
+TMP=/tmp/familydns-update.ipk
+if ! curl -fsSL -o "$TMP" "$LATEST_URL"; then
+  log "download failed: $LATEST_URL"
+  rm -f "$TMP"
+  exit 1
+fi
+
+if opkg install --force-reinstall "$TMP" >/tmp/familydns-update.log 2>&1; then
+  log "installed $LATEST_VER"
+  rm -f "$TMP" /tmp/familydns-update.log
+else
+  log "opkg install failed; see /tmp/familydns-update.log"
+  rm -f "$TMP"
+  exit 1
+fi

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -17,3 +17,4 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/familydns/?.lua;./test/s
 
 echo ""
 sh test/init_spec.sh
+sh test/update_spec.sh

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Shell-level smoke tests for openwrt/files/usr/sbin/familydns-update
+# and the cron-install postinst hook in openwrt/build-ipk.sh and Makefile.
+# Run from the openwrt/ directory:  sh test/update_spec.sh
+set -e
+
+PASS=0; FAIL=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/files/usr/sbin/familydns-update"
+MAKEFILE="$ROOT/Makefile"
+BUILDER="$ROOT/build-ipk.sh"
+
+check() {
+  if [ "$2" = "ok" ]; then
+    printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "$1" "$2"; FAIL=$((FAIL + 1))
+  fi
+}
+
+[ -f "$SCRIPT" ] || { printf "MISSING: %s\n" "$SCRIPT"; exit 1; }
+
+# 1. Executable bit
+[ -x "$SCRIPT" ] \
+  && check "update script is executable" ok \
+  || check "update script is executable" "missing +x bit"
+
+# 2. Logs to syslog under familydns tag
+grep -q 'logger -t familydns' "$SCRIPT" \
+  && check "logs to syslog tag familydns" ok \
+  || check "logs to syslog tag familydns" "no logger -t familydns"
+
+# 3. Bails silently on apk-only systems (no opkg)
+grep -q 'command -v opkg' "$SCRIPT" \
+  && check "checks for opkg presence (apk-only safe)" ok \
+  || check "checks for opkg presence (apk-only safe)" "missing command -v opkg guard"
+
+# 4. Uses opkg compare-versions for robust version compare
+grep -q 'opkg compare-versions' "$SCRIPT" \
+  && check "uses opkg compare-versions" ok \
+  || check "uses opkg compare-versions" "missing — string compare alone breaks 1.10 vs 1.9"
+
+# 5. Hits GitHub releases/latest API
+grep -q 'releases/latest' "$SCRIPT" \
+  && check "fetches GitHub latest release" ok \
+  || check "fetches GitHub latest release" "wrong API endpoint"
+
+# 6. Installs with --force-reinstall (preserves conffiles)
+grep -q 'opkg install --force-reinstall' "$SCRIPT" \
+  && check "uses opkg install --force-reinstall" ok \
+  || check "uses opkg install --force-reinstall" "must --force-reinstall"
+
+# 7. Cleans up the downloaded .ipk
+grep -qE 'rm -f .*(\.ipk|\$TMP|"\$TMP")' "$SCRIPT" \
+  && check "cleans up downloaded .ipk after install" ok \
+  || check "cleans up downloaded .ipk after install" "no rm -f for downloaded .ipk"
+
+# 8. Makefile installs the update script
+grep -q 'familydns-update' "$MAKEFILE" \
+  && check "Makefile installs familydns-update" ok \
+  || check "Makefile installs familydns-update" "not referenced in Makefile"
+
+# 9. Makefile declares /etc/config/familydns as conffile
+grep -A1 'Package/familydns/conffiles' "$MAKEFILE" | grep -q '/etc/config/familydns' \
+  && check "Makefile lists familydns conffile" ok \
+  || check "Makefile lists familydns conffile" "missing conffiles stanza"
+
+# 10. Makefile postinst installs the cron entry
+grep -q "familydns-update" "$MAKEFILE" && \
+grep -q "/etc/crontabs/root" "$MAKEFILE" \
+  && check "Makefile postinst adds cron entry" ok \
+  || check "Makefile postinst adds cron entry" "cron install missing in postinst"
+
+# 11. build-ipk.sh ships the update script (it cp -r's files/, so reference is implicit;
+#     check it does not exclude the new script and that postinst+conffiles are present)
+grep -q '/etc/crontabs/root' "$BUILDER" \
+  && check "build-ipk.sh postinst installs cron entry" ok \
+  || check "build-ipk.sh postinst installs cron entry" "missing cron install"
+
+grep -q 'conffiles' "$BUILDER" && \
+grep -A2 'ctrl/conffiles' "$BUILDER" | grep -q '/etc/config/familydns' \
+  && check "build-ipk.sh declares conffile" ok \
+  || check "build-ipk.sh declares conffile" "missing conffiles file"
+
+# 12. Cron interval is every 6 hours (matches design)
+grep -q '0 \*/6 \* \* \* /usr/sbin/familydns-update' "$MAKEFILE" \
+  && check "Makefile cron is every 6 hours" ok \
+  || check "Makefile cron is every 6 hours" "wrong cron expression"
+
+grep -q '0 \*/6 \* \* \* /usr/sbin/familydns-update' "$BUILDER" \
+  && check "build-ipk.sh cron is every 6 hours" ok \
+  || check "build-ipk.sh cron is every 6 hours" "wrong cron expression"
+
+printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `/usr/sbin/familydns-update`: checks GitHub releases/latest, parses the `.ipk` asset version, and runs `opkg install --force-reinstall` only when a strictly-newer version is published. Uses `opkg compare-versions` (so 1.10.0 > 1.9.0 is correct), logs to syslog under tag `familydns`, and exits silently on apk-only systems (24.10+, see #176).
- Postinst hook (in both `openwrt/Makefile` and `openwrt/build-ipk.sh`) installs a cron entry: `0 */6 * * * /usr/sbin/familydns-update`. Idempotent — only adds the line if not already present.
- Declares `/etc/config/familydns` as a conffile in both build paths so `opkg` preserves `router_token` across auto-upgrades. Verified by inspecting the built `.ipk` (`control.tar.gz` now contains a `conffiles` entry).
- README "Auto-update" section documents the cadence, how to disable, how to force-run.
- New `openwrt/test/update_spec.sh` shell-level smoke test (mirrors `init_spec.sh`); wired into `run_tests.sh`. 14 checks pass locally.

Closes #131. Refs #123, #130, #134.

## Test plan

- [x] `sh openwrt/test/update_spec.sh` — 14/14 pass
- [x] `sh openwrt/test/init_spec.sh` — still 11/11 pass
- [x] `./openwrt/build-ipk.sh` builds an `.ipk` containing `usr/sbin/familydns-update` and a control-archive `conffiles` listing `/etc/config/familydns`
- [ ] On a real OpenWRT router after install: `crontab -l` shows the entry; running `/usr/sbin/familydns-update` while on the latest release is a silent no-op (verify via `logread | grep familydns`); UCI config persists across a simulated upgrade. (Requires VM e2e or live router — defer to install-test harness #154 if/when that lands.)