### PR TITLE
fix: e2e-router.sh + fake-router send new HostId wire form on usage (#453)

### DIFF
--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -141,7 +141,7 @@ def _post_usage(router_id: str, router_token: str) -> None:
         {
             "mac":           MACS[i],
             "ip":            IPS[i],
-            "hostname":      HOSTNAMES[i],
+            "host":          {"type": "fqdn", "value": HOSTNAMES[i]},
             "activeSeconds": rng.randint(30, 300),
             "bytesIn":       rng.randint(10_000, 1_000_000),
             "bytesOut":      rng.randint(1_000, 100_000),

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -104,7 +104,7 @@ USAGE_BODY=$(cat <<EOF
   "periodEnd":   "$NOW",
   "records": [
     {
-      "mac": "$MAC", "ip": "192.168.1.20", "hostname": "laptop.local",
+      "mac": "$MAC", "ip": "192.168.1.20", "host": {"type": "fqdn", "value": "laptop.local"},
       "activeSeconds": 90, "bytesIn": 50000, "bytesOut": 5000
     }
   ]


### PR DESCRIPTION
## Root cause

Commit fb602b5 (#391) renamed `UsageRecord.hostname: String` to `UsageRecord.host: HostId` (a tagged union with wire form `{"type": "fqdn"|"ipv4"|"ipv6", "value": "..."}`). Two callers were not migrated and have been posting the legacy bare-string `"hostname"` field, which the API rejects with HTTP 400. This breaks Master CD's `e2e` job on every push to `main` and blocks `publish-api`.

## Files changed

- `scripts/e2e-router.sh` — `USAGE_BODY` heredoc now sends `"host": {"type": "fqdn", "value": "laptop.local"}` instead of `"hostname": "laptop.local"`.
- `docker/fake-router.py` — `_post_usage` records likewise use the tagged-union form.

Out of scope but noticed: `docker/fake-router.py:_post_events` still sends `"hostname": "youtube.com"` on a `connection_attempt` event. Per `Models.scala` docs that should be `host: HostId` too. Leaving as a separate concern since the failing CI signal is purely the usage 400.

## Test plan

- [ ] Did not run docker-compose stack locally — relying on the wire-shape match against `shared/src/types/HostId.scala` and `UsageRecord` in `shared/src/Models.scala:430`. Master CD's `e2e` job is the authoritative verification.
- [ ] Confirm Master CD `e2e` step "Usage ingest → timeUsedToday + last_seen_ip" passes after merge.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)