### PR TITLE
api: rename DashboardNowRoutes.ActiveWindow → RecentActivityWindow

### DIFF
--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -16,18 +16,19 @@ import java.time.Instant
  *
  * Returns every profile visible to the caller, including idle ones (so dashboard layout is stable).
  * Within each profile, lists devices that produced either a connection_events row in the last
- * `ActiveWindow` (60s) OR a traffic_reports period whose `period_end` falls in the last
+ * `RecentActivityWindow` (5m) OR a traffic_reports period whose `period_end` falls in the last
  * `TrafficActiveWindow` (5m). For each active device, returns the top hosts by active_seconds over
  * the last `TopHostsWindow` (30m) and the in-progress session (via [[Sessions.stitch]]) iff its
  * latest period_end is within `SessionTolerance` (10m) of "now".
  */
 object DashboardNowRoutes {
 
-  private val ActiveWindow        = java.time.Duration.ofSeconds(300) // connection_events: last 5m
-  private val TrafficActiveWindow = java.time.Duration.ofMinutes(5)
-  private val TopHostsWindow      = java.time.Duration.ofMinutes(30)
-  private val SessionTolerance    = java.time.Duration.ofMinutes(10)
-  private val TopHostsLimit       = 3
+  // UX-level "is this device recently active?" knob; not config-tunable. See #738.
+  private val RecentActivityWindow = java.time.Duration.ofSeconds(300) // connection_events: last 5m
+  private val TrafficActiveWindow  = java.time.Duration.ofMinutes(5)
+  private val TopHostsWindow       = java.time.Duration.ofMinutes(30)
+  private val SessionTolerance     = java.time.Duration.ofMinutes(10)
+  private val TopHostsLimit        = 3
 
   def routes(
       auth: AuthService,
@@ -51,7 +52,7 @@ object DashboardNowRoutes {
             visibleMacs = visibleDevs.map(_.mac)
             // Both inputs in parallel.
             since       = now.minus(TopHostsWindow)
-            connSince   = now.minus(ActiveWindow)
+            connSince   = now.minus(RecentActivityWindow)
             lastSeenF <- connRepo.lastSeenByMacSince(connSince).fork
             rowsF     <- trafficRepo
               .listSessionRows(


### PR DESCRIPTION
## Summary
- Rename `ActiveWindow` → `RecentActivityWindow` in [api/src/routes/DashboardNowRoutes.scala](api/src/routes/DashboardNowRoutes.scala) to remove the implication of tunability; it's a fixed UX-level "is this device recently active?" threshold.
- Add a comment marking it not config-tunable and pointing to the audit issue.
- Drive-by: fix stale "60s" in the scaladoc (actual value is 300s = 5m).
- Confirmed not tied to bucket math — it only feeds `connSince = now.minus(...)` for `connRepo.lastSeenByMacSince`.

Refs #738 (checklist item 2)

## Test plan
- [ ] `grep -rn ActiveWindow api/ shared/` shows no stale references
- [ ] Compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)