### PR TITLE
openwrt: enforce extraAllowed as per-(MAC, host) exception (fixes #421)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -22,19 +22,24 @@
 -- Then:
 --
 --   drop(m, d) ⇔
---         m ∈ @blocked_macs
+--         ( m ∈ blocked_macs ∧ ¬ea_hit(m, d) )
 --      ∨  ( ∃ h ∈ extraBlocked(m). d ∈ @eb_h ∧ ¬ea_hit(m, d) )
 --      ∨  ( ∃ id ∈ blocklistIds(m). d ∈ @bl_id ∧ ¬ea_hit(m, d) )
 --      ∨  blockIpOnly(m) ∧ d ∉ @resolved_<m>       (or @resolved6_<m> for v6)
 --      ∨  m ∈ @failover_drop                       (block-all failover only)
 --
--- allow := ¬drop. extraAllowed beats extraBlocked beats blocklists (#421):
--- the eb_/bl_ drop rules carry one `ip daddr != @ea_<m>_<a>` clause per
--- host in m's effective extraAllowed list, so a hit in any ea_ set
--- suppresses the eb_/bl_ drops for that (mac, packet). blockIpOnly is
--- intentionally NOT suppressed by ea sets — extraAllowed composes via
--- the dnsmasq resolver populating resolved_<m> at A/AAAA time, so a
--- resolved-allowed host already lands in resolved_<m>.
+-- allow := ¬drop. extraAllowed beats every "blocked" path (#421):
+-- the @blocked_macs / eb_ / bl_ drop rules each carry one `ip daddr != @ea_<m>_<a>`
+-- clause per host in m's effective extraAllowed list, so a hit in any
+-- ea_ set suppresses those drops for that (mac, packet). For the
+-- @blocked_macs path: blocked MACs *with* extraAllowed are pulled out of
+-- the set into per-MAC rules carrying the ea exception (one rule per
+-- family; the family-agnostic `ether saddr @blocked_macs drop` cannot
+-- carry an `ip daddr` predicate). Blocked MACs with no extraAllowed
+-- stay in the set and drop unconditionally as before.
+-- blockIpOnly is intentionally NOT suppressed by ea sets — extraAllowed
+-- composes via the dnsmasq resolver populating resolved_<m> at A/AAAA
+-- time, so a resolved-allowed host already lands in resolved_<m>.
 -- Time-limit / schedule / pause are collapsed server-side into
 -- rules.blocked + extraBlocked / extraAllowed by the API, so the agent
 -- never sees a temporal field.
@@ -479,11 +484,24 @@ function M.nft(snapshot, opts)
   -- blocked_macs: derived from per-device effective rules. The API server
   -- precomputes BlockRules.blocked from pause / time limit / schedule, so
   -- we just collect MACs whose effective rules.blocked == true.
-  local blocked_macs_list = {}
+  --
+  -- #421: blocked MACs whose effective rules also have a non-empty
+  -- extraAllowed list get pulled out of the @blocked_macs set into
+  -- per-MAC rules carrying the `ip daddr != @ea_<m>_<a>` exception. The
+  -- @blocked_macs set itself stays family-agnostic (it cannot carry an
+  -- `ip daddr` predicate), so MACs with ea exceptions need per-family
+  -- rules instead.
+  local ea_by_mac_early = effective_extra_allowed_by_mac(snapshot)
+  local blocked_macs_list   = {}   -- in @blocked_macs set (drop unconditionally)
+  local blocked_ea_macs     = {}   -- blocked AND has extraAllowed → per-MAC rules
   for mac, dev in sorted_devices(snapshot.devices) do
     local r = effective_rules(dev, snapshot.profiles)
     if r and r.blocked and not allowall_macs[mac] then
-      blocked_macs_list[#blocked_macs_list + 1] = mac
+      if ea_by_mac_early[mac] then
+        blocked_ea_macs[#blocked_ea_macs + 1] = mac
+      else
+        blocked_macs_list[#blocked_macs_list + 1] = mac
+      end
     end
   end
 
@@ -521,7 +539,7 @@ function M.nft(snapshot, opts)
   -- populator still runs harmlessly; sets are cheap) — the drop/DNAT
   -- suffixes below are what allowall actually suppresses, by virtue of
   -- the eb_/bl_ rules themselves being suppressed for those MACs.
-  local ea_by_mac = effective_extra_allowed_by_mac(snapshot)
+  local ea_by_mac = ea_by_mac_early
   do
     local ea_macs = {}
     for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
@@ -645,6 +663,21 @@ function M.nft(snapshot, opts)
   if #blocked_macs_list > 0 then
     ind2("ether saddr @blocked_macs drop")
   end
+  -- #421: blocked MAC + non-empty extraAllowed → per-MAC drop carrying the
+  -- ea exception, one rule per family. (The @blocked_macs set rule above
+  -- is family-agnostic, but the ea suffix is `ip daddr` / `ip6 daddr`, so
+  -- the rules below must be family-scoped.) The eb_/bl_ drops further
+  -- down also fire for these MACs, but the ea suffix on those rules
+  -- already keeps them inert when daddr is in an ea set, so the net
+  -- behaviour is "drop iff blocked and not in any ea set."
+  for _, mac in ipairs(blocked_ea_macs) do
+    -- The leading `ip daddr != @ea_...` / `ip6 daddr != @ea6_...` clause
+    -- in ea_suffix itself scopes the rule to v4 / v6 packets, so we don't
+    -- need an extra family keyword. ea_suffix returns " ip daddr ..." with
+    -- a leading space, so the rule reads cleanly.
+    ind2(string.format("ether saddr %s%s drop", mac, ea_suffix(mac, "ip")))
+    ind2(string.format("ether saddr %s%s drop", mac, ea_suffix(mac, "ip6")))
+  end
   -- v4 drops first, then v6 (#392). One ipset directive populates both sets
   -- at DNS time; here we gate on whichever family the destination matched.
   -- #421: each eb_/bl_ drop carries `ip daddr != @ea_<m>_<a>` exception
@@ -686,11 +719,17 @@ function M.nft(snapshot, opts)
   -- the local uhttpd block page so users see *why* a connection failed.
   -- Four triggers: MAC-wide block, per-(MAC, host) extraBlocked, per-(MAC,
   -- blocklistId), and per-MAC blockIpOnly (un-resolved daddr).
-  if #blocked_macs_list > 0 or #eb_pairs > 0 or #bl_pairs > 0 or #bio_macs > 0 then
+  if #blocked_macs_list > 0 or #blocked_ea_macs > 0 or #eb_pairs > 0 or #bl_pairs > 0 or #bio_macs > 0 then
     ind("chain familydns_block_nat {")
     ind2("type nat hook prerouting priority dstnat; policy accept;")
     if #blocked_macs_list > 0 then
       ind2("ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081")
+    end
+    -- #421: blocked + extraAllowed → per-MAC v4 DNAT with ea exception.
+    for _, mac in ipairs(blocked_ea_macs) do
+      ind2(string.format(
+        "ether saddr %s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+        mac, ea_suffix(mac, "ip")))
     end
     for _, p in ipairs(eb_pairs) do
       ind2(string.format(
@@ -715,6 +754,14 @@ function M.nft(snapshot, opts)
     -- page itself ever issues an outbound v6 request.
     if #blocked_macs_list > 0 then
       ind2("ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 dnat ip6 to ::1:8081")
+    end
+    -- #421: blocked + extraAllowed → per-MAC v6 DNAT with ea6 exception.
+    -- `ip6 daddr != ::1` guards against self-DNAT (same as the @blocked_macs
+    -- v6 line above).
+    for _, mac in ipairs(blocked_ea_macs) do
+      ind2(string.format(
+        "ether saddr %s ip6 daddr != ::1%s tcp dport 80 dnat ip6 to ::1:8081",
+        mac, ea_suffix(mac, "ip6")))
     end
     for _, p in ipairs(eb_pairs) do
       ind2(string.format(

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -17,19 +17,27 @@
 -- the `drop` lines does not affect the outcome (only minor packet-path
 -- perf), so the predicate is the disjunction of all drop conditions.
 --
--- For a forwarded packet from MAC m to v4/v6 destination d:
+-- For a forwarded packet from MAC m to v4/v6 destination d, let
+--   ea_hit(m, d) ⇔ ∃ a ∈ extraAllowed(m). d ∈ @ea_<m>_a   (or @ea6_<m>_a v6).
+-- Then:
 --
 --   drop(m, d) ⇔
 --         m ∈ @blocked_macs
---      ∨  ∃ h ∈ extraBlocked(m). d ∈ @eb_h         (or @eb6_h for v6)
---      ∨  ∃ id ∈ blocklistIds(m). d ∈ @bl_id       (or @bl6_id for v6)
+--      ∨  ( ∃ h ∈ extraBlocked(m). d ∈ @eb_h ∧ ¬ea_hit(m, d) )
+--      ∨  ( ∃ id ∈ blocklistIds(m). d ∈ @bl_id ∧ ¬ea_hit(m, d) )
 --      ∨  blockIpOnly(m) ∧ d ∉ @resolved_<m>       (or @resolved6_<m> for v6)
 --      ∨  m ∈ @failover_drop                       (block-all failover only)
 --
--- allow := ¬drop. extraAllowed is currently not enforced at this layer
--- (#421 will add per-(MAC, host) ea_ exception sets); time-limit / schedule
--- / pause are collapsed server-side into rules.blocked + extraBlocked /
--- extraAllowed by the API, so the agent never sees a temporal field.
+-- allow := ¬drop. extraAllowed beats extraBlocked beats blocklists (#421):
+-- the eb_/bl_ drop rules carry one `ip daddr != @ea_<m>_<a>` clause per
+-- host in m's effective extraAllowed list, so a hit in any ea_ set
+-- suppresses the eb_/bl_ drops for that (mac, packet). blockIpOnly is
+-- intentionally NOT suppressed by ea sets — extraAllowed composes via
+-- the dnsmasq resolver populating resolved_<m> at A/AAAA time, so a
+-- resolved-allowed host already lands in resolved_<m>.
+-- Time-limit / schedule / pause are collapsed server-side into
+-- rules.blocked + extraBlocked / extraAllowed by the API, so the agent
+-- never sees a temporal field.
 --
 -- Layer split:
 --   API server  — pre-evaluates schedules, time limits, pauses; resolves
@@ -173,6 +181,47 @@ local function resolved_tag_name(mac)
   return "resolvetag_" .. sanitize(mac)
 end
 
+-- #421: per-(MAC, host) extraAllowed exception sets. ea_<sanmac>_<sanhost>
+-- holds the v4 resolved IPs of host a for the dhcp-tagged MAC m; ea6_ is the
+-- v6 sibling. The eb_/bl_ drop rules append `ip daddr != @ea_<m>_<a>` for
+-- each a ∈ extraAllowed(m), so a hit suppresses the drop. eatag_<sanmac>
+-- is the dhcp-host tag that scopes the dnsmasq nftset= populator to one MAC
+-- (separate from resolvetag_ so a device can opt into blockIpOnly without
+-- also having extraAllowed, and vice-versa).
+local function ea_set_name(mac, host)
+  return "ea_" .. sanitize(mac) .. "_" .. sanitize(host)
+end
+local function ea6_set_name(mac, host)
+  return "ea6_" .. sanitize(mac) .. "_" .. sanitize(host)
+end
+local function ea_tag_name(mac)
+  return "eatag_" .. sanitize(mac)
+end
+
+-- Per-MAC effective extraAllowed hosts. Returns { [mac] = {host, ...} } with
+-- hosts sorted + deduplicated; macs with no effective extraAllowed entries
+-- are absent from the map.
+local function effective_extra_allowed_by_mac(snapshot)
+  local result = {}
+  for mac, dev in pairs(snapshot.devices or {}) do
+    local r = effective_rules(dev, snapshot.profiles)
+    if r and type(r.extraAllowed) == "table" and #r.extraAllowed > 0 then
+      local seen = {}
+      local hosts = {}
+      for _, h in ipairs(r.extraAllowed) do
+        if not seen[h] then
+          seen[h] = true
+          hosts[#hosts + 1] = h
+        end
+      end
+      table.sort(hosts)
+      result[mac] = hosts
+    end
+  end
+  return result
+end
+M.effective_extra_allowed_by_mac = effective_extra_allowed_by_mac
+
 -- Sorted list of MACs with effective blockIpOnly=true. Used by both
 -- render.dnsmasq (to emit the per-MAC nftset populator) and render.nft
 -- (to declare sets + emit drops).
@@ -204,6 +253,10 @@ function M.dnsmasq(snapshot)
   local bio_macs = {}
   for _, m in ipairs(block_ip_only_macs(snapshot)) do bio_macs[m] = true end
 
+  -- #421: which MACs need a per-MAC eatag (have non-empty effective
+  -- extraAllowed). Same lookup-by-MAC pattern as bio_macs.
+  local ea_by_mac = effective_extra_allowed_by_mac(snapshot)
+
   -- MAC → profile tag so dnsmasq can apply per-profile tagged callbacks.
   -- Devices auto-created from first_seen_mac events have profileId=nil
   -- until an admin assigns them; skip them (no policy to apply yet).
@@ -211,15 +264,19 @@ function M.dnsmasq(snapshot)
   -- #353: blockIpOnly MACs get an additional `set:resolvetag_<sanmac>` tag
   -- on the same line so the tag-scoped `nftset=` populator below catches
   -- every A/AAAA answered to this client.
+  -- #421: MACs with extraAllowed get an additional `set:eatag_<sanmac>` tag
+  -- so the per-(MAC, host) ea_ populator below catches the right MAC.
   emit("# device MAC → profile tag")
   for mac, dev in sorted_devices(snapshot.devices) do
     if dev.profileId then
+      local tags = { string.format("set:profile%d", dev.profileId) }
       if bio_macs[mac] then
-        emit(string.format("dhcp-host=%s,set:profile%d,set:%s",
-                           mac, dev.profileId, resolved_tag_name(mac)))
-      else
-        emit(string.format("dhcp-host=%s,set:profile%d", mac, dev.profileId))
+        tags[#tags + 1] = "set:" .. resolved_tag_name(mac)
       end
+      if ea_by_mac[mac] then
+        tags[#tags + 1] = "set:" .. ea_tag_name(mac)
+      end
+      emit(string.format("dhcp-host=%s,%s", mac, table.concat(tags, ",")))
     end
   end
   emit("")
@@ -237,6 +294,28 @@ function M.dnsmasq(snapshot)
         resolved_tag_name(mac), resolved_set_name(mac), resolved6_set_name(mac)))
     end
     emit("")
+  end
+
+  -- #421: per-(MAC, host) extraAllowed nftset populators. Tag-scoped so
+  -- only the targeted MAC's DNS responses for host a land in ea_<m>_<a> /
+  -- ea6_<m>_<a>. The eb_/bl_ drop rules then carry `ip daddr != @ea_...`
+  -- clauses to suppress the drop when daddr is in any ea set for that MAC.
+  do
+    local ea_macs = {}
+    for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
+    table.sort(ea_macs)
+    if #ea_macs > 0 then
+      emit("# extraAllowed → per-(MAC, host) ea_ nftsets (#421)")
+      for _, mac in ipairs(ea_macs) do
+        for _, host in ipairs(ea_by_mac[mac]) do
+          emit(string.format(
+            "nftset=tag:%s,/%s/4#inet#familydns#%s,6#inet#familydns#%s",
+            ea_tag_name(mac), host,
+            ea_set_name(mac, host), ea6_set_name(mac, host)))
+        end
+      end
+      emit("")
+    end
   end
 
   -- #351: extraBlocked is enforced at the connection layer (per-MAC nft
@@ -436,6 +515,52 @@ function M.nft(snapshot, opts)
     emit("")
   end
 
+  -- #421: per-(MAC, host) extraAllowed sets. One v4 + one v6 set per
+  -- (mac, host) pair that appears in some device's effective extraAllowed
+  -- list. Sets are declared even for allowall-suppressed MACs (the dnsmasq
+  -- populator still runs harmlessly; sets are cheap) — the drop/DNAT
+  -- suffixes below are what allowall actually suppresses, by virtue of
+  -- the eb_/bl_ rules themselves being suppressed for those MACs.
+  local ea_by_mac = effective_extra_allowed_by_mac(snapshot)
+  do
+    local ea_macs = {}
+    for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
+    table.sort(ea_macs)
+    for _, mac in ipairs(ea_macs) do
+      for _, host in ipairs(ea_by_mac[mac]) do
+        ind(string.format("set %s {", ea_set_name(mac, host)))
+        ind2("type ipv4_addr")
+        ind2("flags dynamic,timeout")
+        ind2("timeout 1h")
+        ind("}")
+        emit("")
+        ind(string.format("set %s {", ea6_set_name(mac, host)))
+        ind2("type ipv6_addr")
+        ind2("flags dynamic,timeout")
+        ind2("timeout 1h")
+        ind("}")
+        emit("")
+      end
+    end
+  end
+
+  -- #421: helper — emit the `ip daddr != @ea_<m>_<a>` exception suffix
+  -- to append to a (mac, family) drop / dnat predicate. Joins one clause
+  -- per a ∈ extraAllowed(m); returns "" if the MAC has no extraAllowed.
+  local function ea_suffix(mac, family)
+    local hosts = ea_by_mac[mac]
+    if not hosts or #hosts == 0 then return "" end
+    local parts = {}
+    for _, host in ipairs(hosts) do
+      if family == "ip6" then
+        parts[#parts + 1] = " ip6 daddr != @" .. ea6_set_name(mac, host)
+      else
+        parts[#parts + 1] = " ip daddr != @" .. ea_set_name(mac, host)
+      end
+    end
+    return table.concat(parts)
+  end
+
   -- #351: per-(MAC, host) drop pairs. We build the cross-product from each
   -- device's *effective* extraBlocked list (device override > profile rules),
   -- so a profile's extraBlocked applies only to MACs in that profile and a
@@ -522,21 +647,25 @@ function M.nft(snapshot, opts)
   end
   -- v4 drops first, then v6 (#392). One ipset directive populates both sets
   -- at DNS time; here we gate on whichever family the destination matched.
+  -- #421: each eb_/bl_ drop carries `ip daddr != @ea_<m>_<a>` exception
+  -- clauses (one per a ∈ extraAllowed(m)) so an allowed host's resolved
+  -- IPs suppress the drop. ea_suffix("") for MACs with no extraAllowed,
+  -- so behaviour for those is unchanged.
   for _, p in ipairs(eb_pairs) do
-    ind2(string.format("ether saddr %s ip daddr @%s drop",
-                       p.mac, eb_set_name(p.host)))
+    ind2(string.format("ether saddr %s ip daddr @%s%s drop",
+                       p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip")))
   end
   for _, p in ipairs(eb_pairs) do
-    ind2(string.format("ether saddr %s ip6 daddr @%s drop",
-                       p.mac, eb6_set_name(p.host)))
+    ind2(string.format("ether saddr %s ip6 daddr @%s%s drop",
+                       p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6")))
   end
   for _, p in ipairs(bl_pairs) do
-    ind2(string.format("ether saddr %s ip daddr @%s drop",
-                       p.mac, bl_set_name(p.id)))
+    ind2(string.format("ether saddr %s ip daddr @%s%s drop",
+                       p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip")))
   end
   for _, p in ipairs(bl_pairs) do
-    ind2(string.format("ether saddr %s ip6 daddr @%s drop",
-                       p.mac, bl6_set_name(p.id)))
+    ind2(string.format("ether saddr %s ip6 daddr @%s%s drop",
+                       p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6")))
   end
   -- #353: blockIpOnly drop. Predicate `ip daddr != @resolved_<mac>` matches
   -- any v4 destination the device did not DNS-resolve via our resolver in
@@ -565,13 +694,13 @@ function M.nft(snapshot, opts)
     end
     for _, p in ipairs(eb_pairs) do
       ind2(string.format(
-        "ether saddr %s ip daddr @%s tcp dport 80 dnat ip to 127.0.0.1:8081",
-        p.mac, eb_set_name(p.host)))
+        "ether saddr %s ip daddr @%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+        p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip")))
     end
     for _, p in ipairs(bl_pairs) do
       ind2(string.format(
-        "ether saddr %s ip daddr @%s tcp dport 80 dnat ip to 127.0.0.1:8081",
-        p.mac, bl_set_name(p.id)))
+        "ether saddr %s ip daddr @%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+        p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip")))
     end
     -- #353: blockIpOnly v4 DNAT. Same predicate as the forward-chain drop;
     -- the DNAT fires *before* the drop (prerouting < forward), so the
@@ -589,13 +718,13 @@ function M.nft(snapshot, opts)
     end
     for _, p in ipairs(eb_pairs) do
       ind2(string.format(
-        "ether saddr %s ip6 daddr @%s tcp dport 80 dnat ip6 to ::1:8081",
-        p.mac, eb6_set_name(p.host)))
+        "ether saddr %s ip6 daddr @%s%s tcp dport 80 dnat ip6 to ::1:8081",
+        p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6")))
     end
     for _, p in ipairs(bl_pairs) do
       ind2(string.format(
-        "ether saddr %s ip6 daddr @%s tcp dport 80 dnat ip6 to ::1:8081",
-        p.mac, bl6_set_name(p.id)))
+        "ether saddr %s ip6 daddr @%s%s tcp dport 80 dnat ip6 to ::1:8081",
+        p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6")))
     end
     -- #353 + #411: blockIpOnly v6 DNAT. `ip6 daddr != ::1` guards against
     -- self-redirect (the uhttpd listener at ::1 is "not in resolved set"

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1394,4 +1394,106 @@ describe("render extraAllowed enforcement (#421)", function()
       "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads", 1, true))
   end)
 
+  -- ── extraAllowed beats `blocked` (the @blocked_macs path too) ───────────
+  --
+  -- A fully-blocked device (pause / schedule / time-limit) must still be
+  -- able to reach hosts in its extraAllowed list. The @blocked_macs drop
+  -- is family-agnostic and can't carry an `ip daddr` predicate, so MACs
+  -- that are blocked AND have extraAllowed are pulled out of the set
+  -- into per-MAC, per-family rules with the ea exception.
+
+  it("pulls a blocked-AND-has-extraAllowed MAC out of @blocked_macs", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    -- @blocked_macs elements line either absent (set empty) or does not
+    -- include the kid MAC. Adult is not blocked here so the set is empty.
+    local pos = nft:find("set blocked_macs", 1, true)
+    assert.truthy(pos)
+    local blk_end = nft:find("\n  }", pos, true)
+    local blk = nft:sub(pos, blk_end)
+    assert.is_nil(blk:find("aa:bb:cc:11:22:33", 1, true))
+  end)
+
+  it("emits per-MAC v4 + v6 drops with ea exception for blocked-AND-has-extraAllowed", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  it("emits per-MAC v4 + v6 DNAT with ea exception for blocked-AND-has-extraAllowed", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != ::1 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      1, true))
+  end)
+
+  it("leaves blocked MACs *without* extraAllowed in @blocked_macs (unconditional drop)", function()
+    local s = snap_ea()
+    -- Make adult both blocked AND keep extraAllowed={} → still in @blocked_macs.
+    s.profiles["1"].rules.blocked = true
+    s.profiles["1"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    -- Adult MAC must appear in @blocked_macs elements.
+    local pos = nft:find("set blocked_macs", 1, true)
+    local blk_end = nft:find("\n  }", pos, true)
+    local blk = nft:sub(pos, blk_end)
+    assert.truthy(blk:find("de:ad:be:ef:00:01", 1, true))
+    -- And the family-agnostic @blocked_macs drop fires for adult.
+    assert.truthy(nft:find("ether saddr @blocked_macs drop", 1, true))
+  end)
+
+  it("emits the @blocked_macs DNAT only when the set is non-empty", function()
+    local s = snap_ea()
+    -- ONLY the kid is blocked, and the kid has extraAllowed → set is empty.
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    -- No bare @blocked_macs DNAT (the set is empty).
+    assert.is_nil(nft:find(
+      "ether saddr @blocked_macs tcp dport 80", 1, true))
+    assert.is_nil(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80", 1, true))
+    -- But the per-MAC ea-gated DNAT is present.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+  end)
+
+  it("emits the block-page nat chain when only a blocked-with-ea MAC exists (no eb/bl/bio)", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    s.profiles["1"].rules.extraBlocked = {}
+    local nft = render.nft(s)
+    assert.truthy(nft:find("chain familydns_block_nat", 1, true))
+  end)
+
+  it("composes multiple extraAllowed hosts in the per-MAC blocked drop", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
 end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -24,7 +24,7 @@ local function snap_one()
           blocked      = false,
           blockReason  = nil,
           extraBlocked = { "tiktok.com" },
-          extraAllowed = { "khanacademy.org" },
+          extraAllowed = {},
           blocklistIds = { "ads", "adult" },
           blockIpOnly  = false,
         },
@@ -72,9 +72,11 @@ describe("render.dnsmasq", function()
       1, true))
   end)
 
-  it("does NOT emit nftset= for extraAllowed hosts", function()
+  it("does NOT emit nftset= for extraAllowed hosts when extraAllowed is empty", function()
+    -- snap_one has extraAllowed = {} so no ea_ nftsets / eatag should appear.
     local conf = render.dnsmasq(snap_one())
-    assert.is_nil(conf:find("/khanacademy.org/", 1, true))
+    assert.is_nil(conf:find("eatag_", 1, true))
+    assert.is_nil(conf:find("#familydns#ea_", 1, true))
   end)
 
   it("handles multiple devices in different profiles", function()
@@ -1100,6 +1102,296 @@ describe("render blockIpOnly enforcement (#353)", function()
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 drop",
       1, true))
+  end)
+
+end)
+
+-- ── extraAllowed per-(MAC, host) exception (#421) ───────────────────────────
+--
+-- extraAllowed beats extraBlocked beats blocklists. Each eb_/bl_ drop rule
+-- for MAC m carries `ip daddr != @ea_<m>_<a>` clauses (one per a ∈
+-- extraAllowed(m)) so a hit in any ea_ set for that MAC suppresses the drop.
+-- Scoping is per-(MAC, host): a host can be allowed for MAC A and blocked
+-- for MAC B independently. blockIpOnly is NOT suppressed by ea sets — its
+-- composition is via DNS resolution landing the IP in resolved_<m>.
+
+describe("render extraAllowed enforcement (#421)", function()
+
+  -- Snapshot: kid (profile 3) has extraBlocked={"tiktok.com"} and
+  -- extraAllowed={"music.tiktok.com"} so the blocked-domain drop has an
+  -- in-tree carve-out. Adult (profile 1) has nothing.
+  local function snap_ea()
+    return {
+      etag        = "sha256:abc123",
+      generatedAt = "2026-05-15T14:00:00Z",
+      devices = {
+        ["aa:bb:cc:11:22:33"] = { profileId = 3, name = "kid-ipad",     rules = nil },
+        ["de:ad:be:ef:00:01"] = { profileId = 1, name = "parent-phone", rules = nil },
+      },
+      profiles = {
+        ["3"] = {
+          name = "kids",
+          rules = {
+            blocked      = false,
+            blockReason  = nil,
+            extraBlocked = { "tiktok.com" },
+            extraAllowed = { "music.tiktok.com" },
+            blocklistIds = { "test_ads" },
+            blockIpOnly  = false,
+          },
+          failureMode = "block-all",
+        },
+        ["1"] = {
+          name = "adults",
+          rules = {
+            blocked = false, blockReason = nil,
+            extraBlocked = { "tiktok.com" },
+            extraAllowed = {},
+            blocklistIds = {},
+            blockIpOnly  = false,
+          },
+          failureMode = "last-known-good",
+        },
+      },
+      blocklists = {
+        test_ads = { version = "v1", url = "http://api/api/blocklists/test_ads" },
+      },
+      _blocklist_hosts = { test_ads = { "adserver.example.com" } },
+    }
+  end
+
+  -- ── dnsmasq side ────────────────────────────────────────────────────────
+
+  it("appends set:eatag_<sanmac> to the dhcp-host line of a MAC with extraAllowed", function()
+    local conf = render.dnsmasq(snap_ea())
+    assert.truthy(conf:find(
+      "dhcp-host=aa:bb:cc:11:22:33,set:profile3,set:eatag_aa_bb_cc_11_22_33",
+      1, true))
+  end)
+
+  it("does NOT append eatag_ to MACs with empty extraAllowed", function()
+    local conf = render.dnsmasq(snap_ea())
+    -- Adult MAC has extraAllowed={}; its line must be plain set:profile1.
+    assert.truthy(conf:find("dhcp-host=de:ad:be:ef:00:01,set:profile1\n", 1, true)
+               or conf:match("dhcp-host=de:ad:be:ef:00:01,set:profile1$"))
+    assert.is_nil(conf:find(
+      "dhcp-host=de:ad:be:ef:00:01,.-eatag_", 1, false))
+  end)
+
+  it("emits tag-scoped nftset= populator for the per-(MAC, host) ea_ / ea6_ sets", function()
+    local conf = render.dnsmasq(snap_ea())
+    assert.truthy(conf:find(
+      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com,6#inet#familydns#ea6_aa_bb_cc_11_22_33_music_tiktok_com",
+      1, true))
+  end)
+
+  it("emits one nftset= populator per (mac, host) when a MAC has multiple extraAllowed hosts", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find(
+      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com",
+      1, true))
+    assert.truthy(conf:find(
+      "nftset=tag:eatag_aa_bb_cc_11_22_33,/khanacademy.org/4#inet#familydns#ea_aa_bb_cc_11_22_33_khanacademy_org",
+      1, true))
+  end)
+
+  it("does NOT emit ea_ nftsets or eatag dhcp-host suffix when no device has extraAllowed", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.extraAllowed = {}
+    local conf = render.dnsmasq(s)
+    assert.is_nil(conf:find("eatag_", 1, true))
+    assert.is_nil(conf:find("#familydns#ea_", 1, true))
+  end)
+
+  it("device-override extraAllowed scopes the ea populator to that MAC only", function()
+    local s = snap_ea()
+    -- Profile flips OFF; sibling under same profile has no override.
+    s.profiles["3"].rules.extraAllowed = {}
+    s.devices["11:22:33:44:55:66"] = { profileId = 3, name = "kid-phone", rules = nil }
+    s.devices["aa:bb:cc:11:22:33"].rules = {
+      blocked = false, blockReason = nil,
+      extraBlocked = { "tiktok.com" }, extraAllowed = { "music.tiktok.com" },
+      blocklistIds = {}, blockIpOnly = false,
+    }
+    local conf = render.dnsmasq(s)
+    -- Override MAC gets eatag + populator.
+    assert.truthy(conf:find(
+      "dhcp-host=aa:bb:cc:11:22:33,set:profile3,set:eatag_aa_bb_cc_11_22_33",
+      1, true))
+    assert.truthy(conf:find(
+      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/", 1, true))
+    -- Sibling under same profile must NOT inherit.
+    assert.is_nil(conf:find("eatag_11_22_33_44_55_66", 1, true))
+  end)
+
+  -- ── nft side: set declarations ──────────────────────────────────────────
+
+  it("declares set ea_<sanmac>_<sanhost> (ipv4_addr, dynamic, 1h timeout)", function()
+    local nft = render.nft(snap_ea())
+    local pos = nft:find("set ea_aa_bb_cc_11_22_33_music_tiktok_com", 1, true)
+    assert.truthy(pos)
+    local blk = nft:sub(pos, pos + 200)
+    assert.truthy(blk:find("type ipv4_addr", 1, true))
+    assert.truthy(blk:find("flags dynamic,timeout", 1, true))
+    assert.truthy(blk:find("timeout 1h", 1, true))
+  end)
+
+  it("declares set ea6_<sanmac>_<sanhost> (ipv6_addr, dynamic, 1h timeout)", function()
+    local nft = render.nft(snap_ea())
+    local pos = nft:find("set ea6_aa_bb_cc_11_22_33_music_tiktok_com", 1, true)
+    assert.truthy(pos)
+    local blk = nft:sub(pos, pos + 200)
+    assert.truthy(blk:find("type ipv6_addr", 1, true))
+    assert.truthy(blk:find("flags dynamic,timeout", 1, true))
+    assert.truthy(blk:find("timeout 1h", 1, true))
+  end)
+
+  it("declares no ea_/ea6_ sets when no device has extraAllowed", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.extraAllowed = {}
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("set ea_", 1, true))
+    assert.is_nil(nft:find("set ea6_", 1, true))
+  end)
+
+  -- ── nft side: drop predicate gets `ip daddr != @ea_...` suffix ──────────
+
+  it("appends `ip daddr != @ea_<m>_<a>` to the eb_<host> drop for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  it("appends `ip6 daddr != @ea6_<m>_<a>` to the eb6_<host> drop for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  it("appends `ip daddr != @ea_<m>_<a>` to the bl_<id> drop for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  it("appends `ip6 daddr != @ea6_<m>_<a>` to the bl6_<id> drop for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @bl6_test_ads ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  it("appends one `ip daddr != @ea_...` clause per extraAllowed host (multiple hosts)", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
+    local nft = render.nft(s)
+    -- Both clauses present in the same eb_ drop rule, in sorted order.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+  end)
+
+  -- Multi-MAC scoping: extraAllowed for MAC A must NOT carve out MAC B's drops.
+  it("does NOT append ea suffix to a different MAC's drop rule (per-MAC scoping)", function()
+    local nft = render.nft(snap_ea())
+    -- Adult MAC has the same eb_tiktok_com drop but extraAllowed={}, so no
+    -- ea_ suffix on its rule.
+    assert.truthy(nft:find(
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com drop", 1, true))
+    -- And specifically not carrying the kid's ea set.
+    assert.is_nil(nft:find(
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com",
+      1, true))
+  end)
+
+  it("leaves drops without ea suffix when MAC has empty extraAllowed", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.extraAllowed = {}
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com drop", 1, true))
+  end)
+
+  -- ── DNAT chain: same suffix applied ─────────────────────────────────────
+
+  it("appends `ip daddr != @ea_<m>_<a>` to the eb_<host> DNAT for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+  end)
+
+  it("appends `ip6 daddr != @ea6_<m>_<a>` to the eb6_<host> DNAT for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip6 to ::1:8081",
+      1, true))
+  end)
+
+  it("appends `ip daddr != @ea_<m>_<a>` to the bl_<id> DNAT for MAC m", function()
+    local nft = render.nft(snap_ea())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com tcp dport 80 dnat ip to 127.0.0.1:8081",
+      1, true))
+  end)
+
+  -- ── blockIpOnly composition (#353): ea sets do NOT modify the bio drop ──
+  --
+  -- The issue's design: extraAllowed composes with blockIpOnly naturally —
+  -- a resolved-allowed host lands in resolved_<m> via the same DNS path,
+  -- so the `ip daddr != @resolved_<m>` predicate is already false for it.
+  -- No `!= @ea_...` clause needs to (or should) be added to the bio drop.
+
+  it("does NOT add ea exception clauses to the blockIpOnly drop rule (#353 composition)", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blockIpOnly = true
+    local nft = render.nft(s)
+    -- The bio drop is unchanged — no `!= @ea_...` clause appended.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 drop",
+      1, true))
+    -- And no spurious mixed rule like
+    -- "ip daddr != @resolved_... ip daddr != @ea_..." either.
+    assert.is_nil(nft:find(
+      "ip daddr != @resolved_aa_bb_cc_11_22_33 ip daddr != @ea_", 1, true))
+  end)
+
+  it("blockIpOnly + extraAllowed: eb_ drop still has the ea exception, bio drop does not", function()
+    local s = snap_ea()
+    s.profiles["3"].rules.blockIpOnly = true
+    local nft = render.nft(s)
+    -- eb drop has ea suffix:
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      1, true))
+    -- bio drop has no ea suffix:
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 drop",
+      1, true))
+  end)
+
+  -- ── failover allow-all suppression ──────────────────────────────────────
+  --
+  -- For an allow-all-failover MAC, the eb_/bl_ drops are suppressed
+  -- entirely (existing behaviour). The ea suffix becomes moot because
+  -- there's no drop to suffix. ea sets may still be declared (cheap,
+  -- harmless) and the dnsmasq populator still runs — mirrors the
+  -- bio_macs declaration policy.
+
+  it("suppresses eb_/bl_ drops (including their ea exception) under allow-all failover", function()
+    local s = snap_ea()
+    s.profiles["3"].failureMode = "allow-all"
+    local nft = render.nft(s, { poll_age_seconds = 301 })
+    -- No eb / bl drops at all for the kid MAC.
+    assert.is_nil(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com", 1, true))
+    assert.is_nil(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @bl_test_ads", 1, true))
   end)
 
 end)


### PR DESCRIPTION
## Summary

- Implement `BlockRules.extraAllowed` at the router as per-(MAC, host) exception sets, mirroring the `#426` tag-scoping pattern. dnsmasq populates `ea_<sanmac>_<sanhost>` / `ea6_<sanmac>_<sanhost>` via a new `set:eatag_<sanmac>` dhcp-host tag.
- Each `eb_<host>` / `bl_<id>` drop and DNAT rule for MAC m gains one `ip daddr != @ea_<m>_<a>` clause per `a ∈ extraAllowed(m)`. A hit in any ea_ set for that MAC suppresses the drop/DNAT for that packet.
- **Conflict resolution** per #421's design: extraAllowed beats extraBlocked beats blocklists. blockIpOnly (#353) is intentionally not suffixed — the resolved-allowed host's IP already lands in `resolved_<m>` via the same DNS path, so the predicate composes naturally.
- Predicate doc at the top of [render.lua](openwrt/files/usr/lib/lua/familydns/render.lua) is extended with the ea_hit clause.

## Refs

- Closes #421
- Builds on #353 / #426 (tag-scoping pattern) and #351 / #352 / #392 (eb_/bl_ drop pattern)
- Design discussion in #421 body (per-(MAC, host) granularity, composite-rule form)

## Test plan

- [x] 22 new lua specs in [render_spec.lua](openwrt/test/render_spec.lua) covering: ea_/ea6_ set declarations, dnsmasq nftset emission + eatag dhcp-host tag, eb_/bl_ drop + DNAT suffix (v4 + v6), multi-host suffix ordering, per-(MAC, host) scoping (host allowed for MAC A not B), device-override scoping, blockIpOnly composition (bio drop intentionally not suffixed), allow-all failover suppression, empty-extraAllowed no-op.
- [x] `sh openwrt/test/run_tests.sh` → 298 lua + all shell specs pass.
- [ ] Live router validation deferred to after #424 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)