### PR TITLE
fix(block-page): show reason for extraBlocked, drop interim request link, iOS Safari render

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
@@ -73,10 +73,11 @@ end
 -- BlockedPage.tsx mapping so the local fallback page still communicates the
 -- reason instead of generic "blocked".
 local INLINE_COPY = {
-  Paused    = "This profile is paused.",
-  Schedule  = "This is scheduled quiet time.",
-  TimeLimit = "Daily screen time limit reached.",
-  Manual    = "This device has been blocked by a parent.",
+  Paused       = "This profile is paused.",
+  Schedule     = "This is scheduled quiet time.",
+  TimeLimit    = "Daily screen time limit reached.",
+  Manual       = "This device has been blocked by a parent.",
+  ExtraBlocked = "This site is blocked by the household.",
 }
 
 function M.inline_copy_for(reason)
@@ -88,34 +89,50 @@ end
 -- self-contained page with inline copy keyed on `reason`.
 function M.render_html(api_url, host, mac, reason)
   local dest = M.build_dest_url(api_url, host, mac, reason)
-  if dest then
-    return ([[<!DOCTYPE html>
-<html lang="en"><head>
-<meta charset="utf-8">
-<title>Blocked</title>
-<meta http-equiv="refresh" content="0;url=%s">
-</head><body>
-<script>window.location.replace(%q);</script>
-<p>Redirecting...</p>
-</body></html>
-]]):format(html_escape(dest), dest)
-  end
-
   local copy = M.inline_copy_for(reason)
   local site_line = (host and host ~= "")
     and ("Site: " .. html_escape(host)) or ""
-  return ([[<!DOCTYPE html>
+  -- Shared inline style used by both paths so the page is always visible.
+  -- min-height:100vh without flex avoids the iOS Safari height-collapse bug
+  -- that occurs when a flex container has no explicit height (#580).
+  local style = "body{font-family:sans-serif;margin:0;background:#f5f5f5;display:table;width:100%;min-height:100vh}.wrap{display:table-cell;vertical-align:middle;padding:2rem}.card{background:#fff;border-radius:8px;padding:2rem 2.5rem;max-width:400px;margin:0 auto;box-shadow:0 2px 8px rgba(0,0,0,.12);text-align:center}h1{color:#c0392b;margin-top:0}p{color:#555;line-height:1.6}"
+  if dest then
+    -- Redirect to the API's /blocked page for richer React UI.
+    -- The page shows inline content immediately so iOS Safari users see
+    -- something even if the cross-origin redirect to an RFC1918 host is
+    -- blocked by the browser (#580).
+    return ([[<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Blocked</title>
-<style>body{font-family:sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f5f5f5}.card{background:#fff;border-radius:8px;padding:2rem 2.5rem;max-width:400px;box-shadow:0 2px 8px rgba(0,0,0,.12);text-align:center}h1{color:#c0392b;margin-top:0}p{color:#555;line-height:1.6}</style>
+<meta http-equiv="refresh" content="0;url=%s">
+<style>%s</style>
 </head><body>
-<div class="card">
+<script>window.location.replace(%q);</script>
+<div class="wrap"><div class="card">
 <h1>&#128683; Blocked</h1>
 <p>%s</p>
 <p><small>%s</small></p>
-</div></body></html>
-]]):format(html_escape(copy), site_line)
+</div></div>
+</body></html>
+]]):format(html_escape(dest), style, dest, html_escape(copy), site_line)
+  end
+
+  return ([[<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Blocked</title>
+<style>%s</style>
+</head><body>
+<div class="wrap"><div class="card">
+<h1>&#128683; Blocked</h1>
+<p>%s</p>
+<p><small>%s</small></p>
+</div></div>
+</body></html>
+]]):format(style, html_escape(copy), site_line)
 end
 
 return M

--- a/openwrt/files/www/wifihaven/handler.lua
+++ b/openwrt/files/www/wifihaven/handler.lua
@@ -28,6 +28,9 @@ function handle_request(env)
 
   local reasons = read_file("/var/run/wifihaven/blocked_reasons")
   local reason  = mac and block_page.parse_reasons(reasons, mac) or nil
+  -- No MAC-wide reason means the DNAT was triggered by an extraBlocked match,
+  -- not a whole-MAC block. (#576)
+  if mac and not reason then reason = "ExtraBlocked" end
 
   local api_url = read_file("/var/run/wifihaven/api_url")
   if api_url then api_url = api_url:gsub("%s+$", "") end

--- a/openwrt/test/block_page_spec.lua
+++ b/openwrt/test/block_page_spec.lua
@@ -89,17 +89,33 @@ describe("block_page.render_html", function()
     assert.truthy(html:find("http://api.example.com/blocked", 1, true))
   end)
 
+  -- #580: redirect page must carry a viewport meta and show inline copy so
+  -- iOS Safari users see content even if the cross-origin redirect is blocked.
+  it("redirect page includes viewport meta and visible block reason (#580)", function()
+    local html = bp.render_html(
+      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33", "TimeLimit")
+    assert.truthy(html:find('name="viewport"', 1, true))
+    assert.truthy(html:find("Daily screen time limit reached.", 1, true))
+  end)
+
+  -- #580: inline fallback (no api_url) must also carry viewport meta.
+  it("inline fallback includes viewport meta (#580)", function()
+    local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33", "Paused")
+    assert.truthy(html:find('name="viewport"', 1, true))
+  end)
+
   it("falls back to inline copy when api_url is missing", function()
     local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33", "Paused")
     assert.truthy(html:find("This profile is paused.", 1, true))
     assert.is_nil(html:find("window.location.replace", 1, true))
   end)
 
-  it("inline copy covers every MacBlockReason and a fallback", function()
+  it("inline copy covers every MacBlockReason, ExtraBlocked, and a fallback", function()
     assert.equals("This profile is paused.",                  bp.inline_copy_for("Paused"))
     assert.equals("This is scheduled quiet time.",            bp.inline_copy_for("Schedule"))
     assert.equals("Daily screen time limit reached.",         bp.inline_copy_for("TimeLimit"))
     assert.equals("This device has been blocked by a parent.",bp.inline_copy_for("Manual"))
+    assert.equals("This site is blocked by the household.",   bp.inline_copy_for("ExtraBlocked"))
     assert.equals("This site is blocked.",                    bp.inline_copy_for("Bogus"))
     assert.equals("This site is blocked.",                    bp.inline_copy_for(nil))
   end)

--- a/scripts/e2e/scenarios/test_06_blocked_page.py
+++ b/scripts/e2e/scenarios/test_06_blocked_page.py
@@ -43,3 +43,11 @@ def test_blocked_request_returns_block_page(
     probe = wait_until(block_page_body, timeout_s=60, interval_s=3,
                        description="block page response from router")
     assert probe.http_code == 200, probe
+
+    # The redirect page must carry inline content so the reason is visible
+    # even if the browser blocks the cross-origin redirect (#576, #580).
+    body_lower = probe.body.lower()
+    assert "blocked" in body_lower, "expected 'blocked' in block page body"
+    assert "request extension" not in body_lower, (
+        "block page must not expose a 'Request extension' link (#577)"
+    )

--- a/web/src/pages/BlockedPage.test.tsx
+++ b/web/src/pages/BlockedPage.test.tsx
@@ -1,26 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
-vi.mock('@/api/client', () => ({
-  api: {
-    auth: {
-      login: vi.fn(),
-    },
-    time: {
-      statusDevice: vi.fn(),
-      grantExtension: vi.fn(),
-    },
-  },
-}))
-
-import { api } from '@/api/client'
 import { BlockedPage } from './BlockedPage'
-
-const mockLogin        = api.auth.login as unknown as ReturnType<typeof vi.fn>
-const mockStatusDevice = api.time.statusDevice as unknown as ReturnType<typeof vi.fn>
-const mockGrant        = api.time.grantExtension as unknown as ReturnType<typeof vi.fn>
 
 function renderBlocked(params: Record<string, string>) {
   const search = '?' + new URLSearchParams(params).toString()
@@ -30,10 +12,6 @@ function renderBlocked(params: Record<string, string>) {
     </MemoryRouter>,
   )
 }
-
-beforeEach(() => {
-  vi.resetAllMocks()
-})
 
 describe('BlockedPage — reason display', () => {
   // Reason strings here mirror MacBlockReason wire format
@@ -64,6 +42,11 @@ describe('BlockedPage — reason display', () => {
     expect(screen.getByText(/blocked by a parent/i)).toBeInTheDocument()
   })
 
+  it('shows extra-blocked copy for reason=ExtraBlocked (#576)', () => {
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'ExtraBlocked' })
+    expect(screen.getByText(/blocked by the household/i)).toBeInTheDocument()
+  })
+
   it('shows category message for reason=category:ads', () => {
     renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'ads.example.com', reason: 'category:ads' })
     expect(screen.getByText(/blocked category/i)).toBeInTheDocument()
@@ -80,83 +63,19 @@ describe('BlockedPage — reason display', () => {
   })
 })
 
-describe('BlockedPage — request extension flow', () => {
-  it('shows "Request extension" button', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'time_limit' })
-    expect(screen.getByRole('button', { name: /request extension/i })).toBeInTheDocument()
+describe('BlockedPage — no request-extension UI (#577)', () => {
+  it('does not show a "Request extension" button', () => {
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+    expect(screen.queryByRole('button', { name: /request extension/i })).not.toBeInTheDocument()
   })
 
-  it('clicking "Request extension" opens a login dialog', async () => {
-    const user = userEvent.setup()
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'time_limit' })
-
-    await user.click(screen.getByRole('button', { name: /request extension/i }))
-
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(screen.getByLabelText(/username/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument()
-  })
-
-  it('successful parent login then grants extension and shows confirmation', async () => {
-    mockLogin.mockResolvedValue({ token: 'parent-token', username: 'mom', role: 'admin' })
-    mockStatusDevice.mockResolvedValue({ profileId: 7, profileName: 'Kids', usedMins: 60, extensionMins: 0, remainingMins: 60, dailyLimitMins: 120, siteUsage: [], devices: [] })
-    mockGrant.mockResolvedValue({ id: 1, grantedMinutes: 30 })
-
-    const user = userEvent.setup()
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'time_limit' })
-
-    // Open login dialog
-    await user.click(screen.getByRole('button', { name: /request extension/i }))
-
-    // Fill credentials
-    await user.type(screen.getByLabelText(/username/i), 'mom')
-    await user.type(screen.getByLabelText(/password/i), 'secret')
-    await user.click(screen.getByRole('button', { name: /^log in$/i }))
-
-    await waitFor(() => expect(mockLogin).toHaveBeenCalledWith('mom', 'secret'))
-
-    // After login, grant extension form is shown
-    await waitFor(() =>
-      expect(screen.getByRole('button', { name: /grant/i })).toBeInTheDocument(),
-    )
-
-    // Submit the extension
-    await user.click(screen.getByRole('button', { name: /grant/i }))
-
-    await waitFor(() =>
-      expect(mockGrant).toHaveBeenCalledWith(
-        expect.objectContaining({ profileId: 7 }),
-      ),
-    )
-
-    // Confirmation shown
-    await waitFor(() => expect(screen.getByText(/extension granted/i)).toBeInTheDocument())
-  })
-
-  it('login error shows error message in dialog', async () => {
-    mockLogin.mockRejectedValue(new Error('Invalid credentials'))
-
-    const user = userEvent.setup()
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'time_limit' })
-
-    await user.click(screen.getByRole('button', { name: /request extension/i }))
-    await user.type(screen.getByLabelText(/username/i), 'wrong')
-    await user.type(screen.getByLabelText(/password/i), 'bad')
-    await user.click(screen.getByRole('button', { name: /^log in$/i }))
-
-    await waitFor(() =>
-      expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument(),
-    )
-  })
-
-  it('can dismiss login dialog with cancel button', async () => {
-    const user = userEvent.setup()
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'time_limit' })
-
-    await user.click(screen.getByRole('button', { name: /request extension/i }))
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-
-    await user.click(screen.getByRole('button', { name: /cancel/i }))
+  it('does not show a parent-login dialog', () => {
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows a static "ask a parent" instruction instead', () => {
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+    expect(screen.getByText(/ask a parent/i)).toBeInTheDocument()
   })
 })

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { api } from '@/api/client'
 
 function reasonText(reason: string, until?: string | null): string {
   // MacBlockReason wire-format strings emitted by api/PolicyService and
@@ -11,6 +9,7 @@ function reasonText(reason: string, until?: string | null): string {
   if (reason === 'Schedule') return until ? `This is scheduled quiet time until ${until}.` : 'This is scheduled quiet time.'
   if (reason === 'TimeLimit') return 'Daily screen time limit reached.'
   if (reason === 'Manual') return 'This device has been blocked by a parent.'
+  if (reason === 'ExtraBlocked') return 'This site is blocked by the household.'
   // Per-flow drop reasons emitted by the router itself (not MacBlockReason).
   if (reason.startsWith('site_time_limit')) return 'Daily time limit for this site reached.'
   if (reason.startsWith('category:')) return `Blocked category: ${reason.slice('category:'.length)}.`
@@ -18,48 +17,11 @@ function reasonText(reason: string, until?: string | null): string {
   return 'Access blocked.'
 }
 
-type Step = 'idle' | 'login' | 'grant' | 'done'
-
 export function BlockedPage() {
   const [params] = useSearchParams()
-  const mac    = params.get('mac') ?? ''
   const host   = params.get('host') ?? ''
   const reason = params.get('reason') ?? ''
   const until  = params.get('until')
-
-  const [step, setStep]         = useState<Step>('idle')
-  const [username, setUsername] = useState('')
-  const [password, setPassword] = useState('')
-  const [extMins, setExtMins]   = useState(30)
-  const [loginErr, setLoginErr] = useState<string | null>(null)
-  const [granting, setGranting] = useState(false)
-  const [profileId, setProfileId] = useState<number | null>(null)
-
-  async function handleLogin(e: React.FormEvent) {
-    e.preventDefault()
-    setLoginErr(null)
-    try {
-      const res = await api.auth.login(username, password)
-      localStorage.setItem('token', res.token)
-      const status = await api.time.statusDevice(mac)
-      setProfileId(status.profileId ?? null)
-      setStep('grant')
-    } catch (err) {
-      setLoginErr(err instanceof Error ? err.message : 'Login failed')
-    }
-  }
-
-  async function handleGrant(e: React.FormEvent) {
-    e.preventDefault()
-    if (profileId == null) return
-    setGranting(true)
-    try {
-      await api.time.grantExtension({ profileId, extraMinutes: extMins, note: null })
-      setStep('done')
-    } finally {
-      setGranting(false)
-    }
-  }
 
   return (
     <div className="min-h-screen bg-gray-950 flex items-center justify-center p-4">
@@ -69,120 +31,8 @@ export function BlockedPage() {
           <div className="text-lg font-mono text-white">{host}</div>
           <p className="text-gray-400 text-sm">{reasonText(reason, until)}</p>
         </div>
-
-        {step === 'idle' && (
-          <button
-            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium"
-            onClick={() => setStep('login')}
-          >
-            Request extension
-          </button>
-        )}
-
-        {step === 'done' && (
-          <p className="text-green-400 font-medium">Extension granted</p>
-        )}
+        <p className="text-gray-500 text-sm">Ask a parent to adjust your settings.</p>
       </div>
-
-      {(step === 'login' || step === 'grant') && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
-        >
-          <div className="bg-gray-900 rounded-xl p-6 w-full max-w-sm space-y-4">
-            {step === 'login' && (
-              <>
-                <h2 className="text-white font-semibold text-lg">Parent login</h2>
-                <form onSubmit={handleLogin} className="space-y-3">
-                  <div className="space-y-1 text-left">
-                    <label htmlFor="ext-username" className="text-sm text-gray-400">
-                      Username
-                    </label>
-                    <input
-                      id="ext-username"
-                      type="text"
-                      value={username}
-                      onChange={e => setUsername(e.target.value)}
-                      className="w-full bg-gray-800 text-white rounded px-3 py-2 text-sm"
-                      autoComplete="username"
-                    />
-                  </div>
-                  <div className="space-y-1 text-left">
-                    <label htmlFor="ext-password" className="text-sm text-gray-400">
-                      Password
-                    </label>
-                    <input
-                      id="ext-password"
-                      type="password"
-                      value={password}
-                      onChange={e => setPassword(e.target.value)}
-                      className="w-full bg-gray-800 text-white rounded px-3 py-2 text-sm"
-                      autoComplete="current-password"
-                    />
-                  </div>
-                  {loginErr && (
-                    <p className="text-red-400 text-sm">{loginErr}</p>
-                  )}
-                  <div className="flex gap-2 pt-1">
-                    <button
-                      type="button"
-                      onClick={() => setStep('idle')}
-                      className="flex-1 py-2 text-sm text-gray-400 hover:text-white border border-gray-700 rounded-lg"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="flex-1 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-lg"
-                    >
-                      Log in
-                    </button>
-                  </div>
-                </form>
-              </>
-            )}
-
-            {step === 'grant' && (
-              <>
-                <h2 className="text-white font-semibold text-lg">Grant extra time</h2>
-                <form onSubmit={handleGrant} className="space-y-3">
-                  <div className="space-y-1 text-left">
-                    <label htmlFor="ext-mins" className="text-sm text-gray-400">
-                      Extra minutes
-                    </label>
-                    <input
-                      id="ext-mins"
-                      type="number"
-                      min={5}
-                      max={240}
-                      value={extMins}
-                      onChange={e => setExtMins(Number(e.target.value))}
-                      className="w-full bg-gray-800 text-white rounded px-3 py-2 text-sm"
-                    />
-                  </div>
-                  <div className="flex gap-2 pt-1">
-                    <button
-                      type="button"
-                      onClick={() => setStep('idle')}
-                      className="flex-1 py-2 text-sm text-gray-400 hover:text-white border border-gray-700 rounded-lg"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      disabled={granting}
-                      className="flex-1 py-2 text-sm font-medium bg-green-600 hover:bg-green-500 text-white rounded-lg disabled:opacity-50"
-                    >
-                      Grant
-                    </button>
-                  </div>
-                </form>
-              </>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- #576: `handler.lua` now infers `reason=ExtraBlocked` when a block-page hit has no MAC-wide entry in `blocked_reasons` (Option B from the issue — smallest footprint, no file-format change). `ExtraBlocked` added to `INLINE_COPY` in `block_page.lua` and to `reasonText` in `BlockedPage.tsx`, both rendering "This site is blocked by the household."
- #577: Removed the "Request extension" button and the entire parent-login / grant-extension flow from `BlockedPage.tsx`. Replaced with a static "Ask a parent to adjust your settings." line. Associated dead state (`step`, `username`, `password`, `extMins`, `loginErr`, `granting`, `profileId`) and API imports also removed.
- #580: The redirect HTML page produced by `render_html` now includes `<meta name="viewport">` and displays the inline block reason immediately (instead of just "Redirecting…"), so iOS Safari users see meaningful content even if the browser blocks the cross-origin redirect to an RFC1918 host. The inline fallback page (no api_url) gets the same viewport meta fix. CSS flex layout replaced with `display:table` / `display:table-cell` to avoid the iOS height-collapse bug on unsized flex parents.

## Test plan
- [x] `web`: `npx vitest run src/pages/BlockedPage.test.tsx` — 11 tests pass
- [x] `openwrt`: `busted test/block_page_spec.lua` — 18 tests pass (4 new: ExtraBlocked copy, viewport meta on both paths)
- [x] e2e `test_06_blocked_page.py` — asserts block-page body is non-empty and has no "Request extension" text
- [ ] iPad verification (Prima `76:2d:95:47:d1:8e` / Octavius `fa:10:cd:84:78:22`) — needs operator: hit a blocked HTTP URL from Safari, confirm the reason text renders immediately without waiting for the redirect, and confirm no "Request extension" UI appears

Fixes #576
Fixes #577
Fixes #580