### PR TITLE
openwrt: populate bytesOut via second per-direction nft set

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -462,7 +462,14 @@ function M.nft(snapshot, opts)
     emit("")
   end
 
-  -- Per-flow accounting set.
+  -- Per-flow accounting sets. Two sets, one per direction, both keyed on
+  -- (device_mac, remote_ip) so usage.lua can join them into a single record
+  -- carrying bytesIn and bytesOut (#717). The set for the device→remote
+  -- direction matches `ether saddr (mac) . ip daddr (remote)`; the reverse
+  -- direction matches `ether daddr (mac) . ip saddr (remote)`. The chain
+  -- below updates both atomically per packet, so a row's bytesIn/bytesOut
+  -- always cover the same window and the agent's per-bucket nft reset
+  -- zeroes both in lock-step.
   ind("set mac_ip_tracking {")
   ind2("type ether_addr . ipv4_addr")
   ind2("flags dynamic,timeout")
@@ -471,10 +478,21 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
-  -- Accounting chain: forward hook, low priority; updates tracking set per packet.
+  ind("set mac_ip_tracking_rx {")
+  ind2("type ether_addr . ipv4_addr")
+  ind2("flags dynamic,timeout")
+  ind2("timeout 6h")
+  ind2("counter")
+  ind("}")
+  emit("")
+
+  -- Accounting chain: forward hook, low priority; updates both tracking sets
+  -- per packet. Both updates happen in the same rule walk so a single
+  -- forwarded packet bumps exactly one element on exactly one set.
   ind("chain wifihaven_account {")
   ind2("type filter hook forward priority 1; policy accept;")
-  ind2("update @mac_ip_tracking { ether saddr . ip daddr } counter")
+  ind2("update @mac_ip_tracking    { ether saddr . ip daddr } counter")
+  ind2("update @mac_ip_tracking_rx { ether daddr . ip saddr } counter")
   ind("}")
   emit("")
 

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -24,7 +24,15 @@
 -- Public API:
 --   usage.parse_nft_counters(json_str)
 --     → list of { mac, dst_ip, bytes, packets }
---     Input: JSON from `nft -j list set inet wifihaven mac_ip_tracking`
+--     Input: JSON from `nft -j list set inet wifihaven mac_ip_tracking{,_rx}`
+--
+--   usage.merge_counters(tx, rx)
+--     → list of { mac, dst_ip, bytes, packets, bytes_out, packets_out }
+--     Joins the two per-direction counter lists on (mac, dst_ip). `bytes`/
+--     `packets` come from the tx set (device→remote, traffic ingressing the
+--     router); `bytes_out`/`packets_out` come from the rx set (remote→device,
+--     traffic egressing the router). Pairs missing from one direction are
+--     still emitted with that side zeroed (#717).
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id,
 --                      leases, lookup_hostname, tracker,
@@ -112,6 +120,50 @@ function M.parse_nft_counters(json_str)
 end
 
 -- ---------------------------------------------------------------------------
+-- usage.merge_counters(tx, rx)
+--
+-- Joins per-direction counter lists (each as produced by parse_nft_counters)
+-- on (mac, dst_ip). The tx side is the existing `ether saddr . ip daddr`
+-- direction and stays in `bytes`/`packets`; the rx side is the new
+-- `ether daddr . ip saddr` direction and goes into `bytes_out`/`packets_out`.
+-- A (mac, dst_ip) pair seen in only one direction still produces a record
+-- with the other direction's fields at zero.
+-- ---------------------------------------------------------------------------
+function M.merge_counters(tx, rx)
+  local index = {}
+  local result = {}
+  local function key(mac, dst_ip) return mac .. "|" .. dst_ip end
+  local function get_or_make(mac, dst_ip)
+    local k = key(mac, dst_ip)
+    local rec = index[k]
+    if not rec then
+      rec = {
+        mac         = mac,
+        dst_ip      = dst_ip,
+        bytes       = 0,
+        packets     = 0,
+        bytes_out   = 0,
+        packets_out = 0,
+      }
+      index[k] = rec
+      result[#result + 1] = rec
+    end
+    return rec
+  end
+  for _, c in ipairs(tx or {}) do
+    local rec = get_or_make(c.mac, c.dst_ip)
+    rec.bytes   = rec.bytes   + (c.bytes   or 0)
+    rec.packets = rec.packets + (c.packets or 0)
+  end
+  for _, c in ipairs(rx or {}) do
+    local rec = get_or_make(c.mac, c.dst_ip)
+    rec.bytes_out   = rec.bytes_out   + (c.bytes   or 0)
+    rec.packets_out = rec.packets_out + (c.packets or 0)
+  end
+  return result
+end
+
+-- ---------------------------------------------------------------------------
 -- host_for_ip(dst_ip, nft_sets, lookup_hostname) → { type, value }
 -- ---------------------------------------------------------------------------
 -- Returns a HostId-shaped table (#391) identifying the destination of this
@@ -162,16 +214,19 @@ end
 -- count it as an active sample if the new value is > 0.
 function M.tracker_sample(tracker, counters)
   for _, c in ipairs(counters or {}) do
-    local key  = tracker_key(c.mac, c.dst_ip)
-    local prev = tracker.last[key] or 0
-    if c.bytes > prev then
+    local key   = tracker_key(c.mac, c.dst_ip)
+    local prev  = tracker.last[key] or 0
+    -- Counter total spans both directions (#717) — growth in either bytes
+    -- (device→remote) or bytes_out (remote→device) marks an active sample.
+    local total = (c.bytes or 0) + (c.bytes_out or 0)
+    if total > prev then
       tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
-      tracker.last[key] = c.bytes
-    elseif c.bytes < prev then
-      if c.bytes > 0 then
+      tracker.last[key] = total
+    elseif total < prev then
+      if total > 0 then
         tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
       end
-      tracker.last[key] = c.bytes
+      tracker.last[key] = total
     end
   end
 end
@@ -201,7 +256,7 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
     local active_seconds
     if samples > 0 then
       active_seconds = math.min(sample_seconds * samples, bucket_seconds)
-    elseif c.bytes > 0 then
+    elseif (c.bytes or 0) + (c.bytes_out or 0) > 0 then
       -- Set element first appeared after the final sample tick: credit one sample.
       active_seconds = sample_seconds
     else
@@ -211,8 +266,8 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
       mac           = c.mac,
       host          = host,
       activeSeconds = active_seconds,
-      bytesIn       = c.bytes,
-      bytesOut      = 0,   -- nftables ingress-only counters; egress tracked separately
+      bytesIn       = c.bytes     or 0,
+      bytesOut      = c.bytes_out or 0,
     }
     if leases then
       rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -298,9 +298,13 @@ end
 
 -- Snapshot nft counters for the activity tracker.  Cheap (same JSON we'd
 -- read at flush time) and reused by both the per-minute sampler and the
--- 60 s usage timer below.
-local function read_nft_counters()
-  local pipe = io.popen("nft -j list set inet wifihaven mac_ip_tracking 2>/dev/null", "r")
+-- 60 s usage timer below. Reads both per-direction sets (#717) and merges
+-- them into one list per (mac, dst_ip) carrying both bytes (tx) and
+-- bytes_out (rx). A missing set is treated as an empty side rather than a
+-- hard failure — the chain installs both atomically, so a single-set absence
+-- only happens transiently during a render swap.
+local function read_one_set(name)
+  local pipe = io.popen("nft -j list set inet wifihaven " .. name .. " 2>/dev/null", "r")
   if not pipe then return nil end
   local json_str = pipe:read("*a") or ""
   pipe:close()
@@ -308,6 +312,13 @@ local function read_nft_counters()
   local ok, counters = pcall(usage.parse_nft_counters, json_str)
   if not ok then return nil end
   return counters
+end
+
+local function read_nft_counters()
+  local tx = read_one_set("mac_ip_tracking")
+  local rx = read_one_set("mac_ip_tracking_rx")
+  if not tx and not rx then return nil end
+  return usage.merge_counters(tx or {}, rx or {})
 end
 
 -- ── Start conntrack event watcher (blocking; runs for the lifetime of the process)
@@ -470,9 +481,10 @@ conntrack.watch({
       last_usage_run     = mono
       last_usage_wall_ts = wall
 
-      -- Per-(mac,ip) counters live as element counters on the dynamic set
-      -- `mac_ip_tracking` (see render.lua). After a successful POST we
-      -- `nft reset set ...` to zero those per-element counters in place.
+      -- Per-(mac,ip) counters live as element counters on two dynamic sets
+      -- `mac_ip_tracking` (tx) and `mac_ip_tracking_rx` (rx) — see
+      -- render.lua. After a successful POST we `nft reset set ...` on both
+      -- to zero those per-element counters in lock-step (#717).
       local counters = read_nft_counters()
       if counters then
         -- Final sample at flush so set elements that appeared after the
@@ -493,6 +505,7 @@ conntrack.watch({
         -- is now owned by the retry queue (or already sent), so leaving the
         -- nft counters intact would double-count on the next bucket.
         os.execute("nft reset set inet wifihaven mac_ip_tracking >/dev/null 2>&1")
+        os.execute("nft reset set inet wifihaven mac_ip_tracking_rx >/dev/null 2>&1")
         usage.tracker_reset(activity_tracker)
         if not posted then
           log.warn("usage timer: queued for retry (queue depth=%d)",

--- a/openwrt/test/contract_gen.lua
+++ b/openwrt/test/contract_gen.lua
@@ -227,9 +227,13 @@ local USAGE_FIELD_ORDER = {
 }
 
 local function build_usage_report()
+  -- Mirror what the agent passes after merging the two per-direction nft
+  -- sets (#717): bytes = tx (device→remote), bytes_out = rx (remote→device).
   local counters = {
-    { mac = "aa:bb:cc:11:22:33", dst_ip = "151.101.65.69",  bytes = 1048576 },
-    { mac = "76:2d:95:47:d1:8e", dst_ip = "192.168.10.99",  bytes = 4096 },
+    { mac = "aa:bb:cc:11:22:33", dst_ip = "151.101.65.69",
+      bytes = 1048576, bytes_out = 8388608 },
+    { mac = "76:2d:95:47:d1:8e", dst_ip = "192.168.10.99",
+      bytes = 4096,    bytes_out = 16384 },
   }
   local lookup = function(ip)
     if ip == "151.101.65.69" then return "khanacademy.org" end

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -193,6 +193,25 @@ describe("render.nft", function()
     assert.truthy(nft:find("mac_ip_tracking", 1, true))
   end)
 
+  -- #717: a second per-direction set captures bytes egressing the router to
+  -- LAN clients (downloads), keyed `ether daddr (mac) . ip saddr (remote)`,
+  -- so usage.lua can populate `bytesOut` alongside `bytesIn`.
+  it("declares the mac_ip_tracking_rx set for the download direction (#717)", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find("set mac_ip_tracking_rx", 1, true))
+  end)
+
+  it("wifihaven_account chain updates BOTH tx and rx tracking sets atomically (#717)", function()
+    local nft = render.nft(snap_one())
+    local pos = nft:find("chain wifihaven_account", 1, true)
+    assert.truthy(pos)
+    -- Same chain (one rule walk per packet) so a bucket's bytesIn and
+    -- bytesOut always cover the same window.
+    local block = nft:sub(pos, pos + 500)
+    assert.truthy(block:find("update @mac_ip_tracking%s+{%s*ether saddr %. ip daddr%s*}%s+counter"))
+    assert.truthy(block:find("update @mac_ip_tracking_rx%s+{%s*ether daddr %. ip saddr%s*}%s+counter"))
+  end)
+
   -- #354: blocked_macs is derived per-device from effective BlockRules.blocked.
   -- The API server precomputes pause / time-limit / schedule into that flag.
 

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -85,6 +85,52 @@ describe("usage.parse_nft_counters", function()
 
 end)
 
+-- ── merge_counters (#717) ─────────────────────────────────────────────────
+--
+-- The agent reads the two per-direction nft sets — `mac_ip_tracking` (tx,
+-- device→remote) and `mac_ip_tracking_rx` (rx, remote→device) — and joins
+-- them on (mac, dst_ip) before passing to the tracker and build_report.
+
+describe("usage.merge_counters", function()
+
+  it("joins matching (mac, dst_ip) into one record with both directions populated", function()
+    local tx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 3 } }
+    local rx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 900, packets = 7 } }
+    local merged = usage.merge_counters(tx, rx)
+    assert.equal(1, #merged)
+    assert.equal(100, merged[1].bytes)
+    assert.equal(3,   merged[1].packets)
+    assert.equal(900, merged[1].bytes_out)
+    assert.equal(7,   merged[1].packets_out)
+  end)
+
+  it("emits records for tx-only and rx-only (mac, dst_ip) pairs with the missing side zeroed", function()
+    local tx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 1 } }
+    local rx = { { mac = "de:ad:be:ef:00:01", dst_ip = "8.8.8.8", bytes = 200, packets = 2 } }
+    local merged = usage.merge_counters(tx, rx)
+    assert.equal(2, #merged)
+    local by_mac = {}
+    for _, c in ipairs(merged) do by_mac[c.mac] = c end
+    assert.equal(100, by_mac["aa:bb:cc:11:22:33"].bytes)
+    assert.equal(0,   by_mac["aa:bb:cc:11:22:33"].bytes_out)
+    assert.equal(0,   by_mac["de:ad:be:ef:00:01"].bytes)
+    assert.equal(200, by_mac["de:ad:be:ef:00:01"].bytes_out)
+  end)
+
+  it("treats nil tx or rx as empty (single-direction snapshot during a render swap)", function()
+    local rx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 500, packets = 4 } }
+    local merged = usage.merge_counters(nil, rx)
+    assert.equal(1, #merged)
+    assert.equal(0,   merged[1].bytes)
+    assert.equal(500, merged[1].bytes_out)
+  end)
+
+  it("returns an empty list when both sides are empty", function()
+    assert.equal(0, #usage.merge_counters({}, {}))
+  end)
+
+end)
+
 -- ── build_report ──────────────────────────────────────────────────────────
 
 describe("usage.build_report", function()
@@ -140,6 +186,41 @@ describe("usage.build_report", function()
     assert.equal("youtube.com",      by_host["youtube.com"].host.value)
     assert.equal("aa:bb:cc:11:22:33", by_host["youtube.com"].mac)
     assert.equal(50000,               by_host["youtube.com"].bytesIn)
+  end)
+
+  -- #717: bytesOut must be wired through from the merged counter's
+  -- bytes_out field (the rx nft set), not hard-coded to 0.
+  it("populates bytesOut from c.bytes_out (download direction, #717)", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4",
+        bytes = 50000, packets = 100, bytes_out = 4000000, packets_out = 3500 },
+    }
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, full_tracker(counters), SAMPLE_S, BUCKET_S)
+    assert.equal(50000,    r.records[1].bytesIn)
+    assert.equal(4000000,  r.records[1].bytesOut)
+  end)
+
+  it("defaults bytesOut to 0 when c.bytes_out is missing (tx-only snapshot)", function()
+    local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S)
+    for _, rec in ipairs(r.records) do
+      assert.equal(0, rec.bytesOut)
+    end
+  end)
+
+  it("credits one sample when bytes=0 but bytes_out>0 (rx-only flow first appearing post-tick)", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4",
+        bytes = 0, packets = 0, bytes_out = 1234, packets_out = 5 },
+    }
+    -- Empty tracker → falls through to the post-tick path. That path
+    -- previously gated on `c.bytes > 0`; with #717 it must also treat
+    -- bytes_out > 0 as activity.
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, usage.new_tracker(), SAMPLE_S, BUCKET_S)
+    assert.equal(SAMPLE_S, r.records[1].activeSeconds)
+    assert.equal(1234,     r.records[1].bytesOut)
   end)
 
   -- #391: the "unknown" sentinel is gone. When DNS attribution misses we emit
@@ -355,6 +436,20 @@ describe("usage.tracker", function()
     })
     assert.equal(1, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
     assert.equal(2, t.active_samples["aa:bb:cc:11:22:33|5.6.7.8"])
+  end)
+
+  -- #717: counter total is bytes + bytes_out, so a download-only flow still
+  -- counts as active even when bytes (tx) stays at 0 across samples.
+  it("counts activity from bytes_out growth alone (rx-only flow, #717)", function()
+    local function rx_only(mac, dst_ip, bytes_out)
+      return { mac = mac, dst_ip = dst_ip, bytes = 0, packets = 0,
+               bytes_out = bytes_out, packets_out = 0 }
+    end
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, { rx_only("aa:bb:cc:11:22:33", "1.2.3.4",  500) })
+    usage.tracker_sample(t, { rx_only("aa:bb:cc:11:22:33", "1.2.3.4", 1500) })
+    usage.tracker_sample(t, { rx_only("aa:bb:cc:11:22:33", "1.2.3.4", 1500) })  -- no growth
+    assert.equal(2, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
   end)
 
   it("tracker_reset clears all state", function()

--- a/shared/contract/router-to-api/usage_report.json
+++ b/shared/contract/router-to-api/usage_report.json
@@ -12,7 +12,7 @@
       },
       "activeSeconds" : 240,
       "bytesIn" : 1048576,
-      "bytesOut" : 0
+      "bytesOut" : 8388608
     },
     {
       "mac" : "76:2d:95:47:d1:8e",
@@ -22,7 +22,7 @@
       },
       "activeSeconds" : 60,
       "bytesIn" : 4096,
-      "bytesOut" : 0
+      "bytesOut" : 16384
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #717.

The agent's per-flow accounting only had one nft counter (`mac_ip_tracking`, keyed `ether saddr . ip daddr`), so `usage.build_report` hard-coded `bytesOut = 0`. Every `traffic_reports` / `time_usage` row landed with zero download bytes, undercounting Screen Time on download-heavy traffic.

Pure agent-side change — the wire format already accepts `bytesOut`, the API already stores `bytes_out`, no migration.

- `render.lua`: add `mac_ip_tracking_rx` (keyed `ether daddr . ip saddr`) and a second `update` line in the same `wifihaven_account` chain so both directions get bumped atomically per packet.
- `usage.lua`: add `merge_counters(tx, rx)` that joins the two per-direction lists on `(mac, dst_ip)` into records carrying `bytes`/`packets` (tx) and `bytes_out`/`packets_out` (rx). `build_report` now reads `c.bytes_out` for `bytesOut`. `tracker_sample` watches `bytes + bytes_out` so a download-only flow still counts toward `activeSeconds`.
- `wifihaven-agent`: read both sets per tick, merge, reset both after POST (in lock-step so windows stay aligned).
- Regenerated `shared/contract/router-to-api/usage_report.json` to reflect non-zero `bytesOut`.

## Test plan

- [x] `busted` unit tests (407 passing) — includes new coverage for `merge_counters`, `bytesOut` wired through `build_report`, tracker activity from rx-only growth, and render emitting both sets + chain lines.
- [x] Contract fixture regenerated cleanly; the only diff is `bytesOut` going from `0` to a non-zero value.
- [ ] CI: Gate 2 publish-openwrt qemu suite (fake-API) runs the full agent against a live `nft` to validate ruleset syntax.
- [ ] Operator: deploy to a test router, generate a download, confirm `traffic_reports.bytes_out > 0` for the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)