### PR TITLE
ci(master): grant contents:write to publish-openwrt reusable call

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -176,5 +176,11 @@ jobs:
     if: >-
       needs.changes.outputs.openwrt == 'true'
       || startsWith(github.ref, 'refs/tags/v')
+    # Reusable-workflow callers cap the called workflow's GITHUB_TOKEN.
+    # openwrt-build.yml's build job requests `contents: write` (to attach
+    # files to the GitHub release on v* tags), so the caller must grant it
+    # here too — otherwise Master CD startup-fails before any job dispatches.
+    permissions:
+      contents: write
     uses: ./.github/workflows/openwrt-build.yml
     secrets: inherit


### PR DESCRIPTION
## Problem

After #497 merged, Master CD on \`main\` fails immediately with \`startup_failure\` ([run 25972493175](https://github.com/sameerparekh/familydns/actions/runs/25972493175)) — no jobs dispatch at all.

Cause: \`openwrt-build.yml\`'s \`build\` job declares \`permissions: contents: write\` (needed to attach files to the GitHub release on \`v*\` tags). When invoked as a reusable workflow, the **caller's** job-level permissions are the ceiling on the called workflow's \`GITHUB_TOKEN\`. \`master.yml\`'s \`publish-openwrt\` job specified no \`permissions\` block, so the implicit ceiling didn't cover \`contents: write\` — and GitHub rejects the run at startup rather than at job dispatch.

## Fix

Add an explicit \`permissions: contents: write\` block to the \`publish-openwrt\` job in \`master.yml\`, matching what the called workflow needs.

## Test plan

- [x] \`master.yml\` parses.
- [ ] Next push to \`main\` runs Master CD past startup (jobs actually dispatch).
- [ ] \`publish-openwrt\` (when it does run) still gets \`contents: write\` and can attach release artifacts on \`v*\` tags.

Refs: #494, #497.