### PR TITLE
fix(gate 1): point /blocked check at SPA host post-SPA-split

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -347,6 +347,9 @@ jobs:
       - name: Router API smoke against staging
         env:
           E2E_BASE_URL: ${{ env.STAGING_API_URL }}
+          # Post-#613 the SPA is on Cloudflare Pages, not the API host —
+          # so the `/blocked` SPA-route check has to hit the SPA host.
+          E2E_SPA_URL: https://staging.wifihaven.net
           ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
           RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}
         run: scripts/e2e-router.sh

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -6,9 +6,17 @@
 #
 # Env:
 #   E2E_BASE_URL  default http://127.0.0.1:8080
+#   E2E_SPA_URL   default $E2E_BASE_URL — separate when SPA is on a different
+#                 host (post-#613: Cloudflare Pages serves the SPA, Render
+#                 serves the API). In-compose they coincide.
 set -euo pipefail
 
 BASE="${E2E_BASE_URL:-http://127.0.0.1:8080}"
+# Post-SPA-split (#613) the API host no longer serves SPA fallback, so
+# `/blocked` 404s on api-staging.wifihaven.net. Point that check at the SPA
+# host explicitly; default to BASE so the in-compose stack (which serves
+# both API and SPA from the same port) keeps working unchanged.
+SPA_BASE="${E2E_SPA_URL:-$BASE}"
 # See scripts/e2e-tests.sh — fake-router rotates the seeded admin password on
 # first boot, so by the time this script runs the DB has the rotated value.
 # Against deployed staging (Gate 1 / #653) overridden from STAGING_ADMIN_PASS.
@@ -329,10 +337,12 @@ case "$SCHED_REASON" in
 esac
 
 # ── 8. /blocked page renders 200 for each reason ─────────────────────────
-step "GET /blocked — SPA renders 200 for each block reason"
+# Hits the SPA host (#613 split it from the API host). In-compose, SPA_BASE
+# defaults to BASE so the same docker-compose path keeps working unchanged.
+step "GET /blocked — SPA renders 200 for each block reason ($SPA_BASE)"
 for REASON in "paused" "time_limit" "schedule" "category:adult" "extra_blocked"; do
   CODE=$(curl -s -o /dev/null -w '%{http_code}' \
-    "$BASE/blocked?mac=$MAC&host=youtube.com&reason=$REASON")
+    "$SPA_BASE/blocked?mac=$MAC&host=youtube.com&reason=$REASON")
   [ "$CODE" = "200" ] || fail "/blocked?reason=$REASON returned $CODE (expected 200)"
   pass "/blocked?reason=$REASON → 200"
 done


### PR DESCRIPTION
## Summary

- Gate 1 (`api-smoke-staging`) just failed on `/blocked?reason=paused returned 404 (expected 200)` — the script was hitting the API host for a SPA route. Post-#613, Cloudflare Pages serves the SPA from `staging.wifihaven.net` and the API host on Render no longer does SPA fallback. Failing run: https://github.com/wifihaven/wifihaven/actions/runs/26110448436/job/76787371455.
- Adds `E2E_SPA_URL` env var to `scripts/e2e-router.sh` (defaults to `E2E_BASE_URL` so in-compose runs are unchanged) and routes the `/blocked` checks through it.
- Sets `E2E_SPA_URL: https://staging.wifihaven.net` on the `api-smoke-staging` step in `master.yml`.

This isn't a server bug — the SPA route is correctly served by Pages, the test was just asking the wrong host.

Unblocks master CD (Gate 1 is the only red job; #688's ETag fix already landed and is passing in the same run).

## Test plan

- [x] `bash -n scripts/e2e-router.sh` clean.
- [x] `actionlint .github/workflows/master.yml` clean.
- [ ] After merge, the next main build's `api-smoke-staging` job passes the `/blocked` step.
- [ ] In-compose `e2e` job continues to pass (no change to behavior when `E2E_SPA_URL` is unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)