### PR TITLE
test(openwrt-agent): guard selfheal wiring at agent startup (#903)

### DIFF
--- a/openwrt/test/agent_spec.sh
+++ b/openwrt/test/agent_spec.sh
@@ -36,5 +36,21 @@ else
   check "no dependency on coreutils stat -c" ok
 fi
 
+# #903: PR #899 shipped openwrt/files/usr/lib/lua/wifihaven/selfheal.lua with
+# unit-test coverage but originally forgot to require + call it from the
+# agent, so the heal never ran on startup. Wiring was added in a follow-up.
+# Guard both halves so a future refactor can't silently drop them again.
+if grep -q '^local selfheal[[:space:]]*=[[:space:]]*require("wifihaven\.selfheal")' "$SCRIPT"; then
+  check "selfheal module required at agent startup (#903)" ok
+else
+  check "selfheal module required at agent startup (#903)" "missing 'require(\"wifihaven.selfheal\")' — startup heal won't run"
+fi
+
+if grep -q 'selfheal\.selfheal_cron(' "$SCRIPT"; then
+  check "selfheal_cron called at agent startup (#903)" ok
+else
+  check "selfheal_cron called at agent startup (#903)" "module required but selfheal_cron() never invoked"
+fi
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds two grep guards in `openwrt/test/agent_spec.sh` asserting `require("wifihaven.selfheal")` and `selfheal.selfheal_cron(` both appear in the agent script.
- Closes #903.

## Background — why this is just a test PR

#903 reports that PR #899 (#896 follow-up) shipped `wifihaven/selfheal.lua` but never wired it into `wifihaven-agent`. The reproducer in #903 was true at filing — but a follow-up commit on PR #899 actually did add the wiring. On `main` today:

```
$ grep -n selfheal openwrt/files/usr/sbin/wifihaven-agent
25:local selfheal   = require("wifihaven.selfheal")
62:selfheal.selfheal_cron({ log = log })
```

And live on `openwrt.lan` (already running the wired build via auto-update):

```
$ ssh root@openwrt.lan 'sed -i "/wifihaven-update/d" /etc/crontabs/root; \
    /etc/init.d/wifihaven restart; sleep 5; \
    cat /etc/crontabs/root; logread | grep selfheal | tail -2'
0 4 * * * /usr/sbin/wifihaven-update
Sat May 23 12:12:22 2026 user.info wifihaven: selfheal: installed missing wifihaven-update cron entry
Sat May 23 14:27:30 2026 user.info wifihaven: selfheal: installed missing wifihaven-update cron entry
```

So the behavioral fix is already in place. What was still missing — and what #903 effectively asks for — is a regression guard so the wiring can't silently disappear again. `selfheal_spec.lua` covers the function but not the call site, and the agent daemon can't be required from a busted spec (no module return), so the guard lives in the existing shell-level `agent_spec.sh`.

## Verification

```
$ cd openwrt && sh test/agent_spec.sh
  PASS: no dependency on coreutils stat -c
  PASS: selfheal module required at agent startup (#903)
  PASS: selfheal_cron called at agent startup (#903)
  3 passed, 0 failed
```

Negative case — remove both wiring lines from the agent, re-run:

```
  PASS: no dependency on coreutils stat -c
  FAIL: selfheal module required at agent startup (#903) — missing 'require("wifihaven.selfheal")' — startup heal won't run
  FAIL: selfheal_cron called at agent startup (#903) — module required but selfheal_cron() never invoked
  1 passed, 2 failed
exit=1
```

## Test plan

- [x] `sh openwrt/test/agent_spec.sh` passes on this branch.
- [x] Guard fails (exit 1) when wiring lines are deleted.
- [x] Live heal on `openwrt.lan` confirmed end-to-end.

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)