### PR TITLE
openwrt: propagate dns-cache hostname into usage reports (#287)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -26,10 +26,13 @@
 --     → list of { mac, dst_ip, bytes, packets }
 --     Input: JSON from `nft -j list set inet familydns mac_ip_tracking`
 --
---   usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases])
+--   usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases [, lookup_hostname]])
 --     → report table ready for JSON encoding and POST /api/router/usage
---     nft_sets: { hostname → { ip → true } }  (maintained by render.update_shared + dnsmasq)
---     leases:   { mac → ip }  (optional; populates the ip field on each record)
+--     nft_sets:        { hostname → { ip → true } }  (maintained by render.update_shared + dnsmasq)
+--     leases:          { mac → ip }  (optional; populates the ip field on each record)
+--     lookup_hostname: fn(dst_ip) → string|nil  (optional; consulted before
+--                      falling back to "unknown" — same dnsmasq-query-log
+--                      cache the conntrack path uses, see #287)
 --
 --   usage.post(api_url, router_token, report, post_fn)
 --     → bool
@@ -98,9 +101,21 @@ function M.parse_nft_counters(json_str)
 end
 
 -- ---------------------------------------------------------------------------
--- hostname_for_ip(dst_ip, nft_sets) → string
+-- hostname_for_ip(dst_ip, nft_sets, lookup_hostname) → string
 -- ---------------------------------------------------------------------------
-local function hostname_for_ip(dst_ip, nft_sets)
+-- Resolution order, matching conntrack.handle_flow (#287):
+--   1. dnsmasq-query-log cache (lookup_hostname) — covers any LAN client that
+--      resolved through the router's dnsmasq.
+--   2. nft_sets — only populated for site_limits ipsets, but authoritative
+--      when present (it's the hostname dnsmasq's ipset= callback recorded
+--      at resolve time).
+--   3. "unknown" — used by the Sessions UI to group traffic with no
+--      attributable hostname (DoH/Apple Private Relay/direct-IP).
+local function hostname_for_ip(dst_ip, nft_sets, lookup_hostname)
+  if lookup_hostname then
+    local h = lookup_hostname(dst_ip)
+    if h then return h end
+  end
   for hostname, ips in pairs(nft_sets or {}) do
     if ips[dst_ip] then return hostname end
   end
@@ -108,15 +123,15 @@ local function hostname_for_ip(dst_ip, nft_sets)
 end
 
 -- ---------------------------------------------------------------------------
--- usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases])
+-- usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases [, lookup_hostname]])
 -- ---------------------------------------------------------------------------
 -- active_seconds heuristic (§9 architecture doc):
 --   Any counter with bytes > 0 in the 5-min bucket counts as the full period (300 s).
-function M.build_report(counters, nft_sets, period_start, period_end, router_id, leases)
+function M.build_report(counters, nft_sets, period_start, period_end, router_id, leases, lookup_hostname)
   local records = {}
 
   for _, c in ipairs(counters or {}) do
-    local hostname = hostname_for_ip(c.dst_ip, nft_sets)
+    local hostname = hostname_for_ip(c.dst_ip, nft_sets, lookup_hostname)
     local rec = {
       mac           = c.mac,
       hostname      = hostname,

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -271,7 +271,8 @@ conntrack.watch({
           local ok, counters = pcall(usage.parse_nft_counters, json_str)
           if ok and counters then
             local report = usage.build_report(
-              counters, nft_sets, period_start, period_end, router_id)
+              counters, nft_sets, period_start, period_end, router_id,
+              nil, lookup_hostname)
             log.debug("usage timer: %d counter(s), %d record(s) prepared",
                       #counters, report.records and #report.records or 0)
             local posted = usage.post(api_url, router_token, report, http_post, log)

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -131,6 +131,45 @@ describe("usage.build_report", function()
     assert.equal("unknown", r.records[1].hostname)
   end)
 
+  -- #287: nft_sets only carries hostnames for site_limits-tracked domains, so
+  -- without the dnsmasq-query-log lookup every traffic_reports row landed as
+  -- "unknown" and the Sessions UI rendered every flow as unknown traffic.
+  it("consults lookup_hostname (dns-cache) before falling back to 'unknown'", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "140.82.114.6", bytes = 100, packets = 3 },
+    }
+    local lookup = function(ip)
+      if ip == "140.82.114.6" then return "api.github.com" end
+      return nil
+    end
+    local r = usage.build_report(counters, {}, P_START, P_END, ROUTER, nil, lookup)
+    assert.equal("api.github.com", r.records[1].hostname)
+  end)
+
+  it("prefers lookup_hostname over nft_sets when both have an entry", function()
+    -- nft_sets reflects what dnsmasq's ipset= callback stored at resolve time
+    -- for site_limits domains. If the dns-cache has a hit too, we trust that
+    -- since it's the hostname the *client actually resolved*, not whatever
+    -- ipset bucket the IP happens to live in.
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 3 },
+    }
+    local sets = { ["site_limit.example"] = { ["1.2.3.4"] = true } }
+    local lookup = function(_) return "actual.example" end
+    local r = usage.build_report(counters, sets, P_START, P_END, ROUTER, nil, lookup)
+    assert.equal("actual.example", r.records[1].hostname)
+  end)
+
+  it("falls through to nft_sets when lookup_hostname misses", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 3 },
+    }
+    local sets = { ["youtube.com"] = { ["1.2.3.4"] = true } }
+    local lookup = function(_) return nil end
+    local r = usage.build_report(counters, sets, P_START, P_END, ROUTER, nil, lookup)
+    assert.equal("youtube.com", r.records[1].hostname)
+  end)
+
   it("sets activeSeconds = 300 (full period) for any counter with bytes > 0", function()
     local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER)
     for _, rec in ipairs(r.records) do


### PR DESCRIPTION
Follow-up to [#292](https://github.com/sameerparekh/familydns/pull/292), which squash-merged only the first of two commits on its branch. This PR carries the second commit forward against the post-#292 main.

## Symptom

After #292 landed, the Raw Events surface correctly resolved hostnames via the dnsmasq query-log cache, but the Sessions surface (derived from `traffic_reports`) showed every flow as `unknown`.

## Cause

`usage.build_report` only consulted `nft_sets`, which is populated solely for `site_limits`-tracked domains (via dnsmasq's `ipset=` callback). Every other counter defaulted to the literal string `"unknown"` — so the Sessions UI rendered an unknown-traffic bucket regardless of what dnsmasq had observed.

The conntrack/`connection_events` path was fixed in #292 by injecting `lookup_hostname` (the dnsmasq query-log cache from `dns_log.lua`); this PR mirrors that on the usage path.

## Fix

`hostname_for_ip` now resolves in the same order `conntrack.handle_flow` uses:

1. `lookup_hostname(dst_ip)` — dnsmasq query-log cache (`dns_log.lua`)
2. `nft_sets` — `site_limits` ipsets (authoritative when present)
3. `"unknown"` — the Sessions UI's catch-all bucket

`usage.build_report` takes the optional `lookup_hostname` fn as its 7th arg, and `familydns-agent` threads in the same closure it already passes to the conntrack watcher.

## Verified live

Pushed to the test router via `dev-push-router.sh` after the agent restart. New `traffic_reports` rows show real hostnames (api.github.com, play.googleapis.com, …) where every row previously landed as `unknown`.

## Tests

`openwrt/test/usage_spec.lua` adds three cases covering the new fallback chain (lookup hit, lookup-overrides-nft_sets, lookup-miss-falls-through). Full `bash openwrt/test/run_tests.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)