### PR TITLE
fix(vm): recreate router overlay when backing image changes (#756)

### DIFF
--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -67,10 +67,27 @@ ensure_openwrt_image() {
 }
 
 # Create the qcow2 overlay backed by the raw OpenWRT image (idempotent).
+#
+# If the overlay already exists but its recorded backing-file path does not
+# match ${WH_ROUTER_BASE_IMG}, recreate it. Otherwise an operator who points
+# WH_ROUTER_IMAGE_PATH at a freshly built image would silently keep booting
+# the old one (see issue #756).
 ensure_router_overlay() {
   require_cmd qemu-img
+  if [[ -f "${WH_ROUTER_OVERLAY}" ]]; then
+    local current
+    current="$(qemu-img info -U --output=json "${WH_ROUTER_OVERLAY}" \
+      | sed -n 's/.*"backing-filename":[[:space:]]*"\([^"]*\)".*/\1/p' \
+      | head -n1)"
+    if [[ "${current}" != "${WH_ROUTER_BASE_IMG}" ]]; then
+      log "overlay backing-file mismatch: have '${current}', want '${WH_ROUTER_BASE_IMG}' — recreating"
+      rm -f "${WH_ROUTER_OVERLAY}"
+    else
+      log "reusing overlay ${WH_ROUTER_OVERLAY} (backing ${current})"
+    fi
+  fi
   if [[ ! -f "${WH_ROUTER_OVERLAY}" ]]; then
-    log "creating qcow2 overlay ${WH_ROUTER_OVERLAY}"
+    log "creating qcow2 overlay ${WH_ROUTER_OVERLAY} (backing ${WH_ROUTER_BASE_IMG})"
     qemu-img create -q -f qcow2 -F raw -b "${WH_ROUTER_BASE_IMG}" \
       "${WH_ROUTER_OVERLAY}" "${WH_ROUTER_DISK_SIZE}"
   fi


### PR DESCRIPTION
## Summary

- `ensure_router_overlay()` previously only checked overlay existence, so a new `WH_ROUTER_IMAGE_PATH` was silently ignored when an overlay from a prior run still pointed at the old base image (issue #756).
- Now inspect the recorded `backing-filename` via `qemu-img info -U --output=json` and recreate the overlay when it diverges from `${WH_ROUTER_BASE_IMG}`. Log the backing path on every call so any future mismatch is visible in runner output.

## Test plan

Verified the three acceptance cases against a throwaway harness using the new function body:

- [x] No overlay present → creates overlay with the requested backing file.
- [x] Same base across runs → reuses the overlay, no recreate (log: `reusing overlay ...`).
- [x] Base changed between runs → logs mismatch and recreates overlay against the new base.
- [ ] Full VM e2e on host (serialized, per local convention) — left for whichever validation cycle picks this up next.

Closes #756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)