### PR TITLE
fix(install): refresh docker-compose.prod.yml in update.sh

### DIFF
--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -5,7 +5,27 @@
 # `compose up -d` only recreates containers whose image changed, so
 # postgres stays put unless its image was bumped, and the api restarts
 # only when there's actually a new build to roll out.
+#
+# Also refreshes docker-compose.prod.yml from the repo before pulling, so
+# new env vars / service additions in a release reach the container instead
+# of silently no-opping against a stale local compose file.
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
+
+REPO_RAW="${WIFIHAVEN_REPO_RAW:-https://raw.githubusercontent.com/wifihaven/wifihaven/main}"
+COMPOSE_URL="${REPO_RAW}/deploy/docker-compose.prod.yml"
+
+# Refresh docker-compose.prod.yml from main. Preserve the old file as .bak
+# so a network blip doesn't wipe out a working install.
+if [ -f docker-compose.prod.yml ]; then
+  cp docker-compose.prod.yml docker-compose.prod.yml.bak
+fi
+if curl -fsSL "$COMPOSE_URL" -o docker-compose.prod.yml.new; then
+  mv docker-compose.prod.yml.new docker-compose.prod.yml
+else
+  echo "warn: failed to fetch $COMPOSE_URL; keeping existing docker-compose.prod.yml" >&2
+  rm -f docker-compose.prod.yml.new
+fi
+
 docker compose -f docker-compose.prod.yml --env-file .env pull
 docker compose -f docker-compose.prod.yml --env-file .env up -d


### PR DESCRIPTION
## Summary
- `update.sh` now re-fetches `deploy/docker-compose.prod.yml` from `main` before `compose pull && up -d`, so new env vars / service additions in a release actually reach the container instead of silently no-opping against the locally-cached compose file.
- Tolerant of network blips: existing compose file is preserved as `docker-compose.prod.yml.bak`, and a failed `curl` leaves the current file in place.

## Motivation
Hit during the #944 (`WIFIHAVEN_UI_ALLOWED_HOSTS`) rollout on the api.lan dev install. `~/.wifihaven/update.sh` pulled the new API image, but the new env var never made it into the container because the local `docker-compose.prod.yml` was stale. Had to manually `curl` the compose file from main and re-run `compose up -d`. Future releases that touch the compose file would hit the same trap.

## Test plan
- [ ] Run `~/.wifihaven/update.sh` on the api.lan dev install; verify `docker-compose.prod.yml` is refreshed and `.bak` is written.
- [ ] Simulate a network failure (e.g. point `WIFIHAVEN_REPO_RAW` at a bad host) and confirm the existing compose file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)