### PR TITLE
feat(web+api): restore Dashboard NOW activity line (#852)

### DIFF
--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -26,6 +26,9 @@ object DashboardNowRoutes {
   private val TrafficActiveWindow  = java.time.Duration.ofMinutes(5)
   private val TopHostsWindow       = java.time.Duration.ofMinutes(30)
   private val TopHostsLimit        = 3
+  // #852 — nowActivity "watching X · Nm" runs back through consecutive earlier buckets where the
+  // same host is also top; cap so we never claim hours of foreground use from sparse data.
+  private val NowActivityMaxMinutes = 60
 
   def routes(
       auth: AuthService,
@@ -107,6 +110,7 @@ object DashboardNowRoutes {
             mac = d.mac,
             lastSeenSeconds = lastSeenSeconds,
             topHosts = topHostsFromRows(devRows),
+            nowActivity = nowActivityFromRows(devRows),
           )
         }
       }
@@ -120,6 +124,45 @@ object DashboardNowRoutes {
 
     DashboardNow(asOf = now.toString, profiles = profile)
   }
+
+  /**
+   * Per-device "what is this device watching right now". Reads rows from the latest populated 5-min
+   * bucket and returns its top host. If earlier consecutive buckets share the same top host,
+   * reports a `minutes` run (capped at 60); otherwise `minutes = None`. See #852.
+   */
+  def nowActivityFromRows(rows: List[TrafficRollupRow]): Option[DashboardNowActivity] = {
+    val buckets = rows
+      .groupBy(_.periodEnd)
+      .toList
+      .sortBy { case (end, _) => -end.getEpochSecond }
+    buckets.headOption.flatMap { case (_, latestRows) =>
+      bucketTopHost(latestRows).map { top =>
+        val tail       = buckets.tail
+        val streakRest = tail.takeWhile { case (_, rs) => bucketTopHost(rs).contains(top) }
+        val streakSecs = (latestRows :: streakRest.map(_._2)).map { rs =>
+          val s = rs.head.periodStart.getEpochSecond
+          val e = rs.head.periodEnd.getEpochSecond
+          math.max(0L, e - s)
+        }.sum
+        val minutes    = math.min(NowActivityMaxMinutes, math.max(1, (streakSecs / 60L).toInt))
+        // Only attach a duration once we have a multi-bucket signal — a single 5-min bucket isn't
+        // strong enough to claim "watching for N minutes".
+        val mins       = if (streakRest.nonEmpty) Some(minutes) else None
+        DashboardNowActivity(topHost = top, minutes = mins)
+      }
+    }
+  }
+
+  private def bucketTopHost(rows: List[TrafficRollupRow]): Option[HostId] =
+    rows
+      .groupBy(_.host)
+      .view
+      .mapValues(_.map(_.activeSeconds.toLong).sum)
+      .toList
+      .filter { case (_, s) => s > 0 }
+      .sortBy { case (h, s) => (-s, h.value) }
+      .headOption
+      .map(_._1)
 
   def topHostsFromRows(rows: List[TrafficRollupRow]): List[DashboardNowHost] =
     rows

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -249,6 +249,117 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         dev.topHosts.head.activeSeconds == 360L,
       )
     },
+    test("nowActivity: consistent top host across 3 buckets → topHost + accurate minutes") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        // Three 5-min buckets ending at: now-1m, now-6m, now-11m, all top youtube.com.
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "youtube.com",
+          now0.minusSeconds(16 * 60),
+          activeSeconds = 250,
+        )
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "youtube.com",
+          now0.minusSeconds(11 * 60),
+          activeSeconds = 280,
+        )
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "youtube.com",
+          now0.minusSeconds(6 * 60),
+          activeSeconds = 290,
+        )
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(5))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(
+        dev.nowActivity.exists(_.topHost == HostId.Fqdn(Hostname.unsafe("youtube.com"))),
+        dev.nowActivity.flatMap(_.minutes).contains(15),
+      )
+    },
+    test("nowActivity: top host varies bucket-to-bucket → latest bucket's top, no minutes") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        // Latest bucket dominated by netflix; the earlier one by tiktok — should not extend the run.
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "tiktok.com",
+          now0.minusSeconds(11 * 60),
+          activeSeconds = 290,
+        )
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "netflix.com",
+          now0.minusSeconds(6 * 60),
+          activeSeconds = 280,
+        )
+        _        <- insertReport(
+          routerId,
+          mac1,
+          "tiktok.com",
+          now0.minusSeconds(6 * 60),
+          activeSeconds = 10,
+        )
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(5))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(
+        dev.nowActivity.exists(_.topHost == HostId.Fqdn(Hostname.unsafe("netflix.com"))),
+        dev.nowActivity.flatMap(_.minutes).isEmpty,
+      )
+    },
+    test("nowActivity: idle device (no rows) → None") {
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        // Active via connection_events only — no traffic rows, so no nowActivity.
+        _        <- insertConn(routerId, mac1, now0.minusSeconds(5))
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token)
+        routes   <- buildRoutes(auth)
+        resp     <- getJson(routes, "/api/dashboard/now", token)
+        body     <- resp.body.asString
+        parsed   <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(dev.nowActivity.isEmpty)
+    },
     test("multiple profiles, idle ones retained in id-asc order") {
       for {
         _        <- cleanDb

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -702,12 +702,21 @@ case class TrafficUsageResponse(
 
 case class DashboardNowHost(host: HostId, activeSeconds: Long) derives JsonCodec
 
+/**
+ * "Watching right now" replacement for the removed `currentSession` line. Derived per-request from
+ * `traffic_reports` — `topHost` is the host with the most active_seconds in the latest populated
+ * 5-min bucket; `minutes` is the run of consecutive earlier buckets in which that same host was
+ * also top, capped at 60. None when we can't make a confident call. See #852.
+ */
+case class DashboardNowActivity(topHost: HostId, minutes: Option[Int]) derives JsonCodec
+
 case class DashboardNowDevice(
     id: DeviceId,
     name: String,
     mac: MacAddress,
     lastSeenSeconds: Long,
     topHosts: List[DashboardNowHost],
+    nowActivity: Option[DashboardNowActivity],
 ) derives JsonCodec
 
 case class DashboardNowProfile(

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -62,6 +62,10 @@ const liveNow: DashboardNow = {
             { host: { type: 'fqdn', value: 'youtube.com' }, activeSeconds: 840 },
             { host: { type: 'fqdn', value: 'tiktok.com' }, activeSeconds: 120 },
           ],
+          nowActivity: {
+            topHost: { type: 'fqdn', value: 'youtube.com' },
+            minutes: 25,
+          },
         },
       ],
     },
@@ -145,6 +149,54 @@ describe('NowSection', () => {
     expect(screen.getAllByText('youtube.com').length).toBeGreaterThan(0)
     expect(screen.getByText('tiktok.com')).toBeInTheDocument()
     expect(screen.getByText('14m')).toBeInTheDocument()
+  })
+
+  it('renders "watching X · Nm" activity line for an active device', async () => {
+    mockNow().mockResolvedValue(liveNow)
+    render(withQuery(<NowSection />))
+    await screen.findByTestId('now-device-aa:bb:cc:dd:ee:01')
+    expect(screen.getByText(/watching/)).toBeInTheDocument()
+    expect(screen.getByText(/· 25m/)).toBeInTheDocument()
+  })
+
+  it('renders "(active)" fallback when nowActivity is null', async () => {
+    mockNow().mockResolvedValue({
+      ...liveNow,
+      profiles: [
+        {
+          ...liveNow.profiles[0],
+          activeDevices: [{ ...liveNow.profiles[0].activeDevices[0], nowActivity: null }],
+        },
+        liveNow.profiles[1],
+      ],
+    })
+    render(withQuery(<NowSection />))
+    await screen.findByTestId('now-device-aa:bb:cc:dd:ee:01')
+    expect(screen.getByText('(active)')).toBeInTheDocument()
+    expect(screen.queryByText(/watching/)).not.toBeInTheDocument()
+  })
+
+  it('omits the minutes suffix when minutes is null (single-bucket signal)', async () => {
+    mockNow().mockResolvedValue({
+      ...liveNow,
+      profiles: [
+        {
+          ...liveNow.profiles[0],
+          activeDevices: [{
+            ...liveNow.profiles[0].activeDevices[0],
+            nowActivity: {
+              topHost: { type: 'fqdn', value: 'youtube.com' },
+              minutes: null,
+            },
+          }],
+        },
+        liveNow.profiles[1],
+      ],
+    })
+    render(withQuery(<NowSection />))
+    await screen.findByTestId('now-device-aa:bb:cc:dd:ee:01')
+    expect(screen.getByText(/watching/)).toBeInTheDocument()
+    expect(screen.queryByText(/·\s*\d+m/)).not.toBeInTheDocument()
   })
 
   it('renders Paused badge when profile is paused', async () => {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -167,6 +167,7 @@ function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
         <p className="text-sm font-medium text-white truncate">{device.name}</p>
         <p className="text-xs text-gray-500 shrink-0">{formatLastSeen(device.lastSeenSeconds)}</p>
       </div>
+      <NowActivityLine device={device} />
       {device.topHosts.length > 0 && (
         <ul className="mt-2 space-y-0.5">
           {device.topHosts.map(h => (
@@ -178,6 +179,23 @@ function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
         </ul>
       )}
     </div>
+  )
+}
+
+// #852 — "watching X · Nm" line, the replacement for the old `currentSession` widget.
+// Show `(active)` when the device is talking but the latest bucket has no resolvable top host
+// (heartbeat-only, all-IP, or the bucket hasn't closed yet) — be honest about the unknown.
+function NowActivityLine({ device }: { device: DashboardNowDevice }) {
+  const a = device.nowActivity
+  if (a === null) {
+    return <p className="mt-1 text-xs text-gray-500 italic">(active)</p>
+  }
+  return (
+    <p className="mt-1 text-xs text-gray-300">
+      <span className="text-gray-500">watching</span>{' '}
+      <span className="font-mono"><HostCell host={a.topHost} /></span>
+      {a.minutes !== null && <span className="text-gray-500"> · {a.minutes}m</span>}
+    </p>
   )
 }
 

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -187,14 +187,14 @@ function NowDeviceRow({ device }: { device: DashboardNowDevice }) {
 // (heartbeat-only, all-IP, or the bucket hasn't closed yet) — be honest about the unknown.
 function NowActivityLine({ device }: { device: DashboardNowDevice }) {
   const a = device.nowActivity
-  if (a === null) {
+  if (a == null) {
     return <p className="mt-1 text-xs text-gray-500 italic">(active)</p>
   }
   return (
     <p className="mt-1 text-xs text-gray-300">
       <span className="text-gray-500">watching</span>{' '}
       <span className="font-mono"><HostCell host={a.topHost} /></span>
-      {a.minutes !== null && <span className="text-gray-500"> · {a.minutes}m</span>}
+      {a.minutes != null && <span className="text-gray-500"> · {a.minutes}m</span>}
     </p>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -159,12 +159,18 @@ export interface DashboardNowHost {
   activeSeconds: number
 }
 
+export interface DashboardNowActivity {
+  topHost: HostId
+  minutes: number | null
+}
+
 export interface DashboardNowDevice {
   id: number
   name: string
   mac: string
   lastSeenSeconds: number
   topHosts: DashboardNowHost[]
+  nowActivity: DashboardNowActivity | null
 }
 
 export interface DashboardNowProfile {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -161,7 +161,8 @@ export interface DashboardNowHost {
 
 export interface DashboardNowActivity {
   topHost: HostId
-  minutes: number | null
+  // zio-json omits None — field is absent on the wire (treat absent as no run).
+  minutes?: number | null
 }
 
 export interface DashboardNowDevice {
@@ -170,7 +171,8 @@ export interface DashboardNowDevice {
   mac: string
   lastSeenSeconds: number
   topHosts: DashboardNowHost[]
-  nowActivity: DashboardNowActivity | null
+  // zio-json omits None — field is absent on the wire (treat absent as idle).
+  nowActivity?: DashboardNowActivity | null
 }
 
 export interface DashboardNowProfile {


### PR DESCRIPTION
## Summary
- Adds `DashboardNowDevice.nowActivity = { topHost, minutes? }`, derived per-request from `traffic_reports`: top host in the latest 5-min bucket, plus a consecutive-bucket "minutes" run when the same host stays on top (capped at 60).
- SPA renders `watching X · Nm` under each active device on the Dashboard NOW card, falling back to `(active)` when the bucket has no resolvable top host (heartbeat-only / IP-only / not yet closed).
- Replaces the per-device watching line that was removed alongside the Sessions feature in [#845](https://github.com/wifihaven/wifihaven/issues/845). Same data, no new schema, no new DB queries, no router-side changes.

## Why not rebuild sessions
The stitcher's contiguous-buckets framing is what produced the [#817](https://github.com/wifihaven/wifihaven/issues/817) data-quality problems. This implementation answers the *what* directly from the latest bucket; the `minutes` field only attaches when ≥2 consecutive buckets agree, so we never claim a duration we don't have evidence for.

Closes [#852](https://github.com/wifihaven/wifihaven/issues/852).

## Test plan
- [x] `mill shared.test` — 138/138
- [x] `mill api.test` — 190/190 (3 new tests: consistent buckets, varying top, idle)
- [x] `npm test` (web) — 181/181 (3 new tests: activity line, `(active)` fallback, null minutes)
- [x] `tsc --noEmit`
- [ ] Smoke against a deployed API: confirm the "watching" line reappears under each active device and shows `(active)` when the bucket is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)