### PR TITLE
render: fix domains schema (list of strings, not {name:...} maps)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,7 +30,7 @@ services:
     image:
       url: ghcr.io/wifihaven/wifihaven-api:latest
     domains:
-      - name: api-staging.wifihaven.net
+      - api-staging.wifihaven.net
     envVars:
       - key: WIFIHAVEN_DB_HOST
         fromDatabase:
@@ -78,7 +78,7 @@ services:
     image:
       url: ghcr.io/wifihaven/wifihaven-api:latest
     domains:
-      - name: api.wifihaven.net
+      - api.wifihaven.net
     envVars:
       - key: WIFIHAVEN_DB_HOST
         fromDatabase:
@@ -126,7 +126,7 @@ services:
     staticPublishPath: ./dist
     rootDir: web
     domains:
-      - name: staging.wifihaven.net
+      - staging.wifihaven.net
     routes:
       - type: rewrite
         source: /*
@@ -147,8 +147,8 @@ services:
     staticPublishPath: ./dist
     rootDir: web
     domains:
-      - name: wifihaven.net
-      - name: www.wifihaven.net
+      - wifihaven.net
+      - www.wifihaven.net
     routes:
       - type: rewrite
         source: /*


### PR DESCRIPTION
## Summary
- Blueprint sync failed with `cannot unmarshal !!map into file.Host`.
- Render's `render.yaml` expects `domains:` as a bare list of strings, not `{name: ...}` objects.
- Swap all 4 occurrences (2 API services, 2 SPA Static Sites).

## Why
The map shape was introduced in #587. Render parses the value as `file.Host` (a string-typed field), so a YAML mapping fails to unmarshal. Hotfix unblocks the first Blueprint apply for #251.

## Note for the in-flight domain-swap PR
The `domain-swap-net` branch was written against the broken shape. It will hit a trivial conflict here — resolve by keeping this PR's bare-string shape and adding `www.wifihaven.net` as a second bare string under `wifihaven-spa-prod`.

## Test plan
- [ ] Re-run Blueprint sync in Render dashboard; expect no unmarshal error.
- [ ] Confirm all 4 custom domains appear in their respective service settings.

Refs: #251, #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)