### PR TITLE
deploy(spa): drop --config for wrangler pages deploy (#672)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -235,18 +235,20 @@ jobs:
           VITE_API_BASE_URL: https://api-staging.wifihaven.net
         run: npm run build
 
+      - name: Stage wrangler.staging.toml as wrangler.toml
+        working-directory: web
+        # Wrangler 4 rejects `--config` for `pages deploy` entirely (#672).
+        # Pages only reads the default `wrangler.toml`, so swap it in.
+        run: cp wrangler.staging.toml wrangler.toml
+
       - name: Deploy to Cloudflare Pages (staging)
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Pin wrangler 4 — node_modules transitively pulls wrangler 3.x,
-          # which the action would otherwise pick up. Wrangler 3 rejects
-          # `--config` for Pages projects (#613 follow-up).
           wranglerVersion: '4'
           workingDirectory: web
-          # Project name + build dir come from web/wrangler.staging.toml.
-          command: pages deploy --config wrangler.staging.toml --branch=main
+          command: pages deploy --branch=main
 
   # ── 5. Smoke-test staging ─────────────────────────────────────────────────
   # Fast (<2 min) end-user-facing checks against the deployed staging URL.
@@ -449,10 +451,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Pin wrangler 4 — node_modules transitively pulls wrangler 3.x,
-          # which the action would otherwise pick up. Wrangler 3 rejects
-          # `--config` for Pages projects (#613 follow-up).
+          # Wrangler 4 rejects `--config` for `pages deploy` (#672); the
+          # default `wrangler.toml` in web/ already targets the prod project.
           wranglerVersion: '4'
           workingDirectory: web
-          # Project name + build dir come from web/wrangler.toml.
-          command: pages deploy --config wrangler.toml --branch=main
+          command: pages deploy --branch=main

--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -145,10 +145,12 @@ After §1-§4 are done, the first SPA deploy fires on the next push to
 workflow → **Run workflow**).
 
 1. CI runs `npm ci && VITE_API_BASE_URL=... npm run build` for each env.
-2. CI runs `wrangler pages deploy --config <wrangler.toml|wrangler.staging.toml>`.
-   Project name (`wifihaven` or `wifihaven-staging`) and publish dir
-   (`./dist`) come from the wrangler config file — keep the Pages
-   project name in the dashboard and the `name =` field in sync.
+2. CI runs `wrangler pages deploy`. Wrangler 4 forbids `--config` for
+   Pages, so the staging job first copies `wrangler.staging.toml` over
+   `wrangler.toml`; prod uses the file as-is. Project name (`wifihaven`
+   or `wifihaven-staging`) and publish dir (`./dist`) come from the
+   wrangler config file — keep the Pages project name in the dashboard
+   and the `name =` field in sync.
 3. Cloudflare assigns a deployment URL like
    `https://<hash>.wifihaven.pages.dev`, then aliases the configured
    custom domains to the new deployment.


### PR DESCRIPTION
## Summary

- Wrangler 4.92.0 errors out on `wrangler pages deploy --config <anything>` ("Pages does not support custom paths for the Wrangler configuration file"), breaking both staging and prod SPA deploys on master CD ([run 26064949602](https://github.com/wifihaven/wifihaven/actions/runs/26064949602)).
- Staging now copies `wrangler.staging.toml` over `wrangler.toml` before invoking `pages deploy` (which reads the default name). Prod just drops the redundant `--config wrangler.toml`. Same wrangler v4 pin for both jobs.
- Minimal blast radius: no Cloudflare-side rename, no env-section restructure of the configs, no version pinning roulette.

## Why this approach

Issue #672 lists three options: pin a known-good 4.x, restructure into `[env.*]` sections, or stage the right config as `wrangler.toml`. Wrangler Pages does not honor Workers-style `[env.X]` selection — each Pages project still needs its own `wrangler.toml`. Pinning would require chasing whichever 4.x release silently regressed and re-chasing it next time it gets yanked. The cp/swap is the smallest correct change.

## Test plan

CI on this PR does NOT exercise the SPA deploy (master-only). Post-merge verification:

- [ ] Master CD on the merge commit: `Deploy SPA to Cloudflare Pages (staging)` goes green.
- [ ] Production chain reaches the manual-approval gate (do not auto-approve from CI; that's a human call).
- [ ] Unblocks #665 once `:latest` is published.

Closes #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)