### PR TITLE
ci(vm-e2e): rename LAN bridge fdns-lan0 → wh-lan0

### DIFF
--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -29,7 +29,7 @@ provision ourselves.
   - `binutils` (for `ar`, used by `openwrt/build-ipk.sh`)
 
 Use `docs/vm-e2e-ubuntu.md` as the per-host bootstrap checklist: it covers
-`/dev/kvm` group membership, the `fdns-lan0` bridge, `qemu-bridge-helper`
+`/dev/kvm` group membership, the `wh-lan0` bridge, `qemu-bridge-helper`
 capabilities, and the narrow `NOPASSWD` rule for `ip`.
 
 ### Suggested hosts
@@ -138,7 +138,7 @@ execution is unprivileged:
 |---|---|
 | `/dev/kvm` read/write | runner user is in the `kvm` group |
 | docker socket | runner user is in the `docker` group |
-| attach taps to `fdns-lan0` | `cap_net_admin` on `qemu-bridge-helper` (`setcap`) + `/etc/qemu/bridge.conf` allowlists the bridge |
+| attach taps to `wh-lan0` | `cap_net_admin` on `qemu-bridge-helper` (`setcap`) + `/etc/qemu/bridge.conf` allowlists the bridge |
 | `ip link add/set …` for the LAN bridge | NOPASSWD sudo rule in `/etc/sudoers.d/familydns-vm`, scoped to `/usr/sbin/ip` only |
 | outbound HTTPS to GitHub | none (standard outbound) |
 

--- a/docs/vm-e2e-ubuntu.md
+++ b/docs/vm-e2e-ubuntu.md
@@ -56,7 +56,7 @@ hooks on some hosts — the `usermod` route is more reliable.
 
 ### LAN bridge + `qemu-bridge-helper`
 
-`client-up.sh` attaches the client VM's LAN NIC to the `fdns-lan0` bridge
+`client-up.sh` attaches the client VM's LAN NIC to the `wh-lan0` bridge
 via `qemu-bridge-helper`, which is not setuid by default on Ubuntu and
 which refuses to attach to bridges that aren't in `/etc/qemu/bridge.conf`.
 Both need fixing once:
@@ -64,7 +64,7 @@ Both need fixing once:
 ```bash
 sudo bash -c '
   mkdir -p /etc/qemu
-  echo "allow fdns-lan0" > /etc/qemu/bridge.conf
+  echo "allow wh-lan0" > /etc/qemu/bridge.conf
   setcap cap_net_admin+ep /usr/lib/qemu/qemu-bridge-helper
 '
 ```
@@ -149,7 +149,7 @@ scripts/vm/router-down.sh
   Permission denied` after it was working, use the `usermod -aG kvm`
   approach above instead of `setfacl`.
 
-- **Bridge MTU.** `lan-bridge-up.sh` creates `fdns-lan0` without setting
+- **Bridge MTU.** `lan-bridge-up.sh` creates `wh-lan0` without setting
   an MTU; the default 1500 is fine for the e2e plan, but if you bridge
   this to a tun/tap with smaller MTU you'll see TCP stalls.
 
@@ -165,7 +165,7 @@ done
 test -r /dev/kvm && test -w /dev/kvm && echo "ok /dev/kvm" || echo "MISSING /dev/kvm rw"
 
 # Bridge + qemu-bridge-helper:
-grep -q "^allow fdns-lan0\b" /etc/qemu/bridge.conf && echo "ok bridge.conf"
+grep -q "^allow wh-lan0\b" /etc/qemu/bridge.conf && echo "ok bridge.conf"
 getcap /usr/lib/qemu/qemu-bridge-helper | grep -q cap_net_admin && echo "ok qemu-bridge-helper cap"
 
 # Passwordless ip:

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -17,7 +17,7 @@ of #144 (router VM) and #146 (client VM).
   `client-up.sh` runs. `router-up.sh` brings it up automatically; otherwise
   call `lan-bridge-up.sh` directly.
 - `/etc/qemu/bridge.conf` must contain `allow ${FDNS_LAN_BRIDGE}` (default
-  `allow fdns-lan0`) so `qemu-bridge-helper` will attach taps.
+  `allow wh-lan0`) so `qemu-bridge-helper` will attach taps.
 
 The harness is not expected to work on macOS — no KVM. Use a Linux dev host
 or CI runner. For running in CI, see

--- a/scripts/vm/config.sh
+++ b/scripts/vm/config.sh
@@ -7,7 +7,7 @@
 # --- LAN bridge (shared with the router VM from #144) ------------------------
 # If #144 picks different names/ranges, update *here* — these constants are
 # referenced everywhere else by variable, not by literal.
-FDNS_LAN_BRIDGE="${FDNS_LAN_BRIDGE:-fdns-lan0}"
+FDNS_LAN_BRIDGE="${FDNS_LAN_BRIDGE:-wh-lan0}"
 FDNS_LAN_SUBNET="${FDNS_LAN_SUBNET:-192.168.100.0/24}"
 FDNS_LAN_ROUTER_IP="${FDNS_LAN_ROUTER_IP:-192.168.100.1}"
 


### PR DESCRIPTION
## Why

The self-hosted CI runner's `/etc/qemu/bridge.conf` was updated to allow `wh-lan0` (during the broader FamilyDNS→WifiHaven rename) but the repo still defaulted the LAN bridge name to `fdns-lan0`. The mismatch made `qemu-bridge-helper` refuse every tap attach, so every VM e2e job failed with:

```
qemu-system-x86_64: -netdev bridge,id=lan,br=fdns-lan0: bridge helper failed
```

This is the actual root cause of the recent string of "infra-flake" VM e2e failures (PR #562 saw this on its first failed run; PR #564's VM e2e also failed on this). The runner is fine, the helper has the right cap — only the bridge name didn't match.

## What

- `scripts/vm/config.sh`: `FDNS_LAN_BRIDGE` default `fdns-lan0` → `wh-lan0` (the single SoT).
- `docs/ops/kvm-runner.md`, `docs/vm-e2e-ubuntu.md`, `scripts/vm/README.md`: hardcoded references updated.
- Host: bridge interface renamed in tandem (`sudo ip link set fdns-lan0 down; rename fdns-lan0 → wh-lan0`).

## Scope

Just the LAN bridge name. The other `FDNS_*` env vars (`FDNS_ROUTER_IMAGE_PATH`, `FDNS_ROUTER_HTTP_PORT`, …) and `fdns-` prefixes (`fdns-client` cloud-init hostname, `fdns-imagebuilder` docker container) are untouched — they don't block CI and can be swept in a follow-up.

## Local validation

```
$ source scripts/vm/config.sh && echo "$FDNS_LAN_BRIDGE"
wh-lan0
$ ip link show wh-lan0 >/dev/null && echo OK
OK
$ grep -E '^allow wh-lan0\b' /etc/qemu/bridge.conf
allow wh-lan0
$ getcap /usr/lib/qemu/qemu-bridge-helper
/usr/lib/qemu/qemu-bridge-helper cap_net_admin=ep
$ timeout 5 qemu-system-x86_64 -accel kvm -nographic -monitor none -serial null \
    -nodefaults -netdev bridge,id=lan,br=wh-lan0 -device virtio-net-pci,netdev=lan
Terminated  (exit 143 — SIGTERM after 5s; no "bridge helper failed")
```

Pre-rename the same qemu invocation fails immediately with `bridge helper failed`.

## After merge

PRs branched off the prior ci/vm-e2e (#562, etc.) need to be rebased so their config.sh picks up the new default; otherwise they keep tripping on the old name.

Refs #519, #520 (the broader wifihaven rename effort).