### PR TITLE
api+web: timezone-aware schedules + per-household daily reset (fixes #334)

### DIFF
--- a/api/resources/db/migration/V16__time_handling.sql
+++ b/api/resources/db/migration/V16__time_handling.sql
@@ -1,0 +1,47 @@
+-- V14__time_handling.sql
+-- #334: timezone-aware schedules + per-household daily-reset config.
+--
+-- Schedules now carry a single IANA timezone; start/end are wall-clock
+-- LocalTimes interpreted in that zone. PolicyService converts Instant.now()
+-- to that zone before comparing, so DST is handled automatically.
+--
+-- household_settings is a new single-row table holding the household-wide
+-- daily-reset time + tz. Previously the daily reset was hardcoded to
+-- UTC midnight in PolicyService; now it's configurable.
+--
+-- Backfill: existing block_from/block_until strings are reinterpreted as
+-- LocalTime + tz='UTC'. That preserves the old behavior bit-for-bit
+-- (since the old code did all math in server-UTC). Operators can change
+-- the tz per-schedule afterward.
+
+-- ── household_settings ────────────────────────────────────────────────────
+-- Single-row table: id is constrained to 1. The row is created at boot
+-- time by HouseholdSettingsRepo.ensureDefault, which uses the API JVM's
+-- ZoneId.systemDefault for the install-time tz default.
+CREATE TABLE household_settings (
+  id                INT PRIMARY KEY CHECK (id = 1),
+  daily_reset_time  TIME    NOT NULL DEFAULT '00:00',
+  daily_reset_tz    TEXT    NOT NULL DEFAULT 'UTC',
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ── schedules tz-aware columns ────────────────────────────────────────────
+ALTER TABLE schedules
+  ADD COLUMN start_local TIME,
+  ADD COLUMN end_local   TIME,
+  ADD COLUMN tz          TEXT;
+
+-- Backfill from existing TEXT 'HH:MM' strings.
+UPDATE schedules
+   SET start_local = block_from::TIME,
+       end_local   = block_until::TIME,
+       tz          = 'UTC';
+
+ALTER TABLE schedules
+  ALTER COLUMN start_local SET NOT NULL,
+  ALTER COLUMN end_local   SET NOT NULL,
+  ALTER COLUMN tz          SET NOT NULL;
+
+ALTER TABLE schedules
+  DROP COLUMN block_from,
+  DROP COLUMN block_until;

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -30,6 +30,13 @@ object Main extends ZIOAppDefault {
         .when(cfg.debugEnabled)
       _      <- Database.runMigrations(cfg.db)
       _      <- ZIO.logInfo("Database migrations complete")
+      // #334: ensure household_settings has its single row, defaulting the
+      // daily-reset tz to the API server's local zone on first install. No-op
+      // on subsequent boots because of ON CONFLICT DO NOTHING.
+      hsRepo <- ZIO.service[HouseholdSettingsRepo]
+      tz = java.time.ZoneId.systemDefault()
+      _      <- hsRepo.ensureDefault(tz)
+      _      <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       routes <- allRoutes
       _      <- Server
         .serve(routes)
@@ -53,6 +60,7 @@ object Main extends ZIOAppDefault {
       upRepo      <- ZIO.service[UserProfileRepo]
       profileRepo <- ZIO.service[ProfileRepo]
       schedRepo   <- ZIO.service[ScheduleRepo]
+      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
       tlRepo      <- ZIO.service[TimeLimitRepo]
       stlRepo     <- ZIO.service[SiteTimeLimitRepo]
       deviceRepo  <- ZIO.service[DeviceRepo]
@@ -72,6 +80,7 @@ object Main extends ZIOAppDefault {
     } yield HealthRoutes.routes(dbHealthCheck) ++
       AuthRoutes.routes(auth, userRepo, upRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo, userRepo) ++
+      HouseholdSettingsRoutes.routes(auth, hsRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
       TimeRoutes.routes(
         auth,

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -10,7 +10,7 @@ import familydns.shared.Schedule
 import familydns.api.db.TypeMeta.given
 import zio.*
 import zio.interop.catz.*
-import java.time.{Instant, LocalDate}
+import java.time.{Instant, LocalDate, LocalTime, ZoneId}
 
 given Meta[List[String]] = Meta[Array[String]].imap(_.toList)(_.toArray)
 
@@ -72,6 +72,14 @@ trait ScheduleRepo {
   def listAll: Task[List[Schedule]]
   def listForProfile(pid: ProfileId): Task[List[Schedule]]
   def replaceForProfile(pid: ProfileId, scheds: List[ScheduleRequest]): Task[Unit]
+}
+
+trait HouseholdSettingsRepo {
+  def get: Task[HouseholdSettings]
+  def update(s: HouseholdSettings): Task[Unit]
+
+  /** Insert the default row if missing, using `defaultZone` as the install-time tz. */
+  def ensureDefault(defaultZone: ZoneId): Task[Unit]
 }
 
 trait TimeLimitRepo {
@@ -397,16 +405,16 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
 }
 
 class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
-  private type R = (ScheduleId, ProfileId, String, List[String], String, String)
-  private def toS(r: R)              = Schedule(r._1, r._2, r._3, r._4, r._5, r._6)
+  private type R = (ScheduleId, ProfileId, String, List[String], LocalTime, LocalTime, ZoneId)
+  private def toS(r: R)              = Schedule(r._1, r._2, r._3, r._4, r._5, r._6, r._7)
   def listAll                        =
-    sql"SELECT id,profile_id,name,days,block_from,block_until FROM schedules ORDER BY id"
+    sql"SELECT id,profile_id,name,days,start_local,end_local,tz FROM schedules ORDER BY id"
       .query[R]
       .map(toS)
       .to[List]
       .transact(xa)
   def listForProfile(pid: ProfileId) =
-    sql"SELECT id,profile_id,name,days,block_from,block_until FROM schedules WHERE profile_id=$pid ORDER BY id"
+    sql"SELECT id,profile_id,name,days,start_local,end_local,tz FROM schedules WHERE profile_id=$pid ORDER BY id"
       .query[R]
       .map(toS)
       .to[List]
@@ -414,10 +422,31 @@ class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
   def replaceForProfile(pid: ProfileId, ss: List[ScheduleRequest]) = {
     val del = sql"DELETE FROM schedules WHERE profile_id=$pid".update.run
     val ins = ss.map(s =>
-      sql"INSERT INTO schedules(profile_id,name,days,block_from,block_until) VALUES($pid,${s.name},${s.days.toArray},${s.blockFrom},${s.blockUntil})".update.run,
+      sql"INSERT INTO schedules(profile_id,name,days,start_local,end_local,tz) VALUES($pid,${s.name},${s.days.toArray},${s.startLocal},${s.endLocal},${s.tz})".update.run,
     )
     (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
   }
+}
+
+class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsRepo {
+  def get: Task[HouseholdSettings] =
+    sql"SELECT daily_reset_time, daily_reset_tz FROM household_settings WHERE id=1"
+      .query[(LocalTime, ZoneId)]
+      .unique
+      .map(HouseholdSettings.apply)
+      .transact(xa)
+
+  def update(s: HouseholdSettings): Task[Unit] =
+    sql"""UPDATE household_settings
+            SET daily_reset_time=${s.dailyResetTime},
+                daily_reset_tz=${s.dailyResetTz},
+                updated_at=NOW()
+          WHERE id=1""".update.run.transact(xa).unit
+
+  def ensureDefault(defaultZone: ZoneId): Task[Unit] =
+    sql"""INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz)
+          VALUES (1, '00:00', ${defaultZone})
+          ON CONFLICT (id) DO NOTHING""".update.run.transact(xa).unit
 }
 
 class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
@@ -1006,20 +1035,21 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
 }
 
 object Repos {
-  val userRepo          = ZLayer.fromFunction(UserRepoLive(_))
-  val userProfileRepo   = ZLayer.fromFunction(UserProfileRepoLive(_))
-  val profileRepo       = ZLayer.fromFunction(ProfileRepoLive(_))
-  val scheduleRepo      = ZLayer.fromFunction(ScheduleRepoLive(_))
-  val timeLimitRepo     = ZLayer.fromFunction(TimeLimitRepoLive(_))
-  val siteTimeLimitRepo = ZLayer.fromFunction(SiteTimeLimitRepoLive(_))
-  val deviceRepo        = ZLayer.fromFunction(DeviceRepoLive(_))
-  val blocklistRepo     = ZLayer.fromFunction(BlocklistRepoLive(_))
-  val timeUsageRepo     = ZLayer.fromFunction(TimeUsageRepoLive(_))
-  val timeExtRepo       = ZLayer.fromFunction(TimeExtensionRepoLive(_))
-  val routerRepo        = ZLayer.fromFunction(RouterRepoLive(_))
-  val trafficReportRepo = ZLayer.fromFunction(TrafficReportRepoLive(_))
-  val blockEventRepo    = ZLayer.fromFunction(BlockEventRepoLive(_))
-  val connEventRepo     = ZLayer.fromFunction(ConnectionEventRepoLive(_))
-  val all               =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo
+  val userRepo              = ZLayer.fromFunction(UserRepoLive(_))
+  val userProfileRepo       = ZLayer.fromFunction(UserProfileRepoLive(_))
+  val profileRepo           = ZLayer.fromFunction(ProfileRepoLive(_))
+  val scheduleRepo          = ZLayer.fromFunction(ScheduleRepoLive(_))
+  val householdSettingsRepo = ZLayer.fromFunction(HouseholdSettingsRepoLive(_))
+  val timeLimitRepo         = ZLayer.fromFunction(TimeLimitRepoLive(_))
+  val siteTimeLimitRepo     = ZLayer.fromFunction(SiteTimeLimitRepoLive(_))
+  val deviceRepo            = ZLayer.fromFunction(DeviceRepoLive(_))
+  val blocklistRepo         = ZLayer.fromFunction(BlocklistRepoLive(_))
+  val timeUsageRepo         = ZLayer.fromFunction(TimeUsageRepoLive(_))
+  val timeExtRepo           = ZLayer.fromFunction(TimeExtensionRepoLive(_))
+  val routerRepo            = ZLayer.fromFunction(RouterRepoLive(_))
+  val trafficReportRepo     = ZLayer.fromFunction(TrafficReportRepoLive(_))
+  val blockEventRepo        = ZLayer.fromFunction(BlockEventRepoLive(_))
+  val connEventRepo         = ZLayer.fromFunction(ConnectionEventRepoLive(_))
+  val all                   =
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo
 }

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -5,6 +5,8 @@ import doobie.postgres.implicits.*
 import familydns.shared.{FailureMode, MacBlockReason, UserRole}
 import familydns.shared.types.*
 
+import java.time.ZoneId
+
 /**
  * Doobie `Meta` instances for opaque-type wrappers (#114). Each delegates to the underlying base
  * type's `Meta` — so the DB schema (text / bigint / uuid) is unchanged, only the in-Scala type
@@ -48,6 +50,11 @@ object TypeMeta {
   given Meta[Url]              = Meta[String].imap(Url.unsafe)(_.value)
   given Meta[BlocklistUrl]     = Meta[String].imap(BlocklistUrl.unsafe)(_.value)
   given Meta[JwtToken]         = Meta[String].imap(JwtToken.unsafe)(_.value)
+
+  // #334: schedules + household_settings persist IANA zone names as TEXT.
+  // ZoneId.of throws on unknown zones; presumed canonical because writes go
+  // through validated wire types that already construct ZoneId via .of.
+  given Meta[ZoneId] = Meta[String].imap(ZoneId.of)(_.getId)
 
   // ── Enums persisted as text columns ────────────────────────────────────
   given Meta[UserRole] = Meta[String].imap(s =>

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -7,7 +7,7 @@ import familydns.shared.types.*
 import zio.{Clock as _, *}
 
 import java.security.MessageDigest
-import java.time.{DayOfWeek, LocalDate, LocalTime, OffsetDateTime, ZoneOffset}
+import java.time.{DayOfWeek, Instant}
 
 trait PolicyService {
   def snapshot: Task[PolicySnapshot]
@@ -37,6 +37,7 @@ private[policy] case class ProfileInputs(
 class PolicyServiceLive(
     profileRepo: ProfileRepo,
     scheduleRepo: ScheduleRepo,
+    householdSettingsRepo: HouseholdSettingsRepo,
     timeLimitRepo: TimeLimitRepo,
     siteTimeLimitRepo: SiteTimeLimitRepo,
     deviceRepo: DeviceRepo,
@@ -48,8 +49,9 @@ class PolicyServiceLive(
 
   def snapshot: Task[PolicySnapshot] =
     for {
-      today    <- clock.today
-      now      <- clock.now
+      settings <- householdSettingsRepo.get
+      now      <- clock.instant
+      today = now.atZone(settings.dailyResetTz).toLocalDate
       profiles <- profileRepo.listAll
       devices  <- deviceRepo.listAll
       scheds   <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
@@ -92,7 +94,7 @@ class PolicyServiceLive(
           minutesByDomain = byDomain,
           extensionsMinutes = extMins,
         )
-        val rules  = PolicyService.computeBlockRules(inputs, now.toLocalTime, today)
+        val rules  = PolicyService.computeBlockRules(inputs, now)
 
         p.id -> ProfilePolicy(name = p.name, rules = rules, failureMode = p.failureMode)
       }.toMap
@@ -143,8 +145,9 @@ class PolicyServiceLive(
    */
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
     for {
-      today  <- clock.today
-      now    <- clock.now
+      settings <- householdSettingsRepo.get
+      now      <- clock.instant
+      today = now.atZone(settings.dailyResetTz).toLocalDate
       device <- deviceRepo.listAll.map(_.find(_.mac.value.equalsIgnoreCase(mac)))
       result <- device.flatMap(_.profileId) match {
         case None      =>
@@ -168,7 +171,7 @@ class PolicyServiceLive(
                 if p.paused then
                   ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Block, "paused", None))
                 else
-                  scheduleBlock(scheds, now.toLocalTime, today) match {
+                  scheduleBlock(scheds, now) match {
                     case Some(r) => ZIO.succeed(r)
                     case None    =>
                       if matchesAny(h, p.extraAllowed) then
@@ -193,7 +196,8 @@ class PolicyServiceLive(
                         val totalMins  = devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
                         timeLimitBlockFromDb(
                           h,
-                          today,
+                          now,
+                          settings,
                           tl.map(_.dailyMinutes),
                           stlims,
                           byDomain,
@@ -222,40 +226,30 @@ class PolicyServiceLive(
 
   private def scheduleBlock(
       schedules: List[DbSchedule],
-      nowTime: LocalTime,
-      today: LocalDate,
+      now: Instant,
   ): Option[RouterDecisionResponse] = {
-    val todayName = dayName(today)
-    val prevName  = dayName(today.minusDays(1))
-    val active    = schedules.find { s =>
-      val from  = parseTime(s.blockFrom)
-      val until = parseTime(s.blockUntil)
-      if from.isAfter(until) then
-        (s.days.contains(todayName) && !nowTime.isBefore(from)) ||
-        (s.days.contains(prevName) && nowTime.isBefore(until))
-      else s.days.contains(todayName) && !nowTime.isBefore(from) && nowTime.isBefore(until)
-    }
-    active.map { s =>
-      val from        = parseTime(s.blockFrom)
-      val until       = parseTime(s.blockUntil)
-      val isOvernight = from.isAfter(until)
-      val expiresAt   =
-        if isOvernight && !nowTime.isBefore(from) then utcString(today.plusDays(1), until)
-        else utcString(today, until)
-      RouterDecisionResponse(ConnectionDecision.Block, "schedule", Some(expiresAt))
+    schedules.find(s => PolicyService.scheduleActiveAt(s, now)).map { s =>
+      // expiresAt for an active schedule = the next instant the window's `endLocal`
+      // occurs in the schedule's tz. For overnight windows where we're past startLocal
+      // it's tomorrow's endLocal; otherwise it's today's endLocal (which may be in the
+      // past for the "tail" of a previous day's overnight window — handled below).
+      val expiresAt = PolicyService.scheduleEndInstantAfter(s, now)
+      RouterDecisionResponse(ConnectionDecision.Block, "schedule", Some(expiresAt.toString))
     }
   }
 
   private def timeLimitBlockFromDb(
       hostname: String,
-      today: LocalDate,
+      now: Instant,
+      settings: HouseholdSettings,
       dailyMinutes: Option[Int],
       siteLimits: List[SiteTimeLimit],
       minutesByDomain: Map[String, Int],
       totalMinutesUsed: Int,
       extensionsMinutes: Int,
   ): Option[RouterDecisionResponse] = {
-    val midnight     = utcString(today.plusDays(1), LocalTime.MIDNIGHT)
+    // Time-limit blocks expire at the next household daily-reset Instant.
+    val resetAt      = PolicyService.nextDailyResetAfter(settings, now).toString
     val siteLimitHit = siteLimits.find { sl =>
       matchesDomainPattern(hostname, sl.domainPattern) &&
       minutesByDomain.getOrElse(sl.domainPattern, 0) >= sl.dailyMinutes
@@ -265,7 +259,7 @@ class PolicyServiceLive(
         RouterDecisionResponse(
           ConnectionDecision.Block,
           s"site_time_limit:${sl.label}",
-          Some(midnight),
+          Some(resetAt),
         ),
       )
       .orElse {
@@ -276,7 +270,7 @@ class PolicyServiceLive(
         else
           dailyMinutes.flatMap { limit =>
             Option.when(totalMinutesUsed >= limit + extensionsMinutes)(
-              RouterDecisionResponse(ConnectionDecision.Block, "time_limit", Some(midnight)),
+              RouterDecisionResponse(ConnectionDecision.Block, "time_limit", Some(resetAt)),
             )
           }
       }
@@ -311,25 +305,6 @@ class PolicyServiceLive(
     (0 until parts.length - 1).exists(i => list.contains(parts.drop(i).mkString(".")))
   }
 
-  private def parseTime(s: String): LocalTime = {
-    val Array(h, m) = s.split(':')
-    LocalTime.of(h.toInt, m.toInt)
-  }
-
-  private val dayNames: Map[DayOfWeek, String] = Map(
-    DayOfWeek.MONDAY    -> "mon",
-    DayOfWeek.TUESDAY   -> "tue",
-    DayOfWeek.WEDNESDAY -> "wed",
-    DayOfWeek.THURSDAY  -> "thu",
-    DayOfWeek.FRIDAY    -> "fri",
-    DayOfWeek.SATURDAY  -> "sat",
-    DayOfWeek.SUNDAY    -> "sun",
-  )
-
-  private def dayName(d: LocalDate): String = dayNames(d.getDayOfWeek)
-
-  private def utcString(date: LocalDate, time: LocalTime): String =
-    OffsetDateTime.of(date, time, ZoneOffset.UTC).toInstant.toString
 }
 
 private case class SnapshotCore(
@@ -340,11 +315,11 @@ private case class SnapshotCore(
 
 object PolicyService {
   val layer: ZLayer[
-    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo &
-      TrafficReportRepo & TimeExtensionRepo & Clock,
+    ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo & SiteTimeLimitRepo &
+      DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo & Clock,
     Nothing,
     PolicyService,
-  ] = ZLayer.fromFunction(PolicyServiceLive(_, _, _, _, _, _, _, _, _))
+  ] = ZLayer.fromFunction(PolicyServiceLive(_, _, _, _, _, _, _, _, _, _))
 
   /** Content-derived version: first 16 hex chars of SHA-256 over sorted domain list. */
   def blocklistContentVersion(domains: Iterable[String]): String = {
@@ -391,8 +366,7 @@ object PolicyService {
    */
   private[policy] def computeBlockRules(
       in: ProfileInputs,
-      nowTime: LocalTime,
-      today: LocalDate,
+      now: Instant,
   ): BlockRules = {
     val p = in.profile
 
@@ -409,7 +383,7 @@ object PolicyService {
 
     val (blocked, reason) =
       if p.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
-      else if scheduleActiveNow(in.schedules, nowTime, today) then
+      else if in.schedules.exists(s => scheduleActiveAt(s, now)) then
         (true, Some(MacBlockReason.Schedule: MacBlockReason))
       else
         in.dailyMinutes match {
@@ -429,26 +403,69 @@ object PolicyService {
     )
   }
 
-  private def scheduleActiveNow(
-      schedules: List[DbSchedule],
-      nowTime: LocalTime,
-      today: LocalDate,
-  ): Boolean = {
-    val todayName = dowShort(today.getDayOfWeek)
-    val prevName  = dowShort(today.minusDays(1).getDayOfWeek)
-    schedules.exists { s =>
-      val from  = parseHm(s.blockFrom)
-      val until = parseHm(s.blockUntil)
-      if from.isAfter(until) then
-        (s.days.contains(todayName) && !nowTime.isBefore(from)) ||
-        (s.days.contains(prevName) && nowTime.isBefore(until))
-      else s.days.contains(todayName) && !nowTime.isBefore(from) && nowTime.isBefore(until)
+  // ── #334: timezone-aware time math ────────────────────────────────────────
+  //
+  // Schedules + daily-reset carry an IANA zone with the data. All evaluation
+  // projects `Instant.now()` into that zone and compares wall-clock components.
+  // DST is handled transparently by ZonedDateTime: the same wall-clock time
+  // reliably resolves "9pm every day" regardless of standard/daylight time.
+
+  /**
+   * True iff `instant`, projected into `s.tz`, falls in the schedule's window. Same-day window:
+   * `[startLocal, endLocal)` on a day in `s.days`. Cross-midnight (overnight) window when
+   * `startLocal > endLocal`: `[startLocal, 24:00)` on a day in `s.days`, OR `[00:00, endLocal)` on
+   * the day *after* a day in `s.days` (the tail).
+   *
+   * `startLocal == endLocal` is treated as a never-active empty window.
+   */
+  def scheduleActiveAt(s: DbSchedule, instant: Instant): Boolean = {
+    if s.startLocal == s.endLocal then false
+    else {
+      val zdt         = instant.atZone(s.tz)
+      val today       = zdt.toLocalDate
+      val now         = zdt.toLocalTime
+      val isOvernight = s.startLocal.isAfter(s.endLocal)
+      if !isOvernight then
+        s.days.contains(dowShort(today.getDayOfWeek)) &&
+        !now.isBefore(s.startLocal) && now.isBefore(s.endLocal)
+      else {
+        val todayName = dowShort(today.getDayOfWeek)
+        val prevName  = dowShort(today.minusDays(1).getDayOfWeek)
+        (s.days.contains(todayName) && !now.isBefore(s.startLocal)) ||
+        (s.days.contains(prevName) && now.isBefore(s.endLocal))
+      }
     }
   }
 
-  private def parseHm(s: String): LocalTime = {
-    val Array(h, m) = s.split(':')
-    LocalTime.of(h.toInt, m.toInt)
+  /**
+   * The Instant at which the currently-active window for `s` ends. Caller must have established
+   * that `scheduleActiveAt(s, now)` is true.
+   */
+  def scheduleEndInstantAfter(s: DbSchedule, now: Instant): Instant = {
+    val zdt         = now.atZone(s.tz)
+    val today       = zdt.toLocalDate
+    val isOvernight = s.startLocal.isAfter(s.endLocal)
+    val endDate     =
+      if isOvernight && !zdt.toLocalTime.isBefore(s.startLocal) then today.plusDays(1)
+      else today
+    endDate.atTime(s.endLocal).atZone(s.tz).toInstant
+  }
+
+  /**
+   * The next Instant strictly after `now` at which the household's daily-reset wall-clock time
+   * occurs in its zone. Used to populate `expiresAt` on time-limit blocks served to the router.
+   */
+  def nextDailyResetAfter(settings: HouseholdSettings, now: Instant): Instant = {
+    val zdt       = now.atZone(settings.dailyResetTz)
+    val candidate =
+      zdt.toLocalDate.atTime(settings.dailyResetTime).atZone(settings.dailyResetTz).toInstant
+    if candidate.isAfter(now) then candidate
+    else
+      zdt.toLocalDate
+        .plusDays(1)
+        .atTime(settings.dailyResetTime)
+        .atZone(settings.dailyResetTz)
+        .toInstant
   }
 
   private def dowShort(d: DayOfWeek): String = d match {

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -594,6 +594,37 @@ object BlocklistRoutes {
     )
 }
 
+// ── Household settings (#334) ──────────────────────────────────────────────
+
+object HouseholdSettingsRoutes {
+  def routes(
+      auth: AuthService,
+      repo: HouseholdSettingsRepo,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "household" / "settings" ->
+        handler { (req: Request) =>
+          for {
+            _ <- requireAuth(req, auth)
+            s <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.json(s.toJson)
+        },
+      Method.PUT / "api" / "household" / "settings" ->
+        handler { (req: Request) =>
+          for {
+            _    <- requireAdmin(req, auth)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            upd  <- ZIO
+              .fromEither(body.fromJson[UpdateHouseholdSettingsRequest])
+              .mapError(e => Response.badRequest(e))
+            _    <- repo
+              .update(HouseholdSettings(upd.dailyResetTime, upd.dailyResetTz))
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+    )
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 private def bearerToken(req: Request): Option[String] =

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -79,13 +79,27 @@ object TestDatabase {
         } finally conn.close()
       }
       _  <- ZIO.attempt(runMigrations(pg))
+      // #334: replicate Main.ensureDefault so PolicyService.snapshot/decide can
+      // read household_settings during tests. Use UTC so DST doesn't perturb
+      // existing test expectations.
+      _  <- ZIO.attempt {
+        val conn = pg.getPostgresDatabase.getConnection
+        try {
+          conn
+            .createStatement()
+            .execute(
+              "INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz) " +
+                "VALUES (1, '00:00', 'UTC') ON CONFLICT (id) DO NOTHING",
+            )
+        } finally conn.close()
+      }
     } yield ()
 
   /** All repo types bundled for convenience */
   type AllRepos =
-    UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo &
-      DeviceRepo & BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & RouterRepo &
-      TrafficReportRepo & BlockEventRepo & ConnectionEventRepo
+    UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
+      TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
+      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg
@@ -118,8 +132,9 @@ object TestLayers {
           familydns.shared.ScheduleRequest(
             "Bedtime",
             List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
-            "21:00",
-            "07:00",
+            java.time.LocalTime.of(21, 0),
+            java.time.LocalTime.of(7, 0),
+            java.time.ZoneId.of("UTC"),
           ),
         ),
       )

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -45,6 +45,7 @@ object PolicySnapshotBlockedMacsSpec
     for {
       pr     <- ZIO.service[ProfileRepo]
       sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
       stlr   <- ZIO.service[SiteTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
@@ -53,7 +54,7 @@ object PolicySnapshotBlockedMacsSpec
       er     <- ZIO.service[TimeExtensionRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clk)): PolicyService
+    } yield (new PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, clk)): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", Sha256Hex.unsafe("o" * 64)))

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -32,6 +32,7 @@ object PolicySnapshotFailureModeSpec
         _      <- cleanDb
         pr     <- ZIO.service[ProfileRepo]
         sr     <- ZIO.service[ScheduleRepo]
+        hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
         stlr   <- ZIO.service[SiteTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
@@ -39,7 +40,7 @@ object PolicySnapshotFailureModeSpec
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, clock)
         profiles0 <- pr.listAll
         kidsId   = profiles0.find(_.name == "Kids").get.id
         adultsId = profiles0.find(_.name == "Adults").get.id
@@ -63,6 +64,7 @@ object PolicySnapshotFailureModeSpec
         _      <- cleanDb
         pr     <- ZIO.service[ProfileRepo]
         sr     <- ZIO.service[ScheduleRepo]
+        hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
         stlr   <- ZIO.service[SiteTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
@@ -70,7 +72,7 @@ object PolicySnapshotFailureModeSpec
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, clock)
         profiles0 <- pr.listAll
         _         <- pr.update(
           profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),
@@ -88,6 +90,7 @@ object PolicySnapshotFailureModeSpec
         _      <- cleanDb
         pr     <- ZIO.service[ProfileRepo]
         sr     <- ZIO.service[ScheduleRepo]
+        hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
         stlr   <- ZIO.service[SiteTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
@@ -95,7 +98,7 @@ object PolicySnapshotFailureModeSpec
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, clock)
         profiles0 <- pr.listAll
         _         <- pr.update(
           profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -123,7 +123,13 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             extraAllowed = List(Hostname.unsafe("khanacademy.org")),
             paused = false,
             schedules = List(
-              ScheduleRequest("Bedtime", List("mon", "tue", "wed", "thu", "fri"), "22:00", "08:00"),
+              ScheduleRequest(
+                "Bedtime",
+                List("mon", "tue", "wed", "thu", "fri"),
+                java.time.LocalTime.of(22, 0),
+                java.time.LocalTime.of(8, 0),
+                java.time.ZoneId.of("UTC"),
+              ),
             ),
             timeLimit = Some(180),
             siteTimeLimits = List(
@@ -148,7 +154,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(teen.extraBlocked.contains(Hostname.unsafe("tiktok.com"))) &&
           assertTrue(teen.extraAllowed.contains(Hostname.unsafe("khanacademy.org"))) &&
           assertTrue(scheds.length == 1) &&
-          assertTrue(scheds.head.blockFrom == "22:00") &&
+          assertTrue(scheds.head.startLocal == java.time.LocalTime.of(22, 0)) &&
           assertTrue(tl.exists(_.dailyMinutes == 180)) &&
           assertTrue(stls.length == 1) &&
           assertTrue(stls.head.label == "YouTube") &&
@@ -330,7 +336,13 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             extraAllowed = List(Hostname.unsafe("pbs.org")),
             paused = false,
             schedules = List(
-              ScheduleRequest("Bedtime", List("mon", "tue", "wed", "thu", "fri"), "20:00", "07:00"),
+              ScheduleRequest(
+                "Bedtime",
+                List("mon", "tue", "wed", "thu", "fri"),
+                java.time.LocalTime.of(20, 0),
+                java.time.LocalTime.of(7, 0),
+                java.time.ZoneId.of("UTC"),
+              ),
             ),
             timeLimit = Some(120),
             siteTimeLimits = Nil,
@@ -350,7 +362,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(updated.exists(_.name == "Kids Updated")) &&
           assertTrue(updated.exists(_.extraAllowed.contains(Hostname.unsafe("pbs.org")))) &&
           assertTrue(tl.exists(_.dailyMinutes == 120)) &&
-          assertTrue(scheds.exists(_.blockFrom == "20:00"))
+          assertTrue(scheds.exists(_.startLocal == java.time.LocalTime.of(20, 0)))
       },
     ),
     suite("PUT /api/profiles/:id pause is idempotent (#406)")(

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -39,6 +39,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
     for {
       pr     <- ZIO.service[ProfileRepo]
       sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
       stlr   <- ZIO.service[SiteTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
@@ -46,7 +47,18 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       clock  <- ZIO.service[Clock]
-    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)): PolicyService
+    } yield (new PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      clock,
+    )): PolicyService
 
   /**
    * Seed `minutes/5` non-overlapping 5-min traffic_reports buckets, starting `bucketOffset` past

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -29,6 +29,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     for {
       pr     <- ZIO.service[ProfileRepo]
       sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
       stlr   <- ZIO.service[SiteTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
@@ -37,7 +38,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       er     <- ZIO.service[TimeExtensionRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clk)): PolicyService
+    } yield (new PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, clk)): PolicyService
 
   private def makePsDefault = makePsAt(TestClock.schoolDayAfternoon)
 

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -64,6 +64,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     for {
       pr     <- ZIO.service[ProfileRepo]
       sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
       stlr   <- ZIO.service[SiteTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
@@ -71,7 +72,18 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       clock  <- ZIO.service[Clock]
-    } yield (new PolicyServiceLive(pr, sr, tlr, stlr, dr, blr, trRepo, er, clock)): PolicyService
+    } yield (new PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      clock,
+    )): PolicyService
 
   private def post(
       routes: Routes[Any, Response],

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -622,10 +622,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _             <- seedTraffic(routerId, mac2, "roblox.com", today, 25)
           // Build policy snapshot directly via PolicyService
           blocklistRepo <- ZIO.service[BlocklistRepo]
+          hsRepo        <- ZIO.service[HouseholdSettingsRepo]
           clock         <- ZIO.service[Clock]
           policyService = PolicyServiceLive(
             profileRepo,
             schedRepo,
+            hsRepo,
             tlRepo,
             stlRepo,
             deviceRepo,

--- a/api/test/src/unit/SchedulingSpec.scala
+++ b/api/test/src/unit/SchedulingSpec.scala
@@ -1,0 +1,182 @@
+package familydns.api.unit
+
+import familydns.api.policy.PolicyService
+import familydns.shared.{HouseholdSettings, Schedule}
+import familydns.shared.types.*
+import zio.test.*
+
+import java.time.{Instant, LocalTime, ZoneId, ZonedDateTime}
+
+/**
+ * #334: timezone-aware schedule evaluation + daily-reset Instant computation.
+ *
+ * The pure functions under test do all timezone math against `Instant.now()` projected into the
+ * per-row IANA zone. Tests pin DST behavior (spring-forward + fall-back) and cross-midnight windows
+ * since those are the bug-prone cases.
+ */
+object SchedulingSpec extends ZIOSpecDefault {
+
+  private val LA  = ZoneId.of("America/Los_Angeles")
+  private val NY  = ZoneId.of("America/New_York")
+  private val UTC = ZoneId.of("UTC")
+
+  /** Build an Instant from a wall-clock time in a given zone. */
+  private def instantAt(
+      year: Int,
+      month: Int,
+      day: Int,
+      hour: Int,
+      min: Int,
+      zone: ZoneId,
+  ): Instant =
+    ZonedDateTime.of(year, month, day, hour, min, 0, 0, zone).toInstant
+
+  private val allDays = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+  private def schedule(
+      tz: ZoneId,
+      startLocal: LocalTime,
+      endLocal: LocalTime,
+      days: List[String] = allDays,
+  ): Schedule =
+    Schedule(
+      id = ScheduleId(1L),
+      profileId = ProfileId(1L),
+      name = "test",
+      days = days,
+      startLocal = startLocal,
+      endLocal = endLocal,
+      tz = tz,
+    )
+
+  def spec = suite("Scheduling")(
+    suite("scheduleActiveAt — basic")(
+      test("simple in-window, same-day window") {
+        val s = schedule(LA, LocalTime.of(9, 0), LocalTime.of(17, 0))
+        // 2026-05-13 (Wed) 12:00 PDT
+        val t = instantAt(2026, 5, 13, 12, 0, LA)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+      test("just before window starts → not active") {
+        val s = schedule(LA, LocalTime.of(9, 0), LocalTime.of(17, 0))
+        val t = instantAt(2026, 5, 13, 8, 59, LA)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+      test("right at window end → not active (end is exclusive)") {
+        val s = schedule(LA, LocalTime.of(9, 0), LocalTime.of(17, 0))
+        val t = instantAt(2026, 5, 13, 17, 0, LA)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+      test("day-of-week filter excludes other days") {
+        val s = schedule(LA, LocalTime.of(9, 0), LocalTime.of(17, 0), days = List("mon"))
+        // Wednesday
+        val t = instantAt(2026, 5, 13, 12, 0, LA)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+    ),
+    suite("scheduleActiveAt — cross-midnight (overnight)")(
+      test("23:30 → 06:00 NY: in-window at 23:30 NY") {
+        val s = schedule(NY, LocalTime.of(23, 30), LocalTime.of(6, 0))
+        val t = instantAt(2026, 5, 13, 23, 30, NY)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+      test("23:30 → 06:00 NY: in-window at 02:00 NY (next day, prev-day's window)") {
+        val s = schedule(NY, LocalTime.of(23, 30), LocalTime.of(6, 0))
+        // 2026-05-14 02:00 NY is the tail of the schedule that started 2026-05-13 23:30
+        val t = instantAt(2026, 5, 14, 2, 0, NY)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+      test("23:30 → 06:00 NY: out-of-window at 06:01 NY") {
+        val s = schedule(NY, LocalTime.of(23, 30), LocalTime.of(6, 0))
+        val t = instantAt(2026, 5, 14, 6, 1, NY)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+      test("23:30 → 06:00 NY with days=[mon]: tue 02:00 still in-window (mon's tail)") {
+        val s = schedule(NY, LocalTime.of(23, 30), LocalTime.of(6, 0), days = List("mon"))
+        // 2026-05-11 is Monday; 2026-05-12 02:00 is Tuesday morning, tail of Monday's window
+        val t = instantAt(2026, 5, 12, 2, 0, NY)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+      test("23:30 → 06:00 NY with days=[mon]: tue 23:30 not in-window (tue not in days)") {
+        val s = schedule(NY, LocalTime.of(23, 30), LocalTime.of(6, 0), days = List("mon"))
+        val t = instantAt(2026, 5, 12, 23, 30, NY)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+    ),
+    suite("scheduleActiveAt — DST")(
+      test(
+        "21:00 → 07:00 LA across spring-forward 2026-03-08 → next morning still in-window at 06:30 PDT",
+      ) {
+        val s = schedule(LA, LocalTime.of(21, 0), LocalTime.of(7, 0))
+        // Spring-forward in LA happens 2026-03-08 02:00 PST → 03:00 PDT.
+        // Window starts 2026-03-07 21:00 PST, runs through 2026-03-08 07:00 PDT.
+        // 2026-03-08 06:30 PDT must be in-window even though wall-clock skipped 02:00–02:59.
+        val t = instantAt(2026, 3, 8, 6, 30, LA)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+      test("21:00 → 07:00 LA across spring-forward → 07:01 PDT out-of-window") {
+        val s = schedule(LA, LocalTime.of(21, 0), LocalTime.of(7, 0))
+        val t = instantAt(2026, 3, 8, 7, 1, LA)
+        assertTrue(!PolicyService.scheduleActiveAt(s, t))
+      },
+      test("21:00 → 07:00 LA across fall-back 2026-11-01 → both 01:30 instants are in-window") {
+        val s          = schedule(LA, LocalTime.of(21, 0), LocalTime.of(7, 0))
+        // 2026-11-01 02:00 PDT → 01:00 PST; the wall-clock 01:30 happens twice.
+        // First 01:30 = 2026-11-01 08:30Z (PDT), second = 2026-11-01 09:30Z (PST). Both must be in-window.
+        val firstHalf  = Instant.parse("2026-11-01T08:30:00Z")
+        val secondHalf = Instant.parse("2026-11-01T09:30:00Z")
+        assertTrue(
+          PolicyService.scheduleActiveAt(s, firstHalf),
+          PolicyService.scheduleActiveAt(s, secondHalf),
+        )
+      },
+      test("21:00 → 07:00 LA: 21:00 PDT on 2026-03-07 (start day) is in-window") {
+        val s = schedule(LA, LocalTime.of(21, 0), LocalTime.of(7, 0))
+        val t = instantAt(2026, 3, 7, 21, 0, LA)
+        assertTrue(PolicyService.scheduleActiveAt(s, t))
+      },
+    ),
+    suite("scheduleActiveAt — per-row tz isolation")(
+      test("two schedules, different tz, same Instant: each evaluated against its own tz") {
+        // 2026-05-13 23:00 NY = 2026-05-13 20:00 LA
+        val t   = instantAt(2026, 5, 13, 23, 0, NY)
+        // Schedule A: 22:00–02:00 NY → 23:00 NY is in-window
+        val sNy = schedule(NY, LocalTime.of(22, 0), LocalTime.of(2, 0))
+        // Schedule B: 22:00–02:00 LA → 20:00 LA is NOT in-window
+        val sLa = schedule(LA, LocalTime.of(22, 0), LocalTime.of(2, 0))
+        assertTrue(
+          PolicyService.scheduleActiveAt(sNy, t),
+          !PolicyService.scheduleActiveAt(sLa, t),
+        )
+      },
+    ),
+    suite("nextDailyResetAfter")(
+      test("00:00 LA in standard time (PST, Jan 15 2026) → 08:00Z next day") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA)
+        val now      = Instant.parse("2026-01-15T20:00:00Z") // Jan 15 12:00 PST
+        // Next 00:00 PST = 2026-01-16 00:00 PST = 2026-01-16 08:00Z
+        val expected = Instant.parse("2026-01-16T08:00:00Z")
+        assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
+      },
+      test("00:00 LA in daylight time (PDT, Jun 15 2026) → 07:00Z next day") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA)
+        val now      = Instant.parse("2026-06-15T19:00:00Z") // Jun 15 12:00 PDT
+        // Next 00:00 PDT = 2026-06-16 00:00 PDT = 2026-06-16 07:00Z
+        val expected = Instant.parse("2026-06-16T07:00:00Z")
+        assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
+      },
+      test("at exactly the reset Instant: returns NEXT day's reset (strict-after)") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), UTC)
+        val now      = Instant.parse("2026-05-13T00:00:00Z")
+        val expected = Instant.parse("2026-05-14T00:00:00Z")
+        assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
+      },
+      test("reset later in the day, before reset → today's reset") {
+        val settings = HouseholdSettings(LocalTime.of(3, 0), UTC)
+        val now      = Instant.parse("2026-05-13T01:00:00Z")
+        val expected = Instant.parse("2026-05-13T03:00:00Z")
+        assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
+      },
+    ),
+  )
+}

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -368,6 +368,26 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ---
 
+## 7a. Host clock and timezone (#334)
+
+The API host should run an **NTP-synced UTC system clock**. Decision logic
+is `Instant`-based and per-row timezone-aware (see
+[`time-handling.md`](time-handling.md)) — the host's local timezone setting
+is not consulted for schedule or daily-reset evaluation.
+
+The host's local timezone *is* read once on first boot to seed the
+household's default daily-reset timezone (`household_settings.daily_reset_tz`).
+After that the operator can change it via the UI; the host tz is never
+re-read. So:
+
+- If you intend most schedules to be in your own home timezone, set the
+  host tz to that zone (`sudo timedatectl set-timezone America/Los_Angeles`)
+  *before* the first API boot.
+- If you forgot, no harm done — set the household's tz from the
+  **Profiles** page after install.
+
+---
+
 ## 8. Firewall
 
 The OpenWRT router agent must be able to reach the API. Open the path it

--- a/docs/time-handling.md
+++ b/docs/time-handling.md
@@ -1,0 +1,154 @@
+# Time handling — schedules, daily reset, DST
+
+This document explains how FamilyDNS handles wall-clock time across timezones
+and DST transitions. The rules apply to schedule windows and daily-usage
+reset; both are evaluated by `PolicyService` on the API server.
+
+See issue [#334](https://github.com/sameerparekh/familydns/issues/334) for
+the design discussion.
+
+## The rule: timezone lives with the data
+
+Every time-anchored value carries its own IANA timezone. There is **no**
+server-wide or household-wide "current timezone" that everything inherits.
+
+| What                | Stored as                              | In the model                                |
+|---------------------|----------------------------------------|---------------------------------------------|
+| Schedule window     | `start_local TIME, end_local TIME, tz` | `Schedule.startLocal/endLocal/tz`           |
+| Daily-usage reset   | `daily_reset_time TIME, daily_reset_tz`| `HouseholdSettings.dailyResetTime/Tz`       |
+
+The API server's own clock is `Instant`-based (UTC). Per-row timezone math
+projects `Instant.now()` into the row's `tz` and compares wall-clock components
+there. The host's local timezone is **not** consulted at decision time.
+
+## Why store tz with the data?
+
+Two reasons:
+
+1. **Wall-clock stability across DST.** A schedule of "9 PM to 7 AM
+   America/Los_Angeles" stays "9 PM to 7 AM" forever. On the night clocks
+   spring forward, the window's UTC duration is 9 hours instead of 10; on the
+   night they fall back, 11 hours instead of 10 — but to the user, it's the
+   same 9 PM to 7 AM every night, which matches user intent ("bedtime is
+   9 PM"). If we stored the window in UTC instead, the user-visible time
+   would shift by an hour twice a year.
+
+2. **A household can have schedules in multiple zones.** A travelling family
+   member's profile can have schedules in their travel zone, distinct from
+   the household-wide reset zone, without any per-profile or per-row
+   "override the default" plumbing.
+
+## DST mechanics
+
+The math reduces to:
+
+```scala
+val zdt = instant.atZone(schedule.tz)
+val now = zdt.toLocalTime
+val today = zdt.toLocalDate
+```
+
+`ZonedDateTime` handles both DST transitions correctly:
+
+- **Spring forward** (e.g. 2026-03-08 02:00 PST → 03:00 PDT in LA): no
+  `Instant` maps to a wall-clock time in `[02:00, 03:00)` PDT. A schedule
+  that spans this gap (e.g. `21:00 → 07:00 LA`) simply has fewer in-window
+  Instants that night — about 9 hours instead of 10. Edge times like
+  `06:30` and `07:01` evaluate as expected.
+- **Fall back** (e.g. 2026-11-01 02:00 PDT → 01:00 PST in LA): wall-clock
+  times in `[01:00, 02:00)` happen *twice*. Both of those Instants project
+  to the same `LocalTime` and are evaluated against the schedule
+  identically — the in-window state is continuous; there is no "double
+  block" or "off then on again."
+
+## Schedule windows
+
+A schedule has `startLocal: LocalTime`, `endLocal: LocalTime`, `tz: ZoneId`,
+`days: List[String]` (`"mon"` … `"sun"`).
+
+- **Same-day** (`startLocal < endLocal`): in-window iff today's local date is
+  in `days` and `startLocal <= now < endLocal`.
+- **Cross-midnight overnight** (`startLocal > endLocal`, e.g. 21:00 → 07:00):
+  in-window iff
+  - today is in `days` and `now >= startLocal`, *or*
+  - yesterday is in `days` and `now < endLocal` (the "tail" of yesterday's
+    window).
+- **Empty** (`startLocal == endLocal`): never in-window.
+
+`endLocal` is *exclusive*: a `09:00 → 17:00` window is in-window at 16:59 and
+out-of-window at 17:00.
+
+## Daily reset
+
+The household has one configurable reset time + tz. The next reset Instant is
+computed strictly-after `now`:
+
+```scala
+def nextDailyResetAfter(settings, now): Instant =
+  val zdt = now.atZone(settings.dailyResetTz)
+  val candidate = zdt.toLocalDate.atTime(settings.dailyResetTime)
+                       .atZone(settings.dailyResetTz).toInstant
+  if candidate.isAfter(now) then candidate
+  else /* tomorrow's reset */
+```
+
+This Instant populates the `expiresAt` field on `time_limit` and
+`site_time_limit` block decisions sent to the router. The router then
+expires the block at exactly that wall-clock moment in the configured zone,
+regardless of DST.
+
+The household-local "today" used for usage-bucket lookup is
+`now.atZone(settings.dailyResetTz).toLocalDate`. (For non-midnight reset
+times this slightly diverges from the strict "the bucket starts at the last
+reset Instant" interpretation; we'll revisit if anyone configures a
+non-midnight reset.)
+
+## Validation
+
+- IANA zone names are validated at the wire boundary by `JsonCodec[ZoneId]`
+  in `shared/src/Models.scala`. Unknown zones (`"Foo/Bar"`) → 400 with a
+  clear error.
+- `LocalTime` is `"HH:mm"` 24-hour, validated by `JsonCodec[LocalTime]`.
+
+## Backfill (V14 migration)
+
+Pre-#334 schedules used `block_from TEXT, block_until TEXT` (HH:mm strings)
+with no timezone field; the server interpreted them as server-local time
+(effectively UTC, since the API container runs UTC). The V14 migration:
+
+1. Adds `start_local TIME, end_local TIME, tz TEXT NOT NULL` to `schedules`.
+2. Backfills `start_local`/`end_local` from the existing strings; sets
+   `tz = 'UTC'` (preserves prior behavior bit-for-bit).
+3. Drops `block_from`, `block_until`.
+4. Creates `household_settings` (single row, `id = 1`) with default
+   `daily_reset_time = '00:00'` and `daily_reset_tz = 'UTC'`.
+
+On first boot, `Main.scala` calls `HouseholdSettingsRepo.ensureDefault(...)`,
+which inserts the row using `ZoneId.systemDefault()` from the JVM (so a fresh
+install picks up the API server's host tz). On subsequent boots this is a
+no-op (`ON CONFLICT DO NOTHING`).
+
+After upgrading, the operator can change `tz` per schedule (and the household
+reset tz) via the UI. There is no automatic conversion — UTC is preserved
+until someone touches the row.
+
+## API server host clock
+
+The API server should run with an NTP-synced UTC system clock. Per-row
+timezone math means the server's local timezone setting does not affect
+decisions; only `Instant.now()` (a UTC-based monotonic point) matters. The
+host tz only affects the install-time default for `household_settings.tz`.
+
+## What we did *not* do
+
+- **No agent-side time decisions.** The router agent does not evaluate
+  schedules or daily limits — `PolicyService` collapses everything into the
+  per-MAC `BlockRules` in the snapshot, plus the `expiresAt` Instant on
+  per-host decisions. See [#350](https://github.com/sameerparekh/familydns/issues/350)
+  (Truth 2) and [#415](https://github.com/sameerparekh/familydns/issues/415)
+  (agent skew code removal).
+- **No per-user viewer-local time display.** The UI shows a schedule's time
+  in the schedule's stored tz so all viewers see the same string ("9 PM
+  America/Los_Angeles"). Showing each viewer their own local-time
+  re-projection would create confusion when two parents in different zones
+  edit the same schedule.

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -3,12 +3,39 @@ package familydns.shared
 import familydns.shared.types.*
 import zio.json.*
 
+import java.time.{LocalTime, ZoneId}
 import java.util.UUID
 
 given JsonCodec[UUID] =
   JsonCodec[String].transformOrFail(
     s => scala.util.Try(UUID.fromString(s)).toEither.left.map(_.getMessage),
     _.toString,
+  )
+
+// #334: schedules + daily-reset carry an IANA timezone. We serialize
+// LocalTime as "HH:mm" (24-hour, zero-padded) and ZoneId as the IANA name
+// (e.g. "America/Los_Angeles"). ZoneId.of validates the name; an unknown
+// zone fails at the wire boundary with a clear error.
+given JsonCodec[LocalTime] =
+  JsonCodec[String].transformOrFail(
+    s =>
+      scala.util
+        .Try(LocalTime.parse(s))
+        .toEither
+        .left
+        .map(e => s"invalid time '$s': ${e.getMessage}"),
+    t => "%02d:%02d".format(t.getHour, t.getMinute),
+  )
+
+given JsonCodec[ZoneId] =
+  JsonCodec[String].transformOrFail(
+    s =>
+      scala.util
+        .Try(ZoneId.of(s))
+        .toEither
+        .left
+        .map(e => s"invalid timezone '$s': ${e.getMessage}"),
+    _.getId,
   )
 
 enum UserRole {
@@ -83,8 +110,9 @@ case class Schedule(
     profileId: ProfileId,
     name: String,
     days: List[String],
-    blockFrom: String,
-    blockUntil: String,
+    startLocal: LocalTime,
+    endLocal: LocalTime,
+    tz: ZoneId,
 ) derives JsonCodec
 
 case class TimeLimit(
@@ -184,8 +212,19 @@ case class UpsertProfileRequest(
 case class ScheduleRequest(
     name: String,
     days: List[String],
-    blockFrom: String,
-    blockUntil: String,
+    startLocal: LocalTime,
+    endLocal: LocalTime,
+    tz: ZoneId,
+) derives JsonCodec
+
+case class HouseholdSettings(
+    dailyResetTime: LocalTime,
+    dailyResetTz: ZoneId,
+) derives JsonCodec
+
+case class UpdateHouseholdSettingsRequest(
+    dailyResetTime: LocalTime,
+    dailyResetTz: ZoneId,
 ) derives JsonCodec
 
 case class SiteTimeLimitRequest(

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,8 +1,9 @@
 import type {
   CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardNow, DashboardStats, Device,
-  DeviceTimeStatus, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, QueryLog,
-  RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension, UpsertDeviceRequest,
-  UpsertProfileRequest, GrantExtensionRequest, User,
+  DeviceTimeStatus, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus,
+  QueryLog, RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension,
+  UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
+  User,
 } from '@/types/api'
 
 const BASE = '/api'
@@ -78,6 +79,13 @@ export const api = {
     getUsers: (id: number) => req<User[]>('GET', `/profiles/${id}/users`),
     setUsers: (id: number, userIds: number[]) =>
       req<void>('PUT', `/profiles/${id}/users`, { userIds }),
+  },
+
+  // ── Household settings (#334) ──────────────────────────────────────────
+  household: {
+    get: () => req<HouseholdSettings>('GET', '/household/settings'),
+    update: (data: UpdateHouseholdSettingsRequest) =>
+      req<void>('PUT', '/household/settings', data),
   },
 
   // ── Devices ────────────────────────────────────────────────────────────

--- a/web/src/components/TimezonePicker.tsx
+++ b/web/src/components/TimezonePicker.tsx
@@ -1,0 +1,101 @@
+import { useMemo, useState } from 'react'
+
+// Curated US-centric short list. The "more…" expander reveals every IANA zone
+// the runtime knows about (Intl.supportedValuesOf), filtered by a search box.
+// (#334 design choice: short list covers the home-network common case while
+// still letting an operator pick any zone.)
+const COMMON_ZONES = [
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'America/Anchorage',
+  'Pacific/Honolulu',
+  'UTC',
+] as const
+
+interface Props {
+  value: string
+  onChange: (tz: string) => void
+  testId?: string
+}
+
+function allZones(): string[] {
+  // Intl.supportedValuesOf is in all modern browsers. Fall back to common list
+  // if unavailable (very old browser); the operator can still pick from common.
+  type IntlWithSupported = typeof Intl & { supportedValuesOf?: (key: string) => string[] }
+  const I = Intl as IntlWithSupported
+  if (typeof I.supportedValuesOf === 'function') {
+    return I.supportedValuesOf('timeZone')
+  }
+  return [...COMMON_ZONES]
+}
+
+export function TimezonePicker({ value, onChange, testId }: Props) {
+  const [expanded, setExpanded] = useState(false)
+  const [filter, setFilter] = useState('')
+
+  const all = useMemo(allZones, [])
+  const filtered = useMemo(() => {
+    const f = filter.trim().toLowerCase()
+    if (!f) return all
+    return all.filter(z => z.toLowerCase().includes(f))
+  }, [all, filter])
+
+  // If the current value isn't in the short list, force the expander open so
+  // the user can see what they have selected.
+  const valueInShortList = (COMMON_ZONES as readonly string[]).includes(value)
+  const showExpanded = expanded || !valueInShortList
+
+  return (
+    <div className="space-y-1" data-testid={testId}>
+      {!showExpanded ? (
+        <select
+          value={value}
+          onChange={e => {
+            if (e.target.value === '__more__') setExpanded(true)
+            else onChange(e.target.value)
+          }}
+          data-testid={testId ? `${testId}-select` : undefined}
+          className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-full"
+        >
+          {COMMON_ZONES.map(z => (
+            <option key={z} value={z}>{z}</option>
+          ))}
+          <option value="__more__">More…</option>
+        </select>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            placeholder="Filter (e.g. London, Tokyo)"
+            data-testid={testId ? `${testId}-filter` : undefined}
+            className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-full"
+          />
+          <select
+            value={value}
+            onChange={e => onChange(e.target.value)}
+            size={6}
+            data-testid={testId ? `${testId}-select` : undefined}
+            className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-full"
+          >
+            {filtered.map(z => (
+              <option key={z} value={z}>{z}</option>
+            ))}
+          </select>
+        </>
+      )}
+    </div>
+  )
+}
+
+/** Best-effort: the browser's current IANA tz (e.g. "America/Los_Angeles"). */
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  } catch {
+    return 'UTC'
+  }
+}

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -21,6 +21,10 @@ vi.mock('@/api/client', () => ({
     users: {
       list: vi.fn(),
     },
+    household: {
+      get: vi.fn(),
+      update: vi.fn(),
+    },
   },
 }))
 
@@ -44,7 +48,7 @@ const kidsProfile: ProfileDetail = {
     failureMode: 'block-all',
   },
   schedules: [
-    { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], blockFrom: '21:00', blockUntil: '07:00' },
+    { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
   ],
   timeLimit: { id: 5, profileId: 1, dailyMinutes: 120 },
   siteTimeLimits: [
@@ -95,6 +99,11 @@ beforeEach(() => {
   ;(api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.devices.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([phoneDevice, tabletDevice])
   ;(api.users.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aliceUser, bobUser, carolUser])
+  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+    dailyResetTime: '00:00',
+    dailyResetTz: 'America/Los_Angeles',
+  })
+  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 })
 
 describe('ProfilesPage — list', () => {
@@ -219,7 +228,7 @@ describe('ProfilesPage — create', () => {
       paused: false,
       timeLimit: 90,
       schedules: [
-        { name: 'Bedtime', days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat'], blockFrom: '21:00', blockUntil: '07:00' },
+        { name: 'Bedtime', days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat'], startLocal: '21:00', endLocal: '07:00', tz: 'America/Los_Angeles' },
       ],
       siteTimeLimits: [
         { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30, exemptFromDaily: true },
@@ -261,7 +270,7 @@ describe('ProfilesPage — edit', () => {
       paused: false,
       timeLimit: 120,
       schedules: [
-        { name: 'Bedtime', days: ['mon', 'tue'], blockFrom: '21:00', blockUntil: '07:00' },
+        { name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
       ],
       siteTimeLimits: [
         { domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -2,9 +2,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type {
-  Device, FailureMode, ProfileDetail, ScheduleRequest, SiteTimeLimitRequest,
-  UpsertProfileRequest, User,
+  Device, FailureMode, HouseholdSettings, ProfileDetail, ScheduleRequest,
+  SiteTimeLimitRequest, UpsertProfileRequest, User,
 } from '@/types/api'
+import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { PageLoader } from './DashboardPage'
 
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
@@ -48,7 +49,7 @@ function detailToForm(pd: ProfileDetail): FormState {
     paused: pd.profile.paused,
     timeLimit: pd.timeLimit ? String(pd.timeLimit.dailyMinutes) : '',
     schedules: pd.schedules.map(s => ({
-      name: s.name, days: s.days, blockFrom: s.blockFrom, blockUntil: s.blockUntil,
+      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
     })),
     siteTimeLimits: pd.siteTimeLimits.map(s => ({
       domainPattern: s.domainPattern,
@@ -89,6 +90,9 @@ export function ProfilesPage() {
   const [error, setError] = useState<string | null>(null)
   const [editingUsersFor, setEditingUsersFor] = useState<number | null>(null)
   const [userPick, setUserPick] = useState<number[]>([])
+  const [household, setHousehold] = useState<HouseholdSettings | null>(null)
+  const [hsForm, setHsForm] = useState<HouseholdSettings | null>(null)
+  const [hsSaving, setHsSaving] = useState(false)
 
   const devicesByProfile = useMemo(() => {
     const m = new Map<number, Device[]>()
@@ -114,16 +118,33 @@ export function ProfilesPage() {
   }, [allUsers])
 
   async function reload() {
-    const [p, cats, devs, users] = await Promise.all([
+    const [p, cats, devs, users, hs] = await Promise.all([
       api.profiles.list(),
       api.blocklists.counts().catch(() => []),
       api.devices.list().catch(() => [] as Device[]),
       isAdmin ? api.users.list().catch(() => [] as User[]) : Promise.resolve([] as User[]),
+      api.household.get().catch(() => null),
     ])
     setProfiles(p)
     setCategories(cats.map(c => c.category))
     setDevices(devs)
     setAllUsers(users)
+    setHousehold(hs)
+    if (hs) setHsForm(hs)
+  }
+
+  async function saveHousehold() {
+    if (!hsForm) return
+    setHsSaving(true)
+    try {
+      await api.household.update({
+        dailyResetTime: hsForm.dailyResetTime,
+        dailyResetTz: hsForm.dailyResetTz,
+      })
+      setHousehold(hsForm)
+    } finally {
+      setHsSaving(false)
+    }
   }
 
   useEffect(() => {
@@ -218,6 +239,44 @@ export function ProfilesPage() {
         )}
       </div>
 
+      {isAdmin && hsForm && (
+        <div data-testid="household-settings-card"
+          className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="font-bold text-white">Household settings</h2>
+            <button
+              onClick={saveHousehold}
+              disabled={hsSaving || (household != null && household.dailyResetTime === hsForm.dailyResetTime && household.dailyResetTz === hsForm.dailyResetTz)}
+              data-testid="household-save"
+              className="text-xs bg-emerald-500/20 text-emerald-300 px-3 py-1.5 rounded-lg border border-emerald-500/30 hover:bg-emerald-500/30 disabled:opacity-40">
+              {hsSaving ? 'Saving…' : 'Save settings'}
+            </button>
+          </div>
+          <p className="text-xs text-gray-400">
+            The wall-clock time at which daily usage limits reset. Both the reset time and timezone
+            are stored together — the reset always fires at the configured local clock time, even
+            across DST.
+          </p>
+          <div className="flex flex-wrap gap-3 items-end">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Reset time</label>
+              <input type="time" value={hsForm.dailyResetTime}
+                onChange={e => setHsForm({ ...hsForm, dailyResetTime: e.target.value })}
+                data-testid="household-reset-time"
+                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
+            </div>
+            <div className="flex-1 min-w-[14rem]">
+              <label className="block text-xs text-gray-500 mb-1">Timezone</label>
+              <TimezonePicker
+                value={hsForm.dailyResetTz}
+                onChange={tz => setHsForm({ ...hsForm, dailyResetTz: tz })}
+                testId="household-reset-tz"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       <div className="grid gap-4 md:grid-cols-2">
         {profiles.map(pd => (
           <div key={pd.profile.id} data-testid={`profile-card-${pd.profile.id}`} className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-4">
@@ -294,7 +353,9 @@ export function ProfilesPage() {
                 {pd.schedules.map(s => (
                   <div key={s.id} className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
                     <span className="text-gray-300">{s.name}</span>
-                    <span className="text-yellow-400 font-mono text-xs">{s.blockFrom} → {s.blockUntil}</span>
+                    <span className="text-yellow-400 font-mono text-xs">
+                      {s.startLocal} → {s.endLocal} <span className="text-yellow-300/60">({s.tz})</span>
+                    </span>
                   </div>
                 ))}
               </div>
@@ -430,6 +491,7 @@ export function ProfilesPage() {
           error={error}
           onCancel={() => setEditingId(null)}
           onSave={save}
+          defaultTz={household?.dailyResetTz ?? browserTimezone()}
         />
       )}
     </div>
@@ -437,7 +499,7 @@ export function ProfilesPage() {
 }
 
 function ProfileEditor({
-  isNew, form, setForm, categories, saving, error, onCancel, onSave,
+  isNew, form, setForm, categories, saving, error, onCancel, onSave, defaultTz,
 }: {
   isNew: boolean
   form: FormState
@@ -447,6 +509,7 @@ function ProfileEditor({
   error: string | null
   onCancel: () => void
   onSave: () => void
+  defaultTz: string
 }) {
   function toggleCat(c: string) {
     setForm(f => ({
@@ -458,9 +521,14 @@ function ProfileEditor({
   }
 
   function addSchedule() {
+    // Default tz comes from the parent (household's daily-reset tz, or
+    // browser tz fallback). Most homes want all schedules in the same zone.
     setForm(f => ({
       ...f,
-      schedules: [...f.schedules, { name: 'Bedtime', days: [...DAYS], blockFrom: '21:00', blockUntil: '07:00' }],
+      schedules: [
+        ...f.schedules,
+        { name: 'Bedtime', days: [...DAYS], startLocal: '21:00', endLocal: '07:00', tz: defaultTz },
+      ],
     }))
   }
 
@@ -670,14 +738,24 @@ function ProfileEditor({
                     className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 rounded-lg">Remove</button>
                 </div>
                 <div className="flex gap-2 items-center text-sm">
-                  <input type="time" value={s.blockFrom}
-                    onChange={e => updateSchedule(i, { blockFrom: e.target.value })}
+                  <input type="time" value={s.startLocal}
+                    onChange={e => updateSchedule(i, { startLocal: e.target.value })}
+                    data-testid={`schedule-${i}-start`}
                     className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white" />
                   <span className="text-gray-500">→</span>
-                  <input type="time" value={s.blockUntil}
-                    onChange={e => updateSchedule(i, { blockUntil: e.target.value })}
+                  <input type="time" value={s.endLocal}
+                    onChange={e => updateSchedule(i, { endLocal: e.target.value })}
+                    data-testid={`schedule-${i}-end`}
                     className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white" />
                 </div>
+                <div className="text-xs text-gray-400">
+                  Timezone (the same wall-clock window applies every day, even across DST)
+                </div>
+                <TimezonePicker
+                  value={s.tz}
+                  onChange={tz => updateSchedule(i, { tz })}
+                  testId={`schedule-${i}-tz`}
+                />
                 <div className="flex flex-wrap gap-1">
                   {DAYS.map(d => {
                     const on = s.days.includes(d)

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -19,8 +19,19 @@ export interface Schedule {
   profileId: number
   name: string
   days: string[]
-  blockFrom: string
-  blockUntil: string
+  startLocal: string  // "HH:mm" wall-clock time in `tz`
+  endLocal: string    // "HH:mm" wall-clock time in `tz`
+  tz: string          // IANA timezone, e.g. "America/Los_Angeles"
+}
+
+export interface HouseholdSettings {
+  dailyResetTime: string  // "HH:mm" wall-clock time in `dailyResetTz`
+  dailyResetTz: string    // IANA timezone
+}
+
+export interface UpdateHouseholdSettingsRequest {
+  dailyResetTime: string
+  dailyResetTz: string
 }
 
 export interface TimeLimit {
@@ -247,8 +258,9 @@ export interface SetUserProfilesRequest {
 export interface ScheduleRequest {
   name: string
   days: string[]
-  blockFrom: string
-  blockUntil: string
+  startLocal: string
+  endLocal: string
+  tz: string
 }
 
 export interface SiteTimeLimitRequest {


### PR DESCRIPTION
## Summary

Schedules and the daily-usage reset now carry their own IANA timezone with the data. `PolicyService` projects `Instant.now()` into each row's tz before comparing wall-clock components — DST is handled transparently by `ZonedDateTime`, so \"9 PM bedtime\" stays 9 PM across spring-forward and fall-back. Per-row tz also lets a household have schedules in multiple zones without a server-wide setting.

- **Schema (V16):** adds `start_local TIME, end_local TIME, tz TEXT` to `schedules`, backfills from the prior `block_from`/`block_until` strings with `tz='UTC'` (preserves bit-for-bit behavior), drops the legacy columns. Creates single-row `household_settings` (`daily_reset_time`, `daily_reset_tz`). On first boot, `Main.ensureDefault` inserts the row using `ZoneId.systemDefault()` so a fresh install picks up the host tz.
- **PolicyService:** new pure helpers `scheduleActiveAt`, `scheduleEndInstantAfter`, `nextDailyResetAfter`. \"Today\" for usage-bucket lookup is now the local date in the reset zone, not server-UTC.
- **API:** `GET /api/household/settings` (any auth) and `PUT /api/household/settings` (admin). Wire validation rejects unknown IANA zone names with 400.
- **UI:** new `TimezonePicker` component (US-curated short list + \"More…\" expander revealing all `Intl.supportedValuesOf('timeZone')` zones with a filter input). Schedule edit form gets a tz picker that defaults to the household reset tz (or browser tz fallback). New \"Household settings\" admin card on `ProfilesPage`.
- **Docs:** [`docs/time-handling.md`](docs/time-handling.md) explains the rule, DST mechanics, backfill policy. Install guide gets a new §7a on host clock + tz.

See [`docs/time-handling.md`](docs/time-handling.md) for the design rationale.

## Test plan

- [x] `mill api.test` — 190/190 passing, including new `SchedulingSpec` (DST spring-forward + fall-back, cross-midnight windows, day-of-week scoping, per-row tz isolation, daily-reset boundary semantics).
- [x] `npx vitest run` (web) — 94/94 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] Deployed `familydns-api:fix-334` to 192.168.10.43; V16 migration applied cleanly, `household_settings` ensured (`tz=Etc/UTC` since the API container runs UTC).
- [x] **End-to-end:** set Kids schedule to `09:00-13:00 America/Los_Angeles` at 10:01 LA wall-clock; `PolicyService.snapshot` returned `blocked=True, reason=Schedule` for the Kids profile, the router agent picked up the new etag on the next 60s poll, and `nft list set inet familydns blocked_macs` populated with all three Kids macs (`be:89:10:82:c7:4c, f6:1c:86:e1:c2:b4, fa:10:cd:84:78:22`). Reverted to `21:00-07:00 UTC` after validation.

## Notes

- **#406 item 5** (wrong-tz schedule firing): the new model makes this bug-class impossible — every schedule is evaluated in its own stored tz. Not separately reproduced here; if the symptom recurs in the wild it will be a different bug.
- **[#415](https://github.com/sameerparekh/familydns/issues/415)** (agent clock-skew removal) is the companion change that already landed on main.
- **[#350](https://github.com/sameerparekh/familydns/issues/350)** (Truth 2): time decisions remain server-side only — agent is unchanged.
- **[#368](https://github.com/sameerparekh/familydns/issues/368)** §5 flagged time handling as load-bearing; this is the audit.
- **Deployment housekeeping:** `~/.familydns/update.sh` on 192.168.10.43 is patched to include the override compose so the host stays on `familydns-api:fix-334` until ghcr.io publishes a `:latest` containing V16. After this PR merges and CI builds a new `:latest`, revert that file to its upstream content (or just `git checkout deploy/update.sh.template ~/.familydns/update.sh` from `/tmp/familydns-fix-334`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)