### PR TITLE
web: admin UI for #714 heartbeat filter (#754)

### DIFF
--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -12,30 +12,43 @@ vi.mock('@/api/client', () => ({
 }))
 
 import { api } from '@/api/client'
+import type { HeartbeatFilter, HouseholdSettings } from '@/types/api'
 import { AdminPage } from './AdminPage'
+
+const DEFAULT_HF: HeartbeatFilter = {
+  enabled: false,
+  bytesThreshold: 2048,
+  activeFractionPct: 20,
+}
 
 beforeEach(() => {
   vi.resetAllMocks()
   // Server-of-record: simulates the live API. `update` mutates this and
   // `get` reads from it, so tests exercise the real round-trip the UI does
   // (PUT, then re-GET to refresh the summary — #571).
-  let stored: { dailyResetTime: string; dailyResetTz: string } = {
+  let stored: HouseholdSettings = {
     dailyResetTime: '00:00',
     dailyResetTz: 'America/Los_Angeles',
+    heartbeatFilter: { ...DEFAULT_HF },
   }
   ;(api.household.get as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-    async () => ({ ...stored }),
+    async () => ({ ...stored, heartbeatFilter: { ...stored.heartbeatFilter } }),
   )
   ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-    async (next: { dailyResetTime: string; dailyResetTz: string }) => {
-      stored = { ...next }
+    async (next: HouseholdSettings) => {
+      stored = { ...next, heartbeatFilter: { ...next.heartbeatFilter } }
     },
   )
 })
 
 // Per-test override helper for the initial server state.
-function seedServer(s: { dailyResetTime: string; dailyResetTz: string }) {
-  (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ...s })
+function seedServer(s: Partial<HouseholdSettings>) {
+  (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    dailyResetTime: '00:00',
+    dailyResetTz: 'America/Los_Angeles',
+    heartbeatFilter: { ...DEFAULT_HF },
+    ...s,
+  })
 }
 
 describe('AdminPage — daily reset card', () => {
@@ -86,6 +99,7 @@ describe('AdminPage — daily reset card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '06:00',
         dailyResetTz: 'America/Los_Angeles',
+        heartbeatFilter: DEFAULT_HF,
       }),
     )
     const summary = await screen.findByTestId('household-summary')
@@ -130,6 +144,7 @@ describe('AdminPage — daily reset card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '00:00',
         dailyResetTz: 'America/New_York',
+        heartbeatFilter: DEFAULT_HF,
       }),
     )
   })
@@ -159,6 +174,7 @@ describe('AdminPage — daily reset card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '00:00',
         dailyResetTz: 'America/Denver',
+        heartbeatFilter: DEFAULT_HF,
       }),
     )
   })
@@ -181,6 +197,7 @@ describe('AdminPage — daily reset card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '00:00',
         dailyResetTz: 'Europe/London',
+        heartbeatFilter: DEFAULT_HF,
       }),
     )
   })
@@ -196,6 +213,7 @@ describe('AdminPage — daily reset card', () => {
         (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
           dailyResetTime: next.dailyResetTime,
           dailyResetTz: 'America/Los_Angeles',
+          heartbeatFilter: { ...DEFAULT_HF },
         })
       },
     )
@@ -227,5 +245,121 @@ describe('AdminPage — daily reset card', () => {
     // Still in editing state
     expect(screen.getByTestId('household-reset-time')).toBeInTheDocument()
     expect(screen.queryByTestId('household-summary')).not.toBeInTheDocument()
+  })
+})
+
+describe('AdminPage — heartbeat filter card', () => {
+  it('summary shows "Disabled" when filter is off', async () => {
+    render(<AdminPage />)
+    const summary = await screen.findByTestId('heartbeat-filter-summary')
+    expect(summary).toHaveTextContent(/Disabled/i)
+  })
+
+  it('summary shows thresholds when filter is enabled', async () => {
+    seedServer({
+      heartbeatFilter: { enabled: true, bytesThreshold: 4096, activeFractionPct: 30 },
+    })
+    render(<AdminPage />)
+    const summary = await screen.findByTestId('heartbeat-filter-summary')
+    expect(summary).toHaveTextContent(/Enabled/i)
+    expect(summary).toHaveTextContent('4096')
+    expect(summary).toHaveTextContent('30%')
+  })
+
+  it('clicking Edit opens the form pre-filled with current values', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('heartbeat-filter-summary')
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+
+    const enabled = screen.getByTestId('heartbeat-filter-enabled') as HTMLInputElement
+    const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
+    const fraction = screen.getByTestId('heartbeat-filter-fraction') as HTMLInputElement
+    expect(enabled.checked).toBe(false)
+    expect(bytes.value).toBe('2048')
+    expect(fraction.value).toBe('20')
+  })
+
+  it('toggle + save sends the right body and the summary reflects the GET reconcile', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('heartbeat-filter-summary')
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+
+    await user.click(screen.getByTestId('heartbeat-filter-enabled'))
+    await user.click(screen.getByTestId('heartbeat-filter-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '00:00',
+        dailyResetTz: 'America/Los_Angeles',
+        heartbeatFilter: { enabled: true, bytesThreshold: 2048, activeFractionPct: 20 },
+      }),
+    )
+    const summary = await screen.findByTestId('heartbeat-filter-summary')
+    expect(summary).toHaveTextContent(/Enabled/i)
+    expect(summary).toHaveTextContent('2048')
+  })
+
+  it('threshold edits round-trip via update + re-GET', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('heartbeat-filter-summary')
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+
+    await user.click(screen.getByTestId('heartbeat-filter-enabled'))
+    const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
+    await user.clear(bytes)
+    await user.type(bytes, '8192')
+    const fraction = screen.getByTestId('heartbeat-filter-fraction') as HTMLInputElement
+    await user.clear(fraction)
+    await user.type(fraction, '40')
+
+    await user.click(screen.getByTestId('heartbeat-filter-save'))
+
+    await waitFor(() =>
+      expect(api.household.update).toHaveBeenCalledWith({
+        dailyResetTime: '00:00',
+        dailyResetTz: 'America/Los_Angeles',
+        heartbeatFilter: { enabled: true, bytesThreshold: 8192, activeFractionPct: 40 },
+      }),
+    )
+    const summary = await screen.findByTestId('heartbeat-filter-summary')
+    expect(summary).toHaveTextContent('8192')
+    expect(summary).toHaveTextContent('40%')
+  })
+
+  it('cancel discards local changes', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('heartbeat-filter-summary')
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+
+    const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
+    await user.clear(bytes)
+    await user.type(bytes, '9999')
+    await user.click(screen.getByTestId('heartbeat-filter-cancel'))
+
+    expect(api.household.update).not.toHaveBeenCalled()
+    const summary = await screen.findByTestId('heartbeat-filter-summary')
+    expect(summary).toHaveTextContent(/Disabled/i)
+
+    // Re-opening edit shows server value, not the dirty form.
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+    expect((screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement).value).toBe('2048')
+  })
+
+  it('disables Save and shows a validation error when the active fraction is out of range', async () => {
+    const user = userEvent.setup()
+    render(<AdminPage />)
+    await screen.findByTestId('heartbeat-filter-summary')
+    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+
+    const fraction = screen.getByTestId('heartbeat-filter-fraction') as HTMLInputElement
+    await user.clear(fraction)
+    await user.type(fraction, '150')
+
+    expect(screen.getByTestId('heartbeat-filter-validation')).toBeInTheDocument()
+    expect(screen.getByTestId('heartbeat-filter-save')).toBeDisabled()
   })
 })

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { api } from '@/api/client'
-import type { HouseholdSettings } from '@/types/api'
+import type { HeartbeatFilter, HouseholdSettings } from '@/types/api'
 import { TimezonePicker } from '@/components/TimezonePicker'
 import { PageLoader } from './DashboardPage'
 
@@ -34,6 +34,186 @@ export function AdminPage() {
       </div>
 
       {hs && <DailyResetCard value={hs} onSaved={setHs} />}
+      {hs && <HeartbeatFilterCard value={hs} onSaved={setHs} />}
+    </div>
+  )
+}
+
+function HeartbeatFilterCard({
+  value, onSaved,
+}: {
+  value: HouseholdSettings
+  onSaved: (next: HouseholdSettings) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState<HeartbeatFilter>(value.heartbeatFilter)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function startEdit() {
+    setForm(value.heartbeatFilter)
+    setError(null)
+    setEditing(true)
+  }
+
+  function cancel() {
+    setForm(value.heartbeatFilter)
+    setError(null)
+    setEditing(false)
+  }
+
+  const validationError: string | null = (() => {
+    if (!Number.isFinite(form.bytesThreshold) || form.bytesThreshold < 0) {
+      return 'Bytes threshold must be ≥ 0.'
+    }
+    if (
+      !Number.isFinite(form.activeFractionPct)
+      || form.activeFractionPct < 0
+      || form.activeFractionPct > 100
+    ) {
+      return 'Active fraction must be between 0 and 100.'
+    }
+    return null
+  })()
+
+  async function save() {
+    if (validationError) return
+    setSaving(true)
+    setError(null)
+    try {
+      await api.household.update({
+        dailyResetTime: value.dailyResetTime,
+        dailyResetTz: value.dailyResetTz,
+        heartbeatFilter: {
+          enabled: form.enabled,
+          bytesThreshold: Math.trunc(form.bytesThreshold),
+          activeFractionPct: Math.trunc(form.activeFractionPct),
+        },
+      })
+      const fresh = await api.household.get()
+      onSaved(fresh)
+      setEditing(false)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const hf = value.heartbeatFilter
+
+  return (
+    <div
+      data-testid="heartbeat-filter-card"
+      className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-3"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-bold text-white">Heartbeat filter</h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={startEdit}
+            data-testid="heartbeat-filter-edit"
+            className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+
+      {!editing ? (
+        <p data-testid="heartbeat-filter-summary" className="text-sm text-gray-300">
+          {hf.enabled ? (
+            <>
+              <span className="font-medium text-white">Enabled</span>
+              {' — bytes ≥ '}
+              <span className="font-mono text-gray-200">{hf.bytesThreshold}</span>
+              {', active fraction ≥ '}
+              <span className="font-mono text-gray-200">{hf.activeFractionPct}%</span>
+            </>
+          ) : (
+            <span className="font-medium text-white">Disabled</span>
+          )}
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-xs text-gray-400">
+            Excludes low-traffic background "heartbeat" rows from device/profile screen-time
+            totals. A row is classified as a heartbeat when both its bytes/minute and active
+            fraction are below the configured floors.
+          </p>
+          {error && (
+            <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+              {error}
+            </div>
+          )}
+          {validationError && (
+            <div
+              data-testid="heartbeat-filter-validation"
+              className="bg-amber-500/10 border border-amber-500/30 text-amber-300 text-sm rounded-xl px-4 py-2"
+            >
+              {validationError}
+            </div>
+          )}
+          <label className="flex items-center gap-2 text-sm text-gray-200">
+            <input
+              type="checkbox"
+              checked={form.enabled}
+              onChange={e => setForm({ ...form, enabled: e.target.checked })}
+              data-testid="heartbeat-filter-enabled"
+              className="h-4 w-4"
+            />
+            Filter enabled
+          </label>
+          <div className="flex flex-wrap gap-3 items-end">
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Bytes/min threshold</label>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={form.bytesThreshold}
+                onChange={e => setForm({ ...form, bytesThreshold: Number(e.target.value) })}
+                data-testid="heartbeat-filter-bytes"
+                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-32"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">Active fraction (%)</label>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                step={1}
+                value={form.activeFractionPct}
+                onChange={e => setForm({ ...form, activeFractionPct: Number(e.target.value) })}
+                data-testid="heartbeat-filter-fraction"
+                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-32"
+              />
+            </div>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={cancel}
+              disabled={saving}
+              data-testid="heartbeat-filter-cancel"
+              className="px-4 py-2 rounded-lg bg-gray-800 text-gray-300 text-sm font-medium disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving || validationError !== null}
+              data-testid="heartbeat-filter-save"
+              className="px-4 py-2 rounded-lg bg-emerald-500 text-black text-sm font-semibold disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -68,6 +248,7 @@ function DailyResetCard({
       await api.household.update({
         dailyResetTime: form.dailyResetTime,
         dailyResetTz: form.dailyResetTz,
+        heartbeatFilter: value.heartbeatFilter,
       })
       // Re-read from the server so the summary reflects what was actually
       // persisted, not just the local form. Without this, a server that

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -24,14 +24,25 @@ export interface Schedule {
   tz: string          // IANA timezone, e.g. "America/Los_Angeles"
 }
 
+// #714 — server-side heartbeat filter for device/profile screen-time totals.
+// Rows classified as heartbeats are excluded from rollups; the filter is
+// household-wide.
+export interface HeartbeatFilter {
+  enabled: boolean
+  bytesThreshold: number       // bytes/min floor (rows below are heartbeats)
+  activeFractionPct: number    // 0–100 active-seconds-fraction floor
+}
+
 export interface HouseholdSettings {
   dailyResetTime: string  // "HH:mm" wall-clock time in `dailyResetTz`
   dailyResetTz: string    // IANA timezone
+  heartbeatFilter: HeartbeatFilter
 }
 
 export interface UpdateHouseholdSettingsRequest {
   dailyResetTime: string
   dailyResetTz: string
+  heartbeatFilter: HeartbeatFilter
 }
 
 export interface TimeLimit {


### PR DESCRIPTION
## Summary

Adds a **Heartbeat filter** card to the Admin page directly below the existing **Daily reset** card. The card lets an operator toggle the [#714](https://github.com/wifihaven/wifihaven/issues/714) server-side heartbeat filter on/off and edit both thresholds (bytes/min and active-fraction percent) without curling the API.

- Same UX shape as the Daily-reset card: summary line → Edit → Cancel/Save, with a PUT then re-GET reconcile so a silently-dropped field is surfaced rather than falsely confirmed (mirrors [#571](https://github.com/wifihaven/wifihaven/issues/571)).
- Validation: bytes ≥ 0, active fraction 0–100 — Save is disabled and an inline warning shows when invalid.
- TS types extended (`HeartbeatFilter` interface; `HouseholdSettings` and `UpdateHouseholdSettingsRequest` gain the sub-object). No API changes — the server side was shipped in [#740](https://github.com/wifihaven/wifihaven/pull/740).

## test-id surface

`heartbeat-filter-card`, `heartbeat-filter-summary`, `heartbeat-filter-edit`, `heartbeat-filter-enabled`, `heartbeat-filter-bytes`, `heartbeat-filter-fraction`, `heartbeat-filter-validation`, `heartbeat-filter-save`, `heartbeat-filter-cancel`.

## Test plan

- [x] `npm test` for `AdminPage.test.tsx` — 17 tests pass (10 existing + 7 new: summary off/on, edit pre-fill, toggle round-trip, threshold round-trip, cancel discard, validation disables Save).
- [x] `tsc --noEmit` clean.
- [x] Live round-trip against `api.lan:8080`: PUT `{enabled:true, bytesThreshold:4096, activeFractionPct:25}` persists, GET reflects it, defaults restored after.
- [ ] Manual click-through in dev server — relied on unit tests + live curl roundtrip; UI is a direct mirror of the existing Daily-reset card.

## Out of scope

- Explain debug surface (`/api/time/heartbeat-explain/{mac}`) — separate follow-up.
- Per-device / per-profile overrides — filter is household-wide.

Fixes #754. Refs [#714](https://github.com/wifihaven/wifihaven/issues/714), [#740](https://github.com/wifihaven/wifihaven/pull/740).

🤖 Generated with [Claude Code](https://claude.com/claude-code)