### PR TITLE
fix: time_usage minute-granularity rounding (#474)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -115,6 +115,6 @@ object Main extends ZIOAppDefault {
         deviceRepo,
         connRepo,
       ) ++
-      DebugRoutes.routes(cfg.debugEnabled, deviceRepo, connRepo, usageRepo, clock) ++
+      DebugRoutes.routes(cfg.debugEnabled, deviceRepo, connRepo, usageRepo, trafficRepo, clock) ++
       StaticRoutes.routes(cfg.http.staticDir)
 }

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -29,6 +29,7 @@ object DebugRoutes {
       deviceRepo: DeviceRepo,
       connEventRepo: ConnectionEventRepo,
       timeUsageRepo: TimeUsageRepo,
+      trafficRepo: TrafficReportRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     if !enabled then Routes.empty
@@ -65,10 +66,28 @@ object DebugRoutes {
               snap  <- timeUsageRepo
                 .snapshotAll(today)
                 .mapError(ErrorMapper.dbErrorToResponse)
+              // Per-host minutes from `time_usage` over-count wall-clock time when a
+              // single 5-min agent bucket touches multiple hosts (each host row holds
+              // ~60s for that bucket, summing them inflates "online minutes"). Surface
+              // the bucket-deduplicated per-mac total alongside each row so callers
+              // measuring device-online time can read a single value instead of summing.
+              // (#474)
+              macs = snap.keys.map(_._1).toList.distinct
+              presence <- trafficRepo
+                .listPresenceRows(macs, today)
+                .mapError(ErrorMapper.dbErrorToResponse)
+              totals = familydns.api.presence.Presence
+                .totalMinutesByMac(presence, exemptPatterns = Nil)
             } yield Response.json(
               snap
                 .map { case ((mac, host), mins) =>
-                  TimeUsageRow(mac.value, host.value, today.toString, mins)
+                  TimeUsageRow(
+                    mac.value,
+                    host.value,
+                    today.toString,
+                    mins,
+                    totals.getOrElse(mac, 0),
+                  )
                 }
                 .toList
                 .toJson,
@@ -77,8 +96,16 @@ object DebugRoutes {
         },
       )
 
-  private case class TimeUsageRow(mac: String, host: String, date: String, minutesUsed: Int)
-      derives JsonCodec
+  private case class TimeUsageRow(
+      mac: String,
+      host: String,
+      date: String,
+      minutesUsed: Int,
+      // Per-(mac, day) bucket-deduplicated online minutes (Presence-based, #474).
+      // Same value on every row for the same mac; callers should take this once
+      // per mac rather than summing `minutesUsed` across hosts.
+      deviceTotalMinutes: Int,
+  ) derives JsonCodec
 
   /**
    * Reject non-loopback callers. We check both the connection's remote address (when zio-http

--- a/api/test/src/feature/DebugApiSpec.scala
+++ b/api/test/src/feature/DebugApiSpec.scala
@@ -29,8 +29,9 @@ object DebugApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       dRepo  <- ZIO.service[DeviceRepo]
       cRepo  <- ZIO.service[ConnectionEventRepo]
       tuRepo <- ZIO.service[TimeUsageRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
       clock  <- ZIO.service[Clock]
-    } yield DebugRoutes.routes(enabled, dRepo, cRepo, tuRepo, clock)
+    } yield DebugRoutes.routes(enabled, dRepo, cRepo, tuRepo, trRepo, clock)
 
   /**
    * Build a request whose Host header is loopback-y by default. zio-http's Request.remoteAddress is

--- a/scripts/e2e/scenarios/test_time_limit.py
+++ b/scripts/e2e/scenarios/test_time_limit.py
@@ -58,21 +58,20 @@ def _mac_in_set(mac: str) -> bool:
 
 
 def _total_minutes_for_mac(debug_api, mac: str) -> int:
-    """Sum `minutesUsed` for `mac` across all hosts in today's time_usage.
+    """Bucket-deduplicated online minutes for `mac` from today's time_usage.
 
-    The debug endpoint exposes only integer `minutesUsed` (truncated from
-    the underlying `seconds_used` column — see DebugRoutes.scala). That
-    truncation is the granularity we can observe at this layer.
+    Reads `deviceTotalMinutes` (#474), which is computed server-side from
+    `traffic_reports` via Presence: each 5-min agent bucket counts once per
+    device regardless of how many hosts the device touched. Naively summing
+    per-host `minutesUsed` would inflate when DNS + gateway + the actual
+    site all see traffic in the same bucket.
     """
     needle = _norm_mac(mac)
-    total = 0
-    saw_any = False
     for row in debug_api.time_usage():
-        if _norm_mac(row.get("mac", "")) != needle:
-            continue
-        saw_any = True
-        total += int(row.get("minutesUsed", 0))
-    return total if saw_any else -1  # sentinel: no rows yet
+        if _norm_mac(row.get("mac", "")) == needle:
+            # Same value on every row for the same mac — first wins.
+            return int(row.get("deviceTotalMinutes", 0))
+    return -1  # sentinel: no rows yet
 
 
 # ── D2 (@smoke) — minute granularity (verifies #295) ───────────────────────


### PR DESCRIPTION
## Summary

The bug was **API-side**, but not where the issue hypothesized. The agent
(post-#295) correctly emits per-minute `activeSeconds` and the API stores
it correctly in `time_usage.seconds_used`. The over-count came from the
shape of `/api/debug/time_usage`: it returns one row per `(mac, host)`,
and the test helper summed `minutesUsed` across hosts.

A single 5-min agent bucket touching N hosts (e.g. example.com + DNS
server + gateway) yields N rows each carrying ~60s for that bucket.
Naively summing inflates wall-clock online time by ~N×. ~90s of real
traffic in D2 had ≈3 hosts × 2 buckets → ≈6 min reported. We don't have
the per-record `activeSeconds` from this run (api-logs.txt artifact was
empty), but the math matches and the path is unambiguous: each (mac,
host) row in the snapshot is independently summed in `_total_minutes_for_mac`.

`Presence.totalMinutesByMac` already exists and bucket-dedupes against
`traffic_reports`, so this is a plumbing fix, not new logic.

## Root cause

`api/src/routes/DebugRoutes.scala:61` returned per-(mac, host) minutes;
`scripts/e2e/scenarios/test_time_limit.py:60` summed them.

## Fix

- Add `deviceTotalMinutes` to each `TimeUsageRow` — the bucket-deduped
  per-(mac, day) Presence total. Same value on every row for the same
  mac. Per-host `minutesUsed` is unchanged for callers that want
  per-site visibility.
- Update `_total_minutes_for_mac` to read `deviceTotalMinutes` instead
  of summing.
- `TimeUsageRepo` is untouched (per task constraint).

## Test plan

- [x] `mill api.test.testOnly familydns.api.feature.DebugApiSpec` passes locally.
- [ ] `scenarios/test_time_limit.py::test_time_limit_minute_granularity` should pass on next VM e2e run.
- [ ] `test_time_limit_cross_day_rollover` (skipped pending #334) may now exercise its post-rollover assertions cleanly since the helper no longer over-reads.

## Related

- #295 was the agent-side fix (closed); this is the matching API-side
  surface so callers get a usable per-mac total instead of having to
  redo bucket dedup themselves.

Closes #474