### PR TITLE
web: rename Seconds/Total seconds columns to Time, format as H:MM (#911)

### DIFF
--- a/web/src/components/usage/usageHelpers.test.ts
+++ b/web/src/components/usage/usageHelpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { fmtDuration } from './usageHelpers'
+
+describe('fmtDuration (H:MM, round-half-up minute; 0<s<60 → 0:01)', () => {
+  const cases: Array<[number, string]> = [
+    [0,     '0:00'],
+    [1,     '0:01'],
+    [30,    '0:01'],
+    [59,    '0:01'],
+    [60,    '0:01'],
+    [89,    '0:01'],
+    [90,    '0:02'],
+    [330,   '0:06'],
+    [3599,  '1:00'],
+    [3600,  '1:00'],
+    [7199,  '2:00'],
+    [36000, '10:00'],
+  ]
+  for (const [secs, expected] of cases) {
+    it(`${secs}s → ${expected}`, () => {
+      expect(fmtDuration(secs)).toBe(expected)
+    })
+  }
+})

--- a/web/src/components/usage/usageHelpers.ts
+++ b/web/src/components/usage/usageHelpers.ts
@@ -50,14 +50,13 @@ export function fmtBytes(n: number): string {
   return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
 }
 
+// H:MM with round-half-up on the minute. Special case: any active period
+// `0 < seconds < 60` rounds UP to `0:01` so an active cell never reads `0:00`.
 export function fmtDuration(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  const m = Math.floor(seconds / 60)
-  const s = seconds % 60
-  if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`
-  const h = Math.floor(m / 60)
-  const mm = m % 60
-  return mm > 0 ? `${h}h ${mm}m` : `${h}h`
+  const totalMinutes = seconds > 0 && seconds < 60 ? 1 : Math.round(seconds / 60)
+  const h = Math.floor(totalMinutes / 60)
+  const mm = totalMinutes % 60
+  return `${h}:${String(mm).padStart(2, '0')}`
 }
 
 export function localTime(iso: string): string {

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -208,7 +208,7 @@ function RawTable({ data }: { data: TrafficUsageResponse }) {
             <th className="text-left px-2 py-1">Host</th>
             <th className="text-right px-2 py-1">Bytes in</th>
             <th className="text-right px-2 py-1">Bytes out</th>
-            <th className="text-right px-2 py-1">Seconds</th>
+            <th className="text-right px-2 py-1">Time</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">
@@ -227,7 +227,7 @@ function RawTable({ data }: { data: TrafficUsageResponse }) {
               <td className="px-2 py-1"><HostCell host={r.host} /></td>
               <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.bytesIn)}</td>
               <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.bytesOut)}</td>
-              <td className="px-2 py-1 text-right font-mono">{r.activeSeconds}</td>
+              <td className="px-2 py-1 text-right font-mono">{fmtDuration(r.activeSeconds)}</td>
             </tr>
           ))}
         </tbody>
@@ -296,7 +296,7 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
             </th>
             <th className="text-right px-2 py-1">Bytes in</th>
             <th className="text-right px-2 py-1">Bytes out</th>
-            <th className="text-right px-2 py-1">Total seconds</th>
+            <th className="text-right px-2 py-1">Time</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">


### PR DESCRIPTION
## Summary
- Both Traffic Usage tables (raw + aggregate) now use a single `Time` column rendered as `H:MM`.
- New `fmtDuration()` uses round-half-up on the minute; an active period `0 < s < 60` rounds UP to `0:01` so an active cell never reads `0:00`.
- Connection Events page (`LogsPage`) has no active-seconds column — no change there.

Before → after (raw view emitted bare ints; aggregate emitted mixed units):
- `60` / `1m` → `0:01`
- `5m 30s` → `0:06`
- `2h 15m` → `2:15`

## Test plan
- [x] `web/src/components/usage/usageHelpers.test.ts` covers boundary cases: 0, 1, 30, 59, 60, 89, 90, 330, 3599, 3600, 7199, 36000.
- [x] `npm test -- usageHelpers TrafficUsagePage` passes (17/17).
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean.
- [ ] Visual verification of column alignment in dev SPA.

Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)