### PR TITLE
feat(usage): server-side FQDN heartbeat allowlist (closes #788)

### DIFF
--- a/api/resources/db/migration/V24__heartbeat_host_patterns.sql
+++ b/api/resources/db/migration/V24__heartbeat_host_patterns.sql
@@ -1,0 +1,33 @@
+-- V23__heartbeat_host_patterns.sql
+-- #788: FQDN allowlist for the server-side heartbeat filter.
+--
+-- Adds a configurable list of FQDN patterns (same `*.foo.com` / `foo.com`
+-- semantics as Presence.matchesPattern). Any traffic_reports row whose
+-- host matches one of these patterns is classified as a heartbeat by
+-- Presence.isHeartbeat, regardless of bytes / active-fraction. This closes
+-- the gap from #779 where well-known background hosts (APNs, RCS, Apple
+-- iCloud Private Relay, time sync, captive probes) occasionally burst
+-- past the byte floor on TLS resumption / OCSP / cert rotation.
+--
+-- Ships with a default seed list of well-known heartbeat hosts. Operator
+-- can edit via PUT /api/admin/household-settings.
+
+ALTER TABLE household_settings
+  ADD COLUMN heartbeat_host_patterns TEXT[] NOT NULL DEFAULT ARRAY[
+    '*.push.apple.com',
+    '*.apple-dns.net',
+    '*.akadns.net',
+    '*.ess.apple.com',
+    'time.apple.com',
+    'gdmf.apple.com',
+    'pancake.apple.com',
+    'mask.icloud.com',
+    'mask-h2.icloud.com',
+    'mask-api.icloud.com',
+    '*.rcs.telephony.goog',
+    'mtalk.google.com',
+    'connectivitycheck.gstatic.com',
+    'captive.apple.com',
+    '*.ntp.org',
+    'time.cloudflare.com'
+  ]::TEXT[];

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -491,12 +491,13 @@ class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
 class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsRepo {
   def get: Task[HouseholdSettings] =
     sql"""SELECT daily_reset_time, daily_reset_tz,
-                 heartbeat_filter_enabled, heartbeat_bytes_threshold
+                 heartbeat_filter_enabled, heartbeat_bytes_threshold,
+                 heartbeat_host_patterns
             FROM household_settings WHERE id=1"""
-      .query[(LocalTime, ZoneId, Boolean, Int)]
+      .query[(LocalTime, ZoneId, Boolean, Int, List[String])]
       .unique
-      .map { case (t, z, hbEnabled, hbBytes) =>
-        HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes))
+      .map { case (t, z, hbEnabled, hbBytes, hbHosts) =>
+        HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts))
       }
       .transact(xa)
 
@@ -506,6 +507,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
                 daily_reset_tz=${s.dailyResetTz},
                 heartbeat_filter_enabled=${s.heartbeatFilter.enabled},
                 heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
+                heartbeat_host_patterns=${s.heartbeatFilter.heartbeatHostPatterns.toArray},
                 updated_at=NOW()
           WHERE id=1""".update.run.transact(xa).unit
 

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -100,7 +100,12 @@ object Presence {
    * are below `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few hundred).
    */
   def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
-    filter.enabled && row.bytes < filter.bytesThreshold
+    filter.enabled && (
+      row.bytes < filter.bytesThreshold ||
+        row.host.asFqdn.exists(fqdn =>
+          filter.heartbeatHostPatterns.exists(p => matchesPattern(fqdn.value, p)),
+        )
+    )
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
@@ -118,6 +123,11 @@ object Presence {
       val rsns  = scala.collection.mutable.ListBuffer.empty[String]
       if filter.enabled then {
         if r.bytes < filter.bytesThreshold then rsns += s"bytes<${filter.bytesThreshold}"
+        for {
+          fqdn <- r.host.asFqdn
+          p    <- filter.heartbeatHostPatterns
+          if matchesPattern(fqdn.value, p)
+        } rsns += s"host:$p"
       }
       val label = if filter.enabled && rsns.nonEmpty then "heartbeat" else "active"
       Classified(r, label, rsns.toList)

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -234,6 +234,41 @@ object PresenceSpec extends ZIOSpecDefault {
         assertTrue(out.head.classified == "active") &&
         assertTrue(out.head.reasons.isEmpty)
       },
+      test("#788 host pattern match classifies as heartbeat even when bytes pass") {
+        // Row that would otherwise pass the bytes floor — only the FQDN allowlist trips it.
+        // Confirms host-pattern path is OR'd in correctly.
+        val f = HeartbeatFilter(
+          enabled = true,
+          bytesThreshold = 2048,
+          heartbeatHostPatterns = List("*.push.apple.com"),
+        )
+        val r =
+          row(mac1, 0, "api-push.push.apple.com", secs = 200, bytes = 50_000L, periodSeconds = 300)
+        assertTrue(Presence.isHeartbeat(r, f)) &&
+        assertTrue(Presence.totalMinutesByMac(List(r), Nil, f) == Map.empty[MacAddress, Int])
+      },
+      test("#788 classifyRows surfaces host:<pattern> reason for FQDN match") {
+        val f    = HeartbeatFilter(
+          enabled = true,
+          bytesThreshold = 2048,
+          heartbeatHostPatterns = List("*.push.apple.com", "time.apple.com"),
+        )
+        val rows = List(
+          row(mac1, 0, "courier.push.apple.com", secs = 200, bytes = 50_000L, periodSeconds = 300),
+        )
+        val out  = Presence.classifyRows(rows, f)
+        assertTrue(out.head.classified == "heartbeat") &&
+        assertTrue(out.head.reasons == List("host:*.push.apple.com"))
+      },
+      test("#788 host pattern only matches FQDNs, not IP literals") {
+        val f = HeartbeatFilter(
+          enabled = true,
+          bytesThreshold = 0,
+          heartbeatHostPatterns = List("*.push.apple.com"),
+        )
+        val r = ipRow(mac1, 0, "17.57.146.1", secs = 200, bytes = 50_000L, periodSeconds = 300)
+        assertTrue(!Presence.isHeartbeat(r, f))
+      },
     ),
     suite("hostMinutes")(
       test("empty rows yields empty map") {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -247,11 +247,36 @@ case class UpdateHouseholdSettingsRequest(
 case class HeartbeatFilter(
     enabled: Boolean,
     bytesThreshold: Int,
+    heartbeatHostPatterns: List[String] = Nil,
 ) derives JsonCodec
 
 object HeartbeatFilter {
   val Off: HeartbeatFilter =
-    HeartbeatFilter(enabled = false, bytesThreshold = 0)
+    HeartbeatFilter(enabled = false, bytesThreshold = 0, heartbeatHostPatterns = Nil)
+
+  /**
+   * #788: default seed list of FQDN patterns to ship at install. These are well-known
+   * background/heartbeat hosts (APNs, RCS, Apple iCloud Private Relay, time sync, captive portal
+   * probes) that can occasionally burst >10 KB and slip past the byte floor.
+   */
+  val DefaultHostPatterns: List[String] = List(
+    "*.push.apple.com",
+    "*.apple-dns.net",
+    "*.akadns.net",
+    "*.ess.apple.com",
+    "time.apple.com",
+    "gdmf.apple.com",
+    "pancake.apple.com",
+    "mask.icloud.com",
+    "mask-h2.icloud.com",
+    "mask-api.icloud.com",
+    "*.rcs.telephony.goog",
+    "mtalk.google.com",
+    "connectivitycheck.gstatic.com",
+    "captive.apple.com",
+    "*.ntp.org",
+    "time.cloudflare.com",
+  )
 }
 
 /**

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -253,30 +253,6 @@ case class HeartbeatFilter(
 object HeartbeatFilter {
   val Off: HeartbeatFilter =
     HeartbeatFilter(enabled = false, bytesThreshold = 0, heartbeatHostPatterns = Nil)
-
-  /**
-   * #788: default seed list of FQDN patterns to ship at install. These are well-known
-   * background/heartbeat hosts (APNs, RCS, Apple iCloud Private Relay, time sync, captive portal
-   * probes) that can occasionally burst >10 KB and slip past the byte floor.
-   */
-  val DefaultHostPatterns: List[String] = List(
-    "*.push.apple.com",
-    "*.apple-dns.net",
-    "*.akadns.net",
-    "*.ess.apple.com",
-    "time.apple.com",
-    "gdmf.apple.com",
-    "pancake.apple.com",
-    "mask.icloud.com",
-    "mask-h2.icloud.com",
-    "mask-api.icloud.com",
-    "*.rcs.telephony.goog",
-    "mtalk.google.com",
-    "connectivitycheck.gstatic.com",
-    "captive.apple.com",
-    "*.ntp.org",
-    "time.cloudflare.com",
-  )
 }
 
 /**

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -18,6 +18,7 @@ import { AdminPage } from './AdminPage'
 const DEFAULT_HF: HeartbeatFilter = {
   enabled: false,
   bytesThreshold: 2048,
+  heartbeatHostPatterns: [],
 }
 
 beforeEach(() => {
@@ -256,7 +257,7 @@ describe('AdminPage — heartbeat filter card', () => {
 
   it('summary shows thresholds when filter is enabled', async () => {
     seedServer({
-      heartbeatFilter: { enabled: true, bytesThreshold: 4096 },
+      heartbeatFilter: { enabled: true, bytesThreshold: 4096, heartbeatHostPatterns: [] },
     })
     render(<AdminPage />)
     const summary = await screen.findByTestId('heartbeat-filter-summary')
@@ -289,7 +290,7 @@ describe('AdminPage — heartbeat filter card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '00:00',
         dailyResetTz: 'America/Los_Angeles',
-        heartbeatFilter: { enabled: true, bytesThreshold: 2048 },
+        heartbeatFilter: { enabled: true, bytesThreshold: 2048, heartbeatHostPatterns: [] },
       }),
     )
     const summary = await screen.findByTestId('heartbeat-filter-summary')
@@ -314,7 +315,7 @@ describe('AdminPage — heartbeat filter card', () => {
       expect(api.household.update).toHaveBeenCalledWith({
         dailyResetTime: '00:00',
         dailyResetTz: 'America/Los_Angeles',
-        heartbeatFilter: { enabled: true, bytesThreshold: 8192 },
+        heartbeatFilter: { enabled: true, bytesThreshold: 8192, heartbeatHostPatterns: [] },
       }),
     )
     const summary = await screen.findByTestId('heartbeat-filter-summary')

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -80,6 +80,9 @@ function HeartbeatFilterCard({
         heartbeatFilter: {
           enabled: form.enabled,
           bytesThreshold: Math.trunc(form.bytesThreshold),
+          heartbeatHostPatterns: form.heartbeatHostPatterns
+            .map(p => p.trim())
+            .filter(p => p.length > 0),
         },
       })
       const fresh = await api.household.get()
@@ -114,17 +117,26 @@ function HeartbeatFilterCard({
       </div>
 
       {!editing ? (
-        <p data-testid="heartbeat-filter-summary" className="text-sm text-gray-300">
-          {hf.enabled ? (
-            <>
-              <span className="font-medium text-white">Enabled</span>
-              {' — bytes ≥ '}
-              <span className="font-mono text-gray-200">{hf.bytesThreshold}</span>
-            </>
-          ) : (
-            <span className="font-medium text-white">Disabled</span>
-          )}
-        </p>
+        <div className="space-y-1">
+          <p data-testid="heartbeat-filter-summary" className="text-sm text-gray-300">
+            {hf.enabled ? (
+              <>
+                <span className="font-medium text-white">Enabled</span>
+                {' — bytes ≥ '}
+                <span className="font-mono text-gray-200">{hf.bytesThreshold}</span>
+              </>
+            ) : (
+              <span className="font-medium text-white">Disabled</span>
+            )}
+          </p>
+          <p
+            data-testid="heartbeat-filter-hosts-summary"
+            className="text-xs text-gray-500"
+          >
+            {hf.heartbeatHostPatterns.length} host pattern
+            {hf.heartbeatHostPatterns.length === 1 ? '' : 's'}
+          </p>
+        </div>
       ) : (
         <div className="space-y-3">
           <p className="text-xs text-gray-400">
@@ -168,6 +180,28 @@ function HeartbeatFilterCard({
                 className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm w-32"
               />
             </div>
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">
+              Host allowlist (one pattern per line — `*.foo.com` or `foo.com`)
+            </label>
+            <textarea
+              value={form.heartbeatHostPatterns.join('\n')}
+              onChange={e =>
+                setForm({
+                  ...form,
+                  heartbeatHostPatterns: e.target.value.split(/\r?\n/),
+                })
+              }
+              data-testid="heartbeat-filter-hosts"
+              rows={8}
+              spellCheck={false}
+              className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-xs font-mono w-full"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Rows whose host matches any pattern are classified as heartbeats regardless of
+              bytes / active fraction.
+            </p>
           </div>
           <div className="flex gap-3 pt-1">
             <button

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -29,7 +29,8 @@ export interface Schedule {
 // household-wide.
 export interface HeartbeatFilter {
   enabled: boolean
-  bytesThreshold: number       // bytes/min floor (rows below are heartbeats)
+  bytesThreshold: number          // bytes/min floor (rows below are heartbeats)
+  heartbeatHostPatterns: string[] // #788 FQDN allowlist; *.foo.com / foo.com semantics
 }
 
 export interface HouseholdSettings {


### PR DESCRIPTION
## Summary

- Adds a configurable per-household FQDN allowlist (`heartbeatHostPatterns`) to the heartbeat filter. Any `traffic_reports` row whose host matches a pattern (`*.foo.com` / `foo.com` semantics, same as `Presence.matchesPattern`) is classified as a heartbeat regardless of bytes / active-fraction.
- Ships with a default seed list at install (V23 migration sets it as the column DEFAULT): Apple APNs / iCloud Private Relay / time, Google RCS / GCM, gstatic connectivity probe, NTP, Cloudflare time, captive-portal probes.
- Surfaced through the wire: round-trips through `GET`/`PUT /api/admin/household-settings`; `classifyRows` adds a `host:<pattern>` reason on `/api/time/heartbeat-explain/{mac}`.
- Web admin UI: textarea of patterns (one per line) on the existing Heartbeat filter card.

Closes #788. Follow-up from operator decision 1 on #779.

## Coordination with #789

#789 is dropping `activeFractionPct` and bumping the bytes default. This branch leaves both knobs untouched and only ORs in the host-pattern path — whichever lands first wins the conflict, the other rebases trivially.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.unit.PresenceSpec` — adds three #788 cases (host-pattern-only match → heartbeat, explain reason surfacing, IP-literal never matches).
- [x] `mill __.compile` clean across shared / api / web layers.
- [x] `mill api.test` — full API suite green.
- [x] `npm test -- AdminPage`, `npm run type-check`, `npm run lint` (node 22).
- [ ] Manual sanity on a live deploy: `GET /api/admin/household-settings` shows the default seed list after fresh migration; PUT round-trips an edited list; `/api/time/heartbeat-explain/{mac}` surfaces `host:*.push.apple.com` on a real APNs row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)