### PR TITLE
e2e: harness extensions for #346 enforcement suites

### DIFF
--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -29,6 +29,7 @@ E2E_DIR="${REPO_ROOT}/scripts/e2e"
 VENV_DIR="${REPO_ROOT}/.e2e-vm-venv"
 
 ONLY=""
+SMOKE=0
 PYTEST_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -36,6 +37,8 @@ while [[ $# -gt 0 ]]; do
       ONLY="$2"; shift 2 ;;
     --only=*)
       ONLY="${1#--only=}"; shift ;;
+    --smoke)
+      SMOKE=1; shift ;;
     --keep)
       export E2E_VM_KEEP=1 E2E_VM_KEEP_STACK=1; shift ;;
     --skip-vms)
@@ -65,10 +68,28 @@ case "${ONLY}" in
   usage)        MARK="usage" ;;
   blocked-page|blocked_page)
                 MARK="blocked_page" ;;
+  pause)        MARK="pause" ;;
+  extra-blocked|extra_blocked)
+                MARK="extra_blocked" ;;
+  schedule)     MARK="schedule" ;;
+  time-limit|time_limit)
+                MARK="time_limit" ;;
+  reassignment) MARK="reassignment" ;;
+  unknown-device|unknown_device)
+                MARK="unknown_device" ;;
   *) echo "unknown --only: ${ONLY}" >&2
-     echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page" >&2
+     echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page," >&2
+     echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device" >&2
      exit 2 ;;
 esac
+
+if [[ "${SMOKE}" == "1" ]]; then
+  if [[ -n "${MARK}" ]]; then
+    MARK="${MARK} and smoke"
+  else
+    MARK="smoke"
+  fi
+fi
 
 # ── venv ─────────────────────────────────────────────────────────────────────
 

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -124,6 +124,25 @@ class AdminAPI:
     def set_profile_paused(self, profile_id: int, paused: bool) -> dict[str, Any]:
         return self.apply_profile_update(profile_id, paused=paused)
 
+    def add_schedule(self, profile_id: int, schedule: dict[str, Any]) -> dict[str, Any]:
+        """Append a schedule to the profile via fold-and-PUT.
+
+        `schedule` is a dict in the shape the API expects (e.g. `{"daysOfWeek":
+        ["MON"], "startTime": "09:00", "endTime": "17:00", "timezone":
+        "America/Los_Angeles"}`). The server may assign an `id` on round-trip;
+        the returned profile reflects what was stored.
+        """
+        full = self.get_profile(profile_id)
+        existing = full.get("schedules", []) if isinstance(full, dict) else []
+        return self.apply_profile_update(profile_id, schedules=existing + [schedule])
+
+    def remove_schedule(self, profile_id: int, schedule_id: Any) -> dict[str, Any]:
+        """Drop the schedule with the given id; no-op if absent."""
+        full = self.get_profile(profile_id)
+        existing = full.get("schedules", []) if isinstance(full, dict) else []
+        kept = [s for s in existing if s.get("id") != schedule_id]
+        return self.apply_profile_update(profile_id, schedules=kept)
+
     # ── devices ───────────────────────────────────────────────────────────
 
     def upsert_device(self, *, mac: str, name: str, profile_id: int) -> dict[str, Any]:

--- a/scripts/e2e/lib/api_debug.py
+++ b/scripts/e2e/lib/api_debug.py
@@ -39,6 +39,33 @@ class DebugAPI:
     def events_for_mac(self, mac: str, *, limit: int = 200) -> list[dict[str, Any]]:
         return [e for e in self.events(limit=limit) if (e.get("mac") or "").lower() == mac.lower()]
 
+    def events_for_mac_filtered(
+        self,
+        mac: str,
+        *,
+        hostname: str | None = None,
+        allowed: bool | None = None,
+        reason: str | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Filter `events_for_mac` by common predicates.
+
+        `hostname` is substring-matched (case-insensitive); `allowed` and
+        `reason` must be exact. All None-valued filters are ignored.
+        """
+        out = []
+        host_needle = hostname.lower() if hostname else None
+        for e in self.events_for_mac(mac, limit=limit):
+            if host_needle is not None:
+                if host_needle not in (e.get("hostname") or "").lower():
+                    continue
+            if allowed is not None and e.get("allowed") is not allowed:
+                continue
+            if reason is not None and e.get("reason") != reason:
+                continue
+            out.append(e)
+        return out
+
     def _get(self, path: str) -> Any:
         url = f"http://127.0.0.1:8080{path}"
         proc = subprocess.run(

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -119,6 +119,35 @@ def router_restore(name: str) -> Result:
     return run([_vm_script("router-restore.sh"), name], timeout=60)
 
 
+def router_nft_set(set_name: str, *, table: str = "fw4", family: str = "inet") -> list[str]:
+    """Return the elements of an nftables set on the router.
+
+    Used by the enforcement suites (#346) to assert MAC / IP membership in
+    sets like `blocked_macs` or per-MAC drop sets without depending on
+    log-line parsing. Returns an empty list if the set exists but is empty,
+    or if the set is absent.
+
+    Implementation detail: `nft -j list set ...` would be cleaner but isn't
+    always present on the OpenWRT image; we parse the human-readable form.
+    Elements appear after `elements = { ... }`, comma-separated.
+    """
+    res = router_ssh(
+        f"nft list set {family} {table} {set_name} 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    out = res.stdout or ""
+    if "elements" not in out:
+        return []
+    # Pull the brace-delimited element list.
+    start = out.find("elements")
+    brace = out.find("{", start)
+    end = out.find("}", brace)
+    if brace == -1 or end == -1:
+        return []
+    inner = out[brace + 1 : end]
+    return [tok.strip() for tok in inner.split(",") if tok.strip()]
+
+
 def router_ssh(cmd: str, *, timeout: float = 30, check: bool = True) -> Result:
     """Run a command on the router via the WAN-side hostfwd SSH port."""
     args = [

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -9,6 +9,13 @@ markers =
     daily_limit: scenario 4 — per-app daily limit enforced
     usage: scenario 5 — usage reflected in /api/logs and /api/time/status
     blocked_page: scenario 6 — block page rendered for blocked HTTP traffic
+    pause: suite A (#428) — pause enforcement
+    extra_blocked: suite B (#429) — extraBlocked Truth-1 + scoping
+    schedule: suite C (#430) — schedule enforcement
+    time_limit: suite D (#431) — daily time-limit granularity + rollover
+    reassignment: suite E (#432) — profile reassignment
+    unknown_device: suite F (#432) — unknown-device autocreation
+    smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO
 log_cli_format = %(asctime)s %(levelname)s %(name)s: %(message)s


### PR DESCRIPTION
## Summary
- `api_admin`: `add_schedule` / `remove_schedule` fold-and-PUT wrappers.
- `api_debug`: `events_for_mac_filtered(hostname=, allowed=, reason=)` — predicate-loop pattern lifted from `test_03`/`test_06`.
- `vm`: `router_nft_set(name)` — SSH + parse `nft list set` for membership assertions.
- `pytest.ini`: markers `pause`, `extra_blocked`, `schedule`, `time_limit`, `reassignment`, `unknown_device`, `smoke`.
- `e2e-vm.sh`: extend `--only` to new tags; `--smoke` shortcut AND-composes with `--only`.

Lib-only, no test additions. First in-tree caller lands with #428 (Suite A).

## Test plan
- [ ] `python3 -c "import ast; ..."` parses cleanly (done locally)
- [ ] `bash -n scripts/e2e-vm.sh` passes (done locally)
- [ ] Existing six scenarios still pass on a host with KVM (out-of-band — no KVM available in PR context)
- [ ] `scripts/e2e-vm.sh --only pause --smoke` resolves to `-m "pause and smoke"` (verified by `bash -x`)

Closes #427
Parent: #346