### PR TITLE
openwrt: auto-update from rolling openwrt-latest release (fixes #279)

### DIFF
--- a/openwrt/files/usr/sbin/familydns-update
+++ b/openwrt/files/usr/sbin/familydns-update
@@ -1,13 +1,23 @@
 #!/bin/sh
 # Auto-updater for the familydns package.
-# Checks GitHub Releases for a newer build and upgrades in place.
+# Pulls the rolling `openwrt-latest` GitHub pre-release and re-installs whenever
+# that release's published_at timestamp changes. This matches the rolling-build
+# CD set up by #245 (image-per-push to main, no per-release tag cut).
+#
+# Reverted alongside #244, once we're ready for semver-gated production updates
+# again — see TODO(#244) below.
+#
 # Supports both opkg (OpenWRT <= 23.05) and apk-tools (OpenWRT 24.10+).
 # /etc/config/familydns is declared as a conffile, so router_token survives
 # upgrades under either package manager.
 # Safe to run from cron; logs to syslog under tag "familydns".
 set -u
 
-API_URL="https://api.github.com/repos/sameerparekh/familydns/releases/latest"
+# TODO(#244): revert to /releases/latest + semver compare once the rolling
+# debug period for #228 is done and proper tags resume.
+API_URL="https://api.github.com/repos/sameerparekh/familydns/releases/tags/openwrt-latest"
+STATE_DIR=/var/lib/familydns
+STAMP_FILE="$STATE_DIR/last_update_stamp"
 
 log() { logger -t familydns "update: $*"; }
 
@@ -26,65 +36,30 @@ else
   exit 0
 fi
 
-# Current installed version.
-case "$PM" in
-  apk)
-    # `apk list -I familydns` prints lines like:
-    #   familydns-1.2.3-r0 x86_64 {familydns} (license) [installed]
-    # Strip the leading "familydns-" to get the version.
-    CURRENT=$(apk list -I familydns 2>/dev/null \
-      | awk '{print $1; exit}' \
-      | sed -n 's/^familydns-//p')
-    ;;
-  opkg)
-    CURRENT=$(opkg info familydns 2>/dev/null | awk '/^Version:/{print $2; exit}')
-    ;;
-esac
-
-if [ -z "$CURRENT" ]; then
-  log "familydns not installed via $PM; nothing to update"
+META=$(curl -sf "$API_URL") || META=
+if [ -z "$META" ]; then
+  log "could not fetch $API_URL; skipping"
   exit 0
 fi
 
-LATEST_URL=$(curl -sf "$API_URL" \
+# Rolling-release freshness signal: the release's published_at timestamp
+# changes every time CI replaces the rolling asset.
+LATEST_STAMP=$(printf '%s' "$META" | jsonfilter -e '@.published_at')
+LATEST_URL=$(printf '%s' "$META" \
   | jsonfilter -e '@.assets[*].browser_download_url' \
   | grep -E "$PKG_EXT" \
   | head -n1)
-if [ -z "$LATEST_URL" ]; then
-  log "could not resolve latest $PM asset URL; skipping"
+if [ -z "$LATEST_STAMP" ] || [ -z "$LATEST_URL" ]; then
+  log "could not resolve rolling release stamp/asset; skipping"
   exit 0
 fi
 
-LATEST_VER=$(echo "$LATEST_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+' | head -n1)
-if [ -z "$LATEST_VER" ]; then
-  log "could not parse version from $LATEST_URL; skipping"
+LAST_STAMP=$(cat "$STAMP_FILE" 2>/dev/null || true)
+if [ "$LATEST_STAMP" = "$LAST_STAMP" ]; then
   exit 0
 fi
 
-# Robust version compare per package manager. Both opkg and apk-tools handle
-# 1.10.0 > 1.9.0 correctly; the string-equality fallback covers parse failures.
-case "$PM" in
-  apk)
-    # `apk version -t a b` prints one of <, =, > to stdout.
-    CMP=$(apk version -t "$LATEST_VER" "$CURRENT" 2>/dev/null || echo '?')
-    if [ "$CMP" = '>' ]; then
-      :
-    else
-      exit 0
-    fi
-    ;;
-  opkg)
-    if opkg compare-versions "$LATEST_VER" '>' "$CURRENT" 2>/dev/null; then
-      :
-    elif [ "$LATEST_VER" = "$CURRENT" ]; then
-      exit 0
-    else
-      exit 0
-    fi
-    ;;
-esac
-
-log "upgrading $CURRENT -> $LATEST_VER via $PM"
+log "rolling release changed ($LAST_STAMP -> $LATEST_STAMP); upgrading via $PM"
 if ! curl -fsSL -o "$TMP" "$LATEST_URL"; then
   log "download failed: $LATEST_URL"
   rm -f "$TMP"
@@ -94,7 +69,7 @@ fi
 case "$PM" in
   apk)
     if apk add --allow-untrusted "$TMP" >/tmp/familydns-update.log 2>&1; then
-      log "installed $LATEST_VER"
+      log "installed rolling build $LATEST_STAMP"
       rm -f "$TMP" /tmp/familydns-update.log
     else
       log "apk add failed; see /tmp/familydns-update.log"
@@ -104,7 +79,7 @@ case "$PM" in
     ;;
   opkg)
     if opkg install --force-reinstall "$TMP" >/tmp/familydns-update.log 2>&1; then
-      log "installed $LATEST_VER"
+      log "installed rolling build $LATEST_STAMP"
       rm -f "$TMP" /tmp/familydns-update.log
     else
       log "opkg install failed; see /tmp/familydns-update.log"
@@ -113,3 +88,6 @@ case "$PM" in
     fi
     ;;
 esac
+
+mkdir -p "$STATE_DIR"
+printf '%s\n' "$LATEST_STAMP" > "$STAMP_FILE"

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -35,15 +35,15 @@ grep -q 'command -v apk' "$SCRIPT" && grep -q 'command -v opkg' "$SCRIPT" \
   && check "detects both apk and opkg package managers" ok \
   || check "detects both apk and opkg package managers" "missing apk/opkg detection"
 
-# 4. Uses opkg compare-versions for robust version compare on opkg path
-grep -q 'opkg compare-versions' "$SCRIPT" \
-  && check "uses opkg compare-versions on opkg path" ok \
-  || check "uses opkg compare-versions on opkg path" "missing — string compare alone breaks 1.10 vs 1.9"
+# 4. Rolling-release mode: compares release published_at stamp instead of semver.
+#    Reverts to semver compare alongside #244.
+grep -q '@.published_at' "$SCRIPT" \
+  && check "uses release published_at as freshness signal" ok \
+  || check "uses release published_at as freshness signal" "missing published_at compare"
 
-# 4b. Uses apk version -t for robust version compare on apk path
-grep -q 'apk version -t' "$SCRIPT" \
-  && check "uses apk version -t on apk path" ok \
-  || check "uses apk version -t on apk path" "missing — apk needs its own comparator"
+grep -q 'last_update_stamp' "$SCRIPT" \
+  && check "persists last-applied stamp under /var/lib/familydns" ok \
+  || check "persists last-applied stamp under /var/lib/familydns" "missing stamp file"
 
 # 4c. Installs via apk add --allow-untrusted on apk path
 grep -q 'apk add --allow-untrusted' "$SCRIPT" \
@@ -58,15 +58,13 @@ grep -q "'\\\\.ipk\$'" "$SCRIPT" \
   && check "filters .ipk asset on opkg path" ok \
   || check "filters .ipk asset on opkg path" "missing .ipk regex"
 
-# 4e. Reads current installed version on apk path (apk list -I or db parse)
-grep -qE 'apk (list -I|info)' "$SCRIPT" \
-  && check "reads current version on apk path" ok \
-  || check "reads current version on apk path" "missing apk version lookup"
+# 4e. Rolling mode doesn't need to read installed version — the published_at
+#     stamp is authoritative. Restored alongside #244.
 
-# 5. Hits GitHub releases/latest API
-grep -q 'releases/latest' "$SCRIPT" \
-  && check "fetches GitHub latest release" ok \
-  || check "fetches GitHub latest release" "wrong API endpoint"
+# 5. Hits the rolling openwrt-latest pre-release (see #245; reverts with #244).
+grep -q 'releases/tags/openwrt-latest' "$SCRIPT" \
+  && check "fetches rolling openwrt-latest release" ok \
+  || check "fetches rolling openwrt-latest release" "wrong API endpoint"
 
 # 6. Installs with --force-reinstall (preserves conffiles)
 grep -q 'opkg install --force-reinstall' "$SCRIPT" \


### PR DESCRIPTION
## Summary

- Auto-updater now pulls the rolling `openwrt-latest` pre-release introduced by #245, instead of `/releases/latest`.
- Uses the release's `published_at` timestamp (persisted to `/var/lib/familydns/last_update_stamp`) as the freshness signal — semver compare can't drive a rolling tag that re-uses the same `PKG_VERSION` each cycle.
- Both PM paths (apk + opkg) re-install whenever the stamp changes; `--allow-untrusted` / `--force-reinstall` already happily reinstall the same version.

## Why

Today the updater is broken for the rolling-debug period: it hits `/releases/latest`, which (a) excludes pre-releases and (b) currently returns `v0.0.99` — numerically lower than the `v0.1.x` tags already deployed. Routers compute `0.0.99 < 0.1.x` and skip the update, so the rolling builds we're shipping for #228 never reach the field. See #279.

## Lifetime

Paired with #245. Reverts alongside #244 once we resume semver-gated production updates — there's a `TODO(#244)` marker in the script pointing at the right spot.

## Test plan

- [x] `sh openwrt/test/run_tests.sh` — 18/18 pass
- [ ] Deploy to a test router, run `/usr/sbin/familydns-update`, confirm it pulls the current rolling `.apk`, writes `/var/lib/familydns/last_update_stamp`, and exits 0 on a second invocation without re-installing
- [ ] Manually re-publish the `openwrt-latest` release, confirm the next cron tick picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)