### PR TITLE
fix(ci): halt JVM after ContractGenerate writes fixtures (#674)

### DIFF
--- a/shared/test/src/contract/ContractGenerate.scala
+++ b/shared/test/src/contract/ContractGenerate.scala
@@ -30,12 +30,15 @@ object ContractGenerate {
       n += 1
     }
     println(s"Wrote $n api-to-router fixture(s).")
-    // Force exit so the mill `runMain` subprocess returns 0 even if a
-    // transitive dependency leaves a non-daemon thread alive past main
-    // (#674). ContractGoldenSpec exercises the same codecs inside the test
-    // runner without issue, so the hang is specific to the forked
-    // `runMain` JVM's shutdown. TODO(#675): remove once root cause found.
-    System.exit(0)
+    Console.out.flush()
+    // Force-halt the JVM so the mill `runMain` subprocess returns 0
+    // (#674). `System.exit(0)` was insufficient on CI's Linux runner —
+    // the subprocess kept returning non-zero, meaning a shutdown hook
+    // (logback / zio / ServiceLoader cleanup) is throwing or
+    // exit-coding the JVM after `main` returns cleanly. `halt` skips
+    // shutdown hooks entirely and forces an immediate exit-0.
+    // TODO(#675): remove once the offending shutdown hook is identified.
+    Runtime.getRuntime.halt(0)
   }
 
   private def writeFile(path: Path, body: String): Unit = {


### PR DESCRIPTION
Follow-up to [#676](https://github.com/wifihaven/wifihaven/pull/676), which is not sufficient.

## What happened

[#676](https://github.com/wifihaven/wifihaven/pull/676) added \`System.exit(0)\` to \`ContractGenerate.main\`. That PR's own \`Contract Tests\` job passed in 1m20s, but the very next push on \`main\` ([Master CD run 26073420442](https://github.com/wifihaven/wifihaven/actions/runs/26073420442/job/76659351429), commit \`4607c24\`) failed on the same step with the same symptom:

\`\`\`
Wrote 1 api-to-router fixture(s).
133/133, 1 FAILED] mill shared.test.runMain ... 1s
[error] shared.test.runMain Subprocess failed
\`\`\`

The fix IS in \`4607c24\` (verified). So \`System.exit(0)\` is being called, the JVM enters shutdown, but the subprocess still returns non-zero. That means a **shutdown hook** is the culprit — likely logback / zio runtime / some ServiceLoader cleanup throwing or exit-coding the JVM after \`main\` returns.

## Fix

Replace \`System.exit(0)\` with \`Runtime.getRuntime.halt(0)\`. \`halt\` skips all shutdown hooks and forces an immediate exit-0. Flush stdout first so the final \`Wrote N ...\` line is preserved.

## Test plan

- [x] Local \`bash scripts/regen-contract-fixtures.sh\` → exit 0.
- [x] \`git diff --exit-code shared/contract/\` clean.
- [ ] CI \`Contract Tests (API ↔ Router)\` passes here, then on next \`main\` push.

## Notes

- Goldens still untouched.
- [#675](https://github.com/wifihaven/wifihaven/issues/675) still tracks finding the offending shutdown hook so we can remove the workaround.
- Master CD has been red for ~6 commits now; this is the priority unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)