### PR TITLE
ci: pin wrangler 4 in master.yml SPA deploys

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -233,6 +233,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pin wrangler 4 — node_modules transitively pulls wrangler 3.x,
+          # which the action would otherwise pick up. Wrangler 3 rejects
+          # `--config` for Pages projects (#613 follow-up).
+          wranglerVersion: '4'
           workingDirectory: web
           # Project name + build dir come from web/wrangler.staging.toml.
           command: pages deploy --config wrangler.staging.toml --branch=main
@@ -427,6 +431,10 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Pin wrangler 4 — node_modules transitively pulls wrangler 3.x,
+          # which the action would otherwise pick up. Wrangler 3 rejects
+          # `--config` for Pages projects (#613 follow-up).
+          wranglerVersion: '4'
           workingDirectory: web
           # Project name + build dir come from web/wrangler.toml.
           command: pages deploy --config wrangler.toml --branch=main


### PR DESCRIPTION
Follow-up to #632 / #613.

`cloudflare/wrangler-action@v3` auto-detects an existing wrangler in `node_modules` and uses it. After `npm ci` in the SPA build step, wrangler 3.90.0 (a transitive dep of something in `web/`) is present, and the action skips installing the latest. Wrangler 3 rejects the `--config` flag for Pages projects, so `deploy-spa-staging` fails immediately with exit 1.

Pin via the action's `wranglerVersion: '4'` input on both SPA jobs.

## Test plan

- [ ] Master CD runs to completion past `deploy-spa-staging`.
- [ ] `smoke-staging` SPA bundle check passes (confirms the new build was deployed, not the manually-seeded one).
- [ ] `deploy-spa-prod` succeeds in the deploy-production block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)