### PR TITLE
perf+ux(web): collapse profiles + lazy-load on screen-time (#777)

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -387,6 +387,112 @@ object TimeRoutes {
       cache: TimeStatusCache = TimeStatusCache.makeUnsafe(),
   ): Routes[Any, Response] =
     Routes(
+      // #777 — collapsed accordion summary. One batched presence query over ALL devices
+      // returns per-profile usedMins / dailyLimitMins / extensionMins / remainingMins. Used
+      // by the SPA to render the unexpanded list without fanning out the full rollup.
+      Method.GET / "api" / "time" / "status" / "summary"                ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAuth(req, auth)
+            today  <- clock.today
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
+            date    = LocalDate.parse(dateStr)
+            allProfiles   <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allDevices    <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allLimits     <- timeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allSiteLimits <- siteTimeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            extsByPid     <- extRepo
+              .snapshotAllByProfile(date)
+              .mapError(ErrorMapper.dbErrorToResponse)
+            settings      <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            visible       <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            devicesByPid = allDevices.groupBy(_.profileId)
+            allMacs      = visible.iterator
+              .flatMap(p => devicesByPid.getOrElse(Some(p.id), Nil))
+              .map(_.mac)
+              .toList
+              .distinct
+            presence <- (if allMacs.isEmpty then ZIO.succeed(Nil)
+                         else trafficRepo.listPresenceRows(allMacs, date))
+              .mapError(ErrorMapper.dbErrorToResponse)
+            limitByPid  = allLimits.iterator.map(l => l.profileId -> l.dailyMinutes).toMap
+            exemptByPid = allSiteLimits.iterator
+              .filter(_.exemptFromDaily)
+              .toList
+              .groupBy(_.profileId)
+              .view
+              .mapValues(_.map(_.domainPattern))
+              .toMap
+            summaries   = visible.map { p =>
+              val devices   = devicesByPid.getOrElse(Some(p.id), Nil)
+              val macSet    = devices.map(_.mac).toSet
+              val pRows     = presence.filter(r => macSet.contains(r.mac))
+              val exempts   = exemptByPid.getOrElse(p.id, Nil)
+              val perMac    = wifihaven.api.presence.Presence
+                .totalMinutesByMac(pRows, exempts, settings.heartbeatFilter)
+              val used      = devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+              val limit     = limitByPid.get(p.id)
+              val extMins   = extsByPid.getOrElse(p.id, 0)
+              val remaining = limit.map(l => (l + extMins - used).max(0))
+              ProfileTimeSummary(
+                p.id,
+                p.name,
+                date.toString,
+                limit,
+                used,
+                extMins,
+                remaining,
+              )
+            }
+          } yield Response
+            .json(summaries.toJson)
+            .addHeader(cacheControlFor(isTodayMode = !date.isBefore(today)))
+        },
+      // #777 — weekly variant of the summary endpoint. Single presence query over the trailing
+      // 7-day range, per-mac bucket-deduped totals summed per profile.
+      Method.GET / "api" / "time" / "status" / "summary" / "week"       ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAuth(req, auth)
+            today  <- clock.today
+            toStr = req.url.queryParam("to").getOrElse(today.toString)
+            to    = LocalDate.parse(toStr)
+            from  = to.minusDays(6)
+            allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allLimits   <- timeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            settings    <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            devicesByPid = allDevices.groupBy(_.profileId)
+            allMacs      = visible.iterator
+              .flatMap(p => devicesByPid.getOrElse(Some(p.id), Nil))
+              .map(_.mac)
+              .toList
+              .distinct
+            presence <- (if allMacs.isEmpty then ZIO.succeed(Nil)
+                         else trafficRepo.listPresenceRows(allMacs, from, to))
+              .mapError(ErrorMapper.dbErrorToResponse)
+            limitByPid = allLimits.iterator.map(l => l.profileId -> l.dailyMinutes).toMap
+            summaries  = visible.map { p =>
+              val devices = devicesByPid.getOrElse(Some(p.id), Nil)
+              val macSet  = devices.map(_.mac).toSet
+              val pRows   = presence.filter(r => macSet.contains(r.mac))
+              val perMac  = wifihaven.api.presence.Presence
+                .totalMinutesByMac(pRows, Nil, settings.heartbeatFilter)
+              val total   = devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+              ProfileTimeSummaryWeek(
+                p.id,
+                p.name,
+                from.toString,
+                to.toString,
+                limitByPid.get(p.id),
+                total,
+              )
+            }
+          } yield Response
+            .json(summaries.toJson)
+            .addHeader(cacheControlFor(isTodayMode = !to.isBefore(today)))
+        },
       Method.GET / "api" / "time" / "status"                            ->
         handler { (req: Request) =>
           for {

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -941,6 +941,141 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
       },
     ) @@ TestAspect.sequential,
 
+    // ── #777 collapsed accordion summary endpoint ───────────────────────────
+    suite("GET /api/time/status/summary")(
+      test("returns headline totals per profile across all visible profiles") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          adultsId    <- profileRepo
+            .create("Adults", Nil)
+            .flatMap(pid =>
+              profileRepo
+                .update(
+                  Profile(
+                    pid,
+                    "Adults",
+                    Nil,
+                    Nil,
+                    Nil,
+                    paused = false,
+                    FailureMode.LastKnownGood,
+                    blockIpOnly = false,
+                  ),
+                )
+                .as(pid),
+            )
+          _           <- tlRepo.upsert(kidsId, 60)
+          // Adults has no daily limit.
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "Laptop", adultsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // 45 min for kids, 20 min for adults. The summary should sum these
+          // independently per profile from a single presence query.
+          _               <- seedTraffic(routerId, mac1, "minecraft.net", today, 45)
+          _               <- seedTraffic(routerId, mac2, "wikipedia.org", today, 20)
+          // 15 min extension on the kids profile → remaining = 60 + 15 - 45 = 30.
+          _               <- extRepo.grantForProfile(kidsId, today, 15, "admin", None)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status/summary").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeSummary]])
+          kids   = list.find(_.profileId == kidsId).get
+          adults = list.find(_.profileId == adultsId).get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // The V1 migration seeds default Kids+Adults profiles; my seeds are additional.
+          // Just assert mine are present with the right numbers.
+          assertTrue(list.exists(_.profileId == kidsId)) &&
+          assertTrue(list.exists(_.profileId == adultsId)) &&
+          assertTrue(kids.usedMins == 45) &&
+          assertTrue(kids.dailyLimitMins.contains(60)) &&
+          assertTrue(kids.extensionMins == 15) &&
+          assertTrue(kids.remainingMins.contains(30)) &&
+          assertTrue(adults.usedMins == 20) &&
+          assertTrue(adults.dailyLimitMins.isEmpty) &&
+          assertTrue(adults.remainingMins.isEmpty)
+      },
+      test("weekly summary returns totals over the trailing 7 days") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          _               <- seedTraffic(routerId, mac1, "minecraft.net", today.minusDays(2), 30)
+          _               <- seedTraffic(routerId, mac1, "youtube.com", today, 25)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status/summary/week").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeSummaryWeek]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(kids.totalMins == 55) &&
+          assertTrue(kids.dailyLimitMins.contains(120)) &&
+          assertTrue(kids.from == today.minusDays(6).toString) &&
+          assertTrue(kids.to == today.toString)
+      },
+    ) @@ TestAspect.sequential,
+
     // ── #723 weekly view ────────────────────────────────────────────────────
     suite("GET /api/time/status/week")(
       test("per-day totals match a Today view computed for each date") {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -339,6 +339,35 @@ case class DeviceUsageSummary(
 
 case class HostUsage(host: HostId, usedMins: Int) derives JsonCodec
 
+/**
+ * #777 lightweight per-profile rollup for the collapsed accordion on the screen-time page. Just the
+ * headline numbers; no per-host / per-device / per-bucket arrays. The endpoint computes the whole
+ * list in a single batched presence query instead of fanning out per-profile, so the page load is
+ * `1 summary + N on-demand` rather than `N rollups`.
+ */
+case class ProfileTimeSummary(
+    profileId: ProfileId,
+    profileName: String,
+    date: String,
+    dailyLimitMins: Option[Int],
+    usedMins: Int,
+    extensionMins: Int,
+    remainingMins: Option[Int],
+) derives JsonCodec
+
+/**
+ * #777 weekly sibling of [[ProfileTimeSummary]]. Just `totalMins` over the trailing 7 days; the
+ * per-bucket chart and per-host breakdown still come from the heavyweight endpoint on expand.
+ */
+case class ProfileTimeSummaryWeek(
+    profileId: ProfileId,
+    profileName: String,
+    from: String,
+    to: String,
+    dailyLimitMins: Option[Int],
+    totalMins: Int,
+) derives JsonCodec
+
 case class ProfileTimeStatus(
     profileId: ProfileId,
     profileName: String,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,6 @@
 import type {
   CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardNow, DashboardStats, Device,
-  DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek,
+  DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek,
   QueryLog, RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension,
   UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
@@ -63,10 +63,11 @@ async function req<T>(
   return res.json() as Promise<T>
 }
 
-function weekQuery(to?: string, bucketOffsetMin?: number): string {
+function weekQuery(to?: string, bucketOffsetMin?: number, profileId?: number): string {
   const parts: string[] = []
   if (to !== undefined) parts.push(`to=${to}`)
   if (bucketOffsetMin !== undefined) parts.push(`bucketOffsetMin=${bucketOffsetMin}`)
+  if (profileId !== undefined) parts.push(`profileId=${profileId}`)
   return parts.length === 0 ? '' : `?${parts.join('&')}`
 }
 
@@ -121,10 +122,23 @@ export const api = {
 
   // ── Time ───────────────────────────────────────────────────────────────
   time: {
-    statusAll: (date?: string) =>
-      req<ProfileTimeStatus[]>('GET', `/time/status${date ? `?date=${date}` : ''}`),
-    statusAllWeek: (to?: string, bucketOffsetMin?: number) =>
-      req<ProfileTimeStatusWeek[]>('GET', `/time/status/week${weekQuery(to, bucketOffsetMin)}`),
+    statusAll: (date?: string, profileId?: number) => {
+      const qs = new URLSearchParams()
+      if (date) qs.set('date', date)
+      if (profileId !== undefined) qs.set('profileId', String(profileId))
+      const tail = qs.toString()
+      return req<ProfileTimeStatus[]>('GET', `/time/status${tail ? `?${tail}` : ''}`)
+    },
+    // #777 lightweight per-profile summary used by the collapsed accordion.
+    summaryAll: (date?: string) =>
+      req<ProfileTimeSummary[]>('GET', `/time/status/summary${date ? `?date=${date}` : ''}`),
+    summaryAllWeek: (to?: string) =>
+      req<ProfileTimeSummaryWeek[]>('GET', `/time/status/summary/week${to ? `?to=${to}` : ''}`),
+    statusAllWeek: (to?: string, bucketOffsetMin?: number, profileId?: number) =>
+      req<ProfileTimeStatusWeek[]>(
+        'GET',
+        `/time/status/week${weekQuery(to, bucketOffsetMin, profileId)}`,
+      ),
     // Colons in MAC addresses are valid URL path chars (sub-delims); zio-http
     // does NOT auto-decode percent-encoded colons in path segments, so
     // `encodeURIComponent` would turn the MAC into a 404. Send raw.

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -9,6 +9,7 @@ import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-
 import { api } from '@/api/client'
 import type {
   DashboardNow, Device, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek,
+  ProfileTimeSummary, ProfileTimeSummaryWeek,
 } from '@/types/api'
 
 const MIN = 60_000
@@ -31,6 +32,14 @@ export const qk = {
   timeStatusDate: (date: string) => ['time', 'status', 'date', date] as const,
   timeStatusWeek: (to?: string, bucketOffsetMin?: number) =>
     ['time', 'status', 'week', to ?? 'current', bucketOffsetMin ?? 0] as const,
+  // #777 — per-profile detail (today/week) cached on first expand so collapse-then-
+  // re-expand within the same page mount doesn't refetch.
+  timeStatusProfileToday: (profileId: number) =>
+    ['time', 'status', 'today', 'profile', profileId] as const,
+  timeStatusProfileWeek: (profileId: number, to: string | undefined, bucketOffsetMin: number) =>
+    ['time', 'status', 'week', to ?? 'current', bucketOffsetMin, 'profile', profileId] as const,
+  timeStatusSummaryToday: () => ['time', 'status', 'summary', 'today'] as const,
+  timeStatusSummaryWeek: (to?: string) => ['time', 'status', 'summary', 'week', to ?? 'current'] as const,
 }
 
 type QueryOpts<T> = Omit<UseQueryOptions<T, Error, T, readonly unknown[]>, 'queryKey' | 'queryFn'>
@@ -90,6 +99,56 @@ export function useTimeStatusWeek(
   return useQuery({
     queryKey: qk.timeStatusWeek(to, bucketOffsetMin),
     queryFn: () => api.time.statusAllWeek(to, bucketOffsetMin),
+    staleTime: STALE.timeStatusWeek,
+    ...opts,
+  })
+}
+
+// #777 — summary endpoints: lightweight rollups for the collapsed accordion view.
+export function useTimeStatusSummary(opts?: QueryOpts<ProfileTimeSummary[]>) {
+  return useQuery({
+    queryKey: qk.timeStatusSummaryToday(),
+    queryFn: () => api.time.summaryAll(),
+    staleTime: STALE.timeStatusToday,
+    ...opts,
+  })
+}
+
+export function useTimeStatusSummaryWeek(
+  to?: string,
+  opts?: QueryOpts<ProfileTimeSummaryWeek[]>,
+) {
+  return useQuery({
+    queryKey: qk.timeStatusSummaryWeek(to),
+    queryFn: () => api.time.summaryAllWeek(to),
+    staleTime: STALE.timeStatusWeek,
+    ...opts,
+  })
+}
+
+// #777 — per-profile detail, fetched only when the accordion row is expanded.
+// The query stays cached for the page mount so collapse + re-expand doesn't refetch.
+export function useTimeStatusProfileToday(
+  profileId: number,
+  opts?: QueryOpts<ProfileTimeStatus | undefined>,
+) {
+  return useQuery({
+    queryKey: qk.timeStatusProfileToday(profileId),
+    queryFn: () => api.time.statusAll(undefined, profileId).then(rows => rows[0]),
+    staleTime: STALE.timeStatusToday,
+    ...opts,
+  })
+}
+
+export function useTimeStatusProfileWeek(
+  profileId: number,
+  to: string | undefined,
+  bucketOffsetMin: number,
+  opts?: QueryOpts<ProfileTimeStatusWeek | undefined>,
+) {
+  return useQuery({
+    queryKey: qk.timeStatusProfileWeek(profileId, to, bucketOffsetMin),
+    queryFn: () => api.time.statusAllWeek(to, bucketOffsetMin, profileId).then(rows => rows[0]),
     staleTime: STALE.timeStatusWeek,
     ...opts,
   })

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import type { ProfileTimeStatus, ProfileTimeStatusWeek } from '@/types/api'
+import type {
+  ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek,
+} from '@/types/api'
 import { withQuery } from '@/test/queryWrapper'
 
 vi.mock('@/api/client', () => ({
@@ -10,6 +12,8 @@ vi.mock('@/api/client', () => ({
     time: {
       statusAll: vi.fn(),
       statusAllWeek: vi.fn(),
+      summaryAll: vi.fn(),
+      summaryAllWeek: vi.fn(),
       grantExtension: vi.fn(),
     },
   },
@@ -69,6 +73,13 @@ const noLimit: ProfileTimeStatus = {
   hostUsage: [],
 }
 
+// #777 summary payload mirrors the daily card headlines.
+const summaries: ProfileTimeSummary[] = [
+  { profileId: 1, profileName: 'Kids',   date: '2026-05-07', dailyLimitMins: 120, usedMins: 90,  extensionMins: 0,  remainingMins: 30 },
+  { profileId: 2, profileName: 'Teens',  date: '2026-05-07', dailyLimitMins: 60,  usedMins: 100, extensionMins: 30, remainingMins: 0 },
+  { profileId: 3, profileName: 'Adults', date: '2026-05-07', dailyLimitMins: null,usedMins: 0,   extensionMins: 0,  remainingMins: null },
+]
+
 // #794: server now returns UTC-hour buckets. Pin each day's minutes onto a single early-UTC
 // hour of that day so JS Date in the test environment (TZ=UTC under vitest) re-buckets cleanly
 // back to the same local date. Totals sum to 210m as before.
@@ -93,47 +104,108 @@ const weekKids: ProfileTimeStatusWeek = {
   ],
 }
 
+const weekSummaries: ProfileTimeSummaryWeek[] = [
+  { profileId: 1, profileName: 'Kids',   from: '2026-05-14', to: '2026-05-20', dailyLimitMins: 120, totalMins: 210 },
+  { profileId: 2, profileName: 'Teens',  from: '2026-05-14', to: '2026-05-20', dailyLimitMins: 60,  totalMins: 50 },
+]
+
 beforeEach(() => {
   vi.resetAllMocks()
+  localStorage.clear()
   mockAuth = { isAdmin: true }
-  ;(api.time.statusAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([limited, overLimit, noLimit])
-  ;(api.time.statusAllWeek as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([weekKids])
+  // Per-profile detail mocks: the lazy fetch passes profileId and the server returns a
+  // single-element array.
+  ;(api.time.statusAll as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_date?: string, profileId?: number) => {
+      const all = [limited, overLimit, noLimit]
+      const row = profileId === undefined ? all : all.filter(s => s.profileId === profileId)
+      return Promise.resolve(row)
+    },
+  )
+  ;(api.time.statusAllWeek as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_to?: string, _bucketOffsetMin?: number, profileId?: number) => {
+      if (profileId === 1 || profileId === undefined) return Promise.resolve([weekKids])
+      return Promise.resolve([])
+    },
+  )
+  ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(summaries)
+  ;(api.time.summaryAllWeek as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(weekSummaries)
   ;(api.time.grantExtension as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, grantedMinutes: 45 })
 })
 
-describe('TimePage — list', () => {
-  it('renders cards with usage, remaining, extensions, and site usage', async () => {
+describe('TimePage — accordion (#777)', () => {
+  it('renders the lightweight summary for every profile with no detail fetches', async () => {
+    // Start with the first profile already expanded (auto-expand default).
+    // The other two stay collapsed → no per-profile detail fetch for them.
     render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-1')
+    expect(screen.getByTestId('time-row-2')).toBeInTheDocument()
+    expect(screen.getByTestId('time-row-3')).toBeInTheDocument()
+    // Page-load fetch: one summary call. Not the heavyweight per-profile endpoint.
+    expect(api.time.summaryAll).toHaveBeenCalledTimes(1)
+    // Wait for the auto-expanded first profile to finish loading.
+    await screen.findByTestId('time-card-1')
+    // Only the auto-expanded profile (id=1) fired the detail fetch.
+    expect(api.time.statusAll).toHaveBeenCalledTimes(1)
+    expect(api.time.statusAll).toHaveBeenCalledWith(undefined, 1)
+  })
+
+  it('expanding a collapsed profile triggers its per-profile fetch; collapsing then re-expanding does NOT refetch', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-2')
+    // Auto-expand fired once for profile 1.
+    await waitFor(() => expect(api.time.statusAll).toHaveBeenCalledTimes(1))
+
+    // Expand profile 2 — fires its detail fetch.
+    await user.click(screen.getByTestId('time-row-toggle-2'))
+    await screen.findByTestId('time-card-2')
+    expect(api.time.statusAll).toHaveBeenCalledTimes(2)
+    expect(api.time.statusAll).toHaveBeenLastCalledWith(undefined, 2)
+
+    // Collapse and re-expand profile 2 — TanStack cache satisfies the second view.
+    await user.click(screen.getByTestId('time-row-toggle-2'))
+    expect(screen.queryByTestId('time-card-2')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('time-row-toggle-2'))
+    await screen.findByTestId('time-card-2')
+    expect(api.time.statusAll).toHaveBeenCalledTimes(2)
+  })
+
+  it('headline number renders from the summary (no detail required)', async () => {
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-3')
+    // noLimit row stays collapsed — only the summary's "0m used" surfaces.
+    const row3 = screen.getByTestId('time-row-3')
+    expect(row3).toHaveTextContent('Adults')
+    expect(row3).toHaveTextContent('0m used')
+  })
+})
+
+describe('TimePage — expanded card content', () => {
+  it('renders devices, hosts, and site usage inside the expanded profile', async () => {
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    // Profile 1 is auto-expanded → detail card surfaces.
     expect(await screen.findByText("Kid's iPad")).toBeInTheDocument()
-    // #791: usedMins=90 → "1:30 used"; remainingMins=30 stays "30m left"
-    expect(screen.getByText('1:30 used')).toBeInTheDocument()
-    expect(screen.getByText('30m left')).toBeInTheDocument()
+    // "1:30 used" appears once in the summary header and once in the expanded card.
+    expect(screen.getAllByText('1:30 used').length).toBeGreaterThanOrEqual(1)
+    // "30m left" similarly appears in both header and card.
+    expect(screen.getAllByText('30m left').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('YouTube')).toBeInTheDocument()
-    // over limit card
-    expect(screen.getByText('Phone')).toBeInTheDocument()
+    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
+    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('35m')
+  })
+
+  it('over-limit and no-limit details render when expanded', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-2')
+    await user.click(screen.getByTestId('time-row-toggle-2'))
+    await user.click(screen.getByTestId('time-row-toggle-3'))
+    await screen.findByText('Phone')
     expect(screen.getAllByText('Limit reached').length).toBeGreaterThan(0)
     expect(screen.getByText('+30m extended')).toBeInTheDocument()
-    // no-limit card
     expect(screen.getByText('Laptop')).toBeInTheDocument()
     expect(screen.getByText(/No time limit set/)).toBeInTheDocument()
-  })
-
-  it('renders top-host breakdown when hostUsage is present (#262)', async () => {
-    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
-    expect(await screen.findByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
-    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('35m')
-    expect(screen.getByTestId('time-host-1-khan-academy.org')).toHaveTextContent('khan-academy.org')
-    expect(screen.getByTestId('time-host-1-khan-academy.org')).toHaveTextContent('10m')
-    // (both under 60m, so they keep the bare "Xm" form post-#791)
-    // IP-literal host is shown by its address form
-    expect(screen.getByTestId('time-host-1-192.0.2.1')).toHaveTextContent('192.0.2.1')
-  })
-
-  it('omits the top-host section when hostUsage is empty (#262)', async () => {
-    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
-    // overLimit profile (id=2) has hostUsage: [] — no time-host-* testids for it
-    await screen.findByTestId('time-card-2')
-    expect(screen.queryByTestId(/^time-host-2-/)).not.toBeInTheDocument()
   })
 })
 
@@ -143,7 +215,6 @@ describe('TimePage — grant extension', () => {
     render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
     await screen.findByTestId('time-card-1')
 
-    // Click first "+ Time" button (Kids profile)
     const grantButtons = screen.getAllByRole('button', { name: /\+ Time/ })
     await user.click(grantButtons[0])
 
@@ -161,8 +232,8 @@ describe('TimePage — grant extension', () => {
         note: 'great job',
       })
     )
-    // reload
-    await waitFor(() => expect(api.time.statusAll).toHaveBeenCalledTimes(2))
+    // After mutation: summary + any active detail queries refetch.
+    await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
   })
 
   it('passes null note when blank', async () => {
@@ -183,59 +254,50 @@ describe('TimePage — grant extension', () => {
 })
 
 describe('TimePage — week toggle (#723)', () => {
-  it('defaults to Today and only fetches the today endpoint', async () => {
+  it('defaults to Today and only fetches the today summary', async () => {
     render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
-    await screen.findByTestId('time-card-1')
-    expect(api.time.statusAll).toHaveBeenCalledTimes(1)
-    expect(api.time.statusAllWeek).not.toHaveBeenCalled()
+    await screen.findByTestId('time-row-1')
+    expect(api.time.summaryAll).toHaveBeenCalledTimes(1)
+    expect(api.time.summaryAllWeek).not.toHaveBeenCalled()
   })
 
-  it('clicking Week fetches the weekly endpoint and renders chart + totals', async () => {
+  it('clicking Week fetches the weekly summary and lazy-loads the detail of the auto-expanded row', async () => {
     const user = userEvent.setup()
     render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
-    await screen.findByTestId('time-card-1')
+    await screen.findByTestId('time-row-1')
     await user.click(screen.getByTestId('time-window-week'))
+    await screen.findByTestId('time-week-row-1')
+    expect(api.time.summaryAllWeek).toHaveBeenCalledTimes(1)
+    // Today rows are gone
+    expect(screen.queryByTestId('time-row-1')).not.toBeInTheDocument()
+    // Auto-expand of the first week row → weekly detail loaded.
     expect(await screen.findByTestId('time-week-card-1')).toBeInTheDocument()
-    expect(api.time.statusAllWeek).toHaveBeenCalledTimes(1)
-    // Today cards are gone
-    expect(screen.queryByTestId('time-card-1')).not.toBeInTheDocument()
-    // Weekly total surfaced — #791: 210m → "3:30"
     expect(screen.getByText('3:30 used this week')).toBeInTheDocument()
-    // Per-day chart container present (recharts renders SVG inside).
     expect(screen.getByTestId('time-week-chart-1')).toBeInTheDocument()
-    // Top-host breakdown carries over to the weekly card — #791: 90m → "1:30"
     expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('1:30')
-    // Device link wires through to the per-device timeline (#721).
     expect(screen.getByTestId('time-week-device-link-aa:bb:cc:dd:ee:01'))
       .toHaveAttribute('href', '/devices/aa%3Abb%3Acc%3Add%3Aee%3A01/timeline')
   })
 
-  it('toggling back to Today serves the cached response without refetching (#803)', async () => {
+  it('toggling back to Today serves the cached summary without refetching (#803)', async () => {
     const user = userEvent.setup()
     render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
-    await screen.findByTestId('time-card-1')
+    await screen.findByTestId('time-row-1')
     await user.click(screen.getByTestId('time-window-week'))
-    await screen.findByTestId('time-week-card-1')
+    await screen.findByTestId('time-week-row-1')
     await user.click(screen.getByTestId('time-window-today'))
-    await screen.findByTestId('time-card-1')
-    // #803: the SPA-side cache holds the Today response across the round-trip
-    // to Week, so the second view is served from cache. Each endpoint hit once.
-    expect(api.time.statusAll).toHaveBeenCalledTimes(1)
-    expect(api.time.statusAllWeek).toHaveBeenCalledTimes(1)
+    await screen.findByTestId('time-row-1')
+    expect(api.time.summaryAll).toHaveBeenCalledTimes(1)
+    expect(api.time.summaryAllWeek).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('localBucketOffsetMin (#794)', () => {
   it('returns 0 for whole-hour zones', () => {
-    // Faux UTC-aligned Date: local midnight equals UTC midnight, so minute=0.
     const d = new Date('2026-05-21T12:00:00Z')
-    // Override the host's tz with UTC by feeding an instant whose local representation we
-    // control; in the vitest default env TZ=UTC, so this is already UTC-aligned.
     expect(localBucketOffsetMin(d)).toBe(0)
   })
   it('snaps to the nearest 15-min multiple', () => {
-    // We can't change the host tz from a unit test, but snap-rounding is pure-arithmetic; the
-    // 0 case above plus the in-prod manual cases (India=30, Nepal=15) cover the matrix.
     expect([0, 15, 30, 45]).toContain(localBucketOffsetMin())
   })
 })
@@ -257,7 +319,6 @@ describe('groupBucketsByLocalDay (#794)', () => {
     expect(out.find(r => r.date === '2026-05-14')!.usedMins).toBe(20)
     expect(out.find(r => r.date === '2026-05-17')!.usedMins).toBe(60)
     expect(out.find(r => r.date === '2026-05-20')!.usedMins).toBe(15)
-    // Empty days fill with zero, not gaps
     expect(out.find(r => r.date === '2026-05-18')!.usedMins).toBe(0)
   })
   it('accumulates multiple UTC hours into the same local day', () => {

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -1,13 +1,22 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import {
   Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis,
 } from 'recharts'
 import { api } from '@/api/client'
-import { useTimeStatusToday, useTimeStatusWeek, useInvalidators } from '@/api/queries'
+import {
+  useInvalidators,
+  useTimeStatusProfileToday,
+  useTimeStatusProfileWeek,
+  useTimeStatusSummary,
+  useTimeStatusSummaryWeek,
+} from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
-import type { ProfileTimeBucket, ProfileTimeStatus, ProfileTimeStatusWeek } from '@/types/api'
+import type {
+  ProfileTimeBucket, ProfileTimeStatus, ProfileTimeStatusWeek,
+  ProfileTimeSummary, ProfileTimeSummaryWeek,
+} from '@/types/api'
 import { PageLoader } from './DashboardPage'
 // #723 weekly card matches the visual tokens used by the #721/#722 hourly chart
 // (UsageHourlyBarChart). The shared component bakes in an `hour`-shaped X-axis
@@ -91,27 +100,68 @@ export function formatMins(n: number): string {
 
 type Window = 'today' | 'week'
 
+// #777 — remember which profile rows are expanded across navigations. Kept in
+// localStorage so the operator's expansion choices persist across page mounts;
+// keyed per-tab so Today and Week don't share state.
+const STORAGE_KEY = 'timepage:expanded:v1'
+
+function loadExpanded(): { today: number[]; week: number[] } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { today: [], week: [] }
+    const v = JSON.parse(raw)
+    return {
+      today: Array.isArray(v?.today) ? v.today.filter((x: unknown) => typeof x === 'number') : [],
+      week: Array.isArray(v?.week) ? v.week.filter((x: unknown) => typeof x === 'number') : [],
+    }
+  } catch {
+    return { today: [], week: [] }
+  }
+}
+
 export function TimePage() {
   const { isAdmin }   = useAuth()
   const invalidators  = useInvalidators()
   const [window, setWindow] = useState<Window>('today')
-  // #803: only the active window is enabled, so switching tabs doesn't
-  // pay for the inactive query, but a quick switch back within the
-  // per-endpoint stale window serves cached data without a network hit.
-  const todayQuery = useTimeStatusToday({ enabled: window === 'today' })
-  // #794: pass the offset that aligns hourly buckets to the viewer's local
-  // midnight so the chart can attribute each bucket to one local day without
-  // straddling. The offset is part of the cache key (queries.ts).
-  const weekQuery  = useTimeStatusWeek(
-    undefined,
-    localBucketOffsetMin(),
-    { enabled: window === 'week' },
-  )
-  const statuses     = todayQuery.data ?? []
-  const weekStatuses = weekQuery.data  ?? []
+  // #777 — fetch only the lightweight summary on page load. Per-profile detail is
+  // fetched lazily when a row is expanded.
+  const todaySummaryQuery = useTimeStatusSummary({ enabled: window === 'today' })
+  const weekSummaryQuery  = useTimeStatusSummaryWeek(undefined, { enabled: window === 'week' })
+  const summaries     = todaySummaryQuery.data ?? []
+  const weekSummaries = weekSummaryQuery.data  ?? []
   const loading =
-    (window === 'today' && todayQuery.isPending) ||
-    (window === 'week'  && weekQuery.isPending)
+    (window === 'today' && todaySummaryQuery.isPending) ||
+    (window === 'week'  && weekSummaryQuery.isPending)
+
+  const [expanded, setExpanded] = useState<{ today: Set<number>; week: Set<number> }>(() => {
+    const v = loadExpanded()
+    return { today: new Set(v.today), week: new Set(v.week) }
+  })
+  // Once summaries are first loaded, auto-expand the first row if nothing is expanded yet
+  // (issue's "one profile expanded by default" rule — avoids an empty-looking page).
+  useEffect(() => {
+    if (window !== 'today' || summaries.length === 0 || expanded.today.size > 0) return
+    setExpanded(e => ({ ...e, today: new Set([summaries[0].profileId]) }))
+  }, [window, summaries, expanded.today.size])
+  useEffect(() => {
+    if (window !== 'week' || weekSummaries.length === 0 || expanded.week.size > 0) return
+    setExpanded(e => ({ ...e, week: new Set([weekSummaries[0].profileId]) }))
+  }, [window, weekSummaries, expanded.week.size])
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        today: [...expanded.today], week: [...expanded.week],
+      }))
+    } catch { /* private mode etc. — best-effort */ }
+  }, [expanded])
+
+  const toggle = (tab: Window, pid: number) => setExpanded(e => {
+    const next = new Set(e[tab])
+    if (next.has(pid)) next.delete(pid)
+    else next.add(pid)
+    return { ...e, [tab]: next }
+  })
+
   const [extProfileId, setExtProfileId] = useState<number | null>(null)
   const [extMins, setExtMins]   = useState(30)
   const [extNote, setExtNote]   = useState('')
@@ -140,8 +190,8 @@ export function TimePage() {
   const granting = grantMutation.isPending
 
   const profileName = (id: number) =>
-    statuses.find(s => s.profileId === id)?.profileName
-      ?? weekStatuses.find(s => s.profileId === id)?.profileName
+    summaries.find(s => s.profileId === id)?.profileName
+      ?? weekSummaries.find(s => s.profileId === id)?.profileName
       ?? ''
 
   return (
@@ -170,24 +220,31 @@ export function TimePage() {
         ))}
       </div>
 
-      {window === 'today' && statuses.length === 0 && (
+      {window === 'today' && summaries.length === 0 && (
         <p className="text-gray-500 text-sm">No profiles found.</p>
       )}
-      {window === 'week' && weekStatuses.length === 0 && (
+      {window === 'week' && weekSummaries.length === 0 && (
         <p className="text-gray-500 text-sm">No profiles found.</p>
       )}
 
-      <div className="grid gap-4 md:grid-cols-2">
-        {window === 'today' && statuses.map(s => (
-          <ProfileTimeCard
+      <div className="space-y-3">
+        {window === 'today' && summaries.map(s => (
+          <ProfileAccordionRow
             key={s.profileId}
-            status={s}
+            summary={s}
+            expanded={expanded.today.has(s.profileId)}
+            onToggle={() => toggle('today', s.profileId)}
             isAdmin={isAdmin}
             onGrant={() => setExtProfileId(s.profileId)}
           />
         ))}
-        {window === 'week' && weekStatuses.map(s => (
-          <ProfileTimeWeekCard key={s.profileId} status={s} />
+        {window === 'week' && weekSummaries.map(s => (
+          <ProfileAccordionWeekRow
+            key={s.profileId}
+            summary={s}
+            expanded={expanded.week.has(s.profileId)}
+            onToggle={() => toggle('week', s.profileId)}
+          />
         ))}
       </div>
 
@@ -371,6 +428,125 @@ function ProfileTimeCard({
               </div>
             </div>
           ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// #777 — collapsed accordion row for the Today tab. The header shows the headline
+// numbers from the lightweight summary; the heavy per-profile fetch fires only on
+// first expand and stays cached via TanStack so collapse/re-expand is free.
+function ProfileAccordionRow({
+  summary, expanded, onToggle, isAdmin, onGrant,
+}: {
+  summary: ProfileTimeSummary
+  expanded: boolean
+  onToggle: () => void
+  isAdmin: boolean
+  onGrant: () => void
+}) {
+  const hasLimit = summary.dailyLimitMins != null
+  const overLimit = hasLimit && summary.remainingMins != null && summary.remainingMins <= 0
+  // Detail is only queried after the row has been expanded once. `enabled` flips
+  // permanently to true after that; re-collapse keeps the query in cache.
+  const [everExpanded, setEverExpanded] = useState(expanded)
+  useEffect(() => { if (expanded) setEverExpanded(true) }, [expanded])
+  const detail = useTimeStatusProfileToday(summary.profileId, { enabled: everExpanded })
+
+  return (
+    <div
+      data-testid={`time-row-${summary.profileId}`}
+      className={`bg-gray-900 rounded-2xl border ${overLimit ? 'border-red-500/40' : 'border-gray-800'}`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        data-testid={`time-row-toggle-${summary.profileId}`}
+        className="w-full flex items-center justify-between gap-3 px-5 py-4 text-left"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span className={`text-gray-500 transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+          <span className="font-semibold text-white text-lg truncate">{summary.profileName}</span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0 text-xs">
+          <span className="text-gray-400 font-mono">{formatMins(summary.usedMins)} used</span>
+          {hasLimit && (
+            <span className={overLimit ? 'text-red-400' : 'text-gray-500'}>
+              {summary.remainingMins != null && summary.remainingMins > 0
+                ? `${formatMins(summary.remainingMins)} left`
+                : 'Limit reached'}
+            </span>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-5 pb-5 border-t border-gray-800 pt-4">
+          {detail.isPending && (
+            <p className="text-xs text-gray-500" data-testid={`time-row-loading-${summary.profileId}`}>
+              Loading…
+            </p>
+          )}
+          {detail.data && (
+            <ProfileTimeCard status={detail.data} isAdmin={isAdmin} onGrant={onGrant} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// #777 — weekly accordion row sibling.
+function ProfileAccordionWeekRow({
+  summary, expanded, onToggle,
+}: {
+  summary: ProfileTimeSummaryWeek
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const [everExpanded, setEverExpanded] = useState(expanded)
+  useEffect(() => { if (expanded) setEverExpanded(true) }, [expanded])
+  const detail = useTimeStatusProfileWeek(
+    summary.profileId,
+    undefined,
+    localBucketOffsetMin(),
+    { enabled: everExpanded },
+  )
+
+  return (
+    <div
+      data-testid={`time-week-row-${summary.profileId}`}
+      className="bg-gray-900 rounded-2xl border border-gray-800"
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        data-testid={`time-week-row-toggle-${summary.profileId}`}
+        className="w-full flex items-center justify-between gap-3 px-5 py-4 text-left"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <span className={`text-gray-500 transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+          <span className="font-semibold text-white text-lg truncate">{summary.profileName}</span>
+        </div>
+        <div className="flex items-center gap-3 shrink-0 text-xs">
+          <span className="text-gray-400 font-mono">{formatMins(summary.totalMins)} this week</span>
+          {summary.dailyLimitMins != null && (
+            <span className="text-gray-600">Daily limit: {formatMins(summary.dailyLimitMins)}</span>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-5 pb-5 border-t border-gray-800 pt-4">
+          {detail.isPending && (
+            <p className="text-xs text-gray-500" data-testid={`time-week-row-loading-${summary.profileId}`}>
+              Loading…
+            </p>
+          )}
+          {detail.data && <ProfileTimeWeekCard status={detail.data} />}
         </div>
       )}
     </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -214,6 +214,29 @@ export interface HostUsage {
   usedMins: number
 }
 
+// #777 — collapsed-accordion payload: just the headline numbers, no per-device /
+// per-host / per-bucket arrays. The server computes the whole list in a single
+// batched presence query, so page load is `1 summary + N on-demand` instead of
+// `N rollups`.
+export interface ProfileTimeSummary {
+  profileId: number
+  profileName: string
+  date: string
+  dailyLimitMins?: number | null
+  usedMins: number
+  extensionMins: number
+  remainingMins?: number | null
+}
+
+export interface ProfileTimeSummaryWeek {
+  profileId: number
+  profileName: string
+  from: string
+  to: string
+  dailyLimitMins?: number | null
+  totalMins: number
+}
+
 export interface ProfileTimeStatus {
   profileId: number
   profileName: string


### PR DESCRIPTION
## Summary

- Collapsed profiles render from a single new `/api/time/status/summary` endpoint that batches all profiles into one presence query, so page load is **`1 summary + N on-demand`** instead of **`N per-profile rollups`**. The heavyweight detail (devices, host breakdown, weekly buckets) only fires when a row is expanded, and stays cached in TanStack so collapse/re-expand within a page mount doesn't refetch.
- Today and Week share the accordion shape and use their own summary endpoint variant. The first row auto-expands so the page isn't empty, and expansion state persists in localStorage (per-tab) across navigations.
- New `ProfileTimeSummary` / `ProfileTimeSummaryWeek` shapes carry only the headline numbers — `usedMins`, `dailyLimitMins`, `extensionMins`, `remainingMins` (+ `totalMins` for week). The existing detailed `ProfileTimeStatus` payload is unchanged; the per-profile-on-expand fetch uses the existing `?profileId=N` narrowing path added in #795.

### Before / after fetch counts on page load

For a household with **N** visible profiles:
- **Before:** `GET /api/time/status` triggered N per-profile rollups server-side (presence + extension + site-limit queries per profile).
- **After:** `GET /api/time/status/summary` runs a single batched presence query across all macs (plus one each for time-limits, site-limits, extensions snapshot) and folds the results per profile in-memory. Per-profile detail only fires on first expand, cached thereafter.

## Test plan

- [x] `mill api.test` — full suite green (incl. two new tests for the summary endpoint: per-profile daily totals/limit/remaining and weekly trailing-7d totals)
- [x] `npm test` in `web/` — full suite green (rewritten TimePage tests cover: collapsed-no-detail-fetch, expand-fires-fetch, collapse+re-expand-served-from-cache, summary headline rendering, week toggle, role gating)
- [x] `npm run type-check` + `npm run lint` clean
- [ ] Manual: visit `/time` in prod-like build — confirm tight collapsed list, one row auto-expanded, network panel shows no rollup fetches until expand

## Notes for reviewers

- The summary endpoint stays in-process — no new caches. The existing `TimeStatusCache` is unaffected; per-profile detail still goes through it on expand.
- No router-side changes. `shared/contract/api-to-router/policy_snapshot.json` untouched.
- The `?profileId=N` narrowing on the existing `/time/status` endpoint (already supported since #795) is what the lazy fetch uses, so no compat shims needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)