### PR TITLE
api+openwrt+web: drop router name prompt from enrollment script (fixes #197)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,20 @@ Rules:
 - Worktrees live under `.claude/worktrees/<slug>` and use branch names
   `claude/<slug>` by convention (see `git worktree list`).
 
+## Backwards compatibility
+
+Nothing has been deployed yet. **Do not add backwards-compatibility shims,
+deprecation paths, or "ignore unknown fields" tolerance for the sake of
+older clients.** Breaking changes to API request/response shapes, UCI keys,
+DB schema (pre-migration), and CLI flags are fine — just change the code
+on all sides in the same PR.
+
+This policy flips once we've done our first real deploy, which is gated on
+picking a permanent project name ([#38](https://github.com/sameerparekh/familydns/issues/38)).
+After that ships, API request/response shapes become a public contract and
+we keep them backwards compatible (additive fields, ignore-unknown on input,
+deprecation windows for removals).
+
 ## Docker inside Claude Code agents (worktrees)
 
 Docker commands (`docker info`, `docker compose`, etc.) will **hang

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -80,7 +80,37 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(out.routerId == id) &&
         assertTrue(out.routerToken.startsWith("rt_")) &&
         assertTrue(row.enrollmentTokenHash.isEmpty) &&
-        assertTrue(row.tokenHash.contains(PolicyService.hashToken(out.routerToken)))
+        assertTrue(row.tokenHash.contains(PolicyService.hashToken(out.routerToken))) &&
+        assertTrue(row.name == "home-gw")
+    },
+    test("admin-created name survives enrollment end-to-end") {
+      for {
+        _          <- cleanDb
+        auth       <- makeAuth
+        rr         <- ZIO.service[RouterRepo]
+        ber        <- ZIO.service[BlockEventRepo]
+        adminLogin <- auth.login("admin", "changeme")
+        adminRoutes = AdminRouterRoutes.routes(auth, rr)
+        agentRoutes = RouterRoutes.routes(rr, null, RouterAuthLive(rr), ber)
+        createResp <- adminRoutes.runZIO(
+          Request
+            .post(
+              URL.decode("/api/admin/routers").toOption.get,
+              Body.fromString(CreateRouterRequest("kitchen-gw").toJson),
+            )
+            .addHeader(Header.Authorization.Bearer(adminLogin.token)),
+        )
+        createBody <- createResp.body.asString
+        created    <- ZIO.fromEither(createBody.fromJson[CreateRouterResponse])
+        regResp    <- doRegister(agentRoutes, created.enrollmentToken)
+        regBody    <- regResp.body.asString
+        reg        <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        row        <- rr.findById(reg.routerId).map(_.get)
+      } yield assertTrue(createResp.status == Status.Ok) &&
+        assertTrue(regResp.status == Status.Ok) &&
+        assertTrue(reg.routerId == created.routerId) &&
+        assertTrue(reg.routerToken.startsWith("rt_")) &&
+        assertTrue(row.name == "kitchen-gw")
     },
     test("enrollment token is single-use: second register returns 401") {
       for {

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -38,8 +38,10 @@ The script prompts for:
 |---|---|
 | API server URL | e.g. `https://api.example.com` (no trailing slash needed; the script trims it). |
 | Enrollment token | The `et_…` value from the admin UI. Single-use; invalidated on success. |
-| Router name | Defaults to the router's hostname. |
 | LAN prefix | Auto-detected from `network.lan.ipaddr` (last octet stripped). Must end with a dot. |
+
+The router's display name comes from whatever you typed in the admin UI
+when you generated the enrollment token — the agent does not collect it.
 
 It then:
 
@@ -161,7 +163,6 @@ curl -s -X POST https://api.example.com/api/router/register \
   -H 'Content-Type: application/json' \
   -d '{
     "enrollmentToken": "et_5f3c9b…",
-    "routerName":      "home-router",
     "platformVersion": "23.05.5",
     "agentVersion":    "0.1.0"
   }'

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -11,11 +11,13 @@
 #     https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
 #   sh /tmp/familydns-install.sh
 #
-# The script prompts for the API URL, the one-time enrollment token, a router
-# name, and the LAN prefix; downloads the latest .ipk from GitHub Releases;
-# installs it; enrolls the router against the API; writes the returned
-# credentials into UCI; sets up the uhttpd block-page listener; and starts
-# the agent.
+# The script prompts for the API URL, the one-time enrollment token, and the
+# LAN prefix; downloads the latest .ipk from GitHub Releases; installs it;
+# enrolls the router against the API; writes the returned credentials into
+# UCI; sets up the uhttpd block-page listener; and starts the agent.
+#
+# The router's display name is set in the admin UI when the enrollment token
+# is generated — the agent does not collect it.
 
 set -eu
 
@@ -75,7 +77,6 @@ if [ -n "$lan_ip" ]; then
 else
   lan_default="192.168.1."
 fi
-hostname_default=$(uci -q get system.@system[0].hostname || echo home-router)
 platform_ver=$(awk -F"'" '/DISTRIB_RELEASE/{print $2}' /etc/openwrt_release 2>/dev/null || echo unknown)
 
 cat >"$TTY" <<EOF
@@ -94,7 +95,6 @@ API_URL=${API_URL%/}
 prompt ENROLLMENT_TOKEN "One-time enrollment token (admin UI -> Routers -> Add router)"
 [ -n "${ENROLLMENT_TOKEN:-}" ] || err "enrollment token is required"
 
-prompt ROUTER_NAME      "Router name" "$hostname_default"
 prompt LAN_PREFIX       "LAN prefix (literal, with trailing dot)" "$lan_default"
 
 case "$LAN_PREFIX" in
@@ -149,8 +149,8 @@ if [ "$PKG_MGR" = apk ]; then
 else
   agent_ver=$(opkg info familydns | awk '/^Version:/{print $2}' | head -n1)
 fi
-body=$(printf '{"enrollmentToken":"%s","routerName":"%s","platformVersion":"%s","agentVersion":"%s"}' \
-  "$ENROLLMENT_TOKEN" "$ROUTER_NAME" "$platform_ver" "$agent_ver")
+body=$(printf '{"enrollmentToken":"%s","platformVersion":"%s","agentVersion":"%s"}' \
+  "$ENROLLMENT_TOKEN" "$platform_ver" "$agent_ver")
 
 resp=$(curl -fsS -X POST "$API_URL/api/router/register" \
   -H 'Content-Type: application/json' \
@@ -186,7 +186,6 @@ cat <<EOF
 
 Done. Router enrolled successfully.
 
-  Router name: $ROUTER_NAME
   Router ID:   $router_id
   API URL:     $API_URL
   LAN prefix:  $LAN_PREFIX
@@ -194,6 +193,6 @@ Done. Router enrolled successfully.
 Watch the agent log:
   logread -f | grep familydns
 
-The admin UI -> Routers -> $ROUTER_NAME should show a fresh last_seen_at
+The admin UI -> Routers should show a fresh last_seen_at for this router
 within ~60 seconds.
 EOF

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -350,7 +350,6 @@ case class RouterSummary(
 
 case class RegisterRouterRequest(
     enrollmentToken: String,
-    routerName: Option[String] = None,
     platformVersion: Option[String] = None,
     agentVersion: Option[String] = None,
 ) derives JsonCodec

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -122,16 +122,22 @@ export function RoutersPage() {
             </div>
           )}
           <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Name</label>
-            <input type="text" value={name} autoFocus
+            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+              Name <span className="text-red-400">*</span>
+            </label>
+            <input type="text" value={name} autoFocus required
               onChange={e => setName(e.target.value)}
               placeholder="home-gw"
               className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500" />
+            <p className="text-xs text-gray-500 mt-2">
+              This is the only place the router's display name is set — the
+              install script on the router doesn't ask for it.
+            </p>
           </div>
           <p className="text-sm text-gray-400">
-            We'll generate a one-time enrollment token. Paste it into the
-            OpenWRT package's UCI config (<code className="font-mono text-gray-300">/etc/config/familydns</code>),
-            then start the agent. The token is single-use.
+            We'll generate a one-time enrollment token. Run the OpenWRT
+            install script on the router and paste the token when prompted;
+            no other identifier is needed. The token is single-use.
           </p>
           <div className="flex gap-3 pt-2">
             <button onClick={() => setCreating(false)} disabled={saving}


### PR DESCRIPTION
## Summary

- Router name was being asked for twice — once in the admin UI when generating the enrollment token, then again on the router during install. The token already uniquely identifies the pre-created row, so the second prompt was just a way to get the name wrong.
- This PR drops the name from the agent side entirely: `RegisterRouterRequest` no longer has `routerName`, the OpenWRT install script no longer prompts for it, and the docs/UI are updated to reflect that the admin UI is the only place a router's name is set.
- Also adds a `Backwards compatibility` note to AGENTS.md: nothing's been deployed yet, so we can make breaking changes; this flips once #38 (the project rename) ships and we do our first real deploy.

Part of the install-polish set headed into the UX audit (#227).

## Test plan

- [x] `mill api.test.testOnly familydns.api.feature.RouterApiSpec` — 9/9 pass, including two assertions that lock in "the row's name comes from admin create, not the agent": one on the seeded-router path, one end-to-end through `POST /api/admin/routers` → `POST /api/router/register`.
- [x] `tsc --noEmit` clean on web.
- [ ] Manual: enroll a router via the OpenWRT install script and confirm only the API URL, token, and LAN prefix are prompted; the admin UI shows the name typed at create time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)