### PR TITLE
app: schema for apps, app_hosts, app_policy_assignments (#761)

### DIFF
--- a/api/resources/db/migration/V23__apps.sql
+++ b/api/resources/db/migration/V23__apps.sql
@@ -1,0 +1,35 @@
+-- #761 / #105: app concept — household-scoped named bundles of host patterns
+-- (FQDN apex; subdomains implicit at dnsmasq match time). Authoring/UX layer
+-- only; the policy snapshot still ships flat per-MAC extraBlocked /
+-- extraAllowed lists (#105 §0).
+--
+-- Single-tenant deployment today, so no households table / household_id yet.
+-- slug is globally unique; if multi-tenancy ever lands the unique key moves
+-- to (household_id, slug).
+
+CREATE TABLE apps (
+  id          BIGSERIAL PRIMARY KEY,
+  name        TEXT NOT NULL,
+  slug        TEXT NOT NULL UNIQUE,
+  template_id TEXT,
+  icon        TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE app_hosts (
+  app_id BIGINT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  host   TEXT   NOT NULL,
+  PRIMARY KEY (app_id, host)
+);
+
+CREATE TABLE app_policy_assignments (
+  id                BIGSERIAL PRIMARY KEY,
+  app_id            BIGINT  NOT NULL REFERENCES apps(id)     ON DELETE CASCADE,
+  profile_id        BIGINT  NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  mode              TEXT    NOT NULL CHECK (mode IN ('blocked','allowed','time_limited')),
+  daily_minutes     INT,
+  exempt_from_daily BOOLEAN NOT NULL DEFAULT TRUE,
+  UNIQUE (app_id, profile_id)
+);
+
+CREATE INDEX idx_app_policy_assignments_profile ON app_policy_assignments(profile_id);

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -99,6 +99,44 @@ trait SiteTimeLimitRepo {
   def replaceForProfile(pid: ProfileId, limits: List[SiteTimeLimitRequest]): Task[Unit]
 }
 
+case class AppInsert(
+    name: String,
+    slug: String,
+    templateId: Option[String] = None,
+    icon: Option[String] = None,
+)
+
+case class AppUpdate(
+    name: String,
+    slug: String,
+    templateId: Option[String],
+    icon: Option[String],
+)
+
+case class AssignmentUpsert(
+    appId: AppId,
+    profileId: ProfileId,
+    mode: AppMode,
+    dailyMinutes: Option[Int],
+    exemptFromDaily: Boolean = true,
+)
+
+trait AppRepo {
+  def insertApp(a: AppInsert): Task[AppId]
+  def getApp(id: AppId): Task[Option[App]]
+  def listApps: Task[List[App]]
+  def updateApp(id: AppId, u: AppUpdate): Task[Unit]
+  def deleteApp(id: AppId): Task[Unit]
+
+  def listHosts(appId: AppId): Task[List[Hostname]]
+  def setHosts(appId: AppId, hosts: List[Hostname]): Task[Unit]
+
+  def upsertAssignment(a: AssignmentUpsert): Task[AppPolicyAssignmentId]
+  def deleteAssignment(appId: AppId, profileId: ProfileId): Task[Unit]
+  def listAssignmentsByProfile(profileId: ProfileId): Task[List[AppPolicyAssignment]]
+  def listAssignmentsByApp(appId: AppId): Task[List[AppPolicyAssignment]]
+}
+
 trait DeviceRepo {
   def listAll: Task[List[Device]]
   def findByMac(mac: MacAddress): Task[Option[Device]]
@@ -1312,6 +1350,88 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       .map(_.toMap)
 }
 
+class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
+  private type R = (AppId, String, String, Option[String], Option[String], Instant)
+  private def toApp(r: R) = App(r._1, r._2, r._3, r._4, r._5, r._6.toString)
+
+  def insertApp(a: AppInsert) =
+    sql"INSERT INTO apps(name,slug,template_id,icon) VALUES(${a.name},${a.slug},${a.templateId},${a.icon}) RETURNING id"
+      .query[AppId]
+      .unique
+      .transact(xa)
+
+  def getApp(id: AppId) =
+    sql"SELECT id,name,slug,template_id,icon,created_at FROM apps WHERE id=$id"
+      .query[R]
+      .map(toApp)
+      .option
+      .transact(xa)
+
+  def listApps =
+    sql"SELECT id,name,slug,template_id,icon,created_at FROM apps ORDER BY id"
+      .query[R]
+      .map(toApp)
+      .to[List]
+      .transact(xa)
+
+  def updateApp(id: AppId, u: AppUpdate) =
+    sql"""UPDATE apps SET name=${u.name}, slug=${u.slug},
+                         template_id=${u.templateId}, icon=${u.icon}
+          WHERE id=$id""".update.run.transact(xa).unit
+
+  def deleteApp(id: AppId) =
+    sql"DELETE FROM apps WHERE id=$id".update.run.transact(xa).unit
+
+  def listHosts(appId: AppId) =
+    sql"SELECT host FROM app_hosts WHERE app_id=$appId ORDER BY host"
+      .query[Hostname]
+      .to[List]
+      .transact(xa)
+
+  def setHosts(appId: AppId, hosts: List[Hostname]) = {
+    val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run
+    val ins =
+      hosts.distinct.map(h => sql"INSERT INTO app_hosts(app_id,host) VALUES($appId,$h)".update.run)
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
+
+  def upsertAssignment(a: AssignmentUpsert) =
+    sql"""INSERT INTO app_policy_assignments(app_id,profile_id,mode,daily_minutes,exempt_from_daily)
+          VALUES(${a.appId},${a.profileId},${a.mode},${a.dailyMinutes},${a.exemptFromDaily})
+          ON CONFLICT(app_id,profile_id) DO UPDATE SET
+            mode=EXCLUDED.mode,
+            daily_minutes=EXCLUDED.daily_minutes,
+            exempt_from_daily=EXCLUDED.exempt_from_daily
+          RETURNING id"""
+      .query[AppPolicyAssignmentId]
+      .unique
+      .transact(xa)
+
+  def deleteAssignment(appId: AppId, profileId: ProfileId) =
+    sql"DELETE FROM app_policy_assignments WHERE app_id=$appId AND profile_id=$profileId".update.run
+      .transact(xa)
+      .unit
+
+  private type AR = (AppPolicyAssignmentId, AppId, ProfileId, AppMode, Option[Int], Boolean)
+  private def toAssignment(r: AR) = AppPolicyAssignment(r._1, r._2, r._3, r._4, r._5, r._6)
+
+  def listAssignmentsByProfile(profileId: ProfileId) =
+    sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
+          FROM app_policy_assignments WHERE profile_id=$profileId ORDER BY id"""
+      .query[AR]
+      .map(toAssignment)
+      .to[List]
+      .transact(xa)
+
+  def listAssignmentsByApp(appId: AppId) =
+    sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
+          FROM app_policy_assignments WHERE app_id=$appId ORDER BY id"""
+      .query[AR]
+      .map(toAssignment)
+      .to[List]
+      .transact(xa)
+}
+
 object Repos {
   val userRepo              = ZLayer.fromFunction(UserRepoLive(_))
   val userProfileRepo       = ZLayer.fromFunction(UserProfileRepoLive(_))
@@ -1328,6 +1448,7 @@ object Repos {
   val trafficReportRepo     = ZLayer.fromFunction(TrafficReportRepoLive(_))
   val blockEventRepo        = ZLayer.fromFunction(BlockEventRepoLive(_))
   val connEventRepo         = ZLayer.fromFunction(ConnectionEventRepoLive(_))
+  val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ appRepo
 }

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -2,7 +2,7 @@ package wifihaven.api.db
 
 import doobie.*
 import doobie.postgres.implicits.*
-import wifihaven.shared.{FailureMode, MacBlockReason, UserRole}
+import wifihaven.shared.{AppMode, FailureMode, MacBlockReason, UserRole}
 import wifihaven.shared.types.*
 
 import java.time.ZoneId
@@ -19,18 +19,20 @@ import java.time.ZoneId
 object TypeMeta {
 
   // ── Long-backed identifiers ────────────────────────────────────────────
-  given Meta[ProfileId]         = Meta[Long].imap(ProfileId(_))(_.value)
-  given Meta[DeviceId]          = Meta[Long].imap(DeviceId(_))(_.value)
-  given Meta[ScheduleId]        = Meta[Long].imap(ScheduleId(_))(_.value)
-  given Meta[TimeLimitId]       = Meta[Long].imap(TimeLimitId(_))(_.value)
-  given Meta[SiteTimeLimitId]   = Meta[Long].imap(SiteTimeLimitId(_))(_.value)
-  given Meta[TimeExtensionId]   = Meta[Long].imap(TimeExtensionId(_))(_.value)
-  given Meta[UserId]            = Meta[Long].imap(UserId(_))(_.value)
-  given Meta[BlockEventId]      = Meta[Long].imap(BlockEventId(_))(_.value)
-  given Meta[ConnectionEventId] = Meta[Long].imap(ConnectionEventId(_))(_.value)
-  given Meta[QueryLogId]        = Meta[Long].imap(QueryLogId(_))(_.value)
-  given Meta[TrafficReportId]   = Meta[Long].imap(TrafficReportId(_))(_.value)
-  given Meta[TimeUsageId]       = Meta[Long].imap(TimeUsageId(_))(_.value)
+  given Meta[ProfileId]             = Meta[Long].imap(ProfileId(_))(_.value)
+  given Meta[DeviceId]              = Meta[Long].imap(DeviceId(_))(_.value)
+  given Meta[ScheduleId]            = Meta[Long].imap(ScheduleId(_))(_.value)
+  given Meta[TimeLimitId]           = Meta[Long].imap(TimeLimitId(_))(_.value)
+  given Meta[SiteTimeLimitId]       = Meta[Long].imap(SiteTimeLimitId(_))(_.value)
+  given Meta[TimeExtensionId]       = Meta[Long].imap(TimeExtensionId(_))(_.value)
+  given Meta[UserId]                = Meta[Long].imap(UserId(_))(_.value)
+  given Meta[BlockEventId]          = Meta[Long].imap(BlockEventId(_))(_.value)
+  given Meta[ConnectionEventId]     = Meta[Long].imap(ConnectionEventId(_))(_.value)
+  given Meta[QueryLogId]            = Meta[Long].imap(QueryLogId(_))(_.value)
+  given Meta[TrafficReportId]       = Meta[Long].imap(TrafficReportId(_))(_.value)
+  given Meta[TimeUsageId]           = Meta[Long].imap(TimeUsageId(_))(_.value)
+  given Meta[AppId]                 = Meta[Long].imap(AppId(_))(_.value)
+  given Meta[AppPolicyAssignmentId] = Meta[Long].imap(AppPolicyAssignmentId(_))(_.value)
 
   // ── UUID-backed ────────────────────────────────────────────────────────
   given Meta[RouterId] = Meta[java.util.UUID].imap(RouterId(_))(_.value)
@@ -68,6 +70,14 @@ object TypeMeta {
         throw new IllegalStateException(s"DB has unknown failureMode: $s"),
       ),
   )(FailureMode.asString)
+
+  given Meta[AppMode] = Meta[String].imap(s =>
+    AppMode
+      .parse(s)
+      .getOrElse(
+        throw new IllegalStateException(s"DB has unknown appMode: $s"),
+      ),
+  )(AppMode.asString)
 
   given Meta[MacBlockReason] = Meta[String].imap(s =>
     MacBlockReason

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -110,7 +110,8 @@ object TestDatabase {
   type AllRepos =
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
-      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo
+      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
+      AppRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -1,0 +1,147 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.Transactor
+import zio.*
+import zio.test.*
+
+object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private val yt   = Hostname.unsafe("youtube.com")
+  private val ytg  = Hostname.unsafe("ytimg.com")
+  private val gvid = Hostname.unsafe("googlevideo.com")
+
+  def spec = suite("AppRepo")(
+    test("insertApp + getApp round-trips name/slug/template/icon") {
+      for {
+        _   <- cleanDb
+        r   <- ZIO.service[AppRepo]
+        id  <- r.insertApp(AppInsert("YouTube", "youtube", Some("youtube"), Some("📺")))
+        got <- r.getApp(id)
+      } yield assertTrue(
+        got.exists(a =>
+          a.name == "YouTube" && a.slug == "youtube" &&
+            a.templateId.contains("youtube") && a.icon.contains("📺"),
+        ),
+      )
+    },
+    test("listApps returns all rows ordered by id") {
+      for {
+        _   <- cleanDb
+        r   <- ZIO.service[AppRepo]
+        a   <- r.insertApp(AppInsert("YouTube", "youtube"))
+        b   <- r.insertApp(AppInsert("TikTok", "tiktok"))
+        all <- r.listApps
+      } yield assertTrue(all.map(_.id) == List(a, b))
+    },
+    test("slug uniqueness is enforced") {
+      for {
+        _   <- cleanDb
+        r   <- ZIO.service[AppRepo]
+        _   <- r.insertApp(AppInsert("YouTube", "youtube"))
+        dup <- r.insertApp(AppInsert("YouTube 2", "youtube")).exit
+      } yield assertTrue(dup.isFailure)
+    },
+    test("updateApp mutates name/slug/template/icon") {
+      for {
+        _   <- cleanDb
+        r   <- ZIO.service[AppRepo]
+        id  <- r.insertApp(AppInsert("YouTube", "youtube"))
+        _   <- r.updateApp(id, AppUpdate("YT", "yt", Some("youtube"), Some("🎥")))
+        got <- r.getApp(id)
+      } yield assertTrue(
+        got.exists(a =>
+          a.name == "YT" && a.slug == "yt" && a.templateId.contains("youtube") &&
+            a.icon.contains("🎥"),
+        ),
+      )
+    },
+    test("setHosts replaces the host set; deleteApp cascades hosts and assignments") {
+      for {
+        _          <- cleanDb
+        appR       <- ZIO.service[AppRepo]
+        profR      <- ZIO.service[ProfileRepo]
+        pid        <- profR.create("Kids", Nil)
+        id         <- appR.insertApp(AppInsert("YouTube", "youtube"))
+        _          <- appR.setHosts(id, List(yt, ytg))
+        h1         <- appR.listHosts(id)
+        _          <- appR.setHosts(id, List(yt, gvid))
+        h2         <- appR.listHosts(id)
+        _          <- appR.upsertAssignment(AssignmentUpsert(id, pid, AppMode.Blocked, None))
+        _          <- appR.deleteApp(id)
+        gone       <- appR.getApp(id)
+        hostsAfter <- appR.listHosts(id)
+        asgAfter   <- appR.listAssignmentsByProfile(pid)
+      } yield assertTrue(h1.toSet == Set(yt, ytg)) &&
+        assertTrue(h2.toSet == Set(yt, gvid)) &&
+        assertTrue(gone.isEmpty) &&
+        assertTrue(hostsAfter.isEmpty) &&
+        assertTrue(asgAfter.isEmpty)
+    },
+    test("upsertAssignment is idempotent on (app_id, profile_id) and updates fields") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        profR <- ZIO.service[ProfileRepo]
+        pid   <- profR.create("Kids", Nil)
+        id    <- appR.insertApp(AppInsert("YouTube", "youtube"))
+        a1    <- appR.upsertAssignment(
+          AssignmentUpsert(id, pid, AppMode.TimeLimited, Some(30), exemptFromDaily = true),
+        )
+        a2    <- appR.upsertAssignment(
+          AssignmentUpsert(id, pid, AppMode.Blocked, None, exemptFromDaily = false),
+        )
+        rows  <- appR.listAssignmentsByProfile(pid)
+      } yield assertTrue(a1 == a2) && assertTrue(rows.size == 1) &&
+        assertTrue(rows.head.mode == AppMode.Blocked) &&
+        assertTrue(rows.head.dailyMinutes.isEmpty) &&
+        assertTrue(!rows.head.exemptFromDaily)
+    },
+    test("deleteAssignment removes only the targeted (app, profile) row") {
+      for {
+        _      <- cleanDb
+        appR   <- ZIO.service[AppRepo]
+        profR  <- ZIO.service[ProfileRepo]
+        kids   <- profR.create("Kids", Nil)
+        adults <- profR.create("Adults", Nil)
+        id     <- appR.insertApp(AppInsert("YouTube", "youtube"))
+        _      <- appR.upsertAssignment(AssignmentUpsert(id, kids, AppMode.Blocked, None))
+        _      <- appR.upsertAssignment(AssignmentUpsert(id, adults, AppMode.Allowed, None))
+        _      <- appR.deleteAssignment(id, kids)
+        byApp  <- appR.listAssignmentsByApp(id)
+      } yield assertTrue(byApp.size == 1) &&
+        assertTrue(byApp.head.profileId == adults) &&
+        assertTrue(byApp.head.mode == AppMode.Allowed)
+    },
+    test("deleting a profile cascades to its app assignments") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        profR <- ZIO.service[ProfileRepo]
+        pid   <- profR.create("Kids", Nil)
+        id    <- appR.insertApp(AppInsert("YouTube", "youtube"))
+        _     <- appR.upsertAssignment(AssignmentUpsert(id, pid, AppMode.Blocked, None))
+        _     <- profR.delete(pid)
+        byApp <- appR.listAssignmentsByApp(id)
+      } yield assertTrue(byApp.isEmpty)
+    },
+    test("Hostname.canonicalize strips a leading *. then parses") {
+      val a = Hostname.canonicalize("*.youtube.com")
+      val b = Hostname.canonicalize("youtube.com")
+      val c = Hostname.canonicalize("*.NotAHost!!")
+      assertTrue(a == Right(Hostname.unsafe("youtube.com"))) &&
+      assertTrue(b == Right(Hostname.unsafe("youtube.com"))) &&
+      assertTrue(c.isLeft)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -95,6 +95,51 @@ object FailureMode {
   )
 }
 
+enum AppMode {
+  case Blocked, Allowed, TimeLimited
+}
+
+object AppMode {
+  def asString(m: AppMode): String      = m match {
+    case Blocked     => "blocked"
+    case Allowed     => "allowed"
+    case TimeLimited => "time_limited"
+  }
+  def parse(s: String): Option[AppMode] = s match {
+    case "blocked"      => Some(Blocked)
+    case "allowed"      => Some(Allowed)
+    case "time_limited" => Some(TimeLimited)
+    case _              => None
+  }
+  given JsonCodec[AppMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown appMode: $s"),
+    asString,
+  )
+}
+
+case class App(
+    id: AppId,
+    name: String,
+    slug: String,
+    templateId: Option[String],
+    icon: Option[String],
+    createdAt: String,
+) derives JsonCodec
+
+case class AppHost(
+    appId: AppId,
+    host: Hostname,
+) derives JsonCodec
+
+case class AppPolicyAssignment(
+    id: AppPolicyAssignmentId,
+    appId: AppId,
+    profileId: ProfileId,
+    mode: AppMode,
+    dailyMinutes: Option[Int],
+    exemptFromDaily: Boolean = true,
+) derives JsonCodec
+
 case class Profile(
     id: ProfileId,
     name: String,

--- a/shared/src/types/Hostname.scala
+++ b/shared/src/types/Hostname.scala
@@ -30,6 +30,16 @@ object Hostname {
 
   def unsafe(s: String): Hostname = s
 
+  /**
+   * Strip a leading `*.` (the "apex + subdomains" wildcard form per #105 design) then parse as a
+   * normal Hostname. `foo.com` and `*.foo.com` are equivalent on input; both canonicalize to the
+   * apex `foo.com`.
+   */
+  def canonicalize(input: String): Either[String, Hostname] = {
+    val stripped = if input.startsWith("*.") then input.drop(2) else input
+    parse(stripped)
+  }
+
   extension (h: Hostname) def value: String = h
 
   given Ordering[Hostname]         = Ordering.String

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -10,18 +10,20 @@ import java.util.UUID
  * and as a string when used as a JSON object key (matching `Map[Long, _]`'s default rendering).
  */
 
-opaque type ProfileId         = Long
-opaque type DeviceId          = Long
-opaque type ScheduleId        = Long
-opaque type TimeLimitId       = Long
-opaque type SiteTimeLimitId   = Long
-opaque type TimeExtensionId   = Long
-opaque type UserId            = Long
-opaque type BlockEventId      = Long
-opaque type ConnectionEventId = Long
-opaque type QueryLogId        = Long
-opaque type TrafficReportId   = Long
-opaque type TimeUsageId       = Long
+opaque type ProfileId             = Long
+opaque type DeviceId              = Long
+opaque type ScheduleId            = Long
+opaque type TimeLimitId           = Long
+opaque type SiteTimeLimitId       = Long
+opaque type TimeExtensionId       = Long
+opaque type UserId                = Long
+opaque type BlockEventId          = Long
+opaque type ConnectionEventId     = Long
+opaque type QueryLogId            = Long
+opaque type TrafficReportId       = Long
+opaque type TimeUsageId           = Long
+opaque type AppId                 = Long
+opaque type AppPolicyAssignmentId = Long
 
 object ProfileId {
   def apply(l: Long): ProfileId            = l
@@ -101,6 +103,21 @@ object TimeUsageId {
   def apply(l: Long): TimeUsageId            = l
   extension (t: TimeUsageId) def value: Long = t
   given JsonCodec[TimeUsageId]               = JsonCodec.long
+}
+
+object AppId {
+  def apply(l: Long): AppId            = l
+  extension (a: AppId) def value: Long = a
+  given JsonCodec[AppId]               = JsonCodec.long
+  given JsonFieldEncoder[AppId]        = JsonFieldEncoder.long
+  given JsonFieldDecoder[AppId]        = JsonFieldDecoder.long
+  given Ordering[AppId]                = Ordering.Long
+}
+
+object AppPolicyAssignmentId {
+  def apply(l: Long): AppPolicyAssignmentId            = l
+  extension (a: AppPolicyAssignmentId) def value: Long = a
+  given JsonCodec[AppPolicyAssignmentId]               = JsonCodec.long
 }
 
 /** UUID-backed router identifier. */


### PR DESCRIPTION
## Summary

Closes #761. Part of #105.

Adds the data model that backs the **app** concept (household-scoped named bundle of host patterns):

- **V23 migration**: `apps (id, name, slug UNIQUE, template_id, icon, created_at)`, `app_hosts (app_id, host, PK (app_id, host))`, `app_policy_assignments (id, app_id, profile_id, mode CHECK IN ('blocked','allowed','time_limited'), daily_minutes, exempt_from_daily, UNIQUE (app_id, profile_id))`. All FKs cascade.
- **Scala models**: `App`, `AppHost`, `AppPolicyAssignment`, `AppMode` enum (`Blocked`/`Allowed`/`TimeLimited`) with JSON codec; `AppId` / `AppPolicyAssignmentId` opaque types and matching doobie `Meta` instances.
- **`AppRepo`**: `insertApp` / `getApp` / `listApps` / `updateApp` / `deleteApp`; `listHosts` / `setHosts` (replace-all); `upsertAssignment` / `deleteAssignment` / `listAssignmentsByProfile` / `listAssignmentsByApp`. No business logic.
- **`Hostname.canonicalize`**: strips a leading `*.` then parses, so `youtube.com` and `*.youtube.com` both round-trip to the apex (per #105 §1).

## Notes / deviations from spec

- **No `household_id`**: the spec calls for `household_id BIGINT FK households(id)` but there is no `households` table yet. The system is currently single-tenant, so `slug` is the global unique key. When multi-tenancy lands, the unique key moves to `(household_id, slug)`.

## Out of scope (separate issues)

- HTTP routes (#762)
- PolicyService expansion (`app_hosts` union into per-MAC `BlockRules`) (#763)
- Migration of legacy `extra_blocked` / `extra_allowed` / `site_time_limits` into apps (#764)

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.AppRepoSpec` — 9 tests pass (insert/get/list/update round-trips, slug uniqueness enforced, `setHosts` replace-all, app delete cascades to hosts + assignments, `upsertAssignment` idempotent on `(app_id, profile_id)`, `deleteAssignment` scoped, profile delete cascades, `Hostname.canonicalize`)
- [x] `mill api.test` — full api suite green (no regressions)
- [x] `mill shared.test` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)