### PR TITLE
usage: per-profile daily timeline + stack-by toggle (#722)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -100,7 +100,7 @@ object Main extends ZIOAppDefault {
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++
       SessionRoutes.routes(auth, trafficRepo, deviceRepo, profileRepo, upRepo, clock) ++
-      UsageRoutes.routes(auth, deviceRepo, trafficRepo, upRepo, clock) ++
+      UsageRoutes.routes(auth, deviceRepo, trafficRepo, upRepo, profileRepo, clock) ++
       DashboardNowRoutes.routes(
         auth,
         trafficRepo,

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -13,13 +13,15 @@ import java.time.{LocalDate, ZoneId}
 
 // ── Usage routes (#716) ─────────────────────────────────────────────────────
 //
-// First consumer: #721 per-device daily timeline.
+// Per-device timeline (#721) and per-profile timeline (#722) share one endpoint.
+// Exactly one of `mac=` or `profileId=` must be set.
 object UsageRoutes {
   def routes(
       auth: AuthService,
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
+      profileRepo: ProfileRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -28,10 +30,21 @@ object UsageRoutes {
           for {
             claims <- requireAuth(req, auth)
             today  <- clock.today
-            macRaw <- ZIO
-              .fromOption(req.url.queryParam("mac"))
-              .orElseFail(Response.badRequest("mac is required"))
-            mac     = MacAddress.unsafe(normalizeMac(macRaw))
+            macOpt        = req.url.queryParam("mac").map(s => MacAddress.unsafe(normalizeMac(s)))
+            profileIdOpt <- ZIO
+              .fromEither(
+                req.url.queryParam("profileId") match {
+                  case None    => Right(None)
+                  case Some(s) =>
+                    s.toLongOption
+                      .map(l => Some(ProfileId(l)))
+                      .toRight(s"invalid profileId: $s")
+                },
+              )
+              .mapError(Response.badRequest)
+            _      <- ZIO
+              .fail(Response.badRequest("exactly one of mac or profileId is required"))
+              .when(macOpt.isDefined == profileIdOpt.isDefined)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date <- ZIO
               .attempt(LocalDate.parse(dateStr))
@@ -46,37 +59,92 @@ object UsageRoutes {
               .getOrElse(5)
               .max(1)
               .min(20)
-            device  <- deviceRepo
-              .findByMac(mac)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _       <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
-            // Pull two adjacent UTC days so a tz like America/Los_Angeles can
-            // assemble its calendar day from buckets split across midnight UTC.
-            // Cheap on a per-mac filter via idx_traffic_reports_mac_date.
-            rowsD   <- trafficRepo
-              .listPresenceRows(List(mac), date)
-              .mapError(ErrorMapper.dbErrorToResponse)
-            rowsNxt <- trafficRepo
-              .listPresenceRows(List(mac), date.plusDays(1))
-              .mapError(ErrorMapper.dbErrorToResponse)
-            rowsPrv <- trafficRepo
-              .listPresenceRows(List(mac), date.minusDays(1))
-              .mapError(ErrorMapper.dbErrorToResponse)
-            // Keep only the rows whose period_start falls on `date` in `zone`.
-            inDay               = (rowsPrv ++ rowsD ++ rowsNxt).filter { r =>
-              r.periodStart.atZone(zone).toLocalDate == date
+            resp <- (macOpt, profileIdOpt) match {
+              case (Some(mac), _) => buildForDevice(mac, date, zone, topN, claims, deviceRepo, trafficRepo, userProfileRepo)
+              case (_, Some(pid)) => buildForProfile(pid, date, zone, topN, claims, profileRepo, deviceRepo, trafficRepo, userProfileRepo)
+              case _              => ZIO.fail(Response.badRequest("unreachable"))
             }
-            (topHosts, buckets) = UsageSeries.build(inDay, zone, topN)
-            resp                = UsageSeriesResponse(
-              deviceMac = mac,
-              deviceName = device.name,
-              date = date.toString,
-              tz = zone.getId,
-              topHosts = topHosts,
-              buckets = buckets,
-            )
           } yield Response.json(resp.toJson)
         },
     )
+
+  private def buildForDevice(
+      mac: MacAddress,
+      date: LocalDate,
+      zone: ZoneId,
+      topN: Int,
+      claims: JwtClaims,
+      deviceRepo: DeviceRepo,
+      trafficRepo: TrafficReportRepo,
+      userProfileRepo: UserProfileRepo,
+  ): IO[Response, UsageSeriesResponse] =
+    for {
+      device  <- deviceRepo
+        .findByMac(mac)
+        .mapError(ErrorMapper.dbErrorToResponse)
+        .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+      _       <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+      rows    <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
+      (topHosts, buckets) = UsageSeries.build(rows, zone, topN)
+    } yield UsageSeriesResponse(
+      deviceMac = Some(mac),
+      deviceName = Some(device.name),
+      date = date.toString,
+      tz = zone.getId,
+      topHosts = topHosts,
+      buckets = buckets,
+    )
+
+  private def buildForProfile(
+      pid: ProfileId,
+      date: LocalDate,
+      zone: ZoneId,
+      topN: Int,
+      claims: JwtClaims,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      trafficRepo: TrafficReportRepo,
+      userProfileRepo: UserProfileRepo,
+  ): IO[Response, UsageSeriesResponse] =
+    for {
+      _       <- requireProfileReadAccess(claims, pid, userProfileRepo)
+      profile <- profileRepo
+        .findById(pid)
+        .mapError(ErrorMapper.dbErrorToResponse)
+        .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
+      all     <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      devices  = all.filter(_.profileId.contains(pid))
+      macs     = devices.map(_.mac)
+      nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
+      rows    <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
+      (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
+        UsageSeries.buildProfile(rows, nameByMac, zone, topN)
+    } yield UsageSeriesResponse(
+      profileId = Some(pid),
+      profileName = Some(profile.name),
+      date = date.toString,
+      tz = zone.getId,
+      topHosts = topHosts,
+      buckets = bucketsByHost,
+      topDevices = topDevices,
+      bucketsByDevice = bucketsByDevice,
+    )
+
+  // Pull the requested local-day window. Two adjacent UTC days bracket every
+  // calendar day in every IANA zone, then filter by `periodStart` in `zone`.
+  private def fetchPresenceDayWindow(
+      trafficRepo: TrafficReportRepo,
+      macs: List[MacAddress],
+      date: LocalDate,
+      zone: ZoneId,
+  ): IO[Response, List[wifihaven.api.presence.PresenceRow]] =
+    if (macs.isEmpty) ZIO.succeed(Nil)
+    else
+      for {
+        d   <- trafficRepo.listPresenceRows(macs, date).mapError(ErrorMapper.dbErrorToResponse)
+        nxt <- trafficRepo.listPresenceRows(macs, date.plusDays(1)).mapError(ErrorMapper.dbErrorToResponse)
+        prv <- trafficRepo.listPresenceRows(macs, date.minusDays(1)).mapError(ErrorMapper.dbErrorToResponse)
+      } yield (prv ++ d ++ nxt).filter { r =>
+        r.periodStart.atZone(zone).toLocalDate == date
+      }
 }

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -30,7 +30,7 @@ object UsageRoutes {
           for {
             claims <- requireAuth(req, auth)
             today  <- clock.today
-            macOpt        = req.url.queryParam("mac").map(s => MacAddress.unsafe(normalizeMac(s)))
+            macOpt = req.url.queryParam("mac").map(s => MacAddress.unsafe(normalizeMac(s)))
             profileIdOpt <- ZIO
               .fromEither(
                 req.url.queryParam("profileId") match {
@@ -42,7 +42,7 @@ object UsageRoutes {
                 },
               )
               .mapError(Response.badRequest)
-            _      <- ZIO
+            _            <- ZIO
               .fail(Response.badRequest("exactly one of mac or profileId is required"))
               .when(macOpt.isDefined == profileIdOpt.isDefined)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
@@ -60,8 +60,29 @@ object UsageRoutes {
               .max(1)
               .min(20)
             resp <- (macOpt, profileIdOpt) match {
-              case (Some(mac), _) => buildForDevice(mac, date, zone, topN, claims, deviceRepo, trafficRepo, userProfileRepo)
-              case (_, Some(pid)) => buildForProfile(pid, date, zone, topN, claims, profileRepo, deviceRepo, trafficRepo, userProfileRepo)
+              case (Some(mac), _) =>
+                buildForDevice(
+                  mac,
+                  date,
+                  zone,
+                  topN,
+                  claims,
+                  deviceRepo,
+                  trafficRepo,
+                  userProfileRepo,
+                )
+              case (_, Some(pid)) =>
+                buildForProfile(
+                  pid,
+                  date,
+                  zone,
+                  topN,
+                  claims,
+                  profileRepo,
+                  deviceRepo,
+                  trafficRepo,
+                  userProfileRepo,
+                )
               case _              => ZIO.fail(Response.badRequest("unreachable"))
             }
           } yield Response.json(resp.toJson)
@@ -79,12 +100,12 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
   ): IO[Response, UsageSeriesResponse] =
     for {
-      device  <- deviceRepo
+      device <- deviceRepo
         .findByMac(mac)
         .mapError(ErrorMapper.dbErrorToResponse)
         .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-      _       <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
-      rows    <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
+      _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+      rows   <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
       (topHosts, buckets) = UsageSeries.build(rows, zone, topN)
     } yield UsageSeriesResponse(
       deviceMac = Some(mac),
@@ -113,10 +134,10 @@ object UsageRoutes {
         .mapError(ErrorMapper.dbErrorToResponse)
         .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
       all     <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-      devices  = all.filter(_.profileId.contains(pid))
-      macs     = devices.map(_.mac)
+      devices   = all.filter(_.profileId.contains(pid))
+      macs      = devices.map(_.mac)
       nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
-      rows    <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
+      rows <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
       (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
         UsageSeries.buildProfile(rows, nameByMac, zone, topN)
     } yield UsageSeriesResponse(
@@ -142,9 +163,11 @@ object UsageRoutes {
     else
       for {
         d   <- trafficRepo.listPresenceRows(macs, date).mapError(ErrorMapper.dbErrorToResponse)
-        nxt <- trafficRepo.listPresenceRows(macs, date.plusDays(1)).mapError(ErrorMapper.dbErrorToResponse)
-        prv <- trafficRepo.listPresenceRows(macs, date.minusDays(1)).mapError(ErrorMapper.dbErrorToResponse)
-      } yield (prv ++ d ++ nxt).filter { r =>
-        r.periodStart.atZone(zone).toLocalDate == date
-      }
+        nxt <- trafficRepo
+          .listPresenceRows(macs, date.plusDays(1))
+          .mapError(ErrorMapper.dbErrorToResponse)
+        prv <- trafficRepo
+          .listPresenceRows(macs, date.minusDays(1))
+          .mapError(ErrorMapper.dbErrorToResponse)
+      } yield (prv ++ d ++ nxt).filter { r => r.periodStart.atZone(zone).toLocalDate == date }
 }

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -102,4 +102,121 @@ object UsageSeries {
 
     (topHosts, buckets)
   }
+
+  /**
+   * Profile-mode build (#722). Aggregates `rows` across one profile's devices for one local day.
+   *
+   * Returns four parallel views of the same activity:
+   *   - `topHosts` / `bucketsByHost` — proportionally allocated within each (mac, period_start)
+   *     bucket, same semantics as the per-device build above.
+   *   - `topDevices` / `bucketsByDevice` — minutes attributed to whichever device's mac the
+   *     bucket belongs to (one bucket → one device); `sum(perDevice) + otherMins == totalMins`.
+   *
+   * Profile total semantics match `Routes.buildProfileTimeStatus`: per-mac bucket-deduped minutes
+   * are summed across devices (overlap is not deduped at the profile level). Per-host stacks use
+   * the same even-share within each (mac, period_start) bucket as the per-device build.
+   *
+   * @param deviceNames
+   *   Display names keyed by mac. Devices missing from the map fall back to the mac string.
+   * @param topN
+   *   Number of named-host / named-device entries; the long tail collapses to `otherMins`.
+   */
+  def buildProfile(
+      rows: List[PresenceRow],
+      deviceNames: Map[MacAddress, String],
+      zone: ZoneId,
+      topN: Int,
+  ): (List[UsageHostTotal], List[UsageBucket], List[UsageDeviceTotal], List[UsageDeviceBucket]) = {
+    // Group by (mac, periodStart) — same 5-min bucketing as the per-device build,
+    // but now we keep the mac so we can later stack-by-device.
+    val fiveMin = rows.groupBy(r => (r.mac, r.periodStart)).toList.map { case ((mac, ps), bucket) =>
+      val hour  = ps.atZone(zone).getHour
+      val secs  = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+      val hosts = bucket.iterator.map(_.host).toSet.toList
+      (hour, mac, secs, hosts)
+    }
+
+    // ── Per-host day totals (proportional within each bucket) ─────────────
+    val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
+    for ((_, _, secs, hosts) <- fiveMin if hosts.nonEmpty) {
+      val share = secs.toDouble / hosts.size
+      for (h <- hosts) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+    }
+    val orderedHosts = perHostDaySecs.toList
+      .map { case (h, s) => (h, (s / 60).toInt) }
+      .filter { case (_, m) => m > 0 }
+      .sortBy { case (h, m) => (-m, h.value) }
+    val topHostIds   = orderedHosts.take(topN).map(_._1).toSet
+    val topHosts     = orderedHosts.take(topN).map((h, m) => UsageHostTotal(h, m))
+    val hostRank     = topHosts.iterator.map(_.host).zipWithIndex.toMap
+
+    // ── Per-device day totals (one bucket → one device) ───────────────────
+    val perDeviceDaySecs = scala.collection.mutable.Map.empty[MacAddress, Long]
+    for ((_, mac, secs, _) <- fiveMin)
+      perDeviceDaySecs.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
+    val orderedDevices = perDeviceDaySecs.toList
+      .map { case (m, s) => (m, (s / 60).toInt) }
+      .filter { case (_, m) => m > 0 }
+      .sortBy { case (mac, m) => (-m, mac.value) }
+    val topDeviceMacs  = orderedDevices.take(topN).map(_._1).toSet
+    val topDevices     = orderedDevices.take(topN).map { case (mac, mins) =>
+      UsageDeviceTotal(mac, deviceNames.getOrElse(mac, mac.value), mins)
+    }
+    val deviceRank     = topDevices.iterator.map(_.deviceMac).zipWithIndex.toMap
+
+    // ── Per-hour aggregation, both views ──────────────────────────────────
+    val byHour          = fiveMin.groupBy(_._1)
+    val bucketsByHost   = scala.collection.mutable.ArrayBuffer.empty[UsageBucket]
+    val bucketsByDevice = scala.collection.mutable.ArrayBuffer.empty[UsageDeviceBucket]
+    for (hr <- 0 until 24) {
+      val hrBuckets = byHour.getOrElse(hr, Nil)
+      val totalSecs = hrBuckets.iterator.map((_, _, s, _) => s.toLong).sum
+      val totalMins = (totalSecs / 60).toInt
+
+      // Per-host stack within the hour (even-share within each 5-min bucket).
+      val perHost = scala.collection.mutable.Map.empty[HostId, Double]
+      var hostOther = 0.0
+      for ((_, _, secs, hosts) <- hrBuckets if hosts.nonEmpty) {
+        val share = secs.toDouble / hosts.size
+        for (h <- hosts)
+          if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+          else hostOther += share
+      }
+      val perHostList = perHost.iterator
+        .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }
+        .filter(_.mins > 0)
+        .toList
+        .sortBy(u => hostRank.getOrElse(u.host, Int.MaxValue))
+      val perHostSum  = perHostList.iterator.map(_.mins).sum
+      bucketsByHost += UsageBucket(
+        hour = hr,
+        totalMins = totalMins,
+        perHost = perHostList,
+        otherMins = (totalMins - perHostSum).max(0),
+      )
+
+      // Per-device stack within the hour (each bucket attributes to its mac).
+      val perDevice = scala.collection.mutable.Map.empty[MacAddress, Long]
+      var devOther  = 0L
+      for ((_, mac, secs, _) <- hrBuckets)
+        if (topDeviceMacs.contains(mac)) perDevice.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
+        else devOther += secs.toLong
+      val perDeviceList = perDevice.iterator
+        .map { case (mac, s) =>
+          UsageBucketDevice(mac, deviceNames.getOrElse(mac, mac.value), (s / 60).toInt)
+        }
+        .filter(_.mins > 0)
+        .toList
+        .sortBy(u => deviceRank.getOrElse(u.deviceMac, Int.MaxValue))
+      val perDeviceSum  = perDeviceList.iterator.map(_.mins).sum
+      bucketsByDevice += UsageDeviceBucket(
+        hour = hr,
+        totalMins = totalMins,
+        perDevice = perDeviceList,
+        otherMins = (totalMins - perDeviceSum).max(0),
+      )
+    }
+
+    (topHosts, bucketsByHost.toList, topDevices, bucketsByDevice.toList)
+  }
 }

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -109,8 +109,8 @@ object UsageSeries {
    * Returns four parallel views of the same activity:
    *   - `topHosts` / `bucketsByHost` — proportionally allocated within each (mac, period_start)
    *     bucket, same semantics as the per-device build above.
-   *   - `topDevices` / `bucketsByDevice` — minutes attributed to whichever device's mac the
-   *     bucket belongs to (one bucket → one device); `sum(perDevice) + otherMins == totalMins`.
+   *   - `topDevices` / `bucketsByDevice` — minutes attributed to whichever device's mac the bucket
+   *     belongs to (one bucket → one device); `sum(perDevice) + otherMins == totalMins`.
    *
    * Profile total semantics match `Routes.buildProfileTimeStatus`: per-mac bucket-deduped minutes
    * are summed across devices (overlap is not deduped at the profile level). Per-host stacks use
@@ -146,9 +146,9 @@ object UsageSeries {
       .map { case (h, s) => (h, (s / 60).toInt) }
       .filter { case (_, m) => m > 0 }
       .sortBy { case (h, m) => (-m, h.value) }
-    val topHostIds   = orderedHosts.take(topN).map(_._1).toSet
-    val topHosts     = orderedHosts.take(topN).map((h, m) => UsageHostTotal(h, m))
-    val hostRank     = topHosts.iterator.map(_.host).zipWithIndex.toMap
+    val topHostIds = orderedHosts.take(topN).map(_._1).toSet
+    val topHosts = orderedHosts.take(topN).map((h, m) => UsageHostTotal(h, m))
+    val hostRank = topHosts.iterator.map(_.host).zipWithIndex.toMap
 
     // ── Per-device day totals (one bucket → one device) ───────────────────
     val perDeviceDaySecs = scala.collection.mutable.Map.empty[MacAddress, Long]
@@ -174,7 +174,7 @@ object UsageSeries {
       val totalMins = (totalSecs / 60).toInt
 
       // Per-host stack within the hour (even-share within each 5-min bucket).
-      val perHost = scala.collection.mutable.Map.empty[HostId, Double]
+      val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
       var hostOther = 0.0
       for ((_, _, secs, hosts) <- hrBuckets if hosts.nonEmpty) {
         val share = secs.toDouble / hosts.size
@@ -187,7 +187,7 @@ object UsageSeries {
         .filter(_.mins > 0)
         .toList
         .sortBy(u => hostRank.getOrElse(u.host, Int.MaxValue))
-      val perHostSum  = perHostList.iterator.map(_.mins).sum
+      val perHostSum = perHostList.iterator.map(_.mins).sum
       bucketsByHost += UsageBucket(
         hour = hr,
         totalMins = totalMins,
@@ -199,7 +199,8 @@ object UsageSeries {
       val perDevice = scala.collection.mutable.Map.empty[MacAddress, Long]
       var devOther  = 0L
       for ((_, mac, secs, _) <- hrBuckets)
-        if (topDeviceMacs.contains(mac)) perDevice.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
+        if (topDeviceMacs.contains(mac))
+          perDevice.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
         else devOther += secs.toLong
       val perDeviceList = perDevice.iterator
         .map { case (mac, s) =>

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -82,9 +82,10 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       deviceRepo      <- ZIO.service[DeviceRepo]
       trafficRepo     <- ZIO.service[TrafficReportRepo]
       userProfileRepo <- ZIO.service[UserProfileRepo]
+      profileRepo     <- ZIO.service[ProfileRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
-    } yield (UsageRoutes.routes(auth, deviceRepo, trafficRepo, userProfileRepo, clock), auth)
+    } yield (UsageRoutes.routes(auth, deviceRepo, trafficRepo, userProfileRepo, profileRepo, clock), auth)
 
   def spec = suite("Usage API")(
     suite("GET /api/usage/series")(
@@ -242,6 +243,94 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.NotFound)
+      },
+      test("rejects requests with both mac and profileId") {
+        for {
+          _  <- cleanDb
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode("/api/usage/series?mac=aa:bb:cc:dd:ee:01&profileId=1").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.BadRequest)
+      },
+      test("profileId mode: aggregates across the profile's devices, both stacks sum to totalMins") {
+        val macA = "aa:bb:cc:dd:ee:0a"
+        val macB = "aa:bb:cc:dd:ee:0b"
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, macA, "iPad-A", kidsId)
+          _           <- TestLayers.seedDevice(deviceRepo, macB, "iPad-B", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Hour 14: macA sole on youtube + macA two-host bucket (5+5min=10),
+          // and macB on google.com for one 5-min bucket. Profile total = 15m.
+          _  <- insertRow(routerId, macA, "youtube.com", today, 14, 0)
+          _  <- insertRow(routerId, macA, "youtube.com", today, 14, 5)
+          _  <- insertRow(routerId, macA, "google.com", today, 14, 5)
+          _  <- insertRow(routerId, macB, "google.com", today, 14, 10)
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          h14H = out.buckets(14)
+          h14D = out.bucketsByDevice(14)
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.profileId.contains(kidsId)) &&
+          assertTrue(out.profileName.contains("Kids")) &&
+          assertTrue(out.deviceMac.isEmpty) &&
+          assertTrue(out.buckets.length == 24 && out.bucketsByDevice.length == 24) &&
+          assertTrue(h14H.totalMins == 15 && h14D.totalMins == 15) &&
+          // Per-device stack: macA 10m + macB 5m, no Other.
+          assertTrue(h14D.perDevice.length == 2 && h14D.otherMins == 0) &&
+          assertTrue(h14D.perDevice.iterator.map(_.mins).sum + h14D.otherMins == 15) &&
+          // Per-host stack invariant: sum(perHost.mins) + otherMins == totalMins.
+          assertTrue(h14H.perHost.iterator.map(_.mins).sum + h14H.otherMins == 15) &&
+          // Day totals reconcile.
+          assertTrue(out.topDevices.iterator.map(_.dayMins).sum == 15)
+      },
+      test("profileId mode: rejects unknown profile with 404") {
+        for {
+          _  <- cleanDb
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode("/api/usage/series?profileId=99999").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+        } yield assertTrue(resp.status == Status.NotFound)
+      },
+      test("profileId mode: empty profile (no devices) returns 24 zero buckets") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          rb          <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/usage/series?profileId=${kidsId.value}").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.buckets.length == 24 && out.bucketsByDevice.length == 24) &&
+          assertTrue(out.buckets.forall(_.totalMins == 0)) &&
+          assertTrue(out.topHosts.isEmpty && out.topDevices.isEmpty)
       },
     ) @@ TestAspect.sequential,
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -85,7 +85,10 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       profileRepo     <- ZIO.service[ProfileRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
-    } yield (UsageRoutes.routes(auth, deviceRepo, trafficRepo, userProfileRepo, profileRepo, clock), auth)
+    } yield (
+      UsageRoutes.routes(auth, deviceRepo, trafficRepo, userProfileRepo, profileRepo, clock),
+      auth,
+    )
 
   def spec = suite("Usage API")(
     suite("GET /api/usage/series")(
@@ -256,7 +259,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.BadRequest)
       },
-      test("profileId mode: aggregates across the profile's devices, both stacks sum to totalMins") {
+      test(
+        "profileId mode: aggregates across the profile's devices, both stacks sum to totalMins",
+      ) {
         val macA = "aa:bb:cc:dd:ee:0a"
         val macB = "aa:bb:cc:dd:ee:0b"
         for {
@@ -279,7 +284,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           (routes, auth) = rb
           token <- auth.login("admin", "changeme").map(_.token.value)
           req = Request
-            .get(URL.decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today").toOption.get)
+            .get(
+              URL.decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today").toOption.get,
+            )
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
           body <- resp.body.asString

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -378,13 +378,29 @@ case class UsageBucket(
     perHost: List[UsageBucketHost],
     otherMins: Int,
 ) derives JsonCodec
+
+// #722 — profile-mode adds parallel per-device aggregates so the SPA can
+// toggle stack-by-device vs stack-by-host without a second round-trip.
+case class UsageDeviceTotal(deviceMac: MacAddress, deviceName: String, dayMins: Int) derives JsonCodec
+case class UsageBucketDevice(deviceMac: MacAddress, deviceName: String, mins: Int) derives JsonCodec
+case class UsageDeviceBucket(
+    hour: Int,
+    totalMins: Int,
+    perDevice: List[UsageBucketDevice],
+    otherMins: Int,
+) derives JsonCodec
+
 case class UsageSeriesResponse(
-    deviceMac: MacAddress,
-    deviceName: String,
+    deviceMac: Option[MacAddress] = None,
+    deviceName: Option[String] = None,
+    profileId: Option[ProfileId] = None,
+    profileName: Option[String] = None,
     date: String,
     tz: String,
     topHosts: List[UsageHostTotal],
     buckets: List[UsageBucket],
+    topDevices: List[UsageDeviceTotal] = Nil,
+    bucketsByDevice: List[UsageDeviceBucket] = Nil,
 ) derives JsonCodec
 
 // ── Dashboard "Now" ────────────────────────────────────────────────────────

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -381,7 +381,8 @@ case class UsageBucket(
 
 // #722 — profile-mode adds parallel per-device aggregates so the SPA can
 // toggle stack-by-device vs stack-by-host without a second round-trip.
-case class UsageDeviceTotal(deviceMac: MacAddress, deviceName: String, dayMins: Int) derives JsonCodec
+case class UsageDeviceTotal(deviceMac: MacAddress, deviceName: String, dayMins: Int)
+    derives JsonCodec
 case class UsageBucketDevice(deviceMac: MacAddress, deviceName: String, mins: Int) derives JsonCodec
 case class UsageDeviceBucket(
     hour: Int,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { DevicesPage } from '@/pages/DevicesPage'
 import { DeviceTimelinePage } from '@/pages/DeviceTimelinePage'
 import { ProfilesPage } from '@/pages/ProfilesPage'
 import { TimePage } from '@/pages/TimePage'
+import { ProfileTimelinePage } from '@/pages/ProfileTimelinePage'
 import { LogsPage } from '@/pages/LogsPage'
 import { AccountPage } from '@/pages/AccountPage'
 import { UsersPage } from '@/pages/UsersPage'
@@ -50,6 +51,7 @@ function AppRoutes() {
         <Route path="devices/:mac/timeline" element={<RequirePwChanged><DeviceTimelinePage /></RequirePwChanged>} />
         <Route path="profiles"  element={<RequirePwChanged><ProfilesPage /></RequirePwChanged>} />
         <Route path="time"      element={<RequirePwChanged><TimePage /></RequirePwChanged>} />
+        <Route path="time/:profileId/timeline" element={<RequirePwChanged><ProfileTimelinePage /></RequirePwChanged>} />
         <Route path="logs"      element={<RequirePwChanged><LogsPage /></RequirePwChanged>} />
         <Route path="users"     element={<RequirePwChanged><RequireAdmin><UsersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="routers"   element={<RequirePwChanged><RequireAdmin><RoutersPage /></RequireAdmin></RequirePwChanged>} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -126,11 +126,19 @@ export const api = {
 
   // ── Usage (#716) ───────────────────────────────────────────────────────
   usage: {
-    series: (params: { mac: string; date?: string; tz?: string; topN?: number }) => {
-      const qs = new URLSearchParams({ mac: params.mac })
-      if (params.date) qs.set('date', params.date)
-      if (params.tz)   qs.set('tz', params.tz)
-      if (params.topN) qs.set('topN', String(params.topN))
+    series: (params: {
+      mac?: string
+      profileId?: number
+      date?: string
+      tz?: string
+      topN?: number
+    }) => {
+      const qs = new URLSearchParams()
+      if (params.mac)       qs.set('mac', params.mac)
+      if (params.profileId !== undefined) qs.set('profileId', String(params.profileId))
+      if (params.date)      qs.set('date', params.date)
+      if (params.tz)        qs.set('tz', params.tz)
+      if (params.topN)      qs.set('topN', String(params.topN))
       return req<UsageSeriesResponse>('GET', `/usage/series?${qs}`)
     },
   },

--- a/web/src/components/usage/UsageHourlyBarChart.tsx
+++ b/web/src/components/usage/UsageHourlyBarChart.tsx
@@ -1,0 +1,98 @@
+import {
+  Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer,
+  Tooltip, XAxis, YAxis,
+} from 'recharts'
+
+// Shared 24-hour stacked-bar chart used by:
+//   - DeviceTimelinePage (#721) — stack by host
+//   - ProfileTimelinePage (#722) — stack by host OR device (toggleable)
+//
+// The chart is intentionally dumb: it only knows how to render N stacks of
+// minutes against the X-axis "hour" key. Callers compute the rows + series
+// definitions for the chosen stacking mode and pass them in.
+
+export const HOST_COLORS = [
+  '#10b981', // emerald
+  '#3b82f6', // blue
+  '#a855f7', // purple
+  '#f59e0b', // amber
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#8b5cf6', // violet
+]
+export const OTHER_COLOR = '#4b5563' // gray-600
+export const OTHER_KEY   = '__other'
+
+export interface ChartSeries {
+  key: string    // dataKey on each row
+  name: string   // legend / tooltip label
+  color: string
+}
+
+export interface ChartRow {
+  hour: string
+  total: number
+  [key: string]: number | string
+}
+
+interface Props {
+  rows: ChartRow[]
+  series: ChartSeries[]   // named stacks (top-N). "Other" is rendered as a final stack if any row has __other > 0.
+  showLegend?: boolean
+  legendFormatter?: (name: string) => string
+  testId?: string
+}
+
+export function UsageHourlyBarChart({ rows, series, showLegend = false, legendFormatter, testId }: Props) {
+  return (
+    <div data-testid={testId} className="h-72 -ml-2">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+          <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="hour"
+            tick={{ fill: '#6b7280', fontSize: 11 }}
+            axisLine={{ stroke: '#374151' }}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{ fill: '#6b7280', fontSize: 11 }}
+            axisLine={{ stroke: '#374151' }}
+            tickLine={false}
+            width={32}
+            unit="m"
+          />
+          <Tooltip
+            cursor={{ fill: '#1f293780' }}
+            contentStyle={{
+              background: '#0a0f1c',
+              border: '1px solid #374151',
+              borderRadius: '8px',
+              fontSize: 12,
+            }}
+            labelFormatter={(h) => `${String(h)}:00 – ${String(h)}:59`}
+            // Hide 0m rows entirely — they're noise for sparse periods where
+            // multiple background series each accrue sub-minute shares.
+            formatter={(v, n) => {
+              if (Number(v) === 0) return null as unknown as [string, string]
+              const label = n === OTHER_KEY ? 'Other' : (legendFormatter ? legendFormatter(String(n)) : String(n))
+              return [`${String(v)}m`, label]
+            }}
+          />
+          {showLegend && (
+            <Legend
+              iconType="square"
+              wrapperStyle={{ fontSize: 12, color: '#9ca3af', paddingTop: 8 }}
+              formatter={(n: string) => (n === OTHER_KEY ? 'Other' : (legendFormatter ? legendFormatter(n) : n))}
+            />
+          )}
+          {series.map(s => (
+            <Bar key={s.key} dataKey={s.key} stackId="stacks" fill={s.color} name={s.name} />
+          ))}
+          <Bar dataKey={OTHER_KEY} stackId="stacks" fill={OTHER_COLOR} name="Other" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
-import {
-  Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer,
-  Tooltip, XAxis, YAxis,
-} from 'recharts'
 import { api } from '@/api/client'
 import type { UsageBucket, UsageSeriesResponse } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+import {
+  HOST_COLORS, OTHER_KEY, UsageHourlyBarChart, type ChartSeries,
+} from '@/components/usage/UsageHourlyBarChart'
 
 // #721 — per-device daily timeline. Hourly stacked-bar chart of minutes-of-use
 // for a single device on a chosen day. Hosts beyond topN collapse into "Other";
@@ -15,18 +14,6 @@ import { PageLoader } from './DashboardPage'
 const TOP_N = 5
 const DEFAULT_TZ =
   Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
-
-const HOST_COLORS = [
-  '#10b981', // emerald
-  '#3b82f6', // blue
-  '#a855f7', // purple
-  '#f59e0b', // amber
-  '#ec4899', // pink
-  '#14b8a6', // teal
-  '#f97316', // orange
-  '#8b5cf6', // violet
-]
-const OTHER_COLOR = '#4b5563' // gray-600
 
 function todayISO(): string {
   const d = new Date()
@@ -46,22 +33,19 @@ function addDays(iso: string, n: number): string {
   return `${yy}-${mm}-${dd}`
 }
 
-interface ChartRow {
-  hour: string
-  total: number
-  [hostKey: string]: number | string
-}
-
 function buildChartData(
   buckets: UsageBucket[],
   hostKeys: string[],
-): ChartRow[] {
+) {
   return buckets.map(b => {
-    const row: ChartRow = { hour: String(b.hour).padStart(2, '0'), total: b.totalMins }
+    const row: Record<string, number | string> = {
+      hour: String(b.hour).padStart(2, '0'),
+      total: b.totalMins,
+    }
     for (const k of hostKeys) row[k] = 0
     for (const ph of b.perHost) row[ph.host.value] = ph.mins
-    row['__other'] = b.otherMins
-    return row
+    row[OTHER_KEY] = b.otherMins
+    return row as { hour: string; total: number; [k: string]: number | string }
   })
 }
 
@@ -92,12 +76,17 @@ export function DeviceTimelinePage() {
   }
 
   const chart = useMemo(() => {
-    if (!data) return { rows: [] as ChartRow[], hostKeys: [] as string[] }
+    if (!data) return { rows: [], series: [] as ChartSeries[] }
     // Belt-and-suspenders: skip hosts that floor to 0m in the legend/stack.
     // The server already filters these out, but rendering an invisible bar
     // with a "0m" legend entry looks broken if anything slips through.
     const hostKeys = data.topHosts.filter(h => h.dayMins > 0).map(h => h.host.value)
-    return { rows: buildChartData(data.buckets, hostKeys), hostKeys }
+    const series: ChartSeries[] = hostKeys.map((k, i) => ({
+      key: k,
+      name: k,
+      color: HOST_COLORS[i % HOST_COLORS.length],
+    }))
+    return { rows: buildChartData(data.buckets, hostKeys), series }
   }, [data])
 
   if (loading && !data) return <PageLoader />
@@ -162,57 +151,12 @@ export function DeviceTimelinePage() {
             No usage recorded on {date}.
           </div>
         ) : (
-          <div data-testid="device-timeline-chart" className="h-72 -ml-2">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={chart.rows} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
-                <CartesianGrid stroke="#1f2937" strokeDasharray="3 3" vertical={false} />
-                <XAxis
-                  dataKey="hour"
-                  tick={{ fill: '#6b7280', fontSize: 11 }}
-                  axisLine={{ stroke: '#374151' }}
-                  tickLine={false}
-                />
-                <YAxis
-                  tick={{ fill: '#6b7280', fontSize: 11 }}
-                  axisLine={{ stroke: '#374151' }}
-                  tickLine={false}
-                  width={32}
-                  unit="m"
-                />
-                <Tooltip
-                  cursor={{ fill: '#1f293780' }}
-                  contentStyle={{
-                    background: '#0a0f1c',
-                    border: '1px solid #374151',
-                    borderRadius: '8px',
-                    fontSize: 12,
-                  }}
-                  labelFormatter={(h) => `${String(h)}:00 – ${String(h)}:59`}
-                  // Hide 0m rows entirely — they're noise for sparse devices
-                  // where multiple background hosts each accrue sub-minute
-                  // shares within an hour and floor to zero.
-                  formatter={(v, n) => {
-                    if (Number(v) === 0) return null as unknown as [string, string]
-                    return [`${String(v)}m`, n === '__other' ? 'Other' : String(n)]
-                  }}
-                />
-                <Legend
-                  iconType="square"
-                  wrapperStyle={{ fontSize: 12, color: '#9ca3af', paddingTop: 8 }}
-                  formatter={(n: string) => (n === '__other' ? 'Other' : n)}
-                />
-                {chart.hostKeys.map((k, i) => (
-                  <Bar
-                    key={k}
-                    dataKey={k}
-                    stackId="hosts"
-                    fill={HOST_COLORS[i % HOST_COLORS.length]}
-                  />
-                ))}
-                <Bar dataKey="__other" stackId="hosts" fill={OTHER_COLOR} name="Other" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+          <UsageHourlyBarChart
+            rows={chart.rows}
+            series={chart.series}
+            showLegend
+            testId="device-timeline-chart"
+          />
         )}
       </div>
 

--- a/web/src/pages/ProfileTimelinePage.test.tsx
+++ b/web/src/pages/ProfileTimelinePage.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { UsageSeriesResponse } from '@/types/api'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    usage: {
+      series: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('recharts', () => {
+  const Pass = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>
+  return {
+    Bar: () => null,
+    BarChart: Pass,
+    CartesianGrid: () => null,
+    Legend: () => null,
+    ResponsiveContainer: Pass,
+    Tooltip: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+  }
+})
+
+import { api } from '@/api/client'
+import { ProfileTimelinePage } from './ProfileTimelinePage'
+
+const PID = 7
+
+function renderPage(initialEntries: string[] = [`/time/${PID}/timeline`]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/time/:profileId/timeline" element={<ProfileTimelinePage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function emptyResponse(date: string): UsageSeriesResponse {
+  return {
+    profileId: PID,
+    profileName: 'Kids',
+    date,
+    tz: 'UTC',
+    topHosts: [],
+    buckets: Array.from({ length: 24 }, (_, h) => ({
+      hour: h, totalMins: 0, perHost: [], otherMins: 0,
+    })),
+    topDevices: [],
+    bucketsByDevice: Array.from({ length: 24 }, (_, h) => ({
+      hour: h, totalMins: 0, perDevice: [], otherMins: 0,
+    })),
+  }
+}
+
+function richResponse(date: string): UsageSeriesResponse {
+  return {
+    profileId: PID,
+    profileName: 'Kids',
+    date,
+    tz: 'UTC',
+    topHosts: [
+      { host: { type: 'fqdn', value: 'youtube.com' }, dayMins: 30 },
+      { host: { type: 'fqdn', value: 'google.com' }, dayMins: 15 },
+    ],
+    buckets: Array.from({ length: 24 }, (_, h) => ({
+      hour: h,
+      totalMins: h === 14 ? 45 : 0,
+      perHost: h === 14 ? [
+        { host: { type: 'fqdn', value: 'youtube.com' }, mins: 30 },
+        { host: { type: 'fqdn', value: 'google.com' }, mins: 15 },
+      ] : [],
+      otherMins: 0,
+    })),
+    topDevices: [
+      { deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", dayMins: 30 },
+      { deviceMac: 'aa:bb:cc:dd:ee:02', deviceName: "Kid's iPhone", dayMins: 15 },
+    ],
+    bucketsByDevice: Array.from({ length: 24 }, (_, h) => ({
+      hour: h,
+      totalMins: h === 14 ? 45 : 0,
+      perDevice: h === 14 ? [
+        { deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", mins: 30 },
+        { deviceMac: 'aa:bb:cc:dd:ee:02', deviceName: "Kid's iPhone", mins: 15 },
+      ] : [],
+      otherMins: 0,
+    })),
+  }
+}
+
+describe('ProfileTimelinePage', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'fake')
+    vi.clearAllMocks()
+  })
+
+  it('passes profileId (not mac) to the usage API', async () => {
+    const mock = api.usage.series as unknown as ReturnType<typeof vi.fn>
+    mock.mockResolvedValue(emptyResponse('2026-05-20'))
+    renderPage([`/time/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() => expect(mock).toHaveBeenCalled())
+    expect(mock.mock.calls[0][0]).toMatchObject({ profileId: PID, date: '2026-05-20' })
+  })
+
+  it('renders profile name and empty state', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      emptyResponse('2026-05-20'),
+    )
+    renderPage([`/time/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-empty')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('profile-timeline-name')).toHaveTextContent('Kids')
+  })
+
+  it('renders host stack by default, switches to device stack on toggle', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/time/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
+    )
+    // Default: host stack visible, top-hosts list shown.
+    expect(screen.getByTestId('profile-timeline-host-youtube.com')).toBeInTheDocument()
+    expect(screen.queryByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('profile-timeline-stack-device'))
+
+    // After toggle: device list visible, host list gone.
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('profile-timeline-host-youtube.com')).toBeNull()
+  })
+
+  it('reads stackBy=device from URL', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/time/${PID}/timeline?date=2026-05-20&stackBy=device`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument(),
+    )
+  })
+})

--- a/web/src/pages/ProfileTimelinePage.tsx
+++ b/web/src/pages/ProfileTimelinePage.tsx
@@ -1,0 +1,302 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { api } from '@/api/client'
+import type {
+  UsageBucket, UsageDeviceBucket, UsageSeriesResponse,
+} from '@/types/api'
+import { PageLoader } from './DashboardPage'
+import {
+  HOST_COLORS, OTHER_KEY, UsageHourlyBarChart, type ChartSeries,
+} from '@/components/usage/UsageHourlyBarChart'
+
+// #722 — per-profile daily timeline. Hourly stacked-bar chart of minutes-of-use
+// across all of a profile's devices, with a stack-by toggle (device | host)
+// that switches which dimension drives the stacks. Colors are derived from a
+// stable index of the top-N entries so the same host (or device) keeps its
+// color across re-renders.
+
+const TOP_N = 5
+const DEFAULT_TZ =
+  Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+
+type StackBy = 'host' | 'device'
+
+function todayISO(): string {
+  const d = new Date()
+  const yyyy = d.getFullYear()
+  const mm = String(d.getMonth() + 1).padStart(2, '0')
+  const dd = String(d.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function addDays(iso: string, n: number): string {
+  const [y, m, d] = iso.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  dt.setUTCDate(dt.getUTCDate() + n)
+  const yy = dt.getUTCFullYear()
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(dt.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+function buildHostRows(buckets: UsageBucket[], keys: string[]) {
+  return buckets.map(b => {
+    const row: Record<string, number | string> = {
+      hour: String(b.hour).padStart(2, '0'),
+      total: b.totalMins,
+    }
+    for (const k of keys) row[k] = 0
+    for (const ph of b.perHost) row[ph.host.value] = ph.mins
+    row[OTHER_KEY] = b.otherMins
+    return row as { hour: string; total: number; [k: string]: number | string }
+  })
+}
+
+function buildDeviceRows(buckets: UsageDeviceBucket[], keys: string[]) {
+  return buckets.map(b => {
+    const row: Record<string, number | string> = {
+      hour: String(b.hour).padStart(2, '0'),
+      total: b.totalMins,
+    }
+    for (const k of keys) row[k] = 0
+    for (const pd of b.perDevice) row[pd.deviceMac] = pd.mins
+    row[OTHER_KEY] = b.otherMins
+    return row as { hour: string; total: number; [k: string]: number | string }
+  })
+}
+
+export function ProfileTimelinePage() {
+  const { profileId = '' } = useParams<{ profileId: string }>()
+  const [params, setParams] = useSearchParams()
+
+  const initialDate = params.get('date') ?? todayISO()
+  const initialStack = (params.get('stackBy') === 'device' ? 'device' : 'host') as StackBy
+  const [date, setDate]       = useState<string>(initialDate)
+  const [stackBy, setStackBy] = useState<StackBy>(initialStack)
+  const [data, setData]       = useState<UsageSeriesResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError]     = useState<string | null>(null)
+
+  useEffect(() => {
+    const pid = Number(profileId)
+    if (!Number.isFinite(pid)) {
+      setError('invalid profile id')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    api.usage.series({ profileId: pid, date, tz: DEFAULT_TZ, topN: TOP_N })
+      .then(setData)
+      .catch(e => setError(e.message ?? 'Failed to load'))
+      .finally(() => setLoading(false))
+  }, [profileId, date])
+
+  function pushParam(key: string, val: string) {
+    const sp = new URLSearchParams(params)
+    sp.set(key, val)
+    setParams(sp, { replace: true })
+  }
+  function setDateAndPush(next: string) { setDate(next); pushParam('date', next) }
+  function setStackAndPush(next: StackBy) { setStackBy(next); pushParam('stackBy', next) }
+
+  const chart = useMemo(() => {
+    if (!data) return { rows: [], series: [] as ChartSeries[] }
+    if (stackBy === 'host') {
+      // Top-host indices drive colors; same host across renders keeps the
+      // same slot because the server returns topHosts sorted deterministically.
+      const keys = (data.topHosts ?? []).filter(h => h.dayMins > 0).map(h => h.host.value)
+      const series: ChartSeries[] = keys.map((k, i) => ({
+        key: k, name: k, color: HOST_COLORS[i % HOST_COLORS.length],
+      }))
+      return { rows: buildHostRows(data.buckets, keys), series }
+    } else {
+      const top = (data.topDevices ?? []).filter(d => d.dayMins > 0)
+      const keys = top.map(d => d.deviceMac)
+      const series: ChartSeries[] = top.map((d, i) => ({
+        key: d.deviceMac, name: d.deviceName, color: HOST_COLORS[i % HOST_COLORS.length],
+      }))
+      const rows = buildDeviceRows(data.bucketsByDevice ?? [], keys)
+      return { rows, series }
+    }
+  }, [data, stackBy])
+
+  if (loading && !data) return <PageLoader />
+
+  const buckets = stackBy === 'host' ? data?.buckets : data?.bucketsByDevice
+  const dayTotal = buckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
+  const isEmpty  = dayTotal === 0
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="min-w-0">
+          <Link to="/time" className="text-xs text-gray-500 hover:text-emerald-400">
+            ← Screen time
+          </Link>
+          <h1 className="text-xl font-bold text-white truncate" data-testid="profile-timeline-name">
+            {data?.profileName ?? `Profile ${profileId}`}
+          </h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setDateAndPush(addDays(date, -1))}
+            className="bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm px-3 py-2 rounded-lg"
+            aria-label="Previous day"
+          >‹</button>
+          <input
+            type="date"
+            value={date}
+            onChange={e => setDateAndPush(e.target.value)}
+            className="bg-gray-900 border border-gray-700 text-gray-200 text-sm rounded-lg px-3 py-2 focus:outline-none focus:border-emerald-500"
+            data-testid="profile-timeline-date"
+          />
+          <button
+            onClick={() => setDateAndPush(addDays(date, 1))}
+            className="bg-gray-800 hover:bg-gray-700 text-gray-300 text-sm px-3 py-2 rounded-lg"
+            aria-label="Next day"
+          >›</button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-3">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+        <div className="flex items-center justify-between mb-4 gap-2 flex-wrap">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+            Hourly minutes
+          </h2>
+          <div className="flex items-center gap-3">
+            <div className="inline-flex rounded-lg bg-gray-800 p-0.5 text-xs" role="tablist" aria-label="Stack by">
+              {(['host', 'device'] as StackBy[]).map(opt => (
+                <button
+                  key={opt}
+                  role="tab"
+                  aria-selected={stackBy === opt}
+                  data-testid={`profile-timeline-stack-${opt}`}
+                  onClick={() => setStackAndPush(opt)}
+                  className={`px-3 py-1.5 rounded-md font-medium transition-colors ${
+                    stackBy === opt
+                      ? 'bg-emerald-500 text-black'
+                      : 'text-gray-400 hover:text-gray-200'
+                  }`}
+                >
+                  {opt === 'host' ? 'Host' : 'Device'}
+                </button>
+              ))}
+            </div>
+            <span className="text-xs text-gray-500 font-mono">
+              {dayTotal}m total · {data?.tz}
+            </span>
+          </div>
+        </div>
+
+        {isEmpty ? (
+          <div
+            data-testid="profile-timeline-empty"
+            className="h-64 flex items-center justify-center text-gray-600 text-sm border border-dashed border-gray-800 rounded-xl"
+          >
+            No usage recorded on {date}.
+          </div>
+        ) : (
+          <UsageHourlyBarChart
+            rows={chart.rows}
+            series={chart.series}
+            showLegend
+            // The chart receives device-mac keys when stack-by=device; map them
+            // back to friendly names so the legend reads "Kid's iPad" not the mac.
+            legendFormatter={stackBy === 'device'
+              ? (k) => chart.series.find(s => s.key === k)?.name ?? k
+              : undefined}
+            testId="profile-timeline-chart"
+          />
+        )}
+
+        {/* Profile total uses sum-of-per-device-minutes semantics. Two siblings
+            both active in the same 5-min window count as 10 minutes here, but
+            the per-host stack still even-shares within each device's bucket
+            (#715). The numbers reconcile with the Screen Time daily totals on
+            /time, within that overlap caveat. */}
+        <p className="text-[11px] text-gray-600 mt-3">
+          Stacks total to wall-clock minutes per hour. Per-host minutes are proportional
+          within each 5-minute window; overlapping device activity counts once per device
+          (matches the Screen Time daily total).
+        </p>
+      </div>
+
+      {data && stackBy === 'host' && (data.topHosts ?? []).length > 0 && (
+        <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Top hosts
+          </h2>
+          <ul className="space-y-1.5">
+            {data.topHosts.filter(h => h.dayMins > 0).map((h, i) => {
+              const isIp = h.host.type !== 'fqdn'
+              return (
+                <li
+                  key={`${h.host.type}:${h.host.value}`}
+                  data-testid={`profile-timeline-host-${h.host.value}`}
+                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+                >
+                  <span className="flex items-center gap-2 min-w-0">
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                      style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
+                    />
+                    <span
+                      className={`font-mono truncate ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
+                      title={h.host.value}
+                    >
+                      {h.host.value}
+                      {isIp && (
+                        <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
+                          {h.host.type}
+                        </span>
+                      )}
+                    </span>
+                  </span>
+                  <span className="text-gray-500 font-mono shrink-0 ml-2">{h.dayMins}m</span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+
+      {data && stackBy === 'device' && (data.topDevices ?? []).length > 0 && (
+        <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Devices
+          </h2>
+          <ul className="space-y-1.5">
+            {data.topDevices!.filter(d => d.dayMins > 0).map((d, i) => (
+              <li
+                key={d.deviceMac}
+                data-testid={`profile-timeline-device-${d.deviceMac}`}
+                className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                    style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
+                  />
+                  <Link
+                    to={`/devices/${encodeURIComponent(d.deviceMac)}/timeline?date=${date}`}
+                    className="text-gray-300 hover:text-emerald-400 truncate"
+                  >
+                    {d.deviceName}
+                  </Link>
+                </span>
+                <span className="text-gray-500 font-mono shrink-0 ml-2">{d.dayMins}m</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -144,7 +144,13 @@ function ProfileTimeCard({
   return (
     <div data-testid={`time-card-${status.profileId}`} className={`bg-gray-900 rounded-2xl border p-5 space-y-4 ${overLimit ? 'border-red-500/40' : 'border-gray-800'}`}>
       <div className="flex items-start justify-between gap-2">
-        <h3 className="font-semibold text-white text-lg">{status.profileName}</h3>
+        <Link
+          to={`/time/${status.profileId}/timeline`}
+          data-testid={`time-profile-link-${status.profileId}`}
+          className="font-semibold text-white text-lg hover:text-emerald-400 transition-colors"
+        >
+          {status.profileName}
+        </Link>
         {isAdmin && hasLimit && (
           <button
             onClick={onGrant}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -237,13 +237,40 @@ export interface UsageBucket {
   otherMins: number
 }
 
-export interface UsageSeriesResponse {
+// #722 — profile-mode adds parallel per-device aggregates so the SPA can
+// toggle stack-by-device vs stack-by-host on the same payload.
+export interface UsageDeviceTotal {
   deviceMac: string
   deviceName: string
+  dayMins: number
+}
+
+export interface UsageBucketDevice {
+  deviceMac: string
+  deviceName: string
+  mins: number
+}
+
+export interface UsageDeviceBucket {
+  hour: number
+  totalMins: number
+  perDevice: UsageBucketDevice[]
+  otherMins: number
+}
+
+export interface UsageSeriesResponse {
+  // device-mode fields (mac=)
+  deviceMac?: string
+  deviceName?: string
+  // profile-mode fields (profileId=)
+  profileId?: number
+  profileName?: string
   date: string
   tz: string
   topHosts: UsageHostTotal[]
   buckets: UsageBucket[]
+  topDevices?: UsageDeviceTotal[]
+  bucketsByDevice?: UsageDeviceBucket[]
 }
 
 export interface TimeExtension {


### PR DESCRIPTION
## Summary
- Extends `GET /api/usage/series` to accept `profileId=` (mutually exclusive with `mac=`). Profile-mode responses carry parallel per-host and per-device aggregates (`buckets` + `bucketsByDevice`, `topHosts` + `topDevices`) so the SPA toggle doesn't need a second round-trip.
- New `ProfileTimelinePage` at `/time/:profileId/timeline` with a stack-by `host | device` toggle, date picker, and back-link to `/time`. Reuses the chart visuals extracted from #721 into `web/src/components/usage/UsageHourlyBarChart`.
- `TimePage` profile names now link into the new view; existing per-device drill-in (`/devices/:mac/timeline`) is unchanged. `DeviceTimelinePage` was refactored to consume the shared chart component (no behavior change — existing tests still pass).

## Numbers reconciliation
Profile totals match `Routes.buildProfileTimeStatus` semantics (sum of per-mac bucket-deduped minutes). Two devices in the same profile both active in one 5-min window count twice toward the profile total — matches Screen Time totals on `/time`. Per-host minutes are even-share within each `(mac, period_start)` bucket (#715 sketch — bytes-weighting is a follow-up).

## Test plan
- [x] `mill api.test.testOnly wifihaven.api.feature.UsageApiSpec` — 10/10 pass (4 new profile-mode tests cover both-params 400, profile aggregation across two devices with both-stack invariants, unknown profile 404, empty profile)
- [x] `npm test` (vitest) — 133/133 pass, includes 4 new `ProfileTimelinePage` tests (loads with profileId, empty state, host↔device toggle, `?stackBy=device` URL parsing)
- [x] `npm run type-check` clean
- [x] `npm run lint` clean
- [ ] Manual: live walkthrough on `api.lan` once branch deploys — confirm chart renders on a kid profile with multiple devices and the toggle preserves colors.

## Endpoint shape change (heads-up for any callers)
`UsageSeriesResponse.deviceMac` / `deviceName` became optional (omitted in profile mode). Existing SPA consumer (`DeviceTimelinePage`) already handles the `undefined` case via `?? mac`.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)