### PR TITLE
chore: move host-agnostic agent memory into the repo

### DIFF
--- a/.claude/memory/README.md
+++ b/.claude/memory/README.md
@@ -1,0 +1,41 @@
+## Shared agent memory
+
+Memories that apply to anyone working on the codebase, regardless of which
+host they're working from. Each file has frontmatter (`name`, `description`,
+`type`) describing what it is and when it should kick in. Keep them short and
+focused on durable rules — not transient state.
+
+### What lives here vs. host-local memory
+
+In-repo (this directory):
+- Design invariants and code-level rules that everyone touching the codebase
+  needs to know.
+- Cross-cutting project policies (e.g. "wire schema versioning is deferred").
+
+Host-local (under `~/.claude/projects/<slug>/memory/` on each machine):
+- Live infrastructure details — SSH hosts, credentials, deployed paths.
+- Hardware-specific facts (test iPad MACs on the physical test router).
+- Workflow conventions for that machine (e.g. one host iterates on VM e2e,
+  another does live deploys).
+
+If a memory only makes sense on one host, leave it there. If it would change
+the answer for any contributor on any host, move it here.
+
+### Loading these on your machine
+
+Claude Code's automatic memory loader reads from
+`~/.claude/projects/<workspace-slug>/memory/`, not from the repo. To make
+these files load alongside your host-local memories, symlink them in:
+
+```bash
+SLUG=$(pwd | sed 's:/:-:g')
+TARGET=~/.claude/projects/$SLUG/memory
+mkdir -p "$TARGET"
+for f in .claude/memory/*.md; do
+  base=$(basename "$f")
+  [ "$base" = "README.md" ] && continue
+  ln -sf "$PWD/$f" "$TARGET/$base"
+done
+```
+
+Then add a line for each linked file to `$TARGET/MEMORY.md` (the index).

--- a/.claude/memory/feedback_extraallowed_beats_blocked.md
+++ b/.claude/memory/feedback_extraallowed_beats_blocked.md
@@ -1,0 +1,21 @@
+---
+name: extraAllowed beats blocked (router enforcement)
+description: BlockRules.extraAllowed must override BlockRules.blocked at the router — a fully-blocked device still reaches its admin-allowed carve-outs
+type: feedback
+---
+extraAllowed beats blocked, in addition to beating extraBlocked and blocklists.
+
+**Why:** An admin allow is the strongest signal. A device that is fully
+blocked (e.g. paused, schedule-blocked, time-limit-exhausted) should still
+be able to reach the explicitly-allowed hosts in its profile's
+extraAllowed list (e.g. Khan Academy still works on a paused kid iPad).
+This came up on the #421 PR — initial implementation only applied the ea
+exception to eb_/bl_ drops, missing the @blocked_macs drop.
+
+**How to apply:** Anywhere the router drops based on `blocked` (the
+`@blocked_macs` forward-chain drop, the @blocked_macs DNAT in v4 and v6,
+plus any future "fully-blocked" enforcement path), if the MAC has a
+non-empty effective extraAllowed list, gate the drop/DNAT with `ip daddr
+!= @ea_<m>_<a>` (resp. `ip6 daddr != @ea6_<m>_<a>`) per host a. The
+predicate doc at the top of render.lua reflects this — `m ∈ blocked_macs ∧
+¬ea_hit(m, d)`.

--- a/.claude/memory/project_wire_versioning_deferred.md
+++ b/.claude/memory/project_wire_versioning_deferred.md
@@ -1,0 +1,13 @@
+---
+name: Wire schema versioning deferred to pre-v1.0
+description: Issue #376 (snapshotVersion + capability negotiation) is intentionally deferred; API and agent ship in tandem until then
+type: project
+---
+Wire-contract schema-evolution policy (issue [#376](https://github.com/wifihaven/wifihaven/issues/376) — snapshotVersion, serverCapabilities/agentCapabilities negotiation, capability registry) is **deferred until we approach v1.0 release**. Decided 2026-05-14.
+
+**Why:** Pre-v1.0, API and OpenWRT agent are deployed in tandem from the same repo by a single operator (sameer); the cost of a tandem-deploy constraint is lower than the cost of building and maintaining a capability-negotiation framework now. Auto-update mismatch windows are tolerable for the current install base of one.
+
+**How to apply:**
+- Do NOT proactively add `snapshotVersion`, `serverCapabilities`, `agentCapabilities`, capability headers, or registry tables to the wire contract.
+- In-flight shape-change issues (e.g. #385 `failure-mode-three`, #386 `failover-threshold-in-snapshot`, #374 `unmanaged-mac-policy`, #383 `https-block-page`, #391 `hostid-tagged-union`, #392 `ipv6-ipsets`) ship as plain breaking shape changes coordinated by tandem deploy — they do NOT need to name a capability or gate emission.
+- If a future task asks for the capability framework, surface this memory and confirm v1.0 timing before starting. The draft design (rules + registry) is in the #376 thread / chat history if it needs to be revived.


### PR DESCRIPTION
## Summary

- Move two host-agnostic agent memories from `~/.claude/projects/<slug>/memory/` into `.claude/memory/` in the repo:
  - `feedback_extraallowed_beats_blocked.md` — router enforcement invariant (extraAllowed beats `blocked`), originally captured during #421.
  - `project_wire_versioning_deferred.md` — policy that snapshotVersion + capability negotiation (#376) is deferred until pre-v1.0.
- Host-local memories (live API host SSH, admin password, live test router SSH, physical test iPad MACs) stay per-machine — they describe one operator's specific deployment, not the codebase.
- README explains the split and ships a snippet for symlinking the in-repo files into each host's loader path (`~/.claude/projects/<slug>/memory/`).

Context: we iterate on VM e2e from one host and deploy/live-debug from another, so memory needs are different — but design invariants and project-wide policy decisions should be visible to anyone working on the repo, on any machine.

## Test plan

- [ ] After merge, on the Mac: replace the existing local copies of these two files under `~/.claude/projects/-Users-sameer-workspace-wifihaven/memory/` with symlinks per the README snippet; confirm the next session still surfaces both memories.
- [ ] On plex: run the symlink snippet so future sessions there pick up the design invariants without inheriting the Mac-specific deploy memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)