### PR TITLE
vm-e2e: bake DNS-leak block into router image (fixes #226 step 5)

### DIFF
--- a/scripts/vm/uci-defaults/99-familydns
+++ b/scripts/vm/uci-defaults/99-familydns
@@ -25,6 +25,30 @@ uci set network.lan.ipaddr='192.168.100.1'
 uci set network.lan.netmask='255.255.255.0'
 uci commit network
 
+# Block out-of-band DNS leaks: drop LAN→WAN forwarded traffic to port 53
+# (UDP+TCP). Without this, OpenWRT's stock LAN→WAN accept rule lets a client
+# run `dig @1.1.1.1 …` straight through SLIRP to the host's real upstream
+# resolver, defeating the harness's DNS-leak test (issue #226 step 5). The
+# rule is on FORWARD only, so LAN→router (INPUT) DNS — i.e. the router's own
+# dnsmasq, which is the only resolver in the client's /etc/resolv.conf —
+# keeps working, and step 6 (`dig example.com` via the router) is unaffected.
+#
+# In production the familydns-agent is expected to install equivalent
+# enforcement once it's enrolled against an API and has a policy. Until that
+# path lands (#148 orchestrator + agent-side egress-DNS rules in render.lua),
+# seed it here so the harness in scripts/vm/ is testable standalone without
+# a live API stack.
+uci batch <<EOF
+add firewall rule
+set firewall.@rule[-1].name='block-dns-leak'
+set firewall.@rule[-1].src='lan'
+set firewall.@rule[-1].dest='wan'
+set firewall.@rule[-1].proto='tcpudp'
+set firewall.@rule[-1].dest_port='53'
+set firewall.@rule[-1].target='DROP'
+EOF
+uci commit firewall
+
 # Allow password-less root SSH from the QEMU host so the orchestrator can
 # drive the router without an interactive enrollment step. This image is
 # intended for ephemeral VMs only — never flash it to real hardware.


### PR DESCRIPTION
## Summary

Adds a firewall rule to `scripts/vm/uci-defaults/99-familydns` that drops LAN→WAN forwarded traffic to port 53 (UDP+TCP). This unblocks the last failing step of the #226 e2e plan: step 5 (`dig +time=2 +tries=1 @1.1.1.1 example.com` from a client must fail/time out).

Without this rule, OpenWRT's stock LAN→WAN accept happily forwards the query through SLIRP to the host's real upstream resolver, and step 5 returns an answer in ~15 ms instead of timing out.

The rule is on the FORWARD chain only — LAN→router (INPUT) DNS still works, so step 6 (`dig example.com` via the router's dnsmasq, which is the only resolver in the client's `/etc/resolv.conf`) is unaffected.

### Why bake it into the image instead of letting the agent install it?

Looked at the agent's `render.lua` — it doesn't currently emit any egress-DNS rules, only per-profile time/pause drops. So even bringing up a real API stack and fully enrolling the router would not make step 5 pass today. Until the orchestrator path (#148) and matching agent-side egress-DNS rules land, baking this into the first-boot uci-defaults makes the `scripts/vm/` harness testable standalone, with no live API stack required.

The change is small, self-contained, and matches the same pattern used by the existing first-boot LAN-IP and familydns-config seeds in this file.

## Test plan (verified on `plex`)

```
=== STEP 5: dig @1.1.1.1 (expect FAIL/timeout) ===
$ scripts/vm/client-exec.sh -- dig +time=2 +tries=1 @1.1.1.1 example.com
;; communications error to 1.1.1.1#53: timed out

; <<>> DiG 9.20.22 <<>> +time=2 +tries=1 @1.1.1.1 example.com
;; no servers could be reached
exit=9
✅ pass — query times out

=== STEP 6: dig example.com (via router) ===
;; ANSWER SECTION:
example.com.        229    IN    A    172.66.147.243
example.com.        229    IN    A    104.20.23.154
;; SERVER: 192.168.100.1#53(192.168.100.1) (UDP)
exit=0
✅ pass

=== STEP 7: curl http://example.com ===
200
exit=0
✅ pass
```

Refs #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)