### PR TITLE
rename: GitHub repo URLs sameerparekh/familydns → wifihaven/wifihaven (closes #364, #365)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ DB schema (pre-migration), and CLI flags are fine — just change the code
 on all sides in the same PR.
 
 This policy flips once we've done our first real deploy, which is gated on
-picking a permanent project name ([#38](https://github.com/sameerparekh/familydns/issues/38)).
+picking a permanent project name ([#38](https://github.com/wifihaven/wifihaven/issues/38)).
 After that ships, API request/response shapes become a public contract and
 we keep them backwards compatible (additive fields, ignore-unknown on input,
 deprecation windows for removals).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # WifiHaven
 
-<!-- TODO(#364): GitHub repo URLs (raw.githubusercontent.com/sameerparekh/familydns/…,
-     git@github.com:sameerparekh/familydns.git, etc.) and the post-clone
-     directory name `familydns/` still appear throughout this README. They
-     move to `sameerparekh/wifihaven` when the repo rename (#364) lands. -->
-<!-- TODO(#360): env-var prefix (FAMILYDNS_*) and HOCON config namespace
-     (`familydns.*`) still use the old name. They flip when the env-var
-     rename sub-issue lands. -->
-
 A self-hosted, network-level parental-control system with a web UI. Block
 categories of sites, set per-profile schedules ("no internet after 9pm"),
 enforce daily and per-site time limits, log queries, and grant temporary
@@ -61,7 +53,7 @@ router. Each script prompts for the values it needs and is safe to re-run.
 **1. API + Postgres** — on a Linux host with Docker + Compose v2:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh | bash
 ```
 
 Prompts for install path, port, bind address, and a new admin password;
@@ -71,7 +63,7 @@ Full walkthrough (TLS, reverse proxy, firewall, debugging): [`docs/install-api.m
 **2. OpenWRT router agent** — SSH in as root, then:
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh)"
 ```
 
 Prompts for the API URL, an enrollment token (admin UI → **Routers → Add
@@ -85,8 +77,8 @@ installs the matching artifact. Full walkthrough: [`docs/install-openwrt.md`](do
 
 ```bash
 # Prereqs: JDK 21, Node 22, mill 1.1.5, scalafmt (cs install scalafmt)
-git clone git@github.com:sameerparekh/familydns.git
-cd familydns
+git clone git@github.com:wifihaven/wifihaven.git
+cd wifihaven
 scripts/install-hooks.sh         # set up pre-commit / pre-push hooks
 
 # Run all tests
@@ -163,7 +155,7 @@ unit file under `deploy/` is kept for existing installs.
 On a fresh Debian / Ubuntu box, as your **normal login user** (not root):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/scripts/bootstrap-host.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/scripts/bootstrap-host.sh | bash
 ```
 
 The script asks for `sudo` once, then handles everything: installing the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,7 +19,7 @@ README — prereq checks, secret generation, `.env`, image pull, stack
 start, health wait, and admin password rotation:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh | bash
 ```
 
 See [`docs/install-api.md`](../docs/install-api.md) for the full

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
       retries: 30
 
   api:
-    image: ghcr.io/sameerparekh/wifihaven-api:latest
+    image: ghcr.io/wifihaven/wifihaven-api:latest
     build:
       context: ..
       dockerfile: docker/Dockerfile

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -2,10 +2,10 @@
 #
 # WifiHaven API — first-install bootstrap.
 #
-#   curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh | bash
 #
 # Or, to review first (recommended):
-#   curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
+#   curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh -o install.sh
 #   less install.sh
 #   bash install.sh
 #
@@ -32,7 +32,7 @@ case "${1:-}" in
     ;;
 esac
 
-REPO_RAW="${WIFIHAVEN_REPO_RAW:-https://raw.githubusercontent.com/sameerparekh/familydns/main}"
+REPO_RAW="${WIFIHAVEN_REPO_RAW:-https://raw.githubusercontent.com/wifihaven/wifihaven/main}"
 COMPOSE_URL="${REPO_RAW}/deploy/docker-compose.prod.yml"
 ENV_EXAMPLE_URL="${REPO_RAW}/deploy/.env.example"
 HELPER_SCRIPTS=(start stop restart logs status update)
@@ -163,15 +163,15 @@ if [ ! -d "$WIFIHAVEN_INSTALL_DIR" ]; then
   one of:
 
     # 1. User-mode install (no sudo needed):
-    curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh \\
+    curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh \\
       | WIFIHAVEN_PREFIX=\$HOME/.wifihaven bash
 
     # 2. Save and run with sudo:
-    curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
+    curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh -o install.sh
     sudo bash install.sh
 
     # 3. Warm up sudo first, then pipe:
-    sudo -v && curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+    sudo -v && curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh | bash
 EOF
       die "$msg"
     fi

--- a/deploy/wifihaven-api.service
+++ b/deploy/wifihaven-api.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=WifiHaven API server
-Documentation=https://github.com/sameerparekh/familydns
+Documentation=https://github.com/wifihaven/wifihaven
 After=network-online.target postgresql.service
 Wants=network-online.target
 

--- a/docs/architecture-critique.md
+++ b/docs/architecture-critique.md
@@ -1,6 +1,6 @@
 # Architecture critique — pre-rename, pre-go-live
 
-Status: **review draft.** Tracks [#368](https://github.com/sameerparekh/familydns/issues/368).
+Status: **review draft.** Tracks [#368](https://github.com/wifihaven/wifihaven/issues/368).
 
 This is a hostile-critic review of the **design record** — `docs/architecture.md`,
 `docs/resilience.md`, `AGENTS.md`'s two truths, and the wire contracts in
@@ -17,7 +17,7 @@ between the docs and the wire types.
 The deliverable is this document plus eleven sub-issues. Each finding has a
 concrete design response — agreed in the #368 thread.
 
-Out of scope: security has its own audit ([#369](https://github.com/sameerparekh/familydns/issues/369)).
+Out of scope: security has its own audit ([#369](https://github.com/wifihaven/wifihaven/issues/369)).
 Where a finding has both structural and security framing, this doc owns the
 structural side and cross-references #369.
 
@@ -32,7 +32,7 @@ structural side and cross-references #369.
    **Response:** explicit `unmanagedMacPolicy` in the snapshot, an
    "unmanaged" admin-UI page with per-MAC enroll/block/allow actions,
    and push notification when a new MAC appears (web now, mobile later).
-   Sub-issue: [#374](https://github.com/sameerparekh/familydns/issues/374) (rewritten).
+   Sub-issue: [#374](https://github.com/wifihaven/wifihaven/issues/374) (rewritten).
 
 2. **The wire contract has no schema-evolution policy.** §0.2 and §6.2
    define field names; nothing says how versions evolve, no `snapshotVersion`,
@@ -42,7 +42,7 @@ structural side and cross-references #369.
    **Response:** define a capability set on both ends; snapshot carries
    `snapshotVersion` + `serverCapabilities`; agent advertises
    `agentCapabilities` on enrollment and policy GET; API serves the highest
-   shape both ends understand. Sub-issue: [#376](https://github.com/sameerparekh/familydns/issues/376) (rewritten).
+   shape both ends understand. Sub-issue: [#376](https://github.com/wifihaven/wifihaven/issues/376) (rewritten).
 
 3. **`FailureMode` is internally inconsistent across the design record.**
    `architecture.md` §0.2 specifies `BlockAll | AllowAll | LastKnownGood`.
@@ -113,7 +113,7 @@ This is the right answer to MAC randomization in a parental-controls
 product: you can't prevent it, but you CAN make the resulting unmanaged
 MAC a loud, surfaced event rather than a silent bypass.
 
-Sub-issue: [#374](https://github.com/sameerparekh/familydns/issues/374).
+Sub-issue: [#374](https://github.com/wifihaven/wifihaven/issues/374).
 
 ---
 
@@ -214,7 +214,7 @@ The capability set lets new features land server-side without breaking
 older agents — the canonical example is shipping #370 (canonical-shape
 collapse) safely while old agents still poll.
 
-Sub-issue: [#376](https://github.com/sameerparekh/familydns/issues/376) (rewritten).
+Sub-issue: [#376](https://github.com/wifihaven/wifihaven/issues/376) (rewritten).
 
 ---
 
@@ -556,14 +556,14 @@ Recorded for traceability:
 
 | # | Title | Finding |
 |---|-------|---------|
-| [#374](https://github.com/sameerparekh/familydns/issues/374) | unmanaged-mac: alerting, default-block flag, admin UI page, push notification | §1 |
-| [#383](https://github.com/sameerparekh/familydns/issues/383) | block-page: serve HTTPS variant with self-signed cert | §2 |
-| [#384](https://github.com/sameerparekh/familydns/issues/384) | blockIpOnly: allow IPs that resolved-for-this-MAC to extraAllowed hosts | §3 |
-| [#376](https://github.com/sameerparekh/familydns/issues/376) | wire-contract: schema versioning + capability negotiation | §4 |
-| [#385](https://github.com/sameerparekh/familydns/issues/385) | FailureMode: align design record on three modes (BlockAll / AllowAll / LastKnownGood) | §5 |
-| [#386](https://github.com/sameerparekh/familydns/issues/386) | snapshot: failover threshold owned by API, shipped in snapshot | §6 |
-| [#387](https://github.com/sameerparekh/familydns/issues/387) | OpnSense agent: design doc proving wire-contract portability before #94 | §7 |
-| [#388](https://github.com/sameerparekh/familydns/issues/388) | docs: fully specify agent responsibilities in architecture.md §3.2 | §8 |
-| [#389](https://github.com/sameerparekh/familydns/issues/389) | docs: document the one-ETag two-rate-classes tradeoff | §9 |
-| [#390](https://github.com/sameerparekh/familydns/issues/390) | router-deletion: 410 Gone + agent stops + allow-all | §10 |
-| [#391](https://github.com/sameerparekh/familydns/issues/391) | wire-contract: hostname becomes union of FQDN \| IPv4 \| IPv6 | §11 |
+| [#374](https://github.com/wifihaven/wifihaven/issues/374) | unmanaged-mac: alerting, default-block flag, admin UI page, push notification | §1 |
+| [#383](https://github.com/wifihaven/wifihaven/issues/383) | block-page: serve HTTPS variant with self-signed cert | §2 |
+| [#384](https://github.com/wifihaven/wifihaven/issues/384) | blockIpOnly: allow IPs that resolved-for-this-MAC to extraAllowed hosts | §3 |
+| [#376](https://github.com/wifihaven/wifihaven/issues/376) | wire-contract: schema versioning + capability negotiation | §4 |
+| [#385](https://github.com/wifihaven/wifihaven/issues/385) | FailureMode: align design record on three modes (BlockAll / AllowAll / LastKnownGood) | §5 |
+| [#386](https://github.com/wifihaven/wifihaven/issues/386) | snapshot: failover threshold owned by API, shipped in snapshot | §6 |
+| [#387](https://github.com/wifihaven/wifihaven/issues/387) | OpnSense agent: design doc proving wire-contract portability before #94 | §7 |
+| [#388](https://github.com/wifihaven/wifihaven/issues/388) | docs: fully specify agent responsibilities in architecture.md §3.2 | §8 |
+| [#389](https://github.com/wifihaven/wifihaven/issues/389) | docs: document the one-ETag two-rate-classes tradeoff | §9 |
+| [#390](https://github.com/wifihaven/wifihaven/issues/390) | router-deletion: 410 Gone + agent stops + allow-all | §10 |
+| [#391](https://github.com/wifihaven/wifihaven/issues/391) | wire-contract: hostname becomes union of FQDN \| IPv4 \| IPv6 | §11 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ a small fixed snapshot. The agent resolves device → effective rules once at
 apply time and then enforces purely per-MAC. **Profiles never appear in the
 enforcement pipeline.**
 
-Target snapshot shape (Scala 3, sealed-trait ADTs per [#114](https://github.com/sameerparekh/familydns/issues/114);
+Target snapshot shape (Scala 3, sealed-trait ADTs per [#114](https://github.com/wifihaven/wifihaven/issues/114);
 typed names used here even though the current code is stringly):
 
 ```scala

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -44,7 +44,7 @@ has already published `latest`.
 The `sha-` tag is immutable and safe to reference for rollbacks. `latest` is
 what the prod compose stack pulls on auto-update.
 
-**Image name**: `ghcr.io/sameerparekh/wifihaven-api`
+**Image name**: `ghcr.io/wifihaven/wifihaven-api`
 
 The GHCR token is the built-in `GITHUB_TOKEN`; no manual secret needed.
 
@@ -57,7 +57,7 @@ In production, the `api` service is configured to pull from ghcr.io:
 
 ```yaml
 api:
-  image: ghcr.io/sameerparekh/wifihaven-api:latest
+  image: ghcr.io/wifihaven/wifihaven-api:latest
 ```
 
 The image is never built on the prod host. All builds happen in CI.
@@ -190,7 +190,7 @@ Place at `/usr/sbin/familydns-update` on the router:
 ```sh
 #!/bin/sh
 CURRENT=$(opkg info familydns | awk '/^Version:/{print $2}')
-LATEST_URL=$(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
+LATEST_URL=$(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
   | jsonfilter -e '@.assets[0].browser_download_url')
 LATEST_VER=$(echo "$LATEST_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+')
 if [ "$LATEST_VER" != "$CURRENT" ]; then
@@ -243,7 +243,7 @@ guides for runnable commands, prerequisites, and verification steps.
 
 ```sh
 # 1. Clone the repo or copy deploy/ to the host
-git clone git@github.com:sameerparekh/familydns.git /opt/wifihaven
+git clone git@github.com:wifihaven/wifihaven.git /opt/wifihaven
 cd /opt/wifihaven/deploy
 
 # 2. Create .env from the example
@@ -285,7 +285,7 @@ End users install via the one-shot script — see
 manual-fallback path. The headline command, run as root on the router:
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh)"
 ```
 
 It prompts for the API URL, the one-time enrollment token (generated in the

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -21,7 +21,7 @@ install.sh`), this gets you a running stack with sensible defaults and a
 rotated admin password:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh | bash
 ```
 
 The script:
@@ -44,7 +44,7 @@ under `/opt/wifihaven` (recommended for production hosts), set
 `WIFIHAVEN_PREFIX` explicitly and run the script with `sudo`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh -o install.sh
 sudo WIFIHAVEN_PREFIX=/opt/wifihaven bash install.sh
 ```
 
@@ -73,7 +73,7 @@ For unattended installs, set `WIFIHAVEN_NONINTERACTIVE=1` and any of the
 env vars below to skip prompts. You can pass them on the same one-liner:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/install.sh \
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh \
   | WIFIHAVEN_NONINTERACTIVE=1 \
     WIFIHAVEN_PREFIX=$HOME/.wifihaven \
     WIFIHAVEN_API_HOST_PORT=8080 \
@@ -136,7 +136,7 @@ and §8 (firewall).
 ## 2. Obtain the image
 
 The API image is published to GitHub Container Registry at
-`ghcr.io/sameerparekh/wifihaven-api`. Tags:
+`ghcr.io/wifihaven/wifihaven-api`. Tags:
 
 | Tag | When to use |
 |-----|-------------|
@@ -146,7 +146,7 @@ The API image is published to GitHub Container Registry at
 After issue #128 lands the package will be public, so anonymous pulls work:
 
 ```sh
-docker pull ghcr.io/sameerparekh/wifihaven-api:latest
+docker pull ghcr.io/wifihaven/wifihaven-api:latest
 ```
 
 If the package is still private when you install, log in to ghcr.io first
@@ -154,7 +154,7 @@ with a GitHub personal access token that has the `read:packages` scope:
 
 ```sh
 echo "$GHCR_PAT" | docker login ghcr.io -u <your-github-username> --password-stdin
-docker pull ghcr.io/sameerparekh/wifihaven-api:latest
+docker pull ghcr.io/wifihaven/wifihaven-api:latest
 ```
 
 You don't strictly need to pre-pull — `docker compose up -d` in §4 will
@@ -173,7 +173,7 @@ simplest path is a shallow clone:
 ```sh
 sudo mkdir -p /opt/wifihaven
 sudo chown "$USER" /opt/wifihaven
-git clone --depth 1 https://github.com/sameerparekh/familydns.git /opt/wifihaven
+git clone --depth 1 https://github.com/wifihaven/wifihaven.git /opt/wifihaven
 cd /opt/wifihaven/deploy
 ```
 
@@ -182,8 +182,8 @@ from GitHub:
 
 ```sh
 mkdir -p /opt/wifihaven/deploy && cd /opt/wifihaven/deploy
-curl -fsSLO https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/docker-compose.prod.yml
-curl -fsSLO https://raw.githubusercontent.com/sameerparekh/familydns/main/deploy/.env.example
+curl -fsSLO https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/docker-compose.prod.yml
+curl -fsSLO https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/.env.example
 ```
 
 ### 3.2 Create your `.env`

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -40,7 +40,7 @@ pulled in automatically by the system package manager (`opkg` on 23.05.x,
 SSH into the router as root and run:
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh)"
 ```
 
 The script prompts for:
@@ -76,7 +76,7 @@ Download and inspect the script first:
 
 ```sh
 uclient-fetch -qO /tmp/familydns-install.sh \
-  https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh
+  https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh
 less /tmp/familydns-install.sh
 sh /tmp/familydns-install.sh
 ```
@@ -88,7 +88,7 @@ package, drop the uhttpd block-page listener, wipe the familydns UCI
 config):
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/uninstall.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/uninstall.sh)"
 ```
 
 Pass `--purge` to additionally remove `/usr/lib/familydns` and
@@ -119,7 +119,7 @@ interval).
 
 Routers running unattended should pull new agent releases automatically. The
 auto-update cron job is tracked in
-[#131](https://github.com/sameerparekh/familydns/issues/131). Until then,
+[#131](https://github.com/wifihaven/wifihaven/issues/131). Until then,
 upgrade manually by re-running the one-shot install command from §2 — the
 script's install step (`opkg install` or `apk add --allow-untrusted`) uses
 the standard upgrade path, which preserves `/etc/config/familydns`, so the
@@ -141,13 +141,13 @@ generation.
 ```sh
 # OpenWRT 23.05.x (opkg):
 curl -fsSL -o /tmp/familydns.ipk \
-  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
+  $(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
     | jsonfilter -e '@.assets[*].browser_download_url' \
     | grep -E '\.ipk$' | head -n1)
 
 # OpenWRT 24.10+/SNAPSHOT (apk):
 curl -fsSL -o /tmp/familydns.apk \
-  $(curl -sf https://api.github.com/repos/sameerparekh/familydns/releases/latest \
+  $(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
     | jsonfilter -e '@.assets[*].browser_download_url' \
     | grep -E '\.apk$' | head -n1)
 ```

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -75,7 +75,7 @@ The runner installs under `~/actions-runner` in the runner user's home directory
 2. Get a one-time registration token (from any machine with `gh` auth — the
    token's only valid ~1 hour, so do this right before step 4):
    ```bash
-   gh api -X POST repos/sameerparekh/familydns/actions/runners/registration-token --jq .token
+   gh api -X POST repos/wifihaven/wifihaven/actions/runners/registration-token --jq .token
    ```
 
 3. As the runner user, download and unpack the latest runner release. Check
@@ -92,7 +92,7 @@ The runner installs under `~/actions-runner` in the runner user's home directory
    ```bash
    cd ~/actions-runner
    ./config.sh \
-     --url https://github.com/sameerparekh/familydns \
+     --url https://github.com/wifihaven/wifihaven \
      --token <REGISTRATION_TOKEN> \
      --name familydns-kvm-1 \
      --labels self-hosted,linux,kvm \
@@ -106,8 +106,8 @@ The runner installs under `~/actions-runner` in the runner user's home directory
    ```
    In another shell, dispatch the sanity workflow and watch it land:
    ```bash
-   gh workflow run e2e-kvm-sanity.yml -R sameerparekh/familydns
-   gh run watch -R sameerparekh/familydns
+   gh workflow run e2e-kvm-sanity.yml -R wifihaven/wifihaven
+   gh run watch -R wifihaven/wifihaven
    ```
    Ctrl-C `./run.sh` once the workflow finishes.
 

--- a/docs/rename-decision.md
+++ b/docs/rename-decision.md
@@ -16,8 +16,8 @@ Rename the project from `familydns` to **`wifihaven`**.
 - Scala package root: `wifihaven.*`.
 - OpenWRT package name: `wifihaven`.
 - Env-var prefix: `WIFIHAVEN_*`.
-- Docker image: `ghcr.io/sameerparekh/wifihaven-api`.
-- GitHub repo (eventually): `sameerparekh/wifihaven`.
+- Docker image: `ghcr.io/wifihaven/wifihaven-api`.
+- GitHub repo (eventually): `wifihaven/wifihaven`.
 
 ## Why rename at all
 

--- a/docs/sessions-design.md
+++ b/docs/sessions-design.md
@@ -1,6 +1,6 @@
 # Sessions: stitching `traffic_reports` into per-host sessions
 
-Design for [#260](https://github.com/sameerparekh/familydns/issues/260) — replace
+Design for [#260](https://github.com/wifihaven/wifihaven/issues/260) — replace
 the per-query log surface with sessions-per-host as the primary user-facing
 view of device activity.
 
@@ -180,21 +180,21 @@ behavior moves to its own test file.
 ## Out of scope for this PR
 
 - Graphs of usage per profile/device/app — that's
-  [#127](https://github.com/sameerparekh/familydns/issues/127). The session
+  [#127](https://github.com/wifihaven/wifihaven/issues/127). The session
   shape is the building block; graphs will aggregate it.
 - Removing `connection_events` ingestion — it backs Raw events.
 - Materialized sessions table — filed as follow-up if (a) is too slow.
 
 ## Coordination
 
-- [#259](https://github.com/sameerparekh/familydns/issues/259) — hostnames in
+- [#259](https://github.com/wifihaven/wifihaven/issues/259) — hostnames in
   query log. Sessions are useless if `hostname` is an IP. Confirm #259's fix
   has landed (or at least that the `traffic_reports.hostname` column is
   populated with real hostnames, not IPs) before merging this PR.
-- [#261](https://github.com/sameerparekh/familydns/issues/261) — screen-time
+- [#261](https://github.com/wifihaven/wifihaven/issues/261) — screen-time
   shows 0m. Already closed; same source data, so this PR should benefit from
   that fix.
-- [#127](https://github.com/sameerparekh/familydns/issues/127) — usage
+- [#127](https://github.com/wifihaven/wifihaven/issues/127) — usage
   graphs. Sessions API will be the input.
-- [#64](https://github.com/sameerparekh/familydns/issues/64) — traffic /
+- [#64](https://github.com/wifihaven/wifihaven/issues/64) — traffic /
   session UI. This PR is the v1 of that surface.

--- a/docs/time-handling.md
+++ b/docs/time-handling.md
@@ -4,7 +4,7 @@ This document explains how WifiHaven handles wall-clock time across timezones
 and DST transitions. The rules apply to schedule windows and daily-usage
 reset; both are evaluated by `PolicyService` on the API server.
 
-See issue [#334](https://github.com/sameerparekh/familydns/issues/334) for
+See issue [#334](https://github.com/wifihaven/wifihaven/issues/334) for
 the design discussion.
 
 ## The rule: timezone lives with the data
@@ -144,8 +144,8 @@ host tz only affects the install-time default for `household_settings.tz`.
 - **No agent-side time decisions.** The router agent does not evaluate
   schedules or daily limits — `PolicyService` collapses everything into the
   per-MAC `BlockRules` in the snapshot, plus the `expiresAt` Instant on
-  per-host decisions. See [#350](https://github.com/sameerparekh/familydns/issues/350)
-  (Truth 2) and [#415](https://github.com/sameerparekh/familydns/issues/415)
+  per-host decisions. See [#350](https://github.com/wifihaven/wifihaven/issues/350)
+  (Truth 2) and [#415](https://github.com/wifihaven/wifihaven/issues/415)
   (agent skew code removal).
 - **No per-user viewer-local time display.** The UI shows a schedule's time
   in the schedule's stored tz so all viewers see the same string ("9 PM

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -1,8 +1,5 @@
 # WifiHaven OpenWrt package
 
-<!-- TODO(#364): GitHub repo URLs in this file still use `sameerparekh/familydns`;
-     they will move to `sameerparekh/wifihaven` when #364 lands. -->
-
 OpenWrt agent for WifiHaven. Supports both **OpenWRT 23.05.x** (opkg / `.ipk`)
 and **OpenWRT 24.10+ / SNAPSHOT** (apk / `.apk`). Enforces per-device
 connection-level filtering via **nftables** (forward-drop keyed on MAC +
@@ -134,7 +131,7 @@ git push origin v0.2.0
 End users install via the one-shot script:
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh)"
 ```
 
 The script source is [`install.sh`](install.sh); the full guide (with the
@@ -152,7 +149,7 @@ remove the package, drop the uhttpd block-page listener, wipe the
 wifihaven UCI config including the bearer token):
 
 ```sh
-sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/uninstall.sh)"
+sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/uninstall.sh)"
 ```
 
 Pass `--purge` to additionally remove `/usr/lib/wifihaven` and
@@ -251,7 +248,7 @@ the released version is strictly newer than the installed one (verified via
 conffile so the router token survives the upgrade — no re-enrollment.
 
 On OpenWRT 24.10+/SNAPSHOT (apk-only systems) the script exits silently;
-the parallel `.apk` track is in [#176](https://github.com/sameerparekh/familydns/issues/176).
+the parallel `.apk` track is in [#176](https://github.com/wifihaven/wifihaven/issues/176).
 
 To force an update immediately:
 

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -106,14 +106,13 @@ chmod 0755 "$WORK/post-install"
 
 # ── build .apk ───────────────────────────────────────────────────────────────
 rm -f "$OUT_APK"
-# TODO(#364): update url to sameerparekh/wifihaven after repo rename
 "$APK_BIN" mkpkg \
     --info "name:wifihaven" \
     --info "version:${PKG_VERSION}-r${PKG_RELEASE}" \
     --info "description:WifiHaven router agent (per-device DNS filtering + time limits)" \
     --info "arch:noarch" \
     --info "license:MIT" \
-    --info "url:https://github.com/sameerparekh/familydns" \
+    --info "url:https://github.com/wifihaven/wifihaven" \
     --info "maintainer:WifiHaven <noreply@example.com>" \
     --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua" \
     --script "post-install:$WORK/post-install" \

--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -15,7 +15,7 @@ set -u
 
 # TODO(#244): revert to /releases/latest + semver compare once the rolling
 # debug period for #228 is done and proper tags resume.
-API_URL="https://api.github.com/repos/sameerparekh/familydns/releases/tags/openwrt-latest"  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+API_URL="https://api.github.com/repos/wifihaven/wifihaven/releases/tags/openwrt-latest"
 STATE_DIR=/var/lib/wifihaven
 STAMP_FILE="$STATE_DIR/last_update_stamp"
 

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -3,12 +3,12 @@
 #
 # Usage (on an OpenWRT 23.05.x router, as root):
 #
-#   sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh)"  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+#   sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh)"
 #
 # Or download then run:
 #
 #   uclient-fetch -qO /tmp/wifihaven-install.sh \
-#     https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/install.sh  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+#     https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh
 #   sh /tmp/wifihaven-install.sh
 #
 # The script prompts for the API URL, the one-time enrollment token, and the
@@ -23,7 +23,7 @@ set -eu
 
 # TODO(#244): revert to /releases/latest once the rolling debug period for
 # #228 is done and proper tags resume. Pairs with #280 (auto-updater swap).
-RELEASES_API="https://api.github.com/repos/sameerparekh/familydns/releases/tags/openwrt-latest"  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+RELEASES_API="https://api.github.com/repos/wifihaven/wifihaven/releases/tags/openwrt-latest"
 
 err() { printf 'error: %s\n' "$*" >&2; exit 1; }
 info() { printf '==> %s\n' "$*"; }

--- a/openwrt/uninstall.sh
+++ b/openwrt/uninstall.sh
@@ -8,12 +8,12 @@
 #
 # Usage (on an OpenWRT router, as root):
 #
-#   sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/uninstall.sh)"  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+#   sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/uninstall.sh)"
 #
 # Or download then run:
 #
 #   uclient-fetch -qO /tmp/wifihaven-uninstall.sh \
-#     https://raw.githubusercontent.com/sameerparekh/familydns/main/openwrt/uninstall.sh  # TODO(#364): update to sameerparekh/wifihaven after repo rename
+#     https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/uninstall.sh
 #   sh /tmp/wifihaven-uninstall.sh
 #
 # Flags:

--- a/opnsense/manifest.xml
+++ b/opnsense/manifest.xml
@@ -10,7 +10,7 @@
     planned for a follow-up release.
   </desc>
   <maintainer>sameer@creativedestruction.com</maintainer>
-  <www>https://github.com/sameerparekh/familydns</www>
+  <www>https://github.com/wifihaven/wifihaven</www>
   <prefix>/usr/local</prefix>
   <files>
     <file>/usr/local/sbin/familydns-agent</file>

--- a/scripts/bootstrap-host.sh
+++ b/scripts/bootstrap-host.sh
@@ -3,7 +3,7 @@
 #
 # Designed to be curl-piped:
 #
-#   curl -fsSL https://raw.githubusercontent.com/sameerparekh/familydns/main/scripts/bootstrap-host.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/scripts/bootstrap-host.sh | bash
 #
 # Or run from a checkout:  scripts/bootstrap-host.sh
 #
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-REPO_URL="${WIFIHAVEN_REPO_URL:-https://github.com/sameerparekh/familydns.git}"
+REPO_URL="${WIFIHAVEN_REPO_URL:-https://github.com/wifihaven/wifihaven.git}"
 BRANCH="${WIFIHAVEN_BRANCH:-production}"
 PREFIX="${WIFIHAVEN_PREFIX:-/opt/wifihaven}"
 USER_NAME="${WIFIHAVEN_USER:-wifihaven}"

--- a/scripts/deploy-api-from-branch.sh
+++ b/scripts/deploy-api-from-branch.sh
@@ -6,7 +6,7 @@
 #   ~/familydns/   git checkout (source)
 #   ~/.wifihaven/  runtime: docker-compose.prod.yml, .env, helper scripts
 #
-# The runtime compose file pins ghcr.io/sameerparekh/wifihaven-api:latest.
+# The runtime compose file pins ghcr.io/wifihaven/wifihaven-api:latest.
 # We build locally on the server and tag with that exact reference; the
 # next `start.sh` (compose up -d) picks up the new image id and recreates
 # the api container.
@@ -26,7 +26,7 @@ set -euo pipefail
 API_HOST="${API_HOST:-192.168.10.43}"
 SRC_DIR="${SRC_DIR:-\$HOME/familydns}"
 RUN_DIR="${RUN_DIR:-\$HOME/.wifihaven}"
-IMAGE="ghcr.io/sameerparekh/wifihaven-api:latest"
+IMAGE="ghcr.io/wifihaven/wifihaven-api:latest"
 BRANCH="${1:-main}"
 
 echo "==> deploying branch '$BRANCH' to $API_HOST"


### PR DESCRIPTION
## Summary

Final URL sweep for the project rename. The repo has been transferred to a new GitHub org — canonical URL is now `github.com/wifihaven/wifihaven`. This PR rewrites every hardcoded reference in the tree.

- `raw.githubusercontent.com`, `github.com`, `api.github.com` paths in docs, install scripts, the OpenWRT updater binary, the systemd unit, and the opnsense manifest.
- GHCR image refs: `ghcr.io/sameerparekh/wifihaven-api` → `ghcr.io/wifihaven/wifihaven-api`. The publish workflow already targets the new location via `${{ github.repository_owner }}`.
- Post-clone `cd familydns` → `cd wifihaven` in the README quick-start.
- Drops resolved `TODO(#364)` markers in openwrt scripts and the README/openwrt README header blocks (and the stale `TODO(#360)` block — env-var rename already landed in #519).

Wave-3 final rename PR — follows the upstream slices that landed earlier:

- #355, #356, #357 (#520), #358, #359 (#522), #360 (#519), #361 — all merged.

Closes #364, closes #365 (META).

## Validation

- New URLs return 200:
  ```
  curl -fsI https://raw.githubusercontent.com/wifihaven/wifihaven/main/README.md  # HTTP/2 200
  ```
- Old bare-repo URL redirects 301 → new:
  ```
  curl -fsIL https://github.com/sameerparekh/familydns  # 301 → github.com/wifihaven/wifihaven
  ```
- Old SSH clone URL still works via GitHub's redirect (`git ls-remote git@github.com:sameerparekh/familydns.git HEAD` resolves).
- Old API path still resolves (`gh issue view 364 -R sameerparekh/familydns` returns the issue).
- `grep -rn 'sameerparekh/familydns\|sameerparekh/wifihaven\|TODO(#364)' .` is empty.

## Out of scope (intentional)

- HOCON config namespace (`familydns.db.*`, `familydns.http.*`, …) — not a repo URL.
- Binary/process name `familydns-api` in ASCII diagrams — not a repo URL.
- Docker-compose project label `familydns-e2e-vm` in CI — renaming it would orphan cached state.

These will be picked up by their own follow-up issues if not already tracked.

## After-merge cleanup

- The next `master.yml` run will publish images to `ghcr.io/wifihaven/wifihaven-api`. Confirm the publish step succeeds.
- Live router will pick up the new `wifihaven-update` API_URL on its next cron run; or operator can run `dev-push-router.sh push` to force-sync the binary.
- Bookmarks referencing `sameerparekh/familydns` keep working via GitHub redirect but should be updated.

## Test plan

- [ ] CI green
- [ ] After merge: next `master.yml` build publishes to `ghcr.io/wifihaven/wifihaven-api`
- [ ] After merge: `wifihaven-update` on the live test router (192.168.10.42) successfully fetches from `api.github.com/repos/wifihaven/wifihaven/releases/tags/openwrt-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)