### PR TITLE
e2e-vm: stabilize scenarios 02/03/05/06 (closes #407)

### DIFF
--- a/scripts/e2e/conftest.py
+++ b/scripts/e2e/conftest.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 import uuid
 
 import pytest
@@ -31,7 +30,12 @@ from lib.vm import (
     router_snapshot,
     router_up,
 )
-from lib.wait import wait_for_router_active
+from lib.wait import (
+    wait_for_client_dns,
+    wait_for_etag_change,
+    wait_for_router_active,
+    wait_for_router_slirp_ready,
+)
 
 log = logging.getLogger(__name__)
 
@@ -117,11 +121,13 @@ def router(router_session) -> EnrolledRouter:
     running, no profiles or devices touching this MAC yet.
     """
     router_restore(BASE_SNAPSHOT)
-    # Give the agent + dnsmasq + networking a chance to settle after the live
-    # restore. 1s is too short — curl from the client side raced and saw
-    # connection-refused on the first scenario after enrollment. 8s buys us a
-    # fully-converged state without slowing the suite materially.
-    time.sleep(8)
+    # `loadvm` restores guest memory but QEMU SLIRP's NAT/DHCP table is
+    # process-local and starts empty. Drive an HTTP probe from inside the
+    # router until the host API answers — that gates on the agent's own
+    # reachability path, which is what every scenario depends on. Without
+    # this, scenarios racing the agent's first post-restore poll see
+    # status 0 ("policy.fetch: unexpected status 0") and time out.
+    wait_for_router_slirp_ready(api_port=API_PORT, timeout_s=60)
     return router_session
 
 
@@ -146,7 +152,13 @@ def client_factory():
 @pytest.fixture()
 def client(client_factory) -> Client:
     """Default single-client fixture for scenarios that don't need multiple."""
-    return client_factory()
+    c = client_factory()
+    # The router-side `_wait_for_client_lan` gates on DHCP + a single
+    # `getent hosts` answer, but post-loadvm the upstream DNS path through
+    # SLIRP can flap (UDP NAT entries time out independently of TCP). Block
+    # here on a fresh `dig` so the test's first curl doesn't race.
+    wait_for_client_dns(c, timeout_s=30)
+    return c
 
 
 # ── ephemeral profile + device ───────────────────────────────────────────────
@@ -165,8 +177,23 @@ def scratch_profile(admin):
 
 
 @pytest.fixture()
-def scratch_device(admin, scratch_profile, client):
+def scratch_device(admin, scratch_profile, client, router_session):
     admin.upsert_device(mac=client.mac, name=f"e2e-dev-{client.name}", profile_id=scratch_profile["id"])
+    # The router boots with a default-deny boot.nft skeleton (#308) and the
+    # agent only knows about MACs that appear in the policy snapshot it last
+    # fetched. Without waiting for the agent to pick up this device, the
+    # very first packet from the new MAC is dropped and curl returns
+    # HTTPCODE:000 — the failure mode that masked scenarios 2/3/5/6.
+    # Without this gate, the very first packet from the new MAC is dropped
+    # (boot.nft default-deny + agent has no per-MAC accept rule yet). The
+    # device upsert above changes the snapshot's `devicePolicies` map, which
+    # bumps the policy etag — so wait_for_etag_change reliably gates on the
+    # agent having fetched + applied the snapshot that includes our MAC.
+    wait_for_etag_change(admin, router_session.router_id, timeout_s=180)
+    # PolicyApply restarts dnsmasq (#341). The first DNS query immediately
+    # after restart races and curl reports HTTPCODE:000. Re-gate the client
+    # on a fresh resolver answer before yielding to the scenario.
+    wait_for_client_dns(client, timeout_s=30)
     yield {"mac": client.mac, "profile_id": scratch_profile["id"]}
     try:
         admin.delete_device(client.mac)
@@ -200,6 +227,21 @@ def pytest_runtest_makereport(item, call):
                 sections.append(("api logs (tail)", stack.logs(service="api", tail=120)))
         except Exception as e:  # noqa: BLE001
             sections.append(("api logs", f"<unavailable: {e}>"))
+        try:
+            client_obj = item.funcargs.get("client")
+            debug = item.funcargs.get("debug_api")
+            if client_obj is not None and debug is not None:
+                evs = debug.events_for_mac(client_obj.mac)
+                lines = [f"events for mac {client_obj.mac} ({len(evs)} total):"]
+                for e in evs[-20:]:
+                    lines.append(
+                        f"  ts={e.get('ts')} allowed={e.get('allowed')} "
+                        f"reason={e.get('reason')!r} hostname={e.get('hostname')!r} "
+                        f"destIp={e.get('destIp')!r}"
+                    )
+                sections.append(("debug events", "\n".join(lines)))
+        except Exception as e:  # noqa: BLE001
+            sections.append(("debug events", f"<unavailable: {e}>"))
         for title, body in sections:
             rep.sections.append((title, body))
 

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -183,7 +183,17 @@ def client_up(*, mac: str, name: str = "client1", ssh_port: int = 2223) -> Clien
     args = [_vm_script("client-up.sh"), "--mac", mac, "--name", name, "--ssh-port", str(ssh_port)]
     run(args, timeout=180)
     c = Client(name=name, mac=mac, ssh_port=ssh_port)
-    _wait_for_client_lan(c)
+    try:
+        _wait_for_client_lan(c)
+    except BaseException:
+        # If LAN-ready gating raises, the qemu daemon is still running and
+        # holds the SSH hostfwd port — leaving it would break every later
+        # scenario with "Could not set up host forwarding rule".
+        try:
+            client_down(name)
+        except Exception:  # noqa: BLE001
+            log.warning("client_down(%s) during client_up cleanup failed", name)
+        raise
     return c
 
 
@@ -203,8 +213,16 @@ def _wait_for_client_lan(client: Client, *, timeout_s: float = 60, interval_s: f
         "ip -4 addr show eth0 | grep -q '192\\.168\\.100\\.' && "
         "getent hosts example.com >/dev/null",
     ]
+    import subprocess as _sp
     while _time.monotonic() < deadline:
-        res = client_exec(client, probe_cmd, timeout=10, check=False)
+        try:
+            res = client_exec(client, probe_cmd, timeout=10, check=False)
+        except _sp.TimeoutExpired as e:
+            # SSH to a freshly-booted client can stall briefly; treat as a
+            # transient miss rather than aborting the whole wait.
+            last = f"client_exec timed out: {e}"
+            _time.sleep(interval_s)
+            continue
         if res.returncode == 0:
             return
         last = (res.stderr or res.stdout or "").strip()

--- a/scripts/e2e/lib/wait.py
+++ b/scripts/e2e/lib/wait.py
@@ -48,6 +48,97 @@ def _parse_iso(ts: str | None) -> datetime | None:
     return datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
 
+def wait_for_router_slirp_ready(
+    *,
+    api_port: int,
+    timeout_s: float = 60,
+    interval_s: float = 1.0,
+) -> None:
+    """Gate scenarios on the router's outbound NAT being usable.
+
+    QEMU SLIRP keeps NAT/DHCP state in the host process, not in guest memory.
+    A `loadvm` restores the guest but the SLIRP table is empty, so the agent's
+    first post-restore TCP open to 10.0.2.2 fails with status 0. We poll a
+    cheap HTTP probe from inside the router until SLIRP rehydrates and the
+    API answers (any HTTP response counts — 400/401/404 all mean the path
+    works; we only reject status 000).
+    """
+    # Imported here to avoid a circular import (vm imports wait indirectly via
+    # other helpers in some call paths).
+    from .vm import router_ssh
+
+    # Two-phase probe: (a) router→host service via SLIRP-internal routing
+    # (10.0.2.2 is the SLIRP gateway → host loopback), (b) router→internet via
+    # SLIRP→host network outbound, masqueraded the same way client traffic is.
+    # Scenarios that curl example.com from the client need (b) to be hot, not
+    # just (a). Both must return a non-000 HTTP code.
+    probe = (
+        "code_a=$(curl -sS -o /dev/null -m 3 "
+        f"-w '%{{http_code}}' http://10.0.2.2:{api_port}/api/auth/login "
+        "-H 'content-type: application/json' -d '{}' 2>/dev/null || echo 000); "
+        "code_b=$(curl -sS -o /dev/null -m 5 "
+        "-w '%{http_code}' http://example.com/ 2>/dev/null || echo 000); "
+        "echo \"$code_a $code_b\""
+    )
+    deadline = time.monotonic() + timeout_s
+    last = ""
+    attempts = 0
+    started = time.monotonic()
+    while time.monotonic() < deadline:
+        attempts += 1
+        res = router_ssh(probe, timeout=15, check=False)
+        last = (res.stdout or "").strip()
+        parts = last.split()
+        if len(parts) == 2 and parts[0] != "000" and parts[1] != "000":
+            log.info("router SLIRP ready after %.1fs (%d attempts, codes=%s)",
+                     time.monotonic() - started, attempts, last)
+            return
+        time.sleep(interval_s)
+    raise TimeoutError(
+        f"router SLIRP NAT never rehydrated after {timeout_s}s "
+        f"({attempts} attempts, last codes={last!r})"
+    )
+
+
+def wait_for_client_dns(
+    client,
+    *,
+    host: str = "example.com",
+    timeout_s: float = 30,
+    interval_s: float = 1.0,
+) -> None:
+    """Gate test traffic on the client's view of DNS being resolvable.
+
+    The router's dnsmasq forwards upstream via the WAN — same SLIRP path as
+    the agent. After a `loadvm` restore, the first upstream DNS forward can
+    time out (SLIRP UDP table empty) which leaves the client's curl seeing
+    HTTPCODE:000. Poll an actual `dig` from inside the client until it
+    returns an answer.
+    """
+    from .vm import client_exec
+
+    deadline = time.monotonic() + timeout_s
+    attempts = 0
+    started = time.monotonic()
+    last = ""
+    cmd = ["sh", "-c", f"dig +time=2 +tries=1 +short {host} | head -n1"]
+    while time.monotonic() < deadline:
+        attempts += 1
+        res = client_exec(client, cmd, timeout=8, check=False)
+        last = (res.stdout or "").strip()
+        # Accept any A-record-looking answer (dotted-quad). dig prints a
+        # single line per record; the first non-empty stdout line is enough.
+        if last and last[0].isdigit():
+            log.info("client DNS for %s ready after %.1fs (%d attempts, answer=%s)",
+                     host, time.monotonic() - started, attempts, last.split()[0])
+            return
+        time.sleep(interval_s)
+    raise TimeoutError(
+        f"client DNS for {host} never resolved after {timeout_s}s "
+        f"({attempts} attempts, last={last!r})"
+    )
+
+
 def wait_for_router_active(
     admin: AdminAPI,
     router_id: str,

--- a/scripts/e2e/scenarios/test_03_blocked_domain.py
+++ b/scripts/e2e/scenarios/test_03_blocked_domain.py
@@ -1,8 +1,10 @@
 """Scenario 3: Blocked domain rejected.
 
 Add a domain to extraBlocked, wait for the agent's next policy fetch (etag
-change), then verify a request to that domain is dropped/redirected and an
-allowed=False event is recorded.
+change), then verify HTTP/80 traffic to that host is intercepted: per
+render.lua the per-(MAC, host) rule DNATs port-80 traffic to the local
+uhttpd block page (127.0.0.1:8081), so the response body should come from
+the block page rather than the real upstream.
 """
 import pytest
 
@@ -22,18 +24,22 @@ def test_blocked_domain_request_dropped(
 
     wait_for_etag_change(admin, router.router_id, timeout_s=120)
 
-    probe = http_get(client, f"http://{BLOCKED_HOST}/", timeout_s=10)
-    # Either curl gets a connection failure (drop) or it gets the block-page
-    # response from the router. In either case the API should log an
-    # allowed=False event.
-    def find_block_event():
-        for e in debug_api.events_for_mac(client.mac):
-            if BLOCKED_HOST in (e.get("hostname") or "") and e.get("allowed") is False:
-                return e
+    # Per #351 + render.lua, extraBlocked HTTP/80 traffic is DNAT'd to the
+    # local block page; the response should not contain the real
+    # example.org content. Wait until at least one curl pass returns the
+    # block page — the agent may still be re-rendering the nft ruleset
+    # immediately after `wait_for_etag_change` returns.
+    def block_page_intercepted():
+        probe = http_get(client, f"http://{BLOCKED_HOST}/", timeout_s=8)
+        body_lower = (probe.body or "").lower()
+        if probe.http_code == 200 and (
+            "familydns" in body_lower or "blocked" in body_lower
+        ):
+            return probe
         return None
 
-    blocked = wait_until(
-        find_block_event, timeout_s=30, interval_s=2,
-        description=f"blocked event for {BLOCKED_HOST}",
+    probe = wait_until(
+        block_page_intercepted, timeout_s=60, interval_s=3,
+        description=f"block page response for {BLOCKED_HOST}",
     )
-    assert blocked is not None, f"no block event observed; probe={probe!r}"
+    assert probe is not None

--- a/scripts/e2e/scenarios/test_04_daily_limit.py
+++ b/scripts/e2e/scenarios/test_04_daily_limit.py
@@ -14,7 +14,7 @@ import time
 import pytest
 
 from lib.traffic import http_get
-from lib.wait import wait_for_etag_change, wait_until
+from lib.wait import wait_for_etag_change, wait_for_next_poll, wait_until
 
 pytestmark = pytest.mark.daily_limit
 
@@ -23,7 +23,12 @@ def test_daily_limit_blocks_after_quota(
     router, client, scratch_device, scratch_profile, admin, debug_api,
 ):
     admin.apply_profile_update(scratch_profile["id"], timeLimit=1)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    # Setting dailyMinutes when usage=0 doesn't alter the snapshot's
+    # BlockRules (computeBlockRules only emits a TimeLimit reason once
+    # totalMinutesUsed >= limit), so the etag does NOT bump here. Gate on a
+    # plain poll round-trip — that's enough to prove the agent has the new
+    # `dailyMinutes` value cached for its next usage-driven render.
+    wait_for_next_poll(admin, router.router_id, timeout_s=120)
 
     # Generate ~90 seconds of traffic against an allowed host to exceed 1 min.
     deadline = time.monotonic() + 90

--- a/scripts/e2e/scenarios/test_05_usage_in_api.py
+++ b/scripts/e2e/scenarios/test_05_usage_in_api.py
@@ -32,14 +32,16 @@ def test_usage_visible_in_logs_and_time_status(
     assert any((l.get("mac") or "").lower() == client.mac.lower() for l in logs), \
         f"no /api/logs entry for {client.mac}; got {len(logs)} entries"
 
-    # /api/time/status returns ProfileTimeStatus[] keyed by profile, each with
-    # a deviceSummaries: [{mac, name, minutesUsed}] list. The device shows up
-    # there as soon as it has a profile, even before usage is ingested.
+    # /api/time/status returns ProfileTimeStatus[] keyed by profile, each
+    # with a `devices: [DeviceUsageSummary]` list. The schema is
+    # {deviceMac, deviceName, usedMins} (shared/Models.scala) — note the
+    # field is `deviceMac`, not `mac`. The device shows up there as soon
+    # as it has a profile, even before usage is ingested.
     statuses = admin.time_status()
     summaries = [
         d
         for prof in statuses
-        for d in prof.get("deviceSummaries", [])
+        for d in prof.get("devices", [])
     ]
-    assert any((d.get("mac") or "").lower() == client.mac.lower() for d in summaries), \
+    assert any((d.get("deviceMac") or "").lower() == client.mac.lower() for d in summaries), \
         f"no /api/time/status entry for {client.mac}; got {len(summaries)} summaries"

--- a/scripts/e2e/scenarios/test_06_blocked_page.py
+++ b/scripts/e2e/scenarios/test_06_blocked_page.py
@@ -13,7 +13,12 @@ from lib.wait import wait_for_etag_change, wait_until
 pytestmark = pytest.mark.blocked_page
 
 
-BLOCKED_HOST = "blocked-page-test.example.net"
+# Must be a domain whose A-records are reachable from the router's WAN —
+# the agent populates the per-host nft set from dnsmasq's actual upstream
+# answers, and the DNAT-to-block-page rule only fires for IPs that landed
+# in that set. A non-existent host never gets any IPs, so no DNAT, no
+# block-page interception.
+BLOCKED_HOST = "example.net"
 
 
 def test_blocked_request_returns_block_page(

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -155,12 +155,22 @@ if ! timeout 5 docker info >/dev/null 2>&1; then
 fi
 
 echo "==> Running Image Builder in $IMAGEBUILDER_DOCKER_IMAGE"
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
 docker run --rm \
+    -e HOST_UID="$HOST_UID" \
+    -e HOST_GID="$HOST_GID" \
     -v "$IB_ROOT":/ib \
     -v "$STAGING_DIR":/staging:ro \
     -w /ib \
     "$IMAGEBUILDER_DOCKER_IMAGE" \
     bash -euxo pipefail -c '
+        # Cleanup trap: even on build failure, hand bin/ and build_dir/
+        # back to the invoking user so subsequent host-side `rm` and
+        # incremental rebuilds work without sudo. Without this, a single
+        # build leaves root-owned artifacts that block every later run.
+        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib/bin /ib/build_dir 2>/dev/null || true" EXIT
+
         export DEBIAN_FRONTEND=noninteractive
         apt-get update -qq
         apt-get install -y --no-install-recommends \
@@ -202,9 +212,13 @@ docker run --rm \
         # agent renders into /tmp/dnsmasq.d/familydns.conf are accepted —
         # plain dnsmasq is built without HAVE_IPSET and rejects the config
         # at line 7 (#148 e2e).
+        # uhttpd hosts the local block page on 127.0.0.1:8081 (#303 / #351).
+        # render.lua DNATs blocked HTTP/80 traffic there; without uhttpd in
+        # the image, the DNAT lands on a dead port and curl times out
+        # instead of receiving the block page.
         make image \
             PROFILE=generic \
-            PACKAGES="familydns -dnsmasq dnsmasq-full" \
+            PACKAGES="familydns -dnsmasq dnsmasq-full uhttpd" \
             FILES=/staging
     '
 

--- a/scripts/vm/uci-defaults/99-familydns
+++ b/scripts/vm/uci-defaults/99-familydns
@@ -83,9 +83,18 @@ uci set dhcp.@dnsmasq[0].logfacility='/tmp/familydns-dnsmasq.log'
 uci commit dhcp
 
 # Block-page listener on 127.0.0.1:8081 (mirrors install.sh, #303).
+# Drop uhttpd's stock LuCI listener — its default config tries to bind
+# 0.0.0.0:80 and 0.0.0.0:443, both of which collide with the LAN-side
+# block-page DNAT target and stop the service from starting at all.
+uci -q delete uhttpd.main
 section=$(uci add uhttpd uhttpd)
 uci set "uhttpd.${section}.listen_http=127.0.0.1:8081"
 uci set "uhttpd.${section}.home=/www/familydns"
 uci commit uhttpd
+
+# Without `enable`, OpenWRT has the package but procd never starts it on
+# boot — the DNAT'd block-page traffic then hits a closed port and curl
+# times out (HTTPCODE:000) instead of receiving the page.
+[ -x /etc/init.d/uhttpd ] && /etc/init.d/uhttpd enable
 
 exit 0


### PR DESCRIPTION
## Summary

Five independent races/gaps were masking each other on a Linux+KVM host. Fixing them in concert turns the v1 e2e-vm suite green end-to-end (6/6 in ~21min on the test host, from a clean checkout).

- **router fixture**: replaces the post-loadvm `time.sleep(8)` with two real gates — a SLIRP rehydration probe (router→host:18080 + router→internet, both must return non-000) and a client-side DNS gate. `loadvm` doesn't restart QEMU, but SLIRP's NAT table is process-local and starts cold for any new outbound flow.
- **scratch_device fixture**: waits for an etag advance after device upsert so the new MAC's nft accept rule is rendered before the test sends traffic (boot.nft default-deny + agent has no per-MAC accept rule yet → first packet from unknown MAC is silently dropped). Re-gates on client DNS afterwards because PolicyApply restarts dnsmasq (#341), which races the first curl.
- **router image**: adds `uhttpd` to the imagebuilder PACKAGES line and enables it from the uci-defaults seed. render.lua DNATs blocked HTTP/80 traffic to 127.0.0.1:8081 (#303 / #351); without uhttpd that lands on a closed port and curl times out instead of receiving the block page. Stock LuCI listener removed so it doesn't try to bind :80.
- **build-router-image.sh**: chowns `bin/` + `build_dir/` back to the invoking UID on docker EXIT so a single root-as-docker run doesn't leave artifacts that block every later host-side `rm`.
- **scenario corrections** to match current architecture:
  - test_03: asserts the block-page response — per-(MAC, host) drops are at FORWARD before conntrack confirms NEW, so no `allowed=False` event is ever emitted.
  - test_04: `wait_for_next_poll` instead of `wait_for_etag_change` after setting `timeLimit=1` — `computeBlockRules` only emits a TimeLimit reason once `totalMinutesUsed >= limit`, so the etag doesn't bump at zero usage.
  - test_05: fixes two field-name mismatches against `shared/Models.scala` (`devices`, `deviceMac`).
  - test_06: switches `BLOCKED_HOST` to a resolvable domain (`example.net`). The agent populates the per-host nft set from dnsmasq's actual upstream answers — a non-existent host produces zero IPs to DNAT.
- **client_up**: tears down qemu on LAN-ready failure so the SSH hostfwd port doesn't leak across scenarios.
- **diagnostics**: pytest failure report now includes `events_for_mac`; SLIRP and DNS waits log attempt counts + latency.

Closes #407.

## Test plan
- [x] `scripts/e2e-vm.sh` runs all 6 scenarios green from a clean checkout on Linux+KVM
- [ ] Repeat on a fresh worktree without the cached imagebuilder layer (verify the chown-on-EXIT trap)
- [ ] CI / second host

🤖 Generated with [Claude Code](https://claude.com/claude-code)