### PR TITLE
ci(gate 2): wire fake-API qemu suite into Master CD as publish-openwrt gate (#686)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -20,6 +20,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-vm
   cancel-in-progress: false

--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -1,0 +1,109 @@
+name: VM e2e (fake API — Gate 2)
+
+# Gate 2 of the three-gate plan (#652/#654/#686). Boots qemu OpenWRT +
+# Alpine client on the self-hosted KVM runner against the in-process fake
+# API (scripts/e2e/fake-api/), runs scripts/e2e/scenarios_fake/.
+#
+# Gates publish-openwrt in master.yml via workflow_call. Does NOT gate
+# publish-api — Gate 1 (api-smoke-staging) and the planned Gate 3
+# integration smoke cover the API side.
+#
+# Triggers:
+#   - workflow_call    — invoked from master.yml as a needs: of publish-openwrt
+#   - workflow_dispatch — manual debugging from the Actions tab
+#
+# Concurrency: shares the e2e-vm group with the live-mode VM e2e workflow
+# so runs serialize on the single self-hosted KVM runner — the CI runner
+# is the same host as local dev and collisions are real.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-vm
+  cancel-in-progress: false
+
+jobs:
+  e2e-fake:
+    name: VM e2e (fake API) suite
+    # Block fork PRs on the self-hosted runner; same guard as e2e-vm.yml.
+    # (workflow_call and workflow_dispatch are always allowed.)
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, kvm]
+    # Local wall time for the full fake-mode pack is ~15m (per #684
+    # validation: `24 passed in 927s`). 30m covers a cold router-image
+    # build on the runner plus headroom; concurrency=e2e-vm serializes so
+    # a slow run can't pile up.
+    timeout-minutes: 30
+
+    steps:
+      # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
+      # can leave root-owned files under scripts/vm/.cache/imagebuilder/.
+      # actions/checkout cleans the workspace and fails with EACCES on
+      # those files; the runner has no NOPASSWD sudo (only /usr/sbin/ip
+      # per docs/ops/kvm-runner.md), so we use docker — which runs as root
+      # — to chown the cache back. No-op on clean runners. Same pattern
+      # as e2e-vm.yml.
+      - name: Reclaim root-owned cache files (pre-checkout)
+        run: |
+          docker rm -f wh-imagebuilder 2>/dev/null || true
+          CACHE="${{ github.workspace }}/scripts/vm/.cache"
+          if [ -d "$CACHE" ]; then
+            docker run --rm -v "$CACHE":/c alpine sh -c '
+              chmod -R u+rwX,a+rX /c 2>/dev/null
+              chown -R '"$(id -u):$(id -g)"' /c 2>/dev/null
+            ' || true
+          fi
+
+      - uses: actions/checkout@v6
+
+      - name: Preflight (kvm/qemu/docker)
+        run: |
+          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
+            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          qemu-system-x86_64 --version | head -n1
+          docker --version
+
+      - name: Build router image (if not cached)
+        run: |
+          if [[ -f scripts/vm/.cache/openwrt-wifihaven.img ]]; then
+            echo "router image cached, skipping build"
+          else
+            scripts/vm/build-router-image.sh
+          fi
+
+      - name: Build client base (if not cached)
+        run: scripts/vm/build-client-base.sh
+
+      - name: Pre-flight kill of stale wh VMs
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+
+      # Fake mode runs the API as an in-process asyncio app inside pytest
+      # (scripts/e2e/scenarios_fake/conftest.py), so no docker-compose
+      # stack bring-up / teardown / log capture is needed here.
+      - name: Run e2e fake-mode suite
+        env:
+          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven.img
+        run: scripts/e2e-vm.sh --mode=fake
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-vm-fake-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            scripts/vm/.run/**
+            !scripts/vm/.run/**/*.qcow2
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Tear down VMs
+        if: always()
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -3,6 +3,10 @@ name: Master CD
 # Runs on every push to main. After #588 + #613 the flow is:
 #
 #   ci-tests + bootstrap-smoke + e2e + prod-stack-smoke   (vm-e2e on its own track)
+#     ‖ gate-2-router-fake-api       (#686: qemu router + fake API on the
+#                                     self-hosted KVM runner; gates
+#                                     publish-openwrt only, runs in parallel
+#                                     with the staging chain after ci-tests)
 #     → build-image                  (push sha-<commit> + `staging` tags ONLY; not `:latest`)
 #     → deploy-staging               (curl staging deploy hook; wait for /api/health)
 #       ‖ deploy-spa-staging         (build + wrangler push to Cloudflare Pages — parallel
@@ -415,13 +419,31 @@ jobs:
           echo "Promoting $src → $dst"
           docker buildx imagetools create -t "$dst" "$src"
 
+  # Gate 2 (#654/#686): router enforcement in qemu OpenWRT + Alpine client
+  # against an in-process fake API serving snapshot fixtures. Gates
+  # publish-openwrt only — API publish is unaffected (Gate 1 covers that
+  # via api-smoke-staging, Gate 3 will cover thin integration once #655
+  # lands). Runs on the self-hosted KVM runner; concurrency=e2e-vm
+  # serializes against the existing live-mode VM e2e workflow on the same
+  # host. Gated on ci-tests to avoid burning runner cycles when lint/unit
+  # is broken.
+  gate-2-router-fake-api:
+    name: Gate 2 — router fake-API e2e
+    needs: [ci-tests]
+    uses: ./.github/workflows/e2e-vm-fake.yml
+    secrets: inherit
+
   # 6b. Publish the openwrt rolling release. The build runs anyway via the
   # standalone openwrt-build.yml triggers for PRs and main pushes — what's
   # gated is the GitHub Release upload, controlled by the publish_release
   # input. See openwrt-build.yml for the gating logic.
+  #
+  # Gated on Gate 2 (#686): a Gate-2-red main does not publish OpenWRT.
+  # `approve-production` keeps the manual atomic-publish semantics for
+  # router+API tandem release; Gate 2 sits before it on the OpenWRT leg.
   publish-openwrt:
     name: Publish OpenWRT release (deploy-production)
-    needs: [approve-production]
+    needs: [approve-production, gate-2-router-fake-api]
     permissions:
       contents: write
     uses: ./.github/workflows/openwrt-build.yml


### PR DESCRIPTION
Closes #686.

Wires the Gate 2 fake-API qemu suite (from #682/#683/#684) into Master CD as a `needs:` of `publish-openwrt`. Gate-2-red main no longer publishes OpenWRT artifacts.

## Summary

- New `.github/workflows/e2e-vm-fake.yml` — `workflow_call` + `workflow_dispatch`, `concurrency: e2e-vm` (serializes with `e2e-vm.yml` on the shared self-hosted KVM runner), fork-safety guard. Runs `scripts/e2e-vm.sh --mode=fake`. No docker-compose stack (fake API is in-process). 30m timeout vs. ~15m local wall time (#684).
- `master.yml` — new `gate-2-router-fake-api` caller job gated on `ci-tests`; added to `publish-openwrt.needs` alongside `approve-production`.

## What is NOT touched (per #686 constraints)

- `publish-api` / `build-image` / `retag-latest` / `deploy-prod-render` / `deploy-spa-prod` — API + SPA publish unaffected (Gate 1 owns it; Gate 3 follow-up in #655).
- `approve-production` `needs:` unchanged — manual atomic-publish gate stays reachable for API-only releases even if Gate 2 is red.
- `e2e-vm.yml` — decom is #656.
- Top-level `concurrency: master-${{ github.ref }}` — scoping is deliberate (see comment around line 41).

## Why safe to merge

- Gates `publish-openwrt` only; does not block API ship or the manual approval gate.
- `concurrency: e2e-vm` prevents runner collisions with the live-mode VM e2e workflow on the shared host.
- Fork PRs blocked from the self-hosted runner (same guard as `e2e-vm.yml`).
- `needs: [ci-tests]` avoids burning KVM cycles on a broken lint/unit run.

## Test plan

- [ ] On first push to main after merge: Master CD launches `gate-2-router-fake-api` in parallel with the staging chain after `ci-tests`.
- [ ] Gate 2 green: `publish-openwrt` runs as before (post `approve-production`).
- [ ] Simulated router regression (revert a `render.lua` blocked-MAC entry): Gate 2 red blocks `publish-openwrt`; `publish-api` path (retag-latest / deploy-prod-render / deploy-spa-prod) is unaffected.
- [ ] No concurrent runs with `e2e-vm.yml` on the self-hosted KVM runner (concurrency group `e2e-vm`).
- [ ] Manual `workflow_dispatch` of `e2e-vm-fake.yml` works for debugging.

## Follow-ups (out of scope)

- #685 — `.ipk` / `.apk` matrix leg (single-leg gate for now per #686: "wire ipk-only first").
- #656 — decom `e2e-vm.yml`.
- #657 — runner capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)