### PR TITLE
ops: bump prod API to standard plan (closes #786)

### DIFF
--- a/docs/deploy-cloud.md
+++ b/docs/deploy-cloud.md
@@ -70,7 +70,7 @@ config for the API to read the real client IP. Out of scope for now.
 Cloudflare):
 
 - `wifihaven-api-staging` (Web Service, free)
-- `wifihaven-api-prod` (Web Service, free)
+- `wifihaven-api-prod` (Web Service, paid — `standard`; bumped from free in #786)
 - `wifihaven-pg-staging` (Postgres, free)
 - `wifihaven-pg-prod` (Postgres, paid — `basic-256mb`)
 

--- a/render.yaml
+++ b/render.yaml
@@ -91,7 +91,7 @@ services:
   - type: web
     runtime: image
     name: wifihaven-api-prod
-    plan: free
+    plan: standard
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health
@@ -126,10 +126,13 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
-      # #590: Render Hobby caps at ~512 MB. Leave headroom for OS + JIT +
-      # native heap; bump or move to `plan: pro` if OOM appears in logs.
+      # #786 / #785: bumped to `plan: standard` (2 GB / 1 CPU, $25/mo) after
+      # prod started flapping under household load on free's 512 MB cap.
+      # Heap sized to leave ~600 MB for OS + JIT + native; revisit if OOM
+      # appears in logs or if growing dataset pushes `traffic_reports`
+      # working set past the new ceiling.
       - key: JVM_HEAP_OPTS
-        value: "-Xms256m -Xmx384m"
+        value: "-Xms512m -Xmx1400m"
       # Production uses INFO to avoid PII leakage in logs.
       # Resolves the TODO from #586 / PR #599.
       - key: WIFIHAVEN_LOG_LEVEL


### PR DESCRIPTION
## What changed

`render.yaml` — production API service (`wifihaven-api-prod`) only:

- `plan: free` → `plan: standard`
- `JVM_HEAP_OPTS`: `-Xms256m -Xmx384m` → `-Xms512m -Xmx1400m`
- Inline comment block rewritten to reference #786 / #785 (replaces stale #590 note that pointed at `plan: pro`).

`docs/deploy-cloud.md` — Blueprint resource list updated so prod no longer reads as `free`.

Staging API, both Postgres blocks, image refs, deploy hooks, env vars, and domains are untouched.

## Plan chosen

**`standard`** — 2 GB RAM / 1 CPU / $25/mo. Cheapest paid tier with real memory headroom over free's 512 MB ceiling: 4× the RAM is enough to absorb the new heartbeat-filter and weekly-view query working set without immediately revisiting. `pro` ($85/mo) is the next step up at 4 GB / 2 CPU and is overkill for current household load — leave it as the next bump if `standard` proves tight.

Heap sized to `-Xms512m -Xmx1400m`, leaving ~600 MB for OS + JIT + native (Render's container overhead historically eats ~200–300 MB).

## Symptoms this addresses

From [#785](https://github.com/wifihaven/wifihaven/issues/785) (measured 2026-05-21 ~15:53 UTC):

> | endpoint | latency | status |
> |---|---|---|
> | `/api/time/status` | **12.1s** | 200 |
> | `/api/sessions` | **29.6s** | 200 |
>
> Render's edge gateway gives up before the API responds and returns a 502 HTML page.

The upgrade is a cushion, not a cure — the query-perf side of #785 (slow SQL on `traffic_reports`, missing indexes from #740 / #739 / #732) is still worth pursuing as a follow-up.

## Operator action after merge

Apply the Render Blueprint per `docs/deploy-cloud.md` §2:

1. Render dashboard → **Blueprints** → `wifihaven` → **Apply**.
2. Wait for `wifihaven-api-prod` to redeploy and reach **Live**.
3. Sanity-check: rapid-fire `curl https://api.wifihaven.net/api/health` returns 200 consistently; `/api/time/status` and `/api/sessions` return without gateway 502s.

Closes #786.