### PR TITLE
fix(render): suppress per-(MAC,host) ea drops under allow-all failover

### DIFF
--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1471,7 +1471,7 @@ describe("render extraAllowed enforcement (#421)", function()
   it("suppresses eb_/bl_ drops (including their ea exception) under allow-all failover", function()
     local s = snap_ea()
     s.profiles["3"].failureMode = "allow-all"
-    local nft = render.nft(s, { poll_age_seconds = 301 })
+    local nft = render.nft(s, { poll_failed = true })
     -- No eb / bl drops at all for the kid MAC.
     assert.is_nil(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com", 1, true))


### PR DESCRIPTION
## Summary

- The test at `render_spec.lua:1471` was passing `{ poll_age_seconds = 301 }` to `render.nft` — the old opt from before commit 170e80f (#422) replaced it with `{ poll_failed = true }`.
- Since `render.nft` only checks `opts.poll_failed`, the failover gate (`in_failover`) stayed `false`, so `allowall_macs` was never populated and eb_/bl_ drops were emitted for the allow-all-failover MAC.
- Fix: replace the stale opt with `{ poll_failed = true }`. No render.lua change needed — `allowall_macs` already gates `eb_pairs` / `bl_pairs` correctly once the flag is set.

Fixes #595

## Test plan

- [ ] `cd openwrt && sh test/run_tests.sh` → 365 successes / 0 failures / 0 errors / 1 pending (the pending is the `nft binary not available` skip, expected)
- [ ] Non-failover extraAllowed tests still pass (lines 1317–1462)
- [ ] Other failover tests still pass (line 1158 `poll_failed=true` test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)