### PR TITLE
openwrt: fix pause enforcement and per-mac block labeling (#297)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -252,8 +252,8 @@ end
 -- ctx: {
 --   arp_table      table   { ip -> mac }
 --   nft_sets       table   { hostname -> { ip -> true } }
---   blocked_ips    table   { ip -> true }
---   blocked_reason table   { ip -> reason }
+--   blocked_macs   table   { mac -> true }       (filled by render.update_shared)
+--   blocked_reason table   { mac -> reason }     (filled by render.update_shared)
 --   reported_macs  table   { mac -> true }  (mutated)
 --   leases         table   { mac -> { ip, hostname } } (may be nil/empty)
 --   ts             string  ISO8601 timestamp to attach to the events
@@ -301,10 +301,13 @@ function M.handle_flow(flow, ctx, batcher)
   if not hname then
     hname = M.ipset_lookup_hostname(flow.dst_ip, ctx.nft_sets or {})
   end
-  local allowed = not (ctx.blocked_ips and ctx.blocked_ips[flow.dst_ip])
+  -- Per-MAC block lookup (#297): pause and time-limit block every flow from
+  -- the device, regardless of destination IP. render.update_shared rebuilds
+  -- blocked_macs/blocked_reason from the policy snapshot on every poll.
+  local allowed = not (mac and ctx.blocked_macs and ctx.blocked_macs[mac])
   local reason
   if not allowed and ctx.blocked_reason then
-    reason = ctx.blocked_reason[flow.dst_ip]
+    reason = ctx.blocked_reason[mac]
   end
   log.debug("handle_flow: connection_attempt src=%s dst=%s mac=%s hostname=%s allowed=%s reason=%s",
             flow.src_ip, flow.dst_ip, tostring(mac), tostring(hname),
@@ -353,8 +356,8 @@ end
 --   api_url        string    base URL, e.g. "http://192.168.1.1:8080"
 --   router_token   string    bearer token
 --   nft_sets       table     shared ref: { hostname -> { ip -> true } }
---   blocked_ips    table     shared ref: { ip -> true }  (filled by render.lua)
---   blocked_reason table     shared ref: { ip -> reason_string }
+--   blocked_macs   table     shared ref: { mac -> true }  (filled by render.lua)
+--   blocked_reason table     shared ref: { mac -> reason_string }
 --   lan_prefix     string    default "192.168.1."
 --   max_batch      int       default 50
 --   flush_interval int       default 10  (seconds)
@@ -434,7 +437,7 @@ function M.watch(cfg)
         arp_table             = arp,
         nft_sets              = cfg.nft_sets or {},
         lookup_hostname       = cfg.lookup_hostname,
-        blocked_ips           = cfg.blocked_ips,
+        blocked_macs          = cfg.blocked_macs,
         blocked_reason        = cfg.blocked_reason,
         reported_macs         = reported_macs,
         pending_hostname_macs = pending_hostname_macs,

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -1,10 +1,18 @@
 -- render.lua — generates dnsmasq and nftables config from a policy snapshot
 --
+-- Snapshot field naming: the API serializes PolicySnapshot/PolicyProfile/
+-- PolicyDevice via zio-json deriveCodec, which keeps the Scala case-class
+-- field names verbatim (camelCase) — see shared/src/Models.scala. This module
+-- reads those keys (profileId, extraBlocked, siteLimits, dailyMinutes,
+-- timeUsedToday.totalMinutes, extensionsTodayMinutes) directly. If the API's
+-- JSON casing ever changes, change it here too (and update render_spec.lua).
+--
 -- Public API:
 --   render.dnsmasq(snapshot)  → string  (/tmp/dnsmasq.d/familydns.conf content)
 --   render.nft(snapshot)      → string  (/tmp/nftables.d/familydns.nft content)
---   render.update_shared(snapshot, nft_sets, blocked_ips, blocked_reason)
---     Seeds the shared tables that conntrack.lua uses for hostname attribution.
+--   render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
+--     Seeds the shared tables that conntrack.lua uses for hostname attribution
+--     and for labeling per-MAC blocked flows (pause / time-exhausted).
 --
 -- Counter naming convention (used by usage.lua):
 --   ct_<mac_underscored>__<dst_ip_underscored>
@@ -36,21 +44,21 @@ function M.dnsmasq(snapshot)
   -- check (#287).
 
   -- MAC → profile tag so dnsmasq can apply per-profile rules.
-  -- Devices auto-created from first_seen_mac events have profile_id=nil
+  -- Devices auto-created from first_seen_mac events have profileId=nil
   -- until an admin assigns them; skip them (no policy to apply yet).
   emit("# device MAC → profile tag")
   for _, dev in ipairs(snapshot.devices or {}) do
-    if dev.profile_id then
-      emit(string.format("dhcp-host=%s,set:profile%d", dev.mac, dev.profile_id))
+    if dev.profileId then
+      emit(string.format("dhcp-host=%s,set:profile%d", dev.mac, dev.profileId))
     end
   end
   emit("")
 
-  -- extra_blocked → NXDOMAIN; deduplicate domains that appear in multiple profiles
-  emit("# extra_blocked → NXDOMAIN")
+  -- extraBlocked → NXDOMAIN; deduplicate domains that appear in multiple profiles
+  emit("# extraBlocked → NXDOMAIN")
   local seen_blocked = {}
   for _, prof in ipairs(snapshot.profiles or {}) do
-    for _, domain in ipairs(prof.extra_blocked or {}) do
+    for _, domain in ipairs(prof.extraBlocked or {}) do
       if not seen_blocked[domain] then
         seen_blocked[domain] = true
         emit("address=/" .. domain .. "/#")
@@ -59,10 +67,10 @@ function M.dnsmasq(snapshot)
   end
   emit("")
 
-  -- site_limits → ipset= so dnsmasq populates nftables sets with resolved IPs
-  emit("# site_limits → nftables ipset population for usage accounting")
+  -- siteLimits → ipset= so dnsmasq populates nftables sets with resolved IPs
+  emit("# siteLimits → nftables ipset population for usage accounting")
   for _, prof in ipairs(snapshot.profiles or {}) do
-    for _, sl in ipairs(prof.site_limits or {}) do
+    for _, sl in ipairs(prof.siteLimits or {}) do
       local set_name = string.format("profile%d_%s", prof.id, sanitize(sl.domain))
       emit(string.format("ipset=/%s/%s", sl.domain, set_name))
     end
@@ -86,11 +94,11 @@ function M.nft(snapshot)
   emit("table inet familydns {")
   emit("")
 
-  -- Build profile_id → [macs] index. Skip unassigned devices (profile_id=nil);
+  -- Build profileId → [macs] index. Skip unassigned devices (profileId=nil);
   -- they have no profile to be matched against in the nft sets.
   local profile_macs = {}
   for _, dev in ipairs(snapshot.devices or {}) do
-    local pid = dev.profile_id
+    local pid = dev.profileId
     if pid then
       if not profile_macs[pid] then profile_macs[pid] = {} end
       profile_macs[pid][#profile_macs[pid] + 1] = dev.mac
@@ -109,9 +117,9 @@ function M.nft(snapshot)
     emit("")
   end
 
-  -- Per-domain IP sets for site_limits (dynamic: populated by dnsmasq --ipset= at query time)
+  -- Per-domain IP sets for siteLimits (dynamic: populated by dnsmasq --ipset= at query time)
   for _, prof in ipairs(snapshot.profiles or {}) do
-    for _, sl in ipairs(prof.site_limits or {}) do
+    for _, sl in ipairs(prof.siteLimits or {}) do
       local set_name = string.format("profile%d_%s", prof.id, sanitize(sl.domain))
       ind(string.format("set %s {", set_name))
       ind2("type ipv4_addr")
@@ -149,10 +157,10 @@ function M.nft(snapshot)
 
     if prof.paused then
       block_reason = "paused"
-    elseif (prof.daily_minutes or 0) > 0 then
-      local used       = (prof.time_used_today and prof.time_used_today.total_minutes) or 0
-      local extensions = prof.extensions_today_minutes or 0
-      local remaining  = prof.daily_minutes + extensions - used
+    elseif (prof.dailyMinutes or 0) > 0 then
+      local used       = (prof.timeUsedToday and prof.timeUsedToday.totalMinutes) or 0
+      local extensions = prof.extensionsTodayMinutes or 0
+      local remaining  = prof.dailyMinutes + extensions - used
       if remaining <= 0 then
         block_reason = "time_limit"
       end
@@ -160,9 +168,11 @@ function M.nft(snapshot)
 
     if block_reason then
       ind2(string.format("# profile %d (%s): %s", prof.id, prof.name, block_reason))
-      -- DNAT HTTP/80 to block page before the drop so browsers get a response
-      ind2(string.format(
-        "ether saddr @profile%d_macs tcp dport 80 dnat to 127.0.0.1:8081", prof.id))
+      -- Drop all forwarded traffic from devices on this profile. DNAT to a
+      -- block page would be nicer UX but needs a separate nat-type chain
+      -- (DNAT is not supported in filter chains), and the bare `dnat to`
+      -- form rejected `nft -f` entirely (#297) — so until we wire up a
+      -- prerouting nat chain, we just drop.
       ind2(string.format("ether saddr @profile%d_macs drop", prof.id))
       emit("")
     end
@@ -177,17 +187,60 @@ function M.nft(snapshot)
 end
 
 -- ---------------------------------------------------------------------------
--- render.update_shared(snapshot, nft_sets, blocked_ips, blocked_reason)
+-- render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
 -- ---------------------------------------------------------------------------
--- Seeds nft_sets with empty tables for each site_limits domain so that
+-- Seeds nft_sets with empty tables for each siteLimits domain so that
 -- conntrack.lua can attribute hostnames from the moment the agent starts.
 -- Actual IPs are populated at runtime by dnsmasq --ipset= callbacks.
-function M.update_shared(snapshot, nft_sets, _blocked_ips, _blocked_reason)
+--
+-- Also rebuilds blocked_macs / blocked_reason from the current snapshot so
+-- conntrack.lua can label connection_attempt events as blocked when the
+-- device's profile is paused or has exhausted its daily time (#297). nft
+-- already drops these flows at the forward hook, but the conntrack -E -e NEW
+-- watcher still sees the SYN_SENT entry and needs an independent signal to
+-- classify it correctly — labeling purely by destination IP misses pause
+-- (every IP is blocked) and time-limit (same).
+--
+-- Both tables are mutated in place (shared refs held by conntrack.lua); we
+-- clear stale entries first so a profile that un-pauses stops marking flows
+-- as blocked on the next poll.
+function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
   for _, prof in ipairs(snapshot.profiles or {}) do
-    for _, sl in ipairs(prof.site_limits or {}) do
+    for _, sl in ipairs(prof.siteLimits or {}) do
       if not nft_sets[sl.domain] then
         nft_sets[sl.domain] = {}
       end
+    end
+  end
+
+  if blocked_macs then
+    for k in pairs(blocked_macs) do blocked_macs[k] = nil end
+  end
+  if blocked_reason then
+    for k in pairs(blocked_reason) do blocked_reason[k] = nil end
+  end
+
+  local profile_block = {}
+  for _, prof in ipairs(snapshot.profiles or {}) do
+    local reason
+    if prof.paused then
+      reason = "paused"
+    elseif (prof.dailyMinutes or 0) > 0 then
+      local used = (prof.timeUsedToday and prof.timeUsedToday.totalMinutes) or 0
+      local ext  = prof.extensionsTodayMinutes or 0
+      if used >= prof.dailyMinutes + ext then
+        reason = "time_limit"
+      end
+    end
+    if reason then profile_block[prof.id] = reason end
+  end
+
+  for _, dev in ipairs(snapshot.devices or {}) do
+    local pid    = dev.profileId
+    local reason = pid and profile_block[pid] or nil
+    if reason then
+      if blocked_macs   then blocked_macs[dev.mac]   = true end
+      if blocked_reason then blocked_reason[dev.mac] = reason end
     end
   end
 end

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -53,8 +53,8 @@ end
 -- ── Shared state (render.lua writes; conntrack.lua reads) ─────────────────────
 
 local nft_sets     = {}   -- { hostname -> { ip -> true } }
-local blocked_ips  = {}   -- { ip -> true }
-local blocked_reason = {} -- { ip -> reason_string }
+local blocked_macs   = {} -- { mac -> true }          (paused / time-exhausted)
+local blocked_reason = {} -- { mac -> reason_string }
 
 -- ── HTTP helpers (curl, available on all OpenWrt builds) ──────────────────────
 
@@ -178,7 +178,7 @@ do
   local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
   if snap then
     policy.apply(snap, write_file, run_cmd, log)
-    render.update_shared(snap, nft_sets, blocked_ips, blocked_reason)
+    render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
     current_etag = etag
     log.info("startup: applied initial policy etag=%s", tostring(etag))
   else
@@ -225,7 +225,7 @@ conntrack.watch({
   router_token    = router_token,
   nft_sets        = nft_sets,
   lookup_hostname = lookup_hostname,
-  blocked_ips     = blocked_ips,
+  blocked_macs    = blocked_macs,
   blocked_reason  = blocked_reason,
   lan_prefix      = lan_prefix,
   max_batch       = max_batch,
@@ -244,7 +244,7 @@ conntrack.watch({
       local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log)
       if snap then
         policy.apply(snap, write_file, run_cmd, log)
-        render.update_shared(snap, nft_sets, blocked_ips, blocked_reason)
+        render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
         current_etag = etag
         log.debug("policy timer: applied snapshot etag=%s", tostring(etag))
       elseif etag then

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -238,7 +238,7 @@ describe("handle_flow", function()
     local base = {
       arp_table      = { [SRC_IP] = MAC },
       nft_sets       = {},
-      blocked_ips    = {},
+      blocked_macs   = {},
       blocked_reason = {},
       reported_macs  = {},
       leases         = {},
@@ -386,6 +386,33 @@ describe("handle_flow", function()
     })
     conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
     assert.equal("legacy.example", b.events[2].hostname)
+  end)
+
+  -- #297: connection_attempt events for paused/time-exhausted profiles must
+  -- be labeled blocked. nftables drops the flow, but conntrack -E -e NEW
+  -- still observes the SYN_SENT entry — without a MAC-based block table the
+  -- classifier defaulted to allowed=true and the admin UI showed "permitted".
+  it("labels connection_attempt as blocked when the MAC is in blocked_macs", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "paused" },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal("connection_attempt", ev["type"])
+    assert.equal(false,                ev.allowed)
+    assert.equal("paused",             ev.reason)
+  end)
+
+  it("labels connection_attempt as allowed when blocked_macs is empty", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({ reported_macs = { [MAC] = true } })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal("connection_attempt", ev["type"])
+    assert.equal(true,                 ev.allowed)
   end)
 
   it("does NOT emit dhcp_lease while the pending MAC's lease still has no hostname", function()

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -3,32 +3,38 @@
 
 local render = require("render")
 
--- Minimal but complete one-device snapshot (mirrors §5.2 wire contract).
+-- Minimal but complete one-device snapshot. Field names match the wire JSON
+-- emitted by the API (camelCase — Scala case-class fields, zio-json
+-- deriveCodec; see shared/src/Models.scala PolicySnapshot/PolicyProfile/
+-- PolicyDevice). render.lua reads those keys directly; if a test uses
+-- snake_case here the assertions will look correct but the real agent gets
+-- nothing (#297 — entire enforcement chain was no-op because the test fixture
+-- diverged from the wire contract).
 local function snap_one()
   return {
-    etag               = "sha256:abc123",
-    default_profile_id = 3,
+    etag             = "sha256:abc123",
+    defaultProfileId = 3,
     devices = {
-      { mac = "aa:bb:cc:11:22:33", profile_id = 3, name = "kid-ipad" },
+      { mac = "aa:bb:cc:11:22:33", profileId = 3, name = "kid-ipad" },
     },
     profiles = {
       {
-        id                      = 3,
-        name                    = "kids",
-        paused                  = false,
-        blocked_categories      = { "ads", "adult" },
-        extra_blocked           = { "tiktok.com" },
-        extra_allowed           = { "khanacademy.org" },
-        schedules               = {
+        id                     = 3,
+        name                   = "kids",
+        paused                 = false,
+        blockedCategories      = { "ads", "adult" },
+        extraBlocked           = { "tiktok.com" },
+        extraAllowed           = { "khanacademy.org" },
+        schedules              = {
           { days = {"MON","TUE","WED","THU","FRI"},
-            block_from = "21:00", block_until = "07:00" }
+            blockFrom = "21:00", blockUntil = "07:00" }
         },
-        daily_minutes           = 120,
-        site_limits             = {
+        dailyMinutes           = 120,
+        siteLimits             = {
           { domain = "youtube.com", minutes = 30, label = "YouTube" }
         },
-        time_used_today         = { total_minutes = 47, by_domain = { ["youtube.com"] = 12 } },
-        extensions_today_minutes = 15,
+        timeUsedToday          = { totalMinutes = 47, byDomain = { ["youtube.com"] = 12 } },
+        extensionsTodayMinutes = 15,
       },
     },
   }
@@ -58,36 +64,36 @@ describe("render.dnsmasq", function()
     assert.truthy(conf:find("ipset=/youtube.com/profile3_youtube_com", 1, true))
   end)
 
-  it("sanitises multi-label site_limits domains in the set name", function()
+  it("sanitises multi-label siteLimits domains in the set name", function()
     local s = snap_one()
-    s.profiles[1].site_limits = { { domain = "cdn.example.co.uk", minutes = 10, label = "X" } }
+    s.profiles[1].siteLimits = { { domain = "cdn.example.co.uk", minutes = 10, label = "X" } }
     local conf = render.dnsmasq(s)
     assert.truthy(conf:find("ipset=/cdn.example.co.uk/profile3_cdn_example_co_uk", 1, true))
   end)
 
   it("handles multiple devices in different profiles", function()
     local s = snap_one()
-    table.insert(s.devices, { mac = "de:ad:be:ef:00:01", profile_id = 1, name = "parent-phone" })
+    table.insert(s.devices, { mac = "de:ad:be:ef:00:01", profileId = 1, name = "parent-phone" })
     s.profiles[2] = {
       id = 1, name = "adults", paused = false,
-      blocked_categories = {}, extra_blocked = {}, extra_allowed = {},
-      schedules = {}, daily_minutes = 0, site_limits = {},
-      time_used_today = { total_minutes = 0, by_domain = {} },
-      extensions_today_minutes = 0,
+      blockedCategories = {}, extraBlocked = {}, extraAllowed = {},
+      schedules = {}, dailyMinutes = 0, siteLimits = {},
+      timeUsedToday = { totalMinutes = 0, byDomain = {} },
+      extensionsTodayMinutes = 0,
     }
     local conf = render.dnsmasq(s)
     assert.truthy(conf:find("dhcp-host=aa:bb:cc:11:22:33,set:profile3", 1, true))
     assert.truthy(conf:find("dhcp-host=de:ad:be:ef:00:01,set:profile1", 1, true))
   end)
 
-  it("deduplicates extra_blocked domains that appear in multiple profiles", function()
+  it("deduplicates extraBlocked domains that appear in multiple profiles", function()
     local s = snap_one()
     s.profiles[2] = {
       id = 1, name = "adults", paused = false,
-      blocked_categories = {}, extra_blocked = { "tiktok.com" }, extra_allowed = {},
-      schedules = {}, daily_minutes = 0, site_limits = {},
-      time_used_today = { total_minutes = 0, by_domain = {} },
-      extensions_today_minutes = 0,
+      blockedCategories = {}, extraBlocked = { "tiktok.com" }, extraAllowed = {},
+      schedules = {}, dailyMinutes = 0, siteLimits = {},
+      timeUsedToday = { totalMinutes = 0, byDomain = {} },
+      extensionsTodayMinutes = 0,
     }
     local conf = render.dnsmasq(s)
     -- "address=/tiktok.com/#" should appear exactly once
@@ -101,13 +107,13 @@ describe("render.dnsmasq", function()
   end)
 
   -- Regression for #228: devices auto-created via /api/router/events
-  -- first_seen_mac have profile_id=nil until an admin assigns them in the UI.
+  -- first_seen_mac have profileId=nil until an admin assigns them in the UI.
   -- The earlier render.dnsmasq used string.format("%d", nil) on them and the
   -- whole agent crash-looped in policy.apply.
-  it("skips devices with nil profile_id (no string.format %d nil crash)", function()
+  it("skips devices with nil profileId (no string.format %d nil crash)", function()
     local s = snap_one()
     table.insert(s.devices,
-      { mac = "be:89:10:82:c7:4c", profile_id = nil, name = "iPhone" })
+      { mac = "be:89:10:82:c7:4c", profileId = nil, name = "iPhone" })
     local conf
     local ok = pcall(function() conf = render.dnsmasq(s) end)
     assert.is_true(ok)
@@ -177,7 +183,7 @@ describe("render.nft", function()
     -- remaining = 120 + 15 - 47 = 88 → NOT exhausted yet
     local nft_ok = render.nft(s)
     -- exhaust it: 136 >= 120 + 15 = 135
-    s.profiles[1].time_used_today.total_minutes = 136
+    s.profiles[1].timeUsedToday.totalMinutes = 136
     local nft_ex = render.nft(s)
     -- exhausted config must contain a drop referencing profile3_macs
     assert.truthy(nft_ex:find("profile3_macs", 1, true))
@@ -195,18 +201,22 @@ describe("render.nft", function()
   it("does NOT include a drop for profile3 when it still has remaining time", function()
     local s = snap_one()
     s.profiles[1].paused = false
-    s.profiles[1].time_used_today.total_minutes = 10  -- well within 120 + 15
+    s.profiles[1].timeUsedToday.totalMinutes = 10  -- well within 120 + 15
     local nft = render.nft(s)
     -- There must be no 'ether saddr @profile3_macs drop' pattern
     assert.falsy(nft:find("@profile3_macs%s+drop"))
   end)
 
-  it("includes DNAT rule redirecting blocked HTTP/80 to local block page on port 8081", function()
+  -- #297: previous render emitted `tcp dport 80 dnat to 127.0.0.1:8081` to
+  -- DNAT blocked HTTP to a block page, but `dnat` in an inet filter chain is
+  -- rejected by `nft -f` (DNAT requires a nat-type chain), which silently
+  -- failed the entire ruleset and disabled all blocking. Drop the redirect
+  -- until block-page support is rebuilt on a prerouting nat chain.
+  it("does NOT emit dnat in the block filter chain (inet filter rejects it)", function()
     local s = snap_one()
-    s.profiles[1].paused = true  -- ensure block rule fires
+    s.profiles[1].paused = true
     local nft = render.nft(s)
-    assert.truthy(nft:find("dnat", 1, true))
-    assert.truthy(nft:find("8081", 1, true))
+    assert.is_nil(nft:find("dnat", 1, true))
   end)
 
   it("returns a non-empty string", function()
@@ -214,12 +224,12 @@ describe("render.nft", function()
     assert.truthy(type(nft) == "string" and #nft > 0)
   end)
 
-  -- Regression for #228: same nil-profile_id crash that hit render.dnsmasq
+  -- Regression for #228: same nil-profileId crash that hit render.dnsmasq
   -- also hit render.nft at `profile_macs[nil][#profile_macs[nil] + 1]`.
-  it("skips devices with nil profile_id when building profile-mac sets", function()
+  it("skips devices with nil profileId when building profile-mac sets", function()
     local s = snap_one()
     table.insert(s.devices,
-      { mac = "be:89:10:82:c7:4c", profile_id = nil, name = "iPhone" })
+      { mac = "be:89:10:82:c7:4c", profileId = nil, name = "iPhone" })
     local nft
     local ok = pcall(function() nft = render.nft(s) end)
     assert.is_true(ok)
@@ -236,15 +246,15 @@ end)
 describe("render.update_shared", function()
 
   it("does not error on a well-formed snapshot", function()
-    local nft_sets, blocked_ips, blocked_reason = {}, {}, {}
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     assert.has_no.errors(function()
-      render.update_shared(snap_one(), nft_sets, blocked_ips, blocked_reason)
+      render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
     end)
   end)
 
-  it("seeds nft_sets with an entry for each site_limits domain", function()
-    local nft_sets, blocked_ips, blocked_reason = {}, {}, {}
-    render.update_shared(snap_one(), nft_sets, blocked_ips, blocked_reason)
+  it("seeds nft_sets with an entry for each siteLimits domain", function()
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
     -- dnsmasq will fill in IPs at query time; render.update_shared just seeds the key
     assert.not_nil(nft_sets["youtube.com"])
     assert.equal("table", type(nft_sets["youtube.com"]))
@@ -253,10 +263,60 @@ describe("render.update_shared", function()
   it("does not error on snapshot with zero devices", function()
     local s = snap_one()
     s.devices = {}
-    local nft_sets, blocked_ips, blocked_reason = {}, {}, {}
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     assert.has_no.errors(function()
-      render.update_shared(s, nft_sets, blocked_ips, blocked_reason)
+      render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
     end)
+  end)
+
+  -- #297: pause must populate blocked_macs so the conntrack classifier labels
+  -- the paused device's flows as blocked (not "permitted"). nftables also
+  -- drops the packets, but conntrack -E -e NEW still sees the SYN_SENT entry
+  -- and needs an independent signal to classify it.
+  it("marks devices of a paused profile in blocked_macs with reason=paused", function()
+    local s = snap_one()
+    s.profiles[1].paused = true
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
+    assert.is_true(blocked_macs["aa:bb:cc:11:22:33"])
+    assert.equal("paused", blocked_reason["aa:bb:cc:11:22:33"])
+  end)
+
+  it("marks devices of a time-exhausted profile with reason=time_limit", function()
+    local s = snap_one()
+    -- dailyMinutes=120, extensions=15 → exhaust at 135
+    s.profiles[1].timeUsedToday.totalMinutes = 200
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
+    assert.is_true(blocked_macs["aa:bb:cc:11:22:33"])
+    assert.equal("time_limit", blocked_reason["aa:bb:cc:11:22:33"])
+  end)
+
+  it("clears stale blocked_macs entries when a profile un-pauses", function()
+    -- Simulate a previous tick that flagged the device as paused.
+    local nft_sets        = {}
+    local blocked_macs    = { ["aa:bb:cc:11:22:33"] = true }
+    local blocked_reason  = { ["aa:bb:cc:11:22:33"] = "paused" }
+    -- Now apply a fresh snapshot where the profile is no longer paused.
+    render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
+    assert.is_nil(blocked_macs["aa:bb:cc:11:22:33"])
+    assert.is_nil(blocked_reason["aa:bb:cc:11:22:33"])
+  end)
+
+  it("does not mark devices whose profile is not paused or time-exhausted", function()
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
+    assert.is_nil(blocked_macs["aa:bb:cc:11:22:33"])
+  end)
+
+  it("ignores devices with nil profileId (unassigned)", function()
+    local s = snap_one()
+    s.profiles[1].paused = true
+    table.insert(s.devices,
+      { mac = "be:89:10:82:c7:4c", profileId = nil, name = "iPhone" })
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
+    assert.is_nil(blocked_macs["be:89:10:82:c7:4c"])
   end)
 
 end)


### PR DESCRIPTION
## Summary
Fixes #297. Pausing a profile didn't block its devices and connection events logged as "permitted." Three layered bugs:

1. **`render.lua` field naming.** The API ships camelCase JSON (zio-json `deriveCodec` of `PolicyDevice`/`PolicyProfile` — `profileId`, `extraBlocked`, `siteLimits`, `dailyMinutes`, `timeUsedToday.totalMinutes`, `extensionsTodayMinutes`), but `render.lua` read snake_case. `dev.profileId` was always `nil`, so `profileN_macs` sets were empty and no device ever matched the pause/time-limit block rules.
2. **nft `dnat` in a filter chain.** `chain familydns_block` emitted `tcp dport 80 dnat to 127.0.0.1:8081`, but DNAT isn't supported in a filter chain — `nft -f` rejected the entire ruleset with "Could not process rule: Not supported" and `nft list table inet familydns` came up empty. Even when the MAC sets would have been populated, nothing was enforced. Drop the redirect for now; block-page UX can be rebuilt on a separate prerouting nat chain.
3. **conntrack classifier.** `conntrack.lua` consulted a `blocked_ips` table that `render.update_shared` never populated — and a per-IP table can't model pause (every dest is blocked). Replace with `blocked_macs` (`mac → true`) + `blocked_reason` (`mac → "paused"|"time_limit"`), rebuilt from the snapshot on every poll, looked up by source MAC. Stale entries are cleared so an un-pause stops marking flows blocked.

The render_spec fixtures used snake_case, which is why this never tripped locally. All fixtures converted to camelCase + regressions added for each of the three bugs.

**Live verification on 192.168.1.1:** `profile2_macs` now carries the iPhone MAC, the nft ruleset loads, `iPhone → router` flows emit `allowed=false reason=paused`.

### Regressed vs #264?
#264 added the pause/time-limit block-chain logic but never exercised it end-to-end against a real API response — the JSON contract drifted (or was never aligned), and the test fixtures masked the divergence. So this isn't a regression of #264's intent but a latent integration bug in what #264 shipped.

### What test would have caught it
Any of the new regressions in `render_spec.lua` would have caught (1) and (2); the new `conntrack_spec` assertion against `blocked_macs` would have caught (3). The root cause was that the render_spec fixture was hand-written instead of derived from the API contract — worth considering an e2e harness that POSTs a real snapshot through the lua render in a follow-up.

## Test plan
- [x] `cd openwrt && bash test/run_tests.sh` — 109/109 lua tests pass (was 108, +5 new regressions).
- [x] Live: deployed locally-built `main` then this branch to 192.168.10.43 and 192.168.1.1, confirmed paused-profile iPhone flows emit `allowed=false reason=paused`, `nft list table inet familydns` shows the table loaded with `profile2_macs={iPhone MAC}` and a `drop` rule.

cc @sameerparekh