### PR TITLE
ci: harden master CD — test-gate + path-filtered, approved publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
     # Run on PRs targeting any branch
-  push:
-    # Only run on main post-merge — feature/claude branches get coverage via
-    # the PR's pull_request trigger. Avoids double-runs (issue #53).
-    branches: [main]
+  workflow_call:
+    # Invoked by master.yml on push to main so the CD pipeline gates publish
+    # on the same test matrix PRs run. Direct push: main is intentionally
+    # omitted — main coverage flows through master.yml (issue #190).
   workflow_dispatch:
 
 env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,8 +1,14 @@
-name: Publish API Server
+name: Master CD
 
-# Runs e2e and smoke checks on every push to main, then publishes the image
-# to ghcr.io after all checks are green.
-# The opkg .ipk is published separately by openwrt-build.yml on v* tags.
+# Runs on every push to main:
+#   1. ci-tests   — full CI matrix via workflow_call to ci.yml (unconditional).
+#   2. e2e/smoke  — bootstrap, e2e, prod-stack smokes (unconditional).
+#   3. publish    — Docker image to ghcr.io, only when api-image inputs changed
+#                   AND all of the above passed AND a reviewer approves the
+#                   `production` environment.
+#
+# OpenWRT .ipk/.apk publishing is handled by openwrt-build.yml on v* tags
+# (issues #190, #191).
 
 on:
   push:
@@ -13,7 +19,7 @@ on:
 # run is still paused waiting on the production environment approval, cancel
 # the older one — we always want the latest commit's run to take precedence.
 concurrency:
-  group: e2e-${{ github.ref }}
+  group: master-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -22,6 +28,39 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # ── 0. Detect path changes (gates publish only, not tests) ────────────────
+  changes:
+    name: Detect path changes
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Inputs that get baked into the API Docker image. Keep in sync with
+          # docker/Dockerfile COPY directives — if it's not copied into the
+          # image, it shouldn't trigger a republish.
+          filters: |
+            api:
+              - 'api/**'
+              - 'shared/**'
+              - 'web/**'
+              - 'build.mill'
+              - 'docker/**'
+              - 'config/application.conf.example'
+              - '.scalafmt.conf'
+              - '.scalafix.conf'
+
+  # ── 1. Full CI test matrix (unit, lint, lua, python, shell, frontend) ─────
+  # Runs unconditionally — issue #190 wants test failures on main to block
+  # publish regardless of which paths changed.
+  ci-tests:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  # ── 2. E2E + smoke tests (unconditional) ──────────────────────────────────
   bootstrap-smoke:
     name: bootstrap-host.sh smoke (Ubuntu container)
     runs-on: ubuntu-latest
@@ -67,9 +106,11 @@ jobs:
       - name: Run prod-stack smoke
         run: scripts/smoke-prod.sh
 
-  publish:
+  # ── 3. Publish API image (path-filtered + manual approval) ────────────────
+  publish-api:
     name: Publish Docker image to ghcr.io
-    needs: [bootstrap-smoke, e2e, prod-stack-smoke]
+    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,8 +1,13 @@
-name: Publish OpenWRT Package
+name: OpenWRT Package Build
 
+# Branch pushes to main are intentionally excluded — that path burned CI on
+# unrelated changes (docs-only merges) and the per-PR `paths` filter already
+# covers code changes pre-merge. A release only happens on a v* tag push;
+# the `Create GitHub release` step below stays gated on the tag ref.
+# See issues #191 (no branch pushes) and #212 (workflow name no longer
+# implies every run publishes).
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   pull_request:
     paths: ["openwrt/**"]


### PR DESCRIPTION
## Summary

Restructures the push-to-`main` pipeline so **every test runs before any publish**, then gates publishes by relevance and intent:

- **`master.yml`** (renamed from `e2e.yml`) now runs on `push: main`:
  1. `changes` — `dorny/paths-filter@v3` flags whether the API Docker image's inputs changed.
  2. `ci-tests` — invokes `ci.yml` via `workflow_call` (unit, lint, lua, python, shell, frontend). Unconditional.
  3. `bootstrap-smoke` / `e2e` / `prod-stack-smoke` — unconditional.
  4. `publish-api` — `needs:` all of the above, `if: needs.changes.outputs.api == 'true'`, `environment: production` (existing required-reviewer gate).
- **`ci.yml`** swaps `push: branches: [main]` for `workflow_call` so the same job matrix is reused on PRs and on master (no double-run, no drift).
- **`openwrt-build.yml`** drops `branches: [main]` from its `push:` trigger (fixes #191) and renames to **"OpenWRT Package Build"** so the Actions tab no longer implies every run publishes a release (fixes #212). The tag-only release step inside the workflow was already correct and is unchanged.

Closes #190, #191, #212.

## Verification matrix

| Event | `ci-tests` | smokes / e2e | `publish-api` | openwrt-build |
|---|---|---|---|---|
| No-op push to main (docs only) | runs | runs | **skipped** (path filter false) | not triggered |
| API-only push to main | runs | runs | runs → waits for `production` approval | not triggered |
| OpenWRT-only push to main | runs | runs | skipped | not triggered (no tag) |
| `v0.0.1` tag push | not triggered | not triggered | not triggered | runs + publishes release |
| Any failing test | runs | runs | **skipped** (`needs:` fail) | n/a |
| PR | runs (via `pull_request`) | not triggered | n/a | only if `openwrt/**` touched |

Path-filter misses produce skipped (grey) job statuses, not red X failures.

## Required setup (already in place)

- `production` environment exists with `sameerparekh` as a required reviewer — confirmed via `gh api repos/.../environments`. No action needed.

## Notes on related issues

- #138 (path-filtered CI on PRs) is orthogonal — it filters per-suite on PRs; this PR filters per-publish on main. They don't conflict.
- #115 (required checks) is unaffected: PR checks still come from `ci.yml` direct `pull_request` trigger; job names are unchanged.

## Test plan

- [ ] Merge → confirm master run shows `CI / Scala Build & Test` etc. nested under the `ci-tests` reusable job
- [ ] Confirm `publish-api` is skipped (path filter false on this PR's merge — only `.github/workflows/**` changed)
- [ ] On the next API-touching merge, confirm `publish-api` enters the "Waiting" state for the `production` reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)