### PR TITLE
test(gate2): assert bytesOut/bytesIn > 0 in usage scenario (closes #920)

### DIFF
--- a/scripts/e2e/scenarios_fake/test_05_usage_in_api.py
+++ b/scripts/e2e/scenarios_fake/test_05_usage_in_api.py
@@ -76,3 +76,11 @@ def test_usage_flows_to_fake_for_client_mac(router, client, fake_api):
     assert "activeSeconds" in rec
     assert "bytesIn" in rec
     assert "bytesOut" in rec
+    # bytes_out cascade (#717 → #833 → #858 → #866 → #905 → #913): key-presence
+    # alone let zeroed/swapped counters ship repeatedly. See #920.
+    assert rec["bytesOut"] > 0, f"bytesOut should be >0 after HTTP GETs, got {rec!r}"
+    assert rec["bytesIn"] > 0, f"bytesIn should be >0 after HTTP GETs, got {rec!r}"
+    # GET-only workload is download-heavy; catches #905-class direction swaps.
+    assert rec["bytesIn"] > rec["bytesOut"], (
+        f"GET-only workload should have bytesIn > bytesOut, got {rec!r}"
+    )


### PR DESCRIPTION
## Summary

Closes #920. The Gate 2 fake-mode usage scenario only checked key presence
for `bytesIn`/`bytesOut`, which let the bytes_out cascade
(#717 → #833 → #858 → #866 → #905 → #913) ship zeroed and
direction-swapped counters repeatedly.

This tightens [scripts/e2e/scenarios_fake/test_05_usage_in_api.py](scripts/e2e/scenarios_fake/test_05_usage_in_api.py)
to assert:

- `bytesOut > 0` and `bytesIn > 0` after the 5 HTTP GETs the scenario
  already drives.
- `bytesIn > bytesOut` for the GET-only (download-heavy) workload —
  catches #905-class direction swaps without hard-coding a ratio.

Per-direction byte-size assertions and an upload-heavy probe are
out of scope here; that's the separate gap tracked in #923. Audit
context: PR #934 (#916).

## Test plan

- [ ] `scripts/e2e-vm.sh --mode=fake --only usage` on a Linux/KVM host
  (cannot exercise the qemu pipeline from this macOS dev box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>