### PR TITLE
docs: fix stale 5-min usage-cadence references (actual cadence is 60s)

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -20,15 +20,15 @@ case class PresenceRow(
  * Background: the router emits one usage record per (mac, dst_ip) per reporting window (~60 s),
  * each carrying the bucket duration in `active_seconds`. Summing `active_seconds` across hostnames
  * per mac over-counts wall-clock time — a device active in one bucket but connecting to
- * youtube.com, google.com and dropbox.com all in the same window would otherwise show 3× the
- * actual screen time. Presence collapses each bucket to one count per (mac, period_start) and then
+ * youtube.com, google.com and dropbox.com all in the same window would otherwise show 3× the actual
+ * screen time. Presence collapses each bucket to one count per (mac, period_start) and then
  * aggregates by mac.
  *
  * `site_time_limits.exempt_from_daily` decides whether a per-site bucket counts toward the daily
  * total. A bucket is excluded from the daily total only when EVERY hostname in it matches an exempt
- * pattern; a single non-exempt hostname pulls the whole bucket back into the total. The
- * per-site (per-pattern) minutes are computed the same way but per pattern, so the per-app limit
- * still ticks independently for its own cap check.
+ * pattern; a single non-exempt hostname pulls the whole bucket back into the total. The per-site
+ * (per-pattern) minutes are computed the same way but per pattern, so the per-app limit still ticks
+ * independently for its own cap check.
  */
 object Presence {
 
@@ -68,10 +68,9 @@ object Presence {
   }
 
   /**
-   * Per-mac total minutes for the day, counting each bucket once. A bucket counts iff at
-   * least one host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on
-   * something that bears on the daily cap. IP-literal hosts are never exempt (patterns only match
-   * FQDNs).
+   * Per-mac total minutes for the day, counting each bucket once. A bucket counts iff at least one
+   * host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on something that
+   * bears on the daily cap. IP-literal hosts are never exempt (patterns only match FQDNs).
    */
   def totalMinutesByMac(
       rows: List[PresenceRow],
@@ -82,8 +81,8 @@ object Presence {
   /**
    * Per-(mac, pattern) minutes, counting each bucket once per device per pattern when any host in
    * the bucket matches the pattern. Two hosts that both match the same pattern in one bucket still
-   * only contribute one bucket's worth of time; the same host matching two patterns contributes
-   * one bucket's worth to each (per-pattern caps are independent). IP-literal hosts never match
+   * only contribute one bucket's worth of time; the same host matching two patterns contributes one
+   * bucket's worth to each (per-pattern caps are independent). IP-literal hosts never match
    * patterns.
    */
   def patternMinutesByMac(
@@ -103,8 +102,8 @@ object Presence {
   /**
    * Per-host minutes across all macs, attributing each bucket's duration to every distinct host in
    * the bucket once. Used for the per-profile "what did they spend time on today" breakdown (#262).
-   * Note: summing across hosts can exceed the device's daily total — by design, the same bucket
-   * of activity contributes its full duration to each host the device touched in that window. The
+   * Note: summing across hosts can exceed the device's daily total — by design, the same bucket of
+   * activity contributes its full duration to each host the device touched in that window. The
    * daily cap still counts the bucket once via `totalMinutesByMac`.
    */
   def hostMinutes(rows: List[PresenceRow]): Map[HostId, Int] = {

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -17,16 +17,16 @@ case class PresenceRow(
 /**
  * Bucket-deduplicated minute accounting from `traffic_reports`.
  *
- * Background: the router emits one usage record per (mac, dst_ip) per 5-min window, each carrying
- * the bucket duration in `active_seconds`. Summing `active_seconds` across hostnames per mac
- * over-counts wall-clock time — a device active in one bucket but connecting to youtube.com,
- * google.com and dropbox.com all in the same 5 minutes would otherwise show 15 minutes of screen
- * time instead of 5. Presence collapses each bucket to one count per (mac, period_start) and then
+ * Background: the router emits one usage record per (mac, dst_ip) per reporting window (~60 s),
+ * each carrying the bucket duration in `active_seconds`. Summing `active_seconds` across hostnames
+ * per mac over-counts wall-clock time — a device active in one bucket but connecting to
+ * youtube.com, google.com and dropbox.com all in the same window would otherwise show 3× the
+ * actual screen time. Presence collapses each bucket to one count per (mac, period_start) and then
  * aggregates by mac.
  *
  * `site_time_limits.exempt_from_daily` decides whether a per-site bucket counts toward the daily
  * total. A bucket is excluded from the daily total only when EVERY hostname in it matches an exempt
- * pattern; a single non-exempt hostname pulls the whole 5-min window back into the total. The
+ * pattern; a single non-exempt hostname pulls the whole bucket back into the total. The
  * per-site (per-pattern) minutes are computed the same way but per pattern, so the per-app limit
  * still ticks independently for its own cap check.
  */
@@ -43,7 +43,7 @@ object Presence {
     bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
 
   /**
-   * Per-mac total active-seconds for the day, summing each 5-min bucket's max activeSeconds
+   * Per-mac total active-seconds for the day, summing each bucket's max activeSeconds
    * (bucket-deduplicated across hosts) once. A bucket counts iff at least one host in the bucket is
    * NOT in `exemptPatterns`. IP-literal hosts are never exempt (patterns only match FQDNs).
    *
@@ -68,7 +68,7 @@ object Presence {
   }
 
   /**
-   * Per-mac total minutes for the day, counting each 5-min bucket once. A bucket counts iff at
+   * Per-mac total minutes for the day, counting each bucket once. A bucket counts iff at
    * least one host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on
    * something that bears on the daily cap. IP-literal hosts are never exempt (patterns only match
    * FQDNs).
@@ -82,8 +82,9 @@ object Presence {
   /**
    * Per-(mac, pattern) minutes, counting each bucket once per device per pattern when any host in
    * the bucket matches the pattern. Two hosts that both match the same pattern in one bucket still
-   * only contribute 5 minutes; the same host matching two patterns contributes 5 minutes to each
-   * (per-pattern caps are independent). IP-literal hosts never match patterns.
+   * only contribute one bucket's worth of time; the same host matching two patterns contributes
+   * one bucket's worth to each (per-pattern caps are independent). IP-literal hosts never match
+   * patterns.
    */
   def patternMinutesByMac(
       rows: List[PresenceRow],
@@ -102,8 +103,8 @@ object Presence {
   /**
    * Per-host minutes across all macs, attributing each bucket's duration to every distinct host in
    * the bucket once. Used for the per-profile "what did they spend time on today" breakdown (#262).
-   * Note: summing across hosts can exceed the device's daily total — by design, the same 5-min
-   * bucket of activity contributes 5 minutes to each host the device touched in that window. The
+   * Note: summing across hosts can exceed the device's daily total — by design, the same bucket
+   * of activity contributes its full duration to each host the device touched in that window. The
    * daily cap still counts the bucket once via `totalMinutesByMac`.
    */
   def hostMinutes(rows: List[PresenceRow]): Map[HostId, Int] = {

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -11,7 +11,7 @@ import java.time.{Duration, Instant, ZoneOffset}
 
 /**
  * Router-side ingest endpoints. See docs/architecture-openwrt.md §5.4 / §5.5.
- *   - `POST /api/router/usage` — periodic 5-minute traffic + time rollups.
+ *   - `POST /api/router/usage` — periodic ~60 s traffic + time rollups.
  *   - `POST /api/router/events` — DHCP lease + first-seen-MAC + connection_attempt events.
  *
  * Both require a router bearer token resolved via [[RouterAuth]].
@@ -148,7 +148,7 @@ object RouterIngestRoutes {
     val date    = periodEnd.atZone(ZoneOffset.UTC).toLocalDate
     // A batch carries one record per (mac, dst_ip) but time_usage is keyed
     // by (mac, hostname, date), and activeSeconds is the bucket duration
-    // (the 5-min window — same value on every record that saw bytes>0). Two
+    // (the report window, ~60 s — same value on every record that saw bytes>0). Two
     // records with the same (mac, hostname) describe the *same* window of
     // active time, not two windows back-to-back, so the seconds delta is
     // the max of activeSeconds, not the sum. Bytes still sum because they

--- a/docs/architecture-critique.md
+++ b/docs/architecture-critique.md
@@ -350,7 +350,7 @@ code, and recent fix PRs):
 - Flash-cache snapshot for boot recovery (#309)
 - Boot-time default-deny skeleton (#308)
 - Smoke-probe post-reload to verify external tool actually applied (#328)
-- Usage POST every 5min, with exponential-backoff retry queue (#309)
+- Usage POST every 60s, with exponential-backoff retry queue (#309)
 - Events POST with cap-and-drop retry queue (#330)
 - Monotonic-clock scheduler immune to wall-clock jumps (#336)
 - Failover state machine with poll-age tracking (#311 / #321 / #331)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Every router agent must:
 1. **Enroll** once: exchange a one-time enrollment token for a long-lived bearer token.
 2. **Poll policy** every ~60 s, render the snapshot into the platform's native
    enforcement config, and reload atomically.
-3. **Report usage** every ~5 min: scrape platform-native traffic counters,
+3. **Report usage** every ~60 s: scrape platform-native traffic counters,
    attribute bytes to `(mac, hostname)` pairs, POST to `/api/router/usage`.
 4. **Stream events**: forward DHCP lease events and DNS query events to
    `/api/router/events`.
@@ -448,7 +448,7 @@ refetches when the version changes.
 
 ### 6.4 `POST /api/router/usage`
 
-Sent every 5 minutes. Idempotent on
+Sent every 60 s (configurable via `usage_report_interval`). Idempotent on
 `(routerId, periodStart, mac, host.type, host.value)` so retries are safe.
 
 **Request**
@@ -457,13 +457,13 @@ Sent every 5 minutes. Idempotent on
 {
   "routerId": "9c1f2e8a-...",
   "periodStart": "2026-05-02T14:00:00Z",
-  "periodEnd":   "2026-05-02T14:05:00Z",
+  "periodEnd":   "2026-05-02T14:01:00Z",
   "records": [
     {
       "mac": "aa:bb:cc:11:22:33",
       "ip":  "192.168.1.42",
       "host": { "type": "fqdn", "value": "youtube.com" },
-      "activeSeconds": 240,
+      "activeSeconds": 50,
       "bytesIn":  38123412,
       "bytesOut": 921000
     },
@@ -471,7 +471,7 @@ Sent every 5 minutes. Idempotent on
       "mac": "aa:bb:cc:11:22:33",
       "ip":  "192.168.1.42",
       "host": { "type": "ipv4", "value": "1.2.3.4" },
-      "activeSeconds": 60,
+      "activeSeconds": 30,
       "bytesIn":  120000,
       "bytesOut": 4000
     }
@@ -631,7 +631,7 @@ openwrt/
   does not re-read `conf-dir` files, so `reload` would leave new
   `dhcp-host=` / `nftset=` directives silently inactive (#328). On `304`:
   do nothing.
-- **Usage timer (5 min)** — scrape nftables counters, correlate with dnsmasq
+- **Usage timer (60 s)** — scrape nftables counters, correlate with dnsmasq
   query log + DHCP leases, POST to `/api/router/usage`. On 200, reset counters;
   on failure, retain and retry (endpoint is idempotent).
 - **Event watcher** — dnsmasq `--dhcp-script` hook for DHCP events; log tail
@@ -645,9 +645,9 @@ emits the affected MAC with `blocked = true, blockReason = TimeLimit` in
 the next snapshot. When a per-site limit is exhausted, the relevant host
 is added to that MAC's `extraBlocked`. **The agent does no time arithmetic.**
 
-Per-MAC usage is reported to the API every 5 minutes via
+Per-MAC usage is reported to the API every 60 s via
 `POST /api/router/usage` (§6.4); the API accumulates and decides. Worst-case
-overshoot is one usage-report interval (~5 min) plus one policy-poll interval
+overshoot is one usage-report interval (~60 s) plus one policy-poll interval
 (~60 s).
 
 ### 7.6 Block-page redirect

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -45,7 +45,7 @@ The agent runs three co-operative responsibilities in a single process:
 | Timer | Interval | What it does |
 |---|---|---|
 | Policy | 60 s | `GET /api/router/policy?since=<etag>`; on 200 atomically rewrites `/tmp/dnsmasq.d/wifihaven.conf` and `/tmp/nftables.d/wifihaven.nft`, then reloads dnsmasq + nft |
-| Usage | 5 min | Scrapes nftables counters, builds per-(mac, hostname) records, `POST /api/router/usage`, resets counters on success |
+| Usage | 60 s | Scrapes nftables counters, builds per-(mac, hostname) records, `POST /api/router/usage`, resets counters on success |
 | Events | per-flow | Watches `conntrack -E -e NEW`; batches `connection_attempt` events to `POST /api/router/events` |
 
 Policy decisions (drop, DNAT to block page) are enforced in-kernel by

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -3,7 +3,7 @@
 --
 -- Three concurrent responsibilities (cooperative timer loop):
 --   1. Policy timer  (60 s)  — GET /api/router/policy; rewrite dnsmasq + nft config
---   2. Usage timer   (5 min) — scrape nft counters; POST /api/router/usage
+--   2. Usage timer   (60 s)  — scrape nft counters; POST /api/router/usage
 --   3. Event watcher (async) — watch conntrack NEW flows; POST /api/router/events
 --
 -- Module layout:
@@ -288,7 +288,7 @@ end
 
 -- Snapshot nft counters for the activity tracker.  Cheap (same JSON we'd
 -- read at flush time) and reused by both the per-minute sampler and the
--- 5-min usage timer below.
+-- 60 s usage timer below.
 local function read_nft_counters()
   local pipe = io.popen("nft -j list set inet wifihaven mac_ip_tracking 2>/dev/null", "r")
   if not pipe then return nil end


### PR DESCRIPTION
## Summary

The agent has reported usage every 60s for some time (default in `openwrt/files/etc/config/wifihaven` is `usage_report_interval '60'`), but several docstrings, comments, and architecture sections still claimed ~5 min. Reword to match actual cadence. Doc/comment-only — no behavior change. `openwrt/files/usr/lib/lua/wifihaven/usage.lua` is intentionally left alone; #733 owns its cleanup.

Closes #734.

## Test plan
- [ ] Verify diff is comment/markdown-only (no `.scala`/`.lua` executable changes)