### PR TITLE
FailureMode: align on three modes (BlockAll / AllowAll / LastKnownGood) — fixes #385

### DIFF
--- a/api/resources/db/migration/V12__failure_mode_three_modes.sql
+++ b/api/resources/db/migration/V12__failure_mode_three_modes.sql
@@ -1,0 +1,47 @@
+-- #385: align FailureMode on three modes (BlockAll / AllowAll / LastKnownGood).
+--
+-- The original V10 column was a binary 'open' / 'closed' that collapsed two
+-- semantically distinct modes — "pass everything" and "keep enforcing the
+-- cached snapshot" — into one ('open'). The agent (render.lua + policy.lua)
+-- picked the LastKnownGood interpretation (keep enforcing) for 'open', while
+-- the design doc shipped both names. This migration aligns wire/storage on
+-- the three-mode vocabulary so the doc, code, and agent agree.
+--
+-- Mapping (interpretation of CURRENT behaviour, not original intent):
+--   'closed' → 'block-all'        (agent drops all forwarded traffic — #311)
+--   'open'   → 'last-known-good'  (agent keeps the cached snapshot — #311)
+--
+-- Verified against the production DB (2026-05-14) before merge:
+--   Kids   (no users)      failure_mode='closed'  → 'block-all'
+--   Adults (admin user)    failure_mode='open'    → 'last-known-good'
+--
+-- The new explicit 'allow-all' mode has no pre-image in the binary column —
+-- it is only reachable by an admin who deliberately picks it on the new UI.
+--
+-- Column default switches to 'last-known-good': it is the safe pick when the
+-- API layer omits the field on profile insert (it preserves whatever
+-- enforcement the cached snapshot already had rather than silently clearing
+-- it). Role-aware defaulting (child → block-all, adult/admin →
+-- last-known-good) is a UI concern; the server just persists whatever value
+-- the admin selects, falling back to this column default when the field is
+-- absent.
+
+ALTER TABLE profiles
+  ALTER COLUMN failure_mode DROP DEFAULT;
+
+ALTER TABLE profiles
+  DROP CONSTRAINT IF EXISTS profiles_failure_mode_check;
+
+UPDATE profiles
+   SET failure_mode = CASE failure_mode
+                        WHEN 'closed' THEN 'block-all'
+                        WHEN 'open'   THEN 'last-known-good'
+                        ELSE failure_mode
+                      END;
+
+ALTER TABLE profiles
+  ADD CONSTRAINT profiles_failure_mode_check
+  CHECK (failure_mode IN ('block-all', 'allow-all', 'last-known-good'));
+
+ALTER TABLE profiles
+  ALTER COLUMN failure_mode SET DEFAULT 'last-known-good';

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -365,7 +365,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     r._4.map(Hostname.unsafe),
     r._5.map(Hostname.unsafe),
     r._6,
-    FailureMode.parse(r._7).getOrElse(FailureMode.Closed),
+    FailureMode.parse(r._7).getOrElse(FailureMode.LastKnownGood),
   )
   def listAll                                       =
     sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode FROM profiles ORDER BY id"

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -186,8 +186,11 @@ object ProfileRoutes {
                   upr.extraBlocked,
                   upr.extraAllowed,
                   upr.paused,
-                  // #311: missing failureMode → Closed (fail-safe).
-                  upr.failureMode.getOrElse(FailureMode.Closed),
+                  // #385: missing failureMode → LastKnownGood (preserves
+                  // cached-snapshot enforcement; matches DB column default).
+                  // Role-aware defaulting is a UI concern — the server just
+                  // persists whatever value the admin sent.
+                  upr.failureMode.getOrElse(FailureMode.LastKnownGood),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -224,8 +227,8 @@ object ProfileRoutes {
                   extraBlocked = upr.extraBlocked,
                   extraAllowed = upr.extraAllowed,
                   paused = upr.paused,
-                  // #311: if the caller omits failureMode, preserve the
-                  // existing value rather than resetting to Closed.
+                  // #385: if the caller omits failureMode, preserve the
+                  // existing value rather than resetting to the column default.
                   failureMode = upr.failureMode.getOrElse(p.failureMode),
                 ),
               )

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -11,10 +11,10 @@ import zio.json.*
 import zio.test.*
 
 /**
- * #311: PolicySnapshot must carry the per-profile failureMode so the agent can pick the right
- * failover behaviour after 5 minutes of API unreachability. Closed → drop all forwarded traffic for
- * the profile's devices; Open → keep enforcing the cached snapshot exactly as-is. Without this
- * field on the wire, "fail closed for children, fail open for adults" can't be honoured.
+ * #385: PolicySnapshot must carry the per-profile failureMode so the agent can pick the right
+ * failover behaviour after 5 minutes of API unreachability. Three modes: BlockAll → drop all
+ * forwarded traffic; AllowAll → pass everything; LastKnownGood → keep enforcing the cached snapshot
+ * exactly as-is.
  */
 object PolicySnapshotFailureModeSpec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
@@ -26,7 +26,7 @@ object PolicySnapshotFailureModeSpec
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
-  def spec = suite("PolicySnapshot — failureMode (#311)")(
+  def spec = suite("PolicySnapshot — failureMode (#385)")(
     test("snapshot carries each profile's failureMode value") {
       for {
         _      <- cleanDb
@@ -44,15 +44,19 @@ object PolicySnapshotFailureModeSpec
         kidsId   = profiles0.find(_.name == "Kids").get.id
         adultsId = profiles0.find(_.name == "Adults").get.id
         // Force the two seeded profiles into known modes.
-        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
-        _ <- pr.update(profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.Open))
+        _    <- pr.update(
+          profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),
+        )
+        _    <- pr.update(
+          profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.LastKnownGood),
+        )
         snap <- svc.snapshot
         kids   = snap.profiles(kidsId)
         adults = snap.profiles(adultsId)
-      } yield assertTrue(kids.failureMode == FailureMode.Closed) &&
-        assertTrue(adults.failureMode == FailureMode.Open)
+      } yield assertTrue(kids.failureMode == FailureMode.BlockAll) &&
+        assertTrue(adults.failureMode == FailureMode.LastKnownGood)
     },
-    test("failureMode serializes as lowercase \"open\" / \"closed\" on the wire") {
+    test("failureMode serializes as lower-kebab on the wire (#385)") {
       // The lua agent reads snapshot.failureMode as a plain string; pin the
       // exact wire spelling so render.lua's comparisons don't drift.
       for {
@@ -68,12 +72,16 @@ object PolicySnapshotFailureModeSpec
         clock  <- ZIO.service[Clock]
         svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
         profiles0 <- pr.listAll
-        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
-        _ <- pr.update(profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.Open))
-        snap <- svc.snapshot
+        _         <- pr.update(
+          profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),
+        )
+        _         <- pr.update(
+          profiles0.find(_.name == "Adults").get.copy(failureMode = FailureMode.LastKnownGood),
+        )
+        snap      <- svc.snapshot
         json = snap.toJson
-      } yield assertTrue(json.contains("\"failureMode\":\"closed\"")) &&
-        assertTrue(json.contains("\"failureMode\":\"open\""))
+      } yield assertTrue(json.contains("\"failureMode\":\"block-all\"")) &&
+        assertTrue(json.contains("\"failureMode\":\"last-known-good\""))
     },
     test("ETag flips when a profile's failureMode changes") {
       for {
@@ -89,10 +97,14 @@ object PolicySnapshotFailureModeSpec
         clock  <- ZIO.service[Clock]
         svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
         profiles0 <- pr.listAll
-        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Closed))
-        snap1 <- svc.snapshot
-        _ <- pr.update(profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.Open))
-        snap2 <- svc.snapshot
+        _         <- pr.update(
+          profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),
+        )
+        snap1     <- svc.snapshot
+        _         <- pr.update(
+          profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.LastKnownGood),
+        )
+        snap2     <- svc.snapshot
       } yield assertTrue(snap1.etag != snap2.etag)
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -154,7 +154,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(stls.head.label == "YouTube") &&
           assertTrue(stls.head.dailyMinutes == 45)
       },
-      test("failureMode defaults to Closed when omitted from create request (#311 fail-safe)") {
+      test("failureMode defaults to LastKnownGood when omitted from create request (#385)") {
         for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
@@ -184,9 +184,9 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           _        <- routes.runZIO(req)
           profiles <- profileRepo.listAll
           found = profiles.find(_.name == "Defaulted").get
-        } yield assertTrue(found.failureMode == FailureMode.Closed)
+        } yield assertTrue(found.failureMode == FailureMode.LastKnownGood)
       },
-      test("failureMode=Open in create request persists Open (#311 admin override)") {
+      test("failureMode=AllowAll in create request persists AllowAll (#385 admin override)") {
         for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
@@ -207,7 +207,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             userRepoSvc,
           )
           body   = UpsertProfileRequest(
-            name = "AdultsOpen",
+            name = "AdultsAllowAll",
             blockedCategories = Nil,
             extraBlocked = Nil,
             extraAllowed = Nil,
@@ -215,7 +215,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             schedules = Nil,
             timeLimit = None,
             siteTimeLimits = Nil,
-            failureMode = Some(FailureMode.Open),
+            failureMode = Some(FailureMode.AllowAll),
           ).toJson
           req    = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
@@ -223,8 +223,8 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             .addHeader(Header.ContentType(MediaType.application.json))
           _        <- routes.runZIO(req)
           profiles <- profileRepo.listAll
-          found = profiles.find(_.name == "AdultsOpen").get
-        } yield assertTrue(found.failureMode == FailureMode.Open)
+          found = profiles.find(_.name == "AdultsAllowAll").get
+        } yield assertTrue(found.failureMode == FailureMode.AllowAll)
       },
       test("PUT /api/profiles/:id updates failureMode") {
         for {
@@ -257,7 +257,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             schedules = Nil,
             timeLimit = None,
             siteTimeLimits = Nil,
-            failureMode = Some(FailureMode.Open),
+            failureMode = Some(FailureMode.AllowAll),
           ).toJson
           req    = Request
             .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
@@ -266,7 +266,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           resp    <- routes.runZIO(req)
           updated <- profileRepo.findById(kidsId)
         } yield assertTrue(resp.status == Status.Ok) &&
-          assertTrue(updated.exists(_.failureMode == FailureMode.Open))
+          assertTrue(updated.exists(_.failureMode == FailureMode.AllowAll))
       },
       test("child user cannot create profiles") {
         for {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,10 @@ case class ProfilePolicy(
     rules: BlockRules,
     failureMode: FailureMode,                  // per-profile: what the router does
                                                //   for THIS profile's devices if it can't
-                                               //   reach the API for >5min
+                                               //   reach the API for >5min. See
+                                               //   docs/resilience.md §4 for the
+                                               //   per-mode behaviour and the
+                                               //   defaulting policy.
 )
 
 case class BlockRules(
@@ -397,7 +400,7 @@ Modified` if the client's ETag still matches.
         "blocklistIds": ["ads", "adult"],
         "blockIpOnly": true
       },
-      "failureMode": "closed"
+      "failureMode": "block-all"
     }
   },
   "blocklists": {

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -6,8 +6,9 @@ This document defines how familydns SHOULD behave under five failure scenarios.
 It is the durable design contract. Implementation may lag; gaps are filed as
 individual follow-up issues that reference #269.
 
-The decisions in §4 (fail-closed for child profiles) and §5 (NTP-skew handling)
-are policy calls that need explicit operator sign-off before implementations land.
+The decisions in §4 (per-profile three-mode failover; #385) and §5 (NTP-skew
+handling) are policy calls that need explicit operator sign-off before
+implementations land.
 
 ---
 
@@ -159,55 +160,99 @@ client (the agent) without parsing error bodies.
   shorter than this; the cached snapshot is the correct enforcement
   posture during transient failures.
 - **After 5 minutes of consecutive failed polls**, the agent transitions
-  enforcement per **per-profile `failureMode`**:
-  - **`closed` (default for child profiles):** the profile's devices have
-    all forwarded traffic dropped, with the block page served for HTTP.
-    This is the same posture as "all categorical blocks active + paused."
-  - **`open` (default for adult / admin profiles):** the profile's devices
-    continue under the cached policy with no new restrictions. Existing
-    blocks (categorical, schedule) still apply because they're in the
-    cached snapshot; only the API-unreachable-specific transition is a
-    no-op.
+  enforcement per **per-profile `failureMode`**. Three modes (#385) —
+  named identically across architecture.md §0.2, this section,
+  `shared/src/Models.scala`, the wire JSON, and the DB column:
+  - **`BlockAll`** (wire `"block-all"`, recommended for child profiles):
+    the profile's devices have all forwarded traffic dropped, with the
+    block page served for HTTP. Same posture as "all categorical blocks
+    active + paused."
+  - **`LastKnownGood`** (wire `"last-known-good"`, default and
+    recommended for adult/admin profiles): the profile's devices
+    continue under the cached snapshot exactly as-is. Categorical
+    blocks, schedules, and per-MAC overrides all keep enforcing because
+    they live in the cached snapshot; only the
+    API-unreachable-specific transition is a no-op.
+  - **`AllowAll`** (wire `"allow-all"`, opt-in only): the profile's
+    devices are explicitly carved out of every drop rule — the
+    `@blocked_macs` membership, the per-`(MAC, host)` extraBlocked
+    drops, and the per-`(MAC, blocklistId)` category drops are all
+    suppressed for these MACs during failover, and the block-page DNAT
+    is suppressed too. Cached enforcement is intentionally erased for
+    these MACs; admins must pick this deliberately for trusted profiles
+    where lockout risk outweighs the cached-snapshot defence.
 - **On API return**, the agent applies the fresh snapshot and clears the
   failover state immediately. There is no hysteresis — recovery is instant.
 
 ### Why
-This is the **central parental-controls correctness decision.** Fail-open
-for kids means "yank the WAN cable" is a complete bypass — unacceptable.
-Fail-closed for adults means an ISP blip locks the household out of their
-own LAN — also unacceptable. Per-profile `failureMode` resolves the conflict.
+This is the **central parental-controls correctness decision.** A single
+"pass everything" mode for kids is a complete bypass — "yank the WAN
+cable" defeats the filter. A single "block everything" mode for adults
+locks the household out of their own LAN during ordinary ISP blips.
+Per-profile `failureMode` resolves the conflict.
+
+The original design (#311) shipped only two modes — `Open` and
+`Closed` — and that binary collapsed two semantically distinct
+behaviours: "pass everything with no enforcement" (AllowAll) and "keep
+the cached snapshot enforcing exactly" (LastKnownGood). The agent
+shipped one interpretation (`Open` = LastKnownGood); the doc shipped the
+other (`Open` = AllowAll). #385 separates them.
 
 The 5-minute threshold balances two costs:
-- Too short (< 1 min): every flaky cellular failover triggers a fail-closed
-  event, which kids will notice and learn to exploit (wait it out).
+- Too short (< 1 min): every flaky cellular failover triggers a
+  failover transition, which kids will notice and learn to exploit
+  (wait it out).
 - Too long (> 15 min): a determined kid who unplugs the WAN can browse
-  freely for that whole window. 5 minutes is short enough to be annoying
-  rather than useful.
+  freely for that whole window. 5 minutes is short enough to be
+  annoying rather than useful.
 
-Default `closed` for child role and `open` for adult/admin reflects the
-asymmetric blast radius: a false-closed for an adult is "my work Zoom
-dropped"; a false-open for a child is "they got around the filter."
+Defaults reflect the asymmetric blast radius. For a child profile,
+"BlockAll" trades a false-block (kid loses access during a real ISP
+blip) for the guarantee that "unplug the WAN" is not a bypass. For an
+adult profile, "LastKnownGood" is the conservative choice: the cached
+snapshot keeps enforcing whatever categorical blocks / schedules were
+already in place without taking the household offline. `AllowAll` is
+never a default — it must be picked deliberately.
 
 ### Implementation
-- `shared/src/Models.scala`: add `failureMode: FailureMode` to
-  `PolicyProfile` with `FailureMode = Open | Closed`. Default derived from
-  profile role.
-- `api/src/policy/PolicyService.scala`: include `failureMode` in the rendered
-  `PolicySnapshot`.
-- `openwrt/files/usr/sbin/familydns-agent`: track `last_successful_poll_ts`.
-  When `now - last > 300s`, render a "failover" nft variant — drop forwarded
-  traffic for devices whose profile is `closed`; pass-through for `open`.
-- Admin UI: add a "Failure mode" radio on the profile edit page with a
-  short explanation. Default value baked in by role on profile creation.
+- `shared/src/Models.scala`: `enum FailureMode { case BlockAll, AllowAll,
+  LastKnownGood }`. JSON codec emits lower-kebab wire forms.
+- `api/resources/db/migration/V12__failure_mode_three_modes.sql`:
+  migrate existing rows (`closed` → `block-all`, `open` →
+  `last-known-good`) and add a CHECK constraint pinning the new
+  vocabulary. Column default switches to `last-known-good`.
+- `api/src/routes/Routes.scala`: profile create / update preserves an
+  explicit `failureMode` from the request body; falls back to
+  `LastKnownGood` only when the field is absent (column default mirrors
+  this). Role-aware defaulting (child → BlockAll) is a UI concern —
+  the server does not infer a default from linked-user roles.
+- `api/src/policy/PolicyService.scala`: includes `failureMode` per
+  `ProfilePolicy` in the rendered `PolicySnapshot`. The ETag covers
+  this value so a mode change invalidates client caches.
+- `openwrt/files/usr/lib/lua/familydns/policy.lua`: tracks
+  `last_successful_poll_ts`; on `now - last > 300s`, renders nft with
+  `opts.poll_age_seconds`.
+- `openwrt/files/usr/lib/lua/familydns/render.lua`: branches by mode.
+  `BlockAll` emits a dedicated `failover_drop` set and drop chain.
+  `AllowAll` suppresses the profile's MACs from every drop list before
+  the `familydns_block` and `familydns_block_nat` chains are rendered.
+  `LastKnownGood` is the no-op default — nothing additional is
+  rendered, and the cached snapshot rules keep enforcing exactly.
+- Admin UI: three-option radio on the profile edit page (`ProfilesPage`)
+  with explanatory copy per mode.
 
 ### How to verify
 - Block the API at the router (firewall rule on the router itself
-  blocking egress to the API host). Wait 5 minutes. Confirm that a
-  child-profile device cannot reach the internet but the block page
-  loads; confirm an adult-profile device continues to work under cached
-  policy.
-- Restore API reachability; both profiles return to normal within one
-  poll cycle.
+  blocking egress to the API host). Wait 5 minutes. Confirm that:
+  - A `BlockAll` profile's device cannot reach the internet but the
+    block page loads;
+  - A `LastKnownGood` profile's device continues to work under cached
+    policy, including any categorical / schedule blocks that were
+    already in effect;
+  - An `AllowAll` profile's device passes traffic with no enforcement,
+    even if the cached snapshot has `extraBlocked` entries for it.
+- Restore API reachability; all three profiles return to normal within
+  one poll cycle.
 
 ---
 

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -23,8 +23,9 @@
 --                                   sinkhole-shaped answer means dnsmasq
 --                                   is still applying a stale rendering
 --                                   (failed restart) and triggers a WARN.
---       opts.poll_age_seconds → forwarded to render.nft for the #311 / #331
---                                 failover branch.
+--       opts.poll_age_seconds → forwarded to render.nft for the #385
+--                                 failover branch (three modes: block-all,
+--                                 allow-all, last-known-good).
 
 local M = {}
 

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -176,10 +176,30 @@ end
 -- ---------------------------------------------------------------------------
 -- opts (optional table):
 --   poll_age_seconds  number — seconds since the last successful policy poll.
---                              When > 300, devices whose profile's
---                              failureMode == "closed" get an additional
---                              failover drop rule. failureMode == "open"
---                              profiles are unaffected.
+--                              When > 300, the per-profile failureMode
+--                              decides what happens (#385):
+--                                "block-all"       → emit an additional drop
+--                                                    rule for the profile's
+--                                                    devices (fail-safe).
+--                                "allow-all"       → suppress this profile's
+--                                                    devices from
+--                                                    @blocked_macs and from
+--                                                    every per-(MAC, host)
+--                                                    and per-(MAC,
+--                                                    blocklistId) drop, and
+--                                                    from the DNAT chain.
+--                                                    Cached enforcement is
+--                                                    erased for these MACs.
+--                                "last-known-good" → no change. The profile's
+--                                                    cached snapshot rules
+--                                                    keep enforcing exactly
+--                                                    as-is (this is the
+--                                                    behaviour the original
+--                                                    binary "open" had).
+--                              Below the 5-minute threshold all profiles
+--                              behave as LastKnownGood — the cached
+--                              snapshot stands and no failover transition
+--                              has happened yet.
 function M.nft(snapshot, opts)
   local out = {}
   local function emit(s)  out[#out + 1] = s  end
@@ -206,6 +226,31 @@ function M.nft(snapshot, opts)
     if pid then
       if not profile_macs[pid] then profile_macs[pid] = {} end
       profile_macs[pid][#profile_macs[pid] + 1] = mac
+    end
+  end
+
+  -- #385: during failover (>5 min API-unreachable), an AllowAll profile's
+  -- devices must NOT receive any drop rule — not the @blocked_macs
+  -- entry, not the per-(MAC, host) eb_ drops, not the per-(MAC,
+  -- blocklistId) bl_ drops, and not the block-page DNAT. The cached
+  -- snapshot is intentionally discarded for these MACs (cf. LastKnownGood,
+  -- where the cached snapshot keeps enforcing). Compute the suppress set
+  -- once so every subsequent rule-emission step can filter cheaply.
+  local poll_age = opts and opts.poll_age_seconds
+  local in_failover = poll_age and poll_age > 300
+  local allowall_macs = {}
+  if in_failover then
+    local allowall_pids = {}
+    for pidStr, prof in pairs(snapshot.profiles or {}) do
+      if prof.failureMode == "allow-all" then
+        local pid = tonumber(pidStr)
+        if pid then allowall_pids[pid] = true end
+      end
+    end
+    for mac, dev in pairs(snapshot.devices or {}) do
+      if dev.profileId and allowall_pids[dev.profileId] then
+        allowall_macs[mac] = true
+      end
     end
   end
 
@@ -244,7 +289,7 @@ function M.nft(snapshot, opts)
   local blocked_macs_list = {}
   for mac, dev in sorted_devices(snapshot.devices) do
     local r = effective_rules(dev, snapshot.profiles)
-    if r and r.blocked then
+    if r and r.blocked and not allowall_macs[mac] then
       blocked_macs_list[#blocked_macs_list + 1] = mac
     end
   end
@@ -277,10 +322,12 @@ function M.nft(snapshot, opts)
   -- device override applies only to that one MAC.
   local eb_pairs = {}
   for mac, dev in sorted_devices(snapshot.devices) do
-    local r = effective_rules(dev, snapshot.profiles)
-    if r and type(r.extraBlocked) == "table" then
-      for _, host in ipairs(r.extraBlocked) do
-        eb_pairs[#eb_pairs + 1] = { mac = mac, host = host }
+    if not allowall_macs[mac] then
+      local r = effective_rules(dev, snapshot.profiles)
+      if r and type(r.extraBlocked) == "table" then
+        for _, host in ipairs(r.extraBlocked) do
+          eb_pairs[#eb_pairs + 1] = { mac = mac, host = host }
+        end
       end
     end
   end
@@ -303,11 +350,13 @@ function M.nft(snapshot, opts)
   -- emit a drop rule. Ids absent from snapshot.blocklists are silently skipped.
   local bl_pairs = {}
   for mac, dev in sorted_devices(snapshot.devices) do
-    local r = effective_rules(dev, snapshot.profiles)
-    if r and type(r.blocklistIds) == "table" then
-      for _, id in ipairs(r.blocklistIds) do
-        if (snapshot.blocklists or {})[id] then
-          bl_pairs[#bl_pairs + 1] = { mac = mac, id = id }
+    if not allowall_macs[mac] then
+      local r = effective_rules(dev, snapshot.profiles)
+      if r and type(r.blocklistIds) == "table" then
+        for _, id in ipairs(r.blocklistIds) do
+          if (snapshot.blocklists or {})[id] then
+            bl_pairs[#bl_pairs + 1] = { mac = mac, id = id }
+          end
         end
       end
     end
@@ -353,21 +402,28 @@ function M.nft(snapshot, opts)
     emit("")
   end
 
-  -- #311 / #354: API-unreachable failover. failureMode is now per-profile
-  -- (carried on ProfilePolicy). Collect MACs of devices whose profile's
-  -- failureMode == "closed".
-  local poll_age = opts and opts.poll_age_seconds
-  if poll_age and poll_age > 300 then
-    local closed_pids = {}
+  -- #385: API-unreachable failover. failureMode is per-profile (carried on
+  -- ProfilePolicy) with three variants — see the opts.poll_age_seconds
+  -- doc at the top of M.nft for the per-mode behaviour. This block only
+  -- handles BlockAll: collect MACs of devices whose profile's failureMode
+  -- is "block-all" and emit a drop chain for them. AllowAll is enforced
+  -- by SUPPRESSION earlier in this function (allowall_macs gates the
+  -- @blocked_macs / eb_pairs / bl_pairs lists, so AllowAll devices reach
+  -- this point with zero drop rules attributed to them — exactly what
+  -- "pass forwarded traffic with no enforcement" means). LastKnownGood
+  -- is the no-op default: the cached snapshot's rules keep enforcing
+  -- exactly as-is.
+  if in_failover then
+    local blockall_pids = {}
     for pidStr, prof in pairs(snapshot.profiles or {}) do
-      if prof.failureMode == "closed" then
+      if prof.failureMode == "block-all" then
         local pid = tonumber(pidStr)
-        if pid then closed_pids[pid] = true end
+        if pid then blockall_pids[pid] = true end
       end
     end
     local failover_macs = {}
     for mac, dev in sorted_devices(snapshot.devices) do
-      if dev.profileId and closed_pids[dev.profileId] then
+      if dev.profileId and blockall_pids[dev.profileId] then
         failover_macs[#failover_macs + 1] = mac
       end
     end

--- a/openwrt/test/failover_spec.lua
+++ b/openwrt/test/failover_spec.lua
@@ -1,17 +1,19 @@
--- Tests for #311 fail-closed / fail-open failover in render.nft.
+-- Tests for #385 three-mode failover in render.nft.
 --
 -- The agent passes opts.poll_age_seconds = (now - last_successful_poll_ts).
--- When poll_age > 300, profiles with failureMode == "closed" get an additional
--- drop rule for ALL their devices' MACs (regardless of effective BlockRules).
--- Profiles with failureMode == "open" keep enforcing the cached snapshot
--- exactly as-is.
+-- When poll_age > 300, the per-profile failureMode decides what happens:
+--   "block-all"       — profile's MACs get an additional drop chain.
+--   "allow-all"       — profile's MACs are SUPPRESSED from every drop
+--                       rule (blocked_macs, eb_pairs, bl_pairs) and the
+--                       block-page DNAT. Cached enforcement is erased
+--                       for these MACs during failover.
+--   "last-known-good" — no change. The cached snapshot keeps enforcing
+--                       exactly as-is.
 --
 -- Run with: cd openwrt && busted test/failover_spec.lua
 
 local render = require("render")
 
--- Two-profile snapshot: a Closed-failover "kids" profile (devices A, B) and
--- an Open-failover "adults" profile (devices C, D).
 local function empty_rules()
   return {
     blocked = false, blockReason = nil,
@@ -19,86 +21,184 @@ local function empty_rules()
   }
 end
 
-local function snap_two()
+-- Three-profile snapshot covering every mode. One device per profile.
+local function snap_three()
   return {
     etag        = "sha256:f1",
     generatedAt = "2026-05-14T14:00:00Z",
     devices = {
-      ["aa:aa:aa:00:00:01"] = { profileId = 1, name = "kid-A", rules = nil },
-      ["aa:aa:aa:00:00:02"] = { profileId = 1, name = "kid-B", rules = nil },
-      ["bb:bb:bb:00:00:03"] = { profileId = 2, name = "adult-C", rules = nil },
-      ["bb:bb:bb:00:00:04"] = { profileId = 2, name = "adult-D", rules = nil },
+      ["aa:aa:aa:00:00:01"] = { profileId = 1, name = "kid",      rules = nil },
+      ["bb:bb:bb:00:00:02"] = { profileId = 2, name = "adult",    rules = nil },
+      ["cc:cc:cc:00:00:03"] = { profileId = 3, name = "guest",    rules = nil },
     },
     profiles = {
-      ["1"] = { name = "kids",   rules = empty_rules(), failureMode = "closed" },
-      ["2"] = { name = "adults", rules = empty_rules(), failureMode = "open"   },
+      ["1"] = { name = "kids",   rules = empty_rules(), failureMode = "block-all" },
+      ["2"] = { name = "adults", rules = empty_rules(), failureMode = "last-known-good" },
+      ["3"] = { name = "guest",  rules = empty_rules(), failureMode = "allow-all" },
     },
     blocklists = {},
   }
 end
 
-describe("render.nft — #311 failover", function()
+describe("render.nft — #385 three-mode failover", function()
 
-  it("emits no failover drop set when poll_age_seconds is nil (no signal yet)", function()
-    local nft = render.nft(snap_two())
+  -- ── BlockAll: existing failover_drop chain ────────────────────────────
+
+  it("emits no failover artifacts when poll_age_seconds is nil (no signal yet)", function()
+    local nft = render.nft(snap_three())
     assert.is_nil(nft:find("failover_drop", 1, true))
   end)
 
-  it("emits no failover drop set when poll_age_seconds <= 300 (within window)", function()
-    local nft = render.nft(snap_two(), { poll_age_seconds = 300 })
+  it("emits no failover_drop set when poll_age_seconds <= 300 (within window)", function()
+    local nft = render.nft(snap_three(), { poll_age_seconds = 300 })
     assert.is_nil(nft:find("failover_drop", 1, true))
   end)
 
-  it("emits a failover drop set with Closed-profile MACs when poll_age > 300", function()
-    local nft = render.nft(snap_two(), { poll_age_seconds = 301 })
+  it("BlockAll: emits failover_drop containing only the block-all profile's MACs (>300s)", function()
+    local nft = render.nft(snap_three(), { poll_age_seconds = 301 })
     assert.truthy(nft:find("set failover_drop", 1, true))
-    -- Closed profile devices land in the set.
+    -- Block-all profile device is in the set.
     assert.truthy(nft:find("aa:aa:aa:00:00:01", 1, true))
-    assert.truthy(nft:find("aa:aa:aa:00:00:02", 1, true))
-    -- A drop rule on the set is emitted.
     assert.truthy(nft:find("@failover_drop", 1, true))
-    assert.truthy(nft:find("drop", 1, true))
-  end)
-
-  it("excludes Open-profile MACs from the failover drop set", function()
-    local nft = render.nft(snap_two(), { poll_age_seconds = 301 })
-    -- Locate the failover_drop set body and check the open-profile MACs
-    -- aren't inside it. (The MACs may still appear elsewhere — e.g. in
-    -- profile2_macs — so we must scope this check.)
+    -- Scope the membership check to the set body.
     local s = nft:find("set failover_drop", 1, true)
-    assert.truthy(s)
     local body_end = nft:find("}", s, true)
     local body = nft:sub(s, body_end)
-    assert.is_nil(body:find("bb:bb:bb:00:00:03", 1, true))
-    assert.is_nil(body:find("bb:bb:bb:00:00:04", 1, true))
+    assert.is_nil(body:find("bb:bb:bb:00:00:02", 1, true),
+      "LastKnownGood device must NOT be in failover_drop")
+    assert.is_nil(body:find("cc:cc:cc:00:00:03", 1, true),
+      "AllowAll device must NOT be in failover_drop")
   end)
 
-  it("emits no failover drop rule when a Closed profile has zero devices", function()
-    -- Edge case called out in #311: an empty Closed profile must not produce
-    -- a degenerate drop rule that matches nothing-but-costs-cycles.
-    local s = snap_two()
-    -- Strip the kids-profile devices; kids is still failureMode=closed.
+  it("BlockAll: empty block-all profile produces no drop chain", function()
+    local s = snap_three()
     s.devices = {
-      ["bb:bb:bb:00:00:03"] = { profileId = 2, name = "adult-C", rules = nil },
+      ["bb:bb:bb:00:00:02"] = { profileId = 2, name = "adult", rules = nil },
     }
     local nft = render.nft(s, { poll_age_seconds = 9999 })
-    -- No drop rule against a hypothetical empty set.
     assert.is_nil(nft:find("@failover_drop", 1, true))
   end)
 
-  it("boundary: 300s is in-window, 301s triggers failover (strict > 300)", function()
-    local nft_300 = render.nft(snap_two(), { poll_age_seconds = 300 })
-    local nft_301 = render.nft(snap_two(), { poll_age_seconds = 301 })
+  it("BlockAll: boundary — 300s in-window, 301s trips failover (strict > 300)", function()
+    local nft_300 = render.nft(snap_three(), { poll_age_seconds = 300 })
+    local nft_301 = render.nft(snap_three(), { poll_age_seconds = 301 })
     assert.is_nil(nft_300:find("@failover_drop", 1, true))
     assert.truthy(nft_301:find("@failover_drop", 1, true))
   end)
 
+  -- ── LastKnownGood: cached snapshot keeps enforcing ───────────────────
+
+  it("LastKnownGood: cached snapshot rules keep enforcing during failover", function()
+    -- Adult profile has paused-by-API set to true in the cached snapshot.
+    -- LastKnownGood means the cached @blocked_macs membership must persist.
+    local s = snap_three()
+    s.profiles["2"].rules.blocked = true
+    s.profiles["2"].rules.blockReason = "Paused"
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    assert.truthy(nft:find("bb:bb:bb:00:00:02", 1, true),
+      "LastKnownGood adult MAC must remain in @blocked_macs")
+    -- And LastKnownGood is NOT in the failover_drop set even though it's blocked.
+    local s_off = nft:find("set failover_drop", 1, true)
+    if s_off then
+      local body_end = nft:find("}", s_off, true)
+      local body = nft:sub(s_off, body_end)
+      assert.is_nil(body:find("bb:bb:bb:00:00:02", 1, true))
+    end
+  end)
+
+  -- ── AllowAll: cached enforcement erased for these MACs ───────────────
+
+  it("AllowAll: profile's MAC is SUPPRESSED from @blocked_macs during failover", function()
+    -- Cached snapshot had AllowAll guest blocked (e.g. via scheduled block);
+    -- failover must clear that.
+    local s = snap_three()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    -- Scope to the @blocked_macs set body.
+    local s_off = nft:find("set blocked_macs", 1, true)
+    assert.truthy(s_off)
+    local body_end = nft:find("}", s_off, true)
+    local body = nft:sub(s_off, body_end)
+    assert.is_nil(body:find("cc:cc:cc:00:00:03", 1, true),
+      "AllowAll MAC must be excluded from @blocked_macs during failover")
+  end)
+
+  it("AllowAll: profile's extraBlocked drops are SUPPRESSED during failover", function()
+    local s = snap_three()
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    assert.is_nil(nft:find(
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
+      "AllowAll MAC must NOT have per-(MAC, host) extraBlocked drops during failover")
+  end)
+
+  it("AllowAll: profile's blocklistIds drops are SUPPRESSED during failover", function()
+    local s = snap_three()
+    s.profiles["3"].rules.blocklistIds = { "ads" }
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    assert.is_nil(nft:find(
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @bl_ads drop", 1, true),
+      "AllowAll MAC must NOT have per-(MAC, blocklistId) drops during failover")
+  end)
+
+  it("AllowAll: same blocks still apply pre-failover (poll_age=0 or unset)", function()
+    -- Sanity: the AllowAll suppression must be gated on in_failover. With
+    -- no poll_age signal (or poll_age <= 300), the cached snapshot's
+    -- extraBlocked entry for guest still produces its drop rule.
+    local s = snap_three()
+    s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
+    local nft_no_failover = render.nft(s)
+    assert.truthy(nft_no_failover:find(
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
+      "AllowAll must enforce normally outside the failover window")
+    local nft_in_window = render.nft(s, { poll_age_seconds = 60 })
+    assert.truthy(nft_in_window:find(
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
+      "AllowAll must enforce normally before the 5-minute threshold")
+  end)
+
+  it("AllowAll: other profiles' drops are unaffected by AllowAll suppression", function()
+    -- Block-all profile gets its failover_drop; LastKnownGood retains its
+    -- cached drops. Only the AllowAll profile's MACs are excluded.
+    local s = snap_three()
+    s.profiles["1"].rules.extraBlocked = { "kidblocked.example" }
+    s.profiles["2"].rules.extraBlocked = { "adultblocked.example" }
+    s.profiles["3"].rules.extraBlocked = { "guestblocked.example" }
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    -- Block-all kid keeps its extraBlocked drop.
+    assert.truthy(nft:find(
+      "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example drop",
+      1, true))
+    -- LastKnownGood adult keeps its extraBlocked drop.
+    assert.truthy(nft:find(
+      "ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example drop",
+      1, true))
+    -- AllowAll guest does NOT have its extraBlocked drop.
+    assert.is_nil(nft:find(
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_guestblocked_example drop",
+      1, true))
+  end)
+
+  it("AllowAll: profile's block-page DNAT is SUPPRESSED during failover", function()
+    local s = snap_three()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    assert.is_nil(nft:find(
+      "ether saddr cc:cc:cc:00:00:03", 1, true),
+      "no DNAT rule scoped to AllowAll MAC during failover")
+  end)
+
+  -- ── Regression: omitted opts ─────────────────────────────────────────
+
   it("normal (non-failover) snapshot rendering is unchanged when opts omitted", function()
-    -- Regression: render.nft(snapshot) with no second arg must still work.
-    local nft = render.nft(snap_two())
+    local nft = render.nft(snap_three())
     assert.truthy(nft:find("table inet familydns", 1, true))
     assert.truthy(nft:find("set profile1_macs", 1, true))
     assert.truthy(nft:find("set profile2_macs", 1, true))
+    assert.truthy(nft:find("set profile3_macs", 1, true))
   end)
 
 end)

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -24,7 +24,7 @@ local SNAPSHOT_JSON = [[{
         "blocklistIds": ["ads"],
         "blockIpOnly": false
       },
-      "failureMode": "closed"
+      "failureMode": "block-all"
     }
   },
   "blocklists": {}
@@ -419,7 +419,7 @@ describe("policy.apply", function()
           "extraBlocked": ["badsite.example.com"],
           "extraAllowed": [], "blocklistIds": [], "blockIpOnly": false
         },
-        "failureMode": "closed"
+        "failureMode": "block-all"
       }
     },
     "blocklists": {}
@@ -537,9 +537,9 @@ describe("policy.apply", function()
       "smoke-check failure must not fail the apply — propagation is a separate concern")
   end)
 
-  -- #331: opts pass-through. Use an inline snapshot with an explicit
-  -- failureMode="closed" profile so render.lua's failover branch (which
-  -- gates on `prof.failureMode == "closed"`) actually fires.
+  -- #331/#385: opts pass-through. Use an inline snapshot with an explicit
+  -- failureMode="block-all" profile so render.lua's failover branch (which
+  -- gates on `prof.failureMode == "block-all"`) actually fires.
   local function snap_with_closed_profile()
     return {
       etag = "sha256:test",
@@ -554,7 +554,7 @@ describe("policy.apply", function()
             blocked = false, blockReason = nil,
             extraBlocked = {}, extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
           },
-          failureMode = "closed",
+          failureMode = "block-all",
         },
       },
       blocklists = {},

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -28,7 +28,7 @@ local function snap_one()
           blocklistIds = { "ads", "adult" },
           blockIpOnly  = false,
         },
-        failureMode = "closed",
+        failureMode = "block-all",
       },
     },
     blocklists = {},
@@ -79,7 +79,7 @@ describe("render.dnsmasq", function()
         blocked = false, blockReason = nil,
         extraBlocked = {}, extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
       },
-      failureMode = "open",
+      failureMode = "last-known-good",
     }
     local conf = render.dnsmasq(s)
     assert.truthy(conf:find("dhcp-host=aa:bb:cc:11:22:33,set:profile3", 1, true))
@@ -96,7 +96,7 @@ describe("render.dnsmasq", function()
         extraBlocked = { "tiktok.com" }, extraAllowed = {}, blocklistIds = {},
         blockIpOnly = false,
       },
-      failureMode = "open",
+      failureMode = "last-known-good",
     }
     local conf = render.dnsmasq(s)
     local _, count = conf:gsub("ipset=/tiktok%.com/eb_tiktok_com", "")
@@ -113,7 +113,7 @@ describe("render.dnsmasq", function()
         extraBlocked = { "ghosthost.example" }, extraAllowed = {}, blocklistIds = {},
         blockIpOnly = false,
       },
-      failureMode = "open",
+      failureMode = "last-known-good",
     }
     local conf = render.dnsmasq(s)
     assert.is_nil(conf:find("ipset=/ghosthost.example/", 1, true))
@@ -316,7 +316,7 @@ describe("render.nft extraBlocked enforcement", function()
         blocked = false, blockReason = nil,
         extraBlocked = {}, extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
       },
-      failureMode = "open",
+      failureMode = "last-known-good",
     }
     local nft = render.nft(s)
     -- Kids MAC still has the drop.
@@ -337,7 +337,7 @@ describe("render.nft extraBlocked enforcement", function()
         extraBlocked = { "tiktok.com" }, extraAllowed = {}, blocklistIds = {},
         blockIpOnly = false,
       },
-      failureMode = "closed",
+      failureMode = "block-all",
     }
     local nft = render.nft(s)
     local _, set_count = nft:gsub("set eb_tiktok_com {", "")
@@ -549,7 +549,7 @@ describe("render.update_shared", function()
         blocked = true, blockReason = "TimeLimit",
         extraBlocked = {}, extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
       },
-      failureMode = "closed",
+      failureMode = "block-all",
     }
     local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
     render.update_shared(s, nft_sets, blocked_macs, blocked_reason)
@@ -617,7 +617,7 @@ describe("render blocklist enforcement (#352)", function()
             blocklistIds = { "test_ads" },
             blockIpOnly  = false,
           },
-          failureMode = "closed",
+          failureMode = "block-all",
         },
         ["1"] = {
           name = "adults",
@@ -629,7 +629,7 @@ describe("render blocklist enforcement (#352)", function()
             blocklistIds = {},
             blockIpOnly  = false,
           },
-          failureMode = "open",
+          failureMode = "last-known-good",
         },
       },
       blocklists = {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -33,23 +33,34 @@ object UserRole {
   )
 }
 
-// #311: per-profile failover behaviour when the agent loses contact with the
-// API for >5 min. Closed = drop all forwarded traffic for the profile's
-// devices (fail-safe for kids); Open = keep enforcing the cached snapshot
-// exactly as-is (avoids locking adults out during ISP blips).
+// #385: per-profile failover behaviour when the agent loses contact with the
+// API for >5 min. Three modes (replacing the original binary Open/Closed
+// from #311, which collapsed AllowAll and LastKnownGood into one):
+//   BlockAll      — drop all forwarded traffic for the profile's devices
+//                   (fail-safe; recommended default for child profiles).
+//   AllowAll      — pass forwarded traffic with no enforcement; clears all
+//                   per-MAC drop rules for the profile (only sensible for
+//                   trusted profiles where the cached-snapshot defence is
+//                   not worth the lockout risk).
+//   LastKnownGood — keep enforcing the cached snapshot exactly as-is
+//                   (recommended default for adult/admin profiles —
+//                   preserves existing category/extra/schedule rules
+//                   without auto-blocking everything).
 enum FailureMode {
-  case Open, Closed
+  case BlockAll, AllowAll, LastKnownGood
 }
 
 object FailureMode {
   def asString(m: FailureMode): String      = m match {
-    case Open   => "open"
-    case Closed => "closed"
+    case BlockAll      => "block-all"
+    case AllowAll      => "allow-all"
+    case LastKnownGood => "last-known-good"
   }
   def parse(s: String): Option[FailureMode] = s.toLowerCase match {
-    case "open"   => Some(Open)
-    case "closed" => Some(Closed)
-    case _        => None
+    case "block-all"       => Some(BlockAll)
+    case "allow-all"       => Some(AllowAll)
+    case "last-known-good" => Some(LastKnownGood)
+    case _                 => None
   }
   given JsonCodec[FailureMode]              = JsonCodec[String].transformOrFail(
     s => parse(s).toRight(s"unknown failureMode: $s"),
@@ -64,7 +75,7 @@ case class Profile(
     extraBlocked: List[Hostname],
     extraAllowed: List[Hostname],
     paused: Boolean,
-    failureMode: FailureMode = FailureMode.Closed,
+    failureMode: FailureMode = FailureMode.LastKnownGood,
 ) derives JsonCodec
 
 case class Schedule(

--- a/shared/test/src/types/EnumSpec.scala
+++ b/shared/test/src/types/EnumSpec.scala
@@ -35,11 +35,27 @@ object EnumSpec extends ZIOSpecDefault {
         assertTrue("\"maybe\"".fromJson[ConnectionDecision].isLeft)
       },
     ),
-    suite("FailureMode (existing — wire format preserved)")(
-      test("wire format unchanged") {
-        assertTrue((FailureMode.Open: FailureMode).toJson == "\"open\"") &&
-        assertTrue((FailureMode.Closed: FailureMode).toJson == "\"closed\"") &&
-        assertTrue("\"open\"".fromJson[FailureMode].contains(FailureMode.Open))
+    suite("FailureMode (#385 — three modes, lower-kebab wire)")(
+      test("encodes as lower-kebab") {
+        assertTrue((FailureMode.BlockAll: FailureMode).toJson == "\"block-all\"") &&
+        assertTrue((FailureMode.AllowAll: FailureMode).toJson == "\"allow-all\"") &&
+        assertTrue(
+          (FailureMode.LastKnownGood: FailureMode).toJson == "\"last-known-good\"",
+        )
+      },
+      test("decodes lower-kebab and is case-insensitive") {
+        assertTrue("\"block-all\"".fromJson[FailureMode].contains(FailureMode.BlockAll)) &&
+        assertTrue("\"Allow-All\"".fromJson[FailureMode].contains(FailureMode.AllowAll)) &&
+        assertTrue(
+          "\"LAST-KNOWN-GOOD\"".fromJson[FailureMode].contains(FailureMode.LastKnownGood),
+        )
+      },
+      test("rejects the legacy binary wire forms (#385 — no silent collapse)") {
+        // Old "open" / "closed" must NOT decode — a snapshot served from a
+        // pre-V12 build is a configuration mismatch, not silent data loss.
+        assertTrue("\"open\"".fromJson[FailureMode].isLeft) &&
+        assertTrue("\"closed\"".fromJson[FailureMode].isLeft) &&
+        assertTrue("\"unknown\"".fromJson[FailureMode].isLeft)
       },
     ),
   )

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -37,11 +37,11 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'closed' },
+  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'open' },
+  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'last-known-good' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -42,7 +42,7 @@ const kidsProfile: ProfileDetail = {
     extraBlocked: ['bad.com', 'evil.com'],
     extraAllowed: ['school.com'],
     paused: false,
-    failureMode: 'closed',
+    failureMode: 'block-all',
   },
   schedules: [
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], blockFrom: '21:00', blockUntil: '07:00' },
@@ -61,7 +61,7 @@ const adultsProfile: ProfileDetail = {
     extraBlocked: [],
     extraAllowed: [],
     paused: true,
-    failureMode: 'open',
+    failureMode: 'last-known-good',
   },
   schedules: [],
   timeLimit: null,
@@ -206,8 +206,10 @@ describe('ProfilesPage — create', () => {
       siteTimeLimits: [
         { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30, exemptFromDaily: true },
       ],
-      // #311: form default for a brand-new profile is Closed (safe default).
-      failureMode: 'closed',
+      // #385: form default for a brand-new profile is LastKnownGood
+      // (matches DB column default; UI copy steers admins towards BlockAll
+      // for child profiles).
+      failureMode: 'last-known-good',
     })
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
   })
@@ -246,8 +248,8 @@ describe('ProfilesPage — edit', () => {
       siteTimeLimits: [
         { domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },
       ],
-      // #311: edit preserves the existing failureMode unless changed.
-      failureMode: 'closed',
+      // #385: edit preserves the existing failureMode unless changed.
+      failureMode: 'block-all',
     })
   })
 })
@@ -327,60 +329,77 @@ describe('ProfilesPage — linked users section', () => {
   })
 })
 
-describe('ProfilesPage — #311 failureMode', () => {
-  it('edit form pre-fills failureMode from the profile (Closed for Kids)', async () => {
+describe('ProfilesPage — #385 failureMode (three modes)', () => {
+  it('edit form pre-fills failureMode from the profile (BlockAll for Kids)', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
-    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
-    const open   = screen.getByTestId('profile-failure-mode-open')   as HTMLInputElement
-    expect(closed.checked).toBe(true)
-    expect(open.checked).toBe(false)
+    const blockAll      = screen.getByTestId('profile-failure-mode-block-all')       as HTMLInputElement
+    const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
+    const allowAll      = screen.getByTestId('profile-failure-mode-allow-all')       as HTMLInputElement
+    expect(blockAll.checked).toBe(true)
+    expect(lastKnownGood.checked).toBe(false)
+    expect(allowAll.checked).toBe(false)
   })
 
-  it('edit form pre-fills failureMode from the profile (Open for Adults)', async () => {
+  it('edit form pre-fills failureMode from the profile (LastKnownGood for Adults)', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     const adultsCard = await screen.findByTestId('profile-card-2')
     await user.click(within(adultsCard).getByRole('button', { name: /^Edit$/ }))
-    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
-    const open   = screen.getByTestId('profile-failure-mode-open')   as HTMLInputElement
-    expect(open.checked).toBe(true)
-    expect(closed.checked).toBe(false)
+    const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
+    const blockAll      = screen.getByTestId('profile-failure-mode-block-all')       as HTMLInputElement
+    expect(lastKnownGood.checked).toBe(true)
+    expect(blockAll.checked).toBe(false)
   })
 
-  it('toggling failureMode and saving sends the new value', async () => {
+  it('selecting AllowAll and saving sends the new value', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
-    await user.click(screen.getByTestId('profile-failure-mode-open'))
+    await user.click(screen.getByTestId('profile-failure-mode-allow-all'))
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
     await waitFor(() => expect(api.profiles.update).toHaveBeenCalledTimes(1))
     const call = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
-    expect(call[1].failureMode).toBe('open')
+    expect(call[1].failureMode).toBe('allow-all')
   })
 
-  it('new profile form defaults to Closed (safe default)', async () => {
+  it('selecting LastKnownGood and saving sends the new value', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(screen.getByTestId('profile-failure-mode-last-known-good'))
+    await user.click(screen.getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(api.profiles.update).toHaveBeenCalledTimes(1))
+    const call = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(call[1].failureMode).toBe('last-known-good')
+  })
+
+  it('new profile form defaults to LastKnownGood (column default)', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     await screen.findByText('Kids')
     await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
-    const closed = screen.getByTestId('profile-failure-mode-closed') as HTMLInputElement
-    expect(closed.checked).toBe(true)
+    const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
+    expect(lastKnownGood.checked).toBe(true)
   })
 
-  it('renders explanatory copy for each mode (not a bare checkbox)', async () => {
+  it('renders explanatory copy for each of the three modes', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     expect(
-      screen.getByText(/when the router can't reach the API for 5 minutes, block all internet traffic/i),
+      screen.getByText(/drop all forwarded traffic for this profile's devices/i),
     ).toBeInTheDocument()
     expect(
-      screen.getByText(/keep enforcing the last-known rules; never auto-block/i),
+      screen.getByText(/keep enforcing the cached snapshot exactly/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/clear every block for this profile's devices/i),
     ).toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -31,8 +31,11 @@ function emptyForm(): FormState {
     timeLimit: '',
     schedules: [],
     siteTimeLimits: [],
-    // #311: safe default for a brand-new profile is fail-closed.
-    failureMode: 'closed',
+    // #385: safe default for a brand-new profile is LastKnownGood
+    // (matches the DB column default). The editor calls out the
+    // BlockAll-for-kids recommendation in copy; admins still have to
+    // pick BlockAll explicitly when creating a child profile.
+    failureMode: 'last-known-good',
   }
 }
 
@@ -523,9 +526,10 @@ function ProfileEditor({
           Paused — blocks all internet traffic for devices on this profile.
         </label>
 
-        {/* #311: per-profile failover when the router can't reach the API.
-            Radio (not checkbox) because the concept isn't boolean-friendly
-            without context — both options need their own copy. */}
+        {/* #385: per-profile failover when the router can't reach the API.
+            Three modes (BlockAll / AllowAll / LastKnownGood) — the
+            previous binary closed/open collapsed two semantically distinct
+            behaviours into one. */}
         <div>
           <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
             Failure mode
@@ -535,16 +539,16 @@ function ProfileEditor({
               <input
                 type="radio"
                 name="failureMode"
-                data-testid="profile-failure-mode-closed"
-                checked={form.failureMode === 'closed'}
-                onChange={() => setForm(f => ({ ...f, failureMode: 'closed' }))}
+                data-testid="profile-failure-mode-block-all"
+                checked={form.failureMode === 'block-all'}
+                onChange={() => setForm(f => ({ ...f, failureMode: 'block-all' }))}
                 className="mt-1 w-4 h-4 accent-emerald-500"
               />
               <span>
-                <span className="font-medium text-white">Fail closed</span>
+                <span className="font-medium text-white">Block all traffic</span>
                 <span className="text-gray-500"> (recommended for children)</span>
                 <span className="block text-xs text-gray-400 mt-0.5">
-                  when the router can't reach the API for 5 minutes, block all internet traffic for this profile.
+                  when the router can't reach the API for 5 minutes, drop all forwarded traffic for this profile's devices. The block page still loads.
                 </span>
               </span>
             </label>
@@ -552,16 +556,33 @@ function ProfileEditor({
               <input
                 type="radio"
                 name="failureMode"
-                data-testid="profile-failure-mode-open"
-                checked={form.failureMode === 'open'}
-                onChange={() => setForm(f => ({ ...f, failureMode: 'open' }))}
+                data-testid="profile-failure-mode-last-known-good"
+                checked={form.failureMode === 'last-known-good'}
+                onChange={() => setForm(f => ({ ...f, failureMode: 'last-known-good' }))}
                 className="mt-1 w-4 h-4 accent-emerald-500"
               />
               <span>
-                <span className="font-medium text-white">Fail open</span>
-                <span className="text-gray-500"> (recommended for adults)</span>
+                <span className="font-medium text-white">Last-known rules</span>
+                <span className="text-gray-500"> (recommended for adults — default)</span>
                 <span className="block text-xs text-gray-400 mt-0.5">
-                  when the router can't reach the API, keep enforcing the last-known rules; never auto-block.
+                  when the router can't reach the API, keep enforcing the cached snapshot exactly — categorical blocks, schedules, and time limits all still apply.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-3 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="failureMode"
+                data-testid="profile-failure-mode-allow-all"
+                checked={form.failureMode === 'allow-all'}
+                onChange={() => setForm(f => ({ ...f, failureMode: 'allow-all' }))}
+                className="mt-1 w-4 h-4 accent-emerald-500"
+              />
+              <span>
+                <span className="font-medium text-white">Allow all traffic</span>
+                <span className="text-gray-500"> (only for trusted profiles)</span>
+                <span className="block text-xs text-gray-400 mt-0.5">
+                  when the router can't reach the API, clear every block for this profile's devices. The cached categorical / schedule rules stop applying.
                 </span>
               </span>
             </label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,6 +1,8 @@
 // Mirrors familydns.shared Models.scala
 
-export type FailureMode = 'open' | 'closed'
+// #385: three failover modes. Wire form is lower-kebab to match
+// shared/src/Models.scala FailureMode.asString.
+export type FailureMode = 'block-all' | 'allow-all' | 'last-known-good'
 
 export interface Profile {
   id: number


### PR DESCRIPTION
## Summary

Aligns `FailureMode` on three modes (`BlockAll` / `AllowAll` / `LastKnownGood`) across the doc set, Scala enum, wire JSON, DB column, agent, and admin UI. Closes #385.

The previous binary `Open`/`Closed` collapsed two semantically distinct behaviours into one: \"pass forwarded traffic with no enforcement\" (`AllowAll`) vs. \"keep the cached snapshot enforcing exactly\" (`LastKnownGood`). #311 shipped one interpretation (`Open` = `LastKnownGood`) while the doc shipped both, and #368's critique flagged the divergence.

### Wire vocabulary (lower-kebab to match other multi-word enums)

| Mode | Wire | Behaviour during failover (>5 min API-unreachable) |
|------|------|-----------------------------------------------------|
| `BlockAll` | `\"block-all\"` | Drop all forwarded traffic for the profile's devices. Block page still loads. |
| `LastKnownGood` (default) | `\"last-known-good\"` | Keep enforcing the cached snapshot exactly — categorical / schedule / extra rules still apply. |
| `AllowAll` | `\"allow-all\"` | Suppress the profile's MACs from every drop rule (`@blocked_macs`, `eb_pairs`, `bl_pairs`) and the block-page DNAT. Cached enforcement is intentionally erased. |

### Migration interpretation

[V12](api/resources/db/migration/V12__failure_mode_three_modes.sql) maps from the **current agent behaviour**, not from the original intent:

- `'closed'` → `'block-all'` (the agent's existing failover-drop path)
- `'open'`   → `'last-known-good'` (the agent's keep-cached-snapshot path)

Verified against the deployed DB before merging:

\`\`\`
  name  |  role  | failure_mode 
--------+--------+--------------
 Kids   | (none) | closed   → block-all
 Adults | admin  | open     → last-known-good
\`\`\`

The new `AllowAll` mode has no pre-image in the binary column — admins must pick it deliberately on the new UI. Column default switches from `'closed'` to `'last-known-good'` so a profile created with no explicit `failureMode` lands in the safe fallback that preserves cached enforcement rather than auto-blocking.

### AllowAll rendered behaviour

In [render.lua](openwrt/files/usr/lib/lua/familydns/render.lua), when `opts.poll_age_seconds > 300`, the function builds an `allowall_macs` set from the snapshot's `failureMode == \"allow-all\"` profiles and filters every drop-list step against it:

\`\`\`
# Block-all kid (profile 1) — drop chain still applies
ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example drop

# Last-known-good adult (profile 2) — cached rules persist
ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example drop

# Allow-all guest (profile 3) — NO drop rule emitted
# (cached extraBlocked entry suppressed for the duration of failover)
\`\`\`

`BlockAll` keeps the dedicated `failover_drop` set + `familydns_failover` chain (unchanged from #311 behaviour, just renamed from `\"closed\"`). `LastKnownGood` remains the no-op path.

### Tests

- **Scala**: `FailureMode` JSON codec round-trips all three modes (and rejects the legacy `\"open\"` / `\"closed\"` wire forms — no silent collapse). `PolicySnapshotFailureModeSpec` exercises the new vocabulary end-to-end including ETag flipping. `ProfileApiSpec` covers create-without-`failureMode` defaulting to `LastKnownGood`, explicit `AllowAll` admin override, and PUT updates.
- **Lua**: rewritten [`failover_spec.lua`](openwrt/test/failover_spec.lua) covers all three modes including the new AllowAll suppression of `@blocked_macs`, eb-pairs, bl-pairs, and DNAT. Existing render / policy fixtures updated to the new wire form.
- **Web**: updated `ProfilesPage.test.tsx` for the three-radio UI with role-aware copy.

All Scala (`mill api.test`, `mill shared.test`), Lua (252 tests via `test/run_tests.sh`), and web (`vitest`, 94 tests) suites pass.

## Coordination with concurrent work

- **#311** is closed; this is the behavioural follow-up referenced from the original issue body. PR references the binary→ternary evolution.
- **#386** (failover threshold in snapshot) touches `policy.lua`'s `failover_transition`. Whichever lands second rebases.
- **#376** (capability negotiation) — if it lands first, this issue's API gates three-mode emission on a `\"failure-mode-three\"` capability; if this lands first, #376 retroactively names this in the spec.
- **#401** (admin MAC allowlist) — admin MACs are exempt from all three failover modes. Three-mode `failureMode` branches all leave room for the admin_macs accept rule to land first in the chain when #401 lands.
- **#321 / #337** (resilience audits) will validate the three modes end-to-end.

## Test plan

- [ ] CI: Scala + Lua + web suites pass
- [ ] Block the API at a test router; wait 5 min:
  - [ ] `BlockAll` profile's device cannot reach the internet; block page loads
  - [ ] `LastKnownGood` profile's device continues under cached policy (incl. cached categorical / schedule blocks)
  - [ ] `AllowAll` profile's device passes all traffic, even when the cached snapshot had `extraBlocked` entries for it
- [ ] Restore API; all three profiles return to normal within one poll cycle
- [ ] Migration (V12) runs cleanly against production: `Kids` becomes `block-all`, `Adults` becomes `last-known-good`

🤖 Generated with [Claude Code](https://claude.com/claude-code)