### PR TITLE
resilience: per-profile failureMode (open/closed) for API-unreachable failover

### DIFF
--- a/api/resources/db/migration/V10__profile_failure_mode.sql
+++ b/api/resources/db/migration/V10__profile_failure_mode.sql
@@ -1,0 +1,13 @@
+-- #311: per-profile failover mode. When the OpenWRT agent loses contact
+-- with the API for >5 minutes:
+--   'closed' → drop all forwarded traffic for the profile's devices
+--              (fail-safe; recommended for children)
+--   'open'   → keep enforcing the cached snapshot exactly as-is
+--              (recommended for adults; avoids ISP-blip lockouts)
+--
+-- Default 'closed' is pessimistic — existing rows acquire fail-closed on
+-- migration. The API layer keeps the same default at profile creation; the
+-- web UI surfaces the override so admins can opt adult profiles into Open.
+ALTER TABLE profiles
+  ADD COLUMN failure_mode TEXT NOT NULL DEFAULT 'closed'
+  CHECK (failure_mode IN ('open', 'closed'));

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -345,16 +345,26 @@ class UserProfileRepoLive(xa: Transactor[Task]) extends UserProfileRepo {
 }
 
 class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
-  private type R = (Long, String, List[String], List[String], List[String], Boolean)
-  private def toP(r: R)                        = Profile(r._1, r._2, r._3, r._4, r._5, r._6)
+  private type R = (Long, String, List[String], List[String], List[String], Boolean, String)
+  private def toP(r: R)                        = Profile(
+    r._1,
+    r._2,
+    r._3,
+    r._4,
+    r._5,
+    r._6,
+    // Column has a CHECK constraint of ('open','closed'); fall back to Closed if
+    // somehow violated — fail-safe matches the migration default.
+    FailureMode.parse(r._7).getOrElse(FailureMode.Closed),
+  )
   def listAll                                  =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused FROM profiles ORDER BY id"
+    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode FROM profiles ORDER BY id"
       .query[R]
       .map(toP)
       .to[List]
       .transact(xa)
   def findById(id: Long)                       =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused FROM profiles WHERE id=$id"
+    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode FROM profiles WHERE id=$id"
       .query[R]
       .map(toP)
       .option
@@ -365,7 +375,14 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       .unique
       .transact(xa)
   def update(p: Profile)                       =
-    sql"UPDATE profiles SET name=${p.name},blocked_categories=${p.blockedCategories.toArray},extra_blocked=${p.extraBlocked.toArray},extra_allowed=${p.extraAllowed.toArray},paused=${p.paused} WHERE id=${p.id}".update.run
+    sql"""UPDATE profiles SET
+            name=${p.name},
+            blocked_categories=${p.blockedCategories.toArray},
+            extra_blocked=${p.extraBlocked.toArray},
+            extra_allowed=${p.extraAllowed.toArray},
+            paused=${p.paused},
+            failure_mode=${FailureMode.asString(p.failureMode)}
+          WHERE id=${p.id}""".update.run
       .transact(xa)
       .unit
   def delete(id: Long) = sql"DELETE FROM profiles WHERE id=$id".update.run.transact(xa).unit

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -82,6 +82,7 @@ class PolicyServiceLive(
           siteLimits = pSiteLims,
           timeUsedToday = PolicyTimeUsedToday(totalMins, byDomain),
           extensionsTodayMinutes = extMins,
+          failureMode = p.failureMode,
         )
       }
       val pDevices      = devices.map(d => PolicyDevice(d.mac, d.profileId, d.name))
@@ -301,7 +302,8 @@ object PolicyService {
       .sortBy(_.mac)
       .foreach(d => parts += s"dev:${d.mac}|${d.profileId.getOrElse("-")}|${d.name}")
     core.profiles.sortBy(_.id).foreach { p =>
-      parts += s"p:${p.id}|${p.name}|${p.paused}|${p.dailyMinutes.getOrElse(-1)}|${p.extensionsTodayMinutes}"
+      parts += s"p:${p.id}|${p.name}|${p.paused}|${p.dailyMinutes
+          .getOrElse(-1)}|${p.extensionsTodayMinutes}|fm:${FailureMode.asString(p.failureMode)}"
       parts += s"  bc:${p.blockedCategories.sorted.mkString(",")}"
       parts += s"  eb:${p.extraBlocked.sorted.mkString(",")}"
       parts += s"  ea:${p.extraAllowed.sorted.mkString(",")}"

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -181,6 +181,8 @@ object ProfileRoutes {
                   upr.extraBlocked,
                   upr.extraAllowed,
                   upr.paused,
+                  // #311: missing failureMode → Closed (fail-safe).
+                  upr.failureMode.getOrElse(FailureMode.Closed),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -216,6 +218,9 @@ object ProfileRoutes {
                   extraBlocked = upr.extraBlocked,
                   extraAllowed = upr.extraAllowed,
                   paused = upr.paused,
+                  // #311: if the caller omits failureMode, preserve the
+                  // existing value rather than resetting to Closed.
+                  failureMode = upr.failureMode.getOrElse(p.failureMode),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -1,0 +1,99 @@
+package familydns.api.feature
+
+import familydns.api.db.*
+import familydns.api.policy.*
+import familydns.shared.*
+import familydns.shared.Clock.TestClock
+import familydns.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.json.*
+import zio.test.*
+
+/**
+ * #311: PolicySnapshot must carry the per-profile failureMode so the agent can pick the right
+ * failover behaviour after 5 minutes of API unreachability. Closed → drop all forwarded traffic for
+ * the profile's devices; Open → keep enforcing the cached snapshot exactly as-is. Without this
+ * field on the wire, "fail closed for children, fail open for adults" can't be honoured.
+ */
+object PolicySnapshotFailureModeSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  def spec = suite("PolicySnapshot — failureMode (#311)")(
+    test("snapshot carries each profile's failureMode value") {
+      for {
+        _      <- cleanDb
+        pr     <- ZIO.service[ProfileRepo]
+        sr     <- ZIO.service[ScheduleRepo]
+        tlr    <- ZIO.service[TimeLimitRepo]
+        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        dr     <- ZIO.service[DeviceRepo]
+        blr    <- ZIO.service[BlocklistRepo]
+        trRepo <- ZIO.service[TrafficReportRepo]
+        er     <- ZIO.service[TimeExtensionRepo]
+        clock  <- ZIO.service[Clock]
+        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        profiles0 <- pr.listAll
+        kidsId   = profiles0.find(_.name == "Kids").get.id
+        adultsId = profiles0.find(_.name == "Adults").get.id
+        // Force the two seeded profiles into known modes.
+        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
+        _ <- pr.update(profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.Open))
+        snap <- svc.snapshot
+        kids   = snap.profiles.find(_.id == kidsId).get
+        adults = snap.profiles.find(_.id == adultsId).get
+      } yield assertTrue(kids.failureMode == FailureMode.Closed) &&
+        assertTrue(adults.failureMode == FailureMode.Open)
+    },
+    test("failureMode serializes as lowercase \"open\" / \"closed\" on the wire") {
+      // The lua agent reads snapshot.failureMode as a plain string; pin the
+      // exact wire spelling so render.lua's comparisons don't drift.
+      for {
+        _      <- cleanDb
+        pr     <- ZIO.service[ProfileRepo]
+        sr     <- ZIO.service[ScheduleRepo]
+        tlr    <- ZIO.service[TimeLimitRepo]
+        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        dr     <- ZIO.service[DeviceRepo]
+        blr    <- ZIO.service[BlocklistRepo]
+        trRepo <- ZIO.service[TrafficReportRepo]
+        er     <- ZIO.service[TimeExtensionRepo]
+        clock  <- ZIO.service[Clock]
+        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        profiles0 <- pr.listAll
+        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
+        _ <- pr.update(profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.Open))
+        snap <- svc.snapshot
+        json = snap.toJson
+      } yield assertTrue(json.contains("\"failureMode\":\"closed\"")) &&
+        assertTrue(json.contains("\"failureMode\":\"open\""))
+    },
+    test("ETag flips when a profile's failureMode changes") {
+      for {
+        _      <- cleanDb
+        pr     <- ZIO.service[ProfileRepo]
+        sr     <- ZIO.service[ScheduleRepo]
+        tlr    <- ZIO.service[TimeLimitRepo]
+        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        dr     <- ZIO.service[DeviceRepo]
+        blr    <- ZIO.service[BlocklistRepo]
+        trRepo <- ZIO.service[TrafficReportRepo]
+        er     <- ZIO.service[TimeExtensionRepo]
+        clock  <- ZIO.service[Clock]
+        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        profiles0 <- pr.listAll
+        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
+        snap1 <- svc.snapshot
+        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Open))
+        snap2 <- svc.snapshot
+      } yield assertTrue(snap1.etag != snap2.etag)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -153,6 +153,120 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(stls.head.label == "YouTube") &&
           assertTrue(stls.head.dailyMinutes == 45)
       },
+      test("failureMode defaults to Closed when omitted from create request (#311 fail-safe)") {
+        for {
+          _               <- cleanDb
+          profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
+          tlRepo          <- ZIO.service[TimeLimitRepo]
+          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          auth            <- makeAuth
+          token           <- auth.login("admin", "changeme").map(_.token)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
+          routes = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepoSvc,
+          )
+          // Send create body with no failureMode field at all.
+          body   =
+            """{"name":"Defaulted","blockedCategories":[],"extraBlocked":[],"extraAllowed":[],"paused":false,"schedules":[],"timeLimit":null,"siteTimeLimits":[]}"""
+          req    = Request
+            .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          _        <- routes.runZIO(req)
+          profiles <- profileRepo.listAll
+          found = profiles.find(_.name == "Defaulted").get
+        } yield assertTrue(found.failureMode == FailureMode.Closed)
+      },
+      test("failureMode=Open in create request persists Open (#311 admin override)") {
+        for {
+          _               <- cleanDb
+          profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
+          tlRepo          <- ZIO.service[TimeLimitRepo]
+          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          auth            <- makeAuth
+          token           <- auth.login("admin", "changeme").map(_.token)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
+          routes = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepoSvc,
+          )
+          body   = UpsertProfileRequest(
+            name = "AdultsOpen",
+            blockedCategories = Nil,
+            extraBlocked = Nil,
+            extraAllowed = Nil,
+            paused = false,
+            schedules = Nil,
+            timeLimit = None,
+            siteTimeLimits = Nil,
+            failureMode = Some(FailureMode.Open),
+          ).toJson
+          req    = Request
+            .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          _        <- routes.runZIO(req)
+          profiles <- profileRepo.listAll
+          found = profiles.find(_.name == "AdultsOpen").get
+        } yield assertTrue(found.failureMode == FailureMode.Open)
+      },
+      test("PUT /api/profiles/:id updates failureMode") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token)
+          profiles0   <- profileRepo.listAll
+          kidsId = profiles0.find(_.name == "Kids").get.id
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
+          routes = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepoSvc,
+          )
+          body   = UpsertProfileRequest(
+            name = "Kids",
+            blockedCategories = Nil,
+            extraBlocked = Nil,
+            extraAllowed = Nil,
+            paused = false,
+            schedules = Nil,
+            timeLimit = None,
+            siteTimeLimits = Nil,
+            failureMode = Some(FailureMode.Open),
+          ).toJson
+          req    = Request
+            .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          resp    <- routes.runZIO(req)
+          updated <- profileRepo.findById(kidsId)
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(updated.exists(_.failureMode == FailureMode.Open))
+      },
       test("child user cannot create profiles") {
         for {
           _               <- cleanDb

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -81,9 +81,22 @@ function M.dnsmasq(snapshot)
 end
 
 -- ---------------------------------------------------------------------------
--- render.nft(snapshot) → string
+-- render.nft(snapshot, opts) → string
 -- ---------------------------------------------------------------------------
-function M.nft(snapshot)
+-- opts (optional table):
+--   poll_age_seconds  number — seconds since the last successful policy poll.
+--                              When > 300 (the #269 §4 threshold), profiles
+--                              with failureMode == "closed" get an additional
+--                              failover drop rule for ALL their devices'
+--                              MACs. failureMode == "open" profiles are
+--                              unaffected (cached snapshot keeps enforcing).
+--                              When nil or <= 300, no failover output.
+--
+-- TODO(#323): the agent main loop must compute poll_age and pass it here once
+-- #309 lands last_successful_poll_ts. Until then nothing populates opts, so
+-- this branch is dormant in production — but the field is in the snapshot
+-- and the rendering logic is tested, so flipping it on is a one-liner.
+function M.nft(snapshot, opts)
   local out = {}
   local function emit(s)  out[#out + 1] = s  end
   local function ind(s)   out[#out + 1] = "  " .. s  end
@@ -201,6 +214,44 @@ function M.nft(snapshot)
     ind2("ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081")
     ind("}")
     emit("")
+  end
+
+  -- #311: API-unreachable failover. When poll_age_seconds > 300 we collect
+  -- every device MAC belonging to a profile whose failureMode == "closed"
+  -- and emit a drop rule. failureMode == "open" profiles are left to keep
+  -- enforcing the cached snapshot. We skip emission entirely when there
+  -- are no MACs to drop (empty Closed profile, or no Closed profiles) so
+  -- we don't ship a degenerate rule that matches nothing.
+  --
+  -- TODO(#323): also DNAT HTTP/80 for @failover_drop into the #303 block
+  -- page so failover-cut HTTP requests land on the explanatory page rather
+  -- than hanging. Currently this branch is drop-only.
+  local poll_age = opts and opts.poll_age_seconds
+  if poll_age and poll_age > 300 then
+    local closed_profile_ids = {}
+    for _, prof in ipairs(snapshot.profiles or {}) do
+      if prof.failureMode == "closed" then
+        closed_profile_ids[prof.id] = true
+      end
+    end
+    local failover_macs = {}
+    for _, dev in ipairs(snapshot.devices or {}) do
+      if dev.profileId and closed_profile_ids[dev.profileId] then
+        failover_macs[#failover_macs + 1] = dev.mac
+      end
+    end
+    if #failover_macs > 0 then
+      ind("set failover_drop {")
+      ind2("type ether_addr")
+      ind2("elements = { " .. table.concat(failover_macs, ", ") .. " }")
+      ind("}")
+      emit("")
+      ind("chain familydns_failover {")
+      ind2("type filter hook forward priority -1; policy accept;")
+      ind2("ether saddr @failover_drop drop")
+      ind("}")
+      emit("")
+    end
   end
 
   emit("}")

--- a/openwrt/test/failover_spec.lua
+++ b/openwrt/test/failover_spec.lua
@@ -1,0 +1,109 @@
+-- Tests for #311 fail-closed / fail-open failover in render.nft.
+--
+-- The agent passes opts.poll_age_seconds = (now - last_successful_poll_ts).
+-- When poll_age > 300, profiles with failureMode == "closed" get an additional
+-- drop rule for ALL their devices' MACs (regardless of snapshot.blockedMacs).
+-- Profiles with failureMode == "open" keep enforcing the cached snapshot
+-- exactly as-is.
+--
+-- Run with: cd openwrt && busted test/failover_spec.lua
+
+local render = require("render")
+
+-- Two-profile snapshot: a Closed-failover "kids" profile (devices A, B) and
+-- an Open-failover "adults" profile (devices C, D).
+local function snap_two()
+  return {
+    etag             = "sha256:f1",
+    defaultProfileId = 1,
+    devices = {
+      { mac = "aa:aa:aa:00:00:01", profileId = 1, name = "kid-A" },
+      { mac = "aa:aa:aa:00:00:02", profileId = 1, name = "kid-B" },
+      { mac = "bb:bb:bb:00:00:03", profileId = 2, name = "adult-C" },
+      { mac = "bb:bb:bb:00:00:04", profileId = 2, name = "adult-D" },
+    },
+    profiles = {
+      {
+        id = 1, name = "kids", paused = false, failureMode = "closed",
+        blockedCategories = {}, extraBlocked = {}, extraAllowed = {},
+        schedules = {}, dailyMinutes = 0, siteLimits = {},
+        timeUsedToday = { totalMinutes = 0, byDomain = {} },
+        extensionsTodayMinutes = 0,
+      },
+      {
+        id = 2, name = "adults", paused = false, failureMode = "open",
+        blockedCategories = {}, extraBlocked = {}, extraAllowed = {},
+        schedules = {}, dailyMinutes = 0, siteLimits = {},
+        timeUsedToday = { totalMinutes = 0, byDomain = {} },
+        extensionsTodayMinutes = 0,
+      },
+    },
+    blockedMacs = {},
+  }
+end
+
+describe("render.nft — #311 failover", function()
+
+  it("emits no failover drop set when poll_age_seconds is nil (no signal yet)", function()
+    local nft = render.nft(snap_two())
+    assert.is_nil(nft:find("failover_drop", 1, true))
+  end)
+
+  it("emits no failover drop set when poll_age_seconds <= 300 (within window)", function()
+    local nft = render.nft(snap_two(), { poll_age_seconds = 300 })
+    assert.is_nil(nft:find("failover_drop", 1, true))
+  end)
+
+  it("emits a failover drop set with Closed-profile MACs when poll_age > 300", function()
+    local nft = render.nft(snap_two(), { poll_age_seconds = 301 })
+    assert.truthy(nft:find("set failover_drop", 1, true))
+    -- Closed profile devices land in the set.
+    assert.truthy(nft:find("aa:aa:aa:00:00:01", 1, true))
+    assert.truthy(nft:find("aa:aa:aa:00:00:02", 1, true))
+    -- A drop rule on the set is emitted.
+    assert.truthy(nft:find("@failover_drop", 1, true))
+    assert.truthy(nft:find("drop", 1, true))
+  end)
+
+  it("excludes Open-profile MACs from the failover drop set", function()
+    local nft = render.nft(snap_two(), { poll_age_seconds = 301 })
+    -- Locate the failover_drop set body and check the open-profile MACs
+    -- aren't inside it. (The MACs may still appear elsewhere — e.g. in
+    -- profile2_macs — so we must scope this check.)
+    local s = nft:find("set failover_drop", 1, true)
+    assert.truthy(s)
+    local body_end = nft:find("}", s, true)
+    local body = nft:sub(s, body_end)
+    assert.is_nil(body:find("bb:bb:bb:00:00:03", 1, true))
+    assert.is_nil(body:find("bb:bb:bb:00:00:04", 1, true))
+  end)
+
+  it("emits no failover drop rule when a Closed profile has zero devices", function()
+    -- Edge case called out in #311: an empty Closed profile must not produce
+    -- a degenerate drop rule that matches nothing-but-costs-cycles.
+    local s = snap_two()
+    -- Strip the kids-profile devices; kids is still failureMode=closed.
+    s.devices = {
+      { mac = "bb:bb:bb:00:00:03", profileId = 2, name = "adult-C" },
+    }
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    -- No drop rule against a hypothetical empty set.
+    assert.is_nil(nft:find("@failover_drop", 1, true))
+  end)
+
+  it("boundary: 300s is in-window, 301s triggers failover (strict > 300)", function()
+    local nft_300 = render.nft(snap_two(), { poll_age_seconds = 300 })
+    local nft_301 = render.nft(snap_two(), { poll_age_seconds = 301 })
+    assert.is_nil(nft_300:find("@failover_drop", 1, true))
+    assert.truthy(nft_301:find("@failover_drop", 1, true))
+  end)
+
+  it("normal (non-failover) snapshot rendering is unchanged when opts omitted", function()
+    -- Regression: render.nft(snapshot) with no second arg must still work.
+    local nft = render.nft(snap_two())
+    assert.truthy(nft:find("table inet familydns", 1, true))
+    assert.truthy(nft:find("set profile1_macs", 1, true))
+    assert.truthy(nft:find("set profile2_macs", 1, true))
+  end)
+
+end)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -14,6 +14,35 @@ enum UserRole derives JsonCodec {
   case Admin, Adult, Child
 }
 
+// #311: per-profile failover behaviour when the agent loses contact with the
+// API for >5 min. Closed = drop all forwarded traffic for the profile's
+// devices (fail-safe for kids); Open = keep enforcing the cached snapshot
+// exactly as-is (avoids locking adults out during ISP blips).
+//
+// Wire format is lowercase "open" / "closed" so the lua agent can read the
+// JSON field directly. The default in DB and in UpsertProfileRequest is
+// Closed — the pessimistic choice. The web UI's "new profile" form likewise
+// defaults to Closed; admins can override to Open per profile.
+enum FailureMode {
+  case Open, Closed
+}
+
+object FailureMode {
+  def asString(m: FailureMode): String      = m match {
+    case Open   => "open"
+    case Closed => "closed"
+  }
+  def parse(s: String): Option[FailureMode] = s.toLowerCase match {
+    case "open"   => Some(Open)
+    case "closed" => Some(Closed)
+    case _        => None
+  }
+  given JsonCodec[FailureMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown failureMode: $s"),
+    asString,
+  )
+}
+
 object UserRole {
   def parse(s: String): Option[UserRole] = s.toLowerCase match {
     case "admin" => Some(Admin)
@@ -35,6 +64,7 @@ case class Profile(
     extraBlocked: List[String],
     extraAllowed: List[String],
     paused: Boolean,
+    failureMode: FailureMode = FailureMode.Closed,
 ) derives JsonCodec
 
 case class Schedule(
@@ -137,6 +167,8 @@ case class UpsertProfileRequest(
     schedules: List[ScheduleRequest],
     timeLimit: Option[Int],
     siteTimeLimits: List[SiteTimeLimitRequest],
+    // #311: optional on the wire; server defaults to Closed when omitted.
+    failureMode: Option[FailureMode] = None,
 ) derives JsonCodec
 
 case class ScheduleRequest(
@@ -444,6 +476,9 @@ case class PolicyProfile(
     siteLimits: List[PolicySiteLimit],
     timeUsedToday: PolicyTimeUsedToday,
     extensionsTodayMinutes: Int,
+    // #311: failover mode for the OpenWRT agent when the API is unreachable
+    // for >5 minutes. See FailureMode at the top of this file.
+    failureMode: FailureMode = FailureMode.Closed,
 ) derives JsonCodec
 case class PolicyBlocklist(version: String, url: String) derives JsonCodec
 // Reason is one of: "paused", "time_limit", "schedule" (precedence in that order).

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -37,11 +37,11 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false },
+  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'closed' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false },
+  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'open' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -42,6 +42,7 @@ const kidsProfile: ProfileDetail = {
     extraBlocked: ['bad.com', 'evil.com'],
     extraAllowed: ['school.com'],
     paused: false,
+    failureMode: 'closed',
   },
   schedules: [
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], blockFrom: '21:00', blockUntil: '07:00' },
@@ -60,6 +61,7 @@ const adultsProfile: ProfileDetail = {
     extraBlocked: [],
     extraAllowed: [],
     paused: true,
+    failureMode: 'open',
   },
   schedules: [],
   timeLimit: null,
@@ -204,6 +206,8 @@ describe('ProfilesPage — create', () => {
       siteTimeLimits: [
         { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30, exemptFromDaily: true },
       ],
+      // #311: form default for a brand-new profile is Closed (safe default).
+      failureMode: 'closed',
     })
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
   })
@@ -242,6 +246,8 @@ describe('ProfilesPage — edit', () => {
       siteTimeLimits: [
         { domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },
       ],
+      // #311: edit preserves the existing failureMode unless changed.
+      failureMode: 'closed',
     })
   })
 })
@@ -318,5 +324,63 @@ describe('ProfilesPage — linked users section', () => {
     const call = (api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
     expect(call[0]).toBe(1)
     expect([...call[1]].sort((a, b) => a - b)).toEqual([11, 12])
+  })
+})
+
+describe('ProfilesPage — #311 failureMode', () => {
+  it('edit form pre-fills failureMode from the profile (Closed for Kids)', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
+    const open   = screen.getByTestId('profile-failure-mode-open')   as HTMLInputElement
+    expect(closed.checked).toBe(true)
+    expect(open.checked).toBe(false)
+  })
+
+  it('edit form pre-fills failureMode from the profile (Open for Adults)', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const adultsCard = await screen.findByTestId('profile-card-2')
+    await user.click(within(adultsCard).getByRole('button', { name: /^Edit$/ }))
+    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
+    const open   = screen.getByTestId('profile-failure-mode-open')   as HTMLInputElement
+    expect(open.checked).toBe(true)
+    expect(closed.checked).toBe(false)
+  })
+
+  it('toggling failureMode and saving sends the new value', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(screen.getByTestId('profile-failure-mode-open'))
+    await user.click(screen.getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(api.profiles.update).toHaveBeenCalledTimes(1))
+    const call = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(call[1].failureMode).toBe('open')
+  })
+
+  it('new profile form defaults to Closed (safe default)', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    await screen.findByText('Kids')
+    await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
+    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
+    expect(closed.checked).toBe(true)
+  })
+
+  it('renders explanatory copy for each mode (not a bare checkbox)', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    expect(
+      screen.getByText(/when the router can't reach the API for 5 minutes, block all internet traffic/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/keep enforcing the last-known rules; never auto-block/i),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type {
-  Device, ProfileDetail, ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
+  Device, FailureMode, ProfileDetail, ScheduleRequest, SiteTimeLimitRequest,
+  UpsertProfileRequest, User,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
@@ -17,6 +18,7 @@ interface FormState {
   timeLimit: string
   schedules: ScheduleRequest[]
   siteTimeLimits: SiteTimeLimitRequest[]
+  failureMode: FailureMode
 }
 
 function emptyForm(): FormState {
@@ -29,6 +31,8 @@ function emptyForm(): FormState {
     timeLimit: '',
     schedules: [],
     siteTimeLimits: [],
+    // #311: safe default for a brand-new profile is fail-closed.
+    failureMode: 'closed',
   }
 }
 
@@ -49,6 +53,7 @@ function detailToForm(pd: ProfileDetail): FormState {
       label: s.label,
       exemptFromDaily: s.exemptFromDaily,
     })),
+    failureMode: pd.profile.failureMode,
   }
 }
 
@@ -64,6 +69,7 @@ function formToRequest(f: FormState): UpsertProfileRequest {
     timeLimit: tl !== null && Number.isFinite(tl) ? tl : null,
     schedules: f.schedules,
     siteTimeLimits: f.siteTimeLimits,
+    failureMode: f.failureMode,
   }
 }
 
@@ -516,6 +522,51 @@ function ProfileEditor({
             className="w-4 h-4 accent-emerald-500" />
           Paused — blocks all internet traffic for devices on this profile.
         </label>
+
+        {/* #311: per-profile failover when the router can't reach the API.
+            Radio (not checkbox) because the concept isn't boolean-friendly
+            without context — both options need their own copy. */}
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            Failure mode
+          </label>
+          <div className="space-y-2">
+            <label className="flex items-start gap-3 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="failureMode"
+                data-testid="profile-failure-mode-closed"
+                checked={form.failureMode === 'closed'}
+                onChange={() => setForm(f => ({ ...f, failureMode: 'closed' }))}
+                className="mt-1 w-4 h-4 accent-emerald-500"
+              />
+              <span>
+                <span className="font-medium text-white">Fail closed</span>
+                <span className="text-gray-500"> (recommended for children)</span>
+                <span className="block text-xs text-gray-400 mt-0.5">
+                  when the router can't reach the API for 5 minutes, block all internet traffic for this profile.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-3 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="failureMode"
+                data-testid="profile-failure-mode-open"
+                checked={form.failureMode === 'open'}
+                onChange={() => setForm(f => ({ ...f, failureMode: 'open' }))}
+                className="mt-1 w-4 h-4 accent-emerald-500"
+              />
+              <span>
+                <span className="font-medium text-white">Fail open</span>
+                <span className="text-gray-500"> (recommended for adults)</span>
+                <span className="block text-xs text-gray-400 mt-0.5">
+                  when the router can't reach the API, keep enforcing the last-known rules; never auto-block.
+                </span>
+              </span>
+            </label>
+          </div>
+        </div>
 
         <div>
           <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Blocked categories</label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,5 +1,7 @@
 // Mirrors familydns.shared Models.scala
 
+export type FailureMode = 'open' | 'closed'
+
 export interface Profile {
   id: number
   name: string
@@ -7,6 +9,7 @@ export interface Profile {
   extraBlocked: string[]
   extraAllowed: string[]
   paused: boolean
+  failureMode: FailureMode
 }
 
 export interface Schedule {
@@ -245,6 +248,7 @@ export interface UpsertProfileRequest {
   schedules: ScheduleRequest[]
   timeLimit: number | null
   siteTimeLimits: SiteTimeLimitRequest[]
+  failureMode: FailureMode
 }
 
 export interface UpsertDeviceRequest {


### PR DESCRIPTION
Closes #311. Implements the §4 design from #269 (resilience audit).

## Summary
- Adds `FailureMode { Open, Closed }` to `shared.Models`, on `Profile` and `PolicyProfile`, with lowercase JSON spelling so the lua agent can compare strings directly.
- API: V9 migration adds `profiles.failure_mode TEXT NOT NULL DEFAULT 'closed'` with a `CHECK` constraint. `ProfileRepo` reads/writes; routes accept an optional `failureMode` on `UpsertProfileRequest` (server default Closed on create; PUT preserves existing value when the request omits it). `PolicySnapshot` carries the field per profile and the ETag includes it.
- OpenWRT: `render.nft(snapshot, opts)` now accepts `opts.poll_age_seconds`. When `> 300`, every device MAC belonging to a Closed-failureMode profile lands in a `failover_drop` set with a forward-hook drop rule. Open profiles untouched. No emission when the set would be empty (the called-out edge case in #311). Drop-only for now — block-page DNAT (#303) reuse and main-loop wiring to `last_successful_poll_ts` (#309) are tracked in #323.
- Web: profile edit form has a radio control (Fail closed / Fail open) with the explanatory copy from §4. New-profile default is Closed (safe). Edit pre-fills from `pd.profile.failureMode`.

## Policy choices pinned by tests
- Server default when `failureMode` omitted = **Closed** (fail-safe).
- Failover threshold is **strict `> 300s`** — 300s is in-window, 301s triggers.
- Wire format is lowercase `"open"` / `"closed"`.
- Empty Closed profile → **no** rule emitted (no degenerate \`@empty_set drop\`).

## Test plan
- [x] `mill api.test` — 12/12 ProfileApiSpec (incl. 3 new failureMode tests), 3/3 new PolicySnapshotFailureModeSpec, full suite green.
- [x] `mill shared.test` green.
- [x] `cd openwrt && busted test/` — new `failover_spec.lua` (7 tests) green; `render_spec.lua` unchanged.
- [x] `cd web && vitest run` — 89/89, incl. 5 new failureMode tests for `ProfilesPage`.
- [x] `cd web && tsc --noEmit` clean.
- [ ] Manual: edit a profile in the UI, flip Closed→Open, save, verify it persists via `GET /api/profiles`.

## Coordination
- Depends on **#309** to fully activate at runtime — the agent main loop must compute `poll_age` from `last_successful_poll_ts` and pass it to `render.nft`. Until then the failover branch is dormant (no caller). Field, snapshot, and rendering are all tested today.
- **#303** (block-page DNAT) — once landed, the Closed-failover branch should DNAT HTTP/80 in addition to dropping. Marked with \`TODO(#323)\` in `render.lua`.
- **#321** (resilience audit) will re-verify the §4 transition behaviour end-to-end once #309 and #323 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)