### PR TITLE
openwrt-agent: fix malformed poll_age log lines on cold boot

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -385,6 +385,15 @@ function M.poll_age_seconds(now)
   return age
 end
 
+-- Format a poll_age value for log output. Returns "inf" for the cold-boot
+-- sentinel (math.huge from poll_age_seconds before any successful poll);
+-- otherwise "<seconds>s". string.format("%d", math.huge) does not substitute,
+-- so logging poll_age=%ds with a raw value would emit the literal "%ds inf".
+function M.format_poll_age(poll_age)
+  if poll_age == math.huge then return "inf" end
+  return string.format("%ds", poll_age)
+end
+
 -- Test-only: reset module-level poll state between specs.
 function M.reset_poll_state()
   M.last_successful_poll_ts = nil

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -368,11 +368,12 @@ conntrack.watch({
       elseif etag then
         current_etag = etag  -- 304: just update etag
         policy.mark_poll_success(wall)  -- 304 still counts as a successful poll
-        log.debug("policy timer: 304 not modified etag=%s poll_age=%ds",
-                  tostring(etag), policy.poll_age_seconds(wall))
+        log.debug("policy timer: 304 not modified etag=%s poll_age=%s",
+                  tostring(etag), policy.format_poll_age(policy.poll_age_seconds(wall)))
         fetch_ok = true
       else
-        log.debug("policy timer: fetch failed poll_age=%ds", policy.poll_age_seconds(wall))
+        log.debug("policy timer: fetch failed poll_age=%s",
+                  policy.format_poll_age(policy.poll_age_seconds(wall)))
         fetch_ok = false
       end
 
@@ -393,8 +394,8 @@ conntrack.watch({
           -- effect and there's nothing useful we can render.
           if policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts) then
             if new_in_failover then
-              log.info("failover render: poll_age=%ds, applying failover chain for closed-mode profiles",
-                       poll_age)
+              log.info("failover render: poll_age=%s, applying failover chain for closed-mode profiles",
+                       policy.format_poll_age(poll_age))
             else
               log.info("failover lifted: applying fresh snapshot (poll_age=0)")
             end
@@ -408,8 +409,8 @@ conntrack.watch({
           -- Cold boot during API outage with no cached snapshot. Boot
           -- skeleton (#308) is still enforcing default-deny; nothing to
           -- render. Don't flip the flag so we keep retrying on each tick.
-          log.warn("failover transition skipped: no cached snapshot (boot-skeleton default-deny still active, poll_age=%ds)",
-                   poll_age)
+          log.warn("failover transition skipped: no cached snapshot (boot-skeleton default-deny still active, poll_age=%s)",
+                   policy.format_poll_age(poll_age))
           new_in_failover = in_failover_render
         end
         in_failover_render = new_in_failover

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -782,3 +782,24 @@ describe("policy.mark_poll_success / poll_age_seconds", function()
   end)
 
 end)
+
+-- ── policy.format_poll_age (#410) ────────────────────────────────────────
+--
+-- string.format("%d", math.huge) leaves "%d" literal in the output (since
+-- math.huge isn't integer-coercible), producing malformed log lines like
+-- `poll_age=%ds inf` on a cold-boot agent. format_poll_age normalises both
+-- branches so callers can use %s.
+
+describe("policy.format_poll_age", function()
+
+  it("returns \"inf\" for the math.huge cold-boot sentinel", function()
+    assert.equal("inf", policy.format_poll_age(math.huge))
+  end)
+
+  it("formats finite seconds as \"<n>s\"", function()
+    assert.equal("0s",   policy.format_poll_age(0))
+    assert.equal("60s",  policy.format_poll_age(60))
+    assert.equal("301s", policy.format_poll_age(301))
+  end)
+
+end)


### PR DESCRIPTION
## Summary
- `policy.poll_age_seconds()` returns `math.huge` until the first successful poll (cold-boot sentinel from #309/#326). `string.format("%d", math.huge)` doesn't substitute, so cold-boot logs were emitting `poll_age=%ds inf` literally.
- Add `policy.format_poll_age()` (returns `"inf"` for the sentinel, `"<n>s"` otherwise) and route all four agent call sites through it.
- Busted coverage for both branches.

Fixes #410. Discovered while live-verifying #309 on the test router.

## Test plan
- [x] `busted --filter format_poll_age test/policy_spec.lua` — 2/2 pass
- [x] Full suite: new tests green; the 8 pre-existing failures (render extraBlocked / dns_check_fn) are unrelated to this change
- [ ] Deploy to the test router and confirm `logread` no longer shows `%ds inf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)