### PR TITLE
e2e: Suites E+F — reassignment & unknown-device (#432)

### DIFF
--- a/scripts/e2e/scenarios/test_reassignment.py
+++ b/scripts/e2e/scenarios/test_reassignment.py
@@ -1,0 +1,189 @@
+"""Suite E — profile reassignment (#432, verifies #140).
+
+Locks in the contract that profile assignment changes propagate to the
+router's nft state within one poll cycle:
+
+  - Reassigning a device from a permissive profile to a paused profile
+    blocks the MAC and routes its HTTP traffic to the block page.
+  - Reassigning back to a permissive profile unblocks the MAC and HTTP
+    succeeds normally.
+  - Deleting a device removes it from the router's `blocked_macs` set
+    (if it was there) and removes the row from the API's view.
+
+Asserts current behavior — bugs surfaced here get filed separately.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from lib.traffic import http_get
+from lib.vm import router_nft_set
+from lib.wait import wait_for_etag_change, wait_until
+
+pytestmark = pytest.mark.reassignment
+
+BLOCKED_MACS_SET = "blocked_macs"
+
+
+def _norm_mac(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def _mac_in_set(mac: str) -> bool:
+    members = {_norm_mac(m) for m in router_nft_set(BLOCKED_MACS_SET)}
+    return _norm_mac(mac) in members
+
+
+def _wait_mac_in_blocked_set(mac: str, *, present: bool, timeout_s: float = 90) -> None:
+    target = present
+    wait_until(
+        lambda: True if _mac_in_set(mac) is target else None,
+        timeout_s=timeout_s,
+        interval_s=2,
+        description=(
+            f"{mac} {'present in' if present else 'absent from'} {BLOCKED_MACS_SET}"
+        ),
+    )
+
+
+def _wait_block_page(client, *, host: str = "example.com", timeout_s: float = 60):
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        if p.http_code == 200 and (
+            "familydns" in p.body.lower() or "blocked" in p.body.lower()
+        ):
+            return p
+        return None
+    return wait_until(probe, timeout_s=timeout_s, interval_s=3,
+                      description=f"block page response for {host}")
+
+
+def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float = 60):
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        if p.http_code is not None and 200 <= p.http_code < 400:
+            # block-page also returns 200, so disambiguate by body
+            if "familydns" in p.body.lower() or "blocked" in p.body.lower():
+                return None
+            return p
+        return None
+    return wait_until(probe, timeout_s=timeout_s, interval_s=3,
+                      description=f"allowed HTTP response for {host}")
+
+
+def _device_row_for_mac(admin, mac: str) -> dict | None:
+    norm = _norm_mac(mac)
+    for d in admin.list_devices():
+        if _norm_mac(d.get("mac") or "") == norm:
+            return d
+    return None
+
+
+# ── E1 + E2 ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.smoke
+def test_reassign_to_paused_blocks_and_back_restores(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """E1 + E2 (smoke): A→B(paused) blocks within one poll, B→A restores.
+
+    `scratch_device` pre-registers the client's MAC on the permissive
+    profile A (`scratch_profile`). We create a SECOND profile B, pause it,
+    and walk the MAC across.
+    """
+    profile_a_id = scratch_profile["id"]
+    mac = client.mac
+
+    # Sanity: starting state — permissive profile, MAC not blocked.
+    assert not _mac_in_set(mac), "precondition: MAC should not be blocked yet"
+
+    # Create profile B and pause it.
+    other = admin.create_profile(name=f"e2e-e1-paused-{uuid.uuid4().hex[:6]}")
+    profile_b_id = other["profile"]["id"] if "profile" in other else other["id"]
+
+    try:
+        # ── E1: A → B (paused) ─────────────────────────────────────────
+        admin.set_profile_paused(profile_b_id, True)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        admin.upsert_device(
+            mac=mac, name=f"e2e-e1-{mac[-5:]}", profile_id=profile_b_id,
+        )
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        _wait_block_page(client, timeout_s=60)
+
+        # ── E2: B → A restores ─────────────────────────────────────────
+        admin.upsert_device(
+            mac=mac, name=f"e2e-e2-{mac[-5:]}", profile_id=profile_a_id,
+        )
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+        _wait_http_succeeds(client, timeout_s=60)
+    finally:
+        # Reassignment leaves the device on profile A — scratch_device's
+        # teardown will clean it up. Just drop the extra profile.
+        try:
+            admin.delete_profile(profile_b_id)
+        except Exception:
+            pass
+
+
+# ── E3 ─────────────────────────────────────────────────────────────────────
+
+
+def test_delete_device_clears_rules(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """E3: deleting a device removes the row and drops any nft block entry.
+
+    To exercise the "delete clears rules" path, we first put the device
+    onto a paused profile so its MAC is in `blocked_macs`. Then delete
+    the device row and assert (a) the MAC is gone from `blocked_macs`
+    within one poll, and (b) the row no longer appears via list_devices.
+    """
+    mac = client.mac
+
+    paused = admin.create_profile(name=f"e2e-e3-paused-{uuid.uuid4().hex[:6]}")
+    paused_id = paused["profile"]["id"] if "profile" in paused else paused["id"]
+
+    deleted = False
+    try:
+        admin.set_profile_paused(paused_id, True)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        admin.upsert_device(
+            mac=mac, name=f"e2e-e3-{mac[-5:]}", profile_id=paused_id,
+        )
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+
+        # Now delete the device row.
+        admin.delete_device(mac)
+        deleted = True
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        # MAC should leave blocked_macs within one poll.
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+
+        # Row should be absent from list_devices.
+        wait_until(
+            lambda: True if _device_row_for_mac(admin, mac) is None else None,
+            timeout_s=30, interval_s=2,
+            description=f"device row for {mac} removed from list_devices",
+        )
+    finally:
+        if not deleted:
+            try:
+                admin.delete_device(mac)
+            except Exception:
+                pass
+        try:
+            admin.delete_profile(paused_id)
+        except Exception:
+            pass

--- a/scripts/e2e/scenarios/test_unknown_device.py
+++ b/scripts/e2e/scenarios/test_unknown_device.py
@@ -1,0 +1,177 @@
+"""Suite F — unknown-device autocreation (#432, verifies #62, #249).
+
+Locks in the contract that traffic from a never-registered MAC results in
+an auto-created device row on the API side:
+
+  - On `first_seen_mac` (or `dhcp_lease`) with no hostname, the API
+    upserts a device named `device-XXYYZZ` (lowercased last-three octets
+    of the MAC, no separators) with NULL profile_id (#249).
+  - A subsequent `dhcp_lease` that carries a real hostname upgrades the
+    auto-generated name in place (#249's rename-if-auto path).
+  - The "connection before DHCP" race-ordering preserves the rename — the
+    fallback name is replaced by the real hostname once the lease arrives.
+
+Asserts current behavior — bugs surfaced here get filed separately.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from lib.traffic import http_get
+from lib.vm import client_exec
+from lib.wait import wait_until
+
+pytestmark = pytest.mark.unknown_device
+
+AUTO_NAME_RE = re.compile(r"^device-[0-9a-f]{6}$")
+
+
+def _norm_mac(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def _expected_auto_name(mac: str) -> str:
+    hex_only = _norm_mac(mac).replace(":", "").replace("-", "")
+    return f"device-{hex_only[-6:]}"
+
+
+def _device_row_for_mac(admin, mac: str) -> dict | None:
+    norm = _norm_mac(mac)
+    for d in admin.list_devices():
+        if _norm_mac(d.get("mac") or "") == norm:
+            return d
+    return None
+
+
+def _wait_device_row(admin, mac: str, *, timeout_s: float = 90) -> dict:
+    return wait_until(
+        lambda: _device_row_for_mac(admin, mac),
+        timeout_s=timeout_s, interval_s=2,
+        description=f"device row for {mac} appears via list_devices",
+    )
+
+
+def _wait_device_name(admin, mac: str, expected: str, *, timeout_s: float = 90) -> dict:
+    def pred():
+        row = _device_row_for_mac(admin, mac)
+        if row is None:
+            return None
+        return row if row.get("name") == expected else None
+    return wait_until(
+        pred, timeout_s=timeout_s, interval_s=2,
+        description=f"device row for {mac} renamed to {expected!r}",
+    )
+
+
+# ── F1 ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.smoke
+def test_unknown_mac_autocreates_device_row(router, client, admin, debug_api):
+    """F1 (smoke): first traffic from an unregistered MAC autocreates the row.
+
+    Uses `client` (not `scratch_device`), so the client's MAC has never
+    been registered with the API. We drive any HTTP probe — the agent
+    emits `first_seen_mac` (and/or `dhcp_lease`) and the API upserts a
+    row with NULL profile_id named `device-XXYYZZ` (per #62 + #249).
+    """
+    mac = client.mac
+
+    # Sanity: no device row yet.
+    assert _device_row_for_mac(admin, mac) is None, (
+        "precondition: unregistered MAC must not have a device row"
+    )
+
+    # Drive a request; failure to connect (default-deny pre-policy) is OK —
+    # we only care that the agent observes the MAC and ingests the event.
+    http_get(client, "http://example.com/", timeout_s=8)
+
+    row = _wait_device_row(admin, mac, timeout_s=90)
+
+    # Auto-generated name pattern, no profile assigned.
+    assert AUTO_NAME_RE.match(row.get("name") or ""), (
+        f"expected auto-generated name matching {AUTO_NAME_RE.pattern}, "
+        f"got {row.get('name')!r}"
+    )
+    assert row.get("name") == _expected_auto_name(mac), (
+        f"expected {_expected_auto_name(mac)!r} (lowercased MAC suffix), "
+        f"got {row.get('name')!r}"
+    )
+    assert row.get("profileId") is None, (
+        f"expected profileId=None for autocreated row, got {row.get('profileId')!r}"
+    )
+
+
+# ── F2 ─────────────────────────────────────────────────────────────────────
+
+
+def test_dhcp_lease_upgrades_auto_name(router, client, admin, debug_api):
+    """F2: a later `dhcp_lease` carrying a real hostname renames the row.
+
+    Per #249's rename-if-auto path: a device row whose name still matches
+    `device-XXYYZZ` is renamed when a subsequent DHCP lease arrives with a
+    real hostname (option 12). We set the client hostname to a known value
+    and force a DHCP release+renew, then assert the row's `name` flips.
+    """
+    mac = client.mac
+    new_hostname = "kid-laptop"
+
+    # Drive traffic so a row exists (likely with auto-generated name).
+    http_get(client, "http://example.com/", timeout_s=8)
+    row = _wait_device_row(admin, mac, timeout_s=90)
+    # If the row already has a non-auto name, we still want to exercise the
+    # rename path; #249's predicate only triggers when the current name is
+    # auto-generated, so guard the assertion to current behavior.
+    if not AUTO_NAME_RE.match(row.get("name") or ""):
+        pytest.skip(
+            f"row already has non-auto name {row.get('name')!r}; "
+            "F2 exercises the auto→hostname rename path",
+        )
+
+    # Set hostname and force a fresh DHCP lease (Alpine: udhcpc -R then renew).
+    client_exec(client, ["hostname", new_hostname])
+    client_exec(client, ["sh", "-c", "udhcpc -R -i eth0 >/dev/null 2>&1 || true"])
+    client_exec(client, ["sh", "-c", "udhcpc -i eth0 >/dev/null 2>&1 || true"])
+
+    _wait_device_name(admin, mac, new_hostname, timeout_s=120)
+
+
+# ── F3 ─────────────────────────────────────────────────────────────────────
+
+
+def test_connection_before_dhcp_then_lease_upgrades_name(
+    router, client, admin, debug_api,
+):
+    """F3: race — traffic before DHCP gives fallback name; lease upgrades it.
+
+    Written as a single ordered scenario:
+      1. Drive HTTP traffic from the unknown MAC → agent emits
+         `first_seen_mac` (no hostname yet) → API stores `device-XXYYZZ`.
+      2. Set hostname and force DHCP renew → agent emits `dhcp_lease` with
+         hostname → API upgrades the name.
+
+    Makes the ordering explicit; pairs with F2 which tests the same
+    rename path but doesn't pin the sequence.
+    """
+    mac = client.mac
+    new_hostname = "racey-laptop"
+
+    # Step 1: traffic first — should land an auto-generated row.
+    http_get(client, "http://example.com/", timeout_s=8)
+    row = _wait_device_row(admin, mac, timeout_s=90)
+    if not AUTO_NAME_RE.match(row.get("name") or ""):
+        pytest.skip(
+            f"row already has non-auto name {row.get('name')!r}; "
+            "F3 exercises the connection-before-dhcp ordering",
+        )
+    assert row.get("name") == _expected_auto_name(mac)
+    assert row.get("profileId") is None
+
+    # Step 2: DHCP renew with a real hostname — name must upgrade.
+    client_exec(client, ["hostname", new_hostname])
+    client_exec(client, ["sh", "-c", "udhcpc -R -i eth0 >/dev/null 2>&1 || true"])
+    client_exec(client, ["sh", "-c", "udhcpc -i eth0 >/dev/null 2>&1 || true"])
+
+    _wait_device_name(admin, mac, new_hostname, timeout_s=120)


### PR DESCRIPTION
## Summary

**Suite E — profile reassignment** (`test_reassignment.py`, `@pytest.mark.reassignment`, verifies #140)
- **E1 (@smoke)** A → B (paused): reassign device from permissive profile to a paused one; within one poll MAC is in `blocked_macs` and HTTP returns the block page.
- **E2 (@smoke)** B → A restores: reassign back; MAC leaves `blocked_macs` and HTTP succeeds with a non-block-page body.
- **E3** `delete_device` clears rules: MAC drops from `blocked_macs` and the row disappears from `list_devices()` within one poll.

**Suite F — unknown-device autocreation** (`test_unknown_device.py`, `@pytest.mark.unknown_device`, verifies #62, #249)
- **F1 (@smoke)** Traffic from an unregistered MAC autocreates a row named `device-XXYYZZ` (lowercased MAC suffix) with `profileId=None`.
- **F2** Setting a client hostname and forcing a DHCP renew upgrades the auto-generated name to the lease hostname.
- **F3** Ordered race: traffic before DHCP → fallback name; later DHCP renew upgrades the name in place.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` clean for both files.
- [ ] KVM unavailable in this environment — VM-backed runs (`scripts/e2e-vm.sh --only test_reassignment`, `--only test_unknown_device`, plus `-m smoke`) need to be executed on a host with KVM.
- [ ] Verify markers `reassignment` / `unknown_device` / `smoke` are picked up by `pytest --collect-only -m reassignment` and `-m unknown_device`.

## Discipline

Asserts current behavior only. Bugs surfaced by these tests get filed as separate issues — no fixes bundled here. F2/F3 use `pytest.skip` if the row already has a non-auto name on first observation, since #249's rename predicate only fires on auto-generated names; this keeps the scenarios honest about which path they exercise.

Closes #432
Parent: #346
Related: #140, #62, #249