### PR TITLE
openwrt: per-(MAC, host) nft drops for extraBlocked (fixes #351)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,9 +150,9 @@ for usage attribution (§7.2). It is **never** the enforcement plane.
 > **Known deviations from this model as of May 2026** (tracked follow-ups,
 > not the canonical design):
 >
-> - `extraBlocked` is enforced via `address=/host/#` in `render.lua` and is
->   global rather than per-MAC. Should migrate to per-MAC nft ipset drop
->   (#351).
+> - `extraBlocked` is IPv4-only — dnsmasq populates the `eb_<host>` set on
+>   A records, but AAAA replies are not captured into a parallel `eb6_<host>`
+>   v6 set, so a blocked host that resolves over v6 escapes the drop (#392).
 > - `blocklistIds` / category blocking is not applied on the router at all.
 >   `render.lua` and `familydns-agent` do not fetch RPZ files or render
 >   category rules. `PolicyService.decide` uses categories only on the

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -13,11 +13,16 @@
 --     opts (optional table)   → bag of options. Recognised keys:
 --       opts.dns_check_fn(domain) → string|nil — result of resolving `domain`
 --                                   via the router's own resolver, used by
---                                   the #328 smoke probe to detect a dnsmasq
---                                   restart that silently no-op'd. Nil/empty/
---                                   "0.0.0.0"/"::" mean sinkholed (OK);
---                                   anything else triggers a WARN. Defaults
---                                   to a `dig @127.0.0.1` shell call.
+--                                   the #328 smoke probe. After #351 DNS no
+--                                   longer sinkholes blocked hosts (Truth 1:
+--                                   blocking is at the connection layer); the
+--                                   probe now confirms that dnsmasq is
+--                                   answering at all, by checking that an
+--                                   extraBlocked host resolves to a real IP
+--                                   (NOT 0.0.0.0 / :: / NXDOMAIN). A
+--                                   sinkhole-shaped answer means dnsmasq
+--                                   is still applying a stale rendering
+--                                   (failed restart) and triggers a WARN.
 --       opts.poll_age_seconds → forwarded to render.nft for the #311 / #331
 --                                 failover branch.
 
@@ -198,11 +203,15 @@ end
 -- write_fn(path, content) must return (truthy, nil) on success or (nil, err_string).
 -- reload_fn(cmd) is called with a shell command string; return value is ignored.
 --
--- opts is an optional table. opts.dns_check_fn (#328): when the rendered
--- dnsmasq.conf contains at least one `address=/<domain>/#` line, we probe
--- the first such domain via the router's own resolver after the dnsmasq
--- restart and WARN if it doesn't look sinkholed (detects the silent no-op
--- when dnsmasq fails to restart, or when conf-dir wasn't actually re-read).
+-- opts is an optional table. opts.dns_check_fn (#328 / #351): when the
+-- rendered dnsmasq.conf contains at least one `ipset=/<host>/eb_...` line
+-- (i.e. there is something to enforce), we probe one of those hosts via
+-- the router's own resolver after the dnsmasq restart. Post-#351 DNS is
+-- NOT the enforcement plane — blocked hosts must resolve to a real IP, so
+-- the probe inverts the old semantics: a sinkhole-shaped answer
+-- (`0.0.0.0`, `::`, empty / NXDOMAIN) means dnsmasq is still running a
+-- stale config that has DNS-layer blocks in it, which is the failure mode
+-- we want to catch.
 -- opts.poll_age_seconds (#331): forwarded to render.nft so the agent's
 -- failover-edge re-render can request the closed-mode drop chain.
 
@@ -218,23 +227,34 @@ local function default_dns_check(domain)
   return out
 end
 
-local SINKHOLE_RESULTS = {
+-- Sinkhole-shaped DNS answers. Post-#351 these are *failures* (DNS must
+-- resolve normally — blocking happens at the connection layer), but we
+-- still need to recognise the shape to detect a dnsmasq that's running a
+-- stale, sinkhole-containing config.
+local BLOCKED_RESULTS = {
   ["0.0.0.0"] = true,
   ["::"]      = true,
   ["::0"]     = true,
 }
 
-local function looks_sinkholed(result)
+-- True when the DNS answer indicates the resolver is *blocking* at the
+-- DNS layer (sinkhole IP) or returning no answer at all (NXDOMAIN /
+-- SERVFAIL / timeout → empty first line from `dig +short`). Both shapes
+-- mean we are NOT getting a real upstream answer, which post-#351 is a
+-- regression — dnsmasq should resolve every host normally and let nft
+-- handle blocking.
+local function is_blocked_at_connection(result)
   if result == nil or result == "" then return true end
-  return SINKHOLE_RESULTS[result] == true
+  return BLOCKED_RESULTS[result] == true
 end
 
--- Extract the first `address=/<domain>/#` line from the rendered dnsmasq
--- content. Returns nil if there are no such lines (e.g. no extraBlocked
--- entries in any profile).
-local function first_blocked_domain(dnsmasq_content)
-  return dnsmasq_content:match("\naddress=/([^/\n]+)/#")
-      or dnsmasq_content:match("^address=/([^/\n]+)/#")
+-- Extract the first extraBlocked host from the rendered dnsmasq content by
+-- looking for an `ipset=/<host>/eb_...` directive (the per-host set name
+-- prefix is the agent's canonical marker for #351 enforcement). Returns
+-- nil if there are no extraBlocked hosts active.
+local function first_extrablocked_host(dnsmasq_content)
+  return dnsmasq_content:match("\nipset=/([^/\n]+)/eb_")
+      or dnsmasq_content:match("^ipset=/([^/\n]+)/eb_")
 end
 
 function M.apply(snapshot, write_fn, reload_fn, log, opts)
@@ -266,15 +286,20 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   -- prior runtime table in one transaction, then installs the new ruleset.
   reload_fn("nft -f /tmp/nftables.d/familydns.nft")
 
-  -- #328 smoke probe. Skip cleanly when there's nothing to probe.
-  local probe_domain = first_blocked_domain(dnsmasq_content)
+  -- #328 / #351 smoke probe. Skip cleanly when there's no extraBlocked
+  -- host to probe. Post-#351 expectation: dnsmasq must resolve the host
+  -- to a *real* upstream IP (DNS is not the enforcement plane). A
+  -- sinkhole-shaped or empty answer means dnsmasq is still serving a
+  -- stale config that contains DNS-layer blocks — the failure we are
+  -- watching for.
+  local probe_domain = first_extrablocked_host(dnsmasq_content)
   if probe_domain then
     local check = opts.dns_check_fn or default_dns_check
     local result = check(probe_domain)
-    if not looks_sinkholed(result) then
+    if is_blocked_at_connection(result) then
       log.warn(
-        "policy.apply: smoke check failed; dnsmasq may not have restarted — " ..
-        "got %q for %s (expected sinkhole)",
+        "policy.apply: smoke check failed; dnsmasq may be serving a stale " ..
+        "config — got %q for %s (expected a real upstream IP)",
         tostring(result), probe_domain)
     end
   end

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -38,7 +38,11 @@ local function effective_rules(dev, profiles)
   -- sentinel; luci.jsonc uses nil). Only treat a real table as an override.
   if type(dev.rules) == "table" then return dev.rules end
   if dev.profileId == nil then return nil end
-  local key = tostring(dev.profileId)
+  -- cjson decodes JSON integers as Lua *floats*, so a profileId of 3
+  -- arrives as 3.0 and `tostring(3.0)` yields "3.0" on Lua 5.3+, missing
+  -- the profiles["3"] key. Use %d formatting to coerce to an integer
+  -- decimal representation that matches the JSON-object key shape.
+  local key = string.format("%d", dev.profileId)
   local prof = profiles and profiles[key]
   if type(prof) ~= "table" then return nil end
   if type(prof.rules) ~= "table" then return nil end
@@ -75,6 +79,31 @@ local function sorted_profiles(profiles)
   end
 end
 
+-- Build the set of hosts that appear in any device's *effective* extraBlocked
+-- list. Hosts only referenced by a profile that has no assigned device are
+-- skipped — no point populating an ipset that nothing will drop on. Returns
+-- a sorted unique list of hostnames.
+local function effective_extra_blocked_hosts(snapshot)
+  local seen = {}
+  for _, dev in pairs(snapshot.devices or {}) do
+    local r = effective_rules(dev, snapshot.profiles)
+    if r and type(r.extraBlocked) == "table" then
+      for _, host in ipairs(r.extraBlocked) do seen[host] = true end
+    end
+  end
+  local hosts = {}
+  for h in pairs(seen) do hosts[#hosts + 1] = h end
+  table.sort(hosts)
+  return hosts
+end
+
+-- nft set name for an extraBlocked host. `eb_` prefix scopes against future
+-- categorical blocklists (#352 will use `bl_`). Dots and dashes are replaced
+-- with underscores by sanitize() to keep within the nftables name charset.
+local function eb_set_name(host)
+  return "eb_" .. sanitize(host)
+end
+
 -- ---------------------------------------------------------------------------
 -- render.dnsmasq(snapshot) → string
 -- ---------------------------------------------------------------------------
@@ -96,25 +125,14 @@ function M.dnsmasq(snapshot)
   end
   emit("")
 
-  -- extraBlocked → NXDOMAIN (legacy enforcement, to be replaced by per-MAC
-  -- nft ipset drop in #351). Collect unique hosts across all profiles and
-  -- any device-override rules.
-  emit("# extraBlocked → NXDOMAIN (TODO #351: per-MAC nft drop)")
-  local seen_blocked = {}
-  local function collect_extra_blocked(rules)
-    if type(rules) ~= "table" then return end
-    for _, domain in ipairs(rules.extraBlocked or {}) do
-      if not seen_blocked[domain] then
-        seen_blocked[domain] = true
-        emit("address=/" .. domain .. "/#")
-      end
-    end
-  end
-  for _, prof in sorted_profiles(snapshot.profiles) do
-    collect_extra_blocked(prof.rules)
-  end
-  for _, dev in sorted_devices(snapshot.devices) do
-    collect_extra_blocked(dev.rules)
+  -- #351: extraBlocked is enforced at the connection layer (per-MAC nft
+  -- drop), not via DNS sinkhole. dnsmasq's only role here is to populate
+  -- an nftables ipset with the resolved IPs of each blocked host, so the
+  -- forward-hook drop can match by `ip daddr ∈ @eb_<host>`. DNS still
+  -- resolves the host normally — see docs/architecture.md §0.1 (Truth 1).
+  emit("# extraBlocked → per-host ipset populated at resolve time (#351)")
+  for _, host in ipairs(effective_extra_blocked_hosts(snapshot)) do
+    emit(string.format("ipset=/%s/%s", host, eb_set_name(host)))
   end
   emit("")
 
@@ -207,20 +225,62 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
+  -- #351: per-host ipsets for extraBlocked. Each set is populated at DNS
+  -- resolve time by dnsmasq `ipset=/host/eb_<host>` (rendered by dnsmasq()
+  -- above). Dynamic + 1h timeout so resolved entries age out and we don't
+  -- leak shared-CDN IPs to other hosts indefinitely.
+  local eb_hosts = effective_extra_blocked_hosts(snapshot)
+  for _, host in ipairs(eb_hosts) do
+    ind(string.format("set %s {", eb_set_name(host)))
+    ind2("type ipv4_addr")
+    ind2("flags dynamic,timeout")
+    ind2("timeout 1h")
+    ind("}")
+    emit("")
+  end
+
+  -- #351: per-(MAC, host) drop pairs. We build the cross-product from each
+  -- device's *effective* extraBlocked list (device override > profile rules),
+  -- so a profile's extraBlocked applies only to MACs in that profile and a
+  -- device override applies only to that one MAC.
+  local eb_pairs = {}
+  for mac, dev in sorted_devices(snapshot.devices) do
+    local r = effective_rules(dev, snapshot.profiles)
+    if r and type(r.extraBlocked) == "table" then
+      for _, host in ipairs(r.extraBlocked) do
+        eb_pairs[#eb_pairs + 1] = { mac = mac, host = host }
+      end
+    end
+  end
+
   ind("chain familydns_block {")
   ind2("type filter hook forward priority 0; policy accept;")
   if #blocked_macs_list > 0 then
     ind2("ether saddr @blocked_macs drop")
   end
+  for _, p in ipairs(eb_pairs) do
+    ind2(string.format("ether saddr %s ip daddr @%s drop",
+                       p.mac, eb_set_name(p.host)))
+  end
   ind("}")
   emit("")
 
-  -- Block-page DNAT chain (#303): redirect HTTP/80 from blocked devices to
-  -- the local uhttpd block page.
-  if #blocked_macs_list > 0 then
+  -- Block-page DNAT chain (#303 + #351): redirect HTTP/80 to the local
+  -- uhttpd block page so users see *why* a connection failed. Two
+  -- triggers: MAC-wide block (whole device blocked — pause / time limit /
+  -- schedule), and per-(MAC, host) extraBlocked. We emit the chain if
+  -- either applies so the dnat rules have a hook to live in.
+  if #blocked_macs_list > 0 or #eb_pairs > 0 then
     ind("chain familydns_block_nat {")
     ind2("type nat hook prerouting priority dstnat; policy accept;")
-    ind2("ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081")
+    if #blocked_macs_list > 0 then
+      ind2("ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081")
+    end
+    for _, p in ipairs(eb_pairs) do
+      ind2(string.format(
+        "ether saddr %s ip daddr @%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+        p.mac, eb_set_name(p.host)))
+    end
     ind("}")
     emit("")
   end

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -440,92 +440,99 @@ describe("policy.apply", function()
     }, warns, infos
   end
 
-  it("invokes dns_check_fn with a blocked domain after the restart (#328)", function()
+  it("invokes dns_check_fn with an extraBlocked host after the restart (#328 / #351)", function()
     local probed
     policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      { dns_check_fn = function(domain) probed = domain; return "0.0.0.0" end })
+      { dns_check_fn = function(domain) probed = domain; return "93.184.216.34" end })
     assert.equal("badsite.example.com", probed)
   end)
 
-  it("logs a warning when dns_check_fn returns a non-sinkhole result (#328)", function()
+  -- Post-#351 semantics inversion (Truth 1): DNS is NOT the enforcement
+  -- plane. Blocked hosts must resolve to a real IP — a sinkhole-shaped
+  -- answer means dnsmasq is still applying a stale `address=/.../#`
+  -- config, which is the failure we now want to catch.
+
+  it("logs a warning when dns_check_fn returns a sinkhole IP (post-#351)", function()
     local stub_log, warns = capture_log()
     policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      { dns_check_fn = function(_domain) return "93.184.216.34" end })
+      { dns_check_fn = function(_domain) return "0.0.0.0" end })
     local matched = false
     for _, w in ipairs(warns) do
-      if w:find("smoke", 1, true) and w:find("93.184.216.34", 1, true) then
+      if w:find("smoke", 1, true) and w:find("0.0.0.0", 1, true) then
         matched = true
       end
     end
     assert.is_true(matched,
-      "expected a smoke-check warning mentioning the non-sinkhole IP; got: " ..
+      "expected a smoke-check warning mentioning the sinkhole IP; got: " ..
       table.concat(warns, " | "))
   end)
 
-  it("does NOT warn when dns_check_fn returns 0.0.0.0 (sinkhole)", function()
-    local stub_log, warns = capture_log()
-    policy.apply(decode_smoke(),
-      function(_p, _c) return true, nil end,
-      function(_cmd) return 0 end,
-      stub_log,
-      { dns_check_fn = function(_d) return "0.0.0.0" end })
-    for _, w in ipairs(warns) do
-      assert.is_nil(w:find("smoke", 1, true),
-        "unexpected smoke-check warning: " .. w)
-    end
-  end)
-
-  it("does NOT warn when dns_check_fn returns empty (NXDOMAIN)", function()
+  it("logs a warning when dns_check_fn returns empty (NXDOMAIN — stale or upstream-broken)", function()
     local stub_log, warns = capture_log()
     policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
       { dns_check_fn = function(_d) return "" end })
+    local matched = false
     for _, w in ipairs(warns) do
-      assert.is_nil(w:find("smoke", 1, true))
+      if w:find("smoke", 1, true) then matched = true end
+    end
+    assert.is_true(matched)
+  end)
+
+  it("does NOT warn when dns_check_fn returns a real upstream IP (post-#351)", function()
+    local stub_log, warns = capture_log()
+    policy.apply(decode_smoke(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      stub_log,
+      { dns_check_fn = function(_d) return "93.184.216.34" end })
+    for _, w in ipairs(warns) do
+      assert.is_nil(w:find("smoke", 1, true),
+        "unexpected smoke-check warning: " .. w)
     end
   end)
 
-  it("does NOT warn when dns_check_fn returns nil", function()
+  it("logs a warning when dns_check_fn returns nil (no answer at all)", function()
     local stub_log, warns = capture_log()
     policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
       { dns_check_fn = function(_d) return nil end })
+    local matched = false
     for _, w in ipairs(warns) do
-      assert.is_nil(w:find("smoke", 1, true))
+      if w:find("smoke", 1, true) then matched = true end
     end
+    assert.is_true(matched)
   end)
 
-  it("skips dns_check_fn when the snapshot has no extraBlocked entries (#328)", function()
+  it("skips dns_check_fn when the snapshot has no extraBlocked entries", function()
     local called = false
-    -- Build a snapshot whose profile has empty extraBlocked, so render emits
-    -- no address=/.../# lines and the smoke probe path is skipped.
-    local snap = decode_snap()
+    local snap = decode_smoke()
     snap.profiles["3"].rules.extraBlocked = {}
     policy.apply(snap,
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      { dns_check_fn = function(_d) called = true; return "0.0.0.0" end })
+      { dns_check_fn = function(_d) called = true; return "93.184.216.34" end })
     assert.is_false(called,
-      "dns_check_fn should not be called when no address=/.../# lines were rendered")
+      "dns_check_fn should not be called when there is no extraBlocked host to probe")
   end)
 
-  it("still returns true when dns_check_fn reports a non-sinkhole result (#328)", function()
+  it("still returns true when dns_check_fn reports a sinkhole result (post-#351 — propagation is a separate concern)", function()
     local ok = policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      { dns_check_fn = function(_d) return "93.184.216.34" end })
+      { dns_check_fn = function(_d) return "0.0.0.0" end })
     assert.is_true(ok,
       "smoke-check failure must not fail the apply — propagation is a separate concern")
   end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -44,14 +44,30 @@ describe("render.dnsmasq", function()
     assert.truthy(conf:find("dhcp-host=aa:bb:cc:11:22:33,set:profile3", 1, true))
   end)
 
-  it("emits NXDOMAIN address= for each extraBlocked domain", function()
+  -- #351: extraBlocked is enforced at the connection layer via per-MAC nft
+  -- drops on an ipset populated by dnsmasq's `--ipset=` callback. DNS itself
+  -- resolves normally — there must NEVER be an `address=/host/#` line.
+  it("does NOT emit address=/.../# for extraBlocked (Truth 1: DNS is not the enforcement plane)", function()
     local conf = render.dnsmasq(snap_one())
-    assert.truthy(conf:find("address=/tiktok.com/#", 1, true))
+    assert.is_nil(conf:find("address=/tiktok.com/#", 1, true))
+    assert.is_nil(conf:find("address=/khanacademy.org/#", 1, true))
   end)
 
-  it("does NOT emit NXDOMAIN for extraAllowed domains", function()
+  it("emits ipset=/host/eb_<sanitized-host> for each extraBlocked host that has an assigned device", function()
     local conf = render.dnsmasq(snap_one())
-    assert.falsy(conf:find("address=/khanacademy.org/#", 1, true))
+    assert.truthy(conf:find("ipset=/tiktok.com/eb_tiktok_com", 1, true))
+  end)
+
+  it("sanitises multi-label extraBlocked hosts in the ipset name", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = { "cdn.example.co.uk" }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find("ipset=/cdn.example.co.uk/eb_cdn_example_co_uk", 1, true))
+  end)
+
+  it("does NOT emit ipset= for extraAllowed hosts", function()
+    local conf = render.dnsmasq(snap_one())
+    assert.is_nil(conf:find("ipset=/khanacademy.org/", 1, true))
   end)
 
   it("handles multiple devices in different profiles", function()
@@ -70,8 +86,9 @@ describe("render.dnsmasq", function()
     assert.truthy(conf:find("dhcp-host=de:ad:be:ef:00:01,set:profile1", 1, true))
   end)
 
-  it("deduplicates extraBlocked domains across profiles", function()
+  it("deduplicates extraBlocked ipset= lines across profiles", function()
     local s = snap_one()
+    s.devices["de:ad:be:ef:00:01"] = { profileId = 1, name = "parent-phone", rules = nil }
     s.profiles["1"] = {
       name = "adults",
       rules = {
@@ -82,8 +99,35 @@ describe("render.dnsmasq", function()
       failureMode = "open",
     }
     local conf = render.dnsmasq(s)
-    local _, count = conf:gsub("address=/tiktok%.com/#", "")
+    local _, count = conf:gsub("ipset=/tiktok%.com/eb_tiktok_com", "")
     assert.equal(1, count)
+  end)
+
+  it("skips ipset= emission when an extraBlocked host has no device referencing it", function()
+    -- Profile with extraBlocked but no devices assigned → nothing to populate.
+    local s = snap_one()
+    s.profiles["7"] = {
+      name = "ghost",
+      rules = {
+        blocked = false, blockReason = nil,
+        extraBlocked = { "ghosthost.example" }, extraAllowed = {}, blocklistIds = {},
+        blockIpOnly = false,
+      },
+      failureMode = "open",
+    }
+    local conf = render.dnsmasq(s)
+    assert.is_nil(conf:find("ipset=/ghosthost.example/", 1, true))
+  end)
+
+  it("emits ipset= for device-override extraBlocked", function()
+    local s = snap_one()
+    s.devices["aa:bb:cc:11:22:33"].rules = {
+      blocked = false, blockReason = nil,
+      extraBlocked = { "override.example" },
+      extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
+    }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find("ipset=/override.example/eb_override_example", 1, true))
   end)
 
   it("returns a non-empty string", function()
@@ -237,6 +281,113 @@ describe("render.nft", function()
 
 end)
 
+-- ── extraBlocked per-(MAC, host) enforcement (#351) ──────────────────────
+--
+-- Truth 1 (docs/architecture.md §0.1): DNS is never the enforcement plane.
+-- extraBlocked must be enforced at the connection layer via nft drops on
+-- per-host ipsets populated by dnsmasq `--ipset=`. The old `address=/host/#`
+-- approach was both global (leaked across MACs) and DNS-layer (bypassable by
+-- DoH / hard-coded IPs). These tests pin the new behaviour.
+
+describe("render.nft extraBlocked enforcement", function()
+
+  it("declares set eb_<sanitized-host> with dynamic ipv4 elements + timeout for each unique extraBlocked host", function()
+    local nft = render.nft(snap_one())
+    local pos = nft:find("set eb_tiktok_com", 1, true)
+    assert.truthy(pos)
+    local block = nft:sub(pos, pos + 200)
+    assert.truthy(block:find("type ipv4_addr", 1, true))
+    assert.truthy(block:find("flags dynamic,timeout", 1, true))
+  end)
+
+  it("emits a drop rule `ether saddr <mac> ip daddr @eb_<host> drop` for each (mac, host) pair", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com drop", 1, true))
+  end)
+
+  it("does NOT drop traffic from MACs in OTHER profiles (no global leakage — the bug #351 fixes)", function()
+    -- Kids blocks tiktok.com; Adults does not.
+    local s = snap_one()
+    s.devices["de:ad:be:ef:00:01"] = { profileId = 1, name = "parent-phone", rules = nil }
+    s.profiles["1"] = {
+      name = "adults",
+      rules = {
+        blocked = false, blockReason = nil,
+        extraBlocked = {}, extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
+      },
+      failureMode = "open",
+    }
+    local nft = render.nft(s)
+    -- Kids MAC still has the drop.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com drop", 1, true))
+    -- Adults MAC must NOT appear paired with eb_tiktok_com.
+    assert.is_nil(nft:find(
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com drop", 1, true))
+  end)
+
+  it("two MACs sharing the same extraBlocked host produce ONE ipset and TWO MAC-scoped drops", function()
+    local s = snap_one()
+    s.devices["11:22:33:44:55:66"] = { profileId = 4, name = "kid-phone", rules = nil }
+    s.profiles["4"] = {
+      name = "kids2",
+      rules = {
+        blocked = false, blockReason = nil,
+        extraBlocked = { "tiktok.com" }, extraAllowed = {}, blocklistIds = {},
+        blockIpOnly = false,
+      },
+      failureMode = "closed",
+    }
+    local nft = render.nft(s)
+    local _, set_count = nft:gsub("set eb_tiktok_com {", "")
+    assert.equal(1, set_count)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com drop", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_tiktok_com drop", 1, true))
+  end)
+
+  it("emits no extraBlocked sets or drop rules when no device has extraBlocked", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = {}
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("set eb_", 1, true))
+    assert.is_nil(nft:find("@eb_", 1, true))
+  end)
+
+  it("does NOT emit any address=/.../# style DNS sinkhole regardless of extraBlocked", function()
+    -- Pin Truth 1 from the render side too — render.nft never emits dnsmasq
+    -- directives, but render.dnsmasq must not either. (Cross-checked above;
+    -- this test pins absence in the *combined* output people grep.)
+    local conf = render.dnsmasq(snap_one())
+    local nft  = render.nft(snap_one())
+    assert.is_nil(conf:find("/#", 1, true))
+    assert.is_nil(nft:find("/#", 1, true))
+  end)
+
+  it("respects device-override extraBlocked (host applies only to that MAC, not its profile siblings)", function()
+    local s = snap_one()
+    -- Profile has no extraBlocked.
+    s.profiles["3"].rules.extraBlocked = {}
+    -- Sibling device under same profile (no override).
+    s.devices["11:22:33:44:55:66"] = { profileId = 3, name = "kid-phone", rules = nil }
+    -- Our device gets a per-device extraBlocked override.
+    s.devices["aa:bb:cc:11:22:33"].rules = {
+      blocked = false, blockReason = nil,
+      extraBlocked = { "override.example" },
+      extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
+    }
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_override_example drop", 1, true))
+    -- Sibling under the same profile must NOT inherit the override.
+    assert.is_nil(nft:find(
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_override_example drop", 1, true))
+  end)
+
+end)
+
 -- ── nat chain (block-page DNAT) ───────────────────────────────────────────
 
 describe("render.nft nat chain", function()
@@ -280,7 +431,11 @@ describe("render.nft nat chain", function()
   end)
 
   it("does NOT emit the nat chain when nothing is blocked", function()
-    local nft = render.nft(snap_one())
+    local s = snap_one()
+    -- snap_one has extraBlocked which now also DNATs HTTP/80, so clear it
+    -- to verify the "nothing blocked at all" path.
+    s.profiles["3"].rules.extraBlocked = {}
+    local nft = render.nft(s)
     assert.is_nil(nft:find("familydns_block_nat", 1, true))
     assert.is_nil(nft:find("hook prerouting", 1, true))
   end)
@@ -291,6 +446,30 @@ describe("render.nft nat chain", function()
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
     assert.truthy(nft:find("ether saddr @blocked_macs drop", 1, true))
+  end)
+
+  -- #351: a connection-layer block to an extraBlocked host on HTTP/80 should
+  -- still land on the block page — same UX as MAC-wide block, just scoped.
+  it("DNATs HTTP/80 from a MAC to the block page when daddr ∈ extraBlocked ipset", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+  end)
+
+  it("emits the block-page nat chain even when only extraBlocked applies (no MAC-wide block)", function()
+    -- snap_one has extraBlocked but no MAC-wide block. The nat chain still
+    -- needs to exist so the HTTP/80 dnat rule has a hook to live in.
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find("chain familydns_block_nat", 1, true))
+    assert.truthy(nft:find("type nat hook prerouting priority dstnat", 1, true))
+  end)
+
+  it("does NOT emit the nat chain when neither MAC-wide nor extraBlocked applies", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = {}
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("familydns_block_nat", 1, true))
   end)
 
 end)


### PR DESCRIPTION
## Summary

Replaces the legacy global `address=/host/#` NXDOMAIN emission for `extraBlocked` with per-MAC nftables drops on per-host ipsets populated by dnsmasq `--ipset=` at resolve time. This matches [`docs/architecture.md §0.1`](docs/architecture.md) (Truth 1): **DNS is never the enforcement plane.** Blocking is at the connection layer; HTTP/80 still lands on the block page via DNAT.

The old approach had two bugs the architecture doc called out:

1. **Global, not per-MAC.** A single profile's `extraBlocked` list NXDOMAIN'd that host for every device on the LAN, leaking Kids' blocks onto Adults' devices.
2. **DNS-layer enforcement.** Bypassable by DoH / DoT / hard-coded resolvers, and hard-coded-IP traffic was invisible to it.

## Render changes

- **dnsmasq**: emit `ipset=/<host>/eb_<sanitized>` per unique `extraBlocked` host that has at least one device referencing it. **No `address=/.../#` lines anywhere.**
- **nft**: declare `set eb_<host> { type ipv4_addr; flags dynamic,timeout; timeout 1h }` per unique host. Add `ether saddr <mac> ip daddr @eb_<host> drop` to `familydns_block` for each `(mac, host)` pair from the cross-product of devices and their *effective* rules (profile rules or device override — `effective_rules` already does the deref).
- **nft block-page DNAT**: extend `familydns_block_nat` to DNAT HTTP/80 from `(mac, @eb_<host>)` to `127.0.0.1:8081`. The nat chain is emitted whenever EITHER MAC-wide block OR `extraBlocked` applies (previously only MAC-wide). HTTPS keeps dropping silently — no TLS MITM.
- **Per-device `rules.extraBlocked` override** produces drops scoped to that one MAC only, not its profile siblings.
- **IPv4-only** for now (matches existing `siteLimits` ipset pattern); v6 escape hatch tracked in #392.

## Smoke-probe semantics inversion ([policy.lua](openwrt/files/usr/lib/lua/familydns/policy.lua))

The #328 smoke probe verified dnsmasq actually picked up new config by checking that an `extraBlocked` host was being sinkholed. After this PR DNS resolves normally, so the assertion flips:

- `SINKHOLE_RESULTS` → `BLOCKED_RESULTS`
- `looks_sinkholed` → `is_blocked_at_connection`
- `first_blocked_domain` → `first_extrablocked_host` (now scans for `ipset=/<host>/eb_` instead of `address=/<host>/#`)
- A sinkhole-shaped answer (`0.0.0.0` / `::` / empty / NXDOMAIN) is now the *failure* — it means dnsmasq is still serving a stale config that contains DNS-layer blocks. A real upstream IP is the expected good answer.

A full end-to-end probe (resolve + try to TCP-connect from the blocked MAC) isn't feasible from inside the agent (no easy way to source-MAC a syscall), so connectivity verification stays manual. The DNS-only probe still catches the "dnsmasq didn't restart" failure that #328 was filed for, just inverted.

## Latent Lua-5.3+ bug found while writing tests

`render.effective_rules` did `tostring(dev.profileId)` for the `profiles[key]` lookup. On Lua 5.3+ with the integer/float split, cjson decodes JSON integers as **floats** — so `tostring(3.0)` gives `"3.0"`, missing the `profiles["3"]` key. The new per-(mac, host) cross-product depends on `effective_rules` per device, so this surfaced as policy_spec failures. Fixed by coercing via `string.format("%d", profileId)`. This was latent under #354; the render_spec tests passed because they used Lua-literal `profileId = 3` (integer), not JSON-decoded.

## Test plan

- [x] `busted test/render_spec.lua` — 49 cases pass (8 new for #351 semantics, 1 nft-cli pending without `nft` on host)
- [x] `busted test/policy_spec.lua` — 57 cases pass (smoke-probe inversion)
- [x] Full Lua suite (`render`, `policy`, `conntrack`, `usage`, `clock`, `failover`) — 221 pass / 0 fail
- [x] Visual inspection of generated `dnsmasq.conf` + `familydns.nft` for a two-profile / two-device snapshot: Kids gets drops on `tiktok.com`+`facebook.com`, Adults appears nowhere in extraBlocked drops, single shared ipset per host, DNAT-to-block-page rules present
- [ ] **Hardware verification** (manual, per #351 Step 7): add `tiktok.com` to a Kids profile's `extraBlocked`; from Kids device `dig tiktok.com` returns a real IP (NOT NXDOMAIN), `curl http://tiktok.com` returns the block page (NOT timeout); from Adults device same `dig` and `curl` get real content
- [ ] `architecture.md` "Known deviations" updated — extraBlocked bullet replaced with the IPv6 escape-hatch caveat (now tracked in #392)

## Filed alongside

- #392 — IPv4-only escape hatch follow-up

Closes #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)