### PR TITLE
openwrt: emit minute-granularity activeSeconds in usage reports

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -26,13 +26,20 @@
 --     → list of { mac, dst_ip, bytes, packets }
 --     Input: JSON from `nft -j list set inet familydns mac_ip_tracking`
 --
---   usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases [, lookup_hostname]])
+--   usage.build_report(counters, nft_sets, period_start, period_end, router_id
+--                      [, leases [, lookup_hostname [, tracker]]])
 --     → report table ready for JSON encoding and POST /api/router/usage
 --     nft_sets:        { hostname → { ip → true } }  (maintained by render.update_shared + dnsmasq)
 --     leases:          { mac → ip }  (optional; populates the ip field on each record)
 --     lookup_hostname: fn(dst_ip) → string|nil  (optional; consulted before
 --                      falling back to "unknown" — same dnsmasq-query-log
 --                      cache the conntrack path uses, see #287)
+--     tracker:         opaque tracker from usage.new_tracker(), fed every 60 s
+--                      via usage.tracker_sample() during the bucket; supplies
+--                      real per-minute activeSeconds (issue #295).
+--
+--   usage.new_tracker() / usage.tracker_sample(t, counters) / usage.tracker_reset(t)
+--     Per-minute activity sampler — see comment above the function.
 --
 --   usage.post(api_url, router_token, report, post_fn)
 --     → bool
@@ -123,19 +130,84 @@ local function hostname_for_ip(dst_ip, nft_sets, lookup_hostname)
 end
 
 -- ---------------------------------------------------------------------------
--- usage.build_report(counters, nft_sets, period_start, period_end, router_id [, leases [, lookup_hostname]])
+-- Activity tracker — per-minute "is this (mac, dst_ip) actively using the
+-- network?" sampling.  See #295.
 -- ---------------------------------------------------------------------------
--- active_seconds heuristic (§9 architecture doc):
---   Any counter with bytes > 0 in the 5-min bucket counts as the full period (300 s).
-function M.build_report(counters, nft_sets, period_start, period_end, router_id, leases, lookup_hostname)
+-- The nftables set element counters in `mac_ip_tracking` are reset to 0 once
+-- per 5-min bucket.  The agent calls `tracker_sample` every 60 s with the
+-- currently-parsed counters; each call that observes byte growth bumps the
+-- (mac, dst_ip)'s active-minute count.  At end-of-bucket `build_report`
+-- multiplies that count by 60 (capped at 300) to produce `activeSeconds`,
+-- and the agent resets the tracker for the next bucket.
+--
+-- Wire format is unchanged — `activeSeconds` is still an integer.  The
+-- minute granularity is purely router-side; sub-minute is a future extension
+-- (issue #295 "Future work") that only needs to change SECONDS_PER_SAMPLE
+-- and the sampling cadence in the agent loop.
+local SECONDS_PER_SAMPLE = 60
+local BUCKET_SECONDS     = 300
+
+local function tracker_key(mac, dst_ip) return mac .. "|" .. dst_ip end
+
+function M.new_tracker()
+  return { last = {}, active_minutes = {} }
+end
+
+-- Compare each counter to its previous byte total; an increase counts as one
+-- active minute.  A counter that went DOWN is treated as a fresh start
+-- (element expired and reappeared, or counters reset out-of-band); we still
+-- count it as an active minute if the new value is > 0.
+function M.tracker_sample(tracker, counters)
+  for _, c in ipairs(counters or {}) do
+    local key  = tracker_key(c.mac, c.dst_ip)
+    local prev = tracker.last[key] or 0
+    if c.bytes > prev then
+      tracker.active_minutes[key] = (tracker.active_minutes[key] or 0) + 1
+      tracker.last[key] = c.bytes
+    elseif c.bytes < prev then
+      if c.bytes > 0 then
+        tracker.active_minutes[key] = (tracker.active_minutes[key] or 0) + 1
+      end
+      tracker.last[key] = c.bytes
+    end
+  end
+end
+
+function M.tracker_reset(tracker)
+  tracker.last           = {}
+  tracker.active_minutes = {}
+end
+
+-- ---------------------------------------------------------------------------
+-- usage.build_report(counters, nft_sets, period_start, period_end, router_id
+--                    [, leases [, lookup_hostname [, tracker]]])
+-- ---------------------------------------------------------------------------
+-- activeSeconds:
+--   * With a tracker: 60 × active_minutes[(mac, dst_ip)], capped at 300.
+--     A counter present in `counters` but missing from the tracker (e.g. set
+--     element first appeared after the last per-minute sample) falls back to
+--     one active minute when bytes > 0.
+--   * Without a tracker (legacy / back-compat): bytes > 0 → 300, else 0.
+function M.build_report(counters, nft_sets, period_start, period_end, router_id, leases, lookup_hostname, tracker)
   local records = {}
 
   for _, c in ipairs(counters or {}) do
     local hostname = hostname_for_ip(c.dst_ip, nft_sets, lookup_hostname)
+    local active_seconds
+    if tracker then
+      local minutes = tracker.active_minutes[tracker_key(c.mac, c.dst_ip)]
+      if minutes then
+        active_seconds = math.min(SECONDS_PER_SAMPLE * minutes, BUCKET_SECONDS)
+      else
+        active_seconds = (c.bytes > 0) and SECONDS_PER_SAMPLE or 0
+      end
+    else
+      active_seconds = (c.bytes > 0) and BUCKET_SECONDS or 0
+    end
     local rec = {
       mac           = c.mac,
       hostname      = hostname,
-      activeSeconds = (c.bytes > 0) and 300 or 0,
+      activeSeconds = active_seconds,
       bytesIn       = c.bytes,
       bytesOut      = 0,   -- nftables ingress-only counters; egress tracked separately
     }

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -167,9 +167,12 @@ end
 
 -- ── Timer state ───────────────────────────────────────────────────────────────
 
-local current_etag    = nil
-local last_policy_run = 0
-local last_usage_run  = 0
+local current_etag        = nil
+local last_policy_run     = 0
+local last_usage_run      = 0
+local last_activity_sample = 0
+local activity_sample_int  = 60                 -- per-minute activity granularity (#295)
+local activity_tracker     = usage.new_tracker()
 
 -- ── Initial policy fetch at startup ──────────────────────────────────────────
 
@@ -184,8 +187,23 @@ do
   else
     log.warn("startup: initial policy fetch returned no snapshot (will retry on timer)")
   end
-  last_policy_run = os.time()
-  last_usage_run  = os.time()
+  last_policy_run        = os.time()
+  last_usage_run         = os.time()
+  last_activity_sample   = os.time()
+end
+
+-- Snapshot nft counters for the activity tracker.  Cheap (same JSON we'd
+-- read at flush time) and reused by both the per-minute sampler and the
+-- 5-min usage timer below.
+local function read_nft_counters()
+  local pipe = io.popen("nft -j list set inet familydns mac_ip_tracking 2>/dev/null", "r")
+  if not pipe then return nil end
+  local json_str = pipe:read("*a") or ""
+  pipe:close()
+  if json_str == "" then return nil end
+  local ok, counters = pcall(usage.parse_nft_counters, json_str)
+  if not ok then return nil end
+  return counters
 end
 
 -- ── Start conntrack event watcher (blocking; runs for the lifetime of the process)
@@ -253,6 +271,17 @@ conntrack.watch({
       end
     end
 
+    -- Activity sampler (#295): every 60 s, snapshot counters and feed them
+    -- to the tracker so end-of-bucket activeSeconds reflects real per-minute
+    -- usage rather than collapsing to {0, 300}.
+    if (now - last_activity_sample) >= activity_sample_int then
+      last_activity_sample = now
+      local counters = read_nft_counters()
+      if counters then
+        usage.tracker_sample(activity_tracker, counters)
+      end
+    end
+
     -- Usage timer
     if (now - last_usage_run) >= usage_int then
       local period_end   = os.date("!%Y-%m-%dT%H:%M:%SZ", now)
@@ -262,24 +291,23 @@ conntrack.watch({
       -- Per-(mac,ip) counters live as element counters on the dynamic set
       -- `mac_ip_tracking` (see render.lua). After a successful POST we
       -- `nft reset set ...` to zero those per-element counters in place.
-      local pipe = io.popen(
-        "nft -j list set inet familydns mac_ip_tracking 2>/dev/null", "r")
-      if pipe then
-        local json_str = pipe:read("*a") or ""
-        pipe:close()
-        if json_str ~= "" then
-          local ok, counters = pcall(usage.parse_nft_counters, json_str)
-          if ok and counters then
-            local report = usage.build_report(
-              counters, nft_sets, period_start, period_end, router_id,
-              nil, lookup_hostname)
-            log.debug("usage timer: %d counter(s), %d record(s) prepared",
-                      #counters, report.records and #report.records or 0)
-            local posted = usage.post(api_url, router_token, report, http_post, log)
-            if posted then
-              os.execute("nft reset set inet familydns mac_ip_tracking >/dev/null 2>&1")
-            end
-          end
+      local counters = read_nft_counters()
+      if counters then
+        -- Final per-minute sample at flush so set elements that appeared
+        -- after the last 60s tick still get an active minute counted.
+        usage.tracker_sample(activity_tracker, counters)
+        last_activity_sample = now
+        local report = usage.build_report(
+          counters, nft_sets, period_start, period_end, router_id,
+          nil, lookup_hostname, activity_tracker)
+        log.debug("usage timer: %d counter(s), %d record(s) prepared",
+                  #counters, report.records and #report.records or 0)
+        local posted = usage.post(api_url, router_token, report, http_post, log)
+        if posted then
+          os.execute("nft reset set inet familydns mac_ip_tracking >/dev/null 2>&1")
+          -- Counters are now zeroed; clear tracker so the next bucket starts
+          -- from a 0 baseline like the nft set itself.
+          usage.tracker_reset(activity_tracker)
         end
       end
     end

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -170,7 +170,7 @@ describe("usage.build_report", function()
     assert.equal("youtube.com", r.records[1].hostname)
   end)
 
-  it("sets activeSeconds = 300 (full period) for any counter with bytes > 0", function()
+  it("sets activeSeconds = 300 (full period) for any counter with bytes > 0 (legacy, no tracker)", function()
     local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER)
     for _, rec in ipairs(r.records) do
       assert.equal(300, rec.activeSeconds)
@@ -223,6 +223,185 @@ describe("usage.build_report", function()
   it("handles an empty counters list (zero records)", function()
     local r = usage.build_report({}, NF_SETS, P_START, P_END, ROUTER)
     assert.equal(0, #r.records)
+  end)
+
+end)
+
+-- ── tracker (per-minute activity sampler) ─────────────────────────────────
+--
+-- The router scrapes nft counters every 60 s within a 5-min bucket and feeds
+-- them to a tracker; the tracker remembers how many distinct minutes each
+-- (mac, dst_ip) saw counter growth, which build_report converts into
+-- activeSeconds.  Counter reset / set-element expiry (bytes goes DOWN) is
+-- treated as a fresh start so we don't double-count.
+
+describe("usage.tracker", function()
+
+  local function s(mac, dst_ip, bytes)
+    return { mac = mac, dst_ip = dst_ip, bytes = bytes, packets = 0 }
+  end
+
+  it("new_tracker returns an empty tracker", function()
+    local t = usage.new_tracker()
+    assert.is_table(t)
+    assert.is_table(t.active_minutes)
+    assert.is_nil(next(t.active_minutes))
+  end)
+
+  it("counts a single sample with bytes > 0 (from 0 baseline) as 1 active minute", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("counts each subsequent sample with growth as another active minute", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  100) })
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  500) })
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 1200) })
+    assert.equal(3, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("does NOT count a sample where bytes are unchanged", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- +1
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- no growth
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- no growth
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("treats a counter decrease (reset / element-expire-and-reappear) as a fresh active minute", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })  -- +1
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  50) })  -- reset, bytes>0 → +1
+    assert.equal(2, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("does not count a counter decrease to 0 as an active minute", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })  -- +1
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",   0) })  -- decrease to 0 → no
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+  it("tracks each (mac, dst_ip) independently", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
+      s("de:ad:be:ef:00:01", "8.8.8.8", 200),
+    })
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),     -- no growth
+      s("de:ad:be:ef:00:01", "8.8.8.8", 999),     -- growth
+    })
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.equal(2, t.active_minutes["de:ad:be:ef:00:01|8.8.8.8"])
+  end)
+
+  it("tracks each dst_ip independently for the same mac", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
+      s("aa:bb:cc:11:22:33", "5.6.7.8", 200),
+    })
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
+      s("aa:bb:cc:11:22:33", "5.6.7.8", 800),
+    })
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.equal(2, t.active_minutes["aa:bb:cc:11:22:33|5.6.7.8"])
+  end)
+
+  it("tracker_reset clears all state", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
+    usage.tracker_reset(t)
+    assert.is_nil(next(t.active_minutes))
+    -- After reset, the next sample starts from a fresh 0 baseline.
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 50) })
+    assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
+  end)
+
+end)
+
+describe("usage.build_report with tracker", function()
+
+  local NF_SETS  = { ["youtube.com"] = { ["1.2.3.4"] = true } }
+  local P_START  = "2026-05-08T14:00:00Z"
+  local P_END    = "2026-05-08T14:05:00Z"
+  local ROUTER   = "9c1f2e8a-0000-0000-0000-000000000001"
+
+  local function s(mac, dst_ip, bytes)
+    return { mac = mac, dst_ip = dst_ip, bytes = bytes, packets = 0 }
+  end
+
+  it("uses 60 * active_minutes from the tracker (1 minute → 60s)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
+    assert.equal(60, r.records[1].activeSeconds)
+  end)
+
+  it("reports 300s when all 5 minutes were active", function()
+    local t = usage.new_tracker()
+    for i = 1, 5 do
+      usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100 * i) })
+    end
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
+    assert.equal(300, r.records[1].activeSeconds)
+  end)
+
+  it("caps activeSeconds at 300 even if the tracker recorded more than 5 minutes (drift)", function()
+    local t = usage.new_tracker()
+    for i = 1, 7 do
+      usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100 * i) })
+    end
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 700) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
+    assert.equal(300, r.records[1].activeSeconds)
+  end)
+
+  it("falls back to 60s when bytes > 0 but tracker has no entry (entry appeared after last sample)", function()
+    local t = usage.new_tracker()
+    -- tracker has seen device A but not B
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
+    local r = usage.build_report(
+      { s("de:ad:be:ef:00:01", "9.9.9.9", 200) },
+      NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
+    assert.equal(60, r.records[1].activeSeconds)
+  end)
+
+  it("retains legacy 300 behavior when no tracker is passed (back-compat)", function()
+    local r = usage.build_report(
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      NF_SETS, P_START, P_END, ROUTER)
+    assert.equal(300, r.records[1].activeSeconds)
+  end)
+
+  it("assigns activeSeconds per (mac, dst_ip) independently from the same tracker", function()
+    local t = usage.new_tracker()
+    -- device A: 1 active minute
+    usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
+    -- device B joins at minute 2 with growth across 4 more samples
+    for i = 1, 4 do
+      usage.tracker_sample(t, {
+        s("aa:bb:cc:11:22:33", "1.2.3.4", 100),         -- no growth for A
+        s("de:ad:be:ef:00:01", "8.8.8.8", 100 * i),     -- growth for B
+      })
+    end
+    local r = usage.build_report({
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
+      s("de:ad:be:ef:00:01", "8.8.8.8", 400),
+    }, NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
+    local by_mac = {}
+    for _, rec in ipairs(r.records) do by_mac[rec.mac] = rec end
+    assert.equal(60,  by_mac["aa:bb:cc:11:22:33"].activeSeconds)
+    assert.equal(240, by_mac["de:ad:be:ef:00:01"].activeSeconds)
   end)
 
 end)


### PR DESCRIPTION
## Summary

Closes #295.

The router's \`build_report\` was charging the full 5-minute bucket (300 s) to any (mac, dst_ip) with bytes > 0, so a 60-second session showed up as 5 minutes in the API. This made #294's presence-based screen-time totals coarse — every short visit rounded up to a full bucket.

- New \`usage.new_tracker\` / \`tracker_sample\` / \`tracker_reset\` in [openwrt/files/usr/lib/lua/familydns/usage.lua](openwrt/files/usr/lib/lua/familydns/usage.lua). Snapshots the parsed nft counters; bumps an active-minute count per (mac, dst_ip) whenever the byte counter grew since the previous sample. A counter going DOWN (set element expired and reappeared, or out-of-band reset) is treated as a fresh start so we don't double-count.
- \`build_report\` takes an optional trailing \`tracker\` arg and emits \`activeSeconds = min(60 × active_minutes, 300)\`. Legacy bytes>0→300 fallback is retained when no tracker is passed (back-compat).
- The agent loop in [openwrt/files/usr/sbin/familydns-agent](openwrt/files/usr/sbin/familydns-agent) adds a 60-second sample timer alongside the existing 5-minute usage timer. At flush time it takes one final sample, builds the report with the tracker, posts, then resets both the nft set counters and the tracker for the next bucket.
- API-side aggregation is unchanged (\`api/src/presence/Presence.scala\` already does \`MAX(active_seconds)\` per (mac, period_start)).
- Wire format unchanged — \`activeSeconds\` stays an integer, so the sub-minute granularity called out as future work in #295 is a single-knob change in \`usage.lua\` (\`SECONDS_PER_SAMPLE\`).

Context: prior seconds-vs-minutes saga in #135 / #141.

## Test plan

- [x] \`sh openwrt/test/run_tests.sh\` — 124 busted assertions + 4 shell suites pass
- [x] New tracker tests cover: first-sample-from-zero, repeated growth, no-growth, counter-decrease-with-bytes>0, counter-decrease-to-0, per-(mac, dst_ip) independence, reset clears state
- [x] New build_report tests cover: 1 minute → 60 s, full 5 minutes → 300 s, drift cap at 300 s, missing tracker entry with bytes>0 → 60 s fallback, no-tracker legacy 300 s, two devices independent
- [ ] Hardware verification: open a phone, load one site, close ~30 s later, wait for the next 5-min report, confirm \`traffic_reports.active_seconds\` for that mac is ~60 (not 300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)