### PR TITLE
fix(openwrt): ensure dnsmasq-full is installed before starting the agent

### DIFF
--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -22,11 +22,18 @@ DNS normally — it is not the enforcement plane (see
   [`install-api.md`](install-api.md) if you need to set one up first.
 - A one-time enrollment token generated in the admin UI under
   **Routers → Add router** (looks like `et_5f3c9b…`).
-The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`, all of which
-ship with stock OpenWRT on both 23.05.x and 24.10+. The remaining runtime
-dependencies (`lua`, `luci-lib-jsonc`, `conntrack-tools`, `curl`) are pulled
-in automatically by the system package manager (`opkg` on 23.05.x, `apk` on
-24.10+) — the package names are the same on both.
+The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`. The latter
+two ship with stock OpenWRT on both 23.05.x and 24.10+. `dnsmasq-full` is
+the stock build on a generic OpenWRT image but vendor images (notably
+GL.iNet) ship the basic `dnsmasq` instead, which is compiled without
+`HAVE_NFTSET` and silently refuses to load the agent's config — leaving
+every hostname-based block ineffective. The install script auto-detects
+this and swaps in `dnsmasq-full`; if you're installing manually, do the
+swap yourself before starting the agent (`apk del dnsmasq && apk add
+dnsmasq-full`, or the `opkg` equivalent). The remaining runtime
+dependencies (`lua`, `luci-lib-jsonc`, `conntrack-tools`, `curl`) are
+pulled in automatically by the system package manager (`opkg` on 23.05.x,
+`apk` on 24.10+) — the package names are the same on both.
 
 ## 2. Install with the one-shot script (recommended)
 

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -72,6 +72,35 @@ if ! command -v curl >/dev/null 2>&1; then
   command -v curl >/dev/null 2>&1 || err "curl still not found after '$PKG_MGR $PKG_INSTALL curl'"
 fi
 
+# Ensure dnsmasq-full is installed. The agent's rendered config uses
+# `nftset=...` directives to populate the eb_*/bl_* ipsets that the
+# nftables forward-drop matches against; the basic `dnsmasq` package is
+# compiled with HAVE_NFTSET disabled and silently refuses to start with
+# that config ("recompile with HAVE_NFTSET defined" in syslog), leaving
+# every hostname-based block ineffective. Vendor OpenWRT builds (e.g.
+# GL.iNet) frequently ship plain dnsmasq instead of dnsmasq-full, so we
+# detect and swap rather than relying on package-level depends.
+ensure_dnsmasq_full() {
+  if [ "$PKG_MGR" = apk ]; then
+    apk list -I dnsmasq-full >/dev/null 2>&1 && return 0
+    if apk list -I dnsmasq >/dev/null 2>&1; then
+      info "Replacing dnsmasq with dnsmasq-full (required for nftset support)"
+      apk del dnsmasq >/dev/null
+    else
+      info "Installing dnsmasq-full (required for nftset support)"
+    fi
+    apk add dnsmasq-full >/dev/null || err "failed to install dnsmasq-full"
+  else
+    opkg list-installed | grep -q '^dnsmasq-full ' && return 0
+    info "Replacing dnsmasq with dnsmasq-full (required for nftset support)"
+    opkg update >/dev/null
+    opkg list-installed | grep -q '^dnsmasq ' && opkg remove dnsmasq >/dev/null
+    opkg install dnsmasq-full >/dev/null || err "failed to install dnsmasq-full"
+  fi
+  /etc/init.d/dnsmasq restart >/dev/null 2>&1 || true
+}
+ensure_dnsmasq_full
+
 # Auto-detect defaults.
 lan_ip=$(uci -q get network.lan.ipaddr || true)
 if [ -n "$lan_ip" ]; then


### PR DESCRIPTION
## Summary

- The install script now detects plain `dnsmasq` and swaps it for `dnsmasq-full` before installing the familydns package.
- `docs/install-openwrt.md` calls out the vendor-build gotcha (GL.iNet etc. ship plain dnsmasq) and gives the manual-install equivalent.

## Why

Hit on a fresh install on a GL.iNet GL-MT6000 (OpenWRT 25.12.3 vendor image): plain `dnsmasq` is compiled without `HAVE_NFTSET`. The agent's rendered config uses `nftset=...` directives to populate the `eb_*` / `bl_*` ipsets that nftables forward-drop matches against. With plain dnsmasq, those directives get rejected with `recompile with HAVE_NFTSET defined to enable nftset directives` and dnsmasq refuses to start. End result: pause/schedule (pure-MAC) blocks work, but every hostname-based block (`extra_blocked`, category blocklists) silently fails because the ipset stays empty.

Swapping to `dnsmasq-full` on the affected router fixed it immediately:

```
==> dnsmasq --version | grep -oE "no-nftset|nftset"
nftset
==> nft list set inet familydns eb_example_com
  elements = { 104.20.23.154 expires 59m59s980ms, 172.66.147.243 expires 59m59s990ms }
```

The install script previously assumed `dnsmasq-full` was already present (a comment at line 139 even references "dnsmasq-full bits" auto-resolving via deps, but the package's `DEPENDS` doesn't actually pull it in, and the apk/opkg conflict with the basic `dnsmasq` blocks a transparent upgrade anyway). Explicit detection + swap is the most reliable fix.

## Test plan

- [x] Verified on GL.iNet GL-MT6000 / OpenWRT 25.12.3 (vendor image): basic `dnsmasq` → `dnsmasq-full` swap; `eb_example_com` populates on next DNS lookup.
- [ ] Verify on a clean 23.05.x / opkg install (manually or in CI).
- [ ] Verify on a clean 24.10+ / apk install where `dnsmasq-full` is already present (no-op path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)