### PR TITLE
ci: KVM self-hosted runner setup (#149)

### DIFF
--- a/.github/workflows/e2e-kvm-sanity.yml
+++ b/.github/workflows/e2e-kvm-sanity.yml
@@ -1,0 +1,38 @@
+name: VM e2e KVM sanity
+
+# Smoke-tests the self-hosted KVM runner registered for #149. Runs the
+# orchestrator in skip-VMs mode (E2E_VM_SKIP_VMS=1) so it exercises the
+# docker compose + pytest wiring without booting the router/client VMs.
+# The full enforcement-suite workflow is #433's deliverable, not this one.
+#
+# Manual-only: trigger from Actions → "VM e2e KVM sanity" → Run workflow.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sanity:
+    name: KVM runner sanity check
+    runs-on: [self-hosted, linux, kvm]
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify /dev/kvm
+        run: |
+          test -e /dev/kvm || { echo "/dev/kvm missing"; exit 1; }
+          test -r /dev/kvm && test -w /dev/kvm \
+            || { echo "/dev/kvm not r/w for runner user"; ls -l /dev/kvm; exit 1; }
+          echo "ok /dev/kvm"
+
+      - name: Verify qemu
+        run: qemu-system-x86_64 --version
+
+      - name: Verify docker
+        run: docker --version
+
+      - name: Orchestrator wiring (skip VMs)
+        env:
+          E2E_VM_SKIP_VMS: "1"
+        run: scripts/e2e-vm.sh

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -1,0 +1,143 @@
+# KVM self-hosted GitHub Actions runner
+
+The VM e2e harness (`scripts/e2e-vm.sh`, see `scripts/e2e/README.md`) requires
+`/dev/kvm`. GitHub-hosted runners do not expose KVM, so the VM e2e workflow
+(#433, gated on this issue) must run on a **self-hosted runner** that we
+provision ourselves.
+
+> **Operator action required.** Provisioning the KVM host, installing the
+> runner, and registering it with GitHub are manual steps. The repo ships the
+> sanity workflow (`.github/workflows/e2e-kvm-sanity.yml`) and this runbook;
+> until the runner is online and labeled `kvm`, the workflow has nowhere to
+> dispatch.
+
+## Host requirements
+
+- Linux with `/dev/kvm` accessible (KVM acceleration). Bare metal or a host
+  with nested-virt enabled. Tested target: Ubuntu 24.04.
+- ≥ 6 GB free RAM (`scripts/e2e/README.md` baseline) plus headroom for the
+  Go/Node/Java toolchains pulled in by adjacent jobs.
+- ≥ 20 GB free disk for qcow2 overlays, the OpenWRT image cache, the venv,
+  and docker image cache.
+- Required packages:
+  - `qemu-system-x86` (provides `qemu-system-x86_64`)
+  - `qemu-utils` (provides `qemu-img`)
+  - One of `xorriso` (preferred) / `genisoimage` / `mkisofs`
+  - `socat`, `openssl`, `curl`, `iproute2`
+  - `docker.io` (or upstream Docker CE)
+  - `python3` ≥ 3.11 with `python3-venv`
+  - `binutils` (for `ar`, used by `openwrt/build-ipk.sh`)
+
+Use `docs/vm-e2e-ubuntu.md` as the per-host bootstrap checklist: it covers
+`/dev/kvm` group membership, the `fdns-lan0` bridge, `qemu-bridge-helper`
+capabilities, and the narrow `NOPASSWD` rule for `ip`.
+
+### Suggested hosts
+
+- A dedicated Linux workstation already on the team's network.
+- Bare-metal cloud (e.g. Hetzner AX-series). Hetzner cloud VPS does **not**
+  expose nested-virt; only the dedicated/bare-metal lines do.
+- GitHub-hosted "larger runners" advertise nested virtualization on some
+  SKUs. We have **not** verified this end-to-end with the harness; treat as
+  experimental.
+
+## One-time host bootstrap
+
+After packages and KVM access are in place (see `docs/vm-e2e-ubuntu.md`),
+pre-build the VM caches once so the first sanity run isn't a 10-minute cold
+start:
+
+```bash
+# As the runner user, from a checkout of this repo:
+scripts/vm/build-client-base.sh      # → scripts/vm/.cache/client-base.qcow2
+scripts/vm/build-router-image.sh     # → scripts/vm/.cache/openwrt-familydns.img
+```
+
+Cache locations (kept across runs, safe to delete to force a rebuild):
+
+| path                                    | what                                   |
+|-----------------------------------------|----------------------------------------|
+| `scripts/vm/.cache/client-base.qcow2`   | Alpine client base image               |
+| `scripts/vm/.cache/openwrt-familydns.img` | Custom OpenWRT image w/ agent baked in |
+| `scripts/vm/.cache/imagebuilder/`       | OpenWRT Image Builder working tree     |
+| `.e2e-vm-venv/`                         | pytest venv (created lazily)           |
+
+## Registering the runner with GitHub
+
+1. Pick the runner user (non-root). It must be in the `kvm` and `docker`
+   groups. Create a working directory it owns, e.g. `/opt/actions-runner`.
+
+2. Get a one-time registration token:
+   ```bash
+   gh api -X POST repos/sameerparekh/familydns/actions/runners/registration-token
+   ```
+   The response contains `token` (valid ~1 hour) and `expires_at`.
+
+3. Download and unpack the runner inside `/opt/actions-runner`. Use the
+   latest release listed on the repo's
+   `Settings → Actions → Runners → New self-hosted runner` page, or
+   `https://github.com/actions/runner/releases`.
+
+4. Configure with the labels the workflow expects:
+   ```bash
+   ./config.sh \
+     --url https://github.com/sameerparekh/familydns \
+     --token <REGISTRATION_TOKEN> \
+     --name familydns-kvm-1 \
+     --labels self-hosted,linux,kvm \
+     --work _work \
+     --unattended
+   ```
+
+5. Either run interactively to smoke-test:
+   ```bash
+   ./run.sh
+   ```
+   …or install as a systemd service. A template lives at
+   [`scripts/ci/kvm-runner.service`](../../scripts/ci/kvm-runner.service);
+   copy it to `/etc/systemd/system/`, fill in the placeholders, then:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now kvm-runner.service
+   journalctl -u kvm-runner -f
+   ```
+
+6. Verify the runner appears under
+   `Settings → Actions → Runners` with the `kvm` label and status `Idle`.
+
+7. Smoke-test via the sanity workflow:
+   ```bash
+   gh workflow run e2e-kvm-sanity.yml
+   gh run watch
+   ```
+
+## Maintenance
+
+- **Runner self-updates** are on by default. To pin a version, pass
+  `--disableupdate` to `config.sh` and update manually with `./svc.sh stop`,
+  re-download, `./svc.sh start`.
+- **OS patching**: standard `unattended-upgrades` is fine. Reboots interrupt
+  in-flight jobs — schedule outside business hours, or drain the runner
+  first (`./svc.sh stop`).
+- **Token rotation**: registration tokens expire ~1 hour after issuance and
+  are only needed at `config.sh` time. The runner uses its own long-lived
+  credential thereafter (`.credentials`). To rotate, `./config.sh remove
+  --token <REMOVAL_TOKEN>` (fetch via
+  `gh api -X POST repos/.../actions/runners/remove-token`) then re-register.
+- **Cache hygiene**: prune docker images/volumes weekly. The qcow2 caches
+  are stable; only delete when bumping pinned versions in
+  `scripts/vm/config.sh` or `scripts/vm/versions.sh`.
+- **Disk monitoring**: VM overlays accumulate under `scripts/vm/.run/`. The
+  harness cleans these on success; on aborted runs they linger. A nightly
+  `find scripts/vm/.run -mtime +1 -delete` (on the runner work tree) is a
+  reasonable guardrail.
+
+## See also
+
+- [`scripts/vm/README.md`](../../scripts/vm/README.md) — VM harness internals.
+- [`scripts/e2e/README.md`](../../scripts/e2e/README.md) — orchestrator
+  architecture and the `E2E_VM_SKIP_VMS=1` sanity mode.
+- [`docs/vm-e2e-ubuntu.md`](../vm-e2e-ubuntu.md) — host setup checklist for
+  Ubuntu 24.04 (apt packages, bridge, `qemu-bridge-helper` caps, etc.).
+- Issue #149 — this runner. Issue #433 — the full enforcement-suite workflow
+  that this unblocks.

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -64,22 +64,33 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
 
 ## Registering the runner with GitHub
 
+The runner installs under `~/actions-runner` in the runner user's home directory
+— no sudo needed for the install itself.
+
 1. Pick the runner user (non-root). It must be in the `kvm` and `docker`
-   groups. Create a working directory it owns, e.g. `/opt/actions-runner`.
+   groups and have the NOPASSWD `ip` rule from `docs/vm-e2e-ubuntu.md`.
+   The natural choice is whichever user you already bootstrapped the VM
+   harness with.
 
-2. Get a one-time registration token:
+2. Get a one-time registration token (from any machine with `gh` auth — the
+   token's only valid ~1 hour, so do this right before step 4):
    ```bash
-   gh api -X POST repos/sameerparekh/familydns/actions/runners/registration-token
+   gh api -X POST repos/sameerparekh/familydns/actions/runners/registration-token --jq .token
    ```
-   The response contains `token` (valid ~1 hour) and `expires_at`.
 
-3. Download and unpack the runner inside `/opt/actions-runner`. Use the
-   latest release listed on the repo's
-   `Settings → Actions → Runners → New self-hosted runner` page, or
-   `https://github.com/actions/runner/releases`.
-
-4. Configure with the labels the workflow expects:
+3. As the runner user, download and unpack the latest runner release. Check
+   <https://github.com/actions/runner/releases> for the current version.
    ```bash
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   RUNNER_VER=2.321.0    # ← update to current
+   curl -fsSL -o runner.tar.gz \
+     "https://github.com/actions/runner/releases/download/v${RUNNER_VER}/actions-runner-linux-x64-${RUNNER_VER}.tar.gz"
+   tar xzf runner.tar.gz && rm runner.tar.gz
+   ```
+
+4. Configure with the labels the workflow expects (paste the token from #2):
+   ```bash
+   cd ~/actions-runner
    ./config.sh \
      --url https://github.com/sameerparekh/familydns \
      --token <REGISTRATION_TOKEN> \
@@ -89,14 +100,26 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
      --unattended
    ```
 
-5. Either run interactively to smoke-test:
+5. Smoke-test interactively before installing as a service:
    ```bash
    ./run.sh
    ```
-   …or install as a systemd service. A template lives at
-   [`scripts/ci/kvm-runner.service`](../../scripts/ci/kvm-runner.service);
-   copy it to `/etc/systemd/system/`, fill in the placeholders, then:
+   In another shell, dispatch the sanity workflow and watch it land:
    ```bash
+   gh workflow run e2e-kvm-sanity.yml -R sameerparekh/familydns
+   gh run watch -R sameerparekh/familydns
+   ```
+   Ctrl-C `./run.sh` once the workflow finishes.
+
+6. Install as a systemd service so the runner survives reboots. A template
+   lives at [`scripts/ci/kvm-runner.service`](../../scripts/ci/kvm-runner.service).
+   This is the only step that needs sudo:
+   ```bash
+   sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
+   sudo sed -i \
+     -e "s|<RUNNER_USER>|$USER|g" \
+     -e "s|<RUNNER_HOME>|$HOME/actions-runner|g" \
+     /etc/systemd/system/kvm-runner.service
    sudo systemctl daemon-reload
    sudo systemctl enable --now kvm-runner.service
    journalctl -u kvm-runner -f
@@ -105,11 +128,31 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
 6. Verify the runner appears under
    `Settings → Actions → Runners` with the `kvm` label and status `Idle`.
 
-7. Smoke-test via the sanity workflow:
-   ```bash
-   gh workflow run e2e-kvm-sanity.yml
-   gh run watch
-   ```
+## Runtime privileges
+
+At runtime, the runner needs **no sudo**. Setup-time sudo is limited to
+installing the systemd unit (step 6 above) — everything during job
+execution is unprivileged:
+
+| capability needed at runtime | how it's granted (one-time) |
+|---|---|
+| `/dev/kvm` read/write | runner user is in the `kvm` group |
+| docker socket | runner user is in the `docker` group |
+| attach taps to `fdns-lan0` | `cap_net_admin` on `qemu-bridge-helper` (`setcap`) + `/etc/qemu/bridge.conf` allowlists the bridge |
+| `ip link add/set …` for the LAN bridge | NOPASSWD sudo rule in `/etc/sudoers.d/familydns-vm`, scoped to `/usr/sbin/ip` only |
+| outbound HTTPS to GitHub | none (standard outbound) |
+
+All of these are part of the one-time host bootstrap in
+[`docs/vm-e2e-ubuntu.md`](../vm-e2e-ubuntu.md). If you've already developed
+the VM e2e harness on this host as a regular user, you're done.
+
+## Trust model
+
+The repo is public, but the workflow that uses this runner triggers only on
+`push: main` and `workflow_dispatch` — never on `pull_request`. A self-hosted
+runner is registered to a specific repo, so a fork pushing to *its* main
+does **not** reach our runner; the only way fork code can run on this box is
+if a maintainer merges it to upstream `main`. Trust gate = code review.
 
 ## Maintenance
 

--- a/scripts/ci/kvm-runner.service
+++ b/scripts/ci/kvm-runner.service
@@ -1,11 +1,17 @@
 ## systemd unit template for the FamilyDNS KVM self-hosted GitHub Actions runner.
 ##
-## Copy to /etc/systemd/system/kvm-runner.service, replace the <PLACEHOLDER>
-## values, then:
+## Install via:
+##   sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
+##   sudo sed -i \
+##     -e "s|<RUNNER_USER>|$USER|g" \
+##     -e "s|<RUNNER_HOME>|$HOME/actions-runner|g" \
+##     /etc/systemd/system/kvm-runner.service
 ##   sudo systemctl daemon-reload
 ##   sudo systemctl enable --now kvm-runner.service
 ##
 ## See docs/ops/kvm-runner.md for full setup, including registration.
+## Defaults assume the runner lives at ~/actions-runner in the runner
+## user's home directory.
 
 [Unit]
 Description=GitHub Actions runner (FamilyDNS, KVM)
@@ -32,11 +38,11 @@ TimeoutStopSec=15min
 Restart=always
 RestartSec=10
 
-# Light hardening — the runner still needs broad fs access for builds and
-# qemu, so don't tighten further without testing.
+# Light hardening — the runner needs broad fs access for builds, qemu, and
+# its own _work tree under $HOME, so don't tighten further without testing.
+# ProtectHome is deliberately NOT set: the runner lives under $HOME.
 NoNewPrivileges=true
 ProtectSystem=full
-ProtectHome=read-only
 PrivateTmp=true
 
 [Install]

--- a/scripts/ci/kvm-runner.service
+++ b/scripts/ci/kvm-runner.service
@@ -1,0 +1,43 @@
+## systemd unit template for the FamilyDNS KVM self-hosted GitHub Actions runner.
+##
+## Copy to /etc/systemd/system/kvm-runner.service, replace the <PLACEHOLDER>
+## values, then:
+##   sudo systemctl daemon-reload
+##   sudo systemctl enable --now kvm-runner.service
+##
+## See docs/ops/kvm-runner.md for full setup, including registration.
+
+[Unit]
+Description=GitHub Actions runner (FamilyDNS, KVM)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+
+# Non-root runner user. Must be in the 'kvm' and 'docker' groups.
+User=<RUNNER_USER>
+Group=<RUNNER_USER>
+
+# Directory created by ./config.sh (where run.sh + _work live).
+WorkingDirectory=<RUNNER_HOME>
+
+ExecStart=<RUNNER_HOME>/run.sh
+
+# The runner manages its own graceful shutdown when it receives SIGTERM —
+# it finishes the current job before exiting. Allow time for an e2e run.
+KillSignal=SIGTERM
+TimeoutStopSec=15min
+
+Restart=always
+RestartSec=10
+
+# Light hardening — the runner still needs broad fs access for builds and
+# qemu, so don't tighten further without testing.
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -119,6 +119,15 @@ wait_for_next_poll(admin, router.router_id, timeout_s=90)
 `router` fixture restores from `e2e-base` before each test. On dev hardware
 this typically gives <10 s reset between scenarios.
 
+## Running in CI
+
+The harness needs `/dev/kvm`, so CI runs on a self-hosted runner labeled
+`kvm`. Provisioning, runner registration, and the systemd template live in
+[`docs/ops/kvm-runner.md`](../../docs/ops/kvm-runner.md). The sanity workflow
+([`.github/workflows/e2e-kvm-sanity.yml`](../../.github/workflows/e2e-kvm-sanity.yml))
+exercises orchestrator wiring without booting VMs and is the smoke test for a
+newly registered runner.
+
 ## Running on a host without KVM
 
 The harness requires `/dev/kvm` (no macOS support — see `scripts/vm/README.md`).

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -20,7 +20,9 @@ of #144 (router VM) and #146 (client VM).
   `allow fdns-lan0`) so `qemu-bridge-helper` will attach taps.
 
 The harness is not expected to work on macOS — no KVM. Use a Linux dev host
-or CI runner.
+or CI runner. For running in CI, see
+[`docs/ops/kvm-runner.md`](../../docs/ops/kvm-runner.md) — self-hosted
+runner provisioning, registration, and the systemd unit template.
 
 ## Shared configuration
 


### PR DESCRIPTION
## Summary

Sets up the self-hosted KVM runner contract that #433's full enforcement-suite workflow needs. Four artifacts, no test or source changes:

- **`docs/ops/kvm-runner.md`** — operator runbook: host requirements, package list, registration via `gh api ... /actions/runners/registration-token`, labels (`self-hosted, linux, kvm`), resource sizing (~6 GB RAM, 20+ GB disk), one-time bootstrap (`build-client-base.sh`, `build-router-image.sh`), cache locations, maintenance (updates, token rotation, disk hygiene).
- **`scripts/ci/kvm-runner.service`** — systemd unit template, runs the runner as a non-root user with `<RUNNER_USER>` / `<RUNNER_HOME>` placeholders.
- **`.github/workflows/e2e-kvm-sanity.yml`** — `workflow_dispatch`-only sanity workflow on `[self-hosted, linux, kvm]`. Verifies `/dev/kvm`, `qemu-system-x86_64 --version`, `docker --version`, then runs `E2E_VM_SKIP_VMS=1 scripts/e2e-vm.sh` to exercise orchestrator wiring without booting VMs.
- Pointer updates to `scripts/vm/README.md` and `scripts/e2e/README.md` linking the runbook for "running in CI."

The full enforcement-suite workflow is **not** included here — that's #433.

## Operator action required

This change ships the runner-side plumbing but cannot stand up the runner itself. Before the sanity workflow can run, an operator must:

1. **Provision a Linux host** with `/dev/kvm` (bare metal or nested-virt-capable VM) per the package list in `docs/ops/kvm-runner.md` and the host setup in `docs/vm-e2e-ubuntu.md`.
2. **Bootstrap caches**: `scripts/vm/build-client-base.sh` and `scripts/vm/build-router-image.sh`.
3. **Register the runner** with GitHub using the registration-token API and labels `self-hosted, linux, kvm` (full commands in the runbook).
4. Optionally install the systemd unit from `scripts/ci/kvm-runner.service`.

Until a runner with the `kvm` label is online, the sanity workflow has nowhere to dispatch — this is called out in the runbook itself.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-kvm-sanity.yml'))"` parses cleanly.
- [x] Runbook shell snippets hand-verified (`gh api -X POST .../registration-token`, `./config.sh` flags, systemd commands).
- [x] Workflow uses `runs-on: [self-hosted, linux, kvm]` and `E2E_VM_SKIP_VMS=1` so it does not require booting VMs.
- [ ] Operator: provision the host, register runner, then dispatch `e2e-kvm-sanity.yml` and confirm green.

Closes #149
Unblocks #433