### PR TITLE
docs: router cadence tunables + promote activity_sample_int to UCI (#748)

### DIFF
--- a/docs/router-tuning.md
+++ b/docs/router-tuning.md
@@ -1,0 +1,129 @@
+# Router cadence tuning
+
+The OpenWRT agent's behaviour is shaped by a handful of cadence knobs that
+control how often it polls the API, scrapes counters, samples activity, and
+flushes events. This page documents each knob, the trade-offs in raising or
+lowering it, and the couplings between them.
+
+All settings live in `/etc/config/wifihaven` (`config wifihaven 'wifihaven'`)
+and are read once at agent startup by `wifihaven-agent`. After editing the
+file, restart the service so the new values take effect:
+
+```sh
+/etc/init.d/wifihaven restart
+```
+
+You can edit these in the LuCI web UI under **Administration → Services →
+WifiHaven → Settings**, or by hand in `/etc/config/wifihaven`.
+
+## Cadence knobs
+
+### `policy_poll_interval` (default `5`)
+
+How often (seconds) the agent calls `GET /api/router/policy` to fetch the
+policy snapshot.
+
+- **Lower** → site-limit changes, pauses, and `extraAllowed`/`extraBlocked`
+  edits propagate to the router faster; more API requests/minute (one per
+  router).
+- **Raise** → less API load; admin-UI changes feel laggy (a 30 s interval
+  means a parent's "pause" tap could take up to 30 s to bite).
+- **Suggested range:** `3`–`30`. Below `3` the `curl` spawn overhead
+  dominates; above `30` the UX gets noticeably sluggish.
+
+### `usage_report_interval` (default `60`)
+
+How often (seconds) the agent scrapes nftables counters and POSTs
+`/api/router/usage`.
+
+- **Lower** → more granular daily usage timeline (#721, #716); more API
+  writes; bigger DB churn.
+- **Raise** → coarser timeline buckets; reduced API load. The server treats
+  each POST as a delta, so raising this does **not** lose bytes — only
+  timeline resolution.
+- **Couples with** `activity_sample_int`: must divide
+  `usage_report_interval` evenly. With defaults (10 / 60) every report
+  carries 6 samples.
+
+### `activity_sample_int` (default `10`)
+
+How often (seconds) the agent samples per-MAC conntrack activity to compute
+`activeSeconds` (#295, #516).
+
+- **Lower** → finer `activeSeconds` accuracy (a 5 s sample can attribute
+  use down to 5 s buckets); more CPU on the router (nft + conntrack scrape
+  per tick).
+- **Raise** → less CPU; coarser accuracy, and the upper bound on
+  under-counting grows (a device that pings the router once every
+  `activity_sample_int - 1` seconds would still register as active).
+- **Couples with** `usage_report_interval`: must evenly divide it to avoid
+  partial buckets at report boundaries. The agent emits a `warn` log line
+  at startup if the values are inconsistent and continues with degraded
+  accuracy.
+
+### `event_batch_size` (default `50`)
+
+How many `connection_attempt` events the agent buffers before flushing to
+`/api/router/events`.
+
+- **Lower** → events appear in the UI sooner; more requests/minute.
+- **Raise** → fewer requests; events feel laggy and a router crash loses
+  more in-flight events.
+
+### `event_flush_interval` (default `10`)
+
+Force-flush the event buffer after this many seconds even if
+`event_batch_size` is not reached.
+
+- **Lower** → bounded staleness even on quiet networks; more empty/small
+  POSTs.
+- **Raise** → fewer POSTs on quiet networks; events from rare devices can
+  sit buffered for a long time.
+
+## Non-cadence but cadence-adjacent
+
+- `debug` (default `0`) — does not change cadence but increases log volume
+  per tick. Bump to `1` only when actively diagnosing; leave at `0` in
+  steady state.
+
+## Safe-range / coupling summary
+
+| Knob | Default | Suggested range | Couples with |
+|---|---|---|---|
+| `policy_poll_interval` | 5 | 3–30 | — |
+| `usage_report_interval` | 60 | 30–300 | `activity_sample_int` (must divide evenly) |
+| `activity_sample_int` | 10 | 5–30 | `usage_report_interval` |
+| `event_batch_size` | 50 | 10–200 | `event_flush_interval` |
+| `event_flush_interval` | 10 | 5–60 | `event_batch_size` |
+
+## Worked examples
+
+**Low-traffic home (default-ish but lighter):**
+
+```
+option policy_poll_interval '10'
+option usage_report_interval '120'
+option activity_sample_int '15'   # 120 / 15 = 8 samples per report
+option event_batch_size '25'
+option event_flush_interval '15'
+```
+
+**Lab / development (fast feedback in the UI):**
+
+```
+option policy_poll_interval '3'
+option usage_report_interval '30'
+option activity_sample_int '5'    # 30 / 5 = 6 samples per report
+option event_batch_size '10'
+option event_flush_interval '5'
+```
+
+**Battery-constrained or weak CPU router:**
+
+```
+option policy_poll_interval '20'
+option usage_report_interval '300'
+option activity_sample_int '30'   # 300 / 30 = 10 samples per report
+option event_batch_size '100'
+option event_flush_interval '30'
+```

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -366,6 +366,13 @@ the user resolved. See [`../docs/architecture.md` §7.2](../docs/architecture.md
 Both allowed and blocked flows are reported so the admin UI shows a
 complete connection timeline, not just block events.
 
+## Tuning
+
+The cadence knobs in `/etc/config/wifihaven` (`policy_poll_interval`,
+`usage_report_interval`, `activity_sample_int`, `event_batch_size`,
+`event_flush_interval`) are documented with trade-offs and suggested
+ranges in [`docs/router-tuning.md`](../docs/router-tuning.md).
+
 ## Architecture reference
 
 See [`docs/architecture.md`](../docs/architecture.md) for the full design —

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -22,3 +22,9 @@ config wifihaven 'wifihaven'
 
 	# How often (seconds) to POST usage counters
 	option usage_report_interval '60'
+
+	# How often (seconds) to sample per-MAC activity for activeSeconds
+	# accounting. Must evenly divide usage_report_interval to avoid partial
+	# buckets at report boundaries (e.g. 10 with usage_report_interval=60
+	# yields 6 samples per report). See docs/router-tuning.md.
+	option activity_sample_int '10'

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -38,11 +38,21 @@ local max_batch     = tonumber(uci_get("event_batch_size",        "50"))
 local flush_int     = tonumber(uci_get("event_flush_interval",    "10"))
 local policy_int    = tonumber(uci_get("policy_poll_interval",    "5"))
 local usage_int     = tonumber(uci_get("usage_report_interval",   "60"))
+local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
 log.init({ debug = debug_opt })
-log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds",
-         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int)
+log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds activity_sample_int=%ds",
+         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, activity_sample_int)
+
+-- activity_sample_int should evenly divide usage_report_interval, or the last
+-- partial bucket at report flush time is shorter than the others. Warn and
+-- continue — a misconfig here degrades activeSeconds accuracy slightly but
+-- isn't worth crashing the agent over.
+if activity_sample_int <= 0 or usage_int % activity_sample_int ~= 0 then
+  log.warn("activity_sample_int=%d does not evenly divide usage_report_interval=%d; activeSeconds accuracy will degrade. See docs/router-tuning.md.",
+           activity_sample_int, usage_int)
+end
 
 if router_token == "" then
   log.err("router_token not set — run enrollment first")
@@ -229,7 +239,6 @@ local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
 local last_activity_sample = 0
-local activity_sample_int  = 10                 -- 10s activity granularity (#295, #516)
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
 


### PR DESCRIPTION
## Summary

- Adds [`docs/router-tuning.md`](../blob/router-tuning-docs/docs/router-tuning.md) — per-knob narrative, suggested ranges, coupling notes, and three worked-example configs, lifted from #748's body.
- Promotes `activity_sample_int` from a hardcoded constant in `wifihaven-agent` to a UCI option (default `10`). Adds a startup warning (not crash) if it does not evenly divide `usage_report_interval`.
- Cross-links the new doc from `openwrt/README.md`.

Closes #748. Unblocks the sample-cadence experiment in #714 — operators can now tune `activity_sample_int` without editing the agent.

The LuCI settings scaffold (#750) already includes an `activity_sample_int` field with the matching UCI option name, so once that lands the form will pick this up with no further changes. I deliberately did **not** touch the LuCI files in this PR (the scaffold doesn't exist on `main` yet); the `m.description` tweak pointing readers at `docs/router-tuning.md` should land as a tiny follow-up on top of #750.

## Test plan

- [x] `luac -p openwrt/files/usr/sbin/wifihaven-agent` parses cleanly
- [x] `bash openwrt/build-ipk.sh` builds the package
- [x] `grep -n activity_sample_int` confirms the UCI read at the top, the warning, and the existing timer-loop uses
- [ ] After merge: deploy to test router, confirm `uci get wifihaven.@wifihaven[0].activity_sample_int` returns `10` and `logread | grep wifihaven` shows the new startup line

🤖 Generated with [Claude Code](https://claude.com/claude-code)