### PR TITLE
resilience: re-render failover chain when API outage > 5min (fixes #331, #323)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -6,17 +6,20 @@
 --     http_get_fn(url, headers) → status_code, body, response_headers
 --     Returns (nil, etag) on 304, (nil, nil) on error, (snapshot, etag) on 200.
 --
---   policy.apply(snapshot, write_fn, reload_fn, log, dns_check_fn)
+--   policy.apply(snapshot, write_fn, reload_fn, log, opts)
 --     → bool (true on success)
 --     write_fn(path, content) → ok, err
 --     reload_fn(cmd)          → exit_code
---     dns_check_fn(domain)    → string|nil (optional; result of resolving
---                               `domain` via the router's own resolver — used
---                               by the #328 smoke probe to detect a dnsmasq
---                               reload that silently no-op'd. Nil/empty/
---                               "0.0.0.0"/"::" mean sinkholed (OK); anything
---                               else triggers a WARN log. Defaults to a
---                               `dig @127.0.0.1` shell call.)
+--     opts (optional table)   → bag of options. Recognised keys:
+--       opts.dns_check_fn(domain) → string|nil — result of resolving `domain`
+--                                   via the router's own resolver, used by
+--                                   the #328 smoke probe to detect a dnsmasq
+--                                   restart that silently no-op'd. Nil/empty/
+--                                   "0.0.0.0"/"::" mean sinkholed (OK);
+--                                   anything else triggers a WARN. Defaults
+--                                   to a `dig @127.0.0.1` shell call.
+--       opts.poll_age_seconds → forwarded to render.nft for the #311 / #331
+--                                 failover branch.
 
 local M = {}
 
@@ -189,11 +192,13 @@ end
 -- write_fn(path, content) must return (truthy, nil) on success or (nil, err_string).
 -- reload_fn(cmd) is called with a shell command string; return value is ignored.
 --
--- dns_check_fn is optional. When the rendered dnsmasq.conf contains at least
--- one `address=/<domain>/#` line, we probe the first such domain via the
--- router's own resolver after the dnsmasq restart and WARN if it doesn't
--- look sinkholed (#328 — detects the silent no-op when dnsmasq fails to
--- restart, or when conf-dir wasn't actually re-read).
+-- opts is an optional table. opts.dns_check_fn (#328): when the rendered
+-- dnsmasq.conf contains at least one `address=/<domain>/#` line, we probe
+-- the first such domain via the router's own resolver after the dnsmasq
+-- restart and WARN if it doesn't look sinkholed (detects the silent no-op
+-- when dnsmasq fails to restart, or when conf-dir wasn't actually re-read).
+-- opts.poll_age_seconds (#331): forwarded to render.nft so the agent's
+-- failover-edge re-render can request the closed-mode drop chain.
 
 -- Default smoke probe: `dig @127.0.0.1` and return the first line of stdout.
 local function default_dns_check(domain)
@@ -226,10 +231,11 @@ local function first_blocked_domain(dnsmasq_content)
       or dnsmasq_content:match("^address=/([^/\n]+)/#")
 end
 
-function M.apply(snapshot, write_fn, reload_fn, log, dns_check_fn)
+function M.apply(snapshot, write_fn, reload_fn, log, opts)
   log = log or default_log()
+  opts = opts or {}
   local dnsmasq_content = render.dnsmasq(snapshot)
-  local nft_content     = render.nft(snapshot)
+  local nft_content     = render.nft(snapshot, opts)
 
   local ok1, err1 = write_fn("/tmp/dnsmasq.d/familydns.conf", dnsmasq_content)
   if not ok1 then
@@ -257,7 +263,7 @@ function M.apply(snapshot, write_fn, reload_fn, log, dns_check_fn)
   -- #328 smoke probe. Skip cleanly when there's nothing to probe.
   local probe_domain = first_blocked_domain(dnsmasq_content)
   if probe_domain then
-    local check = dns_check_fn or default_dns_check
+    local check = opts.dns_check_fn or default_dns_check
     local result = check(probe_domain)
     if not looks_sinkholed(result) then
       log.warn(
@@ -350,6 +356,37 @@ end
 -- Test-only: reset module-level poll state between specs.
 function M.reset_poll_state()
   M.last_successful_poll_ts = nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Failover transition decision (#331). Pure function so the agent's on_tick
+-- can stay thin and the boundary behavior is unit-testable.
+--
+-- Inputs:
+--   in_failover : bool  — was the last apply rendered with failover opts?
+--   fetch_ok    : bool  — did this tick's poll succeed (200 or 304)?
+--   poll_age    : number — seconds since last_successful_poll_ts (computed
+--                          by caller; on success this is 0).
+-- Returns:
+--   should_apply       : bool — re-render is needed this tick
+--   apply_opts         : table|nil — opts to pass to policy.apply
+--   new_in_failover    : bool — updated state flag
+--
+-- The threshold matches docs/resilience.md §4 (and render.lua's
+-- `poll_age > 300` check): strictly greater than 5 minutes flips Closed
+-- profiles into drop-mode; any successful poll lifts it immediately.
+-- ---------------------------------------------------------------------------
+function M.failover_transition(in_failover, fetch_ok, poll_age)
+  if fetch_ok then
+    if in_failover then
+      return true, { poll_age_seconds = 0 }, false
+    end
+    return false, nil, false
+  end
+  if poll_age > 300 and not in_failover then
+    return true, { poll_age_seconds = poll_age }, true
+  end
+  return false, nil, in_failover
 end
 
 return M

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -197,6 +197,14 @@ end
 -- ── Timer state ───────────────────────────────────────────────────────────────
 
 local current_etag        = nil
+-- #331: tracks the most recently applied snapshot so we can re-render with
+-- failover opts when the API stays unreachable past the §4 5-minute window
+-- (without a fresh fetch we have no other snapshot to render from).
+local last_snapshot       = nil
+-- #331: whether the last apply emitted the failover chain. Used to dedupe
+-- re-renders while we sit in failover and to detect the recovery edge so we
+-- can apply a clean (non-failover) ruleset on the next successful poll.
+local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
 local last_activity_sample = 0
@@ -216,6 +224,7 @@ do
   if cached then
     if policy.apply(cached, write_file, run_cmd, log) then
       render.update_shared(cached, nft_sets, blocked_macs, blocked_reason)
+      last_snapshot = cached
       log.info("startup: applied cached policy from /etc/familydns/policy.json")
     else
       log.warn("startup: cached policy apply failed — staying on default-deny")
@@ -239,6 +248,7 @@ do
     if policy.apply(snap, write_file, run_cmd, log) then
       render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
       current_etag = etag
+      last_snapshot = snap
       policy.mark_poll_success(os.time())
       policy.save_snapshot(snap, write_file, rename_file, log)
       log.info("startup: applied initial policy etag=%s", tostring(etag))
@@ -329,21 +339,68 @@ conntrack.watch({
     if (mono - last_policy_run) >= policy_int then
       last_policy_run = mono
       local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log)
+      local fetch_ok
       if snap then
+        -- 200: apply with no failover opts. If we were in failover, this
+        -- apply already emits a clean ruleset (no failover chain), so we
+        -- just need to clear the flag below.
         if policy.apply(snap, write_file, run_cmd, log) then
           render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
           current_etag = etag
+          last_snapshot = snap
           policy.mark_poll_success(wall)
           policy.save_snapshot(snap, write_file, rename_file, log)
           log.debug("policy timer: applied snapshot etag=%s", tostring(etag))
+          fetch_ok = true
         end
       elseif etag then
         current_etag = etag  -- 304: just update etag
         policy.mark_poll_success(wall)  -- 304 still counts as a successful poll
         log.debug("policy timer: 304 not modified etag=%s poll_age=%ds",
                   tostring(etag), policy.poll_age_seconds(wall))
+        fetch_ok = true
       else
         log.debug("policy timer: fetch failed poll_age=%ds", policy.poll_age_seconds(wall))
+        fetch_ok = false
+      end
+
+      -- #331: failover transition. On the failure→failover edge we re-render
+      -- the cached snapshot with poll_age_seconds so render.lua emits the
+      -- failover_drop set + familydns_failover chain (#311). On the recovery
+      -- edge we re-render to clear those rules. A 200 already applied a
+      -- clean ruleset above, so we only need to flip the flag in that case;
+      -- a 304 needs an explicit re-apply to drop the failover chain.
+      if fetch_ok ~= nil then
+        local poll_age = policy.poll_age_seconds(wall)
+        local should_apply, fo_opts, new_in_failover =
+          policy.failover_transition(in_failover_render, fetch_ok, poll_age)
+        if should_apply and not snap and last_snapshot then
+          -- Recovery via 304, or entering failover. Re-render last_snapshot
+          -- with the computed opts. Skip if we have no cached snapshot at
+          -- all (cold boot during outage): the #308 boot skeleton stays in
+          -- effect and there's nothing useful we can render.
+          if policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts) then
+            if new_in_failover then
+              log.info("failover render: poll_age=%ds, applying failover chain for closed-mode profiles",
+                       poll_age)
+            else
+              log.info("failover lifted: applying fresh snapshot (poll_age=0)")
+            end
+          else
+            log.warn("failover transition: apply failed (in_failover=%s→%s)",
+                     tostring(in_failover_render), tostring(new_in_failover))
+            -- Don't flip the flag if the apply failed — we'll retry next tick.
+            new_in_failover = in_failover_render
+          end
+        elseif should_apply and not last_snapshot then
+          -- Cold boot during API outage with no cached snapshot. Boot
+          -- skeleton (#308) is still enforcing default-deny; nothing to
+          -- render. Don't flip the flag so we keep retrying on each tick.
+          log.warn("failover transition skipped: no cached snapshot (boot-skeleton default-deny still active, poll_age=%ds)",
+                   poll_age)
+          new_in_failover = in_failover_render
+        end
+        in_failover_render = new_in_failover
       end
     end
 

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -440,7 +440,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      function(domain) probed = domain; return "0.0.0.0" end)
+      { dns_check_fn = function(domain) probed = domain; return "0.0.0.0" end })
     assert.equal("badsite.example.com", probed)
   end)
 
@@ -450,7 +450,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      function(_domain) return "93.184.216.34" end)
+      { dns_check_fn = function(_domain) return "93.184.216.34" end })
     local matched = false
     for _, w in ipairs(warns) do
       if w:find("smoke", 1, true) and w:find("93.184.216.34", 1, true) then
@@ -468,7 +468,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      function(_d) return "0.0.0.0" end)
+      { dns_check_fn = function(_d) return "0.0.0.0" end })
     for _, w in ipairs(warns) do
       assert.is_nil(w:find("smoke", 1, true),
         "unexpected smoke-check warning: " .. w)
@@ -481,7 +481,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      function(_d) return "" end)
+      { dns_check_fn = function(_d) return "" end })
     for _, w in ipairs(warns) do
       assert.is_nil(w:find("smoke", 1, true))
     end
@@ -493,7 +493,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      function(_d) return nil end)
+      { dns_check_fn = function(_d) return nil end })
     for _, w in ipairs(warns) do
       assert.is_nil(w:find("smoke", 1, true))
     end
@@ -507,7 +507,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      function(_d) called = true; return "0.0.0.0" end)
+      { dns_check_fn = function(_d) called = true; return "0.0.0.0" end })
     assert.is_false(called,
       "dns_check_fn should not be called when no address=/.../# lines were rendered")
   end)
@@ -517,9 +517,125 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      function(_d) return "93.184.216.34" end)
+      { dns_check_fn = function(_d) return "93.184.216.34" end })
     assert.is_true(ok,
       "smoke-check failure must not fail the apply — propagation is a separate concern")
+  end)
+
+  -- #331: opts pass-through. Use an inline snapshot with an explicit
+  -- failureMode="closed" profile so render.lua's failover branch (which
+  -- gates on `prof.failureMode == "closed"`) actually fires.
+  local function snap_with_closed_profile()
+    return {
+      etag = "sha256:test",
+      defaultProfileId = 1,
+      devices = {
+        { mac = "aa:aa:aa:00:00:01", profileId = 1, name = "kid-A" },
+      },
+      profiles = {
+        { id = 1, name = "kids", paused = false, failureMode = "closed",
+          blockedCategories = {}, extraBlocked = {}, extraAllowed = {},
+          schedules = {}, dailyMinutes = 0, siteLimits = {},
+          timeUsedToday = { totalMinutes = 0, byDomain = {} },
+          extensionsTodayMinutes = 0 },
+      },
+      blockedMacs = {},
+    }
+  end
+
+  it("passes opts through to render.nft so failover branch fires (#331)", function()
+    local nft_content
+    policy.apply(snap_with_closed_profile(),
+      function(path, content)
+        if path:find("%.nft$") then nft_content = content end
+        return true, nil
+      end,
+      function(_cmd) return 0 end,
+      nil,
+      { poll_age_seconds = 301 })
+    assert.truthy(nft_content)
+    assert.truthy(nft_content:find("set failover_drop", 1, true),
+      "expected failover_drop set when opts.poll_age_seconds > 300")
+    assert.truthy(nft_content:find("familydns_failover", 1, true),
+      "expected familydns_failover chain when opts.poll_age_seconds > 300")
+    assert.truthy(nft_content:find("aa:aa:aa:00:00:01", 1, true),
+      "expected the Closed-profile device MAC inside the failover set")
+  end)
+
+  it("omitting opts leaves the failover branch unreached (#331 regression)", function()
+    local nft_content
+    policy.apply(snap_with_closed_profile(),
+      function(path, content)
+        if path:find("%.nft$") then nft_content = content end
+        return true, nil
+      end,
+      function(_cmd) return 0 end)
+    assert.truthy(nft_content)
+    assert.is_nil(nft_content:find("failover_drop", 1, true),
+      "no failover artifacts when opts omitted")
+  end)
+
+end)
+
+-- ── policy.failover_transition (#331) ─────────────────────────────────────
+
+describe("policy.failover_transition", function()
+
+  it("no-op when fetch succeeds and we were not in failover", function()
+    local should, opts, new = policy.failover_transition(false, true, 0)
+    assert.is_false(should)
+    assert.is_nil(opts)
+    assert.is_false(new)
+  end)
+
+  it("no-op when fetch fails but poll_age is within 5-min window", function()
+    local should, opts, new = policy.failover_transition(false, false, 60)
+    assert.is_false(should)
+    assert.is_nil(opts)
+    assert.is_false(new)
+  end)
+
+  it("triggers failover when fetch fails and poll_age > 300", function()
+    local should, opts, new = policy.failover_transition(false, false, 301)
+    assert.is_true(should)
+    assert.equal(301, opts.poll_age_seconds)
+    assert.is_true(new)
+  end)
+
+  it("does NOT re-trigger while already in failover (dedupe)", function()
+    local should, opts, new = policy.failover_transition(true, false, 500)
+    assert.is_false(should)
+    assert.is_nil(opts)
+    assert.is_true(new)
+  end)
+
+  it("lifts failover on successful fetch with opts.poll_age_seconds=0", function()
+    local should, opts, new = policy.failover_transition(true, true, 0)
+    assert.is_true(should)
+    assert.equal(0, opts.poll_age_seconds)
+    assert.is_false(new)
+  end)
+
+  it("boundary: poll_age=300 stays in-window; 301 trips failover", function()
+    local s300 = (select(1, policy.failover_transition(false, false, 300)))
+    local s301 = (select(1, policy.failover_transition(false, false, 301)))
+    assert.is_false(s300)
+    assert.is_true(s301)
+  end)
+
+  it("rapid recover + re-fail re-arms the transition", function()
+    -- t=295: fail, in_failover=false → no trip
+    local s1, _, nif1 = policy.failover_transition(false, false, 295)
+    assert.is_false(s1); assert.is_false(nif1)
+    -- t=296: success → no-op
+    local s2, _, nif2 = policy.failover_transition(nif1, true, 0)
+    assert.is_false(s2); assert.is_false(nif2)
+    -- t=356: fail with fresh 60s poll_age (last_successful was at 296) → no trip
+    local s3, _, nif3 = policy.failover_transition(nif2, false, 60)
+    assert.is_false(s3); assert.is_false(nif3)
+    -- much later, t=657: poll_age=361 → trip
+    local s4, opts4, nif4 = policy.failover_transition(nif3, false, 361)
+    assert.is_true(s4); assert.equal(361, opts4.poll_age_seconds); assert.is_true(nif4)
   end)
 
 end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -14,6 +14,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/familydns/?.lua;./test/s
          test/policy_spec.lua \
          test/usage_spec.lua \
          test/clock_spec.lua \
+         test/failover_spec.lua \
          "$@"
 
 echo ""


### PR DESCRIPTION
## Summary
- #311's §4 fail-closed-for-kids transition was dead code: `policy.apply` never forwarded poll-age opts to `render.nft`, and the agent's `on_tick` only logged on fetch failure. The render-time failover branch (drop forward traffic for every closed-mode profile's MACs) was unreachable.
- This wires it up end-to-end: `policy.apply` forwards `opts`, a new pure helper `policy.failover_transition` encodes the boundary/dedupe logic, and the agent retains `last_snapshot` + an `in_failover_render` flag so it re-renders the cached snapshot with `poll_age_seconds` on the trip edge and re-renders cleanly on recovery.
- Subsumes #323 (poll-timestamp / failover wire-up + DNAT TODO carried forward in `render.lua`).

## Test plan
- [x] `sh openwrt/test/run_tests.sh` — 185 busted + all shell specs green
- [x] New `policy.apply` opts pass-through tests (render-time failover fires when opts.poll_age_seconds > 300; absent when omitted)
- [x] New `policy.failover_transition` tests covering trip, dedupe, lift, the 300/301 boundary, and rapid recover + re-fail
- [x] `failover_spec.lua` now wired into `run_tests.sh` (was orphaned)
- [x] Hardware verification on test router (Scenario 2/4 of #321):
  - Pre-outage: no `failover_drop` set, no `familydns_failover` chain.
  - API stopped → agent climbs through `poll_age=60s..1361s`; closed-mode device lost forward connectivity (empirical drop confirms the failover chain installed).
  - API restarted → agent logged `failover lifted: applying fresh snapshot (poll_age=0)` on the next successful poll; `nft list table inet familydns` shows the failover chain + set fully removed.

## Edge cases handled
- Cold boot during outage with no cached snapshot: #308 boot skeleton stays in effect; agent logs and skips (doesn't crash).
- Closed profile with zero devices: render layer already emits no rule (covered by `failover_spec`).
- Dedupe: the boolean flag prevents repeated re-applies while sitting in failover.
- 200 success while in failover: the normal apply already emits a clean ruleset, so we only flip the flag.
- 304 success while in failover: explicit re-apply of `last_snapshot` with `poll_age_seconds=0` to remove the chain.

Closes #331. Subsumes #323.
Refs #311 (parent), #309 (poll-timestamp plumbing), #321 (audit), #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)