### PR TITLE
fix(block-page): distinguish category-blocklist reason from ExtraBlocked

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
@@ -40,6 +40,29 @@ function M.parse_reasons(content, mac)
   return nil
 end
 
+-- Parse the per-(MAC, host) classifier file (lines of "<mac>\t<host>\t<source>")
+-- and return the source string for (mac, host), or nil. <source> is
+-- "extra_blocked" or "category:<id>". Lookup uses dnsmasq nftset suffix-match
+-- semantics: the file entry matches when host equals the request host or the
+-- request host is a subdomain of the entry. MAC comparison is
+-- case-insensitive; host comparison is lower-case. (#594)
+function M.parse_blocked_hosts(content, mac, host)
+  if not content or not mac or not host or host == "" then return nil end
+  local mac_target  = mac:lower()
+  local host_target = host:lower()
+  for line in content:gmatch("[^\n]+") do
+    local m, h, s = line:match("^(%S+)\t(%S+)\t(%S+)$")
+    if m and m:lower() == mac_target then
+      local h_lower = h:lower()
+      if host_target == h_lower
+         or host_target:sub(-(#h_lower + 1)) == "." .. h_lower then
+        return s
+      end
+    end
+  end
+  return nil
+end
+
 local function html_escape(s)
   s = tostring(s or "")
   return (s:gsub("&", "&amp;")
@@ -81,7 +104,14 @@ local INLINE_COPY = {
 }
 
 function M.inline_copy_for(reason)
-  return INLINE_COPY[reason or ""] or "This site is blocked."
+  reason = reason or ""
+  -- #594: category-blocklist hits arrive as "category:<id>"; surface the id in
+  -- the inline copy so the user can see which list matched.
+  local cat_id = reason:match("^category:(.+)$")
+  if cat_id then
+    return "Blocked category: " .. cat_id .. "."
+  end
+  return INLINE_COPY[reason] or "This site is blocked."
 end
 
 -- Render the HTML body for the block page. If api_url is set, returns a tiny

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -544,12 +544,14 @@ function M.handle_flow(flow, ctx, batcher)
   -- this MAC using dnsmasq's nftset suffix-match semantics.  The kernel
   -- enforces drops via:
   --   ether saddr <mac> ip daddr @eb_<host> drop
+  --   ether saddr <mac> ip daddr @bl_<id>   drop
   -- We drive this decision off the attributed hostname (hname) matched against
-  -- eb_hosts_by_mac, NOT off nft_sets[host][dst_ip].  The lua nft_sets table
-  -- is never populated in production (only the kernel ipsets are); nft_sets is
-  -- only a partial attribution fallback for site_limits domains.
+  -- eb_hosts_by_mac / bl_hosts_by_mac, NOT off nft_sets[host][dst_ip].  The
+  -- lua nft_sets table is never populated in production (only the kernel
+  -- ipsets are); nft_sets is only a partial attribution fallback for
+  -- site_limits domains.
   --
-  -- Each eb_ drop carries `ip daddr != @ea_<mac>_<host>` exception clauses,
+  -- Each eb_/bl_ drop carries `ip daddr != @ea_<mac>_<host>` exception clauses,
   -- so we must NOT classify as blocked when hname also matches a host in
   -- ea_hosts_by_mac[mac] (#421).
   --
@@ -558,63 +560,73 @@ function M.handle_flow(flow, ctx, batcher)
   -- each extraBlocked host's eb_ set (#579).  This is the slow path: one
   -- `nft get element` call per eb_host per flow.  ctx.exec_fn is injectable
   -- for tests; defaults to os.execute.
+  --
+  -- #594: extraBlocked hits report reason="host"; category-blocklist hits
+  -- report reason="category:<id>" so the block page and connection_event log
+  -- can name the matched list.
+  local function check_ea_carveout(eb_hit_host)
+    local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
+    if not ea_hosts then return false end
+    for ea_host in pairs(ea_hosts) do
+      if hname then
+        if M.host_matches(hname, ea_host) then return true end
+      else
+        if ea_host == eb_hit_host then return true end
+      end
+    end
+    return false
+  end
+
   if allowed and mac then
     local eb_hosts = ctx.eb_hosts_by_mac and ctx.eb_hosts_by_mac[mac]
     if eb_hosts then
-      -- Check whether hname (or any of its parent domains) matches an eb_ host.
-      -- When hname is nil, fall back to nft set membership queries (#579).
       local eb_hit = false
-      local eb_hit_host  -- the eb_ host whose set/name matched (for ea_ check)
+      local eb_hit_host
       for host in pairs(eb_hosts) do
         if hname then
           if M.host_matches(hname, host) then
-            eb_hit = true
-            eb_hit_host = host
-            break
+            eb_hit = true; eb_hit_host = host; break
           end
         else
-          -- Slow-path: no DNS attribution; query the live nft eb_ set.
           if M.nft_eb_hit(flow.dst_ip, host, ctx.exec_fn) then
-            eb_hit = true
-            eb_hit_host = host
-            break
+            eb_hit = true; eb_hit_host = host; break
           end
         end
       end
+      if eb_hit and not check_ea_carveout(eb_hit_host) then
+        allowed = false
+        reason  = "host"
+      end
+    end
+  end
 
-      if eb_hit then
-        -- Check the extraAllowed carve-out: if hname also matches any host in
-        -- ea_hosts_by_mac[mac], the `ip daddr != @ea_...` clause suppresses the
-        -- nft drop and the flow is allowed.
-        --
-        -- When hname is nil we cannot apply suffix-match semantics; treat any
-        -- ea_ host that exactly matches the eb_ host that fired as a carve-out.
-        -- This is a conservative approximation: it will only suppress the block
-        -- classification when the extraAllowed host is an exact match for the
-        -- extraBlocked host that fired, mirroring the exact situation where
-        -- an admin added the same host to both lists (#421).
-        local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
-        local ea_hit = false
-        if ea_hosts then
-          for ea_host in pairs(ea_hosts) do
-            if hname then
-              if M.host_matches(hname, ea_host) then
-                ea_hit = true
-                break
-              end
-            else
-              -- Slow-path: exact match of the ea_ host against the eb_ host.
-              if ea_host == eb_hit_host then
-                ea_hit = true
-                break
-              end
-            end
+  -- #594: per-host category-blocklist check. Same machinery as eb_ above but
+  -- the matched host's blocklist id is carried into the reason string. Skip
+  -- if eb_ already classified the flow as blocked (extraBlocked wins).
+  if allowed and mac then
+    local bl_hosts = ctx.bl_hosts_by_mac and ctx.bl_hosts_by_mac[mac]
+    if bl_hosts then
+      local bl_hit_host
+      local bl_hit_id
+      for host, id in pairs(bl_hosts) do
+        if hname then
+          if M.host_matches(hname, host) then
+            bl_hit_host = host; bl_hit_id = id; break
+          end
+        else
+          -- Slow-path: query the live nft eb_-style set keyed on host. The
+          -- category enforcement uses bl_<id> sets populated at resolve time
+          -- per-host; the per-host eb-style query is still meaningful when
+          -- DNS attribution is missing because the same host saturates both
+          -- the eb_<host> and bl_<id> indexing paths via dnsmasq.
+          if M.nft_eb_hit(flow.dst_ip, host, ctx.exec_fn) then
+            bl_hit_host = host; bl_hit_id = id; break
           end
         end
-        if not ea_hit then
-          allowed = false
-          reason  = "host"
-        end
+      end
+      if bl_hit_host and not check_ea_carveout(bl_hit_host) then
+        allowed = false
+        reason  = "category:" .. tostring(bl_hit_id)
       end
     end
   end
@@ -772,6 +784,7 @@ function M.watch(cfg)
         blocked_reason        = cfg.blocked_reason,
         eb_hosts_by_mac       = cfg.eb_hosts_by_mac,
         ea_hosts_by_mac       = cfg.ea_hosts_by_mac,
+        bl_hosts_by_mac       = cfg.bl_hosts_by_mac,
         exec_fn               = cfg.exec_fn,
         reported_macs         = reported_macs,
         pending_hostname_macs = pending_hostname_macs,

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -829,23 +829,29 @@ end
 
 -- ---------------------------------------------------------------------------
 -- render.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
---                      eb_hosts_by_mac, ea_hosts_by_mac)
+--                      eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
 -- ---------------------------------------------------------------------------
 -- Rebuilds blocked_macs / blocked_reason in place from each device's
 -- effective BlockRules. nft_sets is left intact — population is driven by
 -- dnsmasq --ipset= callbacks at resolution time (and by dns-tail per #259).
 --
--- Also rebuilds eb_hosts_by_mac and ea_hosts_by_mac when provided:
+-- Also rebuilds eb_hosts_by_mac, ea_hosts_by_mac, and bl_hosts_by_mac when
+-- provided:
 --   eb_hosts_by_mac: { mac -> { hostname -> true } }
---     — the set of hostnames whose nft eb_/bl_ drop rules fire for this MAC
---       (derived from effective extraBlocked and blocklistIds).
+--     — hostnames whose nft eb_ drop rules fire for this MAC (effective
+--       extraBlocked only).
 --   ea_hosts_by_mac: { mac -> { hostname -> true } }
---     — the set of hostnames in the MAC's effective extraAllowed list; a hit
---       in this table suppresses the eb_/bl_ block classification.
--- Both tables are cleared and rebuilt on every call. Callers that do not need
--- per-host block classification may omit them (pass nil).
+--     — hostnames in the MAC's effective extraAllowed list; a hit suppresses
+--       the eb_/bl_ block classification.
+--   bl_hosts_by_mac: { mac -> { hostname -> blocklist_id } }
+--     — hostnames whose nft bl_ drop rules fire for this MAC, tagged with the
+--       blocklist id that matched (used to surface a category-specific reason
+--       on the block page and in connection_event.reason — #594). If multiple
+--       blocklists contain the same host, the first by sorted id wins.
+-- All three tables are cleared and rebuilt on every call. Callers that do not
+-- need per-host block classification may omit them (pass nil).
 function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
-                         eb_hosts_by_mac, ea_hosts_by_mac)
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
   if blocked_macs then
     for k in pairs(blocked_macs) do blocked_macs[k] = nil end
   end
@@ -857,6 +863,9 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
   end
   if ea_hosts_by_mac then
     for k in pairs(ea_hosts_by_mac) do ea_hosts_by_mac[k] = nil end
+  end
+  if bl_hosts_by_mac then
+    for k in pairs(bl_hosts_by_mac) do bl_hosts_by_mac[k] = nil end
   end
 
   -- Build a blocklist-id → [hosts] lookup so we can expand blocklistIds below.
@@ -882,13 +891,26 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
 
       -- Per-blocklist blocklistIds: expand each id to its constituent hosts
       -- using the cached blocklist data attached to the snapshot.
-      if eb_hosts_by_mac and type(r.blocklistIds) == "table" and #r.blocklistIds > 0 then
-        for _, id in ipairs(r.blocklistIds) do
+      -- #594: tag each (mac, host) with the blocklist id that matched so the
+      -- block page and connection_event can name the category. Iterate ids in
+      -- sorted order so the chosen id is deterministic when a host appears in
+      -- multiple lists. extraBlocked (eb_) takes precedence over category
+      -- (bl_) when the same host is in both — populate bl_hosts_by_mac only
+      -- if the host isn't already in eb_hosts_by_mac[mac].
+      if bl_hosts_by_mac and type(r.blocklistIds) == "table" and #r.blocklistIds > 0 then
+        local ids = {}
+        for _, id in ipairs(r.blocklistIds) do ids[#ids + 1] = id end
+        table.sort(ids)
+        for _, id in ipairs(ids) do
           local hosts = bl_hosts[id]
           if type(hosts) == "table" then
-            if not eb_hosts_by_mac[mac] then eb_hosts_by_mac[mac] = {} end
             for _, host in ipairs(hosts) do
-              eb_hosts_by_mac[mac][host] = true
+              local eb_for_mac = eb_hosts_by_mac and eb_hosts_by_mac[mac]
+              local already_eb = eb_for_mac and eb_for_mac[host]
+              if not bl_hosts_by_mac[mac] then bl_hosts_by_mac[mac] = {} end
+              if not already_eb and not bl_hosts_by_mac[mac][host] then
+                bl_hosts_by_mac[mac][host] = id
+              end
             end
           end
         end
@@ -922,6 +944,39 @@ function M.write_blocked_reasons(blocked_reason, path)
   local lines = {}
   for mac, reason in pairs(blocked_reason or {}) do
     table.insert(lines, mac .. "\t" .. tostring(reason))
+  end
+  table.sort(lines)
+  local body = table.concat(lines, "\n")
+  if #lines > 0 then body = body .. "\n" end
+  local tmp = path .. ".tmp"
+  local f, err = io.open(tmp, "w")
+  if not f then return nil, err end
+  f:write(body)
+  f:close()
+  local ok, rerr = os.rename(tmp, path)
+  if not ok then return nil, rerr end
+  return true
+end
+
+-- render.write_blocked_hosts(eb_hosts_by_mac, bl_hosts_by_mac, path) → ok, err
+--
+-- Persist the per-(MAC, host) block source classification so the block-page
+-- handler can distinguish an extraBlocked hit from a category-blocklist hit
+-- (#594). Format: one "<mac>\t<host>\t<source>\n" per (mac, host) entry,
+-- sorted for deterministic output. <source> is "extra_blocked" for an
+-- extraBlocked hit or "category:<blocklist_id>" for a category-blocklist hit.
+-- Written atomically via tmp+rename so the handler never sees a partial file.
+function M.write_blocked_hosts(eb_hosts_by_mac, bl_hosts_by_mac, path)
+  local lines = {}
+  for mac, hosts in pairs(eb_hosts_by_mac or {}) do
+    for host in pairs(hosts) do
+      table.insert(lines, mac .. "\t" .. host .. "\textra_blocked")
+    end
+  end
+  for mac, hosts in pairs(bl_hosts_by_mac or {}) do
+    for host, id in pairs(hosts) do
+      table.insert(lines, mac .. "\t" .. host .. "\tcategory:" .. tostring(id))
+    end
   end
   table.sort(lines)
   local body = table.concat(lines, "\n")

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -57,8 +57,9 @@ end
 local nft_sets       = {}   -- { hostname -> { ip -> true } }
 local blocked_macs   = {}   -- { mac -> true }          (paused / time-exhausted)
 local blocked_reason = {}   -- { mac -> reason_string }
-local eb_hosts_by_mac = {}  -- { mac -> { hostname -> true } } (extraBlocked + blocklist)
+local eb_hosts_by_mac = {}  -- { mac -> { hostname -> true } } (extraBlocked)
 local ea_hosts_by_mac = {}  -- { mac -> { hostname -> true } } (extraAllowed carve-outs)
+local bl_hosts_by_mac = {}  -- { mac -> { hostname -> blocklist_id } } (category blocklist) (#594)
 
 -- ── HTTP helpers (curl, available on all OpenWrt builds) ──────────────────────
 
@@ -190,6 +191,7 @@ os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifi
 
 local BLOCK_PAGE_API_URL_PATH  = "/var/run/wifihaven/api_url"
 local BLOCK_PAGE_REASONS_PATH  = "/var/run/wifihaven/blocked_reasons"
+local BLOCK_PAGE_HOSTS_PATH    = "/var/run/wifihaven/blocked_hosts"  -- #594
 
 do
   local f = io.open(BLOCK_PAGE_API_URL_PATH, "w")
@@ -202,6 +204,13 @@ local function persist_blocked_reasons()
   local ok, err = render.write_blocked_reasons(blocked_reason, BLOCK_PAGE_REASONS_PATH)
   if not ok then
     log.debug("could not write %s: %s", BLOCK_PAGE_REASONS_PATH, tostring(err))
+  end
+  -- #594: also persist the per-(MAC, host) classification so the block-page
+  -- handler can distinguish extraBlocked from category-blocklist hits.
+  local ok2, err2 = render.write_blocked_hosts(
+    eb_hosts_by_mac, bl_hosts_by_mac, BLOCK_PAGE_HOSTS_PATH)
+  if not ok2 then
+    log.debug("could not write %s: %s", BLOCK_PAGE_HOSTS_PATH, tostring(err2))
   end
 end
 
@@ -234,7 +243,7 @@ do
   local cached = policy.load_snapshot(read_file, log)
   if cached then
     if policy.apply(cached, write_file, run_cmd, log) then
-      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
+      render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
       persist_blocked_reasons()
       last_snapshot = cached
       log.info("startup: applied cached policy from /etc/wifihaven/policy.json")
@@ -258,7 +267,7 @@ do
   local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
   if snap then
     if policy.apply(snap, write_file, run_cmd, log) then
-      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
+      render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
       persist_blocked_reasons()
       current_etag = etag
       last_snapshot = snap
@@ -332,6 +341,7 @@ conntrack.watch({
   blocked_reason    = blocked_reason,
   eb_hosts_by_mac   = eb_hosts_by_mac,
   ea_hosts_by_mac   = ea_hosts_by_mac,
+  bl_hosts_by_mac   = bl_hosts_by_mac,
   lan_prefix      = lan_prefix,
   max_batch       = max_batch,
   flush_interval  = flush_int,
@@ -368,7 +378,7 @@ conntrack.watch({
         -- apply already emits a clean ruleset (no failover chain), so we
         -- just need to clear the flag below.
         if policy.apply(snap, write_file, run_cmd, log) then
-          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac)
+          render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
           persist_blocked_reasons()
           current_etag = etag
           last_snapshot = snap

--- a/openwrt/files/www/wifihaven/handler.lua
+++ b/openwrt/files/www/wifihaven/handler.lua
@@ -28,9 +28,22 @@ function handle_request(env)
 
   local reasons = read_file("/var/run/wifihaven/blocked_reasons")
   local reason  = mac and block_page.parse_reasons(reasons, mac) or nil
-  -- No MAC-wide reason means the DNAT was triggered by an extraBlocked match,
-  -- not a whole-MAC block. (#576)
-  if mac and not reason then reason = "ExtraBlocked" end
+  -- No MAC-wide reason means the DNAT was triggered by a per-(MAC, host) drop,
+  -- not a whole-MAC block. Look up the host in the per-MAC classifier file to
+  -- distinguish extraBlocked from category-blocklist hits (#594). Falls back
+  -- to "ExtraBlocked" if the classifier file is missing or the lookup misses
+  -- (#576 default).
+  if mac and not reason then
+    local hosts_content = read_file("/var/run/wifihaven/blocked_hosts")
+    local source = block_page.parse_blocked_hosts(hosts_content, mac, host)
+    if source == "extra_blocked" then
+      reason = "ExtraBlocked"
+    elseif source then
+      reason = source  -- e.g. "category:ads"
+    else
+      reason = "ExtraBlocked"
+    end
+  end
 
   local api_url = read_file("/var/run/wifihaven/api_url")
   if api_url then api_url = api_url:gsub("%s+$", "") end

--- a/openwrt/test/block_page_spec.lua
+++ b/openwrt/test/block_page_spec.lua
@@ -58,6 +58,54 @@ describe("block_page.parse_reasons", function()
   end)
 end)
 
+describe("block_page.parse_blocked_hosts (#594)", function()
+  local content = table.concat({
+    "aa:bb:cc:11:22:33\ttiktok.com\textra_blocked",
+    "aa:bb:cc:11:22:33\tad.doubleclick.net\tcategory:ads",
+    "de:ad:be:ef:00:01\tpornhub.com\tcategory:adult",
+  }, "\n") .. "\n"
+
+  it("returns 'extra_blocked' for a per-MAC extraBlocked entry", function()
+    assert.equals("extra_blocked",
+      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "tiktok.com"))
+  end)
+
+  it("returns 'category:<id>' for a per-MAC blocklist entry", function()
+    assert.equals("category:ads",
+      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "ad.doubleclick.net"))
+    assert.equals("category:adult",
+      bp.parse_blocked_hosts(content, "de:ad:be:ef:00:01", "pornhub.com"))
+  end)
+
+  it("matches subdomains via dnsmasq nftset suffix semantics", function()
+    -- entry: tiktok.com → matches m.tiktok.com
+    assert.equals("extra_blocked",
+      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "m.tiktok.com"))
+  end)
+
+  it("does NOT cross-match between MACs", function()
+    assert.is_nil(bp.parse_blocked_hosts(content, "de:ad:be:ef:00:01", "tiktok.com"))
+  end)
+
+  it("does NOT match unrelated hosts (no false-positive suffix match)", function()
+    -- "notexample.com" must not match an entry for "example.com"
+    local c = "aa:bb:cc:11:22:33\texample.com\textra_blocked\n"
+    assert.is_nil(bp.parse_blocked_hosts(c, "aa:bb:cc:11:22:33", "notexample.com"))
+  end)
+
+  it("returns nil on nil/empty inputs", function()
+    assert.is_nil(bp.parse_blocked_hosts(nil, "aa:bb:cc:11:22:33", "tiktok.com"))
+    assert.is_nil(bp.parse_blocked_hosts(content, nil, "tiktok.com"))
+    assert.is_nil(bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", nil))
+    assert.is_nil(bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", ""))
+  end)
+
+  it("is case-insensitive on MAC and host", function()
+    assert.equals("extra_blocked",
+      bp.parse_blocked_hosts(content, "AA:BB:CC:11:22:33", "TikTok.com"))
+  end)
+end)
+
 describe("block_page.build_dest_url", function()
   it("emits a fully-formed /blocked URL with host, reason, and mac", function()
     local u = bp.build_dest_url(
@@ -118,6 +166,11 @@ describe("block_page.render_html", function()
     assert.equals("This site is blocked by the household.",   bp.inline_copy_for("ExtraBlocked"))
     assert.equals("This site is blocked.",                    bp.inline_copy_for("Bogus"))
     assert.equals("This site is blocked.",                    bp.inline_copy_for(nil))
+  end)
+
+  it("inline copy names the blocklist for a category:<id> reason (#594)", function()
+    assert.equals("Blocked category: ads.",   bp.inline_copy_for("category:ads"))
+    assert.equals("Blocked category: adult.", bp.inline_copy_for("category:adult"))
   end)
 
   it("escapes the host in the inline page so it can't break out of HTML", function()

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -585,6 +585,73 @@ describe("handle_flow", function()
     assert.equal(true, ev.allowed)
   end)
 
+  -- ── #594: category blocklist (bl_) hits report a category-specific reason ─
+
+  it("#594: labels connection_attempt with reason='category:<id>' when hname matches a bl_ host", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "ad.doubleclick.net" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = {},
+      ea_hosts_by_mac = {},
+      bl_hosts_by_mac = { [MAC] = { ["ad.doubleclick.net"] = "ads" } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,          ev.allowed)
+    assert.equal("category:ads", ev.reason)
+  end)
+
+  it("#594: suffix-match also applies to bl_ hosts", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "tracker.ads.example" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = {},
+      ea_hosts_by_mac = {},
+      bl_hosts_by_mac = { [MAC] = { ["ads.example"] = "ads" } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,          ev.allowed)
+    assert.equal("category:ads", ev.reason)
+  end)
+
+  it("#594: extraAllowed beats category-blocklist hit (#421 carve-out applies to bl_ too)", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "ad.doubleclick.net" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = {},
+      ea_hosts_by_mac = { [MAC] = { ["ad.doubleclick.net"] = true } },
+      bl_hosts_by_mac = { [MAC] = { ["ad.doubleclick.net"] = "ads" } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(true, ev.allowed)
+  end)
+
+  it("#594: extraBlocked takes precedence over category when both contain the host", function()
+    -- This mirrors render.update_shared's invariant (#594): a host present in
+    -- both extraBlocked and a blocklist is classified as extraBlocked.
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      lookup_hostname = function(ip) if ip == DST_IP then return "shared.example" end end,
+      nft_sets        = {},
+      eb_hosts_by_mac = { [MAC] = { ["shared.example"] = true } },
+      ea_hosts_by_mac = {},
+      bl_hosts_by_mac = {},  -- render.update_shared would suppress this entry
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,  ev.allowed)
+    assert.equal("host", ev.reason)
+  end)
+
   it("does NOT block when eb_hosts_by_mac is absent from ctx", function()
     local b = collecting_batcher()
     local ctx = ctx_with({

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -663,22 +663,55 @@ describe("render.update_shared", function()
     assert.is_true(eb_hosts_by_mac["aa:bb:cc:11:22:33"]["tiktok.com"])
   end)
 
-  it("populates eb_hosts_by_mac from blocklistIds when _blocklist_hosts is present", function()
+  it("populates bl_hosts_by_mac from blocklistIds when _blocklist_hosts is present (#594)", function()
     local s = snap_one()  -- profile 3 has blocklistIds = { "ads", "adult" }
     s._blocklist_hosts = {
       ads   = { "ad.doubleclick.net", "googleads.g.doubleclick.net" },
       adult = { "pornhub.com" },
     }
     local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
-    local eb_hosts_by_mac, ea_hosts_by_mac = {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac = {}, {}, {}
     render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
-                         eb_hosts_by_mac, ea_hosts_by_mac)
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+    -- Category hosts go into bl_hosts_by_mac tagged with the matching id.
+    local bl = bl_hosts_by_mac["aa:bb:cc:11:22:33"]
+    assert.is_not_nil(bl)
+    assert.equal("ads",   bl["ad.doubleclick.net"])
+    assert.equal("ads",   bl["googleads.g.doubleclick.net"])
+    assert.equal("adult", bl["pornhub.com"])
+    -- extraBlocked host from profile is in eb_hosts_by_mac, NOT bl_.
     local eb = eb_hosts_by_mac["aa:bb:cc:11:22:33"]
     assert.is_not_nil(eb)
-    assert.is_true(eb["ad.doubleclick.net"])
-    assert.is_true(eb["pornhub.com"])
-    -- extraBlocked host from profile is also present
     assert.is_true(eb["tiktok.com"])
+    assert.is_nil(eb["ad.doubleclick.net"])
+    assert.is_nil(bl["tiktok.com"])
+  end)
+
+  it("extraBlocked beats category when the same host appears in both (#594)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = { "shared.example" }
+    s._blocklist_hosts = { ads = { "shared.example" } }
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac = {}, {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+    assert.is_true(eb_hosts_by_mac["aa:bb:cc:11:22:33"]["shared.example"])
+    -- bl_hosts_by_mac must NOT also contain this host: eb wins for classification.
+    local bl = bl_hosts_by_mac["aa:bb:cc:11:22:33"] or {}
+    assert.is_nil(bl["shared.example"])
+  end)
+
+  it("chooses a deterministic blocklist id when a host is in multiple lists (#594)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = { "zz", "aa" }
+    s._blocklist_hosts = { aa = { "dup.example" }, zz = { "dup.example" } }
+    local nft_sets, blocked_macs, blocked_reason = {}, {}, {}
+    local eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac = {}, {}, {}
+    render.update_shared(s, nft_sets, blocked_macs, blocked_reason,
+                         eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+    -- Lower id sorts first, so "aa" wins.
+    assert.equal("aa", bl_hosts_by_mac["aa:bb:cc:11:22:33"]["dup.example"])
   end)
 
   it("populates ea_hosts_by_mac from a profile's extraAllowed list", function()
@@ -1625,6 +1658,53 @@ describe("render.write_blocked_reasons", function()
   it("treats a nil map as empty (no crash, empty output)", function()
     local p = tmp_path()
     local ok = render.write_blocked_reasons(nil, p)
+    assert.is_true(ok)
+    assert.equals("", read_all(p))
+    os.remove(p)
+  end)
+end)
+
+-- ── render.write_blocked_hosts (#594) ────────────────────────────────────────
+--
+-- Persists per-(MAC, host) block source so the block-page handler can name a
+-- category-blocklist hit instead of mis-labelling it as ExtraBlocked.
+describe("render.write_blocked_hosts", function()
+  local function tmp_path()
+    local p = os.tmpname(); os.remove(p); return p
+  end
+  local function read_all(path)
+    local f = io.open(path, "r"); if not f then return nil end
+    local c = f:read("*a"); f:close(); return c
+  end
+
+  it("writes one '<mac>\\t<host>\\t<source>' line per entry, sorted", function()
+    local p = tmp_path()
+    local eb = { ["aa:bb:cc:11:22:33"] = { ["tiktok.com"] = true } }
+    local bl = {
+      ["aa:bb:cc:11:22:33"] = { ["ad.doubleclick.net"] = "ads" },
+      ["de:ad:be:ef:00:01"] = { ["pornhub.com"] = "adult" },
+    }
+    local ok = render.write_blocked_hosts(eb, bl, p)
+    assert.is_true(ok)
+    assert.equals(
+      "aa:bb:cc:11:22:33\tad.doubleclick.net\tcategory:ads\n"
+      .. "aa:bb:cc:11:22:33\ttiktok.com\textra_blocked\n"
+      .. "de:ad:be:ef:00:01\tpornhub.com\tcategory:adult\n",
+      read_all(p))
+    os.remove(p)
+  end)
+
+  it("writes an empty file when nothing is blocked", function()
+    local p = tmp_path()
+    local ok = render.write_blocked_hosts({}, {}, p)
+    assert.is_true(ok)
+    assert.equals("", read_all(p))
+    os.remove(p)
+  end)
+
+  it("treats nil tables as empty", function()
+    local p = tmp_path()
+    local ok = render.write_blocked_hosts(nil, nil, p)
     assert.is_true(ok)
     assert.equals("", read_all(p))
     os.remove(p)


### PR DESCRIPTION
## Summary

- Split `render.update_shared` tracking into `eb_hosts_by_mac` (extraBlocked only) and a new `bl_hosts_by_mac` keyed `mac → host → blocklistId`. extraBlocked wins when a host appears in both lists.
- Persist the combined per-(MAC, host) classification to `/var/run/wifihaven/blocked_hosts` via a new `render.write_blocked_hosts`. The uhttpd block-page handler reads it when no whole-MAC reason exists, emitting `extra_blocked` or `category:<id>` instead of unconditionally falling through to `ExtraBlocked` (#576's regression mode).
- `conntrack.handle_flow` now reports `reason="category:<id>"` for category-blocklist hits so `connection_event.reason` distinguishes the two enforcement sources end-to-end.
- `block_page.inline_copy_for` formats `category:<id>` into "Blocked category: <id>." for the inline fallback page. The React `BlockedPage` already supported this wire format (`category:`-prefixed reason) — it just was never reachable before.

## Why

Per #594: the handler's fallback assumed that any per-host nft drop was an extraBlocked hit, but the agent also enforces category blocklists via `bl_<id>` sets. A device blocked because `example.com` is in the `ads` list was shown "ExtraBlocked" on the block page (and the connection event was logged as a generic per-host drop), masking the real cause.

## Verifies #421 still holds

`extraAllowed` still beats both `extra_blocked` and `category:<id>` at the per-host classification step (`check_ea_carveout` is shared between the eb_ and bl_ branches). Covered by the new conntrack tests.

## Test plan

- [x] `cd openwrt && busted` — 390 successes, 0 failures (1 pending: nft binary missing in CI)
- [x] New unit tests cover the split, `write_blocked_hosts` output, `parse_blocked_hosts` (incl. suffix-match, case, no-false-positive subdomain), category reason emission in `conntrack.handle_flow`, and the extraBlocked-wins-over-category invariant.
- [ ] **e2e verification still needed:** assign a device to a profile with `blocklistIds: ["ads"]` and no `extraBlocked`, browse to a host on the ads list, confirm the block page renders "Blocked category: ads." and the connection event in the API shows `reason=category:ads`.

Fixes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)