### PR TITLE
rename: sweep remaining familydns/fdns refs → wifihaven/wh

### DIFF
--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -62,7 +62,7 @@ jobs:
           # the imagebuilder container running, which keeps writing root-owned
           # files into the cache after the reclaim sweep finished. Force-remove
           # by name before reclaiming.
-          docker rm -f fdns-imagebuilder 2>/dev/null || true
+          docker rm -f wh-imagebuilder 2>/dev/null || true
           CACHE="${{ github.workspace }}/scripts/vm/.cache"
           if [ -d "$CACHE" ]; then
             docker run --rm -v "$CACHE":/c alpine sh -c '
@@ -104,14 +104,14 @@ jobs:
           docker compose -f docker/docker-compose.yml -p wifihaven-e2e-vm \
             build --pull api
 
-      - name: Pre-flight kill of stale fdns VMs
+      - name: Pre-flight kill of stale wh VMs
         run: |
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
 
       - name: Run e2e suite
         env:
-          FDNS_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven.img
+          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven.img
           # #473: pytest's stack fixture defaults to tearing the docker
           # compose stack down at session end, which removes containers
           # before the failure-capture step below can read their logs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ WifiHaven is a self-hosted, network-level parental-control system with per-devic
 ## Architecture
 
 ```
-familydns/
+wifihaven/
 ├── shared/        # Domain models shared across all modules (Scala 3, ZIO JSON)
 ├── api/           # REST API + web server (ZIO HTTP, Doobie, PostgreSQL)
 ├── openwrt/       # Lua agent for OpenWRT (dnsmasq + nftables policy enforcement)
@@ -170,7 +170,7 @@ upstream as normal; the enforcement plane is nftables on the resolved IPs.)
 ## Always isolate spawned work in a worktree
 
 This repo is actively developed across many parallel sessions, so the main
-checkout at `/Users/sameer/workspace/familydns` is usually on some in-flight
+checkout at `/Users/sameer/workspace/wifihaven` is usually on some in-flight
 branch. **Spawning a session or agent that edits files without an isolated
 worktree pollutes that working tree and causes branch conflicts.**
 
@@ -185,7 +185,7 @@ Rules:
   latest `main`). State this explicitly in the prompt — the spawned session
   starts with no context.
 - Never push to or check out a new branch in the top-level
-  `/Users/sameer/workspace/familydns` checkout from a spawned session. Treat
+  `/Users/sameer/workspace/wifihaven` checkout from a spawned session. Treat
   it as someone else's working tree.
 - Worktrees live under `.claude/worktrees/<slug>` and use branch names
   `claude/<slug>` by convention (see `git worktree list`).
@@ -229,10 +229,10 @@ after long uptimes. Restarting Docker Desktop is the fix.
 
 ```bash
 # Start Postgres
-docker run -d --name familydns-pg \
-  -e POSTGRES_USER=familydns \
+docker run -d --name wifihaven-pg \
+  -e POSTGRES_USER=wifihaven \
   -e POSTGRES_PASSWORD=secret \
-  -e POSTGRES_DB=familydns \
+  -e POSTGRES_DB=wifihaven \
   -p 5432:5432 postgres:16
 
 # Copy and edit config
@@ -262,7 +262,7 @@ mill __.checkFormatting
 mill __.fix
 
 # OpenWRT agent tests (requires lua5.1 + busted + lua-cjson)
-cd openwrt && LUA_PATH="./files/usr/lib/lua/familydns/?.lua;$(lua -e 'print(package.path)')" busted test/
+cd openwrt && LUA_PATH="./files/usr/lib/lua/wifihaven/?.lua;$(lua -e 'print(package.path)')" busted test/
 
 # OPNsense agent tests (requires Python 3 + pytest)
 cd opnsense && python -m pytest test/ -v

--- a/api/resources/db/migration/V1__init.sql
+++ b/api/resources/db/migration/V1__init.sql
@@ -1,5 +1,5 @@
 -- V1__init.sql
--- FamilyDNS full schema
+-- WifiHaven full schema
 
 CREATE TABLE users (
   id            BIGSERIAL PRIMARY KEY,

--- a/api/resources/db/migration/V1__init.sql
+++ b/api/resources/db/migration/V1__init.sql
@@ -1,5 +1,5 @@
 -- V1__init.sql
--- WifiHaven full schema
+-- FamilyDNS full schema
 
 CREATE TABLE users (
   id            BIGSERIAL PRIMARY KEY,

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -21,7 +21,7 @@ object Main extends ZIOAppDefault {
   def run =
     (for {
       cfg    <- ZIO.service[AppConfig]
-      _      <- ZIO.logInfo(s"FamilyDNS API starting on ${cfg.http.host}:${cfg.http.port}")
+      _      <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
       _      <- ZIO
         .logWarning(
           "WIFIHAVEN_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -625,7 +625,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(d.exists(_.lastSeenIp.contains(IpAddress.unsafe("192.168.1.42"))))
     },
     test("events: accepts the raw JSON shape the OpenWRT Lua agent emits (regression for #215)") {
-      // Verbatim payload shape produced by openwrt/files/usr/lib/lua/familydns/conntrack.lua
+      // Verbatim payload shape produced by openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
       // build_event + jsonc.stringify({ routerId, events }). Hand-rolled rather than going
       // through RouterEventsRequest.toJson so that any drift in case-class field names
       // (snake_case → camelCase regressions etc.) is caught by deserialization here.

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -2,8 +2,8 @@ wifihaven {
   db {
     host     = "localhost"
     port     = 5432
-    database = "familydns"
-    user     = "familydns"
+    database = "wifihaven"
+    user     = "wifihaven"
     password = "changeme"
     poolSize = 10
   }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -48,7 +48,7 @@ Default admin login: `admin / changeme` — change it immediately via
   `docker compose exec postgres psql ...`.
 - **Named volume for data.** `pgdata` is a Docker named volume; data
   survives `down` / `up` cycles. Backups are a `pg_dump` away
-  (`docker compose exec postgres pg_dump -U familydns familydns`).
+  (`docker compose exec postgres pg_dump -U wifihaven wifihaven`).
 - **Restart `unless-stopped`.** Both services come back automatically after
   a crash or host reboot, but stay down if you explicitly `docker compose
   stop` them.
@@ -72,11 +72,11 @@ git pull && docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.
 
 # Backup the database
 docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env \
-  exec postgres pg_dump -U familydns familydns > backup-$(date +%F).sql
+  exec postgres pg_dump -U wifihaven wifihaven > backup-$(date +%F).sql
 
 # Open a psql shell
 docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env \
-  exec postgres psql -U familydns familydns
+  exec postgres psql -U wifihaven wifihaven
 ```
 
 ## Smoke test
@@ -96,7 +96,7 @@ If you're running the older systemd-on-host install (`scripts/deploy.sh` +
 1. `pg_dump` your existing local postgres.
 2. Stop and disable the systemd units.
 3. Bring up the compose stack with a fresh `.env`.
-4. Restore the dump: `docker compose ... exec -T postgres psql -U familydns familydns < backup.sql`.
+4. Restore the dump: `docker compose ... exec -T postgres psql -U wifihaven wifihaven < backup.sql`.
 
 Open an issue if you hit anything missing — this path will get more polish
 as more installs migrate.

--- a/deploy/scripts/restart.sh
+++ b/deploy/scripts/restart.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Restart the FamilyDNS stack in place (without recreating containers).
+# Restart the WifiHaven stack in place (without recreating containers).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
 exec docker compose -f docker-compose.prod.yml --env-file .env restart "$@"

--- a/deploy/scripts/start.sh
+++ b/deploy/scripts/start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Start the FamilyDNS stack (idempotent — safe to re-run).
+# Start the WifiHaven stack (idempotent — safe to re-run).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
 exec docker compose -f docker-compose.prod.yml --env-file .env up -d "$@"

--- a/deploy/scripts/stop.sh
+++ b/deploy/scripts/stop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Stop the FamilyDNS stack. Containers are removed; the postgres data
+# Stop the WifiHaven stack. Containers are removed; the postgres data
 # volume is preserved (use `docker volume rm` to wipe it explicitly).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Staging / e2e image for FamilyDNS.
+# Staging / e2e image for WifiHaven.
 #
 # Multi-stage:
 #   1. scala-build: compile + assemble the api jar with mill

--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-fake-router — simulates an OpenWRT FamilyDNS agent in the staging stack.
+fake-router — simulates an OpenWRT WifiHaven agent in the staging stack.
 
 Self-provisions on startup (admin login → create router → register), then
 runs the same polling loop the real Lua agent runs:

--- a/docs/architecture-critique.md
+++ b/docs/architecture-critique.md
@@ -267,9 +267,9 @@ failover transition. It is a magic number with no design home:
 - Is it negotiated?
 
 Currently it's a hard-coded constant in `policy.lua`'s `failover_transition`
-([policy.lua:386](openwrt/files/usr/lib/lua/familydns/policy.lua:386)) AND
+([policy.lua:386](openwrt/files/usr/lib/lua/wifihaven/policy.lua:386)) AND
 in `render.lua`'s `poll_age > 300` check
-([render.lua:230](openwrt/files/usr/lib/lua/familydns/render.lua:230)). To
+([render.lua:230](openwrt/files/usr/lib/lua/wifihaven/render.lua:230)). To
 change the threshold, the agent has to be re-released and re-installed —
 which is exactly when you'd want to change it (incident response).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,7 +159,7 @@ for usage attribution (§7.2). It is **never** the enforcement plane.
 >   A records, but AAAA replies are not captured into a parallel `eb6_<host>`
 >   v6 set, so a blocked host that resolves over v6 escapes the drop (#392).
 > - `blocklistIds` / category blocking is not applied on the router at all.
->   `render.lua` and `familydns-agent` do not fetch RPZ files or render
+>   `render.lua` and `wifihaven-agent` do not fetch RPZ files or render
 >   category rules. `PolicyService.decide` uses categories only on the
 >   fallback `POST /api/router/decision` endpoint (#352).
 > - `blockIpOnly` is carried in the snapshot but not yet enforced (#353).
@@ -563,11 +563,11 @@ guidance, not part of the wire contract.
 - **nftables counter objects** keyed on `ether saddr . ip daddr` for per-MAC,
   per-IP byte counts.
 - **dnsmasq query log** (`--log-queries=extra`, written to a private file at
-  `/tmp/familydns-dnsmasq.log`) is the primary source for `dst_ip → hostname`
+  `/tmp/wifihaven-dnsmasq.log`) is the primary source for `dst_ip → hostname`
   attribution on every connection event. A sidecar process
-  (`familydns-dns-tail`) tails the file, parses `query[A] <name>` and
+  (`wifihaven-dns-tail`) tails the file, parses `query[A] <name>` and
   `reply <name> is <ip>` lines into a TTL-bounded cache, and writes a snapshot
-  to `/tmp/familydns-dns-cache.txt`. The main agent reads the snapshot when a
+  to `/tmp/wifihaven-dns-cache.txt`. The main agent reads the snapshot when a
   new conntrack flow arrives.
 - **uhttpd** on a loopback port serves the local block page; nftables `dnat`
   redirects blocked HTTP/80 to it.
@@ -603,15 +603,15 @@ UI can render direct-IP rows distinguishably from named hosts.
 openwrt/
 ├── Makefile                            # opkg metadata, builds via OpenWRT SDK
 ├── files/
-│   ├── etc/init.d/familydns            # procd init script
-│   ├── etc/config/familydns            # UCI: api_url, router_token, poll_interval
-│   ├── usr/sbin/familydns-agent        # main daemon (Lua)
-│   ├── usr/sbin/familydns-dns-tail     # dnsmasq query-log tailer (sidecar)
-│   ├── usr/lib/lua/familydns/policy.lua    # snapshot fetcher, atomic apply
-│   ├── usr/lib/lua/familydns/usage.lua     # nftables counter scraper, reporter
-│   ├── usr/lib/lua/familydns/dns_log.lua   # forward-lookup hostname cache (#259)
-│   ├── usr/lib/lua/familydns/render.lua    # writes dnsmasq + nft fragments
-│   └── www/familydns/block.html        # local block page → 302 to api /blocked
+│   ├── etc/init.d/wifihaven            # procd init script
+│   ├── etc/config/wifihaven            # UCI: api_url, router_token, poll_interval
+│   ├── usr/sbin/wifihaven-agent        # main daemon (Lua)
+│   ├── usr/sbin/wifihaven-dns-tail     # dnsmasq query-log tailer (sidecar)
+│   ├── usr/lib/lua/wifihaven/policy.lua    # snapshot fetcher, atomic apply
+│   ├── usr/lib/lua/wifihaven/usage.lua     # nftables counter scraper, reporter
+│   ├── usr/lib/lua/wifihaven/dns_log.lua   # forward-lookup hostname cache (#259)
+│   ├── usr/lib/lua/wifihaven/render.lua    # writes dnsmasq + nft fragments
+│   └── www/wifihaven/block.html        # local block page → 302 to api /blocked
 └── README.md
 ```
 
@@ -687,9 +687,9 @@ opnsense/
 ├── pkg-descr
 ├── Makefile
 ├── files/
-│   ├── usr/local/etc/rc.d/familydns     # rc.d service
+│   ├── usr/local/etc/rc.d/wifihaven     # rc.d service
 │   ├── usr/local/etc/wifihaven.conf     # api_url, router_token, poll_interval
-│   └── usr/local/sbin/familydns-agent   # main daemon (Python)
+│   └── usr/local/sbin/wifihaven-agent   # main daemon (Python)
 └── README.md
 ```
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -106,7 +106,7 @@ This polls ghcr.io once a day (with a 5-min post-boot run so a freshly
 rebooted host catches up quickly). `docker compose pull` is a no-op when
 `latest` already matches the local digest, so it's cheap. To pull a new
 image **on demand** rather than wait for the daily tick, run
-`systemctl start wifihaven-update.service` (or the `familydns-update-now`
+`systemctl start wifihaven-update.service` (or the `wifihaven-update-now`
 operator skill).
 
 **User-mode installs** (`WIFIHAVEN_PREFIX=$HOME/.wifihaven`): `install.sh`
@@ -135,7 +135,7 @@ After that, run updates by hand from the install dir:
 The agent is pure Lua (`PKGARCH:=all`), so no cross-compilation is needed.
 `openwrt/build-ipk.sh` assembles the `.ipk` without the full OpenWRT SDK.
 
-Output: `openwrt/familydns_<version>-<release>_all.ipk`
+Output: `openwrt/wifihaven_<version>-<release>_all.ipk`
 
 ### 2.2 Build and publish: `.ipk` → GitHub Releases
 
@@ -155,7 +155,7 @@ router's auto-update script target the simple `releases/latest` endpoint
 - Push of a `v*` tag → build + attach to a GitHub Release.
 
 On a `v*` tag, `softprops/action-gh-release` creates the release named after
-the tag (e.g. `v0.2.0`) and attaches `openwrt/familydns_*.ipk`. The release
+the tag (e.g. `v0.2.0`) and attaches `openwrt/wifihaven_*.ipk`. The release
 is the distribution mechanism for the router.
 
 To cut a release:
@@ -164,7 +164,7 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-This produces `familydns_0.2.0-1_all.ipk` attached to the `v0.2.0` release
+This produces `wifihaven_0.2.0-1_all.ipk` attached to the `v0.2.0` release
 on GitHub. Routers running the auto-update script (§2.3) pick it up on their
 next poll.
 
@@ -185,11 +185,11 @@ canonical source of truth for versions.
 
 **Implementation** (sub-issue #131):
 
-Place at `/usr/sbin/familydns-update` on the router:
+Place at `/usr/sbin/wifihaven-update` on the router:
 
 ```sh
 #!/bin/sh
-CURRENT=$(opkg info familydns | awk '/^Version:/{print $2}')
+CURRENT=$(opkg info wifihaven | awk '/^Version:/{print $2}')
 LATEST_URL=$(curl -sf https://api.github.com/repos/wifihaven/wifihaven/releases/latest \
   | jsonfilter -e '@.assets[0].browser_download_url')
 LATEST_VER=$(echo "$LATEST_URL" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+-[0-9]+')
@@ -201,14 +201,14 @@ fi
 
 Add to cron (`crontab -e` or `/etc/crontabs/root`):
 ```
-0 4 * * * /usr/sbin/familydns-update
+0 4 * * * /usr/sbin/wifihaven-update
 ```
 
 This checks once a day at 04:00 router-local time. The `.ipk` postinst
 installs this entry automatically and replaces any older entry from a
 previous package version (e.g. the historical `0 */6 * * *` cadence), so
 upgrades migrate the schedule without operator action. `opkg install --force-reinstall` preserves
-`/etc/config/familydns`, so the bearer token and router ID survive upgrades
+`/etc/config/wifihaven`, so the bearer token and router ID survive upgrades
 without re-enrollment.
 
 ### 2.4 Configuration persistence across upgrades
@@ -216,7 +216,7 @@ without re-enrollment.
 opkg's upgrade behavior for config files:
 - Files listed in `conffiles` (or installed under `/etc/config/`) are preserved
   across `opkg install --force-reinstall`.
-- `router_token` and `router_id` (written to `/etc/config/familydns` after
+- `router_token` and `router_id` (written to `/etc/config/wifihaven` after
   enrollment) survive any upgrade.
 - `api_url` is in the same UCI config file and also survives; no re-configuration
   needed after an upgrade.

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -196,8 +196,8 @@ Edit `.env` and set each variable. **Never commit this file.** All values:
 
 | Variable | Required? | Purpose | How to set |
 |----------|-----------|---------|------------|
-| `WIFIHAVEN_DB_NAME` | yes | Postgres database name. | Leave the default (`familydns`) unless you have a reason to change it. |
-| `WIFIHAVEN_DB_USER` | yes | Postgres role used by the API. | Leave the default (`familydns`). |
+| `WIFIHAVEN_DB_NAME` | yes | Postgres database name. | Leave the default (`wifihaven`) unless you have a reason to change it. |
+| `WIFIHAVEN_DB_USER` | yes | Postgres role used by the API. | Leave the default (`wifihaven`). |
 | `WIFIHAVEN_DB_PASSWORD` | yes | Postgres password. Postgres is on the internal compose network only — but use a strong password anyway. | `openssl rand -base64 24` |
 | `WIFIHAVEN_JWT_SECRET` | yes | HMAC secret used to sign user session tokens. **Must be ≥32 random characters.** Anyone with this secret can mint admin tokens. | `openssl rand -base64 48` |
 | `WIFIHAVEN_JWT_HOURS` | no (default `24`) | Session token lifetime in hours. | Leave default unless you need shorter sessions. |
@@ -210,7 +210,7 @@ After editing, `chmod 600 .env` so secrets aren't world-readable.
 
 ## 4. Start the stack
 
-From `/opt/familydns/deploy`:
+From `/opt/wifihaven/deploy`:
 
 ```sh
 docker compose -f docker-compose.prod.yml --env-file .env up -d
@@ -314,7 +314,7 @@ reverse proxy and bind the API to `127.0.0.1` by setting
 `/etc/caddy/Caddyfile`:
 
 ```caddy
-familydns.example.com {
+wifihaven.example.com {
     reverse_proxy 127.0.0.1:8080
 }
 ```
@@ -327,15 +327,15 @@ sudo systemctl reload caddy
 
 ### 7.2 nginx
 
-`/etc/nginx/sites-available/familydns`:
+`/etc/nginx/sites-available/wifihaven`:
 
 ```nginx
 server {
     listen 443 ssl http2;
-    server_name familydns.example.com;
+    server_name wifihaven.example.com;
 
-    ssl_certificate     /etc/letsencrypt/live/familydns.example.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/familydns.example.com/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/wifihaven.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/wifihaven.example.com/privkey.pem;
 
     # The API streams responses for some endpoints; keep timeouts generous.
     proxy_read_timeout 300s;
@@ -354,7 +354,7 @@ server {
 
 server {
     listen 80;
-    server_name familydns.example.com;
+    server_name wifihaven.example.com;
     return 301 https://$host$request_uri;
 }
 ```
@@ -362,7 +362,7 @@ server {
 Issue/renew the cert with `certbot --nginx`, then:
 
 ```sh
-sudo ln -s /etc/nginx/sites-available/familydns /etc/nginx/sites-enabled/
+sudo ln -s /etc/nginx/sites-available/wifihaven /etc/nginx/sites-enabled/
 sudo nginx -t && sudo systemctl reload nginx
 ```
 
@@ -468,7 +468,7 @@ docker compose \
   -f deploy/docker-compose.prod.yml \
   -f deploy/docker-compose.debug.yml \
   --env-file deploy/.env up -d
-psql -h 127.0.0.1 -p 5433 -U familydns familydns
+psql -h 127.0.0.1 -p 5433 -U wifihaven wifihaven
 ```
 
 Override the bind with `WIFIHAVEN_DB_BIND=127.0.0.1:5433` in `deploy/.env`
@@ -485,12 +485,12 @@ docker compose -f deploy/docker-compose.prod.yml --env-file deploy/.env up -d
 
 ## 10. Next steps
 
-- **Auto-update.** Enabled by default via `familydns-update.timer` (installed
+- **Auto-update.** Enabled by default via `wifihaven-update.timer` (installed
   by `deploy/install.sh`). The host pulls and restarts on each new `latest`
   build, once a day. See `deploy.md §1.3` to disable or force an on-demand pull.
 - **Enroll a router.** In the admin UI, **Routers → Add router** generates
   an enrollment token. Then follow `docs/install-openwrt.md` (issue #133)
   on the OpenWRT side.
-- **Backups.** `docker compose exec postgres pg_dump -U familydns familydns`
+- **Backups.** `docker compose exec postgres pg_dump -U wifihaven wifihaven`
   produces a logical dump. Schedule it however you back up the rest of the
   host.

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -60,12 +60,12 @@ It then:
    24.10+/SNAPSHOT), downloads the matching asset (`.ipk` or `.apk`) from
    the latest GitHub release, and installs it (`opkg install …` or
    `apk add --allow-untrusted …`).
-2. Writes `api_url` and `lan_prefix` to `/etc/config/familydns`.
+2. Writes `api_url` and `lan_prefix` to `/etc/config/wifihaven`.
 3. POSTs `/api/router/register` to exchange the enrollment token for a
    `routerId` and `routerToken`, and writes both to UCI.
 4. Adds a `uhttpd` listener on `127.0.0.1:8081` for the local block page
    (idempotent — skipped if already configured).
-5. Enables and starts the `familydns` procd service.
+5. Enables and starts the `wifihaven` procd service.
 
 If anything goes wrong it aborts before starting the agent, leaving the
 router in a clean state so you can re-run after fixing the underlying issue.
@@ -75,24 +75,24 @@ router in a clean state so you can re-run after fixing the underlying issue.
 Download and inspect the script first:
 
 ```sh
-uclient-fetch -qO /tmp/familydns-install.sh \
+uclient-fetch -qO /tmp/wifihaven-install.sh \
   https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/install.sh
-less /tmp/familydns-install.sh
-sh /tmp/familydns-install.sh
+less /tmp/wifihaven-install.sh
+sh /tmp/wifihaven-install.sh
 ```
 
 ### Uninstalling
 
 To cleanly revert the install (stop and disable the service, remove the
-package, drop the uhttpd block-page listener, wipe the familydns UCI
+package, drop the uhttpd block-page listener, wipe the wifihaven UCI
 config):
 
 ```sh
 sh -c "$(uclient-fetch -qO - https://raw.githubusercontent.com/wifihaven/wifihaven/main/openwrt/uninstall.sh)"
 ```
 
-Pass `--purge` to additionally remove `/usr/lib/familydns` and
-`/usr/lib/lua/familydns` (manual-workaround leftovers from older e2e
+Pass `--purge` to additionally remove `/usr/lib/wifihaven` and
+`/usr/lib/lua/wifihaven` (manual-workaround leftovers from older e2e
 shakeouts). The script is idempotent — re-running on an already-clean
 router exits 0.
 
@@ -100,15 +100,15 @@ router exits 0.
 
 ```sh
 # Tail the system log for agent output:
-logread -f | grep familydns
+logread -f | grep wifihaven
 ```
 
 On a healthy start you should see lines like:
 
 ```
-[familydns] starting conntrack watcher
-[familydns] policy snapshot fetched, etag=…
-[familydns] flushed N events to /api/router/events
+[wifihaven] starting conntrack watcher
+[wifihaven] policy snapshot fetched, etag=…
+[wifihaven] flushed N events to /api/router/events
 ```
 
 Then check the admin UI: **Routers → `<your router name>`** should show a
@@ -122,7 +122,7 @@ auto-update cron job is tracked in
 [#131](https://github.com/wifihaven/wifihaven/issues/131). Until then,
 upgrade manually by re-running the one-shot install command from §2 — the
 script's install step (`opkg install` or `apk add --allow-untrusted`) uses
-the standard upgrade path, which preserves `/etc/config/familydns`, so the
+the standard upgrade path, which preserves `/etc/config/wifihaven`, so the
 router credentials survive and no re-enrollment is needed.
 
 ## Manual install (fallback)
@@ -165,7 +165,7 @@ apk add --allow-untrusted /tmp/wifihaven.apk
 
 Either manager resolves and installs `lua`, `luci-lib-jsonc`,
 `conntrack-tools`, and `curl`. The post-install hook enables the
-`familydns` procd service for autostart but does **not** start it yet —
+`wifihaven` procd service for autostart but does **not** start it yet —
 enrollment must complete first.
 
 ### M3. Configure the API URL and LAN prefix
@@ -212,7 +212,7 @@ uci commit wifihaven
 ### M6. Set up the local block page
 
 When the agent blocks an HTTP request, it DNATs port 80 to `127.0.0.1:8081`.
-A local `uhttpd` instance serves `/www/familydns/block.html`, which the
+A local `uhttpd` instance serves `/www/wifihaven/block.html`, which the
 agent installs. The block page redirects the browser to the API's
 `/blocked?host=…&reason=…` endpoint.
 

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -29,7 +29,7 @@ provision ourselves.
   - `binutils` (for `ar`, used by `openwrt/build-ipk.sh`)
 
 Use `docs/vm-e2e-ubuntu.md` as the per-host bootstrap checklist: it covers
-`/dev/kvm` group membership, the `fdns-lan0` bridge, `qemu-bridge-helper`
+`/dev/kvm` group membership, the `wh-lan0` bridge, `qemu-bridge-helper`
 capabilities, and the narrow `NOPASSWD` rule for `ip`.
 
 ### Suggested hosts
@@ -94,7 +94,7 @@ The runner installs under `~/actions-runner` in the runner user's home directory
    ./config.sh \
      --url https://github.com/wifihaven/wifihaven \
      --token <REGISTRATION_TOKEN> \
-     --name familydns-kvm-1 \
+     --name wifihaven-kvm-1 \
      --labels self-hosted,linux,kvm \
      --work _work \
      --unattended
@@ -138,8 +138,8 @@ execution is unprivileged:
 |---|---|
 | `/dev/kvm` read/write | runner user is in the `kvm` group |
 | docker socket | runner user is in the `docker` group |
-| attach taps to `fdns-lan0` | `cap_net_admin` on `qemu-bridge-helper` (`setcap`) + `/etc/qemu/bridge.conf` allowlists the bridge |
-| `ip link add/set …` for the LAN bridge | NOPASSWD sudo rule in `/etc/sudoers.d/familydns-vm`, scoped to `/usr/sbin/ip` only |
+| attach taps to `wh-lan0` | `cap_net_admin` on `qemu-bridge-helper` (`setcap`) + `/etc/qemu/bridge.conf` allowlists the bridge |
+| `ip link add/set …` for the LAN bridge | NOPASSWD sudo rule in `/etc/sudoers.d/wifihaven-vm`, scoped to `/usr/sbin/ip` only |
 | outbound HTTPS to GitHub | none (standard outbound) |
 
 All of these are part of the one-time host bootstrap in

--- a/docs/resilience.md
+++ b/docs/resilience.md
@@ -18,7 +18,7 @@ router is not a wifihaven concern.
 
 ### Intended behavior
 - **Identity survives.** On boot, the agent restores `router_id` and
-  `router_token` from `/etc/config/familydns`. It never re-enrolls if a token
+  `router_token` from `/etc/config/wifihaven`. It never re-enrolls if a token
   is already present — re-enrollment must be an explicit operator action.
 - **No traffic forwards before policy is applied.** Between kernel boot and
   the agent's first successful `policy.apply()`, forwarded LAN→WAN traffic
@@ -50,7 +50,7 @@ A clean power-cycle losing < 60 seconds of usage data is materially harmless
   nft include that loads on firewall start, before the agent runs.
 - Agent removes the deny rules atomically as part of its first
   `policy.apply()`.
-- `familydns-agent` startup logic (already present): exit non-zero if
+- `wifihaven-agent` startup logic (already present): exit non-zero if
   router_id/token absent; never auto-enroll.
 
 ### How to verify
@@ -59,7 +59,7 @@ A clean power-cycle losing < 60 seconds of usage data is materially harmless
    across the reboot. Expectation: ping fails throughout the reboot
    window and only resumes after the agent logs `policy applied` —
    no "unfiltered window" where ping resumes ahead of policy.
-3. Confirm `/etc/config/familydns` retains `router_id`/`router_token`
+3. Confirm `/etc/config/wifihaven` retains `router_id`/`router_token`
    across reboots; agent log shows "using cached credentials," not
    "enrolling."
 
@@ -70,7 +70,7 @@ A clean power-cycle losing < 60 seconds of usage data is materially harmless
 ### Intended behavior
 - **Agent rides through.** While the API is unreachable, the agent continues
   enforcing from its **last-applied policy snapshot**, which is persisted to
-  flash (`/etc/familydns/policy.json` or similar) on every successful poll.
+  flash (`/etc/wifihaven/policy.json` or similar) on every successful poll.
   Tmpfs is not enough — a reboot during the API outage would otherwise drop
   the router to default-deny (§1), which is correct for safety but disruptive
   for adults; the on-flash snapshot lets the router come back up enforcing
@@ -104,11 +104,11 @@ DB with one giant batched usage POST per router, but it SHOULD restore
 correct policy within one poll interval.
 
 ### Implementation
-- `openwrt/files/usr/lib/lua/familydns/policy.lua`: write snapshot to
-  `/etc/familydns/policy.json` after each successful apply.
-- `openwrt/files/usr/lib/lua/familydns/usage.lua`: maintain in-memory
+- `openwrt/files/usr/lib/lua/wifihaven/policy.lua`: write snapshot to
+  `/etc/wifihaven/policy.json` after each successful apply.
+- `openwrt/files/usr/lib/lua/wifihaven/usage.lua`: maintain in-memory
   retry queue; on failure, exponential backoff per-bucket.
-- `openwrt/files/usr/lib/lua/familydns/conntrack.lua`: same retry-queue
+- `openwrt/files/usr/lib/lua/wifihaven/conntrack.lua`: same retry-queue
   pattern for events POSTs (#330); cap = 1000 batches, drop-oldest on
   overflow; drained from the conntrack watcher loop on every tick.
 - Agent main loop: track `last_fetch_ok` for the most-recent poll;
@@ -236,15 +236,15 @@ never a default — it must be picked deliberately.
 - `api/src/policy/PolicyService.scala`: includes `failureMode` per
   `ProfilePolicy` in the rendered `PolicySnapshot`. The ETag covers
   this value so a mode change invalidates client caches.
-- `openwrt/files/usr/lib/lua/familydns/policy.lua`: on every failed
+- `openwrt/files/usr/lib/lua/wifihaven/policy.lua`: on every failed
   poll, renders nft with `opts.poll_failed = true`; on the next
   successful poll, renders with `opts.poll_failed = false` to clear the
   failover chain (#422). `last_successful_poll_ts` is retained for
   human-readable log lines only.
-- `openwrt/files/usr/lib/lua/familydns/render.lua`: branches by mode.
+- `openwrt/files/usr/lib/lua/wifihaven/render.lua`: branches by mode.
   `BlockAll` emits a dedicated `failover_drop` set and drop chain.
   `AllowAll` suppresses the profile's MACs from every drop list before
-  the `familydns_block` and `familydns_block_nat` chains are rendered.
+  the `wifihaven_block` and `wifihaven_block_nat` chains are rendered.
   `LastKnownGood` is the no-op default — nothing additional is
   rendered, and the cached snapshot rules keep enforcing exactly.
 - Admin UI: three-option radio on the profile edit page (`ProfilesPage`)

--- a/docs/vm-e2e-ubuntu.md
+++ b/docs/vm-e2e-ubuntu.md
@@ -56,7 +56,7 @@ hooks on some hosts — the `usermod` route is more reliable.
 
 ### LAN bridge + `qemu-bridge-helper`
 
-`client-up.sh` attaches the client VM's LAN NIC to the `fdns-lan0` bridge
+`client-up.sh` attaches the client VM's LAN NIC to the `wh-lan0` bridge
 via `qemu-bridge-helper`, which is not setuid by default on Ubuntu and
 which refuses to attach to bridges that aren't in `/etc/qemu/bridge.conf`.
 Both need fixing once:
@@ -64,7 +64,7 @@ Both need fixing once:
 ```bash
 sudo bash -c '
   mkdir -p /etc/qemu
-  echo "allow fdns-lan0" > /etc/qemu/bridge.conf
+  echo "allow wh-lan0" > /etc/qemu/bridge.conf
   setcap cap_net_admin+ep /usr/lib/qemu/qemu-bridge-helper
 '
 ```
@@ -81,8 +81,8 @@ password each run. Grant a narrow `NOPASSWD` rule for `ip` only:
 ```bash
 sudo bash -c "
   echo '$USER ALL=(root) NOPASSWD: /usr/sbin/ip, /sbin/ip' \
-    > /etc/sudoers.d/familydns-vm
-  chmod 0440 /etc/sudoers.d/familydns-vm
+    > /etc/sudoers.d/wifihaven-vm
+  chmod 0440 /etc/sudoers.d/wifihaven-vm
 "
 ```
 
@@ -97,7 +97,7 @@ After the one-time setup, the per-session sequence is fully unprivileged:
 # 1. Build the client base image (~30 s the first time, instant after).
 scripts/vm/build-client-base.sh
 
-# 2. Build the custom OpenWRT router image with familydns-agent baked in
+# 2. Build the custom OpenWRT router image with wifihaven-agent baked in
 #    (#150, ~60 s after caches are warm). Required for the LAN to be on
 #    192.168.100.0/24 per the e2e plan in #226.
 scripts/vm/build-router-image.sh
@@ -105,8 +105,8 @@ scripts/vm/build-router-image.sh
 # 3. Bring up the router VM. Point at the custom image with an absolute
 #    path, and pick a non-conflicting host HTTP-forward port if 8080 is
 #    already taken on the host (e.g. by a running wifihaven API stack).
-FDNS_ROUTER_HTTP_PORT=18081 \
-FDNS_ROUTER_IMAGE_PATH="$PWD/scripts/vm/.cache/openwrt-wifihaven.img" \
+WH_ROUTER_HTTP_PORT=18081 \
+WH_ROUTER_IMAGE_PATH="$PWD/scripts/vm/.cache/openwrt-wifihaven.img" \
     scripts/vm/router-up.sh
 
 # 4. Bring up a client with a chosen MAC.
@@ -124,11 +124,11 @@ scripts/vm/router-down.sh
 ## Known gotchas on Ubuntu
 
 - **Port 8080 collisions.** If you already run a wifihaven deploy on the
-  host (e.g. via `/home/$USER/.familydns/docker-compose.yml`), the
+  host (e.g. via `/home/$USER/.wifihaven/docker-compose.yml`), the
   router VM's default HTTP forward (`-hostfwd tcp:127.0.0.1:8080-:80`)
   will fail with `Could not set up host forwarding rule`. Override via
-  `FDNS_ROUTER_HTTP_PORT=18081 scripts/vm/router-up.sh` and adjust your
-  own SSH forward (`FDNS_ROUTER_SSH_PORT`) similarly if 2222 is taken.
+  `WH_ROUTER_HTTP_PORT=18081 scripts/vm/router-up.sh` and adjust your
+  own SSH forward (`WH_ROUTER_SSH_PORT`) similarly if 2222 is taken.
 
 - **Image Builder leaves root-owned files in `.cache/`.** OpenWRT's
   Image Builder runs inside a Debian container as root, and its
@@ -149,7 +149,7 @@ scripts/vm/router-down.sh
   Permission denied` after it was working, use the `usermod -aG kvm`
   approach above instead of `setfacl`.
 
-- **Bridge MTU.** `lan-bridge-up.sh` creates `fdns-lan0` without setting
+- **Bridge MTU.** `lan-bridge-up.sh` creates `wh-lan0` without setting
   an MTU; the default 1500 is fine for the e2e plan, but if you bridge
   this to a tun/tap with smaller MTU you'll see TCP stalls.
 
@@ -165,7 +165,7 @@ done
 test -r /dev/kvm && test -w /dev/kvm && echo "ok /dev/kvm" || echo "MISSING /dev/kvm rw"
 
 # Bridge + qemu-bridge-helper:
-grep -q "^allow fdns-lan0\b" /etc/qemu/bridge.conf && echo "ok bridge.conf"
+grep -q "^allow wh-lan0\b" /etc/qemu/bridge.conf && echo "ok bridge.conf"
 getcap /usr/lib/qemu/qemu-bridge-helper | grep -q cap_net_admin && echo "ok qemu-bridge-helper cap"
 
 # Passwordless ip:

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -59,27 +59,6 @@ define Package/wifihaven/postinst
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] && exit 0
 
-# One-shot migration from pre-rename familydns config (issue #357).
-if [ -f /etc/config/familydns ] && [ ! -s /etc/config/wifihaven ]; then
-    # Copy old UCI section name to the new section name as we move it.
-    sed 's/familydns/wifihaven/g' /etc/config/familydns > /etc/config/wifihaven
-    rm -f /etc/config/familydns
-fi
-if [ -d /var/lib/familydns ] && [ ! -d /var/lib/wifihaven ]; then
-    mv /var/lib/familydns /var/lib/wifihaven
-fi
-# Stop and remove old service scripts if still present from a pre-rename install.
-if [ -x /etc/init.d/familydns ]; then
-    /etc/init.d/familydns stop 2>/dev/null || true
-    /etc/init.d/familydns disable 2>/dev/null || true
-    rm -f /etc/init.d/familydns /etc/init.d/familydns-boot
-fi
-# Drop the stale nftables tables created by the old daemon. The new agent
-# will create `inet wifihaven` / `inet wifihaven_boot` on its first policy
-# render; leaving the old tables around is harmless but confusing.
-nft delete table inet familydns 2>/dev/null || true
-nft delete table inet familydns_boot 2>/dev/null || true
-
 /etc/init.d/wifihaven enable
 # #308: enable the boot default-deny skeleton init script so every reboot
 # loads it before fw4 brings forwarding up. Also load it now so the very

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -79,22 +79,6 @@ fi
 cat > "$WORK/post-install" <<'POSTINSTALL'
 #!/bin/sh
 
-# One-shot migration from pre-rename familydns config (issue #357).
-if [ -f /etc/config/familydns ] && [ ! -s /etc/config/wifihaven ]; then
-    # Copy old UCI section name to the new section name as we move it.
-    sed 's/familydns/wifihaven/g' /etc/config/familydns > /etc/config/wifihaven
-    rm -f /etc/config/familydns
-fi
-if [ -d /var/lib/familydns ] && [ ! -d /var/lib/wifihaven ]; then
-    mv /var/lib/familydns /var/lib/wifihaven
-fi
-# Stop and remove old service scripts if still present from a pre-rename install.
-if [ -x /etc/init.d/familydns ]; then
-    /etc/init.d/familydns stop 2>/dev/null || true
-    /etc/init.d/familydns disable 2>/dev/null || true
-    rm -f /etc/init.d/familydns /etc/init.d/familydns-boot
-fi
-
 /etc/init.d/wifihaven enable
 # #308: enable + start the boot default-deny skeleton init so first install
 # (no reboot) is protected immediately, and every subsequent boot loads it

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -36,22 +36,6 @@ cat > "$WORK/ctrl/postinst" <<'POSTINST'
 #!/bin/sh
 [ -n "$IPKG_INSTROOT" ] && exit 0
 
-# One-shot migration from pre-rename familydns config (issue #357).
-if [ -f /etc/config/familydns ] && [ ! -s /etc/config/wifihaven ]; then
-    # Copy old UCI section name to the new section name as we move it.
-    sed 's/familydns/wifihaven/g' /etc/config/familydns > /etc/config/wifihaven
-    rm -f /etc/config/familydns
-fi
-if [ -d /var/lib/familydns ] && [ ! -d /var/lib/wifihaven ]; then
-    mv /var/lib/familydns /var/lib/wifihaven
-fi
-# Stop and remove old service scripts if still present from a pre-rename install.
-if [ -x /etc/init.d/familydns ]; then
-    /etc/init.d/familydns stop 2>/dev/null || true
-    /etc/init.d/familydns disable 2>/dev/null || true
-    rm -f /etc/init.d/familydns /etc/init.d/familydns-boot
-fi
-
 /etc/init.d/wifihaven enable
 # #308: enable + start the boot default-deny skeleton init so first install
 # (no reboot) is protected immediately, and every subsequent boot loads it

--- a/opnsense/manifest.xml
+++ b/opnsense/manifest.xml
@@ -2,10 +2,10 @@
 <package>
   <name>os-wifihaven</name>
   <version>0.1.0</version>
-  <comment>FamilyDNS router agent for OPNsense</comment>
+  <comment>WifiHaven router agent for OPNsense</comment>
   <desc>
     Tails pflog0 for new outbound flows, attributes hostnames via the Unbound
-    query log, and streams connection_attempt events to the FamilyDNS API
+    query log, and streams connection_attempt events to the WifiHaven API
     (POST /api/router/events).  Policy rendering and usage reporting are
     planned for a follow-up release.
   </desc>

--- a/scripts/ci/kvm-runner.service
+++ b/scripts/ci/kvm-runner.service
@@ -1,4 +1,4 @@
-## systemd unit template for the FamilyDNS KVM self-hosted GitHub Actions runner.
+## systemd unit template for the WifiHaven KVM self-hosted GitHub Actions runner.
 ##
 ## Install via:
 ##   sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
@@ -14,7 +14,7 @@
 ## user's home directory.
 
 [Unit]
-Description=GitHub Actions runner (FamilyDNS, KVM)
+Description=GitHub Actions runner (WifiHaven, KVM)
 After=network-online.target docker.service
 Wants=network-online.target
 
@@ -44,7 +44,7 @@ RestartSec=10
 #
 # NoNewPrivileges is deliberately NOT set: scripts/vm/lan-bridge-up.sh
 # (called by router-up.sh) runs `sudo ip link …` via the NOPASSWD rule in
-# /etc/sudoers.d/familydns-vm (see docs/ops/kvm-runner.md § "Host setup").
+# /etc/sudoers.d/wifihaven-vm (see docs/ops/kvm-runner.md § "Host setup").
 # NoNewPrivileges=true would refuse the setuid transition and break VM
 # bring-up with:
 #   sudo: The "no new privileges" flag is set, which prevents sudo from

--- a/scripts/deploy-api-from-branch.sh
+++ b/scripts/deploy-api-from-branch.sh
@@ -3,7 +3,7 @@
 # server itself from a chosen branch. No registry push, no image transfer.
 #
 # Server layout:
-#   ~/familydns/   git checkout (source)
+#   ~/wifihaven/   git checkout (source)
 #   ~/.wifihaven/  runtime: docker-compose.prod.yml, .env, helper scripts
 #
 # The runtime compose file pins ghcr.io/wifihaven/wifihaven-api:latest.
@@ -24,7 +24,7 @@
 set -euo pipefail
 
 API_HOST="${API_HOST:-192.168.10.43}"
-SRC_DIR="${SRC_DIR:-\$HOME/familydns}"
+SRC_DIR="${SRC_DIR:-\$HOME/wifihaven}"
 RUN_DIR="${RUN_DIR:-\$HOME/.wifihaven}"
 IMAGE="ghcr.io/wifihaven/wifihaven-api:latest"
 BRANCH="${1:-main}"

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # One-shot local validation: bring up an isolated staging stack and run
 # both e2e suites against it. Safe to run alongside a separately-deployed
-# familydns stack — uses a distinct compose project + ports.
+# wifihaven stack — uses a distinct compose project + ports.
 #
 # Usage:
 #   scripts/e2e-local.sh                # build (if needed), run, tear down
@@ -13,7 +13,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 PORT="${E2E_PORT:-18080}"
-PROJECT="${E2E_PROJECT:-familydns-e2e}"
+PROJECT="${E2E_PROJECT:-wifihaven-e2e}"
 COMPOSE=(docker compose -p "$PROJECT" -f docker/docker-compose.yml)
 
 # Override the api service's host port via an inline compose override so we

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -19,7 +19,7 @@
 #   E2E_VM_KEEP=1           don't tear down VMs (router + clients)
 #   E2E_VM_SKIP_STACK=1     assume stack already up at $E2E_VM_API_PORT
 #   E2E_VM_SKIP_VMS=1       skip VM-dependent tests (CI sanity mode)
-#   FDNS_ROUTER_IMAGE_PATH  use a custom-built router image instead of stock
+#   WH_ROUTER_IMAGE_PATH  use a custom-built router image instead of stock
 #                           (required for v1; see scripts/vm/build-router-image.sh)
 
 set -euo pipefail

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -20,7 +20,7 @@ scripts/e2e-vm.sh --keep -- -k usage      # leave VMs/stack up; pytest -k passth
 ┌─────────── host ────────────┐
 │  docker compose             │      ┌── router VM ──┐    ┌── client VM ──┐
 │   ├ postgres                │      │ OpenWRT 23.05 │    │ Alpine 3.22   │
-│   └ api  (WIFIHAVEN_DEBUG=1)│◀─────┤ familydns-    │    │               │
+│   └ api  (WIFIHAVEN_DEBUG=1)│◀─────┤ wifihaven-    │    │               │
 │       :18080 (host port)    │ HTTP │ agent baked in│◀──▶│   eth0 (LAN)  │
 │                             │      │               │ DHCP│   curl/dig   │
 │  pytest orchestrator        │      │ eth1 = SLIRP  │ DNS │               │
@@ -144,7 +144,7 @@ VM-dependent tests `pytest.skip` themselves. Stack-only paths still run.
 `pytest_runtest_makereport` attaches three sections to every failed test:
 
 1. Router VM serial console tail (`scripts/vm/.run/router/console.log`)
-2. `logread -e familydns | tail -n 80` from the router (agent log)
+2. `logread -e wifihaven | tail -n 80` from the router (agent log)
 3. `docker compose logs api --tail 120`
 
 These appear in the standard pytest captured-output footer.

--- a/scripts/e2e/conftest.py
+++ b/scripts/e2e/conftest.py
@@ -40,7 +40,7 @@ from lib.wait import (
 log = logging.getLogger(__name__)
 
 API_PORT = int(os.environ.get("E2E_VM_API_PORT", "18080"))
-ROUTER_IMAGE_PATH = os.environ.get("FDNS_ROUTER_IMAGE_PATH")  # custom image w/ agent baked in
+ROUTER_IMAGE_PATH = os.environ.get("WH_ROUTER_IMAGE_PATH")  # custom image w/ agent baked in
 KEEP_VMS = os.environ.get("E2E_VM_KEEP", "0") == "1"
 KEEP_STACK = os.environ.get("E2E_VM_KEEP_STACK", "0") == "1"
 SKIP_STACK = os.environ.get("E2E_VM_SKIP_STACK", "0") == "1"

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -27,8 +27,8 @@ ROUTER_SSH_USER = "root"
 # Router LuCI HTTP hostfwd. The orchestrator never uses LuCI but the underlying
 # router-up.sh always sets up the forward. Default 8080 collides with a
 # developer's docker-compose stack (and with our own e2e stack on certain
-# layouts), so pin it to a high port. Override with FDNS_ROUTER_HTTP_PORT.
-ROUTER_HTTP_PORT = int(os.environ.get("FDNS_ROUTER_HTTP_PORT", "18081"))
+# layouts), so pin it to a high port. Override with WH_ROUTER_HTTP_PORT.
+ROUTER_HTTP_PORT = int(os.environ.get("WH_ROUTER_HTTP_PORT", "18081"))
 
 # QEMU SLIRP gateway as seen from inside the router VM. The router VM's WAN is
 # user-mode networking, so it reaches the host (where the API stack runs) via
@@ -53,9 +53,9 @@ def router_up(*, image_path: str | None = None, wait_ssh_timeout: float = 180) -
     """
     env = os.environ.copy()
     if image_path:
-        env["FDNS_ROUTER_IMAGE_PATH"] = image_path
-    env.setdefault("FDNS_ROUTER_HTTP_PORT", str(ROUTER_HTTP_PORT))
-    env.setdefault("FDNS_ROUTER_SSH_PORT", str(ROUTER_SSH_PORT))
+        env["WH_ROUTER_IMAGE_PATH"] = image_path
+    env.setdefault("WH_ROUTER_HTTP_PORT", str(ROUTER_HTTP_PORT))
+    env.setdefault("WH_ROUTER_SSH_PORT", str(ROUTER_SSH_PORT))
     res = run([_vm_script("router-up.sh")], env=env, timeout=300)
     _wait_for_router_ssh(timeout_s=wait_ssh_timeout)
     return res

--- a/scripts/e2e/scenarios/test_03_blocked_domain.py
+++ b/scripts/e2e/scenarios/test_03_blocked_domain.py
@@ -33,7 +33,7 @@ def test_blocked_domain_request_dropped(
         probe = http_get(client, f"http://{BLOCKED_HOST}/", timeout_s=8)
         body_lower = (probe.body or "").lower()
         if probe.http_code == 200 and (
-            "familydns" in body_lower or "blocked" in body_lower
+            "wifihaven" in body_lower or "blocked" in body_lower
         ):
             return probe
         return None

--- a/scripts/e2e/scenarios/test_06_blocked_page.py
+++ b/scripts/e2e/scenarios/test_06_blocked_page.py
@@ -2,7 +2,7 @@
 
 Per architecture Truth 1: blocked HTTP traffic is DNATed by nftables to the
 local block page on port 80. The page is served by uhttpd-mod-lua via the
-handler at /www/familydns/handler.lua (#437); the handler resolves the
+handler at /www/wifihaven/handler.lua (#437); the handler resolves the
 client MAC and per-MAC block reason, then returns an HTML document that
 redirects to the API's /blocked page with mac+reason populated. Curling a
 blocked HTTP destination should yield the block page body (its <title> is
@@ -34,7 +34,7 @@ def test_blocked_request_returns_block_page(
     # the DNAT rule is hot.
     def block_page_body():
         probe = http_get(client, f"http://{BLOCKED_HOST}/", timeout_s=8)
-        if probe.http_code == 200 and "familydns" in probe.body.lower():
+        if probe.http_code == 200 and "wifihaven" in probe.body.lower():
             return probe
         if probe.http_code == 200 and "blocked" in probe.body.lower():
             return probe

--- a/scripts/e2e/scenarios/test_extra_blocked.py
+++ b/scripts/e2e/scenarios/test_extra_blocked.py
@@ -50,7 +50,7 @@ BLOCKED_MACS_SET = "blocked_macs"
 
 # render.lua's sanitize() replaces "." and ":" with "_". `example.com`
 # becomes `eb_example_com` (v4) / `eb6_example_com` (v6). See
-# openwrt/files/usr/lib/lua/familydns/render.lua eb_set_name().
+# openwrt/files/usr/lib/lua/wifihaven/render.lua eb_set_name().
 EB_SET_V4 = "eb_" + BLOCKED_HOST.replace(".", "_").replace(":", "_")
 
 IPV4_LINE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
@@ -74,7 +74,7 @@ def _wait_block_page(client, *, host: str = BLOCKED_HOST, timeout_s: float = 90)
         p = http_get(client, f"http://{host}/", timeout_s=8)
         body_lower = (p.body or "").lower()
         if p.http_code == 200 and (
-            "familydns" in body_lower or "blocked" in body_lower
+            "wifihaven" in body_lower or "blocked" in body_lower
         ):
             return p
         return None

--- a/scripts/e2e/scenarios/test_pause.py
+++ b/scripts/e2e/scenarios/test_pause.py
@@ -53,7 +53,7 @@ def _wait_block_page(client, *, host: str = "example.com", timeout_s: float = 60
     def probe():
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code == 200 and (
-            "familydns" in p.body.lower() or "blocked" in p.body.lower()
+            "wifihaven" in p.body.lower() or "blocked" in p.body.lower()
         ):
             return p
         return None
@@ -66,7 +66,7 @@ def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float =
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code is not None and 200 <= p.http_code < 400:
             # block-page also returns 200, so disambiguate by body
-            if "familydns" in p.body.lower() or "blocked" in p.body.lower():
+            if "wifihaven" in p.body.lower() or "blocked" in p.body.lower():
                 return None
             return p
         return None

--- a/scripts/e2e/scenarios/test_reassignment.py
+++ b/scripts/e2e/scenarios/test_reassignment.py
@@ -52,7 +52,7 @@ def _wait_block_page(client, *, host: str = "example.com", timeout_s: float = 60
     def probe():
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code == 200 and (
-            "familydns" in p.body.lower() or "blocked" in p.body.lower()
+            "wifihaven" in p.body.lower() or "blocked" in p.body.lower()
         ):
             return p
         return None
@@ -65,7 +65,7 @@ def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float =
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code is not None and 200 <= p.http_code < 400:
             # block-page also returns 200, so disambiguate by body
-            if "familydns" in p.body.lower() or "blocked" in p.body.lower():
+            if "wifihaven" in p.body.lower() or "blocked" in p.body.lower():
                 return None
             return p
         return None

--- a/scripts/e2e/scenarios/test_schedule.py
+++ b/scripts/e2e/scenarios/test_schedule.py
@@ -70,7 +70,7 @@ def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float =
     def probe():
         p = http_get(client, f"http://{host}/", timeout_s=8)
         if p.http_code is not None and 200 <= p.http_code < 400:
-            if "familydns" in p.body.lower() or "blocked" in p.body.lower():
+            if "wifihaven" in p.body.lower() or "blocked" in p.body.lower():
                 return None
             return p
         return None

--- a/scripts/e2e/scenarios/test_unknown_device.py
+++ b/scripts/e2e/scenarios/test_unknown_device.py
@@ -13,7 +13,7 @@ What is NOT covered here — and why (#517)
 The previous F1b and F2 scenarios attempted to drive the auto-name /
 late-DHCP-rename paths from a single VM by hot-swapping eth0 to a fresh
 MAC + static IP and asserting that no DHCP lease ever attached the
-cloud-init-baked `fdns-client` hostname to the new MAC. Four attempts
+cloud-init-baked `wh-client` hostname to the new MAC. Four attempts
 across #468/PR#470, #475/PR#477, #483/PR#484 and #517 all hit the same
 leak: the fresh MAC appeared on the API with the boot-image hostname.
 

--- a/scripts/smoke-prod.sh
+++ b/scripts/smoke-prod.sh
@@ -15,8 +15,8 @@ ENV_FILE="$(mktemp)"
 trap 'rm -f "$ENV_FILE"; docker compose -f deploy/docker-compose.prod.yml --env-file "$ENV_FILE" down -v --remove-orphans >/dev/null 2>&1 || true' EXIT
 
 cat > "$ENV_FILE" <<'EOF'
-WIFIHAVEN_DB_NAME=familydns
-WIFIHAVEN_DB_USER=familydns
+WIFIHAVEN_DB_NAME=wifihaven
+WIFIHAVEN_DB_USER=wifihaven
 WIFIHAVEN_DB_PASSWORD=smoke-test-password
 WIFIHAVEN_JWT_SECRET=smoke-test-jwt-secret-min-32-chars-long-yes
 WIFIHAVEN_JWT_HOURS=24

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -16,8 +16,8 @@ of #144 (router VM) and #146 (client VM).
 - The LAN bridge from the router VM (#144) must already be up before
   `client-up.sh` runs. `router-up.sh` brings it up automatically; otherwise
   call `lan-bridge-up.sh` directly.
-- `/etc/qemu/bridge.conf` must contain `allow ${FDNS_LAN_BRIDGE}` (default
-  `allow fdns-lan0`) so `qemu-bridge-helper` will attach taps.
+- `/etc/qemu/bridge.conf` must contain `allow ${WH_LAN_BRIDGE}` (default
+  `allow wh-lan0`) so `qemu-bridge-helper` will attach taps.
 
 The harness is not expected to work on macOS — no KVM. Use a Linux dev host
 or CI runner. For running in CI, see
@@ -56,7 +56,7 @@ Each client gets two NICs:
 
 | iface | attached to                | purpose                                 |
 |-------|----------------------------|------------------------------------------|
-| eth0  | `${FDNS_LAN_BRIDGE}` bridge | LAN side. DHCP from router VM. **All real traffic** (DNS, HTTP, etc.) goes here. |
+| eth0  | `${WH_LAN_BRIDGE}` bridge | LAN side. DHCP from router VM. **All real traffic** (DNS, HTTP, etc.) goes here. |
 | eth1  | QEMU user-mode (SLIRP)     | Orchestrator SSH only (port-forwarded to `127.0.0.1:<ssh-port>`). **No default route**, **no DNS** — keeps the SSH path from leaking traffic around the router. |
 
 The DHCP-provided resolver on eth0 (the router) becomes the system resolver,
@@ -109,7 +109,7 @@ OpenWRT 23.05.6 x86/64 booted in QEMU/KVM with two NICs:
 
 | iface | attached to | purpose |
 |---|---|---|
-| eth0 | `${FDNS_LAN_BRIDGE}` bridge | LAN side — shared with client VMs (#146). |
+| eth0 | `${WH_LAN_BRIDGE}` bridge | LAN side — shared with client VMs (#146). |
 | eth1 | QEMU user-mode (SLIRP) | WAN side — gets NAT-to-internet for free, plus host port-forwards for orchestrator access. |
 
 OpenWRT's default board config assigns eth0→lan, eth1→wan, matching the order
@@ -133,23 +133,23 @@ snapshots) and can be inspected with `qemu-img snapshot -l`.
 ### Image pinning + bumping
 
 The OpenWRT version and SHA256 are pinned in [`config.sh`](config.sh)
-(`FDNS_OPENWRT_VERSION`, `FDNS_OPENWRT_SHA256`). To bump:
+(`WH_OPENWRT_VERSION`, `WH_OPENWRT_SHA256`). To bump:
 
-1. Edit `FDNS_OPENWRT_VERSION`.
+1. Edit `WH_OPENWRT_VERSION`.
 2. Fetch the new SHA256:
    ```bash
    curl -sSL "https://downloads.openwrt.org/releases/${VER}/targets/x86/64/sha256sums" \
      | grep generic-ext4-combined.img.gz
    ```
-3. Update `FDNS_OPENWRT_SHA256`.
+3. Update `WH_OPENWRT_SHA256`.
 4. `rm -rf scripts/vm/.cache scripts/vm/.run/router` and re-run `router-up.sh`.
 
 ### Host access
 
-- **SSH**: `ssh -p ${FDNS_ROUTER_SSH_PORT} root@127.0.0.1` (default 2222).
+- **SSH**: `ssh -p ${WH_ROUTER_SSH_PORT} root@127.0.0.1` (default 2222).
   Stock OpenWRT root password is empty on first boot — set one immediately or
   wait for #150 (custom image bakes in a known test password + SSH key).
-- **LuCI HTTP**: `http://127.0.0.1:${FDNS_ROUTER_HTTP_PORT}` (default 8080).
+- **LuCI HTTP**: `http://127.0.0.1:${WH_ROUTER_HTTP_PORT}` (default 8080).
 - **QEMU monitor** (savevm / loadvm / info network / system_powerdown):
   ```bash
   socat - UNIX-CONNECT:scripts/vm/.run/router/monitor.sock
@@ -193,10 +193,10 @@ Output: `.cache/openwrt-wifihaven.img` (uncompressed, ready to feed
 directly to QEMU). Image size: ~30–50 MB.
 
 To boot it via the existing harness, point `router-up.sh` at the file
-through `FDNS_ROUTER_IMAGE_PATH`:
+through `WH_ROUTER_IMAGE_PATH`:
 
 ```bash
-FDNS_ROUTER_IMAGE_PATH=scripts/vm/.cache/openwrt-wifihaven.img \
+WH_ROUTER_IMAGE_PATH=scripts/vm/.cache/openwrt-wifihaven.img \
     scripts/vm/router-up.sh
 ```
 
@@ -243,9 +243,9 @@ VM e2e suite (#148) consumes.
 
 ### Known quirks (v1 — deferred)
 
-- **OpenWRT's default LAN IP is `192.168.1.1`, not in `${FDNS_LAN_SUBNET}`.**
+- **OpenWRT's default LAN IP is `192.168.1.1`, not in `${WH_LAN_SUBNET}`.**
   Clients DHCP from the router so this still works end-to-end, but the host
-  cannot reach the router over the LAN bridge by a `${FDNS_LAN_SUBNET}`
+  cannot reach the router over the LAN bridge by a `${WH_LAN_SUBNET}`
   address yet. Use the WAN-side SSH hostfwd (`127.0.0.1:2222`) to manage
   the router. Tracked as a follow-up.
 
@@ -256,6 +256,6 @@ VM e2e suite (#148) consumes.
 2. `ssh -p 2222 root@127.0.0.1` lands a shell on the router (empty password).
 3. From the router: `ping -c2 8.8.8.8` succeeds (WAN NAT working).
 4. From the router: `ip link show eth0` is `UP`. On the host, `bridge link
-   show` lists a tap attached to `${FDNS_LAN_BRIDGE}`.
+   show` lists a tap attached to `${WH_LAN_BRIDGE}`.
 5. `router-snapshot.sh smoke` succeeds; `qemu-img snapshot -l ...` lists it;
    `router-down.sh && router-up.sh && router-restore.sh smoke` round-trips.

--- a/scripts/vm/build-client-base.sh
+++ b/scripts/vm/build-client-base.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the client VM base qcow2 from a pristine Alpine cloud image.
 #
-# Idempotent: a no-op if ${FDNS_CLIENT_BASE_IMG} already exists, unless --force
+# Idempotent: a no-op if ${WH_CLIENT_BASE_IMG} already exists, unless --force
 # is passed.
 #
 # What it does:
@@ -14,7 +14,7 @@
 #        - poweroffs when done.
 #   3. Boot QEMU once with the seed attached, on user-mode networking so apk
 #      can reach the internet.
-#   4. Move the cured image to ${FDNS_CLIENT_BASE_IMG}.
+#   4. Move the cured image to ${WH_CLIENT_BASE_IMG}.
 #
 # The base is read-only after this point — per-boot scripts layer qcow2
 # overlays on top of it (see client-up.sh).
@@ -38,8 +38,8 @@ for arg in "$@"; do
   esac
 done
 
-if [[ -f "${FDNS_CLIENT_BASE_IMG}" && ${FORCE} -eq 0 ]]; then
-  echo "[build-client-base] ${FDNS_CLIENT_BASE_IMG} already exists (use --force to rebuild)"
+if [[ -f "${WH_CLIENT_BASE_IMG}" && ${FORCE} -eq 0 ]]; then
+  echo "[build-client-base] ${WH_CLIENT_BASE_IMG} already exists (use --force to rebuild)"
   exit 0
 fi
 
@@ -62,31 +62,31 @@ if [[ -z "${ISO_TOOL}" ]]; then
   exit 1
 fi
 
-mkdir -p "${FDNS_CACHE_DIR}/pristine"
-PRISTINE="${FDNS_CACHE_DIR}/pristine/${FDNS_ALPINE_IMAGE}"
+mkdir -p "${WH_CACHE_DIR}/pristine"
+PRISTINE="${WH_CACHE_DIR}/pristine/${WH_ALPINE_IMAGE}"
 
 if [[ ! -f "${PRISTINE}" ]]; then
-  echo "[build-client-base] downloading ${FDNS_ALPINE_URL}"
-  curl -fL --retry 3 -o "${PRISTINE}.tmp" "${FDNS_ALPINE_URL}"
+  echo "[build-client-base] downloading ${WH_ALPINE_URL}"
+  curl -fL --retry 3 -o "${PRISTINE}.tmp" "${WH_ALPINE_URL}"
   mv "${PRISTINE}.tmp" "${PRISTINE}"
 fi
 
 echo "[build-client-base] verifying SHA-512"
 ACTUAL_SHA="$(openssl dgst -sha512 "${PRISTINE}" | awk '{print $NF}')"
-if [[ "${ACTUAL_SHA}" != "${FDNS_ALPINE_SHA512}" ]]; then
+if [[ "${ACTUAL_SHA}" != "${WH_ALPINE_SHA512}" ]]; then
   echo "[build-client-base] SHA-512 mismatch for ${PRISTINE}" >&2
-  echo "  expected: ${FDNS_ALPINE_SHA512}" >&2
+  echo "  expected: ${WH_ALPINE_SHA512}" >&2
   echo "  actual:   ${ACTUAL_SHA}" >&2
   exit 1
 fi
 
-if [[ ! -f "${FDNS_CLIENT_SSH_PUB}" ]]; then
-  echo "[build-client-base] missing ${FDNS_CLIENT_SSH_PUB}" >&2
+if [[ ! -f "${WH_CLIENT_SSH_PUB}" ]]; then
+  echo "[build-client-base] missing ${WH_CLIENT_SSH_PUB}" >&2
   exit 1
 fi
-PUBKEY="$(cat "${FDNS_CLIENT_SSH_PUB}")"
+PUBKEY="$(cat "${WH_CLIENT_SSH_PUB}")"
 
-WORK="$(mktemp -d -t fdns-client-build.XXXXXX)"
+WORK="$(mktemp -d -t wh-client-build.XXXXXX)"
 trap 'rm -rf "${WORK}"' EXIT
 
 WORK_IMG="${WORK}/work.qcow2"
@@ -99,8 +99,8 @@ SEED_DIR="${WORK}/seed"
 mkdir -p "${SEED_DIR}"
 
 cat >"${SEED_DIR}/meta-data" <<EOF
-instance-id: fdns-client-base
-local-hostname: fdns-client
+instance-id: wh-client-base
+local-hostname: wh-client
 EOF
 
 # network-config: tell cloud-init's network renderer how to set up both NICs.
@@ -159,7 +159,7 @@ write_files:
   # Write the test SSH key under /etc (parent dir exists) — runcmd below
   # installs it into /root/.ssh. write_files to /root/.ssh/* is unreliable
   # on this Alpine cloud-init build because the parent dir doesn't yet exist.
-  - path: /etc/fdns-authorized_keys
+  - path: /etc/wh-authorized_keys
     permissions: '0600'
     owner: root:root
     content: |
@@ -194,10 +194,10 @@ runcmd:
   - rc-update add networking default
   # PermitRootLogin prohibit-password is the Alpine default; make explicit.
   - sed -i 's/^#\\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
-  # Install the test SSH key staged at /etc/fdns-authorized_keys.
+  # Install the test SSH key staged at /etc/wh-authorized_keys.
   - mkdir -p /root/.ssh
   - chmod 700 /root/.ssh
-  - install -m 0600 -o root -g root /etc/fdns-authorized_keys /root/.ssh/authorized_keys
+  - install -m 0600 -o root -g root /etc/wh-authorized_keys /root/.ssh/authorized_keys
   # Signal "build complete" by powering off cleanly.
   - poweroff
 EOF
@@ -226,7 +226,7 @@ fi
 echo "[build-client-base] booting Alpine to install tools (this can take 1–2 minutes)"
 # 10 minute hard cap so a stuck build doesn't hang CI.
 timeout 600 qemu-system-x86_64 \
-  -name fdns-client-base-build \
+  -name wh-client-base-build \
   -m 1024 -smp 2 \
   "${ACCEL_ARGS[@]}" \
   -nographic -serial mon:stdio \
@@ -235,6 +235,6 @@ timeout 600 qemu-system-x86_64 \
   -netdev user,id=net0 -device virtio-net-pci,netdev=net0 \
   -no-reboot
 
-mkdir -p "${FDNS_CACHE_DIR}"
-mv "${WORK_IMG}" "${FDNS_CLIENT_BASE_IMG}"
-echo "[build-client-base] wrote ${FDNS_CLIENT_BASE_IMG}"
+mkdir -p "${WH_CACHE_DIR}"
+mv "${WORK_IMG}" "${WH_CLIENT_BASE_IMG}"
+echo "[build-client-base] wrote ${WH_CLIENT_BASE_IMG}"

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -16,7 +16,7 @@
 #
 # Acceptance test (cf. issue #150):
 #   1. This script runs to completion on a clean checkout.
-#   2. FDNS_ROUTER_IMAGE_PATH=$PWD/scripts/vm/.cache/openwrt-wifihaven.img \
+#   2. WH_ROUTER_IMAGE_PATH=$PWD/scripts/vm/.cache/openwrt-wifihaven.img \
 #        scripts/vm/router-up.sh boots it.
 #   3. opkg list-installed | grep wifihaven shows the agent.
 #   4. logread | grep wifihaven shows the agent starting up.
@@ -158,7 +158,7 @@ echo "==> Running Image Builder in $IMAGEBUILDER_DOCKER_IMAGE"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
 docker run --rm \
-    --name fdns-imagebuilder \
+    --name wh-imagebuilder \
     -e HOST_UID="$HOST_UID" \
     -e HOST_GID="$HOST_GID" \
     -v "$IB_ROOT":/ib \
@@ -252,4 +252,4 @@ SIZE_MB=$(( $(stat -f%z "$OUTPUT_IMG" 2>/dev/null || stat -c%s "$OUTPUT_IMG") / 
 echo ""
 echo "==> Done."
 echo "    Image: $OUTPUT_IMG (${SIZE_MB} MB)"
-echo "    Boot with: FDNS_ROUTER_IMAGE_PATH=$OUTPUT_IMG scripts/vm/router-up.sh"
+echo "    Boot with: WH_ROUTER_IMAGE_PATH=$OUTPUT_IMG scripts/vm/router-up.sh"

--- a/scripts/vm/client-down.sh
+++ b/scripts/vm/client-down.sh
@@ -22,7 +22,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-RUN_DIR="${FDNS_RUN_DIR}/${NAME}"
+RUN_DIR="${WH_RUN_DIR}/${NAME}"
 PIDFILE="${RUN_DIR}/qemu.pid"
 QMP_SOCK="${RUN_DIR}/qemu.sock"
 
@@ -65,9 +65,9 @@ rm -rf "${RUN_DIR}"
 # Fallback: a previous run was killed hard (e.g., CI cancellation) and
 # left a qemu alive without an up-to-date pidfile. Kill by name so the
 # next client-up doesn't fail to bind hostfwd ports.
-if pgrep -f "qemu-system-x86_64.*-name fdns-${NAME}" >/dev/null 2>&1; then
-  echo "[client-down] found stale fdns-${NAME} qemu without pidfile match — killing"
-  pkill -f "qemu-system-x86_64.*-name fdns-${NAME}" || true
+if pgrep -f "qemu-system-x86_64.*-name wh-${NAME}" >/dev/null 2>&1; then
+  echo "[client-down] found stale wh-${NAME} qemu without pidfile match — killing"
+  pkill -f "qemu-system-x86_64.*-name wh-${NAME}" || true
   # Give the kernel a moment to release the bound ports.
   sleep 1
 fi

--- a/scripts/vm/client-exec.sh
+++ b/scripts/vm/client-exec.sh
@@ -31,7 +31,7 @@ if [[ $# -eq 0 ]]; then
   exit 2
 fi
 
-RUN_DIR="${FDNS_RUN_DIR}/${NAME}"
+RUN_DIR="${WH_RUN_DIR}/${NAME}"
 if [[ ! -f "${RUN_DIR}/ssh.port" ]]; then
   echo "client-exec.sh: client '${NAME}' is not running (no ${RUN_DIR}/ssh.port)" >&2
   exit 1
@@ -40,7 +40,7 @@ SSH_PORT="$(cat "${RUN_DIR}/ssh.port")"
 
 # Git doesn't track non-executable file modes; the committed private key may
 # check out world-readable, which SSH refuses to use. Tighten it idempotently.
-chmod 0600 "${FDNS_CLIENT_SSH_KEY}" 2>/dev/null || true
+chmod 0600 "${WH_CLIENT_SSH_KEY}" 2>/dev/null || true
 
 # Quote each argv element so the remote shell re-parses back to the same word
 # boundaries. ssh joins multi-arg commands with bare spaces — without this, a
@@ -52,6 +52,6 @@ exec ssh -o StrictHostKeyChecking=no \
          -o UserKnownHostsFile=/dev/null \
          -o LogLevel=ERROR \
          -o BatchMode=yes \
-         -i "${FDNS_CLIENT_SSH_KEY}" \
+         -i "${WH_CLIENT_SSH_KEY}" \
          -p "${SSH_PORT}" \
          root@127.0.0.1 "${REMOTE_CMD}"

--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -5,12 +5,12 @@
 #   client-up.sh --mac aa:bb:cc:dd:ee:ff [--name client1] [--ssh-port 2223]
 #
 # Two NICs:
-#   eth0 — virtio-net attached to ${FDNS_LAN_BRIDGE} (the router VM's LAN).
+#   eth0 — virtio-net attached to ${WH_LAN_BRIDGE} (the router VM's LAN).
 #          DHCP from the router VM. This is the path under test.
 #   eth1 — virtio-net on QEMU user-mode networking with an SSH hostfwd. No
 #          default route, no DNS. Orchestrator SSH only.
 #
-# State for a running client lives under ${FDNS_RUN_DIR}/<name>/:
+# State for a running client lives under ${WH_RUN_DIR}/<name>/:
 #   overlay.qcow2  — disk overlay (discarded by client-down.sh)
 #   qemu.pid       — qemu pid
 #   qemu.sock      — QMP monitor socket
@@ -45,12 +45,12 @@ if [[ ! "${MAC}" =~ ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$ ]]; then
   echo "client-up.sh: --mac must be in aa:bb:cc:dd:ee:ff format (got '${MAC}')" >&2
   exit 2
 fi
-if [[ ! -f "${FDNS_CLIENT_BASE_IMG}" ]]; then
+if [[ ! -f "${WH_CLIENT_BASE_IMG}" ]]; then
   echo "client-up.sh: base image missing — run scripts/vm/build-client-base.sh first" >&2
   exit 1
 fi
-if ! ip link show "${FDNS_LAN_BRIDGE}" >/dev/null 2>&1; then
-  echo "client-up.sh: LAN bridge '${FDNS_LAN_BRIDGE}' does not exist." >&2
+if ! ip link show "${WH_LAN_BRIDGE}" >/dev/null 2>&1; then
+  echo "client-up.sh: LAN bridge '${WH_LAN_BRIDGE}' does not exist." >&2
   echo "  Bring up the router VM (scripts/vm/router-up.sh, #144) first." >&2
   exit 1
 fi
@@ -58,11 +58,11 @@ fi
 # Git doesn't track non-executable file modes, so the committed private key
 # checks out with the umask default (often 0644). SSH refuses to use a key
 # that's group/world-readable. Fix it idempotently before any client SSH.
-if [[ -f "${FDNS_CLIENT_SSH_KEY}" ]]; then
-  chmod 0600 "${FDNS_CLIENT_SSH_KEY}" 2>/dev/null || true
+if [[ -f "${WH_CLIENT_SSH_KEY}" ]]; then
+  chmod 0600 "${WH_CLIENT_SSH_KEY}" 2>/dev/null || true
 fi
 
-RUN_DIR="${FDNS_RUN_DIR}/${NAME}"
+RUN_DIR="${WH_RUN_DIR}/${NAME}"
 if [[ -f "${RUN_DIR}/qemu.pid" ]] && kill -0 "$(cat "${RUN_DIR}/qemu.pid")" 2>/dev/null; then
   echo "client-up.sh: client '${NAME}' already running (pid $(cat "${RUN_DIR}/qemu.pid"))" >&2
   exit 1
@@ -71,11 +71,11 @@ rm -rf "${RUN_DIR}"
 mkdir -p "${RUN_DIR}"
 
 if [[ -z "${SSH_PORT}" ]]; then
-  SSH_PORT="${FDNS_CLIENT_SSH_PORT_BASE}"
+  SSH_PORT="${WH_CLIENT_SSH_PORT_BASE}"
 fi
 
 OVERLAY="${RUN_DIR}/overlay.qcow2"
-qemu-img create -f qcow2 -F qcow2 -b "${FDNS_CLIENT_BASE_IMG}" "${OVERLAY}" >/dev/null
+qemu-img create -f qcow2 -F qcow2 -b "${WH_CLIENT_BASE_IMG}" "${OVERLAY}" >/dev/null
 
 ACCEL_ARGS=()
 if [[ -e /dev/kvm ]]; then
@@ -87,7 +87,7 @@ fi
 # A tap helper is the most portable way to attach to a host bridge from
 # unprivileged QEMU. The router-VM side (#144) is expected to ensure the
 # bridge exists and that /etc/qemu/bridge.conf allows it.
-LAN_NETDEV="bridge,id=lan,br=${FDNS_LAN_BRIDGE}"
+LAN_NETDEV="bridge,id=lan,br=${WH_LAN_BRIDGE}"
 LAN_DEVICE="virtio-net-pci,netdev=lan,mac=${MAC}"
 
 MGMT_NETDEV="user,id=mgmt,net=10.0.2.0/24,host=10.0.2.2,dhcpstart=10.0.2.15,restrict=on,hostfwd=tcp:127.0.0.1:${SSH_PORT}-10.0.2.15:22"
@@ -98,7 +98,7 @@ QMP_SOCK="${RUN_DIR}/qemu.sock"
 
 # Background the qemu process. -daemonize gives us a stable pidfile.
 qemu-system-x86_64 \
-  -name "fdns-${NAME}" \
+  -name "wh-${NAME}" \
   -m 512 -smp 1 \
   "${ACCEL_ARGS[@]}" \
   -display none -serial "file:${RUN_DIR}/console.log" \
@@ -119,7 +119,7 @@ deadline=$(( $(date +%s) + 90 ))
 while (( $(date +%s) < deadline )); do
   if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
         -o ConnectTimeout=2 -o BatchMode=yes \
-        -i "${FDNS_CLIENT_SSH_KEY}" -p "${SSH_PORT}" \
+        -i "${WH_CLIENT_SSH_KEY}" -p "${SSH_PORT}" \
         root@127.0.0.1 true 2>/dev/null; then
     echo "[client-up] '${NAME}' ready"
     exit 0

--- a/scripts/vm/config.sh
+++ b/scripts/vm/config.sh
@@ -7,68 +7,68 @@
 # --- LAN bridge (shared with the router VM from #144) ------------------------
 # If #144 picks different names/ranges, update *here* — these constants are
 # referenced everywhere else by variable, not by literal.
-FDNS_LAN_BRIDGE="${FDNS_LAN_BRIDGE:-fdns-lan0}"
-FDNS_LAN_SUBNET="${FDNS_LAN_SUBNET:-192.168.100.0/24}"
-FDNS_LAN_ROUTER_IP="${FDNS_LAN_ROUTER_IP:-192.168.100.1}"
+WH_LAN_BRIDGE="${WH_LAN_BRIDGE:-wh-lan0}"
+WH_LAN_SUBNET="${WH_LAN_SUBNET:-192.168.100.0/24}"
+WH_LAN_ROUTER_IP="${WH_LAN_ROUTER_IP:-192.168.100.1}"
 
 # --- Alpine cloud image (client VM base) -------------------------------------
 # Pinned to a specific release + checksum. Bump deliberately, not casually.
 # Source index: https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/
-FDNS_ALPINE_VERSION="3.22.4"
-FDNS_ALPINE_IMAGE="nocloud_alpine-${FDNS_ALPINE_VERSION}-x86_64-bios-cloudinit-r0.qcow2"
-FDNS_ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/${FDNS_ALPINE_IMAGE}"
+WH_ALPINE_VERSION="3.22.4"
+WH_ALPINE_IMAGE="nocloud_alpine-${WH_ALPINE_VERSION}-x86_64-bios-cloudinit-r0.qcow2"
+WH_ALPINE_URL="https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/cloud/${WH_ALPINE_IMAGE}"
 # SHA-512 of the pristine qcow2 (Alpine publishes .sha512 alongside the image).
-FDNS_ALPINE_SHA512="d0ddf1faae4d44aee3ad6621f166bd414c2f99b6974fb455408612d59cbb31a5390ca259800ac0c6b60505493880ed6de8beb986f6d0883b26c8e84ce75a266c"
+WH_ALPINE_SHA512="d0ddf1faae4d44aee3ad6621f166bd414c2f99b6974fb455408612d59cbb31a5390ca259800ac0c6b60505493880ed6de8beb986f6d0883b26c8e84ce75a266c"
 
 # --- Paths -------------------------------------------------------------------
 # Resolve relative to the directory containing config.sh, so callers can be
 # invoked from anywhere.
-FDNS_VM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FDNS_CACHE_DIR="${FDNS_VM_DIR}/.cache"
-FDNS_RUN_DIR="${FDNS_VM_DIR}/.run"
-FDNS_KEYS_DIR="${FDNS_VM_DIR}/keys"
-FDNS_CLIENT_BASE_IMG="${FDNS_CACHE_DIR}/client-base.qcow2"
-FDNS_CLIENT_SSH_KEY="${FDNS_KEYS_DIR}/client_test_ed25519"
-FDNS_CLIENT_SSH_PUB="${FDNS_KEYS_DIR}/client_test_ed25519.pub"
+WH_VM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WH_CACHE_DIR="${WH_VM_DIR}/.cache"
+WH_RUN_DIR="${WH_VM_DIR}/.run"
+WH_KEYS_DIR="${WH_VM_DIR}/keys"
+WH_CLIENT_BASE_IMG="${WH_CACHE_DIR}/client-base.qcow2"
+WH_CLIENT_SSH_KEY="${WH_KEYS_DIR}/client_test_ed25519"
+WH_CLIENT_SSH_PUB="${WH_KEYS_DIR}/client_test_ed25519.pub"
 
 # --- Router VM (OpenWRT, #144) -----------------------------------------------
 # Bump procedure:
-#   1. Edit FDNS_OPENWRT_VERSION.
+#   1. Edit WH_OPENWRT_VERSION.
 #   2. Refresh checksum:
-#        curl -sSL "https://downloads.openwrt.org/releases/${FDNS_OPENWRT_VERSION}/targets/x86/64/sha256sums" \
+#        curl -sSL "https://downloads.openwrt.org/releases/${WH_OPENWRT_VERSION}/targets/x86/64/sha256sums" \
 #          | grep generic-ext4-combined.img.gz
-#   3. Update FDNS_OPENWRT_IMAGE_SHA256.
-#   4. Delete ${FDNS_CACHE_DIR} and re-run scripts/vm/router-up.sh.
-FDNS_OPENWRT_VERSION="${FDNS_OPENWRT_VERSION:-23.05.6}"
-FDNS_OPENWRT_IMAGE="openwrt-${FDNS_OPENWRT_VERSION}-x86-64-generic-ext4-combined.img.gz"
-FDNS_OPENWRT_URL="https://downloads.openwrt.org/releases/${FDNS_OPENWRT_VERSION}/targets/x86/64/${FDNS_OPENWRT_IMAGE}"
-FDNS_OPENWRT_SHA256="${FDNS_OPENWRT_SHA256:-c6e22b6f58ba721f15f3ccdbc26d4a85da64b7e3c564cd5bc70676eb91eeec51}"
+#   3. Update WH_OPENWRT_IMAGE_SHA256.
+#   4. Delete ${WH_CACHE_DIR} and re-run scripts/vm/router-up.sh.
+WH_OPENWRT_VERSION="${WH_OPENWRT_VERSION:-23.05.6}"
+WH_OPENWRT_IMAGE="openwrt-${WH_OPENWRT_VERSION}-x86-64-generic-ext4-combined.img.gz"
+WH_OPENWRT_URL="https://downloads.openwrt.org/releases/${WH_OPENWRT_VERSION}/targets/x86/64/${WH_OPENWRT_IMAGE}"
+WH_OPENWRT_SHA256="${WH_OPENWRT_SHA256:-c6e22b6f58ba721f15f3ccdbc26d4a85da64b7e3c564cd5bc70676eb91eeec51}"
 
 # Where the router's qcow2 overlay + runtime state live. Snapshots are stored
 # inside the overlay via qemu savevm.
-FDNS_ROUTER_BASE_IMG="${FDNS_CACHE_DIR}/${FDNS_OPENWRT_IMAGE%.gz}"
-FDNS_ROUTER_RUN_DIR="${FDNS_RUN_DIR}/router"
-FDNS_ROUTER_OVERLAY="${FDNS_ROUTER_RUN_DIR}/overlay.qcow2"
-FDNS_ROUTER_PIDFILE="${FDNS_ROUTER_RUN_DIR}/qemu.pid"
-FDNS_ROUTER_MONITOR_SOCK="${FDNS_ROUTER_RUN_DIR}/monitor.sock"
-FDNS_ROUTER_SERIAL_LOG="${FDNS_ROUTER_RUN_DIR}/console.log"
+WH_ROUTER_BASE_IMG="${WH_CACHE_DIR}/${WH_OPENWRT_IMAGE%.gz}"
+WH_ROUTER_RUN_DIR="${WH_RUN_DIR}/router"
+WH_ROUTER_OVERLAY="${WH_ROUTER_RUN_DIR}/overlay.qcow2"
+WH_ROUTER_PIDFILE="${WH_ROUTER_RUN_DIR}/qemu.pid"
+WH_ROUTER_MONITOR_SOCK="${WH_ROUTER_RUN_DIR}/monitor.sock"
+WH_ROUTER_SERIAL_LOG="${WH_ROUTER_RUN_DIR}/console.log"
 
 # Router VM size + WAN-side SSH hostfwd (LuCI HTTP forwarded for manual poking).
-FDNS_ROUTER_MEM_MB="${FDNS_ROUTER_MEM_MB:-512}"
-FDNS_ROUTER_DISK_SIZE="${FDNS_ROUTER_DISK_SIZE:-512M}"
-FDNS_ROUTER_SSH_PORT="${FDNS_ROUTER_SSH_PORT:-2222}"
-FDNS_ROUTER_HTTP_PORT="${FDNS_ROUTER_HTTP_PORT:-8080}"
+WH_ROUTER_MEM_MB="${WH_ROUTER_MEM_MB:-512}"
+WH_ROUTER_DISK_SIZE="${WH_ROUTER_DISK_SIZE:-512M}"
+WH_ROUTER_SSH_PORT="${WH_ROUTER_SSH_PORT:-2222}"
+WH_ROUTER_HTTP_PORT="${WH_ROUTER_HTTP_PORT:-8080}"
 
 # Stable, locally-administered MACs so the orchestrator can match-by-MAC in
 # router-side logs.
-FDNS_ROUTER_MAC_LAN="${FDNS_ROUTER_MAC_LAN:-52:54:00:fd:00:02}"
-FDNS_ROUTER_MAC_WAN="${FDNS_ROUTER_MAC_WAN:-52:54:00:fd:00:01}"
+WH_ROUTER_MAC_LAN="${WH_ROUTER_MAC_LAN:-52:54:00:fd:00:02}"
+WH_ROUTER_MAC_WAN="${WH_ROUTER_MAC_WAN:-52:54:00:fd:00:01}"
 
 # --- SSH management NIC ------------------------------------------------------
 # The client VM has two NICs:
-#   eth0 — LAN side, attached to ${FDNS_LAN_BRIDGE}, DHCP from router VM.
+#   eth0 — LAN side, attached to ${WH_LAN_BRIDGE}, DHCP from router VM.
 #   eth1 — host-side user-mode NIC (QEMU SLIRP), used ONLY for orchestrator
 #          SSH via hostfwd. No default route, no DNS — keeps all real traffic
 #          on the LAN side so DNS scenarios actually exercise the router.
 # Default port for the first client; client-up.sh increments per --name slot.
-FDNS_CLIENT_SSH_PORT_BASE="${FDNS_CLIENT_SSH_PORT_BASE:-2223}"
+WH_CLIENT_SSH_PORT_BASE="${WH_CLIENT_SSH_PORT_BASE:-2223}"

--- a/scripts/vm/lan-bridge-down.sh
+++ b/scripts/vm/lan-bridge-down.sh
@@ -10,19 +10,19 @@ source "${HERE}/lib.sh"
 
 require_cmd ip
 
-if ! ip link show "${FDNS_LAN_BRIDGE}" >/dev/null 2>&1; then
-  log "bridge ${FDNS_LAN_BRIDGE} not present"
+if ! ip link show "${WH_LAN_BRIDGE}" >/dev/null 2>&1; then
+  log "bridge ${WH_LAN_BRIDGE} not present"
   exit 0
 fi
 
 # bail if anything is still attached so we don't yank the bridge out from
 # under a running VM.
-attached="$(ls "/sys/class/net/${FDNS_LAN_BRIDGE}/brif" 2>/dev/null || true)"
+attached="$(ls "/sys/class/net/${WH_LAN_BRIDGE}/brif" 2>/dev/null || true)"
 if [[ -n "${attached}" ]]; then
-  die "bridge ${FDNS_LAN_BRIDGE} still has interfaces attached: ${attached}. \
+  die "bridge ${WH_LAN_BRIDGE} still has interfaces attached: ${attached}. \
 Stop the router/client VMs first."
 fi
 
-log "removing bridge ${FDNS_LAN_BRIDGE}"
-sudo ip link set "${FDNS_LAN_BRIDGE}" down
-sudo ip link delete "${FDNS_LAN_BRIDGE}" type bridge
+log "removing bridge ${WH_LAN_BRIDGE}"
+sudo ip link set "${WH_LAN_BRIDGE}" down
+sudo ip link delete "${WH_LAN_BRIDGE}" type bridge

--- a/scripts/vm/lan-bridge-up.sh
+++ b/scripts/vm/lan-bridge-up.sh
@@ -10,26 +10,26 @@ source "${HERE}/lib.sh"
 
 require_cmd ip
 
-if ip link show "${FDNS_LAN_BRIDGE}" >/dev/null 2>&1; then
-  log "bridge ${FDNS_LAN_BRIDGE} already exists"
+if ip link show "${WH_LAN_BRIDGE}" >/dev/null 2>&1; then
+  log "bridge ${WH_LAN_BRIDGE} already exists"
 else
-  log "creating bridge ${FDNS_LAN_BRIDGE}"
-  sudo ip link add name "${FDNS_LAN_BRIDGE}" type bridge
+  log "creating bridge ${WH_LAN_BRIDGE}"
+  sudo ip link add name "${WH_LAN_BRIDGE}" type bridge
 fi
 
-sudo ip link set "${FDNS_LAN_BRIDGE}" up
+sudo ip link set "${WH_LAN_BRIDGE}" up
 
 # qemu-bridge-helper refuses to attach taps unless the bridge is in
 # /etc/qemu/bridge.conf. We don't auto-edit it (root-owned), just warn.
 if [[ -f /etc/qemu/bridge.conf ]]; then
-  if ! grep -qE "^allow ${FDNS_LAN_BRIDGE}\b" /etc/qemu/bridge.conf; then
-    log "warning: /etc/qemu/bridge.conf does not allow ${FDNS_LAN_BRIDGE};"
-    log "         add 'allow ${FDNS_LAN_BRIDGE}' as root, e.g.:"
-    log "           echo 'allow ${FDNS_LAN_BRIDGE}' | sudo tee -a /etc/qemu/bridge.conf"
+  if ! grep -qE "^allow ${WH_LAN_BRIDGE}\b" /etc/qemu/bridge.conf; then
+    log "warning: /etc/qemu/bridge.conf does not allow ${WH_LAN_BRIDGE};"
+    log "         add 'allow ${WH_LAN_BRIDGE}' as root, e.g.:"
+    log "           echo 'allow ${WH_LAN_BRIDGE}' | sudo tee -a /etc/qemu/bridge.conf"
   fi
 else
   log "warning: /etc/qemu/bridge.conf missing — qemu-bridge-helper will refuse"
-  log "         to attach. Create it as root with 'allow ${FDNS_LAN_BRIDGE}'."
+  log "         to attach. Create it as root with 'allow ${WH_LAN_BRIDGE}'."
 fi
 
-log "LAN bridge ${FDNS_LAN_BRIDGE} ready"
+log "LAN bridge ${WH_LAN_BRIDGE} ready"

--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -7,7 +7,7 @@ HERE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=config.sh
 source "${HERE_LIB}/config.sh"
 
-mkdir -p "${FDNS_CACHE_DIR}" "${FDNS_ROUTER_RUN_DIR}"
+mkdir -p "${WH_CACHE_DIR}" "${WH_ROUTER_RUN_DIR}"
 
 log() { printf '[router-vm] %s\n' "$*" >&2; }
 die() { printf '[router-vm] error: %s\n' "$*" >&2; exit 1; }
@@ -27,37 +27,37 @@ sha256_file() {
 
 # Download (if missing) and decompress the pinned OpenWRT image.
 #
-# If FDNS_ROUTER_IMAGE_PATH is set, treat it as a pre-built local image
+# If WH_ROUTER_IMAGE_PATH is set, treat it as a pre-built local image
 # (e.g. the output of build-router-image.sh) and use it verbatim, skipping
 # the download + sha256 check. This is how the custom-image flow from #150
 # plugs into the stock router-up.sh path.
 ensure_openwrt_image() {
-  if [[ -n "${FDNS_ROUTER_IMAGE_PATH:-}" ]]; then
-    [[ -f "${FDNS_ROUTER_IMAGE_PATH}" ]] || \
-      die "FDNS_ROUTER_IMAGE_PATH set but file missing: ${FDNS_ROUTER_IMAGE_PATH}"
-    FDNS_ROUTER_BASE_IMG="${FDNS_ROUTER_IMAGE_PATH}"
+  if [[ -n "${WH_ROUTER_IMAGE_PATH:-}" ]]; then
+    [[ -f "${WH_ROUTER_IMAGE_PATH}" ]] || \
+      die "WH_ROUTER_IMAGE_PATH set but file missing: ${WH_ROUTER_IMAGE_PATH}"
+    WH_ROUTER_BASE_IMG="${WH_ROUTER_IMAGE_PATH}"
     return 0
   fi
 
-  local gz="${FDNS_CACHE_DIR}/${FDNS_OPENWRT_IMAGE}"
-  local img="${FDNS_ROUTER_BASE_IMG}"
+  local gz="${WH_CACHE_DIR}/${WH_OPENWRT_IMAGE}"
+  local img="${WH_ROUTER_BASE_IMG}"
 
   if [[ -f "${img}" ]]; then
     return 0
   fi
 
   if [[ ! -f "${gz}" ]]; then
-    log "downloading ${FDNS_OPENWRT_URL}"
+    log "downloading ${WH_OPENWRT_URL}"
     require_cmd curl
-    curl -fSL --retry 3 -o "${gz}.part" "${FDNS_OPENWRT_URL}"
+    curl -fSL --retry 3 -o "${gz}.part" "${WH_OPENWRT_URL}"
     mv "${gz}.part" "${gz}"
   fi
 
   local actual
   actual="$(sha256_file "${gz}")"
-  if [[ "${actual}" != "${FDNS_OPENWRT_SHA256}" ]]; then
+  if [[ "${actual}" != "${WH_OPENWRT_SHA256}" ]]; then
     rm -f "${gz}"
-    die "SHA256 mismatch for ${FDNS_OPENWRT_IMAGE}: got ${actual}, expected ${FDNS_OPENWRT_SHA256}"
+    die "SHA256 mismatch for ${WH_OPENWRT_IMAGE}: got ${actual}, expected ${WH_OPENWRT_SHA256}"
   fi
 
   log "decompressing $(basename "${gz}")"
@@ -69,13 +69,13 @@ ensure_openwrt_image() {
 # Create the qcow2 overlay backed by the raw OpenWRT image (idempotent).
 ensure_router_overlay() {
   require_cmd qemu-img
-  if [[ ! -f "${FDNS_ROUTER_OVERLAY}" ]]; then
-    log "creating qcow2 overlay ${FDNS_ROUTER_OVERLAY}"
-    qemu-img create -q -f qcow2 -F raw -b "${FDNS_ROUTER_BASE_IMG}" \
-      "${FDNS_ROUTER_OVERLAY}" "${FDNS_ROUTER_DISK_SIZE}"
+  if [[ ! -f "${WH_ROUTER_OVERLAY}" ]]; then
+    log "creating qcow2 overlay ${WH_ROUTER_OVERLAY}"
+    qemu-img create -q -f qcow2 -F raw -b "${WH_ROUTER_BASE_IMG}" \
+      "${WH_ROUTER_OVERLAY}" "${WH_ROUTER_DISK_SIZE}"
   fi
 }
 
 router_is_running() {
-  [[ -f "${FDNS_ROUTER_PIDFILE}" ]] && kill -0 "$(cat "${FDNS_ROUTER_PIDFILE}")" 2>/dev/null
+  [[ -f "${WH_ROUTER_PIDFILE}" ]] && kill -0 "$(cat "${WH_ROUTER_PIDFILE}")" 2>/dev/null
 }

--- a/scripts/vm/router-down.sh
+++ b/scripts/vm/router-down.sh
@@ -11,9 +11,9 @@ stale_qemu_sweep() {
   # Fallback: a previous run was killed hard (e.g., CI cancellation) and
   # left a qemu alive without an up-to-date pidfile. Kill by name so the
   # next router-up doesn't fail to bind hostfwd ports.
-  if pgrep -f "qemu-system-x86_64.*-name fdns-router" >/dev/null 2>&1; then
-    log "found stale fdns-router qemu without pidfile match — killing"
-    pkill -f "qemu-system-x86_64.*-name fdns-router" || true
+  if pgrep -f "qemu-system-x86_64.*-name wh-router" >/dev/null 2>&1; then
+    log "found stale wh-router qemu without pidfile match — killing"
+    pkill -f "qemu-system-x86_64.*-name wh-router" || true
     # Give the kernel a moment to release the bound ports.
     sleep 1
   fi
@@ -21,16 +21,16 @@ stale_qemu_sweep() {
 
 if ! router_is_running; then
   log "router VM not running"
-  rm -f "${FDNS_ROUTER_PIDFILE}" "${FDNS_ROUTER_MONITOR_SOCK}"
+  rm -f "${WH_ROUTER_PIDFILE}" "${WH_ROUTER_MONITOR_SOCK}"
   stale_qemu_sweep
   exit 0
 fi
 
-pid="$(cat "${FDNS_ROUTER_PIDFILE}")"
+pid="$(cat "${WH_ROUTER_PIDFILE}")"
 log "asking router VM (pid ${pid}) to power off via monitor"
 
-if [[ -S "${FDNS_ROUTER_MONITOR_SOCK}" ]] && command -v socat >/dev/null 2>&1; then
-  printf 'system_powerdown\n' | socat - "UNIX-CONNECT:${FDNS_ROUTER_MONITOR_SOCK}" >/dev/null 2>&1 || true
+if [[ -S "${WH_ROUTER_MONITOR_SOCK}" ]] && command -v socat >/dev/null 2>&1; then
+  printf 'system_powerdown\n' | socat - "UNIX-CONNECT:${WH_ROUTER_MONITOR_SOCK}" >/dev/null 2>&1 || true
   for _ in $(seq 1 20); do
     kill -0 "${pid}" 2>/dev/null || break
     sleep 0.5
@@ -51,6 +51,6 @@ if kill -0 "${pid}" 2>/dev/null; then
   kill -9 "${pid}" 2>/dev/null || true
 fi
 
-rm -f "${FDNS_ROUTER_PIDFILE}" "${FDNS_ROUTER_MONITOR_SOCK}"
+rm -f "${WH_ROUTER_PIDFILE}" "${WH_ROUTER_MONITOR_SOCK}"
 stale_qemu_sweep
 log "router VM stopped"

--- a/scripts/vm/router-restore.sh
+++ b/scripts/vm/router-restore.sh
@@ -19,16 +19,16 @@ name="${1:-}"
 if router_is_running; then
   require_cmd socat
   log "loading snapshot '${name}' into running VM"
-  out="$(printf 'loadvm %s\n' "${name}" | socat -t2 - "UNIX-CONNECT:${FDNS_ROUTER_MONITOR_SOCK}" 2>&1 || true)"
+  out="$(printf 'loadvm %s\n' "${name}" | socat -t2 - "UNIX-CONNECT:${WH_ROUTER_MONITOR_SOCK}" 2>&1 || true)"
   echo "${out}" | sed 's/^/[qemu] /' >&2
   if echo "${out}" | grep -qiE 'error|failed'; then
     die "loadvm reported an error (see above)"
   fi
 else
   require_cmd qemu-img
-  [[ -f "${FDNS_ROUTER_OVERLAY}" ]] || die "overlay missing: ${FDNS_ROUTER_OVERLAY}"
-  log "applying snapshot '${name}' to ${FDNS_ROUTER_OVERLAY} (offline)"
-  qemu-img snapshot -a "${name}" "${FDNS_ROUTER_OVERLAY}"
+  [[ -f "${WH_ROUTER_OVERLAY}" ]] || die "overlay missing: ${WH_ROUTER_OVERLAY}"
+  log "applying snapshot '${name}' to ${WH_ROUTER_OVERLAY} (offline)"
+  qemu-img snapshot -a "${name}" "${WH_ROUTER_OVERLAY}"
 fi
 
 log "restored to snapshot '${name}'"

--- a/scripts/vm/router-snapshot.sh
+++ b/scripts/vm/router-snapshot.sh
@@ -15,18 +15,18 @@ name="${1:-}"
 
 router_is_running || die "router VM is not running"
 require_cmd socat
-[[ -S "${FDNS_ROUTER_MONITOR_SOCK}" ]] || die "monitor socket missing: ${FDNS_ROUTER_MONITOR_SOCK}"
+[[ -S "${WH_ROUTER_MONITOR_SOCK}" ]] || die "monitor socket missing: ${WH_ROUTER_MONITOR_SOCK}"
 
 log "saving snapshot '${name}'"
 # Send 'savevm' and let the connection close after the reply — never send
 # 'quit' (it would terminate the VM). socat -t2 holds the socket open ~2s
 # for QEMU to reply.
-out="$(printf 'savevm %s\n' "${name}" | socat -t2 - "UNIX-CONNECT:${FDNS_ROUTER_MONITOR_SOCK}" 2>&1 || true)"
+out="$(printf 'savevm %s\n' "${name}" | socat -t2 - "UNIX-CONNECT:${WH_ROUTER_MONITOR_SOCK}" 2>&1 || true)"
 echo "${out}" | sed 's/^/[qemu] /' >&2
 
 if echo "${out}" | grep -qiE 'error|failed'; then
   die "savevm reported an error (see above)"
 fi
 
-log "snapshot '${name}' saved into ${FDNS_ROUTER_OVERLAY}"
-log "list with: qemu-img snapshot -l '${FDNS_ROUTER_OVERLAY}'"
+log "snapshot '${name}' saved into ${WH_ROUTER_OVERLAY}"
+log "list with: qemu-img snapshot -l '${WH_ROUTER_OVERLAY}'"

--- a/scripts/vm/router-up.sh
+++ b/scripts/vm/router-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Boot the OpenWRT router VM:
-#   - LAN NIC attached to ${FDNS_LAN_BRIDGE} (shared with the client VM from #146)
+#   - LAN NIC attached to ${WH_LAN_BRIDGE} (shared with the client VM from #146)
 #   - WAN NIC on QEMU user-mode networking with NAT to the host's internet, plus
 #     hostfwd of SSH (port 22) and LuCI HTTP (port 80) for orchestrator access.
 # Idempotent: a no-op when the VM is already running.
@@ -14,9 +14,9 @@ require_cmd qemu-system-x86_64
 require_cmd qemu-img
 
 if router_is_running; then
-  log "router VM already running (pid $(cat "${FDNS_ROUTER_PIDFILE}"))"
-  log "  ssh:     ssh -p ${FDNS_ROUTER_SSH_PORT} root@127.0.0.1"
-  log "  monitor: socat - UNIX-CONNECT:${FDNS_ROUTER_MONITOR_SOCK}"
+  log "router VM already running (pid $(cat "${WH_ROUTER_PIDFILE}"))"
+  log "  ssh:     ssh -p ${WH_ROUTER_SSH_PORT} root@127.0.0.1"
+  log "  monitor: socat - UNIX-CONNECT:${WH_ROUTER_MONITOR_SOCK}"
   exit 0
 fi
 
@@ -26,42 +26,42 @@ ensure_openwrt_image
 ensure_router_overlay
 
 # OpenWRT 23.05 x86 board defaults: eth0 -> lan, eth1 -> wan. Match that ordering.
-LAN_NETDEV="bridge,id=lan,br=${FDNS_LAN_BRIDGE}"
-WAN_NETDEV="user,id=wan,hostfwd=tcp:127.0.0.1:${FDNS_ROUTER_SSH_PORT}-:22,hostfwd=tcp:127.0.0.1:${FDNS_ROUTER_HTTP_PORT}-:80"
+LAN_NETDEV="bridge,id=lan,br=${WH_LAN_BRIDGE}"
+WAN_NETDEV="user,id=wan,hostfwd=tcp:127.0.0.1:${WH_ROUTER_SSH_PORT}-:22,hostfwd=tcp:127.0.0.1:${WH_ROUTER_HTTP_PORT}-:80"
 
 ACCEL_ARGS=(-cpu max)
 if [[ -e /dev/kvm ]]; then
   ACCEL_ARGS=(-enable-kvm -cpu host)
 fi
 
-rm -f "${FDNS_ROUTER_MONITOR_SOCK}" "${FDNS_ROUTER_PIDFILE}"
+rm -f "${WH_ROUTER_MONITOR_SOCK}" "${WH_ROUTER_PIDFILE}"
 
-log "booting OpenWRT ${FDNS_OPENWRT_VERSION} router VM"
+log "booting OpenWRT ${WH_OPENWRT_VERSION} router VM"
 log "  LAN: ${LAN_NETDEV}"
-log "  WAN: user-mode (ssh 127.0.0.1:${FDNS_ROUTER_SSH_PORT}, http 127.0.0.1:${FDNS_ROUTER_HTTP_PORT})"
+log "  WAN: user-mode (ssh 127.0.0.1:${WH_ROUTER_SSH_PORT}, http 127.0.0.1:${WH_ROUTER_HTTP_PORT})"
 
 qemu-system-x86_64 \
-  -name fdns-router \
-  -m "${FDNS_ROUTER_MEM_MB}" -smp 2 \
+  -name wh-router \
+  -m "${WH_ROUTER_MEM_MB}" -smp 2 \
   "${ACCEL_ARGS[@]}" \
   -display none \
-  -serial "file:${FDNS_ROUTER_SERIAL_LOG}" \
-  -monitor "unix:${FDNS_ROUTER_MONITOR_SOCK},server,nowait" \
-  -pidfile "${FDNS_ROUTER_PIDFILE}" \
-  -drive "file=${FDNS_ROUTER_OVERLAY},if=virtio,format=qcow2" \
+  -serial "file:${WH_ROUTER_SERIAL_LOG}" \
+  -monitor "unix:${WH_ROUTER_MONITOR_SOCK},server,nowait" \
+  -pidfile "${WH_ROUTER_PIDFILE}" \
+  -drive "file=${WH_ROUTER_OVERLAY},if=virtio,format=qcow2" \
   -netdev "${LAN_NETDEV}" \
-  -device "virtio-net-pci,netdev=lan,mac=${FDNS_ROUTER_MAC_LAN}" \
+  -device "virtio-net-pci,netdev=lan,mac=${WH_ROUTER_MAC_LAN}" \
   -netdev "${WAN_NETDEV}" \
-  -device "virtio-net-pci,netdev=wan,mac=${FDNS_ROUTER_MAC_WAN}" \
+  -device "virtio-net-pci,netdev=wan,mac=${WH_ROUTER_MAC_WAN}" \
   -daemonize
 
-log "router VM started (pid $(cat "${FDNS_ROUTER_PIDFILE}" 2>/dev/null || echo '?'))"
+log "router VM started (pid $(cat "${WH_ROUTER_PIDFILE}" 2>/dev/null || echo '?'))"
 log ""
 log "next steps:"
-log "  - first boot takes ~30s; tail '${FDNS_ROUTER_SERIAL_LOG}' to watch."
+log "  - first boot takes ~30s; tail '${WH_ROUTER_SERIAL_LOG}' to watch."
 log "  - SSH (WAN hostfwd, empty root password on stock image):"
-log "      ssh -p ${FDNS_ROUTER_SSH_PORT} root@127.0.0.1"
+log "      ssh -p ${WH_ROUTER_SSH_PORT} root@127.0.0.1"
 log "  - LAN-side router IP (default OpenWRT): 192.168.1.1 (not in"
-log "    ${FDNS_LAN_SUBNET}; see README 'Known quirks' — fixed by #150)."
+log "    ${WH_LAN_SUBNET}; see README 'Known quirks' — fixed by #150)."
 log "  - QEMU monitor (savevm/loadvm/quit):"
-log "      socat - UNIX-CONNECT:${FDNS_ROUTER_MONITOR_SOCK}"
+log "      socat - UNIX-CONNECT:${WH_ROUTER_MONITOR_SOCK}"

--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -17,7 +17,7 @@ set wifihaven.@wifihaven[0].lan_prefix='192.168.100.'
 EOF
 uci commit wifihaven
 
-# Align the OpenWRT LAN with the harness's FDNS_LAN_SUBNET=192.168.100.0/24
+# Align the OpenWRT LAN with the harness's WH_LAN_SUBNET=192.168.100.0/24
 # (defined in scripts/vm/config.sh). Without this the LAN stays on OpenWRT's
 # 192.168.1.0/24 default, which doesn't match what scripts/vm/client-up.sh and
 # the e2e plan (#226) expect.

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    <title>FamilyDNS</title>
+    <title>WifiHaven</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🛡</text></svg>" />
   </head>
   <body>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "familydns-web",
+  "name": "wifihaven-web",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "familydns-web",
+      "name": "wifihaven-web",
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "familydns-web",
+  "name": "wifihaven-web",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -6,7 +6,7 @@ function reasonText(reason: string, until?: string | null): string {
   // MacBlockReason wire-format strings emitted by api/PolicyService and
   // forwarded by the router's block-page handler (#437). Keep in sync with
   // shared/src/Models.scala (MacBlockReason cases) and the inline copy in
-  // openwrt/files/usr/lib/lua/familydns/block_page.lua.
+  // openwrt/files/usr/lib/lua/wifihaven/block_page.lua.
   if (reason === 'Paused') return 'This profile is paused.'
   if (reason === 'Schedule') return until ? `This is scheduled quiet time until ${until}.` : 'This is scheduled quiet time.'
   if (reason === 'TimeLimit') return 'Daily screen time limit reached.'


### PR DESCRIPTION
## Summary

Final pass over the codebase to clear stale `familydns` and `fdns` references that earlier rename PRs missed.

- Docs, scripts, configs, tests, web package, API banner, opnsense manifest: `familydns` → `wifihaven`, `FamilyDNS` → `WifiHaven`.
- `scripts/vm/` and `scripts/e2e/`: `FDNS_*` env vars → `WH_*`; `fdns-*` qemu/bridge names (`wh-lan0` bridge, `wh-router`/`wh-client`/`wh-imagebuilder` qemu names, authorized-keys path) → `wh-*`.
- Stale postgres role/db refs in `config/application.conf.example`, `scripts/smoke-prod.sh`, `deploy/README.md`, `AGENTS.md` updated to `wifihaven` to match the live `docker/docker-compose.yml`.
- Dropped the one-shot pre-rename migration blocks from `openwrt/Makefile`, `openwrt/build-ipk.sh`, and `openwrt/build-apk.sh`. The one deployed dev install will be cleaned up + reinstalled.

Only `docs/rename-decision.md` still mentions `familydns` as the historical record of the rename decision itself.

## Test plan

- [ ] CI green (Scala build/tests, OpenWRT lua tests, e2e VM workflow)
- [ ] Verify `WH_*` env vars resolve correctly in `scripts/vm/router-up.sh` smoke run
- [ ] Wipe + reinstall the dev OpenWRT agent (no migration path remains) and confirm clean install works

🤖 Generated with [Claude Code](https://claude.com/claude-code)