### PR TITLE
fix(admin): walkthrough bugs — stale rename, Enter-submit, TZ persistence

### DIFF
--- a/web/src/components/TimezonePicker.tsx
+++ b/web/src/components/TimezonePicker.tsx
@@ -81,6 +81,16 @@ export function TimezonePicker({ value, onChange, testId }: Props) {
             data-testid={testId ? `${testId}-select` : undefined}
             className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-full"
           >
+            {/* (#571) When the filter narrows to one option and that option
+                != value, the browser pre-highlights the lone <option> as the
+                de-facto selection — clicking it then fires no `change`
+                event and the controlled value never updates. Including a
+                hidden option matching the current value gives the select a
+                real "current selection" so clicking the filtered option is
+                an actual change. */}
+            {!filtered.includes(value) && (
+              <option value={value} hidden>{value}</option>
+            )}
             {filtered.map(z => (
               <option key={z} value={z}>{z}</option>
             ))}

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -43,7 +43,7 @@ export function Layout() {
               </svg>
             </button>
             <span className="font-bold text-emerald-400 text-lg tracking-tight">
-              Family<span className="text-white">DNS</span>
+              Wifi<span className="text-white">Haven</span>
             </span>
           </div>
 

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -16,12 +16,27 @@ import { AdminPage } from './AdminPage'
 
 beforeEach(() => {
   vi.resetAllMocks()
-  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+  // Server-of-record: simulates the live API. `update` mutates this and
+  // `get` reads from it, so tests exercise the real round-trip the UI does
+  // (PUT, then re-GET to refresh the summary — #571).
+  let stored: { dailyResetTime: string; dailyResetTz: string } = {
     dailyResetTime: '00:00',
     dailyResetTz: 'America/Los_Angeles',
-  })
-  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  }
+  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    async () => ({ ...stored }),
+  )
+  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    async (next: { dailyResetTime: string; dailyResetTz: string }) => {
+      stored = { ...next }
+    },
+  )
 })
+
+// Per-test override helper for the initial server state.
+function seedServer(s: { dailyResetTime: string; dailyResetTz: string }) {
+  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ...s })
+}
 
 describe('AdminPage — daily reset card', () => {
   it('defaults to collapsed summary view with current values', async () => {
@@ -35,10 +50,7 @@ describe('AdminPage — daily reset card', () => {
   })
 
   it('formats 13:30 as "1:30 PM" in the summary', async () => {
-    (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      dailyResetTime: '13:30',
-      dailyResetTz: 'America/New_York',
-    })
+    seedServer({ dailyResetTime: '13:30', dailyResetTz: 'America/New_York' })
     render(<AdminPage />)
     const summary = await screen.findByTestId('household-summary')
     expect(summary).toHaveTextContent(/Resets daily at 1:30 PM/i)
@@ -101,6 +113,75 @@ describe('AdminPage — daily reset card', () => {
     // Re-opening edit shows original (not dirty) value
     await user.click(screen.getByTestId('household-edit'))
     expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('00:00')
+  })
+
+  it('(#571) changing the TZ in the dropdown persists it via update', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(tzSelect, 'America/New_York')
+
+    await user.click(screen.getByTestId('household-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '00:00',
+        dailyResetTz: 'America/New_York',
+      }),
+    )
+  })
+
+  it('(#571) picking a non-common TZ via "More…" expander persists it', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(tzSelect, '__more__')
+
+    const expanded = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(expanded, 'Europe/London')
+
+    await user.click(screen.getByTestId('household-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '00:00',
+        dailyResetTz: 'Europe/London',
+      }),
+    )
+  })
+
+  it('(#571) summary after save reflects what the server returns, not the local form', async () => {
+    // Simulate a server that silently drops dailyResetTz (the suspected
+    // shape of bug #571). The UI must surface the server-of-record value,
+    // not the user's typed-in value, so the operator sees the persistence
+    // failure rather than a false confirmation.
+    ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (next: { dailyResetTime: string }) => {
+        // Pretend server only persisted the time, ignoring the tz.
+        ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+          dailyResetTime: next.dailyResetTime,
+          dailyResetTz: 'America/Los_Angeles',
+        })
+      },
+    )
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(tzSelect, 'America/New_York')
+    await user.click(screen.getByTestId('household-save'))
+
+    const summary = await screen.findByTestId('household-summary')
+    // Surfaces the dropped value: America/Los_Angeles, NOT America/New_York.
+    expect(summary).toHaveTextContent('America/Los_Angeles')
   })
 
   it('keeps the form open and shows an error when the API rejects', async () => {

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -134,6 +134,35 @@ describe('AdminPage — daily reset card', () => {
     )
   })
 
+  it('(#571) filter that narrows to one option then click persists it', async () => {
+    // Repro of the on-device bug: operator picks "More…", types a filter
+    // that narrows to a single match, clicks it, hits Save. Pre-fix the
+    // controlled <select>'s value never updated because the lone <option>
+    // was already the browser's de-facto selection, so no `change` fired.
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('household-summary')
+    await user.click(screen.getByTestId('household-edit'))
+
+    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(tzSelect, '__more__')
+
+    const filterInput = screen.getByTestId('household-reset-tz-filter')
+    await user.type(filterInput, 'Denver')
+
+    const expanded = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
+    await user.selectOptions(expanded, 'America/Denver')
+
+    await user.click(screen.getByTestId('household-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '00:00',
+        dailyResetTz: 'America/Denver',
+      }),
+    )
+  })
+
   it('(#571) picking a non-common TZ via "More…" expander persists it', async () => {
     const user = userEvent.setup()
     render(<AdminPage />)

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
 
 // Per-test override helper for the initial server state.
 function seedServer(s: { dailyResetTime: string; dailyResetTz: string }) {
-  ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ...s })
+  (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ...s })
 }
 
 describe('AdminPage — daily reset card', () => {
@@ -190,10 +190,10 @@ describe('AdminPage — daily reset card', () => {
     // shape of bug #571). The UI must surface the server-of-record value,
     // not the user's typed-in value, so the operator sees the persistence
     // failure rather than a false confirmation.
-    ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+    (api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
       async (next: { dailyResetTime: string }) => {
         // Pretend server only persisted the time, ignoring the tz.
-        ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
           dailyResetTime: next.dailyResetTime,
           dailyResetTz: 'America/Los_Angeles',
         })

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -69,7 +69,13 @@ function DailyResetCard({
         dailyResetTime: form.dailyResetTime,
         dailyResetTz: form.dailyResetTz,
       })
-      onSaved(form)
+      // Re-read from the server so the summary reflects what was actually
+      // persisted, not just the local form. Without this, a server that
+      // silently dropped a field (e.g. a route handler ignoring dailyResetTz)
+      // would still show the new value in the UI and confuse the operator
+      // (#571).
+      const fresh = await api.household.get()
+      onSaved(fresh)
       setEditing(false)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to save')

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -32,7 +32,7 @@ export function LoginPage() {
             <span className="text-3xl">🛡</span>
           </div>
           <h1 className="text-2xl font-bold text-white">
-            Family<span className="text-emerald-400">DNS</span>
+            Wifi<span className="text-emerald-400">Haven</span>
           </h1>
           <p className="text-gray-500 text-sm mt-1">Sign in to manage your network</p>
         </div>

--- a/web/src/pages/RoutersPage.test.tsx
+++ b/web/src/pages/RoutersPage.test.tsx
@@ -96,3 +96,19 @@ describe('RoutersPage — copy to clipboard', () => {
   })
 })
 
+describe('RoutersPage — enroll form', () => {
+  it('(#568) submits the form when Enter is pressed in the name field', async () => {
+    const user = userEvent.setup()
+    render(<RoutersPage />)
+    await screen.findByText('home-gw')
+    await user.click(screen.getByRole('button', { name: /enroll router/i }))
+
+    const nameInput = screen.getByPlaceholderText('home-gw') as HTMLInputElement
+    await user.type(nameInput, 'new-gw{Enter}')
+
+    await waitFor(() =>
+      expect(api.routers.create).toHaveBeenCalledWith({ name: 'new-gw' }),
+    )
+  })
+})
+

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -118,39 +118,44 @@ export function RoutersPage() {
 
       {creating && (
         <Modal title="Enroll a Router" onClose={() => setCreating(false)}>
-          {error && (
-            <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
-              {error}
+          <form
+            onSubmit={e => { e.preventDefault(); saveCreate() }}
+            className="space-y-5"
+          >
+            {error && (
+              <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+                {error}
+              </div>
+            )}
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                Name <span className="text-red-400">*</span>
+              </label>
+              <input type="text" value={name} autoFocus required
+                onChange={e => setName(e.target.value)}
+                placeholder="home-gw"
+                className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500" />
+              <p className="text-xs text-gray-500 mt-2">
+                This is the only place the router's display name is set — the
+                install script on the router doesn't ask for it.
+              </p>
             </div>
-          )}
-          <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
-              Name <span className="text-red-400">*</span>
-            </label>
-            <input type="text" value={name} autoFocus required
-              onChange={e => setName(e.target.value)}
-              placeholder="home-gw"
-              className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500" />
-            <p className="text-xs text-gray-500 mt-2">
-              This is the only place the router's display name is set — the
-              install script on the router doesn't ask for it.
+            <p className="text-sm text-gray-400">
+              We'll generate a one-time enrollment token. Run the OpenWRT
+              install script on the router and paste the token when prompted;
+              no other identifier is needed. The token is single-use.
             </p>
-          </div>
-          <p className="text-sm text-gray-400">
-            We'll generate a one-time enrollment token. Run the OpenWRT
-            install script on the router and paste the token when prompted;
-            no other identifier is needed. The token is single-use.
-          </p>
-          <div className="flex gap-3 pt-2">
-            <button onClick={() => setCreating(false)} disabled={saving}
-              className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
-              Cancel
-            </button>
-            <button onClick={saveCreate} disabled={saving}
-              className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
-              {saving ? 'Generating…' : 'Generate Token'}
-            </button>
-          </div>
+            <div className="flex gap-3 pt-2">
+              <button type="button" onClick={() => setCreating(false)} disabled={saving}
+                className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
+                Cancel
+              </button>
+              <button type="submit" disabled={saving}
+                className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
+                {saving ? 'Generating…' : 'Generate Token'}
+              </button>
+            </div>
+          </form>
         </Modal>
       )}
 


### PR DESCRIPTION
## Summary

Three small admin-UI bugs surfaced in today's manual walkthrough.

- **#567** — Login page and main nav still rendered the old `FamilyDNS` brand. Replaced with `WifiHaven` in both spots.
- **#568** — The "Enroll a Router" modal didn't submit on Enter because the inputs and buttons weren't wrapped in a `<form>`. Wrapped them; primary action is `type=\"submit\"`, Cancel is explicit `type=\"button\"`.
- **#571** — Root-caused. In the TimezonePicker's "More…" expander, typing a filter that narrowed to exactly one option (operator's repro: typed `Denver`) and clicking that lone option silently did nothing — the controlled `<select>`'s value never updated, so Save sent the previous TZ. The browser pre-highlights the lone `<option>` as the de-facto selection, so clicking it fires no `change`. Filters with >1 results work because clicking a *different* option is a genuine change. Fix: include a hidden `<option>` matching the current `value` whenever it isn't in the filtered list, so the `<select>` has a real current selection and any click is an actual change. Also added a defensive re-GET in AdminPage.save() so the post-save summary reflects what the server actually persisted, not the local form (surfaces any future dropped-field bug).

Fixes #567
Fixes #568
Fixes #571

## Test plan

- [x] `npx vitest run` — 119 tests pass (5 new). New regression test drives the operator's exact flow: pick More → type \"Denver\" → click America/Denver → Save → assert update called with America/Denver.
- [x] `npm run build` (tsc + vite) — clean.
- [ ] Manual on `192.168.10.43`: `/admin` → Edit daily reset → click More… → type \"Denver\" → click `America/Denver` → Save. Summary should now show `America/Denver`.
- [ ] Manual: `/routers` → + Enroll Router → type name → press Enter → token dialog opens.
- [ ] Manual: login page and top-left brand both read \"WifiHaven\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)