### PR TITLE
ci: ungate publish-api from VM e2e; move suite to ci/vm-e2e branch

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -4,14 +4,25 @@ name: VM e2e
 # the scenarios under scripts/e2e/scenarios/ against a disposable docker
 # compose API stack. Runs on the self-hosted KVM runner (#149).
 #
-# Invoked by master.yml (Master CD) on push:main as a gate before
-# publish-api, and directly via workflow_dispatch for manual runs. Not
-# triggered by pull_request — the repo is public and the runner is
-# self-hosted on a maintainer's host, so we don't execute untrusted fork
-# code on it. See docs/ops/kvm-runner.md → "Trust model" for the full
-# reasoning. Code review on merge is the trust gate.
+# Triggers — VM e2e is currently a stabilization workstream and is not gating
+# publish; see docs/ops/kvm-runner.md → "Trust model":
+#
+#   1. pull_request targeting the `ci/vm-e2e` branch — that branch is the
+#      iteration baseline. Merging fixes into it via PR exercises the suite.
+#      The fork-safety guard on the job restricts execution to PRs from
+#      branches in this repository — fork PRs do not run on the self-hosted
+#      runner (public repo + private hardware).
+#   2. workflow_dispatch — manual runs from the Actions tab against any ref.
+#   3. workflow_call — kept for future use; not currently invoked from any
+#      other workflow.
+#
+# Notably NOT triggered on push:main and NOT a `needs:` of Master CD's
+# publish-api job. Image publish is ungated from the VM e2e while we
+# stabilize the suite.
 
 on:
+  pull_request:
+    branches: [ci/vm-e2e]
   workflow_call:
   workflow_dispatch:
 
@@ -22,6 +33,11 @@ concurrency:
 jobs:
   e2e:
     name: VM e2e suite
+    # Block fork PRs on the self-hosted runner. Same-repo PRs and manual
+    # dispatch / workflow_call invocations are always allowed.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, kvm]
     # Observed durations: 30m was cut off mid-test_pause; 60m got past
     # test_pause but was killed mid-test_time_limit, which sleeps 330s

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -106,18 +106,17 @@ jobs:
       - name: Run prod-stack smoke
         run: scripts/smoke-prod.sh
 
-  # VM-based e2e on the self-hosted KVM runner (#149, #433). Gates publish
-  # so we never push an image that fails the full router-VM scenarios.
-  vm-e2e:
-    name: VM e2e (self-hosted KVM)
-    uses: ./.github/workflows/e2e-vm.yml
+  # VM e2e is intentionally NOT a gate on publish — the suite is being
+  # stabilized on its own track (PRs targeting the `ci/vm-e2e` branch run
+  # .github/workflows/e2e-vm.yml). Reintroduce as a `needs:` here once the
+  # suite is reliably green on that branch.
 
   # ── 3. Publish API image (path-filtered) ──────────────────────────────────
   # NOTE: manual approval gate temporarily removed for live debugging of #228;
   # restore via #244 once the bug is fixed and we're back in normal cadence.
   publish-api:
     name: Publish Docker image to ghcr.io
-    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke, vm-e2e]
+    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
     if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -154,11 +154,27 @@ the VM e2e harness on this host as a regular user, you're done.
 
 ## Trust model
 
-The repo is public, but the workflow that uses this runner triggers only on
-`push: main` and `workflow_dispatch` — never on `pull_request`. A self-hosted
-runner is registered to a specific repo, so a fork pushing to *its* main
-does **not** reach our runner; the only way fork code can run on this box is
-if a maintainer merges it to upstream `main`. Trust gate = code review.
+The repo is public. The VM e2e workflow (`.github/workflows/e2e-vm.yml`) is
+triggered by:
+
+1. `pull_request` whose **base branch is `ci/vm-e2e`** — the dedicated
+   stabilization branch. The workflow job is gated by
+   `if: github.event.pull_request.head.repo.full_name == github.repository`
+   so PRs from forks are refused execution on the self-hosted runner; only
+   branches pushed into this repo can target `ci/vm-e2e` and run the suite.
+2. `workflow_dispatch` — manual runs from the Actions tab against any ref,
+   requires maintainer-equivalent permissions.
+3. `workflow_call` — reserved for future use; not currently invoked from
+   any other workflow.
+
+Notably **not** triggered on `push: main`, and **not** a `needs:` of Master
+CD's `publish-api` job — image publish is ungated from the VM e2e while the
+suite is being stabilized. Reintroduce as a `needs:` once the suite is
+reliably green on `ci/vm-e2e`.
+
+Trust gate for the runner = (a) restriction to `ci/vm-e2e` as the PR base,
+(b) same-repo head-branch requirement on `pull_request`, (c) code review
+before any branch is pushed to this repo.
 
 ## Maintenance
 


### PR DESCRIPTION
## Summary

VM e2e on the self-hosted KVM runner is currently blocking image publish on every push to `main` while we work through the suite's stabilization. Move it off the critical path.

- **`.github/workflows/master.yml`** — remove the `vm-e2e` job (which `uses: ./.github/workflows/e2e-vm.yml`) and drop it from `publish-api.needs`. Publish now gates on `ci-tests + bootstrap-smoke + e2e + prod-stack-smoke` only, matching what we had before #452.
- **`.github/workflows/e2e-vm.yml`** — swap triggers:
  - **Add** `pull_request: branches: [ci/vm-e2e]`. The `ci/vm-e2e` branch becomes the stabilization baseline; any PR targeting it runs the suite.
  - **Keep** `workflow_dispatch` (manual runs against any ref) and `workflow_call` (reserved; not currently invoked from another workflow).
  - **Remove** the previous `workflow_call`-only shape that master.yml relied on (workflow_call is still listed, just no longer the only entry point).
- **Fork-safety guard** on the `e2e` job:
  ```yaml
  if: github.event_name != 'pull_request'
      || github.event.pull_request.head.repo.full_name == github.repository
  ```
  Public repo + self-hosted runner: fork PRs are refused execution. Same-repo PRs and `workflow_dispatch` / `workflow_call` always pass.
- **`docs/ops/kvm-runner.md` § Trust model** — rewritten for the new wiring; explicit note that `publish-api` is no longer gated by VM e2e, with a reminder to reintroduce as a `needs:` once the suite is reliably green.

## Operator follow-up

After this PR merges:

1. **Create the `ci/vm-e2e` branch** from `main` (`git switch -c ci/vm-e2e main && git push -u origin ci/vm-e2e`). Until that branch exists, PRs can't target it, so no VM e2e runs trigger. The `workflow_dispatch` path keeps working in the meantime.
2. **Optional**: enable branch protection on `ci/vm-e2e` to require a passing VM e2e run before merge — that gives you a working signal as you iterate fixes.

## Trigger rationale

`pull_request` against a single stable branch + same-repo head guard is a workable model for a public repo with a personal self-hosted runner: only branches the maintainer has push access to can target `ci/vm-e2e`. Manual `workflow_dispatch` remains for ad-hoc runs.

## Test plan

- [x] Both YAML files parse.
- [x] `publish-api.needs` no longer references `vm-e2e`.
- [ ] First post-merge push to `main` should complete `publish-api` without waiting on VM e2e (assuming the other gates pass — `ci-tests + bootstrap-smoke + e2e + prod-stack-smoke`).
- [ ] After creating `ci/vm-e2e`, opening a PR with target = `ci/vm-e2e` should trigger the VM e2e workflow; opening a PR targeting `main` should NOT.
- [ ] `workflow_dispatch` on `e2e-vm.yml` still works from the Actions tab.