### PR TITLE
docs: manual-qa walkthrough + hostname-attribution ops doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,7 +487,9 @@ attribution sidecar lost the race). IP-typed rows are stored alongside FQDN
 rows but are systematically excluded from FQDN pattern matching (site-limit
 patterns like `*.example.com`) — an IP literal can never match a hostname
 pattern, so counting it against one would be a silent correctness bug. See
-§7.2 and §8.2 for the platform-specific attribution path.
+§7.2 and §8.2 for the platform-specific attribution path, and
+[docs/ops/hostname-attribution.md](ops/hostname-attribution.md) for the
+known buckets of bare-IP events operators encounter in the field.
 
 **Response 200**: empty body.
 

--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -115,6 +115,11 @@ Then check the admin UI: **Routers → `<your router name>`** should show a
 fresh `last_seen_at`, updating roughly every 60 seconds (the policy poll
 interval).
 
+For a deeper end-to-end check that mirrors the VM e2e suite — enrollment,
+allowed browsing, blocking, pause, schedule, time limits, usage reporting,
+unknown-device autocreation — follow [docs/manual-qa.md](manual-qa.md)
+with one connected device.
+
 ## 4. (Optional) Auto-update
 
 Routers running unattended should pull new agent releases automatically. The

--- a/docs/manual-qa.md
+++ b/docs/manual-qa.md
@@ -1,0 +1,331 @@
+# Manual QA — single-device walkthrough
+
+Validates a fresh install end-to-end with one real device. Mirrors the
+VM e2e suite under [`scripts/e2e/scenarios/`](../scripts/e2e/scenarios/) so the same
+behavioral contracts get exercised when the VM harness isn't available —
+bringup, post-rename smoke, hardware shakeouts, or anything the VMs can't
+reproduce.
+
+## Keep in sync with the e2e suite
+
+One manual section per e2e scenario file. The scenario filename appears in
+brackets in every section header so drift can be `grep`-ed.
+
+When you:
+
+- **Add** a scenario to [`scripts/e2e/scenarios/`](../scripts/e2e/scenarios/), add a matching
+  section here. Mirror the docstring's "Verifies" line verbatim.
+- **Change** a scenario's contract, update both.
+- **Spot drift**, treat it as a bug — either delete the manual section
+  (the scenario was removed) or update both (the contract changed).
+
+Reviewer rule of thumb: any PR that touches `scripts/e2e/scenarios/*.py`
+should touch this file too, or explain why not.
+
+## Prereqs
+
+- Agent installed per [install-openwrt.md](install-openwrt.md) and API
+  installed per [install-api.md](install-api.md).
+- Admin UI login (`ADMIN_USER` / `ADMIN_PASS`).
+- SSH to router (`root@…`) and API host.
+- One device on the LAN. Capture its MAC and current IP.
+
+Set these once and reuse them in every snippet below:
+
+```sh
+export DEVICE_MAC=aa:bb:cc:dd:ee:ff
+export ROUTER=192.168.1.1
+export API=http://api.example.com:8080
+export ADMIN_USER=admin
+export ADMIN_PASS='…'
+
+# Admin JWT for the rest of this doc.
+ADMIN_TOKEN=$(curl -fsS -X POST "$API/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}" \
+  | jq -r .token)
+AUTH=(-H "Authorization: Bearer $ADMIN_TOKEN")
+```
+
+Cleanup between scenarios: unpause any profile you paused, clear
+`extraBlocked` entries you added, and reset `timeLimit.dailyMinutes` to 0.
+Each section assumes the previous one was undone.
+
+---
+
+## QA-1: Enrollment [`test_01_enrollment.py`](../scripts/e2e/scenarios/test_01_enrollment.py)
+
+**Verifies:** the router appears in the admin API after install and its
+`last_seen_at` advances on every poll.
+
+```sh
+# Router is registered.
+curl -fsS "${AUTH[@]}" "$API/api/admin/routers" \
+  | jq '.[] | {id, name, lastSeenAt}'
+
+# Agent UCI matches.
+ssh root@"$ROUTER" 'uci get wifihaven.wifihaven.router_id'
+
+# last_seen_at should advance within one poll (default 60s).
+for i in 1 2; do
+  curl -fsS "${AUTH[@]}" "$API/api/admin/routers" | jq '.[].lastSeenAt'
+  sleep 65
+done
+```
+
+**Expected:** a row matching the router's UCI `router_id`; `lastSeenAt`
+strictly increases between samples.
+
+---
+
+## QA-2: Allowed browsing [`test_02_allowed_browsing.py`](../scripts/e2e/scenarios/test_02_allowed_browsing.py)
+
+**Verifies:** with a default (no-block) profile, HTTP succeeds end-to-end
+and a `connection_event` lands with the correct MAC.
+
+```sh
+# 1. Admin UI → create a profile, assign $DEVICE_MAC to it.
+#    (Or do it via the API — see api.ts for the endpoints.)
+
+# 2. From the device:
+curl -v http://example.com/    # → 200, real example.com body
+
+# 3. Event recorded.
+curl -fsS "${AUTH[@]}" "$API/api/logs?limit=20" \
+  | jq --arg m "$DEVICE_MAC" '.[] | select(.deviceMac==$m and .host=="example.com")'
+```
+
+**Expected:** real response (not the block page); event with
+`allowed=true, host="example.com", deviceMac=$DEVICE_MAC` within ~30 s.
+
+---
+
+## QA-3: Blocked domain [`test_03_blocked_domain.py`](../scripts/e2e/scenarios/test_03_blocked_domain.py)
+
+**Verifies:** an `extraBlocked` domain has its HTTP/80 traffic DNAT'd to
+the local block page (Truth 1 — no DNS interception, no TLS interception).
+
+```sh
+# 1. Admin UI → device's profile → add example.org to extraBlocked.
+
+# 2. Wait one poll (~60s) and confirm the nft per-(mac, host) rule landed:
+ssh root@"$ROUTER" 'nft list table inet wifihaven' | grep -iE 'example|extra' | head
+
+# 3. From the device:
+curl -v http://example.org/
+```
+
+**Expected:** HTTP 200 with `wifihaven`/`blocked` in the body (the local
+block page), **not** the real example.org content.
+
+---
+
+## QA-4: Daily time-limit [`test_04_daily_limit.py`](../scripts/e2e/scenarios/test_04_daily_limit.py)
+
+**Verifies:** once `timeLimit.dailyMinutes` is exhausted, further traffic
+from the device is blocked and a `reason=timeLimit` event is recorded.
+
+```sh
+# 1. Admin UI → profile → timeLimit.dailyMinutes = 1.
+
+# 2. From the device, generate ~90 s of activity:
+for i in $(seq 1 90); do curl -sS -o /dev/null http://example.com/; sleep 1; done
+
+# 3. Wait one usage_report_interval + one policy_poll_interval
+#    (defaults: 300s + 60s = ~6 min worst case).
+
+# 4. Re-probe:
+curl -v http://example.com/   # → block page
+
+# 5. Event recorded.
+curl -fsS "${AUTH[@]}" "$API/api/logs?limit=20" \
+  | jq --arg m "$DEVICE_MAC" '.[] | select(.deviceMac==$m and .allowed==false)'
+```
+
+**Expected:** block page after the cap is exceeded; event with
+`allowed=false, reason="timeLimit"`.
+
+---
+
+## QA-5: Usage in API [`test_05_usage_in_api.py`](../scripts/e2e/scenarios/test_05_usage_in_api.py)
+
+**Verifies:** `/api/logs` shows the device's events and `/api/time/status`
+attributes used minutes to the device.
+
+```sh
+curl -fsS "${AUTH[@]}" "$API/api/logs?limit=50" \
+  | jq --arg m "$DEVICE_MAC" '[.[] | select(.deviceMac==$m)] | length'
+
+curl -fsS "${AUTH[@]}" "$API/api/time/status" \
+  | jq --arg m "$DEVICE_MAC" '.[].devices[] | select(.deviceMac==$m)'
+```
+
+**Expected:** non-zero log count for the MAC; a `{deviceMac, deviceName,
+usedMins}` entry with `usedMins > 0` after QA-2/QA-4 traffic. Note the
+field is `deviceMac`, not `mac` (see `shared/Models.scala`).
+
+---
+
+## QA-6: Block page rendering [`test_06_blocked_page.py`](../scripts/e2e/scenarios/test_06_blocked_page.py)
+
+**Verifies:** the block page is rendered by `uhttpd-mod-lua` →
+`handler.lua` and reflects the actually-requested host.
+
+```sh
+# With example.org still in extraBlocked from QA-3:
+curl -sS http://example.org/some/path | head -40
+```
+
+**Expected:** HTML body that names `example.org` and the device. If you
+see a raw 200 with empty body, `uhttpd` or the lua handler is wrong — check
+`logread | grep uhttpd` on the router.
+
+---
+
+## QA-A: Pause [`test_pause.py`](../scripts/e2e/scenarios/test_pause.py)
+
+**Verifies:** pausing a profile adds every assigned MAC to the router's
+`blocked_macs` nft set within one poll; unpausing removes them; events
+carry `reason=paused`.
+
+```sh
+# 1. Pause via admin UI (or PUT /api/profiles/<id> with paused=true).
+
+# 2. Within ~60 s the MAC lands in blocked_macs (case-insensitive):
+ssh root@"$ROUTER" 'nft list set inet wifihaven blocked_macs' | grep -i "$DEVICE_MAC"
+
+# 3. From the device:
+curl -v http://example.com/   # → block page
+
+# 4. Event:
+curl -fsS "${AUTH[@]}" "$API/api/logs?limit=20" \
+  | jq --arg m "$DEVICE_MAC" '.[] | select(.deviceMac==$m and .reason=="paused")'
+
+# 5. Unpause. Within ~60 s:
+ssh root@"$ROUTER" 'nft list set inet wifihaven blocked_macs' | grep -i "$DEVICE_MAC" || echo "(absent — restored)"
+curl -v http://example.com/   # → real example.com
+```
+
+**Expected:** all five checkpoints pass.
+
+---
+
+## QA-B: extraBlocked scoping [`test_extra_blocked.py`](../scripts/e2e/scenarios/test_extra_blocked.py)
+
+**Verifies:** Truth 1 — DNS still returns the real public IP (no DNS
+interception); HTTP/80 still DNATs to the block page; and `extraBlocked`
+is per-profile (a device on a different profile is unaffected).
+
+```sh
+# example.org in extraBlocked on $DEVICE's profile:
+
+# DNS is honest:
+dig +short @"$ROUTER" example.org   # → public A record, never 127.0.0.1
+
+# HTTP is intercepted:
+curl -v http://example.org/         # → block page
+
+# Per-profile: create a second profile without extraBlocked, reassign,
+# wait one poll, retry.
+curl -v http://example.org/         # → succeeds
+```
+
+---
+
+## QA-C: Schedule [`test_schedule.py`](../scripts/e2e/scenarios/test_schedule.py)
+
+**Verifies:** schedule windows block in-window, allow out-of-window; pause
+overrides schedule; windows respect the configured TZ across midnight.
+
+```sh
+# 1. Schedule a "block now" window covering the current minute for today's weekday.
+curl -v http://example.com/   # → block page
+
+# 2. Edit the window end to one minute ago; wait one poll.
+curl -v http://example.com/   # → real example.com
+
+# 3. With the window back in "allow" state, pause the profile.
+curl -v http://example.com/   # → block page (pause wins, per #406)
+```
+
+Cross-midnight + TZ correctness is hard to manual-QA quickly; rely on the
+e2e `test_cross_midnight_LA_tz` and only re-validate manually if the
+schedule evaluator changes.
+
+---
+
+## QA-D: Time-limit edge cases [`test_time_limit.py`](../scripts/e2e/scenarios/test_time_limit.py)
+
+**Verifies:** minute-granularity (49 s ≠ 1 min) and cross-day rollover.
+
+```sh
+# Granularity: dailyMinutes=1, generate 49 s of traffic — still allowed.
+for i in $(seq 1 49); do curl -sS -o /dev/null http://example.com/; sleep 1; done
+curl -v http://example.com/   # → real example.com
+
+# Continue past 60 s total — block kicks in once usage is ingested.
+for i in $(seq 1 20); do curl -sS -o /dev/null http://example.com/; sleep 1; done
+sleep 360
+curl -v http://example.com/   # → block page
+
+# Rollover: re-test the next calendar day (or fast-forward
+# WIFIHAVEN_DEBUG_NOW on the API) — should be allowed again.
+```
+
+---
+
+## QA-E: Reassignment [`test_reassignment.py`](../scripts/e2e/scenarios/test_reassignment.py)
+
+**Verifies:** reassigning a device to a paused profile blocks it within
+one poll; deleting a device row clears its rules.
+
+```sh
+# 1. Create profile "paused-bin" with paused=true.
+# 2. Reassign $DEVICE_MAC to it. Within ~60 s:
+ssh root@"$ROUTER" 'nft list set inet wifihaven blocked_macs' | grep -i "$DEVICE_MAC"
+curl -v http://example.com/   # → block page
+
+# 3. Delete the device row. Within ~60 s the MAC should be gone from any
+#    set, and traffic from it falls through to the unknown-device path
+#    (QA-F) rather than the paused rules.
+```
+
+---
+
+## QA-F: Unknown-device autocreation [`test_unknown_device.py`](../scripts/e2e/scenarios/test_unknown_device.py)
+
+**Verifies:** traffic from a never-registered MAC auto-creates a device
+row with `profile_id=NULL` and a DHCP hostname (when one is supplied).
+
+```sh
+# Connect a brand-new device (or randomize the MAC of the test device).
+# Note the new MAC as $NEW_MAC, then from that device:
+curl -sS http://example.com/
+
+# Within ~30 s:
+curl -fsS "${AUTH[@]}" "$API/api/devices" \
+  | jq --arg m "$NEW_MAC" '.[] | select(.mac==$m)'
+```
+
+**Expected:** row with `mac=$NEW_MAC`, `profileId=null`, and `name` set to
+the DHCP hostname (or empty if the device didn't supply one).
+
+---
+
+## Triage cheats
+
+- **Agent log:** `ssh root@$ROUTER 'logread -f | grep wifihaven'`
+- **Agent UCI:** `ssh root@$ROUTER 'uci show wifihaven'`
+- **Live nft state:** `ssh root@$ROUTER 'nft list table inet wifihaven'`
+- **DNS log (extraBlocked set source of truth):**
+  `ssh root@$ROUTER 'tail -n 50 /tmp/wifihaven-dnsmasq.log'`
+- **API events for a MAC:**
+  `curl -fsS "${AUTH[@]}" "$API/api/logs?limit=200" | jq --arg m "$DEVICE_MAC" '[.[] | select(.deviceMac==$m)]'`
+- **Force a poll:** restart the agent — `ssh root@$ROUTER /etc/init.d/wifihaven restart`
+
+## Reference
+
+- [`scripts/e2e/scenarios/`](../scripts/e2e/scenarios/) — the e2e files this
+  document mirrors.
+- [`scripts/e2e/README.md`](../scripts/e2e/README.md) — VM harness details.
+- [`docs/architecture.md`](architecture.md) — Truths 1–N referenced above.

--- a/docs/ops/hostname-attribution.md
+++ b/docs/ops/hostname-attribution.md
@@ -1,0 +1,128 @@
+# Hostname attribution — what we can and can't name
+
+When the dashboard or `/api/logs` shows a connection event with
+`host.type = "ipv4"` (or `ipv6`) instead of `host.type = "fqdn"`, the
+agent saw the flow but couldn't tie it to a hostname. This is by design
+(architecture Truth 1 — no DNS interception, no TLS interception) but
+not all bare-IP events have the same cause. This doc enumerates the
+known buckets so operators don't re-investigate the same thing.
+
+See [architecture.md §6.4](../architecture.md) for the wire shape and
+[architecture.md §7.2](../architecture.md) for the OpenWRT attribution
+path.
+
+## How attribution actually works
+
+The agent maintains an IP → hostname cache (`/tmp/wifihaven-dns-cache.txt`
+on the router) populated from dnsmasq's query log
+(`/tmp/wifihaven-dnsmasq.log`). When conntrack reports a flow to IP X,
+the agent looks X up in the cache and emits `{type:"fqdn", value:...}`
+on a hit and `{type:"ipv4", value:X}` on a miss.
+
+A miss has exactly one root cause: **no dnsmasq log entry maps that IP
+to a name**. The interesting question is *why*.
+
+## Known causes of misses
+
+### 1. Hardcoded service IPs (will never have a hostname)
+
+Some services connect to fixed IPs that the device never resolves via
+DNS. The biggest offender on iOS/macOS:
+
+- **Apple Push Notification Service (APNs) — `17.0.0.0/8`, predominantly
+  `17.57.0.0/16`.** Every iOS device keeps a long-lived TLS connection
+  to `courier.push.apple.com` (iMessage, mail badges, app push, FaceTime
+  signaling). iOS hardcodes the IP set; no DNS lookup ever fires. You'll
+  see steady low-rate traffic to a `17.57.*` IP per device, continuously.
+
+There is no in-band fix — we don't see a name because no name was
+queried. A future enhancement could ship a static label map for known
+hardcoded ranges (`17.57.0.0/16 → "apple-apns"`), but a flow-event
+annotation like that needs its own design.
+
+### 2. Pre-existing long-lived connections after agent (re)start
+
+After a fresh install or agent restart, the DNS cache is empty. Any TLS
+socket the client had open *before* — to a CDN, a chat backend, a
+streaming service, an OS sync endpoint — keeps flowing through the
+router. The DNS lookup happened on the previous network (or the
+previous dnsmasq process), so the agent has no mapping.
+
+This is **transient**. Long-lived sockets eventually close (server-side
+keepalive, app foreground/background, network change) and the next
+connection does a fresh DNS through our dnsmasq. Expect bare-IP events
+for the first ~1–4 hours after a clean install, tapering off.
+
+To force the issue on a specific device, toggle Wi-Fi off/on on that
+device — most apps will tear down and re-establish through dnsmasq.
+
+### 3. Encrypted DNS bypass (DoH / DoT)
+
+If a device uses encrypted DNS — Apple's iCloud Private Relay (`mask.icloud.com`
++ `mask.apple-dns.net`), Mozilla / Cloudflare DoH (`1.1.1.1` over 443),
+Google DoH (`dns.google` / `8.8.8.8` over 443), NextDNS, etc. — the DNS
+query never traverses our dnsmasq. The connection target IP will appear
+unattributed.
+
+You can detect this by:
+
+- Probing the device for `_dns.resolver.arpa` SVCB queries in
+  `/tmp/wifihaven-dnsmasq.log` — Apple devices send these as upgrade
+  probes; an `NXDOMAIN` reply means the device should fall back to plain
+  DNS, but it's not a guarantee.
+- Counting destination IPs in dnsmasq replies vs. flow events for a MAC.
+  A device with vastly more flow-event destinations than dnsmasq replies
+  is likely using DoH/DoT.
+- For Apple specifically: presence of `mask.icloud.com` /
+  `mask.apple-dns.net` in the dnsmasq log + many bare-IP flows to
+  Cloudflare and Akamai ranges = Private Relay is on.
+
+Mitigations: see [#572](https://github.com/wifihaven/wifihaven/issues/572)
+(block DoH/DoT egress) and [#573](https://github.com/wifihaven/wifihaven/issues/573)
+(recover hostname from TLS SNI).
+
+### 4. Connection-reuse / QUIC sessions
+
+HTTP/3 (QUIC) maintains a single UDP "connection" that the app reuses
+across multiple host fetches without re-resolving DNS. If the first
+fetch in a session predates the agent (cause #2) or used DoH (cause
+#3), every subsequent fetch on that same connection inherits the
+missing attribution. New connections to the same name *will* be named
+correctly.
+
+## Operator triage flow
+
+When `host.type` is bare-IP and you want to know why:
+
+1. **Look up the IP's ASN/owner.** A quick `nslookup <ip>` from the
+   router resolves PTR records via the WAN resolver. Apple = `17.0.0.0/8`,
+   Google = `*.1e100.net`, Cloudflare = `*.cloudflare.com`, AWS = `*.amazonaws.com`.
+
+2. **Is it in `17.0.0.0/8`?** Almost certainly Apple APNs or another
+   Apple hardcoded service. Cause #1, no fix needed.
+
+3. **Was the agent recently (re)started?** Check the dnsmasq log start
+   time:
+   ```sh
+   ssh root@$ROUTER 'head -1 /tmp/wifihaven-dnsmasq.log'
+   ```
+   If the bare-IP events postdate the start by less than a few hours,
+   cause #2 is the likely culprit; wait it out.
+
+4. **Does the device send `_dns.resolver.arpa` SVCB queries or have a
+   ton of unmapped Cloudflare IPs?** Cause #3 (DoH / Private Relay).
+   Mitigation: turn off encrypted DNS on the device (iOS Settings →
+   iCloud → Private Relay; macOS / Android equivalents), or wait for
+   the DoH-blocking feature.
+
+5. **None of the above?** That's worth investigating — file an issue
+   with the MAC, the bare IP, the dnsmasq log for that window, and
+   `/tmp/wifihaven-dns-cache.txt`.
+
+## Reference
+
+- [`docs/architecture.md`](../architecture.md) §0 (Truths), §6.4
+  (`POST /api/router/usage` wire shape), §7.2 (OpenWRT attribution).
+- `/tmp/wifihaven-dnsmasq.log` — dnsmasq query/reply log on the router.
+- `/tmp/wifihaven-dns-cache.txt` — current IP → hostname map (TTLs in
+  the third column).


### PR DESCRIPTION
## Summary

- `docs/manual-qa.md` — single-device walkthrough that mirrors the VM e2e suite scenario-for-scenario, with a top-of-doc sync contract so the two stay aligned.
- `docs/ops/hostname-attribution.md` — operator triage doc for the four real-world buckets of bare-IP events (hardcoded service IPs, pre-existing long-lived sockets, encrypted DNS, QUIC reuse), cross-linked from `architecture.md` §6.4 and referencing #572/#573.
- `docs/install-openwrt.md` §3 Verify gains a pointer to `manual-qa.md`.

## Backstory

Came out of a live single-device QA walkthrough on a fresh install (post-rename bare-reinstall on the test rig). The walkthrough surfaced several real bugs that are now filed separately: #572, #573, #574, #575, #576, #577, #578, #579, #580, #581. This PR is just the docs; the fixes will land in follow-ups.

## Test plan

- [ ] Skim `docs/manual-qa.md` for a missing scenario or stale link
- [ ] Skim `docs/ops/hostname-attribution.md` — does the triage flow match your intuition for what to look at first
- [ ] Confirm the cross-link in `architecture.md` §6.4 reads naturally in context
- [ ] No code changes; CI should be green on docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)