### PR TITLE
fix(openwrt): wire uhttpd block-page handler in postinst path (#542)

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -53,6 +53,12 @@ define Package/wifihaven/install
 
 	$(INSTALL_DIR) $(1)/etc/sysctl.d
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/sysctl.d/99-wifihaven.conf $(1)/etc/sysctl.d/
+
+	$(INSTALL_DIR) $(1)/usr/lib/wifihaven
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh $(1)/usr/lib/wifihaven/
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/uci-defaults/95-wifihaven-uhttpd $(1)/etc/uci-defaults/
 endef
 
 define Package/wifihaven/postinst
@@ -87,6 +93,11 @@ nft delete table inet familydns_boot 2>/dev/null || true
 # first policy.apply().
 /etc/init.d/wifihaven-boot enable
 /etc/init.d/wifihaven-boot start 2>/dev/null || true
+
+# #542: uhttpd block-page wire-up runs from /etc/uci-defaults/95-wifihaven-uhttpd
+# at first boot — postinst runs during offline-install before procd/uhttpd
+# are up, so a uci-defaults stub is the right idiom here. Nothing for
+# postinst to do for the block-page handler.
 # Install cron entry for the auto-updater (daily, 04:00 router-local).
 # Replace any existing wifihaven-update entry so upgrades migrate the
 # cadence — older packages installed it at "0 */6 * * *".

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -101,6 +101,8 @@ fi
 # before fw4.
 /etc/init.d/wifihaven-boot enable
 /etc/init.d/wifihaven-boot start 2>/dev/null || true
+# #542: uhttpd block-page wire-up runs at first boot from
+# /etc/uci-defaults/95-wifihaven-uhttpd (shipped in data/).
 POSTINSTALL
 chmod 0755 "$WORK/post-install"
 

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -58,6 +58,8 @@ fi
 # before fw4.
 /etc/init.d/wifihaven-boot enable
 /etc/init.d/wifihaven-boot start 2>/dev/null || true
+# #542: uhttpd block-page wire-up runs at first boot from
+# /etc/uci-defaults/95-wifihaven-uhttpd (shipped in data/).
 # Install cron entry for the auto-updater (daily, 04:00 router-local).
 # Replace any existing wifihaven-update entry so upgrades migrate the
 # cadence — older packages installed it at "0 */6 * * *".

--- a/openwrt/files/etc/uci-defaults/95-wifihaven-uhttpd
+++ b/openwrt/files/etc/uci-defaults/95-wifihaven-uhttpd
@@ -1,0 +1,12 @@
+#!/bin/sh
+# #542: first-boot wire-up of the uhttpd block-page listener.
+#
+# Postinst runs at offline-install time (Image Builder) before any service
+# is up, so uci writes get partially applied but `/etc/init.d/uhttpd reload`
+# is a no-op. Image-Builder-built routers shipped with an unconfigured
+# block-page listener and served 404 instead of the per-MAC redirect.
+#
+# uci-defaults runs at first boot after procd is up. /etc/init.d/done
+# removes the file after a zero exit; on non-zero, it stays and retries
+# on next boot. Idempotent helper at /usr/lib/wifihaven/.
+sh /usr/lib/wifihaven/setup-uhttpd-block-page.sh

--- a/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
+++ b/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Configure the uhttpd block-page listener on 127.0.0.1:8081 (v4) + [::1]:8081
+# (v6) with the lua handler at /www/wifihaven/handler.lua.
+#
+# Called from:
+#   - openwrt/Makefile  Package/wifihaven/postinst (package installs)
+#   - openwrt/install.sh                           (manual installs)
+#
+# Idempotent. Reloads uhttpd only when the UCI section was actually changed.
+#
+# Without this wiring, requests to the block-page DNAT (127.0.0.1:8081) land
+# on a uhttpd instance with no lua_handler configured, so it tries to serve
+# the requested URL as a static file out of /www/wifihaven and returns 404
+# instead of the per-MAC redirect — which is what fix #542 addresses.
+set -eu
+
+log() { printf '[setup-uhttpd-block-page] %s\n' "$1" >&2; }
+
+uhttpd_section=$(uci show uhttpd 2>/dev/null \
+  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http=.*'127\\.0\\.0\\.1:8081'/{print \$2; exit}")
+uhttpd_changed=0
+
+if [ -n "$uhttpd_section" ]; then
+  current_home=$(uci -q get "uhttpd.${uhttpd_section}.home" || echo "")
+  if [ "$current_home" != "/www/wifihaven" ]; then
+    log "updating block-page uhttpd home to /www/wifihaven"
+    uci set "uhttpd.${uhttpd_section}.home=/www/wifihaven"
+    uhttpd_changed=1
+  fi
+else
+  log "configuring uhttpd block-page listener on 127.0.0.1:8081"
+  uhttpd_section=$(uci add uhttpd uhttpd)
+  uci add_list "uhttpd.${uhttpd_section}.listen_http=127.0.0.1:8081"
+  uci set "uhttpd.${uhttpd_section}.home=/www/wifihaven"
+  uhttpd_changed=1
+fi
+
+# v6 sibling (#411).
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
+    | tr ' ' '\n' | grep -qx '\[::1\]:8081'; then
+  log "adding v6 block-page uhttpd listener on [::1]:8081"
+  uci add_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
+  uhttpd_changed=1
+fi
+
+# Route every URL through handler.lua so the block page can do per-MAC
+# lookups instead of serving a static file (#437).
+desired_lua_prefix='/'
+desired_lua_handler='/www/wifihaven/handler.lua'
+current_lua_prefix=$(uci -q get "uhttpd.${uhttpd_section}.lua_prefix" || echo "")
+current_lua_handler=$(uci -q get "uhttpd.${uhttpd_section}.lua_handler" || echo "")
+if [ "$current_lua_prefix" != "$desired_lua_prefix" ]; then
+  uci set "uhttpd.${uhttpd_section}.lua_prefix=$desired_lua_prefix"
+  uhttpd_changed=1
+fi
+if [ "$current_lua_handler" != "$desired_lua_handler" ]; then
+  uci set "uhttpd.${uhttpd_section}.lua_handler=$desired_lua_handler"
+  uhttpd_changed=1
+fi
+
+if [ "$uhttpd_changed" = 1 ]; then
+  uci commit uhttpd
+  /etc/init.d/uhttpd reload 2>/dev/null || /etc/init.d/uhttpd restart 2>/dev/null || true
+else
+  log "block-page uhttpd listener already configured (v4 + v6, lua handler)"
+fi
+
+# #303: route_localnet so the LAN-side DNAT to 127.0.0.1:8081 is routable.
+if [ -f /etc/sysctl.d/99-wifihaven.conf ]; then
+  sysctl -p /etc/sysctl.d/99-wifihaven.conf >/dev/null 2>&1 || true
+else
+  sysctl -w net.ipv4.conf.br-lan.route_localnet=1 >/dev/null 2>&1 || true
+fi

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -232,76 +232,11 @@ if [ "$dnsmasq_changed" = 1 ]; then
   /etc/init.d/dnsmasq restart
 fi
 
-# Idempotent uhttpd listener for the local block page on 127.0.0.1:8081 and
-# [::1]:8081 (#411 — v6 sibling so v6 HTTP requests to blocked hosts land on
-# the block page, not a connection error).
-#
-# Every request to this listener is dispatched to the lua handler at
-# /www/wifihaven/handler.lua (uhttpd-mod-lua). The handler resolves the
-# requesting device's MAC (from /proc/net/arp by REMOTE_ADDR), looks up the
-# per-MAC block reason written by the agent, and returns a redirect to the
-# API's /blocked page with mac+reason populated (#437). The static
-# index.html that used to live here had no way to know the client's MAC.
-uhttpd_section=$(uci show uhttpd 2>/dev/null \
-  | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http=.*'127\\.0\\.0\\.1:8081'/{print \$2; exit}")
-uhttpd_changed=0
-if [ -n "$uhttpd_section" ]; then
-  current_home=$(uci -q get "uhttpd.${uhttpd_section}.home" || echo "")
-  if [ "$current_home" != "/www/wifihaven" ]; then
-    info "Updating block-page uhttpd home to /www/wifihaven..."
-    uci set "uhttpd.${uhttpd_section}.home=/www/wifihaven"
-    uhttpd_changed=1
-  fi
-else
-  info "Configuring uhttpd block-page listener on 127.0.0.1:8081..."
-  uhttpd_section=$(uci add uhttpd uhttpd)
-  uci add_list "uhttpd.${uhttpd_section}.listen_http=127.0.0.1:8081"
-  uci set "uhttpd.${uhttpd_section}.home=/www/wifihaven"
-  uhttpd_changed=1
-fi
-
-# Add v6 listener if absent. uhttpd treats listen_http as a list, so add_list
-# is safe to append; we just need to dedupe.
-if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
-    | tr ' ' '\n' | grep -qx '\[::1\]:8081'; then
-  info "Adding v6 block-page uhttpd listener on [::1]:8081..."
-  uci add_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
-  uhttpd_changed=1
-fi
-
-# Route every URL through the lua handler so the block page can do per-MAC
-# lookups instead of serving a static file (#437).
-desired_lua_prefix='/'
-desired_lua_handler='/www/wifihaven/handler.lua'
-current_lua_prefix=$(uci -q get "uhttpd.${uhttpd_section}.lua_prefix" || echo "")
-current_lua_handler=$(uci -q get "uhttpd.${uhttpd_section}.lua_handler" || echo "")
-if [ "$current_lua_prefix" != "$desired_lua_prefix" ]; then
-  uci set "uhttpd.${uhttpd_section}.lua_prefix=$desired_lua_prefix"
-  uhttpd_changed=1
-fi
-if [ "$current_lua_handler" != "$desired_lua_handler" ]; then
-  uci set "uhttpd.${uhttpd_section}.lua_handler=$desired_lua_handler"
-  uhttpd_changed=1
-fi
-
-if [ "$uhttpd_changed" = 1 ]; then
-  uci commit uhttpd
-  /etc/init.d/uhttpd reload
-else
-  info "Block-page uhttpd listener already configured (v4 + v6, lua handler)."
-fi
-
-# #303: enable route_localnet on the LAN bridge so the nft prerouting DNAT
-# to 127.0.0.1:8081 (block-page uhttpd) is routable for LAN clients. The
-# persistent file is shipped at /etc/sysctl.d/99-wifihaven.conf by the
-# package; apply it now so the running kernel picks it up without a reboot.
-# Manual installs (no package manager) also need this — sysctl -p loads the
-# file if present.
-if [ -f /etc/sysctl.d/99-wifihaven.conf ]; then
-  sysctl -p /etc/sysctl.d/99-wifihaven.conf >/dev/null 2>&1 || true
-else
-  sysctl -w net.ipv4.conf.br-lan.route_localnet=1 >/dev/null 2>&1 || true
-fi
+# Wire the uhttpd block-page listener + route_localnet sysctl. Shared
+# helper so the package postinst (#542) and this manual installer don't
+# drift — see openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh.
+info "Configuring uhttpd block-page listener..."
+sh /usr/lib/wifihaven/setup-uhttpd-block-page.sh
 
 # Enable and start.
 info "Enabling and starting the wifihaven agent..."

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -12,6 +12,11 @@ set -e
 PASS=0; FAIL=0
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$ROOT/install.sh"
+# #542: the uhttpd block-page wiring is now in a shared helper that both
+# install.sh (manual installer) and the package postinst (.ipk/.apk + the
+# OpenWRT Makefile) invoke, so they can't drift. Several greps below run
+# against the helper for that reason.
+UHTTPD_HELPER="$ROOT/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh"
 
 check() {
   if [ "$2" = "ok" ]; then
@@ -22,6 +27,7 @@ check() {
 }
 
 [ -f "$SCRIPT" ] || { printf "MISSING: %s\n" "$SCRIPT"; exit 1; }
+[ -f "$UHTTPD_HELPER" ] || { printf "MISSING: %s\n" "$UHTTPD_HELPER"; exit 1; }
 
 # #287: confdir must be set so dnsmasq actually loads
 # /tmp/dnsmasq.d/wifihaven.conf (the agent's rendered profile/NXDOMAIN config).
@@ -67,40 +73,64 @@ grep -qE "Router name|router_name|routerName" "$SCRIPT" \
            "install.sh still references router-name input" \
   || check "install.sh does not prompt for router name" ok
 
-# #303: block-page uhttpd listener must have home=/www/wifihaven (not /www).
-# When nft prerouting DNAT redirects http://<anything>/ to 127.0.0.1:8081,
-# uhttpd serves home/index.html — with home=/www that's the LuCI redirect
-# page, not the block page (which lives at /www/wifihaven/index.html).
-grep -q "home=/www/wifihaven" "$SCRIPT" \
+# #303 + #437 + #542: block-page uhttpd UCI lives in the shared helper.
+# install.sh must invoke it (not inline the UCI calls — that was #542's
+# drift bug between install.sh and the package postinst).
+
+grep -q "setup-uhttpd-block-page.sh" "$SCRIPT" \
+  && check "install.sh invokes setup-uhttpd-block-page.sh helper" ok \
+  || check "install.sh invokes setup-uhttpd-block-page.sh helper" \
+           "install.sh no longer wires uhttpd directly; must call the helper"
+
+# Helper itself must wire the right values. These were the inline asserts
+# pre-#542; they live on the helper now.
+grep -q "home=/www/wifihaven" "$UHTTPD_HELPER" \
   && check "block-page uhttpd home is /www/wifihaven" ok \
   || check "block-page uhttpd home is /www/wifihaven" "expected home=/www/wifihaven"
 
-# #303: the installer must not leave a bare home=/www behind. Use a regex
-# that excludes /www/<anything> so home=/www/wifihaven doesn't match.
-if grep -Eq "home=/www([^/a-z]|\$)" "$SCRIPT"; then
-  check "no leftover home=/www in block-page section" "found bare home=/www"
+if grep -Eq "home=/www([^/a-z]|\$)" "$UHTTPD_HELPER"; then
+  check "no leftover home=/www in helper" "found bare home=/www"
 else
-  check "no leftover home=/www in block-page section" ok
+  check "no leftover home=/www in helper" ok
 fi
 
-# #303: installer must idempotently fix an existing listener whose home is
-# still the pre-#303 value (uci set + commit + uhttpd reload on upgrade).
-grep -q "Updating block-page uhttpd home" "$SCRIPT" \
-  && check "upgrades existing block-page listener to new home" ok \
-  || check "upgrades existing block-page listener to new home" "missing upgrade path"
+grep -q "updating block-page uhttpd home" "$UHTTPD_HELPER" \
+  && check "helper has upgrade path for existing block-page listener" ok \
+  || check "helper has upgrade path for existing block-page listener" \
+           "missing upgrade path"
 
-# #437: the block-page listener must dispatch every request through the lua
-# handler (uhttpd-mod-lua) so the page can resolve the requesting device's
-# MAC and render reason-specific copy. Without these UCI options the
-# pre-#437 static index.html (now removed) would be served as a 404.
-grep -q "lua_prefix=" "$SCRIPT" \
-  && check "configures lua_prefix on block-page listener" ok \
-  || check "configures lua_prefix on block-page listener" "missing lua_prefix"
+grep -q "lua_prefix=" "$UHTTPD_HELPER" \
+  && check "helper configures lua_prefix on block-page listener" ok \
+  || check "helper configures lua_prefix on block-page listener" "missing lua_prefix"
 
-grep -q "/www/wifihaven/handler.lua" "$SCRIPT" \
-  && check "configures lua_handler pointing at /www/wifihaven/handler.lua" ok \
-  || check "configures lua_handler pointing at /www/wifihaven/handler.lua" \
+grep -q "/www/wifihaven/handler.lua" "$UHTTPD_HELPER" \
+  && check "helper configures lua_handler pointing at handler.lua" ok \
+  || check "helper configures lua_handler pointing at handler.lua" \
            "missing lua_handler wiring"
+
+# #542: the uci-defaults stub runs the helper at first boot. uci-defaults
+# is the right idiom for postinst-style work that needs the live system
+# (procd, running uhttpd, mounted /etc/config) — postinst itself fires at
+# offline-install time when none of those exist. /etc/init.d/done runs
+# every file in /etc/uci-defaults/ at first boot and deletes any that
+# exit zero.
+UHTTPD_DEFAULTS_STUB="$ROOT/files/etc/uci-defaults/95-wifihaven-uhttpd"
+[ -f "$UHTTPD_DEFAULTS_STUB" ] \
+  && check "/etc/uci-defaults/95-wifihaven-uhttpd shipped in package" ok \
+  || check "/etc/uci-defaults/95-wifihaven-uhttpd shipped in package" \
+           "missing first-boot trigger for uhttpd block-page setup"
+
+grep -q "setup-uhttpd-block-page.sh" "$UHTTPD_DEFAULTS_STUB" \
+  && check "uci-defaults stub invokes setup-uhttpd-block-page.sh" ok \
+  || check "uci-defaults stub invokes setup-uhttpd-block-page.sh" \
+           "stub doesn't call the helper"
+
+# Makefile must ship the uci-defaults stub so Image-Builder-installed routers
+# pick it up at first boot.
+grep -q "95-wifihaven-uhttpd" "$ROOT/Makefile" \
+  && check "Makefile installs the uci-defaults stub" ok \
+  || check "Makefile installs the uci-defaults stub" \
+           "Package/wifihaven/install doesn't ship 95-wifihaven-uhttpd"
 
 # #437: the new handler ships at this path; ensure the file exists in tree.
 [ -f "$ROOT/files/www/wifihaven/handler.lua" ] \


### PR DESCRIPTION
## Why

The block-page uhttpd UCI section (listen on 127.0.0.1:8081 + [::1]:8081, `home=/www/wifihaven`, `lua_handler=/www/wifihaven/handler.lua`) was being configured only by \`openwrt/install.sh\` — the interactive manual installer. Image-Builder-baked routers (what VM e2e and any IPK-from-release path uses) ran with no such section, so uhttpd served 404 on the DNAT'd block-page request and three scenarios timed out:

- \`test_03_blocked_domain::test_blocked_domain_request_dropped\`
- \`test_06_blocked_page::test_blocked_request_returns_block_page\`
- \`test_extra_blocked::test_extra_blocked_http_drops_to_block_page_and_set_populated\`

#531 fixed the \`uhttpd-mod-lua\` dependency on both build scripts but didn't address the bigger gap: the **UCI wiring itself** lived only in install.sh.

## What

1. **Extract** the uhttpd block-page UCI setup from \`install.sh\` into a single helper at \`/usr/lib/wifihaven/setup-uhttpd-block-page.sh\`. Idempotent; handles both fresh and upgrade paths; runs the \`route_localnet\` sysctl too. Single source of truth.
2. **Ship** \`/etc/uci-defaults/95-wifihaven-uhttpd\` in the package — a thin stub that calls the helper at **first boot**. uci-defaults is the right idiom for postinst-style work that needs the live system (procd, running uhttpd, mounted /etc/config). The package postinst runs at offline-install time before any of those exist, so uci writes get persisted but uhttpd reload never fires — that's why my initial attempt with a postinst call only set \`listen_http\` + \`home\` but never \`lua_handler\`.
3. \`install.sh\` now calls the helper directly instead of inlining the UCI block. Same logic in one place; can't drift again.
4. Shipped from all three build paths: \`openwrt/Makefile\` (Image Builder), \`openwrt/build-ipk.sh\`, \`openwrt/build-apk.sh\`.

## Local validation

Clean rebuild + \`scripts/e2e-vm.sh --only blocked-domain\`:

\`\`\`
============= 1 passed, 22 deselected in 90.23s (0:01:30) ==============
\`\`\`

Pre-fix run on the same image (without uci-defaults stub) failed with the same TimeoutError seen in CI.

**Note**: \`test_06_blocked_page\` still fails locally — but at a different point. It mutates extraBlocked at runtime, requiring post-mutation eb_<sanhost> population in nft, which is **#544 / #608 territory** and unrelated to this PR's uhttpd-wiring fix.

Shell-level \`install_spec.sh\`: **19 / 19 pass**.

## Refs

- Closes #542
- Related: #437 (per-MAC block reason), #303 (route_localnet), #531 (uhttpd-mod-lua dep)