### PR TITLE
docs: rename stale familydns.shared.* refs (closes #549)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,7 @@ Test infrastructure lives in `api/test/src/TestDatabase.scala`:
 
 ### Clock is always injected — never call java.time directly
 
-`familydns.shared.Clock` is the only way to get the current time anywhere in the codebase.
+`wifihaven.shared.Clock` is the only way to get the current time anywhere in the codebase.
 
 ```scala
 // WRONG

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,4 +1,4 @@
-// Mirrors familydns.shared Models.scala
+// Mirrors wifihaven.shared Models.scala
 
 // #385: three failover modes. Wire form is lower-kebab to match
 // shared/src/Models.scala FailureMode.asString.


### PR DESCRIPTION
## Summary

Follow-up to #541 — clean up the two stale `familydns.shared.*` doc/comment refs called out as out-of-scope there.

- `AGENTS.md`: `` `familydns.shared.Clock` `` → `` `wifihaven.shared.Clock` ``
- `web/src/types/api.ts`: `// Mirrors familydns.shared Models.scala` → `// Mirrors wifihaven.shared Models.scala`

Comment-only; the Scala packages themselves were renamed in earlier PRs.

## Test plan

- [x] Comment/doc-only — no code paths touched, no tests needed

Closes #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)