### PR TITLE
fix: VM e2e policy-etag wait race (#514)

### DIFF
--- a/scripts/e2e/scenarios/test_pause.py
+++ b/scripts/e2e/scenarios/test_pause.py
@@ -100,17 +100,17 @@ def test_pause_blocks_and_unpause_restores(
 
     # ── A1: pause ─────────────────────────────────────────────────────────
     admin.set_profile_paused(profile_id, True)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-    _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+    _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
     _wait_block_page(client, timeout_s=60)
     _wait_pause_event(debug_api, mac, timeout_s=30)
 
     # ── A2: unpause ───────────────────────────────────────────────────────
     admin.set_profile_paused(profile_id, False)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-    _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+    _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
     _wait_http_succeeds(client, timeout_s=60)
 
 
@@ -128,15 +128,15 @@ def test_pause_then_add_device_blocks_new_mac(
     """
     profile_id = scratch_profile["id"]
     admin.set_profile_paused(profile_id, True)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
     # New MAC, never seen by the router or API before.
     new_mac = "02:e2:e2:a3:00:%02x" % (uuid.uuid4().int & 0xFF)
     admin.upsert_device(mac=new_mac, name=f"e2e-a3-{new_mac[-5:]}", profile_id=profile_id)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
     try:
-        _wait_mac_in_blocked_set(new_mac, present=True, timeout_s=60)
+        _wait_mac_in_blocked_set(new_mac, present=True, timeout_s=180)
     finally:
         try:
             admin.delete_device(new_mac)
@@ -155,16 +155,16 @@ def test_reassign_off_paused_profile_unblocks_mac(
     mac = client.mac
 
     admin.set_profile_paused(paused_pid, True)
-    wait_for_etag_change(admin, router.router_id, timeout_s=120)
-    _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
+    _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
 
     # Create a second, unpaused profile and reassign.
     other = admin.create_profile(name=f"e2e-a4-other-{uuid.uuid4().hex[:6]}")
     other_pid = other["profile"]["id"] if "profile" in other else other["id"]
     try:
         admin.upsert_device(mac=mac, name=f"e2e-a4-{mac[-5:]}", profile_id=other_pid)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
     finally:
         # scratch_device's teardown still tries delete_device(mac); reassign
         # leaves the row pointing at `other_pid`, which is fine. We just need

--- a/scripts/e2e/scenarios/test_reassignment.py
+++ b/scripts/e2e/scenarios/test_reassignment.py
@@ -107,23 +107,23 @@ def test_reassign_to_paused_blocks_and_back_restores(
     try:
         # ── E1: A → B (paused) ─────────────────────────────────────────
         admin.set_profile_paused(profile_b_id, True)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         admin.upsert_device(
             mac=mac, name=f"e2e-e1-{mac[-5:]}", profile_id=profile_b_id,
         )
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_block_page(client, timeout_s=60)
 
         # ── E2: B → A restores ─────────────────────────────────────────
         admin.upsert_device(
             mac=mac, name=f"e2e-e2-{mac[-5:]}", profile_id=profile_a_id,
         )
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-        _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
         _wait_http_succeeds(client, timeout_s=60)
     finally:
         # Reassignment leaves the device on profile A — scratch_device's
@@ -155,21 +155,21 @@ def test_delete_device_clears_rules(
     deleted = False
     try:
         admin.set_profile_paused(paused_id, True)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         admin.upsert_device(
             mac=mac, name=f"e2e-e3-{mac[-5:]}", profile_id=paused_id,
         )
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
 
         # Now delete the device row.
         admin.delete_device(mac)
         deleted = True
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         # MAC should leave blocked_macs within one poll.
-        _wait_mac_in_blocked_set(mac, present=False, timeout_s=60)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
 
         # Row should be absent from list_devices.
         wait_until(

--- a/scripts/e2e/scenarios/test_schedule.py
+++ b/scripts/e2e/scenarios/test_schedule.py
@@ -95,7 +95,7 @@ def _set_clock_and_sync(admin, router, when: datetime) -> None:
     wall-clock jump; `wait_for_next_poll` here pins the next sync to the
     next cycle boundary and asserts the agent actually polled."""
     set_router_clock(when)
-    wait_for_next_poll(admin, router.router_id, timeout_s=120)
+    wait_for_next_poll(admin, router.router_id, timeout_s=240)
 
 
 def _schedule_id_from(profile: dict, name: str) -> int | None:
@@ -134,9 +134,9 @@ def test_in_window_blocks(
         _set_clock_and_sync(admin, router, anchor)
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
     finally:
         sid = _schedule_id_from(result or {}, sched_name)
@@ -176,8 +176,8 @@ def test_out_of_window_allows(
         _set_clock_and_sync(admin, router, anchor)
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        wait_for_next_poll(admin, router.router_id, timeout_s=240)
 
         assert not _mac_in_set(mac), \
             f"{mac} should not be blocked while clock is outside the window"
@@ -230,8 +230,8 @@ def test_cross_midnight_LA_tz(
         _set_clock_and_sync(admin, router, la(23, 57))
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        wait_for_next_poll(admin, router.router_id, timeout_s=240)
 
         # # pending #334
         assert not _mac_in_set(mac), "23:57 LA: outside window, should be allowed"
@@ -239,7 +239,7 @@ def test_cross_midnight_LA_tz(
         # Step to 23:59 LA — inside window.
         _set_clock_and_sync(admin, router, la(23, 59))
         # # pending #334
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
 
         # Step across midnight to 00:01 LA (next day) — still inside window.
         next_la = date_la + timedelta(days=1)
@@ -248,7 +248,7 @@ def test_cross_midnight_LA_tz(
             next_la.replace(hour=0, minute=1).astimezone(timezone.utc),
         )
         # # pending #334
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
 
         # Step to 00:04 LA — past window close.
         _set_clock_and_sync(
@@ -256,7 +256,7 @@ def test_cross_midnight_LA_tz(
             next_la.replace(hour=0, minute=4).astimezone(timezone.utc),
         )
         # # pending #334
-        _wait_mac_in_blocked_set(mac, present=False, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
     finally:
         sid = _schedule_id_from(result or {}, sched_name)
         if sid is not None:
@@ -297,23 +297,23 @@ def test_pause_overrides_schedule(
         _set_clock_and_sync(admin, router, anchor)
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
 
         # Pause — reason should flip to paused within one poll.
         admin.set_profile_paused(profile_id, True)
         paused = True
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_event(debug_api, mac, reason="paused", timeout_s=60)
 
         # Unpause — schedule still in window, reason should revert.
         admin.set_profile_paused(profile_id, False)
         paused = False
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=60)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
     finally:
         if paused:
@@ -364,15 +364,15 @@ def test_all_day_monday(
         _set_clock_and_sync(admin, router, sunday_2359)
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
-        wait_for_next_poll(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
+        wait_for_next_poll(admin, router.router_id, timeout_s=240)
 
         # # pending #334
         assert not _mac_in_set(mac), "Sun 23:59 LA: outside Monday window, should be allowed"
 
         _set_clock_and_sync(admin, router, monday_0001)
         # # pending #334
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
     finally:
         sid = _schedule_id_from(result or {}, sched_name)
         if sid is not None:
@@ -414,13 +414,13 @@ def test_in_then_out_smoke(
         _set_clock_and_sync(admin, router, in_window)
 
         result = admin.add_schedule(profile_id, schedule)
-        wait_for_etag_change(admin, router.router_id, timeout_s=120)
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
-        _wait_mac_in_blocked_set(mac, present=True, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
         _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
 
         _set_clock_and_sync(admin, router, out_window)
-        _wait_mac_in_blocked_set(mac, present=False, timeout_s=90)
+        _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
         _wait_http_succeeds(client, timeout_s=60)
     finally:
         sid = _schedule_id_from(result or {}, sched_name)


### PR DESCRIPTION
## Summary

11 VM e2e scenarios (5 pause/reassign + 6 schedule) were timing out on
`wait_for_etag_change` and `_wait_mac_in_blocked_set`. The #486 diagnostic
logging proved the API is regenerating snapshots and serving fresh etags
correctly — the bug is harness-side: waits assumed a steady ~60s agent poll
cadence, but in practice the gap is much longer.

## Diagnosis (from run 25972689545 artifacts)

`tmp/api-logs.txt` shows the agent's actual policy-fetch cadence (lines where
`etagIn=<hash>`, i.e. an authenticated agent poll with a cached etag):

```
21:03:10 → 21:09:54   gap 6m44s
21:09:54 → 21:16:10   gap 6m16s
21:16:10 → 21:19:34   gap 3m24s
21:19:34 → 21:22:58   gap 3m24s
21:22:58 → 21:27:55   gap 4m57s
21:27:55 → 21:32:48   gap 4m53s
```

These are all well over the existing 120s `wait_for_etag_change` deadline. The
nominal `policy_int=60s` (`openwrt/files/etc/config/familydns`) is enforced by
a conntrack-driven `on_tick` in `openwrt/files/usr/sbin/familydns-agent:351` —
so when the VM is idle / starved for traffic, the timer doesn't fire until
the next packet arrives. Under VM load + sparse synthetic traffic, real
inter-poll gaps drift to multiple minutes.

## Fix

`scripts/e2e/scenarios/test_pause.py`, `test_reassignment.py`, `test_schedule.py`:

- `wait_for_etag_change(..., timeout_s=120)` → `240`
- `wait_for_next_poll(..., timeout_s=120)` → `240`
- `_wait_mac_in_blocked_set(..., timeout_s=60|90)` → `180`

No change to `api/` or to the agent — the server is demonstrably doing the
right thing per the #486 diagnostics, and the agent's conntrack-driven cadence
is intentional (#336). The minimal harness-side fix is to wait long enough
for the agent's next poll to land.

## Test plan

This covers the 11 #514-listed scenarios:

- [ ] `test_pause.py::test_pause_blocks_and_unpause_restores`
- [ ] `test_pause.py::test_pause_then_add_device_blocks_new_mac`
- [ ] `test_pause.py::test_reassign_off_paused_profile_unblocks_mac`
- [ ] `test_reassignment.py` pause-related cases
- [ ] `test_schedule.py::test_in_window_blocks`
- [ ] `test_schedule.py::test_out_of_window_allows`
- [ ] `test_schedule.py::test_cross_midnight_LA_tz`
- [ ] `test_schedule.py::test_pause_overrides_schedule`
- [ ] `test_schedule.py::test_all_day_monday`
- [ ] `test_schedule.py::test_in_then_out_smoke`

Other VM e2e failures (#515, #516, #517) are out of scope here and are
tracked separately.

## Refs

- Parent: #481
- Diagnostic logging that revealed this: #486
- Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)