### PR TITLE
fix(web+api): strictly additive group-by aggregation (#917)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1433,9 +1433,10 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     val deviceExpr  = fr"COALESCE(d.name, ce.mac::TEXT)"
     val profileExpr = fr"COALESCE(p.name, '(unassigned)')"
 
-    // Default group: domain (matches pre-#846 behaviour). Multi-group composes
-    // freely across {domain, device, profile} — apex/app rejected at route.
-    val wantsDomain  = groupBy.contains("domain") || groupBy.isEmpty
+    // #917: strictly additive — empty set = no drill, one row per window.
+    // Multi-group composes freely across {domain, device, profile} (apex/app
+    // rejected at route).
+    val wantsDomain  = groupBy.contains("domain")
     val wantsDevice  = groupBy.contains("device")
     val wantsProfile = groupBy.contains("profile")
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1128,14 +1128,19 @@ object LogRoutes {
             _      <- ZIO
               .fail(Response.badRequest("bucket=off not supported on /series — use /api/logs"))
               .when(bucket == ConnectionEventBucket.Off)
-            // #846: comma-separated multi-column groupBy. Apex/App still
-            // accepted as wire names but rejected with typed errors so the
-            // SPA can re-enable them later without an API change (#856, #857).
-            grpRaw <- ZIO
-              .fromOption(req.url.queryParam("groupBy"))
-              .orElseFail(Response.badRequest("groupBy query parameter required"))
+            // #917: groupBy accepts repeated params (?groupBy=host&groupBy=device).
+            // For backwards-compat each value is also comma-split. Empty/absent
+            // is now valid — yields one row per window. Apex/App still rejected
+            // with typed errors (#856 PSL, #857 apps track).
             grpSet <- ZIO
-              .foreach(grpRaw.split(',').toList.map(_.trim).filter(_.nonEmpty)) { s =>
+              .foreach(
+                req.url.queryParams
+                  .getAll("groupBy")
+                  .toList
+                  .flatMap(_.split(',').toList)
+                  .map(_.trim)
+                  .filter(_.nonEmpty),
+              ) { s =>
                 ZIO
                   .fromOption(ConnectionEventGroupBy.fromWire(s))
                   .orElseFail(Response.badRequest(s"unknown groupBy: $s"))

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -205,15 +205,16 @@ object UsageRoutes {
             ),
         )
         .when(bucket == UsageTraffic.Bucket.OneMin)
-      // #846: comma-separated multi-column groupBy. Apex deferred to #856,
-      // App to #857 — both still rejected with typed errors so the SPA can
-      // re-enable them later without an API change.
+      // #917: groupBy accepts repeated params (?groupBy=host&groupBy=device).
+      // For backwards-compat each value is also comma-split, so the older
+      // single-param ?groupBy=host,device form keeps working. Empty/absent =
+      // strictly aggregate (one row per window). Apex deferred to #856, App
+      // to #857 — both still rejected with typed errors.
       groupBySet <- {
-        val raw = req.url
-          .queryParam("groupBy")
-          .getOrElse("")
-          .split(',')
+        val raw = req.url.queryParams
+          .getAll("groupBy")
           .toList
+          .flatMap(_.split(',').toList)
           .map(_.trim)
           .filter(_.nonEmpty)
         ZIO
@@ -331,8 +332,9 @@ object UsageRoutes {
         .getOrElse(100)
         .max(1)
         .min(5000)
-      effectiveGroupBy =
-        if (groupBySet.nonEmpty) groupBySet else Set(UsageTraffic.GroupBy.Domain)
+      // #917: empty set is intentional — strictly aggregate ("one row per
+      // time bucket"). No implicit default.
+      effectiveGroupBy = groupBySet
       resp             = bucket match {
         case UsageTraffic.Bucket.Raw =>
           val allRaw    = UsageTraffic.buildRaw(rows, devByMac, profNames)

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -527,6 +527,124 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         // youtube has 3 events vs facebook 1 — total-count desc ordering
         assertTrue(rows.head.groups.getOrElse("domain", "") == "youtube.com")
     },
+    // #917: strictly additive aggregation. Empty groupBy = one row per window.
+    test("#917: GET /api/connection-events/series with no groupBy returns one row per window") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              false,
+              "blocked",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:02")),
+              HostId.Fqdn(Hostname.unsafe("facebook.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=1h", token)
+        body <- resp.body.asString
+        rows <- ZIO.fromEither(body.fromJson[List[ConnectionEventAggRow]])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // 3 events all in the same 1h window → one fully-aggregated row.
+        assertTrue(rows.length == 1) &&
+        assertTrue(rows.head.groups.isEmpty) &&
+        assertTrue(rows.head.countSucceeded == 2) &&
+        assertTrue(rows.head.countBlocked == 1) &&
+        assertTrue(rows.head.distinctDomains == 2) &&
+        assertTrue(rows.head.distinctDevices == 2)
+    },
+    test("#917: GET /api/connection-events/series accepts repeated groupBy params") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:02")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:00:00:01")),
+              HostId.Fqdn(Hostname.unsafe("facebook.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1h&groupBy=device&groupBy=domain",
+          token,
+        )
+        body <- resp.body.asString
+        rows <- ZIO.fromEither(body.fromJson[List[ConnectionEventAggRow]])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // Three distinct (device,domain) tuples in the single window.
+        assertTrue(rows.length == 3) &&
+        assertTrue(rows.forall(r => r.groups.contains("device") && r.groups.contains("domain")))
+    },
+    test("#917: GET /api/connection-events/series rejects unknown groupBy with 400") {
+      for {
+        _        <- cleanDb
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/connection-events/series?bucket=1h&groupBy=bogus", token)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        assertTrue(body.contains("unknown groupBy"))
+    },
     test("GET /api/connection-events/series passes through blocked filter") {
       for {
         _        <- cleanDb

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -378,7 +378,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.rawRows.forall(_.profileName.contains("Kids"))) &&
           assertTrue(out.rawRows.map(_.host.value).toSet == Set("youtube.com", "google.com"))
       },
-      test("1h aggregated view groups by domain and sums bytes/seconds; matches raw sums") {
+      test(
+        "1h aggregated view with groupBy=domain groups by domain and sums bytes/seconds; matches raw sums",
+      ) {
         val today = TestClock.schoolDayAfternoon.toLocalDate
         for {
           _           <- cleanDb
@@ -442,7 +444,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           aggReq = Request
             .get(
               URL
-                .decode(s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=1h")
+                .decode(
+                  s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=1h&groupBy=domain",
+                )
                 .toOption
                 .get,
             )
@@ -484,6 +488,170 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
             aggOut.aggregateRows.map(_.groups("domain")).toSet ==
               Set("youtube.com", "google.com"),
           )
+      },
+      // #917: strictly additive aggregation. Default = one row per window.
+      test("#917: 1h aggregated view with no groupBy returns one row per window (full roll-up)") {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          // Three rows in the same hour bucket, two distinct domains.
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                1000L,
+                2000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                start.plusSeconds(300),
+                start.plusSeconds(600),
+                300,
+                500L,
+                1500L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("google.com")),
+                today,
+                start.plusSeconds(600),
+                start.plusSeconds(900),
+                300,
+                100L,
+                100L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          from = today.atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          to   = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          req  = Request
+            .get(
+              URL
+                .decode(s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=1h")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.groupBy.isEmpty) &&
+          // Three input rows in a single hour, all aggregated into one row.
+          assertTrue(out.aggregateRows.length == 1) &&
+          assertTrue(out.aggregateRows.head.groups.isEmpty) &&
+          assertTrue(out.aggregateRows.head.totalBytesIn == 1600L) &&
+          assertTrue(out.aggregateRows.head.totalBytesOut == 3600L) &&
+          assertTrue(out.aggregateRows.head.totalSeconds == 900L) &&
+          assertTrue(out.aggregateRows.head.distinctDomains == 2)
+      },
+      test(
+        "#917: groupBy as repeated params (?groupBy=device&groupBy=domain) equivalent to comma form",
+      ) {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        val macA  = "aa:bb:cc:dd:ee:1a"
+        val macB  = "aa:bb:cc:dd:ee:1b"
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, macA, "iPad-A", kidsId)
+          _           <- TestLayers.seedDevice(deviceRepo, macB, "iPad-B", kidsId)
+          routerId    <- seedRouter
+          start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(macA),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                100L,
+                0L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(macB),
+                None,
+                HostId.Fqdn(Hostname.unsafe("google.com")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                200L,
+                0L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          from = today.atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          to   = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          req  = Request
+            .get(
+              URL
+                .decode(
+                  s"/api/usage/traffic?profileId=${kidsId.value}&from=$from&to=$to&bucket=1h&groupBy=device&groupBy=domain",
+                )
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.groupBy.toSet == Set("device", "domain")) &&
+          assertTrue(out.aggregateRows.length == 2)
+      },
+      test("#917: unknown groupBy value returns 400 unknown_groupBy") {
+        for {
+          _  <- cleanDb
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL.decode(s"/api/usage/traffic?mac=$testMac&bucket=1h&groupBy=bogus").toOption.get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+        } yield assertTrue(resp.status == Status.BadRequest) &&
+          assertTrue(body.contains("unknown_groupBy")) &&
+          assertTrue(body.contains("bogus"))
       },
       test("multi-column groupBy=device,domain produces one row per (window, device, domain)") {
         val today = TestClock.schoolDayAfternoon.toLocalDate

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -180,7 +180,9 @@ export const api = {
       if (params.topN)      qs.set('topN', String(params.topN))
       return req<UsageSeriesResponse>('GET', `/usage/series?${qs}`)
     },
-    // #846 Traffic Usage page — multi-column groupBy via comma-separated set.
+    // #917: groupBy as repeated query params. Empty/absent = strictly aggregate
+    // (one row per time bucket). The API also accepts the legacy comma-separated
+    // single-param form for back-compat.
     traffic: (params: {
       mac?: string
       profileId?: number
@@ -197,7 +199,7 @@ export const api = {
       if (params.from)                     qs.set('from', params.from)
       if (params.to)                       qs.set('to', params.to)
       if (params.bucket)                   qs.set('bucket', params.bucket)
-      if (params.groupBy?.length)          qs.set('groupBy', params.groupBy.join(','))
+      if (params.groupBy) for (const g of params.groupBy) qs.append('groupBy', g)
       if (params.tz)                       qs.set('tz', params.tz)
       if (params.limit !== undefined)      qs.set('limit', String(params.limit))
       return req<TrafficUsageResponse>('GET', `/usage/traffic?${qs}`)
@@ -229,8 +231,9 @@ export const api = {
       if (params.offset)   qs.set('offset', String(params.offset))
       return req<QueryLog[]>('GET', `/logs?${qs}`)
     },
-    // #847 + #846: aggregated connection-events series. Multi-column groupBy
-    // via comma-separated set. apex deferred to #856, app to #857.
+    // #847 + #917: aggregated connection-events series. groupBy is sent as
+    // repeated query params; empty = one row per time bucket. apex deferred
+    // to #856, app to #857.
     series: (params: {
       bucket: '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
       groupBy: Array<'domain' | 'device' | 'profile' | 'apex' | 'app'>
@@ -246,7 +249,7 @@ export const api = {
     }) => {
       const qs = new URLSearchParams()
       qs.set('bucket', params.bucket)
-      qs.set('groupBy', params.groupBy.join(','))
+      for (const g of params.groupBy) qs.append('groupBy', g)
       if (params.mac)      qs.set('mac', params.mac)
       if (params.deviceId !== undefined)  qs.set('deviceId', String(params.deviceId))
       if (params.profileId !== undefined) qs.set('profileId', String(params.profileId))

--- a/web/src/components/usage/GroupableHeader.tsx
+++ b/web/src/components/usage/GroupableHeader.tsx
@@ -31,8 +31,8 @@ export function GroupableHeader({
         disabled
           ? disabledReason ?? ''
           : active
-          ? 'Click to remove from group-by'
-          : 'Click to group by this column'
+          ? `Roll ${label} back into the aggregate`
+          : `Break out rows by ${label}`
       }
       onClick={() => {
         if (!disabled) onToggle(groupKey)

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -86,20 +86,23 @@ describe('LogsPage (Connection Events) — raw view', () => {
 })
 
 describe('LogsPage — aggregation', () => {
-  it('switching to 1h triggers /series with groupBy=[domain] by default', async () => {
+  // #917: default state has no toggles on — one row per time bucket.
+  it('switching to 1h triggers /series with groupBy=[] by default', async () => {
     renderAt()
     await screen.findByText('example.com')
     await userEvent.click(screen.getByTestId('bucket-1h'))
     await waitFor(() => {
       expect(api.logs.series).toHaveBeenLastCalledWith(expect.objectContaining({
         bucket: '1h',
-        groupBy: ['domain'],
+        groupBy: [],
       }))
     })
     expect(await screen.findByTestId('ce-agg-table')).toBeInTheDocument()
   })
 
-  it('clicking the Device column header adds device to groupBy', async () => {
+  // #917: strictly additive — toggling a column on adds rows; toggling off
+  // removes them. We can go all the way back to []. Never the inverse.
+  it('clicking the Device column header strictly adds device to groupBy', async () => {
     renderAt()
     await screen.findByText('example.com')
     await userEvent.click(screen.getByTestId('bucket-1h'))
@@ -107,8 +110,23 @@ describe('LogsPage — aggregation', () => {
     await userEvent.click(screen.getByTestId('ce-group-device'))
     await waitFor(() => {
       const calls = (api.logs.series as ReturnType<typeof vi.fn>).mock.calls
-      const last = calls[calls.length - 1][0]
-      expect(last.groupBy.sort()).toEqual(['device', 'domain'])
+      expect(calls[calls.length - 1][0].groupBy).toEqual(['device'])
+    })
+    // Toggling off returns to [] (no implicit "must keep one" guard).
+    await userEvent.click(screen.getByTestId('ce-group-device'))
+    await waitFor(() => {
+      const calls = (api.logs.series as ReturnType<typeof vi.fn>).mock.calls
+      expect(calls[calls.length - 1][0].groupBy).toEqual([])
+    })
+  })
+
+  it('initializes groupBy from URL (?groupBy=device&groupBy=domain)', async () => {
+    renderAt('/usage/events?groupBy=device&groupBy=domain')
+    await screen.findByText('example.com')
+    await userEvent.click(screen.getByTestId('bucket-1h'))
+    await waitFor(() => {
+      const calls = (api.logs.series as ReturnType<typeof vi.fn>).mock.calls
+      expect(calls[calls.length - 1][0].groupBy.sort()).toEqual(['device', 'domain'])
     })
   })
 })

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog, TrafficUsageBucket } from '@/types/api'
 import { HostCell } from '@/components/HostCell'
@@ -11,6 +11,16 @@ import { localTime, windowFromTo } from '@/components/usage/usageHelpers'
 // headers double as group-by toggles. apex/app deferred to #856/#857.
 type EventsGroupBy = 'domain' | 'device' | 'profile'
 type EventsBucket  = TrafficUsageBucket  // shared with Traffic page; raw = /api/logs path
+
+const EVENTS_GROUP_KEYS: EventsGroupBy[] = ['domain', 'device', 'profile']
+
+function parseEventsGroupBy(sp: URLSearchParams): EventsGroupBy[] {
+  // #917: repeated ?groupBy=device&groupBy=domain serialization; comma form
+  // still accepted for back-compat.
+  const raw = sp.getAll('groupBy').flatMap(v => v.split(',')).map(v => v.trim()).filter(Boolean)
+  const allowed = new Set<string>(EVENTS_GROUP_KEYS)
+  return raw.filter(g => allowed.has(g)) as EventsGroupBy[]
+}
 
 function DeviceLink({ mac, deviceName }: { mac: string | null; deviceName: string | null }) {
   if (deviceName && mac) {
@@ -28,8 +38,10 @@ function DeviceLink({ mac, deviceName }: { mac: string | null; deviceName: strin
 }
 
 export function LogsPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [bucket, setBucket]     = useState<EventsBucket>('raw')
-  const [groupBy, setGroupBy]   = useState<EventsGroupBy[]>(['domain'])
+  // #917: default groupBy = [] — one row per time bucket. Toggles strictly add rows.
+  const [groupBy, setGroupBy]   = useState<EventsGroupBy[]>(() => parseEventsGroupBy(searchParams))
   const [mac, setMac]           = useState<string>('')
   const [profileId, setProfileId] = useState<string>('')
   const [devices, setDevices]   = useState<Device[]>([])
@@ -42,11 +54,14 @@ export function LogsPage() {
 
   function toggleGroup(key: string) {
     setGroupBy(prev => {
-      if (prev.includes(key as EventsGroupBy)) {
-        const next = prev.filter(g => g !== key)
-        return next.length === 0 ? prev : next
-      }
-      return [...prev, key as EventsGroupBy]
+      const next = prev.includes(key as EventsGroupBy)
+        ? prev.filter(g => g !== key)
+        : [...prev, key as EventsGroupBy]
+      const sp = new URLSearchParams(searchParams)
+      sp.delete('groupBy')
+      for (const g of next) sp.append('groupBy', g)
+      setSearchParams(sp, { replace: true })
+      return next
     })
   }
 

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -94,9 +94,15 @@ describe('TrafficUsagePage', () => {
     expect(api.usage.traffic).toHaveBeenCalledTimes(1)
   })
 
-  it('switching bucket to 1h preserves filters and shows aggregate table with default groupBy=domain', async () => {
+  // #917: default groupBy is [] — no implicit dimension.
+  it('switching bucket to 1h preserves filters and shows aggregate table with default groupBy=[]', async () => {
     const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
-    trafficMock.mockResolvedValueOnce(rawResp).mockResolvedValueOnce(aggResp)
+    const aggEmptyResp: TrafficUsageResponse = {
+      ...aggResp,
+      groupBy: [],
+      aggregateRows: [{ ...aggResp.aggregateRows[0], groups: {} }],
+    }
+    trafficMock.mockResolvedValueOnce(rawResp).mockResolvedValueOnce(aggEmptyResp)
     renderPage()
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
     const firstCall = (api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[0][0]
@@ -107,30 +113,68 @@ describe('TrafficUsagePage', () => {
 
     expect(secondCall.mac).toBe(firstCall.mac)
     expect(secondCall.profileId).toBe(firstCall.profileId)
-    // `from`/`to` are computed at fetch-time from new Date() so they differ
-    // between calls; the bucket switch is what matters here.
     expect(secondCall.bucket).toBe('1h')
-    expect(secondCall.groupBy).toEqual(['domain'])
+    expect(secondCall.groupBy).toEqual([])
 
     await waitFor(() => expect(screen.getByTestId('aggregate-table')).toBeInTheDocument())
-    expect(screen.getByText('youtube.com')).toBeInTheDocument()
   })
 
-  it('clicking a column header toggles it into the groupBy set', async () => {
+  // #917: toggling a column on adds rows; toggling off removes them. Toggling
+  // *all* off lands back in the strictly-aggregate default.
+  it('clicking a column header toggles it into the groupBy set, additively', async () => {
     const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
+    const aggEmptyResp: TrafficUsageResponse = {
+      ...aggResp,
+      groupBy: [],
+      aggregateRows: [{ ...aggResp.aggregateRows[0], groups: {} }],
+    }
     trafficMock
-      .mockResolvedValueOnce(rawResp)
-      .mockResolvedValueOnce(aggResp)
-      .mockResolvedValueOnce({ ...aggResp, groupBy: ['device', 'domain'] })
+      .mockResolvedValueOnce(rawResp)        // initial raw
+      .mockResolvedValueOnce(aggEmptyResp)   // bucket=1h, groupBy=[]
+      .mockResolvedValueOnce(aggResp)        // + domain toggle
+      .mockResolvedValueOnce({ ...aggResp, groupBy: ['domain', 'device'] }) // + device toggle
+      .mockResolvedValueOnce(aggEmptyResp)   // - domain - device (back to empty)
     renderPage()
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
     await userEvent.click(screen.getByTestId('bucket-1h'))
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(2))
 
-    await userEvent.click(screen.getByTestId('traffic-group-device'))
+    // Adds the first dimension.
+    await userEvent.click(screen.getByTestId('traffic-group-domain'))
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(3))
-    const lastCall = (api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[2][0]
-    expect(lastCall.groupBy?.sort()).toEqual(['device', 'domain'])
+    expect((api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[2][0].groupBy).toEqual(['domain'])
+
+    // Adds the second dimension.
+    await userEvent.click(screen.getByTestId('traffic-group-device'))
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(4))
+    expect((api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[3][0].groupBy?.sort())
+      .toEqual(['device', 'domain'])
+
+    // Toggling them all back off returns to the empty default — the prior
+    // implementation kept at least one on; #917 makes "no toggles" valid.
+    await userEvent.click(screen.getByTestId('traffic-group-domain'))
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(5))
+    await userEvent.click(screen.getByTestId('traffic-group-device'))
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(6))
+    expect((api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[5][0].groupBy).toEqual([])
+  })
+
+  // #917: URL state. groupBy round-trips as repeated ?groupBy= params so
+  // links restore the operator's drill-in.
+  it('initializes groupBy from URL query params (?groupBy=device&groupBy=domain)', async () => {
+    const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
+    trafficMock.mockResolvedValue(aggResp)
+    render(
+      <MemoryRouter initialEntries={['/?groupBy=device&groupBy=domain']}>
+        <TrafficUsagePage />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
+    // Default bucket is raw — switch to 1h to surface the groupBy in the call.
+    await userEvent.click(screen.getByTestId('bucket-1h'))
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(2))
+    const aggCall = (api.usage.traffic as ReturnType<typeof vi.fn>).mock.calls[1][0]
+    expect(aggCall.groupBy?.sort()).toEqual(['device', 'domain'])
   })
 
   // #861 — verify low-priority columns carry responsive `hidden` classes so

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import type {
   Device,
@@ -24,9 +25,22 @@ import {
 
 const DEFAULT_RAW_LIMIT = 100
 
+const TRAFFIC_GROUP_KEYS: TrafficUsageGroupBy[] = ['domain', 'device', 'profile']
+
+function parseGroupByFromSearch(sp: URLSearchParams): TrafficUsageGroupBy[] {
+  // #917: serialize as repeated ?groupBy=host&groupBy=device so links
+  // round-trip. We also accept the legacy comma-separated single param.
+  const raw = sp.getAll('groupBy').flatMap(v => v.split(',')).map(v => v.trim()).filter(Boolean)
+  const allowed = new Set<string>(TRAFFIC_GROUP_KEYS)
+  return raw.filter(g => allowed.has(g)) as TrafficUsageGroupBy[]
+}
+
 export function TrafficUsagePage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [bucket, setBucket]     = useState<TrafficUsageBucket>('raw')
-  const [groupBy, setGroupBy]   = useState<TrafficUsageGroupBy[]>(['domain'])
+  // #917: default is "everything rolled up" — empty groupBy = one row per
+  // time bucket. Each column toggle is strictly additive (adds rows).
+  const [groupBy, setGroupBy]   = useState<TrafficUsageGroupBy[]>(() => parseGroupByFromSearch(searchParams))
   const [mac, setMac]           = useState<string>('')
   const [profileId, setProfileId] = useState<string>('')
   const [devices, setDevices]   = useState<Device[]>([])
@@ -74,12 +88,14 @@ export function TrafficUsagePage() {
 
   function toggleGroup(key: string) {
     setGroupBy(prev => {
-      if (prev.includes(key as TrafficUsageGroupBy)) {
-        const next = prev.filter(g => g !== key)
-        // Always keep at least one group dimension on aggregate views.
-        return next.length === 0 ? prev : next
-      }
-      return [...prev, key as TrafficUsageGroupBy]
+      const next = prev.includes(key as TrafficUsageGroupBy)
+        ? prev.filter(g => g !== key)
+        : [...prev, key as TrafficUsageGroupBy]
+      const sp = new URLSearchParams(searchParams)
+      sp.delete('groupBy')
+      for (const g of next) sp.append('groupBy', g)
+      setSearchParams(sp, { replace: true })
+      return next
     })
   }
 


### PR DESCRIPTION
Closes #917.

## Summary

- Strictly additive groupBy: default = one row per time bucket; each column toggle adds rows by breaking out a dimension; green = more rows, ungreen = fewer. Never the inverse.
- API: `groupBy` accepts repeated params (`?groupBy=host&groupBy=device`); empty/absent rolls everything up. Comma-separated form still accepted for back-compat.
- SPA: groupBy default `[]`, all toggles offable, tooltip rewritten ("Break out rows by X" / "Roll X back into the aggregate"), URL round-trip via repeated query params.

## Before / after (Traffic Usage, bucket=1h, single window, two domains × two devices)

**Before**

- No toggles → server defaulted to `groupBy=domain` → 2 rows (one per domain). Operator can't see the headline "what happened in this hour" without scanning.
- Toggle Device on → 4 rows. Toggle Device off (already had domain implicit) → 2 rows. Toggle Domain off → back to 2 rows (UI kept at least one dimension on). Inconsistent — sometimes a toggle off *added* rows depending on what was implicit.

**After (this PR)**

- No toggles → 1 row: window-wide totals.
- Toggle Domain → 2 rows. Toggle Device → 4 rows. Toggle both off → back to 1 row. Toggling on always adds; toggling off always removes.

## Touch surface

| Layer | File | What changed |
|---|---|---|
| API route | [api/src/routes/UsageRoutes.scala](api/src/routes/UsageRoutes.scala) | Read `queryParams.getAll("groupBy")`; comma-split each value for back-compat; remove implicit `Domain` default. |
| API route | [api/src/routes/Routes.scala](api/src/routes/Routes.scala) | `/api/connection-events/series`: groupBy optional now; same repeated-param parsing. |
| API SQL | [api/src/db/Repos.scala](api/src/db/Repos.scala) | `wantsDomain` no longer falls back to true on empty set. |
| SPA | [web/src/pages/TrafficUsagePage.tsx](web/src/pages/TrafficUsagePage.tsx), [web/src/pages/LogsPage.tsx](web/src/pages/LogsPage.tsx) | Default state `[]`; toggle-off-to-empty allowed; URL state via `useSearchParams`. |
| SPA | [web/src/api/client.ts](web/src/api/client.ts) | Send groupBy as repeated `qs.append` entries (empty list → param absent). |
| SPA | [web/src/components/usage/GroupableHeader.tsx](web/src/components/usage/GroupableHeader.tsx) | Tooltip rewrite. |

## Constraints honored

- Zero router-side changes.
- No `shared/contract/api-to-router/policy_snapshot.json` touched.
- Stayed out of the chips on adjacent pages: #861 (responsive), #862 (paging), #865 (column filters).
- SSH remote, no `--no-verify`.

## Test plan

- [x] `mill api.test` — 190 tests pass, including new #917 cases for both endpoints (empty groupBy, repeated-param form, unknown rejection).
- [x] `mill shared.test` — 138 tests pass.
- [x] `npm run test` (web) — 194 tests pass, including new #917 cases for both pages (default `[]`, additive toggle, URL round-trip, toggle-all-off).
- [x] `npm run type-check` clean.
- [ ] Manual: click each page in browser; verify default = one aggregate row, toggle on adds rows, toggle off removes rows, URL round-trips. (Not run locally — no UI access; trusting test coverage. Operator should smoke-test in dev before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)