### PR TITLE
api/web: explicit setter for profile.paused (fixes #406 item 1)

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -132,7 +132,7 @@ object ProfileRoutes {
       userRepo: UserRepo,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "profiles"                         ->
+      Method.GET / "api" / "profiles"                        ->
         handler { (req: Request) =>
           for {
             claims      <- requireAuth(req, auth)
@@ -149,7 +149,7 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(details.toJson)
         },
-      Method.GET / "api" / "profiles" / long("id")            ->
+      Method.GET / "api" / "profiles" / long("id")           ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -166,7 +166,7 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(ProfileDetail(p, scheds, tl, stls).toJson)
         },
-      Method.POST / "api" / "profiles"                        ->
+      Method.POST / "api" / "profiles"                       ->
         handler { (req: Request) =>
           for {
             _    <- requireAdmin(req, auth)
@@ -205,7 +205,7 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(s"""{"id":${id.value}}""")
         },
-      Method.PUT / "api" / "profiles" / long("id")            ->
+      Method.PUT / "api" / "profiles" / long("id")           ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -245,13 +245,13 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
-      Method.DELETE / "api" / "profiles" / long("id")         ->
+      Method.DELETE / "api" / "profiles" / long("id")        ->
         handler { (id: Long, req: Request) =>
           requireAdmin(req, auth) *>
             profileRepo.delete(ProfileId(id)).mapError(ErrorMapper.dbErrorToResponse) *>
             ZIO.succeed(Response.ok)
         },
-      Method.GET / "api" / "profiles" / long("id") / "users"  ->
+      Method.GET / "api" / "profiles" / long("id") / "users" ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -266,7 +266,7 @@ object ProfileRoutes {
             }
           } yield Response.json(summaries.toJson)
         },
-      Method.PUT / "api" / "profiles" / long("id") / "users"  ->
+      Method.PUT / "api" / "profiles" / long("id") / "users" ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -280,20 +280,11 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
-      Method.POST / "api" / "profiles" / long("id") / "pause" ->
-        handler { (id: Long, req: Request) =>
-          val pid = ProfileId(id)
-          for {
-            claims <- requireWriter(req, auth)
-            _      <- requireProfileAccess(claims, pid, userProfileRepo)
-            p      <- profileRepo
-              .findById(pid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("")))
-            _      <-
-              profileRepo.setPaused(pid, !p.paused).mapError(ErrorMapper.dbErrorToResponse)
-          } yield Response.json(s"""{"paused":${!p.paused}}""")
-        },
+      // #406: POST /api/profiles/:id/pause used to toggle paused state by
+      // reading the row and writing !paused. That race-flips state under
+      // concurrent calls (two browser tabs, retry-after-blip). Callers now
+      // set `paused` explicitly via PUT /api/profiles/:id. See #423 for the
+      // follow-up to add PATCH for race-safe field-scoped updates.
     )
 }
 

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -353,8 +353,63 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(scheds.exists(_.blockFrom == "20:00"))
       },
     ),
-    suite("POST /api/profiles/:id/pause")(
-      test("toggles pause state") {
+    suite("PUT /api/profiles/:id pause is idempotent (#406)")(
+      // #406: the toggle endpoint POST /api/profiles/:id/pause was deleted
+      // because it was a read-then-write race (two near-simultaneous calls
+      // silently flip state twice). Callers must now set `paused` explicitly
+      // via the full PUT, which is idempotent by construction.
+      test("two consecutive PUT(paused=true) leave state at paused=true") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          profiles    <- profileRepo.listAll
+          kidsId = profiles.find(_.name == "Kids").get.id
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          userRepoSvc     <- ZIO.service[UserRepo]
+          routes = ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            userProfileRepo,
+            userRepoSvc,
+          )
+          mkReq  = (paused: Boolean) => {
+            val body = UpsertProfileRequest(
+              name = "Kids",
+              blockedCategories = Nil,
+              extraBlocked = Nil,
+              extraAllowed = Nil,
+              paused = paused,
+              schedules = Nil,
+              timeLimit = None,
+              siteTimeLimits = Nil,
+            ).toJson
+            Request
+              .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
+              .addHeader(Header.Authorization.Bearer(token))
+              .addHeader(Header.ContentType(MediaType.application.json))
+          }
+          resp1 <- routes.runZIO(mkReq(true))
+          after1 <- profileRepo.findById(kidsId)
+          resp2  <- routes.runZIO(mkReq(true))
+          after2 <- profileRepo.findById(kidsId)
+          resp3  <- routes.runZIO(mkReq(false))
+          after3 <- profileRepo.findById(kidsId)
+        } yield assertTrue(resp1.status == Status.Ok) &&
+          assertTrue(after1.exists(_.paused)) &&
+          assertTrue(resp2.status == Status.Ok) &&
+          assertTrue(after2.exists(_.paused)) &&
+          assertTrue(resp3.status == Status.Ok) &&
+          assertTrue(after3.exists(!_.paused))
+      },
+      test("legacy POST /api/profiles/:id/pause is removed (404)") {
         for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
@@ -377,19 +432,10 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             userRepoSvc,
           )
           req    = Request
-            .post(
-              URL.decode(s"/api/profiles/$kidsId/pause").toOption.get,
-              Body.empty,
-            )
+            .post(URL.decode(s"/api/profiles/$kidsId/pause").toOption.get, Body.empty)
             .addHeader(Header.Authorization.Bearer(token))
-          resp1       <- routes.runZIO(req)
-          afterPause  <- profileRepo.findById(kidsId)
-          resp2       <- routes.runZIO(req)
-          afterResume <- profileRepo.findById(kidsId)
-        } yield assertTrue(resp1.status == Status.Ok) &&
-          assertTrue(afterPause.exists(_.paused)) &&
-          assertTrue(resp2.status == Status.Ok) &&
-          assertTrue(afterResume.exists(!_.paused))
+          resp <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.NotFound)
       },
     ),
     suite("Profile ↔ user linking")(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -75,7 +75,6 @@ export const api = {
     update: (id: number, data: UpsertProfileRequest) =>
       req<void>('PUT', `/profiles/${id}`, data),
     delete: (id: number) => req<void>('DELETE', `/profiles/${id}`),
-    pause: (id: number) => req<{ paused: boolean }>('POST', `/profiles/${id}/pause`, {}),
     getUsers: (id: number) => req<User[]>('GET', `/profiles/${id}/users`),
     setUsers: (id: number, userIds: number[]) =>
       req<void>('PUT', `/profiles/${id}/users`, { userIds }),

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -10,7 +10,6 @@ vi.mock('@/api/client', () => ({
       create: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
-      pause: vi.fn(),
       setUsers: vi.fn(),
     },
     blocklists: {
@@ -93,7 +92,6 @@ beforeEach(() => {
   ;(api.profiles.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 99 })
   ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.delete as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
-  ;(api.profiles.pause as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ paused: true })
   ;(api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.devices.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([phoneDevice, tabletDevice])
   ;(api.users.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aliceUser, bobUser, carolUser])
@@ -119,13 +117,33 @@ describe('ProfilesPage — list', () => {
 })
 
 describe('ProfilesPage — pause / delete', () => {
-  it('clicking Pause/Resume calls api.profiles.pause and reloads', async () => {
+  // #406: pause is now an explicit PUT with the full profile + paused=!current.
+  // The previous POST /pause endpoint was a server-side toggle (race-prone).
+  it('clicking Pause calls api.profiles.update with paused=true and reloads', async () => {
     const user = userEvent.setup()
     render(<ProfilesPage />)
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /Pause/ }))
-    await waitFor(() => expect(api.profiles.pause).toHaveBeenCalledWith(1))
+    await waitFor(() =>
+      expect(api.profiles.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ paused: true, name: 'Kids' }),
+      ),
+    )
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
+  })
+
+  it('clicking Resume calls api.profiles.update with paused=false', async () => {
+    const user = userEvent.setup()
+    render(<ProfilesPage />)
+    const adultsCard = await screen.findByTestId('profile-card-2')
+    await user.click(within(adultsCard).getByRole('button', { name: /Resume/ }))
+    await waitFor(() =>
+      expect(api.profiles.update).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({ paused: false, name: 'Adults' }),
+      ),
+    )
   })
 
   it('confirms then calls api.profiles.delete', async () => {

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -142,8 +142,14 @@ export function ProfilesPage() {
     setError(null)
   }
 
-  async function togglePause(id: number) {
-    await api.profiles.pause(id)
+  async function togglePause(pd: ProfileDetail) {
+    // #406: setting `paused` explicitly via the full-profile PUT is
+    // idempotent under concurrent clicks. The old POST /pause endpoint was
+    // a server-side toggle that race-flipped under double-click / retry.
+    // #423 tracks adding PATCH so we don't have to send the whole profile.
+    const body = formToRequest(detailToForm(pd))
+    body.paused = !pd.profile.paused
+    await api.profiles.update(pd.profile.id, body)
     await reload()
   }
 
@@ -224,7 +230,7 @@ export function ProfilesPage() {
               </div>
               {isAdmin && (
                 <div className="flex flex-wrap gap-2 shrink-0">
-                  <button onClick={() => togglePause(pd.profile.id)}
+                  <button onClick={() => togglePause(pd)}
                     className={`text-xs px-3 py-1.5 rounded-lg border transition-colors ${
                       pd.profile.paused
                         ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20 hover:bg-emerald-500/20'


### PR DESCRIPTION
## Summary

- Delete \`POST /api/profiles/:id/pause\` — it was a server-side toggle (\`setPaused(id, !p.paused)\`) that race-flipped state under two near-simultaneous callers (two browser tabs, retry-after-blip, automation + user).
- Migrate the admin UI pause button to the existing idempotent \`PUT /api/profiles/:id\` with \`paused\` set explicitly.
- Follow-up #423 tracks adding \`PATCH /api/profiles/:id\` so the UI can send only the changed field instead of the whole profile.

## Tests

Added in [\`api/test/src/feature/ProfileApiSpec.scala\`](api/test/src/feature/ProfileApiSpec.scala):

- \`PUT(paused=true)\` twice in a row leaves terminal state \`paused=true\` (no spurious flip).
- \`PUT(paused=false)\` after that flips it back.
- Legacy \`POST /api/profiles/:id/pause\` now returns 404.

Web side ([\`web/src/pages/ProfilesPage.test.tsx\`](web/src/pages/ProfilesPage.test.tsx)):

- Clicking Pause/Resume calls \`api.profiles.update\` with the full profile body and the desired \`paused\` value.

\`mill __.test\` and \`npm test\` both green.

## Live verification on test router (closes out #264 verification debt)

Deployed this branch to \`192.168.10.43\`, ran live verification against the real OpenWRT test router (\`192.168.10.42\`). Test device: Octavius iPad, MAC \`fa:10:cd:84:78:22\`, assigned to Kids (profile 1).

### Test B — pause + unpause restores connectivity

\`\`\`
T0  16:39:38Z  PUT /api/profiles/1  {paused:true}   → HTTP 200, profile.paused=true
T+28s 16:40:06Z  router nft list set inet familydns blocked_macs:
    elements = { be:89:10:82:c7:4c, f6:1c:86:e1:c2:b4, fa:10:cd:84:78:22 }
                                                        ↑ all 3 Kids MACs blocked
                  iPad: hits block page  ✓ (operator confirmed)

T0  16:41:01Z  PUT /api/profiles/1  {paused:false}  → HTTP 200
T+5s  16:41:06Z  blocked_macs: {} (empty)
                  iPad: loads sites normally  ✓ (operator confirmed)
\`\`\`

### Test D — per-profile scoping

\`\`\`
T0  16:42:16Z  PUT /api/profiles/2  {paused:true}  (Adults)  → HTTP 200
T+1s  16:42:17Z  blocked_macs:
    elements = { e2:5d:df:78:c5:2b }   ← only Adults MAC
                                         ✓ Kids MAC fa:10:cd:84:78:22 NOT in set
                  iPad (Kids): continues to load sites normally
                  ✓ (operator confirmed)

T0  16:42:49Z  PUT /api/profiles/2  {paused:false}  → HTTP 200
T+21s 16:43:10Z  blocked_macs: {} (baseline restored)
\`\`\`

### Test C — deferred

Test C (pause vs. schedule precedence) is **deferred** until #334 (API-side timezone audit) lands. The Kids \"Bedtime 21:00–07:00\" schedule has been observed firing at the wrong wall-clock time on this router, so it's not a stable precondition for testing pause-overrides-schedule. #406 stays open with a status comment.

## Follow-ups filed during this work

- #423 — add \`PATCH /api/profiles/:id\` for partial, field-scoped updates (race-safe across concurrent edits to different fields).
- #436 — Flyway: V14 (\`drop_router_clock_skew\`) was authored after V15 was already applied to prod. The live deploy hit a Flyway validation crash; recovered by manually applying V14 + inserting a schema_history row. CI guard proposed to prevent recurrence.
- #437 — block page reaches successfully when MAC is paused-blocked but the page does not render a reason string. Enforcement is correct; this is a UX gap.

## Cross-references

- Closes out #264 verification debt (the live transcripts above).
- Uses #401 (admin allowlist runbook merged via #404) — operator allowlist already in place.
- Does **not** close #406 — Test C remains pending until #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)