### PR TITLE
fix: time_usage minute granularity follow-up (#482)

### DIFF
--- a/scripts/e2e/scenarios/test_time_limit.py
+++ b/scripts/e2e/scenarios/test_time_limit.py
@@ -128,14 +128,19 @@ def test_time_limit_minute_granularity(
 
     # Granularity assertion (#295):
     #   - 0 → usage never accrued (regression)
-    #   - 1 → expected: 90s truncated to 1 minute
-    #   - 2 → acceptable upper bound if the burst stretched out / a second
-    #         report cycle landed before we polled
-    #   - >= 5 → suggests minute-bucket rounding (#295 contract violated)
-    assert 1 <= total_minutes <= 2, (
-        f"D2: expected minutesUsed in [1, 2] after ~90s of traffic, got "
+    #   - 1 → 90s truncated to a single minute bucket
+    #   - 2 → 90s straddled one minute boundary
+    #   - 3 → 90s straddled two minute boundaries (e.g. 0:45–2:15 touches
+    #         minutes 0, 1, 2). The agent reports active-seconds in per-minute
+    #         buckets and the API counts deduped buckets, so up to ~1 minute
+    #         of over-credit per boundary is expected at this granularity.
+    #   - >= 5 → suggests multi-minute bucket rounding (#295 contract violated)
+    assert 1 <= total_minutes <= 3, (
+        f"D2: expected minutesUsed in [1, 3] after ~90s of traffic, got "
         f"{total_minutes}. Either nothing accrued (=0) or the API is "
-        f"rounding to a multi-minute bucket (#295)."
+        f"rounding to a multi-minute bucket (#295). Upper bound is 3 because "
+        f"a 90s span can straddle up to two minute boundaries and the agent's "
+        f"1-minute granularity credits each touched bucket."
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to #478. After dedupe-by-(mac, period_start) the API now
reports 3 min for a ~90s burst (down from 6), but the D2 test bound
was `[1, 2]` and fails at 3.

**Option chosen: (1) loosen the test bound to `[1, 3]`.**

The agent (openwrt-agent) reports active-seconds in per-minute buckets
keyed by `period_start`. A 90s span can straddle up to two minute
boundaries — e.g. 0:45–2:15 touches minutes 0, 1, 2 — and each touched
bucket contributes ~1 minute after dedupe. So the achievable lower
bound at 1-minute agent granularity is 3, not `ceil(90/60)=2`.

Quick check of the API side (`api/src/routes/RouterIngestRoutes.scala`,
`api/src/db/Repos.scala`) confirms `activeSeconds` per bucket equals
the bucket duration (the dedupe in #478 takes `max` of activeSeconds
per `(mac, period_start)`). Option (2) — sum activeSeconds across
deduped buckets, then `ceil(/60)` — would require either reshaping
the read path or a new aggregate endpoint, which is more invasive
than the test bound warrants for what is really a granularity-vs-test
mismatch, not a product bug.

## Test plan

- [ ] D2 (`test_time_limit_minute_granularity`) passes in the VM e2e
      job at 3 (the post-#478 observed value) and still rejects 0 /
      multi-minute bucket rounding (>=5).
- [ ] D3 (`test_time_limit_cross_day_rollover`) — currently skipped
      on a D3 precondition — may now unblock if D2 no longer fails.

Closes #482. Refs #474, #478, #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)