### PR TITLE
config: remove dead dns block from application.conf.example

### DIFF
--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -31,15 +31,4 @@ wifihaven {
     # Example: "https://wifihaven.example,https://www.wifihaven.example"
     allowedOrigins = ""
   }
-
-  dns {
-    cacheRefreshSeconds = 60
-    port                = 53
-    location            = "home"
-    upstreamPrimary     = "1.1.1.1"
-    upstreamSecondary   = "8.8.8.8"
-    upstreamPort        = 53
-    logBatchSize        = 500
-    logFlushSeconds     = 5
-  }
 }


### PR DESCRIPTION
## Summary
- Drops the `dns { ... }` block at lines 35-44 of `config/application.conf.example`. None of the fields (`cacheRefreshSeconds`, `upstreamPrimary`, `logBatchSize`, etc.) are read by `AppConfig` / `Config.scala` — verified via `grep -r DnsConfig api/src shared/` (no hits).
- Operators tuning these today would see no effect; removing prevents that confusion.

Refs #738 (checklist item 1)

## Test plan
- [ ] No code references — grep confirms zero readers
- [ ] `application.conf.example` still parses (pure HOCON delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)