### PR TITLE
ci: bump actions/* off Node 20 ahead of June 2026 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 env:
   MILL_VERSION: "1.1.5"
   # Opt into Node.js 24 now (forced default June 2026 anyway). Silences the
-  # Node 20 deprecation warnings emitted by actions/checkout@v4, setup-java@v4,
+  # Node 20 deprecation warnings emitted by actions/checkout@v6, setup-java@v4,
   # setup-node@v4, cache@v4, codeql-action@v4 etc.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -44,7 +44,7 @@ jobs:
             echo "all=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v3
@@ -123,16 +123,16 @@ jobs:
       WIFIHAVEN_JWT_SECRET: test-jwt-secret-for-ci-only
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Cache Mill / Coursier
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.mill
@@ -177,7 +177,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -196,7 +196,7 @@ jobs:
     if: needs.changes.outputs.shell == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Discover and run *.test.sh
         run: |
@@ -224,7 +224,7 @@ jobs:
     if: needs.changes.outputs.lua == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Lua + busted + lua-cjson
         run: |
@@ -258,16 +258,16 @@ jobs:
       WIFIHAVEN_JWT_SECRET: test-jwt-secret-for-ci-only
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Cache Mill / Coursier
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.mill
@@ -320,10 +320,10 @@ jobs:
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -341,7 +341,7 @@ jobs:
     if: needs.changes.outputs.render == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Parse render.yaml
         # Ruby ships preinstalled on ubuntu-latest. Catches YAML regressions
@@ -359,10 +359,10 @@ jobs:
         working-directory: web
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/e2e-kvm-sanity.yml
+++ b/.github/workflows/e2e-kvm-sanity.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify /dev/kvm
         run: |

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -51,7 +51,7 @@ jobs:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
       # left root-owned files under scripts/vm/.cache/imagebuilder/ (older
       # versions of the script only chowned bin/ and build_dir/ — see the
-      # broadened trap in this same change). actions/checkout@v4 cleans the
+      # broadened trap in this same change). actions/checkout@v6 cleans the
       # workspace and fails with EACCES on those files. The runner has no
       # NOPASSWD sudo (only /usr/sbin/ip per docs/ops/kvm-runner.md), so we
       # use docker — which runs as root — to chown the cache back to the
@@ -71,7 +71,7 @@ jobs:
             ' || true
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Preflight (kvm/qemu/docker)
         run: |
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-vm-failure-${{ github.run_id }}-${{ github.run_attempt }}
           path: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -70,7 +70,7 @@ jobs:
     name: bootstrap-host.sh smoke (Ubuntu container)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build + run bootstrap test image
         run: |
           docker build -f docker/bootstrap-test.Dockerfile -t wifihaven-bootstrap-test .
@@ -80,7 +80,7 @@ jobs:
     name: Live e2e against staging stack
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build + start staging stack
         run: |
@@ -107,7 +107,7 @@ jobs:
     name: deploy/docker-compose.prod.yml smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run prod-stack smoke
         run: scripts/smoke-prod.sh
 
@@ -127,7 +127,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up QEMU (for linux/arm64 emulation)
         uses: docker/setup-qemu-action@v3
@@ -217,9 +217,9 @@ jobs:
     needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -337,7 +337,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Admin API smoke against staging
         env:
           E2E_BASE_URL: ${{ env.STAGING_API_URL }}
@@ -466,9 +466,9 @@ jobs:
     needs: [approve-production]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -40,7 +40,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Derive version
         id: ver
@@ -99,14 +99,14 @@ jobs:
           "$apk_bin" adbdump "$apk_file"
 
       - name: Upload .ipk artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wifihaven-ipk-${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.release }}
           path: openwrt/wifihaven_*.ipk
           if-no-files-found: error
 
       - name: Upload .apk artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wifihaven-apk-${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.release }}
           path: openwrt/wifihaven_*.apk

--- a/.github/workflows/router-image-build.yml
+++ b/.github/workflows/router-image-build.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Read pinned OpenWRT version
         id: ver
@@ -38,7 +38,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Cache Image Builder download
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: scripts/vm/.cache/downloads
           key: openwrt-ib-${{ steps.ver.outputs.openwrt_version }}-${{ steps.ver.outputs.tarball }}
@@ -56,7 +56,7 @@ jobs:
           file scripts/vm/.cache/openwrt-wifihaven.img
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: openwrt-wifihaven-${{ steps.ver.outputs.openwrt_version }}-${{ github.sha }}
           path: scripts/vm/.cache/openwrt-wifihaven.img


### PR DESCRIPTION
## Summary
- Bumps all `actions/*` pins to majors that run on Node.js 24, ahead of the 2026-06-02 forced cutover.
- checkout v4→v6, setup-java v4→v5, setup-python v5→v6, setup-node v4→v6, cache v4→v5, upload-artifact v4→v6.

## Notes
- `actions/upload-artifact@v6` requires runner ≥ 2.327.1; the self-hosted kvm runner is online and auto-updates, so this should be fine but worth eyeballing on the first VM e2e run.
- Verified each major's release notes lists Node 24 as the runtime.

## Test plan
- [ ] All PR workflows green
- [ ] No "Node.js 20 actions are deprecated" annotation on any job

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)