### PR TITLE
fix: time_usage minute-granularity uses sum(activeSeconds) (#516)

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -43,15 +43,18 @@ object Presence {
     bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
 
   /**
-   * Per-mac total minutes for the day, counting each 5-min bucket once. A bucket counts iff at
-   * least one host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on
-   * something that bears on the daily cap. IP-literal hosts are never exempt (patterns only match
-   * FQDNs).
+   * Per-mac total active-seconds for the day, summing each 5-min bucket's max activeSeconds
+   * (bucket-deduplicated across hosts) once. A bucket counts iff at least one host in the bucket is
+   * NOT in `exemptPatterns`. IP-literal hosts are never exempt (patterns only match FQDNs).
+   *
+   * Surfaces raw seconds rather than floor-divided minutes so callers that need the precision (see
+   * #516 e2e test) can ceil-divide themselves; minute-resolution callers should use
+   * [[totalMinutesByMac]].
    */
-  def totalMinutesByMac(
+  def totalSecondsByMac(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
-  ): Map[MacAddress, Int] = {
+  ): Map[MacAddress, Long] = {
     def isExempt(h: HostId) =
       h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
     rows
@@ -62,10 +65,19 @@ object Presence {
           mac -> bucketSeconds(bucket)
       }
       .groupMapReduce(_._1)(_._2)(_ + _)
-      .view
-      .mapValues(s => (s / 60).toInt)
-      .toMap
   }
+
+  /**
+   * Per-mac total minutes for the day, counting each 5-min bucket once. A bucket counts iff at
+   * least one host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on
+   * something that bears on the daily cap. IP-literal hosts are never exempt (patterns only match
+   * FQDNs).
+   */
+  def totalMinutesByMac(
+      rows: List[PresenceRow],
+      exemptPatterns: List[String],
+  ): Map[MacAddress, Int] =
+    totalSecondsByMac(rows, exemptPatterns).view.mapValues(s => (s / 60).toInt).toMap
 
   /**
    * Per-(mac, pattern) minutes, counting each bucket once per device per pattern when any host in

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -76,17 +76,23 @@ object DebugRoutes {
               presence <- trafficRepo
                 .listPresenceRows(macs, today)
                 .mapError(ErrorMapper.dbErrorToResponse)
-              totals = wifihaven.api.presence.Presence
-                .totalMinutesByMac(presence, exemptPatterns = Nil)
+              // Surface raw active-seconds (sum of max-per-bucket activeSeconds) as well as
+              // the floor-divided minute count. The e2e D2 minute-granularity test (#516)
+              // ceil-divides this to get tight bounds; bucket-counting via floor(/60) drifts
+              // when activity straddles 5-min agent buckets.
+              totalSecs = wifihaven.api.presence.Presence
+                .totalSecondsByMac(presence, exemptPatterns = Nil)
             } yield Response.json(
               snap
                 .map { case ((mac, host), mins) =>
+                  val secs = totalSecs.getOrElse(mac, 0L)
                   TimeUsageRow(
                     mac.value,
                     host.value,
                     today.toString,
                     mins,
-                    totals.getOrElse(mac, 0),
+                    (secs / 60).toInt,
+                    secs,
                   )
                 }
                 .toList
@@ -105,6 +111,10 @@ object DebugRoutes {
       // Same value on every row for the same mac; callers should take this once
       // per mac rather than summing `minutesUsed` across hosts.
       deviceTotalMinutes: Int,
+      // Same as deviceTotalMinutes but expressed as raw seconds (no floor /60).
+      // Callers needing tight minute bounds (e.g. e2e D2 test, #516) should
+      // ceil-divide this rather than reading deviceTotalMinutes which floors.
+      deviceTotalActiveSeconds: Long,
   ) derives JsonCodec
 
   /**

--- a/openwrt/files/usr/lib/lua/familydns/usage.lua
+++ b/openwrt/files/usr/lib/lua/familydns/usage.lua
@@ -133,21 +133,24 @@ local function host_for_ip(dst_ip, nft_sets, lookup_hostname)
 end
 
 -- ---------------------------------------------------------------------------
--- Activity tracker — per-minute "is this (mac, dst_ip) actively using the
--- network?" sampling.  See #295.
+-- Activity tracker — sub-minute "is this (mac, dst_ip) actively using the
+-- network?" sampling.  See #295 (#516).
 -- ---------------------------------------------------------------------------
 -- The nftables set element counters in `mac_ip_tracking` are reset to 0 once
--- per 5-min bucket.  The agent calls `tracker_sample` every 60 s with the
--- currently-parsed counters; each call that observes byte growth bumps the
--- (mac, dst_ip)'s active-minute count.  At end-of-bucket `build_report`
--- multiplies that count by 60 (capped at 300) to produce `activeSeconds`,
--- and the agent resets the tracker for the next bucket.
+-- per 5-min bucket.  The agent calls `tracker_sample` every SECONDS_PER_SAMPLE
+-- seconds with the currently-parsed counters; each call that observes byte
+-- growth bumps the (mac, dst_ip)'s active-sample count.  At end-of-bucket
+-- `build_report` multiplies that count by SECONDS_PER_SAMPLE (capped at 300)
+-- to produce `activeSeconds`, and the agent resets the tracker for the next
+-- bucket.
 --
--- Wire format is unchanged — `activeSeconds` is still an integer.  The
--- minute granularity is purely router-side; sub-minute is a future extension
--- (issue #295 "Future work") that only needs to change SECONDS_PER_SAMPLE
--- and the sampling cadence in the agent loop.
-local SECONDS_PER_SAMPLE = 60
+-- Wire format is unchanged — `activeSeconds` is still an integer.  10s
+-- granularity is fine enough that summing activeSeconds across buckets is
+-- accurate to within ~10 s of real wall-clock active time, which is what
+-- the time-limit test (#516) and Presence aggregation need.  Increasing
+-- the sample frequency to every 10 s (from 60 s) trades a small amount of
+-- router CPU (nftables counter reads are cheap) for accuracy.
+local SECONDS_PER_SAMPLE = 10
 local BUCKET_SECONDS     = 300
 
 local function tracker_key(mac, dst_ip) return mac .. "|" .. dst_ip end
@@ -186,10 +189,10 @@ end
 --                    [, leases [, lookup_hostname [, tracker]]])
 -- ---------------------------------------------------------------------------
 -- activeSeconds:
---   * With a tracker: 60 × active_minutes[(mac, dst_ip)], capped at 300.
---     A counter present in `counters` but missing from the tracker (e.g. set
---     element first appeared after the last per-minute sample) falls back to
---     one active minute when bytes > 0.
+--   * With a tracker: SECONDS_PER_SAMPLE × active_samples[(mac, dst_ip)],
+--     capped at 300.  A counter present in `counters` but missing from the
+--     tracker (e.g. set element first appeared after the last sample) falls
+--     back to one active sample when bytes > 0.
 --   * Without a tracker (legacy / back-compat): bytes > 0 → 300, else 0.
 function M.build_report(counters, nft_sets, period_start, period_end, router_id, leases, lookup_hostname, tracker)
   local records = {}

--- a/openwrt/files/usr/sbin/familydns-agent
+++ b/openwrt/files/usr/sbin/familydns-agent
@@ -219,7 +219,7 @@ local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
 local last_activity_sample = 0
-local activity_sample_int  = 60                 -- per-minute activity granularity (#295)
+local activity_sample_int  = 10                 -- 10s activity granularity (#295, #516)
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
 
@@ -430,9 +430,10 @@ conntrack.watch({
       end
     end
 
-    -- Activity sampler (#295): every 60 s, snapshot counters and feed them
-    -- to the tracker so end-of-bucket activeSeconds reflects real per-minute
-    -- usage rather than collapsing to {0, 300}.
+    -- Activity sampler (#295, #516): every 10 s, snapshot counters and feed
+    -- them to the tracker so end-of-bucket activeSeconds reflects real
+    -- ~10-second-granularity usage rather than collapsing to {0, 300} or
+    -- rounding to whole-minute buckets.
     if (mono - last_activity_sample) >= activity_sample_int then
       last_activity_sample = mono
       local counters = read_nft_counters()
@@ -454,8 +455,8 @@ conntrack.watch({
       -- `nft reset set ...` to zero those per-element counters in place.
       local counters = read_nft_counters()
       if counters then
-        -- Final per-minute sample at flush so set elements that appeared
-        -- after the last 60s tick still get an active minute counted.
+        -- Final sample at flush so set elements that appeared after the
+        -- last activity_sample_int tick still get an active sample counted.
         usage.tracker_sample(activity_tracker, counters)
         last_activity_sample = mono
         local report = usage.build_report(

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -245,13 +245,16 @@ describe("usage.build_report", function()
 
 end)
 
--- ── tracker (per-minute activity sampler) ─────────────────────────────────
+-- ── tracker (sub-minute activity sampler, #295, #516) ────────────────────
 --
--- The router scrapes nft counters every 60 s within a 5-min bucket and feeds
--- them to a tracker; the tracker remembers how many distinct minutes each
--- (mac, dst_ip) saw counter growth, which build_report converts into
--- activeSeconds.  Counter reset / set-element expiry (bytes goes DOWN) is
--- treated as a fresh start so we don't double-count.
+-- The router scrapes nft counters every SECONDS_PER_SAMPLE (10 s) within a
+-- 5-min bucket and feeds them to a tracker; the tracker remembers how many
+-- distinct samples each (mac, dst_ip) saw counter growth, which build_report
+-- converts into activeSeconds.  Counter reset / set-element expiry (bytes
+-- goes DOWN) is treated as a fresh start so we don't double-count.
+-- The tracker field is still named `active_minutes` for back-compat — it's
+-- a sample count, not a minute count, since #516 dropped the sample
+-- interval from 60s to 10s.
 
 describe("usage.tracker", function()
 
@@ -266,13 +269,13 @@ describe("usage.tracker", function()
     assert.is_nil(next(t.active_minutes))
   end)
 
-  it("counts a single sample with bytes > 0 (from 0 baseline) as 1 active minute", function()
+  it("counts a single sample with bytes > 0 (from 0 baseline) as 1 active sample", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
     assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
-  it("counts each subsequent sample with growth as another active minute", function()
+  it("counts each subsequent sample with growth as another active sample", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  100) })
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  500) })
@@ -280,7 +283,7 @@ describe("usage.tracker", function()
     assert.equal(3, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
-  it("does NOT count a sample where bytes are unchanged", function()
+  it("does NOT count a sample where bytes are unchanged (no active sample)", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- +1
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })  -- no growth
@@ -288,14 +291,14 @@ describe("usage.tracker", function()
     assert.equal(1, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
-  it("treats a counter decrease (reset / element-expire-and-reappear) as a fresh active minute", function()
+  it("treats a counter decrease (reset / element-expire-and-reappear) as a fresh active sample", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })  -- +1
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",  50) })  -- reset, bytes>0 → +1
     assert.equal(2, t.active_minutes["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
-  it("does not count a counter decrease to 0 as an active minute", function()
+  it("does not count a counter decrease to 0 as an active sample", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })  -- +1
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4",   0) })  -- decrease to 0 → no
@@ -353,45 +356,45 @@ describe("usage.build_report with tracker", function()
     return { mac = mac, dst_ip = dst_ip, bytes = bytes, packets = 0 }
   end
 
-  it("uses 60 * active_minutes from the tracker (1 minute → 60s)", function()
+  it("uses 10 * active_samples from the tracker (1 sample → 10s)", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) })
     local r = usage.build_report(
       { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
       NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
-    assert.equal(60, r.records[1].activeSeconds)
+    assert.equal(10, r.records[1].activeSeconds)
   end)
 
-  it("reports 300s when all 5 minutes were active", function()
+  it("reports 300s when all 30 samples (5 min @ 10s) were active", function()
     local t = usage.new_tracker()
-    for i = 1, 5 do
+    for i = 1, 30 do
       usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100 * i) })
     end
     local r = usage.build_report(
-      { s("aa:bb:cc:11:22:33", "1.2.3.4", 500) },
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 3000) },
       NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
     assert.equal(300, r.records[1].activeSeconds)
   end)
 
-  it("caps activeSeconds at 300 even if the tracker recorded more than 5 minutes (drift)", function()
+  it("caps activeSeconds at 300 even if the tracker recorded more than the bucket (drift)", function()
     local t = usage.new_tracker()
-    for i = 1, 7 do
+    for i = 1, 35 do
       usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100 * i) })
     end
     local r = usage.build_report(
-      { s("aa:bb:cc:11:22:33", "1.2.3.4", 700) },
+      { s("aa:bb:cc:11:22:33", "1.2.3.4", 3500) },
       NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
     assert.equal(300, r.records[1].activeSeconds)
   end)
 
-  it("falls back to 60s when bytes > 0 but tracker has no entry (entry appeared after last sample)", function()
+  it("falls back to one sample (10s) when bytes > 0 but tracker has no entry (entry appeared after last sample)", function()
     local t = usage.new_tracker()
     -- tracker has seen device A but not B
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
     local r = usage.build_report(
       { s("de:ad:be:ef:00:01", "9.9.9.9", 200) },
       NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
-    assert.equal(60, r.records[1].activeSeconds)
+    assert.equal(10, r.records[1].activeSeconds)
   end)
 
   it("retains legacy 300 behavior when no tracker is passed (back-compat)", function()
@@ -403,9 +406,9 @@ describe("usage.build_report with tracker", function()
 
   it("assigns activeSeconds per (mac, dst_ip) independently from the same tracker", function()
     local t = usage.new_tracker()
-    -- device A: 1 active minute
+    -- device A: 1 active sample (10s)
     usage.tracker_sample(t, { s("aa:bb:cc:11:22:33", "1.2.3.4", 100) })
-    -- device B joins at minute 2 with growth across 4 more samples
+    -- device B joins later with growth across 4 more samples (40s total)
     for i = 1, 4 do
       usage.tracker_sample(t, {
         s("aa:bb:cc:11:22:33", "1.2.3.4", 100),         -- no growth for A
@@ -418,8 +421,8 @@ describe("usage.build_report with tracker", function()
     }, NF_SETS, P_START, P_END, ROUTER, nil, nil, t)
     local by_mac = {}
     for _, rec in ipairs(r.records) do by_mac[rec.mac] = rec end
-    assert.equal(60,  by_mac["aa:bb:cc:11:22:33"].activeSeconds)
-    assert.equal(240, by_mac["de:ad:be:ef:00:01"].activeSeconds)
+    assert.equal(10, by_mac["aa:bb:cc:11:22:33"].activeSeconds)
+    assert.equal(40, by_mac["de:ad:be:ef:00:01"].activeSeconds)
   end)
 
 end)

--- a/scripts/e2e/scenarios/test_time_limit.py
+++ b/scripts/e2e/scenarios/test_time_limit.py
@@ -30,6 +30,7 @@ issues, never bundled fixes (see #346 discipline).
 from __future__ import annotations
 
 import logging
+import math
 import time
 from datetime import datetime, timedelta, timezone
 
@@ -60,17 +61,18 @@ def _mac_in_set(mac: str) -> bool:
 def _total_minutes_for_mac(debug_api, mac: str) -> int:
     """Bucket-deduplicated online minutes for `mac` from today's time_usage.
 
-    Reads `deviceTotalMinutes` (#474), which is computed server-side from
-    `traffic_reports` via Presence: each 5-min agent bucket counts once per
-    device regardless of how many hosts the device touched. Naively summing
-    per-host `minutesUsed` would inflate when DNS + gateway + the actual
-    site all see traffic in the same bucket.
+    Reads `deviceTotalActiveSeconds` (#516) and ceil-divides by 60. The raw
+    seconds field sums each 5-min agent bucket's max activeSeconds across
+    hosts (Presence dedupe, #474); the floor-divided `deviceTotalMinutes`
+    drifted under 90s tests because boundary-straddling activity could land
+    up to ~240s of credited time. With #516's sub-minute agent sampling and
+    a ceil here, the bound stays tight.
     """
     needle = _norm_mac(mac)
     for row in debug_api.time_usage():
         if _norm_mac(row.get("mac", "")) == needle:
-            # Same value on every row for the same mac — first wins.
-            return int(row.get("deviceTotalMinutes", 0))
+            secs = int(row.get("deviceTotalActiveSeconds", 0))
+            return math.ceil(secs / 60)
     return -1  # sentinel: no rows yet
 
 
@@ -126,21 +128,24 @@ def test_time_limit_minute_granularity(
         f"D2: MAC was blocked despite 60-min cap; total_minutes={total_minutes}"
     )
 
-    # Granularity assertion (#295):
+    # Granularity assertion (#295, #516):
     #   - 0 → usage never accrued (regression)
-    #   - 1 → 90s truncated to a single minute bucket
-    #   - 2 → 90s straddled one minute boundary
-    #   - 3 → 90s straddled two minute boundaries (e.g. 0:45–2:15 touches
-    #         minutes 0, 1, 2). The agent reports active-seconds in per-minute
-    #         buckets and the API counts deduped buckets, so up to ~1 minute
-    #         of over-credit per boundary is expected at this granularity.
-    #   - >= 5 → suggests multi-minute bucket rounding (#295 contract violated)
-    assert 1 <= total_minutes <= 3, (
-        f"D2: expected minutesUsed in [1, 3] after ~90s of traffic, got "
-        f"{total_minutes}. Either nothing accrued (=0) or the API is "
-        f"rounding to a multi-minute bucket (#295). Upper bound is 3 because "
-        f"a 90s span can straddle up to two minute boundaries and the agent's "
-        f"1-minute granularity credits each touched bucket."
+    #   - 1 → 90s of active-seconds → ceil(90/60) = 2; could read 1 if some
+    #         samples landed below the burst window or if the device's
+    #         background traffic per bucket sums to <60s.
+    #   - 2 → expected: 90s of active-seconds → ceil(90/60) = 2, possibly
+    #         padded by a few seconds of in-bucket background activity.
+    #   - >= 3 → agent sampling drifted; sum(activeSeconds) exceeded 120s.
+    # Pre-#516 this drifted (6 → 3 → 4) because the agent sampled every 60s
+    # and credited a full minute per sample-of-growth; with sub-minute (10s)
+    # sampling and a ceil-divided sum, the bound is back to [1, 2].
+    assert 1 <= total_minutes <= 2, (
+        f"D2: expected minutesUsed in [1, 2] after ~90s of traffic, got "
+        f"{total_minutes}. The agent should now report activeSeconds at ~10s "
+        f"granularity (#516); a value > 2 suggests precision regression or "
+        f"unexpected in-bucket background traffic. Helper ceil-divides "
+        f"deviceTotalActiveSeconds rather than reading the floored "
+        f"deviceTotalMinutes."
     )
 
 


### PR DESCRIPTION
## Summary

- Drops agent's `activity_sample_int` / `SECONDS_PER_SAMPLE` from 60s to 10s so `activeSeconds` is wall-clock accurate to ~10s rather than rounded up to whole-minute increments per sample-of-growth.
- Surfaces a new `deviceTotalActiveSeconds` field on `/api/debug/time_usage` (raw seconds, not floored) alongside the existing `deviceTotalMinutes`.
- e2e helper now ceil-divides `deviceTotalActiveSeconds` instead of reading the floor-divided `deviceTotalMinutes`. Bound back to `[1, 2]`.

## Drift history — why bound-widening was the wrong fix

| run | minutes for 90s | bound at the time | fix |
|---|---|---|---|
| #474 | 6 | [1, 2] | #478 deduped per-mac across host rows → 3 |
| #482 | 3 | [1, 2] | #485 widened bound [1, 2] → [1, 3] |
| #516 | 4 | [1, 3] | **this PR** |

The variance is real, not a flaky test. With `SECONDS_PER_SAMPLE = 60`, every 60s sample window where the device's `mac_ip_tracking` counter grew was credited a full minute. A 90s span that straddled a 5-min agent bucket could trip up to 4 sample boundaries (2 per bucket) → 240s reported → `floor(240/60) = 4 min`. Bound-widening just kicks the can: the next phase-unlucky run can drift further.

## Precision layer

The bucket-counting was already gone after #478; the read path (`Presence.totalMinutesByMac` in `api/src/presence/Presence.scala`) sums each bucket's max activeSeconds across hosts, then floor-divides. The lossy layer was the **agent's sample interval**: `openwrt/files/usr/sbin/familydns-agent:222` and `openwrt/files/usr/lib/lua/familydns/usage.lua:150` both used 60s. `usage.lua` already noted this as the #295 "Future work" path: \"sub-minute is a future extension that only needs to change SECONDS_PER_SAMPLE and the sampling cadence in the agent loop.\"

## Files changed

- `openwrt/files/usr/lib/lua/familydns/usage.lua` — `SECONDS_PER_SAMPLE: 60 → 10`, updated comments to reflect sub-minute semantics.
- `openwrt/files/usr/sbin/familydns-agent` — `activity_sample_int: 60 → 10`, updated comments.
- `openwrt/test/usage_spec.lua` — test assertions retargeted at 10s sample weight (1 sample → 10s, 30 samples → 300s full bucket, etc.). Tracker count semantics (`active_minutes` field, now an active-sample count) are unchanged.
- `api/src/presence/Presence.scala` — extracted `totalSecondsByMac` (Map[Mac, Long]) so `totalMinutesByMac` is a thin floor-divide wrapper; same semantics for existing callers (`Routes.scala`, `PolicyService.scala`).
- `api/src/routes/DebugRoutes.scala` — added `deviceTotalActiveSeconds: Long` to each `TimeUsageRow` in `/api/debug/time_usage`.
- `scripts/e2e/scenarios/test_time_limit.py` — helper reads `deviceTotalActiveSeconds` and computes `math.ceil(secs / 60)`; D2 bound back to `[1, 2]`.

## Cost

The agent now reads nftables counters every 10s instead of every 60s. Counter reads are cheap (one `nft` invocation, set-element scan), and `usage_report_interval` is unchanged (still flushes every 300s), so wire traffic to the API is unaffected. Trade is intentional per the #295 plan.

## Test plan

- [ ] CI: full vm-e2e run — D2 (`test_time_limit_minute_granularity`) passes with tight `[1, 2]` bound.
- [ ] D3 (`test_time_limit_cross_day_rollover`, currently `pytest.skip` on the limit-exhaustion precondition because the 1-min cap takes longer than the test's 90s burst to exhaust under the old 60s-per-sample agent) may now unblock once the agent reports finer-grained accumulation; if it still skips, that's a separate issue.
- [ ] Existing Scala unit tests (`PresenceSpec`, `DebugApiSpec`) — `totalMinutesByMac` semantics unchanged so PresenceSpec passes as-is; DebugApiSpec doesn't pin the new field.
- [ ] Existing Lua tests (`usage_spec.lua`) — updated for new constants; tracker count semantics unchanged.
- [ ] Smoke: build_report continues to cap at `BUCKET_SECONDS = 300` on drift.

Closes #516. Refs #295, #474, #482, PR #478, PR #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)