### PR TITLE
e2e: connection_attempt event uses HostId tagged union

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -165,13 +165,13 @@ EVTS=$(cat <<EOF
       "ts":   "$NOW"
     },
     {
-      "type":     "connection_attempt",
-      "mac":      "$MAC",
-      "hostname": "google.com",
-      "destIp":   "8.8.8.8",
-      "allowed":  true,
-      "reason":   "allow",
-      "ts":       "$NOW"
+      "type":    "connection_attempt",
+      "mac":     "$MAC",
+      "host":    {"type":"fqdn","value":"google.com"},
+      "destIp":  "8.8.8.8",
+      "allowed": true,
+      "reason":  "allow",
+      "ts":      "$NOW"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #460. The router e2e events-ingest step still 400s because the `connection_attempt` payload sends `hostname: "google.com"` — but post-#391, `hostname` is the device's own DHCP name (a label) and the *contacted* host moved to `host: {type, value}` (HostId tagged union). The API rejects the event with "connection_attempt missing host".

Swap `hostname` for `host: {"type":"fqdn","value":"google.com"}`.

## Test plan

- [ ] CI router e2e job goes green past the "Events ingest" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)