### PR TITLE
openwrt: default install.sh API URL prompt to api.wifihaven.net

### DIFF
--- a/docs/install-openwrt.md
+++ b/docs/install-openwrt.md
@@ -47,7 +47,7 @@ The script prompts for:
 
 | Prompt | Notes |
 |---|---|
-| API server URL | e.g. `https://api.example.com` (no trailing slash needed; the script trims it). |
+| API server URL | Defaults to `https://api.wifihaven.net` (production cloud API). Press enter to accept for the main household router; override for on-prem or dev installs (e.g. `http://192.168.1.1:8080`). No trailing slash needed; the script trims it. |
 | Enrollment token | The `et_…` value from the admin UI. Single-use; invalidated on success. |
 | LAN prefix | Auto-detected from `network.lan.ipaddr` (last octet stripped); must end with a dot. The agent uses this literal-string prefix to decide which side of each connection is on the LAN when attributing flows to a device — accept the default unless your LAN isn't a /24 starting at .1. A wrong value silently mis-attributes every flow. For unattended provisioning, skip this script and use the manual `uci` path in §M3. |
 

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -119,7 +119,7 @@ and start the agent. Press Ctrl-C at any prompt to abort.
 
 EOF
 
-prompt API_URL          "API server URL (e.g. https://api.example.com)"
+prompt API_URL          "API server URL" "https://api.wifihaven.net"
 [ -n "${API_URL:-}" ] || err "API URL is required"
 API_URL=${API_URL%/}
 


### PR DESCRIPTION
## Summary

- One-shot installer (`openwrt/install.sh`) previously had no default for the **API server URL** prompt — every operator had to type the full URL. Default it to `https://api.wifihaven.net` (production cloud API), which is the overwhelmingly common case now that the cloud API is the canonical deployment.
- On-prem / dev installs can still override at the prompt (e.g. `http://192.168.1.1:8080` for fresh on-prem, `http://192.168.10.43:8080` for the dev router).
- Updates the §2 prompt table in [`docs/install-openwrt.md`](docs/install-openwrt.md) to reflect the new default and document the override.

Follow-up to the docs work in #589 / #641.

## Test plan

- [ ] On a test router, run the one-shot install command and confirm the API server URL prompt shows `[https://api.wifihaven.net]` and accepts the default on bare enter.
- [ ] Confirm typing an override value (e.g. `http://192.168.1.1:8080`) still works.
- [ ] Confirm the post-install `info` line and UCI write reflect whichever value was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)