### PR TITLE
openwrt: dnsmasq restart (not reload) on policy apply (fixes #328)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -6,10 +6,17 @@
 --     http_get_fn(url, headers) → status_code, body, response_headers
 --     Returns (nil, etag) on 304, (nil, nil) on error, (snapshot, etag) on 200.
 --
---   policy.apply(snapshot, write_fn, reload_fn)
+--   policy.apply(snapshot, write_fn, reload_fn, log, dns_check_fn)
 --     → bool (true on success)
 --     write_fn(path, content) → ok, err
 --     reload_fn(cmd)          → exit_code
+--     dns_check_fn(domain)    → string|nil (optional; result of resolving
+--                               `domain` via the router's own resolver — used
+--                               by the #328 smoke probe to detect a dnsmasq
+--                               reload that silently no-op'd. Nil/empty/
+--                               "0.0.0.0"/"::" mean sinkholed (OK); anything
+--                               else triggers a WARN log. Defaults to a
+--                               `dig @127.0.0.1` shell call.)
 
 local M = {}
 
@@ -181,7 +188,45 @@ end
 -- ---------------------------------------------------------------------------
 -- write_fn(path, content) must return (truthy, nil) on success or (nil, err_string).
 -- reload_fn(cmd) is called with a shell command string; return value is ignored.
-function M.apply(snapshot, write_fn, reload_fn, log)
+--
+-- dns_check_fn is optional. When the rendered dnsmasq.conf contains at least
+-- one `address=/<domain>/#` line, we probe the first such domain via the
+-- router's own resolver after the dnsmasq restart and WARN if it doesn't
+-- look sinkholed (#328 — detects the silent no-op when dnsmasq fails to
+-- restart, or when conf-dir wasn't actually re-read).
+
+-- Default smoke probe: `dig @127.0.0.1` and return the first line of stdout.
+local function default_dns_check(domain)
+  local cmd = string.format(
+    "dig @127.0.0.1 -p 53 %s +short +time=2 +tries=1 2>/dev/null",
+    domain)
+  local f = io.popen(cmd, "r")
+  if not f then return nil end
+  local out = f:read("*l")
+  f:close()
+  return out
+end
+
+local SINKHOLE_RESULTS = {
+  ["0.0.0.0"] = true,
+  ["::"]      = true,
+  ["::0"]     = true,
+}
+
+local function looks_sinkholed(result)
+  if result == nil or result == "" then return true end
+  return SINKHOLE_RESULTS[result] == true
+end
+
+-- Extract the first `address=/<domain>/#` line from the rendered dnsmasq
+-- content. Returns nil if there are no such lines (e.g. no extraBlocked
+-- entries in any profile).
+local function first_blocked_domain(dnsmasq_content)
+  return dnsmasq_content:match("\naddress=/([^/\n]+)/#")
+      or dnsmasq_content:match("^address=/([^/\n]+)/#")
+end
+
+function M.apply(snapshot, write_fn, reload_fn, log, dns_check_fn)
   log = log or default_log()
   local dnsmasq_content = render.dnsmasq(snapshot)
   local nft_content     = render.nft(snapshot)
@@ -198,13 +243,29 @@ function M.apply(snapshot, write_fn, reload_fn, log)
     return false
   end
 
-  log.debug("policy.apply: wrote dnsmasq=%dB nft=%dB; reloading",
+  log.debug("policy.apply: wrote dnsmasq=%dB nft=%dB; restarting",
             #dnsmasq_content, #nft_content)
-  reload_fn("/etc/init.d/dnsmasq reload")
+  -- #328: must be `restart`, not `reload`. SIGHUP doesn't re-read conf-dir,
+  -- so `reload` leaves new address=/, dhcp-host=, and ipset= directives
+  -- silently inactive until something else restarts the service.
+  reload_fn("/etc/init.d/dnsmasq restart")
   -- Single atomic `nft -f`. The rendered file's prelude removes both the
   -- boot default-deny skeleton (table inet familydns_boot — #308) and any
   -- prior runtime table in one transaction, then installs the new ruleset.
   reload_fn("nft -f /tmp/nftables.d/familydns.nft")
+
+  -- #328 smoke probe. Skip cleanly when there's nothing to probe.
+  local probe_domain = first_blocked_domain(dnsmasq_content)
+  if probe_domain then
+    local check = dns_check_fn or default_dns_check
+    local result = check(probe_domain)
+    if not looks_sinkholed(result) then
+      log.warn(
+        "policy.apply: smoke check failed; dnsmasq may not have restarted — " ..
+        "got %q for %s (expected sinkhole)",
+        tostring(result), probe_domain)
+    end
+  end
 
   return true
 end

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -297,16 +297,24 @@ describe("policy.apply", function()
     assert.truthy(writes["/tmp/nftables.d/familydns.nft"])
   end)
 
-  it("calls a dnsmasq reload command after writing", function()
+  -- #328: SIGHUP doesn't re-read conf-dir, so a `reload` leaves the new
+  -- /tmp/dnsmasq.d/familydns.conf entries silently inactive until something
+  -- else restarts dnsmasq. We must `restart` to pick up address=/, dhcp-host=,
+  -- and ipset= directives.
+  it("calls `/etc/init.d/dnsmasq restart` (not reload) after writing (#328)", function()
     local reloads = {}
     policy.apply(decode_snap(),
       function(_path, _content) return true, nil end,
       function(cmd) table.insert(reloads, cmd); return 0 end)
-    local found = false
+    local found_restart, found_reload = false, false
     for _, cmd in ipairs(reloads) do
-      if cmd:find("dnsmasq") then found = true end
+      if cmd == "/etc/init.d/dnsmasq restart" then found_restart = true end
+      if cmd == "/etc/init.d/dnsmasq reload"  then found_reload  = true end
     end
-    assert.is_true(found, "expected a dnsmasq reload command")
+    assert.is_true(found_restart,
+      "expected `/etc/init.d/dnsmasq restart`; got: " .. table.concat(reloads, " | "))
+    assert.is_false(found_reload,
+      "must not use `reload` — SIGHUP doesn't re-read conf-dir (#328)")
   end)
 
   it("calls an nft reload command after writing", function()
@@ -389,6 +397,129 @@ describe("policy.apply", function()
       function(_path, _content) return nil, "io error" end,
       function(_cmd) return 0 end)
     assert.is_false(ok)
+  end)
+
+  -- ── #328 smoke check: confirm dnsmasq actually picked up the new policy ──
+  --
+  -- The snapshot uses camelCase keys (the API's wire format — render.lua reads
+  -- `extraBlocked` directly). The canonical SNAPSHOT_JSON above uses snake_case
+  -- for historical fetch-test reasons, so render() emits no address= lines from
+  -- it; we need a camelCase snapshot to exercise the smoke probe path.
+  local SMOKE_SNAPSHOT_JSON = [[{
+    "etag": "sha256:smoke",
+    "devices": [{ "mac": "aa:bb:cc:11:22:33", "profileId": 3, "name": "k" }],
+    "profiles": [{
+      "id": 3, "name": "kids", "paused": false,
+      "extraBlocked": ["badsite.example.com"],
+      "extraAllowed": [], "schedules": [], "siteLimits": [],
+      "dailyMinutes": 120,
+      "timeUsedToday": { "totalMinutes": 0, "byDomain": {} },
+      "extensionsTodayMinutes": 0
+    }],
+    "blockedMacs": []
+  }]]
+
+  local function decode_smoke()
+    local json = require("cjson")
+    return json.decode(SMOKE_SNAPSHOT_JSON)
+  end
+
+  local function capture_log()
+    local warns, infos = {}, {}
+    return {
+      info  = function(fmt, ...) infos[#infos+1] = string.format(fmt, ...) end,
+      err   = function() end,
+      warn  = function(fmt, ...) warns[#warns+1] = string.format(fmt, ...) end,
+      debug = function() end,
+    }, warns, infos
+  end
+
+  it("invokes dns_check_fn with a blocked domain after the restart (#328)", function()
+    local probed
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      nil,
+      function(domain) probed = domain; return "0.0.0.0" end)
+    assert.equal("badsite.example.com", probed)
+  end)
+
+  it("logs a warning when dns_check_fn returns a non-sinkhole result (#328)", function()
+    local stub_log, warns = capture_log()
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      stub_log,
+      function(_domain) return "93.184.216.34" end)
+    local matched = false
+    for _, w in ipairs(warns) do
+      if w:find("smoke", 1, true) and w:find("93.184.216.34", 1, true) then
+        matched = true
+      end
+    end
+    assert.is_true(matched,
+      "expected a smoke-check warning mentioning the non-sinkhole IP; got: " ..
+      table.concat(warns, " | "))
+  end)
+
+  it("does NOT warn when dns_check_fn returns 0.0.0.0 (sinkhole)", function()
+    local stub_log, warns = capture_log()
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      stub_log,
+      function(_d) return "0.0.0.0" end)
+    for _, w in ipairs(warns) do
+      assert.is_nil(w:find("smoke", 1, true),
+        "unexpected smoke-check warning: " .. w)
+    end
+  end)
+
+  it("does NOT warn when dns_check_fn returns empty (NXDOMAIN)", function()
+    local stub_log, warns = capture_log()
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      stub_log,
+      function(_d) return "" end)
+    for _, w in ipairs(warns) do
+      assert.is_nil(w:find("smoke", 1, true))
+    end
+  end)
+
+  it("does NOT warn when dns_check_fn returns nil", function()
+    local stub_log, warns = capture_log()
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      stub_log,
+      function(_d) return nil end)
+    for _, w in ipairs(warns) do
+      assert.is_nil(w:find("smoke", 1, true))
+    end
+  end)
+
+  it("skips dns_check_fn when the snapshot has no extraBlocked entries (#328)", function()
+    local called = false
+    -- Use the canonical SNAPSHOT_JSON: with snake_case keys render emits no
+    -- address= lines, so the probe path should not fire.
+    policy.apply(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      nil,
+      function(_d) called = true; return "0.0.0.0" end)
+    assert.is_false(called,
+      "dns_check_fn should not be called when no address=/.../# lines were rendered")
+  end)
+
+  it("still returns true when dns_check_fn reports a non-sinkhole result (#328)", function()
+    local ok = policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      nil,
+      function(_d) return "93.184.216.34" end)
+    assert.is_true(ok,
+      "smoke-check failure must not fail the apply — propagation is a separate concern")
   end)
 
 end)


### PR DESCRIPTION
## Summary

- `/etc/init.d/dnsmasq reload` sends SIGHUP, which only re-reads addn-hosts / hostsdir / dhcp-hostsfile — **not** conf-file or conf-dir. The rendered `/tmp/dnsmasq.d/familydns.conf` contains `address=/`, `dhcp-host=`, and `ipset=` directives that all require a full restart to take effect. Symptom: every extraBlocked / extraAllowed / blocklist change silently no-op'd until something else restarted dnsmasq (reboot, manual `/etc/init.d/dnsmasq restart`, OPKG upgrade).
- Switched to `restart`. The brief (~1-2s) DNS outage is acceptable: policy applies are infrequent (admin changes + periodic blocklist refresh), and Option B (hostsdir-based blocking) can't replace `ipset=`, which is a config-file-only directive — so there's no SIGHUP-friendly path without a deeper refactor.
- Added a post-restart smoke probe: pick the first `address=/<domain>/#` from the rendered conf, resolve via the router's own resolver, and `log.warn` (don't fail) if the response isn't sinkholed. Catches future regressions where dnsmasq silently fails to pick up changes. Injectable as a 5th `dns_check_fn` arg for tests; production uses `dig @127.0.0.1`.

Refs #321 (audit), #269.

Closes #328.

## Test plan

- [x] `busted test/policy_spec.lua` — 48/48 pass, including new tests asserting `restart` (not `reload`), and the smoke probe behavior (called with correct domain, warns on non-sinkhole, silent on `0.0.0.0`/`""`/`nil`, skipped when no `address=/` lines, never fails the apply).
- [x] Full lua test suite — 213/213 pass (1 pre-existing pending: `nft -c` skipped on macOS).
- [ ] Hardware verify: add an `extraBlocked` domain via admin UI; within one poll cycle, `dig @<router-ip> <blocked-domain>` returns `0.0.0.0` without manual restart.
- [ ] Hardware verify: agent log shows no smoke-check WARN under normal operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)