### PR TITLE
openwrt: v6 sibling DNAT for block-page chain (fixes #411)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -443,6 +443,22 @@ function M.nft(snapshot, opts)
         "ether saddr %s ip daddr @%s tcp dport 80 dnat ip to 127.0.0.1:8081",
         p.mac, bl_set_name(p.id)))
     end
+    -- #411: v6 siblings. uhttpd also binds [::1]:8081 (see install.sh).
+    -- `ip6 daddr != ::1` guards against self-DNAT recursion if the block
+    -- page itself ever issues an outbound v6 request.
+    if #blocked_macs_list > 0 then
+      ind2("ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 dnat ip6 to ::1:8081")
+    end
+    for _, p in ipairs(eb_pairs) do
+      ind2(string.format(
+        "ether saddr %s ip6 daddr @%s tcp dport 80 dnat ip6 to ::1:8081",
+        p.mac, eb6_set_name(p.host)))
+    end
+    for _, p in ipairs(bl_pairs) do
+      ind2(string.format(
+        "ether saddr %s ip6 daddr @%s tcp dport 80 dnat ip6 to ::1:8081",
+        p.mac, bl6_set_name(p.id)))
+    end
     ind("}")
     emit("")
   end

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -203,29 +203,44 @@ if [ "$dnsmasq_changed" = 1 ]; then
   /etc/init.d/dnsmasq restart
 fi
 
-# Idempotent uhttpd listener for the local block page on 127.0.0.1:8081.
-# Document root is /www/familydns so that the nft DNAT (which lands at "/" —
-# the user's original HTTP request had Host: example.com, path /) serves
-# /www/familydns/index.html, not the LuCI redirect at /www/index.html (#303).
+# Idempotent uhttpd listener for the local block page on 127.0.0.1:8081 and
+# [::1]:8081 (#411 — v6 sibling so v6 HTTP requests to blocked hosts land on
+# the block page, not a connection error). Document root is /www/familydns so
+# the nft DNAT (which lands at "/" — the user's original HTTP request had
+# Host: example.com, path /) serves /www/familydns/index.html, not the LuCI
+# redirect at /www/index.html (#303).
 uhttpd_section=$(uci show uhttpd 2>/dev/null \
-  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http='127\\.0\\.0\\.1:8081'\$/{print \$2; exit}")
+  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http=.*'127\\.0\\.0\\.1:8081'/{print \$2; exit}")
+uhttpd_changed=0
 if [ -n "$uhttpd_section" ]; then
   current_home=$(uci -q get "uhttpd.${uhttpd_section}.home" || echo "")
-  if [ "$current_home" = "/www/familydns" ]; then
-    info "Block-page uhttpd listener already configured."
-  else
+  if [ "$current_home" != "/www/familydns" ]; then
     info "Updating block-page uhttpd home to /www/familydns..."
     uci set "uhttpd.${uhttpd_section}.home=/www/familydns"
-    uci commit uhttpd
-    /etc/init.d/uhttpd reload
+    uhttpd_changed=1
   fi
 else
   info "Configuring uhttpd block-page listener on 127.0.0.1:8081..."
   uhttpd_section=$(uci add uhttpd uhttpd)
-  uci set "uhttpd.${uhttpd_section}.listen_http=127.0.0.1:8081"
+  uci add_list "uhttpd.${uhttpd_section}.listen_http=127.0.0.1:8081"
   uci set "uhttpd.${uhttpd_section}.home=/www/familydns"
+  uhttpd_changed=1
+fi
+
+# Add v6 listener if absent. uhttpd treats listen_http as a list, so add_list
+# is safe to append; we just need to dedupe.
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
+    | tr ' ' '\n' | grep -qx '\[::1\]:8081'; then
+  info "Adding v6 block-page uhttpd listener on [::1]:8081..."
+  uci add_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
+  uhttpd_changed=1
+fi
+
+if [ "$uhttpd_changed" = 1 ]; then
   uci commit uhttpd
   /etc/init.d/uhttpd reload
+else
+  info "Block-page uhttpd listener already configured (v4 + v6)."
 fi
 
 # #303: enable route_localnet on the LAN bridge so the nft prerouting DNAT

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -504,19 +504,36 @@ describe("render.nft nat chain", function()
     assert.is_nil(nft:find("familydns_block_nat", 1, true))
   end)
 
-  -- #392: v6 block-page DNAT is explicitly out of scope. uhttpd binds v4
-  -- only, so a v6 HTTP request to a blocked host drops at the filter chain
-  -- with no DNAT redirect (browser sees a connection error, not the block
-  -- page). Pin the absence so a future test-writer doesn't quietly add a
-  -- v6 DNAT line that points at a non-existent v6 listener.
-  it("does NOT emit ip6/dnat lines in the nat chain (v6 block page deferred, #392)", function()
+  -- #411: v6 block-page DNAT mirrors v4. uhttpd also binds [::1]:8081 so the
+  -- redirect lands on a live listener (see install.sh). Each v4 DNAT line
+  -- gets a parallel v6 sibling targeting the eb6_/bl6_ sets and ::1:8081.
+  it("emits a v6 DNAT rule scoped to @blocked_macs (#411)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 dnat ip6 to ::1:8081",
+      1, true))
+  end)
+
+  it("DNATs v6 HTTP/80 from a MAC to the block page when daddr ∈ eb6_<host> (#411)", function()
     local nft = render.nft(snap_one())
-    local pos = nft:find("chain familydns_block_nat", 1, true)
-    assert.truthy(pos)
-    local close = nft:find("\n%s*}", pos)
-    local body = nft:sub(pos, (close or #nft) - 1)
-    assert.is_nil(body:find("ip6 daddr", 1, true))
-    assert.is_nil(body:find("dnat ip6 to", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      1, true))
+  end)
+
+  -- HTTPS (port 443) is explicitly NOT redirected in either family — DNATing
+  -- TLS to a local listener would produce certificate errors, not a block
+  -- page. The filter chain drops it; the user sees a fast connection error,
+  -- same UX as v4.
+  it("does NOT emit a DNAT rule for HTTPS/443 in either family (#411)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("dport 443", 1, true))
   end)
 
 end)
@@ -831,6 +848,13 @@ describe("render blocklist enforcement (#352)", function()
     local nft = render.nft(snap_bl())
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+  end)
+
+  it("DNATs v6 HTTP/80 from a MAC to the block page when daddr ∈ bl6_<id> (#411)", function()
+    local nft = render.nft(snap_bl())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads tcp dport 80 dnat ip6 to ::1:8081",
       1, true))
   end)
 

--- a/openwrt/uninstall.sh
+++ b/openwrt/uninstall.sh
@@ -90,7 +90,7 @@ FamilyDNS OpenWRT agent — uninstall
 This will:
   - stop and disable the familydns service
   - remove the familydns package via $PKG_MGR
-  - delete the uhttpd block-page listener on 127.0.0.1:8081
+  - delete the uhttpd block-page listener on 127.0.0.1:8081 and [::1]:8081
   - wipe /etc/config/familydns (router_token will be lost)
 EOF
   if [ "$PURGE" -eq 1 ]; then
@@ -162,13 +162,13 @@ esac
 # section index — install.sh used `uci add uhttpd uhttpd` which assigns
 # whatever index was free).
 uhttpd_section=$(uci show uhttpd 2>/dev/null \
-  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http='127\\.0\\.0\\.1:8081'\$/{print \$2; exit}")
+  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http=.*'127\\.0\\.0\\.1:8081'/{print \$2; exit}")
 if [ -n "${uhttpd_section:-}" ]; then
   info "Removing uhttpd block-page listener (section: $uhttpd_section)..."
   uci delete "uhttpd.${uhttpd_section}" 2>/dev/null || true
   uci commit uhttpd
   /etc/init.d/uhttpd reload >/dev/null 2>&1 || true
-  note "removed uhttpd listener on 127.0.0.1:8081"
+  note "removed uhttpd listener on 127.0.0.1:8081 + [::1]:8081 (#411)"
 fi
 
 # 3a. #303: revert the route_localnet sysctl. The package removal takes the


### PR DESCRIPTION
## Summary
- Emit v6 DNAT siblings (`ip6 daddr ... dnat ip6 to ::1:8081`) for every existing v4 line in `familydns_block_nat`: `@blocked_macs`, per-(MAC, host) extraBlocked (`eb6_<host>`), and per-(MAC, blocklistId) (`bl6_<id>`).
- Bind `uhttpd` on `[::1]:8081` in addition to `127.0.0.1:8081` so the v6 DNAT lands on a live listener.
- Replace the obsolete "v6 absence pin" in `render_spec.lua` with the inverse assertions; add HTTPS-not-redirected pin in both families.

Closes #411. Mirrors the v4 DNAT plumbing landed in #303; completes the v6 enforcement UX whose drop layer landed in #392 / #408. `blockIpOnly` (#353) is currently a schema-only field with no render.lua enforcement path, so out of scope. HTTPS variant (#383) intentionally untouched — TLS DNAT to a local listener can't serve a friendly page.

The `ip6 daddr != ::1` guard on the `@blocked_macs` v6 rule prevents pathological self-DNAT if the block-page handler ever issues an outbound v6 request.

## Test plan
- [x] `busted test/render_spec.lua` — 73 pass / 0 fail (1 pending: `nft -c` host-side validation gated on `nft` binary)
- [x] Synthetic snapshot rendered on the live test router (`192.168.10.42`) via `lua` + `require("render")`; `nft -c -f <rendered>` accepts the output cleanly.
- [x] Live load: rendered ruleset applied via `nft -f`; `familydns_block_nat` shows both v4 and v6 DNAT rules present.
- [x] Block page served on both listeners: `curl http://127.0.0.1:8081/` and `curl -6 'http://[::1]:8081/'` return identical 1497-byte HTTP 200 (same `<!DOCTYPE html>` body).
- [x] uhttpd reload confirmed v6 listener up: `netstat -tlnp | grep 8081` shows `127.0.0.1:8081` and `::1:8081` both `LISTEN`.
- [x] Router state restored: agent re-fetched fresh policy from API after test, real ruleset re-applied.
- [ ] End-to-end LAN client `curl -6 http://blocked-host` → block page: not exercised in this PR because the current test-router snapshot has no active blocks (no devices wired to a profile with `extraBlocked` or `blocklistIds` resolving to populated sets). The structural validation above is equivalent to v4 — the v6 lines are mechanical mirrors of the v4 lines, which work today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)