### PR TITLE
ci: keep staging API warm with 10-min cron (#615)

### DIFF
--- a/.github/workflows/keep-staging-warm.yml
+++ b/.github/workflows/keep-staging-warm.yml
@@ -1,0 +1,21 @@
+name: Keep staging warm
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  ping:
+    name: Ping staging health endpoint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hit staging health endpoint
+        # Fallback to the *.onrender.com URL handles the case where the
+        # custom-domain cert is mid-renewal — direct origin keeps working
+        # with Render's wildcard.
+        run: |
+          curl -fsS --max-time 30 \
+            https://api-staging.wifihaven.net/api/health \
+            || curl -fsS --max-time 30 \
+              https://wifihaven-api-staging.onrender.com/api/health


### PR DESCRIPTION
## Summary

Adds `.github/workflows/keep-staging-warm.yml` — a GHA cron that curls the staging health endpoint every 10 minutes so Render's Hobby tier doesn't idle-suspend the service (which otherwise causes Let's Encrypt cert renewals to silently fail mid-renewal).

Staging-only is intentional: prod stays warm via the real router polling `/policy` every 5s, so no ping needed there. Refs #251.

Closes #615.

## Test plan

- [ ] Merge, then confirm a run appears in the Actions tab within ~10 min.
- [ ] Verify staging `wifihaven-api-staging` no longer shows `Suspended` in the Render dashboard during normal operation.
- [ ] Spot-check ~day 60-80 after the next cert issuance that the Let's Encrypt renewal for `api-staging.wifihaven.net` succeeds automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)