### PR TITLE
fix(openwrt/install): swap dnsmasq-full reliably on apk (#704)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'deploy/**/*.sh'
               - 'scripts/**'
+              - 'openwrt/install.sh'
+              - 'openwrt/test/**'
               - '**/*.bats'
               - '**/*.test.sh'
             render:

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -82,8 +82,11 @@ fi
 # detect and swap rather than relying on package-level depends.
 ensure_dnsmasq_full() {
   if [ "$PKG_MGR" = apk ]; then
-    apk list -I dnsmasq-full >/dev/null 2>&1 && return 0
-    if apk list -I dnsmasq >/dev/null 2>&1; then
+    # apk list -I exits 0 with empty stdout when a package is not installed
+    # (apk-tools v3, OpenWRT 24.10+).  Use `apk info -e` instead — it exits
+    # nonzero on miss, making it safe to use as a boolean probe (#704).
+    apk info -e dnsmasq-full >/dev/null 2>&1 && return 0
+    if apk info -e dnsmasq >/dev/null 2>&1; then
       info "Replacing dnsmasq with dnsmasq-full (required for nftset support)"
       apk del dnsmasq >/dev/null
     else

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -176,5 +176,72 @@ grep -q "uhttpd-mod-lua" "$ROOT/build-apk.sh" \
   || check "build-apk.sh depends pulls in uhttpd-mod-lua" \
            "missing uhttpd-mod-lua dep in build-apk.sh"
 
+# #704: ensure_dnsmasq_full apk branch must use `apk info -e`, not
+# `apk list -I`.  On apk-tools v3 (OpenWRT 24.10+) `apk list -I` exits 0
+# with empty stdout when the package is absent, so the old check always
+# returned early and left plain dnsmasq installed.
+#
+# Canary A — the probe must be `apk info -e`, not `apk list -I`:
+grep -q "apk info -e dnsmasq-full" "$SCRIPT" \
+  && check "#704 ensure_dnsmasq_full uses apk info -e for dnsmasq-full check" ok \
+  || check "#704 ensure_dnsmasq_full uses apk info -e for dnsmasq-full check" \
+           "apk branch still uses 'apk list -I dnsmasq-full' — exits 0 when absent on apk-tools v3"
+
+grep -q "apk info -e dnsmasq " "$SCRIPT" \
+  && check "#704 ensure_dnsmasq_full uses apk info -e for dnsmasq check" ok \
+  || check "#704 ensure_dnsmasq_full uses apk info -e for dnsmasq check" \
+           "apk branch still uses 'apk list -I dnsmasq' — exits 0 when absent on apk-tools v3"
+
+# Canary B — regression guard: the old broken form must NOT appear:
+if grep -q "apk list -I dnsmasq-full" "$SCRIPT"; then
+  check "#704 broken apk list -I form removed from dnsmasq-full check" \
+        "'apk list -I dnsmasq-full' still present — reverts #704 fix"
+else
+  check "#704 broken apk list -I form removed from dnsmasq-full check" ok
+fi
+
+if grep -q "apk list -I dnsmasq " "$SCRIPT"; then
+  check "#704 broken apk list -I form removed from dnsmasq check" \
+        "'apk list -I dnsmasq ' still present — reverts #704 fix"
+else
+  check "#704 broken apk list -I form removed from dnsmasq check" ok
+fi
+
+# Canary C — functional simulation: verify ensure_dnsmasq_full installs
+# dnsmasq-full when only plain dnsmasq is present, using stub apk/err
+# functions that replicate the apk-tools v3 exit-code behaviour.
+# Pre-fix, `apk list -I dnsmasq-full` exited 0 even when absent, causing
+# an early return before the swap.  Post-fix, `apk info -e dnsmasq-full`
+# exits nonzero on absence, so the function proceeds to del+add.
+#
+# Side-effects are recorded in a temp file because install.sh suppresses
+# stdout from apk calls (>/dev/null).
+_sim_log=$(mktemp)
+trap 'rm -f "$_sim_log"' EXIT
+sh -c "
+  set -eu
+  err() { printf 'error: %s\n' \"\$*\" >&2; exit 1; }
+  info() { true; }
+  apk() {
+    _cmd=\"\$*\"
+    case \"\$_cmd\" in
+      'info -e dnsmasq-full') return 1;;   # not installed — apk-tools v3 exits nonzero
+      'info -e dnsmasq')      return 0;;   # plain dnsmasq IS installed
+      'del dnsmasq')          printf 'del-dnsmasq\n' >> '${_sim_log}';;
+      'add dnsmasq-full')     printf 'add-dnsmasq-full\n' >> '${_sim_log}';;
+      *)                      true;;
+    esac
+  }
+  PKG_MGR=apk
+  $(sed -n '/^ensure_dnsmasq_full()/,/^}/p' "$SCRIPT")
+  ensure_dnsmasq_full
+" 2>/dev/null || true
+if grep -q "add-dnsmasq-full" "$_sim_log"; then
+  check "#704 ensure_dnsmasq_full installs dnsmasq-full when only dnsmasq present (apk-tools v3)" ok
+else
+  check "#704 ensure_dnsmasq_full installs dnsmasq-full when only dnsmasq present (apk-tools v3)" \
+        "function returned early without installing dnsmasq-full (sim log: $(cat "$_sim_log"))"
+fi
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/install_spec.test.sh
+++ b/openwrt/test/install_spec.test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Thin shim: auto-discovered by the CI shell-tests job (*.test.sh pattern in
+# .github/workflows/ci.yml) and delegates to install_spec.sh, which is the
+# canonical home for openwrt/install.sh assertions.
+#
+# install_spec.sh expects to be invoked with openwrt/ as its working directory.
+set -euo pipefail
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+sh "${OPENWRT_DIR}/test/install_spec.sh"


### PR DESCRIPTION
Fixes #704.

## The bug

On apk-tools v3 (OpenWRT 24.10+ / 25.12), `apk list -I <pkg>` exits **0 with empty stdout** when the package is absent. The previous check:

```sh
apk list -I dnsmasq-full >/dev/null 2>&1 && return 0
```

always short-circuited, leaving plain `dnsmasq` installed and silently breaking all hostname-based blocking (dnsmasq compiled without `HAVE_NFTSET` refuses to start with `nftset=...` directives).

Empirical reproduction on OpenWRT 25.12.3 (Flint 2):
```
# apk list -I dnsmasq-full ; echo exit=$?
exit=0           ← exits 0 even when NOT installed
# apk list -I dnsmasq ; echo exit=$?
dnsmasq-2.91-r2 ... [installed]
exit=0
```

## The fix

Switch to `apk info -e <pkg>` — designed for exact "is this installed?" probes, exits nonzero on a miss on apk-tools v3:

```sh
apk info -e dnsmasq-full >/dev/null 2>&1 && return 0
if apk info -e dnsmasq >/dev/null 2>&1; then
    ...
```

The opkg branch is unchanged (its `opkg list-installed | grep -q` already exits nonzero on no match).

## Canary

Five assertions added to `openwrt/test/install_spec.sh`:
- **A**: probe uses `apk info -e`, not `apk list -I`
- **B**: old broken form is absent (regression guard)
- **C**: functional simulation — stubs `apk info -e` with apk-tools-v3-accurate exit codes; confirms `del dnsmasq` + `add dnsmasq-full` fires when only plain dnsmasq is present

Verified: tests **FAIL** (5 failures) against the old `apk list -I` form and **PASS** (26/26) after the fix.

A new `openwrt/test/install_spec.test.sh` shim makes the spec auto-discoverable by CI's `shell-tests` job. The `shell` paths filter in `ci.yml` is extended to cover `openwrt/install.sh` and `openwrt/test/**`.