### PR TITLE
render: tune JVM heap for Hobby plan, document Oregon region (#590)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -64,4 +64,7 @@ if [ "${WAIT_FOR_POSTGRES:-1}" = "1" ]; then
 fi
 
 cd /app
-exec java -Xms256m -Xmx512m -Dconfig.file=/app/config/application.conf -jar /app/api.jar
+# JVM_HEAP_OPTS lets the deploy env override heap sizing (e.g. Render Hobby's
+# ~512 MB cap needs -Xmx384m for OS + JIT + native headroom). Defaults match
+# the historical baseline for self-hosted compose installs.
+exec java ${JVM_HEAP_OPTS:--Xms256m -Xmx512m} -Dconfig.file=/app/config/application.conf -jar /app/api.jar

--- a/render.yaml
+++ b/render.yaml
@@ -5,8 +5,10 @@
 # and `docs/deploy-cloud.md`. Do NOT add Static Site blocks back here — the
 # SPA hosting boundary is intentionally split.
 #
-# Region: `oregon` is a placeholder — operator should reconfirm the region
-# closest to the deployment before launch. Tuning is tracked in #590.
+# Region: `oregon` (us-west). Operator is on the US West Coast — Oregon is
+# the lowest-RTT US Render region. The OpenWRT agent polls every 5 s, so
+# region choice affects steady-state load on both ends. Revisit if the
+# operator relocates.
 #
 # Image tags (post-#588):
 #   - staging tracks `:staging` — moved by Master CD's build-image job on
@@ -29,8 +31,6 @@ services:
     runtime: image
     name: wifihaven-api-staging
     plan: free
-    # Reconfirm region before launch — pick the Render region closest to the
-    # operator's house. Tuning tracked in #590.
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health
@@ -64,6 +64,10 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
+      # #590: Render Hobby caps at ~512 MB. Leave headroom for OS + JIT +
+      # native heap; bump or move to `plan: pro` if OOM appears in logs.
+      - key: JVM_HEAP_OPTS
+        value: "-Xms256m -Xmx384m"
       # Staging runs DEBUG so issues are visible in the Render log stream.
       - key: WIFIHAVEN_LOG_LEVEL
         value: DEBUG
@@ -88,8 +92,6 @@ services:
     runtime: image
     name: wifihaven-api-prod
     plan: free
-    # Reconfirm region before launch — pick the Render region closest to the
-    # operator's house. Tuning tracked in #590.
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health
@@ -124,6 +126,10 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
+      # #590: Render Hobby caps at ~512 MB. Leave headroom for OS + JIT +
+      # native heap; bump or move to `plan: pro` if OOM appears in logs.
+      - key: JVM_HEAP_OPTS
+        value: "-Xms256m -Xmx384m"
       # Production uses INFO to avoid PII leakage in logs.
       # Resolves the TODO from #586 / PR #599.
       - key: WIFIHAVEN_LOG_LEVEL


### PR DESCRIPTION
## Summary
- Make heap sizing overridable via `JVM_HEAP_OPTS` in `docker/entrypoint.sh`; default preserves the historical `-Xms256m -Xmx512m` so self-hosted compose installs are unchanged.
- Set `JVM_HEAP_OPTS=-Xms256m -Xmx384m` on both Render web services so OS + JIT + native heap fit inside the ~512 MB Hobby cap.
- Document Oregon as the chosen region (lowest-RTT US Render region for a west-coast operator; agent polls every 5 s).

The "generous initial delay" requirement in #590 is already satisfied by `master.yml`'s 8-minute `/api/health` poll loop after each Render deploy hook — Render's web-service schema doesn't expose a separate startup-grace field, and the workflow-side wait is what actually gates the deploy.

Closes #590.

## Test plan
- [ ] Local compose still starts with default heap (no `JVM_HEAP_OPTS` set).
- [ ] Override path works: `JVM_HEAP_OPTS="-Xmx384m" docker compose up` logs `-Xmx384m` in the java exec line.
- [ ] After merge: first Render deploy reaches healthy state; 24 h with no OOM events on the Render dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)