### PR TITLE
fix(openwrt): use asset digest as wifihaven-update freshness signal (#870)

### DIFF
--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -1,8 +1,13 @@
 #!/bin/sh
 # Auto-updater for the wifihaven package.
 # Pulls the rolling `openwrt-latest` GitHub pre-release and re-installs whenever
-# that release's published_at timestamp changes. This matches the rolling-build
-# CD set up by #245 (image-per-push to main, no per-release tag cut).
+# the matched asset's sha256 digest changes. This matches the rolling-build CD
+# set up by #245 (image-per-push to main, no per-release tag cut).
+#
+# We key on the asset digest, not the release's published_at: GitHub does not
+# bump published_at when CI replaces the rolling asset in-place — only the
+# asset's own created_at/digest move. Using published_at meant routers never
+# auto-updated past the original release-tag publish (see #870).
 #
 # Reverted alongside #244, once we're ready for semver-gated production updates
 # again — see TODO(#244) below.
@@ -17,7 +22,10 @@ set -u
 # debug period for #228 is done and proper tags resume.
 API_URL="https://api.github.com/repos/wifihaven/wifihaven/releases/tags/openwrt-latest"
 STATE_DIR=/var/lib/wifihaven
-STAMP_FILE="$STATE_DIR/last_update_stamp"
+# Stores the sha256 digest of the asset last installed (e.g. "sha256:abc..."),
+# not a timestamp. Old routers carrying a published_at timestamp here will
+# simply mismatch on first run and reinstall once, then settle.
+STAMP_FILE="$STATE_DIR/last_update_digest"
 
 log() { logger -t wifihaven "update: $*"; }
 
@@ -42,15 +50,25 @@ if [ -z "$META" ]; then
   exit 0
 fi
 
-# Rolling-release freshness signal: the release's published_at timestamp
-# changes every time CI replaces the rolling asset.
-LATEST_STAMP=$(printf '%s' "$META" | jsonfilter -e '@.published_at')
-LATEST_URL=$(printf '%s' "$META" \
-  | jsonfilter -e '@.assets[*].browser_download_url' \
-  | grep -E "$PKG_EXT" \
-  | head -n1)
+# Rolling-release freshness signal: the matched asset's sha256 digest. We walk
+# assets[*] in order, take the first whose URL matches our package extension,
+# and read its digest at the same index. (jsonfilter has no native way to
+# project paired fields, hence the index loop.)
+LATEST_URL=
+LATEST_STAMP=
+i=0
+while :; do
+  URL=$(printf '%s' "$META" | jsonfilter -e "@.assets[$i].browser_download_url" 2>/dev/null)
+  [ -z "$URL" ] && break
+  if printf '%s' "$URL" | grep -qE "$PKG_EXT"; then
+    LATEST_URL="$URL"
+    LATEST_STAMP=$(printf '%s' "$META" | jsonfilter -e "@.assets[$i].digest")
+    break
+  fi
+  i=$((i + 1))
+done
 if [ -z "$LATEST_STAMP" ] || [ -z "$LATEST_URL" ]; then
-  log "could not resolve rolling release stamp/asset; skipping"
+  log "could not resolve rolling release digest/asset; skipping"
   exit 0
 fi
 
@@ -59,7 +77,7 @@ if [ "$LATEST_STAMP" = "$LAST_STAMP" ]; then
   exit 0
 fi
 
-log "rolling release changed ($LAST_STAMP -> $LATEST_STAMP); upgrading via $PM"
+log "rolling asset digest changed ($LAST_STAMP -> $LATEST_STAMP); upgrading via $PM"
 if ! curl -fsSL -o "$TMP" "$LATEST_URL"; then
   log "download failed: $LATEST_URL"
   rm -f "$TMP"

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -35,15 +35,33 @@ grep -q 'command -v apk' "$SCRIPT" && grep -q 'command -v opkg' "$SCRIPT" \
   && check "detects both apk and opkg package managers" ok \
   || check "detects both apk and opkg package managers" "missing apk/opkg detection"
 
-# 4. Rolling-release mode: compares release published_at stamp instead of semver.
-#    Reverts to semver compare alongside #244.
-grep -q '@.published_at' "$SCRIPT" \
-  && check "uses release published_at as freshness signal" ok \
-  || check "uses release published_at as freshness signal" "missing published_at compare"
+# 4. Rolling-release mode: compares the matched asset's sha256 digest. GitHub
+#    does NOT bump published_at on rolling-asset replacement (see #870), so
+#    keying off published_at means routers never auto-update. Reverts to semver
+#    compare alongside #244.
+grep -q '@.assets\[.*\].digest' "$SCRIPT" \
+  && check "uses asset digest as freshness signal" ok \
+  || check "uses asset digest as freshness signal" "missing assets[*].digest extraction"
 
-grep -q 'last_update_stamp' "$SCRIPT" \
-  && check "persists last-applied stamp under /var/lib/wifihaven" ok \
-  || check "persists last-applied stamp under /var/lib/wifihaven" "missing stamp file"
+grep -q '@.published_at' "$SCRIPT" \
+  && check "does not key off release published_at (#870)" "still references @.published_at" \
+  || check "does not key off release published_at (#870)" ok
+
+grep -q 'last_update_digest' "$SCRIPT" \
+  && check "persists last-applied digest under /var/lib/wifihaven" ok \
+  || check "persists last-applied digest under /var/lib/wifihaven" "missing digest file"
+
+# 4b. Same-digest → no install: when STAMP_FILE matches LATEST_STAMP, exit 0
+#     before downloading or invoking the package manager.
+awk '/LAST_STAMP=.*STAMP_FILE/,/^fi/' "$SCRIPT" | grep -q 'exit 0' \
+  && check "same digest short-circuits before install" ok \
+  || check "same digest short-circuits before install" "no exit 0 in digest-match branch"
+
+# 4c. Different-digest → install: the digest is written to STAMP_FILE only
+#     after a successful install, so a failed install retries next run.
+awk '/^esac/,0' "$SCRIPT" | grep -q "STAMP_FILE" \
+  && check "different digest writes STAMP_FILE after install" ok \
+  || check "different digest writes STAMP_FILE after install" "stamp not written post-install"
 
 # 4c. Installs via apk add --allow-untrusted on apk path
 grep -q 'apk add --allow-untrusted' "$SCRIPT" \


### PR DESCRIPTION
## Summary

- The auto-updater keyed freshness off the release's `published_at`, but GitHub does not bump that field when CI replaces a rolling asset in-place — only the asset's own `created_at`/`digest` move. Result: even with cron and CD working, no router ever auto-updated past the original tag-publish.
- Switches the signal to the matched asset's sha256 `digest`, extracted via an `assets[*]` index walk so the URL and digest stay paired (jsonfilter has no native paired projection).
- Renames `STAMP_FILE` to `last_update_digest` to match the new content. Old routers carrying a timestamp here will mismatch on first run, reinstall once, and settle.

Evidence from the live `openwrt-latest` release at the time of this fix:
`publishedAt: 2026-05-12T17:08:59Z` vs `assets[*].createdAt: 2026-05-21T23:18:01Z`.

Context: discovered via live-debug of #866 / #858. Blocked-by #869 (cron entry) and #871 (CD must publish a fresh artifact) for the end-to-end effect, but this fix stands on its own.

Closes #870

## Test plan

- [x] `sh openwrt/test/update_spec.sh` — 21 passed
- [x] `sh -n` syntax check on the script
- [ ] Post-merge: confirm a router with an old timestamp stamp file picks up the next rolling build on cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)