### PR TITLE
fix(api): SessionApiSpec session-stitching regression (#719)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -99,7 +99,7 @@ object Main extends ZIOAppDefault {
         clock,
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++
-      SessionRoutes.routes(auth, trafficRepo, deviceRepo, profileRepo, upRepo) ++
+      SessionRoutes.routes(auth, trafficRepo, deviceRepo, profileRepo, upRepo, clock) ++
       UsageRoutes.routes(auth, deviceRepo, trafficRepo, upRepo, clock) ++
       DashboardNowRoutes.routes(
         auth,

--- a/api/src/routes/SessionRoutes.scala
+++ b/api/src/routes/SessionRoutes.scala
@@ -27,6 +27,7 @@ object SessionRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      clock: Clock,
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "sessions" ->
@@ -53,7 +54,8 @@ object SessionRoutes {
             // Build the macs filter from the intersection of the device, profile,
             // and mac query params with the user's visibility scope.
             macs = computeMacs(macParam, deviceIdP, profileIdP.map(ProfileId(_)), visibleDevs)
-            effectiveSince = since.orElse(Some(Instant.now().minusSeconds(hours.toLong * 3600L)))
+            now <- clock.instant
+            effectiveSince = since.orElse(Some(now.minusSeconds(hours.toLong * 3600L)))
             filter         = SessionFilter(
               macs = Some(macs),
               host = host,

--- a/api/test/src/feature/SessionApiSpec.scala
+++ b/api/test/src/feature/SessionApiSpec.scala
@@ -46,8 +46,19 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         .addHeader(Header.Authorization.Bearer(token)),
     )
 
-  // Recent base time so default `hours=24` filter includes seeded rows.
-  private def baseInstant = Instant.now().minusSeconds(2 * 3600)
+  // Recent base time so default `hours=24` filter includes seeded rows. The stitching layer
+  // intentionally splits sessions at midnight UTC to align with the daily `time_usage` bucket
+  // (see Sessions.scala and SessionsSpec "sessions split at midnight (UTC)…"). To keep this
+  // feature spec testing contiguity rather than the date boundary, snap the base time backward
+  // when `now - 2h` plus the longest cross-row span any test uses would cross midnight UTC.
+  private val MaxTestSpanSeconds = 6 * 3600L
+  private def baseInstant: Instant = {
+    val raw    = Instant.now().minusSeconds(2 * 3600)
+    val rawDay = raw.atZone(ZoneOffset.UTC).toLocalDate
+    val endDay = raw.plusSeconds(MaxTestSpanSeconds).atZone(ZoneOffset.UTC).toLocalDate
+    if (rawDay == endDay) raw
+    else rawDay.atTime(23, 59).toInstant(ZoneOffset.UTC).minusSeconds(MaxTestSpanSeconds)
+  }
 
   private def insertReport(
       routerId: RouterId,
@@ -95,6 +106,14 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
         t0 = baseInstant
+        // Sanity: this case asserts contiguity stitching, NOT date-boundary behavior.
+        // Both rows must land on the same UTC day (see baseInstant doc) — otherwise the
+        // stitcher will (correctly) split them and the assertions below would fail.
+        _  = {
+          val d0 = t0.atZone(ZoneOffset.UTC).toLocalDate
+          val d1 = t0.plusSeconds(540).atZone(ZoneOffset.UTC).toLocalDate
+          assert(d0 == d1, s"baseInstant must not straddle midnight UTC: $d0 vs $d1")
+        }
         _ <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
         _ <- insertReport(routerId, mac1, "youtube.com", t0.plusSeconds(300), activeSeconds = 240)
         auth  <- makeAuth

--- a/api/test/src/feature/SessionApiSpec.scala
+++ b/api/test/src/feature/SessionApiSpec.scala
@@ -46,19 +46,11 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         .addHeader(Header.Authorization.Bearer(token)),
     )
 
-  // Recent base time so default `hours=24` filter includes seeded rows. The stitching layer
-  // intentionally splits sessions at midnight UTC to align with the daily `time_usage` bucket
-  // (see Sessions.scala and SessionsSpec "sessions split at midnight (UTC)…"). To keep this
-  // feature spec testing contiguity rather than the date boundary, snap the base time backward
-  // when `now - 2h` plus the longest cross-row span any test uses would cross midnight UTC.
-  private val MaxTestSpanSeconds = 6 * 3600L
-  private def baseInstant: Instant = {
-    val raw    = Instant.now().minusSeconds(2 * 3600)
-    val rawDay = raw.atZone(ZoneOffset.UTC).toLocalDate
-    val endDay = raw.plusSeconds(MaxTestSpanSeconds).atZone(ZoneOffset.UTC).toLocalDate
-    if (rawDay == endDay) raw
-    else rawDay.atTime(23, 59).toInstant(ZoneOffset.UTC).minusSeconds(MaxTestSpanSeconds)
-  }
+  // Base time anchored on the injected TestClock (Monday 14:00 UTC) so the seeded rows
+  // stay deterministic regardless of when CI runs. `-2h` keeps rows within the default
+  // hours=24 filter while sitting well clear of midnight UTC on both sides.
+  private val baseInstantZIO: URIO[Clock, Instant] =
+    Clock.instant.map(_.minusSeconds(2 * 3600))
 
   private def insertReport(
       routerId: RouterId,
@@ -105,20 +97,13 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         upRepo   <- ZIO.service[UserProfileRepo]
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
-        t0 = baseInstant
-        // Sanity: this case asserts contiguity stitching, NOT date-boundary behavior.
-        // Both rows must land on the same UTC day (see baseInstant doc) — otherwise the
-        // stitcher will (correctly) split them and the assertions below would fail.
-        _  = {
-          val d0 = t0.atZone(ZoneOffset.UTC).toLocalDate
-          val d1 = t0.plusSeconds(540).atZone(ZoneOffset.UTC).toLocalDate
-          assert(d0 == d1, s"baseInstant must not straddle midnight UTC: $d0 vs $d1")
-        }
-        _ <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
         _ <- insertReport(routerId, mac1, "youtube.com", t0.plusSeconds(300), activeSeconds = 240)
         auth  <- makeAuth
         token <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, "/api/sessions", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])
@@ -143,13 +128,14 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         upRepo   <- ZIO.service[UserProfileRepo]
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
-        t0 = baseInstant
-        _ <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 300)
         // one empty period (t0+300..t0+600), then a fresh session
         _ <- insertReport(routerId, mac1, "youtube.com", t0.plusSeconds(600), activeSeconds = 300)
         auth  <- makeAuth
         token <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, "/api/sessions", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])
@@ -169,11 +155,13 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
         _        <- TestLayers.seedDevice(dr, mac2, "Phone", kid)
-        _        <- insertReport(routerId, mac1, "youtube.com", baseInstant)
-        _        <- insertReport(routerId, mac2, "tiktok.com", baseInstant)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0)
+        _        <- insertReport(routerId, mac2, "tiktok.com", t0)
         auth     <- makeAuth
         token    <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, s"/api/sessions?mac=$mac1", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])
@@ -193,12 +181,14 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         upRepo   <- ZIO.service[UserProfileRepo]
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
-        _        <- insertReport(routerId, mac1, "youtube.com", baseInstant)
-        _        <- insertReport(routerId, mac1, "tiktok.com", baseInstant)
-        _        <- insertReport(routerId, mac1, "www.YOUTUBE.com", baseInstant.plusSeconds(3600))
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0)
+        _        <- insertReport(routerId, mac1, "tiktok.com", t0)
+        _        <- insertReport(routerId, mac1, "www.YOUTUBE.com", t0.plusSeconds(3600))
         auth     <- makeAuth
         token    <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, "/api/sessions?host=youtube", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])
@@ -219,11 +209,13 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         adults   <- pr.create("Adults", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kids)
         _        <- TestLayers.seedDevice(dr, mac2, "Phone", adults)
-        _        <- insertReport(routerId, mac1, "youtube.com", baseInstant)
-        _        <- insertReport(routerId, mac2, "news.com", baseInstant)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0)
+        _        <- insertReport(routerId, mac2, "news.com", t0)
         auth     <- makeAuth
         token    <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, s"/api/sessions?profileId=$kids", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])
@@ -242,13 +234,15 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         upRepo   <- ZIO.service[UserProfileRepo]
         kid      <- pr.create("Kids", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
         _        <- ZIO.foreachDiscard(0 until 5)(i =>
           // Five distinct, non-contiguous periods → five sessions.
-          insertReport(routerId, mac1, s"host$i.com", baseInstant.plusSeconds(i.toLong * 3600)),
+          insertReport(routerId, mac1, s"host$i.com", t0.plusSeconds(i.toLong * 3600)),
         )
         auth     <- makeAuth
         token    <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         r1 <- getJson(routes, "/api/sessions?limit=2", token)
         b1 <- r1.body.asString
         p1 <- ZIO.fromEither(b1.fromJson[SessionPage])
@@ -272,9 +266,10 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         pr     <- ZIO.service[ProfileRepo]
         tr     <- ZIO.service[TrafficReportRepo]
         upRepo <- ZIO.service[UserProfileRepo]
+        clock  <- ZIO.service[Clock]
         auth   <- makeAuth
         token  <- auth.login("admin", "changeme").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, "/api/sessions?limit=9999", token)
       } yield assertTrue(resp.status == Status.Ok)
     },
@@ -286,8 +281,9 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         pr     <- ZIO.service[ProfileRepo]
         tr     <- ZIO.service[TrafficReportRepo]
         upRepo <- ZIO.service[UserProfileRepo]
+        clock  <- ZIO.service[Clock]
         auth   <- makeAuth
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- routes.runZIO(Request.get(URL.decode("/api/sessions").toOption.get))
       } yield assertTrue(resp.status == Status.Unauthorized)
     },
@@ -305,15 +301,17 @@ object SessionApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         adults   <- pr.create("Adults", Nil)
         _        <- TestLayers.seedDevice(dr, mac1, "iPad", kids)
         _        <- TestLayers.seedDevice(dr, mac2, "Phone", adults)
-        _        <- insertReport(routerId, mac1, "youtube.com", baseInstant)
-        _        <- insertReport(routerId, mac2, "news.com", baseInstant)
+        clock    <- ZIO.service[Clock]
+        t0       <- baseInstantZIO
+        _        <- insertReport(routerId, mac1, "youtube.com", t0)
+        _        <- insertReport(routerId, mac2, "news.com", t0)
         auth     <- makeAuth
         hash     <- auth.hashPassword("pass")
         childId  <- userRepo.create("alice", hash, "child")
         _        <- userRepo.clearMustChangePassword(childId)
         _        <- upRepo.setProfilesForUser(childId, List(kids))
         token    <- auth.login("alice", "pass").map(_.token.value)
-        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo)
+        routes = SessionRoutes.routes(auth, tr, dr, pr, upRepo, clock)
         resp <- getJson(routes, "/api/sessions", token)
         body <- resp.body.asString
         page <- ZIO.fromEither(body.fromJson[SessionPage])


### PR DESCRIPTION
## Summary

Master CD is red because `SessionApiSpec` "stitches contiguous periods into one session" failed when the [failing CI run](https://github.com/wifihaven/wifihaven/actions/runs/26136537954) executed at 01:59 UTC. Root cause is wall-clock leakage in two places.

## Root cause

Two sites called `Instant.now()` directly, in violation of the Clock-service contract (["never call java.time directly outside this service"](shared/src/Clock.scala:7)):

- [`SessionRoutes.scala:56`](api/src/routes/SessionRoutes.scala:56) computed `effectiveSince = Instant.now() - hours*3600s` for the default time window.
- [`SessionApiSpec.scala`](api/test/src/feature/SessionApiSpec.scala) anchored its seed data at `Instant.now() - 2h`.

Combined, the spec was wall-clock flaky: at 01:59 UTC the seeds straddled midnight UTC and the (intentional, per [`Sessions.scala:32`](api/src/sessions/Sessions.scala:32) and the unit spec [`"sessions split at midnight (UTC)…"`](api/test/src/unit/SessionsSpec.scala:117)) date-bucketed stitcher split contiguous periods into two sessions.

## Fix

- `SessionRoutes.routes` now takes `Clock` and resolves `now` from it.
- `Main.scala` passes the existing `clock` instance.
- `SessionApiSpec` derives its base instant from the injected `TestClock` (`schoolDayAfternoon`, fixed at Monday 14:00 UTC) — deterministic regardless of CI wall-clock.

Production behavior unchanged. No router-side changes. No fixture regeneration.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.SessionApiSpec` — 9/9 pass
- [x] `mill api.test` (full suite) — all green
- [ ] Master CI green on merge → unblocks deploys

Unblocks deploys: master CD is currently red on this exact failure.

Closes #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)