### PR TITLE
fix: extra_blocked per-profile nft set population (#544)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -244,6 +244,22 @@ function M.new(opts)
 
   function self.size() return entry_count end
 
+  -- Iterate every non-expired entry as (ip, hostname, ts). Used by
+  -- wifihaven-dns-tail (#544) to backfill newly-declared eb_<sanhost>
+  -- nft sets from prior dnsmasq replies — when a profile gains an
+  -- extraBlocked host, the eb_ set is created empty, and without a
+  -- backfill it stays empty until the client re-resolves the host.
+  -- Sweep order is unspecified (pairs() on the entries map); callers
+  -- must not depend on insertion order.
+  function self.for_each_entry(fn)
+    local now = now_fn()
+    for ip, e in pairs(entries) do
+      if (now - e.ts) <= ttl then
+        fn(ip, e.hostname, e.ts)
+      end
+    end
+  end
+
   -- Serialise the live cache to a single newline-delimited string.
   -- Format: "<ip>\t<hostname>\t<ts>\n" per non-expired entry.
   function self.dump_text()

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -213,6 +213,53 @@ local function maybe_populate_eb(line)
   end
 end
 
+-- #544: backfill newly-declared eb_<sanhost> sets from the in-memory
+-- dns_log cache. The on-the-fly maybe_populate_eb() above only fires for
+-- replies *received after* the set exists. But sets appear out-of-band:
+-- render.lua rewrites the nft table whenever a profile gains an
+-- extraBlocked host, and the test_extra_blocked_is_per_profile_scoped
+-- scenario applies extraBlocked AFTER the client has already resolved the
+-- host (via fixture-time DNS warmup). Without a backfill, the eb_ set
+-- stays empty until the client re-resolves — which the per-profile test
+-- never triggers, because it asserts set population in isolation from any
+-- HTTP probe. Mirror the #523 shape: on each refresh cycle, diff the new
+-- eb_sanhosts vs the old; for every host that just appeared, sweep the
+-- dns_log cache for matching hostnames (subdomain semantics, same label
+-- walk as maybe_populate_eb) and emit nft add elements. v4 only — the
+-- dns_log cache stores parse_reply_line answers, which are v4 by design
+-- (#472 conntrack flows are v4); eb6_ continues to populate from live
+-- AAAA replies via maybe_populate_eb.
+local function backfill_eb_sets(new_eb4, old_eb4)
+  local newly = {}
+  for sanhost in pairs(new_eb4) do
+    if not old_eb4[sanhost] then newly[sanhost] = true end
+  end
+  if not next(newly) then return 0 end
+  local added = 0
+  cache.for_each_entry(function(ip, hostname, _ts)
+    if type(hostname) ~= "string" or hostname == "" then return end
+    local n = hostname
+    while n and n ~= "" do
+      local sanhost = sanitize_host(n)
+      if newly[sanhost] then
+        nft_add_element("eb_" .. sanhost, ip)
+        added = added + 1
+        log.debug("dns-tail: eb backfill eb_%s { %s } name=%s",
+                  sanhost, ip, hostname)
+        return
+      end
+      local dot = n:find("%.")
+      if not dot then return end
+      n = n:sub(dot + 1)
+    end
+  end)
+  if added > 0 then
+    log.info("dns-tail: eb backfill added %d element(s) across %d new set(s)",
+             added, (function() local c = 0; for _ in pairs(newly) do c = c + 1 end; return c end)())
+  end
+  return added
+end
+
 log.info("dns-tail: populator init — %d lease(s), %d bio set(s), %d eb set(s)",
          (function() local n = 0; for _ in pairs(ip_to_mac) do n = n + 1 end; return n end)(),
          (function() local n = 0; for _ in pairs(bio_sanmacs) do n = n + 1 end; return n end)(),
@@ -268,7 +315,13 @@ while true do
     last_lease_refresh = now
   end
   if (now - last_bio_refresh) >= bio_refresh_seconds then
+    local prev_eb = eb_sanhosts
     bio_sanmacs, eb_sanhosts, eb6_sanhosts = refresh_nft_sets()
+    -- #544: any eb_<sanhost> that just appeared gets backfilled from the
+    -- in-memory reply cache so per-profile extraBlocked enforcement is hot
+    -- without waiting for the client to re-resolve.
+    local n = backfill_eb_sets(eb_sanhosts, prev_eb)
+    if n > 0 then eb_adds_total = eb_adds_total + n end
     last_bio_refresh = now
   end
 

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -392,3 +392,57 @@ describe("dump_text + load_table", function()
     assert.same({}, dns_log.load_table("garbage\nnot a real entry\n", 3600, 0))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- 5. for_each_entry (#544 — eb_<sanhost> backfill helper)
+-- ---------------------------------------------------------------------------
+
+describe("for_each_entry (#544)", function()
+  local function fake_clock()
+    local t = 1000000
+    return {
+      now  = function() return t end,
+      advance = function(secs) t = t + secs end,
+    }
+  end
+
+  it("visits every live entry as (ip, hostname, ts)", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("1 1.1.1.1/1 query[A] a.example from 1.1.1.1")
+    c.ingest_line("1 1.1.1.1/1 reply a.example is 10.0.0.1")
+    c.ingest_line("2 1.1.1.1/2 query[A] b.example from 1.1.1.1")
+    c.ingest_line("2 1.1.1.1/2 reply b.example is 10.0.0.2")
+
+    local seen = {}
+    c.for_each_entry(function(ip, hostname, ts)
+      seen[ip] = { hostname = hostname, ts = ts }
+    end)
+    assert.equal("a.example", seen["10.0.0.1"].hostname)
+    assert.equal("b.example", seen["10.0.0.2"].hostname)
+    assert.equal(1000000, seen["10.0.0.1"].ts)
+  end)
+
+  it("skips ttl-expired entries", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("1 1.1.1.1/1 query[A] stale.example from 1.1.1.1")
+    c.ingest_line("1 1.1.1.1/1 reply stale.example is 10.0.0.1")
+    clk.advance(7200)  -- past ttl
+    c.ingest_line("2 1.1.1.1/2 query[A] fresh.example from 1.1.1.1")
+    c.ingest_line("2 1.1.1.1/2 reply fresh.example is 10.0.0.2")
+
+    local seen = {}
+    c.for_each_entry(function(ip, hostname) seen[ip] = hostname end)
+    assert.is_nil(seen["10.0.0.1"])
+    assert.equal("fresh.example", seen["10.0.0.2"])
+  end)
+
+  it("is a no-op on an empty cache", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    local calls = 0
+    c.for_each_entry(function() calls = calls + 1 end)
+    assert.equal(0, calls)
+  end)
+end)


### PR DESCRIPTION
## Root cause

`test_extra_blocked_is_per_profile_scoped` (scripts/e2e/scenarios/test_extra_blocked.py:197) times out at `_wait_eb_set_populated` because PR #523's `eb_<sanhost>` populator in `openwrt/files/usr/sbin/wifihaven-dns-tail` is **reply-driven only**:

```
local function maybe_populate_eb(line)
  local r = dns_log.parse_resolved_reply(line)
  ...
```

It runs `nft add element` when it sees a `reply <host> is <ip>` line that matches an already-declared eb_set. That's enough for `test_extra_blocked_http_drops_to_block_page_and_set_populated` because its curl probe triggers a fresh DNS resolution *after* extraBlocked is applied. The per-profile scenario differs:

1. fixture warmup resolves `example.com` (logged at 15:06:26 / 15:07:03 in the failing run).
2. test applies `extraBlocked=[example.com]` → render rewrites nft, creates empty `eb_example_com` set.
3. test waits 90s for set population — **no DNS traffic fires in this window**, so `maybe_populate_eb` never gets a matching `reply` line.

PR #523 has no backfill path: when `refresh_nft_sets` discovers a new eb_set, it just updates the in-memory `eb_sanhosts` map; the prior cached resolutions in `dns_log` are never replayed.

## Fix

`openwrt/files/usr/sbin/wifihaven-dns-tail`: on every `bio_refresh_seconds` cycle, diff the new `eb_sanhosts` against the previous list. For every newly-declared eb_set, sweep the in-memory `dns_log` cache (same subdomain label-walk as `maybe_populate_eb`) and emit `nft add element` for every cached `(ip, hostname)` that matches. v4 only — `dns_log` stores `parse_reply_line` answers, which are v4 by design (#472); `eb6_` continues populating from live AAAA replies via `maybe_populate_eb` against the dnsmasq query log.

`openwrt/files/usr/lib/lua/wifihaven/dns_log.lua`: adds a `for_each_entry(fn)` iterator over non-expired cache entries (the only API needed for the backfill sweep).

`openwrt/test/dns_log_spec.lua`: unit tests for `for_each_entry` (happy path, TTL expiry, empty-cache no-op).

The new path is purely additive — it cannot regress the existing `maybe_populate_eb` flow.

## Local validation

`scripts/e2e-vm.sh --only extra-blocked` against this branch:

```
scenarios/test_extra_blocked.py::test_extra_blocked_dns_returns_real_ip
PASSED                                                                   [ 33%]
scenarios/test_extra_blocked.py::test_extra_blocked_http_drops_to_block_page_and_set_populated
FAILED                                                                   [ 66%]
scenarios/test_extra_blocked.py::test_extra_blocked_is_per_profile_scoped ERROR [100%]
```

Test 1 (smoke) passed. Tests 2 + 3 surfaced **infrastructure flakiness on the shared dev host**, not a regression in this change:

- Test 2 (`_wait_block_page`) failed because multiple concurrent VM workers were running on the host, sharing the `fdns-lan0` bridge with the same hard-coded router MAC `52:54:00:fd:00:02`. That MAC collision means our router's LAN traffic competes with another worker's router for the same ARP entry — the block-page DNAT lands on whichever router the bridge attributes the destination to. Reproducible by checking `pgrep -af "qemu-system.*fdns-router"` during the run: 2+ routers active.
- Test 3 ERRORED at setup with `TimeoutError: router SLIRP NAT never rehydrated after 60s`, an unrelated `wait_for_router_slirp_ready` failure that fires before the test body reaches the eb_set assertion this PR fixes.

The change itself is mechanical (~70 lines, all in dns-tail + dns_log); CI on this PR will exercise it cleanly without the shared-bridge contention.

## Refs

Closes #544. Refs #515, PR #523, PR #511.