### PR TITLE
openwrt: install.sh pulls rolling openwrt-latest release (fixes #281)

### DIFF
--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -21,7 +21,9 @@
 
 set -eu
 
-RELEASES_API="https://api.github.com/repos/sameerparekh/familydns/releases/latest"
+# TODO(#244): revert to /releases/latest once the rolling debug period for
+# #228 is done and proper tags resume. Pairs with #280 (auto-updater swap).
+RELEASES_API="https://api.github.com/repos/sameerparekh/familydns/releases/tags/openwrt-latest"
 
 err() { printf 'error: %s\n' "$*" >&2; exit 1; }
 info() { printf '==> %s\n' "$*"; }


### PR DESCRIPTION
## Summary

- `openwrt/install.sh` now resolves its release assets from `releases/tags/openwrt-latest` instead of `/releases/latest`.
- Pairs with #280 (auto-updater) so fresh installs and ongoing updates both track the rolling pre-release introduced by #245.

## Why

#280 fixed the daily auto-updater, but `install.sh` still hit `/releases/latest` — which returns v0.0.99 (a snapshot of `main` from 2026-05-12 15:25), not the current rolling head. Result: a fresh install lands stale content and only converges to the rolling build at the next 04:00 cron tick (up to 24h later). See #281.

## Lifetime

Reverts alongside #244 and #280 once semver-gated production updates resume. The `TODO(#244)` marker in `openwrt/install.sh` points at the revert site.

## Test plan

- [ ] On a fresh OpenWRT router, run the install one-liner from the README, confirm the `.apk` URL printed in the `==> Downloading ...` line points at `download/openwrt-latest/familydns_*.apk` (not `download/v0.0.99/...`)
- [ ] Confirm the agent comes up and the router enrolls successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)