### PR TITLE
tests: backfill regression tests for audit-driven fixes (#307)

### DIFF
--- a/deploy/install.test.sh
+++ b/deploy/install.test.sh
@@ -196,6 +196,26 @@ else
   fail "wait_for_api timeout path (rc=${rc}, duration=${duration}s, out=${out})"
 fi
 
+# ── 10. #254: install.sh must wire the auto-update systemd timer so
+#       fixes landing on main reach existing hosts without manual ssh.
+#       The unit files ship in-tree under deploy/systemd/; the installer
+#       drops them into /etc/systemd/system/ and enable --now's the timer.
+#       Without this, the deploy gap that motivated #254 reopens silently.
+SYSTEMD_DIR="$(dirname "${SCRIPT}")/systemd"
+if [[ -f "${SYSTEMD_DIR}/familydns-update.service" \
+   && -f "${SYSTEMD_DIR}/familydns-update.timer" ]]; then
+  pass "deploy/systemd ships familydns-update.{service,timer}"
+else
+  fail "deploy/systemd missing familydns-update.{service,timer}"
+fi
+
+if grep -q "/etc/systemd/system/familydns-update.timer" "${SCRIPT}" \
+   && grep -q "systemctl enable --now familydns-update.timer" "${SCRIPT}"; then
+  pass "install.sh installs + enables familydns-update.timer (#254)"
+else
+  fail "install.sh does not install/enable familydns-update.timer — #254 deploy gap"
+fi
+
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ ${FAIL} -eq 0 ]]

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -49,5 +49,23 @@ grep -q "/etc/init.d/dnsmasq restart" "$SCRIPT" \
   && check "restarts dnsmasq after UCI changes" ok \
   || check "restarts dnsmasq after UCI changes" "missing dnsmasq restart"
 
+# #281 / TODO(#244): install.sh must fetch the rolling openwrt-latest
+# release, not /releases/latest. The latter pins the install to a stale
+# v0.0.99 snapshot and the auto-updater is then stuck behind it until
+# the 24h cron tick, leaving fresh installs up to a day stale.
+grep -q "releases/tags/openwrt-latest" "$SCRIPT" \
+  && check "install.sh fetches releases/tags/openwrt-latest" ok \
+  || check "install.sh fetches releases/tags/openwrt-latest" \
+           "install.sh appears to hit /releases/latest — would land stale build"
+
+# #197: the installer must not collect a router name. The name is set
+# once in the admin UI when the enrollment token is issued; the install
+# script only needs the token. A second prompt risks a mismatch that
+# confuses users.
+grep -qE "Router name|router_name|routerName" "$SCRIPT" \
+  && check "install.sh does not prompt for router name" \
+           "install.sh still references router-name input" \
+  || check "install.sh does not prompt for router name" ok
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -220,6 +220,12 @@ describe('ProfilesPage — edit', () => {
     expect(screen.getByDisplayValue('120')).toBeInTheDocument()
     expect(screen.getByDisplayValue('school.com')).toBeInTheDocument()
 
+    // #265: Paused checkbox helper text must describe *all internet traffic*, not just DNS.
+    expect(
+      screen.getByText(/blocks all internet traffic for devices on this profile/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/blocks all DNS/i)).not.toBeInTheDocument()
+
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
 
     await waitFor(() => expect(api.profiles.update).toHaveBeenCalledTimes(1))


### PR DESCRIPTION
## Summary
- Direct, single-file regression tests for the four audit-driven fixes whose merged PRs landed without proportional coverage.
- Companion to the [#307 survey comment](https://github.com/sameerparekh/familydns/issues/307) which scores every audit-driven PR green/yellow/red.

| Pins | PR | Test |
|---|---|---|
| #265 | #272 | `web/src/pages/ProfilesPage.test.tsx` — Paused helper text says "blocks all internet traffic", not "blocks all DNS" |
| #281 | #282 | `openwrt/test/install_spec.sh` — install.sh fetches `releases/tags/openwrt-latest`, not `/releases/latest` |
| #197 | #233 | `openwrt/test/install_spec.sh` — install.sh no longer prompts for a router name |
| #254 | #256 | `deploy/install.test.sh` — deploy/install.sh installs + enables `familydns-update.timer`, and the unit files ship under `deploy/systemd/` |

All other audit-driven changes either already have proportional test coverage or are pure config deletions / CI-only. Details in the survey comment on #307.

## Test plan
- [x] `sh openwrt/test/install_spec.sh` — 6 passed
- [x] `bash deploy/install.test.sh` — 14 passed (2 new)
- [x] `npx vitest run src/pages/ProfilesPage.test.tsx` — 12 passed

Refs #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)