### PR TITLE
chore(ci): remove temporary migration mutation escape hatch (closes #885)

### DIFF
--- a/.github/scripts/check-migrations.sh
+++ b/.github/scripts/check-migrations.sh
@@ -7,11 +7,6 @@
 # Also rejects duplicate version numbers in the resulting tree — if two
 # files share the same V<n>__ prefix, Flyway refuses to start. This
 # guardrail was added after #883, where two PRs independently grabbed V27.
-#
-# Emergency escape hatch: set ALLOW_MIGRATION_MUTATIONS=1 in the workflow
-# environment to skip the mutation check (the duplicate-version check
-# still runs). Added for the #883 dup-V27 rename.
-# TODO(#885): remove the escape-hatch wiring after the #883 PR has merged.
 set -euo pipefail
 
 BASE="${1:?usage: check-migrations.sh <base-ref>}"
@@ -22,28 +17,23 @@ changes="$(git diff --name-status "${BASE}"...HEAD -- "${DIR}")"
 bad=0
 
 if [[ -n "${changes}" ]]; then
-  if [[ "${ALLOW_MIGRATION_MUTATIONS:-0}" == "1" ]]; then
-    echo "ALLOW_MIGRATION_MUTATIONS=1 — skipping migration immutability check."
-    echo "Changes detected (not enforced):"
-    printf '%s\n' "${changes}"
-  else
-    while IFS= read -r line; do
-      [[ -z "${line}" ]] && continue
-      status="$(printf '%s' "${line}" | cut -f1)"
-      files="$(printf '%s' "${line}" | cut -f2-)"
-      case "${status}" in
-        A)
-          echo "OK (added):    ${files}"
-          ;;
-        *)
-          echo "BLOCKED (${status}): ${files}" >&2
-          bad=1
-          ;;
-      esac
-    done <<< "${changes}"
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    status="$(printf '%s' "${line}" | cut -f1)"
+    files="$(printf '%s' "${line}" | cut -f2-)"
+    case "${status}" in
+      A)
+        echo "OK (added):    ${files}"
+        ;;
+      *)
+        echo "BLOCKED (${status}): ${files}" >&2
+        bad=1
+        ;;
+    esac
+  done <<< "${changes}"
 
-    if [[ ${bad} -ne 0 ]]; then
-      cat >&2 <<'MSG'
+  if [[ ${bad} -ne 0 ]]; then
+    cat >&2 <<'MSG'
 
 Migration files in api/resources/db/migration must not be modified, deleted,
 or renamed once merged to main. Editing an applied migration causes a Flyway
@@ -52,8 +42,7 @@ V{n+1}__... migration instead.
 
 This rule is enforced by .github/scripts/check-migrations.sh (issue #61).
 MSG
-      exit 1
-    fi
+    exit 1
   fi
 else
   echo "No migration changes."

--- a/.github/scripts/check-migrations.test.sh
+++ b/.github/scripts/check-migrations.test.sh
@@ -30,7 +30,6 @@ run_case() {
   "${SCRIPT}" "${BASE}" >/tmp/check.out 2>/tmp/check.err
   local rc=$?
   set -e
-  unset ALLOW_MIGRATION_MUTATIONS
   cleanup
   if [[ "${want}" == "pass" && ${rc} -eq 0 ]]; then
     echo "PASS: ${name}"
@@ -85,13 +84,6 @@ case_dup_version() {
   git add . && git commit -q -m dup
 }
 
-# Escape hatch: ALLOW_MIGRATION_MUTATIONS=1 lets a rename through.
-case_rename_with_escape() {
-  export ALLOW_MIGRATION_MUTATIONS=1
-  git mv api/resources/db/migration/V1__init.sql api/resources/db/migration/V2__init.sql
-  git commit -q -m rename
-}
-
 run_case "no migration changes"         pass case_no_changes
 run_case "added new migration"          pass case_add_new
 run_case "unrelated file change"        pass case_unrelated_change
@@ -100,6 +92,5 @@ run_case "deleted existing migration"   fail case_delete
 run_case "renamed existing migration"   fail case_rename
 run_case "added new + modified existing" fail case_add_plus_modify
 run_case "duplicate version numbers"    fail case_dup_version
-run_case "rename allowed via escape hatch" pass case_rename_with_escape
 
 echo "All tests passed."


### PR DESCRIPTION
## Summary

Closes #885.

Removes the `ALLOW_MIGRATION_MUTATIONS` escape hatch in `.github/scripts/check-migrations.sh` that landed with #886 to let the #883 dup-V27 rename PR through CI. #886 has merged, so the escape hatch is dead code and the matching `TODO(#885)` comment is satisfied.

- Drops the `if [[ "${ALLOW_MIGRATION_MUTATIONS:-0}" == "1" ]]; then ... else` branch and the related comment block.
- Drops the `case_rename_with_escape` test case and the `unset ALLOW_MIGRATION_MUTATIONS` cleanup in `run_case` in `check-migrations.test.sh`.
- **Permanent duplicate-version detection from #883 is retained**, along with its `case_dup_version` test.

`.github/workflows/ci.yml` needed no change — the squash-merge of #886 didn't carry the `env: ALLOW_MIGRATION_MUTATIONS` block into main's workflow, so there was nothing to remove there.

Going forward, any future emergency that needs to mutate an existing migration must be a deliberate code change rather than an env-var flip.

## Test plan

- [x] `bash .github/scripts/check-migrations.test.sh` passes locally (8/8 tests)
- [ ] CI `Migrations Immutability Check` passes
- [ ] CI `Shell Tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)