### PR TITLE
openwrt: monotonic-clock scheduler (fixes #336)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/clock.lua
+++ b/openwrt/files/usr/lib/lua/familydns/clock.lua
@@ -1,0 +1,46 @@
+-- familydns.clock — monotonic-clock helper for scheduling math.
+--
+-- Rule of thumb when picking which time source to use:
+--   * Use clock.monotonic_seconds() for any "has X elapsed?" check
+--     (poll cadences, retry backoffs, cache TTL refreshes). The value
+--     never goes backward, so NTP corrections, DST shifts, or deliberate
+--     wall-clock manipulation cannot stall a timer (issue #336).
+--   * Use os.time() / os.date() for any "what is the wall-clock right now?"
+--     need: RFC3339 timestamps in API payloads, clock-skew comparisons vs
+--     the API's Date header (#312), and human-readable log timestamps.
+--
+-- The two time bases must not be mixed within a single diff: e.g. a
+-- `last_run` captured with monotonic_seconds() must only be compared
+-- against another monotonic_seconds() reading.
+--
+-- Backend selection: prefers luaposix's clock_gettime(CLOCK_MONOTONIC) when
+-- available (sub-second resolution); falls back to reading /proc/uptime
+-- (BusyBox-friendly, second-resolution on most kernels). On the rare system
+-- where neither is reachable, falls back to os.time() — at least preserves
+-- existing behavior rather than crashing.
+
+local M = {}
+
+local ok, posix_time = pcall(require, "posix.time")
+if ok and posix_time and posix_time.clock_gettime and posix_time.CLOCK_MONOTONIC then
+  M._backend = "posix"
+  function M.monotonic_seconds()
+    local ts = posix_time.clock_gettime(posix_time.CLOCK_MONOTONIC)
+    if type(ts) == "table" then
+      return (ts.tv_sec or 0) + (ts.tv_nsec or 0) / 1e9
+    end
+    return ts or os.time()
+  end
+else
+  M._backend = "uptime"
+  function M.monotonic_seconds()
+    local f = io.open("/proc/uptime", "r")
+    if not f then return os.time() end
+    local line = f:read("*l") or ""
+    f:close()
+    local up = tonumber(line:match("^(%S+)"))
+    return up or os.time()
+  end
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -173,9 +173,17 @@ end
 --
 -- flush_fn(events) is called with the list of accumulated events.
 -- ---------------------------------------------------------------------------
-function M.new_batcher(max_size, flush_interval_sec, flush_fn)
+-- now_fn is optional; defaults to a monotonic-clock source so interval-based
+-- flushes survive wall-clock jumps (#336). Tests inject a fake to drive time
+-- deterministically.
+function M.new_batcher(max_size, flush_interval_sec, flush_fn, now_fn)
+  now_fn = now_fn or function()
+    local ok, clock = pcall(require, "familydns.clock")
+    if ok then return clock.monotonic_seconds() end
+    return os.time()
+  end
   local buf          = {}
-  local last_flush   = os.time()
+  local last_flush   = now_fn()
 
   local self = {}
 
@@ -194,7 +202,7 @@ function M.new_batcher(max_size, flush_interval_sec, flush_fn)
   end
 
   function self.tick(now)
-    now = now or os.time()
+    now = now or now_fn()
     if (now - last_flush) >= flush_interval_sec then
       last_flush = now
       self.flush()

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -276,7 +276,14 @@ end
 
 function M.poll_age_seconds(now)
   if not M.last_successful_poll_ts then return math.huge end
-  return now - M.last_successful_poll_ts
+  -- Both args are wall-clock (os.time()). A backward wall-clock jump (NTP
+  -- correction, DST, manual change) can momentarily make `now` smaller than
+  -- the stored timestamp; clamp to 0 so callers don't see a negative age
+  -- (defensive bandage for #336). The scheduler proper runs on a monotonic
+  -- clock and is not affected.
+  local age = now - M.last_successful_poll_ts
+  if age < 0 then return 0 end
+  return age
 end
 
 -- Test-only: reset module-level poll state between specs.

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -19,6 +19,7 @@ local conntrack = require("familydns.conntrack")
 local render   = require("familydns.render")
 local dns_log  = require("familydns.dns_log")
 local log      = require("familydns.log")
+local clock    = require("familydns.clock")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -224,6 +225,13 @@ do
   end
 end
 
+-- Wall-clock anchor for usage report periodStart. Updated each time the usage
+-- timer fires; kept on os.time() because the API expects RFC3339 UTC, not a
+-- monotonic value. The "should this timer fire?" decision is monotonic
+-- (last_usage_run, below); the "what time range does this report cover?"
+-- decision is wall-clock (this).
+local last_usage_wall_ts = os.time()
+
 do
   log.debug("startup: initial policy fetch")
   local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
@@ -238,9 +246,12 @@ do
   else
     log.warn("startup: initial policy fetch returned no snapshot (will retry on timer)")
   end
-  last_policy_run        = os.time()
-  last_usage_run         = os.time()
-  last_activity_sample   = os.time()
+  -- Scheduler timers use the monotonic clock so backward wall-clock jumps
+  -- (NTP correction, DST, deliberate manipulation) can't stall polling — #336.
+  local mono = clock.monotonic_seconds()
+  last_policy_run        = mono
+  last_usage_run         = mono
+  last_activity_sample   = mono
 end
 
 -- Snapshot nft counters for the activity tracker.  Cheap (same JSON we'd
@@ -275,13 +286,16 @@ local dns_cache_tbl  = {}
 local dns_cache_load = 0
 
 local function lookup_hostname(dst_ip)
-  local now = os.time()
-  if (now - dns_cache_load) >= 1 then
-    dns_cache_load = now
+  -- Monotonic for the "has 1s elapsed?" gate (#336); wall-clock for the
+  -- dns_log freshness check, which compares against wall-clock TTLs stored
+  -- alongside each cached entry.
+  local mono = clock.monotonic_seconds()
+  if (mono - dns_cache_load) >= 1 then
+    dns_cache_load = mono
     local f = io.open(dns_cache_path, "r")
     if f then
       local text = f:read("*a") or ""
-      dns_cache_tbl = dns_log.load_table(text, dns_cache_ttl, now)
+      dns_cache_tbl = dns_log.load_table(text, dns_cache_ttl, os.time())
       f:close()
     end
   end
@@ -305,35 +319,39 @@ conntrack.watch({
   -- Called on every conntrack line (after event processing).
   -- Drives the policy and usage timers co-operatively.
   on_tick = function()
-    local now = os.time()
+    -- `mono` drives scheduling math (#336: immune to wall-clock jumps).
+    -- `wall` is only used where the API or operator needs UTC (RFC3339
+    -- timestamps, mark_poll_success for human-readable poll_age display).
+    local mono = clock.monotonic_seconds()
+    local wall = os.time()
 
     -- Policy timer
-    if (now - last_policy_run) >= policy_int then
-      last_policy_run = now
+    if (mono - last_policy_run) >= policy_int then
+      last_policy_run = mono
       local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log)
       if snap then
         if policy.apply(snap, write_file, run_cmd, log) then
           render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
           current_etag = etag
-          policy.mark_poll_success(now)
+          policy.mark_poll_success(wall)
           policy.save_snapshot(snap, write_file, rename_file, log)
           log.debug("policy timer: applied snapshot etag=%s", tostring(etag))
         end
       elseif etag then
         current_etag = etag  -- 304: just update etag
-        policy.mark_poll_success(now)  -- 304 still counts as a successful poll
+        policy.mark_poll_success(wall)  -- 304 still counts as a successful poll
         log.debug("policy timer: 304 not modified etag=%s poll_age=%ds",
-                  tostring(etag), policy.poll_age_seconds(now))
+                  tostring(etag), policy.poll_age_seconds(wall))
       else
-        log.debug("policy timer: fetch failed poll_age=%ds", policy.poll_age_seconds(now))
+        log.debug("policy timer: fetch failed poll_age=%ds", policy.poll_age_seconds(wall))
       end
     end
 
     -- Activity sampler (#295): every 60 s, snapshot counters and feed them
     -- to the tracker so end-of-bucket activeSeconds reflects real per-minute
     -- usage rather than collapsing to {0, 300}.
-    if (now - last_activity_sample) >= activity_sample_int then
-      last_activity_sample = now
+    if (mono - last_activity_sample) >= activity_sample_int then
+      last_activity_sample = mono
       local counters = read_nft_counters()
       if counters then
         usage.tracker_sample(activity_tracker, counters)
@@ -341,10 +359,12 @@ conntrack.watch({
     end
 
     -- Usage timer
-    if (now - last_usage_run) >= usage_int then
-      local period_end   = os.date("!%Y-%m-%dT%H:%M:%SZ", now)
-      local period_start = os.date("!%Y-%m-%dT%H:%M:%SZ", last_usage_run)
-      last_usage_run = now
+    if (mono - last_usage_run) >= usage_int then
+      -- periodStart/periodEnd are wall-clock RFC3339: the API expects UTC.
+      local period_end   = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
+      local period_start = os.date("!%Y-%m-%dT%H:%M:%SZ", last_usage_wall_ts)
+      last_usage_run     = mono
+      last_usage_wall_ts = wall
 
       -- Per-(mac,ip) counters live as element counters on the dynamic set
       -- `mac_ip_tracking` (see render.lua). After a successful POST we
@@ -354,14 +374,16 @@ conntrack.watch({
         -- Final per-minute sample at flush so set elements that appeared
         -- after the last 60s tick still get an active minute counted.
         usage.tracker_sample(activity_tracker, counters)
-        last_activity_sample = now
+        last_activity_sample = mono
         local report = usage.build_report(
           counters, nft_sets, period_start, period_end, router_id,
           nil, lookup_hostname, activity_tracker, policy.clock_skew())
         log.debug("usage timer: %d counter(s), %d record(s) prepared",
                   #counters, report.records and #report.records or 0)
+        -- Retry queue's next_attempt_at math runs on the monotonic clock so
+        -- a backward wall-clock jump can't freeze the drain (#336).
         local posted = usage.post_with_retry(
-          api_url, router_token, report, http_post, usage_queue, now, nil, log)
+          api_url, router_token, report, http_post, usage_queue, mono, nil, log)
         -- Reset counters and tracker regardless of post outcome: the report
         -- is now owned by the retry queue (or already sent), so leaving the
         -- nft counters intact would double-count on the next bucket.
@@ -374,9 +396,9 @@ conntrack.watch({
       end
     end
 
-    -- Drain any retry-queued buckets whose backoff has elapsed.
+    -- Drain any retry-queued buckets whose backoff has elapsed (monotonic now).
     if #usage_queue.buckets > 0 then
-      usage.drain(api_url, router_token, usage_queue, http_post, now, nil, log)
+      usage.drain(api_url, router_token, usage_queue, http_post, mono, nil, log)
     end
   end,
 })

--- a/openwrt/test/clock_spec.lua
+++ b/openwrt/test/clock_spec.lua
@@ -1,0 +1,202 @@
+-- Tests for openwrt/files/usr/lib/lua/familydns/clock.lua
+-- Run with: cd openwrt && busted test/clock_spec.lua
+--
+-- The module picks its backend at require time, so we don't try to test the
+-- branch selection in isolation here — we just verify that whichever backend
+-- was selected returns a monotonically non-decreasing reading and that the
+-- /proc/uptime fallback parses correctly when forced.
+
+describe("clock module", function()
+
+  it("monotonic_seconds returns a positive number", function()
+    package.loaded["clock"] = nil
+    package.loaded["familydns.clock"] = nil
+    local clock = require("clock")
+    local t = clock.monotonic_seconds()
+    assert.is_number(t)
+    assert.is_true(t > 0)
+  end)
+
+  it("two successive readings are non-decreasing", function()
+    package.loaded["clock"] = nil
+    local clock = require("clock")
+    local a = clock.monotonic_seconds()
+    local b = clock.monotonic_seconds()
+    assert.is_true(b >= a, "expected b (" .. b .. ") >= a (" .. a .. ")")
+  end)
+
+  it("is independent of os.time() — wall-clock jumps don't move it", function()
+    package.loaded["clock"] = nil
+    package.loaded["familydns.clock"] = nil
+    local clock = require("clock")
+    -- Skip on systems where no real monotonic source is available (e.g.
+    -- macOS dev box without luaposix and without /proc/uptime); the module
+    -- explicitly falls back to os.time() as a last resort and this property
+    -- can't hold. CI runs on Linux where /proc/uptime is always present.
+    local uptime_available = io.open("/proc/uptime", "r")
+    if uptime_available then uptime_available:close() end
+    if clock._backend ~= "posix" and not uptime_available then
+      return  -- environment lacks a monotonic source; nothing to test
+    end
+
+    local original_time = os.time
+    local fake_now = 1700000000
+    _G.os.time = function() return fake_now end
+
+    local a = clock.monotonic_seconds()
+    fake_now = fake_now - 1000  -- simulate backward wall-clock jump
+    local b = clock.monotonic_seconds()
+    _G.os.time = original_time
+
+    -- monotonic source must not have moved backward with the wall clock
+    assert.is_true(b >= a - 0.5,
+      "monotonic reading dropped from " .. a .. " to " .. b ..
+      " when os.time() was rolled back")
+  end)
+end)
+
+-- Force the /proc/uptime fallback by stubbing require("posix.time") to fail,
+-- then reloading the module. Verifies the BusyBox-friendly path parses the
+-- first float from /proc/uptime correctly.
+describe("clock /proc/uptime fallback", function()
+  it("returns the uptime float from /proc/uptime", function()
+    local original_require = _G.require
+    -- Make posix.time look unavailable so the module picks the fallback.
+    _G.require = function(name)
+      if name == "posix.time" then
+        error("simulated missing module: posix.time")
+      end
+      return original_require(name)
+    end
+    -- Drop the cached module so the backend branch re-evaluates.
+    package.loaded["clock"] = nil
+    package.loaded["familydns.clock"] = nil
+    local ok, clock = pcall(original_require, "clock")
+    _G.require = original_require
+    assert.is_true(ok, "clock module failed to load with posix.time absent")
+    assert.equal("uptime", clock._backend)
+
+    local original_open = io.open
+    _G.io.open = function(path, mode)
+      if path == "/proc/uptime" then
+        local s = "12345.67 99999.99\n"
+        local pos = 1
+        return {
+          read = function(self, fmt)
+            if pos > #s then return nil end
+            local out = s
+            pos = #s + 1
+            return out:gsub("\n$", "")
+          end,
+          close = function() end,
+        }
+      end
+      return original_open(path, mode)
+    end
+    local t = clock.monotonic_seconds()
+    _G.io.open = original_open
+    assert.equal(12345.67, t)
+  end)
+end)
+
+-- Regression test for #336: the on_tick scheduler arithmetic
+-- `(now - last_run) >= interval` must fire on monotonic cadence regardless
+-- of wall-clock jumps. The agent itself is a daemon script we can't import
+-- directly, so this verifies the underlying invariant the agent relies on.
+describe("scheduler arithmetic with monotonic clock (#336)", function()
+  local function should_fire(now, last_run, interval)
+    return (now - last_run) >= interval
+  end
+
+  it("forward-jump-then-back regression: monotonic timer fires on cadence", function()
+    -- Mirror the issue body's scenario but on a monotonic clock.
+    -- Agent startup sets last_run = mono (initial poll has just happened).
+    -- Subsequent polls must fire each time mono advances by `interval`,
+    -- independent of any wall-clock churn in between.
+    local interval = 60
+    local mono = 100      -- arbitrary monotonic origin
+    local last_run = mono -- agent just polled at startup
+
+    -- Immediately after startup, no fire.
+    assert.is_false(should_fire(mono, last_run, interval))
+
+    -- 59s elapsed monotonically — still not time.
+    mono = mono + 59
+    assert.is_false(should_fire(mono, last_run, interval))
+
+    -- 60s elapsed monotonically — fires. During this stretch, wall-clock
+    -- might have jumped forward 900s and then snapped back; neither event
+    -- touches `mono`, so the fire decision is unchanged.
+    mono = mono + 1
+    assert.is_true(should_fire(mono, last_run, interval),
+      "second poll must fire on monotonic cadence regardless of wall-clock churn")
+    last_run = mono
+
+    -- next poll lands 60s later, on the dot.
+    mono = mono + 60
+    assert.is_true(should_fire(mono, last_run, interval))
+  end)
+
+  it("forward wall-clock jump on monotonic clock does NOT double-fire", function()
+    local interval = 60
+    local mono = 0
+    local last_run = 0
+
+    -- Pretend wall-clock jumped forward 900s; since we track monotonic,
+    -- only 1s actually passed.
+    mono = mono + 1
+    assert.is_false(should_fire(mono, last_run, interval),
+      "scheduler must not fire just because wall-clock moved — monotonic only +1s")
+  end)
+end)
+
+describe("policy.poll_age_seconds clamp (#336 defensive bandage)", function()
+  it("clamps to 0 when wall-clock jumped backward past last_successful_poll_ts", function()
+    package.loaded["policy"] = nil
+    package.loaded["familydns.policy"] = nil
+    local policy = require("policy")
+    policy.reset_poll_state()
+    policy.mark_poll_success(1000)
+    -- now < last_successful_poll_ts can happen after an NTP correction
+    assert.equal(0, policy.poll_age_seconds(900))
+    -- normal case still works
+    assert.equal(50, policy.poll_age_seconds(1050))
+    policy.reset_poll_state()
+  end)
+end)
+
+describe("usage retry queue with monotonic now (#336)", function()
+  -- The retry queue is internally consistent: it stores `next_attempt_at`
+  -- against whatever `now` value the caller passes, and `drain` compares
+  -- against the same source. As long as the agent always passes monotonic
+  -- now, the queue is jump-safe. Verify this property end-to-end.
+  it("backoff fires on monotonic cadence even after wall-clock would have stalled", function()
+    package.loaded["usage"] = nil
+    package.loaded["familydns.usage"] = nil
+    local usage = require("usage")
+    local q = usage.new_queue()
+    local mono = 1000
+    local rng = function() return 0.5 end  -- deterministic jitter
+
+    -- enqueue a failed bucket at mono=1000
+    local report = { periodEnd = "2025-01-01T00:00:00Z", records = { { foo = 1 } } }
+    local failing_post = function() return 500, "oops", nil end
+    local ok = usage.post_with_retry(
+      "http://api", "tok", report, failing_post, q, mono, rng, nil)
+    assert.is_false(ok)
+    assert.equal(1, #q.buckets)
+    local scheduled = q.buckets[1].next_attempt_at
+    assert.is_true(scheduled > mono,
+      "next_attempt_at must be in the (monotonic) future")
+
+    -- Pretend wall-clock jumped backward 10000s; monotonic only advanced
+    -- to `scheduled`. The drain compares against monotonic now, so the
+    -- bucket should fire.
+    local drained = false
+    local good_post = function() drained = true; return 200, "ok", nil end
+    usage.drain("http://api", "tok", q, good_post, scheduled, rng, nil)
+    assert.is_true(drained,
+      "drain must fire when monotonic now >= scheduled, regardless of wall-clock")
+    assert.equal(0, #q.buckets)
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -13,6 +13,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/familydns/?.lua;./test/s
          test/render_spec.lua \
          test/policy_spec.lua \
          test/usage_spec.lua \
+         test/clock_spec.lua \
          "$@"
 
 echo ""


### PR DESCRIPTION
## Summary
- Switch the OpenWRT agent's `on_tick` scheduler (policy poll, usage report, activity sampler) to a monotonic clock so backward wall-clock jumps (NTP correction, DST, deliberate manipulation) can no longer stall polling. Reproduces the exact #321 Scenario 5 failure.
- New `familydns.clock` module: prefers `posix.clock_gettime(CLOCK_MONOTONIC)`, falls back to `/proc/uptime` (BusyBox-friendly, no new package dep), final fallback to `os.time()` if neither exists.
- Wall-clock paths preserved where the API or operator actually needs UTC: RFC3339 timestamps in usage reports, the #312 skew-vs-API-Date check, and `policy.mark_poll_success` for the `poll_age` debug display.
- Defensive bandage: `policy.poll_age_seconds` clamps negative diffs to 0 so any remaining wall-clock code paths can't surface a negative age in logs.

## Changes
- `openwrt/files/usr/lib/lua/familydns/clock.lua` — new monotonic-clock helper with module-level docstring spelling out the use-it-here-not-there rule.
- `openwrt/files/usr/sbin/familydns-agent` — `last_policy_run`, `last_usage_run`, `last_activity_sample`, `dns_cache_load`, and the usage retry queue's `next_attempt_at` math now run on `clock.monotonic_seconds()`. Periods for the usage report use a separate `last_usage_wall_ts` so RFC3339 boundaries stay accurate.
- `openwrt/files/usr/lib/lua/familydns/conntrack.lua` — batcher's flush-interval timer same treatment; `new_batcher` accepts an optional `now_fn` for tests.
- `openwrt/files/usr/lib/lua/familydns/policy.lua` — `poll_age_seconds` clamps negatives to 0.
- `openwrt/test/clock_spec.lua` — unit tests for the clock helper (both backends), the `(now - last_run) >= interval` scheduler invariant under the issue-body scenario, the wall-clock-rollback clamp, and end-to-end coverage that the usage retry queue's monotonic-now flow fires through a wall-clock rollback.

## Cross-refs
- Fixes #336.
- Sibling clock-handling in the same module: #312 (skew detection — preserved on wall-clock by design), #334 (DST math — orthogonal).
- Found during the #321 resilience audit (Scenario 5).

## Test plan
- [x] `cd openwrt && busted test/conntrack_spec.lua test/render_spec.lua test/policy_spec.lua test/usage_spec.lua test/clock_spec.lua` — 177 pass / 1 pending (pre-existing `nft`-binary-required test).
- [ ] Hardware repro: deploy to the OpenWRT test router, `date -s '+15 minutes'`, wait, `ntpd -nq`, observe `logread -f` — policy/usage polls should continue firing on ~60s/300s cadence through the snap-back. (Cannot run from this worktree; will validate on hardware before merge.)
- [ ] Verify the #312 skew banner still fires after the same maneuver — confirms wall-clock paths weren't accidentally converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)