### PR TITLE
ci: bump VM e2e timeout 60m → 120m

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -23,13 +23,13 @@ jobs:
   e2e:
     name: VM e2e suite
     runs-on: [self-hosted, linux, kvm]
-    # Observed scenario durations (run 25938660408): test_04_daily_limit
-    # alone ran 12m38s. With 9 scenarios averaging 3–5 min plus router-image
-    # build (cold-cache ~2m), 30m wasn't enough — the suite was cut off
-    # mid-test_pause. 60m gives headroom for one long scenario without
-    # masking real regressions; concurrency=e2e-vm keeps the queue
-    # serialized so a slow run doesn't pile up.
-    timeout-minutes: 60
+    # Observed durations: 30m was cut off mid-test_pause; 60m got past
+    # test_pause but was killed mid-test_time_limit, which sleeps 330s
+    # waiting for the agent's usage-report flush. The full suite needs
+    # ~80–100m wall clock. 120m gives one slow scenario's worth of slack
+    # without masking real regressions; concurrency=e2e-vm keeps the
+    # queue serialized so a slow run doesn't pile up.
+    timeout-minutes: 120
 
     steps:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh


### PR DESCRIPTION
## Symptom

VM e2e cut off again at the 60m mark, mid-`test_time_limit::test_time_limit_minute_granularity` — that scenario has a 330s sleep waiting for the agent's usage-report flush:

```
22:34:21 INFO scenarios.test_time_limit: D2 burst loop done after 93.9s
22:34:21 INFO scenarios.test_time_limit: D2 sleeping 330s for agent usage-report flush
```

Suite was past the halfway mark when killed.

## Fix

Bump `timeout-minutes` 60 → 120.

## Test plan

- [x] YAML parses.
- [ ] Next run lets the full suite complete (or fail on real test errors, not the wall clock).