### PR TITLE
fix(openwrt): split tx/rx chains by direction; rx records (lan_ip, remote_ip) (#897)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -462,22 +462,24 @@ function M.nft(snapshot, opts)
     emit("")
   end
 
-  -- Per-flow accounting sets. Two sets, one per direction.
+  -- Per-flow accounting sets — one per direction, each updated from its own
+  -- chain (#897). Both chains hook `forward` at priority 1; the direction
+  -- predicate (`iifname` / `oifname "br-lan"`) is what keeps tx from
+  -- absorbing WAN→LAN packets (which would otherwise land in the tx set
+  -- keyed on the upstream-gateway MAC + the LAN device's IP — pure noise)
+  -- and what keeps rx from absorbing LAN→WAN packets.
   --
-  -- tx (device→remote): `ether saddr (mac) . ip daddr (remote)`. The L2 saddr
-  -- at the forward hook is the LAN device's real MAC, so per-(mac, remote_ip)
-  -- attribution works.
+  -- tx (device→remote, `iifname br-lan`): `ether saddr (device_mac) .
+  -- ip daddr (remote_ip)`. The L2 saddr at the forward hook is the real LAN
+  -- device MAC for LAN→WAN traffic, so per-(mac, remote_ip) attribution works.
   --
-  -- rx (remote→device): keyed on `ip daddr` only — the LAN device's IP. We
-  -- *cannot* use `ether daddr` here: for WAN→LAN routed packets the L2 daddr
-  -- at the forward hook is still the router's WAN-interface MAC (the rewrite
-  -- to the LAN device's MAC happens at egress via the neighbor cache, after
-  -- the forward hook runs). Keying on it would attribute every download to
-  -- the router itself (#879). Instead we record per-(lan_ip) totals and the
-  -- agent resolves the IP back to a MAC via the dnsmasq lease table.
-  --
-  -- The chain below updates both sets per packet, so a bucket's nft reset
-  -- zeroes both in lock-step.
+  -- rx (remote→device, `oifname br-lan`): `ip daddr (lan_device_ip) .
+  -- ip saddr (remote_ip)`. We *cannot* use `ether daddr` here: for a WAN→LAN
+  -- routed packet the L2 daddr at the forward hook is still the router's
+  -- WAN-interface MAC (the rewrite to the LAN device's MAC happens at egress
+  -- via the neighbor cache, after the forward hook runs) — keying on it
+  -- attributed every download to the router itself (#879). The agent
+  -- resolves the LAN IP back to a MAC via the dnsmasq lease table.
   ind("set mac_ip_tracking {")
   ind2("type ether_addr . ipv4_addr")
   ind2("flags dynamic,timeout")
@@ -486,21 +488,25 @@ function M.nft(snapshot, opts)
   ind("}")
   emit("")
 
-  ind("set ip_tracking_rx {")
-  ind2("type ipv4_addr")
+  -- #897: fresh set name (was `ip_tracking_rx`, single-key) so a hot agent
+  -- restart against an older nft ruleset can't misparse the old shape.
+  ind("set ip_pair_tracking_rx {")
+  ind2("type ipv4_addr . ipv4_addr")
   ind2("flags dynamic,timeout")
   ind2("timeout 6h")
   ind2("counter")
   ind("}")
   emit("")
 
-  -- Accounting chain: forward hook, low priority; updates both tracking sets
-  -- per packet. Both updates happen in the same rule walk so a single
-  -- forwarded packet bumps exactly one element on exactly one set.
-  ind("chain wifihaven_account {")
+  ind("chain wifihaven_account_tx {")
   ind2("type filter hook forward priority 1; policy accept;")
-  ind2("update @mac_ip_tracking { ether saddr . ip daddr } counter")
-  ind2("update @ip_tracking_rx  { ip daddr } counter")
+  ind2("iifname \"br-lan\" update @mac_ip_tracking { ether saddr . ip daddr } counter")
+  ind("}")
+  emit("")
+
+  ind("chain wifihaven_account_rx {")
+  ind2("type filter hook forward priority 1; policy accept;")
+  ind2("oifname \"br-lan\" update @ip_pair_tracking_rx { ip daddr . ip saddr } counter")
   ind("}")
   emit("")
 

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -1,31 +1,34 @@
 -- usage.lua — nftables counter scraper and usage reporter
 --
 -- Per-flow byte/packet accounting comes from two dynamic sets declared in
--- render.lua:
+-- render.lua, each updated from its own direction-scoped chain (#897):
 --
 --   set mac_ip_tracking {                   -- tx: device → remote
 --     type ether_addr . ipv4_addr
 --     flags dynamic,timeout
 --     counter
 --   }
---   set ip_tracking_rx {                    -- rx: remote → device
---     type ipv4_addr
+--   set ip_pair_tracking_rx {               -- rx: remote → device
+--     type ipv4_addr . ipv4_addr            -- (lan_device_ip, remote_ip)
 --     flags dynamic,timeout
 --     counter
 --   }
---   chain wifihaven_account {
+--   chain wifihaven_account_tx {
 --     type filter hook forward priority 1; policy accept;
---     update @mac_ip_tracking { ether saddr . ip daddr } counter
---     update @ip_tracking_rx  { ip daddr } counter
+--     iifname "br-lan" update @mac_ip_tracking { ether saddr . ip daddr } counter
+--   }
+--   chain wifihaven_account_rx {
+--     type filter hook forward priority 1; policy accept;
+--     oifname "br-lan" update @ip_pair_tracking_rx { ip daddr . ip saddr } counter
 --   }
 --
 -- The rx set is intentionally NOT keyed on `ether daddr`: at the forward
 -- hook the L2 daddr of a WAN→LAN routed packet is still the router's
 -- WAN-interface MAC (the rewrite to the LAN device MAC happens at egress
 -- via the neighbor cache). Keying on it attributed every download byte to
--- the router itself (#879). Instead the rx set records per-(lan_ip)
--- totals and the agent resolves the IP back to a MAC via the dnsmasq
--- lease table; rx bytes for an IP not in the lease table are dropped.
+-- the router itself (#879). Instead the rx set records per-(lan_ip, remote_ip)
+-- totals and the agent resolves the lan_ip back to a MAC via the dnsmasq
+-- lease table; rx records for a lan_ip not in the lease table are dropped.
 --
 -- Public API:
 --   usage.parse_nft_counters(json_str)
@@ -33,18 +36,18 @@
 --     Input: JSON from `nft -j list set inet wifihaven mac_ip_tracking`
 --
 --   usage.parse_nft_rx_counters(json_str)
---     → list of { ip, bytes, packets }
---     Input: JSON from `nft -j list set inet wifihaven ip_tracking_rx`
+--     → list of { lan_ip, remote_ip, bytes, packets }
+--     Input: JSON from `nft -j list set inet wifihaven ip_pair_tracking_rx`
 --
 --   usage.merge_counters(tx, rx, ip_to_mac, log)
 --     → list of { mac, dst_ip, bytes, packets, bytes_out, packets_out }
 --     `tx` (device→remote) carries `{mac, dst_ip, bytes, packets}` and goes
---     into bytes/packets. `rx` (remote→device) carries `{ip, bytes, packets}`
---     and is resolved to a MAC via `ip_to_mac[ip]` (the dnsmasq lease table);
---     unresolved IPs are dropped with a log line. Resolved rx contributions
---     are attributed to the device with dst_ip = the LAN ip itself (the rx
---     keying carries no remote_ip, so per-remote-host attribution is lost
---     on the download side; the row lands on the device's own IP as host).
+--     into bytes/packets. `rx` (remote→device) carries
+--     `{lan_ip, remote_ip, bytes, packets}` and is resolved to a MAC via
+--     `ip_to_mac[lan_ip]` (the dnsmasq lease table); unresolved lan_ips are
+--     dropped with a log line. Resolved rx contributions are attributed to
+--     `(mac, remote_ip)` — the same shape as the tx side, so a single bucket
+--     row carries both bytesIn and bytesOut against the real remote host.
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id,
 --                      leases, lookup_hostname, tracker,
@@ -134,9 +137,10 @@ end
 -- ---------------------------------------------------------------------------
 -- usage.parse_nft_rx_counters(json_str)
 --
--- Walks the JSON output of `nft -j list set inet wifihaven ip_tracking_rx`
--- (single-key set: `type ipv4_addr`). Each set element's `val` is the IP
--- string directly (not a `concat` array).
+-- Walks the JSON output of `nft -j list set inet wifihaven
+-- ip_pair_tracking_rx` (#897: composite-keyed set, `type ipv4_addr .
+-- ipv4_addr`). Each set element's `val` is a `concat` array of
+-- [lan_device_ip, remote_ip].
 -- ---------------------------------------------------------------------------
 function M.parse_nft_rx_counters(json_str)
   local jsonc   = require("luci.jsonc")
@@ -150,13 +154,15 @@ function M.parse_nft_rx_counters(json_str)
     if set and set.elem then
       for _, wrapper in ipairs(set.elem) do
         local e = wrapper.elem or wrapper
-        local ip = e.val
+        local val = e.val
+        local concat = val and val.concat
         local counter = e.counter
-        if type(ip) == "string" and counter then
+        if concat and counter and concat[1] and concat[2] then
           result[#result + 1] = {
-            ip      = ip,
-            bytes   = counter.bytes   or 0,
-            packets = counter.packets or 0,
+            lan_ip    = concat[1],
+            remote_ip = concat[2],
+            bytes     = counter.bytes   or 0,
+            packets   = counter.packets or 0,
           }
         end
       end
@@ -169,16 +175,15 @@ end
 -- ---------------------------------------------------------------------------
 -- usage.merge_counters(tx, rx, ip_to_mac, log)
 --
--- Joins tx (per (mac, remote_ip)) with rx (per (lan_ip), resolved to mac
--- via `ip_to_mac`). Records are keyed (mac, dst_ip):
+-- Joins tx (per (mac, remote_ip)) with rx (per (lan_ip, remote_ip), with
+-- lan_ip resolved to mac via `ip_to_mac`). Records are keyed (mac, dst_ip)
+-- where `dst_ip` is always the *remote* IP — same shape on both directions
+-- so a single record carries the full bytesIn/bytesOut for one (device,
+-- remote) flow.
 --
---   * tx records add `bytes`/`packets` at (mac, c.dst_ip).
---   * rx records add `bytes_out`/`packets_out` at (resolved_mac, c.ip) —
---     the LAN IP itself doubles as the host placeholder, since the rx set
---     does not capture the remote IP (#879). The merge with a tx record
---     at the same (mac, lan_ip) is incidental (tx normally targets remote
---     IPs, not the device's own LAN IP) and is fine when it happens.
---   * rx records whose `ip` is not in `ip_to_mac` are dropped. We log a
+--   * tx records add `bytes`/`packets` at (c.mac, c.dst_ip).
+--   * rx records add `bytes_out`/`packets_out` at (resolved_mac, c.remote_ip).
+--   * rx records whose `lan_ip` is not in `ip_to_mac` are dropped. We log a
 --     summary count per bucket so unattributed download bytes are visible
 --     in `logread` without spamming a line per packet.
 -- ---------------------------------------------------------------------------
@@ -211,9 +216,9 @@ function M.merge_counters(tx, rx, ip_to_mac, log)
   local unknown_n     = 0
   local unknown_bytes = 0
   for _, c in ipairs(rx or {}) do
-    local mac = ip_to_mac and ip_to_mac[c.ip] or nil
+    local mac = ip_to_mac and ip_to_mac[c.lan_ip] or nil
     if mac then
-      local rec = get_or_make(mac, c.ip)
+      local rec = get_or_make(mac, c.remote_ip)
       rec.bytes_out   = rec.bytes_out   + (c.bytes   or 0)
       rec.packets_out = rec.packets_out + (c.packets or 0)
     else
@@ -222,7 +227,7 @@ function M.merge_counters(tx, rx, ip_to_mac, log)
     end
   end
   if unknown_n > 0 and log and log.debug then
-    log.debug("usage.merge_counters: dropped %d rx record(s) with unresolved ip (bytes=%d)",
+    log.debug("usage.merge_counters: dropped %d rx record(s) with unresolved lan_ip (bytes=%d)",
               unknown_n, unknown_bytes)
   end
   return result

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -321,7 +321,7 @@ local function read_tx_set()
 end
 
 local function read_rx_set()
-  local json_str = read_set_json("ip_tracking_rx")
+  local json_str = read_set_json("ip_pair_tracking_rx")
   if not json_str then return nil end
   local ok, counters = pcall(usage.parse_nft_rx_counters, json_str)
   if not ok then return nil end
@@ -508,11 +508,12 @@ conntrack.watch({
       last_usage_run     = mono
       last_usage_wall_ts = wall
 
-      -- Per-flow counters live as element counters on two dynamic sets
-      -- `mac_ip_tracking` (tx, keyed mac+remote_ip) and `ip_tracking_rx`
-      -- (rx, keyed on lan_ip only — #879). After a successful POST we
-      -- `nft reset set ...` on both to zero those per-element counters
-      -- in lock-step.
+      -- Per-flow counters live as element counters on two dynamic sets:
+      -- `mac_ip_tracking` (tx, keyed mac+remote_ip) and
+      -- `ip_pair_tracking_rx` (rx, keyed lan_ip+remote_ip — #897, was
+      -- single-keyed `ip_tracking_rx` per #879 but that lost the remote
+      -- axis). After a successful POST we `nft reset set ...` on both to
+      -- zero those per-element counters in lock-step.
       local counters = read_nft_counters()
       if counters then
         -- Final sample at flush so set elements that appeared after the
@@ -533,7 +534,7 @@ conntrack.watch({
         -- is now owned by the retry queue (or already sent), so leaving the
         -- nft counters intact would double-count on the next bucket.
         os.execute("nft reset set inet wifihaven mac_ip_tracking >/dev/null 2>&1")
-        os.execute("nft reset set inet wifihaven ip_tracking_rx >/dev/null 2>&1")
+        os.execute("nft reset set inet wifihaven ip_pair_tracking_rx >/dev/null 2>&1")
         usage.tracker_reset(activity_tracker)
         if not posted then
           log.warn("usage timer: queued for retry (queue depth=%d)",

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -193,37 +193,77 @@ describe("render.nft", function()
     assert.truthy(nft:find("mac_ip_tracking", 1, true))
   end)
 
-  -- #879: download bytes used to be keyed on `ether daddr (mac) . ip saddr
-  -- (remote)`, but at the forward hook a WAN→LAN routed packet still has
-  -- the router's WAN-interface MAC as its L2 daddr (the rewrite to the LAN
-  -- device's MAC happens at egress via the neighbor cache). Every rx byte
-  -- got attributed to the router itself. Re-key on `ip daddr` only (the
-  -- LAN device's IP) and resolve to MAC in the agent via the dnsmasq lease
-  -- table.
-  it("declares the ip_tracking_rx set keyed on ipv4_addr only (#879)", function()
+  -- #879/#897: download bytes used to be keyed on `ether daddr (mac) . ip
+  -- saddr (remote)`, but at the forward hook a WAN→LAN routed packet still
+  -- has the router's WAN-interface MAC as its L2 daddr (the rewrite happens
+  -- at egress via the neighbor cache) — every rx byte got attributed to the
+  -- router itself (#879). The interim fix keyed only on `ip daddr` which lost
+  -- the remote-host axis (#897). The set now records (lan_device_ip,
+  -- remote_ip) pairs and the agent resolves the lan_ip back to a MAC via
+  -- the dnsmasq lease table.
+  it("declares the ip_pair_tracking_rx set keyed on (ipv4_addr . ipv4_addr) (#897)", function()
     local nft = render.nft(snap_one())
-    local pos = nft:find("set ip_tracking_rx", 1, true)
+    local pos = nft:find("set ip_pair_tracking_rx", 1, true)
     assert.truthy(pos)
     local block = nft:sub(pos, pos + 200)
-    assert.truthy(block:find("type ipv4_addr"))
-    -- The old composite type would betray the bug returning; assert it's gone.
+    assert.truthy(block:find("type ipv4_addr %. ipv4_addr"))
+    -- Guards against regressing to ether_addr keying (#879) or single-key
+    -- ipv4_addr keying (#897).
     assert.is_nil(block:find("ether_addr"))
   end)
 
-  it("does NOT declare the old mac_ip_tracking_rx set (#879 cleanup)", function()
+  it("does NOT declare the old mac_ip_tracking_rx or ip_tracking_rx sets (#897 cleanup)", function()
     local nft = render.nft(snap_one())
     assert.is_nil(nft:find("mac_ip_tracking_rx", 1, true))
+    -- Old single-keyed set name from #879; superseded by ip_pair_tracking_rx.
+    assert.is_nil(nft:find("set ip_tracking_rx", 1, true))
   end)
 
-  it("wifihaven_account chain updates BOTH tx and rx tracking sets atomically (#879)", function()
+  -- #897: tx and rx live in separate chains, each scoped to one direction
+  -- by an interface predicate. Without the predicate, the tx chain absorbs
+  -- WAN→LAN packets too and writes ghost rows keyed on the upstream-gateway
+  -- MAC + LAN device IP (live evidence in #897 showed these mirror the rx
+  -- rows byte-for-byte, double-counting every download).
+  -- Slice helper: return the body of a `chain <name> { ... }` block, exclusive
+  -- of the braces. Lets each assertion check exactly one chain.
+  local function chain_body(nft, name)
+    local start = nft:find("chain " .. name .. " {", 1, true)
+    if not start then return nil end
+    local open  = nft:find("{", start, true)
+    local close = nft:find("\n  }", open, true)
+    return nft:sub(open + 1, close - 1)
+  end
+
+  it("declares wifihaven_account_tx scoped to iifname \"br-lan\" updating @mac_ip_tracking (#897)", function()
+    local nft  = render.nft(snap_one())
+    local body = chain_body(nft, "wifihaven_account_tx")
+    assert.truthy(body)
+    assert.truthy(body:find("iifname \"br%-lan\""))
+    assert.truthy(body:find("update @mac_ip_tracking%s+{%s*ether saddr %. ip daddr%s*}%s+counter"))
+    -- The rx set must NOT be updated from the tx chain — that would
+    -- re-introduce the double-counting #897 fixes.
+    assert.is_nil(body:find("ip_pair_tracking_rx"))
+    assert.is_nil(body:find("oifname"))
+  end)
+
+  it("declares wifihaven_account_rx scoped to oifname \"br-lan\" updating @ip_pair_tracking_rx (#897)", function()
+    local nft  = render.nft(snap_one())
+    local body = chain_body(nft, "wifihaven_account_rx")
+    assert.truthy(body)
+    assert.truthy(body:find("oifname \"br%-lan\""))
+    assert.truthy(body:find("update @ip_pair_tracking_rx%s+{%s*ip daddr %. ip saddr%s*}%s+counter"))
+    -- Symmetric guard: the tx set must NOT be updated from the rx chain.
+    assert.is_nil(body:find("mac_ip_tracking"))
+    assert.is_nil(body:find("iifname"))
+  end)
+
+  it("does NOT declare the old combined wifihaven_account chain (#897)", function()
     local nft = render.nft(snap_one())
-    local pos = nft:find("chain wifihaven_account", 1, true)
-    assert.truthy(pos)
-    -- Same chain (one rule walk per packet) so a bucket's bytesIn and
-    -- bytesOut always cover the same window.
-    local block = nft:sub(pos, pos + 500)
-    assert.truthy(block:find("update @mac_ip_tracking%s+{%s*ether saddr %. ip daddr%s*}%s+counter"))
-    assert.truthy(block:find("update @ip_tracking_rx%s+{%s*ip daddr%s*}%s+counter"))
+    -- We split into wifihaven_account_tx and wifihaven_account_rx; the
+    -- bare `wifihaven_account ` chain (with trailing space, distinguishing
+    -- from the new `_tx`/`_rx` suffixes) must be gone.
+    assert.is_nil(nft:find("chain wifihaven_account ", 1, true))
+    assert.is_nil(nft:find("chain wifihaven_account\n", 1, true))
   end)
 
   -- #354: blocked_macs is derived per-device from effective BlockRules.blocked.

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -85,10 +85,11 @@ describe("usage.parse_nft_counters", function()
 
 end)
 
--- ── parse_nft_rx_counters (#879) ───────────────────────────────────────────
+-- ── parse_nft_rx_counters (#897) ───────────────────────────────────────────
 --
--- The rx set `ip_tracking_rx` is keyed on `type ipv4_addr` (single key, not a
--- composite), so each element's `val` is a bare IP string — not a `concat`.
+-- The rx set `ip_pair_tracking_rx` is keyed on `type ipv4_addr . ipv4_addr`
+-- (lan_device_ip, remote_ip), so each element's `val` is a `concat` of two
+-- IP strings. The earlier single-key form (#879) lost the remote-host axis.
 
 describe("usage.parse_nft_rx_counters", function()
 
@@ -96,74 +97,77 @@ describe("usage.parse_nft_rx_counters", function()
     "nftables": [
       { "metainfo": {"version":"1.1.6"} },
       { "set": {
-          "family":"inet","table":"wifihaven","name":"ip_tracking_rx",
-          "type":"ipv4_addr",
+          "family":"inet","table":"wifihaven","name":"ip_pair_tracking_rx",
+          "type":["ipv4_addr","ipv4_addr"],
           "flags":["timeout","dynamic"],
           "elem":[
-            { "elem": { "val":"192.168.10.50", "counter":{"packets":42,"bytes":4096} } },
-            { "elem": { "val":"192.168.10.99", "counter":{"packets": 5,"bytes": 500} } }
+            { "elem": { "val":{"concat":["192.168.10.50","1.2.3.4"]},  "counter":{"packets":42,"bytes":4096} } },
+            { "elem": { "val":{"concat":["192.168.10.99","203.0.113.1"]}, "counter":{"packets": 5,"bytes": 500} } }
           ]
       }}
     ]
   }]]
 
-  it("returns one record per element with ip/bytes/packets", function()
+  it("returns one record per element with lan_ip/remote_ip/bytes/packets", function()
     local rx = usage.parse_nft_rx_counters(RX_JSON)
     assert.equal(2, #rx)
-    local by_ip = {}
-    for _, c in ipairs(rx) do by_ip[c.ip] = c end
-    assert.equal(4096, by_ip["192.168.10.50"].bytes)
-    assert.equal(42,   by_ip["192.168.10.50"].packets)
-    assert.equal(500,  by_ip["192.168.10.99"].bytes)
+    local by_lan = {}
+    for _, c in ipairs(rx) do by_lan[c.lan_ip] = c end
+    assert.equal("1.2.3.4",   by_lan["192.168.10.50"].remote_ip)
+    assert.equal(4096,        by_lan["192.168.10.50"].bytes)
+    assert.equal(42,          by_lan["192.168.10.50"].packets)
+    assert.equal("203.0.113.1", by_lan["192.168.10.99"].remote_ip)
+    assert.equal(500,         by_lan["192.168.10.99"].bytes)
   end)
 
   it("returns an empty list when the set is empty", function()
-    local empty = [[{"nftables":[{"set":{"name":"ip_tracking_rx"}}]}]]
+    local empty = [[{"nftables":[{"set":{"name":"ip_pair_tracking_rx"}}]}]]
     assert.equal(0, #usage.parse_nft_rx_counters(empty))
   end)
 
 end)
 
--- ── merge_counters (#879) ─────────────────────────────────────────────────
+-- ── merge_counters (#897) ─────────────────────────────────────────────────
 --
--- tx is keyed (mac, remote_ip); rx is keyed (lan_ip) only and the agent
--- resolves lan_ip → mac via the dnsmasq lease table before merging. rx
--- contributions land on a record with dst_ip = the lan_ip itself (per-
--- remote-host attribution is lost on the download side; #879).
+-- tx is keyed (mac, remote_ip); rx is keyed (lan_ip, remote_ip). The agent
+-- resolves lan_ip → mac via the dnsmasq lease table and merges into
+-- (mac, remote_ip) — same shape on both directions, so a single record
+-- carries the full bytesIn/bytesOut for one (device, remote) flow.
 
 describe("usage.merge_counters", function()
 
-  local LAN_IP = "192.168.10.50"
-  local MAC    = "aa:bb:cc:11:22:33"
-  local IP2M   = { [LAN_IP] = MAC }
+  local LAN_IP    = "192.168.10.50"
+  local REMOTE_IP = "1.2.3.4"
+  local MAC       = "aa:bb:cc:11:22:33"
+  local IP2M      = { [LAN_IP] = MAC }
 
   it("attributes tx records on (mac, dst_ip) unchanged", function()
-    local tx = { { mac = MAC, dst_ip = "1.2.3.4", bytes = 100, packets = 3 } }
+    local tx = { { mac = MAC, dst_ip = REMOTE_IP, bytes = 100, packets = 3 } }
     local merged = usage.merge_counters(tx, {}, IP2M)
     assert.equal(1, #merged)
     assert.equal(MAC,       merged[1].mac)
-    assert.equal("1.2.3.4", merged[1].dst_ip)
+    assert.equal(REMOTE_IP, merged[1].dst_ip)
     assert.equal(100,       merged[1].bytes)
     assert.equal(3,         merged[1].packets)
     assert.equal(0,         merged[1].bytes_out)
   end)
 
-  it("resolves rx records by ip→mac via the lease map and attributes to (mac, lan_ip)", function()
-    local rx = { { ip = LAN_IP, bytes = 900, packets = 7 } }
+  it("resolves rx records by lan_ip→mac via the lease map and attributes to (mac, remote_ip) (#897)", function()
+    local rx = { { lan_ip = LAN_IP, remote_ip = REMOTE_IP, bytes = 900, packets = 7 } }
     local merged = usage.merge_counters({}, rx, IP2M)
     assert.equal(1, #merged)
-    assert.equal(MAC,    merged[1].mac)
-    assert.equal(LAN_IP, merged[1].dst_ip)
-    assert.equal(900,    merged[1].bytes_out)
-    assert.equal(7,      merged[1].packets_out)
-    assert.equal(0,      merged[1].bytes)
+    assert.equal(MAC,       merged[1].mac)
+    -- #897: dst_ip is now the REAL remote IP, not the LAN device's own IP.
+    assert.equal(REMOTE_IP, merged[1].dst_ip)
+    assert.equal(900,       merged[1].bytes_out)
+    assert.equal(7,         merged[1].packets_out)
+    assert.equal(0,         merged[1].bytes)
   end)
 
-  it("drops rx records whose ip is not in the lease table (no router-MAC attribution, #879)", function()
-    -- The router's own WAN IP (or any IP not associated with a LAN client)
-    -- must not produce a record. Otherwise bytesOut would land on a fake
-    -- device row.
-    local rx = { { ip = "8.8.8.8", bytes = 1234, packets = 9 } }
+  it("drops rx records whose lan_ip is not in the lease table (#879)", function()
+    -- An unknown LAN IP (lease aged out, stale set element) must not produce
+    -- a record. Otherwise bytesOut would land on a fake device row.
+    local rx = { { lan_ip = "192.168.99.99", remote_ip = REMOTE_IP, bytes = 1234, packets = 9 } }
     local merged = usage.merge_counters({}, rx, IP2M)
     assert.equal(0, #merged)
   end)
@@ -174,8 +178,8 @@ describe("usage.merge_counters", function()
       debug = function(fmt, ...) seen[#seen + 1] = string.format(fmt, ...) end,
     }
     local rx = {
-      { ip = "8.8.8.8",       bytes = 100, packets = 1 },
-      { ip = "203.0.113.10",  bytes = 200, packets = 2 },
+      { lan_ip = "192.168.99.1", remote_ip = "8.8.8.8",      bytes = 100, packets = 1 },
+      { lan_ip = "192.168.99.2", remote_ip = "203.0.113.10", bytes = 200, packets = 2 },
     }
     usage.merge_counters({}, rx, {}, fake_log)
     assert.equal(1, #seen)
@@ -183,19 +187,29 @@ describe("usage.merge_counters", function()
     assert.truthy(seen[1]:find("bytes=300"))
   end)
 
-  it("merges tx and rx for the same (mac, lan_ip) when both exist", function()
-    -- Possible (rare) when a device addresses its own LAN IP for some reason;
-    -- merge should just sum.
-    local tx = { { mac = MAC, dst_ip = LAN_IP, bytes = 100, packets = 1 } }
-    local rx = { { ip = LAN_IP,                bytes = 200, packets = 2 } }
+  it("merges tx and rx for the same (mac, remote_ip) into a single record (#897)", function()
+    -- The 4-hop case: device sent 100B up to remote_ip and got 200B back.
+    -- Both directions land on one (mac, remote_ip) row.
+    local tx = { { mac = MAC,    dst_ip   = REMOTE_IP, bytes = 100, packets = 1 } }
+    local rx = { { lan_ip = LAN_IP, remote_ip = REMOTE_IP, bytes = 200, packets = 2 } }
     local merged = usage.merge_counters(tx, rx, IP2M)
     assert.equal(1, #merged)
+    assert.equal(MAC,       merged[1].mac)
+    assert.equal(REMOTE_IP, merged[1].dst_ip)
     assert.equal(100, merged[1].bytes)
     assert.equal(200, merged[1].bytes_out)
   end)
 
+  it("keeps a tx-only record (no rx counterpart) with bytes_out=0", function()
+    local tx = { { mac = MAC, dst_ip = REMOTE_IP, bytes = 100, packets = 1 } }
+    local merged = usage.merge_counters(tx, {}, IP2M)
+    assert.equal(1, #merged)
+    assert.equal(100, merged[1].bytes)
+    assert.equal(0,   merged[1].bytes_out)
+  end)
+
   it("treats nil tx or rx as empty (single-direction snapshot during a render swap)", function()
-    local rx = { { ip = LAN_IP, bytes = 500, packets = 4 } }
+    local rx = { { lan_ip = LAN_IP, remote_ip = REMOTE_IP, bytes = 500, packets = 4 } }
     local merged = usage.merge_counters(nil, rx, IP2M)
     assert.equal(1, #merged)
     assert.equal(0,   merged[1].bytes)


### PR DESCRIPTION
## Summary

Two related bugs in per-direction nft accounting, both caused by a single
forward-hook chain with no direction predicate:

- **A.** #879's rx counter was keyed on `ip daddr` only — every `bytes_out`
  row had `host_value` = the LAN device's own IP, losing the remote-host axis.
- **B.** The tx counter also matched WAN→LAN packets and wrote ghost rows
  keyed on the upstream-gateway MAC + LAN device IP.

Fix: split the chain by direction (`iifname`/`oifname "br-lan"`) and change
the rx set to a composite key `(lan_device_ip, remote_ip)`. The agent
resolves the LAN IP to a MAC via the dnsmasq lease table and emits records
keyed on `(mac, remote_ip)` — same shape as the tx side, so a single record
now carries the full bytesIn/bytesOut for one (device, remote) flow.

No wire-format change. The old `ip_tracking_rx` set is replaced by the
new `ip_pair_tracking_rx` set; the old set will be garbage-collected on
the next agent restart since nothing declares or updates it.

## Live verification (openwrt.lan → api.lan dev DB)

**Before** (from the #897 bug report — 3.8 MB mirrored across two ghost rows):

```
        mac        | host_value     | bytes_in | bytes_out
 4a:68:49:c1:79:08 | 192.168.1.217  |        0 |  3808415   ← rx row, real device, LAN IP as "host"
 94:83:c4:d4:9d:d9 | 192.168.1.217  |  3808415 |        0   ← tx-chain ghost, gateway MAC
```

**After** (this PR, post-restart on openwrt.lan, fresh window):

```
        mac        | host_type |        host_value        | bytes_in | bytes_out
 76:2d:95:47:d1:8e | ipv4      | 172.66.0.227             |     9232 |     99160
 76:2d:95:47:d1:8e | ipv4      | 20.140.56.69             |     3115 |     91420
 76:2d:95:47:d1:8e | fqdn      | mask.apple-dns.net       |     3481 |     26577
 76:2d:95:47:d1:8e | fqdn      | 1-courier.push.apple.com |      428 |      1182
```

- ✅ No rows with a gateway/router-own MAC (was: `94:83:c4:d4:*`).
- ✅ No `host_value` in the LAN subnet (was: `192.168.1.*`).
- ✅ `bytes_out > 0` against the real device MAC paired with real remote IPs/FQDNs.

## Note on existing data

Ghost gateway-MAC rows already in the DB are NOT cleaned up by this PR —
the agent simply stops writing them. A separate backfill issue will be
filed for that cleanup.

## Test plan

- [x] `openwrt/test/run_tests.sh` — 416 passing, 0 failing, 1 pending (nft binary unavailable on dev host).
- [x] Live deploy to `openwrt.lan` and confirm the three acceptance criteria above against the live dev DB.

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)