### PR TITLE
test(gate1): assert /api/sessions returns 404 (closes #925)

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -95,6 +95,13 @@ step "Blocklists endpoint"
 curl -fsS "${AUTH[@]}" "$BASE/api/blocklists" >/dev/null
 pass "blocklists OK"
 
+step "Sessions endpoint is gone (#845)"
+# Sessions feature was killed in #845/#851; /api/sessions must 404.
+# 200 = resurrection, 401 = auth regression, anything else = unexpected.
+SESSIONS=$(curl -s -o /dev/null -w '%{http_code}' "${AUTH[@]}" "$BASE/api/sessions")
+[ "$SESSIONS" = "404" ] || fail "expected 404 from /api/sessions, got $SESSIONS"
+pass "/api/sessions returns 404"
+
 step "Time status endpoint"
 # Confirm /api/time/status returns a JSON array.
 STATUS=$(curl -fsS "${AUTH[@]}" "$BASE/api/time/status")


### PR DESCRIPTION
## Summary
- Adds a single Gate 1 admin-smoke assertion that `GET /api/sessions` returns exactly 404.
- Distinguishes accidental resurrection (200) and auth regression (401) from the intended state — both are explicit failures.
- One-step addition using the existing `step`/`pass`/`fail` helpers and `${AUTH[@]}` curl pattern. No new helpers, no refactor.

## Context
- Sessions feature was killed in #845 / #851 — endpoint and SPA page removed.
- Audit that surfaced the gap: #840.
- E2E gate coverage audit doc: #934.

Closes #925.

## Test plan
- [x] `bash -n scripts/e2e-tests.sh` passes (syntax check).
- [ ] CI Gate 1 runs the new assertion against a freshly built API and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)