### PR TITLE
feat(web): logs click-through to device/profile pages (fixes #298)

### DIFF
--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import type { Device, ProfileDetail } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
@@ -22,6 +23,14 @@ vi.mock('@/hooks/useAuth', () => ({
 
 import { api } from '@/api/client'
 import { DevicesPage } from './DevicesPage'
+
+function renderPage(initialEntries: string[] = ['/devices']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <DevicesPage />
+    </MemoryRouter>,
+  )
+}
 
 let mockAuth = { isAdmin: true }
 
@@ -56,7 +65,7 @@ beforeEach(() => {
 
 describe('DevicesPage — list', () => {
   it('renders names, MAC, and profile pills', async () => {
-    render(<DevicesPage />)
+    renderPage()
     expect(await screen.findByText("Kid's iPad")).toBeInTheDocument()
     expect(screen.getByText('aa:bb:cc:dd:ee:01')).toBeInTheDocument()
     expect(screen.getByText('Kids')).toBeInTheDocument()
@@ -67,7 +76,7 @@ describe('DevicesPage — list', () => {
 describe('DevicesPage — add', () => {
   it('opens modal with default profile, fills fields, and calls upsert', async () => {
     const user = userEvent.setup()
-    render(<DevicesPage />)
+    renderPage()
     await screen.findByText("Kid's iPad")
     await user.click(screen.getByRole('button', { name: /\+ Add Device/ }))
 
@@ -92,7 +101,7 @@ describe('DevicesPage — add', () => {
 describe('DevicesPage — edit', () => {
   it('pre-fills modal with existing device values', async () => {
     const user = userEvent.setup()
-    render(<DevicesPage />)
+    renderPage()
     const ipadRow = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
     await user.click(within(ipadRow).getByRole('button', { name: /Edit/ }))
 
@@ -105,7 +114,7 @@ describe('DevicesPage — delete', () => {
   it('confirms then calls api.devices.delete', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const user = userEvent.setup()
-    render(<DevicesPage />)
+    renderPage()
     const ipadRow = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
     await user.click(within(ipadRow).getByRole('button', { name: /Remove/ }))
     expect(confirmSpy).toHaveBeenCalled()
@@ -116,7 +125,7 @@ describe('DevicesPage — delete', () => {
   it('does not call delete when confirm is cancelled', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
     const user = userEvent.setup()
-    render(<DevicesPage />)
+    renderPage()
     const ipadRow = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
     await user.click(within(ipadRow).getByRole('button', { name: /Remove/ }))
     expect(api.devices.delete).not.toHaveBeenCalled()
@@ -124,10 +133,26 @@ describe('DevicesPage — delete', () => {
   })
 })
 
+describe('DevicesPage — highlight from ?mac= (#298)', () => {
+  it('rings the matching device row when ?mac=... is set', async () => {
+    // jsdom doesn't implement scrollIntoView — stub to avoid a runtime throw.
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+    renderPage(['/devices?mac=aa:bb:cc:dd:ee:01'])
+    const row = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
+    await waitFor(() => expect(row.className).toContain('ring-emerald-500'))
+  })
+
+  it('does not ring any row when ?mac= is not set', async () => {
+    renderPage()
+    const row = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
+    expect(row.className).not.toContain('ring-emerald-500')
+  })
+})
+
 describe('DevicesPage — role gating', () => {
   it('hides admin-only buttons for non-admins', async () => {
     mockAuth = { isAdmin: false }
-    render(<DevicesPage />)
+    renderPage()
     await screen.findByText("Kid's iPad")
     expect(screen.queryByRole('button', { name: /\+ Add Device/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Edit/ })).not.toBeInTheDocument()

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -1,8 +1,29 @@
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type { Device, ProfileDetail } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+
+// Apply the LogsPage click-through highlight (#298): when the URL carries
+// `?mac=...`, scroll the matching device row into view and pulse a ring
+// around it so the parent can spot which device they clicked from logs.
+function useHighlightFromQuery(devices: Device[]) {
+  const [params] = useSearchParams()
+  const mac = params.get('mac')
+  const [highlightMac, setHighlightMac] = useState<string | null>(null)
+  useEffect(() => {
+    if (!mac || devices.length === 0) return
+    const exists = devices.some(d => d.mac === mac)
+    if (!exists) return
+    setHighlightMac(mac)
+    const el = document.querySelector(`[data-testid="device-row-${mac}"]`) as HTMLElement | null
+    el?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+    const t = setTimeout(() => setHighlightMac(null), 2000)
+    return () => clearTimeout(t)
+  }, [mac, devices])
+  return highlightMac
+}
 
 // ── Devices page ───────────────────────────────────────────────────────────
 
@@ -13,6 +34,7 @@ export function DevicesPage() {
   const [loading,  setLoading]  = useState(true)
   const [editing,  setEditing]  = useState<Device | null>(null)
   const [form,     setForm]     = useState({ mac: '', name: '', profileId: 0 })
+  const highlightMac = useHighlightFromQuery(devices)
 
   useEffect(() => {
     Promise.all([api.devices.list(), api.profiles.list()])
@@ -61,7 +83,7 @@ export function DevicesPage() {
         {knownDevices.length === 0
           ? <p className="p-6 text-gray-500 text-sm">No devices yet.</p>
           : knownDevices.map(d => (
-              <div key={d.mac} data-testid={`device-row-${d.mac}`} className="flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0">
+              <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-emerald-500/60 ring-inset' : ''}`}>
                 <div className="flex-1 min-w-0">
                   <p className="font-medium text-white truncate">{d.name}</p>
                   <p className="text-xs text-gray-500 font-mono">{d.mac}</p>
@@ -96,7 +118,7 @@ export function DevicesPage() {
           </h2>
           <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
             {unknownDevices.map(d => (
-              <div key={d.mac} data-testid={`device-row-${d.mac}`} className="flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0">
+              <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-emerald-500/60 ring-inset' : ''}`}>
                 <div className="flex-1 min-w-0">
                   <p className="font-medium text-gray-400 truncate">{d.name}</p>
                   <p className="text-xs text-gray-500 font-mono">{d.mac}</p>

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import type { QueryLog, Session, SessionPage } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
@@ -16,6 +17,14 @@ vi.mock('@/api/client', () => ({
 
 import { api } from '@/api/client'
 import { LogsPage } from './LogsPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LogsPage />
+    </MemoryRouter>,
+  )
+}
 
 const session1: Session = {
   mac: 'aa:bb:cc:dd:ee:01',
@@ -64,7 +73,7 @@ beforeEach(() => {
 
 describe('LogsPage — Sessions tab (default)', () => {
   it('renders Sessions tab by default and calls api.sessions.list', async () => {
-    render(<LogsPage />)
+    renderPage()
     expect(await screen.findByText('youtube.com')).toBeInTheDocument()
     expect(screen.getByText('tiktok.com')).toBeInTheDocument()
     expect(api.sessions.list).toHaveBeenCalledWith({
@@ -76,7 +85,7 @@ describe('LogsPage — Sessions tab (default)', () => {
   })
 
   it('shows device name, profile, duration, host for each session', async () => {
-    render(<LogsPage />)
+    renderPage()
     expect(await screen.findByText("Kid's iPad")).toBeInTheDocument()
     expect(screen.getByText('Phone')).toBeInTheDocument()
     // 600s → "10m", 180s → "3m"
@@ -86,7 +95,7 @@ describe('LogsPage — Sessions tab (default)', () => {
 
   it('typing into the host input refetches with the host filter', async () => {
     const user = userEvent.setup()
-    render(<LogsPage />)
+    renderPage()
     await screen.findByText('youtube.com')
     await user.type(screen.getByTestId('sessions-filter-host'), 'youtube')
     await waitFor(() => {
@@ -102,7 +111,7 @@ describe('LogsPage — Sessions tab (default)', () => {
     (api.sessions.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       sessions: [], nextCursor: null,
     } satisfies SessionPage)
-    render(<LogsPage />)
+    renderPage()
     expect(await screen.findByText('No sessions found.')).toBeInTheDocument()
   })
 })
@@ -110,7 +119,7 @@ describe('LogsPage — Sessions tab (default)', () => {
 describe('LogsPage — Connection events tab', () => {
   it('clicking Connection events tab calls api.logs.query and renders connection-event rows', async () => {
     const user = userEvent.setup()
-    render(<LogsPage />)
+    renderPage()
     await screen.findByText('youtube.com')
     await user.click(screen.getByTestId('logs-tab-raw'))
     expect(await screen.findByText('example.com')).toBeInTheDocument()
@@ -118,14 +127,14 @@ describe('LogsPage — Connection events tab', () => {
   })
 
   it('renders the "Connection events" tab label', async () => {
-    render(<LogsPage />)
+    renderPage()
     expect(await screen.findByRole('tab', { name: 'Connection events' })).toBeInTheDocument()
   })
 
   it('Connection events shows empty state with its own copy', async () => {
     (api.logs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
     const user = userEvent.setup()
-    render(<LogsPage />)
+    renderPage()
     await screen.findByText('youtube.com')
     await user.click(screen.getByTestId('logs-tab-raw'))
     expect(await screen.findByText('No events found.')).toBeInTheDocument()
@@ -133,7 +142,7 @@ describe('LogsPage — Connection events tab', () => {
 
   it('Raw events Time column renders in viewer local time (not UTC slice)', async () => {
     const user = userEvent.setup()
-    render(<LogsPage />)
+    renderPage()
     await screen.findByText('youtube.com')
     await user.click(screen.getByTestId('logs-tab-raw'))
     await screen.findByText('example.com')
@@ -142,9 +151,53 @@ describe('LogsPage — Connection events tab', () => {
   })
 })
 
+describe('LogsPage — click-through to device / profile (#298)', () => {
+  it('Sessions tab: device cell links to /devices?mac=...', async () => {
+    renderPage()
+    const link = await screen.findByTestId('logs-device-link-aa:bb:cc:dd:ee:01')
+    expect(link).toHaveAttribute('href', '/devices?mac=aa%3Abb%3Acc%3Add%3Aee%3A01')
+    expect(link).toHaveTextContent("Kid's iPad")
+  })
+
+  it('Sessions tab: profile cell links to /profiles?id=...', async () => {
+    renderPage()
+    // Both fixture sessions share profile 1, so two links carry this testid.
+    const links = await screen.findAllByTestId('logs-profile-link-1')
+    expect(links[0]).toHaveAttribute('href', '/profiles?id=1')
+    expect(links[0]).toHaveTextContent('Kids')
+  })
+
+  it('Connection events tab: device cell links to /devices?mac=...', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    const link = await screen.findByTestId('logs-device-link-aa:bb:cc:dd:ee:01')
+    expect(link).toHaveAttribute('href', '/devices?mac=aa%3Abb%3Acc%3Add%3Aee%3A01')
+  })
+
+  it('Sessions tab: unrecognized MAC (no deviceName) renders MAC as plain text — no link', async () => {
+    const unknownSession: Session = {
+      ...session1,
+      mac: 'fa:fa:fa:fa:fa:fa',
+      deviceName: null,
+      profileId: null,
+      profileName: null,
+      host: { type: 'fqdn', value: 'unknown.example' },
+    }
+    ;(api.sessions.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessions: [unknownSession], nextCursor: null,
+    } satisfies SessionPage)
+    renderPage()
+    await screen.findByText('unknown.example')
+    expect(screen.queryByTestId('logs-device-link-fa:fa:fa:fa:fa:fa')).not.toBeInTheDocument()
+    expect(screen.getByText('fa:fa:fa:fa:fa:fa')).toBeInTheDocument()
+  })
+})
+
 describe('LogsPage — Sessions tab timestamps', () => {
   it('Started column renders session start in viewer local time', async () => {
-    render(<LogsPage />)
+    renderPage()
     await screen.findByText('youtube.com')
     const expected = new Date(session1.startedAt).toLocaleTimeString([], {
       hour: '2-digit', minute: '2-digit',

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,7 +1,43 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { api } from '@/api/client'
 import type { QueryLog, Session } from '@/types/api'
 import { HostCell } from '@/components/HostCell'
+
+// Click-through to the device/profile referenced by a row. The destination
+// pages (DevicesPage / ProfilesPage) read the query param and scroll the
+// matching row into view + highlight it. A dedicated detail route is the
+// proper home for this (#273) but does not exist yet.
+function DeviceLink({ mac, deviceName }: { mac: string | null; deviceName: string | null }) {
+  if (deviceName && mac) {
+    return (
+      <Link
+        to={`/devices?mac=${encodeURIComponent(mac)}`}
+        data-testid={`logs-device-link-${mac}`}
+        className="text-yellow-400 hover:underline"
+      >
+        {deviceName}
+      </Link>
+    )
+  }
+  // Unknown / unregistered MAC: show the MAC (or '?') as plain text — no link.
+  return <span className="text-yellow-400">{mac ?? '?'}</span>
+}
+
+function ProfileLink({ id, name }: { id: number | null; name: string | null }) {
+  if (id != null && name) {
+    return (
+      <Link
+        to={`/profiles?id=${id}`}
+        data-testid={`logs-profile-link-${id}`}
+        className="hover:underline"
+      >
+        {name}
+      </Link>
+    )
+  }
+  return <span>{name ?? ''}</span>
+}
 
 type Tab = 'sessions' | 'raw'
 
@@ -105,8 +141,8 @@ function SessionsTab() {
                         className="border-b border-gray-800/50 hover:bg-gray-800/30"
                         data-testid="session-row">
                       <td className="px-4 py-2.5 text-gray-500">{fmtStarted(s.startedAt)}</td>
-                      <td className="px-4 py-2.5 text-yellow-400">{s.deviceName ?? s.mac}</td>
-                      <td className="px-4 py-2.5 text-gray-400 hidden md:table-cell">{s.profileName ?? ''}</td>
+                      <td className="px-4 py-2.5"><DeviceLink mac={s.mac} deviceName={s.deviceName} /></td>
+                      <td className="px-4 py-2.5 text-gray-400 hidden md:table-cell"><ProfileLink id={s.profileId} name={s.profileName} /></td>
                       <td className="px-4 py-2.5 text-gray-300 max-w-[200px] truncate"><HostCell host={s.host} /></td>
                       <td className="px-4 py-2.5 text-emerald-400">{fmtDuration(s.durationSeconds)}</td>
                       <td className="px-4 py-2.5 text-gray-600 hidden lg:table-cell">{fmtBytes(s.bytesIn + s.bytesOut)}</td>
@@ -186,7 +222,7 @@ function RawEventsTab() {
                   {logs.map(l => (
                     <tr key={l.id} className="border-b border-gray-800/50 hover:bg-gray-800/30">
                       <td className="px-4 py-2.5 text-gray-500">{fmtTime(l.ts)}</td>
-                      <td className="px-4 py-2.5 text-yellow-400">{l.deviceName ?? l.mac ?? '?'}</td>
+                      <td className="px-4 py-2.5"><DeviceLink mac={l.mac} deviceName={l.deviceName} /></td>
                       <td className="px-4 py-2.5 text-gray-300 max-w-[200px] truncate"><HostCell host={l.host} /></td>
                       <td className={`px-4 py-2.5 ${l.blocked ? 'text-red-400' : 'text-emerald-600'}`}>
                         {l.blocked ? '✗ blocked' : '✓ ok'}

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import type { Device, ProfileDetail, User } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
@@ -34,6 +35,14 @@ vi.mock('@/hooks/useAuth', () => ({
 
 import { api } from '@/api/client'
 import { ProfilesPage } from './ProfilesPage'
+
+function renderPage(initialEntries: string[] = ['/profiles']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <ProfilesPage />
+    </MemoryRouter>,
+  )
+}
 
 let mockAuth = { isAdmin: true }
 
@@ -108,7 +117,7 @@ beforeEach(() => {
 
 describe('ProfilesPage — list', () => {
   it('renders profile names, paused badge, blocked categories, schedules, site limits, and daily limit', async () => {
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     expect(within(kidsCard).getByText('Kids')).toBeInTheDocument()
     expect(screen.getByText('Adults')).toBeInTheDocument()
@@ -130,7 +139,7 @@ describe('ProfilesPage — pause / delete', () => {
   // The previous POST /pause endpoint was a server-side toggle (race-prone).
   it('clicking Pause calls api.profiles.update with paused=true and reloads', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /Pause/ }))
     await waitFor(() =>
@@ -144,7 +153,7 @@ describe('ProfilesPage — pause / delete', () => {
 
   it('clicking Resume calls api.profiles.update with paused=false', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')
     await user.click(within(adultsCard).getByRole('button', { name: /Resume/ }))
     await waitFor(() =>
@@ -158,7 +167,7 @@ describe('ProfilesPage — pause / delete', () => {
   it('confirms then calls api.profiles.delete', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
     expect(confirmSpy).toHaveBeenCalled()
@@ -169,7 +178,7 @@ describe('ProfilesPage — pause / delete', () => {
   it('does not delete when confirm is cancelled', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
     expect(api.profiles.delete).not.toHaveBeenCalled()
@@ -180,7 +189,7 @@ describe('ProfilesPage — pause / delete', () => {
 describe('ProfilesPage — create', () => {
   it('shows validation error when name is empty', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     await screen.findByText('Kids')
     await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
@@ -190,7 +199,7 @@ describe('ProfilesPage — create', () => {
 
   it('fills the editor and calls api.profiles.create with the expected body', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     await screen.findByText('Kids')
     await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
 
@@ -245,7 +254,7 @@ describe('ProfilesPage — create', () => {
 describe('ProfilesPage — edit', () => {
   it('pre-fills editor from selected profile and calls api.profiles.update', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
 
@@ -284,7 +293,7 @@ describe('ProfilesPage — edit', () => {
 describe('ProfilesPage — role gating', () => {
   it('hides admin-only buttons for non-admins', async () => {
     mockAuth = { isAdmin: false }
-    render(<ProfilesPage />)
+    renderPage()
     await screen.findByText('Kids')
     expect(screen.queryByRole('button', { name: /\+ New Profile/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Pause/ })).not.toBeInTheDocument()
@@ -296,7 +305,7 @@ describe('ProfilesPage — role gating', () => {
 
 describe('ProfilesPage — devices section', () => {
   it('renders devices grouped under their profile', async () => {
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     const adultsCard = screen.getByTestId('profile-card-2')
 
@@ -310,7 +319,7 @@ describe('ProfilesPage — devices section', () => {
 
 describe('ProfilesPage — linked users section', () => {
   it('renders linked users for each profile (admin view)', async () => {
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     const adultsCard = screen.getByTestId('profile-card-2')
 
@@ -324,7 +333,7 @@ describe('ProfilesPage — linked users section', () => {
 
   it('hides the linked-users section entirely for non-admins', async () => {
     mockAuth = { isAdmin: false }
-    render(<ProfilesPage />)
+    renderPage()
     await screen.findByText('Kids')
     expect(screen.queryByTestId('profile-users-1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('profile-users-2')).not.toBeInTheDocument()
@@ -333,7 +342,7 @@ describe('ProfilesPage — linked users section', () => {
 
   it('admin clicks Edit users → modal opens with current users pre-checked → Save calls api.profiles.setUsers', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /Edit users/ }))
 
@@ -359,7 +368,7 @@ describe('ProfilesPage — linked users section', () => {
 describe('ProfilesPage — #385 failureMode (three modes)', () => {
   it('edit form pre-fills failureMode from the profile (BlockAll for Kids)', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     const blockAll      = screen.getByTestId('profile-failure-mode-block-all')       as HTMLInputElement
@@ -372,7 +381,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
 
   it('edit form pre-fills failureMode from the profile (LastKnownGood for Adults)', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')
     await user.click(within(adultsCard).getByRole('button', { name: /^Edit$/ }))
     const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
@@ -383,7 +392,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
 
   it('selecting AllowAll and saving sends the new value', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(screen.getByTestId('profile-failure-mode-allow-all'))
@@ -395,7 +404,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
 
   it('selecting LastKnownGood and saving sends the new value', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(screen.getByTestId('profile-failure-mode-last-known-good'))
@@ -407,7 +416,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
 
   it('new profile form defaults to LastKnownGood (column default)', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     await screen.findByText('Kids')
     await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
     const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
@@ -416,7 +425,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
 
   it('renders explanatory copy for each of the three modes', async () => {
     const user = userEvent.setup()
-    render(<ProfilesPage />)
+    renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     expect(
@@ -428,5 +437,20 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     expect(
       screen.getByText(/clear every block for this profile's devices/i),
     ).toBeInTheDocument()
+  })
+})
+
+describe('ProfilesPage — highlight from ?id= (#298)', () => {
+  it('rings the matching profile card when ?id=... is set', async () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn()
+    renderPage(['/profiles?id=1'])
+    const card = await screen.findByTestId('profile-card-1')
+    await waitFor(() => expect(card.className).toContain('ring-emerald-500'))
+  })
+
+  it('does not ring any card when ?id= is not set', async () => {
+    renderPage()
+    const card = await screen.findByTestId('profile-card-1')
+    expect(card.className).not.toContain('ring-emerald-500')
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type {
@@ -93,6 +94,22 @@ export function ProfilesPage() {
   const [household, setHousehold] = useState<HouseholdSettings | null>(null)
   const [hsForm, setHsForm] = useState<HouseholdSettings | null>(null)
   const [hsSaving, setHsSaving] = useState(false)
+
+  // #298: LogsPage links to `/profiles?id=...`; scroll + highlight the
+  // matching profile card so the parent sees what they clicked from logs.
+  const [params] = useSearchParams()
+  const queryId = params.get('id')
+  const [highlightId, setHighlightId] = useState<number | null>(null)
+  useEffect(() => {
+    if (!queryId || profiles.length === 0) return
+    const id = Number(queryId)
+    if (!Number.isFinite(id) || !profiles.some(p => p.profile.id === id)) return
+    setHighlightId(id)
+    const el = document.querySelector(`[data-testid="profile-card-${id}"]`) as HTMLElement | null
+    el?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+    const t = setTimeout(() => setHighlightId(null), 2000)
+    return () => clearTimeout(t)
+  }, [queryId, profiles])
 
   const devicesByProfile = useMemo(() => {
     const m = new Map<number, Device[]>()
@@ -279,7 +296,7 @@ export function ProfilesPage() {
 
       <div className="grid gap-4 md:grid-cols-2">
         {profiles.map(pd => (
-          <div key={pd.profile.id} data-testid={`profile-card-${pd.profile.id}`} className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-4">
+          <div key={pd.profile.id} data-testid={`profile-card-${pd.profile.id}`} className={`bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-4 transition-shadow ${highlightId === pd.profile.id ? 'ring-2 ring-emerald-500/60' : ''}`}>
             <div className="flex items-start justify-between gap-2">
               <div>
                 <h3 className="font-bold text-white text-lg">{pd.profile.name}</h3>


### PR DESCRIPTION
## Summary
- **LogsPage**: device and profile cells (Sessions tab + Connection events tab) are now `<Link>`s. Clicking the device name jumps to `/devices?mac=...`; clicking the profile name jumps to `/profiles?id=...`.
- **DevicesPage / ProfilesPage**: read the query param on mount, scroll the matching row/card into view, and pulse a 2s emerald ring so the parent visually lands on what they clicked from logs.
- **Unrecognized MACs**: log rows whose MAC isn't tied to a registered device (no `deviceName`) render the MAC as plain text — no link.

## Notes
- A dedicated per-device detail route doesn't exist yet (#273 tracks it). The acceptance criteria of #298 is click-through behavior, which this delivers via the list-page-with-highlight fallback the issue explicitly allows.
- Coordinates with #342 (log filter-by-device): once that lands, "view logs for this device" can become the natural inverse navigation.

## Test plan
- [x] `npm test` — 13 files, 99 tests pass (added 6 new tests).
  - Sessions tab: device cell renders `<a href="/devices?mac=...">` with the device name.
  - Sessions tab: profile cell renders `<a href="/profiles?id=...">` with the profile name.
  - Connection events tab: device cell renders the device link.
  - Unrecognized-MAC sessions row: MAC rendered as text, no link.
  - DevicesPage: `?mac=...` adds the emerald ring to the matching row; no ring without the param.
  - ProfilesPage: `?id=...` adds the emerald ring to the matching card; no ring without the param.
- [x] `tsc --noEmit` clean.
- [x] `vite build` succeeds.
- [ ] Live verification on the home router after operator `/familydns-update-now`: click a device in /logs → lands on /devices with the row ringed; click a profile → lands on /profiles with the card ringed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)