### PR TITLE
fix(openwrt): drop unsupported tag: prefix from extraAllowed nftset (fixes #496)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/render.lua
+++ b/openwrt/files/usr/lib/lua/familydns/render.lua
@@ -187,20 +187,21 @@ local function resolved_tag_name(mac)
 end
 
 -- #421: per-(MAC, host) extraAllowed exception sets. ea_<sanmac>_<sanhost>
--- holds the v4 resolved IPs of host a for the dhcp-tagged MAC m; ea6_ is the
--- v6 sibling. The eb_/bl_ drop rules append `ip daddr != @ea_<m>_<a>` for
--- each a ∈ extraAllowed(m), so a hit suppresses the drop. eatag_<sanmac>
--- is the dhcp-host tag that scopes the dnsmasq nftset= populator to one MAC
--- (separate from resolvetag_ so a device can opt into blockIpOnly without
--- also having extraAllowed, and vice-versa).
+-- holds the v4 resolved IPs of host a; ea6_ is the v6 sibling. The eb_/bl_
+-- drop rules append `ip daddr != @ea_<m>_<a>` for each a ∈ extraAllowed(m),
+-- so a hit suppresses the drop. The MAC scoping lives entirely in the nft
+-- rule (`ether saddr <m>`); the set name carries the MAC only as a unique
+-- per-(MAC, host) identifier — dnsmasq populates it from any client's
+-- resolution of the host (#496: dnsmasq's `nftset=` does not support a
+-- `tag:` prefix in 2.91, so per-MAC DNS-time scoping isn't an option here).
+-- Cross-pollination is benign: an IP belonging to host h enters every
+-- ea_<m>_h set declared, but a MAC <m'> without h in its extraAllowed has
+-- no corresponding nft rule referencing ea_<m'>_h, so the set is unread.
 local function ea_set_name(mac, host)
   return "ea_" .. sanitize(mac) .. "_" .. sanitize(host)
 end
 local function ea6_set_name(mac, host)
   return "ea6_" .. sanitize(mac) .. "_" .. sanitize(host)
-end
-local function ea_tag_name(mac)
-  return "eatag_" .. sanitize(mac)
 end
 
 -- Per-MAC effective extraAllowed hosts. Returns { [mac] = {host, ...} } with
@@ -258,8 +259,11 @@ function M.dnsmasq(snapshot)
   local bio_macs = {}
   for _, m in ipairs(block_ip_only_macs(snapshot)) do bio_macs[m] = true end
 
-  -- #421: which MACs need a per-MAC eatag (have non-empty effective
-  -- extraAllowed). Same lookup-by-MAC pattern as bio_macs.
+  -- #421: which MACs have non-empty effective extraAllowed. We use this
+  -- below to drive per-(MAC, host) ea_ nftset declarations, but no
+  -- dhcp-host tag is needed (#496: dnsmasq's nftset= parser rejects the
+  -- `tag:` prefix, so the per-MAC scoping lives in the nft rule instead
+  -- and the dnsmasq populator is untagged).
   local ea_by_mac = effective_extra_allowed_by_mac(snapshot)
 
   -- MAC → profile tag so dnsmasq can apply per-profile tagged callbacks.
@@ -269,17 +273,12 @@ function M.dnsmasq(snapshot)
   -- #353: blockIpOnly MACs get an additional `set:resolvetag_<sanmac>` tag
   -- on the same line so the tag-scoped `nftset=` populator below catches
   -- every A/AAAA answered to this client.
-  -- #421: MACs with extraAllowed get an additional `set:eatag_<sanmac>` tag
-  -- so the per-(MAC, host) ea_ populator below catches the right MAC.
   emit("# device MAC → profile tag")
   for mac, dev in sorted_devices(snapshot.devices) do
     if dev.profileId then
       local tags = { string.format("set:profile%d", dev.profileId) }
       if bio_macs[mac] then
         tags[#tags + 1] = "set:" .. resolved_tag_name(mac)
-      end
-      if ea_by_mac[mac] then
-        tags[#tags + 1] = "set:" .. ea_tag_name(mac)
       end
       emit(string.format("dhcp-host=%s,%s", mac, table.concat(tags, ",")))
     end
@@ -301,21 +300,24 @@ function M.dnsmasq(snapshot)
     emit("")
   end
 
-  -- #421: per-(MAC, host) extraAllowed nftset populators. Tag-scoped so
-  -- only the targeted MAC's DNS responses for host a land in ea_<m>_<a> /
-  -- ea6_<m>_<a>. The eb_/bl_ drop rules then carry `ip daddr != @ea_...`
-  -- clauses to suppress the drop when daddr is in any ea set for that MAC.
+  -- #421: per-(MAC, host) extraAllowed nftset populators. One line per
+  -- (mac, host) pair; the set is named per-(mac, host) but populated by
+  -- any client's resolution of host. The MAC scoping happens in the nft
+  -- rule (`ether saddr <mac> ... != @ea_<mac>_<host>`), not at DNS time.
+  -- (#496: dnsmasq 2.91's `nftset=` does NOT parse a `tag:` prefix — the
+  -- earlier tag-scoped form was silently rejected, leaving every ea_ set
+  -- empty and turning the per-MAC drop rule into an unconditional drop.)
   do
     local ea_macs = {}
     for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
     table.sort(ea_macs)
     if #ea_macs > 0 then
-      emit("# extraAllowed → per-(MAC, host) ea_ nftsets (#421)")
+      emit("# extraAllowed → per-(MAC, host) ea_ nftsets (#421, #496)")
       for _, mac in ipairs(ea_macs) do
         for _, host in ipairs(ea_by_mac[mac]) do
           emit(string.format(
-            "nftset=tag:%s,/%s/4#inet#familydns#%s,6#inet#familydns#%s",
-            ea_tag_name(mac), host,
+            "nftset=/%s/4#inet#familydns#%s,6#inet#familydns#%s",
+            host,
             ea_set_name(mac, host), ea6_set_name(mac, host)))
         end
       end

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1235,27 +1235,30 @@ describe("render extraAllowed enforcement (#421)", function()
 
   -- ── dnsmasq side ────────────────────────────────────────────────────────
 
-  it("appends set:eatag_<sanmac> to the dhcp-host line of a MAC with extraAllowed", function()
+  -- #496: dnsmasq 2.91's nftset= parser rejects a `tag:` prefix, so the
+  -- ea_ populator must NOT be tag-scoped. The MAC scoping lives in the
+  -- nft rule (`ether saddr <mac> ... != @ea_<mac>_<host>`) instead.
+  it("does NOT append eatag_ to any dhcp-host line", function()
     local conf = render.dnsmasq(snap_ea())
-    assert.truthy(conf:find(
-      "dhcp-host=aa:bb:cc:11:22:33,set:profile3,set:eatag_aa_bb_cc_11_22_33",
-      1, true))
+    assert.is_nil(conf:find("eatag_", 1, true))
+    -- The MAC with extraAllowed still gets its profile tag, just not an eatag.
+    assert.truthy(conf:find("dhcp-host=aa:bb:cc:11:22:33,set:profile3\n", 1, true)
+               or conf:match("dhcp-host=aa:bb:cc:11:22:33,set:profile3$"))
   end)
 
   it("does NOT append eatag_ to MACs with empty extraAllowed", function()
     local conf = render.dnsmasq(snap_ea())
-    -- Adult MAC has extraAllowed={}; its line must be plain set:profile1.
     assert.truthy(conf:find("dhcp-host=de:ad:be:ef:00:01,set:profile1\n", 1, true)
                or conf:match("dhcp-host=de:ad:be:ef:00:01,set:profile1$"))
-    assert.is_nil(conf:find(
-      "dhcp-host=de:ad:be:ef:00:01,.-eatag_", 1, false))
   end)
 
-  it("emits tag-scoped nftset= populator for the per-(MAC, host) ea_ / ea6_ sets", function()
+  it("emits untagged nftset= populator for the per-(MAC, host) ea_ / ea6_ sets", function()
     local conf = render.dnsmasq(snap_ea())
     assert.truthy(conf:find(
-      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com,6#inet#familydns#ea6_aa_bb_cc_11_22_33_music_tiktok_com",
+      "nftset=/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com,6#inet#familydns#ea6_aa_bb_cc_11_22_33_music_tiktok_com",
       1, true))
+    -- Regression guard: never emit the broken tag:-scoped form (#496).
+    assert.is_nil(conf:find("nftset=tag:", 1, true))
   end)
 
   it("emits one nftset= populator per (mac, host) when a MAC has multiple extraAllowed hosts", function()
@@ -1263,14 +1266,14 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
     local conf = render.dnsmasq(s)
     assert.truthy(conf:find(
-      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com",
+      "nftset=/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com",
       1, true))
     assert.truthy(conf:find(
-      "nftset=tag:eatag_aa_bb_cc_11_22_33,/khanacademy.org/4#inet#familydns#ea_aa_bb_cc_11_22_33_khanacademy_org",
+      "nftset=/khanacademy.org/4#inet#familydns#ea_aa_bb_cc_11_22_33_khanacademy_org",
       1, true))
   end)
 
-  it("does NOT emit ea_ nftsets or eatag dhcp-host suffix when no device has extraAllowed", function()
+  it("does NOT emit ea_ nftsets when no device has extraAllowed", function()
     local s = snap_ea()
     s.profiles["3"].rules.extraAllowed = {}
     local conf = render.dnsmasq(s)
@@ -1280,7 +1283,6 @@ describe("render extraAllowed enforcement (#421)", function()
 
   it("device-override extraAllowed scopes the ea populator to that MAC only", function()
     local s = snap_ea()
-    -- Profile flips OFF; sibling under same profile has no override.
     s.profiles["3"].rules.extraAllowed = {}
     s.devices["11:22:33:44:55:66"] = { profileId = 3, name = "kid-phone", rules = nil }
     s.devices["aa:bb:cc:11:22:33"].rules = {
@@ -1289,14 +1291,12 @@ describe("render extraAllowed enforcement (#421)", function()
       blocklistIds = {}, blockIpOnly = false,
     }
     local conf = render.dnsmasq(s)
-    -- Override MAC gets eatag + populator.
+    -- Override MAC gets the populator under its own per-(MAC, host) set name.
     assert.truthy(conf:find(
-      "dhcp-host=aa:bb:cc:11:22:33,set:profile3,set:eatag_aa_bb_cc_11_22_33",
+      "nftset=/music.tiktok.com/4#inet#familydns#ea_aa_bb_cc_11_22_33_music_tiktok_com",
       1, true))
-    assert.truthy(conf:find(
-      "nftset=tag:eatag_aa_bb_cc_11_22_33,/music.tiktok.com/", 1, true))
-    -- Sibling under same profile must NOT inherit.
-    assert.is_nil(conf:find("eatag_11_22_33_44_55_66", 1, true))
+    -- Sibling under same profile must NOT have a populator with its own set.
+    assert.is_nil(conf:find("ea_11_22_33_44_55_66", 1, true))
   end)
 
   -- ── nft side: set declarations ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes [#496](https://github.com/sameerparekh/familydns/issues/496). #421/#439 supposedly landed router-side enforcement of `BlockRules.extraAllowed` as a per-(MAC, host) accept exception, but it never worked in practice: any device with a non-empty `extraAllowed` under pause / schedule / time-limit collapsed into a hard-drop instead of allowing the listed hosts.

Root cause: dnsmasq 2.91 (shipped on OpenWRT 25.12) does NOT parse a `tag:` prefix in `nftset=` directives. The directive #439 emitted —

```
nftset=tag:eatag_<sanmac>,/host/4#inet#familydns#ea_<mac>_<host>,6#inet#familydns#ea6_<mac>_<host>
```

— triggers dnsmasq to log `Error: syntax error, unexpected colon, expecting string or last` and silently drop the line. The `ea_<mac>_<host>` set therefore stays empty, and the per-MAC drop rule `ether saddr <mac> ip daddr != @ea_<mac>_<host> drop` becomes an unconditional drop.

Fix: drop tag-scoping at the dnsmasq layer. Emit one untagged `nftset=/<host>/4#inet#familydns#ea_<mac>_<host>,6#...` per (mac, host) pair. The set is still named per-(mac, host); the nft rule still scopes the exception by `ether saddr <mac>`. Cross-pollination (an IP for host h enters every `ea_<m>_h` set declared) is harmless — a MAC without h in its extraAllowed has no rule referencing its `ea_*_h` set.

## Diagnosis (5-hop walk on the live test router)

| Hop | Layer | Result |
| --- | --- | --- |
| 1 | DB (`profiles.extra_allowed`) | ✓ persisted |
| 2 | API (`/api/router/policy`) | ✓ field present in `BlockRules` |
| 3 | Agent (`/etc/familydns/policy.json`) | ✓ field present after poll |
| 4 | render.lua → dnsmasq + nft | ✓ rules emitted; ✗ **dnsmasq rejects the `tag:` form, set never populates** |
| 5 | data plane | ✗ blocked: nft sees empty ea set, drop fires |

Smoking gun from `/tmp/familydns-dnsmasq.log` on the live router:

```
nftset tag:eatag_f6_1c_86_e1_c2_b4 Error: syntax error, unexpected colon
nftset /example.org/4 inet familydns ea_f6_1c_86_e1_c2_b4_example_org Error: syntax error, unexpected /
```

After applying the fix locally on the router and triggering a fresh DNS query:

```
set ea_f6_1c_86_e1_c2_b4_example_org {
    elements = { 104.20.26.136 expires 59m58s990ms,
                 172.66.157.237 expires 59m58s990ms }
}
```

## Test plan

- [x] Updated `render_spec.lua` extraAllowed dnsmasq specs to assert the new untagged form. Added a regression guard that asserts `nftset=tag:` never appears anywhere in the rendered dnsmasq config.
- [x] Removed assertions for the now-gone `set:eatag_<sanmac>` dhcp-host suffix; replaced with negative assertions.
- [x] `sh openwrt/test/run_tests.sh` → 303 / 304 specs pass. The one remaining failure (`render_spec.lua:1386`) is a pre-existing failover test bug on `origin/main` (uses `poll_age_seconds` which `render.nft` doesn't read), unrelated to this fix.
- [x] **Deployed to live test router** (192.168.10.42) via `dev-push-router.sh push`. Paused profile + extraAllowed=[example.org] + Quintus iPad (`f6:1c:86:e1:c2:b4`):
  - Before fix: dnsmasq log shows the syntax-error lines; `ea_f6_1c_86_e1_c2_b4_example_org` stays empty.
  - After fix: dnsmasq accepts the directive; the set populates with example.org's resolved IPs; the per-MAC drop rule's `ip daddr != @ea_...` clause now suppresses correctly.
- [x] Live router state restored to non-paused with empty extraAllowed after verification.

## Out of scope

The same `nftset=tag:...` pattern is emitted for blockIpOnly's `resolved_<mac>` populator (#353). That likely fails the same way, but unlike extraAllowed (where the MAC scope lives in the nft rule and per-host shared resolution is acceptable), blockIpOnly's per-MAC scoping is semantically essential — fixing it requires a different mechanism (e.g. dns-tail populating the set in user-space). Filed as a follow-up.

## Refs

- Closes #496
- Follow-up to #421 / #439 (the supposed-fix this completes)
- Touches #350 (Truth 2: extraAllowed is part of the canonical contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)