### PR TITLE
Observability for router-agent → API ingest path (#228 phase 1)

### DIFF
--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -5,9 +5,15 @@
     </encoder>
   </appender>
 
+  <!--
+    FAMILYDNS_LOG_LEVEL controls verbosity of the familydns.* loggers.
+    Defaults to INFO. Set to DEBUG to see per-request detail on the
+    /api/router/* endpoints (mac, hostname, allowed/blocked, etc.). See
+    docs/install-api.md § Debugging.
+  -->
   <root level="WARN">
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="familydns" level="DEBUG" />
+  <logger name="familydns" level="${FAMILYDNS_LOG_LEVEL:-INFO}" />
 </configuration>

--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -9,7 +9,13 @@ case class AppConfig(
     db: DbConfig,
     http: HttpConfig,
     jwt: JwtConfig,
-)
+) {
+  // FAMILYDNS_DEBUG env var: when set to a non-empty, non-"0"/"false"/"no"
+  // value, mounts the read-only /api/debug/* endpoints (loopback only).
+  // Read from env, not HOCON, so it stays out of application.conf — debug
+  // belongs to the runtime environment, not the persistent config.
+  val debugEnabled: Boolean = AppConfig.envTruthy(sys.env.get("FAMILYDNS_DEBUG"))
+}
 
 case class DbConfig(
     host: String,
@@ -32,6 +38,12 @@ case class JwtConfig(
 )
 
 object AppConfig {
+  private[api] def envTruthy(v: Option[String]): Boolean =
+    v.map(_.trim.toLowerCase).exists {
+      case "" | "0" | "false" | "no" | "off" => false
+      case _                                 => true
+    }
+
   val layer: ZLayer[Any, Config.Error, AppConfig] =
     ZLayer.fromZIO {
       val path = sys.props.getOrElse("config.file", "config/application.conf")

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -22,6 +22,12 @@ object Main extends ZIOAppDefault {
     (for {
       cfg    <- ZIO.service[AppConfig]
       _      <- ZIO.logInfo(s"FamilyDNS API starting on ${cfg.http.host}:${cfg.http.port}")
+      _      <- ZIO
+        .logWarning(
+          "FAMILYDNS_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +
+            "Disable in production.",
+        )
+        .when(cfg.debugEnabled)
       _      <- Database.runMigrations(cfg.db)
       _      <- ZIO.logInfo("Database migrations complete")
       routes <- allRoutes
@@ -90,5 +96,6 @@ object Main extends ZIOAppDefault {
         deviceRepo,
         connRepo,
       ) ++
+      DebugRoutes.routes(cfg.debugEnabled, deviceRepo, connRepo, usageRepo, clock) ++
       StaticRoutes.routes(cfg.http.staticDir)
 }

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -1,0 +1,125 @@
+package familydns.api.routes
+
+import familydns.api.db.*
+import familydns.shared.Clock
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+
+/**
+ * Read-only JSON dumps of the underlying tables, intended for diagnosing router/agent ingest issues
+ * live (#228). Mounted ONLY when the API is started with `FAMILYDNS_DEBUG=1`; access is further
+ * restricted to loopback callers on the API host.
+ *
+ * Endpoints: GET /api/debug/devices -> all device rows GET /api/debug/events?limit -> recent
+ * connection_events (default 50, max 500) GET /api/debug/time_usage -> today's per-(mac, domain)
+ * usage
+ *
+ * Auth: none. Loopback check uses BOTH `req.remoteAddress` (when present) AND the `Host` header.
+ * Either being non-loopback returns 403. Every hit logs at INFO so accidentally-leaking installs
+ * are obvious in production.
+ */
+object DebugRoutes {
+
+  private val DefaultLimit = 50
+  private val MaxLimit     = 500
+
+  def routes(
+      enabled: Boolean,
+      deviceRepo: DeviceRepo,
+      connEventRepo: ConnectionEventRepo,
+      timeUsageRepo: TimeUsageRepo,
+      clock: Clock,
+  ): Routes[Any, Response] =
+    if !enabled then Routes.empty
+    else
+      Routes(
+        Method.GET / "api" / "debug" / "devices"    -> handler { (req: Request) =>
+          guardLoopback(req, "/api/debug/devices") {
+            deviceRepo.listAll
+              .mapBoth(
+                t => Response.internalServerError(t.getMessage),
+                xs => Response.json(xs.toJson),
+              )
+          }
+        },
+        Method.GET / "api" / "debug" / "events"     -> handler { (req: Request) =>
+          guardLoopback(req, "/api/debug/events") {
+            val limit = req.url
+              .queryParam("limit")
+              .flatMap(_.toIntOption)
+              .map(_.max(1).min(MaxLimit))
+              .getOrElse(DefaultLimit)
+            connEventRepo
+              .recent(limit)
+              .mapBoth(
+                t => Response.internalServerError(t.getMessage),
+                xs => Response.json(xs.toJson),
+              )
+          }
+        },
+        Method.GET / "api" / "debug" / "time_usage" -> handler { (req: Request) =>
+          guardLoopback(req, "/api/debug/time_usage") {
+            for {
+              today <- clock.today
+              snap  <- timeUsageRepo
+                .snapshotAll(today)
+                .mapError(t => Response.internalServerError(t.getMessage))
+            } yield Response.json(
+              snap
+                .map { case ((mac, domain), mins) =>
+                  TimeUsageRow(mac, domain, today.toString, mins)
+                }
+                .toList
+                .toJson,
+            )
+          }
+        },
+      )
+
+  private case class TimeUsageRow(mac: String, domain: String, date: String, minutesUsed: Int)
+      derives JsonCodec
+
+  /**
+   * Reject non-loopback callers. We check both the connection's remote address (when zio-http
+   * surfaces one) and the `Host` request header. If either signal looks non-loopback, refuse. Logs
+   * every hit (allowed or refused) at INFO so that an accidentally-enabled debug build is loud in
+   * production logs.
+   */
+  private def guardLoopback[A](req: Request, path: String)(
+      inner: IO[Response, Response],
+  ): IO[Response, Response] = {
+    val remoteOk  = req.remoteAddress.forall(_.isLoopbackAddress)
+    // Read the raw Host header value via `headerOrFail` — zio-http's typed
+    // Header.Host parser is strict and rejects "::1" / "[::1]". For a
+    // loopback gate we want the raw text so we can normalize it ourselves.
+    val hostRaw   = req.headers.get("Host").map(_.trim)
+    val hostOk    = hostRaw.exists(isLoopbackHost)
+    val remoteStr = req.remoteAddress.map(_.getHostAddress).getOrElse("unknown")
+    val hostStr   = hostRaw.getOrElse("unknown")
+    if remoteOk && hostOk then
+      ZIO.logInfo(s"debug endpoint hit: path=$path remote=$remoteStr host=$hostStr") *> inner
+    else
+      ZIO.logWarning(
+        s"debug endpoint refused (non-loopback): path=$path remote=$remoteStr host=$hostStr",
+      ) *>
+        ZIO.fail(Response.status(Status.Forbidden))
+  }
+
+  private def isLoopbackHost(raw: String): Boolean = {
+    // Host header may be:  "localhost", "127.0.0.1", "127.0.0.1:8080",
+    // "[::1]", "[::1]:8080", or "::1" (technically invalid but tolerated).
+    val s        = raw.trim.toLowerCase
+    val stripped =
+      if s.startsWith("[") then
+        // bracketed IPv6 — drop "[", then drop everything from "]" on
+        s.drop(1).takeWhile(_ != ']')
+      else if s.count(_ == ':') == 1 then
+        // single colon → host:port (IPv4 or hostname)
+        s.takeWhile(_ != ':')
+      else
+        // bare IPv6 like "::1" — keep as-is
+        s
+    stripped == "localhost" || stripped == "127.0.0.1" || stripped == "::1"
+  }
+}

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -40,6 +40,15 @@ object RouterIngestRoutes {
               .when(rep.routerId != router.id)
             ps     <- parseInstant(rep.periodStart)
             pe     <- parseInstant(rep.periodEnd)
+            _      <- ZIO.logDebug(
+              s"router usage: router=${router.id} period=$ps..$pe records=${rep.records.size}",
+            )
+            _      <- ZIO.foreachDiscard(rep.records)(r =>
+              ZIO.logDebug(
+                s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
+                  s"host=${r.hostname} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
+              ),
+            )
             _ <- handleUsage(router.id, ps, pe, rep.records, trafficRepo, timeUsageRepo, deviceRepo)
             _ <- routerRepo.touch(router.id, None).orElseFail(Response.internalServerError(""))
           } yield Response.ok
@@ -65,6 +74,14 @@ object RouterIngestRoutes {
               .when(rep.routerId != router.id)
             _      <- ZIO.logInfo(
               s"router events: router=${router.id} batchSize=${rep.events.size}",
+            )
+            _      <- ZIO.foreachDiscard(rep.events)(e =>
+              ZIO.logDebug(
+                s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
+                  s"ip=${e.ip.getOrElse("-")} host=${e.hostname.getOrElse("-")} " +
+                  s"destIp=${e.destIp.getOrElse("-")} allowed=${e.allowed.map(_.toString).getOrElse("-")} " +
+                  s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
+              ),
             )
             _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo)
             _      <- routerRepo.touch(router.id, None).orElseFail(Response.internalServerError(""))

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -60,8 +60,14 @@ object RouterRoutes {
             _ <- routerRepo
               .touch(router.id, Some(snap.etag))
               .orElseFail(Response.internalServerError(""))
+            notMod = ifNoneMatch.contains(snap.etag)
+            _ <- ZIO.logDebug(
+              s"router policy: router=${router.id} etagIn=${ifNoneMatch.getOrElse("-")} " +
+                s"etagOut=${snap.etag} notModified=$notMod devices=${snap.devices.size} " +
+                s"profiles=${snap.profiles.size}",
+            )
             resp =
-              if ifNoneMatch.contains(snap.etag) then
+              if notMod then
                 Response
                   .status(Status.NotModified)
                   .addHeader(Header.ETag.Strong(stripQuotes(snap.etag)))

--- a/api/test/src/feature/DebugApiSpec.scala
+++ b/api/test/src/feature/DebugApiSpec.scala
@@ -1,0 +1,136 @@
+package familydns.api.feature
+
+import familydns.api.db.*
+import familydns.api.routes.*
+import familydns.shared.*
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+import java.time.LocalDateTime
+
+// Tests for the /api/debug/... observability endpoints (#228). Endpoints are
+// gated by an `enabled` flag (driven by FAMILYDNS_DEBUG in production) and a
+// per-request loopback check.
+object DebugApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(LocalDateTime.of(2026, 5, 11, 12, 0))
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def buildRoutes(enabled: Boolean) =
+    for {
+      dRepo  <- ZIO.service[DeviceRepo]
+      cRepo  <- ZIO.service[ConnectionEventRepo]
+      tuRepo <- ZIO.service[TimeUsageRepo]
+      clock  <- ZIO.service[Clock]
+    } yield DebugRoutes.routes(enabled, dRepo, cRepo, tuRepo, clock)
+
+  /**
+   * Build a request whose Host header is loopback-y by default. zio-http's Request.remoteAddress is
+   * None in test (no socket), so the loopback guard falls back to the Host header for its decision.
+   */
+  private def get(path: String, host: String = "localhost"): Request =
+    Request
+      .get(URL.decode(path).toOption.get)
+      .addHeader(Header.Host(host, None))
+
+  def spec = suite("Debug API /api/debug/*")(
+    test("returns 404 for every path when enabled = false") {
+      for {
+        _      <- cleanDb
+        routes <- buildRoutes(enabled = false)
+        rDev   <- routes.runZIO(get("/api/debug/devices"))
+        rEv    <- routes.runZIO(get("/api/debug/events"))
+        rTu    <- routes.runZIO(get("/api/debug/time_usage"))
+      } yield assertTrue(rDev.status == Status.NotFound) &&
+        assertTrue(rEv.status == Status.NotFound) &&
+        assertTrue(rTu.status == Status.NotFound)
+    },
+    test("returns 403 when Host header is non-loopback even with enabled = true") {
+      for {
+        _      <- cleanDb
+        routes <- buildRoutes(enabled = true)
+        rDev   <- routes.runZIO(get("/api/debug/devices", host = "evil.example.com"))
+        rEv    <- routes.runZIO(get("/api/debug/events", host = "1.2.3.4"))
+      } yield assertTrue(rDev.status == Status.Forbidden) &&
+        assertTrue(rEv.status == Status.Forbidden)
+    },
+    test("accepts 127.0.0.1 and ::1 as loopback hosts") {
+      for {
+        _      <- cleanDb
+        routes <- buildRoutes(enabled = true)
+        r1     <- routes.runZIO(get("/api/debug/devices", host = "127.0.0.1"))
+        r2     <- routes.runZIO(get("/api/debug/devices", host = "::1"))
+        r3     <- routes.runZIO(get("/api/debug/devices", host = "[::1]"))
+      } yield assertTrue(r1.status == Status.Ok) &&
+        assertTrue(r2.status == Status.Ok) &&
+        assertTrue(r3.status == Status.Ok)
+    },
+    test("/api/debug/devices from loopback returns 200 with seeded rows") {
+      for {
+        _      <- cleanDb
+        pRepo  <- ZIO.service[ProfileRepo]
+        sRepo  <- ZIO.service[ScheduleRepo]
+        dRepo  <- ZIO.service[DeviceRepo]
+        routes <- buildRoutes(enabled = true)
+        kid    <- TestLayers.seedKidsProfile(pRepo, sRepo)
+        _      <- TestLayers.seedDevice(dRepo, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        resp   <- routes.runZIO(get("/api/debug/devices"))
+        body   <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(body.contains("aa:bb:cc:11:22:33")) &&
+        assertTrue(body.contains("kid-ipad"))
+    },
+    test("/api/debug/events?limit=2 returns at most 2 rows") {
+      for {
+        _      <- cleanDb
+        rRepo  <- ZIO.service[RouterRepo]
+        cRepo  <- ZIO.service[ConnectionEventRepo]
+        routes <- buildRoutes(enabled = true)
+        rid    <- rRepo.create("debug-test", "X")
+        evs = (1 to 5).toList.map(i =>
+          ConnectionEventInsert(
+            rid,
+            Some(s"aa:bb:cc:dd:ee:0$i"),
+            s"site$i.example",
+            Some(s"10.0.0.$i"),
+            true,
+            "allow",
+            java.time.Instant.parse("2026-05-11T12:00:00Z"),
+          ),
+        )
+        _    <- cRepo.insertBatch(evs)
+        resp <- routes.runZIO(get("/api/debug/events?limit=2"))
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // Crude row count: count occurrences of "\"id\":"
+        assertTrue("""\"id\":""".r.findAllIn(body).length == 2)
+    },
+    test("/api/debug/time_usage returns 200 with today's usage rows") {
+      for {
+        _      <- cleanDb
+        tuRepo <- ZIO.service[TimeUsageRepo]
+        routes <- buildRoutes(enabled = true)
+        today = java.time.LocalDate.of(2026, 5, 11)
+        _    <- tuRepo.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "youtube.com",
+          today,
+          120L,
+          0L,
+          0L,
+        )
+        resp <- routes.runZIO(get("/api/debug/time_usage"))
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(body.contains("aa:bb:cc:11:22:33")) &&
+        assertTrue(body.contains("youtube.com"))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -19,3 +19,23 @@ FAMILYDNS_JWT_HOURS=24
 # - FAMILYDNS_API_BIND=127.0.0.1 → only reachable from the host (front with nginx/Caddy)
 FAMILYDNS_API_BIND=0.0.0.0
 FAMILYDNS_API_PORT=8080
+
+# ─── Debugging (off by default) ──────────────────────────────────────────────
+#
+# These knobs are READ by deploy/docker-compose.debug.yml. They have no
+# effect on the production stack on their own.
+#
+# Where to publish Postgres when the debug overlay is active. Keep the bind
+# at 127.0.0.1 — exposing the DB on 0.0.0.0 leaks credentials.
+# FAMILYDNS_DB_BIND=127.0.0.1:5433
+#
+# FOR DEBUGGING ONLY. Setting this mounts /api/debug/* on the API server.
+# Those endpoints serve unauthenticated read-only JSON dumps of the devices,
+# connection_events, and time_usage tables, restricted to loopback callers
+# on the API host. Never set this in production.
+# FAMILYDNS_DEBUG=1
+#
+# Override the verbosity of the familydns.* loggers. Accepts TRACE, DEBUG,
+# INFO, WARN, ERROR. Defaults to INFO. DEBUG enables per-request logging on
+# the /api/router/{usage,events,policy} endpoints (mac, hostname, etc.).
+# FAMILYDNS_LOG_LEVEL=DEBUG

--- a/deploy/docker-compose.debug.yml
+++ b/deploy/docker-compose.debug.yml
@@ -1,0 +1,27 @@
+# Debug overlay — adds host-bound Postgres + enables API debug endpoints.
+#
+# Compose with the prod stack ONLY when actively diagnosing an issue. Leaving
+# this on in production exposes a token-free read view of the database to
+# anyone with local access to the API host.
+#
+#   docker compose \
+#     -f deploy/docker-compose.prod.yml \
+#     -f deploy/docker-compose.debug.yml \
+#     --env-file deploy/.env up -d
+#
+# Postgres is bound to 127.0.0.1 by default (never 0.0.0.0). Set
+# FAMILYDNS_DB_BIND in deploy/.env to override the host:port the database
+# port is published on; leave the bind portion at 127.0.0.1 unless you
+# really know what you're doing.
+
+services:
+  postgres:
+    ports:
+      - "${FAMILYDNS_DB_BIND:-127.0.0.1:5433}:5432"
+
+  api:
+    environment:
+      # Mounts /api/debug/* (loopback-only). See docs/install-api.md § Debugging.
+      FAMILYDNS_DEBUG: "1"
+      # Verbose per-request logging on /api/router/* endpoints.
+      FAMILYDNS_LOG_LEVEL: "DEBUG"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,14 @@ set -euo pipefail
 : "${FAMILYDNS_STATIC_DIR:=/app/web}"
 : "${FAMILYDNS_JWT_SECRET:=staging-jwt-secret-do-not-use-in-prod-32ch}"
 : "${FAMILYDNS_JWT_HOURS:=24}"
+: "${FAMILYDNS_LOG_LEVEL:=INFO}"
+: "${FAMILYDNS_DEBUG:=}"
+
+export FAMILYDNS_LOG_LEVEL FAMILYDNS_DEBUG
+
+if [ -n "${FAMILYDNS_DEBUG}" ]; then
+  echo "[entrypoint] WARNING: FAMILYDNS_DEBUG is set — debug endpoints will be mounted (loopback only). Disable in production."
+fi
 
 mkdir -p /app/config
 cat > /app/config/application.conf <<EOF

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -377,7 +377,75 @@ polls in. The host does need outbound HTTPS to `ghcr.io` for image pulls
 
 ---
 
-## 9. Next steps
+## 9. Debugging
+
+When devices are missing from the UI, showing up as 'unknown', or the
+router agent appears silent, three opt-in surfaces help trace the
+mac → API → DB → UI hop without exposing anything in normal production.
+
+### 9.1 Verbose logging (`FAMILYDNS_LOG_LEVEL=DEBUG`)
+
+Each `/api/router/{usage,events,policy}` request emits one log line per
+record/event with the mac, hostname, allowed/blocked flag, and ts. Combine
+with `docker compose logs -f api` while the offending device is active.
+Defaults to `INFO`; set in `deploy/.env` (or use the debug overlay below,
+which turns this on for you).
+
+On the **OpenWRT side**, set `uci set familydns.@familydns[0].debug=1; uci
+commit; /etc/init.d/familydns restart` to make the agent log every policy
+fetch, usage POST, event flush, and per-flow mac/hostname attribution to
+`logread -t familydns` (#228).
+
+### 9.2 Loopback-only debug endpoints (`FAMILYDNS_DEBUG=1`)
+
+When set, the API mounts three unauthenticated read-only JSON dumps,
+restricted by both `remoteAddress` and the `Host` header to loopback
+callers on the API host:
+
+- `GET /api/debug/devices` — all rows in the `devices` table
+- `GET /api/debug/events?limit=N` — recent `connection_events` (default 50, max 500)
+- `GET /api/debug/time_usage` — per-(mac, domain) usage for today
+
+These are equivalent to running `psql` against the DB without the network
+exposure. Every request — allowed or refused — logs at INFO/WARN, so an
+accidentally-left-on debug build is loud in production. The startup banner
+also emits a `FAMILYDNS_DEBUG=1` WARNING.
+
+Usage from the API host:
+
+```sh
+curl -s http://localhost:8080/api/debug/devices | jq .
+curl -s 'http://localhost:8080/api/debug/events?limit=200' | jq '.[].mac'
+```
+
+From off-host: refused with `403`.
+
+### 9.3 Exposed Postgres (`docker-compose.debug.yml`)
+
+For ad-hoc SQL, an overlay file maps the `postgres` service to a host port
+(default `127.0.0.1:5433`) and enables the API knobs above:
+
+```sh
+docker compose \
+  -f deploy/docker-compose.prod.yml \
+  -f deploy/docker-compose.debug.yml \
+  --env-file deploy/.env up -d
+psql -h 127.0.0.1 -p 5433 -U familydns familydns
+```
+
+Override the bind with `FAMILYDNS_DB_BIND=127.0.0.1:5433` in `deploy/.env`
+if the default port is taken. Keep the bind on `127.0.0.1` — exposing the
+DB on `0.0.0.0` leaks credentials.
+
+To return to a clean prod stack, restart without the debug file:
+
+```sh
+docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d
+```
+
+---
+
+## 10. Next steps
 
 - **Auto-update.** Install the `familydns-update.timer` systemd unit so the
   host pulls and restarts on each new `latest` build. See `deploy.md §1.3`.

--- a/openwrt/files/etc/init.d/familydns
+++ b/openwrt/files/etc/init.d/familydns
@@ -9,6 +9,7 @@ start_service() {
     procd_open_instance
     procd_set_param command /usr/sbin/familydns-agent
     procd_set_param respawn 3600 5 5
+    procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
 }

--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -14,6 +14,17 @@
 
 local M = {}
 
+local function default_log()
+  local ok, l = pcall(require, "familydns.log")
+  if ok then return l end
+  return {
+    info  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    err   = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    warn  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    debug = function() end,
+  }
+end
+
 -- ---------------------------------------------------------------------------
 -- ipset_lookup_hostname(dest_ip, nft_sets) -> string | nil
 --
@@ -232,12 +243,15 @@ end
 -- }
 -- ---------------------------------------------------------------------------
 function M.handle_flow(flow, ctx, batcher)
+  local log = ctx.log or default_log()
   local mac = M.arp_lookup_mac(flow.src_ip, ctx.arp_table or {})
 
   if mac and not (ctx.reported_macs or {})[mac] then
     local lease = (ctx.leases or {})[mac]
     local ip, hostname
     if lease then ip = lease.ip; hostname = lease.hostname end
+    log.debug("handle_flow: first_seen_mac mac=%s ip=%s hostname=%s",
+              mac, tostring(ip), tostring(hostname))
     batcher.add(M.build_first_seen_mac_event({
       mac = mac, ip = ip, hostname = hostname, ts = ctx.ts,
     }))
@@ -250,6 +264,9 @@ function M.handle_flow(flow, ctx, batcher)
   if not allowed and ctx.blocked_reason then
     reason = ctx.blocked_reason[flow.dst_ip]
   end
+  log.debug("handle_flow: connection_attempt src=%s dst=%s mac=%s hostname=%s allowed=%s reason=%s",
+            flow.src_ip, flow.dst_ip, tostring(mac), tostring(hname),
+            tostring(allowed), tostring(reason))
   batcher.add(M.build_event({
     mac      = mac,
     hostname = hname,
@@ -307,6 +324,7 @@ end
 -- ---------------------------------------------------------------------------
 function M.watch(cfg)
   local jsonc      = require("luci.jsonc")
+  local log        = cfg.log            or default_log()
   local lan_prefix = cfg.lan_prefix     or "192.168.1."
   local max_batch  = cfg.max_batch      or 50
   local flush_int  = cfg.flush_interval or 10
@@ -323,6 +341,7 @@ function M.watch(cfg)
   end
 
   local batcher = M.new_batcher(max_batch, flush_int, function(events)
+    log.debug("conntrack: flushing batch size=%d url=%s", #events, events_url)
     local payload = jsonc.stringify({
       routerId = cfg.router_id,
       events   = events,
@@ -333,15 +352,19 @@ function M.watch(cfg)
       -- best-effort: log and continue; never block a flow waiting for the API
       local body_str = last_body and tostring(last_body) or ""
       if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
-      io.stderr:write(string.format(
-        "[familydns] conntrack: failed to POST events batch after %d retries (status=%s body=%q) err=%s, dropping %d events\n",
-        max_retry, tostring(last_status), body_str, tostring(last_err), #events))
+      log.err("conntrack: failed to POST events batch after %d retries (status=%s body=%q) err=%s, dropping %d events",
+              max_retry, tostring(last_status), body_str, tostring(last_err), #events)
+    else
+      log.debug("conntrack: POST events success status=%d events=%d",
+                last_status, #events)
     end
   end)
 
+  log.info("conntrack: starting watcher lan_prefix=%s max_batch=%d flush_interval=%ds",
+           lan_prefix, max_batch, flush_int)
   local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
   if not handle then
-    io.stderr:write("[familydns] conntrack: cannot start conntrack -E -e NEW\n")
+    log.err("conntrack: cannot start conntrack -E -e NEW")
     return
   end
 
@@ -370,6 +393,7 @@ function M.watch(cfg)
         reported_macs  = reported_macs,
         leases         = leases or {},
         ts             = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+        log            = log,
       }, batcher)
     end
 

--- a/openwrt/files/usr/lib/lua/familydns/log.lua
+++ b/openwrt/files/usr/lib/lua/familydns/log.lua
@@ -1,0 +1,86 @@
+-- log.lua — small wrapper around the BusyBox `logger` command for the
+-- familydns-agent.  All log lines are tagged "familydns" so they're easy
+-- to grep in `logread`.
+--
+-- Public API:
+--   log.init({ debug = bool|string })  -- call once at agent start
+--   log.debug_enabled() -> bool
+--   log.info(fmt, ...)
+--   log.warn(fmt, ...)
+--   log.err(fmt, ...)
+--   log.debug(fmt, ...)  -- no-op unless init({debug=true}) was called
+--
+-- Format is string.format-style: log.debug("foo=%s bar=%d", x, y).
+--
+-- We deliberately shell out to `logger` instead of writing to stderr because
+-- procd's stderr capture has been a source of "silent agent" bugs in the
+-- past (see #228).  `logger -t familydns ...` reliably appears in `logread`
+-- without depending on procd_set_param wiring.
+
+local M = {}
+
+local _debug = false
+
+-- Injectable for tests.  Default just runs the command; we don't care about
+-- the exit code (best-effort logging).
+function M._exec(cmd)
+  os.execute(cmd)
+end
+
+local function truthy(v)
+  if v == true then return true end
+  if v == nil or v == false then return false end
+  if type(v) == "number" then return v ~= 0 end
+  if type(v) == "string" then
+    local s = v:lower()
+    return s == "1" or s == "true" or s == "yes" or s == "on"
+  end
+  return false
+end
+
+function M.init(opts)
+  opts = opts or {}
+  _debug = truthy(opts.debug)
+end
+
+function M.debug_enabled()
+  return _debug
+end
+
+-- Shell-quote a string for safe use inside a `sh -c` argument: wrap in
+-- single quotes and escape any embedded single quotes by closing, escaping,
+-- and reopening: 'foo'\''bar'
+local function shquote(s)
+  return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
+end
+
+local function emit(priority, fmt, ...)
+  local ok, msg
+  if select("#", ...) == 0 then
+    msg = tostring(fmt)
+  else
+    ok, msg = pcall(string.format, fmt, ...)
+    if not ok then
+      -- string.format failed (bad %d etc.); fall back to raw fmt + args dump.
+      local parts = { tostring(fmt) }
+      for i = 1, select("#", ...) do
+        parts[#parts + 1] = tostring((select(i, ...)))
+      end
+      msg = table.concat(parts, " ")
+    end
+  end
+  local cmd = string.format(
+    "logger -t familydns -p %s %s",
+    priority, shquote(msg))
+  M._exec(cmd)
+end
+
+function M.info(fmt, ...) emit("user.info",    fmt, ...) end
+function M.warn(fmt, ...) emit("user.warning", fmt, ...) end
+function M.err (fmt, ...) emit("user.err",     fmt, ...) end
+function M.debug(fmt, ...)
+  if not _debug then return end
+  emit("user.debug", fmt, ...)
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -15,6 +15,20 @@ local M = {}
 
 local render = require("familydns.render")
 
+-- log is injectable for tests; default uses the real logger wrapper.
+local function default_log()
+  local ok, l = pcall(require, "familydns.log")
+  if ok then return l end
+  -- Fallback to a stderr shim when the module isn't on the path (e.g. older
+  -- test harnesses).
+  return {
+    info  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    err   = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    warn  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    debug = function() end,
+  }
+end
+
 -- Percent-encode characters that would break a query-string value:
 -- the canonical HTTP etag is wrapped in literal `"` characters, which a raw
 -- concatenation would emit into the URL and break server-side routing.
@@ -31,7 +45,8 @@ end
 -- ---------------------------------------------------------------------------
 -- policy.fetch
 -- ---------------------------------------------------------------------------
-function M.fetch(api_url, router_token, etag, http_get_fn)
+function M.fetch(api_url, router_token, etag, http_get_fn, log)
+  log = log or default_log()
   local url = api_url .. "/api/router/policy"
   if etag then
     url = url .. "?since=" .. urlencode(etag)
@@ -42,7 +57,10 @@ function M.fetch(api_url, router_token, etag, http_get_fn)
     hdrs["If-None-Match"] = etag
   end
 
+  log.debug("policy.fetch: GET url=%s etag=%s", url, tostring(etag))
   local status, body, _ = http_get_fn(url, hdrs)
+  log.debug("policy.fetch: response status=%s bodyLen=%d",
+            tostring(status), body and #body or 0)
 
   if status == 304 then
     return nil, etag
@@ -58,22 +76,24 @@ function M.fetch(api_url, router_token, etag, http_get_fn)
     if ok and snap_or_err then
       local snap = snap_or_err
       local new_etag = (snap.etag ~= nil) and snap.etag or etag
+      log.debug("policy.fetch: parsed snapshot devices=%d profiles=%d etag=%s",
+                snap.devices and #snap.devices or 0,
+                snap.profiles and #snap.profiles or 0,
+                tostring(new_etag))
       return snap, new_etag
     end
     -- snap_or_err holds the error message when pcall returns false (e.g. the
     -- luci.jsonc require itself failed, or parse raised/returned nil).
     local body_str = body and tostring(body) or ""
     if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
-    io.stderr:write(string.format(
-      "[familydns] policy.fetch: JSON parse failed: %s (body=%q)\n",
-      tostring(snap_or_err), body_str))
+    log.err("policy.fetch: JSON parse failed: %s (body=%q)",
+            tostring(snap_or_err), body_str)
     return nil, nil
   else
     local body_str = body and tostring(body) or ""
     if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
-    io.stderr:write(string.format(
-      "[familydns] policy.fetch: unexpected status %s body=%q\n",
-      tostring(status), body_str))
+    log.err("policy.fetch: unexpected status %s body=%q",
+            tostring(status), body_str)
     return nil, nil
   end
 end
@@ -83,24 +103,25 @@ end
 -- ---------------------------------------------------------------------------
 -- write_fn(path, content) must return (truthy, nil) on success or (nil, err_string).
 -- reload_fn(cmd) is called with a shell command string; return value is ignored.
-function M.apply(snapshot, write_fn, reload_fn)
+function M.apply(snapshot, write_fn, reload_fn, log)
+  log = log or default_log()
   local dnsmasq_content = render.dnsmasq(snapshot)
   local nft_content     = render.nft(snapshot)
 
   local ok1, err1 = write_fn("/tmp/dnsmasq.d/familydns.conf", dnsmasq_content)
   if not ok1 then
-    io.stderr:write(string.format(
-      "[familydns] policy.apply: write dnsmasq conf failed: %s\n", tostring(err1)))
+    log.err("policy.apply: write dnsmasq conf failed: %s", tostring(err1))
     return false
   end
 
   local ok2, err2 = write_fn("/tmp/nftables.d/familydns.nft", nft_content)
   if not ok2 then
-    io.stderr:write(string.format(
-      "[familydns] policy.apply: write nft file failed: %s\n", tostring(err2)))
+    log.err("policy.apply: write nft file failed: %s", tostring(err2))
     return false
   end
 
+  log.debug("policy.apply: wrote dnsmasq=%dB nft=%dB; reloading",
+            #dnsmasq_content, #nft_content)
   reload_fn("/etc/init.d/dnsmasq reload")
   -- Delete the table first so sets/chains don't conflict on re-import
   reload_fn("nft delete table inet familydns 2>/dev/null; nft -f /tmp/nftables.d/familydns.nft")

--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -22,6 +22,18 @@
 
 local M = {}
 
+-- log is injectable; default to the real logger wrapper, fall back to stderr.
+local function default_log()
+  local ok, l = pcall(require, "familydns.log")
+  if ok then return l end
+  return {
+    info  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    err   = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    warn  = function(fmt, ...) io.stderr:write(string.format(fmt .. "\n", ...)) end,
+    debug = function() end,
+  }
+end
+
 -- ---------------------------------------------------------------------------
 -- decode_counter_name(name) → mac, dst_ip  or  nil
 -- ---------------------------------------------------------------------------
@@ -118,12 +130,14 @@ end
 -- ---------------------------------------------------------------------------
 -- usage.post(api_url, router_token, report, post_fn)
 -- ---------------------------------------------------------------------------
-function M.post(api_url, router_token, report, post_fn)
+function M.post(api_url, router_token, report, post_fn, log)
+  log = log or default_log()
   local jsonc = require("luci.jsonc")
   -- luci.jsonc encodes empty Lua tables as `{}` (object). The API requires
   -- `records` to be a JSON array, so when no usage was observed in this
   -- window, skip the POST entirely rather than send a malformed payload.
   if report.records and next(report.records) == nil then
+    log.debug("usage.post: skipping (no records)")
     return true
   end
   local body = jsonc.stringify(report)
@@ -133,15 +147,18 @@ function M.post(api_url, router_token, report, post_fn)
     ["Content-Type"]  = "application/json",
   }
 
+  log.debug("usage.post: POST url=%s records=%d periodStart=%s periodEnd=%s",
+            url, #report.records, tostring(report.periodStart),
+            tostring(report.periodEnd))
   local status, resp_body, err = post_fn(url, body, hdrs)
   if status and status >= 200 and status < 300 then
+    log.debug("usage.post: success status=%d", status)
     return true
   end
   local body_str = resp_body and tostring(resp_body) or ""
   if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
-  io.stderr:write(string.format(
-    "[familydns] usage.post: POST failed (status=%s body=%q) err=%s\n",
-    tostring(status), body_str, tostring(err)))
+  log.err("usage.post: POST failed (status=%s body=%q) err=%s",
+          tostring(status), body_str, tostring(err))
   return false
 end
 

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -17,6 +17,7 @@ local policy   = require("familydns.policy")
 local usage    = require("familydns.usage")
 local conntrack = require("familydns.conntrack")
 local render   = require("familydns.render")
+local log      = require("familydns.log")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -33,13 +34,18 @@ local max_batch     = tonumber(uci_get("event_batch_size",        "50"))
 local flush_int     = tonumber(uci_get("event_flush_interval",    "10"))
 local policy_int    = tonumber(uci_get("policy_poll_interval",    "60"))
 local usage_int     = tonumber(uci_get("usage_report_interval",   "300"))
+local debug_opt     = uci_get("debug",                            "0")
+
+log.init({ debug = debug_opt })
+log.info("familydns-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds",
+         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int)
 
 if router_token == "" then
-  io.stderr:write("[familydns] router_token not set — run enrollment first\n")
+  log.err("router_token not set — run enrollment first")
   os.exit(1)
 end
 if router_id == "" then
-  io.stderr:write("[familydns] router_id not set — run enrollment first\n")
+  log.err("router_id not set — run enrollment first")
   os.exit(1)
 end
 
@@ -167,11 +173,15 @@ local last_usage_run  = 0
 -- ── Initial policy fetch at startup ──────────────────────────────────────────
 
 do
-  local snap, etag = policy.fetch(api_url, router_token, nil, http_get)
+  log.debug("startup: initial policy fetch")
+  local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
   if snap then
-    policy.apply(snap, write_file, run_cmd)
+    policy.apply(snap, write_file, run_cmd, log)
     render.update_shared(snap, nft_sets, blocked_ips, blocked_reason)
     current_etag = etag
+    log.info("startup: applied initial policy etag=%s", tostring(etag))
+  else
+    log.warn("startup: initial policy fetch returned no snapshot (will retry on timer)")
   end
   last_policy_run = os.time()
   last_usage_run  = os.time()
@@ -194,6 +204,7 @@ conntrack.watch({
   max_batch      = max_batch,
   flush_interval = flush_int,
   http_post      = http_post,
+  log            = log,
 
   -- Called on every conntrack line (after event processing).
   -- Drives the policy and usage timers co-operatively.
@@ -203,13 +214,15 @@ conntrack.watch({
     -- Policy timer
     if (now - last_policy_run) >= policy_int then
       last_policy_run = now
-      local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get)
+      local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log)
       if snap then
-        policy.apply(snap, write_file, run_cmd)
+        policy.apply(snap, write_file, run_cmd, log)
         render.update_shared(snap, nft_sets, blocked_ips, blocked_reason)
         current_etag = etag
+        log.debug("policy timer: applied snapshot etag=%s", tostring(etag))
       elseif etag then
         current_etag = etag  -- 304: just update etag
+        log.debug("policy timer: 304 not modified etag=%s", tostring(etag))
       end
     end
 
@@ -228,7 +241,9 @@ conntrack.watch({
           if ok and counters then
             local report = usage.build_report(
               counters, nft_sets, period_start, period_end, router_id)
-            local posted = usage.post(api_url, router_token, report, http_post)
+            log.debug("usage timer: %d counter(s), %d record(s) prepared",
+                      #counters, report.records and #report.records or 0)
+            local posted = usage.post(api_url, router_token, report, http_post, log)
             if posted then
               -- Reset counters so next period starts clean
               os.execute("nft reset counters table inet familydns 2>/dev/null")

--- a/openwrt/test/init_spec.sh
+++ b/openwrt/test/init_spec.sh
@@ -70,5 +70,11 @@ grep -q 'procd_set_param stderr' "$INIT" \
   && check "enables stderr logging via procd" ok \
   || check "enables stderr logging via procd" "not found"
 
+# 11. stdout logging must also be enabled (#228: agent stdout was previously
+# discarded, leaving `logread -f | grep familydns` empty)
+grep -q 'procd_set_param stdout' "$INIT" \
+  && check "enables stdout logging via procd" ok \
+  || check "enables stdout logging via procd" "not found"
+
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/log_spec.lua
+++ b/openwrt/test/log_spec.lua
@@ -1,0 +1,91 @@
+-- Tests for openwrt/files/usr/lib/lua/familydns/log.lua
+-- Run with: busted openwrt/test/log_spec.lua
+
+local log = require("log")
+
+-- The log module shells out to `logger -t <tag> <msg>`. Each test installs a
+-- fake io.popen / os.execute that records the commands it was asked to run.
+
+local recorded
+local function reset()
+  recorded = {}
+  -- Stub the function the module actually uses.
+  log._exec = function(cmd) recorded[#recorded + 1] = cmd end
+end
+
+describe("log module", function()
+  before_each(reset)
+
+  describe("init", function()
+    it("defaults debug enabled = false", function()
+      log.init({})
+      assert.is_false(log.debug_enabled())
+    end)
+
+    it("accepts debug = true", function()
+      log.init({ debug = true })
+      assert.is_true(log.debug_enabled())
+    end)
+
+    it("accepts string truthy values from UCI ('1', 'true')", function()
+      log.init({ debug = "1" })
+      assert.is_true(log.debug_enabled())
+      log.init({ debug = "true" })
+      assert.is_true(log.debug_enabled())
+      log.init({ debug = "0" })
+      assert.is_false(log.debug_enabled())
+      log.init({ debug = "" })
+      assert.is_false(log.debug_enabled())
+    end)
+  end)
+
+  describe("info / err / warn", function()
+    it("always invokes logger regardless of debug flag", function()
+      log.init({ debug = false })
+      log.info("hello world")
+      log.err("boom")
+      log.warn("careful")
+      assert.equal(3, #recorded)
+      assert.matches("logger %-t familydns ", recorded[1])
+      assert.matches("hello world", recorded[1])
+      assert.matches("%-p user%.err", recorded[2])
+      assert.matches("%-p user%.warning", recorded[3])
+    end)
+
+    it("shell-quotes the message safely", function()
+      log.init({ debug = false })
+      log.info([[a 'b' "c" $(rm -rf /) `evil` end]])
+      assert.equal(1, #recorded)
+      -- Must not contain an unescaped single quote inside a single-quoted block.
+      -- The implementation uses %q-style quoting; the literal command must
+      -- start the message arg with a quote character.
+      assert.matches("logger %-t familydns ", recorded[1])
+      -- And the dangerous characters must not break out:
+      assert.is_nil(recorded[1]:find("`evil`%s*$"))
+    end)
+  end)
+
+  describe("debug", function()
+    it("is a no-op when debug is disabled", function()
+      log.init({ debug = false })
+      log.debug("trace this")
+      assert.equal(0, #recorded)
+    end)
+
+    it("emits a debug-priority logger call when enabled", function()
+      log.init({ debug = true })
+      log.debug("trace this")
+      assert.equal(1, #recorded)
+      assert.matches("%-p user%.debug", recorded[1])
+      assert.matches("trace this", recorded[1])
+    end)
+  end)
+
+  describe("format", function()
+    it("supports string.format-style varargs", function()
+      log.init({ debug = true })
+      log.debug("policy fetch url=%s status=%d", "http://x", 200)
+      assert.matches("policy fetch url=http://x status=200", recorded[1])
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

- **Phase 1 of #228**: makes the agent → `/api/router/*` → DB → UI hop observable so the phone-shows-as-unknown bug can be diagnosed live, rather than re-spawning a debug agent each time. Defaults are off-and-secure; nothing changes in production unless an operator explicitly opts in.
- Three new observability surfaces: OpenWRT agent debug logging (`logger -t familydns`, gated by a UCI flag), API per-request DEBUG logs on the router endpoints, and loopback-only `/api/debug/*` JSON dumps. Postgres exposure is a separate docker-compose overlay file.
- Phase 2 (the actual fix for the missing-MAC behavior) is deliberately not in this PR. Once the observability lands and we have logs from the field, we'll know which hop is dropping the MAC — could be agent, ingest, or UI — and the fix will be a small targeted change.

## What's in this PR

### OpenWRT agent
- `procd_set_param stdout 1` in `openwrt/files/etc/init.d/familydns`. The agent's stdout was previously discarded by procd; this is the likely reason `logread -f | grep familydns` was empty in the field.
- New `openwrt/files/usr/lib/lua/familydns/log.lua` module wrapping BusyBox `logger -t familydns`, with priority-tagged info/warn/err/debug. Replaces every `io.stderr:write` in `policy.lua`, `usage.lua`, `conntrack.lua`, and `familydns-agent`.
- New UCI option \`familydns.@familydns[0].debug\` gates verbose per-flow tracing: policy fetch (URL, status, etag, parsed counts), policy apply, usage POST, event flush, **and the per-flow mac/hostname attribution decision inside \`handle_flow\`** — which is exactly the hop we suspect for #228.

### API
- `FAMILYDNS_LOG_LEVEL` env var controls the `familydns.*` logback level (default INFO; logback reads it via `${FAMILYDNS_LOG_LEVEL:-INFO}` in `api/resources/logback.xml`). At DEBUG, every `/api/router/{usage,events,policy}` request emits one log line per record/event with mac, hostname, allowed/blocked, ts.
- New `DebugRoutes` mounting `/api/debug/devices`, `/api/debug/events?limit=N`, `/api/debug/time_usage` **only** when `FAMILYDNS_DEBUG=1`. Unauthenticated, but refuses non-loopback callers (checks both `remoteAddress` and the `Host` header, with IPv6 bracket-stripping). Startup logs a WARNING when DEBUG=1.

### Deploy
- `deploy/docker-compose.debug.yml` overlay: binds postgres to `127.0.0.1:5433` (never 0.0.0.0) and sets the API debug env vars. Used via `docker compose -f docker-compose.prod.yml -f docker-compose.debug.yml up`. Default prod stack has no postgres host port and no debug endpoints.
- `deploy/.env.example` documents the new knobs with "FOR DEBUGGING ONLY" comments.

### Docs
- `docs/install-api.md` gains a §9 "Debugging" section walking the operator through all three surfaces.

## Diagnostic walk for #228 (once this lands)

With the above in place, the next time we hit a missing-MAC device:

1. **Hop 1 — agent input.** On the router, `uci set familydns.@familydns[0].debug=1; uci commit; /etc/init.d/familydns restart`, then `logread -f | grep familydns`. The `handle_flow: connection_attempt ... mac=... hostname=...` lines tell us whether the agent observes the device's MAC at all.
2. **Hop 2 — agent output.** Same logread will also show the POST batches (`conntrack: POST events success`). If hop 1 has the MAC but the POST is failing, we'll see the error here.
3. **Hop 3 — API ingest.** With `FAMILYDNS_LOG_LEVEL=DEBUG` on the API side, `docker compose logs -f api` shows each event's mac/hostname as received. Plus `curl http://localhost:8080/api/debug/events?limit=200` from the API host gives the actual rows we stored.
4. **Hop 4 — DB state.** `curl http://localhost:8080/api/debug/devices` (or the postgres overlay for ad-hoc SQL) tells us whether the row exists with a NULL mac or doesn't exist at all.

## Test plan

- [x] `mill api.test` — 6 new `DebugApiSpec` tests + all existing pass
- [x] `sh openwrt/test/run_tests.sh` — 8 new `log_spec.lua` tests + `init_spec.sh` `procd_set_param stdout` check + all pre-existing tests (2 render failures pre-date this branch)
- [x] `scalafmt --check --non-interactive` clean
- [ ] **Manual smoke once merged**: enable `uci set familydns.@familydns[0].debug=1` on the deployed router, then run the diagnostic walk above against the phone whose MAC is missing — capture which hop drops it; file Phase 2 fix as a follow-up PR.

Refs #227 (UX audit), #228 (this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)