### PR TITLE
openwrt(install): require wifihaven_ asset prefix, fail loud on 0/many (#569)

### DIFF
--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -148,11 +148,21 @@ esac
 # Download the latest package matching this system's package manager.
 info "Resolving latest release asset (.$PKG_EXT)..."
 releases_json=$(curl -fsSL "$RELEASES_API")
-pkg_url=$(echo "$releases_json" \
+# Require the wifihaven_ prefix so we don't accidentally pick up a stale
+# pre-rename familydns_*.{ipk,apk} that lingers in the openwrt-latest
+# release between cleanup passes (#569). Fail loud on zero or multiple
+# matches — a future surprise (e.g. unexpected per-arch variants of an
+# _all package) should not silently install whichever sorts first.
+pkg_urls=$(echo "$releases_json" \
   | jsonfilter -e '@.assets[*].browser_download_url' \
-  | grep -E "\.${PKG_EXT}\$" \
-  | head -n1)
-[ -n "$pkg_url" ] || err "could not find a .$PKG_EXT asset in the latest release at $RELEASES_API"
+  | grep -E '/wifihaven_[^/]*\.'"${PKG_EXT}"'$')
+pkg_count=$(printf '%s\n' "$pkg_urls" | grep -c .)
+case "$pkg_count" in
+  0) err "could not find a wifihaven_*.${PKG_EXT} asset in the latest release at $RELEASES_API" ;;
+  1) pkg_url=$pkg_urls ;;
+  *) err "expected exactly one wifihaven_*.${PKG_EXT} asset in $RELEASES_API, found $pkg_count:
+$pkg_urls" ;;
+esac
 pkg_path="/tmp/wifihaven.${PKG_EXT}"
 info "Downloading $pkg_url"
 curl -fsSL -o "$pkg_path" "$pkg_url"

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -58,6 +58,22 @@ grep -q "releases/tags/openwrt-latest" "$SCRIPT" \
   || check "install.sh fetches releases/tags/openwrt-latest" \
            "install.sh appears to hit /releases/latest — would land stale build"
 
+# #569: the release-asset filter must require the wifihaven_ prefix.
+# Without it, a stale pre-rename familydns_*.{ipk,apk} co-resident in the
+# openwrt-latest release sorts first and gets installed instead.
+grep -q "wifihaven_\[\^/\]\*" "$SCRIPT" \
+  && check "asset filter requires wifihaven_ prefix" ok \
+  || check "asset filter requires wifihaven_ prefix" \
+           "install.sh asset filter does not anchor on wifihaven_ prefix"
+
+# #569: the filter must fail loud if multiple assets match (the _all
+# package should produce exactly one match; a future surprise should
+# not silently install whichever happens to sort first).
+grep -q "expected exactly one wifihaven" "$SCRIPT" \
+  && check "asset filter errors on multiple matches" ok \
+  || check "asset filter errors on multiple matches" \
+           "install.sh does not fail loud when >1 wifihaven asset matches"
+
 # #197: the installer must not collect a router name. The name is set
 # once in the admin UI when the enrollment token is issued; the install
 # script only needs the token. A second prompt risks a mismatch that


### PR DESCRIPTION
## Summary
- Anchor the openwrt-latest asset filter on the \`wifihaven_\` prefix so a stale pre-rename \`familydns_*.{ipk,apk}\` co-resident in the release can't be picked.
- Replace the silent \`head -n1\` with an explicit count check — error clearly on 0 or >1 matches instead of installing whichever sorts first.
- Add two install_spec.sh assertions covering the prefix anchor and the multi-match guard.

Fixes #569. Today (2026-05-17) the openwrt-latest release briefly contained both \`familydns_0.1.0-1_all.apk\` and \`wifihaven_0.1.0-1_all.apk\`; \`head -n1\` picked the older familydns one, installing the pre-rename package. The stale assets were manually deleted to unblock; this hardens the script so it can't repeat.

## Test plan
- [x] \`sh openwrt/test/install_spec.sh\` — 17 passed, 0 failed.
- [x] \`sh -n openwrt/install.sh\` — syntax clean.
- [ ] Next OpenWRT install against a clean openwrt-latest release picks the wifihaven_ asset (manual, on next agent install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)