### PR TITLE
openwrt: add apk-tools support to familydns-update (fixes #253)

### DIFF
--- a/openwrt/files/usr/sbin/familydns-update
+++ b/openwrt/files/usr/sbin/familydns-update
@@ -1,7 +1,9 @@
 #!/bin/sh
 # Auto-updater for the familydns package.
-# Checks GitHub Releases for a newer .ipk and upgrades in place.
-# opkg preserves /etc/config/familydns, so the router_token survives upgrades.
+# Checks GitHub Releases for a newer build and upgrades in place.
+# Supports both opkg (OpenWRT <= 23.05) and apk-tools (OpenWRT 24.10+).
+# /etc/config/familydns is declared as a conffile, so router_token survives
+# upgrades under either package manager.
 # Safe to run from cron; logs to syslog under tag "familydns".
 set -u
 
@@ -9,22 +11,47 @@ API_URL="https://api.github.com/repos/sameerparekh/familydns/releases/latest"
 
 log() { logger -t familydns "update: $*"; }
 
-# Skip silently on apk-only systems (OpenWRT 24.10+); the .apk track lives
-# elsewhere (see #176).
-command -v opkg >/dev/null 2>&1 || exit 0
+# Detect package manager. Prefer apk (24.10+) when both are present, since
+# routers mid-migration may still ship a vestigial opkg binary.
+if command -v apk >/dev/null 2>&1; then
+  PM=apk
+  PKG_EXT='\.apk$'
+  TMP=/tmp/familydns-update.apk
+elif command -v opkg >/dev/null 2>&1; then
+  PM=opkg
+  PKG_EXT='\.ipk$'
+  TMP=/tmp/familydns-update.ipk
+else
+  log "no package manager found (neither apk nor opkg); skipping"
+  exit 0
+fi
 
-CURRENT=$(opkg info familydns 2>/dev/null | awk '/^Version:/{print $2; exit}')
+# Current installed version.
+case "$PM" in
+  apk)
+    # `apk list -I familydns` prints lines like:
+    #   familydns-1.2.3-r0 x86_64 {familydns} (license) [installed]
+    # Strip the leading "familydns-" to get the version.
+    CURRENT=$(apk list -I familydns 2>/dev/null \
+      | awk '{print $1; exit}' \
+      | sed -n 's/^familydns-//p')
+    ;;
+  opkg)
+    CURRENT=$(opkg info familydns 2>/dev/null | awk '/^Version:/{print $2; exit}')
+    ;;
+esac
+
 if [ -z "$CURRENT" ]; then
-  log "familydns not installed via opkg; nothing to update"
+  log "familydns not installed via $PM; nothing to update"
   exit 0
 fi
 
 LATEST_URL=$(curl -sf "$API_URL" \
   | jsonfilter -e '@.assets[*].browser_download_url' \
-  | grep -E '\.ipk$' \
+  | grep -E "$PKG_EXT" \
   | head -n1)
 if [ -z "$LATEST_URL" ]; then
-  log "could not resolve latest .ipk asset URL; skipping"
+  log "could not resolve latest $PM asset URL; skipping"
   exit 0
 fi
 
@@ -34,30 +61,55 @@ if [ -z "$LATEST_VER" ]; then
   exit 0
 fi
 
-# Prefer opkg's version comparator (handles 1.10.0 > 1.9.0); fall back to
-# string equality.
-if opkg compare-versions "$LATEST_VER" '>' "$CURRENT" 2>/dev/null; then
-  :
-elif [ "$LATEST_VER" = "$CURRENT" ]; then
-  exit 0
-else
-  # compare-versions said not-newer (could be equal or older). Either way no upgrade.
-  exit 0
-fi
+# Robust version compare per package manager. Both opkg and apk-tools handle
+# 1.10.0 > 1.9.0 correctly; the string-equality fallback covers parse failures.
+case "$PM" in
+  apk)
+    # `apk version -t a b` prints one of <, =, > to stdout.
+    CMP=$(apk version -t "$LATEST_VER" "$CURRENT" 2>/dev/null || echo '?')
+    if [ "$CMP" = '>' ]; then
+      :
+    else
+      exit 0
+    fi
+    ;;
+  opkg)
+    if opkg compare-versions "$LATEST_VER" '>' "$CURRENT" 2>/dev/null; then
+      :
+    elif [ "$LATEST_VER" = "$CURRENT" ]; then
+      exit 0
+    else
+      exit 0
+    fi
+    ;;
+esac
 
-log "upgrading $CURRENT -> $LATEST_VER"
-TMP=/tmp/familydns-update.ipk
+log "upgrading $CURRENT -> $LATEST_VER via $PM"
 if ! curl -fsSL -o "$TMP" "$LATEST_URL"; then
   log "download failed: $LATEST_URL"
   rm -f "$TMP"
   exit 1
 fi
 
-if opkg install --force-reinstall "$TMP" >/tmp/familydns-update.log 2>&1; then
-  log "installed $LATEST_VER"
-  rm -f "$TMP" /tmp/familydns-update.log
-else
-  log "opkg install failed; see /tmp/familydns-update.log"
-  rm -f "$TMP"
-  exit 1
-fi
+case "$PM" in
+  apk)
+    if apk add --allow-untrusted "$TMP" >/tmp/familydns-update.log 2>&1; then
+      log "installed $LATEST_VER"
+      rm -f "$TMP" /tmp/familydns-update.log
+    else
+      log "apk add failed; see /tmp/familydns-update.log"
+      rm -f "$TMP"
+      exit 1
+    fi
+    ;;
+  opkg)
+    if opkg install --force-reinstall "$TMP" >/tmp/familydns-update.log 2>&1; then
+      log "installed $LATEST_VER"
+      rm -f "$TMP" /tmp/familydns-update.log
+    else
+      log "opkg install failed; see /tmp/familydns-update.log"
+      rm -f "$TMP"
+      exit 1
+    fi
+    ;;
+esac

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -30,15 +30,38 @@ grep -q 'logger -t familydns' "$SCRIPT" \
   && check "logs to syslog tag familydns" ok \
   || check "logs to syslog tag familydns" "no logger -t familydns"
 
-# 3. Bails silently on apk-only systems (no opkg)
-grep -q 'command -v opkg' "$SCRIPT" \
-  && check "checks for opkg presence (apk-only safe)" ok \
-  || check "checks for opkg presence (apk-only safe)" "missing command -v opkg guard"
+# 3. Detects both package managers (apk for 24.10+, opkg for older)
+grep -q 'command -v apk' "$SCRIPT" && grep -q 'command -v opkg' "$SCRIPT" \
+  && check "detects both apk and opkg package managers" ok \
+  || check "detects both apk and opkg package managers" "missing apk/opkg detection"
 
-# 4. Uses opkg compare-versions for robust version compare
+# 4. Uses opkg compare-versions for robust version compare on opkg path
 grep -q 'opkg compare-versions' "$SCRIPT" \
-  && check "uses opkg compare-versions" ok \
-  || check "uses opkg compare-versions" "missing — string compare alone breaks 1.10 vs 1.9"
+  && check "uses opkg compare-versions on opkg path" ok \
+  || check "uses opkg compare-versions on opkg path" "missing — string compare alone breaks 1.10 vs 1.9"
+
+# 4b. Uses apk version -t for robust version compare on apk path
+grep -q 'apk version -t' "$SCRIPT" \
+  && check "uses apk version -t on apk path" ok \
+  || check "uses apk version -t on apk path" "missing — apk needs its own comparator"
+
+# 4c. Installs via apk add --allow-untrusted on apk path
+grep -q 'apk add --allow-untrusted' "$SCRIPT" \
+  && check "uses apk add --allow-untrusted on apk path" ok \
+  || check "uses apk add --allow-untrusted on apk path" "missing apk install command"
+
+# 4d. Filters for .apk assets on apk path (and still filters .ipk on opkg path)
+grep -q "'\\\\.apk\$'" "$SCRIPT" \
+  && check "filters .apk asset on apk path" ok \
+  || check "filters .apk asset on apk path" "missing .apk regex"
+grep -q "'\\\\.ipk\$'" "$SCRIPT" \
+  && check "filters .ipk asset on opkg path" ok \
+  || check "filters .ipk asset on opkg path" "missing .ipk regex"
+
+# 4e. Reads current installed version on apk path (apk list -I or db parse)
+grep -qE 'apk (list -I|info)' "$SCRIPT" \
+  && check "reads current version on apk path" ok \
+  || check "reads current version on apk path" "missing apk version lookup"
 
 # 5. Hits GitHub releases/latest API
 grep -q 'releases/latest' "$SCRIPT" \
@@ -50,10 +73,10 @@ grep -q 'opkg install --force-reinstall' "$SCRIPT" \
   && check "uses opkg install --force-reinstall" ok \
   || check "uses opkg install --force-reinstall" "must --force-reinstall"
 
-# 7. Cleans up the downloaded .ipk
-grep -qE 'rm -f .*(\.ipk|\$TMP|"\$TMP")' "$SCRIPT" \
-  && check "cleans up downloaded .ipk after install" ok \
-  || check "cleans up downloaded .ipk after install" "no rm -f for downloaded .ipk"
+# 7. Cleans up the downloaded package after install
+grep -qE 'rm -f .*(\.ipk|\.apk|\$TMP|"\$TMP")' "$SCRIPT" \
+  && check "cleans up downloaded package after install" ok \
+  || check "cleans up downloaded package after install" "no rm -f for downloaded package"
 
 # 8. Makefile installs the update script
 grep -q 'familydns-update' "$MAKEFILE" \


### PR DESCRIPTION
## Summary

Fixes #253: the auto-updater silently no-ops on OpenWRT 24.10+ because that release line uses apk-tools and the old script bails out the moment it can't find `opkg`. With the rolling `openwrt-latest` build now producing `.apk` assets every push to main, routers installed via `apk add` were running the cron every 6 hours without doing anything.

### Why the original guard exists (and why it's now obsolete)

When #176 was open, no `.apk` artifact was being shipped, so the safest behavior on apk-only systems was to exit 0 rather than try to install an `.ipk` that wouldn't work. #176 has since closed and `.apk` artifacts are produced on every push, so the guard is now actively harmful — it's the reason 24.10+ routers never update.

### Branching logic

- **Detect**: prefer `apk` when present (covers mixed-binary routers mid-migration), fall back to `opkg`, otherwise log and exit cleanly.
- **Asset filter**: `\.apk$` vs `\.ipk$` against the GitHub Releases asset list.
- **Current version**: `apk list -I familydns` parsed with awk/sed for apk; existing `opkg info` path unchanged for opkg.
- **Compare**: `apk version -t LATEST CURRENT` returns `<`/`=`/`>`; existing `opkg compare-versions` path unchanged.
- **Install**: `apk add --allow-untrusted /tmp/familydns-update.apk` vs the existing `opkg install --force-reinstall`. `/etc/config/familydns` is already declared as a conffile, so apk-tools preserves it across upgrades the same way opkg does — `router_token` survives.

## Test plan

- [x] `sh openwrt/test/update_spec.sh` — 19 checks pass, including 5 new apk-branch assertions (apk/opkg detection, `apk version -t`, `apk add --allow-untrusted`, `.apk` asset filter, current-version lookup) and a broadened cleanup check that covers both extensions.
- [x] `sh openwrt/test/run_tests.sh` — full openwrt suite green.
- [x] `sh -n` syntax check on the updated script.
- [ ] Manual verification on a real OpenWRT 24.10+ router after merge: `logread | grep familydns` should show `update:` lines on the next 6-hour cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)