### PR TITLE
fix(e2e): probe correct nft table + match server reason casing (#646)

### DIFF
--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -119,13 +119,20 @@ def router_restore(name: str) -> Result:
     return run([_vm_script("router-restore.sh"), name], timeout=60)
 
 
-def router_nft_set(set_name: str, *, table: str = "fw4", family: str = "inet") -> list[str]:
+def router_nft_set(set_name: str, *, table: str = "wifihaven", family: str = "inet") -> list[str]:
     """Return the elements of an nftables set on the router.
 
     Used by the enforcement suites (#346) to assert MAC / IP membership in
     sets like `blocked_macs` or per-MAC drop sets without depending on
     log-line parsing. Returns an empty list if the set exists but is empty,
     or if the set is absent.
+
+    The agent emits its runtime ruleset into `table inet wifihaven` (see
+    `add table inet wifihaven` in render.lua and the boot.nft handover in
+    `inet wifihaven_boot`). Earlier this default was `fw4`, which is the
+    OpenWRT firewall4 table — distinct from the agent's runtime table —
+    so every membership probe returned an empty list and Mode A tests in
+    #646 timed out at `_wait_mac_in_blocked_set`.
 
     Implementation detail: `nft -j list set ...` would be cleaner but isn't
     always present on the OpenWRT image; we parse the human-readable form.

--- a/scripts/e2e/scenarios/test_pause.py
+++ b/scripts/e2e/scenarios/test_pause.py
@@ -77,10 +77,10 @@ def _wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float =
 def _wait_pause_event(debug_api, mac: str, *, timeout_s: float = 30):
     return wait_until(
         lambda: (debug_api.events_for_mac_filtered(
-            mac, allowed=False, reason="paused"
+            mac, allowed=False, reason="Paused"
         ) or None),
         timeout_s=timeout_s, interval_s=2,
-        description=f"allowed=False reason=paused event for {mac}",
+        description=f"allowed=False reason=Paused event for {mac}",
     )
 
 

--- a/scripts/e2e/scenarios/test_schedule.py
+++ b/scripts/e2e/scenarios/test_schedule.py
@@ -137,7 +137,7 @@ def test_in_window_blocks(
         wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
-        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+        _wait_event(debug_api, mac, reason="Schedule", timeout_s=60)
     finally:
         sid = _schedule_id_from(result or {}, sched_name)
         if sid is not None:
@@ -300,21 +300,21 @@ def test_pause_overrides_schedule(
         wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
-        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+        _wait_event(debug_api, mac, reason="Schedule", timeout_s=60)
 
         # Pause — reason should flip to paused within one poll.
         admin.set_profile_paused(profile_id, True)
         paused = True
         wait_for_etag_change(admin, router.router_id, timeout_s=240)
         _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
-        _wait_event(debug_api, mac, reason="paused", timeout_s=60)
+        _wait_event(debug_api, mac, reason="Paused", timeout_s=60)
 
         # Unpause — schedule still in window, reason should revert.
         admin.set_profile_paused(profile_id, False)
         paused = False
         wait_for_etag_change(admin, router.router_id, timeout_s=240)
         _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
-        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+        _wait_event(debug_api, mac, reason="Schedule", timeout_s=60)
     finally:
         if paused:
             try:
@@ -417,7 +417,7 @@ def test_in_then_out_smoke(
         wait_for_etag_change(admin, router.router_id, timeout_s=240)
 
         _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
-        _wait_event(debug_api, mac, reason="schedule", timeout_s=60)
+        _wait_event(debug_api, mac, reason="Schedule", timeout_s=60)
 
         _set_clock_and_sync(admin, router, out_window)
         _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)


### PR DESCRIPTION
## Summary

VM e2e Mode A failures in #646 traced to two stacked bugs in the test harness, not in the api/openwrt code:

1. **`router_nft_set` queried the wrong table.** The helper in `scripts/e2e/lib/vm.py` defaulted to `table=\"fw4\"`, but the agent emits its runtime ruleset into `table inet wifihaven` (see `add table inet wifihaven` in `openwrt/files/usr/lib/lua/wifihaven/render.lua` and the boot-handover in `openwrt/files/usr/share/wifihaven/boot.nft`). Every `nft list set inet fw4 blocked_macs` returned empty, so `_wait_mac_in_blocked_set(present=True)` timed out regardless of what the agent rendered. Bug present since #434 added the helper.
2. **`reason=\"paused\"` / `\"schedule\"` event filter case-mismatch.** `MacBlockReason.asString` in `shared/src/Models.scala` serialises capitalised — `\"Paused\"`, `\"Schedule\"`, `\"TimeLimit\"`. The agent stores those verbatim. `events_for_mac_filtered` is case-sensitive, so the lowercase filters in `test_pause._wait_pause_event` and `test_schedule._wait_event` calls always missed.

## Local validation

Built `openwrt-wifihaven.img` fresh, then ran the pause + reassignment suites:

- [x] `test_pause::test_pause_blocks_and_unpause_restores` — PASS
- [x] `test_pause::test_pause_then_add_device_blocks_new_mac` — PASS
- [x] `test_pause::test_reassign_off_paused_profile_unblocks_mac` — PASS
- [x] `test_reassignment::test_delete_device_clears_rules` — PASS
- [ ] `test_reassignment::test_reassign_to_paused_blocks_and_back_restores` — still FAIL, but **further along**: now times out at `_wait_block_page`, not `_wait_mac_in_blocked_set`. Block-page plumbing is #647 territory.

## Out of scope

**Mode B** in #646 (the 7 `wait_for_etag_change` timeouts in `test_schedule` / `test_time_limit` / `test_04_daily_limit`) is a different root cause: the tests set the router VM clock with `set_router_clock`, but the API server evaluates `scheduleActiveAt(s, now)` against its own host wall clock. Schedules defined for a clock window that isn't currently real-world-active produce an unchanged effective policy, so the etag doesn't move. Fixing that needs an injectable API clock (or test-side adjustment to use real wall-clock windows) — separate change.

## Test plan

- [ ] CI vm-e2e job confirms the 4 Mode A tests above now pass
- [ ] Other CI gates (Scala, Lua, lint) green

Closes #646