### PR TITLE
fix: harness failureMode "closed" → "block-all" (#467)

### DIFF
--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -68,7 +68,7 @@ class AdminAPI:
             "schedules": [],
             "timeLimit": None,
             "siteTimeLimits": [],
-            "failureMode": "closed",
+            "failureMode": "block-all",
         }
         defaults.update(fields)
         return self._request("POST", "/api/profiles", body=defaults)
@@ -107,7 +107,7 @@ class AdminAPI:
             "timeLimit": time_limit_minutes,
             "siteTimeLimits":
                 full.get("siteTimeLimits", []) if isinstance(full, dict) else [],
-            "failureMode": prof.get("failureMode", "closed"),
+            "failureMode": prof.get("failureMode", "block-all"),
         }
         body.update(changes)
         return self._request("PUT", f"/api/profiles/{profile_id}", body=body)


### PR DESCRIPTION
## Symptom

VM e2e setup posts `POST /api/profiles` with `failureMode: "closed"` and gets a 400, causing 12 scenarios to fail with `ERROR at setup`.

## Root cause

#385 / #402 (`abca43e`) renamed the `FailureMode` enum to `block-all | allow-all | last-known-good` (see `shared/src/Models.scala:76-95`). The zio-json codec rejects the legacy `"closed"` value. The harness was never updated.

## Files changed

Grep of `scripts/e2e/` and `docker/` for `failureMode` / `"open"` / `"closed"` turned up only two call sites, both in `scripts/e2e/lib/api_admin.py`:

- `create_profile` defaults: `"closed"` → `"block-all"`
- `apply_profile_update` fallback in `prof.get("failureMode", ...)`: same swap

No other harness fixture, lib, or `docker/fake-router.py` hard-codes these values.

## Test plan

- [x] Harness-only change; no API, shared, or web changes.
- [ ] Next VM e2e run on `push:main` should clear the 12 setup ERRORs.
- [ ] The unrelated `test_unknown_device` failure is tracked separately in #468.

Closes #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)