### PR TITLE
ci: bump VM e2e timeout 30m → 60m

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -23,7 +23,13 @@ jobs:
   e2e:
     name: VM e2e suite
     runs-on: [self-hosted, linux, kvm]
-    timeout-minutes: 30
+    # Observed scenario durations (run 25938660408): test_04_daily_limit
+    # alone ran 12m38s. With 9 scenarios averaging 3–5 min plus router-image
+    # build (cold-cache ~2m), 30m wasn't enough — the suite was cut off
+    # mid-test_pause. 60m gives headroom for one long scenario without
+    # masking real regressions; concurrency=e2e-vm keeps the queue
+    # serialized so a slow run doesn't pile up.
+    timeout-minutes: 60
 
     steps:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh


### PR DESCRIPTION
## Symptom

`VM e2e (self-hosted KVM) / VM e2e suite` is failing with:

> The job has exceeded the maximum execution time of 30m0s

## Observed timings

From run [25938660408](https://github.com/sameerparekh/familydns/actions/runs/25938660408) (where the suite was cut off mid-`test_pause`):

| scenario | duration | outcome |
|---|---|---|
| test_01_enrollment | 37s | PASS |
| test_02_allowed_browsing | 4m21s | FAIL |
| test_03_blocked_domain | 3m29s | PASS |
| test_04_daily_limit | 12m38s | FAIL |
| test_05_usage_in_api | 2m55s | FAIL |
| test_06_blocked_page | 3m29s | PASS |
| test_pause (×3) | cut off | — |

Plus ~2m of router-image build on a cold cache. The 30m budget was based on the README's "scenario 4 ~5–6 min" estimate, which is no longer accurate.

## Fix

Bump `timeout-minutes` 30 → 60. `concurrency: e2e-vm` already serializes runs so a slow run doesn't pile up. The scenario-level failures (#02, #04, #05) are real regressions to be triaged separately — this PR is just about giving the suite enough wall clock to surface them.

## Test plan

- [x] YAML parses.
- [ ] Next push:main / dispatch run will let the full suite complete (or fail explicitly on test failures rather than on the wall-clock cap).