### PR TITLE
ci: gate openwrt-build publish on Master CD checks (#494)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api: ${{ steps.filter.outputs.api }}
+      openwrt: ${{ steps.filter.outputs.openwrt }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -52,6 +53,8 @@ jobs:
               - 'config/application.conf.example'
               - '.scalafmt.conf'
               - '.scalafix.conf'
+            openwrt:
+              - 'openwrt/**'
 
   # ── 1. Full CI test matrix (unit, lint, lua, python, shell, frontend) ─────
   # Runs unconditionally — issue #190 wants test failures on main to block
@@ -161,3 +164,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── 4. Publish OpenWRT .ipk/.apk (path-filtered or v* tag) ────────────────
+  # Gates openwrt build/publish on the same checks as publish-api. Fires when
+  # openwrt/** paths change on main, OR on v* tag pushes so tag releases still
+  # flow through the gate (#494). vm-e2e is intentionally NOT in needs — see
+  # the comment above publish-api / #492.
+  publish-openwrt:
+    name: Build + publish OpenWRT .ipk/.apk
+    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    if: >-
+      needs.changes.outputs.openwrt == 'true'
+      || startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/openwrt-build.yml
+    secrets: inherit

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -5,6 +5,12 @@ name: OpenWRT Package Build
 # on every push to main that touches openwrt/**, so the field router can
 # fetch the updated .apk without us cutting a real tag each iteration.
 # This is reverted by #244 once #228 is fixed.
+#
+# This workflow is also invoked from master.yml as a reusable workflow
+# (`workflow_call`) so the openwrt publish path is gated on the same Master
+# CD checks as publish-api (#494). The standalone push/PR/dispatch triggers
+# below are retained for ad-hoc work (direct tag pushes, PR validation,
+# manual runs).
 on:
   push:
     tags: ["v*"]
@@ -13,6 +19,7 @@ on:
   pull_request:
     paths: ["openwrt/**"]
   workflow_dispatch:
+  workflow_call:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## Problem

`.github/workflows/openwrt-build.yml` currently builds and publishes OpenWRT `.ipk`/`.apk` artifacts (and cuts GitHub releases on `v*` tags) entirely independently of Master CD. Nothing ensures the unit/lint, hosted-runner e2e, bootstrap smoke, or prod-stack-smoke checks passed on the same commit before a release ships — a tag push can publish artifacts even if `master.yml` is red.

## Change

Two-file CI-only change:

- **`.github/workflows/openwrt-build.yml`**: add `workflow_call:` to the trigger list (alongside the existing `push.tags` / `push.branches`+`paths` / `pull_request` / `workflow_dispatch` triggers — all preserved) and a top-of-file comment noting it's now also invoked from `master.yml` as the gated path. No build/release step changes; this PR only changes *what must pass first*, not *when* a release is published.
- **`.github/workflows/master.yml`**: add an `openwrt:` filter (`'openwrt/**'`) to the `changes` job and a new `publish-openwrt` job that mirrors `publish-api`'s `needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]` and reuses `openwrt-build.yml` via `uses:`. Gated on `needs.changes.outputs.openwrt == 'true' || startsWith(github.ref, 'refs/tags/v')` so tag releases still flow through the gate.

`vm-e2e` is intentionally NOT in `needs:` — that suite is being stabilized on its own branch per #492.

## Trade-off note: double-invocation on tag pushes

`workflow_call` on the reusable workflow coexists with its own `push: tags: ["v*"]` trigger, so a `v*` tag push fires `openwrt-build.yml` twice: once standalone (ungated, as today) and once via `master.yml` (gated). Each runs in its own context with its own artifacts/release attempt. In practice `softprops/action-gh-release@v2` is idempotent on the same tag, so duplicates are usually harmless, but it's worth a flag — a future PR could drop `push.tags` from `openwrt-build.yml` once the gated path is proven, leaving tag releases to flow exclusively through `master.yml`.

## Test plan

- [x] Both YAML files parse (`python3 -c \"import yaml; yaml.safe_load(...)\"`).
- [x] `publish-openwrt` is conditional on `changes.outputs.openwrt == 'true' || startsWith(github.ref, 'refs/tags/v')`.
- [x] The new job has the same `needs:` set as `publish-api` (`[changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]`), no `vm-e2e`.
- [ ] A `main` push touching only `web/**` should NOT trigger `publish-openwrt` (the `openwrt` filter output is `false` and the ref isn't a `v*` tag).
- [ ] A `main` push touching `openwrt/**` should trigger `publish-openwrt`, waiting on the full gate set.
- [ ] A `v*` tag push: Master CD's `push` trigger fires, runs the gate, then `publish-openwrt` builds + publishes a release.
- [ ] Direct `workflow_dispatch` on `openwrt-build.yml` still works (standalone trigger preserved).

## Cross-references

- #244 — tag-only release gate restoration (the `if: startsWith(github.ref, 'refs/tags/v')` on the release-attach step is preserved).
- #492 — VM e2e gate moved off main; deliberately excluded from this job's `needs:`.

Closes #494.