### PR TITLE
docs: rename FamilyDNS → WifiHaven across docs + agent context (#361)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — FamilyDNS
+# AGENTS.md — WifiHaven
 
 This file provides context for AI coding agents (Claude, Copilot, Cursor, etc.) working on this codebase.
 
@@ -78,7 +78,7 @@ shape, wire JSON examples, and the enforcement model.
 
 ## What this project is
 
-FamilyDNS is a self-hosted, network-level parental-control system with per-device filtering, time limits, and a web dashboard. The API runs on a Linux home server (Ubuntu) and replaces commercial products like Gryphon or TP-Link HomeShield; the enforcement agent runs on the gateway router (OpenWRT or OPNsense).
+WifiHaven is a self-hosted, network-level parental-control system with per-device filtering, time limits, and a web dashboard. The API runs on a Linux home server (Ubuntu) and replaces commercial products like Gryphon or TP-Link HomeShield; the enforcement agent runs on the gateway router (OpenWRT or OPNsense).
 
 ## Architecture
 
@@ -139,7 +139,7 @@ Order matters because earlier conditions short-circuit:
 The router never re-evaluates any of this. It receives the resolved
 `BlockRules` and applies them mechanically.
 
-(DNS resolution itself is never blocked by FamilyDNS. dnsmasq forwards
+(DNS resolution itself is never blocked by WifiHaven. dnsmasq forwards
 upstream as normal; the enforcement plane is nftables on the resolved IPs.)
 
 ## Tech stack decisions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# FamilyDNS
+# WifiHaven
+
+<!-- TODO(#364): GitHub repo URLs (raw.githubusercontent.com/sameerparekh/familydns/…,
+     git@github.com:sameerparekh/familydns.git, etc.) and the post-clone
+     directory name `familydns/` still appear throughout this README. They
+     move to `sameerparekh/wifihaven` when the repo rename (#364) lands. -->
+<!-- TODO(#355–#360): install paths (/opt/familydns, $HOME/.familydns), system
+     user (`familydns`), systemd units (familydns-api.service, familydns-update.*),
+     Docker image (ghcr.io/sameerparekh/familydns-api), Postgres role/db
+     (`familydns`), and HOCON config namespace (`familydns.*`) all still use
+     the old name. They flip in their respective rename sub-issues. -->
 
 A self-hosted, network-level parental-control system with a web UI. Block
 categories of sites, set per-profile schedules ("no internet after 9pm"),
@@ -127,14 +137,14 @@ agent) and reach the api over the network (see [`docs/architecture-openwrt.md`](
 
 ```bash
 cp deploy/.env.example deploy/.env
-$EDITOR deploy/.env                # set FAMILYDNS_DB_PASSWORD and FAMILYDNS_JWT_SECRET
+$EDITOR deploy/.env                # set WIFIHAVEN_DB_PASSWORD and WIFIHAVEN_JWT_SECRET
 
 docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d --build
 ```
 
 Postgres is internal to the compose network — it is not published on a
-host port. The api binds to `:8080` (configurable via `FAMILYDNS_API_BIND`
-/ `FAMILYDNS_API_PORT`). Run `scripts/smoke-prod.sh` to validate the stack.
+host port. The api binds to `:8080` (configurable via `WIFIHAVEN_API_BIND`
+/ `WIFIHAVEN_API_PORT`). Run `scripts/smoke-prod.sh` to validate the stack.
 
 Full operator notes (backups, reverse-proxy guidance, migration from the
 host-based deploy below) live in [`deploy/README.md`](deploy/README.md).
@@ -164,8 +174,8 @@ the `production` branch — see [Production branch & deploy gate](#production-br
 installing systemd units, and seeding `/etc/familydns/application.conf`.
 Idempotent — safe to re-run.
 
-Override defaults via env: `FAMILYDNS_BRANCH`, `FAMILYDNS_REPO_URL`,
-`FAMILYDNS_PREFIX`, `FAMILYDNS_USER`, `FAMILYDNS_MILL_VERSION`.
+Override defaults via env: `WIFIHAVEN_BRANCH`, `WIFIHAVEN_REPO_URL`,
+`WIFIHAVEN_PREFIX`, `WIFIHAVEN_USER`, `WIFIHAVEN_MILL_VERSION`.
 
 What it does:
 
@@ -236,7 +246,7 @@ Branches:
   refuses to push and the divergence has to be resolved by hand.
 
 The host's deploy timer and `scripts/deploy.sh` track `production` (via
-`FAMILYDNS_BRANCH=production`, the new default), so the live box only
+`WIFIHAVEN_BRANCH=production`, the new default), so the live box only
 ever runs commits that have passed the e2e gate.
 
 ### Manual deploy
@@ -252,10 +262,10 @@ Environment knobs (set on the command line or in
 
 | Var                   | Default | Effect                                      |
 | --------------------- | ------- | ------------------------------------------- |
-| `FAMILYDNS_BRANCH`    | `production` | Branch to track (e2e-gated)            |
-| `FAMILYDNS_PREFIX`    | `/opt/familydns` | Install root                       |
-| `FAMILYDNS_NO_WEB`    | `0`     | Skip frontend build                         |
-| `FAMILYDNS_NO_RESTART`| `0`     | Build but don't restart the service         |
+| `WIFIHAVEN_BRANCH`    | `production` | Branch to track (e2e-gated)            |
+| `WIFIHAVEN_PREFIX`    | `/opt/familydns` | Install root                       |
+| `WIFIHAVEN_NO_WEB`    | `0`     | Skip frontend build                         |
+| `WIFIHAVEN_NO_RESTART`| `0`     | Build but don't restart the service         |
 
 ### Why the deploy logic lives in the repo
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,4 +1,4 @@
-# Deploying FamilyDNS
+# Deploying WifiHaven
 
 The api + postgres pair ships as a single Docker Compose stack. The dns and
 traffic services do **not** live here — they run on an OpenWRT router and
@@ -29,7 +29,7 @@ walkthrough or to install manually.
 
 ```bash
 cp deploy/.env.example deploy/.env
-$EDITOR deploy/.env                # set FAMILYDNS_DB_PASSWORD and FAMILYDNS_JWT_SECRET
+$EDITOR deploy/.env                # set WIFIHAVEN_DB_PASSWORD and WIFIHAVEN_JWT_SECRET
 
 docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d --build
 ```

--- a/docs/architecture-critique.md
+++ b/docs/architecture-critique.md
@@ -447,7 +447,7 @@ On router-record deletion:
 Rationale for allow-all (not default-deny on disownment): the admin's
 action of deleting the router signals "this router is no longer mine";
 keeping the LAN locked down after that is hostile. The LAN reverts to
-"no familydns enforcement" — same as if the package were uninstalled.
+"no wifihaven enforcement" — same as if the package were uninstalled.
 
 Sub-issue filed.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,4 +1,4 @@
-# FamilyDNS Deploy Architecture
+# WifiHaven Deploy Architecture
 
 This document covers the full CD pipeline, first-install bootstrap, and
 auto-update strategy for both deployment targets.
@@ -109,7 +109,7 @@ image **on demand** rather than wait for the daily tick, run
 `systemctl start familydns-update.service` (or the `familydns-update-now`
 operator skill).
 
-**User-mode installs** (`FAMILYDNS_PREFIX=$HOME/.familydns`): `install.sh`
+**User-mode installs** (`WIFIHAVEN_PREFIX=$HOME/.familydns`): `install.sh`
 rewrites `WorkingDirectory=` to the actual install dir before copying the
 unit into `/etc/systemd/system/`, so user-mode installs also get auto-update.
 
@@ -261,10 +261,10 @@ docker compose -f docker-compose.prod.yml --env-file .env up -d
 
 | Variable | Description |
 |----------|-------------|
-| `FAMILYDNS_DB_USER` | Postgres username |
-| `FAMILYDNS_DB_PASSWORD` | Postgres password (strong, random) |
-| `FAMILYDNS_DB_NAME` | Postgres database name |
-| `FAMILYDNS_JWT_SECRET` | JWT signing secret, ≥32 random characters |
+| `WIFIHAVEN_DB_USER` | Postgres username |
+| `WIFIHAVEN_DB_PASSWORD` | Postgres password (strong, random) |
+| `WIFIHAVEN_DB_NAME` | Postgres database name |
+| `WIFIHAVEN_JWT_SECRET` | JWT signing secret, ≥32 random characters |
 
 Optional vars have defaults; see `deploy/.env.example` for the full list.
 

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -1,6 +1,6 @@
-# First-install guide: FamilyDNS API server
+# First-install guide: WifiHaven API server
 
-This guide walks you through installing the FamilyDNS API + Postgres stack
+This guide walks you through installing the WifiHaven API + Postgres stack
 on a fresh Linux host. By the end, you will have:
 
 - The `api` and `postgres` containers running under Docker Compose.
@@ -41,11 +41,11 @@ By default the one-liner installs into `$HOME/.familydns` (user-writable, no
 sudo required) — this is the recommended path for first-time users and is
 what the `curl | bash` invocation above will do. For a system-wide install
 under `/opt/familydns` (recommended for production hosts), set
-`FAMILYDNS_PREFIX` explicitly and run the script with `sudo`:
+`WIFIHAVEN_PREFIX` explicitly and run the script with `sudo`:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
-sudo FAMILYDNS_PREFIX=/opt/familydns bash install.sh
+sudo WIFIHAVEN_PREFIX=/opt/familydns bash install.sh
 ```
 
 Piping `curl … | sudo bash` works too, but only if sudo is already warmed up
@@ -65,30 +65,30 @@ In environments where there is no controlling terminal at all (CI runners,
 nohup, some container shells), `/dev/tty` is not available; the script
 detects that and switches to non-interactive mode automatically — values
 come from env vars (see below) or defaults. To force non-interactive mode
-even when a tty is present, set `FAMILYDNS_NONINTERACTIVE=1`.
+even when a tty is present, set `WIFIHAVEN_NONINTERACTIVE=1`.
 
 ### Non-interactive install
 
-For unattended installs, set `FAMILYDNS_NONINTERACTIVE=1` and any of the
+For unattended installs, set `WIFIHAVEN_NONINTERACTIVE=1` and any of the
 env vars below to skip prompts. You can pass them on the same one-liner:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh \
-  | FAMILYDNS_NONINTERACTIVE=1 \
-    FAMILYDNS_PREFIX=$HOME/.familydns \
-    FAMILYDNS_API_HOST_PORT=8080 \
-    FAMILYDNS_NEW_ADMIN_PW='choose-a-good-one' \
+  | WIFIHAVEN_NONINTERACTIVE=1 \
+    WIFIHAVEN_PREFIX=$HOME/.familydns \
+    WIFIHAVEN_API_HOST_PORT=8080 \
+    WIFIHAVEN_NEW_ADMIN_PW='choose-a-good-one' \
     bash
 ```
 
 | Env var | Purpose | Default |
 |---|---|---|
-| `FAMILYDNS_PREFIX` | install path (preferred name) | `$HOME/.familydns` (non-root) or `/opt/familydns` (root) |
-| `FAMILYDNS_INSTALL_DIR` | legacy alias for `FAMILYDNS_PREFIX` | — |
-| `FAMILYDNS_API_HOST_PORT` | host port to bind | `8080` |
-| `FAMILYDNS_API_BIND` | host interface to bind on | `0.0.0.0` |
-| `FAMILYDNS_NEW_ADMIN_PW` | new admin password (skips rotation prompt) | prompt |
-| `FAMILYDNS_NONINTERACTIVE` | if set, never prompt; fail if any required value is missing | unset |
+| `WIFIHAVEN_PREFIX` | install path (preferred name) | `$HOME/.familydns` (non-root) or `/opt/familydns` (root) |
+| `WIFIHAVEN_INSTALL_DIR` | legacy alias for `WIFIHAVEN_PREFIX` | — |
+| `WIFIHAVEN_API_HOST_PORT` | host port to bind | `8080` |
+| `WIFIHAVEN_API_BIND` | host interface to bind on | `0.0.0.0` |
+| `WIFIHAVEN_NEW_ADMIN_PW` | new admin password (skips rotation prompt) | prompt |
+| `WIFIHAVEN_NONINTERACTIVE` | if set, never prompt; fail if any required value is missing | unset |
 
 Run `bash install.sh --help` to print the same list.
 
@@ -113,7 +113,7 @@ and §8 (firewall).
 
 - **Port 8080/tcp** open from wherever the OpenWRT router agent will reach
   the API (typically your LAN, or the public internet if the router is
-  remote). The port is configurable via `FAMILYDNS_API_PORT` — see §3.
+  remote). The port is configurable via `WIFIHAVEN_API_PORT` — see §3.
 - **Disk for Postgres data**. Data lives in the Docker named volume
   `pgdata`, which by default lands under `/var/lib/docker/volumes/` on the
   host. Make sure that filesystem has room (a few GB is plenty for typical
@@ -196,13 +196,13 @@ Edit `.env` and set each variable. **Never commit this file.** All values:
 
 | Variable | Required? | Purpose | How to set |
 |----------|-----------|---------|------------|
-| `FAMILYDNS_DB_NAME` | yes | Postgres database name. | Leave the default (`familydns`) unless you have a reason to change it. |
-| `FAMILYDNS_DB_USER` | yes | Postgres role used by the API. | Leave the default (`familydns`). |
-| `FAMILYDNS_DB_PASSWORD` | yes | Postgres password. Postgres is on the internal compose network only — but use a strong password anyway. | `openssl rand -base64 24` |
-| `FAMILYDNS_JWT_SECRET` | yes | HMAC secret used to sign user session tokens. **Must be ≥32 random characters.** Anyone with this secret can mint admin tokens. | `openssl rand -base64 48` |
-| `FAMILYDNS_JWT_HOURS` | no (default `24`) | Session token lifetime in hours. | Leave default unless you need shorter sessions. |
-| `FAMILYDNS_API_BIND` | no (default `0.0.0.0`) | Host interface the API port binds to. Set to `127.0.0.1` if you're putting a reverse proxy in front (§7). | `127.0.0.1` for proxied installs, `0.0.0.0` for direct LAN access. |
-| `FAMILYDNS_API_PORT` | no (default `8080`) | Host port mapped to the API. | Change only if 8080 is taken. |
+| `WIFIHAVEN_DB_NAME` | yes | Postgres database name. | Leave the default (`familydns`) unless you have a reason to change it. |
+| `WIFIHAVEN_DB_USER` | yes | Postgres role used by the API. | Leave the default (`familydns`). |
+| `WIFIHAVEN_DB_PASSWORD` | yes | Postgres password. Postgres is on the internal compose network only — but use a strong password anyway. | `openssl rand -base64 24` |
+| `WIFIHAVEN_JWT_SECRET` | yes | HMAC secret used to sign user session tokens. **Must be ≥32 random characters.** Anyone with this secret can mint admin tokens. | `openssl rand -base64 48` |
+| `WIFIHAVEN_JWT_HOURS` | no (default `24`) | Session token lifetime in hours. | Leave default unless you need shorter sessions. |
+| `WIFIHAVEN_API_BIND` | no (default `0.0.0.0`) | Host interface the API port binds to. Set to `127.0.0.1` if you're putting a reverse proxy in front (§7). | `127.0.0.1` for proxied installs, `0.0.0.0` for direct LAN access. |
+| `WIFIHAVEN_API_PORT` | no (default `8080`) | Host port mapped to the API. | Change only if 8080 is taken. |
 
 After editing, `chmod 600 .env` so secrets aren't world-readable.
 
@@ -262,7 +262,7 @@ docker compose -f docker-compose.prod.yml --env-file .env ps
 ```
 
 If the API container shows `unhealthy`, check `docker compose logs api`
-— common causes are a wrong `FAMILYDNS_DB_PASSWORD` or a `FAMILYDNS_JWT_SECRET`
+— common causes are a wrong `WIFIHAVEN_DB_PASSWORD` or a `WIFIHAVEN_JWT_SECRET`
 shorter than 32 characters.
 
 ---
@@ -307,7 +307,7 @@ For LAN-only deployments where the router and the API are on the same
 trusted network, you can skip TLS — the OpenWRT agent doesn't strictly
 require it. For anything reachable from the internet, terminate TLS in a
 reverse proxy and bind the API to `127.0.0.1` by setting
-`FAMILYDNS_API_BIND=127.0.0.1` in `.env`, then `docker compose up -d` again.
+`WIFIHAVEN_API_BIND=127.0.0.1` in `.env`, then `docker compose up -d` again.
 
 ### 7.1 Caddy
 
@@ -421,7 +421,7 @@ When devices are missing from the UI, showing up as 'unknown', or the
 router agent appears silent, three opt-in surfaces help trace the
 mac → API → DB → UI hop without exposing anything in normal production.
 
-### 9.1 Verbose logging (`FAMILYDNS_LOG_LEVEL=DEBUG`)
+### 9.1 Verbose logging (`WIFIHAVEN_LOG_LEVEL=DEBUG`)
 
 Each `/api/router/{usage,events,policy}` request emits one log line per
 record/event with the mac, hostname, allowed/blocked flag, and ts. Combine
@@ -434,7 +434,7 @@ commit; /etc/init.d/familydns restart` to make the agent log every policy
 fetch, usage POST, event flush, and per-flow mac/hostname attribution to
 `logread -t familydns` (#228).
 
-### 9.2 Loopback-only debug endpoints (`FAMILYDNS_DEBUG=1`)
+### 9.2 Loopback-only debug endpoints (`WIFIHAVEN_DEBUG=1`)
 
 When set, the API mounts three unauthenticated read-only JSON dumps,
 restricted by both `remoteAddress` and the `Host` header to loopback
@@ -447,7 +447,7 @@ callers on the API host:
 These are equivalent to running `psql` against the DB without the network
 exposure. Every request — allowed or refused — logs at INFO/WARN, so an
 accidentally-left-on debug build is loud in production. The startup banner
-also emits a `FAMILYDNS_DEBUG=1` WARNING.
+also emits a `WIFIHAVEN_DEBUG=1` WARNING.
 
 Usage from the API host:
 
@@ -471,7 +471,7 @@ docker compose \
 psql -h 127.0.0.1 -p 5433 -U familydns familydns
 ```
 
-Override the bind with `FAMILYDNS_DB_BIND=127.0.0.1:5433` in `deploy/.env`
+Override the bind with `WIFIHAVEN_DB_BIND=127.0.0.1:5433` in `deploy/.env`
 if the default port is taken. Keep the bind on `127.0.0.1` — exposing the
 DB on `0.0.0.0` leaks credentials.
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -1,13 +1,13 @@
-# Installing the FamilyDNS Agent on OpenWRT
+# Installing the WifiHaven Agent on OpenWRT
 
-This guide walks through a first install of the FamilyDNS agent on an OpenWRT
+This guide walks through a first install of the WifiHaven agent on an OpenWRT
 router. The recommended path is the one-shot install script; the manual
 steps below it exist for debugging and for environments where running a
 piped shell script is not acceptable.
 
 The agent enforces per-device connection-level filtering (nftables forward-drop
 keyed on MAC + destination ipset), accounts traffic per `(mac, hostname)`, and
-streams connection events to the FamilyDNS API. dnsmasq on the router resolves
+streams connection events to the WifiHaven API. dnsmasq on the router resolves
 DNS normally — it is not the enforcement plane (see
 [`architecture.md` §0](architecture.md#0-enforcement-model)).
 
@@ -18,7 +18,7 @@ DNS normally — it is not the enforcement plane (see
   release.
 - Internet access from the router.
 - Root SSH access to the router.
-- A FamilyDNS API server already deployed and reachable from the router. See
+- A WifiHaven API server already deployed and reachable from the router. See
   [`install-api.md`](install-api.md) if you need to set one up first.
 - A one-time enrollment token generated in the admin UI under
   **Routers → Add router** (looks like `et_5f3c9b…`).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,6 +1,6 @@
 # Operations
 
-Runbooks for operating a deployed FamilyDNS test or production setup.
+Runbooks for operating a deployed WifiHaven test or production setup.
 
 ## Developer access to the test router (WAN-side SSH)
 

--- a/docs/rename-decision.md
+++ b/docs/rename-decision.md
@@ -1,8 +1,10 @@
-# Project rename: `familydns` → `wifihaven` (pencilled in)
+# Project rename: `familydns` → `wifihaven` (approved, in progress)
 
-**Status:** Pencilled in pending family consultation. Not executed yet — execution
-is tracked in the META tracker issue (filed alongside this doc) and the per-slice
-rename issues it links to.
+**Status:** Name `wifihaven` approved (#365). Execution is in progress across
+the per-slice rename issues linked from META #365. This docs-and-agent-context
+slice is #361. Technical identifiers (Scala packages, Docker image, install
+paths, env vars in code, OpenWRT package + UCI, GitHub repo URL) are renamed
+by sibling sub-issues — see #365 for ordering.
 
 **Closes (when execution lands):** #38
 

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -2,7 +2,7 @@
 
 Status: **PROPOSAL — awaiting sign-off.** Tracks #269.
 
-This document defines how familydns SHOULD behave under five failure scenarios.
+This document defines how wifihaven SHOULD behave under five failure scenarios.
 It is the durable design contract. Implementation may lag; gaps are filed as
 individual follow-up issues that reference #269.
 
@@ -10,7 +10,7 @@ The decision in §4 (per-profile three-mode failover; #385) is a policy
 call that needs explicit operator sign-off before implementation lands.
 §5 was previously a sign-off item too, but is now settled by design: the
 router carries no time-based logic (Truth 2 / #350), so clock skew on the
-router is not a familydns concern.
+router is not a wifihaven concern.
 
 ---
 

--- a/docs/time-handling.md
+++ b/docs/time-handling.md
@@ -1,6 +1,6 @@
 # Time handling — schedules, daily reset, DST
 
-This document explains how FamilyDNS handles wall-clock time across timezones
+This document explains how WifiHaven handles wall-clock time across timezones
 and DST transitions. The rules apply to schedule windows and daily-usage
 reset; both are evaluated by `PolicyService` on the API server.
 

--- a/docs/vm-e2e-ubuntu.md
+++ b/docs/vm-e2e-ubuntu.md
@@ -104,7 +104,7 @@ scripts/vm/build-router-image.sh
 
 # 3. Bring up the router VM. Point at the custom image with an absolute
 #    path, and pick a non-conflicting host HTTP-forward port if 8080 is
-#    already taken on the host (e.g. by a running familydns API stack).
+#    already taken on the host (e.g. by a running wifihaven API stack).
 FDNS_ROUTER_HTTP_PORT=18081 \
 FDNS_ROUTER_IMAGE_PATH="$PWD/scripts/vm/.cache/openwrt-familydns.img" \
     scripts/vm/router-up.sh
@@ -123,7 +123,7 @@ scripts/vm/router-down.sh
 
 ## Known gotchas on Ubuntu
 
-- **Port 8080 collisions.** If you already run a familydns deploy on the
+- **Port 8080 collisions.** If you already run a wifihaven deploy on the
   host (e.g. via `/home/$USER/.familydns/docker-compose.yml`), the
   router VM's default HTTP forward (`-hostfwd tcp:127.0.0.1:8080-:80`)
   will fail with `Could not set up host forwarding rule`. Override via

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,10 +1,16 @@
-# familydns OpenWrt package
+# WifiHaven OpenWrt package
 
-OpenWrt agent for FamilyDNS. Supports both **OpenWRT 23.05.x** (opkg / `.ipk`)
+<!-- TODO(#357): rename the OpenWRT package itself (familydns → wifihaven) —
+     paths, UCI config, init script, agent binary, ipk/apk name. This doc
+     describes those identifiers as `familydns` until #357 lands. -->
+<!-- TODO(#364): GitHub repo URLs in this file still use `sameerparekh/familydns`;
+     they will move to `sameerparekh/wifihaven` when #364 lands. -->
+
+OpenWrt agent for WifiHaven. Supports both **OpenWRT 23.05.x** (opkg / `.ipk`)
 and **OpenWRT 24.10+ / SNAPSHOT** (apk / `.apk`). Enforces per-device
 connection-level filtering via **nftables** (forward-drop keyed on MAC +
 destination ipset), accounts traffic per `(mac, hostname)`, and streams
-connection events to the FamilyDNS API. dnsmasq on the router resolves DNS
+connection events to the WifiHaven API. dnsmasq on the router resolves DNS
 normally — it is **not** the enforcement plane; it is used for hostname
 attribution (`--ipset=` callbacks). See
 [`../docs/architecture.md` §0](../docs/architecture.md#0-enforcement-model).
@@ -215,7 +221,7 @@ logread -f | grep familydns
 uci show familydns
 ```
 
-The FamilyDNS admin UI → Routers → `<router name>` shows `last_seen_at`;
+The WifiHaven admin UI → Routers → `<router name>` shows `last_seen_at`;
 it should update every ~60 s once the policy timer is running.
 
 If the agent refuses to start, the most common cause is a missing or empty

--- a/opnsense/README.md
+++ b/opnsense/README.md
@@ -1,7 +1,11 @@
-# familydns OPNsense agent
+# WifiHaven OPNsense agent
+
+<!-- TODO(#363, #357): OPNsense agent paths and identifiers (familydns-agent,
+     /usr/local/etc/familydns.conf, rc.d/familydns, etc.) get renamed when
+     the OPNsense rename lands. -->
 
 Python agent for OPNsense routers.  Streams `connection_attempt` events to
-the FamilyDNS API by tailing pflog0 (via `tcpdump`) and attributing hostnames
+the WifiHaven API by tailing pflog0 (via `tcpdump`) and attributing hostnames
 from the Unbound query log.
 
 ## Scope for this release (#94)

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -20,7 +20,7 @@ scripts/e2e-vm.sh --keep -- -k usage      # leave VMs/stack up; pytest -k passth
 ┌─────────── host ────────────┐
 │  docker compose             │      ┌── router VM ──┐    ┌── client VM ──┐
 │   ├ postgres                │      │ OpenWRT 23.05 │    │ Alpine 3.22   │
-│   └ api  (FAMILYDNS_DEBUG=1)│◀─────┤ familydns-    │    │               │
+│   └ api  (WIFIHAVEN_DEBUG=1)│◀─────┤ familydns-    │    │               │
 │       :18080 (host port)    │ HTTP │ agent baked in│◀──▶│   eth0 (LAN)  │
 │                             │      │               │ DHCP│   curl/dig   │
 │  pytest orchestrator        │      │ eth1 = SLIRP  │ DNS │               │

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -1,7 +1,7 @@
 # VM e2e harness
 
 Scripted QEMU/KVM setup for end-to-end testing of the OpenWRT side of
-FamilyDNS. The big picture is in #106; this directory is the implementation
+WifiHaven. The big picture is in #106; this directory is the implementation
 of #144 (router VM) and #146 (client VM).
 
 ## Host requirements


### PR DESCRIPTION
## Summary

- Renames the project name in prose, titles, and env-var examples across `README.md`, `AGENTS.md`, `docs/`, and module READMEs (`openwrt/`, `opnsense/`, `deploy/`, `scripts/`) to **WifiHaven** / `wifihaven` / `WIFIHAVEN_*`.
- Updates `docs/rename-decision.md` status from "pencilled in" to "approved, in progress" per META #365.
- Adds `TODO(#…)` HTML comments at the top of `README.md`, `openwrt/README.md`, and `opnsense/README.md` flagging the technical identifiers that still reference `familydns` because they belong to sibling rename sub-issues.

## Scope (per #361 + #365)

This is the **docs-and-agent-context** slice only. Technical identifiers stay under their old name in this PR and flip in their respective sub-issues:

- Scala packages / HOCON namespace → #355
- Postgres role + DB → #356
- OpenWRT package + UCI + agent paths → #357
- Docker image + compose service → #358
- Install paths + systemd units + system user → #359
- Env vars in code → #360 (docs in this PR already use the new `WIFIHAVEN_*` names so #360 doesn't have to touch docs)
- GitHub repo URL → #364

Refs META [#365](https://github.com/sameerparekh/familydns/issues/365). Land order per #365 puts this slice after the canonical-docs work in [#350](https://github.com/sameerparekh/familydns/issues/350) (already closed) — no live conflict.

## Acceptance

- `grep -rn 'FamilyDNS\|FAMILYDNS_\|FamilyDns' --include='*.md' .` returns empty.
- Lowercase `familydns` hits that remain are all technical identifiers (paths, image names, package name, repo URLs, Scala/HOCON namespace, systemd units, DB names) — covered by the TODO comments and the sibling rename sub-issues.
- `docs/rename-decision.md` retains its historical decision content; only the status header was updated.

## Test plan

- [x] Casing audit grep is clean for `FamilyDNS` / `FAMILYDNS_` / `FamilyDns` (FAMILYDNS_ env-var prefix renamed too).
- [x] Markdown renders cleanly (HTML-comment TODO blocks are hidden from rendered output).
- [ ] No-op for runtime / no deploy validation needed — docs only.

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)