### PR TITLE
ci: regen contract fixtures + trigger contract-tests on producer changes (#667)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
               - 'shared/**'
               - 'build.mill'
               - 'scripts/regen-contract-fixtures.sh'
+              # Additional producers (#667): the install.sh printf that
+              # generates POST /api/router/register bodies (the documented
+              # exception in shared/contract/README.md), and the python
+              # fake-router which is a second producer of router→API bodies
+              # — #664 demonstrated it can drift the contract independently.
+              - 'openwrt/install.sh'
+              - 'docker/fake-router.py'
             python:
               - '.github/workflows/ci.yml'
               - 'opnsense/**'


### PR DESCRIPTION
## Summary

Fix the gap in the contract-tests paths-filter that let #664's drift through PR CI and only surfaced post-merge on master CD (run [26064242856](https://github.com/wifihaven/wifihaven/actions/runs/26064242856)).

### Part 1 — regen fixtures (no-op locally)

Ran `bash scripts/regen-contract-fixtures.sh` against `origin/main`. Both generators (Scala `ContractGenerate` and `openwrt/test/contract_gen.lua`) produced output identical to the committed fixtures — `git diff shared/contract/` was clean.

The master CD failure on 80d3104 reported `mill shared.test.runMain ... Subprocess failed` with no stack trace, despite the Scala main printing `Wrote 1 api-to-router fixture(s).` first. Could not reproduce locally on macOS or via the test→regen sequence the CI job uses. Treating it as a Linux/mill flake; Part 2 is the real defensive fix.

### Part 2 — broaden the paths-filter

Added two producer paths to the `changes.contract` filter:

- `openwrt/install.sh` — the printf that emits `register_router_request` bodies (the documented non-lua producer per `shared/contract/README.md`).
- `docker/fake-router.py` — the python fake-router, a second producer of router→API bodies. #664 demonstrated it can silently 400 in steady-state without any contract signal because it wasn't on the filter.

Kept the filter targeted (2 paths, not 10+); did not fall back to making the job unconditional.

Closes #667. Unblocks #665 once this lands and master CD goes green.

## Test plan

- [x] `bash scripts/regen-contract-fixtures.sh` → `git diff --exit-code shared/contract/` clean.
- [x] `mill shared.test.testOnly wifihaven.shared.contract.ContractGoldenSpec` → 4/4 pass.
- [x] `busted openwrt/test/contract_spec.lua` → 8/8 pass.
- [ ] `Contract Tests (API ↔ Router)` job must trigger and pass on this PR (the filter now matches `.github/workflows/ci.yml`, so it runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)