### PR TITLE
ci: offset keep-staging-warm cron to dodge top-of-10min stampede

### DIFF
--- a/.github/workflows/keep-staging-warm.yml
+++ b/.github/workflows/keep-staging-warm.yml
@@ -2,7 +2,12 @@ name: Keep staging warm
 
 on:
   schedule:
-    - cron: "*/10 * * * *"
+    # Offset cron avoids the "top of every 10 min" stampede on GHA shared
+    # runners — :00/:10/:20/... are the most-contested and most-frequently-
+    # dropped slots. Offsetting trades a tiny bit of phase for substantially
+    # more reliable firing. Still well under the 15-min Hobby idle-suspend
+    # threshold.
+    - cron: "3,13,23,33,43,53 * * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Switch the staging-warm cron from \`*/10 * * * *\` to \`3,13,23,33,43,53 * * * *\`.
- GHA shared-runner scheduled jobs at \`:00/:10/:20/...\` are the most-contested slots and most frequently dropped under load. An offset cadence tends to fire more reliably; period is unchanged and still well under the 15-min Hobby idle-suspend window.

Follow-up to #628 (#615).

## Test plan

- [ ] Confirm runs appear in the Actions tab at \`:03/:13/:23/...\` over the next ~hour with no large gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)