### PR TITLE
fix: VM e2e checkout fails on root-owned imagebuilder cache

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -26,6 +26,22 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
+      # left root-owned files under scripts/vm/.cache/imagebuilder/ (older
+      # versions of the script only chowned bin/ and build_dir/ — see the
+      # broadened trap in this same change). actions/checkout@v4 cleans the
+      # workspace and fails with EACCES on those files. The runner has no
+      # NOPASSWD sudo (only /usr/sbin/ip per docs/ops/kvm-runner.md), so we
+      # use docker — which runs as root — to chown the cache back to the
+      # runner user before checkout. No-op on clean runners.
+      - name: Reclaim root-owned cache files (pre-checkout)
+        run: |
+          CACHE="${{ github.workspace }}/scripts/vm/.cache"
+          if [ -d "$CACHE" ]; then
+            docker run --rm -v "$CACHE":/c alpine \
+              chown -R "$(id -u):$(id -g)" /c || true
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Preflight (kvm/qemu/docker)

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -165,11 +165,14 @@ docker run --rm \
     -w /ib \
     "$IMAGEBUILDER_DOCKER_IMAGE" \
     bash -euxo pipefail -c '
-        # Cleanup trap: even on build failure, hand bin/ and build_dir/
-        # back to the invoking user so subsequent host-side `rm` and
-        # incremental rebuilds work without sudo. Without this, a single
-        # build leaves root-owned artifacts that block every later run.
-        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib/bin /ib/build_dir 2>/dev/null || true" EXIT
+        # Cleanup trap: even on build failure, hand the entire imagebuilder
+        # tree back to the invoking user. Image Builder writes to bin/,
+        # build_dir/, tmp/, dl/, staging_dir/ — anything left root-owned
+        # blocks subsequent host-side `rm` and (on CI) breaks the next
+        # actions/checkout cleanup with EACCES on stale .ipk / tmp/test.fs
+        # files. chown the whole tree to be future-proof against new IB
+        # output dirs.
+        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib 2>/dev/null || true" EXIT
 
         export DEBIAN_FRONTEND=noninteractive
         apt-get update -qq


### PR DESCRIPTION
## Symptom

VM e2e step `Run actions/checkout@v4` fails:

> Error: File was unable to be removed
> Error: EACCES: permission denied, unlink
> `/home/sameer/actions-runner/_work/familydns/familydns/scripts/vm/.cache/imagebuilder/tmp/test.fs`

(plus many `warning: failed to remove .../dl/*.ipk: Permission denied` preceding it). Blocks the `vm-e2e` job → blocks `publish-api`. Failing run: https://github.com/sameerparekh/familydns/actions/runs/25934370535/job/76235914577

## Root cause

`scripts/vm/build-router-image.sh` runs OpenWRT's Image Builder in a docker container as root. The container's cleanup trap only chowns `/ib/bin` and `/ib/build_dir` back to the host user:

```
trap "chown -R \"$HOST_UID:$HOST_GID\" /ib/bin /ib/build_dir 2>/dev/null || true" EXIT
```

But IB also writes to `/ib/tmp/` (`test.fs`), `/ib/dl/` (`.ipk` downloads), `/ib/staging_dir/`, etc. — all of which stay owned by uid 0 on the host. On the self-hosted KVM runner, the next `actions/checkout@v4` runs `git clean -ffdx`, hits those root-owned files, and bails with EACCES.

## Fix

1. **Broaden the chown trap** in `scripts/vm/build-router-image.sh` to cover the entire `/ib` tree. Future-proof against any new IB output dirs.
2. **Add a defensive pre-checkout step** in `.github/workflows/e2e-vm.yml`. The runner has no NOPASSWD sudo for `rm`/`chown` (only `/usr/sbin/ip` per `docs/ops/kvm-runner.md` § "Trust model"), so we use `docker run` — which runs as root — to chown the cache back to the runner user before checkout. No-op on clean runners; lets the existing stuck runner self-heal on the next dispatch without manual cleanup.

## Test plan

- [x] `bash -n scripts/vm/build-router-image.sh`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-vm.yml'))"`
- [ ] First end-to-end exercise will be the post-merge push to `main` (or a manual `workflow_dispatch` on `e2e-vm.yml` after merge). The defensive chown step is expected to fix the EACCES on the very next run.