### PR TITLE
render: add prod env + CDN SPAs + custom domains (#587)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=scala-build /tmp/api.jar /app/api.jar
+# TODO(#601): once the CDN-served Static Sites (#587) are confirmed
+# working in prod, remove the web-build stage and this COPY — the JVM no
+# longer needs to bundle or serve the SPA. Track cleanup in the linked issue.
 COPY --from=web-build /web/dist /app/web
 COPY config/application.conf.example /app/application.conf.example
 COPY docker/entrypoint.sh /app/entrypoint.sh

--- a/docs/render-prod-setup.md
+++ b/docs/render-prod-setup.md
@@ -1,0 +1,153 @@
+# Production + staging Render setup — operator guide
+
+This guide covers provisioning the production environment added in #587 and
+wiring up custom domains for all four Render services (two APIs + two Static
+Site SPAs).
+
+---
+
+## 1. Apply the Blueprint
+
+1. Go to the [Render dashboard](https://dashboard.render.com/) → **Blueprints**.
+2. Connect the `wifihaven/wifihaven` GitHub repo if not already connected.
+3. Click **New Blueprint Instance** and select this repo. Render reads
+   `render.yaml` from the default branch.
+4. Render will show a preview of all six resources to be created:
+   - `wifihaven-api-staging` (Web Service)
+   - `wifihaven-api-prod` (Web Service)
+   - `wifihaven-spa-staging` (Static Site)
+   - `wifihaven-spa-prod` (Static Site)
+   - `wifihaven-pg-staging` (Postgres, free)
+   - `wifihaven-pg-prod` (Postgres, paid — `basic-256mb`)
+5. Click **Apply** and wait for all services to reach **Live** / **Available**.
+
+> **If you already have the staging services from #585**: Render will detect
+> the existing `wifihaven-api-staging` and `wifihaven-pg-staging` resources
+> and update them in-place rather than recreating them. The prod services and
+> both Static Sites will be created fresh.
+
+---
+
+## 2. DNS CNAME records
+
+Once Render finishes provisioning, add these CNAMEs at your DNS provider
+(wherever `wifihaven.app` is registered):
+
+| Subdomain / apex        | CNAME target                                          |
+|-------------------------|-------------------------------------------------------|
+| `api-staging`           | shown in Render → `wifihaven-api-staging` → Settings → Custom Domains |
+| `api`                   | shown in Render → `wifihaven-api-prod` → Settings → Custom Domains    |
+| `staging`               | shown in Render → `wifihaven-spa-staging` → Settings → Custom Domains  |
+| `@` (apex / root)       | shown in Render → `wifihaven-spa-prod` → Settings → Custom Domains     |
+
+**Note on apex domains**: many DNS providers do not support a CNAME at the
+zone apex (`@`). If yours does not, use an **ALIAS** or **ANAME** record
+instead (Route 53 calls it "Alias", Cloudflare calls it a "CNAME flattening"
+record). Render's UI will show the exact target hostname to point at.
+
+After adding CNAMEs, Render provisions Let's Encrypt certificates
+automatically — usually within a few minutes of DNS propagating. You can
+monitor cert status in each service's **Custom Domains** tab.
+
+---
+
+## 3. Verify all four custom domains
+
+Run these checks from your laptop once DNS and certs are live:
+
+```sh
+# Prod API
+curl -sS https://api.wifihaven.app/api/health
+
+# Staging API
+curl -sS https://api-staging.wifihaven.app/api/health
+
+# Prod SPA (look for HTML with <title>WifiHaven</title> or similar)
+curl -sS -o /dev/null -w "%{http_code}" https://wifihaven.app/
+
+# Staging SPA
+curl -sS -o /dev/null -w "%{http_code}" https://staging.wifihaven.app/
+```
+
+Both API health endpoints should return HTTP 200 with a JSON body.
+Both SPA URLs should return HTTP 200.
+
+---
+
+## 4. Production Postgres — daily backup verification
+
+`wifihaven-pg-prod` is on the `basic-256mb` paid plan which includes daily
+backups. Verify after first apply:
+
+1. Render dashboard → **Databases** → `wifihaven-pg-prod`.
+2. Click the **Backups** tab.
+3. Confirm a backup is shown (Render runs the first one within 24 h of
+   creation). The backup schedule should show **Daily**.
+
+If the Backups tab shows no schedule, contact Render support — the `basic-256mb`
+plan should include daily backups by default, but plan names and features can
+change. Do not run prod on the free tier (it expires after ~30 days).
+
+---
+
+## 5. Passwords — 1Password
+
+Store the following credentials in the shared 1Password vault alongside the
+existing staging entries:
+
+| Item name                              | What to store                                 |
+|----------------------------------------|-----------------------------------------------|
+| `WifiHaven — Prod Admin Password`      | The admin password set via `POST /auth/change-password` on first login to `https://api.wifihaven.app` |
+| `WifiHaven — Prod RO Postgres URL`     | The `wifihaven_ro` connection string for `wifihaven-pg-prod` (see `docs/render-readonly-role.md`) |
+| `WifiHaven — Staging Admin Password`   | (already stored from #586; rotate if needed)   |
+| `WifiHaven — Staging RO Postgres URL`  | (already stored from #586; rotate if needed)   |
+
+**Admin password first-login flow**: the prod API ships with a default
+`admin/changeme` credential that is force-expired on first login (#586).
+Open `https://wifihaven.app/` in a browser, log in, and the UI will redirect
+you to `/account` to set a new password before any other action. Store the
+new password in 1Password immediately.
+
+---
+
+## 6. Set the `wifihaven_ro` role password (prod)
+
+Follow the same steps as `docs/render-readonly-role.md`, using
+`wifihaven-pg-prod` instead of `wifihaven-pg-staging`:
+
+1. Render dashboard → `wifihaven-pg-prod` → **PSQL Command**.
+2. Run:
+   ```sql
+   ALTER ROLE wifihaven_ro PASSWORD '<strong-random-password>';
+   ```
+3. Build the connection string (replace `user` with `wifihaven_ro`).
+4. Store in 1Password as `WifiHaven — Prod RO Postgres URL`.
+
+---
+
+## 7. SPA → API wiring (how it works)
+
+The Render Static Site builds bake in the API URL at build time via
+`VITE_API_BASE_URL`:
+
+- `wifihaven-spa-prod` sets `VITE_API_BASE_URL=https://api.wifihaven.app`
+- `wifihaven-spa-staging` sets `VITE_API_BASE_URL=https://api-staging.wifihaven.app`
+
+The JVM Docker image still bundles the SPA as a fallback while the CDN path
+is being validated (see TODO(#601) in `docker/Dockerfile`). The JVM-bundled
+SPA uses relative API paths (`/api/...`), which is correct when accessed via
+the Render service URL (e.g. `wifihaven-api-prod.onrender.com`). Once the
+CDN Static Sites are confirmed healthy, the JVM bundling will be removed in
+#601.
+
+---
+
+## 8. Deferred items
+
+- **CI deploy hook** (#588): the Static Site and API services both need a
+  deploy hook wired to CI so pushes to `main` trigger automatic redeploys.
+  Until then, trigger redeploys manually from the Render dashboard.
+- **JVM SPA cleanup** (#601): remove the web-build stage from
+  `docker/Dockerfile` once CDN serving is confirmed.
+- **Region tuning** (#590): `oregon` is a placeholder — confirm the region
+  closest to the operator's physical location before traffic goes live.

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,7 @@
-# Render Blueprint — wifihaven staging environment
+# Render Blueprint — wifihaven staging + production environments
 #
-# Scope: this file defines the STAGING environment only. Production is added
-# in a follow-up (#587) and will live alongside these resources in this same
-# blueprint.
+# This file defines both the STAGING and PRODUCTION environments as a Blueprint.
+# Staging was added in #585; production + CDN Static Sites added in #587.
 #
 # Region: `oregon` is a placeholder — operator should reconfirm the region
 # closest to the deployment before launch. Tuning is tracked in #590.
@@ -14,9 +13,11 @@
 # NOT rotate this value — rotating invalidates every admin session AND every
 # router agent token, requiring a full re-pair of every deployed gateway.
 #
-# Tracked under #251 (umbrella render.com deploy effort) / closes #585.
+# Tracked under #251 (umbrella render.com deploy effort).
+# Staging closes #585; production + CDN closes #587.
 
 services:
+  # ── Staging API ────────────────────────────────────────────────────────────
   - type: web
     runtime: image
     name: wifihaven-api-staging
@@ -28,6 +29,8 @@ services:
     healthCheckPath: /api/health
     image:
       url: ghcr.io/wifihaven/wifihaven-api:latest
+    domains:
+      - name: api-staging.wifihaven.app
     envVars:
       - key: WIFIHAVEN_DB_HOST
         fromDatabase:
@@ -52,8 +55,6 @@ services:
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
       # Staging runs DEBUG so issues are visible in the Render log stream.
-      # TODO(#587): when the prod env block is added here, set its
-      # WIFIHAVEN_LOG_LEVEL to INFO (not DEBUG) to avoid PII leakage in logs.
       - key: WIFIHAVEN_LOG_LEVEL
         value: DEBUG
       # Entrypoint warns if WIFIHAVEN_DEBUG is non-empty (mounts debug
@@ -64,8 +65,111 @@ services:
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true
 
+  # ── Production API ─────────────────────────────────────────────────────────
+  - type: web
+    runtime: image
+    name: wifihaven-api-prod
+    plan: free
+    # Reconfirm region before launch — pick the Render region closest to the
+    # operator's house. Tuning tracked in #590.
+    region: oregon
+    numInstances: 1
+    healthCheckPath: /api/health
+    image:
+      url: ghcr.io/wifihaven/wifihaven-api:latest
+    domains:
+      - name: api.wifihaven.app
+    envVars:
+      - key: WIFIHAVEN_DB_HOST
+        fromDatabase:
+          name: wifihaven-pg-prod
+          property: host
+      - key: WIFIHAVEN_DB_PORT
+        fromDatabase:
+          name: wifihaven-pg-prod
+          property: port
+      - key: WIFIHAVEN_DB_NAME
+        fromDatabase:
+          name: wifihaven-pg-prod
+          property: database
+      - key: WIFIHAVEN_DB_USER
+        fromDatabase:
+          name: wifihaven-pg-prod
+          property: user
+      - key: WIFIHAVEN_DB_PASSWORD
+        fromDatabase:
+          name: wifihaven-pg-prod
+          property: password
+      - key: WIFIHAVEN_HTTP_PORT
+        value: 8080
+      # Production uses INFO to avoid PII leakage in logs.
+      # Resolves the TODO from #586 / PR #599.
+      - key: WIFIHAVEN_LOG_LEVEL
+        value: INFO
+      # Keep explicitly empty — debug endpoints must never run in prod.
+      - key: WIFIHAVEN_DEBUG
+        value: ""
+      # Generated ONCE on first apply. Never rotate — see header.
+      - key: WIFIHAVEN_JWT_SECRET
+        generateValue: true
+
+  # ── Staging SPA (CDN Static Site) ─────────────────────────────────────────
+  # Serves the React/Vite bundle from Render's CDN edge.
+  # VITE_API_BASE_URL bakes the staging API origin into the bundle at build
+  # time so the SPA always points at the staging API, never prod.
+  # JVM still bundles the SPA (see TODO(#601) in docker/Dockerfile) as a
+  # fallback while the CDN path is being validated.
+  - type: web
+    runtime: static
+    name: wifihaven-spa-staging
+    buildCommand: npm ci && npm run build
+    staticPublishPath: ./dist
+    rootDir: web
+    domains:
+      - name: staging.wifihaven.app
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+    envVars:
+      - key: VITE_API_BASE_URL
+        value: https://api-staging.wifihaven.app
+
+  # ── Production SPA (CDN Static Site) ──────────────────────────────────────
+  # Serves the React/Vite bundle from Render's CDN edge.
+  # VITE_API_BASE_URL bakes the prod API origin into the bundle at build time.
+  # JVM still bundles the SPA (see TODO(#601) in docker/Dockerfile) as a
+  # fallback while the CDN path is being validated.
+  - type: web
+    runtime: static
+    name: wifihaven-spa-prod
+    buildCommand: npm ci && npm run build
+    staticPublishPath: ./dist
+    rootDir: web
+    domains:
+      - name: wifihaven.app
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html
+    envVars:
+      - key: VITE_API_BASE_URL
+        value: https://api.wifihaven.app
+
 databases:
+  # ── Staging Postgres ───────────────────────────────────────────────────────
+  # Free plan — staging data is expendable; recreation is a feature (#585).
   - name: wifihaven-pg-staging
     plan: free
+    postgresMajorVersion: 16
+    region: oregon
+
+  # ── Production Postgres ────────────────────────────────────────────────────
+  # Paid plan (basic-256mb) — free PG expires after ~30 days, which would
+  # nuke household data. The basic-256mb tier is the cheapest paid Render
+  # Managed Postgres plan and includes daily backups. Verify in the Render
+  # dashboard after first apply: Databases → wifihaven-pg-prod → Backups tab.
+  - name: wifihaven-pg-prod
+    plan: basic-256mb
     postgresMajorVersion: 16
     region: oregon

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,7 +6,13 @@ import type {
   User,
 } from '@/types/api'
 
-const BASE = '/api'
+// VITE_API_BASE_URL is empty by default (relative path — SPA served from the
+// same origin as the API, which is the current JVM-bundled behaviour). Static
+// Site builds override this to an absolute URL so the CDN-served SPA knows
+// which API host to reach: https://api.wifihaven.app for prod,
+// https://api-staging.wifihaven.app for staging. See render.yaml and #587.
+const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+const BASE = `${VITE_API_BASE_URL}/api`
 
 function getToken(): string | null {
   return localStorage.getItem('token')

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // Baked in at Static Site build time — empty string by default so the
+  // JVM-bundled SPA continues to use relative API paths (/api/...).
+  // Overridden per environment in render.yaml (see #587).
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Closes #587. Tracked under #251.

## What's in this PR

### `render.yaml`
- **`wifihaven-api-prod`**: production Web Service (`plan: free`, same as staging), with custom domain `api.wifihaven.app`.
- **`wifihaven-pg-prod`**: production Managed Postgres on `plan: basic-256mb` (cheapest paid tier; avoids the free-plan 30-day expiry that would nuke household data). Includes daily backups.
- **`wifihaven-spa-staging`** / **`wifihaven-spa-prod`**: Render Static Sites serving the React/Vite bundle from CDN. Each bakes in the correct API origin via `VITE_API_BASE_URL` at build time (`https://api-staging.wifihaven.app` and `https://api.wifihaven.app` respectively). SPA routes rewrite to `index.html` for client-side navigation.
- Custom domains: `api.wifihaven.app`, `api-staging.wifihaven.app`, `wifihaven.app`, `staging.wifihaven.app`.
- Resolves the `TODO(#587)` comment from #599: prod sets `WIFIHAVEN_LOG_LEVEL=INFO` (not DEBUG) to avoid PII leakage.

### `web/src/api/client.ts`
Introduces `VITE_API_BASE_URL` env var. Defaults to `''` (relative `/api/...` path — preserves current JVM-bundled behaviour). Static Site builds override it with the absolute API origin.

### `web/src/vite-env.d.ts`
Standard Vite `ImportMeta` type declarations including `VITE_API_BASE_URL`. Required for TypeScript to recognise `import.meta.env.*`.

### `docker/Dockerfile`
Added `TODO(#601)` noting that the `web-build` stage and SPA bundle copy should be removed once CDN serving is confirmed working. **JVM still bundles the SPA as a fallback — no behaviour change in this PR.**

### `docs/render-prod-setup.md`
Operator guide covering: applying the blueprint, DNS CNAME records for all four custom domains, verifying Let's Encrypt certs, confirming daily Postgres backups in the Render UI, where to store prod passwords in 1Password, and the SPA→API wiring explanation.

## Deferred — not in this PR

- **JVM SPA serving cleanup** → #601 (filed as part of this PR). Remove `web-build` stage and `WIFIHAVEN_STATIC_DIR` once CDN is verified. TODO is in `docker/Dockerfile`.
- **CI deploy hooks** → #588.
- **Region tuning** → #590 (`oregon` remains a placeholder).

## Operator action items after merge

1. Apply the Blueprint in the Render dashboard (see `docs/render-prod-setup.md`).
2. Add DNS CNAMEs for all four custom domains (targets shown in Render → each service → Custom Domains).
3. Verify daily backups on `wifihaven-pg-prod` (Render dashboard → Databases → Backups tab).
4. Log in to `https://wifihaven.app/` and rotate the admin password on first login. Store in 1Password as `WifiHaven — Prod Admin Password`.
5. Set `wifihaven_ro` role password on prod Postgres (see `docs/render-readonly-role.md`). Store in 1Password as `WifiHaven — Prod RO Postgres URL`.