### PR TITLE
rename: Docker image familydns-api -> wifihaven-api (#358)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/familydns-api
+  IMAGE_NAME: ${{ github.repository_owner }}/wifihaven-api
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
@@ -71,8 +71,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build + run bootstrap test image
         run: |
-          docker build -f docker/bootstrap-test.Dockerfile -t familydns-bootstrap-test .
-          docker run --rm familydns-bootstrap-test
+          docker build -f docker/bootstrap-test.Dockerfile -t wifihaven-bootstrap-test .
+          docker run --rm wifihaven-bootstrap-test
 
   e2e:
     name: Live e2e against staging stack

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
      move to `sameerparekh/wifihaven` when the repo rename (#364) lands. -->
 <!-- TODO(#355–#360): install paths (/opt/familydns, $HOME/.familydns), system
      user (`familydns`), systemd units (familydns-api.service, familydns-update.*),
-     Docker image (ghcr.io/sameerparekh/familydns-api), Postgres role/db
-     (`familydns`), and HOCON config namespace (`familydns.*`) all still use
-     the old name. They flip in their respective rename sub-issues. -->
+     Postgres role/db (`familydns`), and HOCON config namespace (`familydns.*`)
+     all still use the old name. They flip in their respective rename
+     sub-issues. -->
 
 A self-hosted, network-level parental-control system with a web UI. Block
 categories of sites, set per-profile schedules ("no internet after 9pm"),
@@ -206,8 +206,8 @@ We don't want to debug bootstrap on the live box, so the script has a
 container smoke test:
 
 ```bash
-docker build -f docker/bootstrap-test.Dockerfile -t familydns-bootstrap-test .
-docker run --rm familydns-bootstrap-test
+docker build -f docker/bootstrap-test.Dockerfile -t wifihaven-bootstrap-test .
+docker run --rm wifihaven-bootstrap-test
 ```
 
 The container creates a non-root login user, points the bootstrap at the

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
       retries: 30
 
   api:
-    image: ghcr.io/sameerparekh/familydns-api:latest
+    image: ghcr.io/sameerparekh/wifihaven-api:latest
     build:
       context: ..
       dockerfile: docker/Dockerfile

--- a/docker/bootstrap-test.Dockerfile
+++ b/docker/bootstrap-test.Dockerfile
@@ -7,8 +7,8 @@
 # and without touching the host.
 #
 # Usage:
-#   docker build -f docker/bootstrap-test.Dockerfile -t familydns-bootstrap-test .
-#   docker run --rm familydns-bootstrap-test
+#   docker build -f docker/bootstrap-test.Dockerfile -t wifihaven-bootstrap-test .
+#   docker run --rm wifihaven-bootstrap-test
 FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -44,7 +44,7 @@ has already published `latest`.
 The `sha-` tag is immutable and safe to reference for rollbacks. `latest` is
 what the prod compose stack pulls on auto-update.
 
-**Image name**: `ghcr.io/sameerparekh/familydns-api`
+**Image name**: `ghcr.io/sameerparekh/wifihaven-api`
 
 The GHCR token is the built-in `GITHUB_TOKEN`; no manual secret needed.
 
@@ -57,7 +57,7 @@ In production, the `api` service is configured to pull from ghcr.io:
 
 ```yaml
 api:
-  image: ghcr.io/sameerparekh/familydns-api:latest
+  image: ghcr.io/sameerparekh/wifihaven-api:latest
 ```
 
 The image is never built on the prod host. All builds happen in CI.

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -136,7 +136,7 @@ and §8 (firewall).
 ## 2. Obtain the image
 
 The API image is published to GitHub Container Registry at
-`ghcr.io/sameerparekh/familydns-api`. Tags:
+`ghcr.io/sameerparekh/wifihaven-api`. Tags:
 
 | Tag | When to use |
 |-----|-------------|
@@ -146,7 +146,7 @@ The API image is published to GitHub Container Registry at
 After issue #128 lands the package will be public, so anonymous pulls work:
 
 ```sh
-docker pull ghcr.io/sameerparekh/familydns-api:latest
+docker pull ghcr.io/sameerparekh/wifihaven-api:latest
 ```
 
 If the package is still private when you install, log in to ghcr.io first
@@ -154,7 +154,7 @@ with a GitHub personal access token that has the `read:packages` scope:
 
 ```sh
 echo "$GHCR_PAT" | docker login ghcr.io -u <your-github-username> --password-stdin
-docker pull ghcr.io/sameerparekh/familydns-api:latest
+docker pull ghcr.io/sameerparekh/wifihaven-api:latest
 ```
 
 You don't strictly need to pre-pull — `docker compose up -d` in §4 will

--- a/scripts/deploy-api-from-branch.sh
+++ b/scripts/deploy-api-from-branch.sh
@@ -6,7 +6,7 @@
 #   ~/familydns/   git checkout (source)
 #   ~/.familydns/  runtime: docker-compose.prod.yml, .env, helper scripts
 #
-# The runtime compose file pins ghcr.io/sameerparekh/familydns-api:latest.
+# The runtime compose file pins ghcr.io/sameerparekh/wifihaven-api:latest.
 # We build locally on the server and tag with that exact reference; the
 # next `start.sh` (compose up -d) picks up the new image id and recreates
 # the api container.
@@ -26,7 +26,7 @@ set -euo pipefail
 API_HOST="${API_HOST:-192.168.10.43}"
 SRC_DIR="${SRC_DIR:-\$HOME/familydns}"
 RUN_DIR="${RUN_DIR:-\$HOME/.familydns}"
-IMAGE="ghcr.io/sameerparekh/familydns-api:latest"
+IMAGE="ghcr.io/sameerparekh/wifihaven-api:latest"
 BRANCH="${1:-main}"
 
 echo "==> deploying branch '$BRANCH' to $API_HOST"


### PR DESCRIPTION
## Summary
- Renames the published GHCR image from `ghcr.io/sameerparekh/familydns-api` to `ghcr.io/sameerparekh/wifihaven-api`.
- Renames the local `bootstrap-test` docker tag (`familydns-bootstrap-test` → `wifihaven-bootstrap-test`).
- Updates the prod compose file, install docs, and `scripts/deploy-api-from-branch.sh` to reference the new image.
- Pre-production, so no parallel publish / cutover window. Old `familydns-api` package on ghcr.io is left in place; harmless.

## Scope boundary
Out of scope here (left alone, flip in their own sub-issues):
- `*.service` systemd unit names, system user `familydns` → #359
- Postgres role/db, FAMILYDNS_* env vars → #356, #360
- README diagram label `familydns-api` (cosmetic, docs)

The `docker/Dockerfile` has no embedded image labels referencing the old name (verified by grep).
The dev `docker/docker-compose.yml` builds locally and does not pull a published image — no change needed.

## Notes on ghcr.io
The image-package URL on ghcr.io is owner-scoped (`sameerparekh/<pkg>`), not repo-scoped, so the future GitHub repo rename in #364 does NOT affect this URL.

## Test plan
- [ ] Master CD `ci-tests`, `bootstrap-smoke`, `e2e`, `prod-stack-smoke` green on the PR.
- [ ] After merge, Master CD `publish-api` pushes `ghcr.io/sameerparekh/wifihaven-api:latest` (first push creates the new package).
- [ ] **Manual**: if the previous `familydns-api` package was PUBLIC, mark the new `wifihaven-api` package PUBLIC too in ghcr.io package settings.
- [ ] Live deploy on `192.168.10.43`: `docker pull ghcr.io/sameerparekh/wifihaven-api:latest`, `docker compose up -d`, verify `/api/health` returns 200. Test result to be appended below before merge-readiness sign-off.

## Refs
- Closes #358
- Part of #365 (META: rename tracker)
- Depends on #355 (merged at 6bcad8d)
- Repo rename #364 is independent of the image URL (owner-scoped, not repo-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)