### PR TITLE
fix(web): move household settings to /admin and collapse-after-save (#449)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import { LogsPage } from '@/pages/LogsPage'
 import { AccountPage } from '@/pages/AccountPage'
 import { UsersPage } from '@/pages/UsersPage'
 import { RoutersPage } from '@/pages/RoutersPage'
+import { AdminPage } from '@/pages/AdminPage'
 import { BlockedPage } from '@/pages/BlockedPage'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
@@ -42,6 +43,7 @@ function AppRoutes() {
         <Route path="account"   element={<AccountPage />} />
         <Route path="users"     element={<RequireAdmin><UsersPage /></RequireAdmin>} />
         <Route path="routers"   element={<RequireAdmin><RoutersPage /></RequireAdmin>} />
+        <Route path="admin"     element={<RequireAdmin><AdminPage /></RequireAdmin>} />
       </Route>
     </Routes>
   )

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -12,6 +12,7 @@ const navItems: NavItem[] = [
   { to: '/logs',      label: 'Logs',      icon: '≡' },
   { to: '/users',     label: 'Users',     icon: '◐', adminOnly: true },
   { to: '/routers',   label: 'Routers',   icon: '⬢', adminOnly: true },
+  { to: '/admin',     label: 'Admin',     icon: '⚙', adminOnly: true },
 ]
 
 export function Layout() {

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    household: {
+      get: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import { AdminPage } from './AdminPage'
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+    dailyResetTime: '00:00',
+    dailyResetTz: 'America/Los_Angeles',
+  })
+  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+})
+
+describe('AdminPage — daily reset card', () => {
+  it('defaults to collapsed summary view with current values', async () => {
+    render(<AdminPage />)
+    const summary = await screen.findByTestId('household-summary')
+    expect(summary).toHaveTextContent(/Resets daily at 12:00 AM/i)
+    expect(summary).toHaveTextContent('America/Los_Angeles')
+    // Form inputs are hidden in viewing state
+    expect(screen.queryByTestId('household-reset-time')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('household-save')).not.toBeInTheDocument()
+  })
+
+  it('formats 13:30 as "1:30 PM" in the summary', async () => {
+    (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      dailyResetTime: '13:30',
+      dailyResetTz: 'America/New_York',
+    })
+    render(<AdminPage />)
+    const summary = await screen.findByTestId('household-summary')
+    expect(summary).toHaveTextContent(/Resets daily at 1:30 PM/i)
+    expect(summary).toHaveTextContent('America/New_York')
+  })
+
+  it('clicking Edit opens the form pre-filled with current values', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
+    expect(time.value).toBe('00:00')
+    expect(screen.getByTestId('household-save')).toBeInTheDocument()
+    expect(screen.getByTestId('household-cancel')).toBeInTheDocument()
+    expect(screen.queryByTestId('household-summary')).not.toBeInTheDocument()
+  })
+
+  it('saving calls api.household.update and collapses back to the summary with new values', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
+    await user.clear(time)
+    await user.type(time, '06:00')
+
+    await user.click(screen.getByTestId('household-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '06:00',
+        dailyResetTz: 'America/Los_Angeles',
+      }),
+    )
+    const summary = await screen.findByTestId('household-summary')
+    expect(summary).toHaveTextContent(/Resets daily at 6:00 AM/i)
+    expect(screen.queryByTestId('household-reset-time')).not.toBeInTheDocument()
+  })
+
+  it('cancel returns to the summary without persisting changes', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
+    await user.clear(time)
+    await user.type(time, '06:00')
+
+    await user.click(screen.getByTestId('household-cancel'))
+
+    expect(api.household.update).not.toHaveBeenCalled()
+    const summary = await screen.findByTestId('household-summary')
+    // Summary still shows original value
+    expect(summary).toHaveTextContent(/Resets daily at 12:00 AM/i)
+
+    // Re-opening edit shows original (not dirty) value
+    await user.click(screen.getByTestId('household-edit'))
+    expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('00:00')
+  })
+
+  it('keeps the form open and shows an error when the API rejects', async () => {
+    (api.household.update as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('boom from server'),
+    )
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+    await user.click(screen.getByTestId('household-save'))
+
+    expect(await screen.findByText(/boom from server/i)).toBeInTheDocument()
+    // Still in editing state
+    expect(screen.getByTestId('household-reset-time')).toBeInTheDocument()
+    expect(screen.queryByTestId('household-summary')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react'
+import { api } from '@/api/client'
+import type { HouseholdSettings } from '@/types/api'
+import { TimezonePicker } from '@/components/TimezonePicker'
+import { PageLoader } from './DashboardPage'
+
+function formatResetTime(hhmm: string): string {
+  const [hStr, mStr] = hhmm.split(':')
+  const h = Number(hStr)
+  const m = Number(mStr)
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return hhmm
+  const period = h < 12 ? 'AM' : 'PM'
+  const display = h % 12 === 0 ? 12 : h % 12
+  return `${display}:${String(m).padStart(2, '0')} ${period}`
+}
+
+export function AdminPage() {
+  const [hs, setHs] = useState<HouseholdSettings | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.household.get()
+      .then(setHs)
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <PageLoader />
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-white">Admin</h1>
+        <p className="text-sm text-gray-500 mt-1">Settings that apply to the whole household.</p>
+      </div>
+
+      {hs && <DailyResetCard value={hs} onSaved={setHs} />}
+    </div>
+  )
+}
+
+function DailyResetCard({
+  value, onSaved,
+}: {
+  value: HouseholdSettings
+  onSaved: (next: HouseholdSettings) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState<HouseholdSettings>(value)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function startEdit() {
+    setForm(value)
+    setError(null)
+    setEditing(true)
+  }
+
+  function cancel() {
+    setForm(value)
+    setError(null)
+    setEditing(false)
+  }
+
+  async function save() {
+    setSaving(true)
+    setError(null)
+    try {
+      await api.household.update({
+        dailyResetTime: form.dailyResetTime,
+        dailyResetTz: form.dailyResetTz,
+      })
+      onSaved(form)
+      setEditing(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="household-settings-card"
+      className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-bold text-white">Daily reset</h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={startEdit}
+            data-testid="household-edit"
+            className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+
+      {!editing ? (
+        <p data-testid="household-summary" className="text-sm text-gray-300">
+          Resets daily at{' '}
+          <span className="font-medium text-white">{formatResetTime(value.dailyResetTime)}</span>{' '}
+          (<span className="font-mono text-gray-400">{value.dailyResetTz}</span>)
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-gray-400">
+            The wall-clock time at which daily usage limits reset. Both the reset time and
+            timezone are stored together — the reset always fires at the configured local clock
+            time, even across DST.
+          </p>
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+              {error}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-3 items-end">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Reset time</label>
+              <input
+                type="time"
+                value={form.dailyResetTime}
+                onChange={e => setForm({ ...form, dailyResetTime: e.target.value })}
+                data-testid="household-reset-time"
+                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm"
+              />
+            </div>
+            <div className="flex-1 min-w-[14rem]">
+              <label className="block text-xs text-gray-500 mb-1">Timezone</label>
+              <TimezonePicker
+                value={form.dailyResetTz}
+                onChange={tz => setForm({ ...form, dailyResetTz: tz })}
+                testId="household-reset-tz"
+              />
+            </div>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={cancel}
+              disabled={saving}
+              data-testid="household-cancel"
+              className="px-4 py-2 rounded-lg bg-gray-800 text-gray-300 text-sm font-medium disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              data-testid="household-save"
+              className="px-4 py-2 rounded-lg bg-emerald-500 text-black text-sm font-semibold disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -23,7 +23,6 @@ vi.mock('@/api/client', () => ({
     },
     household: {
       get: vi.fn(),
-      update: vi.fn(),
     },
   },
 }))
@@ -103,7 +102,6 @@ beforeEach(() => {
     dailyResetTime: '00:00',
     dailyResetTz: 'America/Los_Angeles',
   })
-  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 })
 
 describe('ProfilesPage — list', () => {

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -91,8 +91,6 @@ export function ProfilesPage() {
   const [editingUsersFor, setEditingUsersFor] = useState<number | null>(null)
   const [userPick, setUserPick] = useState<number[]>([])
   const [household, setHousehold] = useState<HouseholdSettings | null>(null)
-  const [hsForm, setHsForm] = useState<HouseholdSettings | null>(null)
-  const [hsSaving, setHsSaving] = useState(false)
 
   const devicesByProfile = useMemo(() => {
     const m = new Map<number, Device[]>()
@@ -130,21 +128,6 @@ export function ProfilesPage() {
     setDevices(devs)
     setAllUsers(users)
     setHousehold(hs)
-    if (hs) setHsForm(hs)
-  }
-
-  async function saveHousehold() {
-    if (!hsForm) return
-    setHsSaving(true)
-    try {
-      await api.household.update({
-        dailyResetTime: hsForm.dailyResetTime,
-        dailyResetTz: hsForm.dailyResetTz,
-      })
-      setHousehold(hsForm)
-    } finally {
-      setHsSaving(false)
-    }
   }
 
   useEffect(() => {
@@ -238,44 +221,6 @@ export function ProfilesPage() {
           </button>
         )}
       </div>
-
-      {isAdmin && hsForm && (
-        <div data-testid="household-settings-card"
-          className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-3">
-          <div className="flex items-center justify-between">
-            <h2 className="font-bold text-white">Household settings</h2>
-            <button
-              onClick={saveHousehold}
-              disabled={hsSaving || (household != null && household.dailyResetTime === hsForm.dailyResetTime && household.dailyResetTz === hsForm.dailyResetTz)}
-              data-testid="household-save"
-              className="text-xs bg-emerald-500/20 text-emerald-300 px-3 py-1.5 rounded-lg border border-emerald-500/30 hover:bg-emerald-500/30 disabled:opacity-40">
-              {hsSaving ? 'Saving…' : 'Save settings'}
-            </button>
-          </div>
-          <p className="text-xs text-gray-400">
-            The wall-clock time at which daily usage limits reset. Both the reset time and timezone
-            are stored together — the reset always fires at the configured local clock time, even
-            across DST.
-          </p>
-          <div className="flex flex-wrap gap-3 items-end">
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">Reset time</label>
-              <input type="time" value={hsForm.dailyResetTime}
-                onChange={e => setHsForm({ ...hsForm, dailyResetTime: e.target.value })}
-                data-testid="household-reset-time"
-                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
-            </div>
-            <div className="flex-1 min-w-[14rem]">
-              <label className="block text-xs text-gray-500 mb-1">Timezone</label>
-              <TimezonePicker
-                value={hsForm.dailyResetTz}
-                onChange={tz => setHsForm({ ...hsForm, dailyResetTz: tz })}
-                testId="household-reset-tz"
-              />
-            </div>
-          </div>
-        </div>
-      )}
 
       <div className="grid gap-4 md:grid-cols-2">
         {profiles.map(pd => (


### PR DESCRIPTION
## Summary

Closes #449.

- New admin-only **Admin** tab at \`/admin\` with the Daily reset card. Gated via the existing \`RequireAdmin\` pattern from #44 — non-admins redirect to \`/dashboard\` and the nav entry stays hidden.
- Daily reset card defaults to a collapsed summary line (\"Resets daily at 12:00 AM (America/Los_Angeles)\"). \"Edit\" opens the form pre-filled; Save persists and collapses back with new values; Cancel reverts.
- Removed the old household-settings card from the top of \`/profiles\`. ProfilesPage still loads household to use \`dailyResetTz\` as the default for schedule timezone (unchanged behavior).

Single \"Daily reset\" card today, matching the underlying single \`PUT /household/settings\` shape; future admin settings get their own cards on this page.

## Test plan

- [x] RTL: summary view by default, Edit → form pre-filled, Save → \`api.household.update\` called → back to summary with new values.
- [x] RTL: time formatting (00:00 → 12:00 AM, 13:30 → 1:30 PM).
- [x] RTL: Cancel returns to summary without calling the API; re-opening shows original value.
- [x] RTL: API error keeps form open and renders the error.
- [x] \`npm run lint\`, \`npm test\` (97/97), \`npm run build\` all clean.
- [x] Live verification on \`192.168.10.43:8080\`: built dist sideloaded into \`familydns-api-1\` via \`docker cp\`, \`/admin\` returns SPA (200), bundle contains \`AdminPage\` / \`household-summary\` / \`Resets daily at\`. Visual click-through of collapse/expand/save left for post-merge once CI rebuilds the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)