### PR TITLE
rename: HOCON config namespace familydns.* → wifihaven.* (closes #535)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ but you lose the auto-update property.
 `config/application.conf` (HOCON) is the source of truth. The example is at
 `config/application.conf.example`. Notable keys:
 
-- `familydns.db.*` — Postgres connection
-- `familydns.http.port` — API port (default `8080`)
-- `familydns.http.staticDir` — where to serve the React bundle from
-- `familydns.jwt.secret` — **must be ≥ 32 random chars**, change before going live
-- `familydns.jwt.expiryHours` — JWT lifetime (default 24h)
-- `familydns.dns.cacheRefreshSeconds` — how often the policy snapshot cache is refreshed
+- `wifihaven.db.*` — Postgres connection
+- `wifihaven.http.port` — API port (default `8080`)
+- `wifihaven.http.staticDir` — where to serve the React bundle from
+- `wifihaven.jwt.secret` — **must be ≥ 32 random chars**, change before going live
+- `wifihaven.jwt.expiryHours` — JWT lifetime (default 24h)
+- `wifihaven.dns.cacheRefreshSeconds` — how often the policy snapshot cache is refreshed
 
 ## Testing
 

--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -6,7 +6,7 @@
   </appender>
 
   <!--
-    WIFIHAVEN_LOG_LEVEL controls verbosity of the familydns.* loggers.
+    WIFIHAVEN_LOG_LEVEL controls verbosity of the wifihaven.* loggers.
     Defaults to INFO. Set to DEBUG to see per-request detail on the
     /api/router/* endpoints (mac, hostname, allowed/blocked, etc.). See
     docs/install-api.md § Debugging.
@@ -15,5 +15,5 @@
     <appender-ref ref="STDOUT" />
   </root>
 
-  <logger name="familydns" level="${WIFIHAVEN_LOG_LEVEL:-INFO}" />
+  <logger name="wifihaven" level="${WIFIHAVEN_LOG_LEVEL:-INFO}" />
 </configuration>

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -1,4 +1,4 @@
-familydns {
+wifihaven {
   db {
     host     = "localhost"
     port     = 5432

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -35,7 +35,7 @@ WIFIHAVEN_API_PORT=8080
 # on the API host. Never set this in production.
 # WIFIHAVEN_DEBUG=1
 #
-# Override the verbosity of the familydns.* loggers. Accepts TRACE, DEBUG,
+# Override the verbosity of the wifihaven.* loggers. Accepts TRACE, DEBUG,
 # INFO, WARN, ERROR. Defaults to INFO. DEBUG enables per-request logging on
 # the /api/router/{usage,events,policy} endpoints (mac, hostname, etc.).
 # WIFIHAVEN_LOG_LEVEL=DEBUG


### PR DESCRIPTION
## Summary

Final tendril of the project rename — HOCON config namespace `familydns.*` → `wifihaven.*`.

- `config/application.conf.example`: top-level `familydns { }` → `wifihaven { }`
- `README.md` Configuration section: rename documented keys (`familydns.db.*`, `familydns.http.*`, `familydns.jwt.*`, `familydns.dns.*`)
- `api/resources/logback.xml`: logger `name="familydns"` → `name="wifihaven"` so it actually matches the Scala packages (renamed in earlier PRs). Also updates the inline comment.
- `deploy/.env.example`: `WIFIHAVEN_LOG_LEVEL` comment now references `wifihaven.*` loggers

No backwards-compat shim — pre-prod, no field users (per `docs/rename-decision.md`).

## Out of scope

These remaining `familydns.` grep matches are intentionally untouched (not HOCON):

- `opnsense/` FreeBSD agent's python package `familydns` and `/usr/local/etc/familydns.conf` paths — separate port-side rename
- `docs/install-openwrt.md` UCI snippets `uci set familydns.@familydns[0]…` — UCI namespace was renamed in #520; the docs themselves are stale, separate issue
- `docs/install-api.md` references to example domain `familydns.example.com`
- File-path references in docs: `/tmp/familydns.ipk`, `/tmp/dnsmasq.d/familydns.conf`, `openwrt-familydns.img`, etc.
- Stale Scala-namespace doc refs in `AGENTS.md` and `web/src/types/api.ts` comments (`familydns.shared.*`)
- Binary name `familydns-api` (#536), compose label `familydns-e2e-vm` (#537)

## Test plan

- [x] `mill __.test` — 267/267 green
- [x] `grep -rn 'familydns\.' .` over HOCON / Scala / logback / deploy env files returns zero
- [ ] Reviewer: spot-check the logback change — logger name must match the wifihaven Scala packages for `WIFIHAVEN_LOG_LEVEL` to do anything

Closes #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)