### PR TITLE
fix(openwrt): rekey rx counter by ip daddr; resolve to MAC in agent (#879)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -462,13 +462,21 @@ function M.nft(snapshot, opts)
     emit("")
   end
 
-  -- Per-flow accounting sets. Two sets, one per direction, both keyed on
-  -- (device_mac, remote_ip) so usage.lua can join them into a single record
-  -- carrying bytesIn and bytesOut (#717). The set for the device→remote
-  -- direction matches `ether saddr (mac) . ip daddr (remote)`; the reverse
-  -- direction matches `ether daddr (mac) . ip saddr (remote)`. The chain
-  -- below updates both atomically per packet, so a row's bytesIn/bytesOut
-  -- always cover the same window and the agent's per-bucket nft reset
+  -- Per-flow accounting sets. Two sets, one per direction.
+  --
+  -- tx (device→remote): `ether saddr (mac) . ip daddr (remote)`. The L2 saddr
+  -- at the forward hook is the LAN device's real MAC, so per-(mac, remote_ip)
+  -- attribution works.
+  --
+  -- rx (remote→device): keyed on `ip daddr` only — the LAN device's IP. We
+  -- *cannot* use `ether daddr` here: for WAN→LAN routed packets the L2 daddr
+  -- at the forward hook is still the router's WAN-interface MAC (the rewrite
+  -- to the LAN device's MAC happens at egress via the neighbor cache, after
+  -- the forward hook runs). Keying on it would attribute every download to
+  -- the router itself (#879). Instead we record per-(lan_ip) totals and the
+  -- agent resolves the IP back to a MAC via the dnsmasq lease table.
+  --
+  -- The chain below updates both sets per packet, so a bucket's nft reset
   -- zeroes both in lock-step.
   ind("set mac_ip_tracking {")
   ind2("type ether_addr . ipv4_addr")
@@ -478,8 +486,8 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
-  ind("set mac_ip_tracking_rx {")
-  ind2("type ether_addr . ipv4_addr")
+  ind("set ip_tracking_rx {")
+  ind2("type ipv4_addr")
   ind2("flags dynamic,timeout")
   ind2("timeout 6h")
   ind2("counter")
@@ -491,8 +499,8 @@ function M.nft(snapshot, opts)
   -- forwarded packet bumps exactly one element on exactly one set.
   ind("chain wifihaven_account {")
   ind2("type filter hook forward priority 1; policy accept;")
-  ind2("update @mac_ip_tracking    { ether saddr . ip daddr } counter")
-  ind2("update @mac_ip_tracking_rx { ether daddr . ip saddr } counter")
+  ind2("update @mac_ip_tracking { ether saddr . ip daddr } counter")
+  ind2("update @ip_tracking_rx  { ip daddr } counter")
   ind("}")
   emit("")
 

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -1,38 +1,50 @@
 -- usage.lua — nftables counter scraper and usage reporter
 --
--- Per-(mac, dst_ip) byte/packet accounting comes from the dynamic set
--- `mac_ip_tracking` declared in render.lua:
+-- Per-flow byte/packet accounting comes from two dynamic sets declared in
+-- render.lua:
 --
---   set mac_ip_tracking {
+--   set mac_ip_tracking {                   -- tx: device → remote
 --     type ether_addr . ipv4_addr
 --     flags dynamic,timeout
 --     counter
---     ...
+--   }
+--   set ip_tracking_rx {                    -- rx: remote → device
+--     type ipv4_addr
+--     flags dynamic,timeout
+--     counter
 --   }
 --   chain wifihaven_account {
 --     type filter hook forward priority 1; policy accept;
 --     update @mac_ip_tracking { ether saddr . ip daddr } counter
+--     update @ip_tracking_rx  { ip daddr } counter
 --   }
 --
--- Each set element carries its own counter, so we read
--- `nft -j list set inet wifihaven mac_ip_tracking` and walk
--- `nftables[*].set.elem[*].elem.{val.concat:[mac,ip], counter:{packets,bytes}}`.
--- After a successful POST the agent calls
--- `nft reset set inet wifihaven mac_ip_tracking` to zero the per-element
--- counters in place so the next bucket starts clean.
+-- The rx set is intentionally NOT keyed on `ether daddr`: at the forward
+-- hook the L2 daddr of a WAN→LAN routed packet is still the router's
+-- WAN-interface MAC (the rewrite to the LAN device MAC happens at egress
+-- via the neighbor cache). Keying on it attributed every download byte to
+-- the router itself (#879). Instead the rx set records per-(lan_ip)
+-- totals and the agent resolves the IP back to a MAC via the dnsmasq
+-- lease table; rx bytes for an IP not in the lease table are dropped.
 --
 -- Public API:
 --   usage.parse_nft_counters(json_str)
 --     → list of { mac, dst_ip, bytes, packets }
---     Input: JSON from `nft -j list set inet wifihaven mac_ip_tracking{,_rx}`
+--     Input: JSON from `nft -j list set inet wifihaven mac_ip_tracking`
 --
---   usage.merge_counters(tx, rx)
+--   usage.parse_nft_rx_counters(json_str)
+--     → list of { ip, bytes, packets }
+--     Input: JSON from `nft -j list set inet wifihaven ip_tracking_rx`
+--
+--   usage.merge_counters(tx, rx, ip_to_mac, log)
 --     → list of { mac, dst_ip, bytes, packets, bytes_out, packets_out }
---     Joins the two per-direction counter lists on (mac, dst_ip). `bytes`/
---     `packets` come from the tx set (device→remote, traffic ingressing the
---     router); `bytes_out`/`packets_out` come from the rx set (remote→device,
---     traffic egressing the router). Pairs missing from one direction are
---     still emitted with that side zeroed (#717).
+--     `tx` (device→remote) carries `{mac, dst_ip, bytes, packets}` and goes
+--     into bytes/packets. `rx` (remote→device) carries `{ip, bytes, packets}`
+--     and is resolved to a MAC via `ip_to_mac[ip]` (the dnsmasq lease table);
+--     unresolved IPs are dropped with a log line. Resolved rx contributions
+--     are attributed to the device with dst_ip = the LAN ip itself (the rx
+--     keying carries no remote_ip, so per-remote-host attribution is lost
+--     on the download side; the row lands on the device's own IP as host).
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id,
 --                      leases, lookup_hostname, tracker,
@@ -120,16 +132,57 @@ function M.parse_nft_counters(json_str)
 end
 
 -- ---------------------------------------------------------------------------
--- usage.merge_counters(tx, rx)
+-- usage.parse_nft_rx_counters(json_str)
 --
--- Joins per-direction counter lists (each as produced by parse_nft_counters)
--- on (mac, dst_ip). The tx side is the existing `ether saddr . ip daddr`
--- direction and stays in `bytes`/`packets`; the rx side is the new
--- `ether daddr . ip saddr` direction and goes into `bytes_out`/`packets_out`.
--- A (mac, dst_ip) pair seen in only one direction still produces a record
--- with the other direction's fields at zero.
+-- Walks the JSON output of `nft -j list set inet wifihaven ip_tracking_rx`
+-- (single-key set: `type ipv4_addr`). Each set element's `val` is the IP
+-- string directly (not a `concat` array).
 -- ---------------------------------------------------------------------------
-function M.merge_counters(tx, rx)
+function M.parse_nft_rx_counters(json_str)
+  local jsonc   = require("luci.jsonc")
+  local decoded = jsonc.parse(json_str)
+  local result  = {}
+
+  if not decoded then return result end
+
+  for _, entry in ipairs(decoded.nftables or {}) do
+    local set = entry.set
+    if set and set.elem then
+      for _, wrapper in ipairs(set.elem) do
+        local e = wrapper.elem or wrapper
+        local ip = e.val
+        local counter = e.counter
+        if type(ip) == "string" and counter then
+          result[#result + 1] = {
+            ip      = ip,
+            bytes   = counter.bytes   or 0,
+            packets = counter.packets or 0,
+          }
+        end
+      end
+    end
+  end
+
+  return result
+end
+
+-- ---------------------------------------------------------------------------
+-- usage.merge_counters(tx, rx, ip_to_mac, log)
+--
+-- Joins tx (per (mac, remote_ip)) with rx (per (lan_ip), resolved to mac
+-- via `ip_to_mac`). Records are keyed (mac, dst_ip):
+--
+--   * tx records add `bytes`/`packets` at (mac, c.dst_ip).
+--   * rx records add `bytes_out`/`packets_out` at (resolved_mac, c.ip) —
+--     the LAN IP itself doubles as the host placeholder, since the rx set
+--     does not capture the remote IP (#879). The merge with a tx record
+--     at the same (mac, lan_ip) is incidental (tx normally targets remote
+--     IPs, not the device's own LAN IP) and is fine when it happens.
+--   * rx records whose `ip` is not in `ip_to_mac` are dropped. We log a
+--     summary count per bucket so unattributed download bytes are visible
+--     in `logread` without spamming a line per packet.
+-- ---------------------------------------------------------------------------
+function M.merge_counters(tx, rx, ip_to_mac, log)
   local index = {}
   local result = {}
   local function key(mac, dst_ip) return mac .. "|" .. dst_ip end
@@ -155,10 +208,22 @@ function M.merge_counters(tx, rx)
     rec.bytes   = rec.bytes   + (c.bytes   or 0)
     rec.packets = rec.packets + (c.packets or 0)
   end
+  local unknown_n     = 0
+  local unknown_bytes = 0
   for _, c in ipairs(rx or {}) do
-    local rec = get_or_make(c.mac, c.dst_ip)
-    rec.bytes_out   = rec.bytes_out   + (c.bytes   or 0)
-    rec.packets_out = rec.packets_out + (c.packets or 0)
+    local mac = ip_to_mac and ip_to_mac[c.ip] or nil
+    if mac then
+      local rec = get_or_make(mac, c.ip)
+      rec.bytes_out   = rec.bytes_out   + (c.bytes   or 0)
+      rec.packets_out = rec.packets_out + (c.packets or 0)
+    else
+      unknown_n     = unknown_n     + 1
+      unknown_bytes = unknown_bytes + (c.bytes or 0)
+    end
+  end
+  if unknown_n > 0 and log and log.debug then
+    log.debug("usage.merge_counters: dropped %d rx record(s) with unresolved ip (bytes=%d)",
+              unknown_n, unknown_bytes)
   end
   return result
 end

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -303,22 +303,49 @@ end
 -- bytes_out (rx). A missing set is treated as an empty side rather than a
 -- hard failure — the chain installs both atomically, so a single-set absence
 -- only happens transiently during a render swap.
-local function read_one_set(name)
+local function read_set_json(name)
   local pipe = io.popen("nft -j list set inet wifihaven " .. name .. " 2>/dev/null", "r")
   if not pipe then return nil end
   local json_str = pipe:read("*a") or ""
   pipe:close()
   if json_str == "" then return nil end
+  return json_str
+end
+
+local function read_tx_set()
+  local json_str = read_set_json("mac_ip_tracking")
+  if not json_str then return nil end
   local ok, counters = pcall(usage.parse_nft_counters, json_str)
   if not ok then return nil end
   return counters
 end
 
+local function read_rx_set()
+  local json_str = read_set_json("ip_tracking_rx")
+  if not json_str then return nil end
+  local ok, counters = pcall(usage.parse_nft_rx_counters, json_str)
+  if not ok then return nil end
+  return counters
+end
+
+-- Build { ip -> mac } from /tmp/dhcp.leases for rx-side resolution (#879).
+-- Cheap (a handful of lines on tmpfs); read every counter scrape so freshly
+-- DHCP'd clients are attributed without waiting for a re-read.
+local function load_ip_to_mac()
+  local leases = conntrack.parse_dhcp_leases()
+  local m = {}
+  for mac, lease in pairs(leases) do
+    if lease.ip then m[lease.ip] = mac end
+  end
+  return m
+end
+
 local function read_nft_counters()
-  local tx = read_one_set("mac_ip_tracking")
-  local rx = read_one_set("mac_ip_tracking_rx")
+  local tx = read_tx_set()
+  local rx = read_rx_set()
   if not tx and not rx then return nil end
-  return usage.merge_counters(tx or {}, rx or {})
+  local ip_to_mac = load_ip_to_mac()
+  return usage.merge_counters(tx or {}, rx or {}, ip_to_mac, log)
 end
 
 -- ── Start conntrack event watcher (blocking; runs for the lifetime of the process)
@@ -481,10 +508,11 @@ conntrack.watch({
       last_usage_run     = mono
       last_usage_wall_ts = wall
 
-      -- Per-(mac,ip) counters live as element counters on two dynamic sets
-      -- `mac_ip_tracking` (tx) and `mac_ip_tracking_rx` (rx) — see
-      -- render.lua. After a successful POST we `nft reset set ...` on both
-      -- to zero those per-element counters in lock-step (#717).
+      -- Per-flow counters live as element counters on two dynamic sets
+      -- `mac_ip_tracking` (tx, keyed mac+remote_ip) and `ip_tracking_rx`
+      -- (rx, keyed on lan_ip only — #879). After a successful POST we
+      -- `nft reset set ...` on both to zero those per-element counters
+      -- in lock-step.
       local counters = read_nft_counters()
       if counters then
         -- Final sample at flush so set elements that appeared after the
@@ -505,7 +533,7 @@ conntrack.watch({
         -- is now owned by the retry queue (or already sent), so leaving the
         -- nft counters intact would double-count on the next bucket.
         os.execute("nft reset set inet wifihaven mac_ip_tracking >/dev/null 2>&1")
-        os.execute("nft reset set inet wifihaven mac_ip_tracking_rx >/dev/null 2>&1")
+        os.execute("nft reset set inet wifihaven ip_tracking_rx >/dev/null 2>&1")
         usage.tracker_reset(activity_tracker)
         if not posted then
           log.warn("usage timer: queued for retry (queue depth=%d)",

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -193,15 +193,29 @@ describe("render.nft", function()
     assert.truthy(nft:find("mac_ip_tracking", 1, true))
   end)
 
-  -- #717: a second per-direction set captures bytes egressing the router to
-  -- LAN clients (downloads), keyed `ether daddr (mac) . ip saddr (remote)`,
-  -- so usage.lua can populate `bytesOut` alongside `bytesIn`.
-  it("declares the mac_ip_tracking_rx set for the download direction (#717)", function()
+  -- #879: download bytes used to be keyed on `ether daddr (mac) . ip saddr
+  -- (remote)`, but at the forward hook a WAN→LAN routed packet still has
+  -- the router's WAN-interface MAC as its L2 daddr (the rewrite to the LAN
+  -- device's MAC happens at egress via the neighbor cache). Every rx byte
+  -- got attributed to the router itself. Re-key on `ip daddr` only (the
+  -- LAN device's IP) and resolve to MAC in the agent via the dnsmasq lease
+  -- table.
+  it("declares the ip_tracking_rx set keyed on ipv4_addr only (#879)", function()
     local nft = render.nft(snap_one())
-    assert.truthy(nft:find("set mac_ip_tracking_rx", 1, true))
+    local pos = nft:find("set ip_tracking_rx", 1, true)
+    assert.truthy(pos)
+    local block = nft:sub(pos, pos + 200)
+    assert.truthy(block:find("type ipv4_addr"))
+    -- The old composite type would betray the bug returning; assert it's gone.
+    assert.is_nil(block:find("ether_addr"))
   end)
 
-  it("wifihaven_account chain updates BOTH tx and rx tracking sets atomically (#717)", function()
+  it("does NOT declare the old mac_ip_tracking_rx set (#879 cleanup)", function()
+    local nft = render.nft(snap_one())
+    assert.is_nil(nft:find("mac_ip_tracking_rx", 1, true))
+  end)
+
+  it("wifihaven_account chain updates BOTH tx and rx tracking sets atomically (#879)", function()
     local nft = render.nft(snap_one())
     local pos = nft:find("chain wifihaven_account", 1, true)
     assert.truthy(pos)
@@ -209,7 +223,7 @@ describe("render.nft", function()
     -- bytesOut always cover the same window.
     local block = nft:sub(pos, pos + 500)
     assert.truthy(block:find("update @mac_ip_tracking%s+{%s*ether saddr %. ip daddr%s*}%s+counter"))
-    assert.truthy(block:find("update @mac_ip_tracking_rx%s+{%s*ether daddr %. ip saddr%s*}%s+counter"))
+    assert.truthy(block:find("update @ip_tracking_rx%s+{%s*ip daddr%s*}%s+counter"))
   end)
 
   -- #354: blocked_macs is derived per-device from effective BlockRules.blocked.

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -85,48 +85,125 @@ describe("usage.parse_nft_counters", function()
 
 end)
 
--- ── merge_counters (#717) ─────────────────────────────────────────────────
+-- ── parse_nft_rx_counters (#879) ───────────────────────────────────────────
 --
--- The agent reads the two per-direction nft sets — `mac_ip_tracking` (tx,
--- device→remote) and `mac_ip_tracking_rx` (rx, remote→device) — and joins
--- them on (mac, dst_ip) before passing to the tracker and build_report.
+-- The rx set `ip_tracking_rx` is keyed on `type ipv4_addr` (single key, not a
+-- composite), so each element's `val` is a bare IP string — not a `concat`.
+
+describe("usage.parse_nft_rx_counters", function()
+
+  local RX_JSON = [[{
+    "nftables": [
+      { "metainfo": {"version":"1.1.6"} },
+      { "set": {
+          "family":"inet","table":"wifihaven","name":"ip_tracking_rx",
+          "type":"ipv4_addr",
+          "flags":["timeout","dynamic"],
+          "elem":[
+            { "elem": { "val":"192.168.10.50", "counter":{"packets":42,"bytes":4096} } },
+            { "elem": { "val":"192.168.10.99", "counter":{"packets": 5,"bytes": 500} } }
+          ]
+      }}
+    ]
+  }]]
+
+  it("returns one record per element with ip/bytes/packets", function()
+    local rx = usage.parse_nft_rx_counters(RX_JSON)
+    assert.equal(2, #rx)
+    local by_ip = {}
+    for _, c in ipairs(rx) do by_ip[c.ip] = c end
+    assert.equal(4096, by_ip["192.168.10.50"].bytes)
+    assert.equal(42,   by_ip["192.168.10.50"].packets)
+    assert.equal(500,  by_ip["192.168.10.99"].bytes)
+  end)
+
+  it("returns an empty list when the set is empty", function()
+    local empty = [[{"nftables":[{"set":{"name":"ip_tracking_rx"}}]}]]
+    assert.equal(0, #usage.parse_nft_rx_counters(empty))
+  end)
+
+end)
+
+-- ── merge_counters (#879) ─────────────────────────────────────────────────
+--
+-- tx is keyed (mac, remote_ip); rx is keyed (lan_ip) only and the agent
+-- resolves lan_ip → mac via the dnsmasq lease table before merging. rx
+-- contributions land on a record with dst_ip = the lan_ip itself (per-
+-- remote-host attribution is lost on the download side; #879).
 
 describe("usage.merge_counters", function()
 
-  it("joins matching (mac, dst_ip) into one record with both directions populated", function()
-    local tx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 3 } }
-    local rx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 900, packets = 7 } }
-    local merged = usage.merge_counters(tx, rx)
+  local LAN_IP = "192.168.10.50"
+  local MAC    = "aa:bb:cc:11:22:33"
+  local IP2M   = { [LAN_IP] = MAC }
+
+  it("attributes tx records on (mac, dst_ip) unchanged", function()
+    local tx = { { mac = MAC, dst_ip = "1.2.3.4", bytes = 100, packets = 3 } }
+    local merged = usage.merge_counters(tx, {}, IP2M)
     assert.equal(1, #merged)
-    assert.equal(100, merged[1].bytes)
-    assert.equal(3,   merged[1].packets)
-    assert.equal(900, merged[1].bytes_out)
-    assert.equal(7,   merged[1].packets_out)
+    assert.equal(MAC,       merged[1].mac)
+    assert.equal("1.2.3.4", merged[1].dst_ip)
+    assert.equal(100,       merged[1].bytes)
+    assert.equal(3,         merged[1].packets)
+    assert.equal(0,         merged[1].bytes_out)
   end)
 
-  it("emits records for tx-only and rx-only (mac, dst_ip) pairs with the missing side zeroed", function()
-    local tx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 1 } }
-    local rx = { { mac = "de:ad:be:ef:00:01", dst_ip = "8.8.8.8", bytes = 200, packets = 2 } }
-    local merged = usage.merge_counters(tx, rx)
-    assert.equal(2, #merged)
-    local by_mac = {}
-    for _, c in ipairs(merged) do by_mac[c.mac] = c end
-    assert.equal(100, by_mac["aa:bb:cc:11:22:33"].bytes)
-    assert.equal(0,   by_mac["aa:bb:cc:11:22:33"].bytes_out)
-    assert.equal(0,   by_mac["de:ad:be:ef:00:01"].bytes)
-    assert.equal(200, by_mac["de:ad:be:ef:00:01"].bytes_out)
+  it("resolves rx records by ip→mac via the lease map and attributes to (mac, lan_ip)", function()
+    local rx = { { ip = LAN_IP, bytes = 900, packets = 7 } }
+    local merged = usage.merge_counters({}, rx, IP2M)
+    assert.equal(1, #merged)
+    assert.equal(MAC,    merged[1].mac)
+    assert.equal(LAN_IP, merged[1].dst_ip)
+    assert.equal(900,    merged[1].bytes_out)
+    assert.equal(7,      merged[1].packets_out)
+    assert.equal(0,      merged[1].bytes)
+  end)
+
+  it("drops rx records whose ip is not in the lease table (no router-MAC attribution, #879)", function()
+    -- The router's own WAN IP (or any IP not associated with a LAN client)
+    -- must not produce a record. Otherwise bytesOut would land on a fake
+    -- device row.
+    local rx = { { ip = "8.8.8.8", bytes = 1234, packets = 9 } }
+    local merged = usage.merge_counters({}, rx, IP2M)
+    assert.equal(0, #merged)
+  end)
+
+  it("counts dropped-rx-records into a debug log line (visibility, #879)", function()
+    local seen = {}
+    local fake_log = {
+      debug = function(fmt, ...) seen[#seen + 1] = string.format(fmt, ...) end,
+    }
+    local rx = {
+      { ip = "8.8.8.8",       bytes = 100, packets = 1 },
+      { ip = "203.0.113.10",  bytes = 200, packets = 2 },
+    }
+    usage.merge_counters({}, rx, {}, fake_log)
+    assert.equal(1, #seen)
+    assert.truthy(seen[1]:find("dropped 2 rx record"))
+    assert.truthy(seen[1]:find("bytes=300"))
+  end)
+
+  it("merges tx and rx for the same (mac, lan_ip) when both exist", function()
+    -- Possible (rare) when a device addresses its own LAN IP for some reason;
+    -- merge should just sum.
+    local tx = { { mac = MAC, dst_ip = LAN_IP, bytes = 100, packets = 1 } }
+    local rx = { { ip = LAN_IP,                bytes = 200, packets = 2 } }
+    local merged = usage.merge_counters(tx, rx, IP2M)
+    assert.equal(1, #merged)
+    assert.equal(100, merged[1].bytes)
+    assert.equal(200, merged[1].bytes_out)
   end)
 
   it("treats nil tx or rx as empty (single-direction snapshot during a render swap)", function()
-    local rx = { { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 500, packets = 4 } }
-    local merged = usage.merge_counters(nil, rx)
+    local rx = { { ip = LAN_IP, bytes = 500, packets = 4 } }
+    local merged = usage.merge_counters(nil, rx, IP2M)
     assert.equal(1, #merged)
     assert.equal(0,   merged[1].bytes)
     assert.equal(500, merged[1].bytes_out)
   end)
 
   it("returns an empty list when both sides are empty", function()
-    assert.equal(0, #usage.merge_counters({}, {}))
+    assert.equal(0, #usage.merge_counters({}, {}, {}))
   end)
 
 end)


### PR DESCRIPTION
## Summary

#833 introduced a per-direction rx counter `mac_ip_tracking_rx` keyed on
`ether daddr . ip saddr` at the forward hook so the agent could populate
`bytesOut` alongside `bytesIn`. But for WAN→LAN routed packets the L2
daddr at the forward hook is still the router's WAN-interface MAC — the
rewrite to the LAN device's MAC happens at egress via the neighbor cache,
*after* the forward hook runs. So every download byte got attributed to
the router itself, and `bytesOut=0` on every real device row in the UI
(the dominant blocker for #858).

This PR rekeys the rx set on `ip daddr` only (renamed to `ip_tracking_rx`)
and resolves the LAN IP back to a MAC in the agent via the dnsmasq lease
table. Upload-direction packets that also match the rule contribute
remote IPs which are not in `/tmp/dhcp.leases` and are dropped (with a
debug log line summarizing the count + bytes per bucket).

Per-remote-host attribution is lost on the rx side — the lan IP itself
doubles as the host placeholder, so a flow becomes one row of
`(mac=device, host=ipv4/lan_ip, bytesIn=0, bytesOut=N)`. The tx side is
unchanged.

## Before / after (live, openwrt.lan)

**Before (last bucket of broken agent, period_start 19:21:14)**
```
        mac        |     host_value           | bytes_in | bytes_out
-------------------+--------------------------+----------+-----------
 94:83:c4:d4:a7:23 | 170.114.2.65             |        0 |       102
 94:83:c4:d4:a7:23 | 6-courier.push.apple.com |        0 |       232
 94:83:c4:d4:a7:25 | 192.168.1.157            |        0 |       208
 ...                  (router MAC carries every byte of every download)
```

**After (first bucket of fixed agent, period_start 19:22:16)**
```
        mac        | host_value     | bytes_in | bytes_out
-------------------+----------------+----------+-----------
 4a:68:49:c1:79:08 | 192.168.1.217  |        0 |  18654448
```
…and `SELECT count(*) FROM traffic_reports WHERE period_start >=
'2026-05-22 19:22:16+00' AND mac IN ('94:83:c4:d4:a7:23','94:83:c4:d4:a7:25')
AND bytes_out > 0;` returns `0`.

## Operator: re-do #833's deferred verification

#833 shipped with this checkbox unchecked:

- [x] Operator: deploy to a test router, generate a download, confirm `traffic_reports.bytes_out > 0` for the flow — **done in this PR** (live-verified on openwrt.lan, see above).

## Test plan
- [x] `openwrt/test/run_tests.sh` — 413 successes / 0 failures / 1 pending
- [x] `merge_counters`: resolves rx ip→mac via leases; drops rx records with unresolved ip; logs the drop count
- [x] `parse_nft_rx_counters`: handles the single-key (`type ipv4_addr`) set shape
- [x] `render_spec`: asserts new `ip_tracking_rx` set + chain rule; asserts old `mac_ip_tracking_rx` is gone
- [x] Live: bytes_out lands on real LAN device MAC; zero on router's own MACs

Closes #879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)