### PR TITLE
fix(web): reliable screen-time accordion + dedup profile name + move +Time to header (#854)

### DIFF
--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -429,6 +429,51 @@ describe('formatMins (#791)', () => {
   })
 })
 
+describe('TimePage — reliable accordion (#854)', () => {
+  it('profile name appears exactly once per row (header only, not duplicated in body)', async () => {
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    // Profile 1 is auto-expanded — body content present, but profile name should
+    // still appear only once for that row (in the header, not in the body card).
+    await screen.findByTestId('time-card-1')
+    expect(screen.getAllByText('Kids').length).toBe(1)
+  })
+
+  it('+ Time button is reachable in the header without expanding the card', async () => {
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-2')
+    // Profile 2 (Teens) stays collapsed but its + Time button is in the header.
+    expect(screen.queryByTestId('time-card-2')).not.toBeInTheDocument()
+    expect(screen.getByTestId('time-row-grant-2')).toBeInTheDocument()
+  })
+
+  it('clicking + Time in a collapsed row does not toggle it', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-row-2')
+    expect(screen.queryByTestId('time-card-2')).not.toBeInTheDocument()
+    await user.click(screen.getByTestId('time-row-grant-2'))
+    // Modal opened — row 2 stayed collapsed.
+    expect(screen.queryByTestId('time-card-2')).not.toBeInTheDocument()
+    expect(screen.getByText('Grant Extra Time')).toBeInTheDocument()
+  })
+
+  it('user-collapsed rows stay collapsed across summary refetches (no auto-expand race)', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<MemoryRouter><TimePage /></MemoryRouter>))
+    await screen.findByTestId('time-card-1')
+    // Collapse the auto-expanded row.
+    await user.click(screen.getByTestId('time-row-toggle-1'))
+    expect(screen.queryByTestId('time-card-1')).not.toBeInTheDocument()
+    // Simulate a polling refetch by invalidating the summary query through a
+    // grant mutation — onSuccess invalidator forces summaryAll to refetch.
+    await user.click(screen.getByTestId('time-row-grant-2'))
+    await user.click(screen.getByRole('button', { name: /Grant 30m/ }))
+    await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
+    // Row 1 must remain collapsed despite the fresh summary array reference.
+    expect(screen.queryByTestId('time-card-1')).not.toBeInTheDocument()
+  })
+})
+
 describe('TimePage — role gating', () => {
   it('hides "+ Time" button for non-admins', async () => {
     mockAuth = { isAdmin: false }

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import {
@@ -141,16 +141,23 @@ export function TimePage() {
     const v = loadExpanded()
     return { today: new Set(v.today), week: new Set(v.week) }
   })
-  // Once summaries are first loaded, auto-expand the first row if nothing is expanded yet
-  // (issue's "one profile expanded by default" rule — avoids an empty-looking page).
+  // #854 — auto-expand the first row once per tab per page mount. Previously this
+  // effect re-fired on every summary refetch (polling), so after the user collapsed
+  // everything the next poll would re-open the first row — and toggling the only
+  // open row would race with the next refetch. Latch via a ref so the auto-expand
+  // happens exactly once per tab and never interferes with user toggles after.
+  const didAutoExpandToday = useRef(false)
+  const didAutoExpandWeek = useRef(false)
   useEffect(() => {
-    if (window !== 'today' || summaries.length === 0 || expanded.today.size > 0) return
-    setExpanded(e => ({ ...e, today: new Set([summaries[0].profileId]) }))
-  }, [window, summaries, expanded.today.size])
+    if (window !== 'today' || didAutoExpandToday.current || summaries.length === 0) return
+    didAutoExpandToday.current = true
+    setExpanded(e => e.today.size > 0 ? e : { ...e, today: new Set([summaries[0].profileId]) })
+  }, [window, summaries])
   useEffect(() => {
-    if (window !== 'week' || weekSummaries.length === 0 || expanded.week.size > 0) return
-    setExpanded(e => ({ ...e, week: new Set([weekSummaries[0].profileId]) }))
-  }, [window, weekSummaries, expanded.week.size])
+    if (window !== 'week' || didAutoExpandWeek.current || weekSummaries.length === 0) return
+    didAutoExpandWeek.current = true
+    setExpanded(e => e.week.size > 0 ? e : { ...e, week: new Set([weekSummaries[0].profileId]) })
+  }, [window, weekSummaries])
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify({
@@ -314,13 +321,10 @@ export function TimePage() {
   )
 }
 
-function ProfileTimeCard({
-  status, isAdmin, onGrant,
-}: {
-  status: ProfileTimeStatus
-  isAdmin: boolean
-  onGrant: () => void
-}) {
+// #854 — body card no longer renders the profile name or +Time button; both
+// live in the always-visible accordion header so they're reachable when
+// collapsed and avoid the duplicate name.
+function ProfileTimeCard({ status }: { status: ProfileTimeStatus }) {
   const hasLimit  = status.dailyLimitMins != null
   const limitBase = (status.dailyLimitMins ?? 0) + status.extensionMins
   const pct       = hasLimit && limitBase > 0
@@ -340,24 +344,6 @@ function ProfileTimeCard({
 
   return (
     <div data-testid={`time-card-${status.profileId}`} className={`bg-gray-900 rounded-2xl border p-5 space-y-4 ${overLimit ? 'border-red-500/40' : 'border-gray-800'}`}>
-      <div className="flex items-start justify-between gap-2">
-        <Link
-          to={`/time/${status.profileId}/timeline`}
-          data-testid={`time-profile-link-${status.profileId}`}
-          className="font-semibold text-white text-lg hover:text-emerald-400 transition-colors"
-        >
-          {status.profileName}
-        </Link>
-        {isAdmin && hasLimit && (
-          <button
-            onClick={onGrant}
-            className="shrink-0 text-xs bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 px-3 py-1.5 rounded-lg transition-colors"
-          >
-            + Time
-          </button>
-        )}
-      </div>
-
       {hasLimit ? (
         <div>
           <div className="flex justify-between text-xs text-gray-500 mb-1.5">
@@ -526,28 +512,43 @@ function ProfileAccordionRow({
       data-testid={`time-row-${summary.profileId}`}
       className={`bg-gray-900 rounded-2xl border ${overLimit ? 'border-red-500/40' : 'border-gray-800'}`}
     >
-      <button
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-        data-testid={`time-row-toggle-${summary.profileId}`}
-        className="w-full flex items-center justify-between gap-3 px-5 py-4 text-left"
-      >
-        <div className="flex items-center gap-3 min-w-0">
-          <span className={`text-gray-500 transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
-          <span className="font-semibold text-white text-lg truncate">{summary.profileName}</span>
-        </div>
-        <div className="flex items-center gap-3 shrink-0 text-xs">
-          <span className="text-gray-400 font-mono">{formatMins(summary.usedMins)} used</span>
-          {hasLimit && (
-            <span className={overLimit ? 'text-red-400' : 'text-gray-500'}>
-              {summary.remainingMins != null && summary.remainingMins > 0
-                ? `${formatMins(summary.remainingMins)} left`
-                : 'Limit reached'}
-            </span>
-          )}
-        </div>
-      </button>
+      {/* #854 — header row: toggle button takes most of the width; +Time button
+          is a sibling so it stays visible/usable when the card is collapsed and
+          its click doesn't bubble into the toggle. */}
+      <div className="flex items-center gap-2 px-5 py-4">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          data-testid={`time-row-toggle-${summary.profileId}`}
+          className="flex-1 flex items-center justify-between gap-3 text-left min-w-0"
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            <span className={`text-gray-500 transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+            <span className="font-semibold text-white text-lg truncate">{summary.profileName}</span>
+          </div>
+          <div className="flex items-center gap-3 shrink-0 text-xs">
+            <span className="text-gray-400 font-mono">{formatMins(summary.usedMins)} used</span>
+            {hasLimit && (
+              <span className={overLimit ? 'text-red-400' : 'text-gray-500'}>
+                {summary.remainingMins != null && summary.remainingMins > 0
+                  ? `${formatMins(summary.remainingMins)} left`
+                  : 'Limit reached'}
+              </span>
+            )}
+          </div>
+        </button>
+        {isAdmin && hasLimit && (
+          <button
+            type="button"
+            onClick={onGrant}
+            data-testid={`time-row-grant-${summary.profileId}`}
+            className="shrink-0 text-xs bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 px-3 py-1.5 rounded-lg transition-colors"
+          >
+            + Time
+          </button>
+        )}
+      </div>
 
       {expanded && (
         <div className="px-5 pb-5 border-t border-gray-800 pt-4">
@@ -556,9 +557,7 @@ function ProfileAccordionRow({
               Loading…
             </p>
           )}
-          {detail.data && (
-            <ProfileTimeCard status={detail.data} isAdmin={isAdmin} onGrant={onGrant} />
-          )}
+          {detail.data && <ProfileTimeCard status={detail.data} />}
         </div>
       )}
     </div>
@@ -624,14 +623,8 @@ function ProfileTimeWeekCard({ status }: { status: ProfileTimeStatusWeek }) {
   const chartData = groupBucketsByLocalDay(status.perBucket, status.to)
   return (
     <div data-testid={`time-week-card-${status.profileId}`} className="bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-4">
-      <div className="flex items-start justify-between gap-2">
-        <Link
-          to={`/time/${status.profileId}/timeline`}
-          data-testid={`time-week-profile-link-${status.profileId}`}
-          className="font-semibold text-white text-lg hover:text-emerald-400 transition-colors"
-        >
-          {status.profileName}
-        </Link>
+      {/* #854 — profile name now lives only in the accordion header. */}
+      <div className="flex items-center justify-end">
         <span className="text-xs text-gray-500 font-mono">{status.from} → {status.to}</span>
       </div>
 


### PR DESCRIPTION
## Summary

- **Root cause of the unreliable expand/collapse:** the auto-expand `useEffect` in `TimePage` fired whenever `summaries.length > 0 && expanded.today.size === 0`. `useTimeStatusSummary` is a polling query, so each refetch produced a new array reference and re-ran the effect — any time the user collapsed everything, the next poll would spring the first row back open. With only one row expanded, toggling it would race the next refetch and flicker. Fixed by latching the auto-expand behind a `useRef` so it fires exactly once per tab per page mount.
- **+ Time** button moved into the accordion header, alongside the profile name. It's now reachable without expanding the card, and clicking it does not toggle the row.
- **Duplicate profile name** removed from the expanded body (today + week cards) — the header always shows it.

Closes #854

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run TimePage` — **25/25 passing** (under node 22.22.3; node 20.13 was below vite 8's engine requirement)
- New regression tests in `TimePage.test.tsx`:
  - profile name appears exactly once per row
  - + Time visible/clickable while the row is collapsed
  - clicking + Time on a collapsed row opens the modal without toggling the row
  - a user-collapsed row stays collapsed across summary refetches (regression for the auto-expand race)
- [ ] Manual: open Screen Time page, collapse all rows, wait through a polling cycle — rows stay collapsed. Click +Time on a collapsed row — modal opens, row stays collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)