### PR TITLE
fix: block page handler regression (#528)

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -97,7 +97,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/sameerparekh/familydns" \
     --info "maintainer:FamilyDNS <noreply@example.com>" \
-    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl" \
+    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua" \
     --script "post-install:$WORK/post-install" \
     --files "$WORK/data" \
     --output "$OUT_APK"

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -25,7 +25,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: familydns
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl
+Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua
 Architecture: all
 Maintainer: FamilyDNS <noreply@example.com>
 Description: Agent daemon for FamilyDNS. Enforces per-device DNS filtering

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -113,16 +113,22 @@ grep -q "/www/familydns/handler.lua" "$SCRIPT" \
   || check "legacy static index.html has been removed" \
            "openwrt/files/www/familydns/index.html still present"
 
-# #528: build-ipk.sh hardcodes the ipk's Depends line (the OpenWRT Image
-# Builder reads that, not the Makefile, when assembling the router image).
-# It must include uhttpd-mod-lua so the lua_handler wired in just above
-# actually runs — without the module uhttpd silently ignores lua_handler,
-# falls back to static-file serving, and 404s every request (the legacy
-# index.html was removed alongside the handler).
+# #528: build-ipk.sh and build-apk.sh both hardcode the package's depends
+# line (the OpenWRT Image Builder reads the package metadata, not the
+# Makefile, when assembling the router image). Both must include
+# uhttpd-mod-lua so the lua_handler wired in just above actually runs —
+# without the module uhttpd silently ignores lua_handler, falls back to
+# static-file serving, and 404s every request (the legacy index.html was
+# removed alongside the handler).
 grep -q "uhttpd-mod-lua" "$ROOT/build-ipk.sh" \
   && check "build-ipk.sh Depends pulls in uhttpd-mod-lua" ok \
   || check "build-ipk.sh Depends pulls in uhttpd-mod-lua" \
            "missing uhttpd-mod-lua dep in build-ipk.sh"
+
+grep -q "uhttpd-mod-lua" "$ROOT/build-apk.sh" \
+  && check "build-apk.sh depends pulls in uhttpd-mod-lua" ok \
+  || check "build-apk.sh depends pulls in uhttpd-mod-lua" \
+           "missing uhttpd-mod-lua dep in build-apk.sh"
 
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -113,5 +113,16 @@ grep -q "/www/familydns/handler.lua" "$SCRIPT" \
   || check "legacy static index.html has been removed" \
            "openwrt/files/www/familydns/index.html still present"
 
+# #528: build-ipk.sh hardcodes the ipk's Depends line (the OpenWRT Image
+# Builder reads that, not the Makefile, when assembling the router image).
+# It must include uhttpd-mod-lua so the lua_handler wired in just above
+# actually runs — without the module uhttpd silently ignores lua_handler,
+# falls back to static-file serving, and 404s every request (the legacy
+# index.html was removed alongside the handler).
+grep -q "uhttpd-mod-lua" "$ROOT/build-ipk.sh" \
+  && check "build-ipk.sh Depends pulls in uhttpd-mod-lua" ok \
+  || check "build-ipk.sh Depends pulls in uhttpd-mod-lua" \
+           "missing uhttpd-mod-lua dep in build-ipk.sh"
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Symptom

Three previously-passing scenarios regressed in sync-2 VM e2e run [25980016036](https://github.com/sameerparekh/familydns/actions/runs/25980016036/job/76366952409), all timing out waiting for the OpenWRT router's block-page HTTP response:

- `test_03_blocked_domain::test_blocked_domain_request_dropped` — timed out for `example.org`
- `test_06_blocked_page::test_blocked_request_returns_block_page` — timed out from router
- `test_extra_blocked::test_extra_blocked_http_drops_to_block_page_and_set_populated` — timed out for `example.com`

## Root cause

PR #512 / commit 0354279 (#437) replaced the static `openwrt/files/www/familydns/index.html` with a uhttpd-mod-lua handler at `openwrt/files/www/familydns/handler.lua`, wired `lua_prefix='/'` + `lua_handler` into `install.sh`, and added `+uhttpd-mod-lua` to the package `DEPENDS` in `openwrt/Makefile:16`.

It missed the parallel hardcoded dep list in **`openwrt/build-ipk.sh:28`** — and that's the script the VM e2e harness (`scripts/vm/build-router-image.sh` → `openwrt/build-ipk.sh`) actually invokes to produce the `.ipk` the Image Builder consumes. Evidence in the failing job log (line 932):

```
Package: familydns
Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl    ← no uhttpd-mod-lua
```

With the module absent from the image, uhttpd silently ignores the `lua_handler` UCI option and falls back to static-file serving against `home=/www/familydns`. The legacy `index.html` at that path was deleted by #512, so every DNAT'd request 404s and the wait helpers in the three scenarios above time out at 60s/90s.

## Fix

1. `openwrt/build-ipk.sh:28` — append `uhttpd-mod-lua` to the hardcoded `Depends:` line so the generated `.ipk` advertises the module and the Image Builder pulls it into the rootfs. Now matches `openwrt/Makefile:16`.
2. `openwrt/test/install_spec.sh` — add a regression-guard assertion that fails if `uhttpd-mod-lua` ever falls out of `build-ipk.sh` again. The two dep lists drifting silently is exactly what produced this regression.

No changes to `handler.lua` or `block_page.lua` — the lua code was correct, it just wasn't reachable.

## Test plan

- [ ] `openwrt/test/install_spec.sh` passes (verified locally, 14/14).
- [ ] `test_03_blocked_domain::test_blocked_domain_request_dropped` passes on next sync-2 / VM e2e run.
- [ ] `test_06_blocked_page::test_blocked_request_returns_block_page` passes.
- [ ] `test_extra_blocked.http_drops_to_block_page_and_set_populated` at minimum gets past the `_wait_block_page` step.

Closes #528. Refs #437, PR #512, commit 0354279.