### PR TITLE
ci: narrow Scala path filter to actual compile/test inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,15 @@ jobs:
         with:
           filters: |
             scala:
+              # Narrowed: Scala job only compiles + tests Scala. Docker
+              # images, deploy scripts, and config/ (example file only) do
+              # not feed into compile or test, so they shouldn't trigger
+              # a ~minutes-long EmbeddedPostgres run.
               - '.github/workflows/ci.yml'
               - 'api/**'
               - 'shared/**'
               - 'build.mill'
               - '.scalafmt.conf'
-              - 'config/**'
-              - 'docker/**'
-              - 'deploy/**'
             frontend:
               - '.github/workflows/ci.yml'
               - 'web/**'


### PR DESCRIPTION
Stacks on #619. Targets the `ci-path-filter` branch — merge #619 first, then this rebases onto `main`.

Drop `docker/**`, `deploy/**`, and `config/**` from the Scala job's path filter:

- `docker/**` — Dockerfiles and image config. The Scala job runs `mill compile` + `mill {shared,api}.test`; it never reads a Dockerfile. Image builds happen in `master.yml` post-merge.
- `deploy/**` — deploy scripts. Shell content is already covered by the Shell Tests filter (`deploy/**/*.sh`). The Scala job doesn't consume anything in `deploy/`.
- `config/**` — only contains `application.conf.example`, an example file not loaded at test time. Verified: no test source under `api/test` or `shared/test` references `config/`.

Net effect: a Dockerfile-only or deploy-script-only PR no longer pays for a ~minutes-long EmbeddedPostgres run.

Scala filter is now: `api/**`, `shared/**`, `build.mill`, `.scalafmt.conf`, plus `.github/workflows/ci.yml` self-trigger.