### PR TITLE
sync: pull main into ci/vm-e2e (#1)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api: ${{ steps.filter.outputs.api }}
+      openwrt: ${{ steps.filter.outputs.openwrt }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -52,6 +53,8 @@ jobs:
               - 'config/application.conf.example'
               - '.scalafmt.conf'
               - '.scalafix.conf'
+            openwrt:
+              - 'openwrt/**'
 
   # ── 1. Full CI test matrix (unit, lint, lua, python, shell, frontend) ─────
   # Runs unconditionally — issue #190 wants test failures on main to block
@@ -161,3 +164,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── 4. Publish OpenWRT .ipk/.apk (path-filtered or v* tag) ────────────────
+  # Gates openwrt build/publish on the same checks as publish-api. Fires when
+  # openwrt/** paths change on main, OR on v* tag pushes so tag releases still
+  # flow through the gate (#494). vm-e2e is intentionally NOT in needs — see
+  # the comment above publish-api / #492.
+  publish-openwrt:
+    name: Build + publish OpenWRT .ipk/.apk
+    needs: [changes, ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    if: >-
+      needs.changes.outputs.openwrt == 'true'
+      || startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/openwrt-build.yml
+    secrets: inherit

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -5,6 +5,12 @@ name: OpenWRT Package Build
 # on every push to main that touches openwrt/**, so the field router can
 # fetch the updated .apk without us cutting a real tag each iteration.
 # This is reverted by #244 once #228 is fixed.
+#
+# This workflow is also invoked from master.yml as a reusable workflow
+# (`workflow_call`) so the openwrt publish path is gated on the same Master
+# CD checks as publish-api (#494). The standalone push/PR/dispatch triggers
+# below are retained for ad-hoc work (direct tag pushes, PR validation,
+# manual runs).
 on:
   push:
     tags: ["v*"]
@@ -13,6 +19,7 @@ on:
   pull_request:
     paths: ["openwrt/**"]
   workflow_dispatch:
+  workflow_call:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -22,11 +22,18 @@ DNS normally — it is not the enforcement plane (see
   [`install-api.md`](install-api.md) if you need to set one up first.
 - A one-time enrollment token generated in the admin UI under
   **Routers → Add router** (looks like `et_5f3c9b…`).
-The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`, all of which
-ship with stock OpenWRT on both 23.05.x and 24.10+. The remaining runtime
-dependencies (`lua`, `luci-lib-jsonc`, `conntrack-tools`, `curl`) are pulled
-in automatically by the system package manager (`opkg` on 23.05.x, `apk` on
-24.10+) — the package names are the same on both.
+The agent depends on `dnsmasq-full`, `nftables`, and `uhttpd`. The latter
+two ship with stock OpenWRT on both 23.05.x and 24.10+. `dnsmasq-full` is
+the stock build on a generic OpenWRT image but vendor images (notably
+GL.iNet) ship the basic `dnsmasq` instead, which is compiled without
+`HAVE_NFTSET` and silently refuses to load the agent's config — leaving
+every hostname-based block ineffective. The install script auto-detects
+this and swaps in `dnsmasq-full`; if you're installing manually, do the
+swap yourself before starting the agent (`apk del dnsmasq && apk add
+dnsmasq-full`, or the `opkg` equivalent). The remaining runtime
+dependencies (`lua`, `luci-lib-jsonc`, `conntrack-tools`, `curl`) are
+pulled in automatically by the system package manager (`opkg` on 23.05.x,
+`apk` on 24.10+) — the package names are the same on both.
 
 ## 2. Install with the one-shot script (recommended)
 

--- a/openwrt/files/usr/lib/lua/familydns/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/familydns/conntrack.lua
@@ -5,14 +5,44 @@
 --     meta nftrace because it is available on stock OpenWrt 23.x without enabling
 --     per-rule tracing and produces structured, line-oriented output suitable for
 --     a Lua io.popen loop.
---   * Hostname attribution uses the in-memory nft_sets table that render.lua
---     populates from dnsmasq --ipset= callbacks.  We look up dest_ip against that
---     table to recover the hostname the client resolved, NOT reverse DNS.
+--   * Hostname attribution uses the dns_log cache (dnsmasq query-log path, #259).
+--     The in-memory nft_sets table is populated by render.lua only for site_limits
+--     domains and is NOT a complete IP→hostname mirror; per-host (eb_/bl_) and
+--     extraAllowed (ea_) decisions are therefore driven off the attributed hostname
+--     (hname) matched against eb_hosts_by_mac / ea_hosts_by_mac using dnsmasq's
+--     nftset suffix-match semantics (exact OR subdomain), NOT off nft_sets[host][ip].
 --   * Both allowed and blocked flows are batched.  Blocking state comes from the
---     same nft_sets/policy tables that render.lua writes; we read them but never
---     modify them here.
+--     same policy tables that render.lua writes; we read them but never modify them.
+--   * Reporting limitation: when DNS attribution is unavailable (hname=nil) and the
+--     MAC is paused/time-limited, the agent cannot tell whether the kernel's ea_
+--     carve-out fired.  In that case the flow is logged as blocked even if the
+--     kernel actually allowed it (flows to extraAllowed hosts from a blocked MAC
+--     with no DNS attribution are under-reported as blocked).  The same limitation
+--     applies to per-host eb_ classification: without hname we cannot match against
+--     eb_hosts_by_mac and the flow is left as allowed.
 
 local M = {}
+
+-- ---------------------------------------------------------------------------
+-- host_matches(hname, host) -> bool
+--
+-- Returns true when hname is an exact match for host, or when hname is a
+-- subdomain of host (i.e. hname ends with ".<host>").  This mirrors the
+-- suffix-match semantics of dnsmasq's `nftset=/<host>/...` directive, which
+-- also populates the nft set for all subdomains.
+--
+-- Examples:
+--   host_matches("example.com",     "example.com") → true
+--   host_matches("foo.example.com", "example.com") → true   (subdomain)
+--   host_matches("notexample.com",  "example.com") → false  (no dot prefix)
+--   host_matches("foo.bar",         "example.com") → false
+-- ---------------------------------------------------------------------------
+function M.host_matches(hname, host)
+  if hname == host then return true end
+  -- Check suffix ".<host>" — avoids false positive on e.g. "notexample.com"
+  -- matching "example.com".
+  return hname:sub(-(#host + 1)) == "." .. host
+end
 
 local function default_log()
   local ok, l = pcall(require, "familydns.log")
@@ -376,13 +406,17 @@ end
 -- time we observe a given MAC, then always emits a connection_attempt event.
 --
 -- ctx: {
---   arp_table      table   { ip -> mac }
---   nft_sets       table   { hostname -> { ip -> true } }
---   blocked_macs   table   { mac -> true }       (filled by render.update_shared)
---   blocked_reason table   { mac -> reason }     (filled by render.update_shared)
---   reported_macs  table   { mac -> true }  (mutated)
---   leases         table   { mac -> { ip, hostname } } (may be nil/empty)
---   ts             string  ISO8601 timestamp to attach to the events
+--   arp_table        table   { ip -> mac }
+--   nft_sets         table   { hostname -> { ip -> true } }
+--   blocked_macs     table   { mac -> true }       (filled by render.update_shared)
+--   blocked_reason   table   { mac -> reason }     (filled by render.update_shared)
+--   eb_hosts_by_mac  table   { mac -> { hostname -> true } }
+--                            (filled by render.update_shared — per-host eb_/bl_ drops)
+--   ea_hosts_by_mac  table   { mac -> { hostname -> true } }
+--                            (filled by render.update_shared — extraAllowed carve-outs)
+--   reported_macs    table   { mac -> true }  (mutated)
+--   leases           table   { mac -> { ip, hostname } } (may be nil/empty)
+--   ts               string  ISO8601 timestamp to attach to the events
 -- }
 -- ---------------------------------------------------------------------------
 function M.handle_flow(flow, ctx, batcher)
@@ -427,6 +461,7 @@ function M.handle_flow(flow, ctx, batcher)
   if not hname then
     hname = M.ipset_lookup_hostname(flow.dst_ip, ctx.nft_sets or {})
   end
+
   -- Per-MAC block lookup (#297): pause and time-limit block every flow from
   -- the device, regardless of destination IP. render.update_shared rebuilds
   -- blocked_macs/blocked_reason from the policy snapshot on every poll.
@@ -434,6 +469,80 @@ function M.handle_flow(flow, ctx, batcher)
   local reason
   if not allowed and ctx.blocked_reason then
     reason = ctx.blocked_reason[mac]
+  end
+
+  -- extraAllowed override for blocked MACs (#421): if the MAC is blocked by
+  -- the per-MAC rule (pause / schedule / time-limit) but hname matches a host
+  -- in ea_hosts_by_mac[mac] (using dnsmasq's suffix-match semantics), the
+  -- kernel's `ip daddr != @ea_<mac>_<host>` clause fires and the packet IS
+  -- forwarded.  Flip allowed back to true so the event is reported correctly.
+  --
+  -- Limitation: when hname is nil (no DNS attribution), we cannot determine
+  -- whether the ea_ carve-out fired.  The flow is left as blocked=true even
+  -- if the kernel allowed it.  This is documented as a known reporting gap
+  -- when DNS attribution is missing for flows from a blocked MAC.
+  if not allowed and hname and mac then
+    local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
+    if ea_hosts then
+      for ea_host in pairs(ea_hosts) do
+        if M.host_matches(hname, ea_host) then
+          allowed = true
+          reason  = nil
+          break
+        end
+      end
+    end
+  end
+
+  -- Per-host (eb_/bl_) block check: if the MAC is still considered allowed
+  -- above, check whether hname matches an extraBlocked or blocklist host for
+  -- this MAC using dnsmasq's nftset suffix-match semantics.  The kernel
+  -- enforces drops via:
+  --   ether saddr <mac> ip daddr @eb_<host> drop
+  -- We drive this decision off the attributed hostname (hname) matched against
+  -- eb_hosts_by_mac, NOT off nft_sets[host][dst_ip].  The lua nft_sets table
+  -- is never populated in production (only the kernel ipsets are); nft_sets is
+  -- only a partial attribution fallback for site_limits domains.
+  --
+  -- Each eb_ drop carries `ip daddr != @ea_<mac>_<host>` exception clauses,
+  -- so we must NOT classify as blocked when hname also matches a host in
+  -- ea_hosts_by_mac[mac] (#421).
+  --
+  -- Limitation: when hname is nil, we cannot match against eb_hosts_by_mac
+  -- and the flow is left as allowed.  This is a known reporting gap for
+  -- direct-IP flows (no DNS attribution) to extraBlocked addresses.
+  if allowed and hname and mac then
+    local eb_hosts = ctx.eb_hosts_by_mac and ctx.eb_hosts_by_mac[mac]
+    if eb_hosts then
+      -- Check whether hname (or any of its parent domains) matches an eb_ host.
+      local eb_hit = false
+      for host in pairs(eb_hosts) do
+        if M.host_matches(hname, host) then
+          eb_hit = true
+          break
+        end
+      end
+
+      if eb_hit then
+        -- Check the extraAllowed carve-out: if hname also matches any host in
+        -- ea_hosts_by_mac[mac], the `ip daddr != @ea_...` clause suppresses the
+        -- nft drop and the flow is allowed.
+        local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
+        local ea_hit = false
+        if ea_hosts then
+          for ea_host in pairs(ea_hosts) do
+            if M.host_matches(hname, ea_host) then
+              ea_hit = true
+              break
+            end
+          end
+        end
+        if not ea_hit then
+          allowed = false
+          reason  = "host"
+        end
+      end
+    end
   end
   log.debug("handle_flow: connection_attempt src=%s dst=%s mac=%s hostname=%s allowed=%s reason=%s",
             flow.src_ip, flow.dst_ip, tostring(mac), tostring(hname),
@@ -481,9 +590,11 @@ end
 --   router_id      string    UUID of this router
 --   api_url        string    base URL, e.g. "http://192.168.1.1:8080"
 --   router_token   string    bearer token
---   nft_sets       table     shared ref: { hostname -> { ip -> true } }
---   blocked_macs   table     shared ref: { mac -> true }  (filled by render.lua)
---   blocked_reason table     shared ref: { mac -> reason_string }
+--   nft_sets          table     shared ref: { hostname -> { ip -> true } }
+--   blocked_macs      table     shared ref: { mac -> true }  (filled by render.lua)
+--   blocked_reason    table     shared ref: { mac -> reason_string }
+--   eb_hosts_by_mac   table     shared ref: { mac -> { hostname -> true } }
+--   ea_hosts_by_mac   table     shared ref: { mac -> { hostname -> true } }
 --   lan_prefix     string    default "192.168.1."
 --   max_batch      int       default 50
 --   flush_interval int       default 10  (seconds)
@@ -570,6 +681,8 @@ function M.watch(cfg)
         lookup_hostname       = cfg.lookup_hostname,
         blocked_macs          = cfg.blocked_macs,
         blocked_reason        = cfg.blocked_reason,
+        eb_hosts_by_mac       = cfg.eb_hosts_by_mac,
+        ea_hosts_by_mac       = cfg.ea_hosts_by_mac,
         reported_macs         = reported_macs,
         pending_hostname_macs = pending_hostname_macs,
         leases                = leases or {},

--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -834,24 +834,81 @@ function M.nft(snapshot, opts)
 end
 
 -- ---------------------------------------------------------------------------
--- render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
+-- render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
+--                      eb_hosts_by_mac, ea_hosts_by_mac)
 -- ---------------------------------------------------------------------------
 -- Rebuilds blocked_macs / blocked_reason in place from each device's
 -- effective BlockRules. nft_sets is left intact — population is driven by
 -- dnsmasq --ipset= callbacks at resolution time (and by dns-tail per #259).
-function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason)
+--
+-- Also rebuilds eb_hosts_by_mac and ea_hosts_by_mac when provided:
+--   eb_hosts_by_mac: { mac -> { hostname -> true } }
+--     — the set of hostnames whose nft eb_/bl_ drop rules fire for this MAC
+--       (derived from effective extraBlocked and blocklistIds).
+--   ea_hosts_by_mac: { mac -> { hostname -> true } }
+--     — the set of hostnames in the MAC's effective extraAllowed list; a hit
+--       in this table suppresses the eb_/bl_ block classification.
+-- Both tables are cleared and rebuilt on every call. Callers that do not need
+-- per-host block classification may omit them (pass nil).
+function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
   if blocked_macs then
     for k in pairs(blocked_macs) do blocked_macs[k] = nil end
   end
   if blocked_reason then
     for k in pairs(blocked_reason) do blocked_reason[k] = nil end
   end
+  if eb_hosts_by_mac then
+    for k in pairs(eb_hosts_by_mac) do eb_hosts_by_mac[k] = nil end
+  end
+  if ea_hosts_by_mac then
+    for k in pairs(ea_hosts_by_mac) do ea_hosts_by_mac[k] = nil end
+  end
+
+  -- Build a blocklist-id → [hosts] lookup so we can expand blocklistIds below.
+  local bl_hosts = (snapshot and snapshot._blocklist_hosts) or {}
 
   for mac, dev in pairs(snapshot.devices or {}) do
     local r = effective_rules(dev, snapshot.profiles)
-    if r and r.blocked then
-      if blocked_macs   then blocked_macs[mac]   = true end
-      if blocked_reason then blocked_reason[mac] = r.blockReason or "blocked" end
+    if r then
+      if r.blocked then
+        if blocked_macs   then blocked_macs[mac]   = true end
+        if blocked_reason then blocked_reason[mac] = r.blockReason or "blocked" end
+      end
+
+      -- Per-host extraBlocked: collect all hostnames that the nft eb_ rules
+      -- would drop for this MAC (regardless of whether the MAC is also
+      -- blanket-blocked).
+      if eb_hosts_by_mac and type(r.extraBlocked) == "table" and #r.extraBlocked > 0 then
+        if not eb_hosts_by_mac[mac] then eb_hosts_by_mac[mac] = {} end
+        for _, host in ipairs(r.extraBlocked) do
+          eb_hosts_by_mac[mac][host] = true
+        end
+      end
+
+      -- Per-blocklist blocklistIds: expand each id to its constituent hosts
+      -- using the cached blocklist data attached to the snapshot.
+      if eb_hosts_by_mac and type(r.blocklistIds) == "table" and #r.blocklistIds > 0 then
+        for _, id in ipairs(r.blocklistIds) do
+          local hosts = bl_hosts[id]
+          if type(hosts) == "table" then
+            if not eb_hosts_by_mac[mac] then eb_hosts_by_mac[mac] = {} end
+            for _, host in ipairs(hosts) do
+              eb_hosts_by_mac[mac][host] = true
+            end
+          end
+        end
+      end
+
+      -- extraAllowed: collect all hostnames that suppress eb_/bl_ drops for
+      -- this MAC. A dst_ip in any ea_ set for this MAC escapes classification
+      -- as blocked.
+      if ea_hosts_by_mac and type(r.extraAllowed) == "table" and #r.extraAllowed > 0 then
+        if not ea_hosts_by_mac[mac] then ea_hosts_by_mac[mac] = {} end
+        for _, host in ipairs(r.extraAllowed) do
+          ea_hosts_by_mac[mac][host] = true
+        end
+      end
     end
   end
 end

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -54,9 +54,11 @@ end
 
 -- ── Shared state (render.lua writes; conntrack.lua reads) ─────────────────────
 
-local nft_sets     = {}   -- { hostname -> { ip -> true } }
-local blocked_macs   = {} -- { mac -> true }          (paused / time-exhausted)
-local blocked_reason = {} -- { mac -> reason_string }
+local nft_sets       = {}   -- { hostname -> { ip -> true } }
+local blocked_macs   = {}   -- { mac -> true }          (paused / time-exhausted)
+local blocked_reason = {}   -- { mac -> reason_string }
+local eb_hosts_by_mac = {}  -- { mac -> { hostname -> true } } (extraBlocked + blocklist)
+local ea_hosts_by_mac = {}  -- { mac -> { hostname -> true } } (extraAllowed carve-outs)
 
 -- ── HTTP helpers (curl, available on all OpenWrt builds) ──────────────────────
 
@@ -224,7 +226,7 @@ do
   local cached = policy.load_snapshot(read_file, log)
   if cached then
     if policy.apply(cached, write_file, run_cmd, log) then
-      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason)
+      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
       last_snapshot = cached
       log.info("startup: applied cached policy from /etc/familydns/policy.json")
     else
@@ -247,7 +249,7 @@ do
   local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
   if snap then
     if policy.apply(snap, write_file, run_cmd, log) then
-      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
+      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
       current_etag = etag
       last_snapshot = snap
       policy.mark_poll_success(os.time())
@@ -314,10 +316,12 @@ conntrack.watch({
   router_id       = router_id,
   api_url         = api_url,
   router_token    = router_token,
-  nft_sets        = nft_sets,
-  lookup_hostname = lookup_hostname,
-  blocked_macs    = blocked_macs,
-  blocked_reason  = blocked_reason,
+  nft_sets          = nft_sets,
+  lookup_hostname   = lookup_hostname,
+  blocked_macs      = blocked_macs,
+  blocked_reason    = blocked_reason,
+  eb_hosts_by_mac   = eb_hosts_by_mac,
+  ea_hosts_by_mac   = ea_hosts_by_mac,
   lan_prefix      = lan_prefix,
   max_batch       = max_batch,
   flush_interval  = flush_int,
@@ -354,7 +358,7 @@ conntrack.watch({
         -- apply already emits a clean ruleset (no failover chain), so we
         -- just need to clear the flag below.
         if policy.apply(snap, write_file, run_cmd, log) then
-          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason)
+          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
           current_etag = etag
           last_snapshot = snap
           policy.mark_poll_success(wall)

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -72,6 +72,35 @@ if ! command -v curl >/dev/null 2>&1; then
   command -v curl >/dev/null 2>&1 || err "curl still not found after '$PKG_MGR $PKG_INSTALL curl'"
 fi
 
+# Ensure dnsmasq-full is installed. The agent's rendered config uses
+# `nftset=...` directives to populate the eb_*/bl_* ipsets that the
+# nftables forward-drop matches against; the basic `dnsmasq` package is
+# compiled with HAVE_NFTSET disabled and silently refuses to start with
+# that config ("recompile with HAVE_NFTSET defined" in syslog), leaving
+# every hostname-based block ineffective. Vendor OpenWRT builds (e.g.
+# GL.iNet) frequently ship plain dnsmasq instead of dnsmasq-full, so we
+# detect and swap rather than relying on package-level depends.
+ensure_dnsmasq_full() {
+  if [ "$PKG_MGR" = apk ]; then
+    apk list -I dnsmasq-full >/dev/null 2>&1 && return 0
+    if apk list -I dnsmasq >/dev/null 2>&1; then
+      info "Replacing dnsmasq with dnsmasq-full (required for nftset support)"
+      apk del dnsmasq >/dev/null
+    else
+      info "Installing dnsmasq-full (required for nftset support)"
+    fi
+    apk add dnsmasq-full >/dev/null || err "failed to install dnsmasq-full"
+  else
+    opkg list-installed | grep -q '^dnsmasq-full ' && return 0
+    info "Replacing dnsmasq with dnsmasq-full (required for nftset support)"
+    opkg update >/dev/null
+    opkg list-installed | grep -q '^dnsmasq ' && opkg remove dnsmasq >/dev/null
+    opkg install dnsmasq-full >/dev/null || err "failed to install dnsmasq-full"
+  fi
+  /etc/init.d/dnsmasq restart >/dev/null 2>&1 || true
+}
+ensure_dnsmasq_full
+
 # Auto-detect defaults.
 lan_ip=$(uci -q get network.lan.ipaddr || true)
 if [ -n "$lan_ip" ]; then

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -30,6 +30,37 @@ describe("ipset_lookup_hostname", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 1b. host_matches — dnsmasq nftset suffix-match semantics
+-- ---------------------------------------------------------------------------
+
+describe("host_matches", function()
+  it("returns true for an exact match", function()
+    assert.is_true(conntrack.host_matches("example.com", "example.com"))
+  end)
+
+  it("returns true when hname is a direct subdomain", function()
+    assert.is_true(conntrack.host_matches("foo.example.com", "example.com"))
+  end)
+
+  it("returns true when hname is a deeper subdomain", function()
+    assert.is_true(conntrack.host_matches("a.b.example.com", "example.com"))
+  end)
+
+  it("returns false for a non-matching host", function()
+    assert.is_false(conntrack.host_matches("other.com", "example.com"))
+  end)
+
+  it("returns false for a suffix without a dot separator (avoids false positive)", function()
+    -- 'notexample.com' must NOT match 'example.com'
+    assert.is_false(conntrack.host_matches("notexample.com", "example.com"))
+  end)
+
+  it("returns false for an empty hname", function()
+    assert.is_false(conntrack.host_matches("", "example.com"))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 2. MAC lookup: src_ip → mac via ARP table
 -- ---------------------------------------------------------------------------
 
@@ -462,6 +493,219 @@ describe("handle_flow", function()
       assert.not_equal("dhcp_lease", ev["type"])
     end
     assert.is_true(ctx.pending_hostname_macs[MAC])
+  end)
+
+  -- ── per-host (eb_/bl_) block classification ──────────────────────────────
+  --
+  -- The kernel drops packets via `ether saddr <mac> ip daddr @eb_<host> drop`
+  -- rules, but conntrack -E -e NEW still observes the SYN before the drop.
+  -- handle_flow must consult eb_hosts_by_mac + hname (attributed hostname from
+  -- dns_log cache) to correctly classify those flows as allowed=false with
+  -- reason="host".  The lua nft_sets table is never populated in production,
+  -- so decisions are driven off hname matching eb_hosts_by_mac — NOT off
+  -- nft_sets[host][dst_ip].
+
+  it("labels connection_attempt as blocked (reason=host) when hname exactly matches an eb_ host for the MAC", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      -- hname is attributed via lookup_hostname; nft_sets is empty (as in production).
+      lookup_hostname = function(ip) if ip == DST_IP then return "example.com" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal("connection_attempt", ev["type"])
+    assert.equal(false,  ev.allowed)
+    assert.equal("host", ev.reason)
+  end)
+
+  it("labels connection_attempt as blocked when hname is a subdomain of an eb_ host (suffix-match)", function()
+    -- dnsmasq's nftset rule for example.com also matches foo.example.com, so
+    -- the agent must apply the same suffix-match semantics.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "foo.example.com" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,  ev.allowed)
+    assert.equal("host", ev.reason)
+  end)
+
+  it("does NOT block when hname does not match any eb_ host for the MAC", function()
+    -- Another host is in the eb_ set, but this flow is to a different hostname.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "other.com" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("does NOT block when eb_hosts_by_mac entry is for a different MAC", function()
+    -- Another MAC's extraBlocked, not this one's.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "example.com" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { ["ff:ff:ff:ff:ff:ff"] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("does NOT block when hname matches an eb_ host but also matches an ea_ (extraAllowed) host (#421)", function()
+    -- #421: extraAllowed beats blocked — the nft drop carries `ip daddr != @ea_...`
+    -- so the kernel forwards the packet; handle_flow must mirror this decision.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "example.com" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("does NOT block when eb_hosts_by_mac is absent from ctx", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "example.com" end end,
+      nft_sets        = {},
+      -- no eb_hosts_by_mac
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("does NOT block when hname is nil (no DNS attribution) even if eb_hosts_by_mac has entries", function()
+    -- Limitation: without hname we can't match against eb_hosts_by_mac, so the
+    -- flow is left as allowed=true.  Direct-IP traffic is a known reporting gap.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      -- no lookup_hostname → hname will be nil (nft_sets also empty)
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("does NOT interfere with blocked_macs block: MAC already blocked stays blocked with original reason when hname is nil", function()
+    -- hname=nil → ea-override can't fire → flow stays blocked with MAC-level reason
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "paused" },
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,    ev.allowed)
+    assert.equal("paused", ev.reason)
+  end)
+
+  -- ── extraAllowed (ea_) override for blocked MACs (#421) ──────────────────
+  --
+  -- When a MAC is paused / schedule-blocked / time-limited, the kernel still
+  -- allows flows to extraAllowed hosts via `ip daddr != @ea_<mac>_<host>`
+  -- clauses.  handle_flow must flip allowed back to true when hname matches.
+
+  it("ea-override: blocked MAC + flow to extraAllowed host → allowed=true reason=nil", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "TimeLimit" },
+      lookup_hostname = function(ip) if ip == DST_IP then return "allowed.com" end end,
+      nft_sets        = {},
+      ea_hosts_by_mac = { [MAC] = { ["allowed.com"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal("connection_attempt", ev["type"])
+    assert.equal(true, ev.allowed)
+    assert.not_equal("TimeLimit", ev.reason)
+    -- reason should be "allow" (the default for allowed=true with no explicit reason)
+    assert.equal("allow", ev.reason)
+  end)
+
+  it("ea-override: blocked MAC + flow to a DIFFERENT (non-extraAllowed) hostname → allowed=false reason=TimeLimit", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "TimeLimit" },
+      lookup_hostname = function(ip) if ip == DST_IP then return "blocked-host.com" end end,
+      nft_sets        = {},
+      ea_hosts_by_mac = { [MAC] = { ["allowed.com"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,       ev.allowed)
+    assert.equal("TimeLimit", ev.reason)
+  end)
+
+  it("ea-override: blocked MAC + hname=nil (no DNS attribution) → allowed=false reason=TimeLimit (known limitation)", function()
+    -- Without hname we cannot determine whether the ea_ carve-out fired.
+    -- Flow stays logged as blocked even if the kernel allowed it.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "TimeLimit" },
+      -- no lookup_hostname, nft_sets empty → hname=nil
+      nft_sets        = {},
+      ea_hosts_by_mac = { [MAC] = { ["allowed.com"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,       ev.allowed)
+    assert.equal("TimeLimit", ev.reason)
+  end)
+
+  it("ea-override suffix-match: blocked MAC + extraAllowed example.com + flow hname=img.example.com → allowed=true", function()
+    -- extraAllowed entry is example.com (no subdomain); dnsmasq's nftset
+    -- semantics also cover img.example.com, so the ea_ override must fire.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "paused" },
+      lookup_hostname = function(ip) if ip == DST_IP then return "img.example.com" end end,
+      nft_sets        = {},
+      ea_hosts_by_mac = { [MAC] = { ["example.com"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true,    ev.allowed)
+    assert.equal("allow", ev.reason)
   end)
 end)
 

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -651,6 +651,79 @@ describe("render.update_shared", function()
     assert.equal("Manual", blocked_reason["aa:bb:cc:11:22:33"])
   end)
 
+  -- ── eb_hosts_by_mac / ea_hosts_by_mac population ──────────────────────────
+
+  it("populates eb_hosts_by_mac from a profile's extraBlocked list", function()
+    local s = snap_one()  -- profile 3 has extraBlocked = { "tiktok.com" }
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac = {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
+    assert.is_not_nil(eb_hosts_by_mac["aa:bb:cc:11:22:33"])
+    assert.is_true(eb_hosts_by_mac["aa:bb:cc:11:22:33"]["tiktok.com"])
+  end)
+
+  it("populates eb_hosts_by_mac from blocklistIds when _blocklist_hosts is present", function()
+    local s = snap_one()  -- profile 3 has blocklistIds = { "ads", "adult" }
+    s._blocklist_hosts = {
+      ads   = { "ad.doubleclick.net", "googleads.g.doubleclick.net" },
+      adult = { "pornhub.com" },
+    }
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac = {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
+    local eb = eb_hosts_by_mac["aa:bb:cc:11:22:33"]
+    assert.is_not_nil(eb)
+    assert.is_true(eb["ad.doubleclick.net"])
+    assert.is_true(eb["pornhub.com"])
+    -- extraBlocked host from profile is also present
+    assert.is_true(eb["tiktok.com"])
+  end)
+
+  it("populates ea_hosts_by_mac from a profile's extraAllowed list", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraAllowed = { "netflix.com", "youtube.com" }
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac = {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
+    local ea = ea_hosts_by_mac["aa:bb:cc:11:22:33"]
+    assert.is_not_nil(ea)
+    assert.is_true(ea["netflix.com"])
+    assert.is_true(ea["youtube.com"])
+  end)
+
+  it("clears stale eb_hosts_by_mac entries on rebuild", function()
+    local s = snap_one()
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac = { ["aa:bb:cc:11:22:33"] = { ["old.com"] = true } }
+    local ea_hosts_by_mac = {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
+    -- "old.com" should be gone; "tiktok.com" (from snap_one profile) should be present
+    local eb = eb_hosts_by_mac["aa:bb:cc:11:22:33"]
+    assert.is_nil(eb and eb["old.com"])
+    assert.is_true(eb and eb["tiktok.com"])
+  end)
+
+  it("does not populate eb_hosts_by_mac for a MAC that has no extraBlocked or blocklistIds", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac = {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac)
+    assert.is_nil(eb_hosts_by_mac["aa:bb:cc:11:22:33"])
+  end)
+
+  it("accepts nil eb_hosts_by_mac / ea_hosts_by_mac without error (backwards compat)", function()
+    assert.has_no.errors(function()
+      render.update_shared(snap_one(), {}, {}, {}, nil, nil)
+    end)
+  end)
+
 end)
 
 -- ── blocklist enforcement (#352) ─────────────────────────────────────────────

--- a/scripts/e2e/scenarios/test_extra_blocked.py
+++ b/scripts/e2e/scenarios/test_extra_blocked.py
@@ -1,0 +1,243 @@
+"""Suite B — extraBlocked Truth-1 + per-profile scoping (#429).
+
+Extends `test_03_blocked_domain.py` / `test_06_blocked_page.py` by locking
+the architectural contract from #351 / #352 / #392:
+
+  Truth 1: extraBlocked is enforced at the *connection* layer (nftables),
+  not the DNS layer. dnsmasq still returns the real upstream IPs; the
+  router then drops port-80 traffic to those IPs (or DNATs to the local
+  block page) via a per-host nft set (`eb_<sanitized_host>`).
+
+Cases:
+  - B1 (@smoke): dig from the client returns a real IPv4, NOT NXDOMAIN.
+  - B2: curl gets block-page body; the resolved dest IP appears in the
+        per-host nft drop set on the router.
+  - B3: per-MAC scoping — the Kids MAC (assigned to a profile WITH
+        extraBlocked) is gated by the per-host set; a second MAC assigned
+        to a profile WITHOUT extraBlocked is not subject to MAC-wide block.
+        Note: render.lua's `eb_<host>` set is per-host (shared across MACs);
+        per-MAC isolation lives in the drop *rules* (ether saddr <mac> AND
+        ip daddr @eb_<host>), not the set membership. So we assert (a) the
+        Kids MAC is NOT in `blocked_macs` (extraBlocked is host-scoped, not
+        a MAC-wide pause), (b) the Adults MAC is NOT in `blocked_macs`
+        either, and (c) the per-host set IS populated — confirming the
+        enforcement plane is alive without claiming a per-MAC set split
+        that render.lua doesn't produce.
+
+Asserts current behavior. Bugs surfaced here get filed separately
+(see Discipline note in #429).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+from lib.traffic import dns_query, http_get
+from lib.vm import router_nft_set
+from lib.wait import wait_for_etag_change, wait_until
+
+pytestmark = pytest.mark.extra_blocked
+
+
+# A host whose A-records are reachable from the router's WAN. Per
+# test_06_blocked_page.py, the agent populates the per-host nft set from
+# dnsmasq's actual upstream answers, so a real domain is required.
+BLOCKED_HOST = "example.com"
+
+BLOCKED_MACS_SET = "blocked_macs"
+
+# render.lua's sanitize() replaces "." and ":" with "_". `example.com`
+# becomes `eb_example_com` (v4) / `eb6_example_com` (v6). See
+# openwrt/files/usr/lib/lua/familydns/render.lua eb_set_name().
+EB_SET_V4 = "eb_" + BLOCKED_HOST.replace(".", "_").replace(":", "_")
+
+IPV4_LINE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+
+
+def _norm_mac(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def _mac_in_blocked_set(mac: str) -> bool:
+    members = {_norm_mac(m) for m in router_nft_set(BLOCKED_MACS_SET)}
+    return _norm_mac(mac) in members
+
+
+def _eb_set_members() -> list[str]:
+    return router_nft_set(EB_SET_V4)
+
+
+def _wait_block_page(client, *, host: str = BLOCKED_HOST, timeout_s: float = 90):
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        body_lower = (p.body or "").lower()
+        if p.http_code == 200 and (
+            "familydns" in body_lower or "blocked" in body_lower
+        ):
+            return p
+        return None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"block page response for {host}",
+    )
+
+
+def _wait_eb_set_populated(*, timeout_s: float = 90) -> list[str]:
+    """Wait until the per-host eb_<host> nft set has at least one IPv4
+    element. Population is driven by dnsmasq --nftset= callbacks fired on
+    real upstream answers; depending on cache state this can take a few
+    seconds after the etag changes."""
+    def probe():
+        elems = _eb_set_members()
+        return elems if elems else None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {EB_SET_V4} to gain at least one element",
+    )
+
+
+def _dig_ipv4_answers(client, host: str) -> list[str]:
+    """Return the IPv4 answer lines from `dig +short <host>` on the client."""
+    res = dns_query(client, host, timeout_s=5)
+    lines = [l.strip() for l in (res.stdout or "").splitlines() if l.strip()]
+    return [l for l in lines if IPV4_LINE.match(l)]
+
+
+# ── B1 / B4 ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.smoke
+def test_extra_blocked_dns_returns_real_ip(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """B1 + B4 (smoke): Truth-1 — DNS for an extraBlocked host returns
+    real IPv4 answers, not NXDOMAIN.
+
+    Guards against regression to the old dnsmasq `address=/.../#` sinkhole
+    behavior (#351). The enforcement plane is nft drops, NOT DNS lies.
+    """
+    admin.apply_profile_update(scratch_profile["id"], extraBlocked=[BLOCKED_HOST])
+    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+    # Allow one poll cycle worth of slack for the new dnsmasq config to be
+    # re-rendered and reloaded before we sample DNS.
+    answers = wait_until(
+        lambda: _dig_ipv4_answers(client, BLOCKED_HOST) or None,
+        timeout_s=90, interval_s=3,
+        description=f"dig {BLOCKED_HOST} to return an IPv4 answer",
+    )
+    assert answers, f"expected real IPv4 answers for {BLOCKED_HOST}, got none"
+    for a in answers:
+        assert IPV4_LINE.match(a), f"unexpected non-IPv4 answer line: {a!r}"
+
+
+# ── B2 ─────────────────────────────────────────────────────────────────────
+
+
+def test_extra_blocked_http_drops_to_block_page_and_set_populated(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """B2: HTTP/80 to an extraBlocked host is intercepted (block page body),
+    and the resolved dest IP appears in the per-host nft set on the router.
+
+    The set name pattern is `eb_<sanitize(host)>` where sanitize maps
+    [.:] → _ (see render.lua eb_set_name). It is per-HOST, not per-MAC —
+    per-MAC isolation lives in the drop rules (ether saddr <mac> AND
+    ip daddr @eb_<host>), which we cover indirectly via the block-page
+    observable.
+    """
+    admin.apply_profile_update(scratch_profile["id"], extraBlocked=[BLOCKED_HOST])
+    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+    # 1) The block page is served (Truth-1 enforcement, DNAT to local uhttpd).
+    probe = _wait_block_page(client, timeout_s=90)
+    assert probe.http_code == 200
+
+    # 2) The per-host nft set has elements (dnsmasq --nftset= populated it
+    # from the real upstream answer). The exact IP varies — we only need
+    # at least one member to prove the enforcement plane is hot.
+    members = _wait_eb_set_populated(timeout_s=90)
+    assert members, (
+        f"expected nft set {EB_SET_V4} to have at least one IP element, "
+        f"got empty"
+    )
+
+
+# ── B3 ─────────────────────────────────────────────────────────────────────
+
+
+def test_extra_blocked_is_per_profile_scoped(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """B3: extraBlocked on the Kids profile does NOT MAC-wide block either
+    the Kids MAC or a phantom Adults MAC.
+
+    We can't drive HTTP from a phantom MAC without a second client VM
+    (see scripts/vm/README.md), so we assert per-MAC isolation via NFT
+    state:
+
+      - Neither MAC appears in `blocked_macs` (extraBlocked is host-scoped,
+        not a MAC-wide pause — that's the pause suite's job, #428).
+      - The per-host eb_<host> set is populated (Kids enforcement is hot).
+      - The Adults profile has no extraBlocked, so its derived state should
+        not introduce any MAC-wide block on its assigned device.
+
+    This indirectly proves per-(MAC, host) drop scoping: the Kids MAC's
+    HTTP gets the block page (verified by B2), but neither MAC is in
+    blocked_macs, so the Adults MAC is not subject to a MAC-wide drop.
+    """
+    kids_pid = scratch_profile["id"]
+    kids_mac = client.mac
+
+    # Apply extraBlocked to Kids only.
+    admin.apply_profile_update(kids_pid, extraBlocked=[BLOCKED_HOST])
+    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    _wait_eb_set_populated(timeout_s=90)
+
+    # Create a second profile (Adults) with NO extraBlocked, assigned to a
+    # phantom MAC the router has never seen. The profile defaults
+    # (create_profile in api_admin.py) already set extraBlocked=[].
+    adults = admin.create_profile(name=f"e2e-b3-adults-{uuid.uuid4().hex[:6]}")
+    adults_pid = adults["profile"]["id"] if "profile" in adults else adults["id"]
+    adults_mac = "02:b3:b3:00:00:%02x" % (uuid.uuid4().int & 0xFF)
+    try:
+        admin.upsert_device(
+            mac=adults_mac,
+            name=f"e2e-b3-adults-{adults_mac[-5:]}",
+            profile_id=adults_pid,
+        )
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        # Neither MAC should be in blocked_macs — extraBlocked is per-host,
+        # not a profile-wide pause.
+        def neither_blocked():
+            kb = _mac_in_blocked_set(kids_mac)
+            ab = _mac_in_blocked_set(adults_mac)
+            return True if (not kb and not ab) else None
+
+        wait_until(
+            neither_blocked, timeout_s=60, interval_s=2,
+            description=(
+                f"neither {kids_mac} nor {adults_mac} present in "
+                f"{BLOCKED_MACS_SET}"
+            ),
+        )
+
+        # And the Kids per-host set is still populated (extraBlocked applied
+        # to Kids only — Adults having no extraBlocked must not tear down
+        # the Kids enforcement set).
+        assert _eb_set_members(), (
+            f"Kids enforcement set {EB_SET_V4} unexpectedly empty after "
+            f"adding an unrelated Adults profile"
+        )
+    finally:
+        try:
+            admin.delete_device(adults_mac)
+        except Exception:
+            pass
+        try:
+            admin.delete_profile(adults_pid)
+        except Exception:
+            pass

--- a/scripts/e2e/scenarios/test_schedule.py
+++ b/scripts/e2e/scenarios/test_schedule.py
@@ -1,0 +1,435 @@
+"""Suite C — schedule enforcement (#430).
+
+Verifies #305 / #317 and the pause-over-schedule precedence locked in by
+#406. TZ-sensitive assertions assert *current* behavior; the API gained
+timezone-aware schedules via #334 / #442, but the agent's wall-clock
+sampling vs. CLOCK_MONOTONIC poll cadence (#336) still means we have to
+`wait_for_next_poll` after every `set_router_clock`.
+
+Schedule wire shape (see shared/src/Models.scala `ScheduleRequest`):
+    {"name": str,
+     "days": ["mon", "tue", ...],   # lowercase 3-letter
+     "startLocal": "HH:MM:SS",
+     "endLocal":   "HH:MM:SS",
+     "tz": "America/Los_Angeles"}
+
+Connection-attempt events use lowercase reason strings: "schedule",
+"paused" (see api/src/policy/PolicyService.scala).
+
+Asserts CURRENT behavior. Bugs surfaced here get filed separately —
+this file never bundles fixes.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from lib.clock import get_router_clock, set_router_clock
+from lib.traffic import http_get
+from lib.vm import router_nft_set
+from lib.wait import wait_for_etag_change, wait_for_next_poll, wait_until
+
+pytestmark = pytest.mark.schedule
+
+BLOCKED_MACS_SET = "blocked_macs"
+LA = ZoneInfo("America/Los_Angeles")
+ALL_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+
+# ── shared helpers (mirroring test_pause.py style) ─────────────────────────
+
+
+def _norm_mac(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def _mac_in_set(mac: str) -> bool:
+    members = {_norm_mac(m) for m in router_nft_set(BLOCKED_MACS_SET)}
+    return _norm_mac(mac) in members
+
+
+def _wait_mac_in_blocked_set(mac: str, *, present: bool, timeout_s: float = 90) -> None:
+    target = present
+    wait_until(
+        lambda: True if _mac_in_set(mac) is target else None,
+        timeout_s=timeout_s,
+        interval_s=2,
+        description=(
+            f"{mac} {'present in' if present else 'absent from'} {BLOCKED_MACS_SET}"
+        ),
+    )
+
+
+def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float = 60):
+    """Probe HTTP to `host`, disambiguating block page from real allowed response.
+
+    The block page returns 200 too, so a substring check on the body rules
+    it out (same trick as test_pause.py)."""
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        if p.http_code is not None and 200 <= p.http_code < 400:
+            if "familydns" in p.body.lower() or "blocked" in p.body.lower():
+                return None
+            return p
+        return None
+    return wait_until(probe, timeout_s=timeout_s, interval_s=3,
+                      description=f"allowed HTTP response for {host}")
+
+
+def _wait_event(debug_api, mac: str, *, reason: str, timeout_s: float = 30):
+    return wait_until(
+        lambda: (debug_api.events_for_mac_filtered(
+            mac, allowed=False, reason=reason,
+        ) or None),
+        timeout_s=timeout_s, interval_s=2,
+        description=f"allowed=False reason={reason} event for {mac}",
+    )
+
+
+def _set_clock_and_sync(admin, router, when: datetime) -> None:
+    """Jump the router VM clock, then wait one poll so the agent observes it.
+
+    Per #336 the agent's CLOCK_MONOTONIC cadence is unaffected by a
+    wall-clock jump; `wait_for_next_poll` here pins the next sync to the
+    next cycle boundary and asserts the agent actually polled."""
+    set_router_clock(when)
+    wait_for_next_poll(admin, router.router_id, timeout_s=120)
+
+
+def _schedule_id_from(profile: dict, name: str) -> int | None:
+    for s in (profile.get("schedules") or []):
+        if s.get("name") == name:
+            return s.get("id")
+    return None
+
+
+# ── C1 — in-window blocks ──────────────────────────────────────────────────
+
+
+def test_in_window_blocks(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """C1: schedule covering current router time → MAC blocked within one poll, event reason=schedule."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    assert not _mac_in_set(mac), "precondition: MAC should not be blocked yet"
+
+    original_clock = get_router_clock()
+    # Anchor at a fixed UTC instant inside the window we'll configure. Using
+    # UTC tz here keeps C1 free of TZ math — that's what C3/C5 are for.
+    anchor = datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
+    sched_name = f"e2e-c1-{anchor.strftime('%H%M%S')}"
+    schedule = {
+        "name": sched_name,
+        "days": ALL_DAYS,
+        "startLocal": "11:00:00",
+        "endLocal":   "13:00:00",
+        "tz": "UTC",
+    }
+    result = None
+    try:
+        _set_clock_and_sync(admin, router, anchor)
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+    finally:
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass
+
+
+# ── C2 — out-of-window allows ──────────────────────────────────────────────
+
+
+def test_out_of_window_allows(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """C2: clock outside the configured window → MAC stays unblocked, HTTP works."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    original_clock = get_router_clock()
+    anchor = datetime(2026, 5, 15, 6, 0, 0, tzinfo=timezone.utc)  # well outside 11:00–13:00
+    sched_name = f"e2e-c2-{anchor.strftime('%H%M%S')}"
+    schedule = {
+        "name": sched_name,
+        "days": ALL_DAYS,
+        "startLocal": "11:00:00",
+        "endLocal":   "13:00:00",
+        "tz": "UTC",
+    }
+    result = None
+    try:
+        _set_clock_and_sync(admin, router, anchor)
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+
+        assert not _mac_in_set(mac), \
+            f"{mac} should not be blocked while clock is outside the window"
+        _wait_http_succeeds(client, timeout_s=60)
+    finally:
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass
+
+
+# ── C3 — cross-midnight 23:58→00:03 LA-tz ──────────────────────────────────
+
+
+def test_cross_midnight_LA_tz(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """C3: window 23:58–00:03 LA. Verify enforcement on both sides of midnight.
+
+    `# pending #334` — TZ math went live in #442; if these assertions flip
+    the failure is a real regression, file a separate issue.
+    """
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    original_clock = get_router_clock()
+    sched_name = "e2e-c3-cross-midnight"
+    schedule = {
+        "name": sched_name,
+        "days": ALL_DAYS,
+        "startLocal": "23:58:00",
+        "endLocal":   "00:03:00",
+        "tz": "America/Los_Angeles",
+    }
+
+    # Pick a date and convert each local instant to UTC for the VM clock.
+    date_la = datetime(2026, 5, 15, tzinfo=LA)
+    def la(h, m) -> datetime:
+        return date_la.replace(hour=h, minute=m).astimezone(timezone.utc)
+
+    result = None
+    try:
+        # Start at 23:57 LA — just before the window opens.
+        _set_clock_and_sync(admin, router, la(23, 57))
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+
+        # # pending #334
+        assert not _mac_in_set(mac), "23:57 LA: outside window, should be allowed"
+
+        # Step to 23:59 LA — inside window.
+        _set_clock_and_sync(admin, router, la(23, 59))
+        # # pending #334
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+
+        # Step across midnight to 00:01 LA (next day) — still inside window.
+        next_la = date_la + timedelta(days=1)
+        _set_clock_and_sync(
+            admin, router,
+            next_la.replace(hour=0, minute=1).astimezone(timezone.utc),
+        )
+        # # pending #334
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+
+        # Step to 00:04 LA — past window close.
+        _set_clock_and_sync(
+            admin, router,
+            next_la.replace(hour=0, minute=4).astimezone(timezone.utc),
+        )
+        # # pending #334
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=90)
+    finally:
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass
+
+
+# ── C4 — pause overrides schedule ──────────────────────────────────────────
+
+
+def test_pause_overrides_schedule(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """C4: during a scheduled-block window, pause → reason flips to paused;
+    unpause → reason returns to schedule. Precedence per #406."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    original_clock = get_router_clock()
+    anchor = datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
+    sched_name = f"e2e-c4-{anchor.strftime('%H%M%S')}"
+    schedule = {
+        "name": sched_name,
+        "days": ALL_DAYS,
+        "startLocal": "11:00:00",
+        "endLocal":   "13:00:00",
+        "tz": "UTC",
+    }
+    result = None
+    paused = False
+    try:
+        _set_clock_and_sync(admin, router, anchor)
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+
+        # Pause — reason should flip to paused within one poll.
+        admin.set_profile_paused(profile_id, True)
+        paused = True
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        _wait_event(debug_api, mac, reason="paused", timeout_s=60)
+
+        # Unpause — schedule still in window, reason should revert.
+        admin.set_profile_paused(profile_id, False)
+        paused = False
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+    finally:
+        if paused:
+            try:
+                admin.set_profile_paused(profile_id, False)
+            except Exception:
+                pass
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass
+
+
+# ── C5 — all-day weekday ───────────────────────────────────────────────────
+
+
+def test_all_day_monday(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """C5: all-day-Monday schedule; Sunday 23:59 → allowed, Monday 00:01 → blocked.
+
+    `# pending #334` — depends on TZ-aware day-of-week evaluation."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    original_clock = get_router_clock()
+    sched_name = "e2e-c5-all-day-monday"
+    schedule = {
+        "name": sched_name,
+        "days": ["mon"],
+        "startLocal": "00:00:00",
+        "endLocal":   "23:59:00",
+        "tz": "America/Los_Angeles",
+    }
+
+    # 2026-05-17 is a Sunday in LA; 2026-05-18 is a Monday.
+    sunday_2359 = datetime(2026, 5, 17, 23, 59, tzinfo=LA).astimezone(timezone.utc)
+    monday_0001 = datetime(2026, 5, 18, 0, 1, tzinfo=LA).astimezone(timezone.utc)
+
+    result = None
+    try:
+        _set_clock_and_sync(admin, router, sunday_2359)
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+
+        # # pending #334
+        assert not _mac_in_set(mac), "Sun 23:59 LA: outside Monday window, should be allowed"
+
+        _set_clock_and_sync(admin, router, monday_0001)
+        # # pending #334
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+    finally:
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass
+
+
+# ── C6 — smoke (C1 + C2 back-to-back, no clock acrobatics) ─────────────────
+
+
+@pytest.mark.smoke
+def test_in_then_out_smoke(
+    router, client, scratch_device, scratch_profile, admin, debug_api,
+):
+    """C6 smoke: in-window blocks, then sliding the clock outside the window
+    unblocks. Single schedule lifecycle, two clock jumps — fastest signal."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    original_clock = get_router_clock()
+    in_window  = datetime(2026, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
+    out_window = datetime(2026, 5, 15, 6,  0, 0, tzinfo=timezone.utc)
+    sched_name = "e2e-c6-smoke"
+    schedule = {
+        "name": sched_name,
+        "days": ALL_DAYS,
+        "startLocal": "11:00:00",
+        "endLocal":   "13:00:00",
+        "tz": "UTC",
+    }
+    result = None
+    try:
+        _set_clock_and_sync(admin, router, in_window)
+
+        result = admin.add_schedule(profile_id, schedule)
+        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+
+        _set_clock_and_sync(admin, router, out_window)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=90)
+        _wait_http_succeeds(client, timeout_s=60)
+    finally:
+        sid = _schedule_id_from(result or {}, sched_name)
+        if sid is not None:
+            try:
+                admin.remove_schedule(profile_id, sid)
+            except Exception:
+                pass
+        try:
+            set_router_clock(original_clock)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

Sync `ci/vm-e2e` with latest `main`. This PR exists to trigger the VM e2e suite against the current state of `main` so we can see how close we are to green and what real failures (vs. infrastructure issues) remain.

Commits being merged in:

- c3c962a ci: gate openwrt publish on Master CD checks (#497)
- 722e150 e2e: Suite B — extraBlocked Truth-1 + scoping (#444)
- fa6d835 e2e: Suite C — schedule enforcement (#446)
- de018a5 fix(conntrack): report allowed=false for per-host (eb_/bl_) blocked flows (#495)
- 1b94d46 fix(openwrt): ensure dnsmasq-full is installed before starting the agent (#493)

No code changes in this PR beyond the merge.

## Test plan

- [ ] VM e2e workflow triggers automatically (base = ci/vm-e2e).
- [ ] On completion, analyze failures + file/spawn fix tasks for each distinct root cause.