### PR TITLE
fix(openwrt): heartbeat conntrack stream so policy timer ticks while LAN is idle (#543)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -598,6 +598,9 @@ end
 --   lan_prefix     string    default "192.168.1."
 --   max_batch      int       default 50
 --   flush_interval int       default 10  (seconds)
+--   tick_interval  int       default 1   (seconds) — heartbeat cadence that
+--                                          unblocks the conntrack reader so
+--                                          on_tick fires while LAN is idle
 --   max_retries    int       default 3
 --   base_delay     int       default 2   (seconds, doubles each retry)
 --   http_post      function  injectable: post_fn(url, body) -> status, body
@@ -610,6 +613,7 @@ function M.watch(cfg)
   local lan_prefix = cfg.lan_prefix     or "192.168.1."
   local max_batch  = cfg.max_batch      or 50
   local flush_int  = cfg.flush_interval or 10
+  local tick_int   = cfg.tick_interval  or 1
   local max_retry  = cfg.max_retries    or 3
   local base_delay = cfg.base_delay     or 2
 
@@ -647,9 +651,23 @@ function M.watch(cfg)
     end
   end)
 
-  log.info("conntrack: starting watcher lan_prefix=%s max_batch=%d flush_interval=%ds",
-           lan_prefix, max_batch, flush_int)
-  local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
+  log.info("conntrack: starting watcher lan_prefix=%s max_batch=%d flush_interval=%ds tick_int=%ds",
+           lan_prefix, max_batch, flush_int, tick_int)
+  -- Wrap conntrack in a shell that emits an empty line every tick_int seconds
+  -- so the blocking handle:read("*l") below returns regularly even when the
+  -- LAN is idle. Without this heartbeat, on_tick — which drives policy poll
+  -- and usage report — only fires when a NEW flow appears, starving timer
+  -- work during quiescent periods (fixes #543).
+  --
+  -- Heartbeat lines are empty; parse_conntrack_line returns nil for them, so
+  -- the rest of the loop body (batcher.tick, retry drain, on_tick) runs
+  -- without any flow-handling side effects.
+  local cmd = string.format(
+    "( while :; do sleep %d; printf '\\n'; done ) & HB=$!; " ..
+    "trap 'kill -TERM $HB 2>/dev/null || true' EXIT INT TERM HUP; " ..
+    "conntrack -E -e NEW 2>/dev/null",
+    tick_int)
+  local handle = io.popen(cmd, "r")
   if not handle then
     log.err("conntrack: cannot start conntrack -E -e NEW")
     return

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -5,6 +5,36 @@
 local conntrack = require("conntrack")
 
 -- ---------------------------------------------------------------------------
+-- 0. parse_conntrack_line — must return nil for empty heartbeat lines (#543)
+-- ---------------------------------------------------------------------------
+
+describe("parse_conntrack_line", function()
+  it("parses a NEW flow line", function()
+    local flow = conntrack.parse_conntrack_line(
+      "[NEW] tcp 6 120 SYN_SENT src=192.168.1.42 dst=1.2.3.4 sport=54321 dport=443")
+    assert.is_not_nil(flow)
+    assert.equal("192.168.1.42", flow.src_ip)
+    assert.equal("1.2.3.4",      flow.dst_ip)
+    assert.equal("tcp",          flow.proto)
+    assert.equal(443,            flow.dport)
+  end)
+
+  -- The watch loop (#543 fix) wraps `conntrack -E -e NEW` in a shell that
+  -- emits an empty heartbeat line every tick_interval seconds, so the blocking
+  -- handle:read("*l") returns regularly while the LAN is idle. Heartbeat
+  -- lines MUST parse to nil so the per-iteration flow-handling is skipped
+  -- but the iteration's batcher.tick / drain / on_tick still fires.
+  it("returns nil for an empty heartbeat line", function()
+    assert.is_nil(conntrack.parse_conntrack_line(""))
+  end)
+
+  it("returns nil for an UPDATE line (only NEW is parsed)", function()
+    assert.is_nil(conntrack.parse_conntrack_line(
+      "[UPDATE] tcp 6 432000 ESTABLISHED src=192.168.1.42 dst=1.2.3.4"))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 1. ipset attribution: dest_ip → hostname
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

The router agent's policy & usage timers are gated by the conntrack watcher's outer loop in `openwrt/files/usr/lib/lua/wifihaven/conntrack.lua`:

```lua
while true do
  local line = handle:read("*l")  -- BLOCKING until next conntrack NEW
  if not line then break end
  ...
  if cfg.on_tick then cfg.on_tick() end
end
```

`on_tick` is what drives `policy.fetch` on `policy_int` seconds (5s post-#529). It only fires when a conntrack `NEW` line arrives. If the client VM is idle during `wait_for_etag_change` after a mutation, conntrack emits nothing, the read blocks indefinitely, and the policy timer never ticks.

That's the same starvation pattern PR #521 papered over by bumping test timeouts and PR #529 made worse by tightening `policy_int` — neither fixed the underlying coupling. This PR fixes the coupling.

## What

Wrap `conntrack -E -e NEW` in a shell that **also emits an empty line every `tick_interval` seconds** (default 1s). Heartbeat lines parse to `nil` via the existing `parse_conntrack_line` guard, so flow-handling is skipped for them, but `batcher.tick`, retry-queue drain, and `on_tick` still fire — exactly what the cooperative-timer architecture needs.

```lua
local cmd = string.format(
  "( while :; do sleep %d; printf '\\n'; done ) & HB=\$!; " ..
  "trap 'kill -TERM \$HB 2>/dev/null || true' EXIT INT TERM HUP; " ..
  "conntrack -E -e NEW 2>/dev/null",
  tick_int)
```

Trap kills the heartbeat subshell on agent exit / pipe-close, so no orphaned `sleep` processes.

## Local validation (kept router VM, openwrt 23.05.5)

With this branch, debug logs from `wifihaven-agent` show the policy timer ticking at exact 5s intervals while the LAN is idle:

```
23:09:32 policy.fetch GET ... etag=nil → 200 bodyLen=689
23:09:37 policy.fetch GET ... → 304 not modified
23:09:42 policy.fetch GET ... → 304 not modified
23:09:47 policy.fetch GET ... → 304 not modified
23:09:52 policy.fetch GET ... → 304 not modified
23:09:57 policy.fetch GET ... → 304 not modified
... (every 5s = policy_int, indefinitely, no LAN traffic at all)
```

\`ps w\` on the router confirms the heartbeat subshell is co-resident with the conntrack process and dies on agent exit.

Unit tests (busted): **349 passes / 1 pre-existing failure** (test/render_spec.lua:1471, #421 extraAllowed — unrelated, fails on `origin/ci/vm-e2e` without this branch).

A new \`parse_conntrack_line\` describe block locks in the empty-line → nil behavior that the fix depends on.

## Known follow-up

The `test_pause::test_pause_blocks_and_unpause_restores` VM e2e scenario still fails at `_wait_mac_in_blocked_set` even with this fix applied — but for a different reason now. With heartbeat off, the agent doesn't poll. With heartbeat on (this PR), the agent polls every 5s but the test MAC still never lands in the router's `blocked_macs` nft set within the 180s window.

That's a separate downstream bug in the mutation → snapshot → render → nft path, NOT a timer-starvation issue. I'll file it as its own issue once this lands.

## Refs

- Closes #543 — the timer-starvation root cause
- #514 / #481 / PR #486 / PR #521 / PR #529 — prior partial fixes