### PR TITLE
fix(fake-router): drop legacy hostname field; add e2e event coverage

### DIFF
--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -215,14 +215,38 @@ def _post_events(router_id: str, router_token: str) -> None:
             "hostname": HOSTNAMES[0],
             "ts":       ts,
         },
+        # connection_attempt carries `host` as a HostId tagged union (#391), not
+        # the legacy `hostname` string. Cover all three on-wire shapes the real
+        # OpenWRT agent emits so e2e catches future drift:
+        #   1) DNS-attributed flow — host.type=fqdn
+        #   2) Unattributed flow (DoH / hard-coded IP) — host.type=ipv4
+        #   3) Block verdict echo — allowed=false, reason=blocked
         {
-            "type":     "connection_attempt",
-            "mac":      MACS[1],
-            "hostname": "youtube.com",
-            "destIp":   "142.250.80.14",
-            "allowed":  True,
-            "reason":   "allow",
-            "ts":       ts,
+            "type":    "connection_attempt",
+            "mac":     MACS[1],
+            "host":    {"type": "fqdn", "value": "youtube.com"},
+            "destIp":  "142.250.80.14",
+            "allowed": True,
+            "reason":  "allow",
+            "ts":      ts,
+        },
+        {
+            "type":    "connection_attempt",
+            "mac":     MACS[1],
+            "host":    {"type": "ipv4", "value": "203.0.113.7"},
+            "destIp":  "203.0.113.7",
+            "allowed": True,
+            "reason":  "allow",
+            "ts":      ts,
+        },
+        {
+            "type":    "connection_attempt",
+            "mac":     MACS[2],
+            "host":    {"type": "fqdn", "value": "ads.example.com"},
+            "destIp":  "198.51.100.42",
+            "allowed": False,
+            "reason":  "blocked",
+            "ts":      ts,
         },
     ]
     _post(

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -157,7 +157,15 @@ print((d or {}).get('lastSeenIp') or '')
 pass "last_seen_ip=192.168.1.20"
 
 # ── 5. Events ingest ───────────────────────────────────────────────────────
-step "Events ingest (dhcp_lease + connection_attempt)"
+#
+# connection_attempt carries `host` as a HostId tagged union (#391). The real
+# OpenWRT agent (openwrt/files/usr/lib/lua/wifihaven/conntrack.lua build_event)
+# emits three on-wire shapes; each must round-trip 2xx so the next time the
+# wire contract drifts we catch it here instead of in production logs:
+#   1) host.type=fqdn  — DNS-attributed flow
+#   2) host.type=ipv4  — unattributed flow (DoH / hard-coded IP)
+#   3) allowed=false + reason=blocked — block-verdict echo (#456)
+step "Events ingest (dhcp_lease + connection_attempt × 3 shapes)"
 EVTS=$(cat <<EOF
 {
   "routerId": "$RID",
@@ -175,6 +183,24 @@ EVTS=$(cat <<EOF
       "allowed": true,
       "reason":  "allow",
       "ts":      "$NOW"
+    },
+    {
+      "type":    "connection_attempt",
+      "mac":     "$MAC",
+      "host":    {"type":"ipv4","value":"203.0.113.7"},
+      "destIp":  "203.0.113.7",
+      "allowed": true,
+      "reason":  "allow",
+      "ts":      "$NOW"
+    },
+    {
+      "type":    "connection_attempt",
+      "mac":     "$MAC",
+      "host":    {"type":"fqdn","value":"ads.example.com"},
+      "destIp":  "198.51.100.42",
+      "allowed": false,
+      "reason":  "blocked",
+      "ts":      "$NOW"
     }
   ]
 }
@@ -183,7 +209,34 @@ EOF
 curl -fsS -X POST "$BASE/api/router/events" "${RAUTH[@]}" \
   -H 'content-type: application/json' \
   -d "$EVTS" >/dev/null
-pass "dhcp_lease + connection_attempt posted"
+pass "dhcp_lease + 3 connection_attempt shapes posted"
+
+# Reject the legacy bare-string `hostname` form so this regression cannot
+# silently come back — old agents writing `hostname` instead of `host` will
+# 400 now, not be silently dropped.
+LEGACY_EVTS=$(cat <<EOF
+{
+  "routerId": "$RID",
+  "events": [
+    {
+      "type": "connection_attempt",
+      "mac":  "$MAC",
+      "hostname": "youtube.com",
+      "destIp":   "142.250.80.14",
+      "allowed":  true,
+      "reason":   "allow",
+      "ts":       "$NOW"
+    }
+  ]
+}
+EOF
+)
+CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/api/router/events" "${RAUTH[@]}" \
+  -H 'content-type: application/json' -d "$LEGACY_EVTS")
+case "$CODE" in
+  4*) pass "legacy hostname-on-connection_attempt rejected ($CODE)" ;;
+  *)  fail "legacy hostname-on-connection_attempt unexpectedly accepted ($CODE)" ;;
+esac
 
 # ── 6. Paused profile reflected immediately in snapshot ───────────────────
 #

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -84,5 +84,34 @@ STATUS=$(curl -fsS "${AUTH[@]}" "$BASE/api/time/status")
 echo "$STATUS" | grep -q '^\[' || fail "time/status did not return a JSON array: $STATUS"
 pass "/api/time/status responded"
 
+# ── fake-router steady-state health (#456) ───────────────────────────────
+# Even with a 2xx contract assertion in e2e-router.sh, the fake-router
+# container in compose can silently 4xx on every tick if its on-wire shape
+# drifts — CI stays green because no test reads its logs. Scan post-warmup
+# logs once and fail on any `events error` / `usage error` line.
+#
+# `docker` is the gatekeeper: when available we assert; otherwise skip (this
+# script also runs against non-compose deployments).
+step "fake-router steady-state log scan (no events/usage errors)"
+if command -v docker >/dev/null 2>&1; then
+  CID=$(docker ps --filter "label=com.docker.compose.service=fake-router" \
+    --format '{{.ID}}' | head -n1)
+  if [ -n "$CID" ]; then
+    # Drop the first 5s of bootstrap chatter — login retries against the
+    # not-yet-ready API legitimately log errors before settling.
+    if docker logs --since 5s "$CID" 2>&1 | grep -E 'events error|usage error' >"$TMP/fr-errs.txt"; then
+      echo "--- fake-router error lines ---"
+      cat "$TMP/fr-errs.txt"
+      echo "-------------------------------"
+      fail "fake-router posted errors after warmup — wire contract drift?"
+    fi
+    pass "fake-router post-warmup logs clean"
+  else
+    pass "fake-router container not running — skipped"
+  fi
+else
+  pass "docker not available — skipped"
+fi
+
 echo
 echo "All e2e checks passed."


### PR DESCRIPTION
## Summary

- `docker/fake-router.py` was missed in the #391 `HostId` migration and has been silently 4xx-ing every `connection_attempt` POST. CI didn't catch it because no e2e test exercises the events path and nothing reads fake-router's logs.
- Switch fake-router to the current wire shape and cover all three on-wire shapes the real OpenWRT agent emits (`build_event` in `openwrt/files/usr/lib/lua/wifihaven/conntrack.lua`).
- Add a fake-router log-health check to `scripts/e2e-tests.sh` so a future wire-shape drift can't silently fail every tick.

## Changes

- `docker/fake-router.py`: emit `host: {type, value}` on `connection_attempt`; emit three shapes per tick — fqdn-attributed, ipv4-unattributed, block-verdict echo.
- `scripts/e2e-router.sh` §5: post all three `connection_attempt` shapes and assert 2xx; add a negative assertion that the legacy `hostname`-on-`connection_attempt` form is rejected (matches `RouterIngestRoutes.handleEvents` "connection_attempt missing host" branch).
- `scripts/e2e-tests.sh`: grep fake-router container logs post-warmup and fail on any `events error` / `usage error` line. Skipped when `docker` isn't available so this script still works against non-compose deployments.

## Test plan

- [ ] `docker compose -f docker/docker-compose.yml up -d --build --wait` — fake-router stays healthy, no `events error` log lines.
- [ ] `scripts/e2e-router.sh` — §5 passes for all three event shapes; legacy-form negative check returns 4xx.
- [ ] `scripts/e2e-tests.sh` — final fake-router log-scan step is clean.

Fixes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)