### PR TITLE
dashboard: live "Now" view of active devices per profile (fixes #266)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -86,6 +86,15 @@ object Main extends ZIOAppDefault {
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++
       SessionRoutes.routes(auth, trafficRepo, deviceRepo, profileRepo, upRepo) ++
+      DashboardNowRoutes.routes(
+        auth,
+        trafficRepo,
+        connRepo,
+        deviceRepo,
+        profileRepo,
+        upRepo,
+        clock,
+      ) ++
       BlocklistRoutes.routes(auth, blRepo) ++
       RouterRoutes.routes(routerRepo, policy, routerAuth, blockEvRepo) ++
       AdminRouterRoutes.routes(auth, routerRepo) ++

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -248,6 +248,12 @@ trait ConnectionEventRepo {
   def query(f: LogFilter): Task[List[QueryLog]]
   def stats: Task[DashboardStats]
   def topBlocked(hours: Int, limit: Int): Task[List[DomainCount]]
+
+  /**
+   * Latest `ts` per mac for events strictly newer than `since`. Used by the "now" dashboard to
+   * detect devices that produced at least one connection attempt in the recent window.
+   */
+  def lastSeenByMacSince(since: Instant): Task[Map[String, Instant]]
 }
 
 class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
@@ -894,6 +900,16 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       .map(DomainCount.apply)
       .to[List]
       .transact(xa)
+
+  def lastSeenByMacSince(since: Instant): Task[Map[String, Instant]] =
+    sql"""SELECT mac, MAX(ts)
+          FROM connection_events
+          WHERE mac IS NOT NULL AND ts > $since
+          GROUP BY mac"""
+      .query[(String, Instant)]
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
 }
 
 object Repos {

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -1,0 +1,158 @@
+package familydns.api.routes
+
+import familydns.api.auth.*
+import familydns.api.db.*
+import familydns.api.sessions.{SessionRow, Sessions}
+import familydns.shared.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+
+import java.time.Instant
+
+/**
+ * `GET /api/dashboard/now` — live "what is happening right now" snapshot.
+ *
+ * Returns every profile visible to the caller, including idle ones (so dashboard layout is stable).
+ * Within each profile, lists devices that produced either a connection_events row in the last
+ * `ActiveWindow` (60s) OR a traffic_reports period whose `period_end` falls in the last
+ * `TrafficActiveWindow` (5m). For each active device, returns the top hosts by active_seconds over
+ * the last `TopHostsWindow` (30m) and the in-progress session (via [[Sessions.stitch]]) iff its
+ * latest period_end is within `SessionTolerance` (10m) of "now".
+ */
+object DashboardNowRoutes {
+
+  private val ActiveWindow        = java.time.Duration.ofSeconds(300) // connection_events: last 5m
+  private val TrafficActiveWindow = java.time.Duration.ofMinutes(5)
+  private val TopHostsWindow      = java.time.Duration.ofMinutes(30)
+  private val SessionTolerance    = java.time.Duration.ofMinutes(10)
+  private val TopHostsLimit       = 3
+
+  def routes(
+      auth: AuthService,
+      trafficRepo: TrafficReportRepo,
+      connRepo: ConnectionEventRepo,
+      deviceRepo: DeviceRepo,
+      profileRepo: ProfileRepo,
+      userProfileRepo: UserProfileRepo,
+      clock: Clock,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "dashboard" / "now" ->
+        handler { (req: Request) =>
+          for {
+            claims      <- requireAuth(req, auth)
+            now         <- clock.instant
+            allDevices  <- deviceRepo.listAll.orElseFail(Response.internalServerError(""))
+            visibleDevs <- filterDevices(claims, allDevices, userProfileRepo)
+            allProfiles <- profileRepo.listAll.orElseFail(Response.internalServerError(""))
+            visibleProf <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            visibleMacs = visibleDevs.map(_.mac)
+            // Both inputs in parallel.
+            since       = now.minus(TopHostsWindow)
+            connSince   = now.minus(ActiveWindow)
+            lastSeenF <- connRepo.lastSeenByMacSince(connSince).fork
+            rowsF     <- trafficRepo
+              .listSessionRows(
+                SessionFilter(
+                  macs = Some(visibleMacs),
+                  host = None,
+                  since = Some(since),
+                  until = None,
+                ),
+              )
+              .fork
+            lastSeen  <- lastSeenF.join.orElseFail(Response.internalServerError(""))
+            rows      <- rowsF.join.orElseFail(Response.internalServerError(""))
+            response = buildResponse(
+              now = now,
+              profiles = visibleProf,
+              devices = visibleDevs,
+              lastSeen = lastSeen,
+              rows = rows,
+            )
+          } yield Response.json(response.toJson)
+        },
+    )
+
+  /** Pure assembly — exposed for unit tests. */
+  def buildResponse(
+      now: Instant,
+      profiles: List[Profile],
+      devices: List[Device],
+      lastSeen: Map[String, Instant],
+      rows: List[SessionRow],
+  ): DashboardNow = {
+    val trafficCutoff                         = now.minus(TrafficActiveWindow)
+    val sessionCutoff                         = now.minus(SessionTolerance)
+    val rowsByMac                             = rows.groupBy(_.mac)
+    val latestTrafficTs: Map[String, Instant] =
+      rowsByMac.view
+        .mapValues(rs => rs.map(_.periodEnd).max)
+        .toMap
+
+    val profile = profiles.sortBy(_.id).map { p =>
+      val devs   = devices.filter(_.profileId.contains(p.id))
+      val active = devs.flatMap { d =>
+        val connTs    = lastSeen.get(d.mac)
+        val trafficTs = latestTrafficTs.get(d.mac).filter(_.isAfter(trafficCutoff))
+        val activeTs  = (connTs, trafficTs) match {
+          case (Some(a), Some(b)) => Some(if a.isAfter(b) then a else b)
+          case (a, b)             => a.orElse(b)
+        }
+        activeTs.map { ts =>
+          val lastSeenSeconds = math.max(0L, now.getEpochSecond - ts.getEpochSecond)
+          val devRows         = rowsByMac.getOrElse(d.mac, Nil)
+          DashboardNowDevice(
+            id = d.id,
+            name = d.name,
+            mac = d.mac,
+            lastSeenSeconds = lastSeenSeconds,
+            topHosts = topHostsFromRows(devRows),
+            currentSession = currentSessionFromRows(devRows, sessionCutoff),
+          )
+        }
+      }
+      DashboardNowProfile(
+        id = p.id,
+        name = p.name,
+        paused = p.paused,
+        activeDevices = active.sortBy(_.lastSeenSeconds),
+      )
+    }
+
+    DashboardNow(asOf = now.toString, profiles = profile)
+  }
+
+  def topHostsFromRows(rows: List[SessionRow]): List[DashboardNowHost] =
+    rows
+      .groupBy(_.hostname)
+      .view
+      .mapValues(rs => rs.map(_.activeSeconds.toLong).sum)
+      .toList
+      .sortBy { case (h, s) => (-s, h) }
+      .take(TopHostsLimit)
+      .map { case (h, s) => DashboardNowHost(h, s) }
+
+  def currentSessionFromRows(
+      rows: List[SessionRow],
+      sessionCutoff: Instant,
+  ): Option[DashboardNowCurrentSession] =
+    if rows.isEmpty then None
+    else {
+      val stitched = Sessions.stitch(rows)
+      // Sessions.stitch returns newest-first by startedAt; pick the one whose endedAt is most recent
+      // and after the cutoff.
+      stitched
+        .filter(s => Instant.parse(s.endedAt).isAfter(sessionCutoff))
+        .sortBy(s => -Instant.parse(s.endedAt).toEpochMilli)
+        .headOption
+        .map { s =>
+          DashboardNowCurrentSession(
+            hostname = s.hostname,
+            startedAt = s.startedAt,
+            durationSeconds = s.durationSeconds,
+          )
+        }
+    }
+}

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -1,0 +1,371 @@
+package familydns.api.feature
+
+import familydns.api.JwtConfig
+import familydns.api.auth.*
+import familydns.api.db.*
+import familydns.api.routes.*
+import familydns.shared.*
+import familydns.shared.Clock.TestClock
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.time.{Instant, ZoneOffset}
+import java.util.UUID
+
+object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def seedRouter(name: String = "home"): ZIO[RouterRepo, Throwable, UUID] =
+    ZIO.serviceWithZIO[RouterRepo] { rRepo =>
+      for {
+        id <- rRepo.create(name, "ENROLL_HASH")
+        _  <- rRepo.completeEnrollment(id, "TOKEN_HASH")
+      } yield id
+    }
+
+  private def insertReport(
+      routerId: UUID,
+      mac: String,
+      host: String,
+      start: Instant,
+      activeSeconds: Int = 300,
+      periodLen: Long = 300,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val end  = start.plusSeconds(periodLen)
+      val date = start.atZone(ZoneOffset.UTC).toLocalDate
+      tr.insertBatch(
+        List(
+          TrafficReportInsert(routerId, mac, None, host, date, start, end, activeSeconds, 1, 1),
+        ),
+      ).unit
+    }
+
+  private def insertConn(
+      routerId: UUID,
+      mac: String,
+      ts: Instant,
+  ): ZIO[ConnectionEventRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[ConnectionEventRepo] { cr =>
+      cr.insertBatch(
+        List(
+          ConnectionEventInsert(routerId, Some(mac), "example.com", None, true, "allow", ts),
+        ),
+      ).unit
+    }
+
+  private def getJson(routes: Routes[Any, Response], path: String, token: String) =
+    routes.runZIO(
+      Request
+        .get(URL.decode(path).toOption.get)
+        .addHeader(Header.Authorization.Bearer(token)),
+    )
+
+  private def buildRoutes(auth: AuthService) =
+    for {
+      tr     <- ZIO.service[TrafficReportRepo]
+      cr     <- ZIO.service[ConnectionEventRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      pr     <- ZIO.service[ProfileRepo]
+      upRepo <- ZIO.service[UserProfileRepo]
+      clock  <- ZIO.service[Clock]
+    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, clock)
+
+  /**
+   * V1__init seeds two profiles ("Kids" and "Adults"). Tests that need a clean slate clear them so
+   * profile-id assertions are stable.
+   */
+  private def clearSeededProfiles: ZIO[ProfileRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[ProfileRepo](pr =>
+      pr.listAll.flatMap(ps => ZIO.foreachDiscard(ps)(p => pr.delete(p.id))),
+    )
+
+  private val mac1 = "aa:bb:cc:dd:ee:01"
+  private val mac2 = "aa:bb:cc:dd:ee:02"
+
+  def spec = suite("Dashboard Now API")(
+    test("empty DB → 200 with idle seeded profiles, no active devices") {
+      for {
+        _      <- cleanDb
+        auth   <- makeAuth
+        token  <- auth.login("admin", "changeme").map(_.token)
+        routes <- buildRoutes(auth)
+        resp   <- getJson(routes, "/api/dashboard/now", token)
+        body   <- resp.body.asString
+        parsed <- ZIO.fromEither(body.fromJson[DashboardNow])
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        parsed.profiles.forall(_.activeDevices.isEmpty),
+      )
+    },
+    test("active device with current session: top host + currentSession populated") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        // 6 contiguous 5-min periods ending 1 min ago.
+        t0 = now0.minusSeconds(31 * 60)
+        _      <- ZIO.foreachDiscard(0 until 6) { i =>
+          insertReport(routerId, mac1, "youtube.com", t0.plusSeconds(i.toLong * 300))
+        }
+        _      <- insertConn(routerId, mac1, now0.minusSeconds(5))
+        auth   <- makeAuth
+        token  <- auth.login("admin", "changeme").map(_.token)
+        routes <- buildRoutes(auth)
+        resp   <- getJson(routes, "/api/dashboard/now", token)
+        body   <- resp.body.asString
+        parsed <- ZIO.fromEither(body.fromJson[DashboardNow])
+        prof = parsed.profiles.find(_.id == kid).get
+        dev  = prof.activeDevices.head
+      } yield assertTrue(
+        parsed.profiles.length == 1,
+        prof.activeDevices.length == 1,
+        dev.mac == mac1,
+        dev.name == "iPad",
+        dev.lastSeenSeconds <= 60L,
+        dev.topHosts.headOption.exists(_.hostname == "youtube.com"),
+        dev.topHosts.head.activeSeconds == 1800L,
+        dev.currentSession.exists(_.hostname == "youtube.com"),
+        dev.currentSession.get.durationSeconds == 1800L,
+      )
+    },
+    test("stale device (no conn + no recent traffic) is excluded") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        _        <- insertReport(routerId, mac1, "youtube.com", now0.minusSeconds(20 * 60))
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(10 * 60))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+      } yield assertTrue(parsed.profiles.find(_.id == kid).get.activeDevices.isEmpty)
+    },
+    test("traffic_report inside 5min keeps device active even if connection events are stale") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(6 * 60))
+        _        <- insertReport(routerId, mac1, "youtube.com", now0.minusSeconds(6 * 60))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        prof = parsed.profiles.find(_.id == kid).get
+        dev  = prof.activeDevices.head
+      } yield assertTrue(
+        prof.activeDevices.length == 1,
+        dev.mac == mac1,
+        dev.lastSeenSeconds <= 90L,
+      )
+    },
+    test("currentSession is null when the latest session ended > 10 min ago") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        _        <- insertReport(routerId, mac1, "youtube.com", now0.minusSeconds(17 * 60))
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(30))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        prof = parsed.profiles.find(_.id == kid).get
+        dev  = prof.activeDevices.head
+      } yield assertTrue(prof.activeDevices.length == 1, dev.currentSession.isEmpty)
+    },
+    test("topHosts: sums active_seconds, sorts desc, caps at 3") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        t0 = now0.minusSeconds(10 * 60)
+        _    <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
+        _    <- insertReport(routerId, mac1, "youtube.com", t0.plusSeconds(300), activeSeconds = 60)
+        _    <- insertReport(routerId, mac1, "tiktok.com", t0, activeSeconds = 200)
+        _    <- insertReport(routerId, mac1, "reddit.com", t0, activeSeconds = 100)
+        _    <- insertReport(routerId, mac1, "news.com", t0, activeSeconds = 50)
+        _    <- insertReport(routerId, mac1, "wiki.com", t0, activeSeconds = 20)
+        _    <- insertConn(routerId, mac1, now0.minusSeconds(15))
+        auth <- makeAuth
+        token  <- auth.login("admin", "changeme").map(_.token)
+        routes <- buildRoutes(auth)
+        resp   <- getJson(routes, "/api/dashboard/now", token)
+        body   <- resp.body.asString
+        parsed <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(
+        dev.topHosts.length == 3,
+        dev.topHosts.map(_.hostname) == List("youtube.com", "tiktok.com", "reddit.com"),
+        dev.topHosts.head.activeSeconds == 360L,
+      )
+    },
+    test("multiple profiles, idle ones retained in id-asc order") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kids     <- pr.create("Kids", Nil)
+        adults   <- pr.create("Adults", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kids)
+        _        <- TestLayers.seedDevice(dr, mac2, "Laptop", adults)
+        now0     <- Clock.instant
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(10))
+        _        <- insertReport(routerId, mac1, "youtube.com", now0.minusSeconds(4 * 60))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+      } yield assertTrue(
+        parsed.profiles.map(_.id) == List(kids, adults),
+        parsed.profiles.find(_.id == kids).get.activeDevices.length == 1,
+        parsed.profiles.find(_.id == adults).get.activeDevices.isEmpty,
+      )
+    },
+    test("paused profile is flagged paused: true with active devices still listed") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- pr.setPaused(kid, true)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(10))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        prof = parsed.profiles.find(_.id == kid).get
+      } yield assertTrue(prof.paused, prof.activeDevices.length == 1)
+    },
+    test("child token sees only profiles linked to their user") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        userRepo <- ZIO.service[UserRepo]
+        kids     <- pr.create("Kids", Nil)
+        adults   <- pr.create("Adults", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kids)
+        _        <- TestLayers.seedDevice(dr, mac2, "Laptop", adults)
+        now0     <- Clock.instant
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(10))
+        _        <- insertConn(routerId, mac2, now0.minusSeconds(10))
+        auth     <- makeAuth
+        hash     <- auth.hashPassword("pass")
+        childId  <- userRepo.create("alice", hash, "child")
+        _        <- upRepo.setProfilesForUser(childId, List(kids))
+        token    <- auth.login("alice", "pass").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+      } yield assertTrue(
+        parsed.profiles.length == 1,
+        parsed.profiles.head.id == kids,
+        parsed.profiles.head.activeDevices.length == 1,
+        parsed.profiles.head.activeDevices.head.mac == mac1,
+      )
+    },
+    test("unauthenticated → 401") {
+      for {
+        _      <- cleanDb
+        auth   <- makeAuth
+        routes <- buildRoutes(auth)
+        resp   <- routes.runZIO(Request.get(URL.decode("/api/dashboard/now").toOption.get))
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+    test("perf smoke: 20 devices × 6 buckets responds within 1s") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        now0     <- Clock.instant
+        _        <- ZIO.foreachDiscard(0 until 20) { i =>
+          val mac = f"aa:bb:cc:dd:ee:$i%02x"
+          TestLayers.seedDevice(dr, mac, s"dev$i", kid) *>
+            insertConn(routerId, mac, now0.minusSeconds(10)) *>
+            ZIO.foreachDiscard(0 until 6) { j =>
+              insertReport(
+                routerId,
+                mac,
+                s"host${j % 4}.com",
+                now0.minusSeconds(30L * 60 - j * 300L),
+              )
+            }
+        }
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        t0       <- zio.Clock.nanoTime
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        t1       <- zio.Clock.nanoTime
+        elapsedMs = (t1 - t0) / 1_000_000L
+      } yield assertTrue(resp.status == Status.Ok, elapsedMs < 1000L)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -223,6 +223,37 @@ case class ProfileDetail(
     siteTimeLimits: List[SiteTimeLimit],
 ) derives JsonCodec
 
+// ── Dashboard "Now" ────────────────────────────────────────────────────────
+
+case class DashboardNowHost(hostname: String, activeSeconds: Long) derives JsonCodec
+
+case class DashboardNowCurrentSession(
+    hostname: String,
+    startedAt: String,
+    durationSeconds: Long,
+) derives JsonCodec
+
+case class DashboardNowDevice(
+    id: Long,
+    name: String,
+    mac: String,
+    lastSeenSeconds: Long,
+    topHosts: List[DashboardNowHost],
+    currentSession: Option[DashboardNowCurrentSession],
+) derives JsonCodec
+
+case class DashboardNowProfile(
+    id: Long,
+    name: String,
+    paused: Boolean,
+    activeDevices: List[DashboardNowDevice],
+) derives JsonCodec
+
+case class DashboardNow(
+    asOf: String,
+    profiles: List[DashboardNowProfile],
+) derives JsonCodec
+
 case class CachedProfile(
     profile: Profile,
     schedules: List[Schedule],

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,5 @@
 import type {
-  CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardStats, Device,
+  CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardNow, DashboardStats, Device,
   DeviceTimeStatus, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, QueryLog,
   RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension, UpsertDeviceRequest,
   UpsertProfileRequest, GrantExtensionRequest, User,
@@ -122,6 +122,11 @@ export const api = {
       return req<QueryLog[]>('GET', `/logs?${qs}`)
     },
     stats: () => req<DashboardStats>('GET', '/stats'),
+  },
+
+  // ── Dashboard "now" ────────────────────────────────────────────────────
+  dashboard: {
+    now: () => req<DashboardNow>('GET', '/dashboard/now'),
   },
 
   // ── Sessions ───────────────────────────────────────────────────────────

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import type { DashboardStats, QueryLog } from '@/types/api'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import type { DashboardNow, DashboardStats, QueryLog } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
   api: {
@@ -8,11 +8,14 @@ vi.mock('@/api/client', () => ({
       stats: vi.fn(),
       query: vi.fn(),
     },
+    dashboard: {
+      now: vi.fn(),
+    },
   },
 }))
 
 import { api } from '@/api/client'
-import { DashboardPage } from './DashboardPage'
+import { DashboardPage, NowSection } from './DashboardPage'
 
 const stats: DashboardStats = {
   totalToday: 1234,
@@ -35,10 +38,46 @@ const recent: QueryLog = {
   location: 'home', ts: '2026-05-07T10:15:30Z',
 }
 
+const emptyNow: DashboardNow = { asOf: '2026-05-13T10:00:00Z', profiles: [] }
+
+const liveNow: DashboardNow = {
+  asOf: '2026-05-13T10:00:00Z',
+  profiles: [
+    {
+      id: 1,
+      name: 'Kids',
+      paused: false,
+      activeDevices: [
+        {
+          id: 10,
+          name: 'iPhone',
+          mac: 'aa:bb:cc:dd:ee:01',
+          lastSeenSeconds: 30,
+          topHosts: [
+            { hostname: 'youtube.com', activeSeconds: 840 },
+            { hostname: 'tiktok.com', activeSeconds: 120 },
+          ],
+          currentSession: {
+            hostname: 'youtube.com',
+            startedAt: '2026-05-13T09:46:00Z',
+            durationSeconds: 840,
+          },
+        },
+      ],
+    },
+    { id: 2, name: 'Adults', paused: false, activeDevices: [] },
+  ],
+}
+
+const mockStats = () => api.logs.stats as unknown as ReturnType<typeof vi.fn>
+const mockQuery = () => api.logs.query as unknown as ReturnType<typeof vi.fn>
+const mockNow   = () => api.dashboard.now as unknown as ReturnType<typeof vi.fn>
+
 beforeEach(() => {
   vi.resetAllMocks()
-  ;(api.logs.stats as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(stats)
-  ;(api.logs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([recent])
+  mockStats().mockResolvedValue(stats)
+  mockQuery().mockResolvedValue([recent])
+  mockNow().mockResolvedValue(emptyNow)
 })
 
 describe('DashboardPage', () => {
@@ -59,7 +98,7 @@ describe('DashboardPage', () => {
   })
 
   it('shows empty state when no blocked queries', async () => {
-    (api.logs.stats as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ ...stats, topBlocked: [] })
+    mockStats().mockResolvedValue({ ...stats, topBlocked: [] })
     render(<DashboardPage />)
     expect(await screen.findByText(/No blocked queries yet/)).toBeInTheDocument()
   })
@@ -69,5 +108,84 @@ describe('DashboardPage', () => {
     await screen.findByText('example.com')
     const expected = new Date(recent.ts).toLocaleTimeString()
     expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('renders Now section above stat cards', async () => {
+    mockNow().mockResolvedValue(liveNow)
+    render(<DashboardPage />)
+    await screen.findByText('1234')
+    await waitFor(() => expect(screen.getByTestId('now-profile-1')).toBeInTheDocument())
+    const nowHeading = screen.getByText('Now')
+    const statsCard  = screen.getByText('Queries today')
+    const comparison = nowHeading.compareDocumentPosition(statsCard)
+    expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
+describe('NowSection', () => {
+  it('renders one card per profile in id order, idle profiles dimmed', async () => {
+    mockNow().mockResolvedValue(liveNow)
+    render(<NowSection />)
+    const kids   = await screen.findByTestId('now-profile-1')
+    const adults = screen.getByTestId('now-profile-2')
+    expect(kids).toBeInTheDocument()
+    expect(adults).toHaveClass('opacity-60')
+    expect(screen.getByText(/No activity in the last 5 minutes/)).toBeInTheDocument()
+  })
+
+  it('shows device name, last-seen, current session, and top hosts', async () => {
+    mockNow().mockResolvedValue(liveNow)
+    render(<NowSection />)
+    await screen.findByTestId('now-device-aa:bb:cc:dd:ee:01')
+    expect(screen.getByText('iPhone')).toBeInTheDocument()
+    expect(screen.getByText('30s ago')).toBeInTheDocument()
+    expect(screen.getByText(/watching/)).toBeInTheDocument()
+    expect(screen.getAllByText('youtube.com').length).toBeGreaterThan(0)
+    expect(screen.getByText('tiktok.com')).toBeInTheDocument()
+    expect(screen.getAllByText('14m').length).toBeGreaterThan(0)
+  })
+
+  it('renders Paused badge when profile is paused', async () => {
+    mockNow().mockResolvedValue({
+      ...liveNow,
+      profiles: [{ ...liveNow.profiles[0], paused: true }],
+    })
+    render(<NowSection />)
+    expect(await screen.findByText('Paused')).toBeInTheDocument()
+  })
+
+  it('polls /dashboard/now every 10s', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      mockNow().mockResolvedValue(emptyNow)
+      render(<NowSection />)
+      await waitFor(() => expect(mockNow()).toHaveBeenCalledTimes(1))
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+      expect(mockNow()).toHaveBeenCalledTimes(2)
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+      expect(mockNow()).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps previous data on poll failure', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      mockNow().mockResolvedValueOnce(liveNow).mockRejectedValue(new Error('boom'))
+      render(<NowSection />)
+      await waitFor(() => expect(screen.getByTestId('now-profile-1')).toBeInTheDocument())
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+      expect(screen.getByTestId('now-profile-1')).toBeInTheDocument()
+      expect(screen.getByText('iPhone')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('renders empty-profiles message when API returns no profiles', async () => {
+    mockNow().mockResolvedValue(emptyNow)
+    render(<NowSection />)
+    expect(await screen.findByText(/No profiles configured yet/)).toBeInTheDocument()
   })
 })

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,14 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from '@/api/client'
-import type { DashboardStats, QueryLog } from '@/types/api'
+import type {
+  DashboardNow,
+  DashboardNowDevice,
+  DashboardNowProfile,
+  DashboardStats,
+  QueryLog,
+} from '@/types/api'
+
+const NOW_POLL_MS = 10_000
 
 export function DashboardPage() {
   const [stats,  setStats]  = useState<DashboardStats | null>(null)
@@ -18,6 +26,8 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       <h1 className="text-xl font-bold text-white">Dashboard</h1>
+
+      <NowSection />
 
       {stats && (
         <>
@@ -75,6 +85,111 @@ export function DashboardPage() {
       </section>
     </div>
   )
+}
+
+// ── "Now" section — live snapshot, polls every 10s ───────────────────────────
+
+export function NowSection() {
+  const [data, setData] = useState<DashboardNow | null>(null)
+  const dataRef = useRef<DashboardNow | null>(null)
+  dataRef.current = data
+
+  useEffect(() => {
+    let cancelled = false
+    const tick = () => {
+      api.dashboard.now()
+        .then(d => { if (!cancelled) setData(d) })
+        .catch(() => { /* keep showing previous snapshot on transient errors */ })
+    }
+    tick()
+    const id = setInterval(tick, NOW_POLL_MS)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [])
+
+  return (
+    <section data-testid="now-section" className="space-y-3">
+      <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">Now</h2>
+      {data === null
+        ? <p className="text-gray-600 text-sm">Loading live activity…</p>
+        : data.profiles.length === 0
+          ? <p className="text-gray-600 text-sm">No profiles configured yet.</p>
+          : (
+            <div className="grid md:grid-cols-2 gap-4">
+              {data.profiles.map(p => <NowProfileCard key={p.id} profile={p} />)}
+            </div>
+          )
+      }
+    </section>
+  )
+}
+
+function NowProfileCard({ profile }: { profile: DashboardNowProfile }) {
+  const idle = profile.activeDevices.length === 0
+  return (
+    <div
+      data-testid={`now-profile-${profile.id}`}
+      className={`bg-gray-900 rounded-2xl border p-5 ${idle ? 'border-gray-800 opacity-60' : 'border-emerald-900/50'}`}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <h3 className="text-base font-semibold text-white">{profile.name}</h3>
+        {profile.paused && (
+          <span className="text-[10px] font-bold uppercase tracking-wider bg-yellow-900/60 text-yellow-300 px-2 py-0.5 rounded">
+            Paused
+          </span>
+        )}
+      </div>
+      {idle
+        ? <p className="text-gray-600 text-xs">No activity in the last 5 minutes</p>
+        : (
+          <div className="space-y-3">
+            {profile.activeDevices.map(d => <NowDeviceRow key={d.mac} device={d} />)}
+          </div>
+        )
+      }
+    </div>
+  )
+}
+
+function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
+  return (
+    <div data-testid={`now-device-${device.mac}`} className="border-t border-gray-800 first:border-0 pt-3 first:pt-0">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-sm font-medium text-white truncate">{device.name}</p>
+        <p className="text-xs text-gray-500 shrink-0">{formatLastSeen(device.lastSeenSeconds)}</p>
+      </div>
+      {device.currentSession && (
+        <p className="text-xs text-emerald-400 mt-1">
+          watching <span className="font-mono">{device.currentSession.hostname}</span>
+          {' · '}{formatDuration(device.currentSession.durationSeconds)}
+        </p>
+      )}
+      {device.topHosts.length > 0 && (
+        <ul className="mt-2 space-y-0.5">
+          {device.topHosts.map(h => (
+            <li key={h.hostname} className="flex justify-between text-xs text-gray-400">
+              <span className="font-mono truncate">{h.hostname}</span>
+              <span className="text-gray-600 ml-2 shrink-0">{formatDuration(h.activeSeconds)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function formatLastSeen(seconds: number): string {
+  if (seconds < 60) return `${Math.max(0, Math.round(seconds))}s ago`
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`
+  return `${Math.round(seconds / 3600)}h ago`
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const mins = Math.round(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const h = Math.floor(mins / 60)
+  const m = mins % 60
+  return m === 0 ? `${h}h` : `${h}h ${m}m`
 }
 
 function StatCard({ label, value, accent }: { label: string; value: number; accent: string }) {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -94,6 +94,38 @@ export interface DashboardStats {
   perDevice: DeviceStats[]
 }
 
+export interface DashboardNowHost {
+  hostname: string
+  activeSeconds: number
+}
+
+export interface DashboardNowCurrentSession {
+  hostname: string
+  startedAt: string
+  durationSeconds: number
+}
+
+export interface DashboardNowDevice {
+  id: number
+  name: string
+  mac: string
+  lastSeenSeconds: number
+  topHosts: DashboardNowHost[]
+  currentSession: DashboardNowCurrentSession | null
+}
+
+export interface DashboardNowProfile {
+  id: number
+  name: string
+  paused: boolean
+  activeDevices: DashboardNowDevice[]
+}
+
+export interface DashboardNow {
+  asOf: string
+  profiles: DashboardNowProfile[]
+}
+
 export interface DomainCount {
   domain: string
   count: number


### PR DESCRIPTION
## Summary
- Adds `GET /api/dashboard/now` returning, for each visible profile, the devices that are active right now plus their top hosts and in-progress session.
- Adds a top-of-dashboard "Now" section to the React dashboard with 10s polling and stable layout (idle profiles dimmed, prior snapshot kept on transient errors).
- Reuses [`Sessions.stitch`](https://github.com/sameerparekh/familydns/blob/main/api/src/sessions/Sessions.scala) from #260 for current-session detection — no parallel implementation.

## Behavior
- **Active device** — has a `connection_events` row with `ts > now − 5m` OR a `traffic_reports` row whose `period_end > now − 5m`.
- **Top hosts** — last 30m of `traffic_reports`, summed by `active_seconds`, top 3 desc.
- **Current session** — latest stitched session per device, surfaced iff its `endedAt > now − 10m` (one missed 5-min bucket tolerated; matches the reporting cadence).
- **Profile order** — all visible profiles returned in id-asc, including idle ones, so the dashboard layout doesn't shift.

## Scope boundaries
This PR ships only the "right now" snapshot.
- #260 sessions-per-host surface — algorithm reused, not reimplemented.
- #127, #301 — usage graphs / historical activity remain a separate surface.
- #64 — traffic/session browsing UI stays separate; this PR is the "now" half of the same UX gap.
- #227 — closes one of the UX-audit gaps.

## Test plan
- [x] `mill api.test.testOnly familydns.api.feature.DashboardNowApiSpec` — 11 feature tests covering shape, active-window edge cases, current-session tolerance, top-host ranking + cap, multi-profile id-order, paused, child-token visibility, auth, and a perf smoke (20 devs × 6 buckets in < 1s).
- [x] `mill api.test` — full suite green.
- [x] `npx vitest run` — full web suite green (84 tests).
- [ ] Manual: spin up dev server, watch the Now card update on real traffic.

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)