### PR TITLE
docker: pin build stages to $BUILDPLATFORM (fixes 45min publish)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,12 @@
 # scripts/deploy.sh on the host (no docker on the prod box).
 
 # ── 1. Scala build ────────────────────────────────────────────────────────
-FROM eclipse-temurin:21-jdk AS scala-build
+# Pin to BUILDPLATFORM (always the runner's native arch). Without this,
+# buildx runs this stage once per target arch — and the arm64 leg compiles
+# Scala under QEMU emulation, which is glacial (~30 min on its own). The
+# .jar is platform-neutral, so cross-arch builds gain nothing from running
+# scalac twice.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk AS scala-build
 ARG MILL_VERSION=1.1.5
 RUN apt-get update -qq && apt-get install -y -qq curl git ca-certificates \
  && curl -fsSL "https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/${MILL_VERSION}/mill-dist-${MILL_VERSION}-mill.sh" \
@@ -24,7 +29,8 @@ RUN mill api.assembly \
  && cp out/api/assembly.dest/out.jar /tmp/api.jar
 
 # ── 2. Web build ──────────────────────────────────────────────────────────
-FROM node:22-bookworm-slim AS web-build
+# Same rationale: Vite output is static JS/CSS, no native code.
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS web-build
 WORKDIR /web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci --silent


### PR DESCRIPTION
## Summary

Multi-arch API publish was taking ~45 min. Pin the `scala-build` and `web-build` stages to `\$BUILDPLATFORM` so they run once on native amd64 instead of running again under QEMU for the arm64 leg. The final runtime stage stays per-arch — that's where the actual JRE binary differs.

## Why this works

Both intermediate stages produce platform-neutral artifacts:
- `scala-build` → JVM `.jar` (bytecode runs anywhere)
- `web-build` → static JS/CSS bundle (interpreted at runtime)

There's no value in compiling Scala twice. The arm64 target image already does `COPY --from=scala-build /tmp/api.jar /app/api.jar`, which is platform-neutral regardless of where the build ran.

## Expected impact

~45 min → ~6 min. Blocks the #228 live debug iteration loop, so getting this in fast.

## Test plan

- [x] CI on this PR builds the same image locally for both arches via the docker/build-push-action — if buildx mis-tags the platform now, the arm64 leg will fail to start (wrong jre arch in the runtime stage). Easy to spot.
- [ ] After merge, time the master.yml publish-api step and confirm it dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)