### PR TITLE
feat(api+web): per-profile cross-device overlap mode (#751)

### DIFF
--- a/api/resources/db/migration/V27__profile_cross_device_overlap_mode.sql
+++ b/api/resources/db/migration/V27__profile_cross_device_overlap_mode.sql
@@ -1,0 +1,7 @@
+-- #751: per-profile knob controlling how the screen-time total treats the
+-- case where two devices on the same profile are active in the same 5-min
+-- bucket. `sum` (default, current behavior) adds per-device totals; `dedup`
+-- unions the per-device active-bucket sets so overlap counts once.
+ALTER TABLE profiles
+  ADD COLUMN cross_device_overlap_mode VARCHAR NOT NULL DEFAULT 'sum'
+    CHECK (cross_device_overlap_mode IN ('sum', 'dedup'));

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -474,6 +474,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       Boolean,
       String,
       Boolean,
+      String,
   )
   private def toP(r: R)                             = Profile(
     r._1,
@@ -484,15 +485,16 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     r._6,
     FailureMode.parse(r._7).getOrElse(FailureMode.LastKnownGood),
     r._8,
+    CrossDeviceOverlapMode.parse(r._9).getOrElse(CrossDeviceOverlapMode.Sum),
   )
   def listAll                                       =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only FROM profiles ORDER BY id"
+    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
       .query[R]
       .map(toP)
       .to[List]
       .transact(xa)
   def findById(id: ProfileId)                       =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only FROM profiles WHERE id=$id"
+    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
       .query[R]
       .map(toP)
       .option
@@ -510,7 +512,8 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
             extra_allowed=${p.extraAllowed.map(_.value).toArray},
             paused=${p.paused},
             failure_mode=${FailureMode.asString(p.failureMode)},
-            block_ip_only=${p.blockIpOnly}
+            block_ip_only=${p.blockIpOnly},
+            cross_device_overlap_mode=${CrossDeviceOverlapMode.asString(p.crossDeviceOverlapMode)}
           WHERE id=${p.id}""".update.run
       .transact(xa)
       .unit

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -82,7 +82,15 @@ class PolicyServiceLive(
         }
         val exemptPats = pSiteLims.filter(_.exemptFromDaily).map(_.domainPattern)
         val perMacTot  = Presence.totalMinutesByMac(pPresence, exemptPats, settings.heartbeatFilter)
-        val totalMins  = devicesIn.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+        // #751: cap-enforcement reads the same Sum/Dedup branch as the
+        // /api/time/status surface so the policy snapshot agrees with what
+        // the screen-time UI shows.
+        val totalMins  = p.crossDeviceOverlapMode match {
+          case CrossDeviceOverlapMode.Sum   =>
+            devicesIn.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+          case CrossDeviceOverlapMode.Dedup =>
+            Presence.dedupedTotalMinutes(pPresence, exemptPats, settings.heartbeatFilter)
+        }
         val extMins    = exts.getOrElse(p.id, 0)
 
         val inputs = ProfileInputs(
@@ -194,7 +202,18 @@ class PolicyServiceLive(
                           stlims.filter(_.exemptFromDaily).map(_.domainPattern)
                         val perMacTot  =
                           Presence.totalMinutesByMac(pPres, exemptPats, settings.heartbeatFilter)
-                        val totalMins  = devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+                        // #751: same branch as snapshot — keeps decide()
+                        // consistent with the snapshot's cap evaluation.
+                        val totalMins  = p.crossDeviceOverlapMode match {
+                          case CrossDeviceOverlapMode.Sum   =>
+                            devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+                          case CrossDeviceOverlapMode.Dedup =>
+                            Presence.dedupedTotalMinutes(
+                              pPres,
+                              exemptPats,
+                              settings.heartbeatFilter,
+                            )
+                        }
                         timeLimitBlockFromDb(
                           h,
                           now,

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -93,6 +93,41 @@ object Presence {
     totalSecondsByMac(rows, exemptPatterns, filter).view.mapValues(s => (s / 60).toInt).toMap
 
   /**
+   * #751: profile-scoped active-bucket union across multiple macs. Each `period_start` instant
+   * counts once regardless of how many of the profile's devices were active in it — the right
+   * semantic when one profile = one human with multiple devices. A bucket counts iff at least one
+   * (mac, host) row in the bucket is non-heartbeat AND non-exempt; its contribution is the max
+   * `activeSeconds` across all macs present in that bucket (the longest-active device sets the
+   * wall-clock floor). Use [[totalSecondsByMac]] + sum when the operator wants per-device totals
+   * added (the `sum` mode).
+   */
+  def dedupedTotalSeconds(
+      rows: List[PresenceRow],
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+  ): Long = {
+    def isExempt(h: HostId) =
+      h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
+    rows.iterator
+      .filterNot(r => isHeartbeat(r, filter))
+      .toList
+      .groupBy(_.periodStart)
+      .iterator
+      .collect {
+        case (_, bucket) if bucket.exists(r => !isExempt(r.host)) =>
+          bucketSeconds(bucket)
+      }
+      .sum
+  }
+
+  def dedupedTotalMinutes(
+      rows: List[PresenceRow],
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+  ): Int =
+    (dedupedTotalSeconds(rows, exemptPatterns, filter) / 60).toInt
+
+  /**
    * #714 heartbeat classification, applied ONLY inside `totalSecondsByMac`/`totalMinutesByMac`.
    * Per-site (`patternMinutesByMac`) and per-host (`hostMinutes`) breakdowns intentionally do not
    * filter — heartbeats keep counting for per-site time for now; the operator wants to evaluate

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -198,6 +198,10 @@ object ProfileRoutes {
                   // #424: omitted blockIpOnly defaults to false on create
                   // (matches the DB column default).
                   upr.blockIpOnly.getOrElse(false),
+                  // #751: omitted crossDeviceOverlapMode defaults to Sum
+                  // (matches the DB column default and preserves
+                  // pre-#751 per-profile semantics).
+                  upr.crossDeviceOverlapMode.getOrElse(CrossDeviceOverlapMode.Sum),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -240,6 +244,9 @@ object ProfileRoutes {
                   // #424: if caller omits blockIpOnly, preserve the
                   // existing value rather than clearing it.
                   blockIpOnly = upr.blockIpOnly.getOrElse(p.blockIpOnly),
+                  // #751: same preserve-on-omit semantics.
+                  crossDeviceOverlapMode =
+                    upr.crossDeviceOverlapMode.getOrElse(p.crossDeviceOverlapMode),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -436,7 +443,14 @@ object TimeRoutes {
               val exempts   = exemptByPid.getOrElse(p.id, Nil)
               val perMac    = wifihaven.api.presence.Presence
                 .totalMinutesByMac(pRows, exempts, settings.heartbeatFilter)
-              val used      = devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+              // #751: honor the profile's overlap mode.
+              val used      = p.crossDeviceOverlapMode match {
+                case CrossDeviceOverlapMode.Sum   =>
+                  devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+                case CrossDeviceOverlapMode.Dedup =>
+                  wifihaven.api.presence.Presence
+                    .dedupedTotalMinutes(pRows, exempts, settings.heartbeatFilter)
+              }
               val limit     = limitByPid.get(p.id)
               val extMins   = extsByPid.getOrElse(p.id, 0)
               val remaining = limit.map(l => (l + extMins - used).max(0))
@@ -485,7 +499,14 @@ object TimeRoutes {
               val pRows   = presence.filter(r => macSet.contains(r.mac))
               val perMac  = wifihaven.api.presence.Presence
                 .totalMinutesByMac(pRows, Nil, settings.heartbeatFilter)
-              val total   = devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+              // #751: same Sum/Dedup branch as the daily summary.
+              val total   = p.crossDeviceOverlapMode match {
+                case CrossDeviceOverlapMode.Sum   =>
+                  devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
+                case CrossDeviceOverlapMode.Dedup =>
+                  wifihaven.api.presence.Presence
+                    .dedupedTotalMinutes(pRows, Nil, settings.heartbeatFilter)
+              }
               ProfileTimeSummaryWeek(
                 p.id,
                 p.name,
@@ -768,7 +789,17 @@ object TimeRoutes {
         .totalMinutesByMac(presence, exemptPats, heartbeatFilter)
       perMacPat       = wifihaven.api.presence.Presence
         .patternMinutesByMac(presence, stls.map(_.domainPattern))
-      totalUsed       = devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
+      // #751: in Dedup mode the profile total unions per-device active buckets
+      // (one bucket → one minute, regardless of how many of this profile's
+      // devices were active in it). In Sum mode we keep the historical
+      // behaviour: per-device totals added.
+      totalUsed       = profile.crossDeviceOverlapMode match {
+        case CrossDeviceOverlapMode.Sum   =>
+          devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
+        case CrossDeviceOverlapMode.Dedup =>
+          wifihaven.api.presence.Presence
+            .dedupedTotalMinutes(presence, exemptPats, heartbeatFilter)
+      }
       remaining       = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
       siteUsage       = stls.map { stl =>
         val used = devices.iterator.map(d => perMacPat.getOrElse((d.mac, stl.domainPattern), 0)).sum
@@ -837,7 +868,16 @@ object TimeRoutes {
       // view (#714). Per-FQDN attribution caveats from #715 still apply.
       perMacTotal     = wifihaven.api.presence.Presence
         .totalMinutesByMac(presence, Nil, heartbeatFilter)
-      totalUsed       = devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
+      // #751: same Sum/Dedup branch as the daily endpoint, applied across the
+      // entire weekly range. perBucket below also respects the mode so the
+      // bars reconcile to totalUsed.
+      totalUsed       = profile.crossDeviceOverlapMode match {
+        case CrossDeviceOverlapMode.Sum   =>
+          devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
+        case CrossDeviceOverlapMode.Dedup =>
+          wifihaven.api.presence.Presence
+            .dedupedTotalMinutes(presence, Nil, heartbeatFilter)
+      }
       deviceSummaries = devices.map { d =>
         DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
       }
@@ -851,7 +891,13 @@ object TimeRoutes {
           .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
           .take(10)
       }
-      perBucket       = bucketHourlyAligned(presence, heartbeatFilter, bucketOffsetMin)
+      perBucket       =
+        bucketHourlyAligned(
+          presence,
+          heartbeatFilter,
+          bucketOffsetMin,
+          profile.crossDeviceOverlapMode,
+        )
     } yield ProfileTimeStatusWeek(
       profile.id,
       profile.name,
@@ -897,7 +943,10 @@ object TimeRoutes {
           .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
           .take(10)
       }
-      perBucket = bucketHourlyAligned(presence, heartbeatFilter, bucketOffsetMin)
+      // Per-device path: only one mac in play, so the dedup/sum distinction is
+      // moot; use the Sum branch to keep the historical wiring.
+      perBucket =
+        bucketHourlyAligned(presence, heartbeatFilter, bucketOffsetMin, CrossDeviceOverlapMode.Sum)
     } yield DeviceTimeStatusWeek(
       device.mac,
       device.name,
@@ -942,6 +991,7 @@ object TimeRoutes {
       presence: List[wifihaven.api.presence.PresenceRow],
       heartbeatFilter: HeartbeatFilter,
       offsetMin: Int,
+      overlap: CrossDeviceOverlapMode,
   ): List[ProfileTimeBucket] = {
     val hourSeconds   = 3600L
     val offsetSeconds = offsetMin.toLong * 60L
@@ -954,10 +1004,18 @@ object TimeRoutes {
       }
       .iterator
       .map { case (bucketStart, rows) =>
-        val mins = wifihaven.api.presence.Presence
-          .totalMinutesByMac(rows, Nil, heartbeatFilter)
-          .values
-          .sum
+        // #751: respect the profile's overlap mode so the hourly bars reconcile
+        // with the headline totalUsed.
+        val mins = overlap match {
+          case CrossDeviceOverlapMode.Sum   =>
+            wifihaven.api.presence.Presence
+              .totalMinutesByMac(rows, Nil, heartbeatFilter)
+              .values
+              .sum
+          case CrossDeviceOverlapMode.Dedup =>
+            wifihaven.api.presence.Presence
+              .dedupedTotalMinutes(rows, Nil, heartbeatFilter)
+        }
         ProfileTimeBucket(bucketStart, mins)
       }
       .filter(_.usedMins > 0)

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -143,7 +143,7 @@ object UsageRoutes {
       nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
       rows <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
       (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
-        UsageSeries.buildProfile(rows, nameByMac, zone, topN)
+        UsageSeries.buildProfile(rows, nameByMac, zone, topN, profile.crossDeviceOverlapMode)
     } yield UsageSeriesResponse(
       profileId = Some(pid),
       profileName = Some(profile.name),

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -150,6 +150,7 @@ object UsageSeries {
       deviceNames: Map[MacAddress, String],
       zone: ZoneId,
       topN: Int,
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
   ): (List[UsageHostTotal], List[UsageBucket], List[UsageDeviceTotal], List[UsageDeviceBucket]) = {
     // Group by (mac, periodStart) — same 5-min bucketing as the per-device build,
     // but now we keep the mac so we can later stack-by-device.
@@ -160,12 +161,12 @@ object UsageSeries {
         .map(r => r.host -> r.bytes)
         .toList
         .groupMapReduce(_._1)(_._2)(_ + _)
-      (hour, mac, secs, byHost)
+      (hour, mac, ps, secs, byHost)
     }
 
     // ── Per-host day totals (#715 byte-share within each (mac, bucket)) ────
     val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, _, secs, byHost) <- fiveMin if byHost.nonEmpty) {
+    for ((_, _, _, secs, byHost) <- fiveMin if byHost.nonEmpty) {
       val totalBytes = byHost.valuesIterator.sum
       if (totalBytes > 0L)
         for ((h, b) <- byHost) {
@@ -187,7 +188,7 @@ object UsageSeries {
 
     // ── Per-device day totals (one bucket → one device) ───────────────────
     val perDeviceDaySecs = scala.collection.mutable.Map.empty[MacAddress, Long]
-    for ((_, mac, secs, _) <- fiveMin)
+    for ((_, mac, _, secs, _) <- fiveMin)
       perDeviceDaySecs.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
     val orderedDevices = perDeviceDaySecs.toList
       .map { case (m, s) => (m, (s / 60).toInt) }
@@ -205,13 +206,30 @@ object UsageSeries {
     val bucketsByDevice = scala.collection.mutable.ArrayBuffer.empty[UsageDeviceBucket]
     for (hr <- 0 until 24) {
       val hrBuckets = byHour.getOrElse(hr, Nil)
-      val totalSecs = hrBuckets.iterator.map((_, _, s, _) => s.toLong).sum
+      // #751: in Dedup mode the per-hour total collapses to the union of
+      // periodStarts (one bucket → one wall-clock contribution regardless of
+      // how many of the profile's devices were active in it). The per-host
+      // and per-device stacks below stay summed (they're the contribution
+      // breakdown, not a strict reconcile-to-total), so in Dedup mode the
+      // stacks can exceed totalMins; the otherMins clamp keeps the rendered
+      // chart non-negative.
+      val totalSecs = overlap match {
+        case CrossDeviceOverlapMode.Sum   =>
+          hrBuckets.iterator.map((_, _, _, s, _) => s.toLong).sum
+        case CrossDeviceOverlapMode.Dedup =>
+          hrBuckets.iterator
+            .map { case (_, _, ps, s, _) => ps -> s.toLong }
+            .toList
+            .groupMapReduce(_._1)(_._2)(_ max _)
+            .valuesIterator
+            .sum
+      }
       val totalMins = (totalSecs / 60).toInt
 
       // Per-host stack within the hour (#715 byte-share within each 5-min bucket).
       val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
       var hostOther = 0.0
-      for ((_, _, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
+      for ((_, _, _, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
         val totalBytes = byHost.valuesIterator.sum
         if (totalBytes > 0L)
           for ((h, b) <- byHost) {
@@ -242,7 +260,7 @@ object UsageSeries {
       // Per-device stack within the hour (each bucket attributes to its mac).
       val perDevice = scala.collection.mutable.Map.empty[MacAddress, Long]
       var devOther  = 0L
-      for ((_, mac, secs, _) <- hrBuckets)
+      for ((_, mac, _, secs, _) <- hrBuckets)
         if (topDeviceMacs.contains(mac))
           perDevice.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
         else devOther += secs.toLong

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -637,6 +637,164 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           ) &&
           assertTrue(kids.devices.find(_.deviceMac == MacAddress.unsafe(mac2)).get.usedMins == 35)
       },
+      // #751: Sum vs Dedup — two devices active in the same 5-min bucket.
+      // Sum mode adds per-device totals (5+5=10); Dedup unions per-device
+      // active buckets so overlap counts once (5).
+      test("crossDeviceOverlapMode=sum: overlapping buckets across devices count twice") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 60)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Both devices in the SAME 5-min bucket (bucketOffset=0 on each).
+          _               <- seedTraffic(routerId, mac1, "minecraft.net", today, 5, 0)
+          _               <- seedTraffic(routerId, mac2, "youtube.com", today, 5, 0)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(kids.usedMins == 10) // sum mode (default): 5+5
+      },
+      test("crossDeviceOverlapMode=dedup: overlapping buckets count once") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          // Flip the profile to Dedup mode.
+          _           <- profileRepo.findById(kidsId).flatMap { opt =>
+            ZIO.foreachDiscard(opt)(p =>
+              profileRepo.update(p.copy(crossDeviceOverlapMode = CrossDeviceOverlapMode.Dedup)),
+            )
+          }
+          _           <- tlRepo.upsert(kidsId, 60)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Same bucket on both devices.
+          _               <- seedTraffic(routerId, mac1, "minecraft.net", today, 5, 0)
+          _               <- seedTraffic(routerId, mac2, "youtube.com", today, 5, 0)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(kids.usedMins == 5)
+      },
+      test("crossDeviceOverlapMode=dedup: non-overlapping buckets sum the same as sum mode") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- profileRepo.findById(kidsId).flatMap { opt =>
+            ZIO.foreachDiscard(opt)(p =>
+              profileRepo.update(p.copy(crossDeviceOverlapMode = CrossDeviceOverlapMode.Dedup)),
+            )
+          }
+          _           <- tlRepo.upsert(kidsId, 60)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Different bucket ranges → no overlap.
+          off1            <- seedTraffic(routerId, mac1, "minecraft.net", today, 10, 0)
+          _               <- seedTraffic(routerId, mac2, "youtube.com", today, 10, off1)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(kids.usedMins == 20) // 10+10 with no overlap
+      },
       test("per-app site usage aggregated across all profile devices") {
         for {
           _           <- cleanDb

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -95,6 +95,35 @@ object FailureMode {
   )
 }
 
+// #751: per-profile knob controlling how the profile's screen-time total
+// handles two devices on the same profile being active in the same 5-min
+// bucket.
+//   Sum   — current behavior: per-device bucket-deduped minutes are added.
+//           Two siblings on the same profile both active for a bucket count
+//           as two buckets.
+//   Dedup — the per-device active-bucket sets are unioned before counting,
+//           so overlap counts once at the profile level. Right for "one
+//           profile = one human with multiple devices".
+enum CrossDeviceOverlapMode {
+  case Sum, Dedup
+}
+
+object CrossDeviceOverlapMode {
+  def asString(m: CrossDeviceOverlapMode): String      = m match {
+    case Sum   => "sum"
+    case Dedup => "dedup"
+  }
+  def parse(s: String): Option[CrossDeviceOverlapMode] = s.toLowerCase match {
+    case "sum"   => Some(Sum)
+    case "dedup" => Some(Dedup)
+    case _       => None
+  }
+  given JsonCodec[CrossDeviceOverlapMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown crossDeviceOverlapMode: $s"),
+    asString,
+  )
+}
+
 case class Profile(
     id: ProfileId,
     name: String,
@@ -104,6 +133,7 @@ case class Profile(
     paused: Boolean,
     failureMode: FailureMode = FailureMode.LastKnownGood,
     blockIpOnly: Boolean = false,
+    crossDeviceOverlapMode: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
 ) derives JsonCodec
 
 case class Schedule(
@@ -217,6 +247,7 @@ case class UpsertProfileRequest(
     siteTimeLimits: List[SiteTimeLimitRequest],
     failureMode: Option[FailureMode] = None,
     blockIpOnly: Option[Boolean] = None,
+    crossDeviceOverlapMode: Option[CrossDeviceOverlapMode] = None,
 ) derives JsonCodec
 
 case class ScheduleRequest(

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -90,7 +90,7 @@ describe('SWR caching (#803)', () => {
     const qc = freshClient(0)
     const wrapper = makeWrapper(qc)
     ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' as const }, schedules: [], timeLimit: null, siteTimeLimits: [] },
+      { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' as const, crossDeviceOverlapMode: 'sum' as const }, schedules: [], timeLimit: null, siteTimeLimits: [] },
     ])
     const hook = renderHook(() => useProfiles(), { wrapper })
     await waitFor(() => expect(hook.result.current.isSuccess).toBe(true))

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -47,11 +47,11 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' },
+  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'last-known-good' },
+  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum' },
   schedules: [], timeLimit: null, siteTimeLimits: [],
 }
 

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -38,7 +38,7 @@ const devices: Device[] = [
   { id: 10, mac: 'aa:bb:cc:dd:ee:01', name: "Kid's iPad", profileId: 1, profileName: 'Kids', lastSeenIp: null, lastSeenAt: null },
 ]
 const profileDetails: ProfileDetail[] = [
-  { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' }, schedules: [], timeLimit: null, siteTimeLimits: [] },
+  { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' }, schedules: [], timeLimit: null, siteTimeLimits: [] },
 ]
 
 function renderAt(path = '/usage/events') {

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -55,6 +55,7 @@ const kidsProfile: ProfileDetail = {
     extraAllowed: ['school.com'],
     paused: false,
     failureMode: 'block-all',
+    crossDeviceOverlapMode: 'sum',
   },
   schedules: [
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
@@ -74,6 +75,7 @@ const adultsProfile: ProfileDetail = {
     extraAllowed: [],
     paused: true,
     failureMode: 'last-known-good',
+    crossDeviceOverlapMode: 'sum',
   },
   schedules: [],
   timeLimit: null,
@@ -245,6 +247,10 @@ describe('ProfilesPage — create', () => {
       // (matches DB column default; UI copy steers admins towards BlockAll
       // for child profiles).
       failureMode: 'last-known-good',
+      // #751: form default for a brand-new profile is Sum (matches DB
+      // column default; admins opt in to Dedup explicitly when one
+      // profile represents one human with multiple devices).
+      crossDeviceOverlapMode: 'sum',
     })
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
   })
@@ -285,7 +291,32 @@ describe('ProfilesPage — edit', () => {
       ],
       // #385: edit preserves the existing failureMode unless changed.
       failureMode: 'block-all',
+      // #751: edit round-trips the existing crossDeviceOverlapMode.
+      crossDeviceOverlapMode: 'sum',
     })
+  })
+})
+
+describe('ProfilesPage — cross-device overlap toggle (#751)', () => {
+  it('round-trips the dedup selection to api.profiles.update', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+
+    expect(screen.getByTestId('profile-overlap-mode-sum')).toBeChecked()
+    expect(screen.getByTestId('profile-overlap-mode-dedup')).not.toBeChecked()
+
+    await user.click(screen.getByTestId('profile-overlap-mode-dedup'))
+    expect(screen.getByTestId('profile-overlap-mode-dedup')).toBeChecked()
+
+    await user.click(screen.getByRole('button', { name: /^Save$/ }))
+
+    await waitFor(() => expect(api.profiles.update).toHaveBeenCalledTimes(1))
+    expect(api.profiles.update).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ crossDeviceOverlapMode: 'dedup' }),
+    )
   })
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -5,8 +5,8 @@ import { api } from '@/api/client'
 import { useProfiles, useDevices, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import type {
-  Device, FailureMode, HouseholdSettings, ProfileDetail, ScheduleRequest,
-  SiteTimeLimitRequest, UpsertProfileRequest, User,
+  CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
+  ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { PageLoader } from './DashboardPage'
@@ -23,6 +23,7 @@ interface FormState {
   schedules: ScheduleRequest[]
   siteTimeLimits: SiteTimeLimitRequest[]
   failureMode: FailureMode
+  crossDeviceOverlapMode: CrossDeviceOverlapMode
 }
 
 function emptyForm(): FormState {
@@ -40,6 +41,10 @@ function emptyForm(): FormState {
     // BlockAll-for-kids recommendation in copy; admins still have to
     // pick BlockAll explicitly when creating a child profile.
     failureMode: 'last-known-good',
+    // #751: default to the historical behaviour ("two siblings on the same
+    // profile both active count as two") for new profiles. Admins opt in to
+    // dedup explicitly when one profile = one human with multiple devices.
+    crossDeviceOverlapMode: 'sum',
   }
 }
 
@@ -61,6 +66,7 @@ function detailToForm(pd: ProfileDetail): FormState {
       exemptFromDaily: s.exemptFromDaily,
     })),
     failureMode: pd.profile.failureMode,
+    crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
   }
 }
 
@@ -77,6 +83,7 @@ function formToRequest(f: FormState): UpsertProfileRequest {
     schedules: f.schedules,
     siteTimeLimits: f.siteTimeLimits,
     failureMode: f.failureMode,
+    crossDeviceOverlapMode: f.crossDeviceOverlapMode,
   }
 }
 
@@ -650,6 +657,50 @@ function ProfileEditor({
                 <span className="text-gray-500"> (only for trusted profiles)</span>
                 <span className="block text-xs text-gray-400 mt-0.5">
                   when the router can't reach the API, clear every block for this profile's devices. The cached categorical / schedule rules stop applying.
+                </span>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        {/* #751: how the profile's screen-time total handles two devices on
+            the same profile being active in the same 5-min bucket. */}
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            Cross-device overlap
+          </label>
+          <div className="space-y-2">
+            <label className="flex items-start gap-3 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="crossDeviceOverlapMode"
+                data-testid="profile-overlap-mode-sum"
+                checked={form.crossDeviceOverlapMode === 'sum'}
+                onChange={() => setForm(f => ({ ...f, crossDeviceOverlapMode: 'sum' }))}
+                className="mt-1 w-4 h-4 accent-emerald-500"
+              />
+              <span>
+                <span className="font-medium text-white">Count each device separately</span>
+                <span className="text-gray-500"> (default)</span>
+                <span className="block text-xs text-gray-400 mt-0.5">
+                  add per-device totals. Two devices on this profile both active in the same 5-minute window count as 10 minutes against the daily cap.
+                </span>
+              </span>
+            </label>
+            <label className="flex items-start gap-3 text-sm text-gray-300 cursor-pointer">
+              <input
+                type="radio"
+                name="crossDeviceOverlapMode"
+                data-testid="profile-overlap-mode-dedup"
+                checked={form.crossDeviceOverlapMode === 'dedup'}
+                onChange={() => setForm(f => ({ ...f, crossDeviceOverlapMode: 'dedup' }))}
+                className="mt-1 w-4 h-4 accent-emerald-500"
+              />
+              <span>
+                <span className="font-medium text-white">Combine overlapping device usage</span>
+                <span className="text-gray-500"> (one profile = one human)</span>
+                <span className="block text-xs text-gray-400 mt-0.5">
+                  union the per-device active windows. Two devices both active in the same 5-minute window count as 5 minutes against the daily cap. Right when one person carries an iPad and a phone for the same profile.
                 </span>
               </span>
             </label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -4,6 +4,12 @@
 // shared/src/Models.scala FailureMode.asString.
 export type FailureMode = 'block-all' | 'allow-all' | 'last-known-good'
 
+// #751: per-profile knob — `sum` adds per-device totals (siblings on the same
+// profile double-count when both are active in the same bucket); `dedup`
+// unions the per-device active-bucket sets so overlap counts once. Default
+// is `sum` (preserves pre-#751 semantics).
+export type CrossDeviceOverlapMode = 'sum' | 'dedup'
+
 export interface Profile {
   id: number
   name: string
@@ -12,6 +18,7 @@ export interface Profile {
   extraAllowed: string[]
   paused: boolean
   failureMode: FailureMode
+  crossDeviceOverlapMode: CrossDeviceOverlapMode
 }
 
 export interface Schedule {
@@ -469,6 +476,8 @@ export interface UpsertProfileRequest {
   timeLimit: number | null
   siteTimeLimits: SiteTimeLimitRequest[]
   failureMode: FailureMode
+  // #751: omit to preserve existing value on update; defaults to 'sum' on create.
+  crossDeviceOverlapMode?: CrossDeviceOverlapMode
 }
 
 export interface UpsertDeviceRequest {


### PR DESCRIPTION
## Summary

- New per-profile knob `crossDeviceOverlapMode` (`sum` | `dedup`) controlling how the profile screen-time total handles two devices on the same profile being active in the same 5-min bucket.
- `sum` (default): per-device bucket-deduped minutes are added. `dedup`: per-device active-bucket sets are unioned, so cross-device overlap counts once.
- Wired through migration V27, shared model + upsert request, `ProfileRepo`, the whole `/api/time/status` surface (daily / weekly / summary), the policy snapshot cap-enforcement path, the `/api/usage/series?profileId=` rollup, and a labeled radio on the profile edit page.

## Math difference

Two devices on the same profile, both active in the same 5-minute bucket:
- `sum`: contributes **10** minutes (5 per device, added). Right for "each device's screen time matters independently".
- `dedup`: contributes **5** minutes (union of active buckets). Right for "one profile = one human with multiple devices".

Non-overlapping activity sums identically in both modes (covered by a test).

## Screenshot

Two new radios in the profile editor — "Count each device separately" (default) and "Combine overlapping device usage". Each option carries an explanation of the daily-cap implication.

## Test plan

- [x] `mill api.test` — added `crossDeviceOverlapMode=sum` (10 min), `=dedup` (5 min), and `=dedup` with non-overlapping buckets (20 min) cases for `/api/time/status`.
- [x] `mill shared.test`
- [x] `npm test` in `web/` — added round-trip test for the toggle (`api.profiles.update` receives `crossDeviceOverlapMode: 'dedup'` after selecting the radio).
- [x] `tsc --noEmit` in `web/`
- [ ] Manual: edit a profile, flip the radio, reload — value persists.

Closes #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)