### PR TITLE
fix: VM e2e static-IP client hostname leak (#475)

### DIFF
--- a/scripts/e2e/scenarios/test_unknown_device.py
+++ b/scripts/e2e/scenarios/test_unknown_device.py
@@ -102,9 +102,24 @@ def _reconfigure_eth0_static(client, *, mac: str, ip: str) -> None:
     assigns the static IP, and installs a default route to the router. From
     the router-agent's perspective this is a brand-new host that never
     DHCP'd — the very scenario F1b/F2 are about.
+
+    The sed-replace of `/etc/network/interfaces` is load-bearing (#475):
+    plain `pkill udhcpc` alone left a path open for `ifup eth0` to be
+    re-invoked after the MAC was rewritten (most likely via a hotplug
+    on `ip link set eth0 up`). The busybox dhcp method then re-launched
+    udhcpc with `-x hostname:$(hostname)`, the new MAC got a DHCP lease,
+    and the cloud-init-baked `fdns-client` hostname leaked into the
+    `dhcp_lease` event the agent forwards. Forcing the iface to
+    `inet manual` neutralizes any such ifup; the client fixture is
+    function-scoped so we don't need to restore.
     """
     client_exec(client, ["sh", "-c", (
-        "pkill udhcpc 2>/dev/null; "
+        "sed -i 's/^iface eth0 inet dhcp/iface eth0 inet manual/' "
+        "/etc/network/interfaces; "
+        "ifdown eth0 2>/dev/null || true; "
+        "kill -9 $(cat /var/run/udhcpc.eth0.pid 2>/dev/null) 2>/dev/null || true; "
+        "rm -f /var/run/udhcpc.eth0.pid; "
+        "pkill -9 udhcpc 2>/dev/null || true; "
         "sleep 1; "
         "ip addr flush dev eth0; "
         "ip link set eth0 down; "
@@ -212,16 +227,19 @@ def test_auto_named_row_renamed_when_dhcp_lease_arrives(
     assert row.get("name") == _expected_auto_name(static_mac)
 
     # Phase 2: drop the static IP, set hostname, and DHCP. The lease
-    # carries hostname option 12 (busybox udhcpc reads /etc/hostname)
-    # → API renames the auto-named row.
+    # must carry hostname option 12 so the API's rename-if-auto path
+    # fires. busybox udhcpc does NOT auto-send the system hostname —
+    # the ifupdown dhcp method we neutralized in phase 1 is what passes
+    # `-x hostname:$(hostname)` at boot; we invoke udhcpc directly here
+    # so we must pass it explicitly (#475).
     client_exec(client, ["sh", "-c", (
         f"hostname {new_hostname}; "
         f"echo {new_hostname} > /etc/hostname; "
         "ip addr flush dev eth0; "
         "ip route del default 2>/dev/null; "
         "rm -f /var/run/udhcpc.eth0.pid; "
-        "udhcpc -q -n -i eth0 >/dev/null 2>&1 || true; "
-        "udhcpc -i eth0 >/dev/null 2>&1 || true"
+        f"udhcpc -q -n -i eth0 -x hostname:{new_hostname} >/dev/null 2>&1 || true; "
+        f"udhcpc -i eth0 -x hostname:{new_hostname} >/dev/null 2>&1 || true"
     )])
 
     _wait_device_name(admin, static_mac, new_hostname, timeout_s=120)


### PR DESCRIPTION
## Summary

Follow-up to #468. The F1b (static-IP autocreate) and F2 (rename on later DHCP) scenarios kept failing with `name='fdns-client'` instead of the expected auto-name.

### Mechanism (evidence)

Failed row from run 25951502974:
```
{'mac': '02:e2:f0:ca:e4:34', 'lastSeenIp': '192.168.100.236', 'name': 'fdns-client', ...}
```
`192.168.100.236` is well inside the router's dnsmasq DHCP pool — not the static `192.168.100.50` the test assigned. So a DHCP exchange *did* happen for the fresh MAC, and the cloud-init-baked `/etc/hostname='fdns-client'` rode along on DHCP option 12.

`_reconfigure_eth0_static` did `pkill udhcpc; ip link set eth0 down; … set address NEW; … up; ip addr add static`. Killing udhcpc alone is not sufficient on this Alpine image: an `ifup eth0` runs again afterwards (most likely a hotplug fired by `ip link set eth0 up`), the busybox dhcp method launches a fresh udhcpc with `-x hostname:$(hostname)`, and the new-MAC lease leaks the baked hostname.

F2 phase 2 had a second latent bug along the same axis: it invoked `udhcpc -i eth0` directly, but busybox `udhcpc` does *not* auto-send option 12 — the ifupdown dhcp method is what passes the system hostname for us at boot. Even with phase 1 fixed, phase 2's rename couldn't fire as written.

### Fix

`scripts/e2e/scenarios/test_unknown_device.py`:

- `_reconfigure_eth0_static`: sed-replace `iface eth0 inet dhcp` → `iface eth0 inet manual` in `/etc/network/interfaces` so any subsequent `ifup eth0` is a no-op. Belt-and-braces with `ifdown eth0`, kill-by-pidfile, and `pkill -9 udhcpc`. The `client` fixture is function-scoped, so the modified file dies with the VM.
- F2 phase 2: pass `-x hostname:<new_hostname>` to `udhcpc` explicitly so option 12 actually goes out.

Product behavior is unchanged — using the DHCP-advertised hostname for real users is the desired path.

## Test plan

- [ ] CI: `scripts/e2e/scenarios/test_unknown_device.py::test_unknown_static_ip_mac_autocreates_with_auto_name` passes (row gets `device-XXYYZZ`).
- [ ] CI: `scripts/e2e/scenarios/test_unknown_device.py::test_auto_named_row_renamed_when_dhcp_lease_arrives` passes (auto-name precondition + rename to `kid-laptop`).
- [ ] F1 (DHCP, smoke) still passes — untouched.

Closes #475. Cross-references #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)