### PR TITLE
feat(web+api): Connection Events page with raw + aggregated views (#847)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -305,6 +305,7 @@ trait ConnectionEventRepo {
   def listForMac(mac: MacAddress, limit: Int): Task[List[ConnectionEvent]]
   def listForRouter(routerId: RouterId, limit: Int): Task[List[ConnectionEvent]]
   def query(f: LogFilter): Task[List[QueryLog]]
+  def querySeries(f: LogFilter, bucketSeconds: Int): Task[List[ConnectionEventAggRow]]
   def stats: Task[DashboardStats]
   def topBlocked(hours: Int, limit: Int): Task[List[DomainCount]]
 
@@ -1268,6 +1269,42 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
         ),
       ]
       .map(QueryLog.apply)
+      .to[List]
+      .transact(xa)
+  }
+
+  // #847: domain-grouped aggregation over connection_events. Buckets are
+  // computed in UTC via date_bin — UI re-renders boundaries in household-local
+  // tz for display. No rollup table exists yet (#809 in flight); for now even
+  // wide buckets compute on-the-fly from connection_events.
+  def querySeries(f: LogFilter, bucketSeconds: Int) = {
+    val bucketIv = fr"make_interval(secs => $bucketSeconds)"
+    val grpExpr  = fr"COALESCE(ce.resolved_host_value, ce.host_value)"
+    val base     =
+      fr"""SELECT $grpExpr AS grp,
+                  (date_bin($bucketIv, ce.ts, TIMESTAMP '2000-01-01 00:00:00'))::TEXT AS window_start,
+                  COUNT(*) FILTER (WHERE ce.allowed)::INT      AS count_succeeded,
+                  COUNT(*) FILTER (WHERE NOT ce.allowed)::INT  AS count_blocked,
+                  MAX(ce.ts)::TEXT                              AS last_seen,
+                  mode() WITHIN GROUP (ORDER BY COALESCE(d.name, ce.mac::TEXT)) AS top_device
+           FROM connection_events ce
+           LEFT JOIN devices d  ON d.mac = ce.mac
+           LEFT JOIN profiles p ON p.id  = d.profile_id
+           LEFT JOIN routers r  ON r.id  = ce.router_id
+           WHERE 1=1"""
+    val since    = fr"AND ce.ts > NOW() - make_interval(hours => ${f.hours})"
+    val byMac    = f.mac.fold(fr"")(m => fr"AND ce.mac = $m")
+    val byDev    = f.deviceId.fold(fr"")(id => fr"AND d.id = $id")
+    val byPid    = f.profileId.fold(fr"")(pid => fr"AND d.profile_id = $pid")
+    val byBl     = f.blocked.fold(fr"")(b => fr"AND ce.allowed = ${!b}")
+    val byDom    = f.domain.fold(fr"")(d =>
+      fr"AND COALESCE(ce.resolved_host_value, ce.host_value) ILIKE ${s"%$d%"}",
+    )
+    val byLoc    = f.location.fold(fr"")(l => fr"AND r.name = $l")
+    (base ++ since ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++
+      fr"GROUP BY grp, window_start ORDER BY (COUNT(*)) DESC LIMIT ${f.limit} OFFSET ${f.offset}")
+      .query[(String, String, Int, Int, String, Option[String])]
+      .map(ConnectionEventAggRow.apply)
       .to[List]
       .transact(xa)
   }

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1028,7 +1028,7 @@ object LogRoutes {
       userProfileRepo: UserProfileRepo,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "logs"  ->
+      Method.GET / "api" / "logs"                         ->
         handler { (req: Request) =>
           for {
             claims <- requireAuth(req, auth)
@@ -1047,7 +1047,65 @@ object LogRoutes {
             visible <- filterLogs(claims, logs, userProfileRepo)
           } yield Response.json(visible.toJson)
         },
-      Method.GET / "api" / "stats" ->
+      // #847: aggregated connection-event series. bucket+groupBy required; only
+      // domain grouping is implemented (apex needs PSL #849, app needs apps
+      // track #761-#769). Filters mirror /api/logs.
+      Method.GET / "api" / "connection-events" / "series" ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAuth(req, auth)
+            // Aggregated rows don't carry per-row profile_id, so we can't
+            // post-filter the way /api/logs does. Restrict to admin/adult;
+            // children can still use /api/logs raw view with a profileId
+            // filter that goes through filterLogs.
+            _      <- ZIO
+              .fail(Response.forbidden("aggregated view requires admin or adult role"))
+              .when(claims.role != "admin" && claims.role != "adult")
+            bktStr <- ZIO
+              .fromOption(req.url.queryParam("bucket"))
+              .orElseFail(Response.badRequest("bucket query parameter required"))
+            bucket <- ZIO
+              .fromOption(ConnectionEventBucket.fromWire(bktStr))
+              .orElseFail(Response.badRequest(s"unknown bucket: $bktStr"))
+            _      <- ZIO
+              .fail(Response.badRequest("bucket=off not supported on /series — use /api/logs"))
+              .when(bucket == ConnectionEventBucket.Off)
+            grpStr <- ZIO
+              .fromOption(req.url.queryParam("groupBy"))
+              .orElseFail(Response.badRequest("groupBy query parameter required"))
+            grp    <- ZIO
+              .fromOption(ConnectionEventGroupBy.fromWire(grpStr))
+              .orElseFail(Response.badRequest(s"unknown groupBy: $grpStr"))
+            _      <- grp match {
+              case ConnectionEventGroupBy.Domain => ZIO.unit
+              case ConnectionEventGroupBy.Apex   =>
+                ZIO.fail(
+                  Response.badRequest("groupBy=apex not implemented yet — see #849 (needs PSL)"),
+                )
+              case ConnectionEventGroupBy.App    =>
+                ZIO.fail(
+                  Response.badRequest(
+                    "groupBy=app not implemented yet — apps track in flight (#761-#769)",
+                  ),
+                )
+            }
+            filter = LogFilter(
+              mac = req.url.queryParam("mac"),
+              deviceId = req.url.queryParam("deviceId").flatMap(_.toLongOption).map(DeviceId(_)),
+              profileId = req.url.queryParam("profileId").flatMap(_.toLongOption).map(ProfileId(_)),
+              blocked = req.url.queryParam("blocked").map(_ == "true"),
+              domain = req.url.queryParam("domain"),
+              location = req.url.queryParam("location"),
+              hours = req.url.queryParam("hours").flatMap(_.toIntOption).getOrElse(24),
+              limit = req.url.queryParam("limit").flatMap(_.toIntOption).getOrElse(500),
+              offset = req.url.queryParam("offset").flatMap(_.toIntOption).getOrElse(0),
+            )
+            rows   <- connRepo
+              .querySeries(filter, bucket.seconds)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.json(rows.toJson)
+        },
+      Method.GET / "api" / "stats"                        ->
         handler { (req: Request) =>
           requireAdmin(req, auth) *>
             connRepo.stats

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -116,6 +116,7 @@ object DbFailureSpec extends ZIOSpecDefault {
     def listForMac(mac: MacAddress, l: Int)                                             = throwing
     def listForRouter(r: RouterId, l: Int)                                              = throwing
     def query(f: LogFilter)                                                             = throwing
+    def querySeries(f: LogFilter, bucketSeconds: Int)                                   = throwing
     def stats                                                                           = throwing
     def topBlocked(h: Int, l: Int)                                                      = throwing
     def lastSeenByMacSince(since: Instant)                                              = throwing

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -465,5 +465,192 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
       } yield assertTrue(logs.length == 1) &&
         assertTrue(logs.head.host.value == "kids-site.com")
     },
+    test("GET /api/connection-events/series buckets domain counts (1h, groupBy=domain)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              false,
+              "blocked",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:02")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("facebook.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=1h&groupBy=domain", token)
+        body <- resp.body.asString
+        rows <- ZIO.fromEither(body.fromJson[List[ConnectionEventAggRow]])
+        yt = rows.find(_.group == "youtube.com").get
+        fb = rows.find(_.group == "facebook.com").get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(yt.countSucceeded == 2) &&
+        assertTrue(yt.countBlocked == 1) &&
+        assertTrue(fb.countSucceeded == 1) &&
+        assertTrue(fb.countBlocked == 0) &&
+        // youtube has 3 events vs facebook 1 — total-count desc ordering
+        assertTrue(rows.head.group == "youtube.com")
+    },
+    test("GET /api/connection-events/series passes through blocked filter") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.Fqdn(Hostname.unsafe("ok.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.Fqdn(Hostname.unsafe("bad.com")),
+              None,
+              false,
+              "blocked",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&blocked=true",
+          token,
+        )
+        body <- resp.body.asString
+        rows <- ZIO.fromEither(body.fromJson[List[ConnectionEventAggRow]])
+      } yield assertTrue(rows.length == 1) &&
+        assertTrue(rows.head.group == "bad.com") &&
+        assertTrue(rows.head.countBlocked == 1)
+    },
+    test("GET /api/connection-events/series rejects groupBy=apex with 400 (#849)") {
+      for {
+        _        <- cleanDb
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=1h&groupBy=apex", token)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("GET /api/connection-events/series rejects groupBy=app with 400") {
+      for {
+        _        <- cleanDb
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=1h&groupBy=app", token)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("GET /api/connection-events/series rejects bucket=off with 400") {
+      for {
+        _        <- cleanDb
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=off&groupBy=domain", token)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("GET /api/connection-events/series rejects unknown bucket with 400") {
+      for {
+        _        <- cleanDb
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=5m&groupBy=domain", token)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("GET /api/connection-events/series buckets across multiple windows (10m)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        now = Instant.now()
+        // Two events 25 min apart → land in different 10-minute buckets
+        _ <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.Fqdn(Hostname.unsafe("a.com")),
+              None,
+              true,
+              "allowed",
+              now.minusSeconds(60),
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.Fqdn(Hostname.unsafe("a.com")),
+              None,
+              true,
+              "allowed",
+              now.minusSeconds(60 * 25),
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=10m&groupBy=domain", token)
+        body <- resp.body.asString
+        rows <- ZIO.fromEither(body.fromJson[List[ConnectionEventAggRow]])
+      } yield assertTrue(rows.length == 2) &&
+        assertTrue(rows.forall(_.group == "a.com"))
+    },
   ) @@ TestAspect.sequential
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -310,6 +310,44 @@ case class DomainCount(host: HostId, count: Int) derives JsonCodec
 case class DeviceStats(mac: MacAddress, deviceName: String, total: Int, blocked: Int)
     derives JsonCodec
 
+// ── Connection-events aggregation (#847) ───────────────────────────────────
+// Bucket widths supported by /api/connection-events/series. "off" = caller
+// wants raw rows from /api/logs (the series endpoint rejects it as 400).
+enum ConnectionEventBucket(val wire: String, val seconds: Int) {
+  case Off extends ConnectionEventBucket("off", 0)
+  case M1  extends ConnectionEventBucket("1m", 60)
+  case M10 extends ConnectionEventBucket("10m", 600)
+  case H1  extends ConnectionEventBucket("1h", 3600)
+  case H12 extends ConnectionEventBucket("12h", 43200)
+  case D1  extends ConnectionEventBucket("1d", 86400)
+  case W1  extends ConnectionEventBucket("1w", 604800)
+}
+
+object ConnectionEventBucket {
+  def fromWire(s: String): Option[ConnectionEventBucket] =
+    ConnectionEventBucket.values.find(_.wire == s)
+}
+
+enum ConnectionEventGroupBy(val wire: String) {
+  case Domain extends ConnectionEventGroupBy("domain")
+  case Apex   extends ConnectionEventGroupBy("apex")
+  case App    extends ConnectionEventGroupBy("app")
+}
+
+object ConnectionEventGroupBy {
+  def fromWire(s: String): Option[ConnectionEventGroupBy] =
+    ConnectionEventGroupBy.values.find(_.wire == s)
+}
+
+case class ConnectionEventAggRow(
+    group: String,
+    windowStart: String,
+    countSucceeded: Int,
+    countBlocked: Int,
+    lastSeen: String,
+    topDevice: Option[String],
+) derives JsonCodec
+
 case class SiteUsage(
     label: String,
     domainPattern: String,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,7 +1,7 @@
 import type {
   CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardNow, DashboardStats, Device,
   DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek,
-  QueryLog, RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension,
+  ConnectionEventAggRow, QueryLog, RouterSummary, SessionPage, SetUserProfilesRequest, TimeExtension,
   UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
 } from '@/types/api'
@@ -195,6 +195,35 @@ export const api = {
       if (params.limit)    qs.set('limit', String(params.limit))
       if (params.offset)   qs.set('offset', String(params.offset))
       return req<QueryLog[]>('GET', `/logs?${qs}`)
+    },
+    // #847: aggregated connection-events series. bucket+groupBy required;
+    // groupBy=apex/app return 400 until #849 (PSL) / #761-#769 (apps) land.
+    series: (params: {
+      bucket: '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
+      groupBy: 'domain' | 'apex' | 'app'
+      mac?: string
+      deviceId?: number
+      profileId?: number
+      blocked?: boolean
+      domain?: string
+      location?: string
+      hours?: number
+      limit?: number
+      offset?: number
+    }) => {
+      const qs = new URLSearchParams()
+      qs.set('bucket', params.bucket)
+      qs.set('groupBy', params.groupBy)
+      if (params.mac)      qs.set('mac', params.mac)
+      if (params.deviceId !== undefined)  qs.set('deviceId', String(params.deviceId))
+      if (params.profileId !== undefined) qs.set('profileId', String(params.profileId))
+      if (params.blocked !== undefined) qs.set('blocked', String(params.blocked))
+      if (params.domain)   qs.set('domain', params.domain)
+      if (params.location) qs.set('location', params.location)
+      if (params.hours)    qs.set('hours', String(params.hours))
+      if (params.limit)    qs.set('limit', String(params.limit))
+      if (params.offset)   qs.set('offset', String(params.offset))
+      return req<ConnectionEventAggRow[]>('GET', `/connection-events/series?${qs}`)
     },
     stats: () => req<DashboardStats>('GET', '/stats'),
   },

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -2,12 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import type { Device, ProfileDetail, QueryLog, Session, SessionPage } from '@/types/api'
+import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog, Session, SessionPage } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
   api: {
     sessions: { list:  vi.fn() },
-    logs:     { query: vi.fn() },
+    logs:     { query: vi.fn(), series: vi.fn() },
     devices:  { list:  vi.fn() },
     profiles: { list:  vi.fn() },
   },
@@ -76,6 +76,7 @@ beforeEach(() => {
   vi.resetAllMocks()
   ;(api.sessions.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(page)
   ;(api.logs.query    as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([log1])
+  ;(api.logs.series   as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.devices.list  as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(devices)
   ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(profileDetails)
 })
@@ -163,6 +164,79 @@ describe('LogsPage — Connection events tab', () => {
     await screen.findByText('example.com')
     const expected = new Date(log1.ts).toLocaleTimeString()
     expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+})
+
+describe('LogsPage — Connection events aggregation (#847)', () => {
+  const aggRow: ConnectionEventAggRow = {
+    group: 'youtube.com',
+    windowStart: '2026-05-22 14:00:00',
+    countSucceeded: 12,
+    countBlocked: 3,
+    lastSeen: '2026-05-22T14:30:00Z',
+    topDevice: "Kid's iPad",
+  }
+
+  it('Raw is the default; clicking a bucket switches to /series with same filters', async () => {
+    (api.logs.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aggRow])
+    const user = userEvent.setup()
+    renderAt('/logs?profileId=1')
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    await screen.findByText('example.com')
+    // No series call while bucket=off
+    expect(api.logs.series).not.toHaveBeenCalled()
+
+    await user.click(screen.getByTestId('ce-bucket-1h'))
+    await waitFor(() => {
+      expect(api.logs.series).toHaveBeenLastCalledWith(expect.objectContaining({
+        bucket: '1h',
+        groupBy: 'domain',
+        profileId: 1,
+      }))
+    })
+    // The aggregated row renders
+    expect(await screen.findByTestId('ce-agg-table')).toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('switching back to Raw reverts to /api/logs and stops calling /series', async () => {
+    const user = userEvent.setup()
+    renderAt()
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    await user.click(screen.getByTestId('ce-bucket-10m'))
+    await waitFor(() => expect(api.logs.series).toHaveBeenCalled())
+
+    const seriesCallsBefore = (api.logs.series as ReturnType<typeof vi.fn>).mock.calls.length
+    await user.click(screen.getByTestId('ce-bucket-off'))
+    await screen.findByTestId('ce-raw-table')
+    // No new /series calls after switching back
+    expect((api.logs.series as ReturnType<typeof vi.fn>).mock.calls.length).toBe(seriesCallsBefore)
+  })
+
+  it('Group-by selector is hidden in Raw mode and visible when bucketed', async () => {
+    const user = userEvent.setup()
+    renderAt()
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    expect(screen.queryByTestId('ce-groupby')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('ce-bucket-1d'))
+    expect(await screen.findByTestId('ce-groupby')).toBeInTheDocument()
+  })
+
+  it('apex and app group-by options are disabled (gated)', async () => {
+    const user = userEvent.setup()
+    renderAt()
+    await screen.findByText('youtube.com')
+    await user.click(screen.getByTestId('logs-tab-raw'))
+    await user.click(screen.getByTestId('ce-bucket-1h'))
+    const sel = await screen.findByTestId('ce-groupby') as HTMLSelectElement
+    const apex = sel.querySelector('option[value="apex"]') as HTMLOptionElement
+    const app  = sel.querySelector('option[value="app"]')  as HTMLOptionElement
+    expect(apex.disabled).toBe(true)
+    expect(app.disabled).toBe(true)
   })
 })
 

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import type { Device, ProfileDetail, QueryLog, Session } from '@/types/api'
+import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog, Session } from '@/types/api'
 import { HostCell } from '@/components/HostCell'
 
 // Click-through to the device/profile referenced by a row. The destination
@@ -269,33 +269,32 @@ function SessionsTab({
   )
 }
 
-// ── Connection events tab (every row is a connection_attempt from /api/logs) ─
+// ── Connection events tab ─────────────────────────────────────────────────
+// Default Raw → /api/logs. Pick any bucket (1m/10m/…/1w) to switch to
+// /api/connection-events/series with the current filters carried through.
+// groupBy=per-app is gated (apps track #761-#769); per-apex is gated until
+// #849 (PSL). #847.
+
+type Bucket  = 'off' | '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
+type GroupBy = 'domain' | 'apex' | 'app'
+
+const BUCKETS: { value: Bucket; label: string }[] = [
+  { value: 'off', label: 'Raw' },
+  { value: '1m',  label: '1m'  },
+  { value: '10m', label: '10m' },
+  { value: '1h',  label: '1h'  },
+  { value: '12h', label: '12h' },
+  { value: '1d',  label: '1d'  },
+  { value: '1w',  label: '1w'  },
+]
 
 function RawEventsTab({
   filters, hasFilters, onClear,
 }: { filters: Filters; hasFilters: boolean; onClear: () => void }) {
-  const [logs,    setLogs]    = useState<QueryLog[]>([])
-  const [loading, setLoading] = useState(true)
+  const [bucket,  setBucket]  = useState<Bucket>('off')
+  const [groupBy, setGroupBy] = useState<GroupBy>('domain')
   const [domain,  setDomain]  = useState('')
   const [blocked, setBlocked] = useState<'all' | 'true' | 'false'>('all')
-
-  async function load() {
-    setLoading(true)
-    try {
-      const data = await api.logs.query({
-        domain:    domain || undefined,
-        blocked:   blocked === 'all' ? undefined : blocked === 'true',
-        deviceId:  filters.deviceId  ?? undefined,
-        profileId: filters.profileId ?? undefined,
-        limit:     200,
-      })
-      setLogs(data)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => { load() }, [domain, blocked, filters.deviceId, filters.profileId])
 
   return (
     <div className="space-y-4">
@@ -308,47 +307,213 @@ function RawEventsTab({
           className="bg-gray-900 border border-gray-700 rounded-xl px-4 py-2.5 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500 flex-1 min-w-[160px]"
         />
         <select value={blocked} onChange={e => setBlocked(e.target.value as typeof blocked)}
+          data-testid="ce-filter-blocked"
           className="bg-gray-900 border border-gray-700 rounded-xl px-4 py-2.5 text-white text-sm">
           <option value="all">All queries</option>
           <option value="true">Blocked only</option>
           <option value="false">Allowed only</option>
         </select>
-        <button onClick={load} className="bg-gray-800 hover:bg-gray-700 text-white text-sm px-4 py-2.5 rounded-xl transition-colors">
-          Refresh
-        </button>
       </div>
 
-      <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
-        {loading
-          ? <div className="p-8 flex justify-center"><div className="w-6 h-6 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin"/></div>
+      <div className="flex flex-wrap gap-2 items-center" data-testid="ce-bucket-bar">
+        <span className="text-xs text-gray-500 font-mono">Bucket:</span>
+        {BUCKETS.map(b => (
+          <button
+            key={b.value}
+            type="button"
+            data-testid={`ce-bucket-${b.value}`}
+            onClick={() => setBucket(b.value)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-mono transition-colors ${
+              bucket === b.value
+                ? 'bg-emerald-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            {b.label}
+          </button>
+        ))}
+        {bucket !== 'off' && (
+          <>
+            <span className="text-xs text-gray-500 font-mono ml-3">Group by:</span>
+            <select
+              value={groupBy}
+              data-testid="ce-groupby"
+              onChange={e => setGroupBy(e.target.value as GroupBy)}
+              className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-1.5 text-white text-xs font-mono"
+            >
+              <option value="domain">per-domain</option>
+              <option value="apex" disabled title="Coming soon — needs PSL (#849)">
+                per-apex (coming soon)
+              </option>
+              <option value="app" disabled title="Available once apps land (#761-#769)">
+                per-app (coming soon)
+              </option>
+            </select>
+          </>
+        )}
+      </div>
+
+      {bucket === 'off'
+        ? <RawTable
+            domain={domain}
+            blocked={blocked}
+            filters={filters}
+            hasFilters={hasFilters}
+            onClear={onClear}
+          />
+        : <AggregatedTable
+            bucket={bucket}
+            groupBy={groupBy}
+            domain={domain}
+            blocked={blocked}
+            filters={filters}
+            hasFilters={hasFilters}
+            onClear={onClear}
+          />}
+    </div>
+  )
+}
+
+function RawTable({
+  domain, blocked, filters, hasFilters, onClear,
+}: {
+  domain: string
+  blocked: 'all' | 'true' | 'false'
+  filters: Filters
+  hasFilters: boolean
+  onClear: () => void
+}) {
+  const [logs,    setLogs]    = useState<QueryLog[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    api.logs.query({
+      domain:    domain || undefined,
+      blocked:   blocked === 'all' ? undefined : blocked === 'true',
+      deviceId:  filters.deviceId  ?? undefined,
+      profileId: filters.profileId ?? undefined,
+      limit:     200,
+    })
+      .then(data => { if (!cancelled) setLogs(data) })
+      .catch(() => { if (!cancelled) setLogs([]) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [domain, blocked, filters.deviceId, filters.profileId])
+
+  return (
+    <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+      {loading
+        ? <div className="p-8 flex justify-center"><div className="w-6 h-6 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin"/></div>
+        : <div className="overflow-x-auto">
+            <table className="w-full text-xs font-mono" data-testid="ce-raw-table">
+              <thead>
+                <tr className="text-gray-600 border-b border-gray-800">
+                  <th className="text-left px-4 py-3">Time</th>
+                  <th className="text-left px-4 py-3">Device</th>
+                  <th className="text-left px-4 py-3">Domain</th>
+                  <th className="text-left px-4 py-3">Status</th>
+                  <th className="text-left px-4 py-3 hidden md:table-cell">Reason</th>
+                  <th className="text-left px-4 py-3 hidden lg:table-cell">Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map(l => (
+                  <tr key={l.id} className="border-b border-gray-800/50 hover:bg-gray-800/30">
+                    <td className="px-4 py-2.5 text-gray-500">{fmtTime(l.ts)}</td>
+                    <td className="px-4 py-2.5"><DeviceLink mac={l.mac} deviceName={l.deviceName} /></td>
+                    <td className="px-4 py-2.5 text-gray-300 max-w-[200px] truncate"><HostCell host={l.host} /></td>
+                    <td className={`px-4 py-2.5 ${l.blocked ? 'text-red-400' : 'text-emerald-600'}`}>
+                      {l.blocked ? '✗ blocked' : '✓ ok'}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600 hidden md:table-cell">{l.reason}</td>
+                    <td className="px-4 py-2.5 text-gray-600 hidden lg:table-cell">{l.location ?? ''}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {logs.length === 0 && (
+              <EmptyState
+                message={hasFilters ? 'No matching events.' : 'No events found.'}
+                hasFilters={hasFilters}
+                onClear={onClear}
+              />
+            )}
+          </div>
+      }
+    </div>
+  )
+}
+
+function AggregatedTable({
+  bucket, groupBy, domain, blocked, filters, hasFilters, onClear,
+}: {
+  bucket: Exclude<Bucket, 'off'>
+  groupBy: GroupBy
+  domain: string
+  blocked: 'all' | 'true' | 'false'
+  filters: Filters
+  hasFilters: boolean
+  onClear: () => void
+}) {
+  const [rows,    setRows]    = useState<ConnectionEventAggRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error,   setError]   = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    api.logs.series({
+      bucket,
+      groupBy,
+      domain:    domain || undefined,
+      blocked:   blocked === 'all' ? undefined : blocked === 'true',
+      deviceId:  filters.deviceId  ?? undefined,
+      profileId: filters.profileId ?? undefined,
+      limit:     500,
+    })
+      .then(data => { if (!cancelled) setRows(data) })
+      .catch(e => {
+        if (!cancelled) { setRows([]); setError(String(e.message ?? e)) }
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [bucket, groupBy, domain, blocked, filters.deviceId, filters.profileId])
+
+  return (
+    <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+      {loading
+        ? <div className="p-8 flex justify-center"><div className="w-6 h-6 border-2 border-emerald-500 border-t-transparent rounded-full animate-spin"/></div>
+        : error
+          ? <p className="p-6 text-red-400 text-sm" data-testid="ce-agg-error">{error}</p>
           : <div className="overflow-x-auto">
-              <table className="w-full text-xs font-mono">
+              <table className="w-full text-xs font-mono" data-testid="ce-agg-table">
                 <thead>
                   <tr className="text-gray-600 border-b border-gray-800">
-                    <th className="text-left px-4 py-3">Time</th>
-                    <th className="text-left px-4 py-3">Device</th>
-                    <th className="text-left px-4 py-3">Domain</th>
-                    <th className="text-left px-4 py-3">Status</th>
-                    <th className="text-left px-4 py-3 hidden md:table-cell">Reason</th>
-                    <th className="text-left px-4 py-3 hidden lg:table-cell">Location</th>
+                    <th className="text-left px-4 py-3">Window</th>
+                    <th className="text-left px-4 py-3">{groupBy === 'domain' ? 'Domain' : groupBy === 'apex' ? 'Apex' : 'App'}</th>
+                    <th className="text-right px-4 py-3">OK</th>
+                    <th className="text-right px-4 py-3">Blocked</th>
+                    <th className="text-left px-4 py-3 hidden md:table-cell">Last seen</th>
+                    <th className="text-left px-4 py-3 hidden lg:table-cell">Top device</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {logs.map(l => (
-                    <tr key={l.id} className="border-b border-gray-800/50 hover:bg-gray-800/30">
-                      <td className="px-4 py-2.5 text-gray-500">{fmtTime(l.ts)}</td>
-                      <td className="px-4 py-2.5"><DeviceLink mac={l.mac} deviceName={l.deviceName} /></td>
-                      <td className="px-4 py-2.5 text-gray-300 max-w-[200px] truncate"><HostCell host={l.host} /></td>
-                      <td className={`px-4 py-2.5 ${l.blocked ? 'text-red-400' : 'text-emerald-600'}`}>
-                        {l.blocked ? '✗ blocked' : '✓ ok'}
-                      </td>
-                      <td className="px-4 py-2.5 text-gray-600 hidden md:table-cell">{l.reason}</td>
-                      <td className="px-4 py-2.5 text-gray-600 hidden lg:table-cell">{l.location ?? ''}</td>
+                  {rows.map((r, i) => (
+                    <tr key={`${r.group}-${r.windowStart}-${i}`} className="border-b border-gray-800/50 hover:bg-gray-800/30">
+                      <td className="px-4 py-2.5 text-gray-500">{fmtBucketStart(r.windowStart)}</td>
+                      <td className="px-4 py-2.5 text-gray-300 max-w-[280px] truncate">{r.group}</td>
+                      <td className="px-4 py-2.5 text-emerald-400 text-right">{r.countSucceeded}</td>
+                      <td className="px-4 py-2.5 text-red-400 text-right">{r.countBlocked}</td>
+                      <td className="px-4 py-2.5 text-gray-600 hidden md:table-cell">{fmtTime(r.lastSeen)}</td>
+                      <td className="px-4 py-2.5 text-gray-600 hidden lg:table-cell">{r.topDevice ?? ''}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
-              {logs.length === 0 && (
+              {rows.length === 0 && (
                 <EmptyState
                   message={hasFilters ? 'No matching events.' : 'No events found.'}
                   hasFilters={hasFilters}
@@ -356,8 +521,7 @@ function RawEventsTab({
                 />
               )}
             </div>
-        }
-      </div>
+      }
     </div>
   )
 }
@@ -410,4 +574,16 @@ function fmtStarted(iso: string): string {
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString()
+}
+
+// API returns Postgres-formatted UTC timestamps without explicit tz (e.g.
+// "2026-05-22 14:00:00"). Browser-local display gives household-tz boundaries
+// for free since the SPA runs in the operator's timezone.
+function fmtBucketStart(s: string): string {
+  const iso = s.includes('T') ? s : s.replace(' ', 'T') + 'Z'
+  const d = new Date(iso)
+  return d.toLocaleString([], {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -108,6 +108,16 @@ export interface QueryLog {
   ts: string
 }
 
+// #847: aggregated connection-events row.
+export interface ConnectionEventAggRow {
+  group: string
+  windowStart: string
+  countSucceeded: number
+  countBlocked: number
+  lastSeen: string
+  topDevice: string | null
+}
+
 export interface Session {
   mac: string
   deviceName: string | null


### PR DESCRIPTION
## Summary

- New `/api/connection-events/series` endpoint with `bucket` (1m/10m/1h/12h/1d/1w) + `groupBy` (domain/apex/app) params; per-domain aggregation implemented, apex/app return typed 400s referencing [#849](https://github.com/wifihaven/wifihaven/issues/849) and [#761](https://github.com/wifihaven/wifihaven/issues/761)-[#769](https://github.com/wifihaven/wifihaven/issues/769).
- Connection Events tab on the logs page gains a Raw / 1m / 10m / 1h / 12h / 1d / 1w bucket selector and group-by selector (apex/app gated); aggregated view shows group / window / OK / Blocked / last-seen / top-device, sorted by total count desc.
- Filters (device, profile, blocked, host search) carry through both Raw and aggregated views; bucket boundaries render in viewer-local tz.

Umbrella: [#844](https://github.com/wifihaven/wifihaven/issues/844). Sessions tab left untouched — it goes away with [#845](https://github.com/wifihaven/wifihaven/issues/845).

## Screenshots

Not captured locally — UI changes are limited to the LogsPage Connection Events tab; the new controls and aggregated table are exercised by `web/src/pages/LogsPage.test.tsx`.

## Test plan

- [x] `mill api.test` — full API suite green (LogApiSpec covers domain grouping, blocked filter, 1h vs 10m bucketing, apex/app/off/unknown-bucket rejections).
- [x] `mill shared.test` — green.
- [x] `npm test` (web) — 164 tests passing including the new `#847 aggregation` block (bucket toggle calls `/series`, switching back stops, group-by hidden in Raw mode, apex/app options disabled).
- [x] `npm run lint` and `npm run type-check` — clean.
- [ ] Manual smoke against `api.lan:8080` — not run yet; recommend a quick check that 1h grouping returns sensible row counts before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)