### PR TITLE
fix(e2e): drop duplicate uhttpd section in test-VM uci-defaults (#647)

### DIFF
--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -82,14 +82,20 @@ uci set dhcp.@dnsmasq[0].logqueries='1'
 uci set dhcp.@dnsmasq[0].logfacility='/tmp/wifihaven-dnsmasq.log'
 uci commit dhcp
 
-# Block-page listener on 127.0.0.1:8081 (mirrors install.sh, #303).
 # Drop uhttpd's stock LuCI listener — its default config tries to bind
 # 0.0.0.0:80 and 0.0.0.0:443, both of which collide with the LAN-side
 # block-page DNAT target and stop the service from starting at all.
+#
+# #647: this file used to also `uci add uhttpd uhttpd` its own block-page
+# listener section, but the wifihaven package's first-boot script
+# /etc/uci-defaults/95-wifihaven-uhttpd (added in #542, calls
+# setup-uhttpd-block-page.sh) already creates that section *with* the lua
+# handler wiring. Having both add a 127.0.0.1:8081 section meant procd
+# spawned two uhttpd instances racing for the port — whichever bound
+# first won, and when the no-lua section won, the DNAT'd block-page
+# request landed on a directory-listing handler ("Index of /") instead
+# of the rendered block page.
 uci -q delete uhttpd.main
-section=$(uci add uhttpd uhttpd)
-uci set "uhttpd.${section}.listen_http=127.0.0.1:8081"
-uci set "uhttpd.${section}.home=/www/wifihaven"
 uci commit uhttpd
 
 # Without `enable`, OpenWRT has the package but procd never starts it on


### PR DESCRIPTION
## Summary

- `scripts/vm/uci-defaults/99-wifihaven` was racing the wifihaven package's own `/etc/uci-defaults/95-wifihaven-uhttpd` (added in #542): both files created a `uhttpd` section binding `127.0.0.1:8081`. The 95 script wires `lua_prefix='/'` + `lua_handler=...`, but 99 didn't. procd spawned both — whichever bound the port first won. When the no-lua section won, the DNAT'd block-page request landed on a static-file handler that returned a directory listing (`Index of /`) instead of the rendered block page, and test_03's `"familydns" | "blocked"` matcher timed out.
- The fix removes only the duplicate `uci add uhttpd uhttpd` + `listen_http` + `home` block. The `uci -q delete uhttpd.main` (kills the stock LuCI listener on `0.0.0.0:80`) and the `[ -x /etc/init.d/uhttpd ] && /etc/init.d/uhttpd enable` lines stay.
- Diagnosis trail (for the next time something serves a directory listing): `pgrep -af uhttpd` showed two competing processes (`-L /www/wifihaven/handler.lua` vs. plain `-h /www/wifihaven`); `uci show uhttpd` showed both sections.

## Local validation

```
$ FDNS_ROUTER_IMAGE_PATH=\$PWD/scripts/vm/.cache/openwrt-wifihaven.img \\
  scripts/e2e-vm.sh -- -k "test_01_enrollment or test_02_allowed_browsing or test_03_blocked_domain"
...
PASSED                                                                   [ 33%]
PASSED                                                                   [ 66%]
PASSED                                                                   [100%]
================= 3 passed, 20 deselected in 188.27s (0:03:08) =================
```

Reproduces the failure on the same trio before the fix (`Index of /` body, no `Blocked`).

## Test plan

- [x] test_01_enrollment passes
- [x] test_02_allowed_browsing passes
- [x] test_03_blocked_domain passes — block page served, not directory listing
- [ ] CI VM e2e green (non-blocking gate)
- [ ] Other CI checks (Scala, lua, lint) green

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)