### PR TITLE
api: env-gate SPA serving so Render API services return 404 on non-api paths (#614)

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -31,6 +31,7 @@ case class HttpConfig(
     host: String,
     port: Int,
     staticDir: String,
+    serveSpa: Boolean,
 )
 
 case class JwtConfig(

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -120,5 +120,5 @@ object Main extends ZIOAppDefault {
         connRepo,
       ) ++
       DebugRoutes.routes(cfg.debugEnabled, deviceRepo, connRepo, usageRepo, trafficRepo, clock) ++
-      StaticRoutes.routes(cfg.http.staticDir)
+      (if (cfg.http.serveSpa) StaticRoutes.routes(cfg.http.staticDir) else Routes.empty)
 }

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.feature
 
-import wifihaven.api.routes.StaticRoutes
+import wifihaven.api.routes.{HealthRoutes, StaticRoutes}
 import zio.*
 import zio.http.*
 import zio.test.*
@@ -100,6 +100,38 @@ object StaticRoutesSpec extends ZIOSpecDefault {
           ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
         } yield assertTrue(resp.status.code >= 400 && resp.status.code < 500) &&
           assertTrue(!ct.startsWith("text/html"))
+      }
+    },
+    // #614: the env-gated SPA disable for Render API deployments. Main.scala
+    // composes either `StaticRoutes.routes(...)` or `Routes.empty` based on
+    // `cfg.http.serveSpa`. These tests simulate both modes alongside the
+    // /api/health route to verify the acceptance criteria.
+    test("serveSpa=false: GET / returns 404, /api/health still 200") {
+      withTempDir { dir =>
+        for {
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          serveSpa = false
+          rs = HealthRoutes.routes(ZIO.unit) ++
+            (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
+          root   <- get(rs, "/")
+          health <- get(rs, "/api/health")
+        } yield assertTrue(root.status == Status.NotFound) &&
+          assertTrue(health.status == Status.Ok)
+      }
+    },
+    test("serveSpa=true: GET / returns SPA HTML, /api/health still 200") {
+      withTempDir { dir =>
+        for {
+          _ <- write(dir, "index.html", "<html>spa</html>")
+          serveSpa = true
+          rs = HealthRoutes.routes(ZIO.unit) ++
+            (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
+          root   <- get(rs, "/")
+          body   <- root.body.asString
+          health <- get(rs, "/api/health")
+        } yield assertTrue(root.status == Status.Ok) &&
+          assertTrue(body == "<html>spa</html>") &&
+          assertTrue(health.status == Status.Ok)
       }
     },
     test("rejects path traversal attempts") {

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -111,7 +111,7 @@ object StaticRoutesSpec extends ZIOSpecDefault {
         for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           serveSpa = false
-          rs = HealthRoutes.routes(ZIO.unit) ++
+          rs       = HealthRoutes.routes(ZIO.unit) ++
             (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
           root   <- get(rs, "/")
           health <- get(rs, "/api/health")
@@ -124,7 +124,7 @@ object StaticRoutesSpec extends ZIOSpecDefault {
         for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           serveSpa = true
-          rs = HealthRoutes.routes(ZIO.unit) ++
+          rs       = HealthRoutes.routes(ZIO.unit) ++
             (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
           root   <- get(rs, "/")
           body   <- root.body.asString

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -12,6 +12,11 @@ wifihaven {
     host      = "0.0.0.0"
     port      = 8080
     staticDir = "web/dist"
+    # #614: serve the bundled SPA from this JVM. Default true preserves
+    # local-dev and self-hosted single-origin installs. Set to false on
+    # cloud API deployments where the SPA is served by a CDN (Render
+    # Static Sites / Cloudflare Pages) — non-/api/* paths return 404.
+    serveSpa  = true
   }
 
   jwt {

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -49,6 +49,10 @@ services:
       # #612: comma-separated browser origins allowed to call this API. Leave
       # empty for self-hosted single-origin installs (default). Never use "*".
       WIFIHAVEN_ALLOWED_ORIGINS: ${WIFIHAVEN_ALLOWED_ORIGINS:-}
+      # #614: serve the bundled SPA from the JVM. Default true preserves the
+      # self-hosted single-origin install. Set to false only when a CDN
+      # (Render Static Sites / Cloudflare Pages) is the authoritative SPA.
+      WIFIHAVEN_SERVE_SPA: ${WIFIHAVEN_SERVE_SPA:-true}
     ports:
       - "${WIFIHAVEN_API_BIND:-0.0.0.0}:${WIFIHAVEN_API_PORT:-8080}:8080"
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,10 @@ services:
       WIFIHAVEN_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
       # #612: allow the Vite dev server and the JVM-bundled SPA on localhost.
       WIFIHAVEN_ALLOWED_ORIGINS: "http://localhost:5173,http://localhost:8080"
+      # #614: dev defaults to serving the bundled SPA at http://localhost:8080/.
+      # Override with `WIFIHAVEN_SERVE_SPA=false docker compose up` to simulate
+      # the Render API-only mode (non-/api/* paths return 404).
+      WIFIHAVEN_SERVE_SPA: ${WIFIHAVEN_SERVE_SPA:-true}
     ports:
       - "0.0.0.0:8080:8080"
     healthcheck:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 : "${WIFIHAVEN_HTTP_HOST:=0.0.0.0}"
 : "${WIFIHAVEN_HTTP_PORT:=8080}"
 : "${WIFIHAVEN_STATIC_DIR:=/app/web}"
+: "${WIFIHAVEN_SERVE_SPA:=true}"
 : "${WIFIHAVEN_JWT_SECRET:=staging-jwt-secret-do-not-use-in-prod-32ch}"
 : "${WIFIHAVEN_JWT_HOURS:=24}"
 : "${WIFIHAVEN_LOG_LEVEL:=INFO}"
@@ -38,6 +39,7 @@ wifihaven {
     host      = "${WIFIHAVEN_HTTP_HOST}"
     port      = ${WIFIHAVEN_HTTP_PORT}
     staticDir = "${WIFIHAVEN_STATIC_DIR}"
+    serveSpa  = ${WIFIHAVEN_SERVE_SPA}
   }
   jwt {
     secret      = "${WIFIHAVEN_JWT_SECRET}"

--- a/render.yaml
+++ b/render.yaml
@@ -64,6 +64,11 @@ services:
       # #612: SPA on https://staging.wifihaven.net calls this API cross-origin.
       - key: WIFIHAVEN_ALLOWED_ORIGINS
         value: "https://staging.wifihaven.net"
+      # #614: SPA is served by the wifihaven-spa-staging Static Site (CDN).
+      # The JVM still bundles a copy as a self-hosted fallback, but the API
+      # origin must not serve it here — non-/api/* paths return 404.
+      - key: WIFIHAVEN_SERVE_SPA
+        value: "false"
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true
@@ -115,6 +120,11 @@ services:
       # #612: SPA on https://wifihaven.net (apex + www) calls this API cross-origin.
       - key: WIFIHAVEN_ALLOWED_ORIGINS
         value: "https://wifihaven.net,https://www.wifihaven.net"
+      # #614: SPA is served by the wifihaven-spa-prod Static Site (CDN).
+      # The JVM still bundles a copy as a self-hosted fallback, but the API
+      # origin must not serve it here — non-/api/* paths return 404.
+      - key: WIFIHAVEN_SERVE_SPA
+        value: "false"
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true


### PR DESCRIPTION
## Summary

- New env var `WIFIHAVEN_SERVE_SPA` (boolean, default `true`) wired through `docker/entrypoint.sh` → `application.conf` → `HttpConfig.serveSpa`. When `false`, `Main.allRoutes` swaps the `StaticRoutes` handler for `Routes.empty`, so `GET /` and any non-`/api/*` path returns 404 from zio-http's default. `/api/*` routes are unchanged in both modes.
- `render.yaml`: `WIFIHAVEN_SERVE_SPA=false` on both `wifihaven-api-staging` and `wifihaven-api-prod` — the CDN Static Sites (`wifihaven-spa-staging` / `wifihaven-spa-prod`) are the canonical SPA, the API origins must not serve the bundled copy.
- `deploy/docker-compose.prod.yml` and `docker/docker-compose.yml` pass `WIFIHAVEN_SERVE_SPA: ${WIFIHAVEN_SERVE_SPA:-true}` so the default preserves self-hosted / local-dev behavior and override is possible via host env.

## Design

Single image, env decides behavior — same approach #601 settled. The `web-build` Dockerfile stage and the bundled `/app/web` copy stay (self-hosted fallback). We just add an explicit disable switch for cloud envs where a CDN owns the SPA. Closes #614. Refs #601 (keep bundle), #613 (CF Pages migration — once that lands, disabling the JVM SPA here becomes a hard requirement instead of a "no stale bundle drift" hygiene fix).

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.StaticRoutesSpec` — two new cases assert the `serveSpa=true|false` composition against `/` and `/api/health`.
- [x] Local: default `docker compose -f docker/docker-compose.yml up` → `GET /` = 200 SPA HTML, `GET /api/health` = 200.
- [x] Local: `WIFIHAVEN_SERVE_SPA=false docker compose -f docker/docker-compose.yml up` → `GET /` = 404 empty body, `GET /api/health` = 200.
- [ ] Render staging after deploy: `curl https://api-staging.wifihaven.net/` returns 404; `curl https://api-staging.wifihaven.net/api/health` returns 200.
- [ ] Render prod after deploy: `curl https://api.wifihaven.net/` returns 404; `curl https://api.wifihaven.net/api/health` returns 200.
- [ ] Self-hosted (`192.168.10.43:8080`) unaffected — no env change, default behavior preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)