### PR TITLE
openwrt: v6 nft sets (eb6_/bl6_) alongside v4 for extraBlocked + blocklists

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -205,8 +205,8 @@ end
 -- reload_fn(cmd) is called with a shell command string; return value is ignored.
 --
 -- opts is an optional table. opts.dns_check_fn (#328 / #351): when the
--- rendered dnsmasq.conf contains at least one `ipset=/<host>/eb_...` line
--- (i.e. there is something to enforce), we probe one of those hosts via
+-- rendered dnsmasq.conf contains at least one `nftset=/<host>/...#eb_...`
+-- line (i.e. there is something to enforce), we probe one of those hosts via
 -- the router's own resolver after the dnsmasq restart. Post-#351 DNS is
 -- NOT the enforcement plane — blocked hosts must resolve to a real IP, so
 -- the probe inverts the old semantics: a sinkhole-shaped answer
@@ -250,12 +250,13 @@ local function is_blocked_at_connection(result)
 end
 
 -- Extract the first extraBlocked host from the rendered dnsmasq content by
--- looking for an `ipset=/<host>/eb_...` directive (the per-host set name
--- prefix is the agent's canonical marker for #351 enforcement). Returns
+-- looking for an `nftset=/<host>/...#eb_...` directive (the per-host set
+-- name prefix is the agent's canonical marker for #351 enforcement; the
+-- nftset= form replaces legacy ipset= post-OpenWRT-23.05 per #392). Returns
 -- nil if there are no extraBlocked hosts active.
 local function first_extrablocked_host(dnsmasq_content)
-  return dnsmasq_content:match("\nipset=/([^/\n]+)/eb_")
-      or dnsmasq_content:match("^ipset=/([^/\n]+)/eb_")
+  return dnsmasq_content:match("\nnftset=/([^/\n]+)/[^\n]-#eb_")
+      or dnsmasq_content:match("^nftset=/([^/\n]+)/[^\n]-#eb_")
 end
 
 function M.apply(snapshot, write_fn, reload_fn, log, opts)
@@ -279,7 +280,7 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   log.debug("policy.apply: wrote dnsmasq=%dB nft=%dB; restarting",
             #dnsmasq_content, #nft_content)
   -- #328: must be `restart`, not `reload`. SIGHUP doesn't re-read conf-dir,
-  -- so `reload` leaves new address=/, dhcp-host=, and ipset= directives
+  -- so `reload` leaves new address=/, dhcp-host=, and nftset= directives
   -- silently inactive until something else restarts the service.
   reload_fn("/etc/init.d/dnsmasq restart")
   -- Single atomic `nft -f`. The rendered file's prelude removes both the

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -104,19 +104,27 @@ local function effective_extra_blocked_hosts(snapshot)
   return hosts
 end
 
--- nft set name for an extraBlocked host. `eb_` prefix scopes against
--- categorical blocklists (#352 uses `bl_`).
+-- nft set names for an extraBlocked host. `eb_` is the v4 ipset; `eb6_` is
+-- the v6 sibling (#392) so a dual-stack or v6-only host can't escape the
+-- per-(MAC, host) drop via AAAA records. Same hash for both so they stay
+-- parallel in the config.
 local function eb_set_name(host)
   return "eb_" .. sanitize(host)
 end
+local function eb6_set_name(host)
+  return "eb6_" .. sanitize(host)
+end
 
--- nft set name for a blocklist id (#352). Replaces dots, colons, and
+-- nft set names for a blocklist id (#352, #392). Replaces dots, colons, and
 -- hyphens with underscores (nftables set names allow only [a-zA-Z0-9_]).
 local function bl_sanitize(id)
   return (id:gsub("[%.%:%-%s]", "_"))
 end
 local function bl_set_name(id)
   return "bl_" .. bl_sanitize(id)
+end
+local function bl6_set_name(id)
+  return "bl6_" .. bl_sanitize(id)
 end
 
 -- ---------------------------------------------------------------------------
@@ -142,31 +150,42 @@ function M.dnsmasq(snapshot)
 
   -- #351: extraBlocked is enforced at the connection layer (per-MAC nft
   -- drop), not via DNS sinkhole. dnsmasq's only role here is to populate
-  -- an nftables ipset with the resolved IPs of each blocked host, so the
+  -- an nftables set with the resolved IPs of each blocked host, so the
   -- forward-hook drop can match by `ip daddr ∈ @eb_<host>`. DNS still
   -- resolves the host normally — see docs/architecture.md §0.1 (Truth 1).
+  --
   -- OpenWRT 23.05+ ships dnsmasq-full without HAVE_IPSET; the legacy
   -- ipset framework was dropped in favour of native nftables sets, so we
   -- emit `nftset=` and populate the per-host nft set in the `inet
-  -- familydns` table directly. Syntax: nftset=/<host>/4#<family>#<table>#<set>.
-  emit("# extraBlocked → per-host nftset populated at resolve time (#351)")
+  -- familydns` table directly. Syntax:
+  --   nftset=/<host>/<af>#<family>#<table>#<set>[,<af>#...]
+  -- The `4#` / `6#` address-family prefix selects which dnsmasq response
+  -- type routes to which set (#392): A → v4 set, AAAA → v6 set. One
+  -- comma-joined directive per host keeps the config compact.
+  emit("# extraBlocked → per-host nftset populated at resolve time (#351, #392)")
   for _, host in ipairs(effective_extra_blocked_hosts(snapshot)) do
-    emit(string.format("nftset=/%s/4#inet#familydns#%s", host, eb_set_name(host)))
+    emit(string.format(
+      "nftset=/%s/4#inet#familydns#%s,6#inet#familydns#%s",
+      host, eb_set_name(host), eb6_set_name(host)))
   end
   emit("")
 
-  -- #352: category blocklists — populate bl_<id> ipsets at DNS resolve time.
-  -- snapshot._blocklist_hosts = { [id] = {host1, host2, ...} } is populated
-  -- by the agent before calling render (so tests can inject without filesystem).
+  -- #352: category blocklists — populate bl_<id> / bl6_<id> sets at DNS
+  -- resolve time. snapshot._blocklist_hosts = { [id] = {host1, ...} } is
+  -- populated by the agent before calling render (so tests can inject
+  -- without filesystem). Same nftset= migration as eb_ above (#392).
   local bl_hosts = snapshot._blocklist_hosts or {}
   local bl_ids   = sorted_keys(snapshot.blocklists or {})
   if #bl_ids > 0 then
-    emit("# blocklist ipsets → resolved at DNS time (#352)")
+    emit("# blocklist nftsets → resolved at DNS time (#352, #392)")
     for _, id in ipairs(bl_ids) do
-      local hosts = bl_hosts[id] or {}
-      local set_name = bl_set_name(id)
+      local hosts   = bl_hosts[id] or {}
+      local set4    = bl_set_name(id)
+      local set6    = bl6_set_name(id)
       for _, host in ipairs(hosts) do
-        emit(string.format("ipset=/%s/%s", host, set_name))
+        emit(string.format(
+          "nftset=/%s/4#inet#familydns#%s,6#inet#familydns#%s",
+          host, set4, set6))
       end
     end
     emit("")
@@ -306,14 +325,20 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
-  -- #351: per-host ipsets for extraBlocked. Each set is populated at DNS
-  -- resolve time by dnsmasq `ipset=/host/eb_<host>` (rendered by dnsmasq()
-  -- above). Dynamic + 1h timeout so resolved entries age out and we don't
-  -- leak shared-CDN IPs to other hosts indefinitely.
+  -- #351/#392: per-host v4 + v6 sets for extraBlocked. Each set is populated
+  -- at DNS resolve time by dnsmasq nftset= (rendered by dnsmasq() above):
+  -- A records → eb_<host>, AAAA → eb6_<host>. Dynamic + 1h timeout so
+  -- resolved entries age out and we don't leak shared-CDN IPs indefinitely.
   local eb_hosts = effective_extra_blocked_hosts(snapshot)
   for _, host in ipairs(eb_hosts) do
     ind(string.format("set %s {", eb_set_name(host)))
     ind2("type ipv4_addr")
+    ind2("flags dynamic,timeout")
+    ind2("timeout 1h")
+    ind("}")
+    emit("")
+    ind(string.format("set %s {", eb6_set_name(host)))
+    ind2("type ipv6_addr")
     ind2("flags dynamic,timeout")
     ind2("timeout 1h")
     ind("}")
@@ -347,6 +372,12 @@ function M.nft(snapshot, opts)
     ind2("timeout 1h")
     ind("}")
     emit("")
+    ind(string.format("set %s {", bl6_set_name(id)))
+    ind2("type ipv6_addr")
+    ind2("flags dynamic,timeout")
+    ind2("timeout 1h")
+    ind("}")
+    emit("")
   end
 
   -- #352: per-(MAC, blocklistId) drop pairs. For each device, for each
@@ -371,13 +402,23 @@ function M.nft(snapshot, opts)
   if #blocked_macs_list > 0 then
     ind2("ether saddr @blocked_macs drop")
   end
+  -- v4 drops first, then v6 (#392). One ipset directive populates both sets
+  -- at DNS time; here we gate on whichever family the destination matched.
   for _, p in ipairs(eb_pairs) do
     ind2(string.format("ether saddr %s ip daddr @%s drop",
                        p.mac, eb_set_name(p.host)))
   end
+  for _, p in ipairs(eb_pairs) do
+    ind2(string.format("ether saddr %s ip6 daddr @%s drop",
+                       p.mac, eb6_set_name(p.host)))
+  end
   for _, p in ipairs(bl_pairs) do
     ind2(string.format("ether saddr %s ip daddr @%s drop",
                        p.mac, bl_set_name(p.id)))
+  end
+  for _, p in ipairs(bl_pairs) do
+    ind2(string.format("ether saddr %s ip6 daddr @%s drop",
+                       p.mac, bl6_set_name(p.id)))
   end
   ind("}")
   emit("")

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -53,21 +53,28 @@ describe("render.dnsmasq", function()
     assert.is_nil(conf:find("address=/khanacademy.org/#", 1, true))
   end)
 
-  it("emits ipset=/host/eb_<sanitized-host> for each extraBlocked host that has an assigned device", function()
+  -- Post-#394 (e2e-vm): dnsmasq on OpenWRT 23.05+ uses native nftables sets
+  -- via `nftset=`, not the legacy `ipset=` framework. Syntax encodes the
+  -- address family (4# / 6#) so A → v4 set, AAAA → v6 set (#392).
+  it("emits combined v4+v6 nftset=/host/... for each extraBlocked host", function()
     local conf = render.dnsmasq(snap_one())
-    assert.truthy(conf:find("ipset=/tiktok.com/eb_tiktok_com", 1, true))
+    assert.truthy(conf:find(
+      "nftset=/tiktok.com/4#inet#familydns#eb_tiktok_com,6#inet#familydns#eb6_tiktok_com",
+      1, true))
   end)
 
-  it("sanitises multi-label extraBlocked hosts in the ipset name", function()
+  it("sanitises multi-label extraBlocked hosts in both v4 and v6 set names", function()
     local s = snap_one()
     s.profiles["3"].rules.extraBlocked = { "cdn.example.co.uk" }
     local conf = render.dnsmasq(s)
-    assert.truthy(conf:find("ipset=/cdn.example.co.uk/eb_cdn_example_co_uk", 1, true))
+    assert.truthy(conf:find(
+      "nftset=/cdn.example.co.uk/4#inet#familydns#eb_cdn_example_co_uk,6#inet#familydns#eb6_cdn_example_co_uk",
+      1, true))
   end)
 
-  it("does NOT emit ipset= for extraAllowed hosts", function()
+  it("does NOT emit nftset= for extraAllowed hosts", function()
     local conf = render.dnsmasq(snap_one())
-    assert.is_nil(conf:find("ipset=/khanacademy.org/", 1, true))
+    assert.is_nil(conf:find("/khanacademy.org/", 1, true))
   end)
 
   it("handles multiple devices in different profiles", function()
@@ -86,7 +93,7 @@ describe("render.dnsmasq", function()
     assert.truthy(conf:find("dhcp-host=de:ad:be:ef:00:01,set:profile1", 1, true))
   end)
 
-  it("deduplicates extraBlocked ipset= lines across profiles", function()
+  it("deduplicates extraBlocked nftset= lines across profiles", function()
     local s = snap_one()
     s.devices["de:ad:be:ef:00:01"] = { profileId = 1, name = "parent-phone", rules = nil }
     s.profiles["1"] = {
@@ -99,11 +106,11 @@ describe("render.dnsmasq", function()
       failureMode = "last-known-good",
     }
     local conf = render.dnsmasq(s)
-    local _, count = conf:gsub("ipset=/tiktok%.com/eb_tiktok_com", "")
+    local _, count = conf:gsub("nftset=/tiktok%.com/", "")
     assert.equal(1, count)
   end)
 
-  it("skips ipset= emission when an extraBlocked host has no device referencing it", function()
+  it("skips nftset= emission when an extraBlocked host has no device referencing it", function()
     -- Profile with extraBlocked but no devices assigned → nothing to populate.
     local s = snap_one()
     s.profiles["7"] = {
@@ -116,10 +123,10 @@ describe("render.dnsmasq", function()
       failureMode = "last-known-good",
     }
     local conf = render.dnsmasq(s)
-    assert.is_nil(conf:find("ipset=/ghosthost.example/", 1, true))
+    assert.is_nil(conf:find("/ghosthost.example/", 1, true))
   end)
 
-  it("emits ipset= for device-override extraBlocked", function()
+  it("emits combined v4+v6 nftset= for device-override extraBlocked", function()
     local s = snap_one()
     s.devices["aa:bb:cc:11:22:33"].rules = {
       blocked = false, blockReason = nil,
@@ -127,7 +134,9 @@ describe("render.dnsmasq", function()
       extraAllowed = {}, blocklistIds = {}, blockIpOnly = false,
     }
     local conf = render.dnsmasq(s)
-    assert.truthy(conf:find("ipset=/override.example/eb_override_example", 1, true))
+    assert.truthy(conf:find(
+      "nftset=/override.example/4#inet#familydns#eb_override_example,6#inet#familydns#eb6_override_example",
+      1, true))
   end)
 
   it("returns a non-empty string", function()
@@ -300,10 +309,31 @@ describe("render.nft extraBlocked enforcement", function()
     assert.truthy(block:find("flags dynamic,timeout", 1, true))
   end)
 
+  -- #392: v6 sibling set must be declared alongside every eb_ set so the
+  -- nftset=/host/6#inet#familydns#eb6_<host> AAAA callback has somewhere
+  -- to populate.
+  it("declares set eb6_<host> with dynamic ipv6 elements + 1h timeout (#392)", function()
+    local nft = render.nft(snap_one())
+    local pos = nft:find("set eb6_tiktok_com", 1, true)
+    assert.truthy(pos)
+    local block = nft:sub(pos, pos + 200)
+    assert.truthy(block:find("type ipv6_addr", 1, true))
+    assert.truthy(block:find("flags dynamic,timeout", 1, true))
+    assert.truthy(block:find("timeout 1h", 1, true))
+  end)
+
   it("emits a drop rule `ether saddr <mac> ip daddr @eb_<host> drop` for each (mac, host) pair", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com drop", 1, true))
+  end)
+
+  -- #392: v6 drop rule mirrors the v4 one. Without it a dual-stack host
+  -- whose AAAA resolves under a Kids profile slips through the v4 drop.
+  it("emits a v6 drop rule `ether saddr <mac> ip6 daddr @eb6_<host> drop` (#392)", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com drop", 1, true))
   end)
 
   it("does NOT drop traffic from MACs in OTHER profiles (no global leakage — the bug #351 fixes)", function()
@@ -354,6 +384,8 @@ describe("render.nft extraBlocked enforcement", function()
     local nft = render.nft(s)
     assert.is_nil(nft:find("set eb_", 1, true))
     assert.is_nil(nft:find("@eb_", 1, true))
+    assert.is_nil(nft:find("set eb6_", 1, true))
+    assert.is_nil(nft:find("@eb6_", 1, true))
   end)
 
   it("does NOT emit any address=/.../# style DNS sinkhole regardless of extraBlocked", function()
@@ -470,6 +502,21 @@ describe("render.nft nat chain", function()
     s.profiles["3"].rules.extraBlocked = {}
     local nft = render.nft(s)
     assert.is_nil(nft:find("familydns_block_nat", 1, true))
+  end)
+
+  -- #392: v6 block-page DNAT is explicitly out of scope. uhttpd binds v4
+  -- only, so a v6 HTTP request to a blocked host drops at the filter chain
+  -- with no DNAT redirect (browser sees a connection error, not the block
+  -- page). Pin the absence so a future test-writer doesn't quietly add a
+  -- v6 DNAT line that points at a non-existent v6 listener.
+  it("does NOT emit ip6/dnat lines in the nat chain (v6 block page deferred, #392)", function()
+    local nft = render.nft(snap_one())
+    local pos = nft:find("chain familydns_block_nat", 1, true)
+    assert.truthy(pos)
+    local close = nft:find("\n%s*}", pos)
+    local body = nft:sub(pos, (close or #nft) - 1)
+    assert.is_nil(body:find("ip6 daddr", 1, true))
+    assert.is_nil(body:find("dnat ip6 to", 1, true))
   end)
 
 end)
@@ -653,6 +700,17 @@ describe("render blocklist enforcement (#352)", function()
     assert.truthy(blk:find("timeout 1h", 1, true))
   end)
 
+  -- #392: v6 sibling for category blocklists.
+  it("declares set bl6_<id> with type ipv6_addr + dynamic,timeout (#392)", function()
+    local nft  = render.nft(snap_bl())
+    local pos  = nft:find("set bl6_test_ads", 1, true)
+    assert.truthy(pos, "expected 'set bl6_test_ads' in nft output")
+    local blk  = nft:sub(pos, pos + 200)
+    assert.truthy(blk:find("type ipv6_addr", 1, true))
+    assert.truthy(blk:find("flags dynamic,timeout", 1, true))
+    assert.truthy(blk:find("timeout 1h", 1, true))
+  end)
+
   it("emits set declaration even when no device references the blocklist id", function()
     -- Profile 1 (adults) has no blocklistIds, but the set must still be
     -- declared because dnsmasq ipset= callbacks need the set to exist.
@@ -673,30 +731,37 @@ describe("render blocklist enforcement (#352)", function()
     assert.equal(1, cnt, "set declaration must appear exactly once")
   end)
 
-  -- ── dnsmasq ipset= directives ────────────────────────────────────────────
+  -- ── dnsmasq nftset= directives (post-#394 nftset/ipset migration) ───────
 
-  it("emits ipset=/<host>/bl_<id> for each host in snapshot._blocklist_hosts[id]", function()
+  it("emits combined v4+v6 nftset=/<host>/... for each host in _blocklist_hosts[id] (#392)", function()
     local conf = render.dnsmasq(snap_bl())
-    assert.truthy(conf:find("ipset=/adserver.example.com/bl_test_ads", 1, true))
-    assert.truthy(conf:find("ipset=/doubleclick.net/bl_test_ads", 1, true))
+    assert.truthy(conf:find(
+      "nftset=/adserver.example.com/4#inet#familydns#bl_test_ads,6#inet#familydns#bl6_test_ads",
+      1, true))
+    assert.truthy(conf:find(
+      "nftset=/doubleclick.net/4#inet#familydns#bl_test_ads,6#inet#familydns#bl6_test_ads",
+      1, true))
   end)
 
-  it("deduplicates ipset= lines when the same host appears in two blocklists (edge case)", function()
+  it("emits one nftset= line per (host, id) when the same host appears in two blocklists", function()
     local s = snap_bl()
     s.blocklists["test_social"] = { version = "v1", url = "http://api/api/blocklists/test_social" }
     s._blocklist_hosts["test_social"] = { "doubleclick.net", "facebook.com" }
     local conf = render.dnsmasq(s)
-    -- doubleclick.net must appear for test_ads AND test_social
-    -- but should only appear once per set name combination.
-    assert.truthy(conf:find("ipset=/doubleclick.net/bl_test_ads",    1, true))
-    assert.truthy(conf:find("ipset=/doubleclick.net/bl_test_social", 1, true))
+    assert.truthy(conf:find(
+      "nftset=/doubleclick.net/4#inet#familydns#bl_test_ads,6#inet#familydns#bl6_test_ads",
+      1, true))
+    assert.truthy(conf:find(
+      "nftset=/doubleclick.net/4#inet#familydns#bl_test_social,6#inet#familydns#bl6_test_social",
+      1, true))
   end)
 
-  it("emits no ipset= lines when _blocklist_hosts is absent or empty", function()
+  it("emits no nftset= lines when _blocklist_hosts is absent or empty", function()
     local s = snap_bl()
     s._blocklist_hosts = nil
     local conf = render.dnsmasq(s)
     assert.is_nil(conf:find("bl_test_ads", 1, true))
+    assert.is_nil(conf:find("bl6_test_ads", 1, true))
   end)
 
   -- ── nft drop rules ───────────────────────────────────────────────────────
@@ -706,6 +771,19 @@ describe("render blocklist enforcement (#352)", function()
     -- Only kid mac references test_ads; parent does not.
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads drop", 1, true))
+  end)
+
+  -- #392: v6 drop rule mirrors the v4 one for blocklists.
+  it("emits v6 drop 'ether saddr <mac> ip6 daddr @bl6_<id> drop' (#392)", function()
+    local nft = render.nft(snap_bl())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads drop", 1, true))
+  end)
+
+  it("does NOT emit v6 drop for MACs whose profile has no blocklistIds (#392)", function()
+    local nft = render.nft(snap_bl())
+    assert.is_nil(nft:find(
+      "ether saddr de:ad:be:ef:00:01 ip6 daddr @bl6_test_ads", 1, true))
   end)
 
   it("does NOT emit drop for MACs whose profile has blocklistIds = {}", function()
@@ -738,11 +816,13 @@ describe("render blocklist enforcement (#352)", function()
     assert.is_nil(nft:find("bl_missing_id", 1, true))
   end)
 
-  it("emits no bl_ sets or drop rules when snapshot.blocklists is empty", function()
+  it("emits no bl_ or bl6_ sets or drop rules when snapshot.blocklists is empty", function()
     local s = snap_one()  -- snap_one has blocklists = {}
     local nft = render.nft(s)
     assert.is_nil(nft:find("set bl_", 1, true))
     assert.is_nil(nft:find("@bl_", 1, true))
+    assert.is_nil(nft:find("set bl6_", 1, true))
+    assert.is_nil(nft:find("@bl6_", 1, true))
   end)
 
   -- ── DNAT HTTP/80 for blocklist hits (mirrors #351 extraBlocked pattern) ──


### PR DESCRIPTION
## Summary

Fixes #392. #351 lands per-(MAC, host) v4 drops via `eb_<host>` nftables sets populated by dnsmasq nftset= callbacks on A-record resolution; #352 mirrors that for category blocklists via `bl_<id>`. Both paths bypass IPv6 entirely — a v6-only host or a dual-stack host whose client prefers v6 escapes the drop. This PR adds the parallel v6 path.

- New `eb6_<host>` / `bl6_<id>` nft sets, `type ipv6_addr; flags dynamic,timeout; timeout 1h`, emitted alongside each v4 set.
- New `ether saddr <mac> ip6 daddr @eb6_<host> drop` (and `bl6_`) rules alongside each existing v4 drop.
- dnsmasq `nftset=` directive lists both v4 and v6 set names in one comma-joined line, so a single DNS resolution callback populates the family-typed set: A → `eb_<host>`, AAAA → `eb6_<host>`.

## Drive-by completing the #394 migration

#394 (e2e-vm) flipped `eb_` extraBlocked emission from legacy `ipset=` to native `nftset=` (OpenWRT 23.05+ dnsmasq-full ships without HAVE_IPSET) but left the `bl_` blocklist emission on the dead `ipset=` form. Adding v6 needed the family-aware nftset= syntax anyway, so this PR also moves `bl_` to `nftset=` for consistency. The v4 `render_spec` tests that had been silently failing on `main` since #394 (looking for `ipset=/host/eb_…`) are updated to the new directive shape and now pass. `policy.apply`'s smoke-probe regex (`first_extrablocked_host`) likewise updated.

## Deferred: v6 block-page DNAT

The block-page DNAT chain stays v4-only. uhttpd binds v4 only, so v6 HTTP to a blocked host drops at the filter chain with no block-page redirect — browser sees connection-refused, not the block page. A new test pins absence of v6 lines in the nat chain so no one quietly adds a v6 DNAT pointing at a non-existent v6 listener. Worth tracking the v6-block-page UX as a follow-up alongside #383 (HTTPS block-page work).

## #391/HostId interaction

`extraBlocked` is `List[Hostname]` (typed FQDN), not `List[HostId]`, so non-FQDN entries can't reach the ipset path by type — no defensive `if type==fqdn` filter needed in render.lua.

## Test plan

- [x] `openwrt/test/run_tests.sh` — full suite green (was 4 pre-existing render_spec + 4 policy_spec failures from #394's incomplete migration; both root-caused and fixed).
- [x] New unit tests pin: combined v4+v6 nftset= directive shape for both eb_ and bl_, v6 set declarations with `type ipv6_addr`, v6 drop rules with `ip6 daddr @<set>`, v6 absence from nat chain.
- [ ] Hardware verification (after deploy): on a Kids device, `curl -6 http://<extraBlocked-host>` fails (dropped at nft); `curl -4` lands on block page; on Adults device both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)