### PR TITLE
feat(vm): add OpenWRT 25.12 / .apk router-image build path (#532)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Build router image (if not cached)
         run: |
-          if [[ -f scripts/vm/.cache/openwrt-wifihaven.img ]]; then
+          if [[ -f scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img ]]; then
             echo "router image cached, skipping build"
           else
             scripts/vm/build-router-image.sh
@@ -91,7 +91,7 @@ jobs:
       # stack bring-up / teardown / log capture is needed here.
       - name: Run e2e fake-mode suite
         env:
-          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven.img
+          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img
         run: scripts/e2e-vm.sh --mode=fake
 
       - name: Upload failure artifacts

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build router image (if not cached)
         run: |
-          if [[ -f scripts/vm/.cache/openwrt-wifihaven.img ]]; then
+          if [[ -f scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img ]]; then
             echo "router image cached, skipping build"
           else
             scripts/vm/build-router-image.sh
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run e2e suite
         env:
-          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven.img
+          WH_ROUTER_IMAGE_PATH: ${{ github.workspace }}/scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img
           # #473: pytest's stack fixture defaults to tearing the docker
           # compose stack down at session end, which removes containers
           # before the failure-capture step below can read their logs.

--- a/.github/workflows/router-image-build.yml
+++ b/.github/workflows/router-image-build.yml
@@ -52,13 +52,13 @@ jobs:
 
       - name: Image summary
         run: |
-          ls -lh scripts/vm/.cache/openwrt-wifihaven.img
-          file scripts/vm/.cache/openwrt-wifihaven.img
+          ls -lh scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img
+          file scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v6
         with:
           name: openwrt-wifihaven-${{ steps.ver.outputs.openwrt_version }}-${{ github.sha }}
-          path: scripts/vm/.cache/openwrt-wifihaven.img
+          path: scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img
           if-no-files-found: error
           retention-days: 14

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -44,7 +44,15 @@ ensure_apk() {
         cd "$APK_TOOLS_PREFIX/src"
         # -Durl_backend=wget avoids needing libfetch on Ubuntu.
         # -Ddocs/help/zstd disabled where not strictly required for `mkpkg`.
-        meson setup --reconfigure \
+        # --reconfigure only on re-runs; meson 1.0.x (Debian bookworm)
+        # errors out on first-run --reconfigure with "Directory does not
+        # contain a valid build tree". Newer meson is tolerant.
+        if [ -f "$APK_TOOLS_PREFIX/build/build.ninja" ]; then
+            meson_reconfigure="--reconfigure"
+        else
+            meson_reconfigure=""
+        fi
+        meson setup $meson_reconfigure \
             -Dprefix=/usr \
             -Durl_backend=wget \
             -Dhelp=disabled \

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -189,14 +189,16 @@ IPK_SOURCE=path IPK_PATH=/abs/path/wifihaven_X.Y.Z-1_all.ipk \
     scripts/vm/build-router-image.sh
 ```
 
-Output: `.cache/openwrt-wifihaven.img` (uncompressed, ready to feed
+Output: `.cache/openwrt-wifihaven-ipk-23.05.img` for the default ipk
+flavor, or `.cache/openwrt-wifihaven-apk-25.12.img` for `PKG_FORMAT=apk`
+(uncompressed, ready to feed
 directly to QEMU). Image size: ~30–50 MB.
 
 To boot it via the existing harness, point `router-up.sh` at the file
 through `WH_ROUTER_IMAGE_PATH`:
 
 ```bash
-WH_ROUTER_IMAGE_PATH=scripts/vm/.cache/openwrt-wifihaven.img \
+WH_ROUTER_IMAGE_PATH=scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img \
     scripts/vm/router-up.sh
 ```
 

--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -1,25 +1,42 @@
 #!/usr/bin/env bash
-# Build a QEMU-bootable OpenWRT x86_64 image with the wifihaven-agent ipk
+# Build a QEMU-bootable OpenWRT x86_64 image with the wifihaven agent
 # pre-installed.
 #
 # Wraps OpenWRT's official Image Builder, run inside a Docker container so
 # the host toolchain (Linux or macOS) doesn't matter.
 #
+# Flavor selection (PKG_FORMAT env var, default ipk):
+#   ipk → OpenWRT 23.05 (opkg-era) IB + locally-built wifihaven_*.ipk
+#   apk → OpenWRT 25.12 (apk-era)  IB + locally-built wifihaven_*.apk
+#
+# Host prereqs: docker. That's it — for PKG_FORMAT=apk, the apk-tools v3
+# bootstrap (build-apk.sh) is run inside the same debian:bookworm-slim
+# container we use for the Image Builder, so no host-side
+# build-essential/meson/ninja/etc. is needed. This makes the script
+# runner-agnostic: GitHub-hosted ubuntu-latest, self-hosted KVM (#685),
+# and local Linux dev hosts all work identically as long as docker is
+# present. .github/workflows/openwrt-build.yml installs those packages
+# directly only because it doesn't shell out to this script.
+#
 # Usage:
-#   scripts/vm/build-router-image.sh                # build with locally-built ipk
-#   IPK_SOURCE=local   scripts/vm/build-router-image.sh
-#   IPK_SOURCE=release scripts/vm/build-router-image.sh   # latest GitHub release
-#   IPK_SOURCE=path    IPK_PATH=/abs/path/to.ipk scripts/vm/build-router-image.sh
+#   scripts/vm/build-router-image.sh                         # ipk (default)
+#   PKG_FORMAT=apk scripts/vm/build-router-image.sh          # apk path
+#   IPK_SOURCE=release scripts/vm/build-router-image.sh      # latest GH release ipk
+#   IPK_SOURCE=path IPK_PATH=/abs/path/to.ipk scripts/vm/build-router-image.sh
+#   APK_SOURCE=release scripts/vm/build-router-image.sh PKG_FORMAT=apk
+#   APK_SOURCE=path APK_PATH=/abs/path/to.apk PKG_FORMAT=apk scripts/vm/build-router-image.sh
 #
 # Output:
-#   scripts/vm/.cache/openwrt-wifihaven.img        (uncompressed, ready for QEMU)
+#   scripts/vm/.cache/openwrt-wifihaven-ipk-23.05.img   (PKG_FORMAT=ipk)
+#   scripts/vm/.cache/openwrt-wifihaven-apk-25.12.img   (PKG_FORMAT=apk)
 #
-# Acceptance test (cf. issue #150):
-#   1. This script runs to completion on a clean checkout.
-#   2. WH_ROUTER_IMAGE_PATH=$PWD/scripts/vm/.cache/openwrt-wifihaven.img \
-#        scripts/vm/router-up.sh boots it.
-#   3. opkg list-installed | grep wifihaven shows the agent.
-#   4. logread | grep wifihaven shows the agent starting up.
+# Acceptance test (cf. issues #150, #532):
+#   1. This script runs to completion on a clean checkout, for both flavors.
+#   2. WH_ROUTER_IMAGE_PATH=<output-img> scripts/vm/router-up.sh boots it.
+#   3. The wifihaven package is installed:
+#        ipk: opkg list-installed | grep wifihaven
+#        apk: apk list --installed | grep wifihaven
+#   4. logread | grep wifihaven shows the agent starting.
 #   5. uci show wifihaven returns the pre-baked defaults.
 
 set -euo pipefail
@@ -34,51 +51,96 @@ CACHE_DIR="$SCRIPT_DIR/.cache"
 DOWNLOAD_DIR="$CACHE_DIR/downloads"
 IB_ROOT="$CACHE_DIR/imagebuilder"
 STAGING_DIR="$CACHE_DIR/staging"
-OUTPUT_IMG="$CACHE_DIR/openwrt-wifihaven.img"
-
-IPK_SOURCE="${IPK_SOURCE:-local}"
-IPK_PATH="${IPK_PATH:-}"
+OUTPUT_IMG="$CACHE_DIR/openwrt-wifihaven-${PKG_FORMAT}-${OPENWRT_VERSION_SHORT}.img"
 
 mkdir -p "$DOWNLOAD_DIR" "$STAGING_DIR"
 
-# ── 1. Locate the wifihaven-agent ipk ────────────────────────────────────────
-resolve_ipk() {
-    case "$IPK_SOURCE" in
+# ── 1. Locate the wifihaven package (flavor-specific) ────────────────────────
+PKG_SOURCE_DEFAULT="local"
+case "$PKG_FORMAT" in
+    ipk)
+        PKG_SOURCE="${IPK_SOURCE:-$PKG_SOURCE_DEFAULT}"
+        PKG_OVERRIDE_PATH="${IPK_PATH:-}"
+        PKG_EXT="ipk"
+        ;;
+    apk)
+        PKG_SOURCE="${APK_SOURCE:-$PKG_SOURCE_DEFAULT}"
+        PKG_OVERRIDE_PATH="${APK_PATH:-}"
+        PKG_EXT="apk"
+        ;;
+esac
+
+build_apk_in_docker() {
+    # openwrt/build-apk.sh bootstraps apk-tools v3 from source. Run it in
+    # the same debian:bookworm-slim container we use for the Image Builder
+    # so the host doesn't need build-essential/meson/ninja/etc. installed,
+    # and so CI runners (self-hosted KVM included) work without per-host
+    # apt provisioning. The apk-tools source build is cached in
+    # $HOME/.cache/wifihaven-apk-tools (host-side mount) so subsequent
+    # runs reuse it.
+    local apk_cache="$HOME/.cache/wifihaven-apk-tools"
+    mkdir -p "$apk_cache"
+    docker run --rm \
+        -e APK_TOOLS_PREFIX=/cache/apk-tools \
+        -e HOST_UID="$(id -u)" \
+        -e HOST_GID="$(id -g)" \
+        -v "$apk_cache":/cache/apk-tools \
+        -v "$REPO_ROOT":/repo \
+        -w /repo \
+        "$IMAGEBUILDER_DOCKER_IMAGE" \
+        bash -euxo pipefail -c '
+            trap "chown -R \"$HOST_UID:$HOST_GID\" /cache/apk-tools /repo/openwrt 2>/dev/null || true" EXIT
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y --no-install-recommends \
+                build-essential meson ninja-build pkg-config \
+                libssl-dev libzstd-dev zlib1g-dev \
+                git ca-certificates wget
+            cd openwrt && ./build-apk.sh
+        ' >&2
+}
+
+resolve_pkg() {
+    case "$PKG_SOURCE" in
         local)
-            echo "==> Building wifihaven ipk locally" >&2
-            (cd "$REPO_ROOT/openwrt" && ./build-ipk.sh >&2)
-            ls "$REPO_ROOT"/openwrt/wifihaven_*.ipk | head -n1
+            echo "==> Building wifihaven .$PKG_EXT locally" >&2
+            if [ "$PKG_FORMAT" = "apk" ]; then
+                build_apk_in_docker
+            else
+                (cd "$REPO_ROOT/openwrt" && "./build-${PKG_EXT}.sh" >&2)
+            fi
+            ls "$REPO_ROOT"/openwrt/wifihaven_*."$PKG_EXT" | head -n1
             ;;
         release)
-            echo "==> Fetching latest wifihaven ipk from GitHub Releases" >&2
+            echo "==> Fetching latest wifihaven .$PKG_EXT from GitHub Releases" >&2
             local url
             url="$(gh release view --json assets \
-                   --jq '.assets[] | select(.name | endswith(".ipk")) | .url' \
+                   --jq ".assets[] | select(.name | endswith(\".${PKG_EXT}\")) | .url" \
                    | head -n1)"
             if [ -z "$url" ]; then
-                echo "ERROR: no .ipk asset found on latest release" >&2
+                echo "ERROR: no .$PKG_EXT asset found on latest release" >&2
                 exit 1
             fi
             local out="$DOWNLOAD_DIR/$(basename "$url")"
-            gh release download --pattern '*.ipk' --output "$out" --clobber >&2
+            gh release download --pattern "*.${PKG_EXT}" --output "$out" --clobber >&2
             echo "$out"
             ;;
         path)
-            if [ -z "$IPK_PATH" ] || [ ! -f "$IPK_PATH" ]; then
-                echo "ERROR: IPK_SOURCE=path requires IPK_PATH=<file>" >&2
+            if [ -z "$PKG_OVERRIDE_PATH" ] || [ ! -f "$PKG_OVERRIDE_PATH" ]; then
+                echo "ERROR: ${PKG_EXT^^}_SOURCE=path requires ${PKG_EXT^^}_PATH=<file>" >&2
                 exit 1
             fi
-            echo "$IPK_PATH"
+            echo "$PKG_OVERRIDE_PATH"
             ;;
         *)
-            echo "ERROR: unknown IPK_SOURCE=$IPK_SOURCE (use local|release|path)" >&2
+            echo "ERROR: unknown ${PKG_EXT^^}_SOURCE=$PKG_SOURCE (use local|release|path)" >&2
             exit 1
             ;;
     esac
 }
 
-IPK_FILE="$(resolve_ipk)"
-echo "==> Using ipk: $IPK_FILE"
+PKG_FILE="$(resolve_pkg)"
+echo "==> Using package: $PKG_FILE"
 
 # ── 2. Download + verify Image Builder ───────────────────────────────────────
 IB_TARBALL="$DOWNLOAD_DIR/$OPENWRT_IMAGEBUILDER_TARBALL"
@@ -88,7 +150,7 @@ if [ ! -f "$IB_TARBALL" ]; then
 fi
 
 echo "==> Verifying Image Builder sha256"
-SUMS_FILE="$DOWNLOAD_DIR/sha256sums"
+SUMS_FILE="$DOWNLOAD_DIR/sha256sums-${OPENWRT_VERSION}"
 curl -fsSL -o "$SUMS_FILE" "$OPENWRT_SHA256SUMS_URL"
 EXPECTED_SUM="$(grep -E "[[:space:]]\*?${OPENWRT_IMAGEBUILDER_TARBALL}\$" "$SUMS_FILE" | awk '{print $1}')"
 if [ -z "$EXPECTED_SUM" ]; then
@@ -105,10 +167,16 @@ if [ "$ACTUAL_SUM" != "$EXPECTED_SUM" ]; then
 fi
 
 # ── 3. Extract Image Builder ─────────────────────────────────────────────────
+# 23.05 ships .tar.xz; 25.12 ships .tar.zst. GNU tar auto-detects xz; zstd
+# needs the explicit flag (older tar releases don't auto-detect zst).
 rm -rf "$IB_ROOT"
 mkdir -p "$IB_ROOT"
 echo "==> Extracting Image Builder"
-tar -xf "$IB_TARBALL" -C "$IB_ROOT" --strip-components=1
+case "$OPENWRT_IB_EXT" in
+    tar.xz)  tar -xf "$IB_TARBALL" -C "$IB_ROOT" --strip-components=1 ;;
+    tar.zst) tar --zstd -xf "$IB_TARBALL" -C "$IB_ROOT" --strip-components=1 ;;
+    *)       echo "ERROR: unknown IB extension $OPENWRT_IB_EXT" >&2; exit 1 ;;
+esac
 
 # ── 4. Stage FILES tree (overlay copied verbatim into the rootfs) ────────────
 echo "==> Staging overlay files"
@@ -125,20 +193,48 @@ mkdir -p "$STAGING_DIR/etc/dropbear"
 install -m 0600 "$SCRIPT_DIR/keys/client_test_ed25519.pub" \
     "$STAGING_DIR/etc/dropbear/authorized_keys"
 
-# ── 5. Drop the wifihaven ipk into the Image Builder's local packages dir ───
-# OpenWRT 23.05's scripts/ipkg-make-index.sh expects .ipk files to be
-# tarballs (`tar czf foo.ipk debian-binary control.tar.gz data.tar.gz`),
-# but openwrt/build-ipk.sh produces the deb-style `ar` format that opkg
-# also accepts when installed directly. Repackage on the fly so the
-# Image Builder can index it. (We deliberately do not change
-# openwrt/build-ipk.sh — production routers install the ar-format ipk
-# directly and bumping the format risks the deploy path.)
+# ── 5. Stage the wifihaven package into the IB's local packages dir ─────────
 mkdir -p "$IB_ROOT/packages"
-IPK_CONV_DIR="$(mktemp -d)"
-(cd "$IPK_CONV_DIR" && ar x "$IPK_FILE")
-(cd "$IPK_CONV_DIR" && tar -czf "$IB_ROOT/packages/$(basename "$IPK_FILE")" \
-    ./debian-binary ./control.tar.gz ./data.tar.gz)
-rm -rf "$IPK_CONV_DIR"
+case "$PKG_FORMAT" in
+    ipk)
+        # OpenWRT 23.05's scripts/ipkg-make-index.sh expects .ipk files to be
+        # tarballs (`tar czf foo.ipk debian-binary control.tar.gz data.tar.gz`),
+        # but openwrt/build-ipk.sh produces the deb-style `ar` format that opkg
+        # also accepts when installed directly. Repackage on the fly so the
+        # Image Builder can index it. (We deliberately do not change
+        # openwrt/build-ipk.sh — production routers install the ar-format ipk
+        # directly and bumping the format risks the deploy path.)
+        IPK_CONV_DIR="$(mktemp -d)"
+        (cd "$IPK_CONV_DIR" && ar x "$PKG_FILE")
+        (cd "$IPK_CONV_DIR" && tar -czf "$IB_ROOT/packages/$(basename "$PKG_FILE")" \
+            ./debian-binary ./control.tar.gz ./data.tar.gz)
+        rm -rf "$IPK_CONV_DIR"
+        ;;
+    apk)
+        # apk packages are consumed by the IB as-is — no repackaging needed.
+        # We do, however, need to rename: openwrt/build-apk.sh emits the
+        # ipk-convention filename `<name>_<version>-<release>_<arch>.apk`
+        # (e.g. wifihaven_0.1.0-1_all.apk) because that filename pattern is
+        # what the GitHub release / upload artifact pipeline keys on. But
+        # apk-tools v3's default pkgname-spec is `<name>-<version>.apk`
+        # (e.g. wifihaven-0.1.0-r1.apk); the IB's `apk add` lookup uses
+        # that pattern at install time, so an unrenamed file gets indexed
+        # OK by mkndx but install fails with "package mentioned in index
+        # not found (try 'apk update')". Read the version straight from
+        # the .apk's ADB metadata so this stays consistent if PKG_RELEASE
+        # ever bumps.
+        apk_name="$(/home/sameer/.cache/wifihaven-apk-tools/build/src/apk \
+            adbdump "$PKG_FILE" 2>/dev/null \
+            | awk '/^  name:/ {n=$2} /^  version:/ {print n"-"$2; exit}')"
+        if [ -z "$apk_name" ]; then
+            # Fallback: parse from filename (wifihaven_0.1.0-1_all.apk ->
+            # wifihaven-0.1.0-r1). Triggers if adbdump fails for any reason.
+            apk_name="$(basename "$PKG_FILE" | sed -E 's/_([0-9.]+)-([0-9]+)_all\.apk/-\1-r\2/')"
+        fi
+        cp "$PKG_FILE" "$IB_ROOT/packages/${apk_name}.apk"
+        echo "==> Staged as $IB_ROOT/packages/${apk_name}.apk"
+        ;;
+esac
 
 # ── 6. Invoke Image Builder inside a Docker container ────────────────────────
 # Image Builder needs a Linux toolchain; running it through Docker means
@@ -154,41 +250,34 @@ if ! timeout 5 docker info >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "==> Running Image Builder in $IMAGEBUILDER_DOCKER_IMAGE"
+echo "==> Running Image Builder in $IMAGEBUILDER_DOCKER_IMAGE (PKG_FORMAT=$PKG_FORMAT)"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
-docker run --rm \
-    --name wh-imagebuilder \
-    -e HOST_UID="$HOST_UID" \
-    -e HOST_GID="$HOST_GID" \
-    -v "$IB_ROOT":/ib \
-    -v "$STAGING_DIR":/staging:ro \
-    -w /ib \
-    "$IMAGEBUILDER_DOCKER_IMAGE" \
-    bash -euxo pipefail -c '
-        # Cleanup trap: even on build failure, hand the entire imagebuilder
-        # tree back to the invoking user. Image Builder writes to bin/,
-        # build_dir/, tmp/, dl/, staging_dir/ — anything left root-owned
-        # blocks subsequent host-side `rm` and (on CI) breaks the next
-        # actions/checkout cleanup with EACCES on stale .ipk / tmp/test.fs
-        # files. chown the whole tree to be future-proof against new IB
-        # output dirs.
-        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib 2>/dev/null || true; chmod -R u+rwX /ib 2>/dev/null || true" EXIT
 
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update -qq
-        apt-get install -y --no-install-recommends \
-            build-essential libncurses-dev zlib1g-dev gawk git \
-            gettext libssl-dev xsltproc rsync wget unzip file \
-            python3 python3-distutils \
-            ca-certificates coreutils
-        # OpenWRT scripts/ipkg-make-index.sh calls a bare `sha256` binary
-        # that is normally built as a host tool but is not in the Image
-        # Builder distribution. Shim it to sha256sum (compatible output).
+# The set of packages to include. Dependencies declared by the wifihaven
+# package (lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua)
+# are pulled in automatically from the upstream OpenWRT feed.
+#
+# Swap stock dnsmasq for dnsmasq-full so the `ipset=` directives the agent
+# renders into /tmp/dnsmasq.d/wifihaven.conf are accepted — plain dnsmasq is
+# built without HAVE_IPSET and rejects the config at line 7 (#148 e2e).
+#
+# uhttpd hosts the local block page on 127.0.0.1:8081 (#303 / #351).
+# render.lua DNATs blocked HTTP/80 traffic there; without uhttpd in
+# the image, the DNAT lands on a dead port and curl times out
+# instead of receiving the block page.
+PACKAGES_LIST="wifihaven -dnsmasq dnsmasq-full uhttpd"
+
+# Per-flavor IB prep script — chosen branch is run inside the container.
+case "$PKG_FORMAT" in
+    ipk)
+        IB_PREP_SCRIPT='
+        # OpenWRT 23.05 scripts/ipkg-make-index.sh calls a bare `sha256`
+        # binary that is normally built as a host tool but is not in the
+        # Image Builder distribution. Shim it to sha256sum (compatible
+        # output).
         printf "#!/bin/sh\nexec sha256sum \"\$@\"\n" > /usr/local/bin/sha256
         chmod +x /usr/local/bin/sha256
-        # Image Builder writes to bin/; ensure it is clean.
-        rm -rf bin/
         # Build a minimal Packages index for opkg. We deliberately do not
         # call scripts/ipkg-make-index.sh: it choked on our control file
         # in earlier CI runs with a sed error, and the usign signing step
@@ -209,20 +298,72 @@ docker run --rm \
         sed -i "s/^option check_signature/# option check_signature/" repositories.conf
         echo "--- packages/Packages ---"
         cat packages/Packages
-        # The set of packages to include. Dependencies declared by the ipk
-        # (lua, libuci-lua, luci-lib-jsonc, conntrack, curl) are
-        # pulled in automatically from the upstream OpenWRT feed.
-        # Swap stock dnsmasq for dnsmasq-full so the `ipset=` directives the
-        # agent renders into /tmp/dnsmasq.d/wifihaven.conf are accepted —
-        # plain dnsmasq is built without HAVE_IPSET and rejects the config
-        # at line 7 (#148 e2e).
-        # uhttpd hosts the local block page on 127.0.0.1:8081 (#303 / #351).
-        # render.lua DNATs blocked HTTP/80 traffic there; without uhttpd in
-        # the image, the DNAT lands on a dead port and curl times out
-        # instead of receiving the block page.
+        '
+        ;;
+    apk)
+        # 25.12 IB ships staging_dir/host/bin/apk and auto-runs
+        # `apk mkndx --allow-untrusted` over packages/*.apk on every
+        # `make image` (rules.mk:215), so there is no manual index step.
+        # Sanity-check the local apk file is parseable; bail early if not.
+        #
+        # CONFIG_SIGNATURE_CHECK=y in the stock IB .config — that gates
+        # whether the Makefile's APK invocation gets --allow-untrusted
+        # (Makefile:103). Without --allow-untrusted, our locally-built
+        # unsigned wifihaven.apk is silently excluded from candidates and
+        # `make image` fails with "wifihaven (no such package)" despite
+        # the package being present in packages.adb. Flip the flag so
+        # the local unsigned package resolves. Upstream signed feeds
+        # still verify normally (the keys/ dir is untouched).
+        IB_PREP_SCRIPT='
+        echo "--- local apk file ---"
+        ls -la packages/*.apk
+        ./staging_dir/host/bin/apk mkndx --allow-untrusted \
+            --output packages/packages.adb packages/*.apk
+        echo "--- index built ---"
+        ls -la packages/packages.adb
+        sed -i "s/^CONFIG_SIGNATURE_CHECK=y/# CONFIG_SIGNATURE_CHECK is not set/" .config
+        echo "--- .config after sig disable ---"
+        grep CONFIG_SIGNATURE_CHECK .config || true
+        '
+        ;;
+esac
+
+docker run --rm \
+    -e HOST_UID="$HOST_UID" \
+    -e HOST_GID="$HOST_GID" \
+    -e IB_PREP_SCRIPT="$IB_PREP_SCRIPT" \
+    -e PACKAGES_LIST="$PACKAGES_LIST" \
+    -v "$IB_ROOT":/ib \
+    -v "$STAGING_DIR":/staging:ro \
+    -w /ib \
+    "$IMAGEBUILDER_DOCKER_IMAGE" \
+    bash -euxo pipefail -c '
+        # Cleanup trap: even on build failure, hand the entire imagebuilder
+        # tree back to the invoking user. Image Builder writes to bin/,
+        # build_dir/, tmp/, dl/, staging_dir/ — anything left root-owned
+        # blocks subsequent host-side `rm` and (on CI) breaks the next
+        # actions/checkout cleanup with EACCES on stale package / tmp/test.fs
+        # files. chown the whole tree to be future-proof against new IB
+        # output dirs.
+        trap "chown -R \"$HOST_UID:$HOST_GID\" /ib 2>/dev/null || true; chmod -R u+rwX /ib 2>/dev/null || true" EXIT
+
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y --no-install-recommends \
+            build-essential libncurses-dev zlib1g-dev gawk git \
+            gettext libssl-dev xsltproc rsync wget unzip file \
+            python3 python3-distutils \
+            ca-certificates coreutils
+
+        # Image Builder writes to bin/; ensure it is clean.
+        rm -rf bin/
+
+        # Flavor-specific index prep.
+        eval "$IB_PREP_SCRIPT"
+
         make image \
             PROFILE=generic \
-            PACKAGES="wifihaven -dnsmasq dnsmasq-full uhttpd" \
+            PACKAGES="$PACKAGES_LIST" \
             FILES=/staging
     '
 

--- a/scripts/vm/versions.sh
+++ b/scripts/vm/versions.sh
@@ -5,19 +5,54 @@
 # router-image build, the VM bring-up (#144), and CI all agree on which
 # OpenWRT release we are testing against.
 #
-# Bumping the release:
-#   1. Update OPENWRT_VERSION below.
-#   2. Re-run scripts/vm/build-router-image.sh from a clean cache; it
-#      downloads the official sha256sums from the same release directory
-#      and verifies the Image Builder tarball against it, so no hash
-#      needs to be hand-edited here.
-#   3. Re-run the VM e2e suite (#148) end-to-end against the new image.
+# Two flavors are supported, selected via PKG_FORMAT (env var):
+#
+#   ipk (default): OpenWRT 23.05 stable. Image Builder is opkg-based and
+#                  consumes .ipk packages. Legacy production target.
+#   apk          : OpenWRT 25.12 stable. First apk-native stable release
+#                  line; Image Builder ships apk-tools v3 and consumes
+#                  .apk packages. (24.10's IB is still opkg-based despite
+#                  apk being usable at runtime on a 24.10 system, so 25.12
+#                  is the first release where "build image with .apk
+#                  pre-installed via the IB" is testable end-to-end.)
+#
+# Bumping either pin:
+#   1. Update OPENWRT_VERSION_IPK or OPENWRT_VERSION_APK below.
+#   2. Re-run scripts/vm/build-router-image.sh PKG_FORMAT=<format> from a
+#      clean cache. Both flavors fetch the release-dir sha256sums and
+#      verify the downloaded tarball against it, so no hash needs to be
+#      hand-edited here.
+#   3. Re-run the relevant leg of the e2e suite end-to-end.
 
-OPENWRT_VERSION="23.05.5"
+OPENWRT_VERSION_IPK="23.05.5"
+OPENWRT_VERSION_APK="25.12.3"
+
 OPENWRT_TARGET="x86"
 OPENWRT_SUBTARGET="64"
 
-OPENWRT_IMAGEBUILDER_TARBALL="openwrt-imagebuilder-${OPENWRT_VERSION}-${OPENWRT_TARGET}-${OPENWRT_SUBTARGET}.Linux-x86_64.tar.xz"
+# Resolve the active flavor based on PKG_FORMAT. Default: ipk.
+PKG_FORMAT="${PKG_FORMAT:-ipk}"
+case "$PKG_FORMAT" in
+    ipk)
+        OPENWRT_VERSION="$OPENWRT_VERSION_IPK"
+        # 23.05 ships the IB as xz.
+        OPENWRT_IB_EXT="tar.xz"
+        ;;
+    apk)
+        OPENWRT_VERSION="$OPENWRT_VERSION_APK"
+        # 25.12 ships the IB as zstd.
+        OPENWRT_IB_EXT="tar.zst"
+        ;;
+    *)
+        echo "ERROR: unknown PKG_FORMAT=$PKG_FORMAT (use ipk|apk)" >&2
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
+
+# Major.minor used in the cache filename so the two flavors don't collide.
+OPENWRT_VERSION_SHORT="$(echo "$OPENWRT_VERSION" | cut -d. -f1-2)"
+
+OPENWRT_IMAGEBUILDER_TARBALL="openwrt-imagebuilder-${OPENWRT_VERSION}-${OPENWRT_TARGET}-${OPENWRT_SUBTARGET}.Linux-x86_64.${OPENWRT_IB_EXT}"
 OPENWRT_RELEASE_URL="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${OPENWRT_TARGET}/${OPENWRT_SUBTARGET}"
 OPENWRT_IMAGEBUILDER_URL="${OPENWRT_RELEASE_URL}/${OPENWRT_IMAGEBUILDER_TARBALL}"
 OPENWRT_SHA256SUMS_URL="${OPENWRT_RELEASE_URL}/sha256sums"
@@ -26,7 +61,5 @@ OPENWRT_SHA256SUMS_URL="${OPENWRT_RELEASE_URL}/sha256sums"
 # doesn't matter. Pinned for reproducibility.
 IMAGEBUILDER_DOCKER_IMAGE="debian:bookworm-slim"
 
-# Profile + filename for the x86_64 combined ext4 image that QEMU boots.
-# (Image Builder emits this as bin/targets/x86/64/openwrt-${OPENWRT_VERSION}-x86-64-generic-ext4-combined.img.gz)
 OPENWRT_PROFILE="generic"
 OPENWRT_BUILT_IMAGE_NAME="openwrt-${OPENWRT_VERSION}-${OPENWRT_TARGET}-${OPENWRT_SUBTARGET}-${OPENWRT_PROFILE}-ext4-combined.img.gz"


### PR DESCRIPTION
## Summary

- Parameterizes `scripts/vm/build-router-image.sh` with `PKG_FORMAT=ipk|apk` (default `ipk`). `ipk` keeps building OpenWRT 23.05.5 unchanged; `apk` builds OpenWRT 25.12.3 with the locally-built `wifihaven.apk` pre-installed via the apk-native Image Builder.
- 25.12 is the first apk-native stable release line. 24.10's IB is still opkg-based internally (verified by inspecting the 24.10.4 tarball — it ships `staging_dir/host/bin/opkg`, not apk-tools); bumping the opkg leg to 24.10.x is tracked in #834.
- This PR is **scope item 1 of #532** only — build the image, prove it boots, prove the agent runs. **Matrix-wiring both legs into Gate 2 is #685.** No e2e workflow logic changes here.
- Cache layout split: `openwrt-wifihaven.img` → `openwrt-wifihaven-ipk-23.05.img` / `openwrt-wifihaven-apk-25.12.img`. The three workflows that hard-coded the old filename are updated literally (one-line each).

## Implementation notes

**apk-path specifics that took some iteration:**

1. **`openwrt/build-apk.sh` is now run inside docker** (debian:bookworm-slim) from `build-router-image.sh`, so the only host prereq is docker. The apk-tools v3 source build is cached in `$HOME/.cache/wifihaven-apk-tools` via a bind mount, so subsequent runs reuse it. This makes the script runner-agnostic (GitHub-hosted, self-hosted KVM, local Linux dev).
2. **`openwrt/build-apk.sh`** had a latent bug: `meson setup --reconfigure` errors out on first-run with meson 1.0.x (Debian bookworm). GitHub's ubuntu-latest ships newer meson so it works there silently. Made `--reconfigure` conditional on `build/build.ninja` existing.
3. **CONFIG_SIGNATURE_CHECK=y** is the stock IB default; that gates whether the IB's APK invocation gets `--allow-untrusted` (Makefile:103). Without it the local unsigned `wifihaven.apk` is silently excluded and `make image` fails with `wifihaven (no such package)` despite being in `packages.adb`. Flipped to off in the apk IB prep.
4. **Filename rename at staging**: `openwrt/build-apk.sh` emits the ipk-convention `wifihaven_<v>-<r>_all.apk` (kept that way so the existing GitHub release artifact pipeline keeps working), but apk-tools v3's default pkgname-spec lookup expects `<name>-<version>.apk` (`wifihaven-0.1.0-r1.apk`). Without the rename, mkndx indexes the file fine but install fails with `package mentioned in index not found (try 'apk update')`.
5. **`docker run --name wh-imagebuilder` dropped** from both invocations. Local validation and the self-hosted KVM CI runner live on the same host (per the durable VM-serialization rule); a fixed name guarantees collisions. Letting docker autogenerate is collision-proof.

## Test plan

- [x] `PKG_FORMAT=ipk scripts/vm/build-router-image.sh` produces `openwrt-wifihaven-ipk-23.05.img` (121 MB, 1m50s).
- [x] `PKG_FORMAT=apk scripts/vm/build-router-image.sh` produces `openwrt-wifihaven-apk-25.12.img` (121 MB, 1m52s).
- [x] `WH_ROUTER_IMAGE_PATH=<ipk-image> scripts/vm/router-up.sh` boots; SSH shows `OpenWrt 23.05.5`, `opkg list-installed | grep wifihaven` → `wifihaven - 0.1.0-1`, `uci show wifihaven` returns 7 defaults, `logread` shows `wifihaven-agent: starting api_url=...` (agent then exits on missing `router_token` — expected pre-enrollment).
- [x] `WH_ROUTER_IMAGE_PATH=<apk-image> scripts/vm/router-up.sh` boots; SSH shows `OpenWrt 25.12.3 r32912-6639b15f62` (same revision running on the dev router), `apk list --installed | grep wifihaven` → `wifihaven-0.1.0-r1 noarch {wifihaven} (MIT) [installed]`, same uci defaults, same logread evidence.
- [x] No regression on the 23.05 path — ipk build, image filename change (only the literal in 3 workflows), and boot-time behavior unchanged aside from the rename.
- [ ] Existing Gate 2 e2e suite continues to pass via the renamed ipk cache path — will verify via CI on this PR.
- [ ] apk leg into Gate 2 — out of scope here, tracked in #685.

🤖 Generated with [Claude Code](https://claude.com/claude-code)