### PR TITLE
ci: gate publish-api on VM e2e via Master CD

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -4,14 +4,15 @@ name: VM e2e
 # the scenarios under scripts/e2e/scenarios/ against a disposable docker
 # compose API stack. Runs on the self-hosted KVM runner (#149).
 #
-# Triggers: push to main + manual dispatch only. Not pull_request — the repo
-# is public and the runner is self-hosted on a maintainer's host, so we don't
-# execute untrusted fork code on it. See docs/ops/kvm-runner.md → "Trust
-# model" for the full reasoning. Code review on merge is the trust gate.
+# Invoked by master.yml (Master CD) on push:main as a gate before
+# publish-api, and directly via workflow_dispatch for manual runs. Not
+# triggered by pull_request — the repo is public and the runner is
+# self-hosted on a maintainer's host, so we don't execute untrusted fork
+# code on it. See docs/ops/kvm-runner.md → "Trust model" for the full
+# reasoning. Code review on merge is the trust gate.
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,12 +106,18 @@ jobs:
       - name: Run prod-stack smoke
         run: scripts/smoke-prod.sh
 
+  # VM-based e2e on the self-hosted KVM runner (#149, #433). Gates publish
+  # so we never push an image that fails the full router-VM scenarios.
+  vm-e2e:
+    name: VM e2e (self-hosted KVM)
+    uses: ./.github/workflows/e2e-vm.yml
+
   # ── 3. Publish API image (path-filtered) ──────────────────────────────────
   # NOTE: manual approval gate temporarily removed for live debugging of #228;
   # restore via #244 once the bug is fixed and we're back in normal cadence.
   publish-api:
     name: Publish Docker image to ghcr.io
-    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke, vm-e2e]
     if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Follow-up to #451. Wires the VM e2e workflow into Master CD as a gate on `publish-api`, so a failing VM e2e on `main` blocks the API image publish.

- `.github/workflows/e2e-vm.yml`: replace the direct `push: main` trigger with `workflow_call`. `workflow_dispatch` is preserved for manual runs. Removing `push: main` avoids running the suite twice on every merge (once standalone, once via Master CD).
- `.github/workflows/master.yml`: add a `vm-e2e` job that calls `./.github/workflows/e2e-vm.yml`, and add `vm-e2e` to `publish-api.needs`.

## Trigger rationale (unchanged)

`workflow_call` (from Master CD) and `workflow_dispatch` only — explicitly **not** `pull_request`. Public repo + self-hosted runner; code review on merge is the trust gate. See `docs/ops/kvm-runner.md` → "Trust model".

## Test plan

- [x] YAML parses for both files.
- [x] `publish-api.needs` includes `vm-e2e`.
- [ ] First end-to-end exercise will be the post-merge `push: main` event itself — Master CD will invoke the `vm-e2e` job, and `publish-api` will wait on it.