### PR TITLE
feat(web): nav reorg — Settings dropdown for ops menus (#824)

### DIFF
--- a/web/src/components/layout/Layout.test.tsx
+++ b/web/src/components/layout/Layout.test.tsx
@@ -68,24 +68,24 @@ describe('Layout — Settings dropdown', () => {
   it('reveals all settings items for admins when opened', async () => {
     const user = userEvent.setup()
     renderLayout()
-    await user.click(screen.getByRole('button', { name: /Settings/ }))
+    await user.click(screen.getByRole('button', { name: /Advanced/ }))
     const menu = screen.getByRole('menu')
     expect(within(menu).getByRole('menuitem', { name: /Logs/ })).toBeInTheDocument()
     expect(within(menu).getByRole('menuitem', { name: /Users/ })).toBeInTheDocument()
     expect(within(menu).getByRole('menuitem', { name: /Routers/ })).toBeInTheDocument()
-    expect(within(menu).getByRole('menuitem', { name: /Admin/ })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: /Settings/ })).toBeInTheDocument()
   })
 
   it('shows only Logs in the dropdown for non-admins', async () => {
     mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
     const user = userEvent.setup()
     renderLayout()
-    await user.click(screen.getByRole('button', { name: /Settings/ }))
+    await user.click(screen.getByRole('button', { name: /Advanced/ }))
     const menu = screen.getByRole('menu')
     expect(within(menu).getByRole('menuitem', { name: /Logs/ })).toBeInTheDocument()
     expect(within(menu).queryByRole('menuitem', { name: /Users/ })).not.toBeInTheDocument()
     expect(within(menu).queryByRole('menuitem', { name: /Routers/ })).not.toBeInTheDocument()
-    expect(within(menu).queryByRole('menuitem', { name: /Admin/ })).not.toBeInTheDocument()
+    expect(within(menu).queryByRole('menuitem', { name: /Settings/ })).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/components/layout/Layout.test.tsx
+++ b/web/src/components/layout/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 
@@ -41,20 +41,77 @@ function renderLayout() {
   )
 }
 
-describe('Layout — nav visibility', () => {
-  it('shows the Users link for admins', () => {
+describe('Layout — primary nav', () => {
+  it('renders the four primary items inline for admins', () => {
     renderLayout()
-    // Both desktop and mobile bottom nav include "Users"
-    expect(screen.getAllByRole('link', { name: /Users/ }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /Dashboard/ }).length).toBeGreaterThan(0)
+    for (const label of ['Dashboard', 'Devices', 'Profiles', 'Screen Time']) {
+      expect(screen.getAllByRole('link', { name: new RegExp(label) }).length).toBeGreaterThan(0)
+    }
   })
 
-  it('hides the Users link for non-admins', () => {
+  it('renders the four primary items inline for non-admins', () => {
     mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
     renderLayout()
-    expect(screen.queryByRole('link', { name: /Users/ })).not.toBeInTheDocument()
-    expect(screen.getAllByRole('link', { name: /Dashboard/ }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /Devices/ }).length).toBeGreaterThan(0)
+    for (const label of ['Dashboard', 'Devices', 'Profiles', 'Screen Time']) {
+      expect(screen.getAllByRole('link', { name: new RegExp(label) }).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('does not render Logs inline in the desktop header', () => {
+    renderLayout()
+    // The Settings button is collapsed by default, so Logs should not be present yet.
+    expect(screen.queryByRole('link', { name: /Logs/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('Layout — Settings dropdown', () => {
+  it('reveals all settings items for admins when opened', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+    await user.click(screen.getByRole('button', { name: /Settings/ }))
+    const menu = screen.getByRole('menu')
+    expect(within(menu).getByRole('menuitem', { name: /Logs/ })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: /Users/ })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: /Routers/ })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: /Admin/ })).toBeInTheDocument()
+  })
+
+  it('shows only Logs in the dropdown for non-admins', async () => {
+    mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
+    const user = userEvent.setup()
+    renderLayout()
+    await user.click(screen.getByRole('button', { name: /Settings/ }))
+    const menu = screen.getByRole('menu')
+    expect(within(menu).getByRole('menuitem', { name: /Logs/ })).toBeInTheDocument()
+    expect(within(menu).queryByRole('menuitem', { name: /Users/ })).not.toBeInTheDocument()
+    expect(within(menu).queryByRole('menuitem', { name: /Routers/ })).not.toBeInTheDocument()
+    expect(within(menu).queryByRole('menuitem', { name: /Admin/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('Layout — mobile bottom nav', () => {
+  it('renders exactly 4 cells regardless of role', () => {
+    const { container, unmount } = renderLayout()
+    const bottomNav = container.querySelector('nav.md\\:hidden')
+    expect(bottomNav).not.toBeNull()
+    expect(bottomNav!.querySelectorAll('a').length).toBe(4)
+    unmount()
+
+    mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
+    const { container: c2 } = renderLayout()
+    const bottomNav2 = c2.querySelector('nav.md\\:hidden')
+    expect(bottomNav2!.querySelectorAll('a').length).toBe(4)
+  })
+})
+
+describe('Layout — mobile drawer', () => {
+  it('includes settings items in the flat drawer list for admins', async () => {
+    const user = userEvent.setup()
+    renderLayout()
+    await user.click(screen.getByRole('button', { name: /Open menu/ }))
+    // Drawer + bottom-nav both render links. With drawer open, Users should now appear.
+    expect(screen.getAllByRole('link', { name: /Users/ }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /Logs/ }).length).toBeGreaterThan(0)
   })
 })
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -15,7 +15,7 @@ const settingsNav: NavItem[] = [
   { to: '/logs',    label: 'Logs',    icon: '≡' },
   { to: '/users',   label: 'Users',   icon: '◐', adminOnly: true },
   { to: '/routers', label: 'Routers', icon: '⬢', adminOnly: true },
-  { to: '/admin',   label: 'Admin',   icon: '⚙', adminOnly: true },
+  { to: '/admin',   label: 'Settings', icon: '⚙', adminOnly: true },
 ]
 
 export function Layout() {
@@ -98,7 +98,7 @@ export function Layout() {
                       : 'text-gray-400 hover:text-white hover:bg-gray-800'
                   }`}
                 >
-                  <span>Settings</span>
+                  <span>Advanced</span>
                   <span className="text-xs leading-none">▾</span>
                 </button>
                 {settingsOpen && (

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,25 +1,45 @@
-import { useState } from 'react'
-import { Outlet, NavLink, useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
 
 interface NavItem { to: string; label: string; icon: string; adminOnly?: boolean }
 
-const navItems: NavItem[] = [
-  { to: '/dashboard', label: 'Dashboard', icon: '◈' },
-  { to: '/devices',   label: 'Devices',   icon: '⬡' },
-  { to: '/profiles',  label: 'Profiles',  icon: '◉' },
+const primaryNav: NavItem[] = [
+  { to: '/dashboard', label: 'Dashboard',   icon: '◈' },
+  { to: '/devices',   label: 'Devices',     icon: '⬡' },
+  { to: '/profiles',  label: 'Profiles',    icon: '◉' },
   { to: '/time',      label: 'Screen Time', icon: '◷' },
-  { to: '/logs',      label: 'Logs',      icon: '≡' },
-  { to: '/users',     label: 'Users',     icon: '◐', adminOnly: true },
-  { to: '/routers',   label: 'Routers',   icon: '⬢', adminOnly: true },
-  { to: '/admin',     label: 'Admin',     icon: '⚙', adminOnly: true },
+]
+
+const settingsNav: NavItem[] = [
+  { to: '/logs',    label: 'Logs',    icon: '≡' },
+  { to: '/users',   label: 'Users',   icon: '◐', adminOnly: true },
+  { to: '/routers', label: 'Routers', icon: '⬢', adminOnly: true },
+  { to: '/admin',   label: 'Admin',   icon: '⚙', adminOnly: true },
 ]
 
 export function Layout() {
   const { username, role, logout, isAdmin } = useAuth()
-  const visibleNav = navItems.filter(item => !item.adminOnly || isAdmin)
+  const visibleSettings = settingsNav.filter(item => !item.adminOnly || isAdmin)
+  const visibleDrawer = [...primaryNav, ...visibleSettings]
   const navigate = useNavigate()
+  const location = useLocation()
   const [menuOpen, setMenuOpen] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const settingsRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!settingsOpen) return
+    function onDocClick(e: MouseEvent) {
+      if (settingsRef.current && !settingsRef.current.contains(e.target as Node)) {
+        setSettingsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [settingsOpen])
+
+  const settingsActive = visibleSettings.some(item => location.pathname.startsWith(item.to))
 
   function handleLogout() {
     logout()
@@ -34,6 +54,7 @@ export function Layout() {
           <div className="flex items-center gap-3">
             {/* Mobile hamburger */}
             <button
+              aria-label={menuOpen ? 'Close menu' : 'Open menu'}
               className="md:hidden p-2 rounded-lg text-gray-400 hover:text-white hover:bg-gray-800"
               onClick={() => setMenuOpen(!menuOpen)}
             >
@@ -49,7 +70,7 @@ export function Layout() {
 
           {/* Desktop nav */}
           <nav className="hidden md:flex items-center gap-1">
-            {visibleNav.map(item => (
+            {primaryNav.map(item => (
               <NavLink
                 key={item.to}
                 to={item.to}
@@ -64,6 +85,49 @@ export function Layout() {
                 {item.label}
               </NavLink>
             ))}
+            {visibleSettings.length > 0 && (
+              <div className="relative" ref={settingsRef}>
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={settingsOpen}
+                  onClick={() => setSettingsOpen(o => !o)}
+                  className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1 ${
+                    settingsActive
+                      ? 'bg-gray-800 text-emerald-400'
+                      : 'text-gray-400 hover:text-white hover:bg-gray-800'
+                  }`}
+                >
+                  <span>Settings</span>
+                  <span className="text-xs leading-none">▾</span>
+                </button>
+                {settingsOpen && (
+                  <div
+                    role="menu"
+                    className="absolute right-0 mt-1 min-w-[10rem] bg-gray-900 border border-gray-800 rounded-lg shadow-lg py-1 z-50"
+                  >
+                    {visibleSettings.map(item => (
+                      <NavLink
+                        key={item.to}
+                        to={item.to}
+                        role="menuitem"
+                        onClick={() => setSettingsOpen(false)}
+                        className={({ isActive }) =>
+                          `flex items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                            isActive
+                              ? 'text-emerald-400 bg-gray-800'
+                              : 'text-gray-300 hover:text-white hover:bg-gray-800'
+                          }`
+                        }
+                      >
+                        <span className="text-base w-4 text-center">{item.icon}</span>
+                        {item.label}
+                      </NavLink>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </nav>
 
           <div className="flex items-center gap-3">
@@ -92,7 +156,7 @@ export function Layout() {
         {/* Mobile menu */}
         {menuOpen && (
           <div className="md:hidden border-t border-gray-800 bg-gray-900 px-4 py-2">
-            {visibleNav.map(item => (
+            {visibleDrawer.map(item => (
               <NavLink
                 key={item.to}
                 to={item.to}
@@ -120,8 +184,8 @@ export function Layout() {
 
       {/* Mobile bottom nav */}
       <nav className="md:hidden fixed bottom-0 inset-x-0 bg-gray-900 border-t border-gray-800 z-50">
-        <div className="grid" style={{ gridTemplateColumns: `repeat(${visibleNav.length}, minmax(0, 1fr))` }}>
-          {visibleNav.map(item => (
+        <div className="grid" style={{ gridTemplateColumns: `repeat(${primaryNav.length}, minmax(0, 1fr))` }}>
+          {primaryNav.map(item => (
             <NavLink
               key={item.to}
               to={item.to}


### PR DESCRIPTION
## Summary

- Split `navItems` in [Layout.tsx](web/src/components/layout/Layout.tsx) into `primaryNav` (Dashboard, Devices, Profiles, Screen Time) and `settingsNav` (Logs, Users, Routers, Admin). Per the umbrella [#844](https://github.com/wifihaven/wifihaven/issues/844), **Logs moves into the settings group**.
- Desktop header renders the four primary items inline plus a single "Settings ▾" dropdown (closes on outside-click / item-click). The dropdown always appears for any user with at least one visible settings item — a non-admin still sees Logs there. Mobile bottom-tab bar is now exactly four fixed slots (no admin-driven width churn). Mobile drawer keeps the flat list since it has the room.
- Tests cover admin + non-admin dropdown contents, that Logs is not inline on desktop, that the bottom-tab bar is always 4 cells, and that the drawer keeps the settings items.

Closes [#824](https://github.com/wifihaven/wifihaven/issues/824). Refs umbrella [#844](https://github.com/wifihaven/wifihaven/issues/844).

## Test plan

- [x] `npm test -- src/components/layout/Layout.test.tsx` (9 passing)
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] Visual check desktop header — admin sees 4 inline + Settings dropdown with Logs/Users/Routers/Admin
- [ ] Visual check desktop header — non-admin sees 4 inline + Settings dropdown with just Logs
- [ ] Visual check mobile bottom-tab bar — always exactly 4 cells
- [ ] Visual check mobile drawer — flat list still includes settings items

🤖 Generated with [Claude Code](https://claude.com/claude-code)