### PR TITLE
fix(ci): randomize Gate 2 fake-API bind port to avoid orphan-qemu flake (#902)

### DIFF
--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -158,7 +158,10 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
 PY
 }
 
-if [[ "${E2E_VM_SKIP_VMS:-0}" != "1" ]]; then
+# If the caller set WH_PORT_BASE (the #891 concurrent-pair knob), defer to
+# config.sh's base-derived defaults rather than randomizing. Keeps the
+# explicit "give me a deterministic port window" workflow working.
+if [[ "${E2E_VM_SKIP_VMS:-0}" != "1" && -z "${WH_PORT_BASE:-}" ]]; then
   : "${WH_ROUTER_SSH_PORT:=$(alloc_free_port)}"
   : "${WH_ROUTER_HTTP_PORT:=$(alloc_free_port)}"
   : "${WH_CLIENT_SSH_PORT_BASE:=$(alloc_free_port)}"

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -21,13 +21,22 @@
 #
 # Environment overrides (read by conftest.py / conftest_fake.py):
 #   E2E_VM_API_PORT         API stack host port (default 18080; live mode)
-#   WH_FAKE_API_PORT        fake API host port (default 18090; fake mode)
+#   WH_FAKE_API_PORT        fake API host port (fake mode; auto-allocated if unset)
+#   WH_ROUTER_SSH_PORT      router VM WAN-side SSH hostfwd (auto-allocated if unset)
+#   WH_ROUTER_HTTP_PORT     router VM WAN-side HTTP hostfwd (auto-allocated if unset)
+#   WH_CLIENT_SSH_PORT_BASE client VM SSH hostfwd (auto-allocated if unset)
 #   E2E_VM_KEEP_STACK=1     don't tear down docker compose (live mode)
 #   E2E_VM_KEEP=1           don't tear down VMs (router + clients)
 #   E2E_VM_SKIP_STACK=1     assume stack already up at $E2E_VM_API_PORT
 #   E2E_VM_SKIP_VMS=1       skip VM-dependent tests (CI sanity mode)
 #   WH_ROUTER_IMAGE_PATH  use a custom-built router image instead of stock
 #                           (required for v1; see scripts/vm/build-router-image.sh)
+#
+# Host port allocation (#902): all host-side ports (fake-api bind, qemu
+# hostfwd) default to free ports allocated at session start, NOT fixed
+# constants. This sidesteps a self-hosted-runner failure mode where an
+# orphan qemu / fake-api from a prior job lingers and holds the previously
+# hard-coded port. Set the relevant env var to override.
 
 set -euo pipefail
 
@@ -133,6 +142,34 @@ if [[ "${E2E_VM_SKIP_VMS:-0}" != "1" ]]; then
     echo "(set E2E_VM_SKIP_VMS=1 to skip VM-dependent scenarios)" >&2
     exit 1
   }
+fi
+
+# ── host port allocation (#902) ──────────────────────────────────────────────
+# Pick free ports for all host-side bindings so a lingering orphan from a
+# prior CI run on this same self-hosted runner can't collide. Only fill in
+# vars the caller hasn't already set.
+
+alloc_free_port() {
+  "${VENV_DIR}/bin/python3" - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind(("127.0.0.1", 0))
+    print(s.getsockname()[1])
+PY
+}
+
+if [[ "${E2E_VM_SKIP_VMS:-0}" != "1" ]]; then
+  : "${WH_ROUTER_SSH_PORT:=$(alloc_free_port)}"
+  : "${WH_ROUTER_HTTP_PORT:=$(alloc_free_port)}"
+  : "${WH_CLIENT_SSH_PORT_BASE:=$(alloc_free_port)}"
+  export WH_ROUTER_SSH_PORT WH_ROUTER_HTTP_PORT WH_CLIENT_SSH_PORT_BASE
+  echo "host ports: router-ssh=${WH_ROUTER_SSH_PORT} router-http=${WH_ROUTER_HTTP_PORT} client-ssh=${WH_CLIENT_SSH_PORT_BASE}"
+fi
+
+if [[ "${MODE}" == "fake" ]]; then
+  : "${WH_FAKE_API_PORT:=$(alloc_free_port)}"
+  export WH_FAKE_API_PORT
+  echo "host ports: fake-api=${WH_FAKE_API_PORT}"
 fi
 
 # ── run pytest ───────────────────────────────────────────────────────────────

--- a/scripts/e2e/scenarios_fake/conftest.py
+++ b/scripts/e2e/scenarios_fake/conftest.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import socket
 import sys
 import threading
 import time
@@ -51,12 +52,25 @@ from lib.wait import wait_for_client_dns  # noqa: E402
 log = logging.getLogger(__name__)
 
 FAKE_API_HOST = os.environ.get("WH_FAKE_API_HOST", "127.0.0.1")
-FAKE_API_PORT = int(os.environ.get("WH_FAKE_API_PORT", "18090"))
 ROUTER_IMAGE_PATH = os.environ.get("WH_ROUTER_IMAGE_PATH")
 KEEP_VMS = os.environ.get("E2E_VM_KEEP", "0") == "1"
 SKIP_VMS = os.environ.get("E2E_VM_SKIP_VMS", "0") == "1"
 
 BASE_SNAPSHOT = "e2e-base-fake"
+
+
+def alloc_free_port(host: str = "127.0.0.1") -> int:
+    """Bind to port 0, read the kernel-assigned port, release immediately.
+
+    There's a brief race between release and the next bind, but the kernel
+    will not re-hand-out the same port within that window unless the host is
+    under extreme port pressure — fine for a single-process session-scoped
+    allocation. The point is to dodge orphans from prior CI runs on the same
+    self-hosted runner that pin the previous hard-coded port (#902).
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        return s.getsockname()[1]
 
 
 # ── fake API server (background asyncio thread) ──────────────────────────────
@@ -148,7 +162,9 @@ class _FakeServer:
 
 @pytest.fixture(scope="session")
 def fake_server() -> _FakeServer:
-    server = _FakeServer(FAKE_API_HOST, FAKE_API_PORT)
+    env_port = os.environ.get("WH_FAKE_API_PORT")
+    port = int(env_port) if env_port else alloc_free_port(FAKE_API_HOST)
+    server = _FakeServer(FAKE_API_HOST, port)
     server.start()
     try:
         yield server
@@ -188,11 +204,11 @@ def router_session(fake_server, fake_api) -> EnrolledRouter:
 
 
 @pytest.fixture()
-def router(router_session, fake_api) -> EnrolledRouter:
+def router(router_session, fake_server, fake_api) -> EnrolledRouter:
     """Restore the router VM and reset the fake before each scenario."""
     router_restore(BASE_SNAPSHOT)
     fake_api.reset()
-    _wait_for_fake_slirp_ready(port=FAKE_API_PORT, timeout_s=60)
+    _wait_for_fake_slirp_ready(port=fake_server.port, timeout_s=60)
     return router_session
 
 
@@ -200,7 +216,7 @@ def router(router_session, fake_api) -> EnrolledRouter:
 def client_factory():
     booted: list[str] = []
 
-    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int | None = None) -> Client:
+    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int = 2223) -> Client:
         chosen_mac = mac or _gen_mac()
         c = client_up(mac=chosen_mac, name=name, ssh_port=ssh_port)
         booted.append(name)

--- a/scripts/e2e/scenarios_fake/test_port_alloc.py
+++ b/scripts/e2e/scenarios_fake/test_port_alloc.py
@@ -1,0 +1,38 @@
+"""Unit tests for the free-port allocator used by the fake-mode harness (#902).
+
+The allocator's only job is to hand out a host port that's free *right now*.
+We check it (a) returns something bindable, (b) doesn't hand out the same
+port twice in a tight loop (kernel will rotate ephemeral ports), and (c)
+returns a port in the user/ephemeral range.
+"""
+from __future__ import annotations
+
+import socket
+
+from .conftest import alloc_free_port
+
+
+def test_alloc_free_port_returns_bindable_port() -> None:
+    port = alloc_free_port()
+    # Must be bindable immediately after release — proves nothing held it
+    # by accident and that the kernel cleaned up the SO_REUSEADDR-less
+    # close cleanly.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", port))
+
+
+def test_alloc_free_port_in_ephemeral_range() -> None:
+    port = alloc_free_port()
+    # Linux ip_local_port_range defaults to 32768..60999; macOS uses a
+    # higher window. Either way the kernel hands out something > 1024.
+    assert port > 1024
+
+
+def test_alloc_free_port_does_not_repeat_in_100_calls() -> None:
+    seen: set[int] = set()
+    for _ in range(100):
+        seen.add(alloc_free_port())
+    # The kernel rotates ephemeral ports per bind, so a tight loop should
+    # see well over half unique ports. Not strict — under extreme port
+    # pressure the kernel can repeat. Sanity, not contract.
+    assert len(seen) >= 50, f"only {len(seen)} unique ports across 100 calls"

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -65,7 +65,8 @@ WH_RUN_ID=b WH_PORT_BASE=2322 scripts/e2e-vm.sh --mode=fake
   (`WH_ROUTER_SSH_PORT`, `WH_ROUTER_HTTP_PORT`, `WH_CLIENT_SSH_PORT_BASE`)
   still win if set explicitly.
 - `WH_LAN_BRIDGE` — optional override. If set explicitly, skips pool pick.
-- For fake-mode, also set `WH_FAKE_API_PORT` to a free port on the second run.
+- For fake-mode, `WH_FAKE_API_PORT` is auto-allocated to a free port by
+  `scripts/e2e-vm.sh` (#902). Override only if you need a fixed port.
 
 **On a host without the pool**, the bridge picker is a no-op and the run
 falls back to creating `wh-lan0` on the fly — byte-identical to single-pair

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -49,21 +49,25 @@ The bootstrap uses `sudo` for both `ip link add` and `tee -a
 are appended. Run it once per host (or whenever you bump
 `WH_LAN_BRIDGE_POOL_SIZE`).
 
-**Per-run knobs**: to launch a second pair on a bootstrapped host, set only
-two env vars on the second invocation — the bridge is auto-picked from the
-pool:
+**Per-run knobs**: to launch a second pair on a bootstrapped host, set
+`WH_RUN_ID` — the bridge is auto-picked from the pool and host ports are
+auto-allocated by `scripts/e2e-vm.sh`:
 
 ```
-WH_RUN_ID=b WH_PORT_BASE=2322 scripts/e2e-vm.sh --mode=fake
+WH_RUN_ID=b scripts/e2e-vm.sh --mode=fake
 ```
 
 - `WH_RUN_ID` — short token. Suffixes the QEMU `-name` (so `pgrep`-based
   fallbacks in `*-down.sh` only match this instance) and the `.run/` subdir
   (so overlay/pid/socket files don't collide). Also seeds the default MACs.
-- `WH_PORT_BASE` — first host port; router SSH = base, router HTTP =
-  base+1, client SSH = base+2. Individual port vars
-  (`WH_ROUTER_SSH_PORT`, `WH_ROUTER_HTTP_PORT`, `WH_CLIENT_SSH_PORT_BASE`)
-  still win if set explicitly.
+- `WH_PORT_BASE` — optional. First host port; router SSH = base, router
+  HTTP = base+1, client SSH = base+2. When set, `scripts/e2e-vm.sh` skips
+  random port allocation and uses the base-derived window. Individual port
+  vars (`WH_ROUTER_SSH_PORT`, `WH_ROUTER_HTTP_PORT`,
+  `WH_CLIENT_SSH_PORT_BASE`) still win if set explicitly. Most callers
+  shouldn't need this — `scripts/e2e-vm.sh` now auto-allocates free host
+  ports per run (#902), so concurrent pairs no longer need a manual port
+  window.
 - `WH_LAN_BRIDGE` — optional override. If set explicitly, skips pool pick.
 - For fake-mode, `WH_FAKE_API_PORT` is auto-allocated to a free port by
   `scripts/e2e-vm.sh` (#902). Override only if you need a fixed port.


### PR DESCRIPTION
## Summary

- Allocate `WH_FAKE_API_PORT` per run via `socket.bind(0)` instead of pinning to `18090` — the fake-mode pytest harness now grabs a free port at session start, and the env var override is preserved.
- Also randomize the three qemu hostfwd host ports (`WH_ROUTER_SSH_PORT`, `WH_ROUTER_HTTP_PORT`, `WH_CLIENT_SSH_PORT_BASE`) the same way in `scripts/e2e-vm.sh`. Same class of orphan-collision risk; cheap to fix together.
- With ports no longer special, the workflow's existing unprivileged orphan-kill step is left as belt-and-suspenders. The orphan-kill privilege issue (out-of-repo sudoers / systemd work) is **not** addressed here — port randomization makes it non-load-bearing.

Closes #902.

## Evidence

Master Router CD run [26340168159](https://github.com/wifihaven/wifihaven/actions/runs/26340168159) (commit `e0f859b`, 2026-05-23) — 16/24 Gate 2 tests errored with `OSError: [Errno 98] address already in use` on `127.0.0.1:18090`, with the pre-flight `pkill` failing with `Operation not permitted` on a qemu pid owned by a prior job.

## Test plan

- [x] Python syntax + bash syntax check pass
- [x] In-isolation sanity: `alloc_free_port()` returns 100 unique ports across 100 calls
- [x] New unit test `scripts/e2e/scenarios_fake/test_port_alloc.py` covers the helper (bindability, range, no-repeat-in-100)
- [ ] Confirm 3 back-to-back Master Router CD runs on `main` pass Gate 2 without `--failed` reruns — relying on the next few real runs to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)