### PR TITLE
docs: add install quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ connection events back. See [`docs/architecture-openwrt.md`](docs/architecture-o
 | `openwrt/`  | Lua agent: policy pull, dnsmasq/nft enforcement, usage   | OpenWRT ipk |
 | `opnsense/` | Python agent: pflog tail, connection_attempt events      | OPNsense plugin |
 
+## Quick install
+
+Get a running stack on a Linux host plus an enforcement agent on your gateway
+router. Each script prompts for the values it needs and is safe to re-run.
+
+**1. API + Postgres** — on a Linux host with Docker + Compose v2:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+```
+
+Prompts for install path, port, bind address, and a new admin password;
+generates secrets, brings the stack up, rotates the seeded `admin/changeme`.
+Full walkthrough (TLS, reverse proxy, firewall, debugging): [`docs/install-api.md`](docs/install-api.md).
+
+**2. OpenWRT router agent** — SSH in as root, then:
+
+```sh
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+```
+
+Prompts for the API URL, an enrollment token (admin UI → **Routers → Add
+router**), and the LAN prefix. Detects 23.05.x (opkg) vs 24.10+ (apk) and
+installs the matching artifact. Full walkthrough: [`docs/install-openwrt.md`](docs/install-openwrt.md).
+
+**3. OPNsense router agent** — installer not yet published. See the
+[`opnsense/`](opnsense/) directory for the in-progress plugin.
+
 ## Quick start (development, macOS or Linux)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a **Quick install** section to [README.md](README.md) above the existing developer Quick start.
- Three steps: API + Postgres (`deploy/install.sh`), OpenWRT agent (`openwrt/install.sh`), and a placeholder for OPNsense.
- Each step links to the full walkthrough in [docs/install-api.md](docs/install-api.md) / [docs/install-openwrt.md](docs/install-openwrt.md).

## Why

The README previously only had a *developer* quickstart (mill, npm dev server). A reader who wanted to install FamilyDNS had to scroll past the dev setup into the deeply-nested **Deployment** section. This makes the install path the first thing visitors see.

Note: the existing **Deployment** section still documents the legacy `bootstrap-host.sh` / systemd-on-host flow, which is out of date. Tracked separately in #257.

## Test plan

- [ ] Render README on GitHub and verify the new section appears above the dev quickstart with working links to docs/install-api.md and docs/install-openwrt.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)