### PR TITLE
api+openwrt: precompute blockedMacs server-side (fixes #305)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -89,7 +89,13 @@ class PolicyServiceLive(
         c -> PolicyBlocklist(version = today.toString, url = s"/api/blocklists/$c.rpz")
       }.toMap
       val defaultId     = profiles.map(_.id).minOption
-      val core          = SnapshotCore(defaultId, pDevices, pProfiles, pBlocklists)
+      // #305: precompute the set of MACs that should be blocked right now from
+      // pause / daily time limit / active schedule window. The OpenWRT agent
+      // used to derive this itself but never implemented schedule windows;
+      // doing it server-side keeps the router-side enforcement dumb.
+      val blockedMacs   =
+        PolicyService.computeBlockedMacs(pProfiles, pDevices, now.toLocalTime, today)
+      val core          = SnapshotCore(defaultId, pDevices, pProfiles, blockedMacs, pBlocklists)
       val etag          = PolicyService.computeEtag(core)
       PolicySnapshot(
         etag = etag,
@@ -97,6 +103,7 @@ class PolicyServiceLive(
         defaultProfileId = defaultId,
         devices = pDevices,
         profiles = pProfiles,
+        blockedMacs = blockedMacs,
         blocklists = pBlocklists,
       )
     }
@@ -266,6 +273,7 @@ private case class SnapshotCore(
     defaultProfileId: Option[Long],
     devices: List[PolicyDevice],
     profiles: List[PolicyProfile],
+    blockedMacs: List[BlockedMac],
     blocklists: Map[String, PolicyBlocklist],
 )
 
@@ -306,7 +314,72 @@ object PolicyService {
       parts += s"  u:${p.timeUsedToday.totalMinutes}"
       p.timeUsedToday.byDomain.toList.sortBy(_._1).foreach((k, v) => parts += s"    ud:$k=$v")
     }
+    // #305: blockedMacs participates in the etag so an unchanged-row policy
+    // still flips the etag when the wall clock crosses a schedule window edge.
+    core.blockedMacs.sortBy(_.mac).foreach(b => parts += s"bm:${b.mac}|${b.reason}")
     core.blocklists.toList.sortBy(_._1).foreach((k, v) => parts += s"bl:$k=${v.version}")
     "\"sha256:" + sha256Hex(parts.mkString("\n")) + "\""
+  }
+
+  /**
+   * #305: compute the currently-blocked MACs from pause / daily time limit / active schedule
+   * window. Precedence is pause > time_limit > schedule — matches the legacy /api/router/decision
+   * ordering in [[PolicyServiceLive.decide]].
+   */
+  private[policy] def computeBlockedMacs(
+      profiles: List[PolicyProfile],
+      devices: List[PolicyDevice],
+      nowTime: java.time.LocalTime,
+      today: java.time.LocalDate,
+  ): List[BlockedMac] = {
+    val todayName                                  = today.getDayOfWeek match {
+      case java.time.DayOfWeek.MONDAY    => "mon"
+      case java.time.DayOfWeek.TUESDAY   => "tue"
+      case java.time.DayOfWeek.WEDNESDAY => "wed"
+      case java.time.DayOfWeek.THURSDAY  => "thu"
+      case java.time.DayOfWeek.FRIDAY    => "fri"
+      case java.time.DayOfWeek.SATURDAY  => "sat"
+      case java.time.DayOfWeek.SUNDAY    => "sun"
+    }
+    val prevName                                   = today.minusDays(1).getDayOfWeek match {
+      case java.time.DayOfWeek.MONDAY    => "mon"
+      case java.time.DayOfWeek.TUESDAY   => "tue"
+      case java.time.DayOfWeek.WEDNESDAY => "wed"
+      case java.time.DayOfWeek.THURSDAY  => "thu"
+      case java.time.DayOfWeek.FRIDAY    => "fri"
+      case java.time.DayOfWeek.SATURDAY  => "sat"
+      case java.time.DayOfWeek.SUNDAY    => "sun"
+    }
+    def parseTime(s: String): java.time.LocalTime  = {
+      val Array(h, m) = s.split(':')
+      java.time.LocalTime.of(h.toInt, m.toInt)
+    }
+    def scheduleActive(s: PolicySchedule): Boolean = {
+      val from  = parseTime(s.blockFrom)
+      val until = parseTime(s.blockUntil)
+      if from.isAfter(until) then
+        (s.days.contains(todayName) && !nowTime.isBefore(from)) ||
+        (s.days.contains(prevName) && nowTime.isBefore(until))
+      else s.days.contains(todayName) && !nowTime.isBefore(from) && nowTime.isBefore(until)
+    }
+    val byProfile                                  = profiles.iterator.map { p =>
+      val reason =
+        if p.paused then Some("paused")
+        else
+          p.dailyMinutes match {
+            case Some(limit) if p.timeUsedToday.totalMinutes >= limit + p.extensionsTodayMinutes =>
+              Some("time_limit")
+            case _                                                                               =>
+              if p.schedules.exists(scheduleActive) then Some("schedule") else None
+          }
+      p.id -> reason
+    }.toMap
+
+    devices.flatMap { d =>
+      for {
+        pid    <- d.profileId
+        reason <- byProfile.getOrElse(pid, None)
+      } yield BlockedMac(d.mac, reason)
+    }
   }
 }

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -1,0 +1,201 @@
+package familydns.api.feature
+
+import familydns.api.db.*
+import familydns.api.policy.*
+import familydns.shared.*
+import familydns.shared.Clock.TestClock
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+import java.util.UUID
+
+/**
+ * #305: the API precomputes which MACs should be currently blocked (pause / daily time limit /
+ * active schedule window) so the OpenWRT agent can enforce dumbly. These tests pin the contract the
+ * agent depends on: [[PolicySnapshot.blockedMacs]] contains the right MACs with the right reason,
+ * with precedence pause > time_limit > schedule.
+ */
+object PolicySnapshotBlockedMacsSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clk)): PolicyService
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, UUID] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", "ENROLL_HASH"))
+
+  private def seedTraffic(
+      routerId: UUID,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val today0  = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = today0.plusSeconds(i * 300L)
+        val end   = start.plusSeconds(300)
+        TrafficReportInsert(routerId, mac, None, hostname, date, start, end, 300, 0L, 0L)
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  def spec = suite("policy snapshot — blockedMacs (#305)")(
+    test("schoolDayAfternoon with no pause/time/schedule → blockedMacs is empty") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs.isEmpty)
+    },
+    test("paused profile → blockedMacs lists its devices with reason=paused") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- pr.setPaused(kid, true)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:44", "kid-phone", kid)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs.size == 2) &&
+        assertTrue(snap.blockedMacs.forall(_.reason == "paused")) &&
+        assertTrue(
+          snap.blockedMacs.map(_.mac).toSet == Set("aa:bb:cc:11:22:33", "aa:bb:cc:11:22:44"),
+        )
+    },
+    test("active schedule window (bedtime 21:30) → reason=schedule") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs == List(BlockedMac("aa:bb:cc:11:22:33", "schedule")))
+    },
+    test("overnight schedule, early-morning tail (06:00) → reason=schedule (yesterday's window)") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        ps   <- makePsAt(TestClock.earlyMorning)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs == List(BlockedMac("aa:bb:cc:11:22:33", "schedule")))
+    },
+    test("daily time limit exhausted → reason=time_limit") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 120)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, "aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 125)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs == List(BlockedMac("aa:bb:cc:11:22:33", "time_limit")))
+    },
+    test("paused beats schedule: both true → reason=paused") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- pr.setPaused(kid, true)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs == List(BlockedMac("aa:bb:cc:11:22:33", "paused")))
+    },
+    test("time_limit beats schedule: both true → reason=time_limit") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 120)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, "aa:bb:cc:11:22:33", "cnn.com", LocalDate.of(2025, 1, 6), 125)
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs == List(BlockedMac("aa:bb:cc:11:22:33", "time_limit")))
+    },
+    test("unassigned device (profileId=null) is never blocked") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- pr.setPaused(kid, true)
+        _    <- dr.upsertUnknown(
+          "ff:ff:ff:aa:bb:cc",
+          "mystery",
+          Some("10.0.0.99"),
+          java.time.Instant.now(),
+        )
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(snap.blockedMacs.isEmpty)
+    },
+    test("etag flips when wall clock crosses a schedule edge, even with no DB change") {
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        sr       <- ZIO.service[ScheduleRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        kid      <- TestLayers.seedKidsProfile(pr, sr)
+        _        <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        psBefore <- makePsAt(TestClock.schoolDayAfternoon) // 14:00 — not blocked
+        psAfter  <- makePsAt(TestClock.bedtime)            // 21:30 — schedule active
+        before   <- psBefore.snapshot
+        after    <- psAfter.snapshot
+      } yield assertTrue(before.blockedMacs.isEmpty) &&
+        assertTrue(after.blockedMacs.nonEmpty) &&
+        assertTrue(before.etag != after.etag)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -147,37 +147,32 @@ function M.nft(snapshot)
   ind("}")
   emit("")
 
-  -- Block chain: drop/redirect for exhausted time limits, paused profiles, schedules
-  ind("chain familydns_block {")
-  ind2("type filter hook forward priority 0; policy accept;")
+  -- #305: blocked-MAC set. The API precomputes which MACs should be blocked
+  -- *right now* from pause / daily time limit / active schedule window and
+  -- ships them in snapshot.blockedMacs. We just enforce it — no wall-clock
+  -- evaluation here, no per-profile decision logic. The set is read by the
+  -- block chain below.
+  local blocked = snapshot.blockedMacs or {}
+  ind("set blocked_macs {")
+  ind2("type ether_addr")
+  if #blocked > 0 then
+    local macs = {}
+    for i, b in ipairs(blocked) do macs[i] = b.mac end
+    ind2("elements = { " .. table.concat(macs, ", ") .. " }")
+  end
+  ind("}")
   emit("")
 
-  for _, prof in ipairs(snapshot.profiles or {}) do
-    local block_reason = nil
-
-    if prof.paused then
-      block_reason = "paused"
-    elseif (prof.dailyMinutes or 0) > 0 then
-      local used       = (prof.timeUsedToday and prof.timeUsedToday.totalMinutes) or 0
-      local extensions = prof.extensionsTodayMinutes or 0
-      local remaining  = prof.dailyMinutes + extensions - used
-      if remaining <= 0 then
-        block_reason = "time_limit"
-      end
-    end
-
-    if block_reason then
-      ind2(string.format("# profile %d (%s): %s", prof.id, prof.name, block_reason))
-      -- Drop all forwarded traffic from devices on this profile. DNAT to a
-      -- block page would be nicer UX but needs a separate nat-type chain
-      -- (DNAT is not supported in filter chains), and the bare `dnat to`
-      -- form rejected `nft -f` entirely (#297) — so until we wire up a
-      -- prerouting nat chain, we just drop.
-      ind2(string.format("ether saddr @profile%d_macs drop", prof.id))
-      emit("")
-    end
+  -- Block chain: drop forwarded traffic from any MAC in blocked_macs.
+  -- DNAT to a block page would be nicer UX but needs a separate nat-type
+  -- chain (DNAT is not supported in inet filter chains), and the bare
+  -- `dnat to` form rejected `nft -f` entirely (#297) — so until we wire up
+  -- a prerouting nat chain, we just drop.
+  ind("chain familydns_block {")
+  ind2("type filter hook forward priority 0; policy accept;")
+  if #blocked > 0 then
+    ind2("ether saddr @blocked_macs drop")
   end
-
   ind("}")
   emit("")
   emit("}")
@@ -193,17 +188,16 @@ end
 -- conntrack.lua can attribute hostnames from the moment the agent starts.
 -- Actual IPs are populated at runtime by dnsmasq --ipset= callbacks.
 --
--- Also rebuilds blocked_macs / blocked_reason from the current snapshot so
--- conntrack.lua can label connection_attempt events as blocked when the
--- device's profile is paused or has exhausted its daily time (#297). nft
--- already drops these flows at the forward hook, but the conntrack -E -e NEW
--- watcher still sees the SYN_SENT entry and needs an independent signal to
--- classify it correctly — labeling purely by destination IP misses pause
--- (every IP is blocked) and time-limit (same).
+-- Also rebuilds blocked_macs / blocked_reason from snapshot.blockedMacs (#305)
+-- so conntrack.lua can label connection_attempt events as blocked. nft already
+-- drops these flows at the forward hook, but the conntrack -E -e NEW watcher
+-- still sees the SYN_SENT entry and needs an independent signal to classify
+-- it correctly — labeling purely by destination IP misses pause /
+-- time_limit / schedule (every IP is blocked).
 --
 -- Both tables are mutated in place (shared refs held by conntrack.lua); we
--- clear stale entries first so a profile that un-pauses stops marking flows
--- as blocked on the next poll.
+-- clear stale entries first so a profile that un-pauses or a schedule window
+-- that ends stops marking flows as blocked on the next poll.
 function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
   for _, prof in ipairs(snapshot.profiles or {}) do
     for _, sl in ipairs(prof.siteLimits or {}) do
@@ -220,28 +214,9 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
     for k in pairs(blocked_reason) do blocked_reason[k] = nil end
   end
 
-  local profile_block = {}
-  for _, prof in ipairs(snapshot.profiles or {}) do
-    local reason
-    if prof.paused then
-      reason = "paused"
-    elseif (prof.dailyMinutes or 0) > 0 then
-      local used = (prof.timeUsedToday and prof.timeUsedToday.totalMinutes) or 0
-      local ext  = prof.extensionsTodayMinutes or 0
-      if used >= prof.dailyMinutes + ext then
-        reason = "time_limit"
-      end
-    end
-    if reason then profile_block[prof.id] = reason end
-  end
-
-  for _, dev in ipairs(snapshot.devices or {}) do
-    local pid    = dev.profileId
-    local reason = pid and profile_block[pid] or nil
-    if reason then
-      if blocked_macs   then blocked_macs[dev.mac]   = true end
-      if blocked_reason then blocked_reason[dev.mac] = reason end
-    end
+  for _, b in ipairs(snapshot.blockedMacs or {}) do
+    if blocked_macs   then blocked_macs[b.mac]   = true end
+    if blocked_reason then blocked_reason[b.mac] = b.reason end
   end
 end
 

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -37,6 +37,9 @@ local function snap_one()
         extensionsTodayMinutes = 15,
       },
     },
+    -- #305: API precomputes which MACs are currently blocked (pause /
+    -- time_limit / schedule). The agent just enforces. Empty by default.
+    blockedMacs = {},
   }
 end
 
@@ -178,33 +181,42 @@ describe("render.nft", function()
     assert.truthy(nft:find("mac_ip_tracking", 1, true))
   end)
 
-  it("includes a drop rule when profile time limit is exhausted", function()
-    local s = snap_one()
-    -- remaining = 120 + 15 - 47 = 88 → NOT exhausted yet
-    local nft_ok = render.nft(s)
-    -- exhaust it: 136 >= 120 + 15 = 135
-    s.profiles[1].timeUsedToday.totalMinutes = 136
-    local nft_ex = render.nft(s)
-    -- exhausted config must contain a drop referencing profile3_macs
-    assert.truthy(nft_ex:find("profile3_macs", 1, true))
-    assert.truthy(nft_ex:find("drop", 1, true))
+  -- #305: enforcement is driven entirely by snapshot.blockedMacs (API-precomputed).
+  -- The agent no longer evaluates pause / time_limit / schedule itself.
+
+  it("declares a blocked_macs set (type ether_addr)", function()
+    local nft = render.nft(snap_one())
+    local pos = nft:find("set blocked_macs")
+    assert.truthy(pos)
+    local block = nft:sub(pos, pos + 200)
+    assert.truthy(block:find("ether_addr", 1, true))
   end)
 
-  it("includes a drop rule when the profile is paused", function()
+  it("emits a drop rule on @blocked_macs when blockedMacs is non-empty", function()
     local s = snap_one()
-    s.profiles[1].paused = true
+    s.blockedMacs = { { mac = "aa:bb:cc:11:22:33", reason = "paused" } }
     local nft = render.nft(s)
-    assert.truthy(nft:find("profile3_macs", 1, true))
+    assert.truthy(nft:find("aa:bb:cc:11:22:33", 1, true))
+    assert.truthy(nft:find("@blocked_macs", 1, true))
     assert.truthy(nft:find("drop", 1, true))
   end)
 
-  it("does NOT include a drop for profile3 when it still has remaining time", function()
+  it("does NOT emit an @blocked_macs drop rule when blockedMacs is empty", function()
+    local nft = render.nft(snap_one())
+    -- empty blocked_macs set is fine, but no drop rule should reference it
+    assert.falsy(nft:find("@blocked_macs%s+drop"))
+  end)
+
+  it("includes every blocked MAC as a set element regardless of reason", function()
     local s = snap_one()
-    s.profiles[1].paused = false
-    s.profiles[1].timeUsedToday.totalMinutes = 10  -- well within 120 + 15
+    s.devices[2] = { mac = "11:22:33:44:55:66", profileId = 3, name = "kid-phone" }
+    s.blockedMacs = {
+      { mac = "aa:bb:cc:11:22:33", reason = "schedule" },
+      { mac = "11:22:33:44:55:66", reason = "time_limit" },
+    }
     local nft = render.nft(s)
-    -- There must be no 'ether saddr @profile3_macs drop' pattern
-    assert.falsy(nft:find("@profile3_macs%s+drop"))
+    assert.truthy(nft:find("aa:bb:cc:11:22:33", 1, true))
+    assert.truthy(nft:find("11:22:33:44:55:66", 1, true))
   end)
 
   -- #297: previous render emitted `tcp dport 80 dnat to 127.0.0.1:8081` to
@@ -269,54 +281,50 @@ describe("render.update_shared", function()
     end)
   end)
 
-  -- #297: pause must populate blocked_macs so the conntrack classifier labels
-  -- the paused device's flows as blocked (not "permitted"). nftables also
-  -- drops the packets, but conntrack -E -e NEW still sees the SYN_SENT entry
-  -- and needs an independent signal to classify it.
-  it("marks devices of a paused profile in blocked_macs with reason=paused", function()
+  -- #305: blocked_macs / blocked_reason are populated directly from
+  -- snapshot.blockedMacs (API-precomputed). The conntrack classifier reads
+  -- them to label connection_attempt events as blocked with the right reason,
+  -- since `conntrack -E -e NEW` still emits SYN_SENT entries for the dropped
+  -- flows (the in-kernel nft drop happens later).
+
+  it("populates blocked_macs / blocked_reason from snapshot.blockedMacs", function()
     local s = snap_one()
-    s.profiles[1].paused = true
+    s.blockedMacs = {
+      { mac = "aa:bb:cc:11:22:33", reason = "paused" },
+    }
     local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
     assert.is_true(blocked_macs["aa:bb:cc:11:22:33"])
     assert.equal("paused", blocked_reason["aa:bb:cc:11:22:33"])
   end)
 
-  it("marks devices of a time-exhausted profile with reason=time_limit", function()
+  it("preserves the reason verbatim (schedule / time_limit / paused)", function()
     local s = snap_one()
-    -- dailyMinutes=120, extensions=15 → exhaust at 135
-    s.profiles[1].timeUsedToday.totalMinutes = 200
+    s.devices[2] = { mac = "11:22:33:44:55:66", profileId = 3, name = "kid-phone" }
+    s.blockedMacs = {
+      { mac = "aa:bb:cc:11:22:33", reason = "schedule" },
+      { mac = "11:22:33:44:55:66", reason = "time_limit" },
+    }
     local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
-    assert.is_true(blocked_macs["aa:bb:cc:11:22:33"])
-    assert.equal("time_limit", blocked_reason["aa:bb:cc:11:22:33"])
+    assert.equal("schedule",   blocked_reason["aa:bb:cc:11:22:33"])
+    assert.equal("time_limit", blocked_reason["11:22:33:44:55:66"])
   end)
 
-  it("clears stale blocked_macs entries when a profile un-pauses", function()
-    -- Simulate a previous tick that flagged the device as paused.
+  it("clears stale entries when blockedMacs goes empty (un-pause / window ended)", function()
+    -- Previous tick: device was flagged. Now the snapshot has no blockedMacs.
     local nft_sets        = {}
     local blocked_macs    = { ["aa:bb:cc:11:22:33"] = true }
     local blocked_reason  = { ["aa:bb:cc:11:22:33"] = "paused" }
-    -- Now apply a fresh snapshot where the profile is no longer paused.
     render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
     assert.is_nil(blocked_macs["aa:bb:cc:11:22:33"])
     assert.is_nil(blocked_reason["aa:bb:cc:11:22:33"])
   end)
 
-  it("does not mark devices whose profile is not paused or time-exhausted", function()
+  it("leaves blocked_macs empty when snapshot.blockedMacs is empty", function()
     local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     render.update_shared(snap_one(), nft_sets, blocked_macs, blocked_reason)
     assert.is_nil(blocked_macs["aa:bb:cc:11:22:33"])
-  end)
-
-  it("ignores devices with nil profileId (unassigned)", function()
-    local s = snap_one()
-    s.profiles[1].paused = true
-    table.insert(s.devices,
-      { mac = "be:89:10:82:c7:4c", profileId = nil, name = "iPhone" })
-    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
-    render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
-    assert.is_nil(blocked_macs["be:89:10:82:c7:4c"])
   end)
 
 end)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -412,11 +412,16 @@ case class PolicyProfile(
     extensionsTodayMinutes: Int,
 ) derives JsonCodec
 case class PolicyBlocklist(version: String, url: String) derives JsonCodec
+// Reason is one of: "paused", "time_limit", "schedule" (precedence in that order).
+// The API computes this list against the current wall clock; the OpenWRT agent
+// just enforces it (drop forwarded traffic from these MACs). See #305.
+case class BlockedMac(mac: String, reason: String) derives JsonCodec
 case class PolicySnapshot(
     etag: String,
     generatedAt: String,
     defaultProfileId: Option[Long],
     devices: List[PolicyDevice],
     profiles: List[PolicyProfile],
+    blockedMacs: List[BlockedMac],
     blocklists: Map[String, PolicyBlocklist],
 ) derives JsonCodec


### PR DESCRIPTION
## Summary
- API now precomputes \`PolicySnapshot.blockedMacs: List[BlockedMac { mac, reason }]\` from pause / daily time limit / active schedule window. Precedence: pause > time_limit > schedule, matching the existing \`/api/router/decision\` ordering.
- \`blockedMacs\` participates in the snapshot etag, so wall-clock window crossings flip the etag and the agent picks them up on the next 60s poll — no router-side wall-clock evaluation.
- \`render.lua\` collapses the per-profile pause/time-limit decision loop into a single \`blocked_macs\` nft set + one \`ether saddr @blocked_macs drop\` rule. It also mirrors the MACs into the in-memory \`blocked_macs\`/\`blocked_reason\` tables so the conntrack classifier labels \`connection_attempt\` events with the right reason (parallel to #297 for pause).
- Adds schedule-window enforcement that was previously missing entirely — closes #305.

## Why this shape
Schedules already round-tripped through the snapshot but render.lua never evaluated them. Putting that logic in the router would need a wall-clock tick (re-render every minute) and either \`meta hour\` (not portable across OpenWRT nft builds — risk of the #297 footgun) or a Lua-side schedule evaluator. Moving the decision to the API gives a single source of truth, no new nft features, no extra cron on the router.

Follow-up [#315](https://github.com/sameerparekh/familydns/issues/315) takes the next step: moving \`extraBlocked\` / \`siteLimits\` server-side too, so the router becomes a fully dumb enforcer.

## Related
- #264 (round-1 enforcement)
- #297 (pause enforcement + classifier labeling)
- #302 (drop chain)
- #303 (block-page DNAT, parallel work)
- #315 (follow-up: per-MAC site blocks)

## Test plan
- [x] \`mill __.test\` — all Scala suites pass (267/267)
- [x] \`busted openwrt/test/render_spec.lua\` — 30/30 pass
- [x] New \`PolicySnapshotBlockedMacsSpec\` — 9/9 pass (pause, time_limit, schedule, overnight tail, precedence, unassigned-device, etag flip on schedule edge)
- [ ] Verify on real hardware: set a 5-min schedule window on a profile; device gets blocked within 60s; remove window; unblocks within 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)