### PR TITLE
fix(vm-e2e): honor allocated client SSH port in fake conftest

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -47,6 +47,13 @@ jobs:
     # a slow run can't pile up.
     timeout-minutes: 30
 
+    env:
+      # Per-job scope for the qemu `-name wh-*-${WH_RUN_ID}` suffix and the
+      # .run/<id>/ state dir (config.sh:91,145,40-44). Lets teardown's
+      # pkill backstop match only this run's qemu, never a sibling's, and
+      # is a prerequisite for relaxing the e2e-vm concurrency group (#895).
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
     steps:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
       # can leave root-owned files under scripts/vm/.cache/imagebuilder/.
@@ -123,3 +130,8 @@ jobs:
         run: |
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
+          # Backstop: kill anything tagged with *this* run's id that the
+          # pidfile-driven down scripts missed (workspace reclaim, qemu
+          # reparented, etc.). Scoped via WH_RUN_ID so a sibling
+          # concurrent run is never touched.
+          pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}" || true

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -47,6 +47,13 @@ jobs:
     # queue serialized so a slow run doesn't pile up.
     timeout-minutes: 120
 
+    env:
+      # Per-job scope for the qemu `-name wh-*-${WH_RUN_ID}` suffix and the
+      # .run/<id>/ state dir (config.sh:91,145,40-44). Lets teardown's
+      # pkill backstop match only this run's qemu, never a sibling's, and
+      # is a prerequisite for relaxing the e2e-vm concurrency group (#895).
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
     steps:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
       # left root-owned files under scripts/vm/.cache/imagebuilder/ (older
@@ -144,6 +151,11 @@ jobs:
         run: |
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
+          # Backstop: kill anything tagged with *this* run's id that the
+          # pidfile-driven down scripts missed (workspace reclaim, qemu
+          # reparented, etc.). Scoped via WH_RUN_ID so a sibling
+          # concurrent run is never touched.
+          pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}" || true
 
       - name: Tear down API stack
         if: always()

--- a/scripts/e2e/scenarios_fake/conftest.py
+++ b/scripts/e2e/scenarios_fake/conftest.py
@@ -216,7 +216,7 @@ def router(router_session, fake_server, fake_api) -> EnrolledRouter:
 def client_factory():
     booted: list[str] = []
 
-    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int = 2223) -> Client:
+    def _boot(*, mac: str | None = None, name: str = "client1", ssh_port: int | None = None) -> Client:
         chosen_mac = mac or _gen_mac()
         c = client_up(mac=chosen_mac, name=name, ssh_port=ssh_port)
         booted.append(name)

--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -2,7 +2,7 @@
 # Boot a client VM as a qcow2 overlay on top of the cured base image.
 #
 # Usage:
-#   client-up.sh --mac aa:bb:cc:dd:ee:ff [--name client1] [--ssh-port 2223]
+#   client-up.sh --mac aa:bb:cc:dd:ee:ff [--name client1] [--ssh-port PORT]
 #
 # Two NICs:
 #   eth0 — virtio-net attached to ${WH_LAN_BRIDGE} (the router VM's LAN).


### PR DESCRIPTION
## Summary
- `scripts/e2e/scenarios_fake/conftest.py:219` defaulted `ssh_port=2223`, silently overriding the `WH_CLIENT_SSH_PORT_BASE` that `e2e-vm.sh` allocates at session start (#902). A stale qemu holding 2223 on the self-hosted KVM runner therefore blocks every `client_up` — which is what failed Master Router CD ([run 26343802799](https://github.com/wifihaven/wifihaven/actions/runs/26343802799/job/77550543090)) after a chain of cancelled runs left an orphan listening on 2223. Match the live conftest's `ssh_port=None` so `client_up` uses `CLIENT_SSH_PORT_DEFAULT` (env-honoring).
- Set `WH_RUN_ID=${{ github.run_id }}-${{ github.run_attempt }}` per job in `e2e-vm-fake.yml` and `e2e-vm.yml`, and add a scoped `pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}"` to teardown. Catches orphans the pidfile-driven down scripts miss (workspace reclaim, qemu reparented). Scoped by run id so a sibling concurrent run is never touched — also a prerequisite for relaxing the `e2e-vm` concurrency group (#895).
- Cosmetic: drop hardcoded `2223` from `scripts/vm/client-up.sh` usage comment.

## Audit context
Walked the post-#891 / #902 / #907 concurrency changes end-to-end. The port-allocation chain (`e2e-vm.sh` → env → `lib/vm.py::CLIENT_SSH_PORT_DEFAULT` → `client_up(ssh_port=None)`) was complete *except* at the fake conftest, which short-circuited it with a literal `2223`. The live conftest at `scripts/e2e/conftest.py:139` was already correct. This was a copy-paste from the pre-#902 era that didn't get updated.

The bridge picker race (#907 Bug 2) is unrelated to this CD failure and remains the blocker for truly relaxing `concurrency: { group: e2e-vm }`. For local two-arm validation today: `WH_RUN_ID=A WH_PORT_BASE=2222 WH_LAN_BRIDGE=wh-lan0 …` + `WH_RUN_ID=B WH_PORT_BASE=2322 WH_LAN_BRIDGE=wh-lan1 …` works.

## Test plan
- [ ] CI green on this PR (Gate 2 runs).
- [ ] Re-run Master Router CD on main after merge; Gate 2 succeeds.
- [ ] Spot-check: `pgrep -af 'qemu-system.*wh-'` on the runner is empty after a successful run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)