### PR TITLE
Read screen-time usage from seconds_used; drop legacy minutes_used (fixes #261)

### DIFF
--- a/api/resources/db/migration/V8__drop_time_usage_minutes.sql
+++ b/api/resources/db/migration/V8__drop_time_usage_minutes.sql
@@ -1,0 +1,7 @@
+-- V8__drop_time_usage_minutes.sql
+-- The legacy OPNsense usage-reporting path was never implemented (#113), and
+-- the OpenWRT agent writes only seconds_used + bytes_*. minutes_used is dead.
+-- Drop it. UI reads + policy snapshot now derive minutes from seconds_used / 60.
+
+ALTER TABLE time_usage
+  DROP COLUMN minutes_used;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -115,9 +115,6 @@ trait BlocklistRepo {
 }
 
 trait TimeUsageRepo {
-  def getUsage(mac: String, domain: String, date: LocalDate): Task[Int]
-  def getTotalUsage(mac: String, date: LocalDate): Task[Int]
-  def incrementUsage(mac: String, domain: String, date: LocalDate, mins: Int): Task[Unit]
 
   /**
    * Increment seconds + byte counters for (mac, domain, date). Repeats are *additive* — the caller
@@ -484,21 +481,6 @@ class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo {
 }
 
 class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
-  def getUsage(mac: String, dom: String, d: LocalDate)                                     =
-    sql"SELECT COALESCE(minutes_used,0) FROM time_usage WHERE device_mac=$mac AND domain=$dom AND date=$d"
-      .query[Int]
-      .option
-      .transact(xa)
-      .map(_.getOrElse(0))
-  def getTotalUsage(mac: String, d: LocalDate)                                             =
-    sql"SELECT COALESCE(SUM(minutes_used),0)::INT FROM time_usage WHERE device_mac=$mac AND date=$d"
-      .query[Int]
-      .unique
-      .transact(xa)
-  def incrementUsage(mac: String, dom: String, d: LocalDate, mins: Int)                    =
-    sql"INSERT INTO time_usage(device_mac,domain,date,minutes_used,last_seen_at) VALUES($mac,$dom,$d,$mins,NOW()) ON CONFLICT(device_mac,domain,date) DO UPDATE SET minutes_used=time_usage.minutes_used+EXCLUDED.minutes_used,last_seen_at=NOW()".update.run
-      .transact(xa)
-      .unit
   def incrementSecondsAndBytes(
       mac: String,
       dom: String,
@@ -529,7 +511,7 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
       .transact(xa)
       .map(_.getOrElse((0L, 0L, 0L)))
   def listForDevice(mac: String, d: LocalDate)                                             =
-    sql"SELECT id,device_mac,domain,date::TEXT,minutes_used,last_seen_at::TEXT FROM time_usage WHERE device_mac=$mac AND date=$d ORDER BY minutes_used DESC"
+    sql"SELECT id,device_mac,domain,date::TEXT,(COALESCE(seconds_used,0)/60)::INT,last_seen_at::TEXT FROM time_usage WHERE device_mac=$mac AND date=$d ORDER BY seconds_used DESC"
       .query[(Long, String, String, String, Int, String)]
       .map(TimeUsage.apply)
       .to[List]
@@ -538,16 +520,14 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
     if macs.isEmpty then ZIO.succeed(Nil)
     else {
       val arr = macs.toArray
-      sql"SELECT id,device_mac,domain,date::TEXT,minutes_used,last_seen_at::TEXT FROM time_usage WHERE device_mac = ANY($arr) AND date=$d ORDER BY device_mac,minutes_used DESC"
+      sql"SELECT id,device_mac,domain,date::TEXT,(COALESCE(seconds_used,0)/60)::INT,last_seen_at::TEXT FROM time_usage WHERE device_mac = ANY($arr) AND date=$d ORDER BY device_mac,seconds_used DESC"
         .query[(Long, String, String, String, Int, String)]
         .map(TimeUsage.apply)
         .to[List]
         .transact(xa)
     }
-  def snapshotAll(d: LocalDate) =
-    // Combine legacy minutes_used (OPNsense path) with seconds_used (OpenWRT router path).
-    // seconds_used is floor-divided to minutes; both sources are additive so either agent works.
-    sql"SELECT device_mac,domain,COALESCE(minutes_used,0)+(COALESCE(seconds_used,0)/60)::INT FROM time_usage WHERE date=$d"
+  def snapshotAll(d: LocalDate)                                                            =
+    sql"SELECT device_mac,domain,(COALESCE(seconds_used,0)/60)::INT FROM time_usage WHERE date=$d"
       .query[(String, String, Int)]
       .to[List]
       .transact(xa)

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -158,28 +158,42 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       "policy snapshot composition: devices, profiles, schedules, site_limits, blocklists, time_used",
     ) {
       for {
-        _     <- cleanDb
-        pr    <- ZIO.service[ProfileRepo]
-        sr    <- ZIO.service[ScheduleRepo]
-        tlr   <- ZIO.service[TimeLimitRepo]
-        stlr  <- ZIO.service[SiteTimeLimitRepo]
-        dr    <- ZIO.service[DeviceRepo]
-        blr   <- ZIO.service[BlocklistRepo]
-        ur    <- ZIO.service[TimeUsageRepo]
-        rr    <- ZIO.service[RouterRepo]
-        kid   <- TestLayers.seedKidsProfile(pr, sr)
-        _     <- tlr.upsert(kid, 120)
-        _     <- stlr.replaceForProfile(
+        _       <- cleanDb
+        pr      <- ZIO.service[ProfileRepo]
+        sr      <- ZIO.service[ScheduleRepo]
+        tlr     <- ZIO.service[TimeLimitRepo]
+        stlr    <- ZIO.service[SiteTimeLimitRepo]
+        dr      <- ZIO.service[DeviceRepo]
+        blr     <- ZIO.service[BlocklistRepo]
+        ur      <- ZIO.service[TimeUsageRepo]
+        rr      <- ZIO.service[RouterRepo]
+        kid     <- TestLayers.seedKidsProfile(pr, sr)
+        _       <- tlr.upsert(kid, 120)
+        _       <- stlr.replaceForProfile(
           kid,
           List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")), // default exemptFromDaily=true
         )
-        adult <- TestLayers.seedAdultsProfile(pr)
-        _     <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        _     <- TestLayers.seedDevice(dr, "11:22:33:44:55:66", "parent-phone", adult)
-        _     <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 12)
-        _     <- ur.incrementUsage("aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 47)
-        _     <- blr.insertBatch(List(("doubleclick.net", "ads"), ("ads.example.com", "ads")))
-        ber   <- ZIO.service[BlockEventRepo]
+        adult   <- TestLayers.seedAdultsProfile(pr)
+        _       <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        _       <- TestLayers.seedDevice(dr, "11:22:33:44:55:66", "parent-phone", adult)
+        _       <- ur.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "youtube.com",
+          LocalDate.of(2025, 1, 6),
+          12L * 60L,
+          0L,
+          0L,
+        )
+        _       <- ur.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "cnn.com",
+          LocalDate.of(2025, 1, 6),
+          47L * 60L,
+          0L,
+          0L,
+        )
+        _       <- blr.insertBatch(List(("doubleclick.net", "ads"), ("ads.example.com", "ads")))
+        ber     <- ZIO.service[BlockEventRepo]
         (_, et) <- seedRouter("gw")
         ps      <- makePolicyService
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -231,11 +231,13 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         kid <- TestLayers.seedKidsProfile(pr, sr)
         _   <- tlr.upsert(kid, 120)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        _   <- ur.incrementUsage(
+        _   <- ur.incrementSecondsAndBytes(
           "aa:bb:cc:11:22:33",
           "cnn.com",
           LocalDate.of(2025, 1, 6),
-          121,
+          121L * 60L,
+          0L,
+          0L,
         )
         ps  <- makePsDefault // schoolDayAfternoon: 14:00, no schedule active
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
@@ -264,7 +266,14 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         kid <- TestLayers.seedKidsProfile(pr, sr)
         _   <- tlr.upsert(kid, 120)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        _   <- ur.incrementUsage("aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 121)
+        _   <- ur.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "cnn.com",
+          LocalDate.of(2025, 1, 6),
+          121L * 60L,
+          0L,
+          0L,
+        )
         _   <- er.grantForProfile(kid, LocalDate.of(2025, 1, 6), 30, "admin", None)
         ps  <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
@@ -400,7 +409,14 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
           List(SiteTimeLimitRequest("youtube.com", 200, "YouTube", exemptFromDaily = false)),
         )
         _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        _    <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 121)
+        _    <- ur.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "youtube.com",
+          LocalDate.of(2025, 1, 6),
+          121L * 60L,
+          0L,
+          0L,
+        )
         ps   <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
         tok  <- seedAndEnrollRouter(rr, routes)
@@ -435,7 +451,14 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
           ),
         )
         _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        _    <- ur.incrementUsage("aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 121)
+        _    <- ur.incrementSecondsAndBytes(
+          "aa:bb:cc:11:22:33",
+          "youtube.com",
+          LocalDate.of(2025, 1, 6),
+          121L * 60L,
+          0L,
+          0L,
+        )
         ps   <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
         tok  <- seedAndEnrollRouter(rr, routes)

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -252,7 +252,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           xa <- ZIO.service[doobie.Transactor[Task]]
           mac = "aa:bb:cc:dd:ee:01"
           d   = LocalDate.of(2026, 5, 2)
-          _   <- tu.incrementUsage(mac, "youtube.com", d, 5)
+          _   <- tu.incrementSecondsAndBytes(mac, "youtube.com", d, 5L * 60L, 0L, 0L)
           row <-
             sql"SELECT bytes_in, bytes_out FROM time_usage WHERE device_mac=$mac AND domain='youtube.com' AND date=$d"
               .query[(Long, Long)]

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -90,8 +90,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- tlRepo.upsert(kidsId, 120)
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
-          _               <- usageRepo.incrementUsage(testMac, "minecraft.net", today, 45)
-          _               <- usageRepo.incrementUsage(testMac, "google.com", today, 30)
+          _ <- usageRepo.incrementSecondsAndBytes(
+            testMac,
+            "minecraft.net",
+            today,
+            45L * 60L,
+            0L,
+            0L,
+          )
+          _ <- usageRepo.incrementSecondsAndBytes(testMac, "google.com", today, 30L * 60L, 0L, 0L)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
@@ -138,8 +145,8 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
           // 60 min general browsing + 20 min YouTube (site-specific, should NOT count toward 120)
-          _               <- usageRepo.incrementUsage(testMac, "google.com", today, 60)
-          _               <- usageRepo.incrementUsage(testMac, "youtube.com", today, 20)
+          _ <- usageRepo.incrementSecondsAndBytes(testMac, "google.com", today, 60L * 60L, 0L, 0L)
+          _ <- usageRepo.incrementSecondsAndBytes(testMac, "youtube.com", today, 20L * 60L, 0L, 0L)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
@@ -191,7 +198,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
           // 60 min of YouTube usage; since exemptFromDaily=false it must appear in usedMins
-          _               <- usageRepo.incrementUsage(testMac, "youtube.com", today, 60)
+          _ <- usageRepo.incrementSecondsAndBytes(testMac, "youtube.com", today, 60L * 60L, 0L, 0L)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
@@ -237,7 +244,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- tlRepo.upsert(kidsId, 120)
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
-          _               <- usageRepo.incrementUsage(testMac, "minecraft.net", today, 120)
+          _               <- usageRepo.incrementSecondsAndBytes(
+            testMac,
+            "minecraft.net",
+            today,
+            120L * 60L,
+            0L,
+            0L,
+          )
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes  = TimeRoutes.routes(
@@ -456,8 +470,8 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
           // Device 1: 40 min, Device 2: 35 min → combined 75 min > 60 min limit
-          _               <- usageRepo.incrementUsage(mac1, "minecraft.net", today, 40)
-          _               <- usageRepo.incrementUsage(mac2, "youtube.com", today, 35)
+          _ <- usageRepo.incrementSecondsAndBytes(mac1, "minecraft.net", today, 40L * 60L, 0L, 0L)
+          _ <- usageRepo.incrementSecondsAndBytes(mac2, "youtube.com", today, 35L * 60L, 0L, 0L)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
@@ -508,8 +522,8 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
           // Each device uses 20 min YouTube → combined 40 min > 30 min limit
-          _               <- usageRepo.incrementUsage(mac1, "youtube.com", today, 20)
-          _               <- usageRepo.incrementUsage(mac2, "youtube.com", today, 20)
+          _ <- usageRepo.incrementSecondsAndBytes(mac1, "youtube.com", today, 20L * 60L, 0L, 0L)
+          _ <- usageRepo.incrementSecondsAndBytes(mac2, "youtube.com", today, 20L * 60L, 0L, 0L)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
@@ -555,8 +569,8 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _ <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
           _ <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
           today = TestClock.schoolDayAfternoon.toLocalDate
-          _             <- usageRepo.incrementUsage(mac1, "minecraft.net", today, 30)
-          _             <- usageRepo.incrementUsage(mac2, "roblox.com", today, 25)
+          _ <- usageRepo.incrementSecondsAndBytes(mac1, "minecraft.net", today, 30L * 60L, 0L, 0L)
+          _ <- usageRepo.incrementSecondsAndBytes(mac2, "roblox.com", today, 25L * 60L, 0L, 0L)
           // Build policy snapshot directly via PolicyService
           blocklistRepo <- ZIO.service[BlocklistRepo]
           clock         <- ZIO.service[Clock]


### PR DESCRIPTION
## Summary
- Screen Time page showed `0m` for every device because `GET /api/time/status` read `time_usage.minutes_used`, but only the OPNsense usage path (never implemented, see #113) writes to that column. OpenWRT — the only deployed agent — writes `seconds_used`.
- #135 fixed `snapshotAll` for the policy snapshot but missed the UI-facing read path (`listForDevice`, `listForDeviceMacs`).
- `minutes_used` was effectively dead in production. Drop the column entirely; derive minutes everywhere from `seconds_used / 60`.
- Removes the now-dead `incrementUsage` / `getUsage` / `getTotalUsage` from `TimeUsageRepo`. All tests now exercise the same write path production uses (`incrementSecondsAndBytes`) — which would have caught this bug originally.

Related: #227, #228, #135, #141.

## Test plan
- [x] `mill api.test` — all 190 tests pass
- [ ] Verify Screen Time shows non-zero minutes after a usage cycle on real hardware