### PR TITLE
fix: time_usage over-counts background traffic (#545)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -134,15 +134,24 @@ end
 
 -- ---------------------------------------------------------------------------
 -- Activity tracker — sub-minute "is this (mac, dst_ip) actively using the
--- network?" sampling.  See #295 (#516).
+-- network?" sampling.  See #295 (#516, #545).
 -- ---------------------------------------------------------------------------
--- The nftables set element counters in `mac_ip_tracking` are reset to 0 once
--- per 5-min bucket.  The agent calls `tracker_sample` every SECONDS_PER_SAMPLE
--- seconds with the currently-parsed counters; each call that observes byte
--- growth bumps the (mac, dst_ip)'s active-sample count.  At end-of-bucket
--- `build_report` multiplies that count by SECONDS_PER_SAMPLE (capped at 300)
--- to produce `activeSeconds`, and the agent resets the tracker for the next
--- bucket.
+-- The nftables set element counters in `mac_ip_tracking` are reset to 0 at
+-- each usage-flush.  The agent calls `tracker_sample(t, counters, mono)` every
+-- SECONDS_PER_SAMPLE seconds with the currently-parsed counters and the
+-- monotonic clock.  Each call that observes byte growth records the
+-- SECONDS_PER_SAMPLE-aligned monotonic window in which it was observed;
+-- `build_report` reports SECONDS_PER_SAMPLE × |distinct windows| as
+-- `activeSeconds` (capped at BUCKET_SECONDS).
+--
+-- Using *distinct windows* rather than a raw tick count (#545) ensures the
+-- final forced sample at flush — which the usage-timer fires immediately
+-- after a regular activity tick to capture last-second activity — cannot
+-- double-credit the same window.  With usage_int=60s and a sample every
+-- 10s, the previous tick-count scheme could over-credit by up to 10s per
+-- flush (regular tick at T=60 plus forced tick at T=60.x both saw growth
+-- but reflected the same 10s window), letting a 90s test that crossed two
+-- flush boundaries land above the [1,2]-minute test bound.
 --
 -- Wire format is unchanged — `activeSeconds` is still an integer.  10s
 -- granularity is fine enough that summing activeSeconds across buckets is
@@ -156,32 +165,59 @@ local BUCKET_SECONDS     = 300
 local function tracker_key(mac, dst_ip) return mac .. "|" .. dst_ip end
 
 function M.new_tracker()
-  return { last = {}, active_minutes = {} }
+  -- `windows[key]` is a set: window_idx -> true.  The legacy field
+  -- `active_minutes[key]` mirrors |windows[key]| so callers (build_report
+  -- and the existing unit tests) keep working unchanged.
+  return { last = {}, windows = {}, active_minutes = {} }
 end
 
--- Compare each counter to its previous byte total; an increase counts as one
--- active minute.  A counter that went DOWN is treated as a fresh start
--- (element expired and reappeared, or counters reset out-of-band); we still
--- count it as an active minute if the new value is > 0.
-function M.tracker_sample(tracker, counters)
+-- Compare each counter to its previous byte total; an increase records the
+-- current SECONDS_PER_SAMPLE-aligned monotonic window as active.  A counter
+-- that went DOWN is treated as a fresh start (element expired and reappeared,
+-- or counters reset out-of-band); we still record an active window if the
+-- new value is > 0.  Multiple samples within the same SECONDS_PER_SAMPLE
+-- window are deduped — recording the same window twice still credits 10s.
+--
+-- `mono` is the monotonic-clock seconds at the time of sampling.  Tests that
+-- don't care about boundary behavior may pass nil; we fall back to an
+-- internal counter that increments by SECONDS_PER_SAMPLE per call, which
+-- preserves the legacy "1 call = 1 window" semantics.
+function M.tracker_sample(tracker, counters, mono)
+  if not mono then
+    tracker._fake_mono = (tracker._fake_mono or 0) + SECONDS_PER_SAMPLE
+    mono = tracker._fake_mono
+  end
+  local window = math.floor(mono / SECONDS_PER_SAMPLE)
   for _, c in ipairs(counters or {}) do
-    local key  = tracker_key(c.mac, c.dst_ip)
-    local prev = tracker.last[key] or 0
+    local key   = tracker_key(c.mac, c.dst_ip)
+    local prev  = tracker.last[key] or 0
+    local grew  = false
     if c.bytes > prev then
-      tracker.active_minutes[key] = (tracker.active_minutes[key] or 0) + 1
+      grew = true
       tracker.last[key] = c.bytes
     elseif c.bytes < prev then
-      if c.bytes > 0 then
+      if c.bytes > 0 then grew = true end
+      tracker.last[key] = c.bytes
+    end
+    if grew then
+      local set = tracker.windows[key]
+      if not set then
+        set = {}
+        tracker.windows[key] = set
+      end
+      if not set[window] then
+        set[window] = true
         tracker.active_minutes[key] = (tracker.active_minutes[key] or 0) + 1
       end
-      tracker.last[key] = c.bytes
     end
   end
 end
 
 function M.tracker_reset(tracker)
   tracker.last           = {}
+  tracker.windows        = {}
   tracker.active_minutes = {}
+  tracker._fake_mono     = nil
 end
 
 -- ---------------------------------------------------------------------------

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -438,7 +438,7 @@ conntrack.watch({
       last_activity_sample = mono
       local counters = read_nft_counters()
       if counters then
-        usage.tracker_sample(activity_tracker, counters)
+        usage.tracker_sample(activity_tracker, counters, mono)
       end
     end
 
@@ -457,7 +457,10 @@ conntrack.watch({
       if counters then
         -- Final sample at flush so set elements that appeared after the
         -- last activity_sample_int tick still get an active sample counted.
-        usage.tracker_sample(activity_tracker, counters)
+        -- Passing `mono` (#545) means this forced sample dedupes with the
+        -- regular activity tick when both fall in the same 10s window,
+        -- avoiding an extra ~10s of credit per flush boundary.
+        usage.tracker_sample(activity_tracker, counters, mono)
         last_activity_sample = mono
         local report = usage.build_report(
           counters, nft_sets, period_start, period_end, router_id,


### PR DESCRIPTION
## Summary

D2 (`test_time_limit_minute_granularity`) failed on the latest VM-e2e run
([job 76404651904](https://github.com/wifihaven/wifihaven/actions/runs/25993811590/job/76404651904))
with `minutesUsed = 3` after ~90 s of bursty traffic — outside the [1, 2]
bound that #526 (#516) tightened back down to once `activeSeconds` was
plumbed through `traffic_reports` and the helper switched to
`ceil(deviceTotalActiveSeconds / 60)`.

`ceil(activeSeconds / 60) == 3` means the agent reported ≥ 121 s of
activeSeconds for the test's MAC during a 90 s test window. The CI
artifact for this run contained no usable per-MAC `activeSeconds` log
lines (the `api-logs.txt` capture only retained API entrypoint chatter),
so the raw posted value asked for in the issue could not be extracted
from #25993811590. Working from the code path instead:

### Root cause (agent side, `openwrt/files/usr/lib/lua/wifihaven/usage.lua`)

The activity tracker counts *ticks-with-growth* and multiplies by
`SECONDS_PER_SAMPLE` (10 s). With `usage_int = 60 s`:

  - A regular activity sample fires every 10 s
  - The usage flush block *also* fires a forced `tracker_sample` —
    purposely, to capture set elements that appeared after the last
    10 s tick.

When both fire close together on a flush boundary (regular sample at
T = 60.0 s, forced sample at T = 60.x s), both can observe growth and
each adds 10 s to `activeSeconds`, even though the actual elapsed time
between them is sub-second. Over the D2 test's two flush boundaries this
adds up to ~20 s of over-credit, which is the difference between
ceil = 2 and ceil = 3.

### Fix

Switch the tracker to record activity as a *set of distinct
SECONDS_PER_SAMPLE-aligned monotonic windows* per (mac, dst_ip). Multiple
samples that land in the same 10 s window now credit exactly once, so
the forced flush sample no longer double-credits across the boundary.

`tracker_sample` takes a new `mono` argument (the monotonic-clock seconds
at sample time). When `nil` is passed (legacy unit-test path), it falls
back to an internal counter that increments by `SECONDS_PER_SAMPLE` per
call — so the existing `tracker.active_minutes[key]` semantics still
hold call-for-call. The agent always passes `mono`.

Wire format unchanged. `tracker.active_minutes[key]` continues to be the
count `build_report` reads; it now mirrors `|tracker.windows[key]|`.

## Local validation

- `openwrt/test/usage_spec.lua`: **50 / 50 pass** (verified via
  `busted-5.1` in a `nickblah/lua:5.1-alpine` container).
- Simulation of D2's 10-bursts-every-9.4s pattern across every test-start
  → flush-boundary offset (0–55 s in 5 s steps) yields:

  ```
  test offset | total_s | per-flush activeSeconds | ceil(total/60)
  0           | 90      | 60 30                   | 2
  5           | 80      | 50 30                   | 2
  …
  55          | 90      | 10 60 20                | 2
  ```

  Stable at ceil = 2 across all alignments, matching the bound.

- `scripts/e2e-vm.sh --only time-limit`: **could not be validated
  locally** in this development environment. Every e2e scenario,
  including ones I didn't touch, failed at router-SLIRP /
  SSH-ready setup ("router SLIRP NAT never rehydrated after 60s",
  "router SSH never came up after 180s"). The dev host has six
  concurrent worktree QEMU stacks sharing `fdns-lan0` and is under
  hard memory pressure (4 GB swap fully in use), so the harness can't
  cleanly bring up a router VM here. Asking CI to validate end-to-end
  against the real harness.

Refs #295, #474, #482, #516, PR #526.
Closes #545.