### PR TITLE
rename: README diagram familydns-api -> wifihaven-api (closes #536)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ extensions — all on your own hardware, no third-party DNS provider.
 
 ```
                  +-------------------+    +-----------+
-HTTP / web ────▶ |  familydns-api    | ─▶ |  Postgres |
+HTTP / web ────▶ |  wifihaven-api    | ─▶ |  Postgres |
    :8080         +-------------------+    +-----------+
                    ▲              ▲
                    │ policy pull  │ usage push


### PR DESCRIPTION
## Summary
- Updates the ASCII architecture diagram in README.md (the only remaining `familydns-api` reference in the tree) to `wifihaven-api`.
- Verified Mill target name (`api`), Docker artifact (`api.jar`), and systemd unit (`SyslogIdentifier=wifihaven-api`, `/opt/wifihaven/api.jar`) were already consistent — no build/runtime changes needed.

Closes #536.

## Test plan
- [x] `grep -rn 'familydns-api\|familydnsApi\|FamilydnsApi' .` returns zero matches.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)