### PR TITLE
ui(web): responsive layout for Traffic Usage + Connection Events (#861)

### DIFF
--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -68,6 +68,16 @@ describe('LogsPage (Connection Events) — raw view', () => {
     expect(screen.getAllByText('Kids').length).toBeGreaterThan(0)
   })
 
+  // #861 — verify low-priority columns carry responsive `hidden` classes so
+  // the table fits at phone (~375px) and tablet (~768px) widths.
+  it('hides low-priority raw-view columns on narrow viewports', async () => {
+    renderAt()
+    await screen.findByText('example.com')
+    expect(screen.getByRole('columnheader', { name: 'Profile' }).className).toMatch(/hidden md:table-cell/)
+    expect(screen.getByRole('columnheader', { name: 'Reason' }).className).toMatch(/hidden sm:table-cell/)
+    expect(screen.getByRole('columnheader', { name: 'Location' }).className).toMatch(/hidden lg:table-cell/)
+  })
+
   it('shows empty state when no events', async () => {
     (api.logs.query as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
     renderAt()

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -51,10 +51,10 @@ export function LogsPage() {
   }
 
   return (
-    <div className="space-y-4" data-testid="connection-events-page">
+    <div className="space-y-4 min-w-0" data-testid="connection-events-page">
       <header>
-        <h1 className="text-2xl font-bold text-gray-100">Connection Events</h1>
-        <p className="text-sm text-gray-500">
+        <h1 className="text-xl sm:text-2xl font-bold text-gray-100">Connection Events</h1>
+        <p className="text-xs sm:text-sm text-gray-500">
           Per-query DNS / blocking decisions. Click a column header (Domain / Device /
           Profile) to add it to the aggregation.
         </p>
@@ -158,11 +158,11 @@ function RawEventsView({ mac, profileId, devices }: RawProps) {
           <tr className="text-gray-500">
             <th className="text-left px-2 py-1">Time</th>
             <th className="text-left px-2 py-1">Device</th>
-            <th className="text-left px-2 py-1">Profile</th>
+            <th className="text-left px-2 py-1 hidden md:table-cell">Profile</th>
             <th className="text-left px-2 py-1">Domain</th>
             <th className="text-left px-2 py-1">Status</th>
-            <th className="text-left px-2 py-1">Reason</th>
-            <th className="text-left px-2 py-1">Location</th>
+            <th className="text-left px-2 py-1 hidden sm:table-cell">Reason</th>
+            <th className="text-left px-2 py-1 hidden lg:table-cell">Location</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">
@@ -175,15 +175,15 @@ function RawEventsView({ mac, profileId, devices }: RawProps) {
           )}
           {logs.map(l => (
             <tr key={l.id} className="border-t border-gray-800">
-              <td className="px-2 py-1 font-mono text-xs">{localTime(l.ts)}</td>
+              <td className="px-2 py-1 font-mono text-xs whitespace-nowrap">{localTime(l.ts)}</td>
               <td className="px-2 py-1"><DeviceLink mac={l.mac} deviceName={l.deviceName} /></td>
-              <td className="px-2 py-1">{l.profileName ?? '-'}</td>
-              <td className="px-2 py-1 max-w-[280px] truncate"><HostCell host={l.host} /></td>
-              <td className={`px-2 py-1 ${l.blocked ? 'text-red-400' : 'text-emerald-500'}`}>
+              <td className="px-2 py-1 hidden md:table-cell">{l.profileName ?? '-'}</td>
+              <td className="px-2 py-1 max-w-[160px] sm:max-w-[280px] truncate"><HostCell host={l.host} /></td>
+              <td className={`px-2 py-1 whitespace-nowrap ${l.blocked ? 'text-red-400' : 'text-emerald-500'}`}>
                 {l.blocked ? '✗ blocked' : '✓ ok'}
               </td>
-              <td className="px-2 py-1 text-gray-500">{l.reason}</td>
-              <td className="px-2 py-1 text-gray-500">{l.location ?? ''}</td>
+              <td className="px-2 py-1 text-gray-500 hidden sm:table-cell">{l.reason}</td>
+              <td className="px-2 py-1 text-gray-500 hidden lg:table-cell">{l.location ?? ''}</td>
             </tr>
           ))}
         </tbody>
@@ -255,7 +255,7 @@ function AggregatedEventsView({ bucket, groupBy, onToggleGroup, mac, profileId }
               <GroupableHeader label="Device" groupKey="device" groupBy={groupBy}
                 onToggle={onToggleGroup} testIdPrefix="ce-group" />
             </th>
-            <th className="text-left px-2 py-1">
+            <th className="text-left px-2 py-1 hidden md:table-cell">
               <GroupableHeader label="Profile" groupKey="profile" groupBy={groupBy}
                 onToggle={onToggleGroup} testIdPrefix="ce-group" />
             </th>
@@ -265,7 +265,7 @@ function AggregatedEventsView({ bucket, groupBy, onToggleGroup, mac, profileId }
             </th>
             <th className="text-right px-2 py-1">OK</th>
             <th className="text-right px-2 py-1">Blocked</th>
-            <th className="text-left px-2 py-1">Last seen</th>
+            <th className="text-left px-2 py-1 hidden sm:table-cell">Last seen</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">
@@ -281,7 +281,7 @@ function AggregatedEventsView({ bucket, groupBy, onToggleGroup, mac, profileId }
             const showWindow = r.windowStart !== prevWindow
             return (
             <tr key={i} className={`${showWindow ? 'border-t-2 border-gray-700' : 'border-t border-gray-800/40'}`}>
-              <td className="px-2 py-1 font-mono text-xs">
+              <td className="px-2 py-1 font-mono text-xs whitespace-nowrap">
                 {showWindow ? localTime(r.windowStart) : ''}
               </td>
               <td className="px-2 py-1">
@@ -291,14 +291,14 @@ function AggregatedEventsView({ bucket, groupBy, onToggleGroup, mac, profileId }
                   count={r.distinctDevices}
                 />
               </td>
-              <td className="px-2 py-1">
+              <td className="px-2 py-1 hidden md:table-cell">
                 <NonGroupedCell
                   groupedValue={groupBy.includes('profile') ? r.groups.profile : undefined}
                   sole={r.soleProfile}
                   count={r.distinctProfiles}
                 />
               </td>
-              <td className="px-2 py-1 max-w-[280px] truncate">
+              <td className="px-2 py-1 max-w-[160px] sm:max-w-[280px] truncate">
                 <NonGroupedCell
                   groupedValue={groupBy.includes('domain') ? r.groups.domain : undefined}
                   sole={r.soleDomain}
@@ -307,7 +307,7 @@ function AggregatedEventsView({ bucket, groupBy, onToggleGroup, mac, profileId }
               </td>
               <td className="px-2 py-1 text-emerald-400 text-right">{r.countSucceeded}</td>
               <td className="px-2 py-1 text-red-400 text-right">{r.countBlocked}</td>
-              <td className="px-2 py-1 font-mono text-xs">{localTime(r.lastSeen)}</td>
+              <td className="px-2 py-1 font-mono text-xs whitespace-nowrap hidden sm:table-cell">{localTime(r.lastSeen)}</td>
             </tr>
             )
           })}

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -133,6 +133,18 @@ describe('TrafficUsagePage', () => {
     expect(lastCall.groupBy?.sort()).toEqual(['device', 'domain'])
   })
 
+  // #861 — verify low-priority columns carry responsive `hidden` classes so
+  // the table fits at phone (~375px) and tablet (~768px) widths. jsdom doesn't
+  // do real layout, so we assert on classnames rather than measuring overflow.
+  it('hides low-priority raw-table columns on narrow viewports', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByTestId('raw-table')).toBeInTheDocument())
+    const profile = screen.getByRole('columnheader', { name: 'Profile' })
+    expect(profile.className).toMatch(/hidden md:table-cell/)
+    const outbound = screen.getByRole('columnheader', { name: 'Outbound' })
+    expect(outbound.className).toMatch(/hidden sm:table-cell/)
+  })
+
   it('surfaces server error', async () => {
     const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
     trafficMock.mockRejectedValueOnce(new Error('window_too_large'))

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -84,10 +84,10 @@ export function TrafficUsagePage() {
   }
 
   return (
-    <div className="space-y-4" data-testid="traffic-usage-page">
+    <div className="space-y-4 min-w-0" data-testid="traffic-usage-page">
       <header>
-        <h1 className="text-2xl font-bold text-gray-100">Traffic Usage</h1>
-        <p className="text-sm text-gray-500">
+        <h1 className="text-xl sm:text-2xl font-bold text-gray-100">Traffic Usage</h1>
+        <p className="text-xs sm:text-sm text-gray-500">
           Raw <code className="text-emerald-400">traffic_reports</code> rows plus on-the-fly
           aggregation. Click a column header (Host / Device / Profile) to add it to the
           aggregation.
@@ -137,14 +137,14 @@ export function FilterShelf({
   return (
     <div className="space-y-3 bg-gray-900/40 rounded p-3 border border-gray-800">
       <BucketSelector value={bucket} onChange={onBucketChange} />
-      <div className="flex flex-wrap gap-3">
-        <label className="text-xs text-gray-400">
+      <div className="grid grid-cols-1 sm:flex sm:flex-wrap gap-3">
+        <label className="text-xs text-gray-400 min-w-0">
           Device
           <select
             data-testid="device-filter"
             value={mac}
             onChange={e => onMacChange(e.target.value)}
-            className="block mt-1 bg-gray-950 border border-gray-800 rounded px-2 py-1 text-sm"
+            className="block mt-1 w-full sm:w-auto sm:max-w-xs bg-gray-950 border border-gray-800 rounded px-2 py-1 text-sm"
           >
             <option value="">all</option>
             {devices.map(d => (
@@ -152,13 +152,13 @@ export function FilterShelf({
             ))}
           </select>
         </label>
-        <label className="text-xs text-gray-400">
+        <label className="text-xs text-gray-400 min-w-0">
           Profile
           <select
             data-testid="profile-filter"
             value={profileId}
             onChange={e => onProfileChange(e.target.value)}
-            className="block mt-1 bg-gray-950 border border-gray-800 rounded px-2 py-1 text-sm"
+            className="block mt-1 w-full sm:w-auto sm:max-w-xs bg-gray-950 border border-gray-800 rounded px-2 py-1 text-sm"
           >
             <option value="">all</option>
             {profiles.map(p => (
@@ -204,11 +204,11 @@ function RawTable({ data }: { data: TrafficUsageResponse }) {
           <tr className="text-gray-500">
             <th className="text-left px-2 py-1">Period start</th>
             <th className="text-left px-2 py-1">Device</th>
-            <th className="text-left px-2 py-1">Profile</th>
+            <th className="text-left px-2 py-1 hidden md:table-cell">Profile</th>
             <th className="text-left px-2 py-1">Host</th>
             <th className="text-right px-2 py-1">Inbound</th>
-            <th className="text-right px-2 py-1">Outbound</th>
-            <th className="text-right px-2 py-1">Time</th>
+            <th className="text-right px-2 py-1 hidden sm:table-cell">Outbound</th>
+            <th className="text-right px-2 py-1 hidden md:table-cell">Time</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">
@@ -221,13 +221,13 @@ function RawTable({ data }: { data: TrafficUsageResponse }) {
           )}
           {data.rawRows.map((r, i) => (
             <tr key={i} className="border-t border-gray-800">
-              <td className="px-2 py-1 font-mono text-xs">{localTime(r.periodStart)}</td>
+              <td className="px-2 py-1 font-mono text-xs whitespace-nowrap">{localTime(r.periodStart)}</td>
               <td className="px-2 py-1">{r.deviceName ?? r.mac}</td>
-              <td className="px-2 py-1">{r.profileName ?? '-'}</td>
-              <td className="px-2 py-1"><HostCell host={r.host} /></td>
+              <td className="px-2 py-1 hidden md:table-cell">{r.profileName ?? '-'}</td>
+              <td className="px-2 py-1 max-w-[180px] sm:max-w-none truncate"><HostCell host={r.host} /></td>
               <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.bytesIn)}</td>
-              <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.bytesOut)}</td>
-              <td className="px-2 py-1 text-right font-mono">{fmtDuration(r.activeSeconds)}</td>
+              <td className="px-2 py-1 text-right font-mono hidden sm:table-cell">{fmtBytes(r.bytesOut)}</td>
+              <td className="px-2 py-1 text-right font-mono hidden md:table-cell">{fmtDuration(r.activeSeconds)}</td>
             </tr>
           ))}
         </tbody>
@@ -276,7 +276,7 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
                 testIdPrefix="traffic-group"
               />
             </th>
-            <th className="text-left px-2 py-1">
+            <th className="text-left px-2 py-1 hidden md:table-cell">
               <GroupableHeader
                 label="Profile"
                 groupKey="profile"
@@ -295,8 +295,8 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
               />
             </th>
             <th className="text-right px-2 py-1">Inbound</th>
-            <th className="text-right px-2 py-1">Outbound</th>
-            <th className="text-right px-2 py-1">Time</th>
+            <th className="text-right px-2 py-1 hidden sm:table-cell">Outbound</th>
+            <th className="text-right px-2 py-1 hidden md:table-cell">Time</th>
           </tr>
         </thead>
         <tbody className="text-gray-300">
@@ -314,7 +314,7 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
             const showWindow = r.windowStart !== prevWindow
             return (
             <tr key={i} className={`${showWindow ? 'border-t-2 border-gray-700' : 'border-t border-gray-800/40'}`}>
-              <td className="px-2 py-1 font-mono text-xs">
+              <td className="px-2 py-1 font-mono text-xs whitespace-nowrap">
                 {showWindow ? localTime(r.windowStart) : ''}
               </td>
               <td className="px-2 py-1">
@@ -324,14 +324,14 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
                   count={r.distinctDevices}
                 />
               </td>
-              <td className="px-2 py-1">
+              <td className="px-2 py-1 hidden md:table-cell">
                 <NonGroupedCell
                   groupedValue={groupBy.includes('profile') ? r.groups.profile : undefined}
                   sole={r.soleProfile}
                   count={r.distinctProfiles}
                 />
               </td>
-              <td className="px-2 py-1">
+              <td className="px-2 py-1 max-w-[180px] sm:max-w-none truncate">
                 <NonGroupedCell
                   groupedValue={groupBy.includes('domain') ? r.groups.domain : undefined}
                   sole={r.soleDomain}
@@ -339,8 +339,8 @@ function AggregateTable({ data, groupBy, onToggleGroup }: AggProps) {
                 />
               </td>
               <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.totalBytesIn)}</td>
-              <td className="px-2 py-1 text-right font-mono">{fmtBytes(r.totalBytesOut)}</td>
-              <td className="px-2 py-1 text-right font-mono">{fmtDuration(r.totalSeconds)}</td>
+              <td className="px-2 py-1 text-right font-mono hidden sm:table-cell">{fmtBytes(r.totalBytesOut)}</td>
+              <td className="px-2 py-1 text-right font-mono hidden md:table-cell">{fmtDuration(r.totalSeconds)}</td>
             </tr>
             )
           })}


### PR DESCRIPTION
Closes #861.

## Summary

- **FilterShelf** stacks vertically on phone (`grid grid-cols-1 sm:flex sm:flex-wrap`); selects are `w-full sm:w-auto sm:max-w-xs` so long device labels (e.g. `Octavius (fa:10:cd:84:78:22)`) no longer widen the page.
- **Tables** keep horizontal scroll fallback (existing `overflow-x-auto`) but additionally hide lower-priority columns at narrow widths. The high-value columns — Time, Device, Host/Domain, Inbound, Status — stay visible at 375px.
- **Headers** drop one text size on phone (`text-xl sm:text-2xl` / `text-xs sm:text-sm`).

## Design choices per element

| Element | Phone (<640) | Tablet (<768) | Desktop |
|---|---|---|---|
| Filter shelf | stacked, full-width selects | flex-wrap, capped selects | flex-wrap |
| Bucket selector | already `flex-wrap` — unchanged | same | same |
| GroupableHeader | unchanged | unchanged | unchanged |
| **Traffic Usage** raw — hides | Outbound, Profile, Time | Profile, Time | — |
| **Traffic Usage** agg — hides | Outbound, Profile, Time | Profile, Time | — |
| **Connection Events** raw — hides | Reason, Profile, Location | Profile, Location | Location |
| **Connection Events** agg — hides | Last seen, Profile | Profile | — |

Picked Option A (horizontal scroll + selective column hiding) over stacked-card collapse because the project's existing precedent ([DashboardPage.tsx:222](web/src/pages/DashboardPage.tsx:222)) hides table cells with `hidden md:table-cell` rather than collapsing rows.

No new dependencies; pure Tailwind utilities.

## Test plan

- [x] `npm test` — all 192 tests pass (web). Added two new tests asserting the responsive `hidden` classes are present on the deprioritized column headers (jsdom can't measure overflow, so we assert on the classes that produce it).
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean.
- [ ] **Visual screenshots at 375 / 768 / 1440 not captured** — the dev server requires a running API backend to populate either page (both fetch on mount). The responsive utilities are well-known Tailwind primitives covered by the structural unit tests; visual confirmation is best done after merge against a real environment.

## Coordination

Diff is scoped to layout/styles only — no changes to table data path, so #862 (paging) and #865 (column-header filters) can rebase cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)