### PR TITLE
fix(openwrt): APK postinst register wifihaven-update cron (#869)

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -95,6 +95,15 @@ cat > "$WORK/post-install" <<'POSTINSTALL'
 /etc/init.d/wifihaven-boot start 2>/dev/null || true
 # #542: uhttpd block-page wire-up runs at first boot from
 # /etc/uci-defaults/95-wifihaven-uhttpd (shipped in data/).
+
+# #869: Install cron entry for the auto-updater (daily, 04:00 router-local).
+# Replace any existing wifihaven-update entry so upgrades migrate the
+# cadence — older packages installed it at "0 */6 * * *".
+mkdir -p /etc/crontabs
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+/etc/init.d/cron enable 2>/dev/null || true
+/etc/init.d/cron restart 2>/dev/null || true
 POSTINSTALL
 chmod 0755 "$WORK/post-install"
 

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -243,5 +243,29 @@ else
         "function returned early without installing dnsmasq-full (sim log: $(cat "$_sim_log"))"
 fi
 
+# #869: both the IPK postinst (openwrt/Makefile Package/wifihaven/postinst)
+# and the APK postinst (openwrt/build-apk.sh post-install heredoc) must
+# register the wifihaven-update cron entry. The APK builder originally
+# dropped this block, so APK-installed routers never got /etc/crontabs/root
+# wired up and auto-update never ran. Guard both producers so they can't
+# drift again.
+for f in "$ROOT/Makefile" "$ROOT/build-apk.sh"; do
+  label=$(basename "$f")
+  grep -q "wifihaven-update" "$f" \
+    && check "#869 $label postinst references wifihaven-update cron" ok \
+    || check "#869 $label postinst references wifihaven-update cron" \
+             "missing cron registration for /usr/sbin/wifihaven-update"
+
+  grep -q "/usr/sbin/wifihaven-update" "$f" \
+    && check "#869 $label postinst writes /usr/sbin/wifihaven-update to crontab" ok \
+    || check "#869 $label postinst writes /usr/sbin/wifihaven-update to crontab" \
+             "missing crontab line for /usr/sbin/wifihaven-update"
+
+  grep -q "/etc/init.d/cron restart" "$f" \
+    && check "#869 $label postinst restarts cron" ok \
+    || check "#869 $label postinst restarts cron" \
+             "postinst doesn't restart cron after writing crontab"
+done
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- The IPK postinst (`openwrt/Makefile` `Package/wifihaven/postinst`, lines 80-87) writes the daily `wifihaven-update` cron entry to `/etc/crontabs/root` and restarts cron. The APK postinst heredoc in `openwrt/build-apk.sh` was missing the equivalent block, so APK-installed routers never got `/etc/crontabs/root` wired up and auto-update never ran. Discovered via live-debug of #866 / #858 — on the dev router, `/etc/crontabs/root` did not exist after APK install and crond reported "active with no instances".
- Mirror the Makefile cron-registration block into the `build-apk.sh` heredoc.
- Add `install_spec.sh` canaries that assert both producers (`openwrt/Makefile` and `openwrt/build-apk.sh`) register `/usr/sbin/wifihaven-update` and restart cron, so the two postinsts can't drift again.

Note: this fix on its own does NOT restore auto-update end-to-end — it's still blocked behind #870 (freshness signal) and #871 (CD pipeline). This PR is just the postinst.

Closes #869

## Test plan

- [x] `sh openwrt/test/install_spec.sh` — 32 passed, 0 failed (6 new #869 assertions all green)
- [ ] After merge + release, install APK on a fresh router and verify `/etc/crontabs/root` contains `0 4 * * * /usr/sbin/wifihaven-update`