### PR TITLE
feat(vm): parameterize bridge/ports/MACs for concurrent qemu pairs (#891)

### DIFF
--- a/scripts/e2e/conftest.py
+++ b/scripts/e2e/conftest.py
@@ -136,7 +136,7 @@ def client_factory():
     """Yields a callable that boots a client VM and tracks it for teardown."""
     booted: list[str] = []
 
-    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int = 2223) -> Client:
+    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int | None = None) -> Client:
         chosen_mac = mac or _gen_mac()
         c = client_up(mac=chosen_mac, name=name, ssh_port=ssh_port)
         booted.append(name)

--- a/scripts/e2e/lib/paths.py
+++ b/scripts/e2e/lib/paths.py
@@ -8,7 +8,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 VM_DIR = SCRIPTS_DIR / "vm"
-VM_RUN_DIR = VM_DIR / ".run"
+# When WH_RUN_ID is set, runtime state lives in a per-run subdir so two
+# concurrent pairs don't share overlay/pid/socket paths (#891). Keep the
+# default identical to the pre-#891 layout.
+_WH_RUN_ID = os.environ.get("WH_RUN_ID", "")
+VM_RUN_DIR = (VM_DIR / ".run" / _WH_RUN_ID) if _WH_RUN_ID else (VM_DIR / ".run")
 VM_CACHE_DIR = VM_DIR / ".cache"
 CLIENT_SSH_KEY = VM_DIR / "keys" / "client_test_ed25519"
 

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -10,7 +10,7 @@ import logging
 import os
 from dataclasses import dataclass
 
-from .paths import CLIENT_SSH_KEY, VM_DIR
+from .paths import CLIENT_SSH_KEY, VM_DIR, VM_RUN_DIR
 
 # The router image bakes the same test keypair the client uses (see
 # build-router-image.sh). Use it for the WAN-side SSH hostfwd so the
@@ -20,7 +20,24 @@ from .sh import Result, run
 
 log = logging.getLogger(__name__)
 
-ROUTER_SSH_PORT = 2222
+def _port_default(name: str, fallback: int) -> int:
+    """Resolve a port env var, falling back to WH_PORT_BASE-derived defaults.
+
+    Mirrors the bash logic in scripts/vm/config.sh so the orchestrator and the
+    VM scripts agree on which port to dial when WH_PORT_BASE is set without
+    individual port vars (#891).
+    """
+    v = os.environ.get(name)
+    if v:
+        return int(v)
+    base = os.environ.get("WH_PORT_BASE")
+    if base:
+        offsets = {"WH_ROUTER_SSH_PORT": 0, "WH_ROUTER_HTTP_PORT": 1, "WH_CLIENT_SSH_PORT_BASE": 2}
+        return int(base) + offsets[name]
+    return fallback
+
+
+ROUTER_SSH_PORT = _port_default("WH_ROUTER_SSH_PORT", 2222)
 ROUTER_HOST = "127.0.0.1"
 ROUTER_SSH_USER = "root"
 
@@ -28,7 +45,11 @@ ROUTER_SSH_USER = "root"
 # router-up.sh always sets up the forward. Default 8080 collides with a
 # developer's docker-compose stack (and with our own e2e stack on certain
 # layouts), so pin it to a high port. Override with WH_ROUTER_HTTP_PORT.
-ROUTER_HTTP_PORT = int(os.environ.get("WH_ROUTER_HTTP_PORT", "18081"))
+ROUTER_HTTP_PORT = _port_default("WH_ROUTER_HTTP_PORT", 18081)
+
+# Default SSH port for the first client slot. Matches the bash-side
+# WH_CLIENT_SSH_PORT_BASE default (and its WH_PORT_BASE-derived override).
+CLIENT_SSH_PORT_DEFAULT = _port_default("WH_CLIENT_SSH_PORT_BASE", 2223)
 
 # QEMU SLIRP gateway as seen from inside the router VM. The router VM's WAN is
 # user-mode networking, so it reaches the host (where the API stack runs) via
@@ -172,7 +193,7 @@ def router_ssh(cmd: str, *, timeout: float = 30, check: bool = True) -> Result:
 
 
 def router_serial_log(tail: int = 200) -> str:
-    log_path = VM_DIR / ".run" / "router" / "console.log"
+    log_path = VM_RUN_DIR / "router" / "console.log"
     if not log_path.exists():
         return "(no router serial log yet)"
     with log_path.open("rb") as f:
@@ -204,7 +225,7 @@ class Client:
         ]
 
     def serial_log(self, tail: int = 200) -> str:
-        log_path = VM_DIR / ".run" / self.name / "console.log"
+        log_path = VM_RUN_DIR / self.name / "console.log"
         if not log_path.exists():
             return f"(no client serial log for {self.name})"
         with log_path.open("rb") as f:
@@ -215,7 +236,9 @@ class Client:
             return f.read().decode("utf-8", errors="replace")
 
 
-def client_up(*, mac: str, name: str = "client1", ssh_port: int = 2223) -> Client:
+def client_up(*, mac: str, name: str = "client1", ssh_port: int | None = None) -> Client:
+    if ssh_port is None:
+        ssh_port = CLIENT_SSH_PORT_DEFAULT
     args = [_vm_script("client-up.sh"), "--mac", mac, "--name", name, "--ssh-port", str(ssh_port)]
     run(args, timeout=180)
     c = Client(name=name, mac=mac, ssh_port=ssh_port)

--- a/scripts/e2e/scenarios_fake/conftest.py
+++ b/scripts/e2e/scenarios_fake/conftest.py
@@ -200,7 +200,7 @@ def router(router_session, fake_api) -> EnrolledRouter:
 def client_factory():
     booted: list[str] = []
 
-    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int = 2223) -> Client:
+    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int | None = None) -> Client:
         chosen_mac = mac or _gen_mac()
         c = client_up(mac=chosen_mac, name=name, ssh_port=ssh_port)
         booted.append(name)

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -31,6 +31,46 @@ client VM: the LAN bridge name, the LAN subnet, the Alpine image version, and
 file paths. **Both halves of the harness read from here.** If you need to
 change a bridge name or subnet, change it in this one file.
 
+### Running two pairs concurrently (#891)
+
+**One-time host setup**: pre-allocate a pool of LAN bridges and authorize
+them all in `/etc/qemu/bridge.conf`. Then any subsequent VM e2e run
+auto-picks a free bridge from the pool — no extra env vars needed for the
+bridge.
+
+```
+# Creates wh-lan0..wh-lan3 (default pool size 4) and ensures bridge.conf
+# has an `allow` line for each. Idempotent.
+sudo scripts/vm/lan-bridge-pool-bootstrap.sh
+```
+
+The bootstrap uses `sudo` for both `ip link add` and `tee -a
+/etc/qemu/bridge.conf` — existing entries are left alone, missing entries
+are appended. Run it once per host (or whenever you bump
+`WH_LAN_BRIDGE_POOL_SIZE`).
+
+**Per-run knobs**: to launch a second pair on a bootstrapped host, set only
+two env vars on the second invocation — the bridge is auto-picked from the
+pool:
+
+```
+WH_RUN_ID=b WH_PORT_BASE=2322 scripts/e2e-vm.sh --mode=fake
+```
+
+- `WH_RUN_ID` — short token. Suffixes the QEMU `-name` (so `pgrep`-based
+  fallbacks in `*-down.sh` only match this instance) and the `.run/` subdir
+  (so overlay/pid/socket files don't collide). Also seeds the default MACs.
+- `WH_PORT_BASE` — first host port; router SSH = base, router HTTP =
+  base+1, client SSH = base+2. Individual port vars
+  (`WH_ROUTER_SSH_PORT`, `WH_ROUTER_HTTP_PORT`, `WH_CLIENT_SSH_PORT_BASE`)
+  still win if set explicitly.
+- `WH_LAN_BRIDGE` — optional override. If set explicitly, skips pool pick.
+- For fake-mode, also set `WH_FAKE_API_PORT` to a free port on the second run.
+
+**On a host without the pool**, the bridge picker is a no-op and the run
+falls back to creating `wh-lan0` on the fly — byte-identical to single-pair
+behavior on un-bootstrapped hosts.
+
 ## Client VM
 
 A minimal Alpine VM that lives on the router VM's LAN bridge with a

--- a/scripts/vm/client-down.sh
+++ b/scripts/vm/client-down.sh
@@ -65,9 +65,10 @@ rm -rf "${RUN_DIR}"
 # Fallback: a previous run was killed hard (e.g., CI cancellation) and
 # left a qemu alive without an up-to-date pidfile. Kill by name so the
 # next client-up doesn't fail to bind hostfwd ports.
-if pgrep -f "qemu-system-x86_64.*-name wh-${NAME}" >/dev/null 2>&1; then
-  echo "[client-down] found stale wh-${NAME} qemu without pidfile match — killing"
-  pkill -f "qemu-system-x86_64.*-name wh-${NAME}" || true
+VM_NAME="$(wh_client_vm_name "${NAME}")"
+if pgrep -f "qemu-system-x86_64.*-name ${VM_NAME} -" >/dev/null 2>&1; then
+  echo "[client-down] found stale ${VM_NAME} qemu without pidfile match — killing"
+  pkill -f "qemu-system-x86_64.*-name ${VM_NAME} -" || true
   # Give the kernel a moment to release the bound ports.
   sleep 1
 fi

--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -98,7 +98,7 @@ QMP_SOCK="${RUN_DIR}/qemu.sock"
 
 # Background the qemu process. -daemonize gives us a stable pidfile.
 qemu-system-x86_64 \
-  -name "wh-${NAME}" \
+  -name "$(wh_client_vm_name "${NAME}")" \
   -m 512 -smp 1 \
   "${ACCEL_ARGS[@]}" \
   -display none -serial "file:${RUN_DIR}/console.log" \

--- a/scripts/vm/config.sh
+++ b/scripts/vm/config.sh
@@ -4,12 +4,22 @@
 # the single source of truth for names that span the router VM (#144) and the
 # client VM (#146), so changes here propagate to both halves.
 
-# --- LAN bridge (shared with the router VM from #144) ------------------------
-# If #144 picks different names/ranges, update *here* — these constants are
-# referenced everywhere else by variable, not by literal.
-WH_LAN_BRIDGE="${WH_LAN_BRIDGE:-wh-lan0}"
-WH_LAN_SUBNET="${WH_LAN_SUBNET:-192.168.100.0/24}"
-WH_LAN_ROUTER_IP="${WH_LAN_ROUTER_IP:-192.168.100.1}"
+# --- Concurrent-run keying (#891) --------------------------------------------
+# Set WH_RUN_ID to a short, filesystem-safe token (e.g. "a", "ci-7") to run a
+# second router+client pair on the same host. When empty, all derived names,
+# paths, ports, and MACs are byte-identical to the pre-#891 layout — single-
+# pair invocations need no changes.
+WH_RUN_ID="${WH_RUN_ID:-}"
+
+# WH_PORT_BASE: shorthand to allocate three consecutive host ports. Only
+# applies as a *default* for the individual port vars below — explicit
+# WH_ROUTER_SSH_PORT / WH_ROUTER_HTTP_PORT / WH_CLIENT_SSH_PORT_BASE still win.
+WH_PORT_BASE="${WH_PORT_BASE:-}"
+
+# WH_MAC_PREFIX: three-octet OUI used to build default WAN/LAN MACs. The
+# per-run suffix is derived from WH_RUN_ID (sha256, first 2 hex bytes) so two
+# concurrent pairs don't collide. Explicit WH_ROUTER_MAC_* still wins.
+WH_MAC_PREFIX="${WH_MAC_PREFIX:-52:54:00}"
 
 # --- Alpine cloud image (client VM base) -------------------------------------
 # Pinned to a specific release + checksum. Bump deliberately, not casually.
@@ -22,14 +32,35 @@ WH_ALPINE_SHA512="d0ddf1faae4d44aee3ad6621f166bd414c2f99b6974fb455408612d59cbb31
 
 # --- Paths -------------------------------------------------------------------
 # Resolve relative to the directory containing config.sh, so callers can be
-# invoked from anywhere.
+# invoked from anywhere. When WH_RUN_ID is set, runtime state lives under
+# .run/<run-id>/ so a second concurrent pair doesn't collide on overlay/pid/
+# socket paths.
 WH_VM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WH_CACHE_DIR="${WH_VM_DIR}/.cache"
-WH_RUN_DIR="${WH_VM_DIR}/.run"
+if [[ -n "${WH_RUN_ID}" ]]; then
+  WH_RUN_DIR="${WH_VM_DIR}/.run/${WH_RUN_ID}"
+else
+  WH_RUN_DIR="${WH_VM_DIR}/.run"
+fi
 WH_KEYS_DIR="${WH_VM_DIR}/keys"
 WH_CLIENT_BASE_IMG="${WH_CACHE_DIR}/client-base.qcow2"
 WH_CLIENT_SSH_KEY="${WH_KEYS_DIR}/client_test_ed25519"
 WH_CLIENT_SSH_PUB="${WH_KEYS_DIR}/client_test_ed25519.pub"
+
+# --- LAN bridge (shared with the router VM from #144) ------------------------
+# Resolution order:
+#   1. WH_LAN_BRIDGE explicitly set in env → use it (back-compat).
+#   2. router-up.sh in this run recorded a pool pick under .run/<id>/lan-bridge
+#      → use that (so client-up.sh sees the same bridge router-up chose).
+#   3. Default to wh-lan0 (today's single-pair behavior).
+# The pool-pick itself happens in lib.sh::wh_pick_lan_bridge, called from
+# router-up.sh before qemu boot (#891).
+if [[ -z "${WH_LAN_BRIDGE:-}" && -f "${WH_RUN_DIR}/lan-bridge" ]]; then
+  WH_LAN_BRIDGE="$(cat "${WH_RUN_DIR}/lan-bridge")"
+fi
+WH_LAN_BRIDGE="${WH_LAN_BRIDGE:-wh-lan0}"
+WH_LAN_SUBNET="${WH_LAN_SUBNET:-192.168.100.0/24}"
+WH_LAN_ROUTER_IP="${WH_LAN_ROUTER_IP:-192.168.100.1}"
 
 # --- Router VM (OpenWRT, #144) -----------------------------------------------
 # Bump procedure:
@@ -53,16 +84,54 @@ WH_ROUTER_PIDFILE="${WH_ROUTER_RUN_DIR}/qemu.pid"
 WH_ROUTER_MONITOR_SOCK="${WH_ROUTER_RUN_DIR}/monitor.sock"
 WH_ROUTER_SERIAL_LOG="${WH_ROUTER_RUN_DIR}/console.log"
 
+# QEMU `-name` for the router VM. Suffixed with WH_RUN_ID so `pgrep -f` in
+# router-down.sh only matches *this* instance — without the suffix two
+# concurrent runs would each kill the other's qemu (#891).
+if [[ -n "${WH_RUN_ID}" ]]; then
+  WH_ROUTER_VM_NAME="${WH_ROUTER_VM_NAME:-wh-router-${WH_RUN_ID}}"
+else
+  WH_ROUTER_VM_NAME="${WH_ROUTER_VM_NAME:-wh-router}"
+fi
+
 # Router VM size + WAN-side SSH hostfwd (LuCI HTTP forwarded for manual poking).
+# When WH_PORT_BASE is set and the individual port var is unset, derive:
+#   router SSH  = WH_PORT_BASE
+#   router HTTP = WH_PORT_BASE + 1
+#   client SSH  = WH_PORT_BASE + 2
 WH_ROUTER_MEM_MB="${WH_ROUTER_MEM_MB:-512}"
 WH_ROUTER_DISK_SIZE="${WH_ROUTER_DISK_SIZE:-512M}"
-WH_ROUTER_SSH_PORT="${WH_ROUTER_SSH_PORT:-2222}"
-WH_ROUTER_HTTP_PORT="${WH_ROUTER_HTTP_PORT:-8080}"
+if [[ -n "${WH_PORT_BASE}" ]]; then
+  WH_ROUTER_SSH_PORT="${WH_ROUTER_SSH_PORT:-${WH_PORT_BASE}}"
+  WH_ROUTER_HTTP_PORT="${WH_ROUTER_HTTP_PORT:-$((WH_PORT_BASE + 1))}"
+  WH_CLIENT_SSH_PORT_BASE="${WH_CLIENT_SSH_PORT_BASE:-$((WH_PORT_BASE + 2))}"
+else
+  WH_ROUTER_SSH_PORT="${WH_ROUTER_SSH_PORT:-2222}"
+  WH_ROUTER_HTTP_PORT="${WH_ROUTER_HTTP_PORT:-8080}"
+  WH_CLIENT_SSH_PORT_BASE="${WH_CLIENT_SSH_PORT_BASE:-2223}"
+fi
 
 # Stable, locally-administered MACs so the orchestrator can match-by-MAC in
-# router-side logs.
-WH_ROUTER_MAC_LAN="${WH_ROUTER_MAC_LAN:-52:54:00:fd:00:02}"
-WH_ROUTER_MAC_WAN="${WH_ROUTER_MAC_WAN:-52:54:00:fd:00:01}"
+# router-side logs. When WH_RUN_ID is set, mix it into the last two octets so
+# two concurrent pairs get distinct MACs even on the same L2; explicit
+# WH_ROUTER_MAC_LAN / WH_ROUTER_MAC_WAN still win.
+if [[ -n "${WH_RUN_ID}" ]]; then
+  # First 2 bytes of sha256(WH_RUN_ID) → 4 hex chars, split into two octets.
+  if command -v sha256sum >/dev/null 2>&1; then
+    _wh_mac_hash="$(printf '%s' "${WH_RUN_ID}" | sha256sum | awk '{print $1}')"
+  else
+    _wh_mac_hash="$(printf '%s' "${WH_RUN_ID}" | shasum -a 256 | awk '{print $1}')"
+  fi
+  _wh_mac_oct3="${_wh_mac_hash:0:2}"
+  _wh_mac_oct4="${_wh_mac_hash:2:2}"
+  WH_ROUTER_MAC_LAN="${WH_ROUTER_MAC_LAN:-${WH_MAC_PREFIX}:fd:${_wh_mac_oct3}:${_wh_mac_oct4}}"
+  # WAN differs in the last octet so router-side logs can disambiguate.
+  _wh_mac_oct4_alt="$(printf '%02x' $(( 0x${_wh_mac_oct4} ^ 0x01 )))"
+  WH_ROUTER_MAC_WAN="${WH_ROUTER_MAC_WAN:-${WH_MAC_PREFIX}:fd:${_wh_mac_oct3}:${_wh_mac_oct4_alt}}"
+  unset _wh_mac_hash _wh_mac_oct3 _wh_mac_oct4 _wh_mac_oct4_alt
+else
+  WH_ROUTER_MAC_LAN="${WH_ROUTER_MAC_LAN:-52:54:00:fd:00:02}"
+  WH_ROUTER_MAC_WAN="${WH_ROUTER_MAC_WAN:-52:54:00:fd:00:01}"
+fi
 
 # --- SSH management NIC ------------------------------------------------------
 # The client VM has two NICs:
@@ -70,5 +139,14 @@ WH_ROUTER_MAC_WAN="${WH_ROUTER_MAC_WAN:-52:54:00:fd:00:01}"
 #   eth1 — host-side user-mode NIC (QEMU SLIRP), used ONLY for orchestrator
 #          SSH via hostfwd. No default route, no DNS — keeps all real traffic
 #          on the LAN side so DNS scenarios actually exercise the router.
-# Default port for the first client; client-up.sh increments per --name slot.
-WH_CLIENT_SSH_PORT_BASE="${WH_CLIENT_SSH_PORT_BASE:-2223}"
+
+# Helper: compute the QEMU `-name` for a client slot. Suffixed with WH_RUN_ID
+# so client-down.sh's pgrep fallback only matches *this* instance.
+wh_client_vm_name() {
+  local slot="$1"
+  if [[ -n "${WH_RUN_ID}" ]]; then
+    printf 'wh-%s-%s' "${slot}" "${WH_RUN_ID}"
+  else
+    printf 'wh-%s' "${slot}"
+  fi
+}

--- a/scripts/vm/lan-bridge-down.sh
+++ b/scripts/vm/lan-bridge-down.sh
@@ -23,6 +23,18 @@ if [[ -n "${attached}" ]]; then
 Stop the router/client VMs first."
 fi
 
+# Pool bridges (wh-lan0, wh-lan1, ...) are owned by lan-bridge-pool-bootstrap.sh
+# and meant to outlive any single run — deleting one here would force the next
+# run to re-create it (needs sudo) and would race with another in-flight
+# concurrent run picking the same pool slot (#891). Only delete bridges we
+# would also create on-the-fly via lan-bridge-up.sh — i.e. bridges *not* in
+# the pool.
+if [[ "${WH_LAN_BRIDGE}" =~ ^wh-lan[0-9]+$ ]] && [[ -f /etc/qemu/bridge.conf ]] \
+    && grep -qE "^[[:space:]]*allow[[:space:]]+${WH_LAN_BRIDGE}\b" /etc/qemu/bridge.conf; then
+  log "leaving pool bridge ${WH_LAN_BRIDGE} in place (managed by lan-bridge-pool-bootstrap.sh)"
+  exit 0
+fi
+
 log "removing bridge ${WH_LAN_BRIDGE}"
 sudo ip link set "${WH_LAN_BRIDGE}" down
 sudo ip link delete "${WH_LAN_BRIDGE}" type bridge

--- a/scripts/vm/lan-bridge-pool-bootstrap.sh
+++ b/scripts/vm/lan-bridge-pool-bootstrap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# One-time host setup: create the LAN bridge pool used for concurrent VM e2e
+# runs (#891). Idempotent.
+#
+# Creates ${WH_LAN_BRIDGE_POOL_SIZE} bridges named wh-lan0 .. wh-lan${N-1}
+# (default N=4) via `sudo ip link add`, and verifies each is listed in
+# /etc/qemu/bridge.conf so qemu-bridge-helper will attach taps.
+#
+# Also ensures /etc/qemu/bridge.conf has an `allow wh-lanK` line for each
+# pool bridge (sudo tee -a). Idempotent: existing lines are left alone.
+#
+# Usage:
+#   sudo scripts/vm/lan-bridge-pool-bootstrap.sh           # default size 4
+#   WH_LAN_BRIDGE_POOL_SIZE=8 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
+
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=config.sh
+source "${HERE}/config.sh"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "lan-bridge-pool-bootstrap: required command not found: $1" >&2
+    exit 1
+  }
+}
+require_cmd ip
+
+SIZE="${WH_LAN_BRIDGE_POOL_SIZE:-4}"
+if ! [[ "${SIZE}" =~ ^[0-9]+$ ]] || (( SIZE < 1 )); then
+  echo "lan-bridge-pool-bootstrap: WH_LAN_BRIDGE_POOL_SIZE must be a positive integer (got '${SIZE}')" >&2
+  exit 2
+fi
+
+echo "[bridge-pool] target size: ${SIZE} (wh-lan0..wh-lan$((SIZE - 1)))"
+
+for ((i = 0; i < SIZE; i++)); do
+  br="wh-lan${i}"
+  if ip link show "${br}" >/dev/null 2>&1; then
+    echo "[bridge-pool] ${br} already exists"
+  else
+    echo "[bridge-pool] creating ${br}"
+    sudo ip link add name "${br}" type bridge
+  fi
+  sudo ip link set "${br}" up
+done
+
+# Ensure /etc/qemu/bridge.conf has an `allow` line for every pool member.
+# qemu-bridge-helper refuses to attach taps for un-allowlisted bridges.
+conf=/etc/qemu/bridge.conf
+conf_dir="$(dirname "${conf}")"
+if [[ ! -d "${conf_dir}" ]]; then
+  echo "[bridge-pool] creating ${conf_dir}"
+  sudo mkdir -p "${conf_dir}"
+fi
+if [[ ! -f "${conf}" ]]; then
+  echo "[bridge-pool] creating empty ${conf}"
+  echo | sudo tee "${conf}" >/dev/null
+fi
+
+missing=()
+for ((i = 0; i < SIZE; i++)); do
+  br="wh-lan${i}"
+  if ! sudo grep -qE "^[[:space:]]*allow[[:space:]]+${br}\b" "${conf}"; then
+    missing+=("${br}")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "[bridge-pool] appending allow entries to ${conf}: ${missing[*]}"
+  for br in "${missing[@]}"; do
+    printf 'allow %s\n' "${br}"
+  done | sudo tee -a "${conf}" >/dev/null
+fi
+
+echo "[bridge-pool] pool ready: $(for ((i=0; i<SIZE; i++)); do printf 'wh-lan%s ' "${i}"; done)"

--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -96,3 +96,82 @@ ensure_router_overlay() {
 router_is_running() {
   [[ -f "${WH_ROUTER_PIDFILE}" ]] && kill -0 "$(cat "${WH_ROUTER_PIDFILE}")" 2>/dev/null
 }
+
+# Pick a LAN bridge from the wh-lan* pool when one wasn't set explicitly (#891).
+#
+# Contract:
+#   - If WH_LAN_BRIDGE was already set in env, or already resolved from a prior
+#     in-run pick (.run/<id>/lan-bridge), this is a no-op.
+#   - If no wh-lan* bridges exist at all, this is a no-op — config.sh's default
+#     (wh-lan0) stands, and lan-bridge-up.sh will create it. Byte-identical to
+#     pre-#891 behavior on un-bootstrapped hosts.
+#   - Otherwise, under a host-wide flock, picks the lowest-numbered wh-lan*
+#     bridge with no attached interfaces, records it in .run/<id>/lan-bridge,
+#     and exports WH_LAN_BRIDGE. The flock is held until this shell exits, so
+#     it bridges the gap between pick and qemu's synchronous tap attach.
+#
+# Exits non-zero with a clear message if every pool bridge is already in use.
+wh_pick_lan_bridge() {
+  # Caller set it explicitly (or we already picked in a prior phase) — leave alone.
+  if [[ -n "${WH_LAN_BRIDGE_PICKED:-}" ]]; then
+    return 0
+  fi
+  if [[ -f "${WH_RUN_DIR}/lan-bridge" ]]; then
+    return 0
+  fi
+  # If the user set WH_LAN_BRIDGE in env to anything other than the wh-lan0
+  # default, treat it as explicit and skip auto-pick. We can't tell "user set
+  # to wh-lan0" from "default wh-lan0", so we always run the pick logic — but
+  # the pick will only override if a pool exists *and* wh-lan0 is in use.
+  # Only consider bridges that are (a) named wh-lanN, (b) actually exist as a
+  # kernel netdev, and (c) listed in /etc/qemu/bridge.conf. (c) is what
+  # distinguishes a real pool member from a stale leftover bridge a previous
+  # experiment forgot to clean up — qemu-bridge-helper would refuse to attach
+  # to such a leftover anyway.
+  local pool=()
+  if [[ -f /etc/qemu/bridge.conf ]]; then
+    local br
+    while IFS= read -r br; do
+      [[ -n "${br}" ]] || continue
+      [[ "${br}" =~ ^wh-lan[0-9]+$ ]] || continue
+      [[ -d "/sys/class/net/${br}" ]] || continue
+      pool+=("${br}")
+    done < <(awk '/^[[:space:]]*allow[[:space:]]+/ {print $2}' /etc/qemu/bridge.conf)
+  fi
+  # No pool bridges exist → fall back to today's behavior (config.sh default).
+  if (( ${#pool[@]} == 0 )); then
+    return 0
+  fi
+  # Sort numerically (wh-lan0, wh-lan1, ..., wh-lan10).
+  local sorted
+  sorted=$(printf '%s\n' "${pool[@]}" | sort -V)
+  mkdir -p "${WH_VM_DIR}/.run"
+  local lock_file="${WH_VM_DIR}/.run/.bridge-pool.lock"
+  exec 9>"${lock_file}"
+  if ! flock -w 60 9; then
+    die "could not acquire bridge-pool lock (${lock_file}) within 60s"
+  fi
+  local chosen=""
+  local br
+  while IFS= read -r br; do
+    local attached
+    attached=$(ls "/sys/class/net/${br}/brif" 2>/dev/null | wc -l)
+    if (( attached == 0 )); then
+      chosen="${br}"
+      break
+    fi
+  done <<<"${sorted}"
+  if [[ -z "${chosen}" ]]; then
+    die "LAN bridge pool exhausted — every wh-lan* has interfaces attached: $(printf '%s ' "${pool[@]}")"
+  fi
+  mkdir -p "${WH_RUN_DIR}"
+  printf '%s\n' "${chosen}" > "${WH_RUN_DIR}/lan-bridge"
+  WH_LAN_BRIDGE="${chosen}"
+  WH_LAN_BRIDGE_PICKED=1
+  export WH_LAN_BRIDGE WH_LAN_BRIDGE_PICKED
+  log "picked LAN bridge from pool: ${chosen}"
+  # Flock is held by FD 9 until this shell exits. qemu's tap attach happens
+  # synchronously inside qemu-system-x86_64 (before -daemonize returns), so by
+  # the time router-up.sh exits the bridge has an attached interface and the
+  # next concurrent run sees it as in-use.
+}

--- a/scripts/vm/router-down.sh
+++ b/scripts/vm/router-down.sh
@@ -11,9 +11,9 @@ stale_qemu_sweep() {
   # Fallback: a previous run was killed hard (e.g., CI cancellation) and
   # left a qemu alive without an up-to-date pidfile. Kill by name so the
   # next router-up doesn't fail to bind hostfwd ports.
-  if pgrep -f "qemu-system-x86_64.*-name wh-router" >/dev/null 2>&1; then
+  if pgrep -f "qemu-system-x86_64.*-name ${WH_ROUTER_VM_NAME} -" >/dev/null 2>&1; then
     log "found stale wh-router qemu without pidfile match — killing"
-    pkill -f "qemu-system-x86_64.*-name wh-router" || true
+    pkill -f "qemu-system-x86_64.*-name ${WH_ROUTER_VM_NAME} -" || true
     # Give the kernel a moment to release the bound ports.
     sleep 1
   fi

--- a/scripts/vm/router-up.sh
+++ b/scripts/vm/router-up.sh
@@ -20,6 +20,11 @@ if router_is_running; then
   exit 0
 fi
 
+# Auto-pick a free bridge from the wh-lan* pool when one wasn't set explicitly
+# (#891). On hosts without a pool, this is a no-op and we fall through to
+# WH_LAN_BRIDGE=wh-lan0 (today's default). Holds a flock until this shell exits.
+wh_pick_lan_bridge
+
 "${HERE}/lan-bridge-up.sh"
 
 ensure_openwrt_image
@@ -41,7 +46,7 @@ log "  LAN: ${LAN_NETDEV}"
 log "  WAN: user-mode (ssh 127.0.0.1:${WH_ROUTER_SSH_PORT}, http 127.0.0.1:${WH_ROUTER_HTTP_PORT})"
 
 qemu-system-x86_64 \
-  -name wh-router \
+  -name "${WH_ROUTER_VM_NAME}" \
   -m "${WH_ROUTER_MEM_MB}" -smp 2 \
   "${ACCEL_ARGS[@]}" \
   -display none \


### PR DESCRIPTION
Closes #891.

## Summary

Lifts the "VM e2e must be serialized" invariant by parameterizing the three shared L2/host resources that forced it: bridge name, host port forwards, and MAC addresses. After this change, two `scripts/e2e-vm.sh --mode=fake` runs can share one host.

## What's new

**Env vars (all opt-in; unset → byte-identical single-pair behavior):**
- `WH_RUN_ID` — per-run keying. Suffixes the QEMU `-name` (so `*-down.sh`'s `pgrep` fallback only matches this instance), the `.run/` subdir (so overlay/pid/socket files don't collide), and seeds the default MACs.
- `WH_PORT_BASE` — shorthand for three consecutive host ports: router SSH = base, router HTTP = base+1, client SSH = base+2. Individual `WH_ROUTER_SSH_PORT` / `WH_ROUTER_HTTP_PORT` / `WH_CLIENT_SSH_PORT_BASE` still win.
- `WH_MAC_PREFIX` — three-octet OUI (default `52:54:00`). When `WH_RUN_ID` is set, default WAN/LAN MACs mix in `sha256(WH_RUN_ID)` so two pairs on the same L2 don't collide. Explicit `WH_ROUTER_MAC_LAN`/`WAN` still win.

**LAN bridge pool** (new):
- `scripts/vm/lan-bridge-pool-bootstrap.sh` — one-time host setup. Creates `wh-lan0..wh-lan${N-1}` (default N=4, override via `WH_LAN_BRIDGE_POOL_SIZE`) and `sudo tee -a`'s missing `allow wh-lanK` lines into `/etc/qemu/bridge.conf`. Idempotent.
- `lib.sh::wh_pick_lan_bridge` — called from `router-up.sh` before qemu boot. Under a host-wide `flock`, scans pool bridges (keyed off `bridge.conf` membership so stray `wh-lan*` leftovers aren't treated as pool members), picks the lowest-numbered with zero attached taps, records it in `.run/<id>/lan-bridge`, exports `WH_LAN_BRIDGE`. Flock is held until `router-up.sh` exits — covers qemu's synchronous tap-attach window.
- `client-up.sh` inherits via `config.sh`'s `.run/<id>/lan-bridge` fallback.
- `lan-bridge-down.sh` refuses to delete a pool bridge (matches `^wh-lan[0-9]+$` AND listed in `bridge.conf`). Pool bridges outlive any single run.
- Hosts without a pool fall through to today's `wh-lan0` create path. No behavior change.

**Python side** — `scripts/e2e/lib/vm.py`, `conftest.py`, `lib/paths.py` now read ports / run-dir from env so the orchestrator and shell scripts agree.

## Two-pair invocation

After one-time bootstrap on the host:

```
# pair A — defaults
scripts/e2e-vm.sh --mode=fake

# pair B — concurrent
WH_RUN_ID=b WH_PORT_BASE=2322 WH_FAKE_API_PORT=18091 scripts/e2e-vm.sh --mode=fake
```

The bridge is auto-picked from the pool — no extra env var needed for it.

## Acceptance

- [x] **Byte-identical baseline (Acceptance #1)** — verified by sourcing `config.sh` and dumping every derived name/port/MAC/path with no env vars set: `WH_LAN_BRIDGE=wh-lan0`, `WH_ROUTER_VM_NAME=wh-router`, `WH_ROUTER_SSH_PORT=2222`, `WH_ROUTER_HTTP_PORT=8080`, `WH_CLIENT_SSH_PORT_BASE=2223`, `WH_ROUTER_MAC_LAN=52:54:00:fd:00:02`, `WH_ROUTER_MAC_WAN=52:54:00:fd:00:01`, `.run/router/{overlay.qcow2,qemu.pid,monitor.sock,console.log}` — all identical to today.
- [ ] **Two concurrent pairs go green (Acceptance #2)** — *pending local validation; the self-hosted runner host was busy with CI Gate 2 / #685 during implementation. Will validate before merge.*

## Follow-up (not in this PR)

Once two concurrent runs are observed clean on the self-hosted runner, relax `concurrency: { group: e2e-vm }` on `.github/workflows/e2e-vm-fake.yml` and `e2e-vm.yml`. **Intentionally not removed here** — the serialization invariant remains until the two-pair behavior is observed on the actual CI runner.

## Test plan

- [ ] On a clean host: `scripts/e2e-vm.sh --mode=fake` (default) passes — confirms baseline byte-identity.
- [ ] After `sudo scripts/vm/lan-bridge-pool-bootstrap.sh`: two concurrent fake-mode runs both green.
- [ ] `lan-bridge-down.sh` leaves pool bridges in place after both runs complete.
- [ ] `router-down.sh` / `client-down.sh` only kill their own qemu (not the sibling instance's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)