### PR TITLE
fix(seed): remove test blocklists from prod + gate dev fixtures (#706)

### DIFF
--- a/api/resources/db/migration/V26__remove_test_blocklists.sql
+++ b/api/resources/db/migration/V26__remove_test_blocklists.sql
@@ -1,0 +1,17 @@
+-- #706: prod cloud DB had `test_ads` / `test_social` rows from the V11 dev
+-- seed running unconditionally. Remove the rows everywhere; dev re-seeds
+-- after migrations via the in-app DevSeeder (runs only when
+-- WIFIHAVEN_ENV=dev), so this is safe on dev too.
+
+DELETE FROM blocklist_domains
+ WHERE category IN ('test_ads', 'test_social');
+
+-- Strip any profile references too. blocked_categories is TEXT[]; no prod
+-- profile is known to reference these, but be defensive.
+UPDATE profiles
+   SET blocked_categories = array_remove(
+                              array_remove(blocked_categories, 'test_ads'),
+                              'test_social'
+                            )
+ WHERE 'test_ads'    = ANY(blocked_categories)
+    OR 'test_social' = ANY(blocked_categories);

--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -16,6 +16,16 @@ case class AppConfig(
   // Read from env, not HOCON, so it stays out of application.conf — debug
   // belongs to the runtime environment, not the persistent config.
   val debugEnabled: Boolean = AppConfig.envTruthy(sys.env.get("WIFIHAVEN_DEBUG"))
+
+  // #706: WIFIHAVEN_ENV gates dev-only fixtures (currently: the test_ads /
+  // test_social blocklist seed). Recognized values: "prod" (default, no
+  // fixtures), "dev" (re-seed test blocklists after migrations). Read from
+  // env, not HOCON — environment identity belongs to the deploy target, not
+  // the persistent config file. Default is "prod" so any unset deployment
+  // is safe.
+  val env: String    =
+    sys.env.get("WIFIHAVEN_ENV").map(_.trim.toLowerCase).filter(_.nonEmpty).getOrElse("prod")
+  val isDev: Boolean = env == "dev"
 }
 
 case class DbConfig(

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -31,6 +31,13 @@ object Main extends ZIOAppDefault {
         .when(cfg.debugEnabled)
       _      <- Database.runMigrations(cfg.db)
       _      <- ZIO.logInfo("Database migrations complete")
+      // #706: re-seed test_ads / test_social blocklists only on dev. V26
+      // removed them from every DB; without this they'd be missing from
+      // local + e2e stacks that expect them as fixtures.
+      _      <- ZIO
+        .serviceWithZIO[BlocklistRepo](DevSeeder.seedTestBlocklists)
+        .zipLeft(ZIO.logInfo(s"WIFIHAVEN_ENV=${cfg.env} — dev fixtures seeded"))
+        .when(cfg.isDev)
       // #334: ensure household_settings has its single row, defaulting the
       // daily-reset tz to the API server's local zone on first install. No-op
       // on subsequent boots because of ON CONFLICT DO NOTHING.

--- a/api/src/db/DevSeeder.scala
+++ b/api/src/db/DevSeeder.scala
@@ -1,0 +1,23 @@
+package wifihaven.api.db
+
+import zio.*
+
+// #706: dev-only fixtures. Previously V11 migration seeded `test_ads` /
+// `test_social` blocklists into every database including prod, which leaked
+// into router policy snapshots. V26 deletes those rows unconditionally;
+// this seeder re-creates them only when WIFIHAVEN_ENV=dev so local stacks
+// and ephemeral staging keep their fixtures.
+object DevSeeder {
+
+  private val TestBlocklistDomains: List[(String, String)] = List(
+    "adserver.example.com" -> "test_ads",
+    "doubleclick.net"      -> "test_ads",
+    "googleadservices.com" -> "test_ads",
+    "facebook.com"         -> "test_social",
+    "instagram.com"        -> "test_social",
+    "tiktok.com"           -> "test_social",
+  )
+
+  def seedTestBlocklists(blRepo: BlocklistRepo): Task[Unit] =
+    blRepo.insertBatch(TestBlocklistDomains).unit
+}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       WIFIHAVEN_DB_PASSWORD: wifihaven
       WIFIHAVEN_HTTP_PORT: "8080"
       WIFIHAVEN_JWT_SECRET: "staging-jwt-secret-do-not-use-in-prod-32ch"
+      # #706: enable dev fixtures (test_ads / test_social blocklists). The
+      # API defaults to env=prod (no fixtures); local + CI need the seed.
+      WIFIHAVEN_ENV: "dev"
       # #612: allow the Vite dev server and the JVM-bundled SPA on localhost.
       WIFIHAVEN_ALLOWED_ORIGINS: "http://localhost:5173,http://localhost:8080"
       # #614: dev defaults to serving the bundled SPA at http://localhost:8080/.

--- a/render.yaml
+++ b/render.yaml
@@ -71,6 +71,11 @@ services:
       # Staging runs DEBUG so issues are visible in the Render log stream.
       - key: WIFIHAVEN_LOG_LEVEL
         value: DEBUG
+      # #706: staging is expendable and used for e2e fixtures, so re-seed
+      # the test_ads / test_social blocklists after migrations. Prod omits
+      # this key entirely — the API defaults to env=prod (no fixtures).
+      - key: WIFIHAVEN_ENV
+        value: dev
       # Entrypoint warns if WIFIHAVEN_DEBUG is non-empty (mounts debug
       # endpoints on loopback). Keep explicitly empty in staging.
       - key: WIFIHAVEN_DEBUG


### PR DESCRIPTION
## Summary
- Adds migration `V26__remove_test_blocklists.sql` that deletes `test_ads` / `test_social` rows from `blocklist_domains` and strips them from any `profiles.blocked_categories` array. Idempotent, runs everywhere.
- Introduces `WIFIHAVEN_ENV` (values: `prod` default, `dev`). Local docker-compose and Render staging set `dev`; Render prod omits it (defaults to `prod`).
- New `DevSeeder` re-inserts the six test blocklist domains after migrations only when `cfg.isDev`. The seed previously lived in V11 unconditionally, which is the original leak source.

Closes #706.

## Before / after — policy snapshot blocklists map

Before (prod, fresh router enrollment):
```json
{
  "test_ads":    { "version": "4b6c87d2270c1c3d", "url": "/api/blocklists/test_ads" },
  "test_social": { "version": "cd721916816ca0e2", "url": "/api/blocklists/test_social" }
}
```

After (prod, post-migration, fresh enrollment): the `blocklists` map contains only categories with real domains, none of which are `test_*`. Local dev / staging still surface `test_ads` and `test_social` because `DevSeeder` re-creates the rows.

## Test plan
- [x] `mill api.test` — 190 tests pass. RouterApiSpec inserts its own `test_ads` / `test_social` rows via `BlocklistRepo.insertBatch`, so it's unaffected by V11 / V26.
- [x] Migration check (`check-migrations.sh`) passes — V26 is the next number after V25.
- [ ] **Operator post-deploy verification (prod, read-only):**
  1. After `:latest` ships, `GET https://api.wifihaven.net/api/blocklists` with admin auth — confirm no `test_ads` / `test_social` keys.
  2. Pick a known router; `GET https://api.wifihaven.net/api/admin/routers/<id>/policy-snapshot` (or equivalent) — confirm the `blocklists` map has no `test_*` entries.
  3. Re-fetch a freshly enrolled router's `/etc/wifihaven/policy.json` and confirm same.
- [ ] **Staging spot-check:** after deploy, hit staging `/api/blocklists` and confirm `test_ads` / `test_social` are still present (verifies `WIFIHAVEN_ENV=dev` path).

## Notes
- Migrations are append-only; V11 stays untouched to keep Flyway checksums valid on already-migrated DBs. The cleanup happens in V26.
- No router-side changes. No `policy_snapshot.json` contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)