### PR TITLE
fix: test_unknown_device static-IP hostname leak follow-up (#483)

### DIFF
--- a/scripts/e2e/scenarios/test_unknown_device.py
+++ b/scripts/e2e/scenarios/test_unknown_device.py
@@ -103,23 +103,45 @@ def _reconfigure_eth0_static(client, *, mac: str, ip: str) -> None:
     the router-agent's perspective this is a brand-new host that never
     DHCP'd — the very scenario F1b/F2 are about.
 
-    The sed-replace of `/etc/network/interfaces` is load-bearing (#475):
-    plain `pkill udhcpc` alone left a path open for `ifup eth0` to be
-    re-invoked after the MAC was rewritten (most likely via a hotplug
-    on `ip link set eth0 up`). The busybox dhcp method then re-launched
-    udhcpc with `-x hostname:$(hostname)`, the new MAC got a DHCP lease,
-    and the cloud-init-baked `fdns-client` hostname leaked into the
-    `dhcp_lease` event the agent forwards. Forcing the iface to
-    `inet manual` neutralizes any such ifup; the client fixture is
-    function-scoped so we don't need to restore.
+    History — three layers of defense, each addressing a previously-observed
+    leak (#475, #468, #483):
+
+      1. `sed dhcp → manual` on `/etc/network/interfaces` (#475) so any
+         later `ifup eth0` won't fire DHCP.
+      2. `ifdown` + `pkill -9 udhcpc` to kill the currently-running client.
+      3. (#483) Rename `/sbin/udhcpc` (and `/usr/sbin/udhcpc` if present) to
+         `.disabled` — the only bombproof way to ensure no remaining path
+         (mdev/udev hotplug, ifupdown if-up.d hooks, cloud-init network
+         module on subsequent boots, anything we haven't catalogued) can
+         re-launch udhcpc with `-x hostname:$(hostname)` and leak the
+         cloud-init-baked `fdns-client` hostname into a `dhcp_lease` event
+         for the new MAC. (1)+(2) alone proved insufficient — symptom
+         persisted in the F1b/F2 failures captured in run 25964749304
+         where the freshly-MAC'd row arrived named `fdns-client`.
+
+    The client fixture is function-scoped so we don't need to restore.
+    F2's Phase 2 calls `_restore_udhcpc(client)` before invoking udhcpc
+    explicitly with its intended hostname.
     """
     client_exec(client, ["sh", "-c", (
+        # Belt: blank /etc/hostname and the running kernel hostname so even
+        # if any DHCP slip-through occurs before the binary rename takes
+        # effect, $(hostname) doesn't expand to `fdns-client`.
+        ": > /etc/hostname; "
+        "hostname '' 2>/dev/null || hostname localhost.unknown; "
         "sed -i 's/^iface eth0 inet dhcp/iface eth0 inet manual/' "
         "/etc/network/interfaces; "
         "ifdown eth0 2>/dev/null || true; "
         "kill -9 $(cat /var/run/udhcpc.eth0.pid 2>/dev/null) 2>/dev/null || true; "
         "rm -f /var/run/udhcpc.eth0.pid; "
         "pkill -9 udhcpc 2>/dev/null || true; "
+        # Bombproof: make the binary itself uninvocable. Rename, don't
+        # delete — F2 Phase 2 restores it.
+        "for p in /sbin/udhcpc /usr/sbin/udhcpc; do "
+        "  if [ -e \"$p\" ] && [ ! -e \"$p.disabled\" ]; then "
+        "    mv \"$p\" \"$p.disabled\"; "
+        "  fi; "
+        "done; "
         "sleep 1; "
         "ip addr flush dev eth0; "
         "ip link set eth0 down; "
@@ -127,6 +149,18 @@ def _reconfigure_eth0_static(client, *, mac: str, ip: str) -> None:
         "ip link set eth0 up; "
         f"ip addr add {ip}/24 dev eth0; "
         f"ip route replace default via {ROUTER_LAN_IP}"
+    )])
+
+
+def _restore_udhcpc(client) -> None:
+    """Undo `_reconfigure_eth0_static`'s udhcpc disable so the binary can
+    be invoked explicitly (F2 Phase 2). No-op if it was never disabled."""
+    client_exec(client, ["sh", "-c", (
+        "for p in /sbin/udhcpc /usr/sbin/udhcpc; do "
+        "  if [ -e \"$p.disabled\" ] && [ ! -e \"$p\" ]; then "
+        "    mv \"$p.disabled\" \"$p\"; "
+        "  fi; "
+        "done"
     )])
 
 
@@ -232,6 +266,7 @@ def test_auto_named_row_renamed_when_dhcp_lease_arrives(
     # the ifupdown dhcp method we neutralized in phase 1 is what passes
     # `-x hostname:$(hostname)` at boot; we invoke udhcpc directly here
     # so we must pass it explicitly (#475).
+    _restore_udhcpc(client)
     client_exec(client, ["sh", "-c", (
         f"hostname {new_hostname}; "
         f"echo {new_hostname} > /etc/hostname; "


### PR DESCRIPTION
## Summary

Follow-up to PR #477 (#475). In VM e2e run [25964749304](https://github.com/sameerparekh/familydns/actions/runs/25964749304/job/76326167612) the static-IP scenarios still failed with the device row named `fdns-client`:

```
FAILED test_unknown_static_ip_mac_autocreates_with_auto_name
   expected auto-generated name matching ^device-[0-9a-f]{6}$, got 'fdns-client'
FAILED test_auto_named_row_renamed_when_dhcp_lease_arrives
   F2 precondition: expected auto-name, got 'fdns-client'
```

## Evidence

The debug-events dump for the boot-time MAC (`02:e2:e2:aa:57:14`) showed 50 events, all with `hostname=None`. The cloud-init seed bakes `local-hostname: fdns-client` into the base image (`scripts/vm/build-client-base.sh`), so the running kernel hostname stays `fdns-client` across all boots. The freshly-MAC'd row (`02:e2:f0:*`) ending up named `fdns-client` means some `dhcp_lease(mac=<fresh>, hostname=fdns-client)` event reaches the API — i.e. *something* is still firing `udhcpc -x hostname:$(hostname)` on the new MAC after `_reconfigure_eth0_static` runs.

## Root cause

PR #477's mitigations (`sed dhcp→manual` on `/etc/network/interfaces`, `ifdown`, `pkill -9 udhcpc`) close the ifupdown-dhcp-method path but not every path. Candidates we have not catalogued exhaustively: `mdev`/udev hotplug on `ip link set eth0 up`, `/etc/network/if-up.d/*` hooks, cloud-init's network module re-running on subsequent boots. Any of them invoking `udhcpc` after the MAC change leaks the cloud-init-baked hostname.

## Fix

The only bombproof harness-level fix: rename `/sbin/udhcpc` (and `/usr/sbin/udhcpc` if present) to `.disabled` before swapping the MAC. The binary becomes uninvocable from every path. F2's Phase 2 — which intentionally invokes udhcpc with `kid-laptop` — calls a new `_restore_udhcpc(client)` helper first.

As belt-and-suspenders, also blank `/etc/hostname` and clear the running kernel hostname so any slip-through before the rename can't expand `$(hostname)` to `fdns-client`.

Harness-only; no product-code changes.

## Test plan

- [ ] VM e2e run on this branch passes `test_unknown_static_ip_mac_autocreates_with_auto_name` and `test_auto_named_row_renamed_when_dhcp_lease_arrives`.
- [ ] F1 (`test_unknown_dhcp_mac_autocreates_with_hostname`) still passes — it uses the boot-time `client.mac` and never enters `_reconfigure_eth0_static`, so the udhcpc binary remains available during boot.
- [ ] F2's Phase 2 still drives the rename — `_restore_udhcpc` re-enables the binary before the explicit `udhcpc -x hostname:kid-laptop` call.

Closes #483. Refs #475, PR #477, #468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)