### PR TITLE
api: add CORS middleware driven by WIFIHAVEN_ALLOWED_ORIGINS (#612)

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -9,6 +9,7 @@ case class AppConfig(
     db: DbConfig,
     http: HttpConfig,
     jwt: JwtConfig,
+    cors: CorsConfig,
 ) {
   // WIFIHAVEN_DEBUG env var: when set to a non-empty, non-"0"/"false"/"no"
   // value, mounts the read-only /api/debug/* endpoints (loopback only).
@@ -36,6 +37,17 @@ case class JwtConfig(
     secret: String,
     expiryHours: Int,
 )
+
+// #612: cross-origin browser access for the split SPA.
+// `allowedOrigins` is a comma-separated list of full origins (scheme+host+
+// optional-port), matched exactly. Empty disables CORS entirely — the
+// self-hosted single-origin path stays header-clean. Never `*`.
+case class CorsConfig(
+    allowedOrigins: String,
+) {
+  val origins: List[String] =
+    allowedOrigins.split(",").iterator.map(_.trim).filter(_.nonEmpty).toList
+}
 
 object AppConfig {
   private[api] def envTruthy(v: Option[String]): Boolean =

--- a/api/src/Cors.scala
+++ b/api/src/Cors.scala
@@ -1,0 +1,46 @@
+package wifihaven.api
+
+import zio.*
+import zio.http.*
+
+// #612: cross-origin browser access for the split SPA (SPA on its own
+// hostname, API on api[-staging].wifihaven.net). Self-hosted single-origin
+// installs leave allowedOrigins empty — the middleware is skipped entirely
+// so no CORS headers are emitted on that path.
+object Cors {
+
+  def wrap[Env, Err](
+      routes: Routes[Env, Err],
+      cfg: CorsConfig,
+  ): Routes[Env, Err] = {
+    val allowed = cfg.origins
+    if (allowed.isEmpty) routes
+    else routes @@ Middleware.cors(buildConfig(allowed))
+  }
+
+  private[api] def buildConfig(allowed: List[String]): Middleware.CorsConfig = {
+    val allowedSet = allowed.toSet
+    Middleware.CorsConfig(
+      allowedOrigin = origin =>
+        if (allowedSet.contains(Header.Origin.render(origin)))
+          Some(Header.AccessControlAllowOrigin.Specific(origin))
+        else None,
+      allowedMethods = Header.AccessControlAllowMethods(
+        Method.GET,
+        Method.POST,
+        Method.PUT,
+        Method.PATCH,
+        Method.DELETE,
+        Method.OPTIONS,
+      ),
+      allowedHeaders = Header.AccessControlAllowHeaders.Some(
+        NonEmptyChunk("Authorization", "Content-Type", "If-None-Match"),
+      ),
+      allowCredentials = Header.AccessControlAllowCredentials.DoNotAllow,
+      exposedHeaders = Header.AccessControlExposeHeaders.Some(
+        NonEmptyChunk("ETag"),
+      ),
+      maxAge = Some(Header.AccessControlMaxAge(10.minutes)),
+    )
+  }
+}

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -39,10 +39,10 @@ object Main extends ZIOAppDefault {
       _      <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       routes <- allRoutes
       withCors = Cors.wrap(routes, cfg.cors)
-      _      <- ZIO
+      _ <- ZIO
         .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
         .when(cfg.cors.origins.nonEmpty)
-      _      <- Server
+      _ <- Server
         .serve(withCors)
         .provide(Server.defaultWithPort(cfg.http.port))
     } yield ()).provide(serverEnv)

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -38,8 +38,12 @@ object Main extends ZIOAppDefault {
       _      <- hsRepo.ensureDefault(tz)
       _      <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       routes <- allRoutes
+      withCors = Cors.wrap(routes, cfg.cors)
+      _      <- ZIO
+        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
+        .when(cfg.cors.origins.nonEmpty)
       _      <- Server
-        .serve(routes)
+        .serve(withCors)
         .provide(Server.defaultWithPort(cfg.http.port))
     } yield ()).provide(serverEnv)
 

--- a/api/test/src/feature/CorsSpec.scala
+++ b/api/test/src/feature/CorsSpec.scala
@@ -1,0 +1,135 @@
+package wifihaven.api.feature
+
+import wifihaven.api.{Cors, CorsConfig}
+import zio.*
+import zio.http.*
+import zio.test.*
+
+// #612: exercises the CORS middleware against a representative subset of
+// routes — a POST endpoint (login-shaped) and a GET endpoint that emits an
+// ETag (router-blocklist-shaped). The middleware is configured once with the
+// staging origin to mirror the production wiring.
+object CorsSpec extends ZIOSpecDefault {
+
+  private val allowedOrigin    = "https://staging.wifihaven.net"
+  private val disallowedOrigin = "https://evil.example"
+  private val cfg              = CorsConfig(allowedOrigins = allowedOrigin)
+
+  private val loginEcho =
+    Method.POST / "api" / "auth" / "login" -> handler(Response.ok)
+
+  private val etagRoute =
+    Method.GET / "api" / "router" / "blocklist" / string("id") ->
+      handler { (_: String, _: Request) =>
+        Response.ok.addHeader(Header.ETag.Strong("abc123"))
+      }
+
+  private val routes = Cors.wrap(Routes(loginEcho, etagRoute), cfg)
+
+  private def runReq(req: Request): UIO[Response] = routes(req).merge
+
+  def spec = suite("CORS middleware (#612)")(
+    test("preflight from allowed origin → 204 with echo + configured headers") {
+      val req = Request
+        .options("/api/auth/login")
+        .addHeader(Header.Origin.parse(allowedOrigin).toOption.get)
+        .addHeader(Header.AccessControlRequestMethod(Method.POST))
+        .addHeader(
+          Header.AccessControlRequestHeaders(NonEmptyChunk("Content-Type")),
+        )
+      for {
+        resp <- runReq(req)
+        ao    = resp.header(Header.AccessControlAllowOrigin)
+        am    = resp.header(Header.AccessControlAllowMethods)
+        ah    = resp.header(Header.AccessControlAllowHeaders)
+        ma    = resp.header(Header.AccessControlMaxAge)
+        ac    = resp.header(Header.AccessControlAllowCredentials)
+      } yield assertTrue(
+        resp.status == Status.NoContent,
+        ao.contains(
+          Header.AccessControlAllowOrigin.Specific(
+            Header.Origin.parse(allowedOrigin).toOption.get,
+          ),
+        ),
+        am.exists(_.contains(Method.POST)),
+        am.exists(_.contains(Method.DELETE)),
+        ah.exists {
+          case Header.AccessControlAllowHeaders.Some(vs) =>
+            vs.exists(_.equalsIgnoreCase("Content-Type"))
+          case _                                         => false
+        },
+        ma.exists(_.duration == 10.minutes),
+        ac.contains(Header.AccessControlAllowCredentials.DoNotAllow),
+      )
+    },
+    test("preflight from disallowed origin → no allow-origin header") {
+      val req = Request
+        .options("/api/auth/login")
+        .addHeader(Header.Origin.parse(disallowedOrigin).toOption.get)
+        .addHeader(Header.AccessControlRequestMethod(Method.POST))
+      for {
+        resp <- runReq(req)
+      } yield assertTrue(
+        resp.header(Header.AccessControlAllowOrigin).isEmpty,
+        resp.status != Status.NoContent,
+      )
+    },
+    test("actual POST from allowed origin → allow-origin echoed, ETag exposed") {
+      val req = Request
+        .post("/api/auth/login", Body.empty)
+        .addHeader(Header.Origin.parse(allowedOrigin).toOption.get)
+      for {
+        resp <- runReq(req)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        resp.header(Header.AccessControlAllowOrigin).contains(
+          Header.AccessControlAllowOrigin.Specific(
+            Header.Origin.parse(allowedOrigin).toOption.get,
+          ),
+        ),
+        resp.header(Header.AccessControlExposeHeaders).exists {
+          case Header.AccessControlExposeHeaders.Some(vs) =>
+            vs.exists(_.toString.equalsIgnoreCase("ETag"))
+          case _                                          => false
+        },
+      )
+    },
+    test("actual POST from disallowed origin → no allow-origin header") {
+      val req = Request
+        .post("/api/auth/login", Body.empty)
+        .addHeader(Header.Origin.parse(disallowedOrigin).toOption.get)
+      for {
+        resp <- runReq(req)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        resp.header(Header.AccessControlAllowOrigin).isEmpty,
+      )
+    },
+    test(
+      "router agent path (no Origin) → no CORS headers, ETag still served",
+    ) {
+      val req = Request.get("/api/router/blocklist/foo")
+      for {
+        resp <- runReq(req)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        resp.header(Header.AccessControlAllowOrigin).isEmpty,
+        resp.header(Header.AccessControlExposeHeaders).isEmpty,
+        resp.header(Header.ETag).isDefined,
+      )
+    },
+    test("empty allowedOrigins disables middleware entirely") {
+      val bare =
+        Cors.wrap(Routes(loginEcho), CorsConfig(allowedOrigins = ""))
+      val req  = Request
+        .post("/api/auth/login", Body.empty)
+        .addHeader(Header.Origin.parse(allowedOrigin).toOption.get)
+      for {
+        resp <- bare(req).merge
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        resp.header(Header.AccessControlAllowOrigin).isEmpty,
+      )
+    },
+  )
+}

--- a/api/test/src/feature/CorsSpec.scala
+++ b/api/test/src/feature/CorsSpec.scala
@@ -20,9 +20,7 @@ object CorsSpec extends ZIOSpecDefault {
 
   private val etagRoute =
     Method.GET / "api" / "router" / "blocklist" / string("id") ->
-      handler { (_: String, _: Request) =>
-        Response.ok.addHeader(Header.ETag.Strong("abc123"))
-      }
+      handler { (_: String, _: Request) => Response.ok.addHeader(Header.ETag.Strong("abc123")) }
 
   private val routes = Cors.wrap(Routes(loginEcho, etagRoute), cfg)
 
@@ -39,11 +37,11 @@ object CorsSpec extends ZIOSpecDefault {
         )
       for {
         resp <- runReq(req)
-        ao    = resp.header(Header.AccessControlAllowOrigin)
-        am    = resp.header(Header.AccessControlAllowMethods)
-        ah    = resp.header(Header.AccessControlAllowHeaders)
-        ma    = resp.header(Header.AccessControlMaxAge)
-        ac    = resp.header(Header.AccessControlAllowCredentials)
+        ao = resp.header(Header.AccessControlAllowOrigin)
+        am = resp.header(Header.AccessControlAllowMethods)
+        ah = resp.header(Header.AccessControlAllowHeaders)
+        ma = resp.header(Header.AccessControlMaxAge)
+        ac = resp.header(Header.AccessControlAllowCredentials)
       } yield assertTrue(
         resp.status == Status.NoContent,
         ao.contains(
@@ -82,11 +80,13 @@ object CorsSpec extends ZIOSpecDefault {
         resp <- runReq(req)
       } yield assertTrue(
         resp.status == Status.Ok,
-        resp.header(Header.AccessControlAllowOrigin).contains(
-          Header.AccessControlAllowOrigin.Specific(
-            Header.Origin.parse(allowedOrigin).toOption.get,
+        resp
+          .header(Header.AccessControlAllowOrigin)
+          .contains(
+            Header.AccessControlAllowOrigin.Specific(
+              Header.Origin.parse(allowedOrigin).toOption.get,
+            ),
           ),
-        ),
         resp.header(Header.AccessControlExposeHeaders).exists {
           case Header.AccessControlExposeHeaders.Some(vs) =>
             vs.exists(_.toString.equalsIgnoreCase("ETag"))

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -19,6 +19,14 @@ wifihaven {
     expiryHours = 24
   }
 
+  cors {
+    # Comma-separated list of full origins (scheme+host+optional-port) allowed
+    # to call this API from a browser. Empty = no CORS headers emitted (the
+    # default for self-hosted single-origin installs). Never use "*".
+    # Example: "https://wifihaven.example,https://www.wifihaven.example"
+    allowedOrigins = ""
+  }
+
   dns {
     cacheRefreshSeconds = 60
     port                = 53

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -20,6 +20,13 @@ WIFIHAVEN_JWT_HOURS=24
 WIFIHAVEN_API_BIND=0.0.0.0
 WIFIHAVEN_API_PORT=8080
 
+# Browser SPA cross-origin allowlist (#612).
+# Set ONLY if you are serving the SPA from a different origin than the API
+# (e.g. SPA on https://wifihaven.example, API on https://api.wifihaven.example).
+# Self-hosted single-origin installs leave this empty — same-origin doesn't
+# need CORS. Comma-separated full origins (scheme+host+optional-port). No "*".
+# WIFIHAVEN_ALLOWED_ORIGINS=https://wifihaven.example,https://www.wifihaven.example
+
 # ─── Debugging (off by default) ──────────────────────────────────────────────
 #
 # These knobs are READ by deploy/docker-compose.debug.yml. They have no

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -46,6 +46,9 @@ services:
       WIFIHAVEN_HTTP_PORT: "8080"
       WIFIHAVEN_JWT_SECRET: ${WIFIHAVEN_JWT_SECRET:?WIFIHAVEN_JWT_SECRET required (>=32 chars)}
       WIFIHAVEN_JWT_HOURS: ${WIFIHAVEN_JWT_HOURS:-24}
+      # #612: comma-separated browser origins allowed to call this API. Leave
+      # empty for self-hosted single-origin installs (default). Never use "*".
+      WIFIHAVEN_ALLOWED_ORIGINS: ${WIFIHAVEN_ALLOWED_ORIGINS:-}
     ports:
       - "${WIFIHAVEN_API_BIND:-0.0.0.0}:${WIFIHAVEN_API_PORT:-8080}:8080"
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       WIFIHAVEN_DB_PASSWORD: wifihaven
       WIFIHAVEN_HTTP_PORT: "8080"
       WIFIHAVEN_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
+      # #612: allow the Vite dev server and the JVM-bundled SPA on localhost.
+      WIFIHAVEN_ALLOWED_ORIGINS: "http://localhost:5173,http://localhost:8080"
     ports:
       - "0.0.0.0:8080:8080"
     healthcheck:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 : "${WIFIHAVEN_JWT_HOURS:=24}"
 : "${WIFIHAVEN_LOG_LEVEL:=INFO}"
 : "${WIFIHAVEN_DEBUG:=}"
+: "${WIFIHAVEN_ALLOWED_ORIGINS:=}"
 
 export WIFIHAVEN_LOG_LEVEL WIFIHAVEN_DEBUG
 
@@ -41,6 +42,9 @@ wifihaven {
   jwt {
     secret      = "${WIFIHAVEN_JWT_SECRET}"
     expiryHours = ${WIFIHAVEN_JWT_HOURS}
+  }
+  cors {
+    allowedOrigins = "${WIFIHAVEN_ALLOWED_ORIGINS}"
   }
 }
 EOF

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -203,6 +203,7 @@ Edit `.env` and set each variable. **Never commit this file.** All values:
 | `WIFIHAVEN_JWT_HOURS` | no (default `24`) | Session token lifetime in hours. | Leave default unless you need shorter sessions. |
 | `WIFIHAVEN_API_BIND` | no (default `0.0.0.0`) | Host interface the API port binds to. Set to `127.0.0.1` if you're putting a reverse proxy in front (§7). | `127.0.0.1` for proxied installs, `0.0.0.0` for direct LAN access. |
 | `WIFIHAVEN_API_PORT` | no (default `8080`) | Host port mapped to the API. | Change only if 8080 is taken. |
+| `WIFIHAVEN_ALLOWED_ORIGINS` | no (default empty) | Browser CORS allowlist. Set ONLY if the SPA is served from a different origin than the API (e.g. SPA on `https://wifihaven.example`, API on `https://api.wifihaven.example`). Comma-separated full origins (scheme+host+optional-port, no trailing slash). **Never `*`** — explicit allowlist only. Leave empty for the default single-origin self-hosted install. | `https://wifihaven.example,https://www.wifihaven.example` |
 
 After editing, `chmod 600 .env` so secrets aren't world-readable.
 

--- a/render.yaml
+++ b/render.yaml
@@ -61,6 +61,9 @@ services:
       # endpoints on loopback). Keep explicitly empty in staging.
       - key: WIFIHAVEN_DEBUG
         value: ""
+      # #612: SPA on https://staging.wifihaven.net calls this API cross-origin.
+      - key: WIFIHAVEN_ALLOWED_ORIGINS
+        value: "https://staging.wifihaven.net"
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true
@@ -109,6 +112,9 @@ services:
       # Keep explicitly empty — debug endpoints must never run in prod.
       - key: WIFIHAVEN_DEBUG
         value: ""
+      # #612: SPA on https://wifihaven.net (apex + www) calls this API cross-origin.
+      - key: WIFIHAVEN_ALLOWED_ORIGINS
+        value: "https://wifihaven.net,https://www.wifihaven.net"
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true


### PR DESCRIPTION
Closes #612.

## Why
With the Render split landing in #587, the SPA lives on its own hostname
(`staging.wifihaven.net`, `wifihaven.net`/`www.wifihaven.net`) and calls the
API on `api[-staging].wifihaven.net`. Every browser request is now cross-origin,
so login (and every other non-GET) fails the CORS preflight unless the API
emits matching `Access-Control-*` headers.

## Design
- New env var `WIFIHAVEN_ALLOWED_ORIGINS` — comma-separated list of full
  origins (scheme + host + optional port), matched **exactly**. Never `*`.
- Empty value (the default for self-hosted single-origin installs) **skips
  the middleware entirely** — no CORS headers on that path, preserving the
  single-origin browser deployment shape.
- ZIO HTTP 3.0.1's built-in `Middleware.cors` does the work. Config:
  - methods: `GET, POST, PUT, PATCH, DELETE, OPTIONS`
  - allowed headers: `Authorization, Content-Type, If-None-Match`
  - exposed headers: `ETag` (keeps the router agent's `If-None-Match` flow on
    `RouterRoutes.scala` browser-visible if ever invoked from the SPA)
  - `Allow-Credentials: false` — JWT bearer, no cookies
  - `Max-Age: 600` (10 min)
- Disallowed origins: middleware returns no `Access-Control-Allow-Origin`
  header at all; preflight gets 404. Allowed origins get an exact-match echo.

## Touched files
- `api/src/Config.scala` — new `CorsConfig` case class on `AppConfig`
- `api/src/Cors.scala` — middleware wrapper + config builder
- `api/src/Main.scala` — wraps `allRoutes` with `Cors.wrap`
- `api/test/src/feature/CorsSpec.scala` — 6 tests: preflight + actual POST
  from allowed/disallowed origin, no-Origin path (ETag preserved), empty
  allowlist disables middleware
- `config/application.conf.example`, `docker/entrypoint.sh` — config plumbing
- `docker/docker-compose.yml` — local dev defaults to
  `http://localhost:5173,http://localhost:8080`
- `deploy/docker-compose.prod.yml`, `deploy/.env.example` — self-hosted
  passthrough, documented as opt-in
- `render.yaml` — staging gets `https://staging.wifihaven.net`,
  prod gets `https://wifihaven.net,https://www.wifihaven.net`
- `docs/install-api.md` — env-var table row, no-`*` guidance

Refs #251 (umbrella Render deploy), #587 (CDN SPA split).

## Test plan
- [x] `mill api.test` — 190 tests pass, including new `CorsSpec` (6 tests)
- [ ] Render staging picks up `WIFIHAVEN_ALLOWED_ORIGINS` on next deploy;
      `curl -i -X OPTIONS https://api-staging.wifihaven.net/api/auth/login -H 'Origin: https://staging.wifihaven.net' -H 'Access-Control-Request-Method: POST'`
      returns 204 with echoed allow-origin
- [ ] Same curl with `Origin: https://evil.example` returns no allow-origin
- [ ] Browser login from `https://staging.wifihaven.net` succeeds end-to-end
- [ ] OpenWRT agent (no `Origin`) still polls `/api/router/*` and the
      `If-None-Match` ETag short-circuit still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)