### PR TITLE
render: swap wifihaven.app → wifihaven.net + add www apex

### DIFF
--- a/docs/render-prod-setup.md
+++ b/docs/render-prod-setup.md
@@ -31,7 +31,7 @@ Site SPAs).
 ## 2. DNS CNAME records
 
 Once Render finishes provisioning, add these CNAMEs at your DNS provider
-(wherever `wifihaven.app` is registered):
+(wherever `wifihaven.net` is registered):
 
 | Subdomain / apex        | CNAME target                                          |
 |-------------------------|-------------------------------------------------------|
@@ -39,6 +39,14 @@ Once Render finishes provisioning, add these CNAMEs at your DNS provider
 | `api`                   | shown in Render → `wifihaven-api-prod` → Settings → Custom Domains    |
 | `staging`               | shown in Render → `wifihaven-spa-staging` → Settings → Custom Domains  |
 | `@` (apex / root)       | shown in Render → `wifihaven-spa-prod` → Settings → Custom Domains     |
+| `www`                   | same target as apex — `wifihaven-spa-prod` accepts both `wifihaven.net` and `www.wifihaven.net` |
+
+The prod SPA Static Site is configured with both `wifihaven.net` and
+`www.wifihaven.net` as custom domains (see `render.yaml`). Render issues
+Let's Encrypt certificates for both and serves the same bundle from either
+hostname; it does not auto-redirect between apex and www, so users who land
+on `www.` stay on `www.` (and vice versa). If a canonical redirect is
+desired later, configure it as a Render redirect rule or in the SPA itself.
 
 **Note on apex domains**: many DNS providers do not support a CNAME at the
 zone apex (`@`). If yours does not, use an **ALIAS** or **ANAME** record
@@ -57,16 +65,16 @@ Run these checks from your laptop once DNS and certs are live:
 
 ```sh
 # Prod API
-curl -sS https://api.wifihaven.app/api/health
+curl -sS https://api.wifihaven.net/api/health
 
 # Staging API
-curl -sS https://api-staging.wifihaven.app/api/health
+curl -sS https://api-staging.wifihaven.net/api/health
 
 # Prod SPA (look for HTML with <title>WifiHaven</title> or similar)
-curl -sS -o /dev/null -w "%{http_code}" https://wifihaven.app/
+curl -sS -o /dev/null -w "%{http_code}" https://wifihaven.net/
 
 # Staging SPA
-curl -sS -o /dev/null -w "%{http_code}" https://staging.wifihaven.app/
+curl -sS -o /dev/null -w "%{http_code}" https://staging.wifihaven.net/
 ```
 
 Both API health endpoints should return HTTP 200 with a JSON body.
@@ -97,14 +105,14 @@ existing staging entries:
 
 | Item name                              | What to store                                 |
 |----------------------------------------|-----------------------------------------------|
-| `WifiHaven — Prod Admin Password`      | The admin password set via `POST /auth/change-password` on first login to `https://api.wifihaven.app` |
+| `WifiHaven — Prod Admin Password`      | The admin password set via `POST /auth/change-password` on first login to `https://api.wifihaven.net` |
 | `WifiHaven — Prod RO Postgres URL`     | The `wifihaven_ro` connection string for `wifihaven-pg-prod` (see `docs/render-readonly-role.md`) |
 | `WifiHaven — Staging Admin Password`   | (already stored from #586; rotate if needed)   |
 | `WifiHaven — Staging RO Postgres URL`  | (already stored from #586; rotate if needed)   |
 
 **Admin password first-login flow**: the prod API ships with a default
 `admin/changeme` credential that is force-expired on first login (#586).
-Open `https://wifihaven.app/` in a browser, log in, and the UI will redirect
+Open `https://wifihaven.net/` in a browser, log in, and the UI will redirect
 you to `/account` to set a new password before any other action. Store the
 new password in 1Password immediately.
 
@@ -130,8 +138,8 @@ Follow the same steps as `docs/render-readonly-role.md`, using
 The Render Static Site builds bake in the API URL at build time via
 `VITE_API_BASE_URL`:
 
-- `wifihaven-spa-prod` sets `VITE_API_BASE_URL=https://api.wifihaven.app`
-- `wifihaven-spa-staging` sets `VITE_API_BASE_URL=https://api-staging.wifihaven.app`
+- `wifihaven-spa-prod` sets `VITE_API_BASE_URL=https://api.wifihaven.net`
+- `wifihaven-spa-staging` sets `VITE_API_BASE_URL=https://api-staging.wifihaven.net`
 
 The JVM Docker image still bundles the SPA as a fallback while the CDN path
 is being validated (see TODO(#601) in `docker/Dockerfile`). The JVM-bundled

--- a/render.yaml
+++ b/render.yaml
@@ -30,7 +30,7 @@ services:
     image:
       url: ghcr.io/wifihaven/wifihaven-api:latest
     domains:
-      - name: api-staging.wifihaven.app
+      - name: api-staging.wifihaven.net
     envVars:
       - key: WIFIHAVEN_DB_HOST
         fromDatabase:
@@ -78,7 +78,7 @@ services:
     image:
       url: ghcr.io/wifihaven/wifihaven-api:latest
     domains:
-      - name: api.wifihaven.app
+      - name: api.wifihaven.net
     envVars:
       - key: WIFIHAVEN_DB_HOST
         fromDatabase:
@@ -126,14 +126,14 @@ services:
     staticPublishPath: ./dist
     rootDir: web
     domains:
-      - name: staging.wifihaven.app
+      - name: staging.wifihaven.net
     routes:
       - type: rewrite
         source: /*
         destination: /index.html
     envVars:
       - key: VITE_API_BASE_URL
-        value: https://api-staging.wifihaven.app
+        value: https://api-staging.wifihaven.net
 
   # ── Production SPA (CDN Static Site) ──────────────────────────────────────
   # Serves the React/Vite bundle from Render's CDN edge.
@@ -147,14 +147,15 @@ services:
     staticPublishPath: ./dist
     rootDir: web
     domains:
-      - name: wifihaven.app
+      - name: wifihaven.net
+      - name: www.wifihaven.net
     routes:
       - type: rewrite
         source: /*
         destination: /index.html
     envVars:
       - key: VITE_API_BASE_URL
-        value: https://api.wifihaven.app
+        value: https://api.wifihaven.net
 
 databases:
   # ── Staging Postgres ───────────────────────────────────────────────────────

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,8 +9,8 @@ import type {
 // VITE_API_BASE_URL is empty by default (relative path — SPA served from the
 // same origin as the API, which is the current JVM-bundled behaviour). Static
 // Site builds override this to an absolute URL so the CDN-served SPA knows
-// which API host to reach: https://api.wifihaven.app for prod,
-// https://api-staging.wifihaven.app for staging. See render.yaml and #587.
+// which API host to reach: https://api.wifihaven.net for prod,
+// https://api-staging.wifihaven.net for staging. See render.yaml and #587.
 const VITE_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
 const BASE = `${VITE_API_BASE_URL}/api`
 


### PR DESCRIPTION
## Summary

Operator acquired `wifihaven.net` — `.app` was a placeholder while the
real domain was being picked. This PR mechanically swaps the in-tree
config from `wifihaven.app` to `wifihaven.net` and adds `www.wifihaven.net`
as a second custom domain on the prod SPA.

## Files touched

- `render.yaml` — all four custom-domain `name:` entries swapped to `.net`; both `VITE_API_BASE_URL` env vars swapped; **added** `www.wifihaven.net` to `wifihaven-spa-prod.domains`.
- `docs/render-prod-setup.md` — all hostnames in the CNAME table, verification curls, and 1Password references swapped; new row + paragraph explaining the apex/www dual-domain setup.
- `web/src/api/client.ts` — two comment-only references (no logic change; client reads `VITE_API_BASE_URL`).

Not touched:
- `docs/rename-decision.md:68` — historical record of the original `.app` decision, intentionally left alone.
- API services (`api.wifihaven.net`, `api-staging.wifihaven.net`) — no `www.` variant on API hostnames.
- `wifihaven-spa-staging` — already a subdomain; `www.staging.wifihaven.net` would be weird.

## www behavior

Render Static Sites accept multiple custom domains and will issue
Let's Encrypt certs for both. Render serves the same bundle from
either hostname without auto-redirecting between apex and www — a user
who lands on `www.` stays on `www.`, and vice versa. If a canonical
redirect is wanted later, it can be added as a Render redirect rule or
in the SPA itself; the PR description for #587 can be updated then.

The operator will still need to add a `www` CNAME at the DNS provider
pointing at the same target as the apex — see the updated table in
`docs/render-prod-setup.md` §2.

## Refs

- Umbrella: #251 (render.com deploy effort).
- Follow-on to #587 (prod env + CDN SPAs + custom domains), which is merged.
- No specific issue closes — small mechanical follow-up.

## Test plan

- [ ] CI passes (no test changes; mechanical edits only).
- [ ] `git grep wifihaven.app` returns only `docs/rename-decision.md:68`.
- [ ] `yq eval . render.yaml` parses (validated locally).
- [ ] After merge + Render re-apply, operator adds `www` CNAME and confirms `https://www.wifihaven.net/` serves the SPA with a valid cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)