### PR TITLE
openwrt: explain LAN prefix prompt before asking (fixes #283)

### DIFF
--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -40,7 +40,7 @@ The script prompts for:
 |---|---|
 | API server URL | e.g. `https://api.example.com` (no trailing slash needed; the script trims it). |
 | Enrollment token | The `et_…` value from the admin UI. Single-use; invalidated on success. |
-| LAN prefix | Auto-detected from `network.lan.ipaddr` (last octet stripped). Must end with a dot. |
+| LAN prefix | Auto-detected from `network.lan.ipaddr` (last octet stripped); must end with a dot. The agent uses this literal-string prefix to decide which side of each connection is on the LAN when attributing flows to a device — accept the default unless your LAN isn't a /24 starting at .1. A wrong value silently mis-attributes every flow. For unattended provisioning, skip this script and use the manual `uci` path in §M3. |
 
 The router's display name comes from whatever you typed in the admin UI
 when you generated the enrollment token — the agent does not collect it.

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -97,6 +97,18 @@ API_URL=${API_URL%/}
 prompt ENROLLMENT_TOKEN "One-time enrollment token (admin UI -> Routers -> Add router)"
 [ -n "${ENROLLMENT_TOKEN:-}" ] || err "enrollment token is required"
 
+cat >"$TTY" <<EOF
+
+The LAN prefix is the literal IP-string prefix the agent uses to decide
+which side of each connection is on your LAN when attributing flows to a
+device. The default below was auto-detected from this router's LAN IP
+(network.lan.ipaddr) and is correct for ~all home LANs — just press Enter
+to accept it. Only override if your LAN is not on a /24 starting at .1
+(e.g. you've carved up 10.0.0.0/16). A wrong value silently mis-attributes
+every flow. For unattended provisioning, skip this script and use the
+manual 'uci set ... lan_prefix=...' path in docs/install-openwrt.md §M3.
+
+EOF
 prompt LAN_PREFIX       "LAN prefix (literal, with trailing dot)" "$lan_default"
 
 case "$LAN_PREFIX" in


### PR DESCRIPTION
## Summary
- Adds a short context block before the interactive LAN-prefix prompt in `openwrt/install.sh`: what `lan_prefix` is for, that the auto-detected default is correct for typical /24 home LANs, the silent mis-attribution failure mode, and a pointer to the manual `uci` path for unattended provisioning.
- Tightens the matching row in `docs/install-openwrt.md` §2 so the doc and prompt carry the same weight as the existing §M3 "Important — read this even if your LAN looks normal" callout.
- Copy only — no detection logic, UCI keys, defaults, or behavior changed.

Fixes #283.

Note on the env-var acceptance criterion: the script's `prompt()` reads unconditionally from `/dev/tty`, so there is no pre-existing env-var bypass to document. Rather than invent one (out of scope per the issue), the new copy points unattended re-runs at the existing manual `uci` path in §M3.

## Test plan
- [ ] `sh -n openwrt/install.sh` — syntax OK locally.
- [ ] Manual: re-run the interactive installer on a test router and confirm the new context block prints before the LAN-prefix prompt, default is still auto-detected, and pressing Enter accepts it.