### PR TITLE
fix(openwrt): swap bytes_in/bytes_out semantics — bytes_out is upload (#905)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -47,7 +47,10 @@
 --     `ip_to_mac[lan_ip]` (the dnsmasq lease table); unresolved lan_ips are
 --     dropped with a log line. Resolved rx contributions are attributed to
 --     `(mac, remote_ip)` — the same shape as the tx side, so a single bucket
---     row carries both bytesIn and bytesOut against the real remote host.
+--     row carries both directions against the real remote host. On the wire
+--     (#905) rx populates bytesIn and tx populates bytesOut; internally the
+--     record's `bytes` (tx) and `bytes_out` (rx) field names refer to which
+--     nft set the counter came from, not the wire direction.
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id,
 --                      leases, lookup_hostname, tracker,
@@ -336,8 +339,13 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
       mac           = c.mac,
       host          = host,
       activeSeconds = active_seconds,
-      bytesIn       = c.bytes     or 0,
-      bytesOut      = c.bytes_out or 0,
+      -- Wire semantics (#905): bytesIn is from the device's POV — traffic
+      -- arriving from the internet (rx counter). bytesOut is traffic leaving
+      -- the device toward the internet (tx counter). The internal record
+      -- fields here are named for their nft-set source (bytes = tx,
+      -- bytes_out = rx) and the swap happens only at the wire boundary.
+      bytesIn       = c.bytes_out or 0,
+      bytesOut      = c.bytes     or 0,
     }
     if leases then
       rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -268,7 +268,8 @@ describe("usage.build_report", function()
     assert.equal(2, #r.records)
   end)
 
-  it("attributes bytes to the hostname the dst_ip resolved to (via nft_sets)", function()
+  -- #905: tx (c.bytes) is the upload direction → maps to bytesOut on the wire.
+  it("maps tx counter (c.bytes) to bytesOut (upload direction, #905)", function()
     local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
                                  nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S)
     local by_host = {}
@@ -276,42 +277,46 @@ describe("usage.build_report", function()
     assert.equal("fqdn",             by_host["youtube.com"].host.type)
     assert.equal("youtube.com",      by_host["youtube.com"].host.value)
     assert.equal("aa:bb:cc:11:22:33", by_host["youtube.com"].mac)
-    assert.equal(50000,               by_host["youtube.com"].bytesIn)
+    assert.equal(50000,               by_host["youtube.com"].bytesOut)
+    assert.equal(0,                   by_host["youtube.com"].bytesIn)
   end)
 
-  -- #717: bytesOut must be wired through from the merged counter's
-  -- bytes_out field (the rx nft set), not hard-coded to 0.
-  it("populates bytesOut from c.bytes_out (download direction, #717)", function()
+  -- #905: tx → bytesOut (upload), rx → bytesIn (download). The internal
+  -- record's c.bytes (tx) feeds bytesOut and c.bytes_out (rx) feeds bytesIn.
+  it("maps tx to bytesOut and rx to bytesIn (combined-direction flow, #905)", function()
     local counters = {
       { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4",
         bytes = 50000, packets = 100, bytes_out = 4000000, packets_out = 3500 },
     }
     local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
                                  nil, nil, full_tracker(counters), SAMPLE_S, BUCKET_S)
-    assert.equal(50000,    r.records[1].bytesIn)
-    assert.equal(4000000,  r.records[1].bytesOut)
+    assert.equal(50000,    r.records[1].bytesOut)
+    assert.equal(4000000,  r.records[1].bytesIn)
   end)
 
-  it("defaults bytesOut to 0 when c.bytes_out is missing (tx-only snapshot)", function()
-    local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
-                                 nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S)
-    for _, rec in ipairs(r.records) do
-      assert.equal(0, rec.bytesOut)
-    end
+  it("tx-only flow produces bytesOut > 0 and bytesIn == 0 (#905)", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4",
+        bytes = 50000, packets = 100 },  -- no bytes_out → rx absent
+    }
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, full_tracker(counters), SAMPLE_S, BUCKET_S)
+    assert.equal(50000, r.records[1].bytesOut)
+    assert.equal(0,     r.records[1].bytesIn)
   end)
 
-  it("credits one sample when bytes=0 but bytes_out>0 (rx-only flow first appearing post-tick)", function()
+  it("rx-only flow produces bytesIn > 0 and bytesOut == 0 (#905)", function()
     local counters = {
       { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4",
         bytes = 0, packets = 0, bytes_out = 1234, packets_out = 5 },
     }
-    -- Empty tracker → falls through to the post-tick path. That path
-    -- previously gated on `c.bytes > 0`; with #717 it must also treat
-    -- bytes_out > 0 as activity.
+    -- Empty tracker → falls through to the post-tick path, which gates on
+    -- bytes + bytes_out > 0 (#717).
     local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
                                  nil, nil, usage.new_tracker(), SAMPLE_S, BUCKET_S)
     assert.equal(SAMPLE_S, r.records[1].activeSeconds)
-    assert.equal(1234,     r.records[1].bytesOut)
+    assert.equal(1234,     r.records[1].bytesIn)
+    assert.equal(0,        r.records[1].bytesOut)
   end)
 
   -- #391: the "unknown" sentinel is gone. When DNS attribution misses we emit

--- a/shared/contract/router-to-api/usage_report.json
+++ b/shared/contract/router-to-api/usage_report.json
@@ -11,8 +11,8 @@
         "value" : "khanacademy.org"
       },
       "activeSeconds" : 240,
-      "bytesIn" : 1048576,
-      "bytesOut" : 8388608
+      "bytesIn" : 8388608,
+      "bytesOut" : 1048576
     },
     {
       "mac" : "76:2d:95:47:d1:8e",
@@ -21,8 +21,8 @@
         "value" : "192.168.10.99"
       },
       "activeSeconds" : 60,
-      "bytesIn" : 4096,
-      "bytesOut" : 16384
+      "bytesIn" : 16384,
+      "bytesOut" : 4096
     }
   ]
 }

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -206,8 +206,8 @@ function RawTable({ data }: { data: TrafficUsageResponse }) {
             <th className="text-left px-2 py-1">Device</th>
             <th className="text-left px-2 py-1">Profile</th>
             <th className="text-left px-2 py-1">Host</th>
-            <th className="text-right px-2 py-1">Bytes in</th>
-            <th className="text-right px-2 py-1">Bytes out</th>
+            <th className="text-right px-2 py-1">Inbound</th>
+            <th className="text-right px-2 py-1">Outbound</th>
             <th className="text-right px-2 py-1">Seconds</th>
           </tr>
         </thead>
@@ -294,8 +294,8 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
                 testIdPrefix="traffic-group"
               />
             </th>
-            <th className="text-right px-2 py-1">Bytes in</th>
-            <th className="text-right px-2 py-1">Bytes out</th>
+            <th className="text-right px-2 py-1">Inbound</th>
+            <th className="text-right px-2 py-1">Outbound</th>
             <th className="text-right px-2 py-1">Total seconds</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary

The agent was emitting the tx counter (LAN device → internet = upload) as `bytesIn` and the rx counter (internet → LAN device = download) as `bytesOut` — backwards from every UI convention (Speedtest, ISP, netstat, WireGuard) and confusing on the Traffic Usage page. Flip the wire mapping in `usage.build_report` so `bytesIn` is downloads (rx) and `bytesOut` is uploads (tx).

- Agent-only change. DB columns keep their names; wire shape unchanged; only the *values* flip on new rows.
- Internal record fields stay named for their nft-set source (`bytes` = tx, `bytes_out` = rx); the swap happens only at the JSON boundary in `build_report`.
- Historical `traffic_reports` rows are intentionally left as-is per the operator decision in [#905](https://github.com/wifihaven/wifihaven/issues/905). Anyone investigating a pre-cutover row needs to know "before today, `bytes_out` meant downloads."
- The `shared/contract/router-to-api/usage_report.json` fixture was regenerated through the production `usage.build_report` path so the example payload reflects the corrected semantics. Wire shape is unchanged.

## Live verification — `openwrt.lan`

Same MAC (Prima iPad, `76:2d:95:47:d1:8e`) hitting the same Cloudflare iCloud host across the restart:

```
pre-fix   period_start 2026-05-23 20:39:11Z
  mac=76:2d:95:47:d1:8e host=162.159.140.229
  bytes_in=7961   bytes_out=118281     ← download landing as bytes_out

post-fix  period_start 2026-05-23 20:41:30Z
  mac=76:2d:95:47:d1:8e host=162.159.140.229
  bytes_in=100687 bytes_out=7391       ← download landing as bytes_in
```

No regression from #897: `host_value` is still a real remote IP / FQDN, not a LAN-device IP, and no router-own-MAC ghost rows.

## Test plan

- [x] `openwrt/test/run_tests.sh` — 421 successes / 0 failures (unchanged total).
- [x] `openwrt/test/usage_spec.lua` updated: tx-only → `bytesOut > 0, bytesIn == 0`; rx-only → `bytesIn > 0, bytesOut == 0`; combined-direction case asserts both.
- [x] `shared/contract/router-to-api/usage_report.json` regenerated via `openwrt/test/contract_gen.lua`.
- [x] Live: pushed to `openwrt.lan`, restarted agent, verified bytesIn vs bytesOut on a known download-heavy iCloud flow flipped as expected.

Closes #905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)