### PR TITLE
openwrt: failover trips on first failed poll, drop 300s cushion (fixes #422)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,8 +71,10 @@ case class ProfilePolicy(
     name: String,
     rules: BlockRules,
     failureMode: FailureMode,                  // per-profile: what the router does
-                                               //   for THIS profile's devices if it can't
-                                               //   reach the API for >5min. See
+                                               //   for THIS profile's devices the moment
+                                               //   a policy poll fails (#422 — failover
+                                               //   trips on the first failed poll; no
+                                               //   time-based cushion). See
                                                //   docs/resilience.md §4 for the
                                                //   per-mode behaviour and the
                                                //   defaulting policy.

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -90,10 +90,12 @@ A clean power-cycle losing < 60 seconds of usage data is materially harmless
   outage (default 30s); the agent does not back off poll attempts as
   aggressively as usage POSTs because policy freshness matters more than
   usage freshness.
-- **Max API-down window before failover.** After **5 minutes** of consecutive
-  unreachable polls, the agent transitions to the per-profile failure mode
-  defined in §4. Until then, the cached snapshot stands. See §4 for the
-  rationale on the 5-minute threshold.
+- **Failover trips immediately on a failed poll.** The agent transitions
+  to the per-profile failure mode defined in §4 the moment a poll attempt
+  fails; the next successful poll lifts the transition. There is no time-
+  based cushion (#422 removed the prior 300s gate, which contradicted the
+  per-profile failureMode design intent — block-all should drop traffic
+  the moment we can't reach the API).
 
 ### Why
 The asymmetry — sequential drain for usage, fixed cadence for policy — is
@@ -109,13 +111,15 @@ correct policy within one poll interval.
 - `openwrt/files/usr/lib/lua/familydns/conntrack.lua`: same retry-queue
   pattern for events POSTs (#330); cap = 1000 batches, drop-oldest on
   overflow; drained from the conntrack watcher loop on every tick.
-- Agent main loop: track `last_successful_poll_ts`; if `now -
-  last_successful_poll_ts > 300s`, transition enforcement per §4.
+- Agent main loop: track `last_fetch_ok` for the most-recent poll;
+  transition enforcement per §4 immediately on any failed poll
+  (#422 — no 300s gate). `last_successful_poll_ts` is kept only for
+  human-readable log lines (`poll_age=NNNs`).
 
 ### How to verify
-- Stop the API container for 60s; agent should log retries and resume
-  cleanly with no policy change.
-- Stop the API for 6+ minutes; agent transitions per §4.
+- Stop the API container; on the first failed poll the agent transitions
+  per §4. Restart the API; on the next successful poll the agent applies
+  the fresh snapshot and clears the failover state.
 - Confirm queued usage drains sequentially after API return (check API
   logs for spaced POSTs, not one batch).
 
@@ -158,11 +162,10 @@ client (the agent) without parsing error bodies.
 ## 4. Internet outage on router (agent can't reach API) — KEY DESIGN DECISION
 
 ### Intended behavior
-- **Cached policy stands for the first 5 minutes.** Most outages are
-  shorter than this; the cached snapshot is the correct enforcement
-  posture during transient failures.
-- **After 5 minutes of consecutive failed polls**, the agent transitions
-  enforcement per **per-profile `failureMode`**. Three modes (#385) —
+- **Failover trips on the first failed poll.** The agent transitions
+  enforcement per **per-profile `failureMode`** the moment a poll
+  attempt fails (#422 — there is no time-based cushion). Three modes
+  (#385) —
   named identically across architecture.md §0.2, this section,
   `shared/src/Models.scala`, the wire JSON, and the DB column:
   - **`BlockAll`** (wire `"block-all"`, recommended for child profiles):
@@ -200,13 +203,15 @@ the cached snapshot enforcing exactly" (LastKnownGood). The agent
 shipped one interpretation (`Open` = LastKnownGood); the doc shipped the
 other (`Open` = AllowAll). #385 separates them.
 
-The 5-minute threshold balances two costs:
-- Too short (< 1 min): every flaky cellular failover triggers a
-  failover transition, which kids will notice and learn to exploit
-  (wait it out).
-- Too long (> 15 min): a determined kid who unplugs the WAN can browse
-  freely for that whole window. 5 minutes is short enough to be
-  annoying rather than useful.
+The failover transition is immediate (no time-based cushion). The earlier
+design used a 300s gate to absorb flaky cellular failovers, but #422
+removed it because the gate contradicted the per-profile `failureMode`
+contract: an admin who picks `BlockAll` expects the profile's devices to
+drop traffic the moment the API is unreachable, and an admin who picks
+`AllowAll` expects an immediate unblock. The transient-flap concern is
+addressed instead by the per-profile mode (e.g. `LastKnownGood` on adult
+profiles keeps the cached snapshot enforcing during a brief blip), not by
+a one-size-fits-all delay.
 
 Defaults reflect the asymmetric blast radius. For a child profile,
 "BlockAll" trades a false-block (kid loses access during a real ISP
@@ -231,9 +236,11 @@ never a default — it must be picked deliberately.
 - `api/src/policy/PolicyService.scala`: includes `failureMode` per
   `ProfilePolicy` in the rendered `PolicySnapshot`. The ETag covers
   this value so a mode change invalidates client caches.
-- `openwrt/files/usr/lib/lua/familydns/policy.lua`: tracks
-  `last_successful_poll_ts`; on `now - last > 300s`, renders nft with
-  `opts.poll_age_seconds`.
+- `openwrt/files/usr/lib/lua/familydns/policy.lua`: on every failed
+  poll, renders nft with `opts.poll_failed = true`; on the next
+  successful poll, renders with `opts.poll_failed = false` to clear the
+  failover chain (#422). `last_successful_poll_ts` is retained for
+  human-readable log lines only.
 - `openwrt/files/usr/lib/lua/familydns/render.lua`: branches by mode.
   `BlockAll` emits a dedicated `failover_drop` set and drop chain.
   `AllowAll` suppresses the profile's MACs from every drop list before
@@ -245,7 +252,7 @@ never a default — it must be picked deliberately.
 
 ### How to verify
 - Block the API at the router (firewall rule on the router itself
-  blocking egress to the API host). Wait 5 minutes. Confirm that:
+  blocking egress to the API host). Within one poll cycle, confirm that:
   - A `BlockAll` profile's device cannot reach the internet but the
     block page loads;
   - A `LastKnownGood` profile's device continues to work under cached
@@ -283,7 +290,7 @@ The previous agent-side skew detector (Date-header capture,
 | Scenario | Current behavior | Status |
 | --- | --- | --- |
 | 1. Power loss | Identity persists; **no default-deny gate before agent renders** — traffic forwards unfiltered for the boot window. Usage buckets in tmpfs (intentional). | **GAP** |
-| 2. API restart | No persisted policy cache (tmpfs only); usage POSTs have **no retry/backoff**; no 5-minute failover threshold. | **GAP** |
+| 2. API restart | No persisted policy cache (tmpfs only); usage POSTs have **no retry/backoff**; no failover-on-poll-fail trigger. | **GAP** |
 | 3. DB blip | Health endpoint correct (503). All other routes return **bare 500 on DB failure**. JWT auth rides through correctly. | **GAP** |
 | 4. Internet outage | No `failureMode` field exists. Agent is **fail-open** on cold start with no cached policy; rules persist in tmpfs only. | **GAP** |
 | 5. Time skew | Router does no time-based evaluation (Truth 2 / #350); API clock is authoritative. See #334 for API-side time handling. | **N/A (by design)** |

--- a/openwrt/files/usr/lib/lua/familydns/policy.lua
+++ b/openwrt/files/usr/lib/lua/familydns/policy.lua
@@ -27,9 +27,12 @@
 --                                   sinkhole-shaped answer means dnsmasq
 --                                   is still applying a stale rendering
 --                                   (failed restart) and triggers a WARN.
---       opts.poll_age_seconds → forwarded to render.nft for the #385
+--       opts.poll_failed → forwarded to render.nft for the #385/#422
 --                                 failover branch (three modes: block-all,
---                                 allow-all, last-known-good).
+--                                 allow-all, last-known-good). True iff
+--                                 the most-recent poll attempt did not
+--                                 succeed; failover trips immediately on
+--                                 a single failure (no 300s cushion).
 
 local M = {}
 
@@ -139,8 +142,9 @@ end
 -- (`0.0.0.0`, `::`, empty / NXDOMAIN) means dnsmasq is still running a
 -- stale config that has DNS-layer blocks in it, which is the failure mode
 -- we want to catch.
--- opts.poll_age_seconds (#331): forwarded to render.nft so the agent's
--- failover-edge re-render can request the closed-mode drop chain.
+-- opts.poll_failed (#331/#422): forwarded to render.nft so the agent's
+-- failover-edge re-render can request the closed-mode drop chain on the
+-- first failed poll (and clear it on the next success).
 
 -- Default reader for the change-detection check (#414). Returns nil if the
 -- file is absent — first apply on a fresh boot treats that as "changed".
@@ -354,34 +358,33 @@ function M.reset_poll_state()
 end
 
 -- ---------------------------------------------------------------------------
--- Failover transition decision (#331). Pure function so the agent's on_tick
--- can stay thin and the boundary behavior is unit-testable.
+-- Failover transition decision (#331/#422). Pure function so the agent's
+-- on_tick can stay thin and the boundary behavior is unit-testable.
 --
 -- Inputs:
---   in_failover : bool  — was the last apply rendered with failover opts?
---   fetch_ok    : bool  — did this tick's poll succeed (200 or 304)?
---   poll_age    : number — seconds since last_successful_poll_ts (computed
---                          by caller; on success this is 0).
+--   in_failover : bool — was the last apply rendered with failover opts?
+--   fetch_ok    : bool — did this tick's poll succeed (200 or 304)?
 -- Returns:
---   should_apply       : bool — re-render is needed this tick
---   apply_opts         : table|nil — opts to pass to policy.apply
---   new_in_failover    : bool — updated state flag
+--   should_apply    : bool       — re-render is needed this tick
+--   apply_opts      : table|nil  — opts to pass to policy.apply
+--   new_in_failover : bool       — updated state flag
 --
--- The threshold matches docs/resilience.md §4 (and render.lua's
--- `poll_age > 300` check): strictly greater than 5 minutes flips Closed
--- profiles into drop-mode; any successful poll lifts it immediately.
+-- Semantics (#422): failover trips immediately on a failed poll and lifts
+-- immediately on a successful poll. There is no time-based cushion — the
+-- previous 300s gate contradicted the per-profile failureMode design intent
+-- (block-all should drop traffic the moment we can't reach the API).
 -- ---------------------------------------------------------------------------
-function M.failover_transition(in_failover, fetch_ok, poll_age)
+function M.failover_transition(in_failover, fetch_ok)
   if fetch_ok then
     if in_failover then
-      return true, { poll_age_seconds = 0 }, false
+      return true, { poll_failed = false }, false
     end
     return false, nil, false
   end
-  if poll_age > 300 and not in_failover then
-    return true, { poll_age_seconds = poll_age }, true
+  if not in_failover then
+    return true, { poll_failed = true }, true
   end
-  return false, nil, in_failover
+  return false, nil, true
 end
 
 return M

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -289,9 +289,9 @@ end
 -- render.nft(snapshot, opts) → string
 -- ---------------------------------------------------------------------------
 -- opts (optional table):
---   poll_age_seconds  number — seconds since the last successful policy poll.
---                              When > 300, the per-profile failureMode
---                              decides what happens (#385):
+--   poll_failed       boolean — true iff the most-recent policy poll attempt
+--                              did not succeed. When true, the per-profile
+--                              failureMode decides what happens (#385/#422):
 --                                "block-all"       → emit an additional drop
 --                                                    rule for the profile's
 --                                                    devices (fail-safe).
@@ -310,10 +310,12 @@ end
 --                                                    as-is (this is the
 --                                                    behaviour the original
 --                                                    binary "open" had).
---                              Below the 5-minute threshold all profiles
---                              behave as LastKnownGood — the cached
---                              snapshot stands and no failover transition
---                              has happened yet.
+--                              When false / absent, all profiles behave as
+--                              LastKnownGood — the cached snapshot stands.
+--                              The transition is immediate: a single failed
+--                              poll trips failover; the next successful poll
+--                              lifts it. There is no time-based cushion
+--                              (#422 removed the prior 300s gate).
 function M.nft(snapshot, opts)
   local out = {}
   local function emit(s)  out[#out + 1] = s  end
@@ -343,15 +345,16 @@ function M.nft(snapshot, opts)
     end
   end
 
-  -- #385: during failover (>5 min API-unreachable), an AllowAll profile's
-  -- devices must NOT receive any drop rule — not the @blocked_macs
-  -- entry, not the per-(MAC, host) eb_ drops, not the per-(MAC,
-  -- blocklistId) bl_ drops, and not the block-page DNAT. The cached
-  -- snapshot is intentionally discarded for these MACs (cf. LastKnownGood,
-  -- where the cached snapshot keeps enforcing). Compute the suppress set
-  -- once so every subsequent rule-emission step can filter cheaply.
-  local poll_age = opts and opts.poll_age_seconds
-  local in_failover = poll_age and poll_age > 300
+  -- #385/#422: during failover (most-recent poll failed), an AllowAll
+  -- profile's devices must NOT receive any drop rule — not the
+  -- @blocked_macs entry, not the per-(MAC, host) eb_ drops, not the
+  -- per-(MAC, blocklistId) bl_ drops, and not the block-page DNAT. The
+  -- cached snapshot is intentionally discarded for these MACs (cf.
+  -- LastKnownGood, where the cached snapshot keeps enforcing). Compute
+  -- the suppress set once so every subsequent rule-emission step can
+  -- filter cheaply. Failover trips on a single failed poll (#422) — there
+  -- is no time-keyed cushion.
+  local in_failover = opts and opts.poll_failed and true or false
   local allowall_macs = {}
   if in_failover then
     local allowall_pids = {}
@@ -610,7 +613,7 @@ function M.nft(snapshot, opts)
   end
 
   -- #385: API-unreachable failover. failureMode is per-profile (carried on
-  -- ProfilePolicy) with three variants — see the opts.poll_age_seconds
+  -- ProfilePolicy) with three variants — see the opts.poll_failed
   -- doc at the top of M.nft for the per-mode behaviour. This block only
   -- handles BlockAll: collect MACs of devices whose profile's failureMode
   -- is "block-all" and emit a drop chain for them. AllowAll is enforced

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -199,8 +199,8 @@ end
 
 local current_etag        = nil
 -- #331: tracks the most recently applied snapshot so we can re-render with
--- failover opts when the API stays unreachable past the §4 5-minute window
--- (without a fresh fetch we have no other snapshot to render from).
+-- failover opts on the first failed poll (#422 — without a fresh fetch we
+-- have no other snapshot to render from).
 local last_snapshot       = nil
 -- #331: whether the last apply emitted the failover chain. Used to dedupe
 -- re-renders while we sit in failover and to detect the recovery edge so we
@@ -377,16 +377,17 @@ conntrack.watch({
         fetch_ok = false
       end
 
-      -- #331: failover transition. On the failure→failover edge we re-render
-      -- the cached snapshot with poll_age_seconds so render.lua emits the
-      -- failover_drop set + familydns_failover chain (#311). On the recovery
-      -- edge we re-render to clear those rules. A 200 already applied a
-      -- clean ruleset above, so we only need to flip the flag in that case;
-      -- a 304 needs an explicit re-apply to drop the failover chain.
+      -- #331/#422: failover transition. On the failure→failover edge we
+      -- re-render the cached snapshot with poll_failed=true so render.lua
+      -- emits the failover_drop set + familydns_failover chain (#311). On
+      -- the recovery edge we re-render to clear those rules. A 200 already
+      -- applied a clean ruleset above, so we only need to flip the flag
+      -- in that case; a 304 needs an explicit re-apply to drop the
+      -- failover chain. The transition trips on a single failed poll
+      -- (#422 — no 300s cushion).
       if fetch_ok ~= nil then
-        local poll_age = policy.poll_age_seconds(wall)
         local should_apply, fo_opts, new_in_failover =
-          policy.failover_transition(in_failover_render, fetch_ok, poll_age)
+          policy.failover_transition(in_failover_render, fetch_ok)
         if should_apply and not snap and last_snapshot then
           -- Recovery via 304, or entering failover. Re-render last_snapshot
           -- with the computed opts. Skip if we have no cached snapshot at
@@ -394,10 +395,10 @@ conntrack.watch({
           -- effect and there's nothing useful we can render.
           if policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts) then
             if new_in_failover then
-              log.info("failover render: poll_age=%s, applying failover chain for closed-mode profiles",
-                       policy.format_poll_age(poll_age))
+              log.info("failover render: poll failed, applying failover chain for closed-mode profiles (poll_age=%s)",
+                       policy.format_poll_age(policy.poll_age_seconds(wall)))
             else
-              log.info("failover lifted: applying fresh snapshot (poll_age=0)")
+              log.info("failover lifted: applying fresh snapshot")
             end
           else
             log.warn("failover transition: apply failed (in_failover=%s→%s)",
@@ -410,7 +411,7 @@ conntrack.watch({
           -- skeleton (#308) is still enforcing default-deny; nothing to
           -- render. Don't flip the flag so we keep retrying on each tick.
           log.warn("failover transition skipped: no cached snapshot (boot-skeleton default-deny still active, poll_age=%s)",
-                   policy.format_poll_age(poll_age))
+                   policy.format_poll_age(policy.poll_age_seconds(wall)))
           new_in_failover = in_failover_render
         end
         in_failover_render = new_in_failover

--- a/openwrt/test/failover_spec.lua
+++ b/openwrt/test/failover_spec.lua
@@ -1,7 +1,7 @@
--- Tests for #385 three-mode failover in render.nft.
+-- Tests for #385/#422 three-mode failover in render.nft.
 --
--- The agent passes opts.poll_age_seconds = (now - last_successful_poll_ts).
--- When poll_age > 300, the per-profile failureMode decides what happens:
+-- The agent passes opts.poll_failed = (not last_fetch_ok). When true,
+-- the per-profile failureMode decides what happens:
 --   "block-all"       — profile's MACs get an additional drop chain.
 --   "allow-all"       — profile's MACs are SUPPRESSED from every drop
 --                       rule (blocked_macs, eb_pairs, bl_pairs) and the
@@ -9,6 +9,11 @@
 --                       for these MACs during failover.
 --   "last-known-good" — no change. The cached snapshot keeps enforcing
 --                       exactly as-is.
+--
+-- #422: failover trips immediately on a single failed poll. There is no
+-- time-keyed cushion (the prior 300s gate was removed because it
+-- contradicted the failureMode design intent — block-all should drop
+-- traffic the moment the API is unreachable).
 --
 -- Run with: cd openwrt && busted test/failover_spec.lua
 
@@ -40,22 +45,32 @@ local function snap_three()
   }
 end
 
-describe("render.nft — #385 three-mode failover", function()
+describe("render.nft — #385/#422 three-mode failover", function()
 
   -- ── BlockAll: existing failover_drop chain ────────────────────────────
 
-  it("emits no failover artifacts when poll_age_seconds is nil (no signal yet)", function()
+  it("emits no failover artifacts when poll_failed is nil (no signal yet)", function()
     local nft = render.nft(snap_three())
     assert.is_nil(nft:find("failover_drop", 1, true))
   end)
 
-  it("emits no failover_drop set when poll_age_seconds <= 300 (within window)", function()
-    local nft = render.nft(snap_three(), { poll_age_seconds = 300 })
+  it("emits no failover_drop set when poll_failed is false", function()
+    local nft = render.nft(snap_three(), { poll_failed = false })
     assert.is_nil(nft:find("failover_drop", 1, true))
   end)
 
-  it("BlockAll: emits failover_drop containing only the block-all profile's MACs (>300s)", function()
-    local nft = render.nft(snap_three(), { poll_age_seconds = 301 })
+  -- #422: failover trips immediately on a failed poll; there is no time-
+  -- keyed cushion. A fresh cached snapshot (no time signal at all) plus
+  -- poll_failed=true must produce failover artifacts.
+  it("BlockAll: poll_failed=true trips failover immediately even with a fresh cached snapshot (#422)", function()
+    local nft = render.nft(snap_three(), { poll_failed = true })
+    assert.truthy(nft:find("set failover_drop", 1, true))
+    assert.truthy(nft:find("@failover_drop", 1, true))
+    assert.truthy(nft:find("aa:aa:aa:00:00:01", 1, true))
+  end)
+
+  it("BlockAll: emits failover_drop containing only the block-all profile's MACs", function()
+    local nft = render.nft(snap_three(), { poll_failed = true })
     assert.truthy(nft:find("set failover_drop", 1, true))
     -- Block-all profile device is in the set.
     assert.truthy(nft:find("aa:aa:aa:00:00:01", 1, true))
@@ -75,15 +90,15 @@ describe("render.nft — #385 three-mode failover", function()
     s.devices = {
       ["bb:bb:bb:00:00:02"] = { profileId = 2, name = "adult", rules = nil },
     }
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     assert.is_nil(nft:find("@failover_drop", 1, true))
   end)
 
-  it("BlockAll: boundary — 300s in-window, 301s trips failover (strict > 300)", function()
-    local nft_300 = render.nft(snap_three(), { poll_age_seconds = 300 })
-    local nft_301 = render.nft(snap_three(), { poll_age_seconds = 301 })
-    assert.is_nil(nft_300:find("@failover_drop", 1, true))
-    assert.truthy(nft_301:find("@failover_drop", 1, true))
+  it("BlockAll: poll_failed=false → no failover; poll_failed=true → failover (#422)", function()
+    local nft_ok   = render.nft(snap_three(), { poll_failed = false })
+    local nft_fail = render.nft(snap_three(), { poll_failed = true })
+    assert.is_nil(nft_ok:find("@failover_drop", 1, true))
+    assert.truthy(nft_fail:find("@failover_drop", 1, true))
   end)
 
   -- ── LastKnownGood: cached snapshot keeps enforcing ───────────────────
@@ -94,7 +109,7 @@ describe("render.nft — #385 three-mode failover", function()
     local s = snap_three()
     s.profiles["2"].rules.blocked = true
     s.profiles["2"].rules.blockReason = "Paused"
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     assert.truthy(nft:find("bb:bb:bb:00:00:02", 1, true),
       "LastKnownGood adult MAC must remain in @blocked_macs")
     -- And LastKnownGood is NOT in the failover_drop set even though it's blocked.
@@ -114,7 +129,7 @@ describe("render.nft — #385 three-mode failover", function()
     local s = snap_three()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Schedule"
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     -- Scope to the @blocked_macs set body.
     local s_off = nft:find("set blocked_macs", 1, true)
     assert.truthy(s_off)
@@ -127,7 +142,7 @@ describe("render.nft — #385 three-mode failover", function()
   it("AllowAll: profile's extraBlocked drops are SUPPRESSED during failover", function()
     local s = snap_three()
     s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     assert.is_nil(nft:find(
       "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
       "AllowAll MAC must NOT have per-(MAC, host) extraBlocked drops during failover")
@@ -137,26 +152,26 @@ describe("render.nft — #385 three-mode failover", function()
     local s = snap_three()
     s.profiles["3"].rules.blocklistIds = { "ads" }
     s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     assert.is_nil(nft:find(
       "ether saddr cc:cc:cc:00:00:03 ip daddr @bl_ads drop", 1, true),
       "AllowAll MAC must NOT have per-(MAC, blocklistId) drops during failover")
   end)
 
-  it("AllowAll: same blocks still apply pre-failover (poll_age=0 or unset)", function()
-    -- Sanity: the AllowAll suppression must be gated on in_failover. With
-    -- no poll_age signal (or poll_age <= 300), the cached snapshot's
+  it("AllowAll: same blocks still apply pre-failover (poll_failed unset or false)", function()
+    -- Sanity: the AllowAll suppression must be gated on poll_failed. With
+    -- no signal, or with poll_failed=false, the cached snapshot's
     -- extraBlocked entry for guest still produces its drop rule.
     local s = snap_three()
     s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
-    local nft_no_failover = render.nft(s)
-    assert.truthy(nft_no_failover:find(
+    local nft_no_signal = render.nft(s)
+    assert.truthy(nft_no_signal:find(
       "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
-      "AllowAll must enforce normally outside the failover window")
-    local nft_in_window = render.nft(s, { poll_age_seconds = 60 })
-    assert.truthy(nft_in_window:find(
+      "AllowAll must enforce normally when no failover signal is present")
+    local nft_ok = render.nft(s, { poll_failed = false })
+    assert.truthy(nft_ok:find(
       "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com drop", 1, true),
-      "AllowAll must enforce normally before the 5-minute threshold")
+      "AllowAll must enforce normally when the most-recent poll succeeded")
   end)
 
   it("AllowAll: other profiles' drops are unaffected by AllowAll suppression", function()
@@ -166,7 +181,7 @@ describe("render.nft — #385 three-mode failover", function()
     s.profiles["1"].rules.extraBlocked = { "kidblocked.example" }
     s.profiles["2"].rules.extraBlocked = { "adultblocked.example" }
     s.profiles["3"].rules.extraBlocked = { "guestblocked.example" }
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     -- Block-all kid keeps its extraBlocked drop.
     assert.truthy(nft:find(
       "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example drop",
@@ -185,7 +200,7 @@ describe("render.nft — #385 three-mode failover", function()
     local s = snap_three()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
-    local nft = render.nft(s, { poll_age_seconds = 9999 })
+    local nft = render.nft(s, { poll_failed = true })
     assert.is_nil(nft:find(
       "ether saddr cc:cc:cc:00:00:03", 1, true),
       "no DNAT rule scoped to AllowAll MAC during failover")

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -486,7 +486,7 @@ describe("policy.apply", function()
     }
   end
 
-  it("passes opts through to render.nft so failover branch fires (#331)", function()
+  it("passes opts through to render.nft so failover branch fires (#331/#422)", function()
     local nft_content
     policy.apply(snap_with_closed_profile(),
       function(path, content)
@@ -495,12 +495,12 @@ describe("policy.apply", function()
       end,
       function(_cmd) return 0 end,
       nil,
-      { poll_age_seconds = 301 })
+      { poll_failed = true })
     assert.truthy(nft_content)
     assert.truthy(nft_content:find("set failover_drop", 1, true),
-      "expected failover_drop set when opts.poll_age_seconds > 300")
+      "expected failover_drop set when opts.poll_failed=true")
     assert.truthy(nft_content:find("familydns_failover", 1, true),
-      "expected familydns_failover chain when opts.poll_age_seconds > 300")
+      "expected familydns_failover chain when opts.poll_failed=true")
     assert.truthy(nft_content:find("aa:aa:aa:00:00:01", 1, true),
       "expected the Closed-profile device MAC inside the failover set")
   end)
@@ -522,63 +522,46 @@ end)
 
 -- ── policy.failover_transition (#331) ─────────────────────────────────────
 
-describe("policy.failover_transition", function()
+describe("policy.failover_transition (#422)", function()
 
   it("no-op when fetch succeeds and we were not in failover", function()
-    local should, opts, new = policy.failover_transition(false, true, 0)
+    local should, opts, new = policy.failover_transition(false, true)
     assert.is_false(should)
     assert.is_nil(opts)
     assert.is_false(new)
   end)
 
-  it("no-op when fetch fails but poll_age is within 5-min window", function()
-    local should, opts, new = policy.failover_transition(false, false, 60)
-    assert.is_false(should)
-    assert.is_nil(opts)
-    assert.is_false(new)
-  end)
-
-  it("triggers failover when fetch fails and poll_age > 300", function()
-    local should, opts, new = policy.failover_transition(false, false, 301)
+  it("trips failover immediately on a single failed fetch (#422)", function()
+    local should, opts, new = policy.failover_transition(false, false)
     assert.is_true(should)
-    assert.equal(301, opts.poll_age_seconds)
+    assert.is_true(opts.poll_failed)
     assert.is_true(new)
   end)
 
   it("does NOT re-trigger while already in failover (dedupe)", function()
-    local should, opts, new = policy.failover_transition(true, false, 500)
+    local should, opts, new = policy.failover_transition(true, false)
     assert.is_false(should)
     assert.is_nil(opts)
     assert.is_true(new)
   end)
 
-  it("lifts failover on successful fetch with opts.poll_age_seconds=0", function()
-    local should, opts, new = policy.failover_transition(true, true, 0)
+  it("lifts failover on next successful fetch with opts.poll_failed=false", function()
+    local should, opts, new = policy.failover_transition(true, true)
     assert.is_true(should)
-    assert.equal(0, opts.poll_age_seconds)
+    assert.is_false(opts.poll_failed)
     assert.is_false(new)
   end)
 
-  it("boundary: poll_age=300 stays in-window; 301 trips failover", function()
-    local s300 = (select(1, policy.failover_transition(false, false, 300)))
-    local s301 = (select(1, policy.failover_transition(false, false, 301)))
-    assert.is_false(s300)
-    assert.is_true(s301)
-  end)
-
   it("rapid recover + re-fail re-arms the transition", function()
-    -- t=295: fail, in_failover=false → no trip
-    local s1, _, nif1 = policy.failover_transition(false, false, 295)
-    assert.is_false(s1); assert.is_false(nif1)
-    -- t=296: success → no-op
-    local s2, _, nif2 = policy.failover_transition(nif1, true, 0)
-    assert.is_false(s2); assert.is_false(nif2)
-    -- t=356: fail with fresh 60s poll_age (last_successful was at 296) → no trip
-    local s3, _, nif3 = policy.failover_transition(nif2, false, 60)
-    assert.is_false(s3); assert.is_false(nif3)
-    -- much later, t=657: poll_age=361 → trip
-    local s4, opts4, nif4 = policy.failover_transition(nif3, false, 361)
-    assert.is_true(s4); assert.equal(361, opts4.poll_age_seconds); assert.is_true(nif4)
+    -- fail #1 → trip
+    local s1, _, nif1 = policy.failover_transition(false, false)
+    assert.is_true(s1); assert.is_true(nif1)
+    -- success → lift
+    local s2, opts2, nif2 = policy.failover_transition(nif1, true)
+    assert.is_true(s2); assert.is_false(opts2.poll_failed); assert.is_false(nif2)
+    -- fail #2 → trip again
+    local s3, opts3, nif3 = policy.failover_transition(nif2, false)
+    assert.is_true(s3); assert.is_true(opts3.poll_failed); assert.is_true(nif3)
   end)
 
 end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1068,10 +1068,10 @@ describe("render blockIpOnly enforcement (#353)", function()
 
   -- ── failover allow-all suppression (mirrors eb_/bl_ pattern) ────────────
 
-  it("suppresses blockIpOnly drops + DNAT for allow-all-failover MACs (poll_age>300)", function()
+  it("suppresses blockIpOnly drops + DNAT for allow-all-failover MACs (poll_failed=true)", function()
     local s = snap_bio()
     s.profiles["3"].failureMode = "allow-all"
-    local nft = render.nft(s, { poll_age_seconds = 301 })
+    local nft = render.nft(s, { poll_failed = true })
     -- Set declarations are still emitted (cheap; population is a no-op since
     -- the dnsmasq tag is still wired). But forward-chain drops and DNAT for
     -- these MACs must be gone.


### PR DESCRIPTION
## Summary

- Replace `opts.poll_age_seconds: Number` with `opts.poll_failed: Boolean` in `render.nft`. The agent now passes `poll_failed = (not last_fetch_ok)` and failover trips on the first failed poll — no 300s cushion.
- Refactor `policy.failover_transition(in_failover, fetch_ok)` to drop the time argument; the function now decides purely on success/failure.
- Keep `policy.poll_age_seconds(now)` and `policy.format_poll_age` for human-readable log lines (`poll_age=NNNs`), but they no longer feed into the render decision.
- Update `architecture.md` §0.2 / `resilience.md` §2+§4 to describe the immediate-trigger semantics.

## Why

The 300s cushion was a leftover from the pre-#385 open/closed model and contradicted the per-profile `failureMode` contract:

- An admin who picks `block-all` expects the profile's devices to drop traffic the moment the router can't reach the API. With the cushion, devices kept enforcing the cached snapshot for 5 minutes first.
- Symmetrically, `allow-all` didn't unblock for 5 minutes.
- `last-known-good` was unaffected (no-op either way).

The transient-flap concern that originally motivated the 300s gate is addressed instead by the per-profile mode (e.g. `LastKnownGood` on adult profiles keeps the cached snapshot enforcing during a brief blip).

## Side effect: also fixes #353's failover behaviour

PR [#426](https://github.com/sameerparekh/familydns/pull/426) (just landed on `main`) added a `blockIpOnly` v4/v6 drop using the same `allowall_macs` suppression pattern that keys off `in_failover`. Because that pattern is now driven by `poll_failed` instead of `poll_age > 300`, the `blockIpOnly` failover behaviour for `allow-all` profiles is fixed automatically — `failover_spec.lua` and the relevant `render_spec.lua` case were updated to pin the new semantics.

## Test plan

- [x] `cd openwrt && sh test/run_tests.sh` — all 275 specs pass.
- [x] `failover_spec.lua` now drives the three failureMode branches with `{ poll_failed = true }` and includes a regression case proving a fresh cached snapshot + `poll_failed=true` trips failover immediately (no time-keying).
- [x] `policy_spec.lua` `policy.failover_transition` cases rewritten for the two-arg signature; the `#331` opts pass-through case asserts `poll_failed=true` produces `set failover_drop` and `familydns_failover`.
- [x] `render_spec.lua` `blockIpOnly` allow-all suppression case switched to `poll_failed=true`.

Closes #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)