### PR TITLE
usage: per-device daily timeline + /api/usage/series (#721, #716)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -99,6 +99,7 @@ object Main extends ZIOAppDefault {
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++
       SessionRoutes.routes(auth, trafficRepo, deviceRepo, profileRepo, upRepo) ++
+      UsageRoutes.routes(auth, deviceRepo, trafficRepo, upRepo, clock) ++
       DashboardNowRoutes.routes(
         auth,
         trafficRepo,

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -31,21 +31,21 @@ object UsageRoutes {
             macRaw <- ZIO
               .fromOption(req.url.queryParam("mac"))
               .orElseFail(Response.badRequest("mac is required"))
-            mac      = MacAddress.unsafe(normalizeMac(macRaw))
-            dateStr  = req.url.queryParam("date").getOrElse(today.toString)
-            date    <- ZIO
+            mac     = MacAddress.unsafe(normalizeMac(macRaw))
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
+            date <- ZIO
               .attempt(LocalDate.parse(dateStr))
               .orElseFail(Response.badRequest(s"invalid date: $dateStr"))
-            tzStr    = req.url.queryParam("tz").getOrElse("UTC")
-            zone    <- ZIO
+            tzStr = req.url.queryParam("tz").getOrElse("UTC")
+            zone <- ZIO
               .attempt(ZoneId.of(tzStr))
               .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
-            topN     = req.url
-                         .queryParam("topN")
-                         .flatMap(_.toIntOption)
-                         .getOrElse(5)
-                         .max(1)
-                         .min(20)
+            topN = req.url
+              .queryParam("topN")
+              .flatMap(_.toIntOption)
+              .getOrElse(5)
+              .max(1)
+              .min(20)
             device  <- deviceRepo
               .findByMac(mac)
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -64,11 +64,11 @@ object UsageRoutes {
               .listPresenceRows(List(mac), date.minusDays(1))
               .mapError(ErrorMapper.dbErrorToResponse)
             // Keep only the rows whose period_start falls on `date` in `zone`.
-            inDay   = (rowsPrv ++ rowsD ++ rowsNxt).filter { r =>
+            inDay               = (rowsPrv ++ rowsD ++ rowsNxt).filter { r =>
               r.periodStart.atZone(zone).toLocalDate == date
             }
             (topHosts, buckets) = UsageSeries.build(inDay, zone, topN)
-            resp = UsageSeriesResponse(
+            resp                = UsageSeriesResponse(
               deviceMac = mac,
               deviceName = device.name,
               date = date.toString,

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -1,0 +1,82 @@
+package wifihaven.api.routes
+
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.usage.UsageSeries
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+
+import java.time.{LocalDate, ZoneId}
+
+// ── Usage routes (#716) ─────────────────────────────────────────────────────
+//
+// First consumer: #721 per-device daily timeline.
+object UsageRoutes {
+  def routes(
+      auth: AuthService,
+      deviceRepo: DeviceRepo,
+      trafficRepo: TrafficReportRepo,
+      userProfileRepo: UserProfileRepo,
+      clock: Clock,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "usage" / "series" ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAuth(req, auth)
+            today  <- clock.today
+            macRaw <- ZIO
+              .fromOption(req.url.queryParam("mac"))
+              .orElseFail(Response.badRequest("mac is required"))
+            mac      = MacAddress.unsafe(normalizeMac(macRaw))
+            dateStr  = req.url.queryParam("date").getOrElse(today.toString)
+            date    <- ZIO
+              .attempt(LocalDate.parse(dateStr))
+              .orElseFail(Response.badRequest(s"invalid date: $dateStr"))
+            tzStr    = req.url.queryParam("tz").getOrElse("UTC")
+            zone    <- ZIO
+              .attempt(ZoneId.of(tzStr))
+              .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
+            topN     = req.url
+                         .queryParam("topN")
+                         .flatMap(_.toIntOption)
+                         .getOrElse(5)
+                         .max(1)
+                         .min(20)
+            device  <- deviceRepo
+              .findByMac(mac)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+            _       <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            // Pull two adjacent UTC days so a tz like America/Los_Angeles can
+            // assemble its calendar day from buckets split across midnight UTC.
+            // Cheap on a per-mac filter via idx_traffic_reports_mac_date.
+            rowsD   <- trafficRepo
+              .listPresenceRows(List(mac), date)
+              .mapError(ErrorMapper.dbErrorToResponse)
+            rowsNxt <- trafficRepo
+              .listPresenceRows(List(mac), date.plusDays(1))
+              .mapError(ErrorMapper.dbErrorToResponse)
+            rowsPrv <- trafficRepo
+              .listPresenceRows(List(mac), date.minusDays(1))
+              .mapError(ErrorMapper.dbErrorToResponse)
+            // Keep only the rows whose period_start falls on `date` in `zone`.
+            inDay   = (rowsPrv ++ rowsD ++ rowsNxt).filter { r =>
+              r.periodStart.atZone(zone).toLocalDate == date
+            }
+            (topHosts, buckets) = UsageSeries.build(inDay, zone, topN)
+            resp = UsageSeriesResponse(
+              deviceMac = mac,
+              deviceName = device.name,
+              date = date.toString,
+              tz = zone.getId,
+              topHosts = topHosts,
+              buckets = buckets,
+            )
+          } yield Response.json(resp.toJson)
+        },
+    )
+}

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -1,0 +1,89 @@
+package wifihaven.api.usage
+
+import wifihaven.api.presence.PresenceRow
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+
+import java.time.ZoneId
+
+/**
+ * Hourly per-device usage timeline used by `GET /api/usage/series` (#716, #721).
+ *
+ * Two facts the routine has to reconcile:
+ *   - Bucket-deduped wall-clock minutes per (mac, period_start) — what the daily cap counts.
+ *   - Per-host minutes within those buckets — currently bucket-presence (overlapping across hosts),
+ *     which over-counts (#715).
+ *
+ * The output proportionally allocates each 5-min bucket's wall-clock duration across the distinct
+ * hosts present in that bucket (even-share), so each hour's `perHost` + `otherMins` sums exactly to
+ * `totalMins`. Bytes-weighted allocation is a #715 follow-up.
+ */
+object UsageSeries {
+
+  /**
+   * Build the per-hour timeline for one device.
+   *
+   * @param rows         PresenceRow values for the day, single mac.
+   * @param date         The local-calendar date the operator requested.
+   * @param zone         Local zone for hour bucketing (UTC bars are useless for parents).
+   * @param topN         Number of named-host stacks to expose; the long tail collapses to
+   *                     `otherMins`.
+   */
+  def build(
+      rows: List[PresenceRow],
+      zone: ZoneId,
+      topN: Int,
+  ): (List[UsageHostTotal], List[UsageBucket]) = {
+    // Group rows into 5-min buckets. activeSeconds is identical for every row
+    // in a bucket (the router emits one batch per window) so .head is fine.
+    val fiveMin = rows.groupBy(r => (r.periodStart)).toList.map { case (ps, bucket) =>
+      val hour = ps.atZone(zone).getHour
+      val secs = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+      val hosts = bucket.iterator.map(_.host).toSet.toList
+      (hour, secs, hosts)
+    }
+
+    // Day-total per host, in proportional seconds (= bucket secs / hosts-in-bucket).
+    val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
+    for ((_, secs, hosts) <- fiveMin if hosts.nonEmpty) {
+      val share = secs.toDouble / hosts.size
+      for (h <- hosts) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+    }
+
+    val ordered = perHostDaySecs.toList
+      .map { case (h, s) => (h, (s / 60).toInt) }
+      .sortBy { case (h, m) => (-m, h.value) }
+
+    val topHostIds = ordered.take(topN).map(_._1).toSet
+    val topHosts   = ordered.take(topN).map((h, m) => UsageHostTotal(h, m))
+
+    // Stable host ordering within each bucket: top-host daily rank.
+    val rank = topHosts.iterator.map(_.host).zipWithIndex.toMap
+
+    val byHour = fiveMin.groupBy(_._1)
+    val buckets = (0 until 24).map { hr =>
+      val hrBuckets = byHour.getOrElse(hr, Nil)
+      val total     = hrBuckets.iterator.map((_, s, _) => s.toLong).sum
+      val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
+      var other     = 0.0
+      for ((_, secs, hosts) <- hrBuckets if hosts.nonEmpty) {
+        val share = secs.toDouble / hosts.size
+        for (h <- hosts)
+          if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+          else other += share
+      }
+      val perHostList = perHost.iterator
+        .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }
+        .toList
+        .sortBy(u => rank.getOrElse(u.host, Int.MaxValue))
+      UsageBucket(
+        hour = hr,
+        totalMins = (total / 60).toInt,
+        perHost = perHostList,
+        otherMins = (other / 60).toInt,
+      )
+    }.toList
+
+    (topHosts, buckets)
+  }
+}

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -53,8 +53,13 @@ object UsageSeries {
       for (h <- hosts) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
     }
 
+    // Drop hosts whose proportional day-total floors to 0 — they'd render
+    // as "host.com 0m" in the legend and as invisible stacks. Whatever
+    // seconds they did accrue still land in otherMins via the per-bucket
+    // residual fold below.
     val ordered = perHostDaySecs.toList
       .map { case (h, s) => (h, (s / 60).toInt) }
+      .filter { case (_, m) => m > 0 }
       .sortBy { case (h, m) => (-m, h.value) }
 
     val topHostIds = ordered.take(topN).map(_._1).toSet

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -72,15 +72,23 @@ object UsageSeries {
           if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
           else other += share
       }
+      // Floor per-host minutes (consistent with how the daily cap reports
+      // wall-clock minutes) and drop hosts that round to zero — keeps the
+      // legend useful for sparse heartbeat traffic. The flooring residual,
+      // including the 0-min hosts, lands in otherMins so the invariant
+      // sum(perHost.mins) + otherMins == totalMins holds for the chart.
       val perHostList = perHost.iterator
         .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }
+        .filter(_.mins > 0)
         .toList
         .sortBy(u => rank.getOrElse(u.host, Int.MaxValue))
+      val totalMins   = (total / 60).toInt
+      val perHostSum  = perHostList.iterator.map(_.mins).sum
       UsageBucket(
         hour = hr,
-        totalMins = (total / 60).toInt,
+        totalMins = totalMins,
         perHost = perHostList,
-        otherMins = (other / 60).toInt,
+        otherMins = (totalMins - perHostSum).max(0),
       )
     }.toList
 

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -23,11 +23,14 @@ object UsageSeries {
   /**
    * Build the per-hour timeline for one device.
    *
-   * @param rows         PresenceRow values for the day, single mac.
-   * @param date         The local-calendar date the operator requested.
-   * @param zone         Local zone for hour bucketing (UTC bars are useless for parents).
-   * @param topN         Number of named-host stacks to expose; the long tail collapses to
-   *                     `otherMins`.
+   * @param rows
+   *   PresenceRow values for the day, single mac.
+   * @param date
+   *   The local-calendar date the operator requested.
+   * @param zone
+   *   Local zone for hour bucketing (UTC bars are useless for parents).
+   * @param topN
+   *   Number of named-host stacks to expose; the long tail collapses to `otherMins`.
    */
   def build(
       rows: List[PresenceRow],
@@ -36,9 +39,9 @@ object UsageSeries {
   ): (List[UsageHostTotal], List[UsageBucket]) = {
     // Group rows into 5-min buckets. activeSeconds is identical for every row
     // in a bucket (the router emits one batch per window) so .head is fine.
-    val fiveMin = rows.groupBy(r => (r.periodStart)).toList.map { case (ps, bucket) =>
-      val hour = ps.atZone(zone).getHour
-      val secs = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+    val fiveMin = rows.groupBy(r => r.periodStart).toList.map { case (ps, bucket) =>
+      val hour  = ps.atZone(zone).getHour
+      val secs  = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
       val hosts = bucket.iterator.map(_.host).toSet.toList
       (hour, secs, hosts)
     }
@@ -60,7 +63,7 @@ object UsageSeries {
     // Stable host ordering within each bucket: top-host daily rank.
     val rank = topHosts.iterator.map(_.host).zipWithIndex.toMap
 
-    val byHour = fiveMin.groupBy(_._1)
+    val byHour  = fiveMin.groupBy(_._1)
     val buckets = (0 until 24).map { hr =>
       val hrBuckets = byHour.getOrElse(hr, Nil)
       val total     = hrBuckets.iterator.map((_, s, _) => s.toLong).sum
@@ -82,8 +85,8 @@ object UsageSeries {
         .filter(_.mins > 0)
         .toList
         .sortBy(u => rank.getOrElse(u.host, Int.MaxValue))
-      val totalMins   = (total / 60).toInt
-      val perHostSum  = perHostList.iterator.map(_.mins).sum
+      val totalMins = (total / 60).toInt
+      val perHostSum = perHostList.iterator.map(_.mins).sum
       UsageBucket(
         hour = hr,
         totalMins = totalMins,

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1,0 +1,246 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.time.{LocalDate, ZoneOffset}
+
+object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private val testMac = "aa:bb:cc:dd:ee:01"
+
+  private def seedRouter: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo] { rr =>
+      for {
+        id <- rr.create("test-router", Sha256Hex.unsafe("t" * 64))
+        _  <- rr.completeEnrollment(id, Sha256Hex.unsafe("u" * 64))
+      } yield id
+    }
+
+  /**
+   * Insert one row into traffic_reports at (date, hour:minute UTC) for (mac, hostname). The full
+   * bucket is `active_seconds = 300`, matching what the router emits in the wild.
+   */
+  private def insertRow(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      hour: Int,
+      minute: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Int] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val start = date.atStartOfDay(ZoneOffset.UTC).toInstant
+        .plusSeconds(hour * 3600L + minute * 60L)
+      val end   = start.plusSeconds(300)
+      tr.insertBatch(
+        List(
+          TrafficReportInsert(
+            routerId,
+            MacAddress.unsafe(mac),
+            None,
+            HostId.Fqdn(Hostname.unsafe(hostname)),
+            date,
+            start,
+            end,
+            300,
+            0L,
+            0L,
+          ),
+        ),
+      )
+    }
+
+  private def buildRoutes =
+    for {
+      deviceRepo      <- ZIO.service[DeviceRepo]
+      trafficRepo     <- ZIO.service[TrafficReportRepo]
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      clock           <- ZIO.service[Clock]
+      auth            <- makeAuth
+    } yield (UsageRoutes.routes(auth, deviceRepo, trafficRepo, userProfileRepo, clock), auth)
+
+  def spec = suite("Usage API")(
+    suite("GET /api/usage/series")(
+      test("requires mac param") {
+        for {
+          _              <- cleanDb
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req             = Request
+            .get(URL.decode("/api/usage/series").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.BadRequest)
+      },
+      test("returns 24 hourly buckets, top-N hosts, and empty long tail for empty day") {
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          deviceRepo     <- ZIO.service[DeviceRepo]
+          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          today           = TestClock.schoolDayAfternoon.toLocalDate
+          req             = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+          body           <- resp.body.asString
+          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.buckets.length == 24) &&
+          assertTrue(out.buckets.forall(_.totalMins == 0)) &&
+          assertTrue(out.topHosts.isEmpty)
+      },
+      test("buckets activity by UTC hour and proportionally allocates per host") {
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          deviceRepo     <- ZIO.service[DeviceRepo]
+          trafficRepo    <- ZIO.service[TrafficReportRepo]
+          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId       <- seedRouter
+          today           = TestClock.schoolDayAfternoon.toLocalDate
+          // 14:00–14:05 UTC, two hosts in same 5-min bucket → 5 wall-clock mins
+          // split 2.5min/2.5min between hosts (floored to 2m each + 1m other).
+          _              <- insertRow(routerId, testMac, "youtube.com", today, 14, 0)
+          _              <- insertRow(routerId, testMac, "google.com", today, 14, 0)
+          // 14:05–14:10 UTC, youtube.com alone → 5m to youtube
+          _              <- insertRow(routerId, testMac, "youtube.com", today, 14, 5)
+          // 03:00 UTC, drop.com alone → 5m to drop in hour 3
+          _              <- insertRow(routerId, testMac, "drop.com", today, 3, 0)
+          _              <- ZIO.service[TrafficReportRepo].as(trafficRepo)
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req             = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+          body           <- resp.body.asString
+          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          h14             = out.buckets(14)
+          h3              = out.buckets(3)
+          h0              = out.buckets(0)
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.buckets.length == 24) &&
+          assertTrue(h14.totalMins == 10) && // two 5-min buckets in hour 14
+          assertTrue(h3.totalMins == 5) &&
+          assertTrue(h0.totalMins == 0) &&
+          // youtube wins hour 14: 2.5min from shared bucket + 5min solo = 7.5
+          assertTrue(h14.perHost.headOption.exists(_.host.value == "youtube.com")) &&
+          assertTrue(h14.perHost.exists(p => p.host.value == "google.com"))
+      },
+      test("topN collapses long-tail into otherMins") {
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          deviceRepo     <- ZIO.service[DeviceRepo]
+          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId       <- seedRouter
+          today           = TestClock.schoolDayAfternoon.toLocalDate
+          // 7 distinct hosts each in their own 5-min bucket. topN=2 must
+          // keep two named, fold the other 5 into otherMins.
+          _              <- ZIO.foreachDiscard(0 until 7) { i =>
+            insertRow(routerId, testMac, s"host$i.com", today, 10, i * 5)
+          }
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req             = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today&topN=2").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+          body           <- resp.body.asString
+          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          h10             = out.buckets(10)
+        } yield assertTrue(out.topHosts.length == 2) &&
+          assertTrue(h10.totalMins == 35) &&
+          assertTrue(h10.perHost.length == 2) &&
+          assertTrue(h10.otherMins == 25) // 5 hosts × 5 min
+      },
+      test("tz parameter buckets by local-hour") {
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          deviceRepo     <- ZIO.service[DeviceRepo]
+          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId       <- seedRouter
+          today           = TestClock.schoolDayAfternoon.toLocalDate
+          // 06:00 UTC on a Jan day == 22:00 previous day in PST (UTC-8). When
+          // requested with tz=America/Los_Angeles for `today`, this row
+          // belongs to the *previous* local day and should not appear.
+          _              <- insertRow(routerId, testMac, "youtube.com", today, 6, 0)
+          // 20:00 UTC == 12:00 PST on `today` → hour 12 in PST bucket layout.
+          _              <- insertRow(routerId, testMac, "google.com", today, 20, 0)
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req             = Request
+            .get(
+              URL
+                .decode(
+                  s"/api/usage/series?mac=$testMac&date=$today&tz=America/Los_Angeles",
+                )
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+          body           <- resp.body.asString
+          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+        } yield assertTrue(out.tz == "America/Los_Angeles") &&
+          // The 06:00 UTC sample falls into the previous local day → excluded.
+          assertTrue(out.buckets.iterator.map(_.totalMins).sum == 5) &&
+          assertTrue(out.buckets(12).totalMins == 5)
+      },
+      test("rejects unknown mac with 404") {
+        for {
+          _              <- cleanDb
+          rb             <- buildRoutes
+          (routes, auth)  = rb
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req             = Request
+            .get(URL.decode("/api/usage/series?mac=aa:bb:cc:dd:ee:ff").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp           <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.NotFound)
+      },
+    ) @@ TestAspect.sequential,
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -54,7 +54,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       minute: Int,
   ): ZIO[TrafficReportRepo, Throwable, Int] =
     ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
-      val start = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val start = date
+        .atStartOfDay(ZoneOffset.UTC)
+        .toInstant
         .plusSeconds(hour * 3600L + minute * 60L)
       val end   = start.plusSeconds(300)
       tr.insertBatch(
@@ -88,34 +90,34 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
     suite("GET /api/usage/series")(
       test("requires mac param") {
         for {
-          _              <- cleanDb
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          req             = Request
+          _  <- cleanDb
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(URL.decode("/api/usage/series").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
+          resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.BadRequest)
       },
       test("returns 24 hourly buckets, top-N hosts, and empty long tail for empty day") {
         for {
-          _              <- cleanDb
-          profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
-          deviceRepo     <- ZIO.service[DeviceRepo]
-          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          today           = TestClock.schoolDayAfternoon.toLocalDate
-          req             = Request
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          rb          <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          req   = Request
             .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
-          body           <- resp.body.asString
-          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(out.buckets.length == 24) &&
           assertTrue(out.buckets.forall(_.totalMins == 0)) &&
@@ -123,36 +125,36 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       },
       test("buckets activity by UTC hour and proportionally allocates per host") {
         for {
-          _              <- cleanDb
-          profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
-          deviceRepo     <- ZIO.service[DeviceRepo]
-          trafficRepo    <- ZIO.service[TrafficReportRepo]
-          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          routerId       <- seedRouter
-          today           = TestClock.schoolDayAfternoon.toLocalDate
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
           // 14:00–14:05 UTC, two hosts in same 5-min bucket → 5 wall-clock mins
           // split 2.5min/2.5min between hosts (floored to 2m each + 1m other).
-          _              <- insertRow(routerId, testMac, "youtube.com", today, 14, 0)
-          _              <- insertRow(routerId, testMac, "google.com", today, 14, 0)
+          _  <- insertRow(routerId, testMac, "youtube.com", today, 14, 0)
+          _  <- insertRow(routerId, testMac, "google.com", today, 14, 0)
           // 14:05–14:10 UTC, youtube.com alone → 5m to youtube
-          _              <- insertRow(routerId, testMac, "youtube.com", today, 14, 5)
+          _  <- insertRow(routerId, testMac, "youtube.com", today, 14, 5)
           // 03:00 UTC, drop.com alone → 5m to drop in hour 3
-          _              <- insertRow(routerId, testMac, "drop.com", today, 3, 0)
-          _              <- ZIO.service[TrafficReportRepo].as(trafficRepo)
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          req             = Request
+          _  <- insertRow(routerId, testMac, "drop.com", today, 3, 0)
+          _  <- ZIO.service[TrafficReportRepo].as(trafficRepo)
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
-          body           <- resp.body.asString
-          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
-          h14             = out.buckets(14)
-          h3              = out.buckets(3)
-          h0              = out.buckets(0)
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          h14 = out.buckets(14)
+          h3  = out.buckets(3)
+          h0  = out.buckets(0)
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(out.buckets.length == 24) &&
           assertTrue(h14.totalMins == 10) && // two 5-min buckets in hour 14
@@ -164,29 +166,29 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       },
       test("topN collapses long-tail into otherMins") {
         for {
-          _              <- cleanDb
-          profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
-          deviceRepo     <- ZIO.service[DeviceRepo]
-          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          routerId       <- seedRouter
-          today           = TestClock.schoolDayAfternoon.toLocalDate
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
           // 7 distinct hosts each in their own 5-min bucket. topN=2 must
           // keep two named, fold the other 5 into otherMins.
-          _              <- ZIO.foreachDiscard(0 until 7) { i =>
+          _  <- ZIO.foreachDiscard(0 until 7) { i =>
             insertRow(routerId, testMac, s"host$i.com", today, 10, i * 5)
           }
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          req             = Request
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today&topN=2").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
-          body           <- resp.body.asString
-          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
-          h10             = out.buckets(10)
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          h10 = out.buckets(10)
         } yield assertTrue(out.topHosts.length == 2) &&
           assertTrue(h10.totalMins == 35) &&
           assertTrue(h10.perHost.length == 2) &&
@@ -194,24 +196,24 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       },
       test("tz parameter buckets by local-hour") {
         for {
-          _              <- cleanDb
-          profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
-          deviceRepo     <- ZIO.service[DeviceRepo]
-          kidsId         <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _              <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          routerId       <- seedRouter
-          today           = TestClock.schoolDayAfternoon.toLocalDate
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
           // 06:00 UTC on a Jan day == 22:00 previous day in PST (UTC-8). When
           // requested with tz=America/Los_Angeles for `today`, this row
           // belongs to the *previous* local day and should not appear.
-          _              <- insertRow(routerId, testMac, "youtube.com", today, 6, 0)
+          _  <- insertRow(routerId, testMac, "youtube.com", today, 6, 0)
           // 20:00 UTC == 12:00 PST on `today` → hour 12 in PST bucket layout.
-          _              <- insertRow(routerId, testMac, "google.com", today, 20, 0)
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          req             = Request
+          _  <- insertRow(routerId, testMac, "google.com", today, 20, 0)
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(
               URL
                 .decode(
@@ -221,9 +223,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 .get,
             )
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
-          body           <- resp.body.asString
-          out            <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
         } yield assertTrue(out.tz == "America/Los_Angeles") &&
           // The 06:00 UTC sample falls into the previous local day → excluded.
           assertTrue(out.buckets.iterator.map(_.totalMins).sum == 5) &&
@@ -231,14 +233,14 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       },
       test("rejects unknown mac with 404") {
         for {
-          _              <- cleanDb
-          rb             <- buildRoutes
-          (routes, auth)  = rb
-          token          <- auth.login("admin", "changeme").map(_.token.value)
-          req             = Request
+          _  <- cleanDb
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(URL.decode("/api/usage/series?mac=aa:bb:cc:dd:ee:ff").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
-          resp           <- routes.runZIO(req)
+          resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.NotFound)
       },
     ) @@ TestAspect.sequential,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -318,6 +318,31 @@ case class ProfileDetail(
     siteTimeLimits: List[SiteTimeLimit],
 ) derives JsonCodec
 
+// #716 / #721 — per-device hourly usage timeline. The endpoint returns 24
+// buckets for the requested local date (in the requested `tz`, UTC by
+// default). Each bucket's `totalMins` is the device's bucket-deduplicated
+// wall-clock minutes — the same number the daily cap sees. Per-host minutes
+// are proportionally allocated within each 5-min sub-bucket so the stack of
+// `perHost.mins + otherMins` sums to `totalMins` — a sketch of #715
+// proposal 2 (bytes-weighted is a follow-up). Hosts beyond `topN` are
+// collapsed into `otherMins`.
+case class UsageHostTotal(host: HostId, dayMins: Int) derives JsonCodec
+case class UsageBucketHost(host: HostId, mins: Int) derives JsonCodec
+case class UsageBucket(
+    hour: Int,
+    totalMins: Int,
+    perHost: List[UsageBucketHost],
+    otherMins: Int,
+) derives JsonCodec
+case class UsageSeriesResponse(
+    deviceMac: MacAddress,
+    deviceName: String,
+    date: String,
+    tz: String,
+    topHosts: List[UsageHostTotal],
+    buckets: List[UsageBucket],
+) derives JsonCodec
+
 // ── Dashboard "Now" ────────────────────────────────────────────────────────
 
 case class DashboardNowHost(host: HostId, activeSeconds: Long) derives JsonCodec

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.26.2"
+        "react-router-dom": "^6.26.2",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -64,12 +65,6 @@
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
       }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -220,7 +215,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
@@ -232,7 +226,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -243,7 +236,6 @@
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -427,7 +419,6 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
@@ -481,7 +472,6 @@
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
       "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -491,6 +481,40 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -508,7 +532,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -525,7 +548,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -542,7 +564,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -559,7 +580,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -576,7 +596,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -593,7 +612,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -610,7 +628,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -627,7 +644,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -644,7 +660,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -661,7 +676,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -678,7 +692,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -695,7 +708,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -712,7 +724,6 @@
         "wasm32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
@@ -731,7 +742,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -748,7 +758,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -766,9 +775,12 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -860,7 +872,6 @@
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -878,37 +889,88 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -922,6 +984,11 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -1109,9 +1176,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1140,16 +1207,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1158,13 +1224,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1185,11 +1250,10 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
       },
@@ -1198,13 +1262,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1212,14 +1275,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1228,23 +1290,21 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.6.tgz",
-      "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.7.tgz",
+      "integrity": "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -1256,17 +1316,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.6"
+        "vitest": "4.1.7"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1398,7 +1457,6 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1452,9 +1510,9 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -1561,9 +1619,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -1585,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -1640,6 +1697,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1748,7 +1813,117 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -1785,6 +1960,11 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1877,9 +2057,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "dev": true
     },
     "node_modules/entities": {
@@ -1916,8 +2096,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1945,6 +2124,15 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2149,7 +2337,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -2163,12 +2350,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2229,9 +2420,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true
     },
     "node_modules/file-entry-cache": {
@@ -2604,6 +2795,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2655,6 +2855,14 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2668,12 +2876,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3138,6 +3346,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -3153,7 +3367,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -3261,9 +3474,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3285,9 +3498,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -3331,8 +3544,7 @@
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -3460,8 +3672,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3500,9 +3711,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3518,9 +3729,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3693,6 +3903,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3746,11 +3963,32 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-router": {
       "version": "6.30.3",
@@ -3803,6 +4041,35 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3815,6 +4082,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -3877,7 +4162,6 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
       "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.130.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -3962,9 +4246,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3998,8 +4282,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -4037,15 +4320,13 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -4199,19 +4480,22 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
       "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -4266,7 +4550,6 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4357,7 +4640,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
       "optional": true
     },
     "node_modules/type-check": {
@@ -4436,18 +4718,46 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.13",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4525,7 +4835,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4534,19 +4843,18 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4574,12 +4882,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4628,7 +4936,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4712,7 +5019,6 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -4740,9 +5046,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.2"
+    "react-router-dom": "^6.26.2",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from '@/components/layout/Layout'
 import { LoginPage } from '@/pages/LoginPage'
 import { DashboardPage } from '@/pages/DashboardPage'
 import { DevicesPage } from '@/pages/DevicesPage'
+import { DeviceTimelinePage } from '@/pages/DeviceTimelinePage'
 import { ProfilesPage } from '@/pages/ProfilesPage'
 import { TimePage } from '@/pages/TimePage'
 import { LogsPage } from '@/pages/LogsPage'
@@ -46,6 +47,7 @@ function AppRoutes() {
         <Route index element={<RequirePwChanged><Navigate to="/dashboard" replace /></RequirePwChanged>} />
         <Route path="dashboard" element={<RequirePwChanged><DashboardPage /></RequirePwChanged>} />
         <Route path="devices"   element={<RequirePwChanged><DevicesPage /></RequirePwChanged>} />
+        <Route path="devices/:mac/timeline" element={<RequirePwChanged><DeviceTimelinePage /></RequirePwChanged>} />
         <Route path="profiles"  element={<RequirePwChanged><ProfilesPage /></RequirePwChanged>} />
         <Route path="time"      element={<RequirePwChanged><TimePage /></RequirePwChanged>} />
         <Route path="logs"      element={<RequirePwChanged><LogsPage /></RequirePwChanged>} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,7 +3,7 @@ import type {
   DeviceTimeStatus, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus,
   QueryLog, RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension,
   UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
-  User,
+  UsageSeriesResponse, User,
 } from '@/types/api'
 
 // VITE_API_BASE_URL is empty by default (relative path — SPA served from the
@@ -122,6 +122,17 @@ export const api = {
       req<{ id: number; grantedMinutes: number }>('POST', '/time/extend', data),
     listExtensions: (profileId: number) =>
       req<TimeExtension[]>('GET', `/time/extensions/${profileId}`),
+  },
+
+  // ── Usage (#716) ───────────────────────────────────────────────────────
+  usage: {
+    series: (params: { mac: string; date?: string; tz?: string; topN?: number }) => {
+      const qs = new URLSearchParams({ mac: params.mac })
+      if (params.date) qs.set('date', params.date)
+      if (params.tz)   qs.set('tz', params.tz)
+      if (params.topN) qs.set('topN', String(params.topN))
+      return req<UsageSeriesResponse>('GET', `/usage/series?${qs}`)
+    },
   },
 
   // ── Logs ───────────────────────────────────────────────────────────────

--- a/web/src/pages/DeviceTimelinePage.test.tsx
+++ b/web/src/pages/DeviceTimelinePage.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { UsageSeriesResponse } from '@/types/api'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    usage: {
+      series: vi.fn(),
+    },
+  },
+}))
+
+// Recharts pulls in ResizeObserver / SVG bits jsdom doesn't fully implement.
+// Stub the chart primitives — DeviceTimelinePage's own logic is what we want
+// to test (data wiring, empty state, navigation), not Recharts itself.
+vi.mock('recharts', () => {
+  const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    Bar: () => null,
+    BarChart: Pass,
+    CartesianGrid: () => null,
+    Legend: () => null,
+    ResponsiveContainer: Pass,
+    Tooltip: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+  }
+})
+
+import { api } from '@/api/client'
+import { DeviceTimelinePage } from './DeviceTimelinePage'
+
+const MAC = 'aa:bb:cc:dd:ee:01'
+
+function renderPage(initialEntries: string[] = [`/devices/${MAC}/timeline`]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/devices/:mac/timeline" element={<DeviceTimelinePage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function emptyDayResponse(date: string): UsageSeriesResponse {
+  return {
+    deviceMac: MAC,
+    deviceName: "Kid's iPad",
+    date,
+    tz: 'UTC',
+    topHosts: [],
+    buckets: Array.from({ length: 24 }, (_, hour) => ({
+      hour, totalMins: 0, perHost: [], otherMins: 0,
+    })),
+  }
+}
+
+function richResponse(date: string): UsageSeriesResponse {
+  return {
+    deviceMac: MAC,
+    deviceName: "Kid's iPad",
+    date,
+    tz: 'America/Los_Angeles',
+    topHosts: [
+      { host: { type: 'fqdn', value: 'youtube.com' },  dayMins: 30 },
+      { host: { type: 'ipv4', value: '170.114.4.226' }, dayMins: 4 },
+    ],
+    buckets: Array.from({ length: 24 }, (_, hour) => {
+      if (hour === 14) {
+        return {
+          hour,
+          totalMins: 10,
+          perHost: [
+            { host: { type: 'fqdn', value: 'youtube.com' }, mins: 7 },
+            { host: { type: 'ipv4', value: '170.114.4.226' }, mins: 2 },
+          ],
+          otherMins: 1,
+        }
+      }
+      return { hour, totalMins: 0, perHost: [], otherMins: 0 }
+    }),
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('DeviceTimelinePage', () => {
+  it('renders empty state when no usage recorded', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      emptyDayResponse('2026-05-20'),
+    )
+    renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('device-timeline-empty')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('device-timeline-name')).toHaveTextContent("Kid's iPad")
+  })
+
+  it('renders chart and top-host list with FQDN + bare-IP rows', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('device-timeline-chart')).toBeInTheDocument(),
+    )
+    // Per-host legend rows render for both FQDN and IP.
+    expect(screen.getByTestId('device-timeline-host-youtube.com')).toBeInTheDocument()
+    const ipRow = screen.getByTestId('device-timeline-host-170.114.4.226')
+    expect(ipRow).toBeInTheDocument()
+    // #718: IP rows are de-emphasized via italic styling so the FQDN gap shows.
+    expect(ipRow.querySelector('.italic')).not.toBeNull()
+  })
+
+  it('uses ?date= from URL when present', async () => {
+    const mock = api.usage.series as unknown as ReturnType<typeof vi.fn>
+    mock.mockResolvedValue(emptyDayResponse('2026-05-15'))
+    renderPage([`/devices/${MAC}/timeline?date=2026-05-15`])
+    await waitFor(() => expect(mock).toHaveBeenCalled())
+    expect(mock.mock.calls[0][0]).toMatchObject({ mac: MAC, date: '2026-05-15' })
+  })
+})

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -93,7 +93,10 @@ export function DeviceTimelinePage() {
 
   const chart = useMemo(() => {
     if (!data) return { rows: [] as ChartRow[], hostKeys: [] as string[] }
-    const hostKeys = data.topHosts.map(h => h.host.value)
+    // Belt-and-suspenders: skip hosts that floor to 0m in the legend/stack.
+    // The server already filters these out, but rendering an invisible bar
+    // with a "0m" legend entry looks broken if anything slips through.
+    const hostKeys = data.topHosts.filter(h => h.dayMins > 0).map(h => h.host.value)
     return { rows: buildChartData(data.buckets, hostKeys), hostKeys }
   }, [data])
 
@@ -213,7 +216,7 @@ export function DeviceTimelinePage() {
             Top hosts
           </h2>
           <ul className="space-y-1.5">
-            {data.topHosts.map((h, i) => {
+            {data.topHosts.filter(h => h.dayMins > 0).map((h, i) => {
               const isIp = h.host.type !== 'fqdn'
               return (
                 <li

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import {
+  Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer,
+  Tooltip, XAxis, YAxis,
+} from 'recharts'
+import { api } from '@/api/client'
+import type { UsageBucket, UsageSeriesResponse } from '@/types/api'
+import { PageLoader } from './DashboardPage'
+
+// #721 — per-device daily timeline. Hourly stacked-bar chart of minutes-of-use
+// for a single device on a chosen day. Hosts beyond topN collapse into "Other";
+// bare-IP rows render (italic) so the operator can spot the FQDN gap (#718).
+
+const TOP_N = 5
+const DEFAULT_TZ =
+  Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+
+const HOST_COLORS = [
+  '#10b981', // emerald
+  '#3b82f6', // blue
+  '#a855f7', // purple
+  '#f59e0b', // amber
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#8b5cf6', // violet
+]
+const OTHER_COLOR = '#4b5563' // gray-600
+
+function todayISO(): string {
+  const d = new Date()
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function addDays(iso: string, n: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  dt.setUTCDate(dt.getUTCDate() + n)
+  const yy = dt.getUTCFullYear()
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(dt.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+interface ChartRow {
+  hour: string
+  total: number
+  [hostKey: string]: number | string
+}
+
+function buildChartData(
+  buckets: UsageBucket[],
+  hostKeys: string[],
+): ChartRow[] {
+  return buckets.map(b => {
+    const row: ChartRow = { hour: String(b.hour).padStart(2, '0'), total: b.totalMins }
+    for (const k of hostKeys) row[k] = 0
+    for (const ph of b.perHost) row[ph.host.value] = ph.mins
+    row['__other'] = b.otherMins
+    return row
+  })
+}
+
+export function DeviceTimelinePage() {
+  const { mac = '' } = useParams<{ mac: string }>()
+  const [params, setParams] = useSearchParams()
+
+  const initialDate = params.get('date') ?? todayISO()
+  const [date, setDate] = useState<string>(initialDate)
+  const [data, setData] = useState<UsageSeriesResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    api.usage.series({ mac, date, tz: DEFAULT_TZ, topN: TOP_N })
+      .then(setData)
+      .catch(e => setError(e.message ?? 'Failed to load'))
+      .finally(() => setLoading(false))
+  }, [mac, date])
+
+  function setDateAndPush(next: string) {
+    setDate(next)
+    const sp = new URLSearchParams(params)
+    sp.set('date', next)
+    setParams(sp, { replace: true })
+  }
+
+  const chart = useMemo(() => {
+    if (!data) return { rows: [] as ChartRow[], hostKeys: [] as string[] }
+    const hostKeys = data.topHosts.map(h => h.host.value)
+    return { rows: buildChartData(data.buckets, hostKeys), hostKeys }
+  }, [data])
+
+  if (loading && !data) return <PageLoader />
+
+  const dayTotal = data?.buckets.reduce((a, b) => a + b.totalMins, 0) ?? 0
+  const isEmpty  = dayTotal === 0
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="min-w-0">
+          <Link to="/devices" className="text-xs text-gray-500 hover:text-emerald-400">
+            ← Devices
+          </Link>
+          <h1 className="text-xl font-bold text-white truncate" data-testid="device-timeline-name">
+            {data?.deviceName ?? mac}
+          </h1>
+          <p className="text-xs text-gray-500 font-mono">{mac}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setDateAndPush(addDays(date, -1))}
+            className="bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm px-3 py-2 rounded-lg"
+            aria-label="Previous day"
+          >‹</button>
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDateAndPush(e.target.value)}
+            className="bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-emerald-500"
+            data-testid="device-timeline-date"
+          />
+          <button
+            onClick={() => setDateAndPush(addDays(date, 1))}
+            className="bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm px-3 py-2 rounded-lg"
+            aria-label="Next day"
+          >›</button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-3">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+            Hourly minutes
+          </h2>
+          <span className="text-xs text-gray-500 font-mono">
+            {dayTotal}m total · {data?.tz}
+          </span>
+        </div>
+
+        {isEmpty ? (
+          <div
+            data-testid="device-timeline-empty"
+            className="h-64 flex items-center justify-center text-gray-600 text-sm border border-dashed border-gray-800 rounded-xl"
+          >
+            No usage recorded on {date}.
+          </div>
+        ) : (
+          <div data-testid="device-timeline-chart" className="h-72 -ml-2">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={chart.rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+                <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" vertical={false} />
+                <XAxis
+                  dataKey="hour"
+                  tick={{ fill: '#6b7280', fontSize: 11 }}
+                  axisLine={{ stroke: '#374151' }}
+                  tickLine={false}
+                />
+                <YAxis
+                  tick={{ fill: '#6b7280', fontSize: 11 }}
+                  axisLine={{ stroke: '#374151' }}
+                  tickLine={false}
+                  width={32}
+                  unit="m"
+                />
+                <Tooltip
+                  cursor={{ fill: '#1f293780' }}
+                  contentStyle={{
+                    background: '#0a0f1c',
+                    border: '1px solid #374151',
+                    borderRadius: '8px',
+                    fontSize: 12,
+                  }}
+                  labelFormatter={(h) => `${String(h)}:00 – ${String(h)}:59`}
+                  formatter={(v, n) => [`${String(v)}m`, n === '__other' ? 'Other' : String(n)]}
+                />
+                <Legend
+                  iconType="square"
+                  wrapperStyle={{ fontSize: 12, color: '#9ca3af', paddingTop: 8 }}
+                  formatter={(n: string) => (n === '__other' ? 'Other' : n)}
+                />
+                {chart.hostKeys.map((k, i) => (
+                  <Bar
+                    key={k}
+                    dataKey={k}
+                    stackId="hosts"
+                    fill={HOST_COLORS[i % HOST_COLORS.length]}
+                  />
+                ))}
+                <Bar dataKey="__other" stackId="hosts" fill={OTHER_COLOR} name="Other" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+
+      {data && data.topHosts.length > 0 && (
+        <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Top hosts
+          </h2>
+          <ul className="space-y-1.5">
+            {data.topHosts.map((h, i) => {
+              const isIp = h.host.type !== 'fqdn'
+              return (
+                <li
+                  key={`${h.host.type}:${h.host.value}`}
+                  data-testid={`device-timeline-host-${h.host.value}`}
+                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+                >
+                  <span className="flex items-center gap-2 min-w-0">
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                      style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
+                    />
+                    {/* Per #718: bare-IP rows render but de-emphasized so the
+                        FQDN attribution gap is visible at a glance. */}
+                    <span
+                      className={`font-mono truncate ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
+                      title={h.host.value}
+                    >
+                      {h.host.value}
+                      {isIp && (
+                        <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
+                          {h.host.type}
+                        </span>
+                      )}
+                    </span>
+                  </span>
+                  <span className="text-gray-500 font-mono shrink-0 ml-2">{h.dayMins}m</span>
+                </li>
+              )
+            })}
+          </ul>
+          <p className="text-[11px] text-gray-600 mt-3">
+            Per-host minutes are proportional within each 5-minute window. The stack sums to
+            the device's wall-clock minutes for that hour.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -188,7 +188,13 @@ export function DeviceTimelinePage() {
                     fontSize: 12,
                   }}
                   labelFormatter={(h) => `${String(h)}:00 – ${String(h)}:59`}
-                  formatter={(v, n) => [`${String(v)}m`, n === '__other' ? 'Other' : String(n)]}
+                  // Hide 0m rows entirely — they're noise for sparse devices
+                  // where multiple background hosts each accrue sub-minute
+                  // shares within an hour and floor to zero.
+                  formatter={(v, n) => {
+                    if (Number(v) === 0) return null as unknown as [string, string]
+                    return [`${String(v)}m`, n === '__other' ? 'Other' : String(n)]
+                  }}
                 />
                 <Legend
                   iconType="square"

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type { Device, ProfileDetail } from '@/types/api'
@@ -84,10 +84,10 @@ export function DevicesPage() {
           ? <p className="p-6 text-gray-500 text-sm">No devices yet.</p>
           : knownDevices.map(d => (
               <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-emerald-500/60 ring-inset' : ''}`}>
-                <div className="flex-1 min-w-0">
+                <Link to={`/devices/${encodeURIComponent(d.mac)}/timeline`} className="flex-1 min-w-0 hover:text-emerald-400 transition-colors" data-testid={`device-timeline-link-${d.mac}`}>
                   <p className="font-medium text-white truncate">{d.name}</p>
                   <p className="text-xs text-gray-500 font-mono">{d.mac}</p>
-                </div>
+                </Link>
                 <div className="hidden sm:block text-sm">
                   <span className="bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 px-2 py-1 rounded-lg text-xs">
                     {d.profileName ?? 'No profile'}

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import type { ProfileTimeStatus } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
@@ -75,7 +76,7 @@ beforeEach(() => {
 
 describe('TimePage — list', () => {
   it('renders cards with usage, remaining, extensions, and site usage', async () => {
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     expect(await screen.findByText("Kid's iPad")).toBeInTheDocument()
     expect(screen.getByText('90m used')).toBeInTheDocument()
     expect(screen.getByText('30m left')).toBeInTheDocument()
@@ -90,7 +91,7 @@ describe('TimePage — list', () => {
   })
 
   it('renders top-host breakdown when hostUsage is present (#262)', async () => {
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     expect(await screen.findByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
     expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('35m')
     expect(screen.getByTestId('time-host-1-khan-academy.org')).toHaveTextContent('khan-academy.org')
@@ -100,7 +101,7 @@ describe('TimePage — list', () => {
   })
 
   it('omits the top-host section when hostUsage is empty (#262)', async () => {
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     // overLimit profile (id=2) has hostUsage: [] — no time-host-* testids for it
     await screen.findByTestId('time-card-2')
     expect(screen.queryByTestId(/^time-host-2-/)).not.toBeInTheDocument()
@@ -110,7 +111,7 @@ describe('TimePage — list', () => {
 describe('TimePage — grant extension', () => {
   it('opens modal, picks 45m preset, types note, and calls grantExtension', async () => {
     const user = userEvent.setup()
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     await screen.findByTestId('time-card-1')
 
     // Click first "+ Time" button (Kids profile)
@@ -137,7 +138,7 @@ describe('TimePage — grant extension', () => {
 
   it('passes null note when blank', async () => {
     const user = userEvent.setup()
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     await screen.findByTestId('time-card-1')
     const grantButtons = screen.getAllByRole('button', { name: /\+ Time/ })
     await user.click(grantButtons[0])
@@ -155,7 +156,7 @@ describe('TimePage — grant extension', () => {
 describe('TimePage — role gating', () => {
   it('hides "+ Time" button for non-admins', async () => {
     mockAuth = { isAdmin: false }
-    render(<TimePage />)
+    render(<MemoryRouter><TimePage /></MemoryRouter>)
     await screen.findByTestId('time-card-1')
     expect(screen.queryByRole('button', { name: /\+ Time/ })).not.toBeInTheDocument()
   })

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useAuth } from '@/hooks/useAuth'
 import type { ProfileTimeStatus } from '@/types/api'
@@ -186,10 +187,15 @@ function ProfileTimeCard({
         <div className="space-y-1">
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Devices</p>
           {status.devices.map(d => (
-            <div key={d.deviceMac} className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2">
+            <Link
+              key={d.deviceMac}
+              to={`/devices/${encodeURIComponent(d.deviceMac)}/timeline`}
+              data-testid={`time-device-link-${d.deviceMac}`}
+              className="flex justify-between text-xs bg-gray-800/50 hover:bg-gray-800 rounded-lg px-3 py-2 transition-colors"
+            >
               <span className="text-gray-300">{d.deviceName}</span>
               <span className="text-gray-500 font-mono">{d.usedMins}m</span>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -216,6 +216,36 @@ export interface ProfileTimeStatus {
   hostUsage: HostUsage[]
 }
 
+// #716 / #721 — per-device hourly usage timeline. `totalMins` is the device's
+// bucket-deduplicated wall-clock minutes for the hour (matches the daily cap).
+// `perHost.mins + otherMins == totalMins` — per-host minutes are proportionally
+// allocated within each 5-min bucket (sketch of #715 proposal 2).
+export interface UsageHostTotal {
+  host: HostId
+  dayMins: number
+}
+
+export interface UsageBucketHost {
+  host: HostId
+  mins: number
+}
+
+export interface UsageBucket {
+  hour: number
+  totalMins: number
+  perHost: UsageBucketHost[]
+  otherMins: number
+}
+
+export interface UsageSeriesResponse {
+  deviceMac: string
+  deviceName: string
+  date: string
+  tz: string
+  topHosts: UsageHostTotal[]
+  buckets: UsageBucket[]
+}
+
 export interface TimeExtension {
   id: number
   profileId: number | null


### PR DESCRIPTION
## Summary

- Adds `GET /api/usage/series?mac=&date=&tz=&topN=` returning 24 hourly buckets with top-N hosts proportionally allocated so the stack sums to wall-clock minutes (#716).
- Adds `DeviceTimelinePage` — stacked-bar hourly view per device with date picker, top-host legend, and empty-day state (#721).
- Click-through from Devices list and Screen Time per-device rows to the new view.
- Standardizes the SPA on **recharts** (no chart lib before this — we'll be doing a lot more charting per #127, #301, #64).

## Notes

- Per-host minutes are proportionally allocated within each 5-min bucket — a sketch of [#715](https://github.com/wifihaven/wifihaven/issues/715) proposal 2, so the stack tells an honest story instead of over-counting. Bytes-weighted allocation stays a #715 follow-up.
- Bare-IP rows still render in the host list (italic + type tag) so the [#718](https://github.com/wifihaven/wifihaven/issues/718) FQDN attribution gap stays visible.
- `tz` query param defaults to UTC server-side; SPA passes the browser's IANA zone so parents see local-hour bars on the chart.
- Router code untouched (Gate 2 / [#654](https://github.com/wifihaven/wifihaven/issues/654)).

## Test plan

- [x] `mill api.test` — full API suite green (incl. new `UsageApiSpec` × 6).
- [x] `mill shared.test` — green.
- [x] `npm run type-check`, `npm run lint`, `npm test` — green (129 web tests, incl. new `DeviceTimelinePage.test.tsx`).
- [x] `npm run build` — green.
- [ ] Manual: click a device on Devices → timeline opens; date picker `±` navigates; empty day renders cleanly.
- [ ] Manual: click a device row on Screen Time → same timeline opens.

Closes #721
Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)