### PR TITLE
fix: orphaned imagebuilder breaks VM e2e checkout (#490)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -42,10 +42,17 @@ jobs:
       # runner user before checkout. No-op on clean runners.
       - name: Reclaim root-owned cache files (pre-checkout)
         run: |
+          # Belt+braces for #487/#490: previously-cancelled CI runs can leave
+          # the imagebuilder container running, which keeps writing root-owned
+          # files into the cache after the reclaim sweep finished. Force-remove
+          # by name before reclaiming.
+          docker rm -f fdns-imagebuilder 2>/dev/null || true
           CACHE="${{ github.workspace }}/scripts/vm/.cache"
           if [ -d "$CACHE" ]; then
-            docker run --rm -v "$CACHE":/c alpine \
-              chown -R "$(id -u):$(id -g)" /c || true
+            docker run --rm -v "$CACHE":/c alpine sh -c '
+              chmod -R u+rwX,a+rX /c 2>/dev/null
+              chown -R '"$(id -u):$(id -g)"' /c 2>/dev/null
+            ' || true
           fi
 
       - uses: actions/checkout@v4

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -158,6 +158,7 @@ echo "==> Running Image Builder in $IMAGEBUILDER_DOCKER_IMAGE"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
 docker run --rm \
+    --name fdns-imagebuilder \
     -e HOST_UID="$HOST_UID" \
     -e HOST_GID="$HOST_GID" \
     -v "$IB_ROOT":/ib \
@@ -172,7 +173,7 @@ docker run --rm \
         # actions/checkout cleanup with EACCES on stale .ipk / tmp/test.fs
         # files. chown the whole tree to be future-proof against new IB
         # output dirs.
-        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib 2>/dev/null || true" EXIT
+        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib 2>/dev/null || true; chmod -R u+rwX /ib 2>/dev/null || true" EXIT
 
         export DEBIAN_FRONTEND=noninteractive
         apt-get update -qq


### PR DESCRIPTION
## Symptom

VM e2e workflow fails at `actions/checkout@v4` with `EACCES` on `scripts/vm/.cache/imagebuilder/build_dir/.../grub2/boot.img` (and similar root-owned files under the imagebuilder cache).

## Root cause

The pre-checkout reclaim step from #455 (`chown -R 1000:1000 /c`) ran, but a previously-cancelled imagebuilder container kept writing root-owned files into the cache after the reclaim sweep finished.

`scripts/vm/build-router-image.sh` runs the OpenWRT Image Builder inside `debian:bookworm-slim`. The in-container `trap "chown -R ... /ib" EXIT` only fires on a clean bash exit — when CI cancels a run, the runner's docker CLI process is SIGKILLed but the daemon-managed container survives and keeps producing root-owned files.

Same family as #487 (stale qemu surviving cancellation), different stale process.

## Fix (two-part)

1. **`scripts/vm/build-router-image.sh`** — give the imagebuilder container a stable name (`fdns-imagebuilder`) so the workflow can target it by name. Also widen the in-container EXIT trap with `chmod -R u+rwX /ib` so subsequent host-side `rm -rf` succeeds even on odd modes.

2. **`.github/workflows/e2e-vm.yml`** — extend the existing pre-checkout reclaim step (from #455) to first `docker rm -f fdns-imagebuilder` (no-op if absent), then do defense-in-depth `chmod -R u+rwX,a+rX` alongside the existing `chown -R` via alpine. Kill scope is intentionally narrow to the named container — the runner is a personal box, so we don't sweep arbitrary containers.

## Operator note

The runner currently has stuck state from the cancelled run. Before the next dispatch, run on the runner box once:

```
docker ps -q | xargs -r docker rm -f
docker run --rm -v /home/sameer/actions-runner/_work/familydns/familydns/scripts/vm/.cache:/c alpine sh -c 'chmod -R u+rwX /c; chown -R 1000:1000 /c'
```

## References

- Closes #490
- #455 — original chown-trap PR that this builds on
- #487 — stale qemu after cancellation (same family of bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)