### PR TITLE
docs: python3-venv is required for VM e2e

### DIFF
--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -25,7 +25,7 @@ provision ourselves.
   - One of `xorriso` (preferred) / `genisoimage` / `mkisofs`
   - `socat`, `openssl`, `curl`, `iproute2`
   - `docker.io` (or upstream Docker CE)
-  - `python3` ≥ 3.11 with `python3-venv`
+  - `python3` ≥ 3.11 **and** `python3-venv` (Ubuntu splits `ensurepip` into a separate package; `scripts/e2e-vm.sh` creates `.e2e-vm-venv/` per checkout and fails without it)
   - `binutils` (for `ar`, used by `openwrt/build-ipk.sh`)
 
 Use `docs/vm-e2e-ubuntu.md` as the per-host bootstrap checklist: it covers

--- a/docs/vm-e2e-ubuntu.md
+++ b/docs/vm-e2e-ubuntu.md
@@ -17,7 +17,8 @@ sudo apt-get install -y \
     qemu-system-x86 qemu-utils \
     xorriso socat \
     binutils \
-    docker.io
+    docker.io \
+    python3-venv
 ```
 
 What each is for:
@@ -30,6 +31,7 @@ What each is for:
 | `socat`          | `client-down.sh` ACPI poweroff via QMP; `router-snapshot.sh`|
 | `binutils`       | `openwrt/build-ipk.sh` uses `ar` to assemble the .ipk       |
 | `docker.io`      | `build-router-image.sh` runs OpenWRT Image Builder in a container |
+| `python3-venv`   | `scripts/e2e-vm.sh` creates `.e2e-vm-venv/` via `python3 -m venv`  |
 
 ### `/dev/kvm` access
 


### PR DESCRIPTION
## Summary

Add `python3-venv` to the apt package list in `docs/vm-e2e-ubuntu.md` and to the runner runbook in `docs/ops/kvm-runner.md`.

Discovered on the first CI run of the KVM sanity workflow registered for #149: a clean Ubuntu 24.04 host with `python3` installed but not `python3-venv` fails at `python3 -m venv .e2e-vm-venv` because ensurepip is a separate package on Debian/Ubuntu.

## Test plan

- [x] Identified by the failing sanity run on the new self-hosted runner.
- [ ] After merge: install `python3-venv` on the runner host and re-dispatch `e2e-kvm-sanity.yml` to confirm green.