### PR TITLE
api: diagnostic logging for snapshot-propagation failures (#481)

### DIFF
--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -62,11 +62,13 @@ object RouterRoutes {
               .touch(router.id, Some(snap.etag))
               .mapError(ErrorMapper.dbErrorToResponse)
             notMod = ifNoneMatch.contains(snap.etag.value)
-            _ <- ZIO.logDebug(
-              s"router policy: router=${router.id} etagIn=${ifNoneMatch.getOrElse("-")} " +
-                s"etagOut=${snap.etag.value} notModified=$notMod devices=${snap.devices.size} " +
-                s"profiles=${snap.profiles.size}",
-            )
+            // #481: 200s (etag changed) are diagnostic gold for snapshot-propagation
+            // failures — log them at INFO so they survive the default log level.
+            // 304s stay at DEBUG to keep the steady-state poll cadence quiet.
+            logMsg = s"router policy: router=${router.id} etagIn=${ifNoneMatch.getOrElse("-")} " +
+              s"etagOut=${snap.etag.value} notModified=$notMod devices=${snap.devices.size} " +
+              s"profiles=${snap.profiles.size}"
+            _ <- if (notMod) ZIO.logDebug(logMsg) else ZIO.logInfo(logMsg)
             resp =
               if notMod then
                 Response

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -239,6 +239,14 @@ object ProfileRoutes {
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
+            // #481: log mutations that should bump the policy snapshot etag.
+            // Without this the only evidence of "did the API even receive the
+            // pause flip?" was the absence of logs, which was useless.
+            _      <- ZIO.logInfo(
+              s"profile updated: id=${pid.value} paused=${p.paused}→${upr.paused} " +
+                s"name=${upr.name} extraBlockedCount=${upr.extraBlocked.size} " +
+                s"extraAllowedCount=${upr.extraAllowed.size}",
+            )
             _      <- scheduleRepo
               .replaceForProfile(pid, upr.schedules)
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -324,6 +332,11 @@ object DeviceRoutes {
             id <- deviceRepo
               .upsert(mac, udr.name, udr.profileId, "")
               .mapError(ErrorMapper.dbErrorToResponse)
+            // #481: log device upsert so the next CI failure makes it obvious
+            // whether the mutation reached the API at all.
+            _  <- ZIO.logInfo(
+              s"device upserted: mac=${mac.value} profileId=${udr.profileId.value} name=${udr.name}",
+            )
           } yield Response.json(s"""{"id":${id.value}}""")
         },
       Method.DELETE / "api" / "devices" / string("mac") ->
@@ -337,6 +350,8 @@ object DeviceRoutes {
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _        <- requireProfileAccess(claims, existing.profileId, userProfileRepo)
             _        <- deviceRepo.delete(normalized).mapError(ErrorMapper.dbErrorToResponse)
+            // #481: same rationale as PUT — make the next CI failure diagnostic.
+            _        <- ZIO.logInfo(s"device deleted: mac=${normalized.value}")
           } yield Response.ok
         },
     )


### PR DESCRIPTION
## Context

#481 is the third pass at the VM-e2e snapshot-propagation failures (5 timeouts in `test_pause` / `test_reassignment`, plus a downstream `test_time_limit_cross_day_rollover` skip). The earlier passes:

- **#473** filed the original symptom.
- **PR #479** (which closed #473) added CI-side log capture but no code fix. The reopened issue (#481) confirmed the 5 failures are unchanged.

## What I tried

I downloaded the failure artifact from run 25964749304 (`/tmp/r481/.../tmp/api-logs.txt`) and went looking for the trail of the PUT/DELETE that should have bumped the snapshot etag, the router's subsequent `GET /api/router/policy`, and any new-etag log. Found: **none of it**. The whole 225-line log is the API banner, postgres checkpointer noise, `router events: batchSize=N` from the ingest route, and `/api/debug/events` hits from the harness. Two specific gaps:

- `Routes.scala` PUT /api/profiles/:id (`set_profile_paused` lands here), PUT /api/devices, and DELETE /api/devices/:mac log nothing per-request.
- `RouterRoutes.scala`'s `GET /api/router/policy` log is at `ZIO.logDebug` (line 65), which the default logger drops. So there's no record of which polls returned 200 (new etag) vs 304.

With that gap, every "is the API even seeing the mutation?", "is the snapshot etag flipping?", "is the router polling?" question is unanswerable from logs alone. Without it I can't tell whether the bug lives in the API (snapshot regen / etag), the router agent (apply step), or the orchestrator (mutation never landed).

## What this PR does

Minimal, additive diagnostic logging — no behavior change:

- `PUT /api/profiles/:id` → `ZIO.logInfo("profile updated: id=… paused=before→after name=… …")` — the pause flip is explicit.
- `PUT /api/devices` → `ZIO.logInfo("device upserted: mac=… profileId=… name=…")`.
- `DELETE /api/devices/:mac` → `ZIO.logInfo("device deleted: mac=…")`.
- `GET /api/router/policy` → split the existing log: **INFO** when the response is 200 (etag flipped), **DEBUG** when 304 (steady-state poll). Now we see exactly which polls picked up a new snapshot.

## Root-cause hypothesis (intentionally unfixed here)

From cold inspection of `api/src/policy/PolicyService.scala`, `api/src/routes/Routes.scala`, and `openwrt/files/usr/lib/lua/familydns/render.lua`, the architecture supports correct behavior:

- `PolicyService.snapshot` recomputes from `profileRepo.listAll` + `deviceRepo.listAll` on every GET — no stored snapshot, no cache to invalidate. So the user's hypothesis #1 ("snapshot regen hook missing") doesn't apply: there is no regen hook because there is no cache.
- `computeEtag` hashes profile `BlockRules` via `blockRulesSig`, which includes `b=${r.blocked}|r=$reason|…`. A paused flip changes `blocked: false→true` and `reason: -→Paused`, so the etag MUST change. Hypothesis #3 doesn't apply either.
- The lua agent's `effective_rules(dev, snapshot.profiles)` correctly walks `dev.profileId → snapshot.profiles[pid].rules`, and `render.nft` adds the MAC to `blocked_macs` iff `r.blocked`. The unit test `PolicySnapshotBlockedMacsSpec` pins this contract and passes.

Either the bug is elsewhere (router-side apply path, orchestrator, fixture state), or it's a real bug whose conditions don't show up in the unit-test setup but do in VM e2e — and I cannot tell which from the current evidence. Picking a speculative "fix" here would risk regressing the unit-tested happy path without addressing the actual VM-e2e failure mode.

## Test plan

- [ ] Next VM e2e run on `main` (or any branch carrying this) will produce log lines for: every `set_profile_paused`, every `upsert_device`, every `delete_device`, and every router poll that returned a new etag.
- [ ] With those lines, the next investigation can answer in seconds: did the API receive the mutation? did the snapshot etag change? did the router pick up the new etag? — instead of guessing.
- [ ] This addresses #481's "evidence gap" framing. The 5 listed failures (and the downstream skip) are still expected to fail until the actual defect is located in the next investigation pass; this PR makes that pass tractable.
- [ ] #480, #482, #483 are out of scope.

Closes #481 only in the sense that #481 was filed as "the next investigation pass has good evidence to work from" — that's what this lands. If reviewers prefer to keep #481 open until the underlying VM-e2e failures actually go green, swap `Closes #481` for a reference and I'll relabel.

Closes #481
Refs #473, #479