### PR TITLE
feat(api): apps schema + Scala models (#761)

### DIFF
--- a/api/resources/db/migration/V27__apps.sql
+++ b/api/resources/db/migration/V27__apps.sql
@@ -1,0 +1,40 @@
+-- V27__apps.sql
+-- #761: schema foundation for the "app" concept — household-scoped named bundles
+-- of host patterns + per-profile policy assignments. See #105 design comment §2.
+--
+-- This is the schema + model PR. CRUD endpoints (#762) and PolicyService
+-- snapshot expansion (#763) land in follow-up PRs. The router wire shape is
+-- NOT touched here.
+--
+-- This codebase is single-household (only `household_settings` exists as a
+-- single-row config). `apps.slug` is uniquely scoped to that implicit
+-- household.
+
+CREATE TABLE apps (
+  id           BIGSERIAL PRIMARY KEY,
+  name         TEXT NOT NULL,
+  slug         TEXT NOT NULL UNIQUE,
+  template_id  TEXT,
+  icon         TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE app_hosts (
+  app_id  BIGINT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  host    TEXT NOT NULL,
+  PRIMARY KEY (app_id, host)
+);
+-- Reverse lookup host -> app(s), used by #763 snapshot builder and group-by-app views.
+CREATE INDEX idx_app_hosts_host ON app_hosts(host);
+
+CREATE TABLE app_policy_assignments (
+  id                BIGSERIAL PRIMARY KEY,
+  app_id            BIGINT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  profile_id        BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  mode              TEXT NOT NULL CHECK (mode IN ('blocked','allowed','time_limited')),
+  daily_minutes     INT CHECK (daily_minutes IS NULL OR daily_minutes > 0),
+  exempt_from_daily BOOLEAN NOT NULL DEFAULT TRUE,
+  UNIQUE (app_id, profile_id)
+);
+-- Per-profile reverse lookup, used by #763 snapshot builder.
+CREATE INDEX idx_app_policy_assignments_profile ON app_policy_assignments(profile_id);

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1556,6 +1556,152 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       .map(_.toMap)
 }
 
+// ── #761: apps ────────────────────────────────────────────────────────────
+//
+// CRUD over the apps / app_hosts / app_policy_assignments tables. No business
+// logic here: slug derivation, host canonicalization, template seeding, and
+// snapshot expansion all live in #762 / #763. Repo just round-trips rows.
+
+trait AppRepo {
+  def listAll: Task[List[App]]
+  def findById(id: AppId): Task[Option[App]]
+  def findBySlug(slug: String): Task[Option[App]]
+  def create(
+      name: String,
+      slug: String,
+      templateId: Option[AppTemplateId],
+      icon: Option[String],
+  ): Task[AppId]
+  def update(a: App): Task[Unit]
+  def delete(id: AppId): Task[Unit]
+
+  /**
+   * Replace the full set of hosts for an app. Wipes prior rows; canonicalization is the caller's
+   * responsibility.
+   */
+  def setHosts(appId: AppId, hosts: List[Hostname]): Task[Unit]
+  def getHosts(appId: AppId): Task[List[Hostname]]
+
+  /** Upsert a (app, profile) assignment. Existing row at that key is overwritten. */
+  def upsertAssignment(
+      appId: AppId,
+      profileId: ProfileId,
+      mode: AppMode,
+      dailyMinutes: Option[Int],
+      exemptFromDaily: Boolean,
+  ): Task[AppPolicyAssignmentId]
+  def deleteAssignment(appId: AppId, profileId: ProfileId): Task[Unit]
+  def listAssignmentsForApp(appId: AppId): Task[List[AppPolicyAssignment]]
+  def listAssignmentsForProfile(profileId: ProfileId): Task[List[AppPolicyAssignment]]
+}
+
+class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
+  private type R = (AppId, String, String, Option[AppTemplateId], Option[String], Instant)
+  private def toApp(r: R) = App(r._1, r._2, r._3, r._4, r._5, r._6)
+
+  def listAll =
+    sql"SELECT id,name,slug,template_id,icon,created_at FROM apps ORDER BY id"
+      .query[R]
+      .map(toApp)
+      .to[List]
+      .transact(xa)
+
+  def findById(id: AppId) =
+    sql"SELECT id,name,slug,template_id,icon,created_at FROM apps WHERE id=$id"
+      .query[R]
+      .map(toApp)
+      .option
+      .transact(xa)
+
+  def findBySlug(slug: String) =
+    sql"SELECT id,name,slug,template_id,icon,created_at FROM apps WHERE slug=$slug"
+      .query[R]
+      .map(toApp)
+      .option
+      .transact(xa)
+
+  def create(
+      name: String,
+      slug: String,
+      templateId: Option[AppTemplateId],
+      icon: Option[String],
+  ) =
+    sql"INSERT INTO apps(name,slug,template_id,icon) VALUES($name,$slug,$templateId,$icon) RETURNING id"
+      .query[AppId]
+      .unique
+      .transact(xa)
+
+  def update(a: App) =
+    sql"""UPDATE apps SET
+            name=${a.name},
+            slug=${a.slug},
+            template_id=${a.templateId},
+            icon=${a.icon}
+          WHERE id=${a.id}""".update.run.transact(xa).unit
+
+  def delete(id: AppId) =
+    sql"DELETE FROM apps WHERE id=$id".update.run.transact(xa).unit
+
+  def setHosts(appId: AppId, hosts: List[Hostname]) = {
+    val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run
+    val ins = hosts.distinct.map(h =>
+      sql"INSERT INTO app_hosts(app_id,host) VALUES($appId,$h) ON CONFLICT DO NOTHING".update.run,
+    )
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+  }
+
+  def getHosts(appId: AppId) =
+    sql"SELECT host FROM app_hosts WHERE app_id=$appId ORDER BY host"
+      .query[Hostname]
+      .to[List]
+      .transact(xa)
+
+  def upsertAssignment(
+      appId: AppId,
+      profileId: ProfileId,
+      mode: AppMode,
+      dailyMinutes: Option[Int],
+      exemptFromDaily: Boolean,
+  ) =
+    sql"""INSERT INTO app_policy_assignments
+            (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
+          VALUES ($appId, $profileId, ${AppMode.asString(mode)}, $dailyMinutes, $exemptFromDaily)
+          ON CONFLICT (app_id, profile_id) DO UPDATE SET
+            mode = EXCLUDED.mode,
+            daily_minutes = EXCLUDED.daily_minutes,
+            exempt_from_daily = EXCLUDED.exempt_from_daily
+          RETURNING id"""
+      .query[AppPolicyAssignmentId]
+      .unique
+      .transact(xa)
+
+  def deleteAssignment(appId: AppId, profileId: ProfileId) =
+    sql"DELETE FROM app_policy_assignments WHERE app_id=$appId AND profile_id=$profileId".update.run
+      .transact(xa)
+      .unit
+
+  private type AR =
+    (AppPolicyAssignmentId, AppId, ProfileId, AppMode, Option[Int], Boolean)
+  private def toAssignment(r: AR) =
+    AppPolicyAssignment(r._1, r._2, r._3, r._4, r._5, r._6)
+
+  def listAssignmentsForApp(appId: AppId) =
+    sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
+          FROM app_policy_assignments WHERE app_id=$appId ORDER BY id"""
+      .query[AR]
+      .map(toAssignment)
+      .to[List]
+      .transact(xa)
+
+  def listAssignmentsForProfile(profileId: ProfileId) =
+    sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
+          FROM app_policy_assignments WHERE profile_id=$profileId ORDER BY id"""
+      .query[AR]
+      .map(toAssignment)
+      .to[List]
+      .transact(xa)
+}
+
 object Repos {
   val userRepo              = ZLayer.fromFunction(UserRepoLive(_))
   val userProfileRepo       = ZLayer.fromFunction(UserProfileRepoLive(_))
@@ -1572,6 +1718,7 @@ object Repos {
   val trafficReportRepo     = ZLayer.fromFunction(TrafficReportRepoLive(_))
   val blockEventRepo        = ZLayer.fromFunction(BlockEventRepoLive(_))
   val connEventRepo         = ZLayer.fromFunction(ConnectionEventRepoLive(_))
+  val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ appRepo
 }

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -2,7 +2,7 @@ package wifihaven.api.db
 
 import doobie.*
 import doobie.postgres.implicits.*
-import wifihaven.shared.{FailureMode, MacBlockReason, UserRole}
+import wifihaven.shared.{AppMode, FailureMode, MacBlockReason, UserRole}
 import wifihaven.shared.types.*
 
 import java.time.ZoneId
@@ -19,27 +19,30 @@ import java.time.ZoneId
 object TypeMeta {
 
   // ── Long-backed identifiers ────────────────────────────────────────────
-  given Meta[ProfileId]         = Meta[Long].imap(ProfileId(_))(_.value)
-  given Meta[DeviceId]          = Meta[Long].imap(DeviceId(_))(_.value)
-  given Meta[ScheduleId]        = Meta[Long].imap(ScheduleId(_))(_.value)
-  given Meta[TimeLimitId]       = Meta[Long].imap(TimeLimitId(_))(_.value)
-  given Meta[SiteTimeLimitId]   = Meta[Long].imap(SiteTimeLimitId(_))(_.value)
-  given Meta[TimeExtensionId]   = Meta[Long].imap(TimeExtensionId(_))(_.value)
-  given Meta[UserId]            = Meta[Long].imap(UserId(_))(_.value)
-  given Meta[BlockEventId]      = Meta[Long].imap(BlockEventId(_))(_.value)
-  given Meta[ConnectionEventId] = Meta[Long].imap(ConnectionEventId(_))(_.value)
-  given Meta[QueryLogId]        = Meta[Long].imap(QueryLogId(_))(_.value)
-  given Meta[TrafficReportId]   = Meta[Long].imap(TrafficReportId(_))(_.value)
-  given Meta[TimeUsageId]       = Meta[Long].imap(TimeUsageId(_))(_.value)
+  given Meta[ProfileId]             = Meta[Long].imap(ProfileId(_))(_.value)
+  given Meta[DeviceId]              = Meta[Long].imap(DeviceId(_))(_.value)
+  given Meta[ScheduleId]            = Meta[Long].imap(ScheduleId(_))(_.value)
+  given Meta[TimeLimitId]           = Meta[Long].imap(TimeLimitId(_))(_.value)
+  given Meta[SiteTimeLimitId]       = Meta[Long].imap(SiteTimeLimitId(_))(_.value)
+  given Meta[TimeExtensionId]       = Meta[Long].imap(TimeExtensionId(_))(_.value)
+  given Meta[UserId]                = Meta[Long].imap(UserId(_))(_.value)
+  given Meta[BlockEventId]          = Meta[Long].imap(BlockEventId(_))(_.value)
+  given Meta[ConnectionEventId]     = Meta[Long].imap(ConnectionEventId(_))(_.value)
+  given Meta[QueryLogId]            = Meta[Long].imap(QueryLogId(_))(_.value)
+  given Meta[TrafficReportId]       = Meta[Long].imap(TrafficReportId(_))(_.value)
+  given Meta[TimeUsageId]           = Meta[Long].imap(TimeUsageId(_))(_.value)
+  given Meta[AppId]                 = Meta[Long].imap(AppId(_))(_.value)
+  given Meta[AppPolicyAssignmentId] = Meta[Long].imap(AppPolicyAssignmentId(_))(_.value)
 
   // ── UUID-backed ────────────────────────────────────────────────────────
   given Meta[RouterId] = Meta[java.util.UUID].imap(RouterId(_))(_.value)
 
   // ── String-backed: identifiers and validated primitives ────────────────
-  given Meta[MacAddress]  = Meta[String].imap(MacAddress.unsafe)(_.value)
-  given Meta[Hostname]    = Meta[String].imap(Hostname.unsafe)(_.value)
-  given Meta[IpAddress]   = Meta[String].imap(IpAddress.unsafe)(_.value)
-  given Meta[BlocklistId] = Meta[String].imap(BlocklistId.unsafe)(_.value)
+  given Meta[MacAddress]    = Meta[String].imap(MacAddress.unsafe)(_.value)
+  given Meta[Hostname]      = Meta[String].imap(Hostname.unsafe)(_.value)
+  given Meta[IpAddress]     = Meta[String].imap(IpAddress.unsafe)(_.value)
+  given Meta[BlocklistId]   = Meta[String].imap(BlocklistId.unsafe)(_.value)
+  given Meta[AppTemplateId] = Meta[String].imap(AppTemplateId.unsafe)(_.value)
 
   // ── String-backed: tokens / hashes ─────────────────────────────────────
   given Meta[ETag]             = Meta[String].imap(ETag.unsafe)(_.value)
@@ -68,6 +71,12 @@ object TypeMeta {
         throw new IllegalStateException(s"DB has unknown failureMode: $s"),
       ),
   )(FailureMode.asString)
+
+  given Meta[AppMode] = Meta[String].imap(s =>
+    AppMode
+      .parse(s)
+      .getOrElse(throw new IllegalStateException(s"DB has unknown app mode: $s")),
+  )(AppMode.asString)
 
   given Meta[MacBlockReason] = Meta[String].imap(s =>
     MacBlockReason

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -110,7 +110,8 @@ object TestDatabase {
   type AllRepos =
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
-      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo
+      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
+      AppRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -1,0 +1,191 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.Transactor
+import zio.*
+import zio.test.*
+
+object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private val youtube = Hostname.unsafe("youtube.com")
+  private val ytimg   = Hostname.unsafe("ytimg.com")
+  private val gvideo  = Hostname.unsafe("googlevideo.com")
+
+  def spec = suite("AppRepo")(
+    test("create + findById round-trips") {
+      for {
+        _    <- cleanDb
+        repo <- ZIO.service[AppRepo]
+        id   <- repo.create(
+          "YouTube",
+          "youtube",
+          Some(AppTemplateId.unsafe("youtube")),
+          Some("📺"),
+        )
+        row  <- repo.findById(id)
+      } yield assertTrue(row.exists(_.name == "YouTube")) &&
+        assertTrue(row.exists(_.slug == "youtube")) &&
+        assertTrue(row.exists(_.templateId.contains(AppTemplateId.unsafe("youtube")))) &&
+        assertTrue(row.exists(_.icon.contains("📺")))
+    },
+    test("findBySlug returns the row") {
+      for {
+        _    <- cleanDb
+        repo <- ZIO.service[AppRepo]
+        id   <- repo.create("TikTok", "tiktok", None, None)
+        row  <- repo.findBySlug("tiktok")
+      } yield assertTrue(row.exists(_.id == id)) &&
+        assertTrue(row.exists(_.templateId.isEmpty)) &&
+        assertTrue(row.exists(_.icon.isEmpty))
+    },
+    test("duplicate slug is rejected") {
+      for {
+        _      <- cleanDb
+        repo   <- ZIO.service[AppRepo]
+        _      <- repo.create("YouTube", "youtube", None, None)
+        result <- repo.create("YouTube 2", "youtube", None, None).exit
+      } yield assertTrue(result.isFailure)
+    },
+    test("update changes name/icon/templateId") {
+      for {
+        _      <- cleanDb
+        repo   <- ZIO.service[AppRepo]
+        id     <- repo.create("YouTube", "youtube", None, None)
+        before <- repo.findById(id)
+        _      <- repo.update(
+          before.get.copy(
+            name = "YT",
+            icon = Some("🎥"),
+            templateId = Some(AppTemplateId.unsafe("youtube")),
+          ),
+        )
+        row    <- repo.findById(id)
+      } yield assertTrue(row.exists(_.name == "YT")) &&
+        assertTrue(row.exists(_.icon.contains("🎥"))) &&
+        assertTrue(row.exists(_.templateId.contains(AppTemplateId.unsafe("youtube"))))
+    },
+    test("setHosts + getHosts round-trips and replaces on rerun") {
+      for {
+        _    <- cleanDb
+        repo <- ZIO.service[AppRepo]
+        id   <- repo.create("YouTube", "youtube", None, None)
+        _    <- repo.setHosts(id, List(youtube, ytimg))
+        a    <- repo.getHosts(id)
+        _    <- repo.setHosts(id, List(youtube, gvideo))
+        b    <- repo.getHosts(id)
+      } yield assertTrue(a.toSet == Set(youtube, ytimg)) &&
+        assertTrue(b.toSet == Set(youtube, gvideo))
+    },
+    test("upsertAssignment inserts and overwrites on same (app, profile)") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        pRepo <- ZIO.service[ProfileRepo]
+        pid   <- pRepo.create("Kids", Nil)
+        id    <- appR.create("YouTube", "youtube", None, None)
+        a1    <- appR.upsertAssignment(id, pid, AppMode.Blocked, None, true)
+        rows1 <- appR.listAssignmentsForApp(id)
+        a2    <- appR.upsertAssignment(id, pid, AppMode.TimeLimited, Some(30), false)
+        rows2 <- appR.listAssignmentsForApp(id)
+      } yield assertTrue(a1 == a2) &&
+        assertTrue(rows1.length == 1 && rows1.head.mode == AppMode.Blocked) &&
+        assertTrue(rows2.length == 1 && rows2.head.mode == AppMode.TimeLimited) &&
+        assertTrue(rows2.head.dailyMinutes.contains(30)) &&
+        assertTrue(!rows2.head.exemptFromDaily)
+    },
+    test("listAssignmentsForProfile filters by profile") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        pRepo <- ZIO.service[ProfileRepo]
+        kids  <- pRepo.create("Kids", Nil)
+        adts  <- pRepo.create("Adults", Nil)
+        yt    <- appR.create("YouTube", "youtube", None, None)
+        tt    <- appR.create("TikTok", "tiktok", None, None)
+        _     <- appR.upsertAssignment(yt, kids, AppMode.Blocked, None, true)
+        _     <- appR.upsertAssignment(tt, kids, AppMode.Blocked, None, true)
+        _     <- appR.upsertAssignment(yt, adts, AppMode.Allowed, None, true)
+        k     <- appR.listAssignmentsForProfile(kids)
+        a     <- appR.listAssignmentsForProfile(adts)
+      } yield assertTrue(k.length == 2) && assertTrue(a.length == 1)
+    },
+    test("delete cascades to hosts and assignments") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        pRepo <- ZIO.service[ProfileRepo]
+        pid   <- pRepo.create("Kids", Nil)
+        id    <- appR.create("YouTube", "youtube", None, None)
+        _     <- appR.setHosts(id, List(youtube, ytimg))
+        _     <- appR.upsertAssignment(id, pid, AppMode.Blocked, None, true)
+        _     <- appR.delete(id)
+        gone  <- appR.findById(id)
+        hosts <- appR.getHosts(id)
+        asgn  <- appR.listAssignmentsForApp(id)
+      } yield assertTrue(gone.isEmpty) && assertTrue(hosts.isEmpty) && assertTrue(asgn.isEmpty)
+    },
+    test("deleting a profile cascades to assignments") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        pRepo <- ZIO.service[ProfileRepo]
+        pid   <- pRepo.create("Kids", Nil)
+        id    <- appR.create("YouTube", "youtube", None, None)
+        _     <- appR.upsertAssignment(id, pid, AppMode.Blocked, None, true)
+        _     <- pRepo.delete(pid)
+        asgn  <- appR.listAssignmentsForApp(id)
+      } yield assertTrue(asgn.isEmpty)
+    },
+    test("deleteAssignment removes only the targeted (app, profile) row") {
+      for {
+        _     <- cleanDb
+        appR  <- ZIO.service[AppRepo]
+        pRepo <- ZIO.service[ProfileRepo]
+        kids  <- pRepo.create("Kids", Nil)
+        adts  <- pRepo.create("Adults", Nil)
+        id    <- appR.create("YouTube", "youtube", None, None)
+        _     <- appR.upsertAssignment(id, kids, AppMode.Blocked, None, true)
+        _     <- appR.upsertAssignment(id, adts, AppMode.Allowed, None, true)
+        _     <- appR.deleteAssignment(id, kids)
+        rows  <- appR.listAssignmentsForApp(id)
+      } yield assertTrue(rows.length == 1 && rows.head.profileId == adts)
+    },
+    test("CHECK constraint rejects unknown mode values") {
+      for {
+        _      <- cleanDb
+        xa     <- ZIO.service[Transactor[Task]]
+        pRepo  <- ZIO.service[ProfileRepo]
+        appR   <- ZIO.service[AppRepo]
+        pid    <- pRepo.create("Kids", Nil)
+        id     <- appR.create("YouTube", "youtube", None, None)
+        result <- {
+          import doobie.implicits.*
+          import zio.interop.catz.*
+          import wifihaven.api.db.TypeMeta.given
+          sql"INSERT INTO app_policy_assignments(app_id, profile_id, mode) VALUES ($id, $pid, 'bogus')".update.run
+            .transact(xa)
+            .exit
+        }
+      } yield assertTrue(result.isFailure)
+    },
+    test("listAll returns all apps ordered by id") {
+      for {
+        _    <- cleanDb
+        repo <- ZIO.service[AppRepo]
+        a    <- repo.create("YouTube", "youtube", None, None)
+        b    <- repo.create("TikTok", "tiktok", None, None)
+        rows <- repo.listAll
+      } yield assertTrue(rows.map(_.id) == List(a, b))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -131,6 +131,52 @@ case class SiteTimeLimit(
     exemptFromDaily: Boolean = true,
 ) derives JsonCodec
 
+// #761: app concept. An App is a household-scoped named bundle of host
+// patterns (apex form — subdomain match is inherent to the wire). See #105
+// design comment §2. Wire stays unchanged — apps are an API-side bundling
+// concept that #763 will expand into the existing per-MAC BlockRules buckets.
+enum AppMode {
+  case Blocked, Allowed, TimeLimited
+}
+
+object AppMode {
+  def asString(m: AppMode): String      = m match {
+    case Blocked     => "blocked"
+    case Allowed     => "allowed"
+    case TimeLimited => "time_limited"
+  }
+  def parse(s: String): Option[AppMode] = s match {
+    case "blocked"      => Some(Blocked)
+    case "allowed"      => Some(Allowed)
+    case "time_limited" => Some(TimeLimited)
+    case _              => None
+  }
+  given JsonCodec[AppMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown app mode: $s"),
+    asString,
+  )
+}
+
+case class App(
+    id: AppId,
+    name: String,
+    slug: String,
+    templateId: Option[AppTemplateId],
+    icon: Option[String],
+    createdAt: java.time.Instant,
+) derives JsonCodec
+
+case class AppHost(appId: AppId, host: Hostname) derives JsonCodec
+
+case class AppPolicyAssignment(
+    id: AppPolicyAssignmentId,
+    appId: AppId,
+    profileId: ProfileId,
+    mode: AppMode,
+    dailyMinutes: Option[Int],
+    exemptFromDaily: Boolean = true,
+) derives JsonCodec
+
 case class TimeUsage(
     id: TimeUsageId,
     deviceMac: MacAddress,

--- a/shared/src/types/AppTemplateId.scala
+++ b/shared/src/types/AppTemplateId.scala
@@ -1,0 +1,29 @@
+package wifihaven.shared.types
+
+import zio.json.*
+
+/**
+ * Identifier for a library app template (e.g. "youtube", "tiktok"). When an app row was seeded from
+ * a YAML template, `apps.template_id` carries this slug; operator-created apps leave it NULL.
+ *
+ * Same character class as [[BlocklistId]] (lowercase alphanumerics plus `_-`).
+ */
+opaque type AppTemplateId = String
+
+object AppTemplateId {
+
+  private val Pattern = "^[a-z0-9][a-z0-9_-]{0,63}$".r
+
+  def parse(raw: String): Either[String, AppTemplateId] =
+    if Pattern.matches(raw) then Right(raw)
+    else Left(s"invalid app template id: $raw")
+
+  def unsafe(s: String): AppTemplateId = s
+
+  extension (a: AppTemplateId) def value: String = a
+
+  given Ordering[AppTemplateId]         = Ordering.String
+  given JsonCodec[AppTemplateId]        = JsonCodec.string.transformOrFail(parse, _.value)
+  given JsonFieldEncoder[AppTemplateId] = JsonFieldEncoder.string.contramap(_.value)
+  given JsonFieldDecoder[AppTemplateId] = JsonFieldDecoder.string.mapOrFail(parse)
+}

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -10,18 +10,20 @@ import java.util.UUID
  * and as a string when used as a JSON object key (matching `Map[Long, _]`'s default rendering).
  */
 
-opaque type ProfileId         = Long
-opaque type DeviceId          = Long
-opaque type ScheduleId        = Long
-opaque type TimeLimitId       = Long
-opaque type SiteTimeLimitId   = Long
-opaque type TimeExtensionId   = Long
-opaque type UserId            = Long
-opaque type BlockEventId      = Long
-opaque type ConnectionEventId = Long
-opaque type QueryLogId        = Long
-opaque type TrafficReportId   = Long
-opaque type TimeUsageId       = Long
+opaque type ProfileId             = Long
+opaque type DeviceId              = Long
+opaque type ScheduleId            = Long
+opaque type TimeLimitId           = Long
+opaque type SiteTimeLimitId       = Long
+opaque type TimeExtensionId       = Long
+opaque type UserId                = Long
+opaque type BlockEventId          = Long
+opaque type ConnectionEventId     = Long
+opaque type QueryLogId            = Long
+opaque type TrafficReportId       = Long
+opaque type TimeUsageId           = Long
+opaque type AppId                 = Long
+opaque type AppPolicyAssignmentId = Long
 
 object ProfileId {
   def apply(l: Long): ProfileId            = l
@@ -101,6 +103,22 @@ object TimeUsageId {
   def apply(l: Long): TimeUsageId            = l
   extension (t: TimeUsageId) def value: Long = t
   given JsonCodec[TimeUsageId]               = JsonCodec.long
+}
+
+object AppId {
+  def apply(l: Long): AppId            = l
+  extension (a: AppId) def value: Long = a
+  given JsonCodec[AppId]               = JsonCodec.long
+  given JsonFieldEncoder[AppId]        = JsonFieldEncoder.long
+  given JsonFieldDecoder[AppId]        = JsonFieldDecoder.long
+  given Ordering[AppId]                = Ordering.Long
+}
+
+object AppPolicyAssignmentId {
+  def apply(l: Long): AppPolicyAssignmentId            = l
+  extension (a: AppPolicyAssignmentId) def value: Long = a
+  given JsonCodec[AppPolicyAssignmentId]               = JsonCodec.long
+  given Ordering[AppPolicyAssignmentId]                = Ordering.Long
 }
 
 /** UUID-backed router identifier. */


### PR DESCRIPTION
## Summary

- Lands the data-model foundation for the "app" concept (#105 / #761) — apps + hosts + policy assignments tables, Scala models, and a doobie-backed `AppRepo`. No endpoints yet (#762 next), no policy-snapshot expansion yet (#763).
- Wire contract is untouched — apps are an API-side bundling concept that #763 will expand into the existing per-MAC `BlockRules` buckets. Router code is unchanged.
- This codebase is single-household (only `household_settings` exists, as a single-row config) so the `household_id` FK from the design comment is dropped here — `apps.slug` is `UNIQUE` globally. If we ever go multi-household, that constraint can be re-scoped.

## Schema (V27)

```sql
CREATE TABLE apps (
  id           BIGSERIAL PRIMARY KEY,
  name         TEXT NOT NULL,
  slug         TEXT NOT NULL UNIQUE,
  template_id  TEXT,
  icon         TEXT,
  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
);

CREATE TABLE app_hosts (
  app_id  BIGINT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
  host    TEXT NOT NULL,
  PRIMARY KEY (app_id, host)
);
CREATE INDEX idx_app_hosts_host ON app_hosts(host);

CREATE TABLE app_policy_assignments (
  id                BIGSERIAL PRIMARY KEY,
  app_id            BIGINT NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
  profile_id        BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
  mode              TEXT NOT NULL CHECK (mode IN ('blocked','allowed','time_limited')),
  daily_minutes     INT CHECK (daily_minutes IS NULL OR daily_minutes > 0),
  exempt_from_daily BOOLEAN NOT NULL DEFAULT TRUE,
  UNIQUE (app_id, profile_id)
);
CREATE INDEX idx_app_policy_assignments_profile ON app_policy_assignments(profile_id);
```

The `idx_app_hosts_host` and `idx_app_policy_assignments_profile` indices are sized for the hot reads that #762 and #763 will need (reverse `host -> app(s)` lookup, per-profile snapshot expansion).

## Models

- `App`, `AppHost`, `AppPolicyAssignment` case classes + `AppMode` enum (`Blocked` / `Allowed` / `TimeLimited`, persisted as text matching the CHECK constraint).
- New opaque-type newtypes: `AppId`, `AppPolicyAssignmentId`, `AppTemplateId` — matching the existing `Ids.scala` / `BlocklistId.scala` style.
- `AppRepo` exposes CRUD over the three tables: `create` / `update` / `delete` / `findById` / `findBySlug` / `listAll`, `setHosts` / `getHosts`, `upsertAssignment` / `deleteAssignment` / `listAssignmentsForApp` / `listAssignmentsForProfile`. No business logic — slug derivation, host canonicalization, and snapshot expansion stay in their respective follow-ups.

## Related

- Umbrella: #105
- Sub-issues: #761 (this), #762, #763, #764-#769
- Design comment: https://github.com/wifihaven/wifihaven/issues/105#issuecomment-4504919974

## Test plan

- [x] `mill shared.test` passes (36/36)
- [x] `mill api.test` passes (full suite green, including new `AppRepoSpec` 12/12)
- [x] AppRepoSpec covers: round-trip create/find/update/delete, slug uniqueness rejection, mode CHECK constraint rejection, setHosts replaces prior rows, upsertAssignment overwrites at (app, profile), cascade delete to hosts + assignments on app delete, cascade delete to assignments on profile delete, deleteAssignment targets only the requested row.
- [x] Flyway migration applies cleanly on a fresh embedded Postgres (every test calls `cleanAndMigrate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)