### PR TITLE
fix(openwrt): apk v3 trigger so --force-reinstall installs cron entry (#898)

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -99,6 +99,7 @@ cat > "$WORK/post-install" <<'POSTINSTALL'
 # #869: Install cron entry for the auto-updater (daily, 04:00 router-local).
 # Replace any existing wifihaven-update entry so upgrades migrate the
 # cadence — older packages installed it at "0 */6 * * *".
+# Kept in sync with the trigger script below and openwrt/Makefile postinst.
 mkdir -p /etc/crontabs
 [ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
 echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
@@ -106,6 +107,26 @@ echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
 /etc/init.d/cron restart 2>/dev/null || true
 POSTINSTALL
 chmod 0755 "$WORK/post-install"
+
+# ── trigger script ───────────────────────────────────────────────────────────
+# #898: apk-tools v3 skips `post-install` on `apk add --force-reinstall` when
+# the package version hasn't changed, so a manual reinstall to "fix"
+# /etc/crontabs/root would otherwise be a no-op. A trigger script keyed on
+# /etc/crontabs fires whenever a package install/upgrade/reinstall touches
+# that directory — and database.c sets ipkg->run_all_triggers=1 on every
+# install of our own package, so reinstalling ourselves is enough to fire
+# this even if /etc/crontabs was untouched on disk.
+# Mirrors the cron-installation block in post-install above and in
+# openwrt/Makefile (.ipk postinst); keep all three in sync.
+cat > "$WORK/trigger" <<'TRIGGER'
+#!/bin/sh
+mkdir -p /etc/crontabs
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+/etc/init.d/cron enable 2>/dev/null || true
+/etc/init.d/cron restart 2>/dev/null || true
+TRIGGER
+chmod 0755 "$WORK/trigger"
 
 # ── build .apk ───────────────────────────────────────────────────────────────
 rm -f "$OUT_APK"
@@ -119,6 +140,8 @@ rm -f "$OUT_APK"
     --info "maintainer:WifiHaven <noreply@example.com>" \
     --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua" \
     --script "post-install:$WORK/post-install" \
+    --script "trigger:$WORK/trigger" \
+    --trigger "/etc/crontabs" \
     --files "$WORK/data" \
     --output "$OUT_APK"
 

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -267,5 +267,38 @@ for f in "$ROOT/Makefile" "$ROOT/build-apk.sh"; do
              "postinst doesn't restart cron after writing crontab"
 done
 
+# #898: build-apk.sh must also register an apk-tools v3 `trigger` script
+# keyed on /etc/crontabs. apk v3 skips `post-install` on a same-version
+# `apk add --force-reinstall`, so without a trigger a manual reinstall to
+# repair /etc/crontabs/root is a no-op. The trigger fires whenever any
+# install touches a path matching its key, and database.c sets
+# run_all_triggers=1 on every install of our own package — so reinstalling
+# ourselves fires it even if /etc/crontabs is untouched on disk.
+APK="$ROOT/build-apk.sh"
+grep -q '"trigger:\$WORK/trigger"' "$APK" \
+  && check "#898 build-apk.sh declares trigger script via --script trigger:" ok \
+  || check "#898 build-apk.sh declares trigger script via --script trigger:" \
+           "build-apk.sh missing --script trigger:... — apk add --force-reinstall would skip cron block"
+
+grep -q '\-\-trigger "/etc/crontabs"' "$APK" \
+  && check "#898 build-apk.sh registers /etc/crontabs as trigger key" ok \
+  || check "#898 build-apk.sh registers /etc/crontabs as trigger key" \
+           "build-apk.sh missing --trigger /etc/crontabs"
+
+# The trigger body must mirror the cron-installation block (same canonical
+# crontab line + cron restart) so reinstall ends in the same state as a
+# fresh install.
+awk '/cat > "\$WORK\/trigger"/,/^TRIGGER$/' "$APK" \
+  | grep -q "0 4 \* \* \* /usr/sbin/wifihaven-update" \
+  && check "#898 trigger script writes canonical wifihaven-update crontab line" ok \
+  || check "#898 trigger script writes canonical wifihaven-update crontab line" \
+           "trigger heredoc missing the canonical '0 4 * * * /usr/sbin/wifihaven-update' line"
+
+awk '/cat > "\$WORK\/trigger"/,/^TRIGGER$/' "$APK" \
+  | grep -q "/etc/init.d/cron restart" \
+  && check "#898 trigger script restarts cron" ok \
+  || check "#898 trigger script restarts cron" \
+           "trigger heredoc doesn't restart cron after writing crontab"
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- Adds an apk-tools v3 `trigger` script (keyed on `/etc/crontabs`) to `openwrt/build-apk.sh` that mirrors the cron-installation block in `post-install`.
- apk v3 skips `post-install` on a same-version `apk add --force-reinstall`, so without this a manual reinstall to repair `/etc/crontabs/root` was a no-op. The trigger fires on every install of our own package (database.c sets `run_all_triggers=1`), so reinstall now re-registers the cron entry without waiting on the agent self-heal from #896.
- Three-source sync: `openwrt/Makefile` (.ipk postinst), `openwrt/build-apk.sh` `post-install`, and the new trigger all carry the same canonical line `0 4 * * * /usr/sbin/wifihaven-update`.

## Test plan
- [x] `openwrt/test/install_spec.sh` — new #898 guards on the mkpkg `--script trigger:` / `--trigger /etc/crontabs` args and the trigger body. All 36 checks pass.
- [x] `apk adbdump` confirms `triggers: - /etc/crontabs` and the trigger script body on the produced .apk.
- [x] Live verification on `openwrt.lan` — cron entry wiped + crond stopped, then `apk add --allow-untrusted --force-reinstall`:

```
--- reinstall
(1/1) Replacing wifihaven (0.1.0-r1 -> 0.1.0-r1)
Executing wifihaven-0.1.0-r1.trigger
OK: 49.7 MiB in 203 packages
--- after
0 4 * * * /usr/sbin/wifihaven-update
--- crond
25342 /usr/sbin/crond
```

Only the `.trigger` line appears (post-install correctly skipped on same-version reinstall), and the cron entry + crond came back without restarting the agent — isolating the trigger's effect from the agent-side self-heal.

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)