### PR TITLE
agents: require worktree isolation for spawned sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,29 @@ Key API surface (under `/api/router/*` and `/api/blocklists/*`):
 - **Formatting**: `scalafmt` enforced in CI. Run `mill __.reformat` before committing.
 - **Imports**: managed by `scalafix OrganizeImports`. Run `mill __.fix` before committing.
 
+## Always isolate spawned work in a worktree
+
+This repo is actively developed across many parallel sessions, so the main
+checkout at `/Users/sameer/workspace/familydns` is usually on some in-flight
+branch. **Spawning a session or agent that edits files without an isolated
+worktree pollutes that working tree and causes branch conflicts.**
+
+Rules:
+
+- When delegating with the `Agent` tool and the agent will edit files, pass
+  `isolation: "worktree"`. Read-only research agents (Explore, plain lookups)
+  don't need it.
+- When spinning off background work with `spawn_task`, write the prompt so
+  the spawned session creates its own worktree before doing anything else
+  (e.g. `git worktree add .claude/worktrees/<slug> -b <branch>` off the
+  latest `main`). State this explicitly in the prompt — the spawned session
+  starts with no context.
+- Never push to or check out a new branch in the top-level
+  `/Users/sameer/workspace/familydns` checkout from a spawned session. Treat
+  it as someone else's working tree.
+- Worktrees live under `.claude/worktrees/<slug>` and use branch names
+  `claude/<slug>` by convention (see `git worktree list`).
+
 ## Docker inside Claude Code agents (worktrees)
 
 Docker commands (`docker info`, `docker compose`, etc.) will **hang


### PR DESCRIPTION
## Summary
- Spawned sessions / agents that edit the top-level checkout pollute the in-flight branch there and cause conflicts.
- Document the rule in AGENTS.md: pass \`isolation: \"worktree\"\` on editing Agent calls, and have \`spawn_task\` prompts create their own worktree off latest main.
- Companion change applied to global \`~/.claude/CLAUDE.md\` (not in repo).

## Test plan
- [ ] Eyeball the new section in [AGENTS.md](AGENTS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)