### PR TITLE
web: render activity timestamps in local time (fixes #284)

### DIFF
--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -63,4 +63,11 @@ describe('DashboardPage', () => {
     render(<DashboardPage />)
     expect(await screen.findByText(/No blocked queries yet/)).toBeInTheDocument()
   })
+
+  it('recent activity Time column renders in viewer local time (not UTC slice)', async () => {
+    render(<DashboardPage />)
+    await screen.findByText('example.com')
+    const expected = new Date(recent.ts).toLocaleTimeString()
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -106,7 +106,7 @@ function LogTable({ logs }: { logs: QueryLog[] }) {
       <tbody>
         {logs.map(l => (
           <tr key={l.id} className="border-b border-gray-800/50 hover:bg-gray-800/30">
-            <td className="px-4 py-2 text-gray-500">{l.ts.slice(11, 19)}</td>
+            <td className="px-4 py-2 text-gray-500">{new Date(l.ts).toLocaleTimeString()}</td>
             <td className="px-4 py-2 text-yellow-400">{l.deviceName ?? l.mac ?? '?'}</td>
             <td className="px-4 py-2 text-gray-300 max-w-[200px] truncate">{l.domain}</td>
             <td className={`px-4 py-2 ${l.blocked ? 'text-red-400' : 'text-emerald-600'}`}>

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -125,4 +125,25 @@ describe('LogsPage — Raw events tab', () => {
     await user.click(screen.getByTestId('logs-tab-raw'))
     expect(await screen.findByText('No events found.')).toBeInTheDocument()
   })
+
+  it('Raw events Time column renders in viewer local time (not UTC slice)', async () => {
+    const user = userEvent.setup()
+    render(<LogsPage />)
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    await screen.findByText('example.com')
+    const expected = new Date(log1.ts).toLocaleTimeString()
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+})
+
+describe('LogsPage — Sessions tab timestamps', () => {
+  it('Started column renders session start in viewer local time', async () => {
+    render(<LogsPage />)
+    await screen.findByText('youtube.com')
+    const expected = new Date(session1.startedAt).toLocaleTimeString([], {
+      hour: '2-digit', minute: '2-digit',
+    })
+    expect(screen.getAllByText(expected).length).toBeGreaterThan(0)
+  })
 })

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -184,7 +184,7 @@ function RawEventsTab() {
                 <tbody>
                   {logs.map(l => (
                     <tr key={l.id} className="border-b border-gray-800/50 hover:bg-gray-800/30">
-                      <td className="px-4 py-2.5 text-gray-500">{l.ts.slice(11,19)}</td>
+                      <td className="px-4 py-2.5 text-gray-500">{fmtTime(l.ts)}</td>
                       <td className="px-4 py-2.5 text-yellow-400">{l.deviceName ?? l.mac ?? '?'}</td>
                       <td className="px-4 py-2.5 text-gray-300 max-w-[200px] truncate">{l.domain}</td>
                       <td className={`px-4 py-2.5 ${l.blocked ? 'text-red-400' : 'text-emerald-600'}`}>
@@ -224,6 +224,9 @@ function fmtBytes(n: number): string {
 }
 
 function fmtStarted(iso: string): string {
-  // ISO 2026-05-12T14:30:00Z → 14:30 (display only, no timezone math)
-  return iso.slice(11, 16)
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString()
 }


### PR DESCRIPTION
## Summary
- Raw Events, Sessions, and Dashboard time columns previously displayed UTC via ISO string slicing; now parse to `Date` and render via `toLocaleTimeString()` so operators see their browser's local time.
- Backend serialization is untouched — API still emits ISO 8601 / `Instant`. Change is display-layer only.
- Routers' `lastSeenAt` already used `toLocaleString()`; left as-is.

Fixes #284.

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test` (73/73 passing)
- [ ] Manual check in browser: Raw Events / Sessions / Dashboard timestamps reflect local tz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)