### PR TITLE
feat(api): expose proportional per-FQDN time-on-site alongside presence (#715)

### DIFF
--- a/api/resources/db/migration/V26__time_usage_proportional_seconds.sql
+++ b/api/resources/db/migration/V26__time_usage_proportional_seconds.sql
@@ -1,0 +1,18 @@
+-- V26__time_usage_proportional_seconds.sql
+-- #715: per-FQDN time-on-site is bucket-max, not real time-on-site.
+--
+-- `seconds_used` is bucket-presence: every host the device touched in a 5-min
+-- bucket gets credited with the whole bucket's duration. That's correct for
+-- the per-device daily cap (which collapses across hosts) but wildly inflates
+-- per-host minutes in the UI — a phone polling icloud.com once per bucket
+-- while a 30-min youtube.com video plays will show both hosts at 30 minutes.
+--
+-- Add `proportional_seconds` as a parallel counter: each (mac, host)'s share
+-- of the bucket duration is weighted by its share of bucket bytes
+-- (bytes_in + bytes_out). Sum across hosts within a mac ≈ bucket duration,
+-- so it's a much fairer "wall-clock attention" number for the screen-time UI.
+-- `seconds_used` is preserved — daily-cap math still reads it (and the
+-- bucket-deduped presence math doesn't touch this column at all).
+
+ALTER TABLE time_usage
+  ADD COLUMN proportional_seconds BIGINT NOT NULL DEFAULT 0;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -146,6 +146,12 @@ trait TimeUsageRepo {
   /**
    * Increment seconds + byte counters for (mac, host, date). Repeats are *additive* — the caller is
    * responsible for idempotency at the request level (traffic_reports unique key).
+   *
+   * `seconds` is the bucket-presence count (bucket duration credited in full to every host the
+   * device touched in the bucket). `proportionalSeconds` is the same bucket duration weighted by
+   * this host's byte share of the bucket (#715) — a fairer wall-clock attribution for per-host
+   * screen-time UI. Daily-cap math reads neither directly: it goes through the presence-based
+   * `totalMinutesByMac` over `traffic_reports`.
    */
   def incrementSecondsAndBytes(
       mac: MacAddress,
@@ -154,6 +160,7 @@ trait TimeUsageRepo {
       seconds: Long,
       bytesIn: Long,
       bytesOut: Long,
+      proportionalSeconds: Long = 0L,
   ): Task[Unit]
 
   /** Read seconds_used for a (mac, host, date) row. Returns 0 if no row. */
@@ -165,6 +172,13 @@ trait TimeUsageRepo {
       host: HostId,
       date: LocalDate,
   ): Task[(Long, Long, Long)]
+
+  /**
+   * #715: read the byte-share-weighted proportional seconds for a (mac, host, date) row. Returns 0
+   * if no row. Cap math doesn't read this; it's stored so the column stays in sync with
+   * `seconds_used` for any consumer that wants a fairer per-host attribution.
+   */
+  def getProportionalSeconds(mac: MacAddress, host: HostId, date: LocalDate): Task[Long]
   def listForDevice(mac: MacAddress, date: LocalDate): Task[List[TimeUsage]]
   def listForDeviceMacs(macs: List[MacAddress], date: LocalDate): Task[List[TimeUsage]]
   def snapshotAll(date: LocalDate): Task[Map[(MacAddress, HostId), Int]]
@@ -663,16 +677,24 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
       seconds: Long,
       bytesIn: Long,
       bytesOut: Long,
+      proportionalSeconds: Long = 0L,
   ): Task[Unit] =
-    sql"""INSERT INTO time_usage(device_mac,host_type,host_value,date,seconds_used,bytes_in,bytes_out,last_seen_at)
-          VALUES($mac,${host.kind},${host.value},$d,$seconds,$bytesIn,$bytesOut,NOW())
+    sql"""INSERT INTO time_usage(device_mac,host_type,host_value,date,seconds_used,proportional_seconds,bytes_in,bytes_out,last_seen_at)
+          VALUES($mac,${host.kind},${host.value},$d,$seconds,$proportionalSeconds,$bytesIn,$bytesOut,NOW())
           ON CONFLICT(device_mac,host_type,host_value,date) DO UPDATE
           SET seconds_used=time_usage.seconds_used+EXCLUDED.seconds_used,
+              proportional_seconds=time_usage.proportional_seconds+EXCLUDED.proportional_seconds,
               bytes_in=time_usage.bytes_in+EXCLUDED.bytes_in,
               bytes_out=time_usage.bytes_out+EXCLUDED.bytes_out,
               last_seen_at=NOW()""".update.run
       .transact(xa)
       .unit
+  def getProportionalSeconds(mac: MacAddress, host: HostId, d: LocalDate): Task[Long]           =
+    sql"SELECT COALESCE(proportional_seconds,0) FROM time_usage WHERE device_mac=$mac AND host_type=${host.kind} AND host_value=${host.value} AND date=$d"
+      .query[Long]
+      .option
+      .transact(xa)
+      .map(_.getOrElse(0L))
   def getSecondsUsed(mac: MacAddress, host: HostId, d: LocalDate): Task[Long]                   =
     sql"SELECT COALESCE(seconds_used,0) FROM time_usage WHERE device_mac=$mac AND host_type=${host.kind} AND host_value=${host.value} AND date=$d"
       .query[Long]

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -171,4 +171,38 @@ object Presence {
     }
     accum.view.mapValues(s => (s / 60).toInt).toMap
   }
+
+  /**
+   * #715: per-host seconds attributed by byte share within each (mac, period_start) bucket. Each
+   * bucket's wall-clock duration is split across the hosts present in proportion to their share of
+   * the bucket's total bytes (bytes_in + bytes_out). Summing across hosts within one mac's bucket ≈
+   * the bucket duration, so this is a much fairer "wall-clock attention" number than
+   * [[hostMinutes]] (which credits every host the device touched with the bucket's full duration).
+   *
+   * Note: when a bucket carries multiple rows for the same host (e.g. two ipv4-typed rows resolving
+   * to the same fqdn via the read-side LATERAL join), their bytes are summed before the share is
+   * computed so the same host doesn't get a double weight. If the bucket has zero total bytes (an
+   * edge case — the agent only emits records with bytes>0), the bucket is skipped entirely.
+   */
+  def proportionalHostSeconds(rows: List[PresenceRow]): Map[HostId, Double] = {
+    val accum = scala.collection.mutable.Map.empty[HostId, Double]
+    for ((_, bucket) <- rows.groupBy(r => (r.mac, r.periodStart))) {
+      val secs   = bucketSeconds(bucket).toDouble
+      val byHost = bucket.iterator
+        .map(r => r.host -> r.bytes)
+        .toList
+        .groupMapReduce(_._1)(_._2)(_ + _)
+      val total  = byHost.valuesIterator.sum
+      if (secs > 0.0 && total > 0L)
+        for ((h, b) <- byHost) {
+          val share = b.toDouble / total.toDouble
+          accum.updateWith(h)(prev => Some(prev.getOrElse(0.0) + secs * share))
+        }
+    }
+    accum.toMap
+  }
+
+  /** Convenience: floor-divided minute view of [[proportionalHostSeconds]]. */
+  def proportionalHostMinutes(rows: List[PresenceRow]): Map[HostId, Int] =
+    proportionalHostSeconds(rows).view.mapValues(s => (s / 60).toInt).toMap
 }

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -145,7 +145,7 @@ object RouterIngestRoutes {
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
   ): IO[Response, Unit] = {
-    val date    = periodEnd.atZone(ZoneOffset.UTC).toLocalDate
+    val date      = periodEnd.atZone(ZoneOffset.UTC).toLocalDate
     // A batch carries one record per (mac, dst_ip) but time_usage is keyed
     // by (mac, hostname, date), and activeSeconds is the bucket duration
     // (the report window, ~60 s — same value on every record that saw bytes>0). Two
@@ -153,7 +153,20 @@ object RouterIngestRoutes {
     // active time, not two windows back-to-back, so the seconds delta is
     // the max of activeSeconds, not the sum. Bytes still sum because they
     // count distinct flows.
-    val grouped = records
+    // Per-mac aggregates needed for #715 proportional attribution: bucket duration
+    // (one batch == one period, so max activeSeconds across the mac is the bucket
+    // duration) and total bytes across the mac in this batch (denominator for the
+    // bytes-share weight).
+    val perMacAgg = records
+      .groupBy(_.mac)
+      .view
+      .mapValues { rs =>
+        val bucketSecs = rs.map(_.activeSeconds).maxOption.getOrElse(0L)
+        val totalBytes = rs.map(r => r.bytesIn + r.bytesOut).sum
+        (bucketSecs, totalBytes)
+      }
+      .toMap
+    val grouped   = records
       .groupBy(r => (r.mac, r.host))
       .view
       .mapValues { rs =>
@@ -165,8 +178,19 @@ object RouterIngestRoutes {
       }
       .toList
     ZIO.foreachDiscard(grouped) { case ((mac, host), (secs, bIn, bOut)) =>
+      // #715: bytes-share weighted attribution within the batch. `bucketSecs` is
+      // the wall-clock duration of the bucket; the share is this host's
+      // (bytes_in + bytes_out) over the mac's total bytes in the batch. When the
+      // mac has zero bytes (shouldn't happen — the agent only emits a record
+      // when it saw bytes>0), fall back to crediting full bucket seconds so the
+      // row still moves and matches `seconds_used`.
+      val (bucketSecs, totalBytes) = perMacAgg.getOrElse(mac, (secs, bIn + bOut))
+      val hostBytes                = bIn + bOut
+      val proportionalSecs         =
+        if (totalBytes > 0L) (bucketSecs.toDouble * hostBytes.toDouble / totalBytes.toDouble).round
+        else bucketSecs
       timeUsageRepo
-        .incrementSecondsAndBytes(mac, host, date, secs, bIn, bOut)
+        .incrementSecondsAndBytes(mac, host, date, secs, bIn, bOut, proportionalSecs)
         .mapError(ErrorMapper.dbErrorToResponse)
     } *>
       // For each unique mac in the batch, touch last_seen on the existing row (no-op if unknown).

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -778,16 +778,20 @@ object TimeRoutes {
         DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
       }
       // #262 — top-N host attribution across all profile devices for the day.
-      // Bucket-deduped per host; informational, so all hosts (including
-      // exempt-pattern matches) appear. UI shows top 10.
-      hostUsage       = wifihaven.api.presence.Presence
-        .hostMinutes(presence)
-        .iterator
-        .filter(_._2 > 0)
-        .map { case (h, m) => HostUsage(h, m) }
-        .toList
-        .sortBy(hu => (-hu.usedMins, hu.host.value))
-        .take(10)
+      // `usedMins` is bucket-presence and `proportionalMins` is the #715
+      // byte-share-weighted attribution; UI defaults to the latter. Hosts
+      // with zero presence are dropped so the top-10 list isn't padded by
+      // hosts that exist only because the bucket touched them at all.
+      hostUsage       = {
+        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
+        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        presenceMins.iterator
+          .filter(_._2 > 0)
+          .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
+          .toList
+          .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
+          .take(10)
+      }
     } yield ProfileTimeStatus(
       profile.id,
       profile.name,
@@ -831,14 +835,16 @@ object TimeRoutes {
       deviceSummaries = devices.map { d =>
         DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
       }
-      hostUsage       = wifihaven.api.presence.Presence
-        .hostMinutes(presence)
-        .iterator
-        .filter(_._2 > 0)
-        .map { case (h, m) => HostUsage(h, m) }
-        .toList
-        .sortBy(hu => (-hu.usedMins, hu.host.value))
-        .take(10)
+      hostUsage       = {
+        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
+        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        presenceMins.iterator
+          .filter(_._2 > 0)
+          .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
+          .toList
+          .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
+          .take(10)
+      }
       perBucket       = bucketHourlyAligned(presence, heartbeatFilter, bucketOffsetMin)
     } yield ProfileTimeStatusWeek(
       profile.id,
@@ -875,14 +881,16 @@ object TimeRoutes {
       perMac    = wifihaven.api.presence.Presence
         .totalMinutesByMac(presence, Nil, heartbeatFilter)
       totalUsed = perMac.getOrElse(device.mac, 0)
-      hostUsage = wifihaven.api.presence.Presence
-        .hostMinutes(presence)
-        .iterator
-        .filter(_._2 > 0)
-        .map { case (h, m) => HostUsage(h, m) }
-        .toList
-        .sortBy(hu => (-hu.usedMins, hu.host.value))
-        .take(10)
+      hostUsage = {
+        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
+        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        presenceMins.iterator
+          .filter(_._2 > 0)
+          .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
+          .toList
+          .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
+          .take(10)
+      }
       perBucket = bucketHourlyAligned(presence, heartbeatFilter, bucketOffsetMin)
     } yield DeviceTimeStatusWeek(
       device.mac,

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -14,9 +14,10 @@ import java.time.ZoneId
  *   - Per-host minutes within those buckets — currently bucket-presence (overlapping across hosts),
  *     which over-counts (#715).
  *
- * The output proportionally allocates each 5-min bucket's wall-clock duration across the distinct
- * hosts present in that bucket (even-share), so each hour's `perHost` + `otherMins` sums exactly to
- * `totalMins`. Bytes-weighted allocation is a #715 follow-up.
+ * The output proportionally allocates each 5-min bucket's wall-clock duration across the hosts
+ * present in that bucket — bytes-weighted (#715) — so each hour's `perHost` + `otherMins` sums
+ * exactly to `totalMins`. When the bucket has zero total bytes (an edge case — agent only emits
+ * records with bytes>0), we fall back to even-share so the per-host stack still adds up.
  */
 object UsageSeries {
 
@@ -38,19 +39,33 @@ object UsageSeries {
       topN: Int,
   ): (List[UsageHostTotal], List[UsageBucket]) = {
     // Group rows into 5-min buckets. activeSeconds is identical for every row
-    // in a bucket (the router emits one batch per window) so .head is fine.
+    // in a bucket (the router emits one batch per window) so max() is fine.
+    // Track per-host bytes (collapsing multiple rows for the same host within a
+    // bucket) so we can do #715 byte-share-weighted allocation.
     val fiveMin = rows.groupBy(r => r.periodStart).toList.map { case (ps, bucket) =>
-      val hour  = ps.atZone(zone).getHour
-      val secs  = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
-      val hosts = bucket.iterator.map(_.host).toSet.toList
-      (hour, secs, hosts)
+      val hour   = ps.atZone(zone).getHour
+      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+      val byHost = bucket.iterator
+        .map(r => r.host -> r.bytes)
+        .toList
+        .groupMapReduce(_._1)(_._2)(_ + _)
+      (hour, secs, byHost)
     }
 
-    // Day-total per host, in proportional seconds (= bucket secs / hosts-in-bucket).
+    // Day-total per host, byte-share-weighted (even-share fallback if the bucket
+    // recorded zero bytes — agent only emits bytes>0 rows in practice).
     val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, secs, hosts) <- fiveMin if hosts.nonEmpty) {
-      val share = secs.toDouble / hosts.size
-      for (h <- hosts) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+    for ((_, secs, byHost) <- fiveMin if byHost.nonEmpty) {
+      val totalBytes = byHost.valuesIterator.sum
+      if (totalBytes > 0L)
+        for ((h, b) <- byHost) {
+          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+          perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+        }
+      else {
+        val share = secs.toDouble / byHost.size
+        for (h <- byHost.keys) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+      }
     }
 
     // Drop hosts whose proportional day-total floors to 0 — they'd render
@@ -74,11 +89,20 @@ object UsageSeries {
       val total     = hrBuckets.iterator.map((_, s, _) => s.toLong).sum
       val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
       var other     = 0.0
-      for ((_, secs, hosts) <- hrBuckets if hosts.nonEmpty) {
-        val share = secs.toDouble / hosts.size
-        for (h <- hosts)
-          if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-          else other += share
+      for ((_, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
+        val totalBytes = byHost.valuesIterator.sum
+        if (totalBytes > 0L)
+          for ((h, b) <- byHost) {
+            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+            else other += share
+          }
+        else {
+          val share = secs.toDouble / byHost.size
+          for (h <- byHost.keys)
+            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+            else other += share
+        }
       }
       // Floor per-host minutes (consistent with how the daily cap reports
       // wall-clock minutes) and drop hosts that round to zero — keeps the
@@ -130,17 +154,28 @@ object UsageSeries {
     // Group by (mac, periodStart) — same 5-min bucketing as the per-device build,
     // but now we keep the mac so we can later stack-by-device.
     val fiveMin = rows.groupBy(r => (r.mac, r.periodStart)).toList.map { case ((mac, ps), bucket) =>
-      val hour  = ps.atZone(zone).getHour
-      val secs  = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
-      val hosts = bucket.iterator.map(_.host).toSet.toList
-      (hour, mac, secs, hosts)
+      val hour   = ps.atZone(zone).getHour
+      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+      val byHost = bucket.iterator
+        .map(r => r.host -> r.bytes)
+        .toList
+        .groupMapReduce(_._1)(_._2)(_ + _)
+      (hour, mac, secs, byHost)
     }
 
-    // ── Per-host day totals (proportional within each bucket) ─────────────
+    // ── Per-host day totals (#715 byte-share within each (mac, bucket)) ────
     val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, _, secs, hosts) <- fiveMin if hosts.nonEmpty) {
-      val share = secs.toDouble / hosts.size
-      for (h <- hosts) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+    for ((_, _, secs, byHost) <- fiveMin if byHost.nonEmpty) {
+      val totalBytes = byHost.valuesIterator.sum
+      if (totalBytes > 0L)
+        for ((h, b) <- byHost) {
+          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+          perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+        }
+      else {
+        val share = secs.toDouble / byHost.size
+        for (h <- byHost.keys) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+      }
     }
     val orderedHosts = perHostDaySecs.toList
       .map { case (h, s) => (h, (s / 60).toInt) }
@@ -173,14 +208,23 @@ object UsageSeries {
       val totalSecs = hrBuckets.iterator.map((_, _, s, _) => s.toLong).sum
       val totalMins = (totalSecs / 60).toInt
 
-      // Per-host stack within the hour (even-share within each 5-min bucket).
+      // Per-host stack within the hour (#715 byte-share within each 5-min bucket).
       val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
       var hostOther = 0.0
-      for ((_, _, secs, hosts) <- hrBuckets if hosts.nonEmpty) {
-        val share = secs.toDouble / hosts.size
-        for (h <- hosts)
-          if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-          else hostOther += share
+      for ((_, _, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
+        val totalBytes = byHost.valuesIterator.sum
+        if (totalBytes > 0L)
+          for ((h, b) <- byHost) {
+            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+            else hostOther += share
+          }
+        else {
+          val share = secs.toDouble / byHost.size
+          for (h <- byHost.keys)
+            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
+            else hostOther += share
+        }
       }
       val perHostList = perHost.iterator
         .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -88,12 +88,14 @@ object DbFailureSpec extends ZIOSpecDefault {
         s: Long,
         bi: Long,
         bo: Long,
+        proportional: Long,
     ) = throwing
-    def getSecondsUsed(mac: MacAddress, host: HostId, date: java.time.LocalDate)     = throwing
-    def getSecondsAndBytes(mac: MacAddress, host: HostId, date: java.time.LocalDate) = throwing
-    def listForDevice(mac: MacAddress, date: java.time.LocalDate)                    = throwing
-    def listForDeviceMacs(macs: List[MacAddress], date: java.time.LocalDate)         = throwing
-    def snapshotAll(date: java.time.LocalDate)                                       = throwing
+    def getSecondsUsed(mac: MacAddress, host: HostId, date: java.time.LocalDate)         = throwing
+    def getSecondsAndBytes(mac: MacAddress, host: HostId, date: java.time.LocalDate)     = throwing
+    def getProportionalSeconds(mac: MacAddress, host: HostId, date: java.time.LocalDate) = throwing
+    def listForDevice(mac: MacAddress, date: java.time.LocalDate)                        = throwing
+    def listForDeviceMacs(macs: List[MacAddress], date: java.time.LocalDate)             = throwing
+    def snapshotAll(date: java.time.LocalDate)                                           = throwing
   }
 
   private def brokenDeviceRepo: DeviceRepo = new DeviceRepo {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -286,6 +286,105 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(sb == ((300L, 350L, 60L)))
     },
+    test("usage: #715 — applyDelta writes byte-share-weighted proportional_seconds per host") {
+      // Two hosts in the same batch with an 80/20 byte split. seconds_used is
+      // bucket-max for each host (= the full bucket duration the agent saw on
+      // that host), but proportional_seconds splits the bucket by byte share so
+      // the heavy host gets most of the wall-clock attribution.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        recs = List(
+          // youtube: 300s bucket, 800 bytes
+          UsageRecord(
+            MacAddress.unsafe(knownMac),
+            None,
+            HostId.Fqdn(Hostname.unsafe("youtube.com")),
+            300L,
+            500L,
+            300L,
+          ),
+          // icloud: 300s bucket, 200 bytes
+          UsageRecord(
+            MacAddress.unsafe(knownMac),
+            None,
+            HostId.Fqdn(Hostname.unsafe("icloud.com")),
+            300L,
+            150L,
+            50L,
+          ),
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, recs).toJson
+        resp   <- post(routes, "/api/router/usage", body, Some(tk))
+        // Bucket-presence is unchanged: each host still credits the full 300s.
+        ytSb   <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+        icSb   <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("icloud.com")),
+          testDate,
+        )
+        ytProp <- tu.getProportionalSeconds(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+        icProp <- tu.getProportionalSeconds(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("icloud.com")),
+          testDate,
+        )
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(ytSb._1 == 300L && icSb._1 == 300L) &&
+        // bucket=300s. youtube share = 800/1000 → 240s. icloud share = 200/1000 → 60s.
+        assertTrue(ytProp == 240L) &&
+        assertTrue(icProp == 60L) &&
+        // The two proportional values reconcile back to the bucket wall-clock duration.
+        assertTrue(ytProp + icProp == 300L)
+    },
+    test("usage: #715 — single-host batches credit full bucket to proportional_seconds") {
+      // No competing hosts → byte share is 100% → proportional_seconds equals
+      // seconds_used. Guarantees we don't regress for the common case.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          None,
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          300L,
+          1000L,
+          500L,
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        _    <- post(routes, "/api/router/usage", body, Some(tk))
+        sb   <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+        prop <- tu.getProportionalSeconds(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+      } yield assertTrue(sb._1 == 300L) && assertTrue(prop == 300L)
+    },
     test("usage: seconds add across distinct periods for same (mac, hostname)") {
       for {
         _        <- cleanDb

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -692,6 +692,101 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
           assertTrue(kids.usedMins == 0)         // site usage NOT counted in total
       },
+      test("hostUsage exposes byte-share proportionalMins alongside bucket-presence (#715)") {
+        // Reproduce the prod shape from #715: device sat at ~60 used minutes
+        // but a per-FQDN bucket-presence breakdown lists 10 polling hosts at
+        // 50–80m each because each was touched in every 5-min bucket. With the
+        // byte-share weight, ~all of the attributed minutes go to the host
+        // that actually moved bytes — the screen-time UI shows that number.
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 240)
+          mac = "aa:bb:cc:dd:ee:01"
+          _        <- TestLayers.seedDevice(deviceRepo, mac, "iPad", kidsId)
+          routerId <- seedRouter
+          today   = TestClock.schoolDayAfternoon.toLocalDate
+          today0  = today.atStartOfDay(ZoneOffset.UTC).toInstant
+          heavy   = "youtube.com"
+          pollers = (0 until 10).map(i => s"poll-$i.example.com").toList
+          // 12 buckets × 5 min = 60 wall-clock mins. In every bucket: youtube
+          // moves 5MB; each of 10 pollers moves 200 bytes.
+          _               <- ZIO.foreachDiscard(0 until 12) { b =>
+            val start    = today0.plusSeconds(b * 300L)
+            val end      = start.plusSeconds(300)
+            val heavyRow = TrafficReportInsert(
+              routerId,
+              MacAddress.unsafe(mac),
+              None,
+              HostId.Fqdn(Hostname.unsafe(heavy)),
+              today,
+              start,
+              end,
+              300,
+              2_500_000L,
+              2_500_000L,
+            )
+            val pollRows = pollers.map(p =>
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(mac),
+                None,
+                HostId.Fqdn(Hostname.unsafe(p)),
+                today,
+                start,
+                end,
+                300,
+                100L,
+                100L,
+              ),
+            )
+            trafficRepo.insertBatch(heavyRow :: pollRows).unit
+          }
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          req    = Request
+            .get(URL.decode("/api/time/status").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids     = list.find(_.profileId == kidsId).get
+          ytRow    = kids.hostUsage.find(_.host.value == heavy).get
+          pollRows = kids.hostUsage.filter(_.host.value.startsWith("poll-"))
+        } yield
+        // Daily cap math unchanged: 12 bucket-deduped × 5 min = 60 mins.
+        assertTrue(kids.usedMins == 60) &&
+          // Bucket-presence still shows every host at the full 60 minutes.
+          assertTrue(ytRow.usedMins == 60) &&
+          // Proportional: youtube dominates, pollers are ~0.
+          assertTrue(ytRow.proportionalMins == 59) &&
+          assertTrue(pollRows.forall(_.usedMins == 60)) &&
+          assertTrue(pollRows.forall(_.proportionalMins == 0)) &&
+          // Top of the list sorts by proportional, so youtube is first.
+          assertTrue(kids.hostUsage.head.host.value == heavy)
+      },
       test("hostUsage breakdown sums across all profile devices, sorted desc (#262)") {
         for {
           _           <- cleanDb

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -340,5 +340,90 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
+    // #715: byte-share-weighted per-host attribution. Same input as hostMinutes,
+    // but each bucket's wall-clock duration is split across hosts by byte share
+    // instead of credited in full to each host.
+    suite("proportionalHostMinutes (#715)")(
+      test("80/20 byte split in a single bucket yields a 4:1 minute attribution") {
+        val rows = List(
+          row(mac1, 0, "youtube.com", secs = 300, bytes = 800L),
+          row(mac1, 0, "icloud.com", secs = 300, bytes = 200L),
+        )
+        // bucket = 300s. youtube 800/1000 → 240s = 4m. icloud 200/1000 → 60s = 1m.
+        assertTrue(
+          Presence.proportionalHostMinutes(rows) == Map(
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 4,
+            HostId.Fqdn(Hostname.unsafe("icloud.com"))  -> 1,
+          ),
+        )
+      },
+      test("ten polling hosts + one heavy host: heavy host dominates proportional minutes") {
+        // Reproduces the prod shape in #715: device shows ~60 used mins, but a
+        // bucket-presence breakdown lists 10 hosts at 50–80m each because each
+        // one was touched in every bucket. With byte-share weighting, ~all of
+        // the attributed minutes go to the host that actually moved bytes.
+        val heavy   = "youtube.com"
+        val pollers = (0 until 10).map(i => s"poll-$i.example.com").toList
+        val rows    = (0 until 12).toList.flatMap { b =>
+          val heavyRow = row(mac1, b, heavy, secs = 300, bytes = 5_000_000L)
+          val pollRows = pollers.map(p => row(mac1, b, p, secs = 300, bytes = 200L))
+          heavyRow :: pollRows
+        }
+        val out     = Presence.proportionalHostMinutes(rows)
+        // 12 buckets × 5min = 60 wall-clock minutes for the mac. youtube gets
+        // 5_000_000 / (5_000_000 + 10 * 200) ≈ 99.96% of each bucket → ~59 mins.
+        // Each poller gets ~1/(2 500) of each bucket → 0m after the floor /60.
+        assertTrue(out(HostId.Fqdn(Hostname.unsafe(heavy))) == 59) &&
+        // Bucket-presence still shows every poller at 12 × 5 = 60 minutes.
+        assertTrue(
+          pollers.forall(p => Presence.hostMinutes(rows)(HostId.Fqdn(Hostname.unsafe(p))) == 60),
+        ) &&
+        // …but proportionally every poller is below the per-minute floor.
+        assertTrue(pollers.forall(p => out.getOrElse(HostId.Fqdn(Hostname.unsafe(p)), 0) == 0))
+      },
+      test("bucket with zero total bytes contributes nothing") {
+        // Defensive: in the wild the agent only emits rows with bytes > 0, but
+        // we guard the divide-by-zero so test fixtures with bytes=0 don't blow
+        // up. Such a bucket simply doesn't attribute to any host proportionally
+        // — bucket-presence (hostMinutes) is the right view for that case.
+        val rows = List(
+          row(mac1, 0, "a.com", secs = 300, bytes = 0L),
+          row(mac1, 0, "b.com", secs = 300, bytes = 0L),
+        )
+        assertTrue(Presence.proportionalHostMinutes(rows).isEmpty) &&
+        assertTrue(Presence.hostMinutes(rows).valuesIterator.toSet == Set(5))
+      },
+      test("multiple rows for the same host in one bucket collapse before splitting") {
+        // Two ipv4-typed rows resolving to the same fqdn via the read-side
+        // LATERAL join. Bytes for the host must sum before computing share —
+        // otherwise the host would lose weight to itself.
+        val rows = List(
+          row(mac1, 0, "youtube.com", secs = 300, bytes = 400L),
+          row(mac1, 0, "youtube.com", secs = 300, bytes = 400L), // same host
+          row(mac1, 0, "icloud.com", secs = 300, bytes = 200L),
+        )
+        // youtube collapses to 800. share = 800/1000 → 240s = 4m.
+        assertTrue(
+          Presence.proportionalHostMinutes(rows) == Map(
+            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 4,
+            HostId.Fqdn(Hostname.unsafe("icloud.com"))  -> 1,
+          ),
+        )
+      },
+      test("sums proportional seconds across buckets and macs") {
+        val rows = List(
+          // bucket 0: mac1 splits youtube 50/50 with poll → 2.5m each
+          row(mac1, 0, "youtube.com", secs = 300, bytes = 500L),
+          row(mac1, 0, "poll.com", secs = 300, bytes = 500L),
+          // bucket 1: mac1 alone on youtube → 5m
+          row(mac1, 1, "youtube.com", secs = 300, bytes = 1_000L),
+          // bucket 2: mac2 alone on poll → 5m
+          row(mac2, 2, "poll.com", secs = 300, bytes = 1_000L),
+        )
+        val out  = Presence.proportionalHostMinutes(rows)
+        assertTrue(out(HostId.Fqdn(Hostname.unsafe("youtube.com"))) == 7) && // 2.5 + 5 = 7.5 → 7
+        assertTrue(out(HostId.Fqdn(Hostname.unsafe("poll.com"))) == 7)       // 2.5 + 5 = 7.5 → 7
+      },
+    ),
   )
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -337,7 +337,19 @@ case class DeviceUsageSummary(
     usedMins: Int,
 ) derives JsonCodec
 
-case class HostUsage(host: HostId, usedMins: Int) derives JsonCodec
+/**
+ * #715: per-host time-on-site has two parallel numbers.
+ *   - `usedMins` is bucket-presence: every host the device touched in a 5-min bucket is credited
+ *     with that bucket's full duration. Sums across hosts can wildly exceed wall-clock time when a
+ *     device polls many endpoints; useful only for "did this host show up at all today".
+ *   - `proportionalMins` is the same bucket duration weighted by this host's byte share of the
+ *     bucket (bytes_in + bytes_out). Summing across hosts within a mac ≈ the device's wall-clock
+ *     minutes, so this is the right number to drive per-app screen-time UI.
+ *
+ * The daily-cap math (which already collapses each bucket once per device) reads neither field —
+ * adding `proportionalMins` is additive and does not affect cap arithmetic.
+ */
+case class HostUsage(host: HostId, usedMins: Int, proportionalMins: Int) derives JsonCodec
 
 /**
  * #777 lightweight per-profile rollup for the collapsed accordion on the screen-time page. Just the

--- a/web/src/pages/DeviceTimelinePage.test.tsx
+++ b/web/src/pages/DeviceTimelinePage.test.tsx
@@ -148,8 +148,8 @@ describe('DeviceTimelinePage', () => {
           { bucketStart: '2026-05-20T08:00:00Z', usedMins: 15 },
         ],
         hostUsage: [
-          { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 40 },
-          { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 25 },
+          { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 40, proportionalMins: 38 },
+          { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 25, proportionalMins: 23 },
         ],
       }
     }
@@ -172,8 +172,10 @@ describe('DeviceTimelinePage', () => {
       expect(await screen.findByTestId('device-timeline-week-chart')).toBeInTheDocument()
       // #791: 65m -> "1:05"
       expect(screen.getByText(/1:05 total/)).toBeInTheDocument()
-      // Top-host list re-renders with weekly per-host totals.
-      expect(screen.getByTestId('device-timeline-host-youtube.com')).toHaveTextContent('40m')
+      // Top-host list re-renders with weekly per-host totals. The proportional number
+      // is what we show first; bucket-presence comes after in parens (#715).
+      expect(screen.getByTestId('device-timeline-host-youtube.com')).toHaveTextContent('38m')
+      expect(screen.getByTestId('device-timeline-host-youtube.com')).toHaveTextContent('(40m)')
     })
 
     it('week mode renders empty state when the trailing window has no usage', async () => {

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -111,9 +111,12 @@ export function DeviceTimelinePage() {
   const dayEmpty = window === 'today' && dayTotal === 0
   const weekEmpty = window === 'week' && (weekData?.totalMins ?? 0) === 0
   const titleName = dayData?.deviceName ?? weekData?.deviceName ?? mac
+  // `mins` is the wall-clock-share number (#715 proportional). For the weekly
+  // breakdown we additionally surface bucket-presence in parens so the operator
+  // can spot heartbeat-style hosts that show up everywhere but with tiny bytes.
   const hosts = window === 'today'
-    ? (dayData?.topHosts.filter(h => h.dayMins > 0) ?? []).map(h => ({ host: h.host, mins: h.dayMins }))
-    : (weekData?.hostUsage ?? []).map(h => ({ host: h.host, mins: h.usedMins }))
+    ? (dayData?.topHosts.filter(h => h.dayMins > 0) ?? []).map(h => ({ host: h.host, mins: h.dayMins, presenceMins: null as number | null }))
+    : (weekData?.hostUsage ?? []).map(h => ({ host: h.host, mins: h.proportionalMins, presenceMins: h.usedMins }))
 
   return (
     <div className="space-y-6">
@@ -278,17 +281,25 @@ export function DeviceTimelinePage() {
                       )}
                     </span>
                   </span>
-                  <span className="text-gray-500 font-mono shrink-0 ml-2">{formatMins(h.mins)}</span>
+                  <span
+                    className="text-gray-500 font-mono shrink-0 ml-2"
+                    title={h.presenceMins !== null
+                      ? `presence ${formatMins(h.presenceMins)} (every bucket this host appeared in)`
+                      : undefined}
+                  >
+                    {formatMins(h.mins)}
+                    {h.presenceMins !== null && (
+                      <span className="text-gray-600"> ({formatMins(h.presenceMins)})</span>
+                    )}
+                  </span>
                 </li>
               )
             })}
           </ul>
-          {window === 'today' && (
-            <p className="text-[11px] text-gray-600 mt-3">
-              Per-host minutes are proportional within each 5-minute window. The stack sums to
-              the device's wall-clock minutes for that hour.
-            </p>
-          )}
+          <p className="text-[11px] text-gray-600 mt-3">
+            Per-host minutes are byte-share-weighted wall-clock attention within each 5-minute
+            window (#715){window === 'week' ? '; presence in parens is how many buckets the host appeared in at all' : ', so the stack sums to the device\'s wall-clock minutes for that hour'}.
+          </p>
         </div>
       )}
     </div>

--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -45,9 +45,9 @@ const limited: ProfileTimeStatus = {
   ],
   devices: [{ deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", usedMins: 90 }],
   hostUsage: [
-    { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 35 },
-    { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 10 },
-    { host: { type: 'ipv4', value: '192.0.2.1' }, usedMins: 5 },
+    { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 35, proportionalMins: 30 },
+    { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 10, proportionalMins: 8 },
+    { host: { type: 'ipv4', value: '192.0.2.1' }, usedMins: 5, proportionalMins: 2 },
   ],
 }
 
@@ -103,8 +103,8 @@ const weekKids: ProfileTimeStatusWeek = {
   ],
   devices: [{ deviceMac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad", usedMins: 210 }],
   hostUsage: [
-    { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 90 },
-    { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 30 },
+    { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 90, proportionalMins: 80 },
+    { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 30, proportionalMins: 25 },
   ],
 }
 
@@ -228,7 +228,9 @@ describe('TimePage — expanded card content', () => {
     expect(screen.getAllByText('30m left').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('YouTube')).toBeInTheDocument()
     expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
-    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('35m')
+    // #715: row shows proportional (wall-clock attention) first, presence in parens.
+    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('30m')
+    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('(35m)')
   })
 
   it('over-limit and no-limit details render when expanded', async () => {
@@ -346,7 +348,9 @@ describe('TimePage — week toggle (#723)', () => {
     expect(await screen.findByTestId('time-week-card-1')).toBeInTheDocument()
     expect(screen.getByText('3:30 used this week')).toBeInTheDocument()
     expect(screen.getByTestId('time-week-chart-1')).toBeInTheDocument()
-    expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('1:30')
+    // Weekly host row shows proportional (1:20 = 80m) first, then presence in parens (1:30 = 90m).
+    expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('1:20')
+    expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('(1:30)')
     expect(screen.getByTestId('time-week-device-link-aa:bb:cc:dd:ee:01'))
       .toHaveAttribute('href', '/devices/aa%3Abb%3Acc%3Add%3Aee%3A01/timeline')
   })

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -447,7 +447,12 @@ function ProfileTimeCard({
 
       {status.hostUsage.length > 0 && (
         <div className="space-y-1">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Top Sites</p>
+          <p
+            className="text-xs font-semibold text-gray-500 uppercase tracking-wider"
+            title="Per-host minutes are a byte-share of each 5-min window (wall-clock attention, #715). The presence number — how many 5-min windows the host appeared in at all — shows in parentheses."
+          >
+            Top Sites
+          </p>
           {status.hostUsage.map(hu => (
             <div
               key={hu.host.value}
@@ -455,7 +460,13 @@ function ProfileTimeCard({
               className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
             >
               <span className="text-gray-300 font-mono truncate" title={hu.host.value}>{hu.host.value}</span>
-              <span className="text-gray-500 font-mono shrink-0 ml-2">{formatMins(hu.usedMins)}</span>
+              <span
+                className="text-gray-500 font-mono shrink-0 ml-2"
+                title={`presence ${formatMins(hu.usedMins)} (every bucket this host appeared in)`}
+              >
+                {formatMins(hu.proportionalMins)}
+                <span className="text-gray-600"> ({formatMins(hu.usedMins)})</span>
+              </span>
             </div>
           ))}
         </div>
@@ -684,7 +695,12 @@ function ProfileTimeWeekCard({ status }: { status: ProfileTimeStatusWeek }) {
 
       {status.hostUsage.length > 0 && (
         <div className="space-y-1">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Top Sites</p>
+          <p
+            className="text-xs font-semibold text-gray-500 uppercase tracking-wider"
+            title="Per-host minutes are byte-share of each 5-min window (wall-clock attention, #715). Presence in parens is how many windows the host appeared in at all."
+          >
+            Top Sites
+          </p>
           {status.hostUsage.map(hu => (
             <div
               key={hu.host.value}
@@ -692,7 +708,13 @@ function ProfileTimeWeekCard({ status }: { status: ProfileTimeStatusWeek }) {
               className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
             >
               <span className="text-gray-300 font-mono truncate" title={hu.host.value}>{hu.host.value}</span>
-              <span className="text-gray-500 font-mono shrink-0 ml-2">{formatMins(hu.usedMins)}</span>
+              <span
+                className="text-gray-500 font-mono shrink-0 ml-2"
+                title={`presence ${formatMins(hu.usedMins)} (every bucket this host appeared in)`}
+              >
+                {formatMins(hu.proportionalMins)}
+                <span className="text-gray-600"> ({formatMins(hu.usedMins)})</span>
+              </span>
             </div>
           ))}
         </div>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -209,9 +209,20 @@ export interface DeviceUsageSummary {
   usedMins: number
 }
 
+// #715: per-host time-on-site has two parallel numbers.
+//   - `usedMins` is bucket-presence: every host the device touched in a 5-min
+//     bucket is credited with that bucket's full duration. Sums across hosts
+//     can wildly exceed wall-clock time when a device polls many endpoints.
+//   - `proportionalMins` is byte-share-weighted within each 5-min bucket — a
+//     fair "wall-clock attention" number. Summing across hosts within a mac ≈
+//     the device's wall-clock minutes. UI defaults to displaying this.
+//
+// The daily-cap math collapses each bucket once per device and reads neither
+// field; both are additive surface area.
 export interface HostUsage {
   host: HostId
   usedMins: number
+  proportionalMins: number
 }
 
 // #777 — collapsed-accordion payload: just the headline numbers, no per-device /


### PR DESCRIPTION
## Summary

- Per-host time on `/api/time/status` was bucket-presence — every host the device touched in a 5-min bucket got credited with the bucket's full duration. Prod scenario from [#715](https://github.com/wifihaven/wifihaven/issues/715): a device sitting at 60 used minutes shows 10 polling hosts (icloud, github, dropbox, …) at 50–80 minutes each.
- Adds a parallel `proportionalMins` per host that splits each bucket's wall-clock duration by the host's share of bucket bytes (`bytes_in + bytes_out`). Sums across hosts within a mac ≈ the device's wall-clock minutes — the right number to drive per-app screen-time UI.
- `usedMins` (bucket-presence) is preserved; daily-cap math collapses each bucket once per device and reads neither field, so cap arithmetic is unchanged.

## Before / after (same prod-shaped fixture — see `TimeApiSpec`'s `#715` test)

```
device daily total: 60 minutes wall-clock
12 buckets × 5 min; in each bucket: youtube.com moves ~5MB; 10 pollers move ~200 bytes each
```

|                | usedMins (bucket-presence) | proportionalMins (#715) |
| -------------- | -------------------------: | ----------------------: |
| youtube.com    |                         60 |                      59 |
| poll-0..poll-9 |                         60 |                       0 |

Same data, dramatically different verdict — per-app limits can finally be written against the proportional number.

## What changed

- `V26__time_usage_proportional_seconds.sql` adds the column. `applyDelta` (`RouterIngestRoutes`) computes per-batch byte-share weights per `(mac, host)` and writes them.
- `Presence.proportionalHostMinutes` is the read-side mirror — `/api/time/status`, weekly variants, and per-device weekly all surface both numbers on `HostUsage`. Top-10 sort key is `(-proportionalMins, -usedMins, host.value)` so the most-attention-getting host is first.
- `UsageSeries` (hourly stack chart) switches from even-share to byte-share allocation with an even-share fallback when a bucket recorded zero bytes.
- SPA `TimePage` and `DeviceTimelinePage` host lists default to proportional, with bucket-presence in parens.

Path 1 of [#715](https://github.com/wifihaven/wifihaven/issues/715) (router-side foreground-host heuristic in `usage.lua`) is deferred behind Gate 2 / router freeze ([#654](https://github.com/wifihaven/wifihaven/issues/654)) and tracked separately in [#842](https://github.com/wifihaven/wifihaven/issues/842).

## Test plan

- [x] `mill api.test` — full suite green, including new `PresenceSpec` proportional cases, `RouterIngestSpec` byte-share assertions, and a `TimeApiSpec` test that reproduces the 10-poller prod shape and asserts the daily total is unchanged.
- [x] `mill shared.test` — green.
- [ ] Web vitest could not run in this sandbox (Node 20.13 vs required 20.19+); updated `TimePage.test.tsx` and `DeviceTimelinePage.test.tsx` mocks + assertions for the new field.
- [ ] Sanity-check `/api/time/status` against prod data after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)