### PR TITLE
api: force admin pw change on first login + read-only PG role (#586)

### DIFF
--- a/api/resources/db/migration/V18__must_change_password.sql
+++ b/api/resources/db/migration/V18__must_change_password.sql
@@ -1,0 +1,21 @@
+-- #586: force admin password change on first login.
+--
+-- Adds must_change_password flag to users. While true, every authenticated
+-- API request (other than POST /api/auth/change-password and POST
+-- /api/auth/logout) returns 403 {"error":"password_change_required"}.
+--
+-- The flag is set true for the seeded admin row (password: changeme) so
+-- that a freshly-deployed Render env cannot serve any real request until
+-- the operator rotates the password. It is cleared by AuthService on a
+-- successful change-password call.
+--
+-- Default false: existing non-admin rows and any new users created via the
+-- API start with the flag off (they were already given a real password).
+
+ALTER TABLE users
+  ADD COLUMN must_change_password BOOLEAN NOT NULL DEFAULT false;
+
+-- The seeded admin row has the well-known default password that must be changed.
+UPDATE users
+  SET must_change_password = true
+  WHERE username = 'admin';

--- a/api/resources/db/migration/V19__readonly_role.sql
+++ b/api/resources/db/migration/V19__readonly_role.sql
@@ -1,0 +1,26 @@
+-- #586: create a read-only Postgres role for ad-hoc debugging.
+--
+-- wifihaven_ro is created with LOGIN so Render's external connection string
+-- can reference it directly. No password is set here — the operator sets the
+-- password out-of-band via Render's PG shell (see docs/render-readonly-role.md).
+--
+-- USAGE on schema public + SELECT on all current tables is granted explicitly.
+-- ALTER DEFAULT PRIVILEGES ensures tables added by future migrations are also
+-- readable without a new grant.
+--
+-- This migration is idempotent via IF NOT EXISTS; re-running on a DB that
+-- already has the role is safe.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'wifihaven_ro') THEN
+    CREATE ROLE wifihaven_ro LOGIN;
+  END IF;
+END$$;
+
+GRANT USAGE ON SCHEMA public TO wifihaven_ro;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO wifihaven_ro;
+
+-- Future tables created by any role in the DB are also readable.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO wifihaven_ro;

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -37,6 +37,13 @@ trait AuthService {
   def verify(token: String): IO[AuthError, JwtClaims]
   def requireAdmin(token: String): IO[AuthError, JwtClaims]
   def requireWriter(token: String): IO[AuthError, JwtClaims]
+
+  /** Verify token and also check that must_change_password is not set.
+   *  Returns Forbidden if the flag is set (caller should 403 with
+   *  {"error":"password_change_required"}).
+   */
+  def requirePasswordChanged(token: String): IO[AuthError, JwtClaims]
+
   def changePassword(username: String, current: String, next: String): IO[AuthError, Unit]
   def hashPassword(password: String): UIO[String]
 }
@@ -70,7 +77,7 @@ class AuthServiceLive(
       token <- ZIO
         .attempt(JwtZIOJson.encode(claim, secret, algo))
         .mapError(e => AuthError.Unexpected(e.getMessage))
-    } yield LoginResponse(JwtToken.unsafe(token), user.role, user.username)
+    } yield LoginResponse(JwtToken.unsafe(token), user.role, user.username, user.mustChangePassword)
 
   // We delegate expiration/not-before checks to our injected Clock (see below).
   private val jwtOpts = JwtOptions(expiration = false, notBefore = false)
@@ -111,6 +118,17 @@ class AuthServiceLive(
       else ZIO.fail(AuthError.Forbidden)
     }
 
+  def requirePasswordChanged(token: String): IO[AuthError, JwtClaims] =
+    verify(token).flatMap { claims =>
+      userRepo
+        .findByUsername(claims.sub)
+        .mapError(e => AuthError.Unexpected(e.getMessage))
+        .flatMap {
+          case Some(user) if user.mustChangePassword => ZIO.fail(AuthError.Forbidden)
+          case _                                     => ZIO.succeed(claims)
+        }
+    }
+
   def changePassword(username: String, current: String, next: String): IO[AuthError, Unit] =
     for {
       user  <- userRepo
@@ -124,6 +142,10 @@ class AuthServiceLive(
       hash  <- hashPassword(next)
       _     <- userRepo
         .updatePassword(user.id, hash)
+        .mapError(e => AuthError.Unexpected(e.getMessage))
+      // Clear must_change_password flag on successful rotation (#586).
+      _     <- userRepo
+        .clearMustChangePassword(user.id)
         .mapError(e => AuthError.Unexpected(e.getMessage))
     } yield ()
 

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -38,9 +38,9 @@ trait AuthService {
   def requireAdmin(token: String): IO[AuthError, JwtClaims]
   def requireWriter(token: String): IO[AuthError, JwtClaims]
 
-  /** Verify token and also check that must_change_password is not set.
-   *  Returns Forbidden if the flag is set (caller should 403 with
-   *  {"error":"password_change_required"}).
+  /**
+   * Verify token and also check that must_change_password is not set. Returns Forbidden if the flag
+   * is set (caller should 403 with {"error":"password_change_required"}).
    */
   def requirePasswordChanged(token: String): IO[AuthError, JwtClaims]
 

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -20,6 +20,7 @@ case class DbUser(
     passwordHash: String,
     role: UserRole,
     createdAt: Instant,
+    mustChangePassword: Boolean = false,
 )
 case class LogFilter(
     mac: Option[String] = None,
@@ -45,6 +46,7 @@ trait UserRepo {
   def findById(id: UserId): Task[Option[DbUser]]
   def create(u: String, h: String, r: String): Task[UserId]
   def updatePassword(id: UserId, h: String): Task[Unit]
+  def clearMustChangePassword(id: UserId): Task[Unit]
   def listAll: Task[List[DbUser]]
   def delete(id: UserId): Task[Unit]
 }
@@ -285,15 +287,15 @@ trait ConnectionEventRepo {
 
 class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
   def findByUsername(u: String)               =
-    sql"SELECT id,username,password_hash,role,created_at FROM users WHERE username=$u"
-      .query[(UserId, String, String, UserRole, Instant)]
-      .map(DbUser.apply)
+    sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE username=$u"
+      .query[(UserId, String, String, UserRole, Instant, Boolean)]
+      .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
       .option
       .transact(xa)
   def findById(id: UserId)                    =
-    sql"SELECT id,username,password_hash,role,created_at FROM users WHERE id=$id"
-      .query[(UserId, String, String, UserRole, Instant)]
-      .map(DbUser.apply)
+    sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE id=$id"
+      .query[(UserId, String, String, UserRole, Instant, Boolean)]
+      .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
       .option
       .transact(xa)
   def create(u: String, h: String, r: String) =
@@ -303,9 +305,11 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
       .transact(xa)
   def updatePassword(id: UserId, h: String)   =
     sql"UPDATE users SET password_hash=$h WHERE id=$id".update.run.transact(xa).unit
-  def listAll = sql"SELECT id,username,password_hash,role,created_at FROM users ORDER BY id"
-    .query[(UserId, String, String, UserRole, Instant)]
-    .map(DbUser.apply)
+  def clearMustChangePassword(id: UserId)     =
+    sql"UPDATE users SET must_change_password=false WHERE id=$id".update.run.transact(xa).unit
+  def listAll = sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users ORDER BY id"
+    .query[(UserId, String, String, UserRole, Instant, Boolean)]
+    .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
     .to[List]
     .transact(xa)
   def delete(id: UserId) = sql"DELETE FROM users WHERE id=$id".update.run.transact(xa).unit

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -307,11 +307,12 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
     sql"UPDATE users SET password_hash=$h WHERE id=$id".update.run.transact(xa).unit
   def clearMustChangePassword(id: UserId)     =
     sql"UPDATE users SET must_change_password=false WHERE id=$id".update.run.transact(xa).unit
-  def listAll = sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users ORDER BY id"
-    .query[(UserId, String, String, UserRole, Instant, Boolean)]
-    .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
-    .to[List]
-    .transact(xa)
+  def listAll                                 =
+    sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users ORDER BY id"
+      .query[(UserId, String, String, UserRole, Instant, Boolean)]
+      .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
+      .to[List]
+      .transact(xa)
   def delete(id: UserId) = sql"DELETE FROM users WHERE id=$id".update.run.transact(xa).unit
 }
 

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -299,7 +299,8 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
       .option
       .transact(xa)
   def create(u: String, h: String, r: String) =
-    sql"INSERT INTO users(username,password_hash,role) VALUES($u,$h,$r) RETURNING id"
+    // Always force a password change on first login for admin-created users (#599).
+    sql"INSERT INTO users(username,password_hash,role,must_change_password) VALUES($u,$h,$r,true) RETURNING id"
       .query[UserId]
       .unique
       .transact(xa)

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -286,13 +286,13 @@ trait ConnectionEventRepo {
 }
 
 class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
-  def findByUsername(u: String)               =
+  def findByUsername(u: String)             =
     sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE username=$u"
       .query[(UserId, String, String, UserRole, Instant, Boolean)]
       .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
       .option
       .transact(xa)
-  def findById(id: UserId)                    =
+  def findById(id: UserId)                  =
     sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE id=$id"
       .query[(UserId, String, String, UserRole, Instant, Boolean)]
       .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
@@ -304,11 +304,11 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
       .query[UserId]
       .unique
       .transact(xa)
-  def updatePassword(id: UserId, h: String)   =
+  def updatePassword(id: UserId, h: String) =
     sql"UPDATE users SET password_hash=$h WHERE id=$id".update.run.transact(xa).unit
-  def clearMustChangePassword(id: UserId)     =
+  def clearMustChangePassword(id: UserId)   =
     sql"UPDATE users SET must_change_password=false WHERE id=$id".update.run.transact(xa).unit
-  def listAll                                 =
+  def listAll                               =
     sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users ORDER BY id"
       .query[(UserId, String, String, UserRole, Instant, Boolean)]
       .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -677,9 +677,9 @@ private val passwordChangeRequiredResponse: Response =
     .json("""{"error":"password_change_required"}""")
     .status(Status.Forbidden)
 
-/** Verify auth token only — does NOT check must_change_password. Used exclusively
- *  by POST /api/auth/change-password so that the flag doesn't block the one route
- *  that can clear it.
+/**
+ * Verify auth token only — does NOT check must_change_password. Used exclusively by POST
+ * /api/auth/change-password so that the flag doesn't block the one route that can clear it.
  */
 def requireAuthSkipPwCheck(req: Request, auth: AuthService): IO[Response, JwtClaims] =
   ZIO
@@ -694,9 +694,10 @@ def requireAuthSkipPwCheck(req: Request, auth: AuthService): IO[Response, JwtCla
         },
     )
 
-/** Verify auth token AND enforce that must_change_password is false.
- *  Returns 403 {"error":"password_change_required"} if the flag is set (#586).
- *  All authenticated routes except change-password use this.
+/**
+ * Verify auth token AND enforce that must_change_password is false. Returns 403
+ * {"error":"password_change_required"} if the flag is set (#586). All authenticated routes except
+ * change-password use this.
  */
 def requireAuth(req: Request, auth: AuthService): IO[Response, JwtClaims] =
   ZIO

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -38,7 +38,10 @@ object AuthRoutes {
       Method.POST / "api" / "auth" / "change-password"       ->
         handler { (req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
+            // Skip the must_change_password guard: this is the one route that
+            // clears it. Using requireAuthSkipPwCheck prevents a deadlock where
+            // the flag blocks the only endpoint that can reset itself (#586).
+            claims <- requireAuthSkipPwCheck(req, auth)
             body   <- req.body.asString.orElseFail(Response.badRequest(""))
             cpr    <- ZIO
               .fromEither(body.fromJson[ChangePasswordRequest])
@@ -668,7 +671,17 @@ private def bearerToken(req: Request): Option[String] =
     if v.startsWith("Bearer ") then Some(v.drop(7)) else None
   }
 
-def requireAuth(req: Request, auth: AuthService): IO[Response, JwtClaims] =
+// 403 body emitted when must_change_password is set (#586).
+private val passwordChangeRequiredResponse: Response =
+  Response
+    .json("""{"error":"password_change_required"}""")
+    .status(Status.Forbidden)
+
+/** Verify auth token only — does NOT check must_change_password. Used exclusively
+ *  by POST /api/auth/change-password so that the flag doesn't block the one route
+ *  that can clear it.
+ */
+def requireAuthSkipPwCheck(req: Request, auth: AuthService): IO[Response, JwtClaims] =
   ZIO
     .fromOption(bearerToken(req))
     .orElseFail(Response.unauthorized("Missing token"))
@@ -681,33 +694,37 @@ def requireAuth(req: Request, auth: AuthService): IO[Response, JwtClaims] =
         },
     )
 
-def requireAdmin(req: Request, auth: AuthService): IO[Response, JwtClaims] =
+/** Verify auth token AND enforce that must_change_password is false.
+ *  Returns 403 {"error":"password_change_required"} if the flag is set (#586).
+ *  All authenticated routes except change-password use this.
+ */
+def requireAuth(req: Request, auth: AuthService): IO[Response, JwtClaims] =
   ZIO
     .fromOption(bearerToken(req))
     .orElseFail(Response.unauthorized("Missing token"))
     .flatMap(t =>
       auth
-        .requireAdmin(t)
+        .requirePasswordChanged(t)
         .mapError {
-          case AuthError.Forbidden    => Response.forbidden("Admin required")
+          case AuthError.Forbidden    => passwordChangeRequiredResponse
           case AuthError.TokenExpired => Response.unauthorized("Token expired")
           case _                      => Response.unauthorized("Invalid token")
         },
     )
 
+def requireAdmin(req: Request, auth: AuthService): IO[Response, JwtClaims] =
+  // requireAuth already enforces must_change_password; then we check role.
+  requireAuth(req, auth).flatMap { claims =>
+    if claims.role == "admin" then ZIO.succeed(claims)
+    else ZIO.fail(Response.forbidden("Admin required"))
+  }
+
 def requireWriter(req: Request, auth: AuthService): IO[Response, JwtClaims] =
-  ZIO
-    .fromOption(bearerToken(req))
-    .orElseFail(Response.unauthorized("Missing token"))
-    .flatMap(t =>
-      auth
-        .requireWriter(t)
-        .mapError {
-          case AuthError.Forbidden    => Response.forbidden("Adult or admin required")
-          case AuthError.TokenExpired => Response.unauthorized("Token expired")
-          case _                      => Response.unauthorized("Invalid token")
-        },
-    )
+  // requireAuth already enforces must_change_password; then we check role.
+  requireAuth(req, auth).flatMap { claims =>
+    if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(claims)
+    else ZIO.fail(Response.forbidden("Adult or admin required"))
+  }
 
 /** Admin and adult see all profiles. Child only sees profiles linked to their user. */
 def visibleProfiles(

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -93,6 +93,17 @@ object TestDatabase {
             )
         } finally conn.close()
       }
+      // #586: V18 migration sets must_change_password=true for the seeded admin so
+      // production deployments force a password rotation. In tests we want the admin
+      // to be fully operational, so clear the flag after each migration reset.
+      _  <- ZIO.attempt {
+        val conn = pg.getPostgresDatabase.getConnection
+        try {
+          conn
+            .createStatement()
+            .execute("UPDATE users SET must_change_password=false WHERE username='admin'")
+        } finally conn.close()
+      }
     } yield ()
 
   /** All repo types bundled for convenience */

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -69,7 +69,10 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         userRepo <- ZIO.service[UserRepo]
         auth     <- makeAuth
         hash     <- auth.hashPassword("childpass")
-        _        <- userRepo.create("child1", hash, "child")
+        id       <- userRepo.create("child1", hash, "child")
+        // Clear the must_change_password flag so this test exercises login/verify,
+        // not the forced-rotation flow (that is tested in UserCreateSpec, #599).
+        _        <- userRepo.clearMustChangePassword(id)
         resp     <- auth.login("child1", "childpass")
         claims   <- auth.verify(resp.token.value)
       } yield assertTrue(resp.role == UserRole.Child) &&
@@ -81,7 +84,10 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         userRepo <- ZIO.service[UserRepo]
         auth     <- makeAuth
         hash     <- auth.hashPassword("pass")
-        _        <- userRepo.create("viewer", hash, "child")
+        id       <- userRepo.create("viewer", hash, "child")
+        // Clear the must_change_password flag; this test checks role enforcement,
+        // not the forced-rotation flow (#599).
+        _        <- userRepo.clearMustChangePassword(id)
         resp     <- auth.login("viewer", "pass")
         result   <- auth.requireAdmin(resp.token.value).exit
       } yield assertTrue(result.isFailure)

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -339,6 +339,7 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         auth     <- makeAuth
         hash     <- auth.hashPassword("pass")
         childId  <- userRepo.create("alice", hash, "child")
+        _        <- userRepo.clearMustChangePassword(childId)
         _        <- upRepo.setProfilesForUser(childId, List(kids))
         token    <- auth.login("alice", "pass").map(_.token)
         routes   <- buildRoutes(auth)

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -39,8 +39,8 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   /**
    * Create a user with a given role and link them to the listed profile ids.
    *
-   * Clears must_change_password so that these test users are fully operational immediately;
-   * the flag behaviour itself is tested in UserCreateSpec (#599).
+   * Clears must_change_password so that these test users are fully operational immediately; the
+   * flag behaviour itself is tested in UserCreateSpec (#599).
    */
   private def createUser(
       userRepo: UserRepo,

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -36,7 +36,12 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
-  /** Create a user with a given role and link them to the listed profile ids. */
+  /**
+   * Create a user with a given role and link them to the listed profile ids.
+   *
+   * Clears must_change_password so that these test users are fully operational immediately;
+   * the flag behaviour itself is tested in UserCreateSpec (#599).
+   */
   private def createUser(
       userRepo: UserRepo,
       upRepo: UserProfileRepo,
@@ -48,6 +53,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     for {
       hash <- auth.hashPassword("pass")
       id   <- userRepo.create(username, hash, role)
+      _    <- userRepo.clearMustChangePassword(id)
       _    <- upRepo.setProfilesForUser(id, profileIds)
     } yield id
 

--- a/api/test/src/feature/SessionApiSpec.scala
+++ b/api/test/src/feature/SessionApiSpec.scala
@@ -291,6 +291,7 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         auth     <- makeAuth
         hash     <- auth.hashPassword("pass")
         childId  <- userRepo.create("alice", hash, "child")
+        _        <- userRepo.clearMustChangePassword(childId)
         _        <- upRepo.setProfilesForUser(childId, List(kids))
         token    <- auth.login("alice", "pass").map(_.token.value)
         routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)

--- a/api/test/src/feature/UserCreateSpec.scala
+++ b/api/test/src/feature/UserCreateSpec.scala
@@ -1,0 +1,111 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+import zio.test.Assertion.*
+
+/**
+ * Tests that admin-created users are forced through the change-password flow (#599, follow-up to
+ * #586).
+ *
+ * On creation via POST /api/users (or direct userRepo.create), must_change_password must be true.
+ * The user can still log in and call POST /api/auth/change-password, but every other authenticated
+ * route returns 403 {"error":"password_change_required"} until the flag is cleared.
+ */
+object UserCreateSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  def spec = suite("User creation sets must_change_password=true")(
+    test("userRepo.create stores must_change_password=true") {
+      for {
+        _        <- cleanDb
+        userRepo <- ZIO.service[UserRepo]
+        auth     <- makeAuth
+        hash     <- auth.hashPassword("secret")
+        id       <- userRepo.create("alice", hash, "adult")
+        user     <- userRepo.findById(id)
+      } yield assertTrue(user.exists(_.mustChangePassword))
+    },
+    test("admin-created user cannot access authenticated routes until password changed") {
+      for {
+        _               <- cleanDb
+        userRepo        <- ZIO.service[UserRepo]
+        upRepo          <- ZIO.service[UserProfileRepo]
+        auth            <- makeAuth
+        // Admin creates a new user via the route handler (exercises the full HTTP path).
+        adminToken      <- auth.login("admin", "changeme").map(_.token.value)
+        authRoutes       = AuthRoutes.routes(auth, userRepo, upRepo)
+        createBody       = CreateUserRequest("newbie", "initial123", UserRole.Adult, Nil).toJson
+        createReq        = Request
+          .post(URL.decode("/api/users").toOption.get, Body.fromString(createBody))
+          .addHeader(Header.Authorization.Bearer(adminToken))
+          .addHeader(Header.ContentType(MediaType.application.json))
+        createResp      <- authRoutes.runZIO(createReq)
+        // Login with the newly created user.
+        newbieLoginResp <- auth.login("newbie", "initial123")
+        newbieToken      = newbieLoginResp.token.value
+        // Any non-change-password authenticated route should return 403.
+        meReq            = Request
+          .get(URL.decode("/api/me").toOption.get)
+          .addHeader(Header.Authorization.Bearer(newbieToken))
+        meResp          <- authRoutes.runZIO(meReq)
+      } yield assertTrue(createResp.status == Status.Ok) &&
+        assertTrue(newbieLoginResp.mustChangePassword) &&
+        assertTrue(meResp.status == Status.Forbidden)
+    },
+    test("change-password route is not blocked by must_change_password flag") {
+      for {
+        _               <- cleanDb
+        userRepo        <- ZIO.service[UserRepo]
+        upRepo          <- ZIO.service[UserProfileRepo]
+        auth            <- makeAuth
+        adminToken      <- auth.login("admin", "changeme").map(_.token.value)
+        authRoutes       = AuthRoutes.routes(auth, userRepo, upRepo)
+        createBody       = CreateUserRequest("charlie", "initial456", UserRole.Adult, Nil).toJson
+        createReq        = Request
+          .post(URL.decode("/api/users").toOption.get, Body.fromString(createBody))
+          .addHeader(Header.Authorization.Bearer(adminToken))
+          .addHeader(Header.ContentType(MediaType.application.json))
+        _               <- authRoutes.runZIO(createReq)
+        charlieToken    <- auth.login("charlie", "initial456").map(_.token.value)
+        // POST /api/auth/change-password must succeed even with must_change_password=true.
+        cpBody           = ChangePasswordRequest("initial456", "mynewpassword99").toJson
+        cpReq            = Request
+          .post(URL.decode("/api/auth/change-password").toOption.get, Body.fromString(cpBody))
+          .addHeader(Header.Authorization.Bearer(charlieToken))
+          .addHeader(Header.ContentType(MediaType.application.json))
+        cpResp          <- authRoutes.runZIO(cpReq)
+        // After changing the password the flag is cleared and /api/me now works.
+        newToken        <- auth.login("charlie", "mynewpassword99").map(_.token.value)
+        meReq            = Request
+          .get(URL.decode("/api/me").toOption.get)
+          .addHeader(Header.Authorization.Bearer(newToken))
+        meResp          <- authRoutes.runZIO(meReq)
+      } yield assertTrue(cpResp.status == Status.Ok) &&
+        assertTrue(meResp.status == Status.Ok)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/UserCreateSpec.scala
+++ b/api/test/src/feature/UserCreateSpec.scala
@@ -51,59 +51,59 @@ object UserCreateSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     },
     test("admin-created user cannot access authenticated routes until password changed") {
       for {
-        _               <- cleanDb
-        userRepo        <- ZIO.service[UserRepo]
-        upRepo          <- ZIO.service[UserProfileRepo]
-        auth            <- makeAuth
+        _          <- cleanDb
+        userRepo   <- ZIO.service[UserRepo]
+        upRepo     <- ZIO.service[UserProfileRepo]
+        auth       <- makeAuth
         // Admin creates a new user via the route handler (exercises the full HTTP path).
-        adminToken      <- auth.login("admin", "changeme").map(_.token.value)
-        authRoutes       = AuthRoutes.routes(auth, userRepo, upRepo)
-        createBody       = CreateUserRequest("newbie", "initial123", UserRole.Adult, Nil).toJson
-        createReq        = Request
+        adminToken <- auth.login("admin", "changeme").map(_.token.value)
+        authRoutes = AuthRoutes.routes(auth, userRepo, upRepo)
+        createBody = CreateUserRequest("newbie", "initial123", UserRole.Adult, Nil).toJson
+        createReq  = Request
           .post(URL.decode("/api/users").toOption.get, Body.fromString(createBody))
           .addHeader(Header.Authorization.Bearer(adminToken))
           .addHeader(Header.ContentType(MediaType.application.json))
         createResp      <- authRoutes.runZIO(createReq)
         // Login with the newly created user.
         newbieLoginResp <- auth.login("newbie", "initial123")
-        newbieToken      = newbieLoginResp.token.value
+        newbieToken = newbieLoginResp.token.value
         // Any non-change-password authenticated route should return 403.
-        meReq            = Request
+        meReq       = Request
           .get(URL.decode("/api/me").toOption.get)
           .addHeader(Header.Authorization.Bearer(newbieToken))
-        meResp          <- authRoutes.runZIO(meReq)
+        meResp <- authRoutes.runZIO(meReq)
       } yield assertTrue(createResp.status == Status.Ok) &&
         assertTrue(newbieLoginResp.mustChangePassword) &&
         assertTrue(meResp.status == Status.Forbidden)
     },
     test("change-password route is not blocked by must_change_password flag") {
       for {
-        _               <- cleanDb
-        userRepo        <- ZIO.service[UserRepo]
-        upRepo          <- ZIO.service[UserProfileRepo]
-        auth            <- makeAuth
-        adminToken      <- auth.login("admin", "changeme").map(_.token.value)
-        authRoutes       = AuthRoutes.routes(auth, userRepo, upRepo)
-        createBody       = CreateUserRequest("charlie", "initial456", UserRole.Adult, Nil).toJson
-        createReq        = Request
+        _          <- cleanDb
+        userRepo   <- ZIO.service[UserRepo]
+        upRepo     <- ZIO.service[UserProfileRepo]
+        auth       <- makeAuth
+        adminToken <- auth.login("admin", "changeme").map(_.token.value)
+        authRoutes = AuthRoutes.routes(auth, userRepo, upRepo)
+        createBody = CreateUserRequest("charlie", "initial456", UserRole.Adult, Nil).toJson
+        createReq  = Request
           .post(URL.decode("/api/users").toOption.get, Body.fromString(createBody))
           .addHeader(Header.Authorization.Bearer(adminToken))
           .addHeader(Header.ContentType(MediaType.application.json))
-        _               <- authRoutes.runZIO(createReq)
-        charlieToken    <- auth.login("charlie", "initial456").map(_.token.value)
+        _            <- authRoutes.runZIO(createReq)
+        charlieToken <- auth.login("charlie", "initial456").map(_.token.value)
         // POST /api/auth/change-password must succeed even with must_change_password=true.
-        cpBody           = ChangePasswordRequest("initial456", "mynewpassword99").toJson
-        cpReq            = Request
+        cpBody = ChangePasswordRequest("initial456", "mynewpassword99").toJson
+        cpReq  = Request
           .post(URL.decode("/api/auth/change-password").toOption.get, Body.fromString(cpBody))
           .addHeader(Header.Authorization.Bearer(charlieToken))
           .addHeader(Header.ContentType(MediaType.application.json))
-        cpResp          <- authRoutes.runZIO(cpReq)
+        cpResp   <- authRoutes.runZIO(cpReq)
         // After changing the password the flag is cleared and /api/me now works.
-        newToken        <- auth.login("charlie", "mynewpassword99").map(_.token.value)
-        meReq            = Request
+        newToken <- auth.login("charlie", "mynewpassword99").map(_.token.value)
+        meReq = Request
           .get(URL.decode("/api/me").toOption.get)
           .addHeader(Header.Authorization.Bearer(newToken))
-        meResp          <- authRoutes.runZIO(meReq)
+        meResp <- authRoutes.runZIO(meReq)
       } yield assertTrue(cpResp.status == Status.Ok) &&
         assertTrue(meResp.status == Status.Ok)
     },

--- a/docs/render-readonly-role.md
+++ b/docs/render-readonly-role.md
@@ -1,0 +1,85 @@
+# Read-only Postgres role (`wifihaven_ro`) — operator guide
+
+Migration V19 creates a `wifihaven_ro` role in the application database with
+`SELECT` on all tables (current and future) and `USAGE` on schema `public`.
+The migration creates the role without a password; the operator must set it
+out-of-band before sharing the connection string.
+
+This guide applies to both **staging** and **prod** (once #587 adds the prod
+Render blueprint).
+
+---
+
+## 1. Set the role password via Render's PSQL shell
+
+1. Open the [Render dashboard](https://dashboard.render.com/) and navigate to
+   the database: **wifihaven-pg-staging** (or the prod equivalent once it
+   exists).
+2. Click **PSQL Command** — Render opens a browser-based psql session connected
+   as the `owner` superuser of the managed database.
+3. Run:
+
+```sql
+ALTER ROLE wifihaven_ro PASSWORD '<strong-random-password>';
+```
+
+   Generate the password locally with e.g.:
+   ```sh
+   openssl rand -base64 32
+   ```
+
+4. Close the PSQL shell.
+
+---
+
+## 2. Build the connection string
+
+Render shows the external connection string for the database on the **Info**
+tab of the database resource. It looks like:
+
+```
+postgresql://<user>:<password>@<host>:<port>/<database>?sslmode=require
+```
+
+Replace `<user>` with `wifihaven_ro` and `<password>` with the password you
+set above.  The `<host>`, `<port>`, and `<database>` segments stay the same.
+
+Example:
+```
+postgresql://wifihaven_ro:REDACTED@oregon-postgres.render.com:5432/wifihaven_staging?sslmode=require
+```
+
+---
+
+## 3. Store in 1Password
+
+Store the read-only connection string in the shared 1Password vault alongside
+the admin API password.  Suggested item name:
+
+```
+WifiHaven — Staging RO Postgres URL
+```
+
+(or `WifiHaven — Prod RO Postgres URL` for the production instance).
+
+---
+
+## 4. Verify from a laptop
+
+```sh
+export STAGING_RO_URL="postgresql://wifihaven_ro:REDACTED@..."
+psql "$STAGING_RO_URL" -c "SELECT count(*) FROM connection_events;"
+```
+
+Expected output: a single integer row.  If you see a permission error, check
+that V19 ran (i.e. the Flyway migration was applied at deploy time).
+
+---
+
+## Notes
+
+- The role has `SELECT` only — `INSERT`, `UPDATE`, `DELETE` will be denied.
+- `ALTER DEFAULT PRIVILEGES` in V19 covers tables added by future migrations;
+  no re-grant is needed.
+- Never put the `wifihaven_ro` connection string in `render.yaml` or any
+  committed file — it is an operator credential, not an app config variable.

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,9 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
+      # Staging runs DEBUG so issues are visible in the Render log stream.
+      # TODO(#587): when the prod env block is added here, set its
+      # WIFIHAVEN_LOG_LEVEL to INFO (not DEBUG) to avoid PII leakage in logs.
       - key: WIFIHAVEN_LOG_LEVEL
         value: DEBUG
       # Entrypoint warns if WIFIHAVEN_DEBUG is non-empty (mounts debug

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -176,7 +176,15 @@ case class QueryLog(
 ) derives JsonCodec
 
 case class LoginRequest(username: String, password: String) derives JsonCodec
-case class LoginResponse(token: JwtToken, role: UserRole, username: String) derives JsonCodec
+// mustChangePassword: true when the server-side flag is set (e.g. freshly-seeded admin).
+// The web uses this to redirect directly to the change-password page after login
+// before the user can reach any other route.
+case class LoginResponse(
+    token: JwtToken,
+    role: UserRole,
+    username: String,
+    mustChangePassword: Boolean = false,
+) derives JsonCodec
 case class ChangePasswordRequest(currentPassword: String, newPassword: String) derives JsonCodec
 case class CreateUserRequest(
     username: String,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,13 @@ function RequireAuth({ children }: { children: React.ReactNode }) {
   return isAuthenticated ? <>{children}</> : <Navigate to="/login" replace />
 }
 
+// #586: redirect to /account when the server-enforced must_change_password flag
+// is set so the operator cannot reach any other route until they rotate.
+function RequirePwChanged({ children }: { children: React.ReactNode }) {
+  const { mustChangePassword } = useAuth()
+  return mustChangePassword ? <Navigate to="/account" replace /> : <>{children}</>
+}
+
 function RequireAdmin({ children }: { children: React.ReactNode }) {
   const { isAdmin } = useAuth()
   return isAdmin ? <>{children}</> : <Navigate to="/dashboard" replace />
@@ -29,21 +36,22 @@ function AppRoutes() {
     <Routes>
       <Route path="/login"   element={<LoginPage />} />
       <Route path="/blocked" element={<BlockedPage />} />
-      <Route path="/" element={
-        <RequireAuth>
-          <Layout />
-        </RequireAuth>
-      }>
-        <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="dashboard" element={<DashboardPage />} />
-        <Route path="devices"   element={<DevicesPage />} />
-        <Route path="profiles"  element={<ProfilesPage />} />
-        <Route path="time"      element={<TimePage />} />
-        <Route path="logs"      element={<LogsPage />} />
-        <Route path="account"   element={<AccountPage />} />
-        <Route path="users"     element={<RequireAdmin><UsersPage /></RequireAdmin>} />
-        <Route path="routers"   element={<RequireAdmin><RoutersPage /></RequireAdmin>} />
-        <Route path="admin"     element={<RequireAdmin><AdminPage /></RequireAdmin>} />
+      {/*
+        /account is outside RequirePwChanged so the operator can reach the
+        change-password form even when the server-side flag is set (#586).
+        All other protected routes redirect to /account until the flag clears.
+      */}
+      <Route path="/" element={<RequireAuth><Layout /></RequireAuth>}>
+        <Route path="account" element={<AccountPage />} />
+        <Route index element={<RequirePwChanged><Navigate to="/dashboard" replace /></RequirePwChanged>} />
+        <Route path="dashboard" element={<RequirePwChanged><DashboardPage /></RequirePwChanged>} />
+        <Route path="devices"   element={<RequirePwChanged><DevicesPage /></RequirePwChanged>} />
+        <Route path="profiles"  element={<RequirePwChanged><ProfilesPage /></RequirePwChanged>} />
+        <Route path="time"      element={<RequirePwChanged><TimePage /></RequirePwChanged>} />
+        <Route path="logs"      element={<RequirePwChanged><LogsPage /></RequirePwChanged>} />
+        <Route path="users"     element={<RequirePwChanged><RequireAdmin><UsersPage /></RequireAdmin></RequirePwChanged>} />
+        <Route path="routers"   element={<RequirePwChanged><RequireAdmin><RoutersPage /></RequireAdmin></RequirePwChanged>} />
+        <Route path="admin"     element={<RequirePwChanged><RequireAdmin><AdminPage /></RequireAdmin></RequirePwChanged>} />
       </Route>
     </Routes>
   )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -34,6 +34,17 @@ async function req<T>(
     throw new Error('Unauthorised')
   }
 
+  // #586: server enforces must_change_password — redirect to /account so
+  // the operator can set a new password before using any other route.
+  if (res.status === 403) {
+    const text = await res.text().catch(() => '')
+    if (text.includes('password_change_required')) {
+      window.location.href = '/account'
+      throw new Error('password_change_required')
+    }
+    throw new Error(text || `HTTP 403`)
+  }
+
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText)
     throw new Error(text || `HTTP ${res.status}`)

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -6,11 +6,18 @@ interface AuthState {
   token: string | null
   username: string | null
   role: UserRole | null
+  // #586: mirrors the server's must_change_password flag. True immediately
+  // after login when the server sends mustChangePassword:true. Cleared
+  // (set to false) by the web after a successful password change.
+  mustChangePassword: boolean
 }
 
 interface AuthContextValue extends AuthState {
-  login: (username: string, password: string) => Promise<void>
+  // Returns { mustChangePassword } so callers can redirect before the React
+  // state update is applied (#586).
+  login: (username: string, password: string) => Promise<{ mustChangePassword: boolean }>
   logout: () => void
+  clearMustChangePassword: () => void
   isAdmin: boolean
   isAdult: boolean      // admin or adult — can edit linked profiles
   isChild: boolean
@@ -27,9 +34,13 @@ function readRole(): UserRole | null {
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AuthState>(() => ({
-    token:    localStorage.getItem('token'),
-    username: localStorage.getItem('username'),
-    role:     readRole(),
+    token:               localStorage.getItem('token'),
+    username:            localStorage.getItem('username'),
+    role:                readRole(),
+    // mustChangePassword is not persisted across page reloads: after a reload
+    // the API will enforce the flag via 403 on the first authenticated call,
+    // which the client handles via the normal 403 handler in client.ts.
+    mustChangePassword:  false,
   }))
 
   const login = useCallback(async (username: string, password: string) => {
@@ -37,14 +48,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem('token', resp.token)
     localStorage.setItem('username', resp.username)
     localStorage.setItem('role', resp.role)
-    setState({ token: resp.token, username: resp.username, role: resp.role })
+    const mcp = resp.mustChangePassword ?? false
+    setState({
+      token:              resp.token,
+      username:           resp.username,
+      role:               resp.role,
+      mustChangePassword: mcp,
+    })
+    // Return the flag so the caller (LoginPage) can redirect synchronously
+    // before the React state update propagates (#586).
+    return { mustChangePassword: mcp }
   }, [])
 
   const logout = useCallback(() => {
     localStorage.removeItem('token')
     localStorage.removeItem('username')
     localStorage.removeItem('role')
-    setState({ token: null, username: null, role: null })
+    setState({ token: null, username: null, role: null, mustChangePassword: false })
+  }, [])
+
+  // Called by AccountPage after a successful password change to allow navigation.
+  const clearMustChangePassword = useCallback(() => {
+    setState(prev => ({ ...prev, mustChangePassword: false }))
   }, [])
 
   const isAdmin = state.role === 'admin'
@@ -56,6 +81,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       ...state,
       login,
       logout,
+      clearMustChangePassword,
       isAdmin,
       isAdult,
       isChild,

--- a/web/src/pages/AccountPage.test.tsx
+++ b/web/src/pages/AccountPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('@/api/client', () => ({
@@ -17,13 +18,36 @@ vi.mock('@/hooks/useAuth', () => ({
 import { api } from '@/api/client'
 import { AccountPage } from './AccountPage'
 
-let mockAuth: { username: string; isAdmin: boolean } = { username: 'alice', isAdmin: true }
+let mockAuth: {
+  username: string
+  isAdmin: boolean
+  mustChangePassword: boolean
+  clearMustChangePassword: () => void
+} = {
+  username: 'alice',
+  isAdmin: true,
+  mustChangePassword: false,
+  clearMustChangePassword: vi.fn(),
+}
 
 beforeEach(() => {
   vi.resetAllMocks()
-  mockAuth = { username: 'alice', isAdmin: true }
+  mockAuth = {
+    username: 'alice',
+    isAdmin: true,
+    mustChangePassword: false,
+    clearMustChangePassword: vi.fn(),
+  }
   ;(api.auth.changePassword as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 })
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AccountPage />
+    </MemoryRouter>,
+  )
+}
 
 async function fillFields(user: ReturnType<typeof userEvent.setup>, current: string, next: string, confirm: string) {
   const inputs = document.querySelectorAll('input[type="password"]')
@@ -34,22 +58,45 @@ async function fillFields(user: ReturnType<typeof userEvent.setup>, current: str
 
 describe('AccountPage — role display', () => {
   it('shows admin role for admin user', () => {
-    render(<AccountPage />)
+    renderPage()
     expect(screen.getByText('alice')).toBeInTheDocument()
     expect(screen.getByText('admin')).toBeInTheDocument()
   })
 
   it('shows readonly role for non-admin user', () => {
-    mockAuth = { username: 'bob', isAdmin: false }
-    render(<AccountPage />)
+    mockAuth = { username: 'bob', isAdmin: false, mustChangePassword: false, clearMustChangePassword: vi.fn() }
+    renderPage()
     expect(screen.getByText('readonly')).toBeInTheDocument()
+  })
+})
+
+describe('AccountPage — must-change-password banner', () => {
+  it('shows the banner when mustChangePassword is true', () => {
+    mockAuth = { username: 'alice', isAdmin: true, mustChangePassword: true, clearMustChangePassword: vi.fn() }
+    renderPage()
+    expect(screen.getByText(/Password change required/i)).toBeInTheDocument()
+  })
+
+  it('does not show the banner when mustChangePassword is false', () => {
+    renderPage()
+    expect(screen.queryByText(/Password change required/i)).not.toBeInTheDocument()
+  })
+
+  it('calls clearMustChangePassword after successful change when mustChangePassword is true', async () => {
+    const clearMustChangePassword = vi.fn()
+    mockAuth = { username: 'alice', isAdmin: true, mustChangePassword: true, clearMustChangePassword }
+    const user = userEvent.setup()
+    renderPage()
+    await fillFields(user, 'oldpass12', 'newpass34', 'newpass34')
+    await user.click(screen.getByRole('button', { name: /Update password/ }))
+    await waitFor(() => expect(clearMustChangePassword).toHaveBeenCalled())
   })
 })
 
 describe('AccountPage — password change', () => {
   it('calls api.auth.changePassword and clears fields on success', async () => {
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'oldpass12', 'newpass34', 'newpass34')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
 
@@ -63,7 +110,7 @@ describe('AccountPage — password change', () => {
 
   it('rejects when new and confirm do not match', async () => {
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'oldpass12', 'newpass34', 'different')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
     expect(await screen.findByText(/do not match/i)).toBeInTheDocument()
@@ -72,7 +119,7 @@ describe('AccountPage — password change', () => {
 
   it('rejects when new password is too short', async () => {
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'oldpass12', 'short', 'short')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
     expect(await screen.findByText(/at least 8 characters/i)).toBeInTheDocument()
@@ -81,7 +128,7 @@ describe('AccountPage — password change', () => {
 
   it('rejects when new password equals current', async () => {
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'samesame12', 'samesame12', 'samesame12')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
     expect(await screen.findByText(/differ from the current/i)).toBeInTheDocument()
@@ -91,7 +138,7 @@ describe('AccountPage — password change', () => {
   it('maps 401 error to "Current password is incorrect"', async () => {
     (api.auth.changePassword as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('HTTP 401 Unauthorised'))
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'oldpass12', 'newpass34', 'newpass34')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
     expect(await screen.findByText(/Current password is incorrect/)).toBeInTheDocument()
@@ -100,7 +147,7 @@ describe('AccountPage — password change', () => {
   it('shows raw error for other failures', async () => {
     (api.auth.changePassword as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Server exploded'))
     const user = userEvent.setup()
-    render(<AccountPage />)
+    renderPage()
     await fillFields(user, 'oldpass12', 'newpass34', 'newpass34')
     await user.click(screen.getByRole('button', { name: /Update password/ }))
     expect(await screen.findByText('Server exploded')).toBeInTheDocument()

--- a/web/src/pages/AccountPage.tsx
+++ b/web/src/pages/AccountPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 
 export function AccountPage() {
-  const { username, isAdmin } = useAuth()
+  const { username, isAdmin, mustChangePassword, clearMustChangePassword } = useAuth()
+  const navigate = useNavigate()
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword]         = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -36,6 +38,12 @@ export function AccountPage() {
       setCurrentPassword('')
       setNewPassword('')
       setConfirmPassword('')
+      // #586: clear the client-side flag so nav unlocks, then redirect to
+      // the dashboard if this was a forced-change flow.
+      if (mustChangePassword) {
+        clearMustChangePassword()
+        navigate('/dashboard')
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to change password'
       setError(msg.includes('401') || msg.toLowerCase().includes('unauth')
@@ -49,6 +57,13 @@ export function AccountPage() {
   return (
     <div className="space-y-6 max-w-xl">
       <h1 className="text-xl font-bold text-white">Account</h1>
+
+      {/* #586: banner shown when the server-enforced must_change_password flag is set */}
+      {mustChangePassword && (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3 text-amber-300 text-sm">
+          <strong>Password change required.</strong> The default password must be changed before you can use the rest of the application.
+        </div>
+      )}
 
       <section className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
         <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -32,7 +32,7 @@ function renderLogin() {
 
 describe('LoginPage', () => {
   it('logs in and navigates to /dashboard on success', async () => {
-    loginMock.mockResolvedValue(undefined)
+    loginMock.mockResolvedValue({ mustChangePassword: false })
     const user = userEvent.setup()
     renderLogin()
 

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -15,8 +15,15 @@ export function LoginPage() {
     setError('')
     setLoading(true)
     try {
-      await login(username, password)
-      navigate('/dashboard')
+      const { mustChangePassword } = await login(username, password)
+      // #586: server sets must_change_password on the seeded admin row.
+      // Redirect to the account page so the operator is forced to rotate
+      // before reaching any other part of the UI.
+      if (mustChangePassword) {
+        navigate('/account')
+      } else {
+        navigate('/dashboard')
+      }
     } catch {
       setError('Invalid username or password')
     } finally {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -240,6 +240,9 @@ export interface LoginResponse {
   token: string
   role: UserRole
   username: string
+  // #586: true when the server has the must_change_password flag set.
+  // The web redirects to /account immediately after login when true.
+  mustChangePassword?: boolean
 }
 
 export interface MeResponse {


### PR DESCRIPTION
## Summary

Closes #586. Tracked under umbrella #251.

Three bootstrap-hardening changes for Render (and on-prem) deployments:

### Part 1 — Force password change on first login

- **V18 migration**: adds `must_change_password BOOLEAN NOT NULL DEFAULT false` to `users`; sets it `true` for the seeded `admin` row so a freshly-deployed Render env cannot serve any real request until the operator rotates the password.
- **API**: `AuthService.requirePasswordChanged` checks the flag after verifying the JWT and returns `AuthError.Forbidden` if set. `requireAuth` (the base helper used by all protected routes) now calls this instead of the raw `verify`. `requireAdmin` and `requireWriter` chain through `requireAuth`, so the guard is automatic across the entire route surface.
- **Change-password bypass**: `POST /api/auth/change-password` uses `requireAuthSkipPwCheck` (token-only, no DB flag check) to avoid the deadlock where the flag would block the one route that can clear it.
- **AuthService.changePassword**: clears the flag via `clearMustChangePassword` after a successful rotation.
- **Web**: `LoginResponse` now carries `mustChangePassword`; `useAuth.login` returns it synchronously so `LoginPage` can redirect to `/account` before the React state update propagates. `RequirePwChanged` guard wraps all non-account protected routes in `App.tsx`; `client.ts` handles `403 {"error":"password_change_required"}` by redirecting to `/account`. `AccountPage` shows a warning banner in the forced-change flow and redirects to `/dashboard` on success.

### Part 2 — Per-env LOG_LEVEL (comment only)

- Annotated the existing `WIFIHAVEN_LOG_LEVEL: DEBUG` line in `render.yaml` with a `TODO(#587)` reminding whoever adds the prod env block to use `INFO` instead of `DEBUG`.

### Part 3 — Read-only Postgres role

- **V19 migration**: creates `wifihaven_ro` with `LOGIN` (no password in migration), grants `USAGE` on `public`, `SELECT` on all existing tables, and `ALTER DEFAULT PRIVILEGES` for future tables. Idempotent via `IF NOT EXISTS`.
- **Operator doc**: `docs/render-readonly-role.md` covers setting the password via Render's PSQL shell, building the connection string, storing it in 1Password, and verifying with a `psql` one-liner.

## What's deferred / out of scope

- Production env block in `render.yaml` (tracked in #587; LOG_LEVEL=INFO comment is the only prod hook here)
- Audit logging of password changes
- Multi-user / RBAC (admin is the only user today)

## Test plan

- [ ] Deploy to staging: confirm `psql "$DB_URL" -c "SELECT must_change_password FROM users WHERE username='admin';"` returns `t`
- [ ] Log in with `admin/changeme` → redirected to `/account` with warning banner, all other routes redirect back to `/account`
- [ ] Change password → redirected to `/dashboard`; any API call no longer returns 403
- [ ] Confirm `psql "$STAGING_RO_URL" -c "SELECT count(*) FROM connection_events;"` works after setting `wifihaven_ro` password per `docs/render-readonly-role.md`
- [ ] Confirm staging logs visible at DEBUG in Render dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)