### PR TITLE
ci: force fresh API build in VM e2e (#465)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -68,6 +68,19 @@ jobs:
       - name: Build client base (if not cached)
         run: scripts/vm/build-client-base.sh
 
+      # The self-hosted KVM runner keeps docker images across jobs (see
+      # docs/ops/kvm-runner.md). scripts/e2e/lib/stack.py defaults to
+      # rebuild=False, so `docker compose up` reuses any cached
+      # familydns-e2e-vm-api image — which can be months stale relative to
+      # current source. Force a fresh build here so CI always tests HEAD.
+      # `--pull` refreshes base layers; only `api` is built locally
+      # (postgres and fake-router use upstream images). Local dev keeps the
+      # fast no-rebuild path. Fixes #465.
+      - name: Build API image (force fresh layer)
+        run: |
+          docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
+            build --pull api
+
       - name: Run e2e suite
         env:
           FDNS_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-familydns.img


### PR DESCRIPTION
## Summary

The last full VM e2e run failed 13/16 scenarios with 400s like `connection_attempt missing hostname` — error strings that no longer exist in current source. Root cause: the self-hosted KVM runner persists docker images across jobs, and `scripts/e2e/lib/stack.py` defaults `rebuild=False`, so `docker compose up` reuses a months-stale `familydns-e2e-vm-api` image built before #391 renamed the `hostname` → `host: HostId` wire field. The agent ipk is rebuilt every run, so the agent sends the new shape; the cached API still expects the old one, and every scenario that hits `/ingest/connection_attempt` cascades.

## Fix

Add one step to `.github/workflows/e2e-vm.yml`, before "Run e2e suite":

```yaml
- name: Build API image (force fresh layer)
  run: |
    docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
      build --pull api
```

`--pull` refreshes base layers; only `api` is built locally (postgres and fake-router are upstream images). Local dev (`scripts/e2e.sh` etc.) keeps the existing fast no-rebuild behavior — only CI forces a fresh build.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-vm.yml'))"` parses
- [ ] Next push:main run rebuilds the API image; the 13-scenario cascade clears. Any failures that remain are real regressions to triage separately.

Closes #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)