### PR TITLE
ci: capture VM e2e logs before stack teardown (#473)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -84,6 +84,13 @@ jobs:
       - name: Run e2e suite
         env:
           FDNS_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-familydns.img
+          # #473: pytest's stack fixture defaults to tearing the docker
+          # compose stack down at session end, which removes containers
+          # before the failure-capture step below can read their logs.
+          # Keep the stack up here; the explicit "Tear down API stack" step
+          # at the bottom of this job (if: always()) handles cleanup after
+          # logs are captured.
+          E2E_VM_KEEP_STACK: "1"
         run: scripts/e2e-vm.sh
 
       - name: Capture docker compose logs


### PR DESCRIPTION
## Summary

The VM e2e workflow's failure-log capture step produced a 0-byte `api-logs.txt` on the run cited in #473 (and presumably every prior failed run). Root cause: pytest's session-end stack fixture calls `docker compose down -v --remove-orphans` (scripts/e2e/lib/stack.py:34), which removes the containers and discards their log streams *before* the workflow's "Capture docker compose logs" step runs.

Fix: set `E2E_VM_KEEP_STACK=1` on the "Run e2e suite" step. pytest already honors this flag (scripts/e2e/conftest.py:45) and leaves the stack up at session end. The workflow's existing "Tear down API stack" step (`if: always()`, runs after the upload-artifacts step) handles cleanup, so total resource lifetime is unchanged.

This does **not** fix #473 itself — it unblocks the next debugging pass by ensuring the next failed run actually retains API logs. #473 stays open until the underlying blocked_macs / etag propagation behavior is diagnosed against real evidence.

## Test plan

- [ ] Trigger the VM e2e workflow (manually or via the next push to main) and confirm a failure produces a non-empty `api-logs.txt` artifact.
- [ ] Verify the "Tear down API stack" step still runs and exits 0 (it should — `if: always()` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)