### PR TITLE
test(api): pin week-chart day-bucket TZ behavior (#794)

### DIFF
--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -408,6 +408,46 @@ describe('groupBucketsByLocalDay (#794)', () => {
     )
     expect(out.find(r => r.date === '2026-05-20')!.usedMins).toBe(40)
   })
+
+  // #794 boundary pin: previously the chart re-bucketed by UTC date, so a late-night
+  // bucket whose UTC instant crossed midnight got attributed to the *next* local day.
+  // These tests construct bucket starts from chosen local Y/M/D + H:M via the
+  // `new Date(y, m, d, h, m)` constructor (always interpreted in host-local tz), so they
+  // pin the boundary correctly regardless of which tz the test runner is in.
+  describe('midnight boundary (#794 regression)', () => {
+    const localBucketISO = (y: number, m0: number, d: number, h: number, min: number) =>
+      new Date(y, m0, d, h, min, 0, 0).toISOString()
+
+    it('a bucket at 23:00 local Thursday attributes to Thursday, not Friday', () => {
+      // Bucket aligned at 23:00 local 2026-05-21 (Thursday).
+      const bs = localBucketISO(2026, 4, 21, 23, 0)
+      const out = groupBucketsByLocalDay([{ bucketStart: bs, usedMins: 17 }], '2026-05-21')
+      expect(out.find(r => r.date === '2026-05-21')!.usedMins).toBe(17)
+      expect(out.find(r => r.date === '2026-05-22')).toBeUndefined()
+    })
+
+    it('a bucket at 00:00 local Friday attributes to Friday, not Thursday', () => {
+      const bs = localBucketISO(2026, 4, 22, 0, 0)
+      const out = groupBucketsByLocalDay([{ bucketStart: bs, usedMins: 9 }], '2026-05-22')
+      expect(out.find(r => r.date === '2026-05-22')!.usedMins).toBe(9)
+      expect(out.find(r => r.date === '2026-05-21')!.usedMins).toBe(0)
+    })
+
+    it('two adjacent buckets straddling local midnight land in different local days', () => {
+      // 23:00 local Thursday + 00:00 local Friday — consecutive hour buckets, different days.
+      const late = localBucketISO(2026, 4, 21, 23, 0)
+      const early = localBucketISO(2026, 4, 22, 0, 0)
+      const out = groupBucketsByLocalDay(
+        [
+          { bucketStart: late, usedMins: 30 },
+          { bucketStart: early, usedMins: 12 },
+        ],
+        '2026-05-22',
+      )
+      expect(out.find(r => r.date === '2026-05-21')!.usedMins).toBe(30)
+      expect(out.find(r => r.date === '2026-05-22')!.usedMins).toBe(12)
+    })
+  })
 })
 
 describe('formatMins (#791)', () => {


### PR DESCRIPTION
## Summary
- Verified the week-chart's day-bucketing is already household-local-correct: server returns hourly UTC buckets aligned via `bucketOffsetMin` so each bucket lives fully within one local-tz day, and the SPA's `groupBucketsByLocalDay` attributes each bucket to its local date via `new Date(bucketStart).getDate()`.
- Adds three boundary regression tests to [TimePage.test.tsx](web/src/pages/TimePage.test.tsx) that pin the late-night case the existing tests missed — they construct bucket starts from chosen local Y/M/D + H:M so the tests are sharp regardless of the runner's host tz.

## Verification evidence
Read-only prod check against `https://api.wifihaven.net/api/time/status/week?bucketOffsetMin=0` (operator's household is US/Pacific). Real buckets include `2026-05-22T01:00:00Z` (= 2026-05-21 18:00 PT, Thursday) and `2026-05-22T10:00:00Z` (= 2026-05-22 03:00 PT, Friday). The SPA `groupBucketsByLocalDay` correctly attributes these to Thursday and Friday respectively.

Server side: existing test `bucketOffsetMin shifts the hourly grid alignment (#794)` in [TimeApiSpec.scala](api/test/src/feature/TimeApiSpec.scala) already pins offset=0 vs offset=30 alignment; no server change needed.

SPA side: existing `groupBucketsByLocalDay` tests passed in UTC but didn't exercise the local-midnight boundary. New tests cover:
- bucket at 23:00 local Thursday → attributes to Thursday
- bucket at 00:00 local Friday → attributes to Friday
- two adjacent buckets straddling local midnight → land in different local days

## Test plan
- [x] `npx vitest run src/pages/TimePage.test.tsx` — passes (28/28) under TZ=UTC and TZ=America/Los_Angeles
- [x] `mill api.test.testOnly wifihaven.api.feature.TimeApiSpec` — passes (27/27)
- [x] `mill shared.test` — passes
- [x] Read-only prod verification of `/api/time/status/week` boundary buckets

## Follow-up note
Two of the *pre-existing* tests in TimePage.test.tsx fail under TZ=Asia/Kolkata (`localBucketOffsetMin returns 0 for whole-hour zones` and the 8/14/20 UTC accumulation test). Those are runner-tz-coupled fixtures, not a TZ-correctness bug — out of scope here. The new boundary tests are sharp across UTC/PT/IST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)