### PR TITLE
fix: extra_blocked nft set population (#515)

### DIFF
--- a/openwrt/files/usr/lib/lua/familydns/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/familydns/dns_log.lua
@@ -88,23 +88,28 @@ end
 M._is_ipv6 = is_ipv6
 M._is_ipv4 = is_ipv4
 
--- parse_resolved_reply(line) → { client_ip, ip, family } | nil
+-- parse_resolved_reply(line) → { client_ip, name, ip, family } | nil
 --
 -- Extracts the dnsmasq client IP (the device that issued the query — the
--- "source IP" we look up in the DHCP lease table to find the MAC) and the
--- answer IP from a `reply`/`cached` log line. Used by familydns-dns-tail
--- (#505) to populate per-MAC blockIpOnly resolved_<mac> / resolved6_<mac>
--- sets out-of-band, because dnsmasq 2.91's `nftset=tag:` is broken (#496)
--- and per-MAC scoping is semantically essential for blockIpOnly.
+-- "source IP" we look up in the DHCP lease table to find the MAC), the
+-- answered hostname, and the answer IP from a `reply`/`cached` log line.
+-- Used by familydns-dns-tail:
+--   - #505: per-MAC blockIpOnly resolved_<mac> / resolved6_<mac> sets
+--     (keyed by client_ip → MAC); dnsmasq 2.91's `nftset=tag:` is broken
+--     (#496) and per-MAC scoping is semantically essential there.
+--   - #515: per-host extraBlocked eb_<sanhost> / eb6_<sanhost> sets,
+--     populated out-of-band for the same reason — dnsmasq's `nftset=/h/...`
+--     path is unreliable in the deployed build (the sets stayed empty
+--     under the e2e test that resolved the host through the LAN resolver).
 --
 -- Unlike parse_reply_line (which feeds the hostname-attribution cache and
 -- intentionally tracks v4 answers only because conntrack flows are v4),
--- this returns BOTH families: the resolved6_<mac> set must be populated
--- for AAAA answers, and v6 daddrs are filtered by the per-MAC drop rule.
+-- this returns BOTH families: the resolved6_ / eb6_ sets must be populated
+-- for AAAA answers, and v6 daddrs are filtered by the matching drop rules.
 -- `family` is "v4" or "v6".
 function M.parse_resolved_reply(line)
   if type(line) ~= "string" or line == "" then return nil end
-  local qid, client_ip, verb, _name, value = line:match(
+  local qid, client_ip, verb, name, value = line:match(
     "(%d+)%s+(%S+)/%d+%s+(%a+)%s+(%S+)%s+is%s+(%S+)")
   if not qid or (verb ~= "reply" and verb ~= "cached") then return nil end
   -- client_ip in the log line includes a port suffix `/53` etc. — already
@@ -112,10 +117,10 @@ function M.parse_resolved_reply(line)
   -- (DHCPv4 lease maps client_ip → MAC).
   if not is_ipv4(client_ip) then return nil end
   if is_ipv4(value) then
-    return { client_ip = client_ip, ip = value, family = "v4" }
+    return { client_ip = client_ip, name = name, ip = value, family = "v4" }
   end
   if is_ipv6(value) then
-    return { client_ip = client_ip, ip = value, family = "v6" }
+    return { client_ip = client_ip, name = name, ip = value, family = "v6" }
   end
   -- <CNAME>, NXDOMAIN, NODATA-IPvX → not a usable answer.
   return nil

--- a/openwrt/files/usr/sbin/familydns-dns-tail
+++ b/openwrt/files/usr/sbin/familydns-dns-tail
@@ -108,19 +108,26 @@ local function refresh_ip_to_mac()
   return out
 end
 
--- Returns a set { [sanmac] = true } of MACs that have a resolved_<sanmac> set
--- declared. resolved6_<sanmac> tracks the same MAC, so we key on the v4 set
--- name (both are always declared together in render.nft).
-local function refresh_bio_sanmacs()
-  local out = {}
+-- Returns three sets keyed by sanitized name:
+--   bio  — { [sanmac]   = true } MACs with a resolved_<sanmac> set (#505).
+--   eb4  — { [sanhost]  = true } hosts with an eb_<sanhost>  set (#515).
+--   eb6  — { [sanhost]  = true } hosts with an eb6_<sanhost> set (#515).
+-- All three live in the same `inet familydns` table and refresh on the same
+-- cadence, so a single `nft list table` popen pays for all of them.
+local function refresh_nft_sets()
+  local bio, eb4, eb6 = {}, {}, {}
   local h = io.popen("nft -a list table " .. nft_table .. " 2>/dev/null", "r")
-  if not h then return out end
+  if not h then return bio, eb4, eb6 end
   for line in h:lines() do
     local sanmac = line:match("set%s+resolved_([%w_]+)%s*{")
-    if sanmac then out[sanmac] = true end
+    if sanmac then bio[sanmac] = true end
+    local sanhost4 = line:match("set%s+eb_([%w_]+)%s*{")
+    if sanhost4 then eb4[sanhost4] = true end
+    local sanhost6 = line:match("set%s+eb6_([%w_]+)%s*{")
+    if sanhost6 then eb6[sanhost6] = true end
   end
   h:close()
-  return out
+  return bio, eb4, eb6
 end
 
 -- Shell-quoting: the answer IP comes from dnsmasq's log line (we already
@@ -146,10 +153,11 @@ local function nft_add_element(set_name, ip)
 end
 
 local ip_to_mac     = refresh_ip_to_mac()
-local bio_sanmacs   = refresh_bio_sanmacs()
+local bio_sanmacs, eb_sanhosts, eb6_sanhosts = refresh_nft_sets()
 local last_lease_refresh = os.time()
 local last_bio_refresh   = os.time()
 local bio_adds_total     = 0
+local eb_adds_total      = 0
 
 local function maybe_populate_bio(line, now)
   local r = dns_log.parse_resolved_reply(line)
@@ -165,9 +173,50 @@ local function maybe_populate_bio(line, now)
             set_name, r.ip, r.client_ip, mac)
 end
 
-log.info("dns-tail: bio populator init — %d lease(s), %d bio set(s)",
+-- #515: per-host extraBlocked set populator.
+--
+-- render.lua emits an `nftset=/host/4#...#eb_<sanhost>,6#...#eb6_<sanhost>`
+-- for every effective extraBlocked host, but in the deployed dnsmasq build
+-- those sets stay empty under e2e (test_extra_blocked × 2 timed out waiting
+-- for eb_example_com to gain its first element). Mirror the #505 fix shape:
+-- tail the same query log we already read for hostname attribution, and run
+-- `nft add element` ourselves when we see a `reply <host> is <ip>` that
+-- matches a declared eb_<sanhost> / eb6_<sanhost> set.
+--
+-- Subdomain semantics: dnsmasq's `nftset=/example.com/...` matches
+-- example.com AND every subdomain. Mirror that by walking labels — for
+-- `www.example.com` we test `www_example_com`, then `example_com`, then
+-- `com`. First hit wins; the v4 and v6 set memberships are checked
+-- independently so a host with only AAAA records still populates eb6_.
+local function sanitize_host(h)
+  return (h:gsub("[%.%:]", "_"))
+end
+
+local function maybe_populate_eb(line)
+  local r = dns_log.parse_resolved_reply(line)
+  if not r or not r.name then return end
+  local sets   = (r.family == "v6") and eb6_sanhosts or eb_sanhosts
+  local prefix = (r.family == "v6") and "eb6_"       or "eb_"
+  local n = r.name
+  while n and n ~= "" do
+    local sanhost = sanitize_host(n)
+    if sets[sanhost] then
+      nft_add_element(prefix .. sanhost, r.ip)
+      eb_adds_total = eb_adds_total + 1
+      log.debug("dns-tail: eb add %s%s { %s } name=%s",
+                prefix, sanhost, r.ip, r.name)
+      return
+    end
+    local dot = n:find("%.")
+    if not dot then return end
+    n = n:sub(dot + 1)
+  end
+end
+
+log.info("dns-tail: populator init — %d lease(s), %d bio set(s), %d eb set(s)",
          (function() local n = 0; for _ in pairs(ip_to_mac) do n = n + 1 end; return n end)(),
-         (function() local n = 0; for _ in pairs(bio_sanmacs) do n = n + 1 end; return n end)())
+         (function() local n = 0; for _ in pairs(bio_sanmacs) do n = n + 1 end; return n end)(),
+         (function() local n = 0; for _ in pairs(eb_sanhosts) do n = n + 1 end; return n end)())
 
 local since_flush      = 0
 local last_tick        = os.time()
@@ -196,6 +245,12 @@ while true do
   -- defeats user-visible connectivity).
   maybe_populate_bio(line, now)
 
+  -- #515: same lockstep argument as bio — the per-host extraBlocked drop
+  -- rule fires on the first packet of the flow, so any delay between the
+  -- dnsmasq reply and the eb_<sanhost> element add lets the first SYN
+  -- through.
+  maybe_populate_eb(line)
+
   if since_flush >= flush_every or (now - last_tick) >= 30 then
     cache.tick(now)
     atomic_write(cache_path, cache.dump_text())
@@ -213,7 +268,7 @@ while true do
     last_lease_refresh = now
   end
   if (now - last_bio_refresh) >= bio_refresh_seconds then
-    bio_sanmacs = refresh_bio_sanmacs()
+    bio_sanmacs, eb_sanhosts, eb6_sanhosts = refresh_nft_sets()
     last_bio_refresh = now
   end
 
@@ -221,9 +276,9 @@ while true do
   -- dropping the pipe, regex never matching) are diagnosable from logread
   -- alone without on-VM access (#480).
   if (now - last_stats_log) >= 60 then
-    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d",
+    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d",
              lines_ingested, lines_since_stat, now - last_stats_log,
-             cache.size(), bio_adds_total)
+             cache.size(), bio_adds_total, eb_adds_total)
     last_stats_log   = now
     lines_since_stat = 0
   end

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -118,8 +118,21 @@ describe("parse_resolved_reply (#505)", function()
       "Nov 12 10:00:01 dnsmasq[1234]: 7 192.168.1.42/54321 reply youtube.com is 142.250.80.46")
     assert.is_not_nil(r)
     assert.equal("192.168.1.42",   r.client_ip)
+    assert.equal("youtube.com",    r.name)
     assert.equal("142.250.80.46",  r.ip)
     assert.equal("v4",             r.family)
+  end)
+
+  -- #515: the per-host eb_<sanhost> populator keys on r.name, so make sure
+  -- the parser is actually surfacing the qname (was previously discarded as
+  -- `_name` when only the bio populator needed the line).
+  it("surfaces the answered name on v6 replies too (#515)", function()
+    local r = dns_log.parse_resolved_reply(
+      "Nov 12 10:00:01 dnsmasq[1234]: 8 192.168.1.42/54321 reply example.com is 2606:2800:220:1::248")
+    assert.is_not_nil(r)
+    assert.equal("example.com",          r.name)
+    assert.equal("2606:2800:220:1::248", r.ip)
+    assert.equal("v6",                   r.family)
   end)
 
   it("returns client_ip + v6 ip + family=v6 for an AAAA reply", function()


### PR DESCRIPTION
## Symptom

Suite B (#444) e2e: `test_extra_blocked_http_drops_to_block_page_and_set_populated` and `test_extra_blocked_is_per_profile_scoped` time out waiting for `eb_example_com` to gain its first element after the client digs `example.com` ([run](https://github.com/sameerparekh/familydns/actions/runs/25972689545/job/76347382242)). The render path emits `nftset=/example.com/4#inet#familydns#eb_example_com,6#inet#familydns#eb6_example_com`, but the deployed dnsmasq build never populates the sets.

## Fix

Mirror PR #511 (which fixed the analogous `resolved_<mac>` population for `blockIpOnly`/#505): populate `eb_<sanhost>` / `eb6_<sanhost>` from the `familydns-dns-tail` sidecar instead of relying on dnsmasq's `nftset=` callback. The sidecar already tails dnsmasq's query log for hostname attribution, so feeding the eb_ sets is a small extension of an existing flow.

- `parse_resolved_reply` now surfaces the answered `name` (was already extracted, just discarded).
- `dns-tail` learns `eb_<sanhost>` + `eb6_<sanhost>` declarations alongside `resolved_<sanmac>` in the same `nft list table` scan, then runs `nft add element` inline with each `reply ... is <ip>` line.
- Subdomain match (`www.example.com` → `eb_example_com`) is preserved by walking labels — mirrors dnsmasq's `nftset=/host/...` semantics.

## Files changed

- `openwrt/files/usr/lib/lua/familydns/dns_log.lua`
- `openwrt/files/usr/sbin/familydns-dns-tail`
- `openwrt/test/dns_log_spec.lua`

## Test plan

- [ ] Next VM e2e cycle: `test_extra_blocked_http_drops_to_block_page_and_set_populated` passes.
- [ ] Next VM e2e cycle: `test_extra_blocked_is_per_profile_scoped` passes.
- [ ] `bio_adds` counter in the existing dns-tail heartbeat is joined by an `eb_adds` counter for diagnosability (#480 pattern).

Precedent: PR #511 / issue #505 (same dns-tail population pattern for `resolved_<mac>` sets).

Closes #515.