### PR TITLE
usage: server-side heartbeat filter for device/profile totals (#714)

### DIFF
--- a/api/resources/db/migration/V21__heartbeat_filter.sql
+++ b/api/resources/db/migration/V21__heartbeat_filter.sql
@@ -1,0 +1,21 @@
+-- V21__heartbeat_filter.sql
+-- #714: server-side heartbeat filter for device/profile screen-time totals.
+--
+-- Adds three knobs on household_settings to control a heartbeat filter applied
+-- inside Presence.totalSecondsByMac. The filter drops a traffic_reports row
+-- from per-device/per-profile totals (NOT from time_usage / per-site totals)
+-- when EITHER heuristic flags it as a heartbeat:
+--
+--   - bytes (bytes_in + bytes_out) below `heartbeat_bytes_threshold`
+--   - activeSeconds / period_seconds below `heartbeat_active_fraction_pct`
+--
+-- Raw traffic_reports rows are NOT modified — the filter is applied at the
+-- Presence aggregation stage only, so the underlying data remains debuggable.
+--
+-- Defaults: filter is OFF for the first roll. Operator flips it on after
+-- validating against prod data via the explain debug surface.
+
+ALTER TABLE household_settings
+  ADD COLUMN heartbeat_filter_enabled       BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN heartbeat_bytes_threshold      INT     NOT NULL DEFAULT 2048,
+  ADD COLUMN heartbeat_active_fraction_pct  INT     NOT NULL DEFAULT 20;

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -95,6 +95,7 @@ object Main extends ZIOAppDefault {
         extRepo,
         profileRepo,
         upRepo,
+        hsRepo,
         clock,
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -478,16 +478,23 @@ class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
 
 class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsRepo {
   def get: Task[HouseholdSettings] =
-    sql"SELECT daily_reset_time, daily_reset_tz FROM household_settings WHERE id=1"
-      .query[(LocalTime, ZoneId)]
+    sql"""SELECT daily_reset_time, daily_reset_tz,
+                 heartbeat_filter_enabled, heartbeat_bytes_threshold, heartbeat_active_fraction_pct
+            FROM household_settings WHERE id=1"""
+      .query[(LocalTime, ZoneId, Boolean, Int, Int)]
       .unique
-      .map(HouseholdSettings.apply)
+      .map { case (t, z, hbEnabled, hbBytes, hbFrac) =>
+        HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbFrac))
+      }
       .transact(xa)
 
   def update(s: HouseholdSettings): Task[Unit] =
     sql"""UPDATE household_settings
             SET daily_reset_time=${s.dailyResetTime},
                 daily_reset_tz=${s.dailyResetTz},
+                heartbeat_filter_enabled=${s.heartbeatFilter.enabled},
+                heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
+                heartbeat_active_fraction_pct=${s.heartbeatFilter.activeFractionPct},
                 updated_at=NOW()
           WHERE id=1""".update.run.transact(xa).unit
 
@@ -857,16 +864,20 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
       .transact(xa)
 
   def listPresenceRows(macs: List[MacAddress], date: LocalDate) = {
-    type Row = (MacAddress, Instant, HostId, Int)
+    type Row = (MacAddress, Instant, HostId, Int, Long, Long, Instant, Instant)
     macs match {
       case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
       case ms  =>
         val nel = cats.data.NonEmptyList.fromListUnsafe(ms.map(_.value))
-        val q   = fr"""SELECT mac, period_start, host_type, host_value, active_seconds
+        val q   = fr"""SELECT mac, period_start, host_type, host_value,
+                              active_seconds, bytes_in, bytes_out, period_start, period_end
                        FROM traffic_reports
                        WHERE date = $date AND """ ++ Fragments.in(fr"mac", nel)
         q.query[Row]
-          .map((m, ps, h, s) => wifihaven.api.presence.PresenceRow(m, ps, h, s))
+          .map { case (m, ps, host, secs, bin, bout, pStart, pEnd) =>
+            val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
+            wifihaven.api.presence.PresenceRow(m, ps, host, secs, bin + bout, periodSeconds)
+          }
           .to[List]
           .transact(xa)
     }

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -81,7 +81,7 @@ class PolicyServiceLive(
           if mins == 0 then acc else acc.updated(pat, mins)
         }
         val exemptPats = pSiteLims.filter(_.exemptFromDaily).map(_.domainPattern)
-        val perMacTot  = Presence.totalMinutesByMac(pPresence, exemptPats)
+        val perMacTot  = Presence.totalMinutesByMac(pPresence, exemptPats, settings.heartbeatFilter)
         val totalMins  = devicesIn.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
         val extMins    = exts.getOrElse(p.id, 0)
 
@@ -192,7 +192,8 @@ class PolicyServiceLive(
                         }
                         val exemptPats =
                           stlims.filter(_.exemptFromDaily).map(_.domainPattern)
-                        val perMacTot  = Presence.totalMinutesByMac(pPres, exemptPats)
+                        val perMacTot  =
+                          Presence.totalMinutesByMac(pPres, exemptPats, settings.heartbeatFilter)
                         val totalMins  = devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
                         timeLimitBlockFromDb(
                           h,

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -112,8 +112,8 @@ object Presence {
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
-   * classification verdict and the specific reasons it tripped, so the operator can tune
-   * thresholds against real prod data.
+   * classification verdict and the specific reasons it tripped, so the operator can tune thresholds
+   * against real prod data.
    */
   case class Classified(
       row: PresenceRow,
@@ -123,7 +123,7 @@ object Presence {
 
   def classifyRows(rows: List[PresenceRow], filter: HeartbeatFilter): List[Classified] =
     rows.map { r =>
-      val rsns = scala.collection.mutable.ListBuffer.empty[String]
+      val rsns  = scala.collection.mutable.ListBuffer.empty[String]
       if filter.enabled then {
         if r.bytes < filter.bytesThreshold then rsns += s"bytes<${filter.bytesThreshold}"
         if r.periodSeconds > 0 &&

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -1,17 +1,23 @@
 package wifihaven.api.presence
 
+import wifihaven.shared.HeartbeatFilter
 import wifihaven.shared.types.*
 import java.time.Instant
 
 /**
  * One bucket-host tuple from traffic_reports, used to compute presence-based minutes (one count per
  * (mac, period_start), regardless of how many hosts the device touched in that window).
+ *
+ * `bytes` is `bytes_in + bytes_out` for the row and `periodSeconds` is `period_end - period_start`;
+ * both exist solely to feed the #714 heartbeat filter and are ignored by all other consumers.
  */
 case class PresenceRow(
     mac: MacAddress,
     periodStart: Instant,
     host: HostId,
     activeSeconds: Int,
+    bytes: Long,
+    periodSeconds: Int,
 )
 
 /**
@@ -54,10 +60,13 @@ object Presence {
   def totalSecondsByMac(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
   ): Map[MacAddress, Long] = {
     def isExempt(h: HostId) =
       h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
-    rows
+    rows.iterator
+      .filterNot(r => isHeartbeat(r, filter))
+      .toList
       .groupBy(r => (r.mac, r.periodStart))
       .toList
       .collect {
@@ -76,8 +85,54 @@ object Presence {
   def totalMinutesByMac(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
   ): Map[MacAddress, Int] =
-    totalSecondsByMac(rows, exemptPatterns).view.mapValues(s => (s / 60).toInt).toMap
+    totalSecondsByMac(rows, exemptPatterns, filter).view.mapValues(s => (s / 60).toInt).toMap
+
+  /**
+   * #714 heartbeat classification, applied ONLY inside `totalSecondsByMac`/`totalMinutesByMac`.
+   * Per-site (`patternMinutesByMac`) and per-host (`hostMinutes`) breakdowns intentionally do not
+   * filter — heartbeats keep counting for per-site time for now; the operator wants to evaluate
+   * that separately. A row is classified as a heartbeat if the filter is enabled AND EITHER:
+   *
+   *   - total bytes < `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few
+   *     hundred), OR
+   *   - `activeSeconds * 100 / periodSeconds` < `activeFractionPct` (heartbeats land in one sample
+   *     in the period; real interactive use lights up many).
+   *
+   * Rows with `periodSeconds <= 0` are never classified as heartbeats — defensive against bad
+   * router clocks; treat as active.
+   */
+  def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
+    filter.enabled && (
+      row.bytes < filter.bytesThreshold ||
+        (row.periodSeconds > 0 &&
+          row.activeSeconds.toLong * 100 < filter.activeFractionPct.toLong * row.periodSeconds.toLong)
+    )
+
+  /**
+   * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
+   * classification verdict and the specific reasons it tripped, so the operator can tune
+   * thresholds against real prod data.
+   */
+  case class Classified(
+      row: PresenceRow,
+      classified: String,
+      reasons: List[String],
+  )
+
+  def classifyRows(rows: List[PresenceRow], filter: HeartbeatFilter): List[Classified] =
+    rows.map { r =>
+      val rsns = scala.collection.mutable.ListBuffer.empty[String]
+      if filter.enabled then {
+        if r.bytes < filter.bytesThreshold then rsns += s"bytes<${filter.bytesThreshold}"
+        if r.periodSeconds > 0 &&
+          r.activeSeconds.toLong * 100 < filter.activeFractionPct.toLong * r.periodSeconds.toLong
+        then rsns += s"activeFraction<${filter.activeFractionPct}%"
+      }
+      val label = if filter.enabled && rsns.nonEmpty then "heartbeat" else "active"
+      Classified(r, label, rsns.toList)
+    }
 
   /**
    * Per-(mac, pattern) minutes, counting each bucket once per device per pattern when any host in

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -372,10 +372,11 @@ object TimeRoutes {
       extRepo: TimeExtensionRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      hsRepo: HouseholdSettingsRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "time" / "status"                         ->
+      Method.GET / "api" / "time" / "status"                                 ->
         handler { (req: Request) =>
           for {
             claims <- requireAuth(req, auth)
@@ -384,6 +385,7 @@ object TimeRoutes {
             date    = LocalDate.parse(dateStr)
             allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            settings    <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
             devicesByPid = allDevices.groupBy(_.profileId)
             statuses <- ZIO
@@ -396,12 +398,13 @@ object TimeRoutes {
                   siteTimeLimitRepo,
                   trafficRepo,
                   extRepo,
+                  settings.heartbeatFilter,
                 )
               }
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(statuses.toJson)
         },
-      Method.GET / "api" / "time" / "status" / string("mac")         ->
+      Method.GET / "api" / "time" / "status" / string("mac")                 ->
         handler { (mac: String, req: Request) =>
           for {
             claims <- requireAuth(req, auth)
@@ -413,6 +416,7 @@ object TimeRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             status <- buildDeviceTimeStatus(
               device,
               date,
@@ -421,9 +425,55 @@ object TimeRoutes {
               siteTimeLimitRepo,
               trafficRepo,
               extRepo,
+              settings.heartbeatFilter,
             )
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(status.toJson)
+        },
+      Method.GET / "api" / "time" / "heartbeat-explain" / string("mac")      ->
+        handler { (mac: String, req: Request) =>
+          // #714: per-row classification of `traffic_reports` rows that feed into
+          // Presence.totalSecondsByMac for this device on `date` (default = today).
+          // The classification reflects current household_settings — i.e. the same
+          // verdict the live screen-time calculation is using right now. Operators
+          // tune `heartbeat_bytes_threshold` / `heartbeat_active_fraction_pct`
+          // against this surface before flipping `heartbeat_filter_enabled` on.
+          for {
+            claims <- requireAuth(req, auth)
+            today  <- clock.today
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
+            date    = LocalDate.parse(dateStr)
+            device <- deviceRepo
+              .findByMac(MacAddress.unsafe(normalizeMac(mac)))
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            rows     <- trafficRepo
+              .listPresenceRows(List(device.mac), date)
+              .mapError(ErrorMapper.dbErrorToResponse)
+            classified = wifihaven.api.presence.Presence
+              .classifyRows(rows, settings.heartbeatFilter)
+              .map { c =>
+                HeartbeatExplainRow(
+                  mac = c.row.mac,
+                  periodStart = c.row.periodStart.toString,
+                  host = c.row.host,
+                  activeSeconds = c.row.activeSeconds,
+                  periodSeconds = c.row.periodSeconds,
+                  bytes = c.row.bytes,
+                  classified = c.classified,
+                  reasons = c.reasons,
+                )
+              }
+          } yield Response.json(
+            HeartbeatExplainResponse(
+              mac = device.mac,
+              date = date.toString,
+              filter = settings.heartbeatFilter,
+              rows = classified,
+            ).toJson,
+          )
         },
       Method.POST / "api" / "time" / "extend"                        ->
         handler { (req: Request) =>
@@ -462,6 +512,7 @@ object TimeRoutes {
       stlRepo: SiteTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
       extRepo: TimeExtensionRepo,
+      heartbeatFilter: HeartbeatFilter,
   ): Task[ProfileTimeStatus] = {
     val macs = devices.map(_.mac)
     for {
@@ -473,7 +524,7 @@ object TimeRoutes {
       // Included sites (exemptFromDaily=false) count against the daily cap.
       exemptPats      = stls.filter(_.exemptFromDaily).map(_.domainPattern)
       perMacTotal     = wifihaven.api.presence.Presence
-        .totalMinutesByMac(presence, exemptPats)
+        .totalMinutesByMac(presence, exemptPats, heartbeatFilter)
       perMacPat       = wifihaven.api.presence.Presence
         .patternMinutesByMac(presence, stls.map(_.domainPattern))
       totalUsed       = devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
@@ -524,6 +575,7 @@ object TimeRoutes {
       stlRepo: SiteTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
       extRepo: TimeExtensionRepo,
+      heartbeatFilter: HeartbeatFilter,
   ): Task[DeviceTimeStatus] = {
     val pid = device.profileId
     for {
@@ -538,7 +590,7 @@ object TimeRoutes {
       // Included sites (exemptFromDaily=false) count against the daily cap.
       exemptPats = stls.filter(_.exemptFromDaily).map(_.domainPattern)
       totalUsed  = wifihaven.api.presence.Presence
-        .totalMinutesByMac(presence, exemptPats)
+        .totalMinutesByMac(presence, exemptPats, heartbeatFilter)
         .getOrElse(device.mac, 0)
       perPat     = wifihaven.api.presence.Presence
         .patternMinutesByMac(presence, stls.map(_.domainPattern))
@@ -656,7 +708,7 @@ object HouseholdSettingsRoutes {
               .fromEither(body.fromJson[UpdateHouseholdSettingsRequest])
               .mapError(e => Response.badRequest(e))
             _    <- repo
-              .update(HouseholdSettings(upd.dailyResetTime, upd.dailyResetTz))
+              .update(HouseholdSettings(upd.dailyResetTime, upd.dailyResetTz, upd.heartbeatFilter))
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -376,7 +376,7 @@ object TimeRoutes {
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "time" / "status"                                 ->
+      Method.GET / "api" / "time" / "status"                            ->
         handler { (req: Request) =>
           for {
             claims <- requireAuth(req, auth)
@@ -404,20 +404,20 @@ object TimeRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(statuses.toJson)
         },
-      Method.GET / "api" / "time" / "status" / string("mac")                 ->
+      Method.GET / "api" / "time" / "status" / string("mac")            ->
         handler { (mac: String, req: Request) =>
           for {
             claims <- requireAuth(req, auth)
             today  <- clock.today
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            device <- deviceRepo
+            device   <- deviceRepo
               .findByMac(MacAddress.unsafe(normalizeMac(mac)))
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            _        <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
             settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
-            status <- buildDeviceTimeStatus(
+            status   <- buildDeviceTimeStatus(
               device,
               date,
               profileRepo,
@@ -430,7 +430,7 @@ object TimeRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(status.toJson)
         },
-      Method.GET / "api" / "time" / "heartbeat-explain" / string("mac")      ->
+      Method.GET / "api" / "time" / "heartbeat-explain" / string("mac") ->
         handler { (mac: String, req: Request) =>
           // #714: per-row classification of `traffic_reports` rows that feed into
           // Presence.totalSecondsByMac for this device on `date` (default = today).
@@ -443,11 +443,11 @@ object TimeRoutes {
             today  <- clock.today
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            device <- deviceRepo
+            device   <- deviceRepo
               .findByMac(MacAddress.unsafe(normalizeMac(mac)))
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            _        <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
             settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             rows     <- trafficRepo
               .listPresenceRows(List(device.mac), date)
@@ -475,7 +475,7 @@ object TimeRoutes {
             ).toJson,
           )
         },
-      Method.POST / "api" / "time" / "extend"                        ->
+      Method.POST / "api" / "time" / "extend"                           ->
         handler { (req: Request) =>
           for {
             claims <- requireWriter(req, auth)
@@ -490,7 +490,7 @@ object TimeRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(s"""{"id":${id.value},"grantedMinutes":${ger.extraMinutes}}""")
         },
-      Method.GET / "api" / "time" / "extensions" / long("profileId") ->
+      Method.GET / "api" / "time" / "extensions" / long("profileId")    ->
         handler { (profileId: Long, req: Request) =>
           val pid = ProfileId(profileId)
           for {

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -104,6 +104,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 120)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -114,6 +115,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -148,6 +150,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           off1            <- seedTraffic(routerId, testMac, "minecraft.net", today, 45)
           _               <- seedTraffic(routerId, testMac, "google.com", today, 30, off1)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -158,6 +161,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -197,6 +201,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           off1            <- seedTraffic(routerId, testMac, "google.com", today, 60)
           _               <- seedTraffic(routerId, testMac, "youtube.com", today, 20, off1)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -207,6 +212,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -250,6 +256,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           // 60 min of YouTube usage; since exemptFromDaily=false it must appear in usedMins
           _               <- seedTraffic(routerId, testMac, "youtube.com", today, 60)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -260,6 +267,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -297,6 +305,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           today = TestClock.schoolDayAfternoon.toLocalDate
           _               <- seedTraffic(routerId, testMac, "minecraft.net", today, 120)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes  = TimeRoutes.routes(
             auth,
@@ -307,6 +316,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           extBody = GrantExtensionRequest(kidsId, 30, Some("Homework finished early")).toJson
@@ -341,6 +351,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 60)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -351,6 +362,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           body   = GrantExtensionRequest(kidsId, 15, Some("Good behavior")).toJson
@@ -383,6 +395,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           kidsId          <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -393,6 +406,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           body   = GrantExtensionRequest(kidsId, 30, None).toJson
@@ -418,6 +432,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- tlRepo.upsert(kidsId, 60)
           _               <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -428,6 +443,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           grant  = (mins: Int) =>
@@ -470,6 +486,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- TestLayers.seedDevice(deviceRepo, "aa:bb:cc:dd:ee:01", "iPad", kidsId)
           _           <- TestLayers.seedDevice(deviceRepo, "aa:bb:cc:dd:ee:02", "iPhone", kidsId)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -480,6 +497,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -518,6 +536,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- seedTraffic(routerId, mac1, "minecraft.net", today, 40)
           _               <- seedTraffic(routerId, mac2, "youtube.com", today, 35)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -528,6 +547,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -573,6 +593,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- seedTraffic(routerId, mac1, "youtube.com", today, 20)
           _               <- seedTraffic(routerId, mac2, "youtube.com", today, 20)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -583,6 +604,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -624,6 +646,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           o2 <- seedTraffic(routerId, mac2, "youtube.com", today, 15)
           _  <- seedTraffic(routerId, mac2, "roblox.com", today, 5, bucketOffset = o2)
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -634,6 +657,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -678,6 +702,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             seedTraffic(routerId, mac, s"host$i.example.com", today, mins, bucketOffset = i * 20)
           }
           userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
           routes = TimeRoutes.routes(
             auth,
@@ -688,6 +713,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             extRepo,
             profileRepo,
             userProfileRepo,
+            hsRepo,
             clock,
           )
           req    = Request
@@ -750,6 +776,95 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           // profile unblocked; we just assert the cap hasn't been hit.
         } yield assertTrue(!kidsPolicy.rules.blocked) &&
           assertTrue(kidsPolicy.rules.blockReason.isEmpty)
+      },
+      test("GET /api/time/heartbeat-explain returns per-row classification matching live config") {
+        // #714: explain endpoint surfaces every traffic_reports row that feeds Presence with the
+        // current heartbeat-filter verdict, so the operator can tune thresholds against real data.
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          tlRepo         <- ZIO.service[TimeLimitRepo]
+          stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          deviceRepo     <- ZIO.service[DeviceRepo]
+          trafficRepo    <- ZIO.service[TrafficReportRepo]
+          extRepo        <- ZIO.service[TimeExtensionRepo]
+          hsRepoSvc      <- ZIO.service[HouseholdSettingsRepo]
+          auth           <- makeAuth
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId       <- seedRouter
+          today           = TestClock.schoolDayAfternoon.toLocalDate
+          today0          = today.atStartOfDay(ZoneOffset.UTC).toInstant
+          // Two rows on the same device today:
+          //   - apns.apple.com: 60-byte heartbeat, 5s active within 60s
+          //   - youtube.com:    500_000 bytes, 60s active within 60s
+          _              <- trafficRepo.insertBatch(List(
+            TrafficReportInsert(
+              routerId,
+              MacAddress.unsafe(testMac),
+              None,
+              HostId.Fqdn(Hostname.unsafe("apns.apple.com")),
+              today,
+              today0,
+              today0.plusSeconds(60),
+              5,
+              30L,
+              30L,
+            ),
+            TrafficReportInsert(
+              routerId,
+              MacAddress.unsafe(testMac),
+              None,
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              today,
+              today0.plusSeconds(120),
+              today0.plusSeconds(180),
+              60,
+              250_000L,
+              250_000L,
+            ),
+          ))
+          // Flip the filter on with the production defaults so the explain output reflects them.
+          _              <- hsRepoSvc.update(
+            HouseholdSettings(
+              java.time.LocalTime.of(0, 0),
+              java.time.ZoneId.of("UTC"),
+              HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20),
+            ),
+          )
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode(s"/api/time/heartbeat-explain/$testMac").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp   <- routes.runZIO(req)
+          body   <- resp.body.asString
+          out    <- ZIO.fromEither(body.fromJson[HeartbeatExplainResponse])
+          apns    = out.rows.find(_.host.value == "apns.apple.com").get
+          yt      = out.rows.find(_.host.value == "youtube.com").get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.filter.enabled) &&
+          assertTrue(out.rows.length == 2) &&
+          assertTrue(apns.classified == "heartbeat") &&
+          assertTrue(apns.reasons.exists(_.startsWith("bytes<"))) &&
+          assertTrue(apns.reasons.exists(_.startsWith("activeFraction<"))) &&
+          assertTrue(yt.classified == "active") &&
+          assertTrue(yt.reasons.isEmpty)
       },
     ) @@ TestAspect.sequential,
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -781,53 +781,55 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         // #714: explain endpoint surfaces every traffic_reports row that feeds Presence with the
         // current heartbeat-filter verdict, so the operator can tune thresholds against real data.
         for {
-          _              <- cleanDb
-          profileRepo    <- ZIO.service[ProfileRepo]
-          tlRepo         <- ZIO.service[TimeLimitRepo]
-          stlRepo        <- ZIO.service[SiteTimeLimitRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
-          deviceRepo     <- ZIO.service[DeviceRepo]
-          trafficRepo    <- ZIO.service[TrafficReportRepo]
-          extRepo        <- ZIO.service[TimeExtensionRepo]
-          hsRepoSvc      <- ZIO.service[HouseholdSettingsRepo]
-          auth           <- makeAuth
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          routerId       <- seedRouter
-          today           = TestClock.schoolDayAfternoon.toLocalDate
-          today0          = today.atStartOfDay(ZoneOffset.UTC).toInstant
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          hsRepoSvc   <- ZIO.service[HouseholdSettingsRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today  = TestClock.schoolDayAfternoon.toLocalDate
+          today0 = today.atStartOfDay(ZoneOffset.UTC).toInstant
           // Two rows on the same device today:
           //   - apns.apple.com: 60-byte heartbeat, 5s active within 60s
           //   - youtube.com:    500_000 bytes, 60s active within 60s
-          _              <- trafficRepo.insertBatch(List(
-            TrafficReportInsert(
-              routerId,
-              MacAddress.unsafe(testMac),
-              None,
-              HostId.Fqdn(Hostname.unsafe("apns.apple.com")),
-              today,
-              today0,
-              today0.plusSeconds(60),
-              5,
-              30L,
-              30L,
+          _               <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("apns.apple.com")),
+                today,
+                today0,
+                today0.plusSeconds(60),
+                5,
+                30L,
+                30L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                today0.plusSeconds(120),
+                today0.plusSeconds(180),
+                60,
+                250_000L,
+                250_000L,
+              ),
             ),
-            TrafficReportInsert(
-              routerId,
-              MacAddress.unsafe(testMac),
-              None,
-              HostId.Fqdn(Hostname.unsafe("youtube.com")),
-              today,
-              today0.plusSeconds(120),
-              today0.plusSeconds(180),
-              60,
-              250_000L,
-              250_000L,
-            ),
-          ))
+          )
           // Flip the filter on with the production defaults so the explain output reflects them.
-          _              <- hsRepoSvc.update(
+          _               <- hsRepoSvc.update(
             HouseholdSettings(
               java.time.LocalTime.of(0, 0),
               java.time.ZoneId.of("UTC"),
@@ -852,11 +854,11 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           req    = Request
             .get(URL.decode(s"/api/time/heartbeat-explain/$testMac").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp   <- routes.runZIO(req)
-          body   <- resp.body.asString
-          out    <- ZIO.fromEither(body.fromJson[HeartbeatExplainResponse])
-          apns    = out.rows.find(_.host.value == "apns.apple.com").get
-          yt      = out.rows.find(_.host.value == "youtube.com").get
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[HeartbeatExplainResponse])
+          apns = out.rows.find(_.host.value == "apns.apple.com").get
+          yt   = out.rows.find(_.host.value == "youtube.com").get
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(out.filter.enabled) &&
           assertTrue(out.rows.length == 2) &&

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -205,16 +205,16 @@ object PresenceSpec extends ZIOSpecDefault {
       test("filter on, but periodSeconds=0 (bad clock): never classified heartbeat by fraction") {
         // Defensive: with periodSeconds=0 the fraction rule is short-circuited so we don't divide
         // by zero or accidentally classify every such row as a heartbeat. Bytes-check still runs.
-        val f          = HeartbeatFilter(enabled = true, bytesThreshold = 100, activeFractionPct = 50)
+        val f = HeartbeatFilter(enabled = true, bytesThreshold = 100, activeFractionPct = 50)
         val passingRow = row(mac1, 0, "x.example.com", secs = 30, bytes = 1_000L, periodSeconds = 0)
         val droppedRow = row(mac2, 0, "y.example.com", secs = 30, bytes = 5L, periodSeconds = 0)
         assertTrue(!Presence.isHeartbeat(passingRow, f)) &&
         assertTrue(Presence.isHeartbeat(droppedRow, f))
       },
       test("classifyRows surfaces both heuristics' reasons when both trip") {
-        val f      = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
-        val rows   = List(row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60))
-        val out    = Presence.classifyRows(rows, f)
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
+        val rows = List(row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60))
+        val out  = Presence.classifyRows(rows, f)
         val reasons = out.head.reasons
         assertTrue(out.length == 1) &&
         assertTrue(out.head.classified == "heartbeat") &&

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.unit
 
 import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.shared.HeartbeatFilter
 import wifihaven.shared.types.*
 import zio.test.*
 
@@ -15,11 +16,25 @@ object PresenceSpec extends ZIOSpecDefault {
   private val base               = Instant.parse("2026-05-13T00:00:00Z")
   private def b(i: Int): Instant = base.plusSeconds(i * 300L)
 
-  private def row(mac: MacAddress, bucket: Int, host: String, secs: Int = 300) =
-    PresenceRow(mac, b(bucket), HostId.Fqdn(Hostname.unsafe(host)), secs)
+  private def row(
+      mac: MacAddress,
+      bucket: Int,
+      host: String,
+      secs: Int = 300,
+      bytes: Long = 1_000_000L,
+      periodSeconds: Int = 300,
+  ) =
+    PresenceRow(mac, b(bucket), HostId.Fqdn(Hostname.unsafe(host)), secs, bytes, periodSeconds)
 
-  private def ipRow(mac: MacAddress, bucket: Int, ip: String, secs: Int = 300) =
-    PresenceRow(mac, b(bucket), HostId.IPv4(IpAddress.unsafe(ip)), secs)
+  private def ipRow(
+      mac: MacAddress,
+      bucket: Int,
+      ip: String,
+      secs: Int = 300,
+      bytes: Long = 1_000_000L,
+      periodSeconds: Int = 300,
+  ) =
+    PresenceRow(mac, b(bucket), HostId.IPv4(IpAddress.unsafe(ip)), secs, bytes, periodSeconds)
 
   def spec = suite("Presence")(
     suite("totalMinutesByMac")(
@@ -147,6 +162,70 @@ object PresenceSpec extends ZIOSpecDefault {
         assertTrue(
           Presence.totalMinutesByMac(rows, List("*")) == Map(mac1 -> 5),
         )
+      },
+    ),
+    suite("heartbeat filter (#714)")(
+      test("filter off: low-byte rows still count toward the daily total") {
+        val rows = List(row(mac1, 0, "apns.apple.com", secs = 60, bytes = 60L, periodSeconds = 60))
+        assertTrue(Presence.totalMinutesByMac(rows, Nil, HeartbeatFilter.Off) == Map(mac1 -> 1))
+      },
+      test("filter on: bucket with only sub-threshold-bytes rows collapses to 0") {
+        // APNs keepalive: 60s period, ~60 bytes total, lights up only the one sample.
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
+        val rows = List(
+          row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60),
+        )
+        assertTrue(Presence.totalMinutesByMac(rows, Nil, f) == Map.empty[MacAddress, Int])
+      },
+      test("filter on: mixed bucket (heartbeat + real traffic) keeps the bucket's minutes") {
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
+        val rows = List(
+          row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60),
+          row(mac1, 0, "youtube.com", secs = 60, bytes = 500_000L, periodSeconds = 60),
+        )
+        // Heartbeat row dropped; real row keeps the 60s bucket alive → 1 min.
+        assertTrue(Presence.totalMinutesByMac(rows, Nil, f) == Map(mac1 -> 1))
+      },
+      test("filter on, low-fraction-only heuristic still trips") {
+        // Above the byte floor, but only 2s of 60s active → drop.
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 100, activeFractionPct = 20)
+        val rows = List(
+          row(mac1, 0, "rcs.google.com", secs = 2, bytes = 5_000L, periodSeconds = 60),
+        )
+        assertTrue(Presence.totalMinutesByMac(rows, Nil, f) == Map.empty[MacAddress, Int])
+      },
+      test("filter on: bytes-only heuristic still trips when active fraction is high") {
+        // Active the whole minute, but tiny payload (e.g. NTP-like) → drop.
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
+        val rows = List(
+          row(mac1, 0, "time.apple.com", secs = 60, bytes = 200L, periodSeconds = 60),
+        )
+        assertTrue(Presence.totalMinutesByMac(rows, Nil, f) == Map.empty[MacAddress, Int])
+      },
+      test("filter on, but periodSeconds=0 (bad clock): never classified heartbeat by fraction") {
+        // Defensive: with periodSeconds=0 the fraction rule is short-circuited so we don't divide
+        // by zero or accidentally classify every such row as a heartbeat. Bytes-check still runs.
+        val f          = HeartbeatFilter(enabled = true, bytesThreshold = 100, activeFractionPct = 50)
+        val passingRow = row(mac1, 0, "x.example.com", secs = 30, bytes = 1_000L, periodSeconds = 0)
+        val droppedRow = row(mac2, 0, "y.example.com", secs = 30, bytes = 5L, periodSeconds = 0)
+        assertTrue(!Presence.isHeartbeat(passingRow, f)) &&
+        assertTrue(Presence.isHeartbeat(droppedRow, f))
+      },
+      test("classifyRows surfaces both heuristics' reasons when both trip") {
+        val f      = HeartbeatFilter(enabled = true, bytesThreshold = 2048, activeFractionPct = 20)
+        val rows   = List(row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60))
+        val out    = Presence.classifyRows(rows, f)
+        val reasons = out.head.reasons
+        assertTrue(out.length == 1) &&
+        assertTrue(out.head.classified == "heartbeat") &&
+        assertTrue(reasons.exists(_.startsWith("bytes<"))) &&
+        assertTrue(reasons.exists(_.startsWith("activeFraction<")))
+      },
+      test("classifyRows reports rows as active when filter is disabled") {
+        val rows = List(row(mac1, 0, "apns.apple.com", secs = 5, bytes = 60L, periodSeconds = 60))
+        val out  = Presence.classifyRows(rows, HeartbeatFilter.Off)
+        assertTrue(out.head.classified == "active") &&
+        assertTrue(out.head.reasons.isEmpty)
       },
     ),
     suite("hostMinutes")(

--- a/api/test/src/unit/SchedulingSpec.scala
+++ b/api/test/src/unit/SchedulingSpec.scala
@@ -1,7 +1,7 @@
 package wifihaven.api.unit
 
 import wifihaven.api.policy.PolicyService
-import wifihaven.shared.{HouseholdSettings, Schedule}
+import wifihaven.shared.{HeartbeatFilter, HouseholdSettings, Schedule}
 import wifihaven.shared.types.*
 import zio.test.*
 
@@ -152,27 +152,27 @@ object SchedulingSpec extends ZIOSpecDefault {
     ),
     suite("nextDailyResetAfter")(
       test("00:00 LA in standard time (PST, Jan 15 2026) → 08:00Z next day") {
-        val settings = HouseholdSettings(LocalTime.of(0, 0), LA)
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
         val now      = Instant.parse("2026-01-15T20:00:00Z") // Jan 15 12:00 PST
         // Next 00:00 PST = 2026-01-16 00:00 PST = 2026-01-16 08:00Z
         val expected = Instant.parse("2026-01-16T08:00:00Z")
         assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
       },
       test("00:00 LA in daylight time (PDT, Jun 15 2026) → 07:00Z next day") {
-        val settings = HouseholdSettings(LocalTime.of(0, 0), LA)
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
         val now      = Instant.parse("2026-06-15T19:00:00Z") // Jun 15 12:00 PDT
         // Next 00:00 PDT = 2026-06-16 00:00 PDT = 2026-06-16 07:00Z
         val expected = Instant.parse("2026-06-16T07:00:00Z")
         assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
       },
       test("at exactly the reset Instant: returns NEXT day's reset (strict-after)") {
-        val settings = HouseholdSettings(LocalTime.of(0, 0), UTC)
+        val settings = HouseholdSettings(LocalTime.of(0, 0), UTC, HeartbeatFilter.Off)
         val now      = Instant.parse("2026-05-13T00:00:00Z")
         val expected = Instant.parse("2026-05-14T00:00:00Z")
         assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
       },
       test("reset later in the day, before reset → today's reset") {
-        val settings = HouseholdSettings(LocalTime.of(3, 0), UTC)
+        val settings = HouseholdSettings(LocalTime.of(3, 0), UTC, HeartbeatFilter.Off)
         val now      = Instant.parse("2026-05-13T01:00:00Z")
         val expected = Instant.parse("2026-05-13T03:00:00Z")
         assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -230,11 +230,54 @@ case class ScheduleRequest(
 case class HouseholdSettings(
     dailyResetTime: LocalTime,
     dailyResetTz: ZoneId,
+    heartbeatFilter: HeartbeatFilter,
 ) derives JsonCodec
 
 case class UpdateHouseholdSettingsRequest(
     dailyResetTime: LocalTime,
     dailyResetTz: ZoneId,
+    heartbeatFilter: HeartbeatFilter,
+) derives JsonCodec
+
+/**
+ * #714: knobs for the server-side heartbeat filter applied at the Presence aggregation stage.
+ * The filter drops a `traffic_reports` row from per-device/per-profile screen-time totals (NOT
+ * from `time_usage`-derived per-site totals) when EITHER heuristic flags it as a heartbeat —
+ * total bytes below `bytesThreshold`, OR `activeSeconds / periodSeconds` below
+ * `activeFractionPct`. Defaults to OFF so the operator can validate against real data via the
+ * `/api/time/heartbeat-explain/{mac}` debug surface before flipping it on.
+ */
+case class HeartbeatFilter(
+    enabled: Boolean,
+    bytesThreshold: Int,
+    activeFractionPct: Int,
+) derives JsonCodec
+
+object HeartbeatFilter {
+  val Off: HeartbeatFilter = HeartbeatFilter(enabled = false, bytesThreshold = 0, activeFractionPct = 0)
+}
+
+/**
+ * #714: response body for `GET /api/time/heartbeat-explain/{mac}?date=`. Returns the live filter
+ * config alongside per-row classification so the operator can tune thresholds against real data
+ * before flipping `heartbeat_filter_enabled` on.
+ */
+case class HeartbeatExplainResponse(
+    mac: MacAddress,
+    date: String,
+    filter: HeartbeatFilter,
+    rows: List[HeartbeatExplainRow],
+) derives JsonCodec
+
+case class HeartbeatExplainRow(
+    mac: MacAddress,
+    periodStart: String,
+    host: HostId,
+    activeSeconds: Int,
+    periodSeconds: Int,
+    bytes: Long,
+    classified: String,
+    reasons: List[String],
 ) derives JsonCodec
 
 case class SiteTimeLimitRequest(

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -240,12 +240,12 @@ case class UpdateHouseholdSettingsRequest(
 ) derives JsonCodec
 
 /**
- * #714: knobs for the server-side heartbeat filter applied at the Presence aggregation stage.
- * The filter drops a `traffic_reports` row from per-device/per-profile screen-time totals (NOT
- * from `time_usage`-derived per-site totals) when EITHER heuristic flags it as a heartbeat —
- * total bytes below `bytesThreshold`, OR `activeSeconds / periodSeconds` below
- * `activeFractionPct`. Defaults to OFF so the operator can validate against real data via the
- * `/api/time/heartbeat-explain/{mac}` debug surface before flipping it on.
+ * #714: knobs for the server-side heartbeat filter applied at the Presence aggregation stage. The
+ * filter drops a `traffic_reports` row from per-device/per-profile screen-time totals (NOT from
+ * `time_usage`-derived per-site totals) when EITHER heuristic flags it as a heartbeat — total bytes
+ * below `bytesThreshold`, OR `activeSeconds / periodSeconds` below `activeFractionPct`. Defaults to
+ * OFF so the operator can validate against real data via the `/api/time/heartbeat-explain/{mac}`
+ * debug surface before flipping it on.
  */
 case class HeartbeatFilter(
     enabled: Boolean,
@@ -254,7 +254,8 @@ case class HeartbeatFilter(
 ) derives JsonCodec
 
 object HeartbeatFilter {
-  val Off: HeartbeatFilter = HeartbeatFilter(enabled = false, bytesThreshold = 0, activeFractionPct = 0)
+  val Off: HeartbeatFilter =
+    HeartbeatFilter(enabled = false, bytesThreshold = 0, activeFractionPct = 0)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a server-side heartbeat filter applied **only** inside `Presence.totalSecondsByMac` so APNs / iCloud / RCS keepalives no longer pad device/profile screen-time totals.
- Raw `traffic_reports` rows are untouched; per-site (`time_usage` / `patternMinutesByMac`) and per-host (`hostMinutes`) accounting are deliberately unfiltered.
- Two heuristics, drop if EITHER trips:
  - `bytes_in + bytes_out < heartbeat_bytes_threshold` (default **2048** — one TCP keepalive ≈ 60 B; real interactive use blows past 2 KB within seconds)
  - `activeSeconds / period_seconds < heartbeat_active_fraction_pct` (default **20** — heartbeats land in one sample, streaming/interactive lights up many)
- Knobs on `household_settings` (new migration `V21`): `heartbeat_filter_enabled` (default **FALSE**), `heartbeat_bytes_threshold` (2048), `heartbeat_active_fraction_pct` (20). The PUT body on `/api/household/settings` now accepts the `heartbeatFilter` block.
- Debug surface: `GET /api/time/heartbeat-explain/{mac}?date=YYYY-MM-DD` returns one entry per traffic_reports row that feeds Presence, each labelled `"active"` or `"heartbeat"` with the specific reason(s) — `bytes<N` and/or `activeFraction<P%` — so the operator can tune thresholds against real prod data before flipping the filter on.

## How to enable

```
PUT /api/household/settings
{
  "dailyResetTime": "00:00",
  "dailyResetTz":   "America/Los_Angeles",
  "heartbeatFilter": {
    "enabled":           true,
    "bytesThreshold":    2048,
    "activeFractionPct": 20
  }
}
```

Validate first against `GET /api/time/heartbeat-explain/{mac}` with `enabled:false`/`true` — the explain output reflects current settings, so a dry-run can be done by flipping the knobs and reading classifications without affecting cap math (caps follow `Presence.totalMinutesByMac`, which reads the same settings).

## Threshold defaults

- `heartbeat_bytes_threshold = 2048` (issue rationale: keepalive ≈ 60 B, HTTP/2 PINGs + handshakes ≈ a few hundred B; real interactive use clears 2 KB within seconds).
- `heartbeat_active_fraction_pct = 20` (issue rationale: 12s of activity within a 60s window — heartbeats hit one sample, real use lights up many).
- `heartbeat_filter_enabled = FALSE` (ship dark; operator validates against prod via the explain surface, then flips on).

## Hard constraints honored

- Server-side only — no agent / ingest changes (`RouterIngestRoutes` untouched).
- `traffic_reports` rows unchanged; filter applies at Presence aggregation only.
- Per-site (`time_usage`) totals untouched.
- Default OFF.

## Test plan

- [x] `mill api.compile` (clean)
- [x] `mill api.test` — 8 new unit tests in `PresenceSpec` (filter off, mixed bucket, bytes-only trip, fraction-only trip, periodSeconds=0 fallback, classifyRows reasons + active label) + 1 new feature test in `TimeApiSpec` exercising `/api/time/heartbeat-explain`.
- [ ] Live: enable filter on Kids profile, watch `usedMins` vs prior baseline for one school day, then compare `/api/time/heartbeat-explain` rows for any unexpected false positives.

Fixes #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)