### PR TITLE
fix: connection_attempt host attribution via dns-tail (#472)

### DIFF
--- a/openwrt/files/usr/sbin/familydns-dns-tail
+++ b/openwrt/files/usr/sbin/familydns-dns-tail
@@ -19,7 +19,15 @@ local debug_opt   = uci_get("debug", "0")
 local source_path = "/tmp/familydns-dnsmasq.log"
 local cache_path  = "/tmp/familydns-dns-cache.txt"
 local tmp_path    = cache_path .. ".tmp"
-local flush_every = 20  -- lines
+-- Flush after every ingested line: the agent's conntrack watcher reads the
+-- cache file at flow-start time (SYN → conntrack -E NEW), which lands
+-- milliseconds after the dnsmasq reply line that resolved the destination
+-- IP. Any flush delay here means lookup_hostname() returns nil and the
+-- connection_attempt event is built with hostname=nil — and that hostname
+-- is frozen on the event before it's queued / POSTed, so a later flush
+-- can't repair it (#472). Tail+ingest is line-driven and tmpfs writes are
+-- cheap, so flushing every line is the cheapest correct behavior.
+local flush_every = 1  -- lines
 
 log.init({ debug = debug_opt })
 log.info("dns-tail: starting source=%s cache=%s", source_path, cache_path)


### PR DESCRIPTION
## Diagnosis

This is failure mode (2) from the issue — but the parsing itself is fine; the problem is **when dns-tail flushes its cache to disk**, not how it parses log lines.

`openwrt/files/usr/sbin/familydns-dns-tail` ingests each dnsmasq log line into an in-memory `ip→hostname` cache and only writes the cache file (`/tmp/familydns-dns-cache.txt`) every **20 lines** or **30 seconds** — and the timer check is gated on a new tail line arriving:

```lua
local flush_every = 20  -- lines
...
if since_flush >= flush_every or (now - last_tick) >= 30 then
  cache.tick(now)
  atomic_write(cache_path, cache.dump_text())
  ...
end
```

A single `curl example.com` from the test client produces ~3–6 dnsmasq log lines (`query[A]` + `reply` ± AAAA). Far below 20, and the 30s timer is irrelevant because:

1. The conntrack `[NEW]` event lands on the agent **milliseconds** after the DNS reply.
2. `conntrack.handle_flow` calls `ctx.lookup_hostname(flow.dst_ip)` synchronously at that moment.
3. `lookup_hostname` reads `/tmp/familydns-dns-cache.txt` — which dns-tail has not yet written.
4. The connection_attempt event is built with `hostname = nil` (and `host = { type = "ipv4", value = <ip> }`) and **frozen** before being queued. A later cache flush cannot retroactively fix the in-flight event — which is exactly what the issue shows (every stored row has `hostname=None` despite events posting successfully).

Evidence from the failed run logs: dns-tail and conntrack both start cleanly (`dns-tail: starting …`, `conntrack: starting watcher …`), no errors from either, and the API stores events with `hostname=None` for every destination IP including ones that obviously had been DNS-resolved (`example.com`).

## Change

Set `flush_every = 1` in `familydns-dns-tail`. The cache lives on tmpfs, `atomic_write` already uses a tmp+rename pair, and the agent's `lookup_hostname` memoizes the file read for 1s — so flushing every ingested line is bounded in cost and is the cheapest correct behavior for an IPC-via-file design.

No tests reference `flush_every` / `since_flush` (grep confirmed), so this change does not move any test.

## Test plan

- [ ] VM e2e: `test_02_allowed_browsing::test_allowed_request_succeeds_and_event_recorded` now sees `host="example.com"` on the recorded event.
- [ ] Any other hostname-asserting scenarios benefit identically.
- [ ] The other 8 failures in run 25951502974 are tracked separately (#473 / #474 / #475).

Closes #472