### PR TITLE
openwrt: share block-page IPC paths via wifihaven.paths module

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -1,0 +1,16 @@
+-- Shared IPC paths used by the wifihaven agent, dns-tail sidecar, and the
+-- uhttpd block-page handler. Centralised here (#738) so a future rename
+-- touches one file instead of three — handler.lua in particular lives under
+-- /www and is easy to miss.
+local M = {}
+
+-- Block-page IPC (#437, #594): the agent writes after every policy apply,
+-- the uhttpd lua handler reads on each request.
+M.block_page_api_url  = "/var/run/wifihaven/api_url"
+M.block_page_reasons  = "/var/run/wifihaven/blocked_reasons"
+M.block_page_hosts    = "/var/run/wifihaven/blocked_hosts"
+
+-- ip → hostname cache (#259): wifihaven-dns-tail writes, wifihaven-agent reads.
+M.dns_cache = "/tmp/wifihaven-dns-cache.txt"
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -21,6 +21,7 @@ local render     = require("wifihaven.render")
 local dns_log    = require("wifihaven.dns_log")
 local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
+local paths      = require("wifihaven.paths")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -189,9 +190,9 @@ os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifi
 -- render.write_blocked_reasons after every snapshot apply) to look up the
 -- per-MAC reason for the current device.
 
-local BLOCK_PAGE_API_URL_PATH  = "/var/run/wifihaven/api_url"
-local BLOCK_PAGE_REASONS_PATH  = "/var/run/wifihaven/blocked_reasons"
-local BLOCK_PAGE_HOSTS_PATH    = "/var/run/wifihaven/blocked_hosts"  -- #594
+local BLOCK_PAGE_API_URL_PATH  = paths.block_page_api_url
+local BLOCK_PAGE_REASONS_PATH  = paths.block_page_reasons
+local BLOCK_PAGE_HOSTS_PATH    = paths.block_page_hosts  -- #594
 
 do
   local f = io.open(BLOCK_PAGE_API_URL_PATH, "w")
@@ -319,7 +320,7 @@ end
 -- Drop the memoization. The cache file lives on tmpfs and is at most a few
 -- kilobytes, so reading it once per outbound flow costs microseconds —
 -- well below the cost of the conntrack -E line that triggered the lookup.
-local dns_cache_path = "/tmp/wifihaven-dns-cache.txt"
+local dns_cache_path = paths.dns_cache
 local dns_cache_ttl  = 3600
 
 local function lookup_hostname(dst_ip)

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -10,6 +10,7 @@ local uci       = require("uci")
 local dns_log   = require("wifihaven.dns_log")
 local conntrack = require("wifihaven.conntrack")
 local log       = require("wifihaven.log")
+local paths     = require("wifihaven.paths")
 
 local cursor = uci.cursor()
 local function uci_get(opt, default)
@@ -18,7 +19,7 @@ end
 
 local debug_opt   = uci_get("debug", "0")
 local source_path = "/tmp/wifihaven-dnsmasq.log"
-local cache_path  = "/tmp/wifihaven-dns-cache.txt"
+local cache_path  = paths.dns_cache
 local tmp_path    = cache_path .. ".tmp"
 local leases_path = "/tmp/dhcp.leases"
 local nft_table   = "inet wifihaven"

--- a/openwrt/files/www/wifihaven/handler.lua
+++ b/openwrt/files/www/wifihaven/handler.lua
@@ -9,6 +9,7 @@
 -- without uhttpd in the loop.
 
 local block_page = require("wifihaven.block_page")
+local paths      = require("wifihaven.paths")
 
 local function read_file(path)
   local f = io.open(path, "r")
@@ -26,7 +27,7 @@ function handle_request(env)
   local arp = read_file("/proc/net/arp")
   local mac = block_page.parse_arp(arp, remote)
 
-  local reasons = read_file("/var/run/wifihaven/blocked_reasons")
+  local reasons = read_file(paths.block_page_reasons)
   local reason  = mac and block_page.parse_reasons(reasons, mac) or nil
   -- No MAC-wide reason means the DNAT was triggered by a per-(MAC, host) drop,
   -- not a whole-MAC block. Look up the host in the per-MAC classifier file to
@@ -34,7 +35,7 @@ function handle_request(env)
   -- to "ExtraBlocked" if the classifier file is missing or the lookup misses
   -- (#576 default).
   if mac and not reason then
-    local hosts_content = read_file("/var/run/wifihaven/blocked_hosts")
+    local hosts_content = read_file(paths.block_page_hosts)
     local source = block_page.parse_blocked_hosts(hosts_content, mac, host)
     if source == "extra_blocked" then
       reason = "ExtraBlocked"
@@ -45,7 +46,7 @@ function handle_request(env)
     end
   end
 
-  local api_url = read_file("/var/run/wifihaven/api_url")
+  local api_url = read_file(paths.block_page_api_url)
   if api_url then api_url = api_url:gsub("%s+$", "") end
 
   local body = block_page.render_html(api_url, host, mac, reason)


### PR DESCRIPTION
## Summary
- New [openwrt/files/usr/lib/lua/wifihaven/paths.lua](openwrt/files/usr/lib/lua/wifihaven/paths.lua) exporting the four IPC paths (`api_url`, `blocked_reasons`, `blocked_hosts`, `dns_cache`).
- `wifihaven-agent`, `wifihaven-dns-tail`, and `www/wifihaven/handler.lua` now `require("wifihaven.paths")` instead of duplicating string literals.
- `handler.lua` lives under `/www/` and is the easy-to-miss reader — centralising prevents a future renamer from updating the agent and forgetting it.
- Makefile install rule globs `*.lua`, so the new module ships automatically. uhttpd lua module path already loads `wifihaven.*` (handler.lua already does `require("wifihaven.block_page")`).
- Comments in `conntrack.lua`, init scripts, and docs left unchanged — the issue is about code drift, not documentation.

Closes #738 (final checklist item; closes the issue after #741 and #743 land).

## Test plan
- [x] `bash openwrt/test/run_tests.sh` — all suites green (397 successes / 0 failures in the busted run, all bats specs pass)
- [x] `lua` smoke-load of `wifihaven.paths` resolves the expected four keys
- [x] `grep -rn` for each literal in `openwrt/files/` returns only the module + comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)