### PR TITLE
web: fix "blocks all DNS" Paused copy (closes #265)

### DIFF
--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -361,7 +361,7 @@ function ProfileEditor({
           <input type="checkbox" checked={form.paused}
             onChange={e => setForm(f => ({ ...f, paused: e.target.checked }))}
             className="w-4 h-4 accent-emerald-500" />
-          Paused (blocks all DNS for devices on this profile)
+          Paused — blocks all internet traffic for devices on this profile.
         </label>
 
         <div>


### PR DESCRIPTION
## Summary
- Reword the Paused checkbox helper text on the profile add/edit form. Post-rearch, pausing a profile blocks all internet traffic for its devices (nftables + dnsmasq attribution on the agent), not just DNS.
- Old: "Paused (blocks all DNS for devices on this profile)"
- New: "Paused — blocks all internet traffic for devices on this profile."

Scanned `web/src/` and `docs/` for other stale "blocks via DNS" framing — none found. Remaining DNS references describe dnsmasq's resolver / ipset attribution role, which is correct.

Closes #265.

## Test plan
- [ ] Visual check of profile add/edit form — helper text reads as new copy.
- [ ] Existing ProfilesPage tests still pass (the "Paused" badge assertion is for a different element and unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)