### PR TITLE
openwrt: dev-push-router.sh syncs full openwrt/files tree (fixes #306)

### DIFF
--- a/scripts/dev-push-router.sh
+++ b/scripts/dev-push-router.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Iterative dev loop for the OpenWRT agent: rsync the lua sources to the
+# Iterative dev loop for the OpenWRT agent: tar the source tree to the
 # router, restart the service, and (optionally) tail the system log.
 #
 # Usage:
@@ -8,25 +8,86 @@
 #   scripts/dev-push-router.sh logs             # just tail logread (no push)
 #   ROUTER=root@192.168.1.1 scripts/dev-push-router.sh
 #
-# This only syncs the Lua files under openwrt/files/usr/lib/lua/familydns/.
-# If you change init scripts, UCI defaults, or the C/nft side, do a full
-# package rebuild + install instead.
+# Syncs the whole openwrt/files/ tree to the router. A file at
+# openwrt/files/usr/sbin/familydns-agent lands at /usr/sbin/familydns-agent.
+# Executables under usr/sbin and init scripts under etc/init.d are chmod +x'd.
+#
+# Caveats — these still require a full package rebuild + install:
+#   - First install of init scripts in etc/init.d/ (enable/symlinks)
+#   - UCI defaults under etc/uci-defaults/ (only run once at install)
+#   - apk/ipk package layout / dependencies / C / nft components
+# Once installed, restarting the service picks up new lua + sbin scripts.
+#
+# /etc/config/familydns is per-router state and is NOT synced (excluded).
 
 set -euo pipefail
 
 ROUTER="${ROUTER:-root@192.168.1.1}"
-SRC="$(cd "$(dirname "$0")/.." && pwd)/openwrt/files/usr/lib/lua/familydns/"
-DST="/usr/lib/lua/familydns/"
+SRC="$(cd "$(dirname "$0")/.." && pwd)/openwrt/files/"
 
 cmd="${1:-push}"
 
+check_router() {
+  if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "$ROUTER" true 2>/dev/null; then
+    echo "ERROR: cannot reach $ROUTER (ssh failed)" >&2
+    exit 1
+  fi
+}
+
 push() {
-  echo "==> tar | ssh $SRC -> $ROUTER:$DST"
+  check_router
+  echo "==> tar | ssh $SRC -> $ROUTER:/"
   # BusyBox on OpenWRT has no rsync; pipe a tarball instead.
-  ( cd "$SRC" && tar -cf - --exclude='*.swp' . ) \
-    | ssh "$ROUTER" "mkdir -p '$DST' && tar -xf - -C '$DST'"
+  # Exclude /etc/config/familydns (per-router UCI state).
+  ( cd "$SRC" && tar -cf - \
+      --exclude='*.swp' \
+      --exclude='./etc/config/familydns' \
+      . ) \
+    | ssh "$ROUTER" "tar -xf - -C /"
+
+  echo "==> fix permissions on executables"
+  ssh "$ROUTER" '
+    for f in /usr/sbin/familydns-agent /usr/sbin/familydns-update /usr/sbin/familydns-dns-tail; do
+      [ -f "$f" ] && chmod +x "$f"
+    done
+    for f in /etc/init.d/familydns /etc/init.d/familydns-boot; do
+      [ -f "$f" ] && chmod +x "$f"
+    done
+    true
+  '
+
+  echo "==> parity check"
+  parity_check
+
   echo "==> restart familydns"
   ssh "$ROUTER" '/etc/init.d/familydns restart'
+}
+
+parity_check() {
+  local files=(
+    "usr/sbin/familydns-agent"
+    "usr/lib/lua/familydns/policy.lua"
+    "usr/lib/lua/familydns/render.lua"
+  )
+  local mismatch=0
+  for rel in "${files[@]}"; do
+    local local_sum remote_sum
+    if command -v sha256sum >/dev/null 2>&1; then
+      local_sum=$(sha256sum "$SRC$rel" | cut -d' ' -f1)
+    else
+      local_sum=$(shasum -a 256 "$SRC$rel" | cut -d' ' -f1)
+    fi
+    remote_sum=$(ssh "$ROUTER" "sha256sum '/$rel' 2>/dev/null | cut -d' ' -f1")
+    if [ "$local_sum" != "$remote_sum" ]; then
+      echo "  MISMATCH: /$rel (local=$local_sum remote=$remote_sum)" >&2
+      mismatch=1
+    fi
+  done
+  if [ "$mismatch" -ne 0 ]; then
+    echo "ERROR: parity check failed — router does not match source" >&2
+    exit 1
+  fi
+  echo "  ✓ agent + lua libs match source"
 }
 
 tail_logs() {


### PR DESCRIPTION
## Summary
- \`scripts/dev-push-router.sh push\` now syncs the entire \`openwrt/files/\` tree, so edits to \`/usr/sbin/familydns-agent\` (and any other path under the tree) actually reach the router. Previously only \`/usr/lib/lua/familydns/\` was synced, silently testing old agent code.
- Excludes \`/etc/config/familydns\` (per-router UCI state); chmods executables (agent + init scripts) after extraction.
- Adds a post-push sha256 parity check on the agent + key lua libs that fails noisily on mismatch.
- Adds a fail-fast ssh reachability check so an unreachable router exits cleanly instead of hanging.

Closes #306. Unblocks fast iteration on the resilience verification work (#331, #336) — without this, live-iteration loops on agent-script changes silently test stale code.

The script header documents what still requires a full package rebuild (first-install init-script enable, UCI defaults, apk/ipk layout, C/nft components).

## Test plan
- [x] Bash syntax check (\`bash -n\`)
- [x] Verified on live test router (root@192.168.1.1): pre-push sha256 differed; post-push sha256 of \`/usr/sbin/familydns-agent\`, \`policy.lua\`, \`render.lua\` all match source
- [x] Confirmed \`/usr/sbin/familydns-agent\` is +x on router post-push
- [x] Confirmed \`/etc/config/familydns\` UCI state preserved (api_url + lan_prefix unchanged after push)
- [x] Service restart succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)