### PR TITLE
ci: rotate admin pw in fake-router bootstrap (#620 — unblocks Master CD)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       API_BASE: "http://api:8080"
       ADMIN_USER: "admin"
       ADMIN_PASS: "changeme"
+      ADMIN_NEW_PASS: "fake-router-bootstrap-pw-do-not-use-elsewhere"
       FAKE_ROUTER_SEED: "42"
       POLL_INTERVAL: "3"
       USAGE_INTERVAL: "10"

--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -27,6 +27,11 @@ from datetime import datetime, timezone, timedelta
 API_BASE        = os.environ.get("API_BASE",        "http://localhost:8080")
 ADMIN_USER      = os.environ.get("ADMIN_USER",      "admin")
 ADMIN_PASS      = os.environ.get("ADMIN_PASS",      "changeme")
+# Post-rotation password used by fake-router only. The API server seeded by
+# #586 forces a password change on first login (mustChangePassword=true in the
+# /api/auth/login response); fake-router rotates ADMIN_PASS → ADMIN_NEW_PASS on
+# fresh DBs and re-logs in with ADMIN_NEW_PASS on subsequent runs.
+ADMIN_NEW_PASS  = os.environ.get("ADMIN_NEW_PASS",  "fake-router-bootstrap-pw-do-not-use-elsewhere")
 SEED            = int(os.environ.get("FAKE_ROUTER_SEED",  "42"))
 POLL_INTERVAL   = int(os.environ.get("POLL_INTERVAL",     "3"))
 USAGE_INTERVAL  = int(os.environ.get("USAGE_INTERVAL",    "10"))
@@ -98,8 +103,47 @@ def _retry(fn, attempts: int = 30, delay: float = 2.0, label: str = ""):
 
 # ── Provisioning ───────────────────────────────────────────────────────────
 
-def _login() -> str:
-    res = _post("/api/auth/login", {"username": ADMIN_USER, "password": ADMIN_PASS})
+def _login(password: str) -> dict:
+    return _post("/api/auth/login", {"username": ADMIN_USER, "password": password})
+
+
+def _change_password(token: str, current: str, new: str) -> None:
+    # The endpoint returns 200 with an empty body, so we can't go through
+    # _post (which always tries to json.loads the response).
+    data = json.dumps({"currentPassword": current, "newPassword": new}).encode()
+    req = urllib.request.Request(
+        f"{API_BASE}/api/auth/change-password",
+        data=data,
+        headers={"content-type": "application/json", "authorization": f"Bearer {token}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=10) as r:
+        r.read()
+
+
+def _bootstrap_admin_token() -> str:
+    """Return an admin JWT, rotating the seeded password if needed.
+
+    Idempotent across runs:
+      • Fresh DB: ADMIN_NEW_PASS login → 401; fall back to ADMIN_PASS, observe
+        mustChangePassword=true, rotate, re-login with ADMIN_NEW_PASS.
+      • Already-rotated DB: ADMIN_NEW_PASS login → 200, use that token.
+    """
+    try:
+        res = _login(ADMIN_NEW_PASS)
+        if not res.get("mustChangePassword", False):
+            return res["token"]
+        # Unexpected: server says rotate even though we logged in with the
+        # post-rotation password. Fall through to the seeded-path branch.
+    except urllib.error.HTTPError as e:
+        if e.code != 401:
+            raise
+
+    res = _login(ADMIN_PASS)
+    if res.get("mustChangePassword", False):
+        _change_password(res["token"], ADMIN_PASS, ADMIN_NEW_PASS)
+        print("[fake-router] rotated admin password", flush=True)
+        res = _login(ADMIN_NEW_PASS)
     return res["token"]
 
 
@@ -193,7 +237,7 @@ def _post_events(router_id: str, router_token: str) -> None:
 def main() -> None:
     print(f"[fake-router] seed={SEED} api={API_BASE}", flush=True)
 
-    admin_token             = _retry(_login, label="login")
+    admin_token             = _retry(_bootstrap_admin_token, label="login")
     router_id, enroll_token = _create_router(admin_token)
     print(f"[fake-router] created router {router_id}", flush=True)
 

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -9,6 +9,9 @@
 set -euo pipefail
 
 BASE="${E2E_BASE_URL:-http://127.0.0.1:8080}"
+# See scripts/e2e-tests.sh — fake-router rotates the seeded admin password on
+# first boot, so by the time this script runs the DB has the rotated value.
+ADMIN_PASS="${ADMIN_PASS:-fake-router-bootstrap-pw-do-not-use-elsewhere}"
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 
 pass() { echo "  ✓ $*"; }
@@ -25,7 +28,7 @@ _py() { python3 -c "$1"; }
 step "Admin login"
 LOGIN=$(curl -fsS -X POST "$BASE/api/auth/login" \
   -H 'content-type: application/json' \
-  -d '{"username":"admin","password":"changeme"}')
+  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PASS\"}")
 ADMIN=$(_py "import sys,json; print(json.loads('$LOGIN'.replace(\"'\",\"'\"))['token'])" 2>/dev/null \
   || echo "$LOGIN" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
 [ -n "$ADMIN" ] || fail "no token in login response: $LOGIN"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -12,6 +12,10 @@
 set -euo pipefail
 
 BASE="${E2E_BASE_URL:-http://127.0.0.1:8080}"
+# fake-router (docker/fake-router.py) rotates the seeded admin password on
+# first run to this value. e2e scripts execute *after* `compose up --wait`,
+# so the DB is always in the post-rotation state by the time we log in.
+ADMIN_PASS="${ADMIN_PASS:-fake-router-bootstrap-pw-do-not-use-elsewhere}"
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 
 pass() { echo "  ✓ $*"; }
@@ -29,10 +33,10 @@ for i in $(seq 1 60); do
   sleep 1
 done
 
-step "Login as admin/changeme"
+step "Login as admin"
 LOGIN=$(curl -fsS -X POST "$BASE/api/auth/login" \
   -H 'content-type: application/json' \
-  -d '{"username":"admin","password":"changeme"}')
+  -d "{\"username\":\"admin\",\"password\":\"$ADMIN_PASS\"}")
 TOKEN=$(echo "$LOGIN" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
 [ -n "$TOKEN" ] || fail "no token in login response: $LOGIN"
 echo "$LOGIN" | grep -q '"role":"admin"' || fail "admin role missing"


### PR DESCRIPTION
**Unblocks Master CD, which has been red since #599 merged.** The `e2e` job's `fake-router` container has been exiting 1 on the `must_change_password` 403, which gates `publish-api` — so no new image (including the CORS fix in #616) has reached ghcr.io or Render staging.

## Fix

`docker/fake-router.py` now mirrors what `deploy/install.sh` already does for real installs:

1. Try `/api/auth/login` with `ADMIN_NEW_PASS` first. If 200 and `mustChangePassword=false`, use that token (already-rotated DB).
2. Otherwise log in with `ADMIN_PASS` (`changeme`). If the response carries `mustChangePassword=true` (the signal added in #586/#599 on `LoginResponse`), POST `/api/auth/change-password` to rotate to `ADMIN_NEW_PASS`, then re-login.
3. Proceed with `_create_router(...)` and the rest of bootstrap unchanged.

The flow is **idempotent**: fresh DBs hit step 2; restarts and re-runs hit step 1.

New env `ADMIN_NEW_PASS` (default `fake-router-bootstrap-pw-do-not-use-elsewhere`) is wired through `docker/docker-compose.yml` explicitly so it's visible at a glance.

`scripts/e2e-tests.sh` and `scripts/e2e-router.sh` updated to use the rotated password (they run *after* `compose --wait`, so the DB is always in the post-rotation state by then). Both override-able via `ADMIN_PASS` env.

## Verified locally

- `compose down -v && compose up -d --build --wait` → all three containers healthy; logs show `rotated admin password`.
- `scripts/e2e-tests.sh` → `All e2e checks passed.`
- `scripts/e2e-router.sh` → `All router e2e checks passed.`
- `compose restart fake-router` → healthy on second boot, no rotation log line (idempotent path taken).

## Scope

Test-harness / CI fix only — no API or production-path code changed. `deploy/install.sh` already does the right thing for real installs and is untouched.

Closes #620.
Refs #599, #616 (CORS PR sitting unpublished behind this break), #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)