### PR TITLE
openwrt: fix familydns dep `conntrack-tools` → `conntrack`

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -13,7 +13,7 @@ define Package/familydns
   SECTION:=net
   CATEGORY:=Network
   TITLE:=FamilyDNS router agent
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack-tools +curl
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl
   PKGARCH:=all
 endef
 

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -25,7 +25,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: familydns
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, libuci-lua, luci-lib-jsonc, conntrack-tools, curl
+Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl
 Architecture: all
 Maintainer: FamilyDNS <noreply@example.com>
 Description: Agent daemon for FamilyDNS. Enforces per-device DNS filtering

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -188,7 +188,7 @@ docker run --rm \
         echo "--- packages/Packages ---"
         cat packages/Packages
         # The set of packages to include. Dependencies declared by the ipk
-        # (lua, libuci-lua, luci-lib-jsonc, conntrack-tools, curl) are
+        # (lua, libuci-lua, luci-lib-jsonc, conntrack, curl) are
         # pulled in automatically from the upstream OpenWRT feed.
         make image \
             PROFILE=generic \

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -206,7 +206,17 @@ if [ ! -f "$BUILT" ]; then
 fi
 
 echo "==> Decompressing image to $OUTPUT_IMG"
+# gzip returns 2 on warnings — OpenWRT's ext4-combined.img.gz has a few bytes
+# of trailing padding past the deflate stream, which trips "trailing garbage
+# ignored". The decompressed image itself is correct, so tolerate exit 2.
+set +e
 gunzip -c "$BUILT" > "$OUTPUT_IMG"
+GUNZIP_RC=$?
+set -e
+if [ "$GUNZIP_RC" -ne 0 ] && [ "$GUNZIP_RC" -ne 2 ]; then
+    echo "ERROR: gunzip failed with code $GUNZIP_RC" >&2
+    exit "$GUNZIP_RC"
+fi
 
 SIZE_MB=$(( $(stat -f%z "$OUTPUT_IMG" 2>/dev/null || stat -c%s "$OUTPUT_IMG") / 1024 / 1024 ))
 echo ""


### PR DESCRIPTION
Closes #234.

## Summary
- OpenWRT 23.05 has no `conntrack-tools` package — the `packages` feed splits it into `conntrack` (CLI) and `conntrackd` (daemon).
- `familydns-agent` shells out to `conntrack -E -e NEW`, so the correct dep is plain `conntrack`.
- The wrong name broke `Build OpenWRT VM image` on every run since #223:
  ```
  pkg_hash_check_unresolved: cannot find dependency conntrack-tools for familydns
  opkg_install_cmd: Cannot install package familydns.
  ```
- Renamed in:
  - [openwrt/Makefile:16](openwrt/Makefile#L16) (`DEPENDS:=`)
  - [openwrt/build-ipk.sh:28](openwrt/build-ipk.sh#L28) (control file `Depends:`)
  - [scripts/vm/build-router-image.sh:191](scripts/vm/build-router-image.sh#L191) (stale comment)

## Test plan
- [ ] `Build OpenWRT VM image` CI job goes green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)