### PR TITLE
fix: dns-tail attribution follow-up (#480)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/familydns/dns_log.lua
@@ -30,6 +30,15 @@ local M = {}
 --
 --   [<syslog prefix> dnsmasq[pid]: ]<qid> <client_ip>/<port> query[A] <qname> from <src_ip>
 --   [<syslog prefix> dnsmasq[pid]: ]<qid> <client_ip>/<port> reply <name> is <value>
+--   [<syslog prefix> dnsmasq[pid]: ]<qid> <client_ip>/<port> cached <name> is <value>
+--
+-- `reply` lines are emitted when dnsmasq receives a response from an upstream
+-- resolver; `cached` lines are emitted when dnsmasq answers from its own
+-- in-memory cache. Both carry the same `<name> is <ip>` payload and both must
+-- be ingested — otherwise a client's repeat lookup (or a lookup that happens
+-- while dnsmasq's TTL is still good) lands no entry in the agent's IP→host
+-- cache, and the resulting connection_attempt event reports hostname=nil
+-- (#480, follow-up to #472).
 --
 -- We match the trailing structured portion and ignore the optional prefix.
 
@@ -53,8 +62,8 @@ end
 
 function M.parse_reply_line(line)
   if type(line) ~= "string" or line == "" then return nil end
-  local qid, name, value = line:match("(%d+)%s+%S+/%d+%s+reply%s+(%S+)%s+is%s+(%S+)")
-  if not qid then return nil end
+  local qid, verb, name, value = line:match("(%d+)%s+%S+/%d+%s+(%a+)%s+(%S+)%s+is%s+(%S+)")
+  if not qid or (verb ~= "reply" and verb ~= "cached") then return nil end
   if value == "<CNAME>" then
     return { qid = qid, name = name, ip = nil }
   end

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -286,31 +286,28 @@ end
 -- We inject them via cfg.on_tick so there's no need for threads or coroutines.
 
 -- Hostname lookup backed by the dns-tail sidecar's snapshot file (#259).
--- Memoized for 1s to keep per-flow overhead bounded. The previous mtime-based
--- freshness check used `stat -c %Y`, which isn't present on stock OpenWRT
--- busybox — the popen returned no output, mt fell to 0, and the equality
--- check with the initial dns_cache_mt=0 meant the cache was never loaded
--- (#287). Re-reading the (small) snapshot once per second is cheap enough.
+-- The previous mtime-based freshness check used `stat -c %Y`, which isn't
+-- present on stock OpenWRT busybox (#287); a follow-up tried a 1-second
+-- time-based memoization, but that re-introduced a race against dns-tail
+-- under tight DNS→SYN sequences: the first reply line, the cache flush,
+-- and the conntrack NEW for the resolved IP can all land inside the same
+-- monotonic-second window, leaving lookup_hostname() answering from the
+-- pre-flush in-memory snapshot and freezing hostname=nil on the event
+-- (#480, follow-up to #472).
+--
+-- Drop the memoization. The cache file lives on tmpfs and is at most a few
+-- kilobytes, so reading it once per outbound flow costs microseconds —
+-- well below the cost of the conntrack -E line that triggered the lookup.
 local dns_cache_path = "/tmp/familydns-dns-cache.txt"
 local dns_cache_ttl  = 3600
-local dns_cache_tbl  = {}
-local dns_cache_load = 0
 
 local function lookup_hostname(dst_ip)
-  -- Monotonic for the "has 1s elapsed?" gate (#336); wall-clock for the
-  -- dns_log freshness check, which compares against wall-clock TTLs stored
-  -- alongside each cached entry.
-  local mono = clock.monotonic_seconds()
-  if (mono - dns_cache_load) >= 1 then
-    dns_cache_load = mono
-    local f = io.open(dns_cache_path, "r")
-    if f then
-      local text = f:read("*a") or ""
-      dns_cache_tbl = dns_log.load_table(text, dns_cache_ttl, os.time())
-      f:close()
-    end
-  end
-  return dns_cache_tbl[dst_ip]
+  local f = io.open(dns_cache_path, "r")
+  if not f then return nil end
+  local text = f:read("*a") or ""
+  f:close()
+  local tbl = dns_log.load_table(text, dns_cache_ttl, os.time())
+  return tbl[dst_ip]
 end
 
 conntrack.watch({

--- a/openwrt/files/usr/sbin/familydns-dns-tail
+++ b/openwrt/files/usr/sbin/familydns-dns-tail
@@ -60,8 +60,11 @@ local function atomic_write(path, content)
   return true
 end
 
-local since_flush = 0
-local last_tick   = os.time()
+local since_flush      = 0
+local last_tick        = os.time()
+local last_stats_log   = os.time()
+local lines_ingested   = 0
+local lines_since_stat = 0
 
 while true do
   local line = handle:read("*l")
@@ -70,7 +73,9 @@ while true do
     break
   end
   cache.ingest_line(line)
-  since_flush = since_flush + 1
+  since_flush      = since_flush + 1
+  lines_ingested   = lines_ingested + 1
+  lines_since_stat = lines_since_stat + 1
 
   local now = os.time()
   if since_flush >= flush_every or (now - last_tick) >= 30 then
@@ -79,6 +84,16 @@ while true do
     log.debug("dns-tail: flushed cache size=%d", cache.size())
     since_flush = 0
     last_tick   = now
+  end
+
+  -- One-line info heartbeat so silent failures (dnsmasq not logging, tail
+  -- dropping the pipe, regex never matching) are diagnosable from logread
+  -- alone without on-VM access (#480).
+  if (now - last_stats_log) >= 60 then
+    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d",
+             lines_ingested, lines_since_stat, now - last_stats_log, cache.size())
+    last_stats_log   = now
+    lines_since_stat = 0
   end
 end
 

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -85,6 +85,26 @@ describe("parse_reply_line", function()
       "Nov 12 10:00:01 dnsmasq[1234]: 7 192.168.1.42/54321 reply youtube.com is 2607:f8b0::1"
     assert.is_nil(dns_log.parse_reply_line(line))
   end)
+
+  -- dnsmasq emits `cached <name> is <ip>` instead of `reply ...` when answering
+  -- from its own in-memory cache. dns-tail must parse those identically — see
+  -- the verb-set comment in dns_log.lua (#480).
+  it("parses a `cached X is <ipv4>` line the same as a reply", function()
+    local line =
+      "Nov 12 10:00:01 dnsmasq[1234]: 8 192.168.1.42/54321 cached example.com is 93.184.216.34"
+    local r = dns_log.parse_reply_line(line)
+    assert.is_not_nil(r)
+    assert.equal("8",           r.qid)
+    assert.equal("example.com", r.name)
+    assert.equal("93.184.216.34", r.ip)
+  end)
+
+  it("ignores other verbs like `forwarded` and `config`", function()
+    assert.is_nil(dns_log.parse_reply_line(
+      "Nov 12 10:00:01 dnsmasq[1]: 9 192.168.1.42/54321 forwarded example.com to 1.1.1.1"))
+    assert.is_nil(dns_log.parse_reply_line(
+      "Nov 12 10:00:01 dnsmasq[1]: 9 127.0.0.1/54321 config error is REFUSED"))
+  end)
 end)
 
 -- ---------------------------------------------------------------------------

--- a/scripts/e2e/conftest.py
+++ b/scripts/e2e/conftest.py
@@ -231,12 +231,17 @@ def pytest_runtest_makereport(item, call):
             client_obj = item.funcargs.get("client")
             debug = item.funcargs.get("debug_api")
             if client_obj is not None and debug is not None:
+                from lib.api_debug import event_hostname
                 evs = debug.events_for_mac(client_obj.mac)
                 lines = [f"events for mac {client_obj.mac} ({len(evs)} total):"]
                 for e in evs[-20:]:
+                    # The connection_event wire schema (#391) wraps the hostname
+                    # in a tagged `host` union; reading the legacy flat
+                    # `hostname` key always returned None and made every event
+                    # look unattributed in the failure dump (#480).
                     lines.append(
                         f"  ts={e.get('ts')} allowed={e.get('allowed')} "
-                        f"reason={e.get('reason')!r} hostname={e.get('hostname')!r} "
+                        f"reason={e.get('reason')!r} hostname={event_hostname(e) or None!r} "
                         f"destIp={e.get('destIp')!r}"
                     )
                 sections.append(("debug events", "\n".join(lines)))

--- a/scripts/e2e/lib/api_debug.py
+++ b/scripts/e2e/lib/api_debug.py
@@ -57,7 +57,7 @@ class DebugAPI:
         host_needle = hostname.lower() if hostname else None
         for e in self.events_for_mac(mac, limit=limit):
             if host_needle is not None:
-                if host_needle not in (e.get("hostname") or "").lower():
+                if host_needle not in event_hostname(e).lower():
                     continue
             if allowed is not None and e.get("allowed") is not allowed:
                 continue
@@ -81,3 +81,18 @@ class DebugAPI:
                 f"{proc.stderr.strip()}"
             )
         return json.loads(proc.stdout)
+
+
+def event_hostname(e: dict[str, Any]) -> str:
+    """Return the FQDN attribution on a connection_attempt event, or "".
+
+    The wire schema (#391) carries the resolved hostname inside a tagged
+    `host` union: `{"type": "fqdn", "value": "<name>"}` when DNS attribution
+    landed, or `{"type": "ipv4"|"ipv6", "value": "<ip>"}` when the agent only
+    had a raw destination IP. Tests want to match on the FQDN, not on a raw
+    IP that happens to substring-match — so filter on `type == "fqdn"`.
+    """
+    host = e.get("host") or {}
+    if isinstance(host, dict) and host.get("type") == "fqdn":
+        return host.get("value") or ""
+    return ""

--- a/scripts/e2e/scenarios/test_02_allowed_browsing.py
+++ b/scripts/e2e/scenarios/test_02_allowed_browsing.py
@@ -6,6 +6,7 @@ client's MAC address.
 """
 import pytest
 
+from lib.api_debug import event_hostname
 from lib.traffic import http_get
 from lib.wait import wait_until
 
@@ -23,7 +24,7 @@ def test_allowed_request_succeeds_and_event_recorded(
     def find_event():
         events = debug_api.events_for_mac(client.mac)
         for e in events:
-            if "example.com" in (e.get("hostname") or "") and e.get("allowed") is True:
+            if "example.com" in event_hostname(e) and e.get("allowed") is True:
                 return e
         return None
 


### PR DESCRIPTION
## On-VM finding

Reproduced `test_02_allowed_browsing` against `scripts/e2e-vm.sh --only allowed-browsing --keep`. The router VM **was** running dnsmasq with `log-queries=1` writing to `/tmp/familydns-dnsmasq.log`, dns-tail **was** reading it, and `/tmp/familydns-dns-cache.txt` **was** getting written with the right entries (`104.20.23.154 → example.com`). So neither of the first two failure modes in #480 ("dnsmasq isn't logging" / "dns-tail can't read") was real.

The actual failure was a mix of three things:

### 1. Agent: lookup_hostname memoization race

`familydns-agent`'s `lookup_hostname()` memoized the parsed snapshot for 1 wall-second. Under a tight DNS → SYN sequence — which is the exact path the test exercises — `dns-tail` did its per-line flush (PR #476), but the agent's in-memory table was still the pre-flush snapshot from a few hundred ms earlier, and the 1s gate suppressed the re-read. The `connection_attempt` event was built and frozen with `hostname=nil`. Drop the memoization; the cache lives on tmpfs and is a few KB at most, so per-flow rereads are microseconds.

### 2. Agent: `cached` lines were ignored

`dns_log.parse_reply_line` only matched `reply <name> is <ip>`. dnsmasq emits `cached <name> is <ip>` for every TTL-still-valid repeat lookup, and for everything if dns-tail starts up against an already-warmed dnsmasq. Those entries were silently dropped. Accept both verbs.

### 3. e2e test: reading a wire field that does not exist

After fixing (1)+(2), `/api/debug/events` correctly returned `host: {type: "fqdn", value: "example.com"}` — but `test_02` and the failure-dump formatter were still calling `e.get("hostname")` (a field the #391 schema change removed), so the test never matched and the failure log always printed `hostname=None` regardless of what the agent actually attributed. Centralize the lookup in `event_hostname()` (reads `host.value` when `type == "fqdn"`) and use it from the test, the filter helper, and the failure dump.

## Diagnostic

`dns-tail` now emits an info-level heartbeat every ~60s with lines-ingested + cache-size, so the next "silent" failure here is diagnosable from `logread` without on-VM access.

## Test plan

- [x] `scripts/e2e-vm.sh --only allowed-browsing` → PASSED (was failing identically pre-fix)
- [x] Agent debug log on the patched VM shows `handle_flow: ... hostname=pool.ntp.org` / `hostname=example.com` instead of `hostname=nil`
- [x] `/api/debug/events` returns `host: {type: "fqdn", value: "example.com"}` for the test's HTTP flow

Refs PR #476, issue #472.
Closes #480.