### PR TITLE
api: defense-in-depth FQDN backfill on event ingest (#720)

### DIFF
--- a/api/resources/db/migration/V20__connection_events_resolved_host.sql
+++ b/api/resources/db/migration/V20__connection_events_resolved_host.sql
@@ -1,0 +1,26 @@
+-- V20__connection_events_resolved_host.sql
+-- Defense-in-depth FQDN backfill (#720, follow-up to #583 / PR #650).
+--
+-- PR #650 closed the agent-side timing race that caused some
+-- connection_attempt events to arrive with host_type='ipv4' even though the
+-- agent's DNS-tail cache would have resolved the IP if the conntrack loop
+-- had retried. This column lets the API back-fill an FQDN attribution from
+-- *other* fqdn-typed events that share (router_id, dest_ip) within a small
+-- window, independent of any agent guarantees, so the router can stay
+-- frozen through Gate 2 (#654) without losing dashboard fidelity.
+--
+-- Design notes:
+--   * Nullable. Set only when host_type ∈ ('ipv4','ipv6') AND we observed
+--     a sibling fqdn-typed event for the same (router_id, dest_ip).
+--   * Implicit host_type='fqdn' when populated — no separate discriminator
+--     column needed.
+--   * Original host_type / host_value remain immutable so event integrity
+--     and idempotent replay (#338) keep working unchanged.
+--   * Index supports the lookup the ingest path performs on every batch.
+
+ALTER TABLE connection_events
+  ADD COLUMN resolved_host_value TEXT;
+
+CREATE INDEX idx_conn_events_router_dest_ip_ts
+  ON connection_events(router_id, dest_ip, ts DESC)
+  WHERE dest_ip IS NOT NULL;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -225,6 +225,10 @@ case class ConnectionEventInsert(
     // gen_random_uuid() so older agents that don't ship an eventId keep
     // inserting cleanly (one fresh UUID per replay, no dedup possible).
     eventId: Option[java.util.UUID] = None,
+    // #720: server-side FQDN attribution looked up from prior fqdn-typed
+    // events sharing (router_id, dest_ip). NULL when host is already fqdn
+    // or when no sibling resolution was found within the lookup window.
+    resolvedHost: Option[Hostname] = None,
 )
 
 trait RouterRepo {
@@ -283,6 +287,31 @@ trait ConnectionEventRepo {
    * detect devices that produced at least one connection attempt in the recent window.
    */
   def lastSeenByMacSince(since: Instant): Task[Map[MacAddress, Instant]]
+
+  /**
+   * #720 backfill: look up the most recent fqdn-typed connection_event with the given (router_id,
+   * dest_ip) whose `ts` is at-or-after `since`. Returns the resolved hostname if any. Used at
+   * ingest time to attach a resolution to a fresh ipv4/ipv6-typed event whose agent-side DNS
+   * cache lost the race.
+   */
+  def findRecentFqdnFor(
+      routerId: RouterId,
+      destIp: IpAddress,
+      since: Instant,
+  ): Task[Option[Hostname]]
+
+  /**
+   * #720 backfill: patch the `resolved_host_value` column on existing ipv4/ipv6-typed rows for the
+   * given (router_id, dest_ip) that landed at-or-after `since` and don't yet carry a resolution.
+   * Called when a fqdn-typed event lands and "teaches" the API the IP→hostname mapping
+   * retroactively. Returns the row count actually updated.
+   */
+  def backfillResolvedFor(
+      routerId: RouterId,
+      destIp: IpAddress,
+      fqdn: Hostname,
+      since: Instant,
+  ): Task[Int]
 }
 
 class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
@@ -921,41 +950,90 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
   // retry-queue replays (#330). NULL → server-generated via gen_random_uuid()
   // (older agents pre-eventId support). ON CONFLICT DO NOTHING collapses
   // replays; updateMany returns count of rows actually inserted.
+  // #720: resolved_host_value carries an API-side FQDN attribution for
+  // ipv4/ipv6-typed events; ingest sets it from sibling fqdn events.
   def insertBatch(events: List[ConnectionEventInsert]) =
     Update[ConnectionEventInsert](
-      "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id) " +
-        "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid())) " +
+      "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value) " +
+        "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?) " +
         "ON CONFLICT (event_id) DO NOTHING",
     ).updateMany(events).transact(xa)
 
+  // #720: read paths coalesce a populated resolved_host_value into the host
+  // tuple so callers see ('fqdn', resolved) instead of ('ipv4', literal-ip).
+  // The raw columns remain untouched on disk; this is purely a render-time
+  // promotion. Done in SQL so doobie's tuple decoder receives the already-
+  // resolved values.
+  private val selectCols: Fragment =
+    fr"""id,
+         router_id,
+         mac,
+         CASE WHEN resolved_host_value IS NOT NULL THEN 'fqdn' ELSE host_type END AS host_type,
+         COALESCE(resolved_host_value, host_value) AS host_value,
+         dest_ip,
+         allowed,
+         reason,
+         ts::TEXT"""
+
   def recent(limit: Int) =
-    sql"SELECT id,router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts::TEXT FROM connection_events ORDER BY ts DESC LIMIT $limit"
+    (fr"SELECT" ++ selectCols ++ fr"FROM connection_events ORDER BY ts DESC LIMIT $limit")
       .query[R]
       .map(toC)
       .to[List]
       .transact(xa)
 
   def listForMac(mac: MacAddress, limit: Int) =
-    sql"SELECT id,router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts::TEXT FROM connection_events WHERE mac=$mac ORDER BY ts DESC LIMIT $limit"
+    (fr"SELECT" ++ selectCols ++ fr"FROM connection_events WHERE mac=$mac ORDER BY ts DESC LIMIT $limit")
       .query[R]
       .map(toC)
       .to[List]
       .transact(xa)
 
   def listForRouter(routerId: RouterId, limit: Int) =
-    sql"SELECT id,router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts::TEXT FROM connection_events WHERE router_id=$routerId ORDER BY ts DESC LIMIT $limit"
+    (fr"SELECT" ++ selectCols ++ fr"FROM connection_events WHERE router_id=$routerId ORDER BY ts DESC LIMIT $limit")
       .query[R]
       .map(toC)
       .to[List]
       .transact(xa)
 
+  def findRecentFqdnFor(routerId: RouterId, destIp: IpAddress, since: Instant) =
+    sql"""SELECT host_value FROM connection_events
+          WHERE router_id = $routerId
+            AND dest_ip   = $destIp
+            AND host_type = 'fqdn'
+            AND ts >= $since
+          ORDER BY ts DESC
+          LIMIT 1"""
+      .query[Hostname]
+      .option
+      .transact(xa)
+
+  def backfillResolvedFor(
+      routerId: RouterId,
+      destIp: IpAddress,
+      fqdn: Hostname,
+      since: Instant,
+  ) =
+    sql"""UPDATE connection_events
+          SET resolved_host_value = ${fqdn.value}
+          WHERE router_id = $routerId
+            AND dest_ip   = $destIp
+            AND host_type IN ('ipv4','ipv6')
+            AND resolved_host_value IS NULL
+            AND ts >= $since""".update.run.transact(xa)
+
   // ── Dashboard / log API ──────────────────────────────────────────────────
 
   def query(f: LogFilter) = {
     // location is sourced from routers.name until routers.location lands (#136)
+    // #720: coalesce resolved_host_value into the returned host tuple so
+    // race-loser ipv4 rows show up under their resolved FQDN in the log UI
+    // and in domain ILIKE filters.
     val base  =
       fr"""SELECT ce.id, ce.mac, d.name, d.profile_id, p.name,
-                  ce.host_type, ce.host_value, 1, NOT ce.allowed, ce.reason, r.name, ce.ts::TEXT
+                  CASE WHEN ce.resolved_host_value IS NOT NULL THEN 'fqdn' ELSE ce.host_type END,
+                  COALESCE(ce.resolved_host_value, ce.host_value),
+                  1, NOT ce.allowed, ce.reason, r.name, ce.ts::TEXT
            FROM connection_events ce
            LEFT JOIN devices d  ON d.mac    = ce.mac
            LEFT JOIN profiles p ON p.id     = d.profile_id
@@ -966,7 +1044,12 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     val byDev = f.deviceId.fold(fr"")(id => fr"AND d.id = $id")
     val byPid = f.profileId.fold(fr"")(pid => fr"AND d.profile_id = $pid")
     val byBl  = f.blocked.fold(fr"")(b => fr"AND ce.allowed = ${!b}")
-    val byDom = f.domain.fold(fr"")(d => fr"AND ce.host_value ILIKE ${s"%$d%"}")
+    val byDom = f.domain.fold(fr"")(d =>
+      // #720: domain filter has to look through the resolution too — otherwise
+      // a search for "youtube.com" would miss race-loser ipv4 rows we just
+      // attributed.
+      fr"AND COALESCE(ce.resolved_host_value, ce.host_value) ILIKE ${s"%$d%"}",
+    )
     val byLoc = f.location.fold(fr"")(l => fr"AND r.name = $l")
     (base ++ since ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++
       fr"ORDER BY ce.ts DESC LIMIT ${f.limit} OFFSET ${f.offset}")
@@ -1010,10 +1093,12 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
           .query[Int]
           .unique
           .transact(xa)
-      top <- sql"""SELECT host_type, host_value, COUNT(*)::INT
+      top <- sql"""SELECT CASE WHEN resolved_host_value IS NOT NULL THEN 'fqdn' ELSE host_type END,
+                          COALESCE(resolved_host_value, host_value),
+                          COUNT(*)::INT
                    FROM connection_events
                    WHERE NOT allowed AND ts > NOW()-INTERVAL '24 hours'
-                   GROUP BY host_type, host_value ORDER BY COUNT(*) DESC LIMIT 10"""
+                   GROUP BY 1, 2 ORDER BY COUNT(*) DESC LIMIT 10"""
         .query[(HostId, Int)]
         .map(DomainCount.apply)
         .to[List]
@@ -1035,10 +1120,12 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     } yield DashboardStats(tt, bt, th, bh, top, dev)
 
   def topBlocked(hours: Int, lim: Int) =
-    sql"""SELECT host_type, host_value, COUNT(*)::INT
+    sql"""SELECT CASE WHEN resolved_host_value IS NOT NULL THEN 'fqdn' ELSE host_type END,
+                 COALESCE(resolved_host_value, host_value),
+                 COUNT(*)::INT
           FROM connection_events
           WHERE NOT allowed AND ts > NOW() - make_interval(hours => $hours)
-          GROUP BY host_type, host_value ORDER BY COUNT(*) DESC LIMIT $lim"""
+          GROUP BY 1, 2 ORDER BY COUNT(*) DESC LIMIT $lim"""
       .query[(HostId, Int)]
       .map(DomainCount.apply)
       .to[List]

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -291,8 +291,8 @@ trait ConnectionEventRepo {
   /**
    * #720 backfill: look up the most recent fqdn-typed connection_event with the given (router_id,
    * dest_ip) whose `ts` is at-or-after `since`. Returns the resolved hostname if any. Used at
-   * ingest time to attach a resolution to a fresh ipv4/ipv6-typed event whose agent-side DNS
-   * cache lost the race.
+   * ingest time to attach a resolution to a fresh ipv4/ipv6-typed event whose agent-side DNS cache
+   * lost the race.
    */
   def findRecentFqdnFor(
       routerId: RouterId,

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -7,7 +7,7 @@ import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
 
-import java.time.{Instant, ZoneOffset}
+import java.time.{Duration, Instant, ZoneOffset}
 
 /**
  * Router-side ingest endpoints. See docs/architecture-openwrt.md §5.4 / §5.5.
@@ -178,6 +178,14 @@ object RouterIngestRoutes {
       }
   }
 
+  /**
+   * #720: how far back the API will look for a sibling fqdn-typed event to attribute an
+   * ipv4/ipv6-typed event to. Matches the spirit of #583 Option 4 — a small race window, not a
+   * long-running IP→host cache. Five minutes covers the conntrack/dns-tail jitter (and any client
+   * DNS TTL skew) without inviting attribution across reused-IP cloud endpoints.
+   */
+  private val fqdnBackfillWindow: Duration = Duration.ofMinutes(5)
+
   private def handleEvents(
       routerId: RouterId,
       events: List[RouterEvent],
@@ -198,23 +206,59 @@ object RouterIngestRoutes {
       validated <- ZIO.foreach(connInserts)(e =>
         ZIO.fromEither(e).mapError(m => Response.badRequest(m)),
       )
+      // #720: for each ipv4/ipv6-typed insert with a dest_ip, consult the
+      // existing connection_events for a sibling fqdn-typed event we can
+      // attribute it to. This handles the "fqdn observed first, ipv4 race-
+      // loser arrives later" arrival order at insert time.
+      enriched  <- ZIO.foreach(validated)(attachResolvedHost(_, connEventRepo))
       // #338: ON CONFLICT DO NOTHING on event_id dedups replays from the
       // retry queue (#330). Insert returns count of new rows; the diff is
       // duplicates collapsed on conflict.
       inserted  <- connEventRepo
-        .insertBatch(validated)
+        .insertBatch(enriched)
         .mapError(ErrorMapper.dbErrorToResponse)
-        .when(validated.nonEmpty)
+        .when(enriched.nonEmpty)
         .map(_.getOrElse(0))
       _         <- ZIO
         .logInfo(
-          s"router events: router=$routerId dedup'd ${validated.size - inserted} of " +
-            s"${validated.size} connection_attempt events (replay)",
+          s"router events: router=$routerId dedup'd ${enriched.size - inserted} of " +
+            s"${enriched.size} connection_attempt events (replay)",
         )
-        .when(inserted < validated.size)
+        .when(inserted < enriched.size)
+      // #720: for each fqdn-typed event we just persisted, patch prior
+      // unresolved ipv4/ipv6 rows in the same window. This handles the
+      // reverse arrival order ("ipv4 race-loser observed first, fqdn lands
+      // moments later").
+      _         <- ZIO.foreachDiscard(enriched)(backfillFromFqdn(_, connEventRepo))
       _         <- ZIO.foreachDiscard(events)(applyDhcpOrFirstSeen(_, deviceRepo))
     } yield ()
   }
+
+  private def attachResolvedHost(
+      ev: ConnectionEventInsert,
+      connEventRepo: ConnectionEventRepo,
+  ): IO[Response, ConnectionEventInsert] =
+    (ev.host, ev.destIp) match {
+      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
+        connEventRepo
+          .findRecentFqdnFor(ev.routerId, destIp, ev.ts.minus(fqdnBackfillWindow))
+          .mapError(ErrorMapper.dbErrorToResponse)
+          .map(h => ev.copy(resolvedHost = h))
+      case _                                               => ZIO.succeed(ev)
+    }
+
+  private def backfillFromFqdn(
+      ev: ConnectionEventInsert,
+      connEventRepo: ConnectionEventRepo,
+  ): IO[Response, Unit] =
+    (ev.host, ev.destIp) match {
+      case (HostId.Fqdn(name), Some(destIp)) =>
+        connEventRepo
+          .backfillResolvedFor(ev.routerId, destIp, name, ev.ts.minus(fqdnBackfillWindow))
+          .mapError(ErrorMapper.dbErrorToResponse)
+          .unit
+      case _                                 => ZIO.unit
+    }
 
   /**
    * Default name for a device whose DHCP lease did not provide a hostname (option 12) — e.g. iOS

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -104,15 +104,15 @@ object DbFailureSpec extends ZIOSpecDefault {
   }
 
   private def brokenConnectionEventRepo: ConnectionEventRepo = new ConnectionEventRepo {
-    def insertBatch(es: List[ConnectionEventInsert]) = throwing
-    def recent(l: Int)                               = throwing
-    def listForMac(mac: MacAddress, l: Int)          = throwing
-    def listForRouter(r: RouterId, l: Int)           = throwing
-    def query(f: LogFilter)                          = throwing
-    def stats                                        = throwing
-    def topBlocked(h: Int, l: Int)                   = throwing
-    def lastSeenByMacSince(since: Instant)           = throwing
-    def findRecentFqdnFor(r: RouterId, ip: IpAddress, since: Instant) = throwing
+    def insertBatch(es: List[ConnectionEventInsert])                                    = throwing
+    def recent(l: Int)                                                                  = throwing
+    def listForMac(mac: MacAddress, l: Int)                                             = throwing
+    def listForRouter(r: RouterId, l: Int)                                              = throwing
+    def query(f: LogFilter)                                                             = throwing
+    def stats                                                                           = throwing
+    def topBlocked(h: Int, l: Int)                                                      = throwing
+    def lastSeenByMacSince(since: Instant)                                              = throwing
+    def findRecentFqdnFor(r: RouterId, ip: IpAddress, since: Instant)                   = throwing
     def backfillResolvedFor(r: RouterId, ip: IpAddress, fqdn: Hostname, since: Instant) =
       throwing
   }

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -112,6 +112,9 @@ object DbFailureSpec extends ZIOSpecDefault {
     def stats                                        = throwing
     def topBlocked(h: Int, l: Int)                   = throwing
     def lastSeenByMacSince(since: Instant)           = throwing
+    def findRecentFqdnFor(r: RouterId, ip: IpAddress, since: Instant) = throwing
+    def backfillResolvedFor(r: RouterId, ip: IpAddress, fqdn: Hostname, since: Instant) =
+      throwing
   }
 
   private def jsonField(body: String, key: String): Option[String] =

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -770,5 +770,165 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         d <- dRepo.findByMac(MacAddress.unsafe(knownMac))
       } yield assertTrue(d.exists(_.name == "kid-ipad"))
     },
+    // ── #720: defense-in-depth API-side FQDN backfill ──────────────────────
+    test("events: ipv4-typed event is backfilled when a sibling fqdn event lands later") {
+      // Race-loser arrives first as ipv4. A subsequent fqdn event for the
+      // same (router_id, dest_ip) within the window teaches the API the
+      // mapping; the earlier row's host should now read as the resolved
+      // fqdn via SELECT-side coalesce.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        evIp = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(false),
+          reason = Some("blocked"),
+          ts = "2026-05-07T14:01:00Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        evFqdn = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.Fqdn(Hostname.unsafe("neverssl.com"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(false),
+          reason = Some("blocked"),
+          ts = "2026-05-07T14:01:05Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
+        rows <- cRepo.listForRouter(id, 100)
+      } yield assertTrue(rows.size == 2) &&
+        // both rows now surface as the resolved fqdn (the ipv4 row via
+        // resolved_host_value coalesce; the fqdn row natively)
+        assertTrue(rows.forall(_.host == HostId.Fqdn(Hostname.unsafe("neverssl.com"))))
+    },
+    test("events: ipv4-typed event picks up resolution from a prior fqdn event") {
+      // Reverse arrival order: fqdn event first, ipv4 event arrives later.
+      // The ipv4 row is inserted with resolved_host_value already populated.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        evFqdn = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.Fqdn(Hostname.unsafe("neverssl.com"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:01:00Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        evIp = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:01:05Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
+        rows <- cRepo.listForRouter(id, 100)
+      } yield assertTrue(rows.size == 2) &&
+        assertTrue(rows.forall(_.host == HostId.Fqdn(Hostname.unsafe("neverssl.com"))))
+    },
+    test("events: different routers with same dest_ip do not cross-attribute") {
+      // Per-router isolation: a fqdn observation on router A must NOT
+      // resolve an ipv4 event on router B. Reused-IP cloud endpoints
+      // would otherwise produce wrong attributions across households.
+      for {
+        _      <- cleanDb
+        rRepo  <- ZIO.service[RouterRepo]
+        cRepo  <- ZIO.service[ConnectionEventRepo]
+        routes <- buildRoutes
+        // seedRouter only seeds one — manually seed two
+        tkA = "ROUTER_TOKEN_A"
+        tkB = "ROUTER_TOKEN_B"
+        idA <- rRepo.create("router-a", Sha256Hex.unsafe("a" * 64))
+        _   <- rRepo.completeEnrollment(idA, Sha256Hex.unsafe(RouterAuth.sha256Hex(tkA)))
+        idB <- rRepo.create("router-b", Sha256Hex.unsafe("b" * 64))
+        _   <- rRepo.completeEnrollment(idB, Sha256Hex.unsafe(RouterAuth.sha256Hex(tkB)))
+        evFqdnA = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.Fqdn(Hostname.unsafe("not-neverssl.example"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:01:00Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        evIpB = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:01:05Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        _     <- post(routes, "/api/router/events", RouterEventsRequest(idA, List(evFqdnA)).toJson, Some(tkA))
+        _     <- post(routes, "/api/router/events", RouterEventsRequest(idB, List(evIpB)).toJson, Some(tkB))
+        rowsB <- cRepo.listForRouter(idB, 100)
+      } yield assertTrue(rowsB.size == 1) &&
+        // router B's ipv4 row must NOT inherit router A's fqdn
+        assertTrue(rowsB.head.host == HostId.IPv4(IpAddress.unsafe("34.223.124.45")))
+    },
+    test("events: fqdn arriving outside the backfill window does not attribute the earlier ipv4 row") {
+      // The backfill is for the conntrack/dns-tail race window — not a
+      // long-running cache. A fqdn observed 10 minutes after an ipv4 event
+      // for the same dest_ip is too late and must not retroactively
+      // re-label what is more plausibly a fresh-DNS-resolution flow.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        evIp = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:01:00Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        // 10 minutes later — outside the 5-minute window
+        evFqdn = RouterEvent(
+          "connection_attempt",
+          mac = Some(MacAddress.unsafe(knownMac)),
+          host = Some(HostId.Fqdn(Hostname.unsafe("neverssl.com"))),
+          destIp = Some(IpAddress.unsafe("34.223.124.45")),
+          allowed = Some(true),
+          reason = Some("allow"),
+          ts = "2026-05-07T14:11:00Z",
+          eventId = Some(UUID.randomUUID()),
+        )
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
+        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
+        rows <- cRepo.listForRouter(id, 100)
+      } yield assertTrue(rows.size == 2) &&
+        // ipv4 row stays unresolved (the late fqdn doesn't reach it)
+        assertTrue(
+          rows.exists(r => r.host == HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
+        ) &&
+        assertTrue(rows.exists(_.host == HostId.Fqdn(Hostname.unsafe("neverssl.com"))))
+    },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -782,7 +782,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         cRepo    <- ZIO.service[ConnectionEventRepo]
         routes   <- buildRoutes
         (id, tk) <- seedRouter(rRepo)
-        evIp = RouterEvent(
+        evIp   = RouterEvent(
           "connection_attempt",
           mac = Some(MacAddress.unsafe(knownMac)),
           host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
@@ -802,8 +802,18 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:01:05Z",
           eventId = Some(UUID.randomUUID()),
         )
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evIp)).toJson,
+          Some(tk),
+        )
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evFqdn)).toJson,
+          Some(tk),
+        )
         rows <- cRepo.listForRouter(id, 100)
       } yield assertTrue(rows.size == 2) &&
         // both rows now surface as the resolved fqdn (the ipv4 row via
@@ -829,7 +839,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:01:00Z",
           eventId = Some(UUID.randomUUID()),
         )
-        evIp = RouterEvent(
+        evIp   = RouterEvent(
           "connection_attempt",
           mac = Some(MacAddress.unsafe(knownMac)),
           host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
@@ -839,8 +849,18 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:01:05Z",
           eventId = Some(UUID.randomUUID()),
         )
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evFqdn)).toJson,
+          Some(tk),
+        )
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evIp)).toJson,
+          Some(tk),
+        )
         rows <- cRepo.listForRouter(id, 100)
       } yield assertTrue(rows.size == 2) &&
         assertTrue(rows.forall(_.host == HostId.Fqdn(Hostname.unsafe("neverssl.com"))))
@@ -871,7 +891,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:01:00Z",
           eventId = Some(UUID.randomUUID()),
         )
-        evIpB = RouterEvent(
+        evIpB   = RouterEvent(
           "connection_attempt",
           mac = Some(MacAddress.unsafe(knownMac)),
           host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
@@ -881,14 +901,26 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:01:05Z",
           eventId = Some(UUID.randomUUID()),
         )
-        _     <- post(routes, "/api/router/events", RouterEventsRequest(idA, List(evFqdnA)).toJson, Some(tkA))
-        _     <- post(routes, "/api/router/events", RouterEventsRequest(idB, List(evIpB)).toJson, Some(tkB))
+        _     <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(idA, List(evFqdnA)).toJson,
+          Some(tkA),
+        )
+        _     <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(idB, List(evIpB)).toJson,
+          Some(tkB),
+        )
         rowsB <- cRepo.listForRouter(idB, 100)
       } yield assertTrue(rowsB.size == 1) &&
         // router B's ipv4 row must NOT inherit router A's fqdn
         assertTrue(rowsB.head.host == HostId.IPv4(IpAddress.unsafe("34.223.124.45")))
     },
-    test("events: fqdn arriving outside the backfill window does not attribute the earlier ipv4 row") {
+    test(
+      "events: fqdn arriving outside the backfill window does not attribute the earlier ipv4 row",
+    ) {
       // The backfill is for the conntrack/dns-tail race window — not a
       // long-running cache. A fqdn observed 10 minutes after an ipv4 event
       // for the same dest_ip is too late and must not retroactively
@@ -899,7 +931,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         cRepo    <- ZIO.service[ConnectionEventRepo]
         routes   <- buildRoutes
         (id, tk) <- seedRouter(rRepo)
-        evIp = RouterEvent(
+        evIp   = RouterEvent(
           "connection_attempt",
           mac = Some(MacAddress.unsafe(knownMac)),
           host = Some(HostId.IPv4(IpAddress.unsafe("34.223.124.45"))),
@@ -920,8 +952,18 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           ts = "2026-05-07T14:11:00Z",
           eventId = Some(UUID.randomUUID()),
         )
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evIp)).toJson, Some(tk))
-        _    <- post(routes, "/api/router/events", RouterEventsRequest(id, List(evFqdn)).toJson, Some(tk))
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evIp)).toJson,
+          Some(tk),
+        )
+        _    <- post(
+          routes,
+          "/api/router/events",
+          RouterEventsRequest(id, List(evFqdn)).toJson,
+          Some(tk),
+        )
         rows <- cRepo.listForRouter(id, 100)
       } yield assertTrue(rows.size == 2) &&
         // ipv4 row stays unresolved (the late fqdn doesn't reach it)


### PR DESCRIPTION
## Summary

- Closes #720 (follow-up to #583 / PR #650).
- Adds an API-side FQDN backfill so ipv4/ipv6-typed `connection_attempt` events get attributed to a sibling fqdn-typed event for the same `(router_id, dest_ip)` within a 5-minute window — independent of any agent-side guarantee.
- Zero router-side changes: uses the fqdn-typed `connection_attempt` events the router already emits, not a new `dns_reply` wire event.

## Design rationale

#583 listed Option 4 as "back-fill server-side using DNS events from the same router within a small window." But the `router-to-api` contract never carried `dns_reply` events — only `connection_attempt`, `dhcp_lease`, and `first_seen_mac`. Adding `dns_reply` would require router changes, which is off the table while the router is frozen through Gate 2 (#654). Instead, every successful agent-side resolution already gives us a `(router_id, dest_ip) → fqdn` mapping in the form of an existing `connection_attempt` row, so the rare race-loser ipv4 rows can be attributed from those. A new nullable `resolved_host_value` column keeps the original `host_type`/`host_value` immutable (so idempotent replay and event integrity remain unchanged) while read paths coalesce the resolved value into the returned `HostId`.

## Test plan

- [x] `mill api.test` — full suite green (190/190).
- [x] New tests in `api/test/src/feature/RouterIngestSpec.scala`:
  - [x] ipv4 event arrives first, fqdn lands 5s later → earlier row coalesces to the resolved fqdn.
  - [x] fqdn event arrives first, ipv4 lands later → new ipv4 row already coalesces to the fqdn.
  - [x] different `router_id` same `dest_ip` → no cross-attribution.
  - [x] fqdn arriving 10 minutes after the ipv4 event (outside the 5-min window) → no backfill.
- [x] `DbFailureSpec` broken-repo stub extended to cover the two new methods.

Refs: #583, #650, #654, #720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)