### PR TITLE
fix(openwrt): self-heal wifihaven-update cron entry at agent startup (#896)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/selfheal.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/selfheal.lua
@@ -1,0 +1,88 @@
+-- selfheal.lua — agent-side self-healing for state the package postinst owns.
+--
+-- Why this exists (#896): apk-tools v3 does NOT re-run a package's
+-- post-install script on a same-version reinstall (even with
+-- --force-reinstall). So a fix that only lives in the postinst — like
+-- #869's wifihaven-update cron registration — never reaches routers that
+-- already had the package installed before the fix shipped. Operators
+-- would have to `apk del + apk add` every router by hand.
+--
+-- The agent runs constantly, so it can heal this on every startup:
+-- idempotent on the happy path, repairing on every other shape.
+
+local M = {}
+
+M.CANONICAL_LINE = "0 4 * * * /usr/sbin/wifihaven-update"
+M.DEFAULT_PATH   = "/etc/crontabs/root"
+
+local function read_lines(path)
+  local f = io.open(path, "r")
+  if not f then return nil end
+  local t = {}
+  for line in f:lines() do t[#t+1] = line end
+  f:close()
+  return t
+end
+
+local function write_lines(path, lines)
+  local f, err = io.open(path, "w")
+  if not f then return nil, err end
+  for _, l in ipairs(lines) do f:write(l, "\n") end
+  f:close()
+  return true
+end
+
+-- Ensure /etc/crontabs/root contains exactly the canonical wifihaven-update
+-- cron entry, and that crond is enabled and running. Returns true if a
+-- heal was applied, false if the file was already in the desired state.
+--
+-- Heals three shapes: missing /etc/crontabs/ dir, missing root crontab, and
+-- stale cadence (e.g. "0 */6 * * *" from pre-#869 routers — same sed -i
+-- behavior as the postinst block).
+function M.selfheal_cron(opts)
+  opts = opts or {}
+  local path    = opts.path    or M.DEFAULT_PATH
+  local run_cmd = opts.run_cmd or os.execute
+  local log     = opts.log
+
+  local dir = path:match("^(.*)/[^/]+$") or "/etc/crontabs"
+  run_cmd(string.format("mkdir -p %q", dir))
+
+  local lines = read_lines(path) or {}
+  local kept  = {}
+  local has_canonical = false
+  local has_other     = false
+  for _, l in ipairs(lines) do
+    if l:find("wifihaven-update", 1, true) then
+      if l == M.CANONICAL_LINE and not has_canonical then
+        has_canonical = true
+        kept[#kept+1] = l
+      else
+        has_other = true
+      end
+    else
+      kept[#kept+1] = l
+    end
+  end
+
+  if has_canonical and not has_other then
+    return false
+  end
+
+  if not has_canonical then
+    kept[#kept+1] = M.CANONICAL_LINE
+  end
+
+  local ok, werr = write_lines(path, kept)
+  if not ok then
+    if log then log.warn("selfheal: failed to write %s: %s", path, tostring(werr)) end
+    return false
+  end
+
+  if log then log.info("selfheal: installed missing wifihaven-update cron entry") end
+  run_cmd("/etc/init.d/cron enable 2>/dev/null")
+  run_cmd("/etc/init.d/cron restart 2>/dev/null")
+  return true
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -22,6 +22,7 @@ local dns_log    = require("wifihaven.dns_log")
 local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
 local paths      = require("wifihaven.paths")
+local selfheal   = require("wifihaven.selfheal")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -53,6 +54,12 @@ if activity_sample_int <= 0 or usage_int % activity_sample_int ~= 0 then
   log.warn("activity_sample_int=%d does not evenly divide usage_report_interval=%d; activeSeconds accuracy will degrade. See docs/router-tuning.md.",
            activity_sample_int, usage_int)
 end
+
+-- #896: self-heal the wifihaven-update cron entry. apk v3 skips post-install
+-- on same-version reinstall, so any router that had the package before #869
+-- shipped would never get the cron line otherwise. Idempotent; logs only when
+-- a heal actually happened.
+selfheal.selfheal_cron({ log = log })
 
 if router_token == "" then
   log.err("router_token not set — run enrollment first")

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -18,6 +18,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/blocklists_spec.lua \
          test/block_page_spec.lua \
          test/contract_spec.lua \
+         test/selfheal_spec.lua \
          "$@"
 
 echo ""

--- a/openwrt/test/selfheal_spec.lua
+++ b/openwrt/test/selfheal_spec.lua
@@ -1,0 +1,101 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/selfheal.lua
+-- Run with: cd openwrt && busted test/selfheal_spec.lua
+
+local selfheal = require("selfheal")
+
+local function tmp_path()
+  return os.tmpname()
+end
+
+local function write_file(path, content)
+  local f = assert(io.open(path, "w"))
+  f:write(content)
+  f:close()
+end
+
+local function read_file(path)
+  local f = io.open(path, "r")
+  if not f then return nil end
+  local s = f:read("*a")
+  f:close()
+  return s
+end
+
+local function fake_run_cmd_recorder()
+  local calls = {}
+  return calls, function(cmd) calls[#calls+1] = cmd; return true end
+end
+
+describe("selfheal.selfheal_cron", function()
+
+  it("creates a missing crontab with the canonical line", function()
+    local p = tmp_path()
+    os.remove(p)
+    local calls, run = fake_run_cmd_recorder()
+    local healed = selfheal.selfheal_cron({ path = p, run_cmd = run })
+    assert.is_true(healed)
+    assert.equals("0 4 * * * /usr/sbin/wifihaven-update\n", read_file(p))
+    -- Should have invoked mkdir and the cron enable/restart triple.
+    local joined = table.concat(calls, "|")
+    assert.is_truthy(joined:find("mkdir %-p"))
+    assert.is_truthy(joined:find("/etc/init.d/cron enable"))
+    assert.is_truthy(joined:find("/etc/init.d/cron restart"))
+    os.remove(p)
+  end)
+
+  it("is a no-op when the canonical line is already present", function()
+    local p = tmp_path()
+    write_file(p, "# header\n0 4 * * * /usr/sbin/wifihaven-update\n0 * * * * /usr/sbin/other-thing\n")
+    local calls, run = fake_run_cmd_recorder()
+    local healed = selfheal.selfheal_cron({ path = p, run_cmd = run })
+    assert.is_false(healed)
+    -- File untouched (still has all three lines in the original order).
+    assert.equals(
+      "# header\n0 4 * * * /usr/sbin/wifihaven-update\n0 * * * * /usr/sbin/other-thing\n",
+      read_file(p))
+    -- No cron enable/restart on the happy path.
+    local joined = table.concat(calls, "|")
+    assert.is_nil(joined:find("/etc/init.d/cron enable"))
+    assert.is_nil(joined:find("/etc/init.d/cron restart"))
+    os.remove(p)
+  end)
+
+  it("rewrites a stale cadence to the canonical line", function()
+    local p = tmp_path()
+    write_file(p, "0 */6 * * * /usr/sbin/wifihaven-update\n# keepme\n")
+    local _, run = fake_run_cmd_recorder()
+    local healed = selfheal.selfheal_cron({ path = p, run_cmd = run })
+    assert.is_true(healed)
+    local out = read_file(p)
+    assert.is_nil(out:find("*/6"))
+    assert.is_truthy(out:find("0 4 %* %* %* /usr/sbin/wifihaven%-update"))
+    -- Preserves unrelated lines.
+    assert.is_truthy(out:find("# keepme"))
+    os.remove(p)
+  end)
+
+  it("preserves unrelated lines on heal", function()
+    local p = tmp_path()
+    write_file(p, "30 2 * * * /usr/bin/something\n")
+    local _, run = fake_run_cmd_recorder()
+    local healed = selfheal.selfheal_cron({ path = p, run_cmd = run })
+    assert.is_true(healed)
+    local out = read_file(p)
+    assert.is_truthy(out:find("30 2 %* %* %* /usr/bin/something"))
+    assert.is_truthy(out:find("0 4 %* %* %* /usr/sbin/wifihaven%-update"))
+    os.remove(p)
+  end)
+
+  it("collapses duplicate wifihaven-update lines to a single canonical entry", function()
+    local p = tmp_path()
+    write_file(p, "0 4 * * * /usr/sbin/wifihaven-update\n0 4 * * * /usr/sbin/wifihaven-update\n")
+    local _, run = fake_run_cmd_recorder()
+    local healed = selfheal.selfheal_cron({ path = p, run_cmd = run })
+    assert.is_true(healed)
+    local out = read_file(p)
+    local _, n = out:gsub("wifihaven%-update", "")
+    assert.equals(1, n)
+    os.remove(p)
+  end)
+
+end)


### PR DESCRIPTION
## Summary

- apk-tools v3 skips post-install on same-version reinstall, so #869's cron-registration never reaches routers that already had the package — heal it at agent startup instead.
- New `wifihaven.selfheal` module ensures `/etc/crontabs/root` has the canonical `0 4 * * * /usr/sbin/wifihaven-update` line and crond is up; idempotent, logs only on actual heal.
- Part 2 (apk-tools v3 `trigger` script) deferred to #898 — Part 1 alone is the load-bearing fix.

Closes #896
Refs #869, #898

## Live verification on openwrt.lan

Removed the cron entry, stopped crond, deployed the new agent + selfheal.lua, restarted:

```
$ ssh root@openwrt.lan 'sed -i "/wifihaven-update/d" /etc/crontabs/root && /etc/init.d/cron stop'
$ # scp new wifihaven-agent + selfheal.lua, then:
$ ssh root@openwrt.lan '/etc/init.d/wifihaven restart'
$ ssh root@openwrt.lan 'cat /etc/crontabs/root; /etc/init.d/cron status'
0 4 * * * /usr/sbin/wifihaven-update
running
$ ssh root@openwrt.lan 'logread | grep selfheal'
...wifihaven: selfheal: installed missing wifihaven-update cron entry
```

A second restart with the entry already present is a silent no-op (no `selfheal` log line).

## Test plan

- [x] `openwrt/test/run_tests.sh` — all green (5 new selfheal_spec cases + existing 418).
- [x] Live verify on `openwrt.lan`: cron entry restored automatically after removal + agent restart.
- [x] Happy-path no-op: second restart emits no `selfheal:` log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)