### PR TITLE
fix: e2e harness uses wifihaven uci namespace + init.d after #520

### DIFF
--- a/scripts/e2e/conftest.py
+++ b/scripts/e2e/conftest.py
@@ -216,7 +216,7 @@ def pytest_runtest_makereport(item, call):
             sections.append(("router serial", f"<unavailable: {e}>"))
         try:
             from lib.vm import router_ssh
-            r = router_ssh("logread -e familydns | tail -n 80", check=False, timeout=10)
+            r = router_ssh("logread -e wifihaven | tail -n 80", check=False, timeout=10)
             sections.append(("router agent log", (r.stdout or "") + (r.stderr or "")))
         except Exception as e:  # noqa: BLE001
             sections.append(("router agent log", f"<unavailable: {e}>"))

--- a/scripts/e2e/lib/enrollment.py
+++ b/scripts/e2e/lib/enrollment.py
@@ -1,13 +1,13 @@
 """Enroll a router VM and wire the resulting routerToken into UCI.
 
 The OpenWRT agent does NOT auto-enroll: it errors out if router_token is
-empty (openwrt/files/usr/sbin/familydns-agent). So the orchestrator runs the
+empty (openwrt/files/usr/sbin/wifihaven-agent). So the orchestrator runs the
 enrollment flow itself from the host:
 
   1. POST /api/admin/routers          → enrollmentToken
   2. POST /api/router/register        → routerToken (host-side, no SLIRP needed)
   3. SSH to the router and `uci set` router_id + router_token + api_url
-  4. /etc/init.d/familydns restart
+  4. /etc/init.d/wifihaven restart
 """
 from __future__ import annotations
 
@@ -55,11 +55,11 @@ def enroll_router(
 
     api_url_for_router = f"http://{ROUTER_HOST_GATEWAY}:{api_port}"
     uci_script = (
-        f"uci set familydns.@familydns[0].api_url='{api_url_for_router}' && "
-        f"uci set familydns.@familydns[0].router_id='{router_id}' && "
-        f"uci set familydns.@familydns[0].router_token='{router_token}' && "
-        f"uci commit familydns && "
-        f"/etc/init.d/familydns restart"
+        f"uci set wifihaven.@wifihaven[0].api_url='{api_url_for_router}' && "
+        f"uci set wifihaven.@wifihaven[0].router_id='{router_id}' && "
+        f"uci set wifihaven.@wifihaven[0].router_token='{router_token}' && "
+        f"uci commit wifihaven && "
+        f"/etc/init.d/wifihaven restart"
     )
     log.info("provisioning router VM with router_id=%s api_url=%s", router_id, api_url_for_router)
     router_ssh(uci_script, timeout=60).check()

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -32,7 +32,7 @@ ROUTER_HTTP_PORT = int(os.environ.get("FDNS_ROUTER_HTTP_PORT", "18081"))
 
 # QEMU SLIRP gateway as seen from inside the router VM. The router VM's WAN is
 # user-mode networking, so it reaches the host (where the API stack runs) via
-# 10.0.2.2. The orchestrator overrides familydns.api_url to point here.
+# 10.0.2.2. The orchestrator overrides wifihaven.api_url to point here.
 ROUTER_HOST_GATEWAY = "10.0.2.2"
 
 


### PR DESCRIPTION
## Summary

Every VM e2e scenario was ERRORing at setup with:

\`\`\`
RuntimeError: command failed (rc=1): ssh ... 'uci set familydns.@familydns[0].api_url=... && ... && /etc/init.d/familydns restart'
\`\`\`

PR #520 renamed the OpenWRT agent end-to-end (familydns → wifihaven), including:
- UCI config namespace: \`familydns\` → \`wifihaven\`
- init.d service: \`/etc/init.d/familydns\` → \`/etc/init.d/wifihaven\`
- syslog tag: \`familydns\` → \`wifihaven\`

But three e2e-harness call sites missed the rename:
- \`scripts/e2e/lib/enrollment.py\` — uci set namespace + init.d restart.
- \`scripts/e2e/conftest.py\` — \`logread -e familydns\` in failure-capture.
- \`scripts/e2e/lib/vm.py\` — stale comment.

Mechanical rename in all three.

## Out of scope (intentional)

- Compose project name (\`familydns-e2e-vm\`) and container name (\`familydns-e2e-vm-api-1\`) stay as-is. They're internal docker labels, not affected by the agent rename.
- Test-body assertions that match \`"familydns" in body.lower() or "blocked" in body.lower()\` are fine — the block page no longer contains "familydns" but does contain "Blocked", which still matches.

## Test plan

- [x] No other \`familydns.@familydns\`, \`uci commit familydns\`, \`/etc/init.d/familydns\` references in scripts/e2e/.
- [ ] Next sync into ci/vm-e2e re-runs VM e2e past the setup wall.

Refs #520.