### PR TITLE
feat(time): per-host breakdown on profile screen-time page (fixes #262)

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -89,10 +89,10 @@ object Presence {
 
   /**
    * Per-host minutes across all macs, attributing each bucket's duration to every distinct host in
-   * the bucket once. Used for the per-profile "what did they spend time on today" breakdown
-   * (#262). Note: summing across hosts can exceed the device's daily total — by design, the same
-   * 5-min bucket of activity contributes 5 minutes to each host the device touched in that
-   * window. The daily cap still counts the bucket once via `totalMinutesByMac`.
+   * the bucket once. Used for the per-profile "what did they spend time on today" breakdown (#262).
+   * Note: summing across hosts can exceed the device's daily total — by design, the same 5-min
+   * bucket of activity contributes 5 minutes to each host the device touched in that window. The
+   * daily cap still counts the bucket once via `totalMinutesByMac`.
    */
   def hostMinutes(rows: List[PresenceRow]): Map[HostId, Int] = {
     val accum = scala.collection.mutable.Map.empty[HostId, Long]

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -86,4 +86,22 @@ object Presence {
     } accum.updateWith((mac, pat))(prev => Some(prev.getOrElse(0L) + bucketSeconds(bucket)))
     accum.view.mapValues(s => (s / 60).toInt).toMap
   }
+
+  /**
+   * Per-host minutes across all macs, attributing each bucket's duration to every distinct host in
+   * the bucket once. Used for the per-profile "what did they spend time on today" breakdown
+   * (#262). Note: summing across hosts can exceed the device's daily total — by design, the same
+   * 5-min bucket of activity contributes 5 minutes to each host the device touched in that
+   * window. The daily cap still counts the bucket once via `totalMinutesByMac`.
+   */
+  def hostMinutes(rows: List[PresenceRow]): Map[HostId, Int] = {
+    val accum = scala.collection.mutable.Map.empty[HostId, Long]
+    for ((_, bucket) <- rows.groupBy(r => (r.mac, r.periodStart))) {
+      val secs  = bucketSeconds(bucket)
+      val hosts = bucket.iterator.map(_.host).toSet
+      for (h <- hosts)
+        accum.updateWith(h)(prev => Some(prev.getOrElse(0L) + secs))
+    }
+    accum.view.mapValues(s => (s / 60).toInt).toMap
+  }
 }

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -491,7 +491,7 @@ object TimeRoutes {
       // #262 — top-N host attribution across all profile devices for the day.
       // Bucket-deduped per host; informational, so all hosts (including
       // exempt-pattern matches) appear. UI shows top 10.
-      hostUsage = familydns.api.presence.Presence
+      hostUsage       = familydns.api.presence.Presence
         .hostMinutes(presence)
         .iterator
         .filter(_._2 > 0)

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -488,6 +488,17 @@ object TimeRoutes {
       deviceSummaries = devices.map { d =>
         DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
       }
+      // #262 — top-N host attribution across all profile devices for the day.
+      // Bucket-deduped per host; informational, so all hosts (including
+      // exempt-pattern matches) appear. UI shows top 10.
+      hostUsage = familydns.api.presence.Presence
+        .hostMinutes(presence)
+        .iterator
+        .filter(_._2 > 0)
+        .map { case (h, m) => HostUsage(h, m) }
+        .toList
+        .sortBy(hu => (-hu.usedMins, hu.host.value))
+        .take(10)
     } yield ProfileTimeStatus(
       profile.id,
       profile.name,
@@ -498,6 +509,7 @@ object TimeRoutes {
       remaining,
       siteUsage,
       deviceSummaries,
+      hostUsage,
     )
   }
 

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -642,14 +642,16 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           resp <- routes.runZIO(req)
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
-          kids = list.find(_.profileId == kidsId).get
+          kids    = list.find(_.profileId == kidsId).get
           hostMap = kids.hostUsage.map(hu => hu.host.value -> hu.usedMins).toMap
         } yield assertTrue(kids.hostUsage.length == 3) &&
-          assertTrue(hostMap == Map(
-            "youtube.com"      -> 35,
-            "khan-academy.org" -> 10,
-            "roblox.com"       -> 5,
-          )) &&
+          assertTrue(
+            hostMap == Map(
+              "youtube.com"      -> 35,
+              "khan-academy.org" -> 10,
+              "roblox.com"       -> 5,
+            ),
+          ) &&
           assertTrue(kids.hostUsage.map(_.usedMins) == List(35, 10, 5)) // sorted desc
       },
       test("hostUsage capped at top 10, smallest dropped (#262)") {
@@ -666,12 +668,12 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           token       <- auth.login("admin", "changeme").map(_.token.value)
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 240)
-          mac         = "aa:bb:cc:dd:ee:01"
+          mac = "aa:bb:cc:dd:ee:01"
           _        <- TestLayers.seedDevice(deviceRepo, mac, "iPad", kidsId)
           routerId <- seedRouter
           today = TestClock.schoolDayAfternoon.toLocalDate
           // Seed 12 distinct hosts; minutes = (12-i)*5 so host0 has the most.
-          _ <- ZIO.foreachDiscard(0 until 12) { i =>
+          _               <- ZIO.foreachDiscard(0 until 12) { i =>
             val mins = (12 - i) * 5
             seedTraffic(routerId, mac, s"host$i.example.com", today, mins, bucketOffset = i * 20)
           }
@@ -694,7 +696,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           resp <- routes.runZIO(req)
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
-          kids = list.find(_.profileId == kidsId).get
+          kids  = list.find(_.profileId == kidsId).get
           hosts = kids.hostUsage.map(_.host.value).toSet
         } yield assertTrue(kids.hostUsage.length == 10) &&
           // The two smallest (host10=10m, host11=5m) dropped; host0..host9 retained.

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -598,6 +598,111 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
           assertTrue(kids.usedMins == 0)         // site usage NOT counted in total
       },
+      test("hostUsage breakdown sums across all profile devices, sorted desc (#262)") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // mac1: youtube 20m + khan 10m (distinct buckets); mac2: youtube 15m + roblox 5m
+          o1 <- seedTraffic(routerId, mac1, "youtube.com", today, 20)
+          _  <- seedTraffic(routerId, mac1, "khan-academy.org", today, 10, bucketOffset = o1)
+          o2 <- seedTraffic(routerId, mac2, "youtube.com", today, 15)
+          _  <- seedTraffic(routerId, mac2, "roblox.com", today, 5, bucketOffset = o2)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+          hostMap = kids.hostUsage.map(hu => hu.host.value -> hu.usedMins).toMap
+        } yield assertTrue(kids.hostUsage.length == 3) &&
+          assertTrue(hostMap == Map(
+            "youtube.com"      -> 35,
+            "khan-academy.org" -> 10,
+            "roblox.com"       -> 5,
+          )) &&
+          assertTrue(kids.hostUsage.map(_.usedMins) == List(35, 10, 5)) // sorted desc
+      },
+      test("hostUsage capped at top 10, smallest dropped (#262)") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 240)
+          mac         = "aa:bb:cc:dd:ee:01"
+          _        <- TestLayers.seedDevice(deviceRepo, mac, "iPad", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Seed 12 distinct hosts; minutes = (12-i)*5 so host0 has the most.
+          _ <- ZIO.foreachDiscard(0 until 12) { i =>
+            val mins = (12 - i) * 5
+            seedTraffic(routerId, mac, s"host$i.example.com", today, mins, bucketOffset = i * 20)
+          }
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+          hosts = kids.hostUsage.map(_.host.value).toSet
+        } yield assertTrue(kids.hostUsage.length == 10) &&
+          // The two smallest (host10=10m, host11=5m) dropped; host0..host9 retained.
+          assertTrue(!hosts.contains("host10.example.com")) &&
+          assertTrue(!hosts.contains("host11.example.com")) &&
+          assertTrue(hosts.contains("host0.example.com")) &&
+          assertTrue(hosts.contains("host9.example.com"))
+      },
       test("policy snapshot has profile-level time_used_today aggregated across devices") {
         for {
           _           <- cleanDb

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -149,5 +149,75 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
+    suite("hostMinutes")(
+      test("empty rows yields empty map") {
+        assertTrue(Presence.hostMinutes(Nil) == Map.empty[HostId, Int])
+      },
+      test("each host in a bucket gets the bucket's minutes attributed once") {
+        // A 5-min bucket with three distinct hosts: each host gets 5 minutes
+        // of attribution. Per-host view is informational, not a fraction of
+        // the daily total (which still counts the bucket once).
+        val rows = List(
+          row(mac1, 0, "youtube.com"),
+          row(mac1, 0, "google.com"),
+          row(mac1, 0, "dropbox.com"),
+        )
+        val res  = Presence.hostMinutes(rows)
+        assertTrue(
+          res == Map(
+            HostId.Fqdn(Hostname.unsafe("youtube.com"))  -> 5,
+            HostId.Fqdn(Hostname.unsafe("google.com"))   -> 5,
+            HostId.Fqdn(Hostname.unsafe("dropbox.com")) -> 5,
+          ),
+        )
+      },
+      test("same host across multiple buckets sums") {
+        val rows = List(
+          row(mac1, 0, "youtube.com"),
+          row(mac1, 1, "youtube.com"),
+          row(mac2, 2, "youtube.com"),
+        )
+        assertTrue(
+          Presence.hostMinutes(rows) == Map(
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 15,
+          ),
+        )
+      },
+      test("same host twice in one bucket only counts once for that bucket") {
+        val rows = List(
+          row(mac1, 0, "youtube.com"),
+          row(mac1, 0, "youtube.com"),
+        )
+        assertTrue(
+          Presence.hostMinutes(rows) == Map(
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 5,
+          ),
+        )
+      },
+      test("IP-literal hosts are attributed under their address form") {
+        val rows = List(
+          ipRow(mac1, 0, "192.0.2.1"),
+          row(mac1, 0, "youtube.com"),
+        )
+        assertTrue(
+          Presence.hostMinutes(rows) == Map(
+            HostId.IPv4(IpAddress.unsafe("192.0.2.1"))  -> 5,
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 5,
+          ),
+        )
+      },
+      test("uses max active_seconds in the bucket as duration") {
+        val rows = List(
+          row(mac1, 0, "a.com", 60),
+          row(mac1, 0, "b.com", 300),
+        )
+        assertTrue(
+          Presence.hostMinutes(rows) == Map(
+            HostId.Fqdn(Hostname.unsafe("a.com")) -> 5,
+            HostId.Fqdn(Hostname.unsafe("b.com")) -> 5,
+          ),
+        )
+      },
+    ),
   )
 }

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -165,8 +165,8 @@ object PresenceSpec extends ZIOSpecDefault {
         val res  = Presence.hostMinutes(rows)
         assertTrue(
           res == Map(
-            HostId.Fqdn(Hostname.unsafe("youtube.com"))  -> 5,
-            HostId.Fqdn(Hostname.unsafe("google.com"))   -> 5,
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 5,
+            HostId.Fqdn(Hostname.unsafe("google.com"))  -> 5,
             HostId.Fqdn(Hostname.unsafe("dropbox.com")) -> 5,
           ),
         )

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -288,6 +288,8 @@ case class DeviceUsageSummary(
     usedMins: Int,
 ) derives JsonCodec
 
+case class HostUsage(host: HostId, usedMins: Int) derives JsonCodec
+
 case class ProfileTimeStatus(
     profileId: ProfileId,
     profileName: String,
@@ -298,6 +300,7 @@ case class ProfileTimeStatus(
     remainingMins: Option[Int],
     siteUsage: List[SiteUsage],
     devices: List[DeviceUsageSummary],
+    hostUsage: List[HostUsage],
 ) derives JsonCodec
 
 case class ProfileDetail(

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -33,6 +33,11 @@ const limited: ProfileTimeStatus = {
     { label: 'YouTube', domainPattern: 'youtube.com', limitMins: 30, usedMins: 30, remainingMins: 0 },
   ],
   devices: [{ deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", usedMins: 90 }],
+  hostUsage: [
+    { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 35 },
+    { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 10 },
+    { host: { type: 'ipv4', value: '192.0.2.1' }, usedMins: 5 },
+  ],
 }
 
 const overLimit: ProfileTimeStatus = {
@@ -45,6 +50,7 @@ const overLimit: ProfileTimeStatus = {
   remainingMins: 0,
   siteUsage: [],
   devices: [{ deviceMac: 'aa:bb:cc:dd:ee:02', deviceName: 'Phone', usedMins: 100 }],
+  hostUsage: [],
 }
 
 const noLimit: ProfileTimeStatus = {
@@ -57,6 +63,7 @@ const noLimit: ProfileTimeStatus = {
   remainingMins: null,
   siteUsage: [],
   devices: [{ deviceMac: 'aa:bb:cc:dd:ee:03', deviceName: 'Laptop', usedMins: 0 }],
+  hostUsage: [],
 }
 
 beforeEach(() => {
@@ -80,6 +87,23 @@ describe('TimePage — list', () => {
     // no-limit card
     expect(screen.getByText('Laptop')).toBeInTheDocument()
     expect(screen.getByText(/No time limit set/)).toBeInTheDocument()
+  })
+
+  it('renders top-host breakdown when hostUsage is present (#262)', async () => {
+    render(<TimePage />)
+    expect(await screen.findByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
+    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('35m')
+    expect(screen.getByTestId('time-host-1-khan-academy.org')).toHaveTextContent('khan-academy.org')
+    expect(screen.getByTestId('time-host-1-khan-academy.org')).toHaveTextContent('10m')
+    // IP-literal host is shown by its address form
+    expect(screen.getByTestId('time-host-1-192.0.2.1')).toHaveTextContent('192.0.2.1')
+  })
+
+  it('omits the top-host section when hostUsage is empty (#262)', async () => {
+    render(<TimePage />)
+    // overLimit profile (id=2) has hostUsage: [] — no time-host-* testids for it
+    await screen.findByTestId('time-card-2')
+    expect(screen.queryByTestId(/^time-host-2-/)).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -194,6 +194,22 @@ function ProfileTimeCard({
         </div>
       )}
 
+      {status.hostUsage.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Top Sites</p>
+          {status.hostUsage.map(hu => (
+            <div
+              key={hu.host.value}
+              data-testid={`time-host-${status.profileId}-${hu.host.value}`}
+              className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+            >
+              <span className="text-gray-300 font-mono truncate" title={hu.host.value}>{hu.host.value}</span>
+              <span className="text-gray-500 font-mono shrink-0 ml-2">{hu.usedMins}m</span>
+            </div>
+          ))}
+        </div>
+      )}
+
       {status.siteUsage.length > 0 && (
         <div className="space-y-2">
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Site Limits</p>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -198,6 +198,11 @@ export interface DeviceUsageSummary {
   usedMins: number
 }
 
+export interface HostUsage {
+  host: HostId
+  usedMins: number
+}
+
 export interface ProfileTimeStatus {
   profileId: number
   profileName: string
@@ -208,6 +213,7 @@ export interface ProfileTimeStatus {
   remainingMins?: number | null
   siteUsage: SiteUsage[]
   devices: DeviceUsageSummary[]
+  hostUsage: HostUsage[]
 }
 
 export interface TimeExtension {


### PR DESCRIPTION
## Summary
- Adds a **Top Sites** section to each profile time card on the Screen Time page — top 10 hostnames the profile used today, sorted by minutes desc. Per-device breakdown was already shipping; this adds the complementary per-host view that #262 asked for.
- New `Presence.hostMinutes()` attributes each 5-min bucket's duration to every distinct host the device touched in that window. Informational only — the daily total still bucket-dedups via `totalMinutesByMac`, so caps and enforcement are unchanged.
- New `HostUsage(host, usedMins)` on `ProfileTimeStatus` and mirrored in `web/src/types/api.ts`.

## What changed
- `api/src/presence/Presence.scala` — `hostMinutes(rows)` aggregator.
- `api/src/routes/Routes.scala` — `buildProfileTimeStatus` populates `hostUsage` (top 10, drop zero-min, ordered by `(-usedMins, host.value)` for stable ties).
- `shared/src/Models.scala` — `HostUsage` case class, new field on `ProfileTimeStatus`.
- `web/src/pages/TimePage.tsx` — renders \"Top Sites\" between Devices and Site Limits; section hidden when empty; \`data-testid\` follows the \`time-host-<profileId>-<host>\` convention.
- `web/src/types/api.ts` — `HostUsage` type.

## Tests
- `PresenceSpec` (unit, 6 new cases): empty rows; each host in a bucket gets attribution once; same host across buckets sums; same host twice in one bucket counts once; IP-literal hosts attributed under their address form; uses max active_seconds.
- `TimeApiSpec` (integration, 2 new cases): hostUsage sums across all profile devices, sorted desc; capped at top 10 with the two smallest dropped.
- `TimePage.test.tsx` (2 new cases): renders top-host rows with minutes and IP-literal display; section omitted when `hostUsage: []`.

All 18 Presence tests + 14 TimeApi tests + 93 web tests pass; \`tsc --noEmit\` clean.

## Deferred
- Weekly view from #262's acceptance criteria — needs date-range support in \`trafficRepo.listPresenceRows\` and a window param on the endpoint. Filed as #507.
- Per-app grouping — folds in when #105's apps concept lands; today each hostname is its own row.

## Live verification
Deployed to `192.168.10.43` via `scripts/deploy-api-from-branch.sh`. `GET /api/time/status` returns top-10 hostUsage for both Kids and Adults profiles:

- Kids — 15m used, 10 hosts (quota.fe2.apple-dns.net 10m leads)
- Adults — 28m used, 10 hosts

Cross-checked against `traffic_reports` in psql — the per-host minute counts match the bucket-deduped presence math (multiple buckets per period, max active_seconds, /60 floor). Top-N truncation visible: both profiles have >10 distinct hosts in raw rows, exactly 10 in the response.

## Test plan
- [x] API: \`mill api.test.testOnly familydns.api.unit.PresenceSpec\` (18/18)
- [x] API: \`mill api.test.testOnly familydns.api.feature.TimeApiSpec\` (14/14)
- [x] Web: \`npm test\` (93/93) + \`tsc --noEmit\`
- [x] Live API on 192.168.10.43 returns hostUsage on real data
- [ ] (optional) Open Kids profile screen-time in the deployed web UI and eyeball the Top Sites list

## Related
- Closes #262
- Follow-up: #507 (weekly view)
- #105 (apps concept — per-host view will regroup by app when it lands)
- #127, #301 (usage graphs — out of scope)
- #229 (the 0m fix prerequisite — already shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)