### PR TITLE
refactor: rename Scala packages familydns.* -> wifihaven.* (#355)

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -1,4 +1,4 @@
-package familydns.api
+package wifihaven.api
 
 import zio.*
 import zio.config.*

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -1,12 +1,12 @@
-package familydns.api
+package wifihaven.api
 
 import doobie.*
 import doobie.implicits.*
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.api.routes.*
-import familydns.shared.Clock
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.Clock
 import zio.*
 import zio.http.*
 import zio.interop.catz.*

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -1,10 +1,10 @@
-package familydns.api.auth
+package wifihaven.api.auth
 
 import at.favre.lib.crypto.bcrypt.BCrypt
-import familydns.api.JwtConfig
-import familydns.api.db.*
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import pdi.jwt.*
 import pdi.jwt.algorithms.JwtHmacAlgorithm
 import zio.{Clock as _, *}

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -1,8 +1,8 @@
-package familydns.api.db
+package wifihaven.api.db
 
 import com.zaxxer.hikari.HikariDataSource
 import doobie.Transactor
-import familydns.api.DbConfig
+import wifihaven.api.DbConfig
 import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1,13 +1,13 @@
-package familydns.api.db
+package wifihaven.api.db
 
 import cats.syntax.all.*
 import doobie.*
 import doobie.implicits.*
 import doobie.postgres.implicits.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Schedule
-import familydns.api.db.TypeMeta.given
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Schedule
+import wifihaven.api.db.TypeMeta.given
 import zio.*
 import zio.interop.catz.*
 import java.time.{Instant, LocalDate, LocalTime, ZoneId}
@@ -245,18 +245,18 @@ trait TrafficReportRepo {
    * period_start) so the caller can fold contiguous runs directly. Filters are AND-composed. `macs
    * \= Some(Nil)` returns an empty list (no devices match).
    */
-  def listSessionRows(f: SessionFilter): Task[List[familydns.api.sessions.SessionRow]]
+  def listSessionRows(f: SessionFilter): Task[List[wifihaven.api.sessions.SessionRow]]
 
   /**
    * Minimal projection used by presence-based minute accounting (see
-   * [[familydns.api.presence.Presence]]). One row per (mac, period_start, hostname) for the given
+   * [[wifihaven.api.presence.Presence]]). One row per (mac, period_start, hostname) for the given
    * macs/date; the caller deduplicates by `(mac, period_start)` so per-hostname rows in a single
    * bucket don't inflate total screen time.
    */
   def listPresenceRows(
       macs: List[MacAddress],
       date: LocalDate,
-  ): Task[List[familydns.api.presence.PresenceRow]]
+  ): Task[List[wifihaven.api.presence.PresenceRow]]
 }
 
 trait BlockEventRepo {
@@ -822,14 +822,14 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
   def listPresenceRows(macs: List[MacAddress], date: LocalDate) = {
     type Row = (MacAddress, Instant, HostId, Int)
     macs match {
-      case Nil => ZIO.succeed(List.empty[familydns.api.presence.PresenceRow])
+      case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
       case ms  =>
         val nel = cats.data.NonEmptyList.fromListUnsafe(ms.map(_.value))
         val q   = fr"""SELECT mac, period_start, host_type, host_value, active_seconds
                        FROM traffic_reports
                        WHERE date = $date AND """ ++ Fragments.in(fr"mac", nel)
         q.query[Row]
-          .map((m, ps, h, s) => familydns.api.presence.PresenceRow(m, ps, h, s))
+          .map((m, ps, h, s) => wifihaven.api.presence.PresenceRow(m, ps, h, s))
           .to[List]
           .transact(xa)
     }
@@ -856,7 +856,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
     sql_
       .query[Row]
       .map { r =>
-        familydns.api.sessions.SessionRow(
+        wifihaven.api.sessions.SessionRow(
           routerId = r._1,
           mac = r._2,
           host = r._3,

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -1,9 +1,9 @@
-package familydns.api.db
+package wifihaven.api.db
 
 import doobie.*
 import doobie.postgres.implicits.*
-import familydns.shared.{FailureMode, MacBlockReason, UserRole}
-import familydns.shared.types.*
+import wifihaven.shared.{FailureMode, MacBlockReason, UserRole}
+import wifihaven.shared.types.*
 
 import java.time.ZoneId
 

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -1,9 +1,9 @@
-package familydns.api.policy
+package wifihaven.api.policy
 
-import familydns.api.db.*
-import familydns.api.presence.Presence
-import familydns.shared.{Schedule as DbSchedule, *}
-import familydns.shared.types.*
+import wifihaven.api.db.*
+import wifihaven.api.presence.Presence
+import wifihaven.shared.{Schedule as DbSchedule, *}
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 
 import java.security.MessageDigest

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -1,6 +1,6 @@
-package familydns.api.presence
+package wifihaven.api.presence
 
-import familydns.shared.types.*
+import wifihaven.shared.types.*
 import java.time.Instant
 
 /**

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -1,10 +1,10 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.sessions.{SessionRow, Sessions}
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.sessions.{SessionRow, Sessions}
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -1,7 +1,7 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.db.*
-import familydns.shared.Clock
+import wifihaven.api.db.*
+import wifihaven.shared.Clock
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
@@ -76,7 +76,7 @@ object DebugRoutes {
               presence <- trafficRepo
                 .listPresenceRows(macs, today)
                 .mapError(ErrorMapper.dbErrorToResponse)
-              totals = familydns.api.presence.Presence
+              totals = wifihaven.api.presence.Presence
                 .totalMinutesByMac(presence, exemptPatterns = Nil)
             } yield Response.json(
               snap

--- a/api/src/routes/ErrorMapper.scala
+++ b/api/src/routes/ErrorMapper.scala
@@ -1,4 +1,4 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
 import zio.http.*
 

--- a/api/src/routes/HealthRoutes.scala
+++ b/api/src/routes/HealthRoutes.scala
@@ -1,4 +1,4 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
 import zio.*
 import zio.http.*

--- a/api/src/routes/RouterAuth.scala
+++ b/api/src/routes/RouterAuth.scala
@@ -1,8 +1,8 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.db.RouterRepo
-import familydns.shared.Router
-import familydns.shared.types.*
+import wifihaven.api.db.RouterRepo
+import wifihaven.shared.Router
+import wifihaven.shared.types.*
 import zio.*
 import zio.http.*
 

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -1,8 +1,8 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.db.*
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -1,10 +1,10 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
@@ -15,7 +15,7 @@ import java.util.{Base64, UUID}
 /**
  * Routes agent-facing router endpoints. All routes require the router bearer token except
  * `/register`, which uses a one-time enrollment token. `RouterAuth` lives in
- * [[familydns.api.routes.RouterAuth]].
+ * [[wifihaven.api.routes.RouterAuth]].
  */
 object RouterRoutes {
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1,9 +1,9 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
@@ -469,9 +469,9 @@ object TimeRoutes {
       // Only exempt site domains are excluded from the daily total.
       // Included sites (exemptFromDaily=false) count against the daily cap.
       exemptPats      = stls.filter(_.exemptFromDaily).map(_.domainPattern)
-      perMacTotal     = familydns.api.presence.Presence
+      perMacTotal     = wifihaven.api.presence.Presence
         .totalMinutesByMac(presence, exemptPats)
-      perMacPat       = familydns.api.presence.Presence
+      perMacPat       = wifihaven.api.presence.Presence
         .patternMinutesByMac(presence, stls.map(_.domainPattern))
       totalUsed       = devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
       remaining       = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
@@ -522,10 +522,10 @@ object TimeRoutes {
       // Only exempt site domains are excluded from the daily total.
       // Included sites (exemptFromDaily=false) count against the daily cap.
       exemptPats = stls.filter(_.exemptFromDaily).map(_.domainPattern)
-      totalUsed  = familydns.api.presence.Presence
+      totalUsed  = wifihaven.api.presence.Presence
         .totalMinutesByMac(presence, exemptPats)
         .getOrElse(device.mac, 0)
-      perPat     = familydns.api.presence.Presence
+      perPat     = wifihaven.api.presence.Presence
         .patternMinutesByMac(presence, stls.map(_.domainPattern))
       remaining  = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
       siteUsage  = stls.map { stl =>

--- a/api/src/routes/SessionRoutes.scala
+++ b/api/src/routes/SessionRoutes.scala
@@ -1,10 +1,10 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.sessions.Sessions
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.sessions.Sessions
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*

--- a/api/src/routes/StaticRoutes.scala
+++ b/api/src/routes/StaticRoutes.scala
@@ -1,4 +1,4 @@
-package familydns.api.routes
+package wifihaven.api.routes
 
 import zio.*
 import zio.http.*

--- a/api/src/sessions/Sessions.scala
+++ b/api/src/sessions/Sessions.scala
@@ -1,7 +1,7 @@
-package familydns.api.sessions
+package wifihaven.api.sessions
 
-import familydns.shared.Session
-import familydns.shared.types.*
+import wifihaven.shared.Session
+import wifihaven.shared.types.*
 
 import java.time.{Instant, LocalDate}
 

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -1,8 +1,8 @@
-package familydns.testinfra
+package wifihaven.testinfra
 
 import doobie.Transactor
-import familydns.api.db.*
-import familydns.shared.types.*
+import wifihaven.api.db.*
+import wifihaven.shared.types.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.flywaydb.core.Flyway
 import zio.*
@@ -110,7 +110,7 @@ object TestDatabase {
 
 /** Helper for building test layers with a controllable clock. */
 object TestLayers {
-  import familydns.shared.Clock
+  import wifihaven.shared.Clock
 
   def withClock(dt: java.time.LocalDateTime): ULayer[Clock] =
     Clock.TestClock.make(dt)
@@ -129,7 +129,7 @@ object TestLayers {
       _  <- scheduleRepo.replaceForProfile(
         id,
         List(
-          familydns.shared.ScheduleRequest(
+          wifihaven.shared.ScheduleRequest(
             "Bedtime",
             List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
             java.time.LocalTime.of(21, 0),

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -1,9 +1,9 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
 import zio.*
 import zio.http.*
 import zio.json.ast.Json

--- a/api/test/src/feature/DebugApiSpec.scala
+++ b/api/test/src/feature/DebugApiSpec.scala
@@ -1,10 +1,10 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/HealthApiSpec.scala
+++ b/api/test/src/feature/HealthApiSpec.scala
@@ -1,6 +1,6 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.routes.HealthRoutes
+import wifihaven.api.routes.HealthRoutes
 import zio.*
 import zio.http.*
 import zio.json.*

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
@@ -1,14 +1,14 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -1,11 +1,11 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.test.*

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -1,10 +1,10 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.shared.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.json.*

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -1,14 +1,14 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -1,12 +1,12 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -1,11 +1,11 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.api.policy.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -1,9 +1,9 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.db.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.testinfra.*
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import doobie.Transactor
 import zio.*

--- a/api/test/src/feature/SessionApiSpec.scala
+++ b/api/test/src/feature/SessionApiSpec.scala
@@ -1,13 +1,13 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -1,6 +1,6 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.routes.StaticRoutes
+import wifihaven.api.routes.StaticRoutes
 import zio.*
 import zio.http.*
 import zio.test.*

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -1,14 +1,14 @@
-package familydns.api.feature
+package wifihaven.api.feature
 
-import familydns.api.JwtConfig
-import familydns.api.auth.*
-import familydns.api.db.*
-import familydns.api.policy.PolicyServiceLive
-import familydns.api.routes.*
-import familydns.shared.*
-import familydns.shared.types.*
-import familydns.shared.Clock.TestClock
-import familydns.testinfra.*
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.PolicyServiceLive
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -1,7 +1,7 @@
-package familydns.api.unit
+package wifihaven.api.unit
 
-import familydns.api.presence.{Presence, PresenceRow}
-import familydns.shared.types.*
+import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.shared.types.*
 import zio.test.*
 
 import java.time.Instant

--- a/api/test/src/unit/SchedulingSpec.scala
+++ b/api/test/src/unit/SchedulingSpec.scala
@@ -1,8 +1,8 @@
-package familydns.api.unit
+package wifihaven.api.unit
 
-import familydns.api.policy.PolicyService
-import familydns.shared.{HouseholdSettings, Schedule}
-import familydns.shared.types.*
+import wifihaven.api.policy.PolicyService
+import wifihaven.shared.{HouseholdSettings, Schedule}
+import wifihaven.shared.types.*
 import zio.test.*
 
 import java.time.{Instant, LocalTime, ZoneId, ZonedDateTime}

--- a/api/test/src/unit/SessionsSpec.scala
+++ b/api/test/src/unit/SessionsSpec.scala
@@ -1,7 +1,7 @@
-package familydns.api.unit
+package wifihaven.api.unit
 
-import familydns.api.sessions.*
-import familydns.shared.types.*
+import wifihaven.api.sessions.*
+import wifihaven.shared.types.*
 import zio.test.*
 
 import java.time.{Instant, LocalDate, ZoneOffset}

--- a/build.mill
+++ b/build.mill
@@ -32,7 +32,7 @@ trait CommonModule extends ScalaModule {
   )
 }
 
-trait FamilyDnsTestModule extends TestModule.ZioTest {
+trait WifiHavenTestModule extends TestModule.ZioTest {
   def testFramework = "zio.test.sbt.ZTestFramework"
   def mvnDeps = super.mvnDeps() ++ Seq(
     mvn"dev.zio::zio-test:$zioVersion",
@@ -52,7 +52,7 @@ object shared extends CommonModule {
     mvn"dev.zio::zio:$zioVersion",
     mvn"dev.zio::zio-json:$zioJsonVersion",
   )
-  object test extends ScalaTests with FamilyDnsTestModule
+  object test extends ScalaTests with WifiHavenTestModule
 }
 
 // ── API ────────────────────────────────────────────────────────────────────
@@ -87,7 +87,7 @@ object api extends CommonModule {
     Assembly.Rule.Append("META-INF/services/org.flywaydb.core.extensibility.Plugin", "\n"),
     Assembly.Rule.Append("META-INF/services/java.sql.Driver", "\n"),
   )
-  object test extends ScalaTests with FamilyDnsTestModule {
+  object test extends ScalaTests with WifiHavenTestModule {
     def moduleDeps = super.moduleDeps ++ Seq(api)
     def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"dev.zio::zio-http-testkit:$zioHttpVersion",

--- a/shared/src/Clock.scala
+++ b/shared/src/Clock.scala
@@ -1,4 +1,4 @@
-package familydns.shared
+package wifihaven.shared
 
 import zio.*
 

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1,6 +1,6 @@
-package familydns.shared
+package wifihaven.shared
 
-import familydns.shared.types.*
+import wifihaven.shared.types.*
 import zio.json.*
 
 import java.time.{LocalTime, ZoneId}

--- a/shared/src/types/BlocklistId.scala
+++ b/shared/src/types/BlocklistId.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/ConnectionDecision.scala
+++ b/shared/src/types/ConnectionDecision.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/HostId.scala
+++ b/shared/src/types/HostId.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/Hostname.scala
+++ b/shared/src/types/Hostname.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/IpAddress.scala
+++ b/shared/src/types/IpAddress.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/MacAddress.scala
+++ b/shared/src/types/MacAddress.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/src/types/Tokens.scala
+++ b/shared/src/types/Tokens.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 

--- a/shared/test/src/ClockSpec.scala
+++ b/shared/test/src/ClockSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared
+package wifihaven.shared
 
 import zio.{Clock as _, *}
 import zio.test.*

--- a/shared/test/src/types/BlockReasonSpec.scala
+++ b/shared/test/src/types/BlockReasonSpec.scala
@@ -1,6 +1,6 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
-import familydns.shared.{BlockReason, MacBlockReason}
+import wifihaven.shared.{BlockReason, MacBlockReason}
 import zio.json.*
 import zio.test.*
 
@@ -61,23 +61,23 @@ object BlockReasonSpec extends ZIOSpecDefault {
     suite("Type-system subtype constraint")(
       test("MacBlockReason is assignable to BlockReason") {
         assertTrue(typeChecks("""
-          val r: familydns.shared.BlockReason =
-            familydns.shared.MacBlockReason.Paused
+          val r: wifihaven.shared.BlockReason =
+            wifihaven.shared.MacBlockReason.Paused
         """))
       },
       test("BlockReason.Host does NOT typecheck as MacBlockReason") {
         assertTrue(!typeChecks("""
-          val r: familydns.shared.MacBlockReason =
-            familydns.shared.BlockReason.Host(
-              familydns.shared.types.Hostname.parse("a.com").toOption.get
+          val r: wifihaven.shared.MacBlockReason =
+            wifihaven.shared.BlockReason.Host(
+              wifihaven.shared.types.Hostname.parse("a.com").toOption.get
             )
         """))
       },
       test("BlockReason.IpOnly does NOT typecheck as MacBlockReason") {
         assertTrue(!typeChecks("""
-          val r: familydns.shared.MacBlockReason =
-            familydns.shared.BlockReason.IpOnly(
-              familydns.shared.types.IpAddress.parse("1.2.3.4").toOption.get
+          val r: wifihaven.shared.MacBlockReason =
+            wifihaven.shared.BlockReason.IpOnly(
+              wifihaven.shared.types.IpAddress.parse("1.2.3.4").toOption.get
             )
         """))
       },

--- a/shared/test/src/types/EnumSpec.scala
+++ b/shared/test/src/types/EnumSpec.scala
@@ -1,6 +1,6 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
-import familydns.shared.{FailureMode, UserRole}
+import wifihaven.shared.{FailureMode, UserRole}
 import zio.json.*
 import zio.test.*
 

--- a/shared/test/src/types/HostIdSpec.scala
+++ b/shared/test/src/types/HostIdSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*

--- a/shared/test/src/types/HostnameSpec.scala
+++ b/shared/test/src/types/HostnameSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*

--- a/shared/test/src/types/IdSpec.scala
+++ b/shared/test/src/types/IdSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*
@@ -17,14 +17,14 @@ object IdSpec extends ZIOSpecDefault {
     test("ProfileId and DeviceId are distinct at the type level") {
       // Same underlying Long but opaque types must not unify.
       assertTrue(!typeChecks("""
-        val p: familydns.shared.types.ProfileId =
-          familydns.shared.types.DeviceId(1L)
+        val p: wifihaven.shared.types.ProfileId =
+          wifihaven.shared.types.DeviceId(1L)
       """))
     },
     test("ProfileId and BlocklistId are distinct at the type level") {
       assertTrue(!typeChecks("""
-        val b: familydns.shared.types.BlocklistId =
-          familydns.shared.types.ProfileId(1L)
+        val b: wifihaven.shared.types.BlocklistId =
+          wifihaven.shared.types.ProfileId(1L)
       """))
     },
     test("RouterId round-trips as UUID JSON string") {
@@ -45,8 +45,8 @@ object IdSpec extends ZIOSpecDefault {
     },
     test("ProfileId and ScheduleId are distinct at the type level") {
       assertTrue(!typeChecks("""
-        val s: familydns.shared.types.ScheduleId =
-          familydns.shared.types.ProfileId(1L)
+        val s: wifihaven.shared.types.ScheduleId =
+          wifihaven.shared.types.ProfileId(1L)
       """))
     },
   )

--- a/shared/test/src/types/IpAddressSpec.scala
+++ b/shared/test/src/types/IpAddressSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*

--- a/shared/test/src/types/MacAddressSpec.scala
+++ b/shared/test/src/types/MacAddressSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*

--- a/shared/test/src/types/MapKeySpec.scala
+++ b/shared/test/src/types/MapKeySpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*

--- a/shared/test/src/types/TokenSpec.scala
+++ b/shared/test/src/types/TokenSpec.scala
@@ -1,4 +1,4 @@
-package familydns.shared.types
+package wifihaven.shared.types
 
 import zio.json.*
 import zio.test.*


### PR DESCRIPTION
Closes #355. Part of META rename tracker #365 (see also #38 / `docs/rename-decision.md`).

## Summary

Pure mechanical rename of Scala package coords and one build module trait name. No behavior changes, no formatting cleanup, no incidental edits — pure search/replace so the diff is easy to review.

- All `package familydns.*` → `package wifihaven.*` (shared, api, tests).
- All `import familydns.*` and FQ `familydns.<...>` refs → `wifihaven.<...>`.
- `build.mill`: trait `FamilyDnsTestModule` → `WifiHavenTestModule`.
- 63 files, +277/-277.

## Out of scope (intentionally NOT renamed)

Two `familydns` string occurrences remain in `*.scala` and are deferred to sibling rename issues:

1. `api/src/Config.scala:52` — `.nested("familydns")` is the HOCON root key tied to `config/application.conf` schema. Belongs with env-var/config rename (#360 area).
2. `api/test/src/feature/RouterIngestSpec.scala:628` — a comment referencing the OpenWRT lua agent path `openwrt/files/usr/lib/lua/familydns/conntrack.lua`. Owned by #357.

Renaming these without their owning rename PRs would break runtime config loading / drift from the actual on-disk paths. Note: this means the issue's blanket "`grep -l familydns` returns empty" acceptance check is intentionally relaxed to two scope-deferred lines.

Image names, scripts, project name, docs, DB, env vars — all untouched (sibling issues).

## Test plan

- [x] `mill shared.compile` clean
- [x] `mill api.compile` clean (19 sources)
- [x] `mill shared.test` — all tests pass
- [x] `mill api.test` — all tests pass
- [ ] CI green
- Live-API deploy intentionally skipped: this is a pure internal-package rename (semantic-preserving by construction) with no behavior change to validate against prod.

## Wave 2 — open AFTER this merges

This is Wave 1 (foundational). Issues #356, #357, #358, #359, #360 should rebase on top of this PR and be opened after this merges to avoid conflicts with the package-coord change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)