### PR TITLE
fix(vm): tolerate gunzip rc=2 (trailing garbage) on OpenWRT image

### DIFF
--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -41,6 +41,7 @@ ensure_openwrt_image() {
 
   local gz="${WH_CACHE_DIR}/${WH_OPENWRT_IMAGE}"
   local img="${WH_ROUTER_BASE_IMG}"
+  local rc
 
   if [[ -f "${img}" ]]; then
     return 0
@@ -62,7 +63,13 @@ ensure_openwrt_image() {
 
   log "decompressing $(basename "${gz}")"
   require_cmd gunzip
-  gunzip -k -f "${gz}"
+  if ! gunzip -k -f "${gz}"; then
+    rc=$?
+    if (( rc != 2 )); then
+      die "gunzip failed (rc=${rc}) on ${gz}"
+    fi
+    log "gunzip warned on ${gz} (rc=2, trailing garbage ignored) — decompression result follows"
+  fi
   [[ -f "${img}" ]] || die "expected ${img} after gunzip"
 }
 


### PR DESCRIPTION
## Summary
- The pinned OpenWRT 23.05.6 `.img.gz` has trailing bytes that make `gunzip` exit rc=2 (`decompression OK, trailing garbage ignored`). Under `set -euo pipefail`, this killed `router-up.sh` before the post-`[[ -f "${img}" ]]` check could confirm the `.img` was produced.
- Symptom: a fresh run with an empty `.cache/` failed; a subsequent run on the same cache succeeded because the `[[ -f "${img}" ]] && return 0` early-out skipped the redecompress.
- Fix in `scripts/vm/lib.sh::ensure_openwrt_image`: treat rc=2 as a warning, `die` on any other non-zero rc, and let the existing existence check catch the no-output case. Not using `|| true` — that would also swallow real failures.

Discovered while validating #907 on a fresh worktree where the cache hadn't been pre-warmed.

## Test plan
- [ ] Remove `.cache/openwrt-*.img` and `.cache/openwrt-*.img.gz`, run `router-up.sh`, confirm image is produced and the script does not exit non-zero.
- [ ] Re-run on warm cache, confirm the early-out still skips redecompress.
- [ ] Simulate a real gunzip failure (e.g. truncate the `.gz`) and confirm the script dies with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)