### PR TITLE
ci: unify api + openwrt publish behind single manual-approval gate (#498)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,7 +9,11 @@ name: Master CD
 #                                     with deploy-staging, gated on the same test chain)
 #     → smoke-staging                (lightweight curl checks against api-staging.wifihaven.net
 #                                     AND staging.wifihaven.net SPA — gates ALL of prod)
-#     → deploy-production            (parallel jobs; all gated on smoke-staging passing):
+#     → approve-production           (manual-approval gate — GitHub `production`
+#                                     environment; required reviewer must click
+#                                     "Approve and deploy" before any of the four
+#                                     deploy-production jobs run; see #498)
+#     → deploy-production            (parallel jobs; all gated on approve-production):
 #                                       • retag-latest      — promote sha-<commit> → :latest
 #                                                             via `docker buildx imagetools create`
 #                                                             (no rebuild — image already gated)
@@ -19,14 +23,17 @@ name: Master CD
 #                                       • deploy-spa-prod    — build + wrangler push to
 #                                                             wifihaven Pages project (#613)
 #
-# Gate semantics: the public consumer surface (`:latest`, the openwrt-latest
-# rolling release, the prod Render service) only updates after staging smoke
-# passes. A failed smoke leaves all three on the previous version — atomic at
-# the gate.
+# Gate semantics: a failed staging smoke short-circuits before approval is
+# even requested. After smoke passes, a human must approve via the
+# `production` environment. Denial leaves the public consumer surface
+# (`:latest`, the openwrt-latest rolling release, the prod Render service,
+# the prod Cloudflare Pages SPA) on the previous version — all four
+# surfaces are atomic at the gate.
 #
-# TODO(#498): re-add a real manual approval gate via `environment: production`
-# on the three deploy-production jobs. Until that lands, deploy-production
-# fires automatically once smoke-staging is green.
+# TODO(#597): the wire-schema bump (capability negotiation framework) gets
+# coordinated here once #597's mechanism lands — the manual gate is the
+# natural choke point to confirm router-agent and API ship compatible
+# protocol versions in the same release.
 
 on:
   push:
@@ -305,15 +312,30 @@ jobs:
           [[ "$status" == "401" || "$status" == "200" || "$status" == "403" ]]
 
   # ════════════════════════════════════════════════════════════════════════
-  # ── DEPLOY-PRODUCTION ── (parallel jobs, all gated on smoke-staging) ────
+  # ── DEPLOY-PRODUCTION ── (manual-approval gate + parallel jobs) ─────────
   # ════════════════════════════════════════════════════════════════════════
-  # Four sibling jobs, each `needs: [smoke-staging]`. They run in parallel.
-  # If any one of them fails, the others may still complete — the gate that
-  # matters (staging smoke) has already passed, and partial promotion is
-  # better than rolling back work that's already shipped to one surface.
+  # An `approve-production` sentinel job carries `environment: production` so
+  # GitHub pauses the run for manual approval before any consumer-facing
+  # surface is touched. All four deploy-production jobs `needs:
+  # [approve-production]`, so a single approval gates them all atomically;
+  # denial blocks every one of them.
   #
-  # TODO(#498): add `environment: production` to all four jobs so they
-  # require manual approval. Until then they auto-fire after smoke passes.
+  # Why a sentinel job instead of putting `environment:` on each job?
+  # Reusable-workflow caller jobs (publish-openwrt) cannot set `environment:`
+  # at the call site — GitHub disallows it alongside `uses:`. A sentinel
+  # also gives the operator one approval click for the whole release rather
+  # than four.
+
+  approve-production:
+    name: Manual approval (production gate)
+    needs: [smoke-staging]
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://api.wifihaven.net
+    steps:
+      - name: Approved
+        run: echo "Production deploy approved — releasing API image + OpenWRT agent + SPA."
 
   # 6a. Retag sha-<commit> → :latest. No rebuild — `imagetools create`
   # operates on the registry-side manifest. The sha image has already been
@@ -322,9 +344,8 @@ jobs:
   # in another tool; buildx is already set up on github-hosted runners.
   retag-latest:
     name: Promote sha → :latest (deploy-production)
-    needs: [smoke-staging]
+    needs: [approve-production]
     runs-on: ubuntu-latest
-    # TODO(#498): environment: production
     permissions:
       contents: read
       packages: write
@@ -353,8 +374,7 @@ jobs:
   # input. See openwrt-build.yml for the gating logic.
   publish-openwrt:
     name: Publish OpenWRT release (deploy-production)
-    needs: [smoke-staging]
-    # TODO(#498): environment: production
+    needs: [approve-production]
     permissions:
       contents: write
     uses: ./.github/workflows/openwrt-build.yml
@@ -368,9 +388,8 @@ jobs:
   # depend on retag-latest to enforce ordering.
   deploy-prod-render:
     name: Deploy production (Render)
-    needs: [smoke-staging, retag-latest]
+    needs: [approve-production, retag-latest]
     runs-on: ubuntu-latest
-    # TODO(#498): environment: production
     steps:
       - name: Trigger Render prod deploy hook
         env:
@@ -400,9 +419,8 @@ jobs:
   # deploy-prod-render is bounded to the duration of either job.
   deploy-spa-prod:
     name: Deploy SPA to Cloudflare Pages (prod) (deploy-production)
-    needs: [smoke-staging]
+    needs: [approve-production]
     runs-on: ubuntu-latest
-    # TODO(#498): environment: production
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,21 +1,22 @@
 name: OpenWRT Package Build
 
-# Normally, releases happen only on v* tag pushes (#191, #212). For live
-# debugging of #228 we also publish a rolling "openwrt-latest" pre-release
-# on every push to main that touches openwrt/**, so the field router can
-# fetch the updated .apk without us cutting a real tag each iteration.
-# This is reverted by #244 once #228 is fixed.
+# Release flow (post-#498): the rolling "openwrt-latest" GitHub Release is
+# published exclusively from Master CD's deploy-production path, behind the
+# manual-approval gate. There is no standalone `push.tags: ["v*"]` trigger —
+# tag pushes would otherwise fire this workflow ungated and race with the
+# coordinated release from master.yml (see #498).
 #
-# This workflow is also invoked from master.yml as a reusable workflow
-# (`workflow_call`). After #588, the GitHub Release / openwrt-latest rolling
-# upload only fires when the caller passes `publish_release: true` — that
-# input is set exclusively from Master CD's deploy-production job, after
-# staging smoke has passed. The build itself still runs in CI for PR
-# validation and main-push confidence; only the public artifact promotion
-# is gated.
+# Triggers retained:
+#   - push to main (paths: openwrt/**)  — build-only confidence run, no upload
+#   - pull_request (paths: openwrt/**)  — PR validation
+#   - workflow_dispatch                 — one-off debug builds
+#   - workflow_call                     — invoked by master.yml deploy-production
+#                                         with publish_release: true
+#
+# The build itself still runs for PR / main-push validation; only the public
+# artifact promotion (GitHub Release upload) is gated by `publish_release`.
 on:
   push:
-    tags: ["v*"]
     branches: ["main"]
     paths: ["openwrt/**"]
   pull_request:
@@ -111,20 +112,10 @@ jobs:
           path: openwrt/wifihaven_*.apk
           if-no-files-found: error
 
-      - name: Create GitHub release and attach packages (tag)
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            openwrt/wifihaven_*.ipk
-            openwrt/wifihaven_*.apk
-          generate_release_notes: true
-
-      # Rolling pre-release. After #588 this only fires when the caller
-      # explicitly opts in (Master CD's deploy-production job, post-staging-smoke).
-      # Direct main pushes no longer publish — the unconditional reusable-workflow
-      # call from master.yml passes publish_release=false so the build runs for
-      # confidence without promoting an unstaged artifact.
+      # Rolling pre-release. Post-#498 this is the ONLY release path — fires
+      # only when the caller passes publish_release=true (Master CD's
+      # deploy-production job, after the manual-approval gate). Direct main
+      # pushes and PR validation runs build for confidence without publishing.
       - name: Publish rolling openwrt-latest release (gated by caller)
         if: inputs.publish_release == true
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Drops the standalone `push.tags: ["v*"]` trigger from `openwrt-build.yml` so the reusable-workflow call from `master.yml` is the **only** path that publishes a GitHub Release. Tag pushes no longer race the gated path.
- Adds a real manual-approval gate (GitHub `production` environment) in `master.yml` between `smoke-staging` and the four `deploy-production` jobs. One approval click releases (or denial blocks) the API image promotion, OpenWRT rolling release, prod Render deploy, and prod Cloudflare Pages SPA — atomically at the gate.

## Coordination with #588

#588 / [#631](https://github.com/wifihaven/wifihaven/pull/631) was already **merged** when this work started, so this PR builds directly on top of `main`. The `TODO(#498):` markers left in master.yml by #631 are replaced with the real gate here.

## Gate design

Reusable-workflow caller jobs (`publish-openwrt` uses `uses:`) cannot set `environment:` at the call site — GitHub disallows it alongside `uses:`. Rather than pull the OpenWRT release into an inline job, this PR uses a small `approve-production` sentinel job that carries `environment: production` and that all four deploy-production jobs depend on:

```
smoke-staging
  → approve-production            ← `environment: production` (manual approval here)
      → retag-latest
      → publish-openwrt           (reusable openwrt-build.yml, publish_release: true)
      → deploy-prod-render
      → deploy-spa-prod
```

Benefits:
- Single approval click in the GitHub UI gates the whole release, not four separate prompts.
- Works uniformly for inline jobs and the reusable-workflow caller.
- Failed staging smoke short-circuits **before** approval is requested — operator is not paged for a deploy that already can't ship.
- Denial leaves every surface (`:latest`, openwrt-latest, prod Render service, prod SPA) on the previous version.

The approval UI links to `https://api.wifihaven.net` via `environment.url`.

## Path-filter cleanup

`master.yml` did not have per-job `changes.api` / `changes.outputs.openwrt` path filters at release time (the workflow runs unconditionally after #631), so no cleanup needed. The deploy-production fan-out already ships both artifacts together on every approved release regardless of which paths changed.

## #597 (wire-schema versioning)

Out of scope per #498's spec; tracked separately. The header comment in `master.yml` now carries a `TODO(#597)` noting the gate is the natural place to coordinate the schema bump once #597's mechanism lands.

## Operator action required before this can ship

- [ ] Create a `production` environment under repo Settings → Environments.
- [ ] Add required reviewers (operator's GitHub account, at minimum).
- [ ] (Optional) Set a wait timer and/or restrict deployments to the `main` branch.
- [ ] After merge, push a no-op to `main` and verify: build + e2e + prod-stack-smoke run → `build-image` pushes the sha tag → `deploy-staging` + `deploy-spa-staging` run → `smoke-staging` passes → workflow **pauses at `approve-production`** awaiting approval. Approve, and confirm all four deploy-production jobs run.
- [ ] Test denial path on a subsequent push: reject the approval, confirm none of the four deploy-production jobs run and `:latest` / `openwrt-latest` / prod services stay on the prior version.

## Test plan

- [ ] `gh workflow view master.yml` parses cleanly after push.
- [ ] First post-merge run pauses at the gate (operator action above).
- [ ] Tag pushes no longer trigger `openwrt-build.yml` standalone (no duplicate openwrt release attempts).
- [ ] `workflow_dispatch` on `openwrt-build.yml` still works for one-off debug builds.

Closes #498. Refs #251, #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)