### PR TITLE
openwrt-agent: skip dnsmasq restart when conf is unchanged (fixes #414)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -617,7 +617,16 @@ openwrt/
 
 - **Policy timer (60 s)** — fetch snapshot, atomically rewrite
   `/tmp/dnsmasq.d/familydns.conf` and `/tmp/nftables.d/familydns.nft`,
-  then reload dnsmasq + nft. On `304`: do nothing.
+  then `nft -f` the new ruleset. The dnsmasq full restart only fires when
+  the rendered `dnsmasq.conf` actually differs byte-for-byte from the
+  on-disk copy (#414) — most policy applies flip nft-side state only
+  (blocked_macs membership from schedule / pause / time-limit transitions)
+  and don't require a DNS service blip. When the dnsmasq fragment does
+  change (new extraBlocked host, device profile reassignment, blocklist
+  membership), a full `/etc/init.d/dnsmasq restart` is required: SIGHUP
+  does not re-read `conf-dir` files, so `reload` would leave new
+  `dhcp-host=` / `nftset=` directives silently inactive (#328). On `304`:
+  do nothing.
 - **Usage timer (5 min)** — scrape nftables counters, correlate with dnsmasq
   query log + DHCP leases, POST to `/api/router/usage`. On 200, reset counters;
   on failure, retain and retry (endpoint is idempotent).

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -11,6 +11,10 @@
 --     write_fn(path, content) → ok, err
 --     reload_fn(cmd)          → exit_code
 --     opts (optional table)   → bag of options. Recognised keys:
+--       opts.read_fn(path) → string|nil — used to read the on-disk copy of
+--                                   the rendered dnsmasq.conf for the
+--                                   change-detection check (#414). Defaults
+--                                   to a plain io.open read.
 --       opts.dns_check_fn(domain) → string|nil — result of resolving `domain`
 --                                   via the router's own resolver, used by
 --                                   the #328 smoke probe. After #351 DNS no
@@ -216,6 +220,16 @@ end
 -- opts.poll_age_seconds (#331): forwarded to render.nft so the agent's
 -- failover-edge re-render can request the closed-mode drop chain.
 
+-- Default reader for the change-detection check (#414). Returns nil if the
+-- file is absent — first apply on a fresh boot treats that as "changed".
+local function default_read(path)
+  local f = io.open(path, "r")
+  if not f then return nil end
+  local content = f:read("*a")
+  f:close()
+  return content
+end
+
 -- Default smoke probe: `dig @127.0.0.1` and return the first line of stdout.
 local function default_dns_check(domain)
   local cmd = string.format(
@@ -265,6 +279,17 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   local dnsmasq_content = render.dnsmasq(snapshot)
   local nft_content     = render.nft(snapshot, opts)
 
+  -- #414: dnsmasq only needs a full restart when its config-dir file
+  -- actually changes (dhcp-host= and nftset= directives are NOT picked up
+  -- on SIGHUP — see #328). Most policy.apply calls flip only nft-side
+  -- state (blocked_macs membership from schedules / pause / time limits,
+  -- failover transitions). Compare against the on-disk copy and skip the
+  -- restart when the rendered content is byte-identical; this avoids a
+  -- DNS service blip on every schedule boundary.
+  local read_fn = opts.read_fn or default_read
+  local existing_dnsmasq = read_fn("/tmp/dnsmasq.d/familydns.conf")
+  local dnsmasq_changed = (existing_dnsmasq ~= dnsmasq_content)
+
   local ok1, err1 = write_fn("/tmp/dnsmasq.d/familydns.conf", dnsmasq_content)
   if not ok1 then
     log.err("policy.apply: write dnsmasq conf failed: %s", tostring(err1))
@@ -277,32 +302,38 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
     return false
   end
 
-  log.debug("policy.apply: wrote dnsmasq=%dB nft=%dB; restarting",
-            #dnsmasq_content, #nft_content)
-  -- #328: must be `restart`, not `reload`. SIGHUP doesn't re-read conf-dir,
-  -- so `reload` leaves new address=/, dhcp-host=, and nftset= directives
-  -- silently inactive until something else restarts the service.
-  reload_fn("/etc/init.d/dnsmasq restart")
+  if dnsmasq_changed then
+    log.debug("policy.apply: wrote dnsmasq=%dB (changed) nft=%dB; restarting dnsmasq",
+              #dnsmasq_content, #nft_content)
+    -- #328: must be `restart`, not `reload`. SIGHUP doesn't re-read conf-dir,
+    -- so `reload` leaves new dhcp-host= and nftset= directives silently
+    -- inactive until something else restarts the service. (Post-#329/#351
+    -- there are no `address=` sinkhole directives — but dhcp-host= and
+    -- nftset= still need a full restart for the same reason.)
+    reload_fn("/etc/init.d/dnsmasq restart")
+  else
+    log.debug("policy.apply: wrote dnsmasq=%dB (unchanged) nft=%dB; skipping dnsmasq restart",
+              #dnsmasq_content, #nft_content)
+  end
   -- Single atomic `nft -f`. The rendered file's prelude removes both the
   -- boot default-deny skeleton (table inet familydns_boot — #308) and any
   -- prior runtime table in one transaction, then installs the new ruleset.
   reload_fn("nft -f /tmp/nftables.d/familydns.nft")
 
-  -- #328 / #351 smoke probe. Skip cleanly when there's no extraBlocked
-  -- host to probe. Post-#351 expectation: dnsmasq must resolve the host
-  -- to a *real* upstream IP (DNS is not the enforcement plane). A
-  -- sinkhole-shaped or empty answer means dnsmasq is still serving a
-  -- stale config that contains DNS-layer blocks — the failure we are
-  -- watching for.
-  local probe_domain = first_extrablocked_host(dnsmasq_content)
-  if probe_domain then
-    local check = opts.dns_check_fn or default_dns_check
-    local result = check(probe_domain)
-    if is_blocked_at_connection(result) then
-      log.warn(
-        "policy.apply: smoke check failed; dnsmasq may be serving a stale " ..
-        "config — got %q for %s (expected a real upstream IP)",
-        tostring(result), probe_domain)
+  -- #328 / #351 smoke probe. Runs only when we actually restarted dnsmasq:
+  -- the probe exists to catch "we restarted but dnsmasq is still serving
+  -- a stale config", so it adds nothing when no restart happened.
+  if dnsmasq_changed then
+    local probe_domain = first_extrablocked_host(dnsmasq_content)
+    if probe_domain then
+      local check = opts.dns_check_fn or default_dns_check
+      local result = check(probe_domain)
+      if is_blocked_at_connection(result) then
+        log.warn(
+          "policy.apply: smoke check failed; dnsmasq may be serving a stale " ..
+          "config — got %q for %s (expected a real upstream IP)",
+          tostring(result), probe_domain)
+      end
     end
   end
 

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -302,13 +302,20 @@ describe("policy.apply", function()
 
   -- #328: SIGHUP doesn't re-read conf-dir, so a `reload` leaves the new
   -- /tmp/dnsmasq.d/familydns.conf entries silently inactive until something
-  -- else restarts dnsmasq. We must `restart` to pick up address=/, dhcp-host=,
-  -- and ipset= directives.
+  -- else restarts dnsmasq. We must `restart` to pick up dhcp-host= and
+  -- nftset= directives. Post-#414 the restart is conditional on the
+  -- rendered content actually differing from the on-disk copy; pass
+  -- read_fn=nil-returning to simulate a cold first apply.
+  local function fresh_opts()
+    return { read_fn = function(_path) return nil end }
+  end
+
   it("calls `/etc/init.d/dnsmasq restart` (not reload) after writing (#328)", function()
     local reloads = {}
     policy.apply(decode_snap(),
       function(_path, _content) return true, nil end,
-      function(cmd) table.insert(reloads, cmd); return 0 end)
+      function(cmd) table.insert(reloads, cmd); return 0 end,
+      nil, fresh_opts())
     local found_restart, found_reload = false, false
     for _, cmd in ipairs(reloads) do
       if cmd == "/etc/init.d/dnsmasq restart" then found_restart = true end
@@ -324,12 +331,71 @@ describe("policy.apply", function()
     local reloads = {}
     policy.apply(decode_snap(),
       function(_path, _content) return true, nil end,
-      function(cmd) table.insert(reloads, cmd); return 0 end)
+      function(cmd) table.insert(reloads, cmd); return 0 end,
+      nil, fresh_opts())
     local found = false
     for _, cmd in ipairs(reloads) do
       if cmd:find("nft") then found = true end
     end
     assert.is_true(found, "expected an nft reload command")
+  end)
+
+  -- #414: avoid the DNS service blip when policy.apply runs but the rendered
+  -- dnsmasq.conf is byte-identical to what's on disk. Most apply calls flip
+  -- only nft-side state (blocked_macs membership from schedule / pause /
+  -- time-limit transitions), so the dnsmasq.conf side is stable.
+  it("skips dnsmasq restart when rendered conf matches on-disk copy (#414)", function()
+    local render = require("render")
+    local rendered = render.dnsmasq(decode_snap())
+    local reloads = {}
+    policy.apply(decode_snap(),
+      function(_path, _content) return true, nil end,
+      function(cmd) table.insert(reloads, cmd); return 0 end,
+      nil,
+      { read_fn = function(path)
+          if path == "/tmp/dnsmasq.d/familydns.conf" then return rendered end
+          return nil
+        end })
+    for _, cmd in ipairs(reloads) do
+      assert.is_nil(cmd:find("dnsmasq"),
+        "must not restart dnsmasq when conf is unchanged; got: " .. cmd)
+    end
+    -- nft reload still runs unconditionally
+    local found_nft = false
+    for _, cmd in ipairs(reloads) do
+      if cmd:find("nft ") then found_nft = true end
+    end
+    assert.is_true(found_nft, "nft reload should still run even when dnsmasq is unchanged")
+  end)
+
+  it("restarts dnsmasq when on-disk copy differs from rendered content (#414)", function()
+    local reloads = {}
+    policy.apply(decode_snap(),
+      function(_path, _content) return true, nil end,
+      function(cmd) table.insert(reloads, cmd); return 0 end,
+      nil,
+      { read_fn = function(_path) return "# stale content\n" end })
+    local found_restart = false
+    for _, cmd in ipairs(reloads) do
+      if cmd == "/etc/init.d/dnsmasq restart" then found_restart = true end
+    end
+    assert.is_true(found_restart,
+      "expected restart when on-disk copy is stale; got: " .. table.concat(reloads, " | "))
+  end)
+
+  it("restarts dnsmasq on first apply when no conf exists on disk (#414)", function()
+    local reloads = {}
+    policy.apply(decode_snap(),
+      function(_path, _content) return true, nil end,
+      function(cmd) table.insert(reloads, cmd); return 0 end,
+      nil,
+      { read_fn = function(_path) return nil end })
+    local found_restart = false
+    for _, cmd in ipairs(reloads) do
+      if cmd == "/etc/init.d/dnsmasq restart" then found_restart = true end
+    end
+    assert.is_true(found_restart,
+      "expected restart on first apply (missing file); got: " .. table.concat(reloads, " | "))
   end)
 
   it("skips both reload commands when the dnsmasq write fails", function()
@@ -440,13 +506,21 @@ describe("policy.apply", function()
     }, warns, infos
   end
 
+  -- Force dnsmasq_changed=true for the smoke-probe tests so the probe path
+  -- always runs regardless of any leftover /tmp/dnsmasq.d file on disk (#414).
+  local function smoke_opts(extra)
+    local o = { read_fn = function(_p) return nil end }
+    for k, v in pairs(extra or {}) do o[k] = v end
+    return o
+  end
+
   it("invokes dns_check_fn with an extraBlocked host after the restart (#328 / #351)", function()
     local probed
     policy.apply(decode_smoke(),
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      { dns_check_fn = function(domain) probed = domain; return "93.184.216.34" end })
+      smoke_opts({ dns_check_fn = function(domain) probed = domain; return "93.184.216.34" end }))
     assert.equal("badsite.example.com", probed)
   end)
 
@@ -461,7 +535,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      { dns_check_fn = function(_domain) return "0.0.0.0" end })
+      smoke_opts({ dns_check_fn = function(_domain) return "0.0.0.0" end }))
     local matched = false
     for _, w in ipairs(warns) do
       if w:find("smoke", 1, true) and w:find("0.0.0.0", 1, true) then
@@ -479,7 +553,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      { dns_check_fn = function(_d) return "" end })
+      smoke_opts({ dns_check_fn = function(_d) return "" end }))
     local matched = false
     for _, w in ipairs(warns) do
       if w:find("smoke", 1, true) then matched = true end
@@ -493,7 +567,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      { dns_check_fn = function(_d) return "93.184.216.34" end })
+      smoke_opts({ dns_check_fn = function(_d) return "93.184.216.34" end }))
     for _, w in ipairs(warns) do
       assert.is_nil(w:find("smoke", 1, true),
         "unexpected smoke-check warning: " .. w)
@@ -506,7 +580,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       stub_log,
-      { dns_check_fn = function(_d) return nil end })
+      smoke_opts({ dns_check_fn = function(_d) return nil end }))
     local matched = false
     for _, w in ipairs(warns) do
       if w:find("smoke", 1, true) then matched = true end
@@ -522,7 +596,7 @@ describe("policy.apply", function()
       function(_p, _c) return true, nil end,
       function(_cmd) return 0 end,
       nil,
-      { dns_check_fn = function(_d) called = true; return "93.184.216.34" end })
+      smoke_opts({ dns_check_fn = function(_d) called = true; return "93.184.216.34" end }))
     assert.is_false(called,
       "dns_check_fn should not be called when there is no extraBlocked host to probe")
   end)


### PR DESCRIPTION
## Summary

- Audit for #414: post-#329 / #351 the rendered dnsmasq.conf contains **no** `address=` sinkhole directives. The two surviving directive types — `dhcp-host=` (DHCP-side MAC→profile tag) and `nftset=` (per-host nft set populated at resolve time) — still require a full restart on change, because SIGHUP does not re-read `conf-dir` (#328).
- However most `policy.apply` calls flip only nft-side state (blocked_macs membership from schedule / pause / time-limit transitions, failover transitions) and leave the rendered dnsmasq.conf byte-identical.
- Read the on-disk copy of `/tmp/dnsmasq.d/familydns.conf` before writing; if the rendered content matches, **skip** the `/etc/init.d/dnsmasq restart`. The `nft -f` reload still runs every apply (cheap, idempotent).
- Net effect: no DNS service blip on every schedule boundary. A full restart still fires when the dnsmasq fragment actually changes (new extraBlocked host, device profile reassignment, blocklist membership).

## Decision rationale (outcome (c) from the audit)

- (a) "remove the reload entirely" was tempting but unsafe: `dhcp-host=` and `nftset=` directives still genuinely require a full restart per dnsmasq's SIGHUP semantics.
- (c) "smart-reload: restart only when dnsmasq.conf changes" was the right cut. No new state tracking needed — we already write the file, so a single read+compare is all the bookkeeping required.

## Live test

Pushed to the test router (192.168.10.42) and watched logread:

```
21:00:13 policy.apply: wrote dnsmasq=233B (changed) nft=987B; restarting dnsmasq
21:00:17 policy.apply: wrote dnsmasq=233B (unchanged) nft=987B; skipping dnsmasq restart
```

First apply was the cached-policy startup path (no /tmp file yet → "changed" → restart, as expected on cold boot). Immediate follow-up was the initial 200 fetch with byte-identical content → restart skipped. `nslookup google.com 127.0.0.1` returns normally; dnsmasq healthy.

## Test plan

- [x] Unit tests pass (266/0).
- [x] New tests: restart skipped when on-disk matches; restart fires when stale; restart fires when file missing (first apply).
- [x] Live router: cold-boot apply restarts; subsequent identical-content apply skips restart.
- [x] dnsmasq still resolves names after the skip path.

Refs: #328 (SIGHUP-vs-restart bug), #329 / #351 (sinkholing dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)