### PR TITLE
ci: flip publish gates for #228 live debugging (fixes #243)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,13 +106,14 @@ jobs:
       - name: Run prod-stack smoke
         run: scripts/smoke-prod.sh
 
-  # ── 3. Publish API image (path-filtered + manual approval) ────────────────
+  # ── 3. Publish API image (path-filtered) ──────────────────────────────────
+  # NOTE: manual approval gate temporarily removed for live debugging of #228;
+  # restore via #244 once the bug is fixed and we're back in normal cadence.
   publish-api:
     name: Publish Docker image to ghcr.io
     needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
     if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,14 +1,15 @@
 name: OpenWRT Package Build
 
-# Branch pushes to main are intentionally excluded — that path burned CI on
-# unrelated changes (docs-only merges) and the per-PR `paths` filter already
-# covers code changes pre-merge. A release only happens on a v* tag push;
-# the `Create GitHub release` step below stays gated on the tag ref.
-# See issues #191 (no branch pushes) and #212 (workflow name no longer
-# implies every run publishes).
+# Normally, releases happen only on v* tag pushes (#191, #212). For live
+# debugging of #228 we also publish a rolling "openwrt-latest" pre-release
+# on every push to main that touches openwrt/**, so the field router can
+# fetch the updated .apk without us cutting a real tag each iteration.
+# This is reverted by #244 once #228 is fixed.
 on:
   push:
     tags: ["v*"]
+    branches: ["main"]
+    paths: ["openwrt/**"]
   pull_request:
     paths: ["openwrt/**"]
   workflow_dispatch:
@@ -96,7 +97,7 @@ jobs:
           path: openwrt/familydns_*.apk
           if-no-files-found: error
 
-      - name: Create GitHub release and attach packages
+      - name: Create GitHub release and attach packages (tag)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
@@ -104,3 +105,19 @@ jobs:
             openwrt/familydns_*.ipk
             openwrt/familydns_*.apk
           generate_release_notes: true
+
+      # Rolling pre-release for #228 live debugging. Reverted by #244.
+      - name: Publish rolling openwrt-latest release (main push)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: openwrt-latest
+          name: "openwrt-latest (rolling)"
+          body: |
+            Rolling build of the OpenWRT agent from the latest `main`.
+            Replaced on every push to `main` touching `openwrt/**`.
+            For #228 live debugging — see #243 / #244.
+          prerelease: true
+          files: |
+            openwrt/familydns_*.ipk
+            openwrt/familydns_*.apk


### PR DESCRIPTION
## Summary

- Drops `environment: production` on `publish-api` so main-branch pushes touching `api/` auto-publish to ghcr.io.
- Adds main-branch trigger to `openwrt-build.yml` (filtered to `openwrt/**`) plus a rolling `openwrt-latest` pre-release.
- Both gates are reverted by #244 once #228 is fixed.

## Why

Iterating on #228 requires fast cycles: edit → main → image on the API host, edit → main → .apk on the router. The current gates (manual approval click + cut-a-tag-per-iteration) add minutes of friction per attempt and the bug is the highest-priority debug right now.

## What changes for an operator

- API host: `docker pull ghcr.io/sameerparekh/familydns-api:latest` always returns the head-of-main build.
- Router: `wget https://github.com/sameerparekh/familydns/releases/download/openwrt-latest/familydns_*.apk` always gets the head-of-main .apk.
- Real `v*` tag pushes still cut proper named releases — that path is unchanged.

## Test plan

- [x] `yamllint` mentally (no schema check available locally)
- [ ] Merge → confirm a main push touching `api/` produces an updated `:latest` without a click in Actions
- [ ] Merge → push a docs-only change to `openwrt/`'s README, confirm a new `openwrt-latest` release appears with attached `.ipk` + `.apk`

Fixes #243. Reverts by #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)