### PR TITLE
config: thread WIFIHAVEN_DB_POOL_SIZE through entrypoint (#737)

### DIFF
--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -5,7 +5,7 @@ wifihaven {
     database = "wifihaven"
     user     = "wifihaven"
     password = "changeme"
-    poolSize = 10
+    poolSize = 5
   }
 
   http {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 : "${WIFIHAVEN_DB_NAME:=wifihaven}"
 : "${WIFIHAVEN_DB_USER:=wifihaven}"
 : "${WIFIHAVEN_DB_PASSWORD:=wifihaven}"
+: "${WIFIHAVEN_DB_POOL_SIZE:=5}"
 : "${WIFIHAVEN_HTTP_HOST:=0.0.0.0}"
 : "${WIFIHAVEN_HTTP_PORT:=8080}"
 : "${WIFIHAVEN_STATIC_DIR:=/app/web}"
@@ -33,7 +34,7 @@ wifihaven {
     database = "${WIFIHAVEN_DB_NAME}"
     user     = "${WIFIHAVEN_DB_USER}"
     password = "${WIFIHAVEN_DB_PASSWORD}"
-    poolSize = 5
+    poolSize = ${WIFIHAVEN_DB_POOL_SIZE}
   }
   http {
     host      = "${WIFIHAVEN_HTTP_HOST}"


### PR DESCRIPTION
## Summary

- Adds `WIFIHAVEN_DB_POOL_SIZE` env (default 5) to [docker/entrypoint.sh](docker/entrypoint.sh) and threads it into the rendered `application.conf`, removing the hardcoded `poolSize = 5` that was silently shadowing every dockerized deploy's HOCON.
- Aligns [config/application.conf.example](config/application.conf.example) from `poolSize = 10` to `5` so the example matches actual prod default and stops misleading operators.
- Intentionally does **not** add the env to [render.yaml](render.yaml) — defaults preserve current behavior; the operator wires it in if/when prod hits pool exhaustion.

Closes #737

## Test plan

- [ ] `bash -n docker/entrypoint.sh` (syntax check passes locally)
- [ ] CI e2e renders `application.conf` with `poolSize = 5` unchanged (default path)
- [ ] Manual: `WIFIHAVEN_DB_POOL_SIZE=7` env override reflects in rendered conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)