### PR TITLE
ci(gate 2): migrate scenario pack to fake-API harness (#684)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ mill.??????
 .e2e-vm-venv/
 .e2e-vm-artifacts/
 scripts/e2e/**/__pycache__/
+
+# OpenWRT package build artifact (produced by openwrt/build-ipk.sh and
+# scripts/vm/build-router-image.sh). Repackaged from openwrt/files/ on
+# every build; not source.
+openwrt/wifihaven_*.ipk

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -1,0 +1,110 @@
+"""Shared observers for fake-mode scenarios (#684).
+
+Same nft / HTTP / DNS probes used by the live-mode scenarios. Kept in a
+private module rather than `lib/` because they exist purely to mirror the
+live scenarios' assertion shape — moving them into `lib/` would pull a
+fake-mode-specific dialect into a module the live conftest also imports.
+
+Helpers are observers only — they read router state, never mutate the fake.
+Snapshot-side mutation goes through `scenarios_fake.snapshot_builder` + the
+fake's `POST /test/snapshot`.
+"""
+from __future__ import annotations
+
+import re
+
+from lib.traffic import dns_query, http_get
+from lib.vm import router_nft_set
+from lib.wait import wait_until
+
+
+BLOCKED_MACS_SET = "blocked_macs"
+
+
+def norm_mac(mac: str) -> str:
+    return mac.lower().strip()
+
+
+def mac_in_blocked_set(mac: str) -> bool:
+    members = {norm_mac(m) for m in router_nft_set(BLOCKED_MACS_SET)}
+    return norm_mac(mac) in members
+
+
+def wait_mac_in_blocked_set(mac: str, *, present: bool, timeout_s: float = 180) -> None:
+    wait_until(
+        lambda: True if mac_in_blocked_set(mac) is present else None,
+        timeout_s=timeout_s,
+        interval_s=2,
+        description=(
+            f"{mac} {'present in' if present else 'absent from'} {BLOCKED_MACS_SET}"
+        ),
+    )
+
+
+def is_block_page_body(body: str | None) -> bool:
+    b = (body or "").lower()
+    return ("wifihaven" in b) or ("blocked" in b)
+
+
+def wait_block_page(client, *, host: str = "example.com", timeout_s: float = 90):
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        if p.http_code == 200 and is_block_page_body(p.body):
+            return p
+        return None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"block page response for {host}",
+    )
+
+
+def wait_http_succeeds(client, *, host: str = "example.com", timeout_s: float = 60):
+    """Probe HTTP success, disambiguating block-page (also 200) by body."""
+    def probe():
+        p = http_get(client, f"http://{host}/", timeout_s=8)
+        if p.http_code is not None and 200 <= p.http_code < 400:
+            if is_block_page_body(p.body):
+                return None
+            return p
+        return None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"allowed HTTP response for {host}",
+    )
+
+
+_IPV4 = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+
+
+def dig_ipv4_answers(client, host: str) -> list[str]:
+    res = dns_query(client, host, timeout_s=5)
+    lines = [l.strip() for l in (res.stdout or "").splitlines() if l.strip()]
+    return [l for l in lines if _IPV4.match(l)]
+
+
+def eb_set_name(host: str) -> str:
+    """render.lua::sanitize(): `[.:]` → `_`. See openwrt/files/usr/lib/lua/wifihaven/render.lua."""
+    return "eb_" + host.replace(".", "_").replace(":", "_")
+
+
+def wait_eb_set_populated(host: str, *, timeout_s: float = 90) -> list[str]:
+    name = eb_set_name(host)
+    def probe():
+        elems = router_nft_set(name)
+        return elems if elems else None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {name} to gain at least one element",
+    )
+
+
+def wait_event_for_mac(fake_api, mac: str, *, allowed: bool, reason: str,
+                       timeout_s: float = 60):
+    """Block until fake captured a connection_attempt event matching predicates."""
+    def probe():
+        evs = fake_api.events_for_mac(mac, allowed=allowed, reason=reason)
+        return evs or None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=2,
+        description=f"fake event allowed={allowed} reason={reason!r} for {mac}",
+    )

--- a/scripts/e2e/scenarios_fake/snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/snapshot_builder.py
@@ -1,20 +1,19 @@
-"""Minimal snapshot dict builders for the fake-API canary scenario (#683).
+"""Typed snapshot builder for fake-mode scenarios (#684).
 
-Just enough to construct the two snapshots `test_pause` needs. The full
-typed builder lives in #684.
+Produces dicts that match `shared/contract/api-to-router/policy_snapshot.json`
+verbatim. The fake's `POST /test/snapshot` accepts any dict and serves it back
+to the agent as-is, so all the shape rules live here, not in the fake.
 
-The wire shape matches `shared/contract/api-to-router/policy_snapshot.json`
-verbatim — the same fixture the fake loads on startup.
+Design: dicts + a couple of asserts. No pydantic / no jsonschema — the contract
+golden is already enforced upstream by `contract-tests` against the Scala codec,
+so this builder only has to faithfully reproduce that shape.
 """
 from __future__ import annotations
 
 from typing import Any
 
 
-def _default_blocklists() -> dict[str, Any]:
-    return {
-        "ads": {"version": "2026.05.01", "url": "/api/blocklists/ads"},
-    }
+_DEFAULT_GENERATED_AT = "2026-05-19T00:00:00Z"
 
 
 def profile_rules(
@@ -26,25 +25,146 @@ def profile_rules(
     blocklist_ids: list[str] | None = None,
     block_ip_only: bool = False,
 ) -> dict[str, Any]:
-    """Build the per-profile BlockRules wire shape.
+    """Build the BlockRules wire shape.
 
-    `block_reason` mirrors the `MacBlockReason` enum the Scala API emits —
-    `"Paused"`, `"Schedule"`, `"TimeLimit"`, `"Manual"`. Required when
-    `blocked=true` so the router agent (`render.lua::update_shared`) tags
-    `blocked_reason[mac]` with a meaningful value rather than the generic
-    fallback `"blocked"` — both the block-page renderer and the event
+    `block_reason` mirrors the `MacBlockReason` enum the Scala API emits
+    (`"Paused"`, `"Schedule"`, `"TimeLimit"`, `"Manual"`). Required when
+    `blocked=True` so the router agent tags `blocked_reason[mac]` with a
+    meaningful value — both the block-page renderer and the connection-event
     `reason` field key off this string.
     """
     rules: dict[str, Any] = {
         "blocked": blocked,
-        "extraBlocked": extra_blocked or [],
-        "extraAllowed": extra_allowed or [],
-        "blocklistIds": blocklist_ids or [],
+        "extraBlocked": list(extra_blocked or []),
+        "extraAllowed": list(extra_allowed or []),
+        "blocklistIds": list(blocklist_ids or []),
         "blockIpOnly": block_ip_only,
     }
     if block_reason is not None:
         rules["blockReason"] = block_reason
     return rules
+
+
+class SnapshotBuilder:
+    """Accumulator that produces a policy-snapshot dict ready for /test/snapshot.
+
+    Usage:
+        b = SnapshotBuilder()
+        b.add_profile(id=3, name="kids", extra_blocked=["tiktok.com"])
+        b.add_device(mac="aa:bb:cc:11:22:33", profile_id=3, name="kid-ipad")
+        b.add_blocklist(id="ads")
+        snap = b.build(etag='"sha256:abc"')
+    """
+
+    def __init__(self, *, generated_at: str = _DEFAULT_GENERATED_AT) -> None:
+        self._generated_at = generated_at
+        self._profiles: dict[str, dict[str, Any]] = {}
+        self._devices: dict[str, dict[str, Any]] = {}
+        self._blocklists: dict[str, dict[str, Any]] = {}
+
+    def add_profile(
+        self,
+        *,
+        id: int,
+        name: str,
+        blocked: bool = False,
+        block_reason: str | None = None,
+        extra_blocked: list[str] | None = None,
+        extra_allowed: list[str] | None = None,
+        blocklist_ids: list[str] | None = None,
+        block_ip_only: bool = False,
+        failure_mode: str = "block-all",
+    ) -> "SnapshotBuilder":
+        if blocked and block_reason is None:
+            # Mirrors render.lua's fallback: without a reason the block-page +
+            # event-reason both degrade to the literal "blocked". For tests
+            # that want enforcement (`blocked=True`) we require an explicit
+            # MacBlockReason so the agent-emitted reason is matchable.
+            raise AssertionError(
+                "add_profile(blocked=True) requires block_reason "
+                "('Paused' | 'Schedule' | 'TimeLimit' | 'Manual')"
+            )
+        self._profiles[str(id)] = {
+            "name": name,
+            "rules": profile_rules(
+                blocked=blocked,
+                block_reason=block_reason,
+                extra_blocked=extra_blocked,
+                extra_allowed=extra_allowed,
+                blocklist_ids=blocklist_ids,
+                block_ip_only=block_ip_only,
+            ),
+            "failureMode": failure_mode,
+        }
+        return self
+
+    def add_device(
+        self,
+        *,
+        mac: str,
+        name: str = "e2e-dev",
+        profile_id: int | None = None,
+        rules: dict[str, Any] | None = None,
+    ) -> "SnapshotBuilder":
+        """Add a device entry.
+
+        Exactly one of `profile_id` (assigned device, inherits profile rules)
+        or `rules` (per-MAC override, e.g. unknown-device branch in the
+        contract golden's `12:34:56:78:9a:bc` row) must be set.
+        """
+        if (profile_id is None) == (rules is None):
+            raise AssertionError(
+                "add_device requires exactly one of profile_id= or rules="
+            )
+        entry: dict[str, Any] = {"name": name}
+        if profile_id is not None:
+            entry["profileId"] = profile_id
+        else:
+            entry["rules"] = dict(rules)  # type: ignore[arg-type]
+        self._devices[mac] = entry
+        return self
+
+    def add_blocklist(
+        self,
+        *,
+        id: str,
+        version: str = "2026.05.01",
+        url: str | None = None,
+    ) -> "SnapshotBuilder":
+        self._blocklists[id] = {
+            "version": version,
+            "url": url if url is not None else f"/api/blocklists/{id}",
+        }
+        return self
+
+    def build(self, *, etag: str) -> dict[str, Any]:
+        # Self-consistency: every device's profileId must reference a profile
+        # we declared. The agent tolerates dangling IDs (treats them as
+        # default-allow), but the tests don't — a typo here means hours
+        # chasing a phantom failure.
+        for mac, dev in self._devices.items():
+            pid = dev.get("profileId")
+            if pid is not None and str(pid) not in self._profiles:
+                raise AssertionError(
+                    f"device {mac} references unknown profileId={pid}; "
+                    f"declared profiles: {sorted(self._profiles)}"
+                )
+        return {
+            "etag": etag,
+            "generatedAt": self._generated_at,
+            "devices": dict(self._devices),
+            "profiles": dict(self._profiles),
+            "blocklists": dict(self._blocklists),
+        }
+
+
+# ── Convenience helpers kept for the #683 canary (test_pause) ───────────────
+
+
+def _default_blocklists() -> dict[str, Any]:
+    return {
+        "ads": {"version": "2026.05.01", "url": "/api/blocklists/ads"},
+    }
 
 
 def snapshot_with_assigned_device(
@@ -55,29 +175,16 @@ def snapshot_with_assigned_device(
     profile_id: int = 100,
     profile_name: str = "e2e-profile",
     paused: bool = False,
-    generated_at: str = "2026-05-19T00:00:00Z",
+    generated_at: str = _DEFAULT_GENERATED_AT,
 ) -> dict[str, Any]:
-    """Snapshot with one device assigned to one profile.
-
-    `paused=True` flips the profile's `rules.blocked` to true, mirroring how
-    the live admin pause toggle propagates at wire level (per the answer to
-    the design checkpoint in #683).
-    """
-    return {
-        "etag": etag,
-        "generatedAt": generated_at,
-        "devices": {
-            mac: {"profileId": profile_id, "name": device_name},
-        },
-        "profiles": {
-            str(profile_id): {
-                "name": profile_name,
-                "rules": profile_rules(
-                    blocked=paused,
-                    block_reason="Paused" if paused else None,
-                ),
-                "failureMode": "block-all",
-            },
-        },
-        "blocklists": _default_blocklists(),
-    }
+    """Single-device snapshot used by the #683 pause canary."""
+    b = SnapshotBuilder(generated_at=generated_at)
+    b.add_profile(
+        id=profile_id,
+        name=profile_name,
+        blocked=paused,
+        block_reason="Paused" if paused else None,
+    )
+    b.add_device(mac=mac, name=device_name, profile_id=profile_id)
+    b.add_blocklist(id="ads")
+    return b.build(etag=etag)

--- a/scripts/e2e/scenarios_fake/test_02_allowed_browsing.py
+++ b/scripts/e2e/scenarios_fake/test_02_allowed_browsing.py
@@ -1,0 +1,53 @@
+"""Scenario 2: Allowed browsing (fake-mode #684).
+
+Default permissive profile → HTTP GET from the client succeeds, AND the
+agent reports the connection_event upstream. The fake captures the event
+batch and `events_for_mac(mac, allowed=True)` returns it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib.wait import wait_until
+
+from ._observers import wait_http_succeeds
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.allowed
+
+PROFILE_ID = 400
+ALLOWED_HOST = "example.com"
+
+
+def test_allowed_request_succeeds_and_event_recorded(router, client, fake_api):
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PROFILE_ID, name="e2e-allowed")
+        .add_device(mac=client.mac, name="e2e-allowed-dev", profile_id=PROFILE_ID)
+        .build(etag='"sha256:allowed-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    probe = wait_http_succeeds(client, host=ALLOWED_HOST, timeout_s=60)
+    assert probe.http_code is not None and 200 <= probe.http_code < 400
+
+    # The agent flushes connection_events on its event-report cadence
+    # (independent of policy polls). The fake captures whatever the agent
+    # POSTs to /api/router/events. Look for an allowed=True event for this MAC
+    # — host attribution lives under the tagged-union `host` field (#391).
+    def find_allowed_event():
+        for e in fake_api.events_for_mac(client.mac, allowed=True):
+            host = e.get("host")
+            if isinstance(host, dict) and ALLOWED_HOST in (host.get("value") or ""):
+                return e
+            # Fallback: even without host attribution, an allowed=True event
+            # for this MAC is the load-bearing observable.
+            return e
+        return None
+
+    matched = wait_until(
+        find_allowed_event, timeout_s=120, interval_s=3,
+        description=f"fake-captured allowed event for {client.mac}",
+    )
+    assert matched is not None

--- a/scripts/e2e/scenarios_fake/test_03_blocked_domain.py
+++ b/scripts/e2e/scenarios_fake/test_03_blocked_domain.py
@@ -1,0 +1,31 @@
+"""Scenario 3: Blocked domain rejected (fake-mode #684).
+
+extraBlocked drives a per-(MAC, host) nft drop rule that DNATs port-80
+traffic to the local block page. The response body comes from the block
+page rather than the real upstream.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import wait_block_page
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.blocked
+
+BLOCKED_HOST = "example.org"
+PROFILE_ID = 500
+
+
+def test_blocked_domain_request_dropped(router, client, fake_api):
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PROFILE_ID, name="e2e-blocked", extra_blocked=[BLOCKED_HOST])
+        .add_device(mac=client.mac, name="e2e-blocked-dev", profile_id=PROFILE_ID)
+        .build(etag='"sha256:blocked-domain-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    probe = wait_block_page(client, host=BLOCKED_HOST, timeout_s=90)
+    assert probe is not None

--- a/scripts/e2e/scenarios_fake/test_05_usage_in_api.py
+++ b/scripts/e2e/scenarios_fake/test_05_usage_in_api.py
@@ -1,0 +1,78 @@
+"""Scenario 5: usage reports flow upstream (fake-mode #684).
+
+Live-mode `scenarios/test_05_usage_in_api.py` asserts that connection_events
+appear in `/api/logs` and that the device shows up in `/api/time/status` —
+both API-side projections of agent-emitted reports.
+
+In fake mode the API-side projections don't exist; what's load-bearing is
+that the agent *emits* the report and *emits* the events. The fake captures
+both; this scenario asserts:
+
+  1. After client HTTP activity, the fake has captured a usage report
+     whose `records` contain an entry for the client's MAC.
+  2. The fake has at least one connection_attempt event for the client's MAC.
+
+This is the wire-shape equivalent of "usage shows up upstream" — the live
+projections are tested separately by the API's own suite.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from lib.traffic import http_get
+from lib.wait import wait_until
+
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.usage
+
+PROFILE_ID = 900
+ALLOWED_HOST = "example.com"
+
+
+def test_usage_flows_to_fake_for_client_mac(router, client, fake_api):
+    """Drive 5 HTTP probes and assert the fake captured a usage report
+    referencing this MAC, plus at least one event."""
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PROFILE_ID, name="e2e-usage")
+        .add_device(mac=client.mac, name="e2e-usage-dev", profile_id=PROFILE_ID)
+        .build(etag='"sha256:usage-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    for _ in range(5):
+        http_get(client, f"http://{ALLOWED_HOST}/", timeout_s=5)
+        time.sleep(1)
+
+    # Events surface on the agent's event-report cadence (seconds). Look for
+    # any event tagged with our MAC.
+    def has_event():
+        return fake_api.events_for_mac(client.mac) or None
+    wait_until(
+        has_event, timeout_s=120, interval_s=3,
+        description=f"fake event captured for {client.mac}",
+    )
+
+    # Usage reports go out on a slower cadence (agent default ~300s). To keep
+    # the suite under wall-time budget we don't wait the full cycle here —
+    # we poll the fake's /test/usage capture buffer and time out gracefully
+    # if no report has been flushed yet. The router-side enforcement signal
+    # (events captured above) is the load-bearing observable.
+    def has_usage_for_mac():
+        for r in (fake_api.usage().get("reports") or []):
+            for rec in (r.get("body", {}).get("records") or []):
+                if (rec.get("mac") or "").lower() == client.mac.lower():
+                    return rec
+        return None
+    rec = wait_until(
+        has_usage_for_mac, timeout_s=360, interval_s=10,
+        description=f"fake usage report with row for {client.mac}",
+    )
+    # Wire-shape sanity: matches shared/contract/router-to-api/usage_report.json.
+    assert "activeSeconds" in rec
+    assert "bytesIn" in rec
+    assert "bytesOut" in rec

--- a/scripts/e2e/scenarios_fake/test_06_blocked_page.py
+++ b/scripts/e2e/scenarios_fake/test_06_blocked_page.py
@@ -1,0 +1,40 @@
+"""Scenario 6: /blocked page rendering (fake-mode #684).
+
+Per architecture Truth-1, blocked HTTP traffic is DNAT'd by nftables to the
+local block page on port 80, served by uhttpd-mod-lua
+(/www/wifihaven/handler.lua, #437). Curling a blocked HTTP destination should
+yield the block page body.
+
+Mirrors `scenarios/test_06_blocked_page.py` but drives policy via the fake.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import wait_block_page
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.blocked_page
+
+BLOCKED_HOST = "example.net"
+PROFILE_ID = 300
+
+
+def test_blocked_request_returns_block_page(router, client, fake_api):
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PROFILE_ID, name="e2e-blockpage", extra_blocked=[BLOCKED_HOST])
+        .add_device(mac=client.mac, name="e2e-blockpage-dev", profile_id=PROFILE_ID)
+        .build(etag='"sha256:blockpage-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    probe = wait_block_page(client, host=BLOCKED_HOST, timeout_s=90)
+    assert probe.http_code == 200
+
+    body_lower = probe.body.lower()
+    assert "blocked" in body_lower, "expected 'blocked' in block page body"
+    assert "request extension" not in body_lower, (
+        "block page must not expose a 'Request extension' link (#577)"
+    )

--- a/scripts/e2e/scenarios_fake/test_extra_blocked.py
+++ b/scripts/e2e/scenarios_fake/test_extra_blocked.py
@@ -1,0 +1,167 @@
+"""Suite B — extraBlocked Truth-1 + per-profile scoping (#429, fake-mode #684).
+
+Mirrors `scenarios/test_extra_blocked.py`. extraBlocked is enforced at the
+*connection* layer (per-host nft drop sets, DNATed to the local block page)
+rather than at DNS — see #351/#352/#392.
+
+Snapshot-driven: each case POSTs a new snapshot with `extraBlocked` populated
+on a profile, waits for the agent to fetch + apply, and inspects nft state +
+block-page response on the client.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    dig_ipv4_answers,
+    eb_set_name,
+    mac_in_blocked_set,
+    wait_block_page,
+    wait_eb_set_populated,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.extra_blocked
+
+BLOCKED_HOST = "example.com"
+KIDS_PID = 200
+ADULTS_PID = 201
+
+
+def _kids_snapshot(*, etag: str, kids_mac: str, extra_blocked: list[str]) -> dict:
+    return (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-kids", extra_blocked=extra_blocked)
+        .add_device(mac=kids_mac, name="e2e-kids-dev", profile_id=KIDS_PID)
+        .build(etag=etag)
+    )
+
+
+# ── B1 / B4 — DNS still returns real IPv4s (Truth-1) ────────────────────────
+
+
+@pytest.mark.smoke
+def test_extra_blocked_dns_returns_real_ip(router, client, fake_api):
+    """B1+B4 (smoke): Truth-1 — DNS for an extraBlocked host returns real
+    IPv4 answers, not NXDOMAIN. Guards against regression to old `address=`
+    sinkhole behavior (#351). Enforcement plane is nft drops, NOT DNS lies.
+    """
+    snap = _kids_snapshot(
+        etag='"sha256:eb-dns-v1"', kids_mac=client.mac, extra_blocked=[BLOCKED_HOST],
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    from lib.wait import wait_until
+    answers = wait_until(
+        lambda: dig_ipv4_answers(client, BLOCKED_HOST) or None,
+        timeout_s=90, interval_s=3,
+        description=f"dig {BLOCKED_HOST} to return an IPv4 answer",
+    )
+    assert answers, f"expected real IPv4 answers for {BLOCKED_HOST}, got none"
+
+
+# ── B2 — HTTP/80 hits block page + eb_<host> set populated ───────────────────
+
+
+def test_extra_blocked_http_drops_to_block_page_and_set_populated(
+    router, client, fake_api,
+):
+    """B2: HTTP/80 to an extraBlocked host is intercepted (block-page body),
+    and the resolved dest IP appears in the per-host nft set `eb_<host>`
+    (rendered by render.lua, populated by dnsmasq `--nftset=` callbacks)."""
+    snap = _kids_snapshot(
+        etag='"sha256:eb-http-v1"', kids_mac=client.mac, extra_blocked=[BLOCKED_HOST],
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    probe = wait_block_page(client, host=BLOCKED_HOST, timeout_s=90)
+    assert probe.http_code == 200
+
+    members = wait_eb_set_populated(BLOCKED_HOST, timeout_s=90)
+    assert members, (
+        f"expected nft set {eb_set_name(BLOCKED_HOST)} to have at least one IP "
+        f"element, got empty"
+    )
+
+
+# ── B3 — per-profile scoping ─────────────────────────────────────────────────
+
+
+def test_extra_blocked_is_per_profile_scoped(router, client, fake_api):
+    """B3: extraBlocked on the Kids profile does NOT MAC-wide block either the
+    Kids MAC or a phantom Adults MAC.
+
+    eb_<host> is per-HOST (shared across MACs); per-MAC isolation lives in the
+    drop *rules* (ether saddr <mac> AND ip daddr @eb_<host>). We assert
+    (a) neither MAC is in blocked_macs (extraBlocked is host-scoped, not a
+    pause); (b) the per-host set IS populated; (c) extraAllowed beats blocked
+    isn't relevant here (no blocking), but extraBlocked on Kids must not bleed
+    into Adults's rule set.
+    """
+    kids_mac = client.mac
+    adults_mac = "02:b3:b3:00:00:01"
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-kids", extra_blocked=[BLOCKED_HOST])
+        .add_profile(id=ADULTS_PID, name="e2e-adults")  # extraBlocked=[]
+        .add_device(mac=kids_mac, name="e2e-kids-dev", profile_id=KIDS_PID)
+        .add_device(mac=adults_mac, name="e2e-adults-dev", profile_id=ADULTS_PID)
+        .build(etag='"sha256:eb-scope-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # `wait_for_etag_served` only confirms the agent FETCHED the new policy,
+    # not that it has rewritten dnsmasq.conf and reloaded dnsmasq. The
+    # `nftset=` directive that drives eb_<host> population is part of that
+    # rewrite. Drive the block-page probe in a poll loop (same shape B2 uses)
+    # so each curl attempt triggers a fresh DNS query — once dnsmasq has been
+    # reloaded with the new nftset directive, the next resolver answer
+    # populates the set and the block page renders for the Kids MAC.
+    wait_block_page(client, host=BLOCKED_HOST, timeout_s=120)
+    wait_eb_set_populated(BLOCKED_HOST, timeout_s=30)
+
+    from lib.wait import wait_until
+    def neither_blocked():
+        kb = mac_in_blocked_set(kids_mac)
+        ab = mac_in_blocked_set(adults_mac)
+        return True if (not kb and not ab) else None
+    wait_until(
+        neither_blocked, timeout_s=60, interval_s=2,
+        description=(
+            f"neither {kids_mac} nor {adults_mac} present in blocked_macs"
+        ),
+    )
+
+
+# ── B5 — extraAllowed beats blocked invariant ───────────────────────────────
+
+
+def test_extra_allowed_beats_blocked(router, client, fake_api):
+    """B5: when a host is in both extraBlocked AND extraAllowed, allowed wins.
+
+    Locks in the router enforcement invariant (memory:
+    `feedback_extraallowed_beats_blocked`). Without this case in the pack, a
+    regression to the alternate precedence would slip past the migration.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-kids-overlap",
+            extra_blocked=[BLOCKED_HOST],
+            extra_allowed=[BLOCKED_HOST],
+        )
+        .add_device(mac=client.mac, name="e2e-kids-dev", profile_id=KIDS_PID)
+        .build(etag='"sha256:eb-allowed-beats-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Allowed must win: the MAC is not blocked and HTTP/80 succeeds without
+    # hitting the block page.
+    from ._observers import wait_http_succeeds
+    wait_http_succeeds(client, host=BLOCKED_HOST, timeout_s=90)
+    assert not mac_in_blocked_set(client.mac)

--- a/scripts/e2e/scenarios_fake/test_pause.py
+++ b/scripts/e2e/scenarios_fake/test_pause.py
@@ -22,7 +22,7 @@ from lib.traffic import http_get
 from lib.vm import router_nft_set
 from lib.wait import wait_until
 
-from .snapshot_builder import snapshot_with_assigned_device
+from .snapshot_builder import SnapshotBuilder, snapshot_with_assigned_device
 
 pytestmark = pytest.mark.pause
 
@@ -105,9 +105,90 @@ def test_pause_blocks_via_fake_api(router, client, fake_api):
     def _has_paused_event():
         evs = fake_api.events_for_mac(mac, allowed=False, reason="paused")
         return evs or None
+    # The agent batches connection_events and POSTs them on its own cadence
+    # (~10-15s per flush). A 60s window raced the flush in #684 validation
+    # even though the underlying behavior was correct; bumping to 120s gives
+    # at least one full event-report cycle of headroom.
     wait_until(
         _has_paused_event,
-        timeout_s=60,
+        timeout_s=120,
         interval_s=2,
         description=f"paused event for {mac} in fake",
     )
+
+
+# ── A3 — paused profile + new device added in second snapshot ──────────────
+
+
+_A_PROFILE_ID = 101
+
+
+def _snapshot_with_two_devices(
+    *, etag: str, mac_a: str, mac_b: str | None, paused: bool,
+) -> dict:
+    b = SnapshotBuilder()
+    b.add_profile(
+        id=_A_PROFILE_ID, name="e2e-pause-extras",
+        blocked=paused, block_reason="Paused" if paused else None,
+    )
+    b.add_device(mac=mac_a, name="e2e-pause-a", profile_id=_A_PROFILE_ID)
+    if mac_b is not None:
+        b.add_device(mac=mac_b, name="e2e-pause-b", profile_id=_A_PROFILE_ID)
+    return b.build(etag=etag)
+
+
+def test_pause_then_add_device_blocks_new_mac(router, client, fake_api):
+    """A3: with the profile paused, adding a second device to the snapshot
+    puts the new MAC into blocked_macs within one poll. No second client VM
+    needed — we only need the nft set to grow."""
+    mac_a = client.mac
+    mac_b = "02:e2:e2:a3:00:42"
+
+    e1 = fake_api.serve_snapshot(
+        _snapshot_with_two_devices(
+            etag='"sha256:a3-paused-only-a"', mac_a=mac_a, mac_b=None, paused=True,
+        ),
+    )
+    fake_api.wait_for_etag_served(etag=e1, timeout_s=240)
+    _wait_mac_in_blocked_set(mac_a, present=True, timeout_s=180)
+
+    e2 = fake_api.serve_snapshot(
+        _snapshot_with_two_devices(
+            etag='"sha256:a3-paused-add-b"', mac_a=mac_a, mac_b=mac_b, paused=True,
+        ),
+    )
+    fake_api.wait_for_etag_served(etag=e2, timeout_s=240)
+    _wait_mac_in_blocked_set(mac_b, present=True, timeout_s=180)
+
+
+# ── A4 — reassign off paused profile unblocks MAC ─────────────────────────
+
+
+_PAUSED_PID = 102
+_OPEN_PID = 103
+
+
+def test_reassign_off_paused_profile_unblocks_mac(router, client, fake_api):
+    """A4: device on paused profile → reassigned to an unpaused profile →
+    MAC clears blocked_macs within one poll."""
+    mac = client.mac
+
+    def _snap(*, etag: str, profile_id: int) -> dict:
+        return (
+            SnapshotBuilder()
+            .add_profile(
+                id=_PAUSED_PID, name="e2e-a4-paused",
+                blocked=True, block_reason="Paused",
+            )
+            .add_profile(id=_OPEN_PID, name="e2e-a4-open")
+            .add_device(mac=mac, name="e2e-a4-dev", profile_id=profile_id)
+            .build(etag=etag)
+        )
+
+    e1 = fake_api.serve_snapshot(_snap(etag='"sha256:a4-paused"', profile_id=_PAUSED_PID))
+    fake_api.wait_for_etag_served(etag=e1, timeout_s=240)
+    _wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
+
+    e2 = fake_api.serve_snapshot(_snap(etag='"sha256:a4-open"', profile_id=_OPEN_PID))
+    fake_api.wait_for_etag_served(etag=e2, timeout_s=240)
+    _wait_mac_in_blocked_set(mac, present=False, timeout_s=180)

--- a/scripts/e2e/scenarios_fake/test_reassignment.py
+++ b/scripts/e2e/scenarios_fake/test_reassignment.py
@@ -1,0 +1,79 @@
+"""Suite E — profile reassignment (fake-mode #684).
+
+Mirrors `scenarios/test_reassignment.py::test_reassign_to_paused_blocks_and_back_restores`
+(E1+E2 smoke). The fake-mode equivalent of "reassign" is "POST a new snapshot
+where the device's `profileId` points at a different profile."
+
+E3 (delete-clears-rules) is dropped: in fake mode the observable for deletion
+is identical to "device removed from the snapshot," and the per-MAC unblock
+on snapshot removal is already covered by E2 (reassignment to a non-paused
+profile).
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    mac_in_blocked_set,
+    wait_block_page,
+    wait_http_succeeds,
+    wait_mac_in_blocked_set,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.reassignment
+
+PROFILE_A_PERMISSIVE = 800
+PROFILE_B_PAUSED = 801
+
+
+def _snapshot_on_profile(*, etag: str, mac: str, profile_id: int) -> dict:
+    """Snapshot with two profiles (A permissive, B paused) and the device
+    pinned to `profile_id`. Both profiles always declared so the agent sees a
+    consistent universe across swaps."""
+    return (
+        SnapshotBuilder()
+        .add_profile(id=PROFILE_A_PERMISSIVE, name="e2e-permissive")
+        .add_profile(
+            id=PROFILE_B_PAUSED, name="e2e-paused",
+            blocked=True, block_reason="Paused",
+        )
+        .add_device(mac=mac, name="e2e-reassign-dev", profile_id=profile_id)
+        .build(etag=etag)
+    )
+
+
+@pytest.mark.smoke
+def test_reassign_to_paused_blocks_and_back_restores(router, client, fake_api):
+    """E1+E2 (smoke): A→B(paused) blocks within one poll; B→A restores."""
+    mac = client.mac
+
+    # Initial: device on permissive profile A — not blocked.
+    e1 = fake_api.serve_snapshot(
+        _snapshot_on_profile(
+            etag='"sha256:reassign-A1"', mac=mac, profile_id=PROFILE_A_PERMISSIVE,
+        ),
+    )
+    fake_api.wait_for_etag_served(etag=e1, timeout_s=240)
+    assert not mac_in_blocked_set(mac), \
+        "precondition: MAC must not be blocked on permissive profile"
+
+    # E1: reassign to paused profile B → blocked + block page.
+    e2 = fake_api.serve_snapshot(
+        _snapshot_on_profile(
+            etag='"sha256:reassign-B"', mac=mac, profile_id=PROFILE_B_PAUSED,
+        ),
+    )
+    fake_api.wait_for_etag_served(etag=e2, timeout_s=240)
+    wait_mac_in_blocked_set(mac, present=True, timeout_s=180)
+    wait_block_page(client, timeout_s=60)
+
+    # E2: reassign back to A → unblocked + HTTP works.
+    e3 = fake_api.serve_snapshot(
+        _snapshot_on_profile(
+            etag='"sha256:reassign-A2"', mac=mac, profile_id=PROFILE_A_PERMISSIVE,
+        ),
+    )
+    fake_api.wait_for_etag_served(etag=e3, timeout_s=240)
+    wait_mac_in_blocked_set(mac, present=False, timeout_s=180)
+    wait_http_succeeds(client, timeout_s=60)

--- a/scripts/e2e/scenarios_fake/test_schedule.py
+++ b/scripts/e2e/scenarios_fake/test_schedule.py
@@ -1,0 +1,107 @@
+"""Suite C — schedule enforcement (fake-mode #684).
+
+Live-mode `scenarios/test_schedule.py` exercises both router enforcement AND
+the API's TZ-aware schedule evaluator (#334/#442) by manipulating the router
+wall clock and adding ScheduleRequest rows on the live API.
+
+In fake mode the API-side evaluator is out of the picture: the fake serves
+whatever `blocked` / `blockReason` we POST. So the schedule scenario
+collapses to three router-side observables:
+
+  - In-window snapshot (blocked=True, blockReason=Schedule) → MAC in
+    blocked_macs + event reason=schedule.
+  - Out-of-window snapshot (blocked=False) → MAC absent, HTTP succeeds.
+  - Pause overrides schedule precedence (#406) — observed at the wire level
+    as `blockReason=Paused` vs `blockReason=Schedule`. The router emits the
+    matching event reason; the precedence math itself lives in the API and
+    is locked in by live-mode `test_schedule.py::test_pause_overrides_schedule`.
+
+C3 (cross-midnight TZ math) and C5 (all-day-Monday) are intentionally NOT
+migrated — they test API-side TZ logic the fake doesn't reproduce. Tracked
+in live-mode test_schedule.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    mac_in_blocked_set,
+    wait_block_page,
+    wait_event_for_mac,
+    wait_http_succeeds,
+    wait_mac_in_blocked_set,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.schedule
+
+PROFILE_ID = 600
+
+
+def _snap(*, etag: str, mac: str, blocked: bool, reason: str | None) -> dict:
+    return (
+        SnapshotBuilder()
+        .add_profile(
+            id=PROFILE_ID, name="e2e-sched",
+            blocked=blocked,
+            block_reason=reason if blocked else None,
+        )
+        .add_device(mac=mac, name="e2e-sched-dev", profile_id=PROFILE_ID)
+        .build(etag=etag)
+    )
+
+
+# ── C1 — in-window blocks ──────────────────────────────────────────────────
+
+
+def test_in_window_blocks(router, client, fake_api):
+    """C1: schedule covering the current window → MAC blocked, reason=schedule."""
+    etag = fake_api.serve_snapshot(
+        _snap(etag='"sha256:sched-in-v1"', mac=client.mac, blocked=True, reason="Schedule"),
+    )
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    wait_mac_in_blocked_set(client.mac, present=True, timeout_s=180)
+    # Drive HTTP from the client so the agent emits a connection_attempt
+    # event we can match. Without traffic, blocked_macs is populated but no
+    # blocked-reason event fires (router emits events on actual packets).
+    wait_block_page(client, timeout_s=60)
+    wait_event_for_mac(fake_api, client.mac, allowed=False, reason="schedule", timeout_s=60)
+
+
+# ── C2 — out-of-window allows ──────────────────────────────────────────────
+
+
+def test_out_of_window_allows(router, client, fake_api):
+    """C2: out-of-window snapshot (blocked=False) → HTTP works, MAC not blocked."""
+    etag = fake_api.serve_snapshot(
+        _snap(etag='"sha256:sched-out-v1"', mac=client.mac, blocked=False, reason=None),
+    )
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    assert not mac_in_blocked_set(client.mac)
+    wait_http_succeeds(client, timeout_s=60)
+
+
+# ── C6 — smoke: in→out transition ──────────────────────────────────────────
+
+
+@pytest.mark.smoke
+def test_in_then_out_smoke(router, client, fake_api):
+    """C6 (smoke): in-window blocks, then sliding the snapshot to out-of-window
+    unblocks within one poll. Single device, two snapshot swaps — fastest
+    signal."""
+    e1 = fake_api.serve_snapshot(
+        _snap(etag='"sha256:sched-smoke-in"', mac=client.mac, blocked=True, reason="Schedule"),
+    )
+    fake_api.wait_for_etag_served(etag=e1, timeout_s=240)
+    wait_mac_in_blocked_set(client.mac, present=True, timeout_s=180)
+    wait_block_page(client, timeout_s=60)
+    wait_event_for_mac(fake_api, client.mac, allowed=False, reason="schedule", timeout_s=60)
+
+    e2 = fake_api.serve_snapshot(
+        _snap(etag='"sha256:sched-smoke-out"', mac=client.mac, blocked=False, reason=None),
+    )
+    fake_api.wait_for_etag_served(etag=e2, timeout_s=240)
+    wait_mac_in_blocked_set(client.mac, present=False, timeout_s=180)
+    wait_http_succeeds(client, timeout_s=60)

--- a/scripts/e2e/scenarios_fake/test_snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/test_snapshot_builder.py
@@ -1,0 +1,160 @@
+"""Unit tests for the snapshot builder (#684).
+
+Pure-dict tests; do not request any VM fixtures. Cross-checks the builder's
+output structure against `shared/contract/api-to-router/policy_snapshot.json`,
+the contract golden the fake itself loads on startup.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from .snapshot_builder import SnapshotBuilder, snapshot_with_assigned_device
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GOLDEN_PATH = REPO_ROOT / "shared" / "contract" / "api-to-router" / "policy_snapshot.json"
+
+
+def _golden() -> dict:
+    return json.loads(GOLDEN_PATH.read_text())
+
+
+# ── Shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_empty_build_has_top_level_contract_keys():
+    snap = SnapshotBuilder().build(etag='"sha256:empty"')
+    assert set(snap) == {"etag", "generatedAt", "devices", "profiles", "blocklists"}
+    assert snap["devices"] == {}
+    assert snap["profiles"] == {}
+    assert snap["blocklists"] == {}
+
+
+def test_builder_matches_golden_shape():
+    """Reproduce the golden snapshot's structure via the builder and verify
+    its key set + per-row sub-shapes line up.
+
+    Not a byte-for-byte equality check — the golden uses string `etag` quoting
+    we shouldn't pin in the builder — but the structural surface must match
+    so the fake serves bytes the agent can decode.
+    """
+    g = _golden()
+    b = SnapshotBuilder(generated_at=g["generatedAt"])
+    # Profiles
+    for pid_str, prof in g["profiles"].items():
+        r = prof["rules"]
+        b.add_profile(
+            id=int(pid_str),
+            name=prof["name"],
+            blocked=r["blocked"],
+            block_reason=r.get("blockReason"),
+            extra_blocked=r.get("extraBlocked"),
+            extra_allowed=r.get("extraAllowed"),
+            blocklist_ids=r.get("blocklistIds"),
+            block_ip_only=r.get("blockIpOnly", False),
+            failure_mode=prof.get("failureMode", "block-all"),
+        )
+    # Devices — golden has both branches (profileId-assigned + per-MAC rules).
+    for mac, dev in g["devices"].items():
+        if "profileId" in dev:
+            b.add_device(mac=mac, name=dev["name"], profile_id=dev["profileId"])
+        else:
+            b.add_device(mac=mac, name=dev["name"], rules=dev["rules"])
+    # Blocklists
+    for bid, bl in g["blocklists"].items():
+        b.add_blocklist(id=bid, version=bl["version"], url=bl["url"])
+
+    built = b.build(etag=g["etag"])
+
+    assert built["etag"] == g["etag"]
+    assert built["generatedAt"] == g["generatedAt"]
+    assert set(built["profiles"]) == set(g["profiles"])
+    assert set(built["devices"]) == set(g["devices"])
+    assert set(built["blocklists"]) == set(g["blocklists"])
+
+    # Each profile's rules block must carry the contract fields. Order
+    # doesn't matter, but the agent reads these by key name.
+    for pid_str, prof in built["profiles"].items():
+        assert set(prof) == {"name", "rules", "failureMode"}
+        r = prof["rules"]
+        contract_keys = {"blocked", "extraBlocked", "extraAllowed", "blocklistIds", "blockIpOnly"}
+        assert contract_keys.issubset(set(r))
+
+    # The per-MAC override device in the golden must round-trip as a `rules`
+    # device, NOT as a profileId device.
+    override_mac = "12:34:56:78:9a:bc"
+    assert override_mac in built["devices"]
+    assert "rules" in built["devices"][override_mac]
+    assert "profileId" not in built["devices"][override_mac]
+
+
+# ── Per-MAC override ──────────────────────────────────────────────────────────
+
+
+def test_add_device_per_mac_override():
+    snap = (
+        SnapshotBuilder()
+        .add_device(
+            mac="aa:bb:cc:dd:ee:ff",
+            name="unknown",
+            rules={
+                "blocked": True,
+                "blockReason": "Manual",
+                "extraBlocked": [],
+                "extraAllowed": [],
+                "blocklistIds": [],
+                "blockIpOnly": False,
+            },
+        )
+        .build(etag='"sha256:override"')
+    )
+    d = snap["devices"]["aa:bb:cc:dd:ee:ff"]
+    assert d["rules"]["blocked"] is True
+    assert "profileId" not in d
+
+
+def test_add_device_rejects_both_profile_and_rules():
+    with pytest.raises(AssertionError):
+        SnapshotBuilder().add_device(
+            mac="aa:bb:cc:dd:ee:ff", profile_id=3, rules={"blocked": False},
+        )
+
+
+def test_add_device_rejects_neither():
+    with pytest.raises(AssertionError):
+        SnapshotBuilder().add_device(mac="aa:bb:cc:dd:ee:ff")
+
+
+# ── Profile guard ─────────────────────────────────────────────────────────────
+
+
+def test_add_profile_requires_block_reason_when_blocked():
+    """`blocked=True` without a reason → render.lua falls back to "blocked".
+    Tests that match on `reason=Paused`/etc. would mysteriously fail; force
+    callers to be explicit."""
+    with pytest.raises(AssertionError):
+        SnapshotBuilder().add_profile(id=1, name="p", blocked=True)
+
+
+def test_build_rejects_device_referencing_unknown_profile():
+    b = SnapshotBuilder()
+    b.add_profile(id=1, name="p")
+    b.add_device(mac="aa:bb:cc:dd:ee:ff", profile_id=999)
+    with pytest.raises(AssertionError):
+        b.build(etag='"sha256:bad"')
+
+
+# ── Convenience helper (canary uses this) ─────────────────────────────────────
+
+
+def test_snapshot_with_assigned_device_canary_shape():
+    snap = snapshot_with_assigned_device(
+        etag='"sha256:c"', mac="aa:bb:cc:dd:ee:ff", paused=True,
+    )
+    assert snap["devices"]["aa:bb:cc:dd:ee:ff"]["profileId"] == 100
+    rules = snap["profiles"]["100"]["rules"]
+    assert rules["blocked"] is True
+    assert rules["blockReason"] == "Paused"

--- a/scripts/e2e/scenarios_fake/test_time_limit.py
+++ b/scripts/e2e/scenarios_fake/test_time_limit.py
@@ -1,0 +1,61 @@
+"""Suite D — daily time-limit enforcement (fake-mode #684).
+
+Live-mode `scenarios/test_time_limit.py` covers:
+  - D1 (in `test_04_daily_limit.py`): exhaustion blocks.
+  - D2: minute-granularity of usage accounting (#295, #516).
+  - D3: cross-day rollover (#334).
+
+In fake mode the API-side evaluator that turns "5 minutes of activeSeconds
+in a 60-minute budget" into a `blocked=True` snapshot is out of scope — the
+fake just serves whatever snapshot we POST. So Suite D collapses to:
+
+  - One scenario: snapshot has `blocked=True, blockReason=TimeLimit` →
+    MAC ends up in blocked_macs and the router emits an event with
+    `reason=timelimit`.
+
+D2 (minute-granularity) verifies the API's processing of agent-side usage
+reports — orthogonal to router behavior. Tracked in live-mode test_time_limit.py.
+D3 (cross-day rollover) is pending #334 even in live mode.
+
+Folds `test_04_daily_limit.py::D1` per #684: same wire shape (blocked=True
+with a time-bucket-derived reason), no separate case needed in fake mode.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    wait_block_page,
+    wait_event_for_mac,
+    wait_mac_in_blocked_set,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.time_limit
+
+PROFILE_ID = 700
+
+
+def test_time_limit_exhausted_blocks(router, client, fake_api):
+    """D1 (folded with D4): snapshot reports time-limit exhausted → MAC blocked,
+    event reason=timelimit."""
+    snap = (
+        SnapshotBuilder()
+        .add_profile(
+            id=PROFILE_ID, name="e2e-time",
+            blocked=True, block_reason="TimeLimit",
+        )
+        .add_device(mac=client.mac, name="e2e-time-dev", profile_id=PROFILE_ID)
+        .build(etag='"sha256:timelimit-exhausted-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    wait_mac_in_blocked_set(client.mac, present=True, timeout_s=180)
+    # Drive client traffic so the agent emits a blocked connection_attempt
+    # event with reason=timelimit. Without packets, blocked_macs is hot but
+    # no event is generated.
+    wait_block_page(client, timeout_s=60)
+    wait_event_for_mac(
+        fake_api, client.mac, allowed=False, reason="timelimit", timeout_s=60,
+    )


### PR DESCRIPTION
## Summary

- Adds typed `SnapshotBuilder` (`scripts/e2e/scenarios_fake/snapshot_builder.py`) + 8 unit tests; replaces the #683 minimal helpers, kept legacy shim so the canary keeps importing unchanged.
- Migrates 9 live-mode scenarios onto the fake-API harness from #683: `test_02_allowed_browsing`, `test_03_blocked_domain`, `test_05_usage_in_api`, `test_06_blocked_page`, `test_extra_blocked` (B1+B4, B2, B3, **B5 new** locking the extraAllowed-beats-blocked invariant), `test_reassignment`, `test_schedule`, `test_time_limit`. Plus the rest of suite A — `test_pause_then_add_device` (A3) and `test_reassign_off_paused` (A4) appended to the #683 canary file.
- Shared `_observers.py` with the nft / HTTP / DNS / event probes used by every scenario.
- Closes #684.

Deferred per the issue body:
- `test_01_enrollment` — covered as a side effect of every fake-mode bring-up.
- `test_04_daily_limit` — folded into `test_time_limit_exhausted_blocks`; same wire shape.
- `test_unknown_device` — broken on live per #648, defer until that's decided.
- `test_schedule` C3 cross-midnight + C5 all-day-Monday — API-side TZ math; tracked in live `scenarios/test_schedule.py`.
- `test_time_limit` D2 minute-granularity + D3 cross-day rollover — API-side usage processing; tracked in live `scenarios/test_time_limit.py`.

## Local validation

KVM dev host, qemu serialised, ran `scripts/e2e-vm.sh --mode=fake` against an image rebuilt from this branch:

| Run | Result | Wall time |
|---|---|---|
| 6 | 24 passed | 18m11s |
| 7 | 24 passed | 16m04s |
| 8 | 24 passed | 16m18s |

Three consecutive green on the full 24-test pack (8 unit + 16 VM scenarios).

## Regression demo (acceptance signal per #684)

Patched `openwrt/files/usr/lib/lua/wifihaven/render.lua` to disable `blocked_macs` emission (single-line comment-out at the per-MAC append site), rebuilt the image, ran the suite:

```
7 failed, 17 passed in 2076s (34m35s)
```

Exactly the blocked_macs-dependent assertions went red:
- `test_pause_blocks_via_fake_api` (canary)
- `test_pause_then_add_device_blocks_new_mac` (A3)
- `test_reassign_off_paused_profile_unblocks_mac` (A4)
- `test_reassign_to_paused_blocks_and_back_restores` (E1+E2)
- `test_in_window_blocks` (C1)
- `test_in_then_out_smoke` (C6)
- `test_time_limit_exhausted_blocks` (D1)

17 PASSED — every scenario that doesn't depend on `@blocked_macs` (8 unit + allowed/blocked-domain/usage/blocked-page/extra-blocked B1/B2/B3/B5/out-of-window).

Reverted the patch, rebuilt, re-ran: `24 passed in 927s (15m26s)`. Pack reacts to the regression and goes green again on revert — meaningful gating signal demonstrated.

## Implementation notes for review

- **Canary timeout bump** (`test_pause_blocks_via_fake_api`): the `wait_until(_has_paused_event, timeout_s=…)` window bumped 60s → 120s. The agent batches connection_events on its own flush cadence (~10-15s) and a single 60s window was tight enough to race even when enforcement was correct. Now there's at least one full event-report cycle of headroom. Did not change the canary's semantics.
- **Snapshot builder location**: kept at `scenarios_fake/snapshot_builder.py` (where #683 placed it) rather than `lib/snapshot_builder.py` (#684 issue's suggestion). The canary already imports relatively from there; moving it would mean churn with no benefit.
- **Schedule + time_limit scenarios drive HTTP**: without packets, the router has nothing to emit blocked events about. Each blocked-state schedule/time_limit test runs a block-page probe first (which doubles as the traffic source).
- **B3 (test_extra_blocked_is_per_profile_scoped) uses `wait_block_page` not a bare http probe**: the eb_<host> set populates on a router-side dnsmasq cache MISS. After `wait_for_etag_served` confirms the agent fetched the new policy, dnsmasq may not yet have reloaded; polling block-page → fresh DNS query each cycle makes the population deterministic.

## Host-side foot-gun discovered

Filed separately (issue spawning chip): `scripts/vm/lib.sh::ensure_router_overlay()` reuses an existing qcow2 overlay even when `WH_ROUTER_IMAGE_PATH` points at a different image — the overlay's stored backing-file path goes stale and tests boot the old image. Surfaced this during validation when two runs against the wrong image cost ~50 min. Workaround: `rm scripts/vm/.run/router/overlay.qcow2` before re-running.

## Test plan

- [x] All 8 unit tests pass (`pytest scenarios_fake/test_snapshot_builder.py`)
- [x] 3 consecutive green runs of the full pack
- [x] Regression demo: patched render.lua → 7 expected failures, reverted → 24 passed
- [x] Canary (`test_pause_blocks_via_fake_api`) still passes after timeout bump
- [x] Existing fake-api tests (`scripts/e2e/fake-api/tests/`) still 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)