### PR TITLE
test(gate2): assert wifihaven-update cron entry present after install (closes #922)

### DIFF
--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -103,9 +103,12 @@ case "${ONLY}" in
   reassignment) MARK="reassignment" ;;
   unknown-device|unknown_device)
                 MARK="unknown_device" ;;
+  install-health|install_health)
+                MARK="install_health" ;;
   *) echo "unknown --only: ${ONLY}" >&2
      echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page," >&2
-     echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device" >&2
+     echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device," >&2
+     echo "       install-health" >&2
      exit 2 ;;
 esac
 

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -15,6 +15,7 @@ markers =
     time_limit: suite D (#431) — daily time-limit granularity + rollover
     reassignment: suite E (#432) — profile reassignment
     unknown_device: suite F (#432) — unknown-device autocreation
+    install_health: post-install router health asserts (#922 — cron, etc.)
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/test_install_health.py
+++ b/scripts/e2e/scenarios_fake/test_install_health.py
@@ -1,0 +1,37 @@
+"""Install-time health asserts against the booted router VM (Gate 2, #922).
+
+The `router_session` fixture has already booted the router, run apk postinst,
+enrolled, and confirmed at least one policy poll. Once we reach this point
+the install must look healthy from the router's perspective.
+
+Why cron specifically (#922): apk postinst (#869/#873) registers the
+`wifihaven-update` cron entry; the agent self-heals it on startup
+(#896/#899) precisely because installs have historically completed without
+it, leaving a router that silently never auto-updates. If both paths fail
+the only signal is a router that drifts further out of date every day —
+exactly the kind of regression Gate 2 should fail loudly on.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib.vm import router_ssh
+
+pytestmark = pytest.mark.install_health
+
+CRONTAB_PATH = "/etc/crontabs/root"
+EXPECTED_SCRIPT = "/usr/sbin/wifihaven-update"
+
+
+def test_wifihaven_update_cron_entry_present(router):
+    """After boot + first poll, /etc/crontabs/root must schedule wifihaven-update."""
+    res = router_ssh(f"grep wifihaven-update {CRONTAB_PATH}", check=False)
+    assert res.returncode == 0, (
+        f"grep wifihaven-update {CRONTAB_PATH} exited {res.returncode}; "
+        f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    )
+    matched = res.stdout.strip()
+    assert matched, f"empty grep match in {CRONTAB_PATH}"
+    assert EXPECTED_SCRIPT in matched, (
+        f"cron entry does not point at {EXPECTED_SCRIPT}: {matched!r}"
+    )


### PR DESCRIPTION
## Summary
- Adds `scripts/e2e/scenarios_fake/test_install_health.py` — after the session-scoped `router_session` fixture finishes boot + first policy poll, asserts `grep wifihaven-update /etc/crontabs/root` exits 0 and the matched line points at `/usr/sbin/wifihaven-update`.
- Registers a new `install_health` pytest marker and wires it into `scripts/e2e-vm.sh --only install-health` for selective runs.
- Narrow scope: cron presence only. Agent version drift and post-update service restart belong to #921.

## Why
Closes #922, a gap surfaced by the e2e coverage audit (#916, doc PR #934). The whole reason the agent self-heals cron on startup (#896/#899) is that apk postinst (#869/#873) has historically left routers without the entry — and the only symptom is silent failure to auto-update. Gate 2 should fail loudly on that.

## Test plan
- [ ] CI Gate 2 (qemu router + fake API) passes with the new scenario green — local verification not possible without KVM, syntax-checked via `python -m py_compile` and `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)