### PR TITLE
docs: sweep stale familydns refs in OpenWRT install/architecture/ops docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -618,7 +618,7 @@ openwrt/
 ### 7.4 Daemon loop (three timers)
 
 - **Policy timer (60 s)** — fetch snapshot, atomically rewrite
-  `/tmp/dnsmasq.d/familydns.conf` and `/tmp/nftables.d/familydns.nft`,
+  `/tmp/dnsmasq.d/wifihaven.conf` and `/tmp/nftables.d/wifihaven.nft`,
   then `nft -f` the new ruleset. The dnsmasq full restart only fires when
   the rendered `dnsmasq.conf` actually differs byte-for-byte from the
   on-disk copy (#414) — most policy applies flip nft-side state only
@@ -688,7 +688,7 @@ opnsense/
 ├── Makefile
 ├── files/
 │   ├── usr/local/etc/rc.d/familydns     # rc.d service
-│   ├── usr/local/etc/familydns.conf     # api_url, router_token, poll_interval
+│   ├── usr/local/etc/wifihaven.conf     # api_url, router_token, poll_interval
 │   └── usr/local/sbin/familydns-agent   # main daemon (Python)
 └── README.md
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -194,8 +194,8 @@ LATEST_URL=$(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/
   | jsonfilter -e '@.assets[0].browser_download_url')
 LATEST_VER=$(echo "$LATEST_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+')
 if [ "$LATEST_VER" != "$CURRENT" ]; then
-  curl -fsSL -o /tmp/familydns.ipk "$LATEST_URL"
-  opkg install --force-reinstall /tmp/familydns.ipk
+  curl -fsSL -o /tmp/wifihaven.ipk "$LATEST_URL"
+  opkg install --force-reinstall /tmp/wifihaven.ipk
 fi
 ```
 

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -429,10 +429,10 @@ with `docker compose logs -f api` while the offending device is active.
 Defaults to `INFO`; set in `deploy/.env` (or use the debug overlay below,
 which turns this on for you).
 
-On the **OpenWRT side**, set `uci set familydns.@familydns[0].debug=1; uci
-commit; /etc/init.d/familydns restart` to make the agent log every policy
+On the **OpenWRT side**, set `uci set wifihaven.@wifihaven[0].debug=1; uci
+commit; /etc/init.d/wifihaven restart` to make the agent log every policy
 fetch, usage POST, event flush, and per-flow mac/hostname attribution to
-`logread -t familydns` (#228).
+`logread -t wifihaven` (#228).
 
 ### 9.2 Loopback-only debug endpoints (`WIFIHAVEN_DEBUG=1`)
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -140,13 +140,13 @@ generation.
 
 ```sh
 # OpenWRT 23.05.x (opkg):
-curl -fsSL -o /tmp/familydns.ipk \
+curl -fsSL -o /tmp/wifihaven.ipk \
   $(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
     | jsonfilter -e '@.assets[*].browser_download_url' \
     | grep -E '\.ipk$' | head -n1)
 
 # OpenWRT 24.10+/SNAPSHOT (apk):
-curl -fsSL -o /tmp/familydns.apk \
+curl -fsSL -o /tmp/wifihaven.apk \
   $(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
     | jsonfilter -e '@.assets[*].browser_download_url' \
     | grep -E '\.apk$' | head -n1)
@@ -157,10 +157,10 @@ curl -fsSL -o /tmp/familydns.apk \
 ```sh
 # OpenWRT 23.05.x (opkg):
 opkg update
-opkg install /tmp/familydns.ipk
+opkg install /tmp/wifihaven.ipk
 
 # OpenWRT 24.10+/SNAPSHOT (apk):
-apk add --allow-untrusted /tmp/familydns.apk
+apk add --allow-untrusted /tmp/wifihaven.apk
 ```
 
 Either manager resolves and installs `lua`, `luci-lib-jsonc`,
@@ -171,11 +171,11 @@ enrollment must complete first.
 ### M3. Configure the API URL and LAN prefix
 
 ```sh
-uci set familydns.@familydns[0].api_url='https://api.example.com'
+uci set wifihaven.@wifihaven[0].api_url='https://api.example.com'
 # Default lan_prefix is '192.168.1.' — override if your LAN is elsewhere.
 # Example: LAN on 10.0.0.0/24
-uci set familydns.@familydns[0].lan_prefix='10.0.0.'
-uci commit familydns
+uci set wifihaven.@wifihaven[0].lan_prefix='10.0.0.'
+uci commit wifihaven
 ```
 
 > **Important — read this even if your LAN looks normal.**
@@ -203,10 +203,10 @@ auth.
 ### M5. Persist credentials and start the agent
 
 ```sh
-uci set familydns.@familydns[0].router_id='9c1f2e8a-…'
-uci set familydns.@familydns[0].router_token='rt_a7d12b…'
-uci commit familydns
-/etc/init.d/familydns start
+uci set wifihaven.@wifihaven[0].router_id='9c1f2e8a-…'
+uci set wifihaven.@wifihaven[0].router_token='rt_a7d12b…'
+uci commit wifihaven
+/etc/init.d/wifihaven start
 ```
 
 ### M6. Set up the local block page

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -50,7 +50,7 @@ start:
 ```bash
 # As the runner user, from a checkout of this repo:
 scripts/vm/build-client-base.sh      # → scripts/vm/.cache/client-base.qcow2
-scripts/vm/build-router-image.sh     # → scripts/vm/.cache/openwrt-familydns.img
+scripts/vm/build-router-image.sh     # → scripts/vm/.cache/openwrt-wifihaven.img
 ```
 
 Cache locations (kept across runs, safe to delete to force a rebuild):
@@ -58,7 +58,7 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
 | path                                    | what                                   |
 |-----------------------------------------|----------------------------------------|
 | `scripts/vm/.cache/client-base.qcow2`   | Alpine client base image               |
-| `scripts/vm/.cache/openwrt-familydns.img` | Custom OpenWRT image w/ agent baked in |
+| `scripts/vm/.cache/openwrt-wifihaven.img` | Custom OpenWRT image w/ agent baked in |
 | `scripts/vm/.cache/imagebuilder/`       | OpenWRT Image Builder working tree     |
 | `.e2e-vm-venv/`                         | pytest venv (created lazily)           |
 

--- a/docs/vm-e2e-ubuntu.md
+++ b/docs/vm-e2e-ubuntu.md
@@ -106,7 +106,7 @@ scripts/vm/build-router-image.sh
 #    path, and pick a non-conflicting host HTTP-forward port if 8080 is
 #    already taken on the host (e.g. by a running wifihaven API stack).
 FDNS_ROUTER_HTTP_PORT=18081 \
-FDNS_ROUTER_IMAGE_PATH="$PWD/scripts/vm/.cache/openwrt-familydns.img" \
+FDNS_ROUTER_IMAGE_PATH="$PWD/scripts/vm/.cache/openwrt-wifihaven.img" \
     scripts/vm/router-up.sh
 
 # 4. Bring up a client with a chosen MAC.


### PR DESCRIPTION
## Summary
- Reconcile stale `familydns` references in OpenWRT-side docs against current code names after the #520 rename.
- UCI namespace (`wifihaven.@wifihaven[0]`), package artifact (`wifihaven.{ipk,apk}`), init.d script (`/etc/init.d/wifihaven`), dnsmasq/nft fragments (`/tmp/.../wifihaven.{conf,nft}`), and VM image (`openwrt-wifihaven.img`) all now match what the build/install code actually produces.
- Closes #548. Same style as #541.

## Out of scope
- Binary names like `familydns-agent`, `familydns-update`, `familydns-dns-tail` (#536).
- `opnsense/` docs (#547) — only the single OpnSense tree-diagram line called out in the issue was updated.
- API-side HOCON, DB user/name, compose label, install path `/opt/familydns/deploy` (#535/#541/#537).
- `familydns.example.com` example domain placeholders in `install-api.md`.

## Test plan
- [x] `grep -n familydns docs/install-openwrt.md docs/install-api.md docs/deploy.md docs/architecture.md docs/vm-e2e-ubuntu.md docs/ops/kvm-runner.md` — only out-of-scope hits remain (binary names, opnsense agent binary line, API HOCON/DB/compose, example domain).
- [x] Verified renames against current code: `openwrt/files/etc/config/wifihaven`, `openwrt/Makefile` (`PKG_NAME:=wifihaven`), `openwrt/files/usr/lib/lua/wifihaven/render.lua` (output paths), `scripts/vm/build-router-image.sh` (`openwrt-wifihaven.img`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)