### PR TITLE
profiles: show assigned devices + linked users; admin can edit links

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -71,7 +71,7 @@ object Main extends ZIOAppDefault {
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield HealthRoutes.routes(dbHealthCheck) ++
       AuthRoutes.routes(auth, userRepo, upRepo) ++
-      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo) ++
+      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo, userRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
       TimeRoutes.routes(
         auth,

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -42,8 +42,10 @@ trait UserRepo {
 trait UserProfileRepo {
   def listProfilesForUser(userId: Long): Task[List[Long]]
   def listProfilesForUsername(username: String): Task[List[Long]]
+  def listUsersForProfile(profileId: Long): Task[List[Long]]
   def listAllMappings: Task[List[(Long, Long)]] // (userId, profileId)
   def setProfilesForUser(userId: Long, profileIds: List[Long]): Task[Unit]
+  def setUsersForProfile(profileId: Long, userIds: List[Long]): Task[Unit]
   def addLink(userId: Long, profileId: Long): Task[Unit]
   def removeLink(userId: Long, profileId: Long): Task[Unit]
   def hasAccess(userId: Long, profileId: Long): Task[Boolean]
@@ -252,37 +254,49 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
 }
 
 class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo {
-  def listProfilesForUser(userId: Long)                  =
+  def listProfilesForUser(userId: Long)                     =
     sql"SELECT profile_id FROM user_profiles WHERE user_id=$userId ORDER BY profile_id"
       .query[Long]
       .to[List]
       .transact(xa)
-  def listProfilesForUsername(u: String)                 =
+  def listProfilesForUsername(u: String)                    =
     sql"SELECT up.profile_id FROM user_profiles up JOIN users us ON us.id=up.user_id WHERE us.username=$u ORDER BY up.profile_id"
       .query[Long]
       .to[List]
       .transact(xa)
-  def listAllMappings                                    =
+  def listUsersForProfile(profileId: Long)                  =
+    sql"SELECT user_id FROM user_profiles WHERE profile_id=$profileId ORDER BY user_id"
+      .query[Long]
+      .to[List]
+      .transact(xa)
+  def listAllMappings                                       =
     sql"SELECT user_id, profile_id FROM user_profiles"
       .query[(Long, Long)]
       .to[List]
       .transact(xa)
-  def setProfilesForUser(userId: Long, pids: List[Long]) = {
+  def setProfilesForUser(userId: Long, pids: List[Long])    = {
     val del = sql"DELETE FROM user_profiles WHERE user_id=$userId".update.run
     val ins = pids.distinct.map(pid =>
       sql"INSERT INTO user_profiles(user_id,profile_id) VALUES($userId,$pid) ON CONFLICT DO NOTHING".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
   }
-  def addLink(userId: Long, pid: Long)                   =
+  def setUsersForProfile(profileId: Long, uids: List[Long]) = {
+    val del = sql"DELETE FROM user_profiles WHERE profile_id=$profileId".update.run
+    val ins = uids.distinct.map(uid =>
+      sql"INSERT INTO user_profiles(user_id,profile_id) VALUES($uid,$profileId) ON CONFLICT DO NOTHING".update.run,
+    )
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
+  def addLink(userId: Long, pid: Long)                      =
     sql"INSERT INTO user_profiles(user_id,profile_id) VALUES($userId,$pid) ON CONFLICT DO NOTHING".update.run
       .transact(xa)
       .unit
-  def removeLink(userId: Long, pid: Long)                =
+  def removeLink(userId: Long, pid: Long)                   =
     sql"DELETE FROM user_profiles WHERE user_id=$userId AND profile_id=$pid".update.run
       .transact(xa)
       .unit
-  def hasAccess(userId: Long, pid: Long)                 =
+  def hasAccess(userId: Long, pid: Long)                    =
     sql"SELECT 1 FROM user_profiles WHERE user_id=$userId AND profile_id=$pid"
       .query[Int]
       .option

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -123,6 +123,7 @@ object ProfileRoutes {
       timeLimitRepo: TimeLimitRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       userProfileRepo: UserProfileRepo,
+      userRepo: UserRepo,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "profiles"                         ->
@@ -233,6 +234,33 @@ object ProfileRoutes {
           requireAdmin(req, auth) *>
             profileRepo.delete(id).orElseFail(Response.internalServerError("")) *>
             ZIO.succeed(Response.ok)
+        },
+      Method.GET / "api" / "profiles" / long("id") / "users"  ->
+        handler { (id: Long, req: Request) =>
+          for {
+            _     <- requireAdmin(req, auth)
+            uids  <- userProfileRepo
+              .listUsersForProfile(id)
+              .orElseFail(Response.internalServerError(""))
+            users <- userRepo.listAll.orElseFail(Response.internalServerError(""))
+            byId      = users.map(u => u.id -> u).toMap
+            summaries = uids.flatMap(byId.get).map { u =>
+              UserSummary(u.id, u.username, u.role, List(id))
+            }
+          } yield Response.json(summaries.toJson)
+        },
+      Method.PUT / "api" / "profiles" / long("id") / "users"  ->
+        handler { (id: Long, req: Request) =>
+          for {
+            _    <- requireAdmin(req, auth)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            r    <- ZIO
+              .fromEither(body.fromJson[SetProfileUsersRequest])
+              .mapError(e => Response.badRequest(e))
+            _    <- userProfileRepo
+              .setUsersForProfile(id, r.userIds)
+              .orElseFail(Response.internalServerError(""))
+          } yield Response.ok
         },
       Method.POST / "api" / "profiles" / long("id") / "pause" ->
         handler { (id: Long, req: Request) =>

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -50,6 +50,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           userRepo        <- ZIO.service[UserRepo]
           token           <- auth.login("admin", "changeme").map(_.token)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -57,6 +58,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           req    = Request
             .get(URL.decode("/api/profiles").toOption.get)
@@ -77,6 +79,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           stlRepo         <- ZIO.service[SiteTimeLimitRepo]
           auth            <- makeAuth
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -84,6 +87,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           req    = Request.get(URL.decode("/api/profiles").toOption.get)
           resp <- routes.runZIO(req)
@@ -101,6 +105,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           auth            <- makeAuth
           token           <- auth.login("admin", "changeme").map(_.token)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -108,6 +113,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           body   = UpsertProfileRequest(
             name = "Teenager",
@@ -160,6 +166,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           _               <- userRepo.create("reader", hash, "child")
           token           <- auth.login("reader", "readpass").map(_.token)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -167,6 +174,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           body   = UpsertProfileRequest("Test", Nil, Nil, Nil, false, Nil, None, Nil).toJson
           req    = Request
@@ -190,6 +198,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profiles    <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -197,6 +206,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           body   = UpsertProfileRequest(
             name = "Kids Updated",
@@ -241,6 +251,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profiles    <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
           routes = ProfileRoutes.routes(
             auth,
             profileRepo,
@@ -248,6 +259,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             tlRepo,
             stlRepo,
             userProfileRepo,
+            userRepoSvc,
           )
           req    = Request
             .post(
@@ -263,6 +275,118 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(afterPause.exists(_.paused)) &&
           assertTrue(resp2.status == Status.Ok) &&
           assertTrue(afterResume.exists(!_.paused))
+      },
+    ),
+    suite("Profile ↔ user linking")(
+      test("PUT /api/profiles/:id/users sets the link set; GET returns those users") {
+        for {
+          _               <- cleanDb
+          profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
+          tlRepo          <- ZIO.service[TimeLimitRepo]
+          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          userRepo        <- ZIO.service[UserRepo]
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          auth            <- makeAuth
+          token           <- auth.login("admin", "changeme").map(_.token)
+          hash            <- auth.hashPassword("pw")
+          aliceId         <- userRepo.create("alice", hash, "child")
+          bobId           <- userRepo.create("bob", hash, "adult")
+          profiles        <- profileRepo.listAll
+          kidsId  = profiles.find(_.name == "Kids").get.id
+          routes  = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepo,
+          )
+          putBody = SetProfileUsersRequest(List(aliceId, bobId)).toJson
+          putReq  = Request
+            .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(putBody))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          putResp <- routes.runZIO(putReq)
+          getReq = Request
+            .get(URL.decode(s"/api/profiles/$kidsId/users").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          getResp   <- routes.runZIO(getReq)
+          body      <- getResp.body.asString
+          summaries <- ZIO.fromEither(body.fromJson[List[UserSummary]])
+        } yield assertTrue(putResp.status == Status.Ok) &&
+          assertTrue(getResp.status == Status.Ok) &&
+          assertTrue(summaries.map(_.username).toSet == Set("alice", "bob"))
+      },
+      test("removing a user from one profile leaves their links to other profiles intact") {
+        for {
+          _               <- cleanDb
+          profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
+          tlRepo          <- ZIO.service[TimeLimitRepo]
+          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          userRepo        <- ZIO.service[UserRepo]
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          auth            <- makeAuth
+          token           <- auth.login("admin", "changeme").map(_.token)
+          hash            <- auth.hashPassword("pw")
+          aliceId         <- userRepo.create("alice", hash, "child")
+          profiles        <- profileRepo.listAll
+          kidsId   = profiles.find(_.name == "Kids").get.id
+          adultsId = profiles.find(_.name == "Adults").get.id
+          // Alice is linked to BOTH profiles.
+          _ <- userProfileRepo.setProfilesForUser(aliceId, List(kidsId, adultsId))
+          routes  = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepo,
+          )
+          // Remove alice from Kids by setting empty user list for Kids.
+          putBody = SetProfileUsersRequest(Nil).toJson
+          putReq  = Request
+            .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(putBody))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          _             <- routes.runZIO(putReq)
+          aliceProfiles <- userProfileRepo.listProfilesForUser(aliceId)
+        } yield assertTrue(aliceProfiles == List(adultsId))
+      },
+      test("non-admin gets 403 on PUT /api/profiles/:id/users") {
+        for {
+          _               <- cleanDb
+          profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
+          tlRepo          <- ZIO.service[TimeLimitRepo]
+          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          userRepo        <- ZIO.service[UserRepo]
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          auth            <- makeAuth
+          hash            <- auth.hashPassword("pw")
+          _               <- userRepo.create("adult1", hash, "adult")
+          token           <- auth.login("adult1", "pw").map(_.token)
+          profiles        <- profileRepo.listAll
+          kidsId = profiles.find(_.name == "Kids").get.id
+          routes = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepo,
+          )
+          body   = SetProfileUsersRequest(Nil).toJson
+          req    = Request
+            .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(body))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          resp <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.Forbidden)
       },
     ),
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -65,7 +65,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kidsId = profiles.find(_.name == "Kids").get.id
         _     <- createUser(userRepo, upRepo, auth, "alice", "child", List(kidsId))
         token <- auth.login("alice", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         req    = Request
           .get(URL.decode("/api/profiles").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
@@ -91,7 +99,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         adultsId = profiles.find(_.name == "Adults").get.id
         _     <- createUser(userRepo, upRepo, auth, "alice", "child", List(kidsId))
         token <- auth.login("alice", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         req    = Request
           .get(URL.decode(s"/api/profiles/$adultsId").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
@@ -112,7 +128,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kidsId = profiles.find(_.name == "Kids").get.id
         _     <- createUser(userRepo, upRepo, auth, "alice", "child", List(kidsId))
         token <- auth.login("alice", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         body   = UpsertProfileRequest("Hacked", Nil, Nil, Nil, false, Nil, None, Nil).toJson
         req    = Request
           .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
@@ -143,7 +167,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           List(kidsId, adultsId),
         )
         token <- auth.login("mom", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         body   = UpsertProfileRequest(
           "Kids Renamed",
           List("adult"),
@@ -178,7 +210,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kidsId = profiles.find(_.name == "Kids").get.id
         _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
         token <- auth.login("mom", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         body   = UpsertProfileRequest(
           "Pwned",
           Nil,
@@ -208,7 +248,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         auth        <- makeAuth
         _           <- createUser(userRepo, upRepo, auth, "mom", "adult", Nil)
         token       <- auth.login("mom", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         body   = UpsertProfileRequest("New", Nil, Nil, Nil, false, Nil, None, Nil).toJson
         req    = Request
           .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
@@ -266,6 +314,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           tlRepo,
           stlRepo,
           upRepo,
+          userRepo,
         )
         listReq    = Request
           .get(URL.decode("/api/profiles").toOption.get)
@@ -340,7 +389,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kidsId = profiles.find(_.name == "Kids").get.id
         _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
         token <- auth.login("mom", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         req    = Request
           .get(URL.decode("/api/profiles").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))
@@ -365,7 +422,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         adultsId = profiles.find(_.name == "Adults").get.id
         _     <- createUser(userRepo, upRepo, auth, "mom", "adult", List(kidsId))
         token <- auth.login("mom", "pass").map(_.token)
-        routes = ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo)
+        routes = ProfileRoutes.routes(
+          auth,
+          profileRepo,
+          schedRepo,
+          tlRepo,
+          stlRepo,
+          upRepo,
+          userRepo,
+        )
         req    = Request
           .get(URL.decode(s"/api/profiles/$adultsId").toOption.get)
           .addHeader(Header.Authorization.Bearer(token))

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -126,6 +126,7 @@ case class MeResponse(
     profileIds: List[Long],
 ) derives JsonCodec
 case class SetUserProfilesRequest(profileIds: List[Long]) derives JsonCodec
+case class SetProfileUsersRequest(userIds: List[Long]) derives JsonCodec
 
 case class UpsertProfileRequest(
     name: String,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -76,6 +76,9 @@ export const api = {
       req<void>('PUT', `/profiles/${id}`, data),
     delete: (id: number) => req<void>('DELETE', `/profiles/${id}`),
     pause: (id: number) => req<{ paused: boolean }>('POST', `/profiles/${id}/pause`, {}),
+    getUsers: (id: number) => req<User[]>('GET', `/profiles/${id}/users`),
+    setUsers: (id: number, userIds: number[]) =>
+      req<void>('PUT', `/profiles/${id}/users`, { userIds }),
   },
 
   // ── Devices ────────────────────────────────────────────────────────────

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ProfileDetail } from '@/types/api'
+import type { Device, ProfileDetail, User } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
   api: {
@@ -11,9 +11,16 @@ vi.mock('@/api/client', () => ({
       update: vi.fn(),
       delete: vi.fn(),
       pause: vi.fn(),
+      setUsers: vi.fn(),
     },
     blocklists: {
       counts: vi.fn(),
+    },
+    devices: {
+      list: vi.fn(),
+    },
+    users: {
+      list: vi.fn(),
     },
   },
 }))
@@ -59,6 +66,19 @@ const adultsProfile: ProfileDetail = {
   siteTimeLimits: [],
 }
 
+const phoneDevice: Device = {
+  id: 100, mac: 'aa:bb:cc:dd:ee:01', name: 'Kid Phone', profileId: 1,
+  profileName: 'Kids', lastSeenIp: null, lastSeenAt: null,
+}
+const tabletDevice: Device = {
+  id: 101, mac: 'aa:bb:cc:dd:ee:02', name: 'Adult Tablet', profileId: 2,
+  profileName: 'Adults', lastSeenIp: null, lastSeenAt: null,
+}
+
+const aliceUser: User = { id: 10, username: 'alice', role: 'child', profileIds: [1] }
+const bobUser:   User = { id: 11, username: 'bob',   role: 'adult', profileIds: [2] }
+const carolUser: User = { id: 12, username: 'carol', role: 'admin', profileIds: [1, 2] }
+
 beforeEach(() => {
   vi.resetAllMocks()
   mockAuth = { isAdmin: true }
@@ -72,16 +92,22 @@ beforeEach(() => {
   ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.delete as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.pause as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ paused: true })
+  ;(api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.devices.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([phoneDevice, tabletDevice])
+  ;(api.users.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aliceUser, bobUser, carolUser])
 })
 
 describe('ProfilesPage — list', () => {
   it('renders profile names, paused badge, blocked categories, schedules, site limits, and daily limit', async () => {
     render(<ProfilesPage />)
-    expect(await screen.findByText('Kids')).toBeInTheDocument()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    expect(within(kidsCard).getByText('Kids')).toBeInTheDocument()
     expect(screen.getByText('Adults')).toBeInTheDocument()
     expect(screen.getByText('Paused')).toBeInTheDocument()
-    expect(screen.getByText('adult')).toBeInTheDocument()
-    expect(screen.getByText('gambling')).toBeInTheDocument()
+    // 'adult' (the blocked category) lives inside the Kids card; the bob/admin role
+    // badges read 'adult' too, so scope this lookup to the Kids card.
+    expect(within(kidsCard).getByText('adult')).toBeInTheDocument()
+    expect(within(kidsCard).getByText('gambling')).toBeInTheDocument()
     expect(screen.getByText('Bedtime')).toBeInTheDocument()
     expect(screen.getByText('21:00 → 07:00')).toBeInTheDocument()
     expect(screen.getByText('YouTube')).toBeInTheDocument()
@@ -223,5 +249,68 @@ describe('ProfilesPage — role gating', () => {
     expect(screen.queryByRole('button', { name: /Pause/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^Edit$/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^Delete$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Edit users/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('ProfilesPage — devices section', () => {
+  it('renders devices grouped under their profile', async () => {
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    const adultsCard = screen.getByTestId('profile-card-2')
+
+    expect(within(kidsCard).getByTestId('profile-device-100')).toHaveTextContent('Kid Phone')
+    expect(within(kidsCard).getByTestId('profile-device-100')).toHaveTextContent('aa:bb:cc:dd:ee:01')
+    expect(within(kidsCard).queryByTestId('profile-device-101')).not.toBeInTheDocument()
+
+    expect(within(adultsCard).getByTestId('profile-device-101')).toHaveTextContent('Adult Tablet')
+  })
+})
+
+describe('ProfilesPage — linked users section', () => {
+  it('renders linked users for each profile (admin view)', async () => {
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    const adultsCard = screen.getByTestId('profile-card-2')
+
+    expect(within(kidsCard).getByTestId('profile-user-10')).toHaveTextContent('alice')
+    expect(within(kidsCard).getByTestId('profile-user-12')).toHaveTextContent('carol')
+    expect(within(kidsCard).queryByTestId('profile-user-11')).not.toBeInTheDocument()
+
+    expect(within(adultsCard).getByTestId('profile-user-11')).toHaveTextContent('bob')
+    expect(within(adultsCard).getByTestId('profile-user-12')).toHaveTextContent('carol')
+  })
+
+  it('hides the linked-users section entirely for non-admins', async () => {
+    mockAuth = { isAdmin: false }
+    render(<ProfilesPage />)
+    await screen.findByText('Kids')
+    expect(screen.queryByTestId('profile-users-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('profile-users-2')).not.toBeInTheDocument()
+    expect(api.users.list).not.toHaveBeenCalled()
+  })
+
+  it('admin clicks Edit users → modal opens with current users pre-checked → Save calls api.profiles.setUsers', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /Edit users/ }))
+
+    const modal = await screen.findByTestId('edit-users-modal')
+    // Pre-checked: alice (id 10) and carol (id 12) on Kids
+    expect(within(modal).getByTestId('user-pick-10').textContent).toMatch(/✓/)
+    expect(within(modal).getByTestId('user-pick-12').textContent).toMatch(/✓/)
+    expect(within(modal).getByTestId('user-pick-11').textContent).not.toMatch(/✓/)
+
+    // Toggle alice off, bob on.
+    await user.click(within(modal).getByTestId('user-pick-10'))
+    await user.click(within(modal).getByTestId('user-pick-11'))
+
+    await user.click(within(modal).getByRole('button', { name: /^Save$/ }))
+
+    await waitFor(() => expect(api.profiles.setUsers).toHaveBeenCalledTimes(1))
+    const call = (api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(call[0]).toBe(1)
+    expect([...call[1]].sort((a, b) => a - b)).toEqual([11, 12])
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type {
-  ProfileDetail, ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest,
+  Device, ProfileDetail, ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
@@ -71,19 +71,50 @@ export function ProfilesPage() {
   const { isAdmin } = useAuth()
   const [profiles, setProfiles] = useState<ProfileDetail[]>([])
   const [categories, setCategories] = useState<string[]>([])
+  const [devices, setDevices] = useState<Device[]>([])
+  const [allUsers, setAllUsers] = useState<User[]>([])
   const [loading, setLoading] = useState(true)
   const [editingId, setEditingId] = useState<number | 'new' | null>(null)
   const [form, setForm] = useState<FormState>(emptyForm())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [editingUsersFor, setEditingUsersFor] = useState<number | null>(null)
+  const [userPick, setUserPick] = useState<number[]>([])
+
+  const devicesByProfile = useMemo(() => {
+    const m = new Map<number, Device[]>()
+    for (const d of devices) {
+      if (d.profileId == null) continue
+      const arr = m.get(d.profileId) ?? []
+      arr.push(d)
+      m.set(d.profileId, arr)
+    }
+    return m
+  }, [devices])
+
+  const usersByProfile = useMemo(() => {
+    const m = new Map<number, User[]>()
+    for (const u of allUsers) {
+      for (const pid of u.profileIds) {
+        const arr = m.get(pid) ?? []
+        arr.push(u)
+        m.set(pid, arr)
+      }
+    }
+    return m
+  }, [allUsers])
 
   async function reload() {
-    const [p, cats] = await Promise.all([
+    const [p, cats, devs, users] = await Promise.all([
       api.profiles.list(),
       api.blocklists.counts().catch(() => []),
+      api.devices.list().catch(() => [] as Device[]),
+      isAdmin ? api.users.list().catch(() => [] as User[]) : Promise.resolve([] as User[]),
     ])
     setProfiles(p)
     setCategories(cats.map(c => c.category))
+    setDevices(devs)
+    setAllUsers(users)
   }
 
   useEffect(() => {
@@ -119,6 +150,28 @@ export function ProfilesPage() {
       await reload()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function startEditUsers(profileId: number) {
+    const current = usersByProfile.get(profileId) ?? []
+    setEditingUsersFor(profileId)
+    setUserPick(current.map(u => u.id))
+    setError(null)
+  }
+
+  async function saveUserLinks() {
+    if (editingUsersFor == null) return
+    setSaving(true)
+    setError(null)
+    try {
+      await api.profiles.setUsers(editingUsersFor, userPick)
+      setEditingUsersFor(null)
+      await reload()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update user links')
     } finally {
       setSaving(false)
     }
@@ -174,6 +227,10 @@ export function ProfilesPage() {
                     className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
                     Edit
                   </button>
+                  <button onClick={() => startEditUsers(pd.profile.id)}
+                    className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
+                    Edit users
+                  </button>
                   <button onClick={() => del(pd.profile.id, pd.profile.name)}
                     className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors">
                     Delete
@@ -228,6 +285,50 @@ export function ProfilesPage() {
               </div>
             )}
 
+            <div data-testid={`profile-devices-${pd.profile.id}`}>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Devices</p>
+              {(devicesByProfile.get(pd.profile.id) ?? []).length === 0
+                ? <p className="text-xs text-gray-600">No devices assigned.</p>
+                : (
+                  <div className="space-y-1">
+                    {(devicesByProfile.get(pd.profile.id) ?? []).map(d => (
+                      <div key={d.id} data-testid={`profile-device-${d.id}`}
+                        className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2">
+                        <span className="text-gray-300">{d.name}</span>
+                        <span className="text-gray-500 font-mono text-xs">{d.mac}</span>
+                      </div>
+                    ))}
+                  </div>
+                )
+              }
+            </div>
+
+            {isAdmin && (
+              <div data-testid={`profile-users-${pd.profile.id}`}>
+                <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Linked users</p>
+                {(usersByProfile.get(pd.profile.id) ?? []).length === 0
+                  ? <p className="text-xs text-gray-600">No users linked.</p>
+                  : (
+                    <div className="flex flex-wrap gap-2">
+                      {(usersByProfile.get(pd.profile.id) ?? []).map(u => (
+                        <span key={u.id} data-testid={`profile-user-${u.id}`}
+                          className="text-xs bg-gray-800 text-gray-300 border border-gray-700 px-2 py-1 rounded-lg">
+                          {u.username}
+                          <span className={`ml-2 font-mono px-1.5 py-0.5 rounded ${
+                            u.role === 'admin'
+                              ? 'bg-emerald-500/10 text-emerald-400'
+                              : u.role === 'adult'
+                                ? 'bg-blue-500/10 text-blue-400'
+                                : 'bg-yellow-500/10 text-yellow-400'
+                          }`}>{u.role}</span>
+                        </span>
+                      ))}
+                    </div>
+                  )
+                }
+              </div>
+            )}
+
             {pd.siteTimeLimits.length > 0 && (
               <div>
                 <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Site Limits</p>
@@ -251,6 +352,58 @@ export function ProfilesPage() {
           </div>
         ))}
       </div>
+
+      {editingUsersFor !== null && (
+        <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto"
+          onClick={() => setEditingUsersFor(null)}>
+          <div data-testid="edit-users-modal"
+            className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-lg my-8 p-6 space-y-5 max-h-[90vh] overflow-y-auto"
+            onClick={e => e.stopPropagation()}>
+            <h3 className="text-lg font-bold text-white">
+              Edit users · {profiles.find(p => p.profile.id === editingUsersFor)?.profile.name ?? ''}
+            </h3>
+            {error && (
+              <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+                {error}
+              </div>
+            )}
+            {allUsers.length === 0
+              ? <p className="text-sm text-gray-500">No users available.</p>
+              : (
+                <div className="flex flex-wrap gap-2">
+                  {allUsers.map(u => {
+                    const on = userPick.includes(u.id)
+                    return (
+                      <button key={u.id} type="button"
+                        data-testid={`user-pick-${u.id}`}
+                        onClick={() =>
+                          setUserPick(on ? userPick.filter(x => x !== u.id) : [...userPick, u.id])
+                        }
+                        className={`text-sm px-3 py-1.5 rounded-lg border transition-colors ${
+                          on
+                            ? 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40'
+                            : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-600'
+                        }`}>
+                        {on ? '✓ ' : ''}{u.username} <span className="text-xs opacity-70">({u.role})</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )
+            }
+            <div className="flex gap-3 pt-2">
+              <button onClick={() => setEditingUsersFor(null)} disabled={saving}
+                className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
+                Cancel
+              </button>
+              <button onClick={saveUserLinks} disabled={saving}
+                className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {editingId !== null && (
         <ProfileEditor


### PR DESCRIPTION
Closes #263, #13.

## Summary
- Profile cards now show two new sections: **Devices** assigned to that profile (name + MAC) and (admin-only) **Linked users** with role badges.
- Admins get an **Edit users** button per card → modal with multi-select against `api.users.list`, submits via the new `api.profiles.setUsers`.

## Backend
- New shared model `SetProfileUsersRequest(userIds)`.
- `UserProfileRepo`: adds `listUsersForProfile` and `setUsersForProfile` mirroring the existing `*ForUser` direction.
- Routes (admin-only): `GET /api/profiles/:id/users` returns `List[UserSummary]`, `PUT /api/profiles/:id/users` replaces the link set for that profile.

## Tests (TDD)
- **Backend** (`ProfileApiSpec`): set/get round-trip; clearing one profile's user list does not disturb other profile links for the same user; non-admin gets 403.
- **Web** (`ProfilesPage.test.tsx`): devices grouped under their profile, linked-users rendered for admins, entire users section hidden for non-admins (and `api.users.list` not called), Edit-users flow opens modal with current users pre-checked and submits the right ids on Save.

## Follow-ups (filed separately, intentionally out of scope)
- #273 — device rows click-through to a device-detail page (no such page exists yet).
- #274 — let non-admin adults *view* the linked-user list (today `/api/users` is admin-only).

## Test plan
- [x] \`mill __.test\` — 267 tests pass.
- [x] \`vitest run\` — 73 tests pass.
- [x] \`scalafmt --check\` — clean.
- [ ] Manual: open a profile card as admin, confirm devices + linked users render, click Edit users, toggle, Save, confirm persistence.

Refs #44 (UsersPage mirror), #118 (data-testid convention), #227 (audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)