### PR TITLE
fix: stale fdns qemu blocks router-up port bind (#487)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -81,6 +81,11 @@ jobs:
           docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
             build --pull api
 
+      - name: Pre-flight kill of stale fdns VMs
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+
       - name: Run e2e suite
         env:
           FDNS_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-familydns.img

--- a/scripts/vm/client-down.sh
+++ b/scripts/vm/client-down.sh
@@ -61,4 +61,15 @@ if [[ -n "${PID}" ]] && kill -0 "${PID}" 2>/dev/null; then
 fi
 
 rm -rf "${RUN_DIR}"
+
+# Fallback: a previous run was killed hard (e.g., CI cancellation) and
+# left a qemu alive without an up-to-date pidfile. Kill by name so the
+# next client-up doesn't fail to bind hostfwd ports.
+if pgrep -f "qemu-system-x86_64.*-name fdns-${NAME}" >/dev/null 2>&1; then
+  echo "[client-down] found stale fdns-${NAME} qemu without pidfile match — killing"
+  pkill -f "qemu-system-x86_64.*-name fdns-${NAME}" || true
+  # Give the kernel a moment to release the bound ports.
+  sleep 1
+fi
+
 echo "[client-down] '${NAME}' stopped"

--- a/scripts/vm/router-down.sh
+++ b/scripts/vm/router-down.sh
@@ -7,9 +7,22 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib.sh
 source "${HERE}/lib.sh"
 
+stale_qemu_sweep() {
+  # Fallback: a previous run was killed hard (e.g., CI cancellation) and
+  # left a qemu alive without an up-to-date pidfile. Kill by name so the
+  # next router-up doesn't fail to bind hostfwd ports.
+  if pgrep -f "qemu-system-x86_64.*-name fdns-router" >/dev/null 2>&1; then
+    log "found stale fdns-router qemu without pidfile match — killing"
+    pkill -f "qemu-system-x86_64.*-name fdns-router" || true
+    # Give the kernel a moment to release the bound ports.
+    sleep 1
+  fi
+}
+
 if ! router_is_running; then
   log "router VM not running"
   rm -f "${FDNS_ROUTER_PIDFILE}" "${FDNS_ROUTER_MONITOR_SOCK}"
+  stale_qemu_sweep
   exit 0
 fi
 
@@ -39,4 +52,5 @@ if kill -0 "${pid}" 2>/dev/null; then
 fi
 
 rm -f "${FDNS_ROUTER_PIDFILE}" "${FDNS_ROUTER_MONITOR_SOCK}"
+stale_qemu_sweep
 log "router VM stopped"


### PR DESCRIPTION
## Symptom

VM e2e setup fails at `router-up` with:

```
qemu-system-x86_64: -netdev user,id=wan,hostfwd=tcp:127.0.0.1:2222-:22,
                    hostfwd=tcp:127.0.0.1:18081-:80:
                    Could not set up host forwarding rule 'tcp:127.0.0.1:18081-:80'
```

Port 18081 is already bound by a stale `qemu-system-x86_64 -name fdns-router` left over from a prior cancelled CI run.

## Root cause

CI runs concurrent-cancelled via `concurrency: e2e-vm` don't get full `if: always()` teardown time. When `router-down.sh` runs late (or not at all), the pidfile can be out of sync with the live qemu process. `router-down.sh` early-exits whenever `router_is_running()` returns false (pidfile missing/stale → returns false), removes the pidfile, and exits clean — leaving the qemu (and its bound hostfwd ports) alive. The next dispatch then can't bind 18081.

## Fix (two parts)

1. **Harness fallback** in `scripts/vm/router-down.sh` and `scripts/vm/client-down.sh`: after the normal pidfile-based shutdown, `pgrep`/`pkill` any qemu still matching `-name fdns-router` / `-name fdns-${NAME}`. This is the canonical defense — it makes `*-down.sh` correct regardless of pidfile state.
2. **CI pre-flight** in `.github/workflows/e2e-vm.yml`: run `router-down.sh || true` and `client-down.sh || true` immediately before "Run e2e suite", so any straggler from a previous (cancelled) job on the same runner is cleared before the next attempt.

## Test plan

- [ ] Next VM e2e dispatch passes setup (router-up successfully binds hostfwd ports).
- [ ] **Maintainer one-time action on the runner**: the fixed `*-down.sh` only takes effect after this PR lands, but the runner box right now still has the stale qemu from the cancelled run. Before the next dispatch, run on the runner:
  ```
  pkill -f 'qemu-system-x86_64.*fdns-' || true
  ```

Closes #487