### PR TITLE
fix: drop NoNewPrivileges from kvm-runner.service (sudo ip is required)

### DIFF
--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -146,6 +146,12 @@ All of these are part of the one-time host bootstrap in
 [`docs/vm-e2e-ubuntu.md`](../vm-e2e-ubuntu.md). If you've already developed
 the VM e2e harness on this host as a regular user, you're done.
 
+> **Don't re-add `NoNewPrivileges=true` to the systemd unit.** It refuses
+> the setuid transition for the `sudo ip link …` call above and breaks VM
+> bring-up with `sudo: The "no new privileges" flag is set …`. The unit
+> file in `scripts/ci/kvm-runner.service` deliberately omits it; the
+> NOPASSWD sudoers rule on `/usr/sbin/ip` is already the security gate.
+
 ## Trust model
 
 The repo is public, but the workflow that uses this runner triggers only on

--- a/scripts/ci/kvm-runner.service
+++ b/scripts/ci/kvm-runner.service
@@ -41,7 +41,14 @@ RestartSec=10
 # Light hardening — the runner needs broad fs access for builds, qemu, and
 # its own _work tree under $HOME, so don't tighten further without testing.
 # ProtectHome is deliberately NOT set: the runner lives under $HOME.
-NoNewPrivileges=true
+#
+# NoNewPrivileges is deliberately NOT set: scripts/vm/lan-bridge-up.sh
+# (called by router-up.sh) runs `sudo ip link …` via the NOPASSWD rule in
+# /etc/sudoers.d/familydns-vm (see docs/ops/kvm-runner.md § "Host setup").
+# NoNewPrivileges=true would refuse the setuid transition and break VM
+# bring-up with:
+#   sudo: The "no new privileges" flag is set, which prevents sudo from
+#         running as root.
 ProtectSystem=full
 PrivateTmp=true
 


### PR DESCRIPTION
## Symptom

VM e2e on the self-hosted KVM runner fails partway through `scripts/vm/router-up.sh`:

```
[router-vm] bridge fdns-lan0 already exists
sudo: The "no new privileges" flag is set, which prevents sudo from running as root.
sudo: If sudo is running in a container, you may need to adjust the container configuration to disable the flag.
ERROR scenarios/test_02_allowed_browsing.py::test_allowed_request_succeeds_and_event_recorded — RuntimeError: command failed (rc=1): /home/sameer/actions-runner/_work/familydns/familydns/scripts/vm/router-up.sh
```

## Root cause

`scripts/ci/kvm-runner.service` set `NoNewPrivileges=true` as part of "light hardening." But the whole VM bring-up flow relies on:

```
# scripts/vm/lan-bridge-up.sh
sudo ip link add name "${FDNS_LAN_BRIDGE}" type bridge   # first boot
sudo ip link set "${FDNS_LAN_BRIDGE}" up                 # every boot
```

These are gated by a NOPASSWD sudoers rule scoped to `/usr/sbin/ip` (`/etc/sudoers.d/familydns-vm`, per `docs/ops/kvm-runner.md` § "Runtime privileges"). `NoNewPrivileges` refuses the setuid transition, so sudo errors out and bridge bring-up fails.

The hardening directive is fundamentally incompatible with the design — the NOPASSWD-sudo-on-`ip` rule **is** the security gate.

## Fix

- Drop `NoNewPrivileges=true` from the unit; leave `ProtectSystem=full` and `PrivateTmp=true`.
- Add an inline comment in the unit file and a callout in `docs/ops/kvm-runner.md` so a future operator doesn't reintroduce it.

## Post-merge operator steps

The change to the unit file in the repo doesn't propagate to the running unit on the runner host. Apply with:

```
sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
sudo sed -i \
  -e "s|<RUNNER_USER>|$USER|g" \
  -e "s|<RUNNER_HOME>|$HOME/actions-runner|g" \
  /etc/systemd/system/kvm-runner.service
sudo systemctl daemon-reload
sudo systemctl restart kvm-runner.service
```

(Same procedure as the install step in `docs/ops/kvm-runner.md`.)

## Test plan

- [x] Unit file still parses (`systemd-analyze verify` after substitution would be the formal check; trivially syntactically valid here).
- [ ] After the operator steps above, the next workflow_dispatch / push:main triggers `lan-bridge-up.sh` and the `sudo ip link set fdns-lan0 up` no longer errors out. The VM-e2e suite then proceeds past router-up.