### PR TITLE
api: read-side FQDN coalesce for time_usage/traffic rollups (#731)

### DIFF
--- a/api/resources/db/migration/V21__time_usage_resolved_fqdn_index.sql
+++ b/api/resources/db/migration/V21__time_usage_resolved_fqdn_index.sql
@@ -1,0 +1,21 @@
+-- V21__time_usage_resolved_fqdn_index.sql
+-- Stop-gap read-side FQDN join for time_usage / traffic_reports (#731).
+--
+-- PR #728 added resolved_host_value to connection_events so the connection
+-- log surfaces resolved FQDNs for race-loser ipv4 events. The 5-minute
+-- traffic rollup (time_usage / traffic_reports) has no dest_ip column, so
+-- the same backfill cannot be applied at ingest time (#730 will fix that
+-- properly once the router thaws after Gate 2 / #654).
+--
+-- This migration adds a partial index to make the read-time LATERAL join
+-- efficient: the SELECT paths in TimeUsageRepoLive and TrafficReportRepoLive
+-- LEFT JOIN connection_events on (mac, dest_ip) to look up a resolved
+-- hostname for ipv4-typed rows. The partial index (WHERE resolved_host_value
+-- IS NOT NULL) keeps the scan tight — only rows that actually carry a
+-- resolution are indexed, which is a small fraction of the table.
+--
+-- TODO(#730): remove this index when the read-side join is deleted.
+
+CREATE INDEX idx_conn_events_mac_dest_resolved
+  ON connection_events(mac, dest_ip)
+  WHERE resolved_host_value IS NOT NULL;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -665,24 +665,90 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
       .option
       .transact(xa)
       .map(_.getOrElse((0L, 0L, 0L)))
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
+  // The LATERAL subquery promotes ipv4-typed time_usage rows to their resolved
+  // fqdn by looking up the most recent connection_events row for the same
+  // (mac, dest_ip) that has a resolved_host_value. The partial index added in
+  // V21 (idx_conn_events_mac_dest_resolved) keeps the join cheap.
   def listForDevice(mac: MacAddress, d: LocalDate)                                              =
-    sql"SELECT id,device_mac,host_type,host_value,date::TEXT,(COALESCE(seconds_used,0)/60)::INT,last_seen_at::TEXT FROM time_usage WHERE device_mac=$mac AND date=$d ORDER BY seconds_used DESC"
+    sql"""SELECT tu.id,
+                 tu.device_mac,
+                 CASE WHEN tu.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                      THEN 'fqdn' ELSE tu.host_type END,
+                 COALESCE(CASE WHEN tu.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                          tu.host_value),
+                 tu.date::TEXT,
+                 (COALESCE(tu.seconds_used,0)/60)::INT,
+                 tu.last_seen_at::TEXT
+          FROM time_usage tu
+          LEFT JOIN LATERAL (
+            SELECT resolved_host_value
+            FROM connection_events
+            WHERE mac          = tu.device_mac
+              AND dest_ip      = tu.host_value
+              AND resolved_host_value IS NOT NULL
+              AND ts >= $d::TIMESTAMPTZ
+              AND ts <  ($d::DATE + INTERVAL '1 day')::TIMESTAMPTZ
+            ORDER BY ts DESC LIMIT 1
+          ) ce ON tu.host_type IN ('ipv4','ipv6')
+          WHERE tu.device_mac = $mac AND tu.date = $d
+          ORDER BY tu.seconds_used DESC"""
       .query[(TimeUsageId, MacAddress, HostId, String, Int, String)]
       .map(TimeUsage.apply)
       .to[List]
       .transact(xa)
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
   def listForDeviceMacs(macs: List[MacAddress], d: LocalDate)                                   =
     if macs.isEmpty then ZIO.succeed(Nil)
     else {
       val arr = macs.map(_.value).toArray
-      sql"SELECT id,device_mac,host_type,host_value,date::TEXT,(COALESCE(seconds_used,0)/60)::INT,last_seen_at::TEXT FROM time_usage WHERE device_mac = ANY($arr) AND date=$d ORDER BY device_mac,seconds_used DESC"
+      sql"""SELECT tu.id,
+                   tu.device_mac,
+                   CASE WHEN tu.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                        THEN 'fqdn' ELSE tu.host_type END,
+                   COALESCE(CASE WHEN tu.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                            tu.host_value),
+                   tu.date::TEXT,
+                   (COALESCE(tu.seconds_used,0)/60)::INT,
+                   tu.last_seen_at::TEXT
+            FROM time_usage tu
+            LEFT JOIN LATERAL (
+              SELECT resolved_host_value
+              FROM connection_events
+              WHERE mac          = tu.device_mac
+                AND dest_ip      = tu.host_value
+                AND resolved_host_value IS NOT NULL
+                AND ts >= $d::TIMESTAMPTZ
+                AND ts <  ($d::DATE + INTERVAL '1 day')::TIMESTAMPTZ
+              ORDER BY ts DESC LIMIT 1
+            ) ce ON tu.host_type IN ('ipv4','ipv6')
+            WHERE tu.device_mac = ANY($arr) AND tu.date = $d
+            ORDER BY tu.device_mac, tu.seconds_used DESC"""
         .query[(TimeUsageId, MacAddress, HostId, String, Int, String)]
         .map(TimeUsage.apply)
         .to[List]
         .transact(xa)
     }
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
   def snapshotAll(d: LocalDate)                                                                 =
-    sql"SELECT device_mac,host_type,host_value,(COALESCE(seconds_used,0)/60)::INT FROM time_usage WHERE date=$d"
+    sql"""SELECT tu.device_mac,
+                 CASE WHEN tu.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                      THEN 'fqdn' ELSE tu.host_type END,
+                 COALESCE(CASE WHEN tu.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                          tu.host_value),
+                 (COALESCE(tu.seconds_used,0)/60)::INT
+          FROM time_usage tu
+          LEFT JOIN LATERAL (
+            SELECT resolved_host_value
+            FROM connection_events
+            WHERE mac          = tu.device_mac
+              AND dest_ip      = tu.host_value
+              AND resolved_host_value IS NOT NULL
+              AND ts >= $d::TIMESTAMPTZ
+              AND ts <  ($d::DATE + INTERVAL '1 day')::TIMESTAMPTZ
+            ORDER BY ts DESC LIMIT 1
+          ) ce ON tu.host_type IN ('ipv4','ipv6')
+          WHERE tu.date = $d"""
       .query[(MacAddress, HostId, Int)]
       .to[List]
       .transact(xa)
@@ -843,28 +909,87 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
     Update[TrafficReportInsert](
       "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
     ).updateMany(reports).transact(xa)
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
+  // Promotes ipv4/ipv6-typed traffic_reports rows to their resolved fqdn at
+  // SELECT time via the same LATERAL join used in TimeUsageRepoLive.
   def listForDevice(mac: MacAddress, date: LocalDate) =
-    sql"SELECT id,router_id,mac,ip,host_type,host_value,date::TEXT,period_start::TEXT,period_end::TEXT,active_seconds,bytes_in,bytes_out FROM traffic_reports WHERE mac=$mac AND date=$date ORDER BY period_start"
+    sql"""SELECT tr.id, tr.router_id, tr.mac, tr.ip,
+                 CASE WHEN tr.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                      THEN 'fqdn' ELSE tr.host_type END,
+                 COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                          tr.host_value),
+                 tr.date::TEXT, tr.period_start::TEXT, tr.period_end::TEXT,
+                 tr.active_seconds, tr.bytes_in, tr.bytes_out
+          FROM traffic_reports tr
+          LEFT JOIN LATERAL (
+            SELECT resolved_host_value
+            FROM connection_events
+            WHERE mac          = tr.mac
+              AND dest_ip      = tr.host_value
+              AND resolved_host_value IS NOT NULL
+              AND ts >= $date::TIMESTAMPTZ
+              AND ts <  ($date::DATE + INTERVAL '1 day')::TIMESTAMPTZ
+            ORDER BY ts DESC LIMIT 1
+          ) ce ON tr.host_type IN ('ipv4','ipv6')
+          WHERE tr.mac = $mac AND tr.date = $date
+          ORDER BY tr.period_start"""
       .query[R]
       .map(toT)
       .to[List]
       .transact(xa)
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
   def listForRouter(routerId: RouterId, limit: Int)   =
-    sql"SELECT id,router_id,mac,ip,host_type,host_value,date::TEXT,period_start::TEXT,period_end::TEXT,active_seconds,bytes_in,bytes_out FROM traffic_reports WHERE router_id=$routerId ORDER BY period_start DESC LIMIT $limit"
+    sql"""SELECT tr.id, tr.router_id, tr.mac, tr.ip,
+                 CASE WHEN tr.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                      THEN 'fqdn' ELSE tr.host_type END,
+                 COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                          tr.host_value),
+                 tr.date::TEXT, tr.period_start::TEXT, tr.period_end::TEXT,
+                 tr.active_seconds, tr.bytes_in, tr.bytes_out
+          FROM traffic_reports tr
+          LEFT JOIN LATERAL (
+            SELECT resolved_host_value
+            FROM connection_events
+            WHERE mac          = tr.mac
+              AND dest_ip      = tr.host_value
+              AND resolved_host_value IS NOT NULL
+              AND ts >= tr.date::TIMESTAMPTZ
+              AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
+            ORDER BY ts DESC LIMIT 1
+          ) ce ON tr.host_type IN ('ipv4','ipv6')
+          WHERE tr.router_id = $routerId
+          ORDER BY tr.period_start DESC LIMIT $limit"""
       .query[R]
       .map(toT)
       .to[List]
       .transact(xa)
 
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
   def listPresenceRows(macs: List[MacAddress], date: LocalDate) = {
     type Row = (MacAddress, Instant, HostId, Int)
     macs match {
       case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
       case ms  =>
         val nel = cats.data.NonEmptyList.fromListUnsafe(ms.map(_.value))
-        val q   = fr"""SELECT mac, period_start, host_type, host_value, active_seconds
-                       FROM traffic_reports
-                       WHERE date = $date AND """ ++ Fragments.in(fr"mac", nel)
+        val q   =
+          fr"""SELECT tr.mac, tr.period_start,
+                      CASE WHEN tr.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                           THEN 'fqdn' ELSE tr.host_type END,
+                      COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                               tr.host_value),
+                      tr.active_seconds
+               FROM traffic_reports tr
+               LEFT JOIN LATERAL (
+                 SELECT resolved_host_value
+                 FROM connection_events
+                 WHERE mac          = tr.mac
+                   AND dest_ip      = tr.host_value
+                   AND resolved_host_value IS NOT NULL
+                   AND ts >= $date::TIMESTAMPTZ
+                   AND ts <  ($date::DATE + INTERVAL '1 day')::TIMESTAMPTZ
+                 ORDER BY ts DESC LIMIT 1
+               ) ce ON tr.host_type IN ('ipv4','ipv6')
+               WHERE tr.date = $date AND """ ++ Fragments.in(fr"tr.mac", nel)
         q.query[Row]
           .map((m, ps, h, s) => wifihaven.api.presence.PresenceRow(m, ps, h, s))
           .to[List]
@@ -872,24 +997,41 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
     }
   }
 
+  // TODO(#730): remove this read-side join once usage records carry dest_ip.
   def listSessionRows(f: SessionFilter) = {
     type Row = (RouterId, MacAddress, HostId, LocalDate, Instant, Instant, Int, Long, Long)
-    val base    = fr"""SELECT router_id, mac, host_type, host_value, date, period_start, period_end,
-                              active_seconds, bytes_in, bytes_out
-                       FROM traffic_reports
-                       WHERE 1=1"""
+    val base    =
+      fr"""SELECT tr.router_id, tr.mac,
+                  CASE WHEN tr.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                       THEN 'fqdn' ELSE tr.host_type END,
+                  COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                           tr.host_value),
+                  tr.date, tr.period_start, tr.period_end,
+                  tr.active_seconds, tr.bytes_in, tr.bytes_out
+           FROM traffic_reports tr
+           LEFT JOIN LATERAL (
+             SELECT resolved_host_value
+             FROM connection_events
+             WHERE mac          = tr.mac
+               AND dest_ip      = tr.host_value
+               AND resolved_host_value IS NOT NULL
+               AND ts >= tr.date::TIMESTAMPTZ
+               AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
+             ORDER BY ts DESC LIMIT 1
+           ) ce ON tr.host_type IN ('ipv4','ipv6')
+           WHERE 1=1"""
     val byMacs  = f.macs match {
       case None      => fr""
       case Some(Nil) => fr"AND FALSE"
       case Some(ms)  =>
         val nel = cats.data.NonEmptyList.fromListUnsafe(ms.map(_.value))
-        fr"AND " ++ Fragments.in(fr"mac", nel)
+        fr"AND " ++ Fragments.in(fr"tr.mac", nel)
     }
-    val byHost  = f.host.fold(fr"")(h => fr"AND host_value ILIKE ${s"%$h%"}")
-    val bySince = f.since.fold(fr"")(s => fr"AND period_end > $s")
-    val byUntil = f.until.fold(fr"")(u => fr"AND period_start < $u")
+    val byHost  = f.host.fold(fr"")(h => fr"AND tr.host_value ILIKE ${s"%$h%"}")
+    val bySince = f.since.fold(fr"")(s => fr"AND tr.period_end > $s")
+    val byUntil = f.until.fold(fr"")(u => fr"AND tr.period_start < $u")
     val sql_    = base ++ byMacs ++ byHost ++ bySince ++ byUntil ++
-      fr"ORDER BY router_id, mac, host_type, host_value, date, period_start"
+      fr"ORDER BY tr.router_id, tr.mac, tr.host_type, tr.host_value, tr.date, tr.period_start"
     sql_
       .query[Row]
       .map { r =>

--- a/api/test/src/feature/TimeUsageBackfillSpec.scala
+++ b/api/test/src/feature/TimeUsageBackfillSpec.scala
@@ -26,8 +26,7 @@ import zio.test.*
 import java.time.{Instant, LocalDate}
 import java.util.UUID
 
-object TimeUsageBackfillSpec
-    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+object TimeUsageBackfillSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
 
   override val bootstrap = TestDatabase.layer
 
@@ -35,10 +34,10 @@ object TimeUsageBackfillSpec
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
-  private val testDate   = LocalDate.of(2026, 5, 7)
-  private val mac1       = MacAddress.unsafe("aa:bb:cc:11:22:33")
-  private val mac2       = MacAddress.unsafe("aa:bb:cc:44:55:66")
-  private val destIp     = IpAddress.unsafe("34.223.124.45")
+  private val testDate     = LocalDate.of(2026, 5, 7)
+  private val mac1         = MacAddress.unsafe("aa:bb:cc:11:22:33")
+  private val mac2         = MacAddress.unsafe("aa:bb:cc:44:55:66")
+  private val destIp       = IpAddress.unsafe("34.223.124.45")
   private val resolvedFqdn = Hostname.unsafe("neverssl.com")
 
   // Timestamp within testDate (UTC)
@@ -77,9 +76,10 @@ object TimeUsageBackfillSpec
     } yield ()
 
   def spec = suite("TimeUsage read-side FQDN coalesce (#731 stop-gap)")(
-
     // ── 1. ipv4 row + matching resolved connection_event → promoted to fqdn ──
-    test("listForDevice: ipv4 time_usage row with matching resolved connection_event reads as fqdn") {
+    test(
+      "listForDevice: ipv4 time_usage row with matching resolved connection_event reads as fqdn",
+    ) {
       for {
         _     <- cleanDb
         tu    <- ZIO.service[TimeUsageRepo]
@@ -162,8 +162,8 @@ object TimeUsageBackfillSpec
         )
         // connection_event from the day *before* testDate — outside the same-day window
         staleTs = testDate.minusDays(1).atTime(23, 59).toInstant(java.time.ZoneOffset.UTC)
-        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, staleTs)
-        rows  <- tu.listForDevice(mac1, testDate)
+        _    <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, staleTs)
+        rows <- tu.listForDevice(mac1, testDate)
       } yield assertTrue(rows.size == 1) &&
         assertTrue(rows.head.host == HostId.IPv4(destIp))
     },
@@ -229,14 +229,14 @@ object TimeUsageBackfillSpec
     // overlap for the stop-gap period. #730 eliminates it at ingest time.
     test("listForDevice: promoted ipv4 row and native fqdn row both appear (documented overlap)") {
       for {
-        _    <- cleanDb
-        tu   <- ZIO.service[TimeUsageRepo]
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
         cRepo <- ZIO.service[ConnectionEventRepo]
         rRepo <- ZIO.service[RouterRepo]
         // ipv4 time_usage row (race-loser)
-        _    <- tu.incrementSecondsAndBytes(mac1, HostId.IPv4(destIp), testDate, 60L, 100L, 50L)
+        _     <- tu.incrementSecondsAndBytes(mac1, HostId.IPv4(destIp), testDate, 60L, 100L, 50L)
         // genuine fqdn time_usage row (agent resolved on a later flow)
-        _    <- tu.incrementSecondsAndBytes(
+        _     <- tu.incrementSecondsAndBytes(
           mac1,
           HostId.Fqdn(resolvedFqdn),
           testDate,
@@ -244,8 +244,8 @@ object TimeUsageBackfillSpec
           200L,
           80L,
         )
-        _    <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
-        rows <- tu.listForDevice(mac1, testDate)
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        rows  <- tu.listForDevice(mac1, testDate)
       } yield {
         // Both rows should be present; after promotion they both show as the fqdn.
         // A GROUP BY rollup will see two entries for the same fqdn — this is the
@@ -254,6 +254,5 @@ object TimeUsageBackfillSpec
         assertTrue(rows.forall(_.host == HostId.Fqdn(resolvedFqdn)))
       }
     },
-
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/TimeUsageBackfillSpec.scala
+++ b/api/test/src/feature/TimeUsageBackfillSpec.scala
@@ -1,0 +1,259 @@
+package wifihaven.api.feature
+
+// Tests for the stop-gap read-side FQDN coalesce added in #731.
+//
+// When a time_usage row was written with host_type='ipv4' because the router's
+// conntrack/dns-tail race fired before the DNS reply arrived, the read paths
+// (listForDevice, listForDeviceMacs, snapshotAll) now LEFT JOIN connection_events
+// to look up a resolved hostname for the same (mac, dest_ip) pair within the
+// same calendar day.  These tests verify:
+//
+//   1. ipv4 row + matching resolved connection_event → promoted to fqdn.
+//   2. ipv4 row + NO matching connection_event → stays ipv4.
+//   3. Different mac, same host_value (dest_ip) → no cross-attribution.
+//   4. connection_event is from a different day → no promotion.
+//
+// TODO(#730): delete this spec along with the join when #730 lands.
+
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate}
+import java.util.UUID
+
+object TimeUsageBackfillSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private val testDate   = LocalDate.of(2026, 5, 7)
+  private val mac1       = MacAddress.unsafe("aa:bb:cc:11:22:33")
+  private val mac2       = MacAddress.unsafe("aa:bb:cc:44:55:66")
+  private val destIp     = IpAddress.unsafe("34.223.124.45")
+  private val resolvedFqdn = Hostname.unsafe("neverssl.com")
+
+  // Timestamp within testDate (UTC)
+  private def tsOnDay(hour: Int): Instant =
+    testDate.atTime(hour, 0).toInstant(java.time.ZoneOffset.UTC)
+
+  // Directly insert a connection_events row with a resolved_host_value set.
+  // We bypass the ingest route and insert directly so we can precisely control
+  // resolved_host_value without triggering the ingest-time backfill logic.
+  private def seedResolvedEvent(
+      cRepo: ConnectionEventRepo,
+      rRepo: RouterRepo,
+      mac: MacAddress,
+      destIp: IpAddress,
+      resolved: Hostname,
+      ts: Instant,
+  ): Task[Unit] =
+    for {
+      rid <- rRepo.create("backfill-test-router", Sha256Hex.unsafe("e" * 64))
+      _   <- rRepo.completeEnrollment(rid, Sha256Hex.unsafe("f" * 64))
+      _   <- cRepo.insertBatch(
+        List(
+          ConnectionEventInsert(
+            routerId = rid,
+            mac = Some(mac),
+            host = HostId.IPv4(destIp),
+            destIp = Some(destIp),
+            allowed = true,
+            reason = "allow",
+            ts = ts,
+            eventId = Some(UUID.randomUUID()),
+            resolvedHost = Some(resolved),
+          ),
+        ),
+      )
+    } yield ()
+
+  def spec = suite("TimeUsage read-side FQDN coalesce (#731 stop-gap)")(
+
+    // ── 1. ipv4 row + matching resolved connection_event → promoted to fqdn ──
+    test("listForDevice: ipv4 time_usage row with matching resolved connection_event reads as fqdn") {
+      for {
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        // Write an ipv4 time_usage row for mac1 / destIp
+        _     <- tu.incrementSecondsAndBytes(
+          mac1,
+          HostId.IPv4(destIp),
+          testDate,
+          300L,
+          1000L,
+          500L,
+        )
+        // Seed a resolved connection_event for same (mac1, destIp) within the same day
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        // Read back via listForDevice — should be promoted to fqdn
+        rows  <- tu.listForDevice(mac1, testDate)
+      } yield assertTrue(rows.size == 1) &&
+        assertTrue(rows.head.host == HostId.Fqdn(resolvedFqdn))
+    },
+
+    // ── 2. ipv4 row + NO matching connection_event → stays ipv4 ───────────
+    test("listForDevice: ipv4 row with no matching connection_event stays ipv4") {
+      for {
+        _    <- cleanDb
+        tu   <- ZIO.service[TimeUsageRepo]
+        _    <- tu.incrementSecondsAndBytes(
+          mac1,
+          HostId.IPv4(destIp),
+          testDate,
+          60L,
+          100L,
+          50L,
+        )
+        rows <- tu.listForDevice(mac1, testDate)
+      } yield assertTrue(rows.size == 1) &&
+        assertTrue(rows.head.host == HostId.IPv4(destIp))
+    },
+
+    // ── 3. Different mac, same dest_ip → no cross-attribution ─────────────
+    test("listForDevice: resolved event for mac1 does NOT promote ipv4 row for mac2") {
+      for {
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        // ipv4 time_usage for mac2
+        _     <- tu.incrementSecondsAndBytes(
+          mac2,
+          HostId.IPv4(destIp),
+          testDate,
+          60L,
+          100L,
+          50L,
+        )
+        // Resolved event is for mac1, not mac2
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        rows  <- tu.listForDevice(mac2, testDate)
+      } yield assertTrue(rows.size == 1) &&
+        // mac2's ipv4 row must NOT be attributed to mac1's fqdn resolution
+        assertTrue(rows.head.host == HostId.IPv4(destIp))
+    },
+
+    // ── 4. Stale connection_event (different day) → no promotion ──────────
+    test("listForDevice: connection_event from a different day does not promote the ipv4 row") {
+      for {
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        // time_usage on testDate
+        _     <- tu.incrementSecondsAndBytes(
+          mac1,
+          HostId.IPv4(destIp),
+          testDate,
+          60L,
+          100L,
+          50L,
+        )
+        // connection_event from the day *before* testDate — outside the same-day window
+        staleTs = testDate.minusDays(1).atTime(23, 59).toInstant(java.time.ZoneOffset.UTC)
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, staleTs)
+        rows  <- tu.listForDevice(mac1, testDate)
+      } yield assertTrue(rows.size == 1) &&
+        assertTrue(rows.head.host == HostId.IPv4(destIp))
+    },
+
+    // ── 5. listForDeviceMacs: multi-mac promotion works correctly ──────────
+    test("listForDeviceMacs: ipv4 rows are promoted per-mac independently") {
+      for {
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        // ipv4 time_usage for both macs, same dest_ip
+        _     <- tu.incrementSecondsAndBytes(mac1, HostId.IPv4(destIp), testDate, 120L, 200L, 100L)
+        _     <- tu.incrementSecondsAndBytes(mac2, HostId.IPv4(destIp), testDate, 60L, 100L, 50L)
+        // Only mac1 has a resolved event
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        rows  <- tu.listForDeviceMacs(List(mac1, mac2), testDate)
+      } yield {
+        val mac1Row = rows.filter(_.deviceMac == mac1)
+        val mac2Row = rows.filter(_.deviceMac == mac2)
+        assertTrue(mac1Row.size == 1) &&
+        assertTrue(mac1Row.head.host == HostId.Fqdn(resolvedFqdn)) &&
+        assertTrue(mac2Row.size == 1) &&
+        assertTrue(mac2Row.head.host == HostId.IPv4(destIp))
+      }
+    },
+
+    // ── 6. snapshotAll: promotion flows through the snapshot map ──────────
+    test("snapshotAll: promoted ipv4 row appears under its fqdn key in the snapshot map") {
+      for {
+        _     <- cleanDb
+        tu    <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        _     <- tu.incrementSecondsAndBytes(
+          mac1,
+          HostId.IPv4(destIp),
+          testDate,
+          // 2 minutes → 2 mins in snapshot
+          120L,
+          200L,
+          100L,
+        )
+        _     <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        snap  <- tu.snapshotAll(testDate)
+      } yield {
+        val fqdnKey = (mac1, HostId.Fqdn(resolvedFqdn))
+        val ipv4Key = (mac1, HostId.IPv4(destIp))
+        assertTrue(snap.contains(fqdnKey)) &&
+        assertTrue(!snap.contains(ipv4Key)) &&
+        assertTrue(snap(fqdnKey) == 2)
+      }
+    },
+
+    // ── 7. De-dup / overlap: both ipv4 and native-fqdn rows exist ─────────
+    // When the agent emits some flows as ipv4 (race losers) and later emits
+    // the same destination as fqdn (after DNS resolved), we get TWO time_usage
+    // rows: one ipv4 row (promoted by the join to fqdn) and one genuine fqdn
+    // row. The join promotes the ipv4 bucket to the same fqdn key, so after
+    // promotion both rows share the same HostId. listForDevice returns both
+    // rows separately (they are distinct time_usage rows); callers that GROUP
+    // BY host will SUM them. We document this here: it's a known, bounded
+    // overlap for the stop-gap period. #730 eliminates it at ingest time.
+    test("listForDevice: promoted ipv4 row and native fqdn row both appear (documented overlap)") {
+      for {
+        _    <- cleanDb
+        tu   <- ZIO.service[TimeUsageRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        rRepo <- ZIO.service[RouterRepo]
+        // ipv4 time_usage row (race-loser)
+        _    <- tu.incrementSecondsAndBytes(mac1, HostId.IPv4(destIp), testDate, 60L, 100L, 50L)
+        // genuine fqdn time_usage row (agent resolved on a later flow)
+        _    <- tu.incrementSecondsAndBytes(
+          mac1,
+          HostId.Fqdn(resolvedFqdn),
+          testDate,
+          120L,
+          200L,
+          80L,
+        )
+        _    <- seedResolvedEvent(cRepo, rRepo, mac1, destIp, resolvedFqdn, tsOnDay(14))
+        rows <- tu.listForDevice(mac1, testDate)
+      } yield {
+        // Both rows should be present; after promotion they both show as the fqdn.
+        // A GROUP BY rollup will see two entries for the same fqdn — this is the
+        // known small overlap documented in the #731 PR body.
+        assertTrue(rows.size == 2) &&
+        assertTrue(rows.forall(_.host == HostId.Fqdn(resolvedFqdn)))
+      }
+    },
+
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary

- Closes #731. Stop-gap read-side join so `time_usage` and `traffic_reports` host-aggregated rollups surface resolved FQDNs for ipv4/ipv6 race-loser rows — mirroring the `connection_events` coalesce from PR #728.
- LATERAL subquery joins `connection_events` on `(mac, dest_ip)` within the same calendar day; zero schema changes to `time_usage` or `traffic_reports`. Migration V21 adds a partial index on `connection_events(mac, dest_ip) WHERE resolved_host_value IS NOT NULL` to keep the join cheap.
- Every join site annotated `// TODO(#730):` so the cleanup PR has an exact grep target. **This stop-gap is removed by #730** once `dest_ip` lands on the usage wire contract after the router thaws (#654).

## Design rationale

`time_usage` has no `dest_ip` column (the router never included it in `UsageRecord`), so the same ingest-time backfill used by #728 for `connection_events` is not possible here. The narrowest correct join key available is `(mac, host_value)` — for an ipv4-typed row, `host_value` *is* the dest IP. A 24-hour window (same calendar day as the `time_usage.date`) bounds the scan; the partial index makes it selective. No cross-mac attribution is possible because the LATERAL is keyed on `tu.device_mac`.

## De-dup decision

If the agent emits some flows for a destination as `ipv4` (race-loser) and later emits the same destination as `fqdn` (after DNS resolved), we end up with two distinct `time_usage` rows for the same `(mac, date)`: one `ipv4` bucket (promoted by the join to `fqdn`) and one native `fqdn` bucket. After promotion both rows carry the same `HostId`, so a `GROUP BY host` rollup will sum them — a small, bounded double-count for the stop-gap period. The alternative (suppressing promoted rows when a native fqdn row exists) would require a second join and is fragile; we accept the overlap and document it in test #7 (`TimeUsageBackfillSpec`). #730 eliminates the overlap at ingest time.

## Test plan

- [x] `mill api.test` — 190/190 green (7 new tests in `TimeUsageBackfillSpec`).
- [x] ipv4 `time_usage` row + matching `resolved_host_value` in `connection_events` → `listForDevice` returns fqdn.
- [x] ipv4 row + no matching event → stays ipv4.
- [x] Different mac, same dest_ip → no cross-attribution.
- [x] connection_event from prior day (outside same-day window) → no promotion.
- [x] `listForDeviceMacs`: per-mac promotion is independent.
- [x] `snapshotAll`: promoted row keyed under fqdn in the result map.
- [x] Documented overlap: promoted ipv4 row + native fqdn row both appear separately.

**This is a stop-gap removed by #730.**

Refs: #583, #650, #654, #720, #728, #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)