### PR TITLE
fix(ci): ContractGenerate regenerator exits non-zero blocks master CD (#674)

### DIFF
--- a/shared/test/src/contract/ContractGenerate.scala
+++ b/shared/test/src/contract/ContractGenerate.scala
@@ -30,6 +30,12 @@ object ContractGenerate {
       n += 1
     }
     println(s"Wrote $n api-to-router fixture(s).")
+    // Force exit so the mill `runMain` subprocess returns 0 even if a
+    // transitive dependency leaves a non-daemon thread alive past main
+    // (#674). ContractGoldenSpec exercises the same codecs inside the test
+    // runner without issue, so the hang is specific to the forked
+    // `runMain` JVM's shutdown. TODO(#675): remove once root cause found.
+    System.exit(0)
   }
 
   private def writeFile(path: Path, body: String): Unit = {


### PR DESCRIPTION
Fixes #674.

## Root cause

`mill shared.test.runMain wifihaven.shared.contract.ContractGenerate` runs `main` to completion on CI (writes the fixture, prints `Wrote 1 api-to-router fixture(s).`) but the forked JVM then exits non-zero. Mill surfaces that as `Subprocess failed`; `set -euo pipefail` in `scripts/regen-contract-fixtures.sh` trips on it; the CI step **Verify fixtures are in sync with producers** fails before it ever reaches the `git diff --exit-code shared/contract/` check.

That has kept master CD red for ~5 commits, blocking `build-image` → `deploy-staging` and downstream gates including Gate 1 ([#671](https://github.com/wifihaven/wifihaven/pull/671)).

There is **no actual contract drift**: `ContractGoldenSpec` round-trips the in-tree goldens through the production codecs and passes 4/4 in the same job. The bug is purely in the regenerator subprocess's shutdown — something (likely a non-daemon thread left running by a transitive dependency) holds the forked JVM open or returns non-zero after `main` cleanly returns.

## Fix

End `ContractGenerate.main` with `System.exit(0)`. Standard pattern for a one-shot Scala main: don't wait on stray non-daemon threads.

This is pragmatic, not the root-cause fix — we cannot reproduce on macOS / mill 1.1.5 locally, only on CI's Linux runner. `ContractGoldenSpec` exercises the same codecs inside the test runner without issue, so this is specific to `runMain`'s subprocess shutdown. Root-cause investigation tracked in [#675](https://github.com/wifihaven/wifihaven/issues/675).

## Test plan

- [x] Local `mill shared.test.runMain wifihaven.shared.contract.ContractGenerate` → exit 0.
- [x] Local `bash scripts/regen-contract-fixtures.sh` end-to-end → exit 0 (lua half still runs).
- [x] `git diff --exit-code shared/contract/` clean — goldens are unchanged.
- [ ] CI `Contract Tests (API ↔ Router)` job goes green on this PR.

## Notes

- Unblocks master CD and Gate 1 ([#671](https://github.com/wifihaven/wifihaven/pull/671)).
- Goldens are NOT modified — `ContractGoldenSpec` confirms they're already consistent with codec output.
- Follow-up: [#675](https://github.com/wifihaven/wifihaven/issues/675) to investigate the underlying JVM-shutdown hang and remove the `System.exit(0)` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)