### PR TITLE
openwrt: scrape usage from mac_ip_tracking set elements (fixes #286)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -1,15 +1,30 @@
 -- usage.lua — nftables counter scraper and usage reporter
 --
--- Counter naming convention (must match render.lua + conntrack.lua):
---   ct_<mac_underscored>__<dst_ip_underscored>
---   e.g.  aa:bb:cc:11:22:33 → dst 1.2.3.4  →  ct_aa_bb_cc_11_22_33__1_2_3_4
---   ':'  and '.'  →  '_'
---   MAC and IP separated by double-underscore '__' to avoid ambiguity.
+-- Per-(mac, dst_ip) byte/packet accounting comes from the dynamic set
+-- `mac_ip_tracking` declared in render.lua:
+--
+--   set mac_ip_tracking {
+--     type ether_addr . ipv4_addr
+--     flags dynamic,timeout
+--     counter
+--     ...
+--   }
+--   chain familydns_account {
+--     type filter hook forward priority 1; policy accept;
+--     update @mac_ip_tracking { ether saddr . ip daddr } counter
+--   }
+--
+-- Each set element carries its own counter, so we read
+-- `nft -j list set inet familydns mac_ip_tracking` and walk
+-- `nftables[*].set.elem[*].elem.{val.concat:[mac,ip], counter:{packets,bytes}}`.
+-- After a successful POST the agent calls
+-- `nft reset set inet familydns mac_ip_tracking` to zero the per-element
+-- counters in place so the next bucket starts clean.
 --
 -- Public API:
 --   usage.parse_nft_counters(json_str)
 --     → list of { mac, dst_ip, bytes, packets }
---     Input: JSON from `nft -j list counters table inet familydns`
+--     Input: JSON from `nft -j list set inet familydns mac_ip_tracking`
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases])
 --     → report table ready for JSON encoding and POST /api/router/usage
@@ -35,50 +50,46 @@ local function default_log()
 end
 
 -- ---------------------------------------------------------------------------
--- decode_counter_name(name) → mac, dst_ip  or  nil
--- ---------------------------------------------------------------------------
-local function decode_counter_name(name)
-  if name:sub(1, 3) ~= "ct_" then return nil end
-  local body = name:sub(4)
-
-  -- split on the first "__" to separate MAC-encoded from IP-encoded
-  local mac_enc, ip_enc = body:match("^(.-)__(.+)$")
-  if not mac_enc then return nil end
-
-  -- MAC: 6 hex octets separated by '_'
-  local mac_parts = {}
-  for p in mac_enc:gmatch("[^_]+") do mac_parts[#mac_parts + 1] = p end
-  if #mac_parts ~= 6 then return nil end
-
-  -- IP: 4 decimal octets separated by '_'
-  local ip_parts = {}
-  for p in ip_enc:gmatch("[^_]+") do ip_parts[#ip_parts + 1] = p end
-  if #ip_parts ~= 4 then return nil end
-
-  return table.concat(mac_parts, ":"), table.concat(ip_parts, ".")
-end
-
--- ---------------------------------------------------------------------------
 -- usage.parse_nft_counters(json_str)
+--
+-- Walks the JSON output of `nft -j list set inet familydns mac_ip_tracking`
+-- and returns one record per set element with a non-zero counter.
+--
+-- Shape (nftables 1.x):
+--   { "nftables": [
+--       { "metainfo": {...} },
+--       { "set": { "name": "mac_ip_tracking",
+--                  "elem": [
+--                    { "elem": { "val": { "concat": [<mac>, <ip>] },
+--                                "counter": { "packets": N, "bytes": M } } },
+--                    ...
+--                  ] } }
+--   ] }
 -- ---------------------------------------------------------------------------
 function M.parse_nft_counters(json_str)
-  local jsonc    = require("luci.jsonc")
-  local decoded  = jsonc.parse(json_str)
-  local result   = {}
+  local jsonc   = require("luci.jsonc")
+  local decoded = jsonc.parse(json_str)
+  local result  = {}
 
   if not decoded then return result end
 
   for _, entry in ipairs(decoded.nftables or {}) do
-    local c = entry.counter
-    if c and type(c.name) == "string" then
-      local mac, dst_ip = decode_counter_name(c.name)
-      if mac then
-        result[#result + 1] = {
-          mac     = mac,
-          dst_ip  = dst_ip,
-          bytes   = c.bytes   or 0,
-          packets = c.packets or 0,
-        }
+    local set = entry.set
+    if set and set.elem then
+      for _, wrapper in ipairs(set.elem) do
+        -- `nft -j` wraps each element as { elem = { val = ..., counter = ... } }
+        local e = wrapper.elem or wrapper
+        local val = e.val
+        local concat = val and val.concat
+        local counter = e.counter
+        if concat and counter and concat[1] and concat[2] then
+          result[#result + 1] = {
+            mac     = concat[1],
+            dst_ip  = concat[2],
+            bytes   = counter.bytes   or 0,
+            packets = counter.packets or 0,
+          }
+        end
       end
     end
   end

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -264,7 +264,11 @@ conntrack.watch({
       local period_start = os.date("!%Y-%m-%dT%H:%M:%SZ", last_usage_run)
       last_usage_run = now
 
-      local pipe = io.popen("nft -j list counters table inet familydns 2>/dev/null", "r")
+      -- Per-(mac,ip) counters live as element counters on the dynamic set
+      -- `mac_ip_tracking` (see render.lua). After a successful POST we
+      -- `nft reset set ...` to zero those per-element counters in place.
+      local pipe = io.popen(
+        "nft -j list set inet familydns mac_ip_tracking 2>/dev/null", "r")
       if pipe then
         local json_str = pipe:read("*a") or ""
         pipe:close()
@@ -277,8 +281,7 @@ conntrack.watch({
                       #counters, report.records and #report.records or 0)
             local posted = usage.post(api_url, router_token, report, http_post, log)
             if posted then
-              -- Reset counters so next period starts clean
-              os.execute("nft reset counters table inet familydns 2>/dev/null")
+              os.execute("nft reset set inet familydns mac_ip_tracking >/dev/null 2>&1")
             end
           end
         end

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -1,27 +1,31 @@
 -- Tests for openwrt/files/usr/lib/lua/familydns/usage.lua
 -- Run with: cd openwrt && busted test/usage_spec.lua
 --
--- Counter name convention (produced by render.lua, consumed here):
---   ct_<mac_underscored>__<dst_ip_underscored>
---   e.g.  aa:bb:cc:11:22:33  +  1.2.3.4  →  ct_aa_bb_cc_11_22_33__1_2_3_4
--- Separator between MAC and IP is double-underscore (__) to avoid ambiguity
--- with the single-underscore replacements inside each field.
+-- Input shape: `nft -j list set inet familydns mac_ip_tracking`.
+-- The `mac_ip_tracking` dynamic set is declared in render.lua with
+-- `flags dynamic,timeout` + `counter`, so each set element carries its own
+-- counter and the JSON layout is:
+--   nftables[*].set.elem[*].elem.{val.concat:[<mac>,<ip>], counter:{packets,bytes}}
 
 local usage = require("usage")
 
--- Sample `nft -j list counters table inet familydns` output
 local NFT_JSON = [[{
   "nftables": [
-    { "metainfo": { "version": "1.0.2", "json_schema_version": 1 } },
-    { "counter": {
-        "family": "inet", "table": "familydns",
-        "name": "ct_aa_bb_cc_11_22_33__1_2_3_4",
-        "packets": 100, "bytes": 50000
-    }},
-    { "counter": {
-        "family": "inet", "table": "familydns",
-        "name": "ct_de_ad_be_ef_00_01__8_8_8_8",
-        "packets": 20, "bytes": 1024
+    { "metainfo": { "version": "1.1.6", "json_schema_version": 1 } },
+    { "set": {
+        "family": "inet", "table": "familydns", "name": "mac_ip_tracking",
+        "type": ["ether_addr", "ipv4_addr"],
+        "flags": ["timeout", "dynamic"],
+        "elem": [
+          { "elem": {
+              "val": { "concat": ["aa:bb:cc:11:22:33", "1.2.3.4"] },
+              "expires": 21000,
+              "counter": { "packets": 100, "bytes": 50000 } } },
+          { "elem": {
+              "val": { "concat": ["de:ad:be:ef:00:01", "8.8.8.8"] },
+              "expires": 21000,
+              "counter": { "packets": 20, "bytes": 1024 } } }
+        ]
     }}
   ]
 }]]
@@ -30,12 +34,12 @@ local NFT_JSON = [[{
 
 describe("usage.parse_nft_counters", function()
 
-  it("returns one entry per counter object (skips metainfo)", function()
+  it("returns one entry per set element (skips metainfo)", function()
     local counters = usage.parse_nft_counters(NFT_JSON)
     assert.equal(2, #counters)
   end)
 
-  it("extracts bytes and packets from each entry", function()
+  it("extracts bytes and packets from each element counter", function()
     local counters = usage.parse_nft_counters(NFT_JSON)
     local by_mac = {}
     for _, c in ipairs(counters) do by_mac[c.mac] = c end
@@ -44,7 +48,7 @@ describe("usage.parse_nft_counters", function()
     assert.equal(1024,  by_mac["de:ad:be:ef:00:01"].bytes)
   end)
 
-  it("decodes counter name back to mac and dst_ip", function()
+  it("extracts mac and dst_ip from the val.concat tuple", function()
     local counters = usage.parse_nft_counters(NFT_JSON)
     local by_mac = {}
     for _, c in ipairs(counters) do by_mac[c.mac] = c end
@@ -54,22 +58,25 @@ describe("usage.parse_nft_counters", function()
     assert.equal("8.8.8.8",           by_mac["de:ad:be:ef:00:01"].dst_ip)
   end)
 
-  it("returns empty list when JSON contains no counter objects", function()
-    local empty = '{"nftables":[{"metainfo":{"version":"1.0.2"}}]}'
+  it("returns empty list when the set has no elements", function()
+    local empty = [[{"nftables":[
+      {"metainfo":{"version":"1.1.6"}},
+      {"set":{"name":"mac_ip_tracking"}}
+    ]}]]
     assert.equal(0, #usage.parse_nft_counters(empty))
   end)
 
-  it("skips counters whose names do not match the ct_ convention", function()
-    local foreign = [[{"nftables":[
-      {"counter":{"family":"inet","table":"familydns","name":"unrelated","packets":1,"bytes":10}}
-    ]}]]
-    assert.equal(0, #usage.parse_nft_counters(foreign))
+  it("returns empty list when no set entry is present", function()
+    local empty = '{"nftables":[{"metainfo":{"version":"1.1.6"}}]}'
+    assert.equal(0, #usage.parse_nft_counters(empty))
   end)
 
   it("handles a multi-octet IP like 192.168.100.200 correctly", function()
     local json_str = [[{"nftables":[
-      {"counter":{"family":"inet","table":"familydns",
-       "name":"ct_aa_bb_cc_11_22_33__192_168_100_200","packets":5,"bytes":999}}
+      {"set":{"name":"mac_ip_tracking","elem":[
+        {"elem":{"val":{"concat":["aa:bb:cc:11:22:33","192.168.100.200"]},
+                 "counter":{"packets":5,"bytes":999}}}
+      ]}}
     ]}]]
     local counters = usage.parse_nft_counters(json_str)
     assert.equal(1, #counters)


### PR DESCRIPTION
## Summary
- usage.lua + familydns-agent now read per-(mac, dst_ip) accounting from the `mac_ip_tracking` dynamic set's element counters, matching what render.lua actually emits. The old per-flow named-counter scraper was parsing a layout that no longer exists, so every 5-min usage tick produced 0 records and skipped the POST.
- After a successful POST the agent now issues `nft reset set inet familydns mac_ip_tracking` so the per-element counters zero in place for the next bucket.
- Tests in `openwrt/test/usage_spec.lua` updated to the new JSON shape.

## Root cause
The pipeline has four hops: router scrapes nft → POST `/api/router/usage` → API inserts traffic_reports / time_usage → UI reads. The break is at hop 1.

`render.lua` declares the per-flow accounting as a dynamic set with element counters:
```nft
set mac_ip_tracking {
  type ether_addr . ipv4_addr
  flags dynamic,timeout
  counter
}
chain familydns_account {
  update @mac_ip_tracking { ether saddr . ip daddr } counter
}
```
But `usage.lua` was still parsing the older convention — top-level counter objects named `ct_<mac>__<ip>` — by calling `nft -j list counters table inet familydns` and walking `nftables[*].counter`. Under the current rendering, that command returns zero standalone counters, so `parse_nft_counters` always returned an empty list. `usage.post` then took the "no records" branch and skipped the POST entirely (silent under `debug=false`). API logs over the 30+ minutes I observed show only `/api/router/events` traffic from the router, never `/api/router/usage`.

## Regression vs round-1 (#260, #261)
Round-1 fixes assumed `ct_<mac>__<ip>` standalone counters. At some point `render.lua` was rewritten to use a single `mac_ip_tracking` set with per-element counters (cleaner, GC'd by the set's `timeout`, no per-flow rule churn) — but the round-1 usage scraper was not migrated, so the surface silently regressed to empty. The architectural comment in `render.lua` ("conntrack.lua adds rules referencing named counters; this set is also used as a fallback…") still describes the old design and is now stale.

## Live verification
Iterated on the running deployment (router 192.168.1.1, API 192.168.10.43). Pushed the patched Lua + agent to the router, temporarily set `debug=1` and `usage_report_interval=30` for visibility, then restored to defaults.

Router log after the first post-fix tick:
```
usage timer: 35 counter(s), 35 record(s) prepared
usage.post: POST url=…/api/router/usage records=35 periodStart=…34:30Z periodEnd=…35:00Z
usage.post: success status=200
```
API DB after that tick:
```
traffic_reports: 4 rows (one per active MAC; multiple dst_ips collapse via unique key + hostname='unknown')
time_usage:     4 rows, seconds_used accumulating, bytes_in non-zero per MAC
```
(The "everything is `hostname=unknown`" issue is downstream attribution via dnsmasq ipsets and is independent of this fix — once nft_sets populate from `--ipset=` callbacks the hostname field will resolve.)

Closes #286.

## Test plan
- [x] Lua unit tests in `openwrt/test/usage_spec.lua` cover the new JSON shape
- [x] Live: usage POST returns 200, traffic_reports + time_usage rows accumulate
- [ ] Reviewer: after this lands, confirm Screen Time and Sessions UI surfaces render rows for the active MACs

🤖 Generated with [Claude Code](https://claude.com/claude-code)