### PR TITLE
docs: canonicalize enforcement model and policy snapshot shape (#350)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,83 @@
 
 This file provides context for AI coding agents (Claude, Copilot, Cursor, etc.) working on this codebase.
 
+## Architectural model — read this before working on anything
+
+These two truths are the canonical architecture. Code or docs that contradict
+them are bugs — fix or flag, do not propagate.
+
+**1. DNS is never the enforcement plane.** DNS always resolves. Blocking
+happens at the connection layer via nftables forward-drop on the gateway
+router. The block page is reached via HTTP DNAT for port 80, **not** via
+DNS sinkhole / NXDOMAIN / RPZ. dnsmasq is still used on the router for
+hostname attribution (forward-lookup ipset population so nftables can match
+on `(mac, dst ip ∈ resolved-hosts-for-this-mac)`), but it is not the
+enforcer.
+
+**2. The router agent is a dumb applier.** The API server ships a policy
+snapshot in which every decision is already pre-computed. After a one-time
+resolution step, the enforcement pipeline sees a `Map[MacAddress, BlockRules]`
+where `BlockRules` is:
+
+- `blocked: Boolean` — drop all forwarded traffic from this MAC. Covers
+  paused profile, out-of-schedule, daily-limit exceeded, manual block, and
+  any other "block right now" reason — **all evaluated server-side and
+  collapsed into this flag**. The router does not look at schedules, daily
+  minutes, or time-used-today.
+- `blockReason: Option[MacBlockReason]` — for block-page text only. Not
+  used for enforcement. `MacBlockReason` is a `sealed trait extends
+  BlockReason` whose cases are `Paused`, `Schedule`, `TimeLimit`, `Manual`
+  — the only reasons a whole-MAC block can come from `PolicyService`. Per-
+  flow drop reasons (host-block, category-block, ip-only-block) are emitted
+  by the router at drop time and never appear in the snapshot; they live
+  on `BlockReason` but not `MacBlockReason`, so the type system prevents
+  them from being assigned here.
+- `extraBlocked: List[Hostname]` — hosts blocked for this MAC. Enforced
+  via nftables drop on `(mac, dst ip ∈ ipset(host))`, where the ipset is
+  populated by dnsmasq's `--ipset=` callback at resolution time.
+- `extraAllowed: List[Hostname]` — hosts allowed for this MAC, including
+  as a carve-out when `blocked = true`.
+- `blocklistIds: List[BlocklistId]` — category lists that apply to this
+  MAC. Enforced via nftables ipset drop, **not** via RPZ or any DNS-layer
+  mechanism. The agent fetches each blocklist by URL (cached by version)
+  and resolves member hosts into a per-blocklist ipset on a periodic
+  cadence.
+- `blockIpOnly: Boolean` — drop forwarded traffic whose destination IP
+  was not resolved via our local DNS for this MAC. No allowlist carve-out:
+  if we cannot attribute the destination IP to a hostname, we cannot
+  evaluate the allowlist against it. Used to prevent DoH / hard-coded-IP
+  bypass.
+
+Profiles exist in the snapshot only as a wire-level dedup aid:
+`profiles: Map[ProfileId, BlockRules]`. Each device carries an optional
+`profileId` and an optional per-device `rules` override; the override, if
+present, **replaces** the profile rules entirely (it is not a merge). The
+agent resolves device → effective rules once at apply time, then enforcement
+is purely per-MAC. **The enforcement pipeline never sees profiles.**
+
+New policy concepts (a new schedule type, a new failover behaviour, a new
+category model) land in the API server's `PolicyService` and present to
+the router as one of the fields above. **Do not add decision logic — schedule
+evaluation, time accounting, category lookup, role-based defaults — to the
+router agent.**
+
+See [`docs/architecture.md`](docs/architecture.md) for the full snapshot
+shape, wire JSON examples, and the enforcement model.
+
+> **Implementation deviations as of May 2026.** Some code does not yet match
+> the model above; these are tracked follow-ups, not the canonical design:
+> `extraBlocked` is currently enforced via dnsmasq NXDOMAIN
+> (`address=/host/#`) and is global rather than per-MAC; category blocklists
+> are not yet applied on the router at all; `blockIpOnly` does not exist
+> yet; the snapshot still carries per-profile `schedules`, `dailyMinutes`,
+> `timeUsedToday`, `siteLimits`, `failureMode`, and `blockedCategories`
+> that should collapse into `blocked` / `extraBlocked` / `blocklistIds`
+> server-side. Treat the model above as the target. If you are working
+> in this area, link the relevant follow-up issue.
+
 ## What this project is
 
-FamilyDNS is a self-hosted parental control DNS server with per-device filtering, time limits, and a web dashboard. It runs on a Linux home server (Ubuntu) and replaces commercial products like Gryphon or TP-Link HomeShield.
+FamilyDNS is a self-hosted, network-level parental-control system with per-device filtering, time limits, and a web dashboard. The API runs on a Linux home server (Ubuntu) and replaces commercial products like Gryphon or TP-Link HomeShield; the enforcement agent runs on the gateway router (OpenWRT or OPNsense).
 
 ## Architecture
 
@@ -18,10 +92,10 @@ familydns/
 ```
 
 One JVM process runs in production:
-1. `api` — REST API on :8080, serves the React SPA, handles auth (JWT), owns the DB
+1. `api` — REST API on :8080, serves the React SPA, handles auth (JWT), owns the DB, runs `PolicyService` (the only place decision logic lives)
 
-DNS enforcement and per-device usage tracking run on the gateway router, not on the API host:
-- **OpenWRT** — the `openwrt/` Lua agent polls `/api/router/policy` and rewrites dnsmasq/nftables rules; reports usage via `/api/router/events` and `/api/router/usage`
+Connection-level enforcement and per-device usage tracking run on the gateway router, not on the API host (see the "Architectural model" callout at the top of this file for why):
+- **OpenWRT** — the `openwrt/` Lua agent polls `/api/router/policy` and rewrites nftables rules + a dnsmasq fragment used only for hostname attribution / ipset population; reports usage via `/api/router/events` and `/api/router/usage`
 - **OPNsense** — the `opnsense/` Python agent tails pflog and posts connection events
 
 Key API surface (under `/api/router/*` and `/api/blocklists/*`):
@@ -44,16 +118,29 @@ Key API surface (under `/api/router/*` and `/api/blocklists/*`):
 - **QueryLog** — every DNS query logged with device, profile, blocked status, reason.
 - **Location** — `home` or `vacation`. Stored on devices and logs. Both locations share profiles/devices but query logs are tagged so you can filter by house.
 
-## DNS blocking priority order
+## Policy decision pipeline (server-side, in `PolicyService`)
 
-1. Profile paused → block all
-2. Schedule active (bedtime etc.) → block all
-3. Domain in extra_allowed → allow (overrides everything below)
-4. Domain in extra_blocked → block
-5. Daily time limit reached (from TimeUsage) → block with reason `time_limit`
-6. Site-specific time limit reached for this domain → block with reason `site_time_limit`
-7. Domain in blocklist category → block with reason `category:X`
-8. Default → allow, forward to upstream CleanBrowsing DNS
+These steps happen **on the API server** when computing the snapshot — not on
+the router. They collapse into the per-MAC `BlockRules` fields described in
+the "Architectural model" callout above.
+
+Order matters because earlier conditions short-circuit:
+
+1. Profile paused → `blocked = true`, reason `Paused`
+2. Schedule active for current time → `blocked = true`, reason `Schedule`
+3. Daily time limit reached (`time_used_today >= daily_minutes + extensions_today`) → `blocked = true`, reason `TimeLimit`
+4. Per-site time limit reached for some domain → that domain added to `extraBlocked` for this MAC
+5. Manual admin block → `blocked = true`, reason `Manual`
+6. Profile / device `extraBlocked` hostnames → `extraBlocked` for this MAC
+7. Profile / device `extraAllowed` hostnames → `extraAllowed` for this MAC (carves out blocks above)
+8. Profile / device assigned categories → `blocklistIds` for this MAC
+9. `blockIpOnly` flag for the profile / device → set as-is
+
+The router never re-evaluates any of this. It receives the resolved
+`BlockRules` and applies them mechanically.
+
+(DNS resolution itself is never blocked by FamilyDNS. dnsmasq forwards
+upstream as normal; the enforcement plane is nftables on the resolved IPs.)
 
 ## Tech stack decisions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # FamilyDNS
 
-A self-hosted parental-control DNS server with a web UI. Block categories of
-sites, set per-profile schedules ("no internet after 9pm"), enforce daily and
-per-site time limits, log queries, and grant temporary extensions — all on
-your own hardware, no third-party DNS provider.
+A self-hosted, network-level parental-control system with a web UI. Block
+categories of sites, set per-profile schedules ("no internet after 9pm"),
+enforce daily and per-site time limits, log queries, and grant temporary
+extensions — all on your own hardware, no third-party DNS provider.
 
 ```
                  +-------------------+    +-----------+
@@ -16,19 +16,34 @@ HTTP / web ────▶ |  familydns-api    | ─▶ |  Postgres |
              (openwrt/ agent)  (opnsense/ agent)
 ```
 
-Enforcement (DNS blocking, per-device usage tracking) runs on the gateway
-router. The router agent pulls a policy snapshot from the API and reports
-connection events back. See [`docs/architecture-openwrt.md`](docs/architecture-openwrt.md).
+## Enforcement model
+
+DNS always resolves. We do **not** block by failing DNS resolution; blocking
+happens at the connection layer (nftables forward-drop on the gateway router).
+The block page is reached via HTTP DNAT on port 80, **not** via DNS sinkhole
+or NXDOMAIN. dnsmasq is still used on the router for hostname attribution
+(forward-lookup ipset population), but it is not the enforcement plane.
+
+All policy decisions — schedules, daily / per-site time limits, pause state,
+category membership, failover behaviour — live on the **API server**. The
+router agent pulls a policy snapshot every ~60 s and is a **dumb applier**:
+it never reasons about schedules, profiles, or categories at enforcement
+time. New policy concepts land in the API and present to the router as one
+of a small fixed set of fields (`blocked`, `extraBlocked`, `extraAllowed`,
+`blocklistIds`, `blockIpOnly`).
+
+See [`docs/architecture.md`](docs/architecture.md) for the snapshot contract
+and the full enforcement model.
 
 ## Components
 
-| Module      | What it does                                             | Runtime |
-| ----------- | -------------------------------------------------------- | ------- |
-| `api`       | REST + JWT auth, profiles, devices, policy snapshots     | runnable (Main) |
-| `shared`    | Common models, clock                                     | library |
-| `web`       | React + Vite admin UI                                    | static bundle (`web/dist`) |
-| `openwrt/`  | Lua agent: policy pull, dnsmasq/nft enforcement, usage   | OpenWRT ipk |
-| `opnsense/` | Python agent: pflog tail, connection_attempt events      | OPNsense plugin |
+| Module      | What it does                                              | Runtime |
+| ----------- | --------------------------------------------------------- | ------- |
+| `api`       | REST + JWT auth, profiles, devices, policy snapshots      | runnable (Main) |
+| `shared`    | Common models, clock                                      | library |
+| `web`       | React + Vite admin UI                                     | static bundle (`web/dist`) |
+| `openwrt/`  | Lua agent: policy pull, nft enforcement, hostname attribution, usage | OpenWRT ipk |
+| `opnsense/` | Python agent: pflog tail, connection_attempt events       | OPNsense plugin |
 
 ## Quick install
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,156 @@ Status: **partially implemented.**
 - §5.6 pending (#70).
 - OpenWRT agent (#72) and OpnSense agent (#94) pending.
 
+> **Read this first.** The "Enforcement model" section below is the canonical
+> architecture. Some current code deviates from it (called out inline and in
+> follow-up issues); the model is the target. If you are writing a new
+> feature, follow the model.
+
+## 0. Enforcement model
+
+Two truths govern everything that follows.
+
+### 0.1 DNS is never the enforcement plane
+
+DNS always resolves. Blocking happens at the **connection layer** via
+nftables forward-drop on the gateway router. The block page is reached via
+HTTP DNAT on port 80, **not** via DNS sinkhole, NXDOMAIN, or RPZ.
+
+dnsmasq is still used on the router, but only for **hostname attribution**:
+it populates per-host nftables ipsets via `--ipset=` callbacks at resolution
+time, so nftables can match destination IPs back to the hostname the device
+asked for. dnsmasq does not return a fake answer for any blocked host — the
+host resolves normally, the device opens a TCP connection, and nftables
+either drops the SYN (blocked) or DNATs HTTP/80 to the local block page.
+
+We rejected DNS-based blocking (sinkhole / RPZ / NXDOMAIN) because:
+
+- DoH / DoT bypasses any DNS-layer block trivially.
+- Hard-coded-IP traffic is invisible to a DNS-layer block.
+- DNS-layer blocks are usually global, not per-MAC, so a single profile's
+  blocklist leaks to other devices.
+- The block-page UX is poor when the device gets NXDOMAIN instead of a
+  real HTTP response.
+
+The `blockIpOnly` flag (see §0.2) is what closes the DoH / hard-coded-IP
+hole: forwarded traffic to an IP we did not resolve for this MAC is
+dropped.
+
+### 0.2 The router agent is a dumb applier
+
+The API server's `PolicyService` evaluates every policy concept — schedules,
+daily and per-site time limits, pause state, category membership, manual
+blocks, role-based defaults, failover behaviour — and bakes the result into
+a small fixed snapshot. The agent resolves device → effective rules once at
+apply time and then enforces purely per-MAC. **Profiles never appear in the
+enforcement pipeline.**
+
+Target snapshot shape (Scala 3, sealed-trait ADTs per [#114](https://github.com/sameerparekh/familydns/issues/114);
+typed names used here even though the current code is stringly):
+
+```scala
+case class PolicySnapshot(
+    etag: ETag,
+    generatedAt: Instant,
+    devices: Map[MacAddress, DevicePolicy],
+    profiles: Map[ProfileId, BlockRules],     // wire-dedup only; not consulted at enforcement
+    blocklists: Map[BlocklistId, Blocklist],
+    failureMode: FailureMode,                  // what the router does if it can't reach the API
+)
+
+case class DevicePolicy(
+    profileId: Option[ProfileId],
+    rules: Option[BlockRules],                 // if Some, replaces profile rules entirely
+)
+
+case class BlockRules(
+    blocked: Boolean,                          // drop all forwarded traffic from this MAC
+    blockReason: Option[MacBlockReason],       // for block-page text only
+    extraBlocked: List[Hostname],
+    extraAllowed: List[Hostname],              // carves out blocks, incl. when blocked = true
+    blocklistIds: List[BlocklistId],
+    blockIpOnly: Boolean,                      // drop literal-IP traffic not resolved for this MAC
+)
+
+case class Blocklist(version: BlocklistVersion, url: Url)
+
+// BlockReason is the unified reason emitted for any drop, both in connection
+// events and on the block-page query string. It is split into two layers:
+//
+//  - MacBlockReason covers reasons a whole MAC is blocked. PolicyService can
+//    only emit these in BlockRules.blockReason — schedule / time-limit / etc.
+//    are server-side computations.
+//  - The remaining BlockReason variants describe per-flow drops decided by
+//    the router at packet time and are never present in the snapshot.
+//
+// The split is enforced by the type system: BlockRules.blockReason is typed
+// as Option[MacBlockReason], so a router-only reason cannot be assigned to
+// a snapshot field.
+sealed trait BlockReason
+
+sealed trait MacBlockReason extends BlockReason
+object MacBlockReason:
+  case object Paused    extends MacBlockReason
+  case object Schedule  extends MacBlockReason
+  case object TimeLimit extends MacBlockReason
+  case object Manual    extends MacBlockReason
+
+object BlockReason:
+  // Per-flow drop reasons — emitted by the router at connection-drop time
+  // for the events log and the /blocked query string.
+  case class Host(host: Hostname)                          extends BlockReason
+  case class Category(host: Hostname, list: BlocklistId)   extends BlockReason
+  case class IpOnly(dstIp: IpAddress)                      extends BlockReason
+
+sealed trait FailureMode
+object FailureMode:
+  case object BlockAll      extends FailureMode
+  case object AllowAll      extends FailureMode
+  case object LastKnownGood extends FailureMode
+```
+
+Resolution step (the only place profiles touch enforcement):
+
+```scala
+def effective(d: DevicePolicy, profiles: Map[ProfileId, BlockRules]): BlockRules =
+  d.rules
+    .orElse(d.profileId.flatMap(profiles.get))
+    .getOrElse(BlockRules.allowAll)
+```
+
+After this single deref, the agent works with a `Map[MacAddress, BlockRules]`
+and profiles are unreachable.
+
+Enforcement plane per field:
+
+| Field | Enforcement |
+|-------|-------------|
+| `blocked` | nftables: `ether saddr ∈ blocked_macs` → drop forwarded traffic; DNAT HTTP/80 to local block page |
+| `extraBlocked` | nftables: `(ether saddr == mac, ip daddr ∈ ipset(host))` → drop. Per-host ipset populated by dnsmasq `--ipset=` at resolution time. **No `address=/host/#` NXDOMAIN.** |
+| `extraAllowed` | nftables: explicit accept above the drop rules for this MAC |
+| `blocklistIds` | Agent fetches blocklist by URL (cached by version), resolves member hosts periodically, populates per-blocklist ipset. nftables: `(mac, ip daddr ∈ ipset(blocklist))` → drop. **No RPZ.** |
+| `blockIpOnly` | nftables: `(mac, ip daddr ∉ ⋃(per-host ipsets resolved for this MAC))` → drop. Strict — no allowlist carve-out, since we cannot attribute the IP to a hostname. |
+
+dnsmasq's role is exclusively: forward DNS upstream, populate per-host
+nftables ipsets via `--ipset=`, and write a query log that `dns-tail` reads
+for usage attribution (§7.2). It is **never** the enforcement plane.
+
+> **Known deviations from this model as of May 2026** (tracked follow-ups,
+> not the canonical design):
+>
+> - `extraBlocked` is enforced via `address=/host/#` in `render.lua` and is
+>   global rather than per-MAC. Should migrate to per-MAC nft ipset drop.
+> - `blocklistIds` / category blocking is not applied on the router at all.
+>   `render.lua` and `familydns-agent` do not fetch RPZ files or render
+>   category rules. `PolicyService.decide` uses categories only on the
+>   fallback `POST /api/router/decision` endpoint.
+> - `blockIpOnly` does not exist yet.
+> - The current `PolicySnapshot` (§6.2) still carries per-profile
+>   `schedules`, `dailyMinutes`, `timeUsedToday`, `extensionsTodayMinutes`,
+>   `siteLimits`, `failureMode`, and `blockedCategories`. Per the model
+>   above, those should collapse server-side into `blocked` / `extraBlocked`
+>   / `blocklistIds`.
+
 ## 1. Why this exists
 
 The original architecture ran a DNS server and a pcap-based traffic monitor on
@@ -89,7 +239,7 @@ Every router agent must:
 | DNS server | dnsmasq | Unbound |
 | Packet filter | nftables | pf / pfctl |
 | Traffic accounting | nftables counters | pflog / pf tables |
-| Per-MAC DNS tagging | dnsmasq `dhcp-host` + `address=` | Unbound `local-data` per-client views |
+| Per-MAC hostname attribution | dnsmasq `dhcp-host` tag + `--ipset=` callback | Unbound query log correlated to DHCP lease |
 | Event sourcing | dnsmasq query log + `--dhcp-script` | Unbound query log + ISC dhcpd / Kea lease file |
 | Package system | opkg / OpenWRT SDK | FreeBSD pkg / OPNsense plugin system |
 | Config format | UCI | OPNsense XML API or conf files |
@@ -131,21 +281,31 @@ Every router agent must:
 
 ## 5. Decision model: policy snapshot, not per-flow round-trips
 
-The router does **not** round-trip to the API on every connection. Instead:
+The router does **not** round-trip to the API on every connection, and it
+does **not** make policy decisions locally. The split is:
 
-1. Every ~60 s the agent pulls a **policy snapshot** containing everything
-   needed to make decisions locally: device→profile assignments, blocked
-   categories, schedules, time limits, `time_used_today`, paused state.
-2. The agent renders that snapshot into DNS + packet-filter config and
-   reloads them atomically.
-3. Per-flow decisions happen in-kernel or in the DNS server — no API
-   call per request.
-4. `POST /api/router/decision` exists as a **fallback** for hostnames not in
-   the snapshot, and is optional for v1.
+1. Every ~60 s the agent pulls a **policy snapshot** in which `PolicyService`
+   on the API server has already evaluated every schedule, time limit, pause
+   state, and category for every device and **collapsed the result into the
+   per-MAC `BlockRules` shape from §0.2**. The snapshot contains target
+   state, not raw policy inputs.
+2. The agent resolves device → `BlockRules` (a single profile-or-override
+   lookup per device) and renders into nftables rules + a dnsmasq fragment
+   used only for hostname attribution / ipset population. Both reload
+   atomically.
+3. Per-flow decisions happen in the kernel against nftables sets — no API
+   call per request, no policy logic in the agent.
+4. `POST /api/router/decision` exists as a **fallback** for the legacy
+   server-side decision path, and is optional for v1.
 
 Worst-case staleness is one poll interval (~60 s). That is acceptable for
-parental-control use cases; an instant-block requirement can be met later by a
-server-push channel (websocket, SSE) if needed.
+parental-control use cases; an instant-block requirement can be met later by
+a server-push channel (websocket, SSE) if needed.
+
+The architectural invariant: **every new policy concept lands in
+`PolicyService` and presents to the agent as one of the existing fields in
+`BlockRules`**. Adding decision logic to the agent (schedule evaluation,
+time accounting, category lookup, role-based defaults) is a bug.
 
 ## 6. Router HTTP API
 
@@ -194,53 +354,72 @@ The enrollment token is single-use; the API marks it consumed on success.
 Polled every ~60 s. Returns the full enforcement snapshot, or `304 Not
 Modified` if the client's ETag still matches.
 
-**Response 200**
+**Target response 200** (matches §0.2):
 
 ```json
 {
   "etag": "sha256:abc123...",
   "generatedAt": "2026-05-02T14:00:00Z",
-  "defaultProfileId": 1,
-  "devices": [
-    { "mac": "aa:bb:cc:11:22:33", "profileId": 3, "name": "kid-ipad" }
-  ],
-  "profiles": [
-    {
-      "id": 3,
-      "name": "kids",
-      "paused": false,
-      "blockedCategories": ["ads", "adult"],
+  "failureMode": "LastKnownGood",
+  "devices": {
+    "aa:bb:cc:11:22:33": {
+      "profileId": "kids",
+      "rules": null
+    },
+    "aa:bb:cc:44:55:66": {
+      "profileId": "kids",
+      "rules": {
+        "blocked": true,
+        "blockReason": "TimeLimit",
+        "extraBlocked": [],
+        "extraAllowed": ["khanacademy.org"],
+        "blocklistIds": ["ads", "adult"],
+        "blockIpOnly": true
+      }
+    }
+  },
+  "profiles": {
+    "kids": {
+      "blocked": false,
+      "blockReason": null,
       "extraBlocked": ["tiktok.com"],
       "extraAllowed": ["khanacademy.org"],
-      "schedules": [
-        { "days": ["MON","TUE","WED","THU","FRI"],
-          "blockFrom": "21:00", "blockUntil": "07:00" }
-      ],
-      "dailyMinutes": 120,
-      "siteLimits": [
-        { "domain": "youtube.com", "minutes": 30, "label": "YouTube" }
-      ],
-      "timeUsedToday": {
-        "totalMinutes": 47,
-        "byDomain": { "youtube.com": 12 }
-      },
-      "extensionsTodayMinutes": 15
+      "blocklistIds": ["ads", "adult"],
+      "blockIpOnly": true
     }
-  ],
+  },
   "blocklists": {
-    "ads":   { "version": "2026-04-29", "url": "/api/blocklists/ads.rpz" },
-    "adult": { "version": "2026-04-29", "url": "/api/blocklists/adult.rpz" }
+    "ads":   { "version": "2026-04-29", "url": "/api/blocklists/ads.json" },
+    "adult": { "version": "2026-04-29", "url": "/api/blocklists/adult.json" }
   }
 }
 ```
 
-**Response 304** when `If-None-Match: <etag>` (or `?since=<etag>`) matches the
-current snapshot. Body is empty.
+**Response 304** when `If-None-Match: <etag>` (or `?since=<etag>`) matches
+the current snapshot. Body is empty.
 
 ETag is computed deterministically over snapshot content.
 
-`timeUsedToday.totalMinutes` excludes domains covered by `siteLimits` — the
-agent enforces both limits independently.
+Notes:
+
+- The first device above takes its rules from the `"kids"` profile.
+- The second device overrides the profile entirely — its `rules` are used
+  verbatim. The override replaces; it does not merge with the profile.
+- The router resolves each device into a single `BlockRules` once and then
+  enforces purely per-MAC. Profiles are not consulted further.
+- All schedule / time-limit / pause / category evaluation has already
+  happened server-side in `PolicyService` and is reflected in
+  `blocked` / `blockReason` / `extraBlocked` / `blocklistIds`.
+
+> **Current implementation deviates from this shape.** The live snapshot
+> still ships `defaultProfileId` at the top level; per-profile `paused`,
+> `blockedCategories`, `schedules`, `dailyMinutes`, `siteLimits`,
+> `timeUsedToday`, `extensionsTodayMinutes`, `failureMode`; a separate
+> top-level `blockedMacs` list; and uses `List` for `devices` / `profiles`
+> rather than `Map`. Migration to the target shape above is tracked
+> alongside #350 — see the follow-up issue list there. New code should
+> read against the target shape and tolerate the legacy fields during
+> migration.
 
 ### 6.3 `GET /api/blocklists/<category>.rpz`
 
@@ -329,14 +508,20 @@ guidance, not part of the wire contract.
 
 ### 7.1 Capabilities used
 
-- **Per-MAC nftables sets** — `ether saddr @profile3_macs` matches packets
-  from any MAC in the named set. One set per profile.
-- **Per-domain IP sets via dnsmasq `--ipset=`** — dnsmasq populates named
-  nftables sets with the IPs a hostname resolves to; nftables matches destination
-  IP against the set.
-- **Per-MAC dnsmasq tagging** — `dhcp-host=...,set:profileN` applies different
-  `address=` / `server=` rules per MAC tag so blocked domains return NXDOMAIN
-  for kids' devices and resolve normally for parents'.
+- **Per-MAC nftables sets** — `ether saddr @blocked_macs` matches packets
+  from any MAC in the named set. Used to express `blocked = true` from the
+  resolved `BlockRules` (§0.2) and to scope per-MAC drop / accept chains.
+- **Per-(MAC, host) IP sets via dnsmasq `--ipset=`** — dnsmasq populates
+  named nftables sets with the IPs a hostname resolves to *for a given
+  client*. nftables matches destination IP against the set, scoped by
+  source MAC. This is how `extraBlocked` / `extraAllowed` / `blocklistIds`
+  are enforced without DNS-layer blocking: the host resolves normally, but
+  the forward rule for that MAC drops the resulting flow.
+- **Per-MAC dnsmasq tagging** — `dhcp-host=...,set:mac<N>` applies a
+  per-MAC tag so `--ipset=` callbacks can populate the right per-MAC ipset
+  for hostname attribution. Dnsmasq tags are **not** used for `address=` /
+  `server=` differentiation — there is no per-tag NXDOMAIN. dnsmasq always
+  resolves normally; enforcement happens in nftables.
 - **nftables counter objects** keyed on `ether saddr . ip daddr` for per-MAC,
   per-IP byte counts.
 - **dnsmasq query log** (`--log-queries=extra`, written to a private file at
@@ -402,9 +587,16 @@ openwrt/
 
 ### 7.5 Time-limit enforcement
 
-The snapshot includes `timeUsedToday.totalMinutes` and `dailyMinutes`. The agent
-computes `remaining = limit - used + extensions` and, when `≤ 0`, drops all
-egress for that profile's MAC set until the next poll (~60 s worst-case bonus).
+`PolicyService` on the API server tracks `time_used_today`, daily limits,
+extensions, and per-site limits. When a daily limit is exhausted, the API
+emits the affected MAC with `blocked = true, blockReason = TimeLimit` in
+the next snapshot. When a per-site limit is exhausted, the relevant host
+is added to that MAC's `extraBlocked`. **The agent does no time arithmetic.**
+
+Per-MAC usage is reported to the API every 5 minutes via
+`POST /api/router/usage` (§6.4); the API accumulates and decides. Worst-case
+overshoot is one usage-report interval (~5 min) plus one policy-poll interval
+(~60 s).
 
 ### 7.6 Block-page redirect
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -5,8 +5,11 @@ router. The recommended path is the one-shot install script; the manual
 steps below it exist for debugging and for environments where running a
 piped shell script is not acceptable.
 
-The agent enforces per-device DNS filtering, accounts traffic per
-`(mac, hostname)`, and streams connection events to the FamilyDNS API.
+The agent enforces per-device connection-level filtering (nftables forward-drop
+keyed on MAC + destination ipset), accounts traffic per `(mac, hostname)`, and
+streams connection events to the FamilyDNS API. dnsmasq on the router resolves
+DNS normally — it is not the enforcement plane (see
+[`architecture.md` §0](architecture.md#0-enforcement-model)).
 
 ## 1. Prerequisites
 

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,9 +1,13 @@
 # familydns OpenWrt package
 
 OpenWrt agent for FamilyDNS. Supports both **OpenWRT 23.05.x** (opkg / `.ipk`)
-and **OpenWRT 24.10+ / SNAPSHOT** (apk / `.apk`). Enforces per-device DNS
-filtering via dnsmasq + nftables, accounts traffic per `(mac, hostname)`, and
-streams connection events to the FamilyDNS API.
+and **OpenWRT 24.10+ / SNAPSHOT** (apk / `.apk`). Enforces per-device
+connection-level filtering via **nftables** (forward-drop keyed on MAC +
+destination ipset), accounts traffic per `(mac, hostname)`, and streams
+connection events to the FamilyDNS API. dnsmasq on the router resolves DNS
+normally — it is **not** the enforcement plane; it is used for hostname
+attribution (`--ipset=` callbacks). See
+[`../docs/architecture.md` §0](../docs/architecture.md#0-enforcement-model).
 
 Each release attaches both a `.ipk` and a `.apk` built from the same
 `openwrt/files/` tree; the one-line installer auto-detects the router's
@@ -345,9 +349,11 @@ CI runs Lua tests automatically in the `lua-tests` job in
 - `meta nftrace` requires a matching `nftrace` rule on every chain and
   produces verbose output that is harder to parse safely.
 
-Hostname attribution uses the `nft_sets` table populated by `render.lua`
-from dnsmasq `--ipset=` callbacks. Reverse DNS is intentionally avoided
-because CDN PTR records do not reflect what the user resolved.
+Hostname attribution uses the forward-lookup cache populated by the
+`familydns-dns-tail` sidecar from the dnsmasq query log, with the
+`--ipset=` callback path as a fallback for the site-limit ipsets. Reverse
+DNS is intentionally avoided because CDN PTR records do not reflect what
+the user resolved. See [`../docs/architecture.md` §7.2](../docs/architecture.md).
 
 Both allowed and blocked flows are reported so the admin UI shows a
 complete connection timeline, not just block events.
@@ -355,5 +361,6 @@ complete connection timeline, not just block events.
 ## Architecture reference
 
 See [`docs/architecture.md`](../docs/architecture.md) for the full design —
-especially §7 (OpenWRT agent design), §7.2 (hostname attribution via dnsmasq
-`--ipset=`), and §7.6 (block-page redirect flow).
+especially §0 (enforcement model: DNS never blocks, router is a dumb applier),
+§7 (OpenWRT agent design), §7.2 (forward-lookup hostname attribution via
+dns-tail), and §7.6 (block-page redirect flow).


### PR DESCRIPTION
Closes #350.

Audit + rewrite of docs / agent-context files so the two architectural truths are unambiguous everywhere a future agent (human or otherwise) will read first:

1. **DNS is never the enforcement plane.** DNS always resolves; blocking is at the connection layer via nftables forward-drop. The block page is reached via HTTP DNAT for port 80, not via DNS sinkhole / NXDOMAIN / RPZ. dnsmasq is used on the router for hostname attribution only.
2. **The router agent is a dumb applier.** \`PolicyService\` on the API server bakes every policy decision (schedules, time limits, pause state, categories, manual blocks) into a per-MAC \`BlockRules\`. Profiles exist in the snapshot only as a wire-level dedup aid and are never consulted at enforcement time.

## Canonical target snapshot shape

Documented in [\`docs/architecture.md\` §0.2](docs/architecture.md):

\`\`\`scala
case class PolicySnapshot(
    etag: ETag,
    generatedAt: Instant,
    devices: Map[MacAddress, DevicePolicy],
    profiles: Map[ProfileId, BlockRules],
    blocklists: Map[BlocklistId, Blocklist],
    failureMode: FailureMode,
)

case class DevicePolicy(
    profileId: Option[ProfileId],
    rules: Option[BlockRules],     // if Some, replaces profile rules entirely
)

case class BlockRules(
    blocked: Boolean,
    blockReason: Option[MacBlockReason],
    extraBlocked: List[Hostname],
    extraAllowed: List[Hostname],
    blocklistIds: List[BlocklistId],
    blockIpOnly: Boolean,
)

sealed trait BlockReason
sealed trait MacBlockReason extends BlockReason
// MacBlockReason: Paused | Schedule | TimeLimit | Manual
// BlockReason additional cases: Host(Hostname) | Category(Hostname, BlocklistId) | IpOnly(IpAddress)
\`\`\`

The split \`BlockReason\` hierarchy lets the type system enforce that \`BlockRules.blockReason\` only ever carries whole-MAC reasons; per-flow drop reasons (\`Host\`, \`Category\`, \`IpOnly\`) are emitted by the router at packet-drop time and only appear in the connection-events log and the block-page query string.

## Files touched

- \`README.md\` — new \"Enforcement model\" section right under the topology diagram. Fixed stale \"DNS blocking\" / \"dnsmasq enforcement\" wording. Updated component table.
- \`AGENTS.md\` — new top-of-file \"Architectural model — read this before working on anything\" callout with the two truths and the full \`BlockRules\` field list. Replaced the stale \"DNS blocking priority order\" list with a server-side \"Policy decision pipeline\" section that documents the order \`PolicyService\` evaluates rules in (not the router).
- \`docs/architecture.md\` — new §0 \"Enforcement model\" section (the canonical reference, types + enforcement plane per field). Rewrote §5 \"Decision model\", §6.2 \"GET /api/router/policy\" with target JSON example, §7.1 capabilities (removed the stale per-tag-NXDOMAIN bullet), §7.5 time-limit enforcement (now correctly says the server computes), and the §3.3 platform-divergence row that called the OpenWRT/OPNsense DNS layer the enforcement plane.
- \`docs/install-openwrt.md\` — fixed the \"per-device DNS filtering\" line.
- \`openwrt/README.md\` — fixed the \"DNS filtering via dnsmasq + nftables\" line, fixed the stale hostname-attribution paragraph (dns-tail, not \`--ipset=\`), updated the architecture-doc cross-references to point at §0.

## Implementation deviations called out (not fixed here — docs-only PR)

Every deviation from the canonical model is called out inline in the affected doc as \"Known deviations as of May 2026\" with a pointer to the follow-up issue. Code fixes are tracked separately so this PR lands fast and unblocks future spawned work:

- #351 — \`extraBlocked\` is enforced via dnsmasq NXDOMAIN (\`address=/host/#\`) and is global; should be per-MAC nft ipset drop.
- #352 — Category blocklists (\`blockedCategories\` / \`blocklists\`) are not applied on the router at all today.
- #353 — \`blockIpOnly\` field does not yet exist.
- #354 — \`PolicySnapshot\` still carries per-profile \`schedules\`, \`dailyMinutes\`, \`timeUsedToday\`, \`siteLimits\`, \`failureMode\`, \`blockedCategories\` etc.; these should collapse into per-MAC \`BlockRules\` server-side.
- [#114 (comment)](https://github.com/sameerparekh/familydns/issues/114#issuecomment-4451759139) — typed names (\`MacAddress\`, \`ETag\`, \`Hostname\`, \`Instant\`, sealed-trait \`MacBlockReason\` / \`FailureMode\` rather than Scala 3 \`enum\` / \`String\`) added to the existing type-audit scope.

## Test plan

- [x] No code changes; CI should pass on docs only.
- [ ] Reviewer: skim AGENTS.md callout and \`docs/architecture.md\` §0 for any wording that drifts from intent before merge.
- [ ] Reviewer: confirm the canonical \`BlockRules\` field names (\`blocked\`, \`blockReason\`, \`extraBlocked\`, \`extraAllowed\`, \`blocklistIds\`, \`blockIpOnly\`) match how follow-ups #351–#354 should be implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)