### PR TITLE
fix(e2e): stop fake-router json-decoding empty bodies (#664)

### DIFF
--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -70,7 +70,8 @@ def _post(path: str, payload: dict, token: str | None = None) -> dict:
         f"{API_BASE}{path}", data=data, headers=headers, method="POST"
     )
     with urllib.request.urlopen(req, timeout=10) as r:
-        return json.loads(r.read())
+        body = r.read()
+        return json.loads(body) if body else {}
 
 
 def _get(


### PR DESCRIPTION
## Root cause

`POST /api/router/usage` and `POST /api/router/events` both return HTTP 200 with an **empty body** (`Response.ok` in ZIO-HTTP — no JSON payload). The `_post()` helper in `docker/fake-router.py` was unconditionally calling `json.loads(r.read())` on every response, which raises Python's `"Expecting value: line 1 column 1 (char 0)"` when the body is empty.

PR #659 added three new `connection_attempt` shapes to `_post_events` and the corresponding usage records to `_post_usage`, which meant both functions were being called on **every** steady-state tick — surfacing a pre-existing latent bug on each interval and flooding the post-warmup logs with `events error` / `usage error` lines. The new log-scan step added by #659 then correctly caught those errors and failed the job.

## Exact location

**`docker/fake-router.py` line 73** — `_post()` helper:

```python
# before
return json.loads(r.read())

# after
body = r.read()
return json.loads(body) if body else {}
```

All callers that need a JSON response (`_login`, `_create_router`, `_register`) talk to endpoints that return populated bodies; `_post_usage` and `_post_events` now silently accept the empty 200.

## Impact

- Unblocks master CD immediately — the fake-router steady-state log scan will pass once this merges.
- This is a prerequisite for the production router install tracked in #660.

Closes #664