### PR TITLE
rename: docker-compose project label familydns-e2e-vm -> wifihaven-e2e-vm (closes #537)

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -94,14 +94,14 @@ jobs:
       # The self-hosted KVM runner keeps docker images across jobs (see
       # docs/ops/kvm-runner.md). scripts/e2e/lib/stack.py defaults to
       # rebuild=False, so `docker compose up` reuses any cached
-      # familydns-e2e-vm-api image — which can be months stale relative to
+      # wifihaven-e2e-vm-api image — which can be months stale relative to
       # current source. Force a fresh build here so CI always tests HEAD.
       # `--pull` refreshes base layers; only `api` is built locally
       # (postgres and fake-router use upstream images). Local dev keeps the
       # fast no-rebuild path. Fixes #465.
       - name: Build API image (force fresh layer)
         run: |
-          docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
+          docker compose -f docker/docker-compose.yml -p wifihaven-e2e-vm \
             build --pull api
 
       - name: Pre-flight kill of stale fdns VMs
@@ -124,7 +124,7 @@ jobs:
       - name: Capture docker compose logs
         if: failure()
         run: |
-          docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
+          docker compose -f docker/docker-compose.yml -p wifihaven-e2e-vm \
             logs --no-color > /tmp/api-logs.txt 2>&1 || true
 
       - name: Upload failure artifacts
@@ -148,5 +148,5 @@ jobs:
       - name: Tear down API stack
         if: always()
         run: |
-          docker compose -f docker/docker-compose.yml -p familydns-e2e-vm \
+          docker compose -f docker/docker-compose.yml -p wifihaven-e2e-vm \
             down -v --remove-orphans || true

--- a/scripts/e2e/lib/api_debug.py
+++ b/scripts/e2e/lib/api_debug.py
@@ -24,7 +24,7 @@ class DebugAPI:
         # Container name to docker-exec into. Defaults to the compose-managed
         # api container created by the e2e stack lifecycle (see stack.py).
         self.container = container or os.environ.get(
-            "E2E_VM_API_CONTAINER", "familydns-e2e-vm-api-1"
+            "E2E_VM_API_CONTAINER", "wifihaven-e2e-vm-api-1"
         )
 
     def devices(self) -> list[dict[str, Any]]:

--- a/scripts/e2e/lib/stack.py
+++ b/scripts/e2e/lib/stack.py
@@ -16,7 +16,7 @@ from .sh import run
 
 log = logging.getLogger(__name__)
 
-DEFAULT_PROJECT = "familydns-e2e-vm"
+DEFAULT_PROJECT = "wifihaven-e2e-vm"
 DEFAULT_API_PORT = 18080
 
 


### PR DESCRIPTION
## Summary

Final tendril of the project rename (META: #365, prior URL sweep: #534). Renames the docker-compose `-p` project label used by the KVM E2E suite from `familydns-e2e-vm` to `wifihaven-e2e-vm`.

Touches:
- Three `docker compose -p` call sites in `.github/workflows/e2e-vm.yml` (plus a stale comment referencing the old image name).
- `DEFAULT_PROJECT` in `scripts/e2e/lib/stack.py`.
- Default container name fallback (`E2E_VM_API_CONTAINER`) in `scripts/e2e/lib/api_debug.py`.

## Acceptance (from #537)

- [x] `grep -rn 'familydns-e2e-vm' .` returns zero.
- [ ] E2E KVM workflow green on a fresh runner.
- [x] One-time cleanup documented (see below).

## One-time cleanup on the existing KVM runner host

The label namespaces compose resources (networks, volumes, container names). Renaming it orphans cached state on any host that had previously run the suite. CI runs use ephemeral hosts so it's fine there, but the persistent KVM runner host (see `docs/ops/kvm-runner.md`) must be cleaned up before re-running the E2E workflow:

```
docker compose -f docker/docker-compose.yml -p familydns-e2e-vm down -v --remove-orphans
```

Otherwise the old `familydns-e2e-vm_*` networks/volumes/containers will linger alongside the new `wifihaven-e2e-vm_*` ones.

## Test plan

- [ ] Operator runs the cleanup command above on the KVM runner host.
- [ ] Next E2E KVM workflow run on the cleaned runner is green.

Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)