### PR TITLE
api: HEAD /api/health returns 200 mirroring GET (#611)

### DIFF
--- a/api/src/routes/HealthRoutes.scala
+++ b/api/src/routes/HealthRoutes.scala
@@ -26,7 +26,7 @@ object HealthRoutes {
       )
 
     Routes(
-      Method.GET / "api" / "health" ->
+      Method.GET / "api" / "health"  ->
         handler { (_: Request) => getResponse },
       Method.HEAD / "api" / "health" ->
         handler { (_: Request) => getResponse.map(_.copy(body = Body.empty)) },

--- a/api/src/routes/HealthRoutes.scala
+++ b/api/src/routes/HealthRoutes.scala
@@ -8,21 +8,28 @@ import zio.http.*
  *
  * `checkDb` performs a cheap round-trip to Postgres (e.g. `SELECT 1`). Only the failure's class
  * name is exposed in the response body so SQL details don't leak.
+ *
+ * HEAD mirrors GET's status code with an empty body, per HTTP convention, so HEAD-based uptime
+ * probes work.
  */
 object HealthRoutes {
-  def routes(checkDb: Task[Unit]): Routes[Any, Response] =
+  def routes(checkDb: Task[Unit]): Routes[Any, Response] = {
+    val getResponse: UIO[Response] =
+      checkDb.fold(
+        err => {
+          val cls = err.getClass.getSimpleName
+          Response
+            .json(s"""{"status":"error","db":"$cls"}""")
+            .status(Status.ServiceUnavailable)
+        },
+        _ => Response.json("""{"status":"ok","db":"ok"}"""),
+      )
+
     Routes(
       Method.GET / "api" / "health" ->
-        handler { (_: Request) =>
-          checkDb.fold(
-            err => {
-              val cls = err.getClass.getSimpleName
-              Response
-                .json(s"""{"status":"error","db":"$cls"}""")
-                .status(Status.ServiceUnavailable)
-            },
-            _ => Response.json("""{"status":"ok","db":"ok"}"""),
-          )
-        },
+        handler { (_: Request) => getResponse },
+      Method.HEAD / "api" / "health" ->
+        handler { (_: Request) => getResponse.map(_.copy(body = Body.empty)) },
     )
+  }
 }

--- a/api/test/src/feature/HealthApiSpec.scala
+++ b/api/test/src/feature/HealthApiSpec.scala
@@ -12,6 +12,9 @@ object HealthApiSpec extends ZIOSpecDefault {
   private def get(routes: Routes[Any, Response]): UIO[Response] =
     routes(Request.get("/api/health")).merge
 
+  private def head(routes: Routes[Any, Response]): UIO[Response] =
+    routes(Request.get("/api/health").copy(method = Method.HEAD)).merge
+
   def spec = suite("Health API")(
     test("GET /api/health returns 200 with status=ok,db=ok when DB check succeeds") {
       val routes = HealthRoutes.routes(ZIO.unit)
@@ -36,6 +39,24 @@ object HealthApiSpec extends ZIOSpecDefault {
         assertTrue(
           json.asObject.flatMap(_.get("db")).flatMap(_.asString).contains("SQLException"),
         )
+    },
+    test("HEAD /api/health returns 200 with empty body when DB check succeeds") {
+      val routes = HealthRoutes.routes(ZIO.unit)
+      for {
+        resp <- head(routes)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(body.isEmpty)
+    },
+    test("HEAD /api/health returns 503 with empty body when DB check fails") {
+      val routes = HealthRoutes.routes(
+        ZIO.fail(new java.sql.SQLException("connection refused")),
+      )
+      for {
+        resp <- head(routes)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(body.isEmpty)
     },
     test("error response does not leak SQL details") {
       val secret = "ERROR: relation \"secret_table\" does not exist at line 42"


### PR DESCRIPTION
## Summary
- `HEAD /api/health` now returns the same status code as `GET` (200 healthy, 503 on DB failure) with an empty body, per HTTP convention (RFC 9110 §9.3.2).
- Unblocks HEAD-based uptime probes / load-balancer health checks that previously got 404.
- GET behavior is unchanged.

Closes #611

## Test plan
- [x] `mill api.test` — added two HEAD cases to `HealthApiSpec` (200 + empty on success, 503 + empty on DB failure); all pass.
- [x] Local docker stack: `curl -I http://localhost:8080/api/health` → `200 Ok` with `content-length: 0`.
- [x] Local docker stack: `curl http://localhost:8080/api/health` → `200` with JSON body unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)