### PR TITLE
fix(ci): restore Master CD after #835 — split cancel-in-progress off deploy-production

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,13 +48,13 @@ on:
 # main push lands while an older run is still in build/staging, dropping
 # the older run is fine. We do NOT want cancel-in-progress applying to the
 # deploy-production jobs: cancelling mid-promotion can leave one of the
-# three sub-jobs done and the others not, producing a partial release.
-# Splitting the concurrency group by job name (via the job-level
-# `concurrency` field) is more surgical than narrowing the top-level group,
-# so we keep this group covering build/staging and let prod jobs run free.
-concurrency:
-  group: master-${{ github.ref }}
-  cancel-in-progress: true
+# three sub-jobs done and the others not, producing a partial release —
+# and in particular leaves the openwrt-latest rolling artifact stale.
+#
+# Workflow-level cancel-in-progress would cancel the whole run, including
+# deploy-production jobs. Instead we apply concurrency at the job level for
+# the cancellable build/staging jobs only; deploy-production jobs carry no
+# concurrency and always run to completion once they start. See #871.
 
 env:
   REGISTRY: ghcr.io
@@ -67,11 +67,17 @@ jobs:
   # ── 1. Full CI test matrix (unit, lint, lua, python, shell, frontend) ─────
   ci-tests:
     name: CI
+    concurrency:
+      group: master-build-${{ github.ref }}-ci-tests
+      cancel-in-progress: true
     uses: ./.github/workflows/ci.yml
 
   # ── 2. E2E + smoke tests (unconditional) ──────────────────────────────────
   bootstrap-smoke:
     name: bootstrap-host.sh smoke (Ubuntu container)
+    concurrency:
+      group: master-build-${{ github.ref }}-bootstrap-smoke
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -82,6 +88,9 @@ jobs:
 
   e2e:
     name: Live e2e against staging stack
+    concurrency:
+      group: master-build-${{ github.ref }}-e2e
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -109,6 +118,9 @@ jobs:
 
   prod-stack-smoke:
     name: deploy/docker-compose.prod.yml smoke
+    concurrency:
+      group: master-build-${{ github.ref }}-prod-stack-smoke
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -126,6 +138,9 @@ jobs:
   build-image:
     name: Build Docker image to ghcr.io (sha + staging tags)
     needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    concurrency:
+      group: master-build-${{ github.ref }}-build-image
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -178,6 +193,9 @@ jobs:
   deploy-staging:
     name: Deploy staging (Render)
     needs: [build-image]
+    concurrency:
+      group: master-build-${{ github.ref }}-deploy-staging
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Render staging deploy hook
@@ -219,6 +237,9 @@ jobs:
   deploy-spa-staging:
     name: Deploy SPA to Cloudflare Pages (staging)
     needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
+    concurrency:
+      group: master-build-${{ github.ref }}-deploy-spa-staging
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -263,6 +284,9 @@ jobs:
   smoke-staging:
     name: Smoke-test staging
     needs: [deploy-staging, deploy-spa-staging]
+    concurrency:
+      group: master-build-${{ github.ref }}-smoke-staging
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Health endpoint returns 200 + db ok
@@ -338,6 +362,9 @@ jobs:
     # CORS plane; this job covers the admin + router API plane. Either
     # going red still blocks prod via approve-production's `needs:`.
     needs: [deploy-staging]
+    concurrency:
+      group: master-build-${{ github.ref }}-api-smoke-staging
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -430,6 +457,9 @@ jobs:
   gate-2-router-fake-api:
     name: Gate 2 — router fake-API e2e
     needs: [ci-tests]
+    concurrency:
+      group: master-build-${{ github.ref }}-gate-2-router-fake-api
+      cancel-in-progress: true
     uses: ./.github/workflows/e2e-vm-fake.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Closes #871.

`Master CD` produced no fresh `openwrt-latest` rolling artifact for ~17h after #833 merged. Root cause is two unrelated issues stacking:

1. **The b4ec8e1 run itself failed** — not in the new APK build path from #835, but in `Gate 1 — API contract smoke (staging)` → `Router API smoke against staging`:

   ```
   ▶ Usage ingest → last_seen_ip + blockReason=TimeLimit
     ✓ usage posted (90 active seconds)
     ✗ expected blocked=True reason=TimeLimit, got: blocked=False reason=None
   ```

   Failing run: [26262713267](https://github.com/wifihaven/wifihaven/actions/runs/26262713267). This is an intermittent race between usage ingest and the next router-policy poll against the freshly-deployed Render staging service — same test passes against the in-CI docker-compose stack and passed again on a later CD run. Filed as #877 for a separate fix (poll for the block transition instead of a single-shot check). Not addressed here.

2. **Every subsequent push cancelled the run before `publish-openwrt` could complete.** This PR fixes that.

## Root cause of the rolling-artifact stall (the part this PR fixes)

`master.yml` had a workflow-level `concurrency.cancel-in-progress: true`, which cancels the **entire** run — including the deploy-production jobs — when a faster push arrives. The existing comment (lines 47–54) explicitly said we do NOT want that, and described splitting via job-level concurrency as the intended fix. That split was documented but never implemented.

With pushes arriving at < ~25 min cadence (the time the full pipeline takes), `publish-openwrt` got cancelled mid-flight on every run after b4ec8e1. The rolling release stayed pinned to the pre-#833 build.

## Change

Replace workflow-level `cancel-in-progress` with per-job concurrency on the cancellable pre-prod jobs only:

- `ci-tests`, `bootstrap-smoke`, `e2e`, `prod-stack-smoke`, `build-image`,
  `deploy-staging`, `deploy-spa-staging`, `smoke-staging`,
  `api-smoke-staging`, `gate-2-router-fake-api` → each gets its own
  job-level group with `cancel-in-progress: true`.
- `approve-production`, `retag-latest`, `publish-openwrt`,
  `deploy-prod-render`, `deploy-spa-prod` → no concurrency, so once they
  start they run to completion regardless of new pushes.

A new push still pre-empts an old run's build/staging phase (so we don't queue work), but cannot cancel an already-running prod-deploy job.

## Notes

- CD self-recovered today at 18:29Z ([run 26305105683](https://github.com/wifihaven/wifihaven/actions/runs/26305105683)) once a long enough gap between pushes let the pipeline complete. `openwrt-latest` got fresh assets at 18:54:21Z. This PR prevents the regression from recurring.
- Filed #877 for the flaky `api-smoke-staging` `TimeLimit` check.

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, monitor next push to main — verify `publish-openwrt` is not cancelled if a subsequent push arrives while it's running
- [ ] Verify the `openwrt-latest` release timestamp advances after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)