### PR TITLE
feat(web): apps management screen — list/create/edit/delete (#765)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { UsersPage } from '@/pages/UsersPage'
 import { RoutersPage } from '@/pages/RoutersPage'
 import { AdminPage } from '@/pages/AdminPage'
 import { BlockedPage } from '@/pages/BlockedPage'
+import { AppsPage } from '@/pages/AppsPage'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -57,6 +58,7 @@ function AppRoutes() {
         <Route path="logs"      element={<Navigate to="/usage/events" replace />} />
         <Route path="usage"          element={<RequirePwChanged><TrafficUsagePage /></RequirePwChanged>} />
         <Route path="usage/events"   element={<RequirePwChanged><LogsPage /></RequirePwChanged>} />
+        <Route path="apps"      element={<RequirePwChanged><RequireAdmin><AppsPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="users"     element={<RequirePwChanged><RequireAdmin><UsersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="routers"   element={<RequirePwChanged><RequireAdmin><RoutersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="admin"     element={<RequirePwChanged><RequireAdmin><AdminPage /></RequireAdmin></RequirePwChanged>} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,9 +1,11 @@
 import type {
-  CreateRouterRequest, CreateRouterResponse, CreateUserRequest, DashboardNow, DashboardStats, Device,
+  AppDetail, CreateAppRequest, CreateRouterRequest, CreateRouterResponse, CreateUserRequest,
+  DashboardNow, DashboardStats, Device,
   DeviceAlert, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek,
-  ConnectionEventAggRow, QueryLog, RouterSummary, SetUserProfilesRequest, TimeExtension,
+  ConnectionEventAggRow, QueryLog, RouterSummary, SetAppHostsRequest, SetUserProfilesRequest,
+  TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
-  UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
+  UpdateAppRequest, UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
 } from '@/types/api'
 
@@ -275,6 +277,18 @@ export const api = {
   blocklists: {
     counts: () => req<{ category: string; count: number }[]>('GET', '/blocklists'),
     clearCategory: (cat: string) => req<void>('POST', `/blocklists/${cat}/clear`, {}),
+  },
+
+  // ── Apps (#762/#765) ───────────────────────────────────────────────────
+  apps: {
+    list: () => req<AppDetail[]>('GET', '/apps'),
+    get: (id: number) => req<AppDetail>('GET', `/apps/${id}`),
+    create: (data: CreateAppRequest) => req<AppDetail>('POST', '/apps', data),
+    update: (id: number, data: UpdateAppRequest) =>
+      req<void>('PUT', `/apps/${id}`, data),
+    delete: (id: number) => req<void>('DELETE', `/apps/${id}`),
+    setHosts: (id: number, hosts: string[]) =>
+      req<void>('PUT', `/apps/${id}/hosts`, { hosts } as SetAppHostsRequest),
   },
 
   // ── Routers (admin) ────────────────────────────────────────────────────

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -29,6 +29,7 @@ const settingsNav: NavItem[] = [
       { to: '/usage/events', label: 'Connection Events', icon: '≡' },
     ],
   },
+  { to: '/apps',    label: 'Apps',    icon: '◳', adminOnly: true },
   { to: '/users',   label: 'Users',   icon: '◐', adminOnly: true },
   { to: '/routers', label: 'Routers', icon: '⬢', adminOnly: true },
   { to: '/admin',   label: 'Settings', icon: '⚙', adminOnly: true },

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AppDetail, ProfileDetail } from '@/types/api'
+import { withQuery } from '@/test/queryWrapper'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    apps: {
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      setHosts: vi.fn(),
+    },
+    profiles: {
+      list: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import { AppsPage } from './AppsPage'
+
+function makeProfile(id: number, name: string): ProfileDetail {
+  return {
+    profile: {
+      id, name,
+      blockedCategories: [],
+      extraBlocked: [],
+      extraAllowed: [],
+      paused: false,
+      failureMode: 'last-known-good',
+      crossDeviceOverlapMode: 'sum',
+    },
+    schedules: [],
+    timeLimit: null,
+    siteTimeLimits: [],
+  }
+}
+
+const kidsProfile = makeProfile(1, 'Kids')
+const adultsProfile = makeProfile(2, 'Adults')
+
+function makeApp(over: Partial<AppDetail['app']> & { id: number; name: string; slug: string }): AppDetail {
+  return {
+    app: {
+      id: over.id,
+      name: over.name,
+      slug: over.slug,
+      templateId: over.templateId ?? null,
+      icon: over.icon ?? null,
+      createdAt: '2026-05-01T00:00:00Z',
+    },
+    hosts: [],
+    assignments: [],
+  }
+}
+
+const youtube: AppDetail = {
+  ...makeApp({ id: 10, name: 'YouTube', slug: 'youtube', icon: '📺' }),
+  hosts: ['youtube.com', 'googlevideo.com'],
+  assignments: [
+    { id: 100, appId: 10, profileId: 1, mode: 'time_limited', dailyMinutes: 60, exemptFromDaily: true },
+  ],
+}
+
+const reddit: AppDetail = {
+  ...makeApp({ id: 11, name: 'Reddit', slug: 'reddit' }),
+  hosts: ['reddit.com'],
+  assignments: [],
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube, reddit])
+  ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([kidsProfile, adultsProfile])
+})
+
+describe('AppsPage — list', () => {
+  it('renders apps with host counts and profile-assignment counts', async () => {
+    render(withQuery(<AppsPage />))
+    await screen.findByText('YouTube')
+    expect(screen.getByText('Reddit')).toBeInTheDocument()
+    // YouTube row: 2 hosts, 1 profile
+    const ytRow = screen.getByRole('button', { name: /youtube/i })
+    expect(within(ytRow).getByText(/2 hosts/i)).toBeInTheDocument()
+    expect(within(ytRow).getByText(/1 profile/i)).toBeInTheDocument()
+    // Reddit row: 1 host, no profiles
+    const rdRow = screen.getByRole('button', { name: /reddit/i })
+    expect(within(rdRow).getByText(/1 host/i)).toBeInTheDocument()
+    expect(within(rdRow).getByText(/no profiles/i)).toBeInTheDocument()
+  })
+
+  it('shows an empty-state when there are no apps', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    render(withQuery(<AppsPage />))
+    await screen.findByText(/no apps yet/i)
+  })
+})
+
+describe('AppsPage — create flow', () => {
+  it('round-trips name + hosts through POST /apps and reloads the list', async () => {
+    (api.apps.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...makeApp({ id: 12, name: 'Discord', slug: 'discord' }),
+      hosts: ['discord.com'],
+    })
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await screen.findByText('YouTube')
+    await user.click(screen.getByRole('button', { name: /new app/i }))
+    await user.type(screen.getByPlaceholderText('YouTube'), 'Discord')
+    await user.type(
+      screen.getByPlaceholderText(/youtube\.com/i),
+      'discord.com, *.discordapp.net',
+    )
+    // After create, the list will include the new app
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      youtube, reddit,
+      { ...makeApp({ id: 12, name: 'Discord', slug: 'discord' }), hosts: ['discord.com'] },
+    ])
+    await user.click(screen.getByRole('button', { name: /create app/i }))
+    await waitFor(() => {
+      expect(api.apps.create).toHaveBeenCalledWith({
+        name: 'Discord',
+        icon: undefined,
+        hosts: ['discord.com', '*.discordapp.net'],
+      })
+    })
+    await screen.findByText('Discord')
+  })
+})
+
+describe('AppsPage — edit flow', () => {
+  it('renders existing hosts as chips and round-trips edits via PUT /apps + PUT /apps/:id/hosts', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await user.click(await screen.findByRole('button', { name: /youtube/i }))
+    // Existing host chips
+    expect(screen.getByText('youtube.com')).toBeInTheDocument()
+    expect(screen.getByText('googlevideo.com')).toBeInTheDocument()
+    // Remove a host
+    await user.click(screen.getByRole('button', { name: /remove googlevideo\.com/i }))
+    expect(screen.queryByText('googlevideo.com')).not.toBeInTheDocument()
+    // Add a new host via the Add button
+    await user.type(
+      screen.getByPlaceholderText(/example\.com or \*\.example\.com/i),
+      '*.ytimg.com',
+    )
+    await user.click(screen.getByRole('button', { name: 'Add' }))
+    expect(screen.getByText('*.ytimg.com')).toBeInTheDocument()
+    // Rename
+    const nameInput = screen.getByDisplayValue('YouTube') as HTMLInputElement
+    await user.clear(nameInput)
+    await user.type(nameInput, 'YT')
+    await user.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => {
+      expect(api.apps.update).toHaveBeenCalledWith(10, {
+        name: 'YT',
+        icon: '📺',
+        templateId: null,
+      })
+      expect(api.apps.setHosts).toHaveBeenCalledWith(10, ['youtube.com', '*.ytimg.com'])
+    })
+  })
+})
+
+describe('AppsPage — delete flow', () => {
+  it('warns when the app has profile assignments and names them', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await user.click(await screen.findByRole('button', { name: /youtube/i }))
+    await user.click(screen.getByRole('button', { name: /delete app/i }))
+    expect(screen.getByText(/assigned to/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/Kids/).length).toBeGreaterThan(0)
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => {
+      expect(api.apps.delete).toHaveBeenCalledWith(10)
+    })
+  })
+
+  it('shows a simpler confirm when the app has no assignments', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await user.click(await screen.findByRole('button', { name: /reddit/i }))
+    await user.click(screen.getByRole('button', { name: /delete app/i }))
+    expect(screen.queryByText(/assigned to/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
+    await waitFor(() => {
+      expect(api.apps.delete).toHaveBeenCalledWith(11)
+    })
+  })
+})

--- a/web/src/pages/AppsPage.tsx
+++ b/web/src/pages/AppsPage.tsx
@@ -1,0 +1,449 @@
+import { useEffect, useMemo, useState } from 'react'
+import { api } from '@/api/client'
+import { useProfiles } from '@/api/queries'
+import type { AppDetail } from '@/types/api'
+import { PageLoader } from './DashboardPage'
+
+interface EditFormState {
+  name: string
+  icon: string
+  hosts: string[]
+}
+
+function blankCreateForm(): EditFormState {
+  return { name: '', icon: '', hosts: [] }
+}
+
+function detailToForm(d: AppDetail): EditFormState {
+  return { name: d.app.name, icon: d.app.icon ?? '', hosts: [...d.hosts] }
+}
+
+function splitHosts(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+export function AppsPage() {
+  const [apps, setApps] = useState<AppDetail[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<AppDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const { data: profiles = [] } = useProfiles()
+
+  const profileNameById = useMemo(() => {
+    const m = new Map<number, string>()
+    for (const p of profiles) m.set(p.profile.id, p.profile.name)
+    return m
+  }, [profiles])
+
+  async function reload() {
+    const list = await api.apps.list()
+    setApps([...list].sort((a, b) => a.app.name.localeCompare(b.app.name)))
+  }
+
+  useEffect(() => {
+    reload()
+      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load apps'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  if (loading) return <PageLoader />
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-white">Apps</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Bundles of hosts you can block, allow, or time-limit per profile.
+          </p>
+        </div>
+        <button
+          onClick={() => { setCreating(true); setError(null) }}
+          className="bg-emerald-500 hover:bg-emerald-400 text-black text-sm font-semibold px-4 py-2 rounded-xl transition-colors"
+        >
+          + New App
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
+        {apps.length === 0
+          ? <p className="p-6 text-gray-500 text-sm">No apps yet. Create one to start grouping hosts.</p>
+          : apps.map(a => {
+              const assignProfiles = new Set(a.assignments.map(x => x.profileId))
+              return (
+                <button
+                  key={a.app.id}
+                  onClick={() => { setEditing(a); setError(null) }}
+                  className="w-full text-left border-b border-gray-800 last:border-0 hover:bg-gray-800/40 transition-colors"
+                >
+                  <div className="flex items-center gap-4 px-5 py-4">
+                    <span className="text-2xl w-8 text-center" aria-hidden>
+                      {a.app.icon || '◳'}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-white truncate">{a.app.name}</p>
+                      <p className="text-xs text-gray-500 mt-0.5 font-mono">{a.app.slug}</p>
+                    </div>
+                    <div className="text-right text-xs text-gray-400 shrink-0">
+                      <p>{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</p>
+                      <p className="text-gray-500 mt-0.5">
+                        {assignProfiles.size === 0
+                          ? 'no profiles'
+                          : `${assignProfiles.size} profile${assignProfiles.size === 1 ? '' : 's'}`}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+              )
+            })
+        }
+      </div>
+
+      {creating && (
+        <CreateAppModal
+          onClose={() => setCreating(false)}
+          onSaved={async () => { setCreating(false); await reload() }}
+        />
+      )}
+
+      {editing && (
+        <EditAppModal
+          detail={editing}
+          profileNameById={profileNameById}
+          onClose={() => setEditing(null)}
+          onSaved={async () => { setEditing(null); await reload() }}
+          onDeleted={async () => { setEditing(null); await reload() }}
+        />
+      )}
+    </div>
+  )
+}
+
+function CreateAppModal({ onClose, onSaved }: {
+  onClose: () => void
+  onSaved: () => void | Promise<void>
+}) {
+  const [form, setForm] = useState<EditFormState>(blankCreateForm)
+  const [hostsInput, setHostsInput] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form.name.trim()) { setError('Name is required'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      await api.apps.create({
+        name: form.name.trim(),
+        icon: form.icon.trim() || undefined,
+        hosts: splitHosts(hostsInput),
+      })
+      await onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create app')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Modal title="New App" onClose={onClose}>
+      <form onSubmit={submit} className="space-y-5">
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+            {error}
+          </div>
+        )}
+        <Field label="Name" required>
+          <input
+            type="text" value={form.name} autoFocus required
+            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            placeholder="YouTube"
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500"
+          />
+        </Field>
+        <Field label="Icon (emoji, optional)">
+          <input
+            type="text" value={form.icon}
+            onChange={e => setForm(f => ({ ...f, icon: e.target.value }))}
+            placeholder="📺"
+            maxLength={4}
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500"
+          />
+        </Field>
+        <Field label="Initial hosts (optional)">
+          {/* #766 — picker comes later; plain comma/newline-separated input for now. */}
+          <textarea
+            rows={4}
+            value={hostsInput}
+            onChange={e => setHostsInput(e.target.value)}
+            placeholder="youtube.com&#10;*.googlevideo.com"
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white font-mono text-sm focus:outline-none focus:border-emerald-500"
+          />
+          <p className="text-xs text-gray-500 mt-2">
+            One per line or comma-separated. <code>*.foo.com</code> and <code>foo.com</code>
+            both canonicalize to the apex.
+          </p>
+        </Field>
+        <div className="flex gap-3 pt-2">
+          <button type="button" onClick={onClose} disabled={saving}
+            className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
+            Cancel
+          </button>
+          <button type="submit" disabled={saving}
+            className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
+            {saving ? 'Saving…' : 'Create App'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+
+function EditAppModal({ detail, profileNameById, onClose, onSaved, onDeleted }: {
+  detail: AppDetail
+  profileNameById: Map<number, string>
+  onClose: () => void
+  onSaved: () => void | Promise<void>
+  onDeleted: () => void | Promise<void>
+}) {
+  const [form, setForm] = useState<EditFormState>(() => detailToForm(detail))
+  const [newHost, setNewHost] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  const assignedProfiles = useMemo(() => {
+    const ids = new Set(detail.assignments.map(a => a.profileId))
+    return [...ids].map(id => profileNameById.get(id) ?? `profile ${id}`)
+  }, [detail.assignments, profileNameById])
+
+  function addHosts() {
+    const additions = splitHosts(newHost)
+    if (additions.length === 0) return
+    setForm(f => ({
+      ...f,
+      hosts: [...new Set([...f.hosts, ...additions])],
+    }))
+    setNewHost('')
+  }
+
+  function removeHost(h: string) {
+    setForm(f => ({ ...f, hosts: f.hosts.filter(x => x !== h) }))
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form.name.trim()) { setError('Name is required'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      await api.apps.update(detail.app.id, {
+        name: form.name.trim(),
+        icon: form.icon.trim() || null,
+        templateId: detail.app.templateId,
+      })
+      await api.apps.setHosts(detail.app.id, form.hosts)
+      await onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save app')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function performDelete() {
+    setSaving(true)
+    setError(null)
+    try {
+      await api.apps.delete(detail.app.id)
+      await onDeleted()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to delete app')
+      setSaving(false)
+    }
+  }
+
+  // #768 — template host list lives on the starter-library track; until that
+  // ships we can only detect "has a template" via templateId. The button is
+  // visible-but-disabled with a tooltip explaining what it'll do once #768
+  // lands. Once #768 publishes a template-fetch endpoint, this should compare
+  // current hosts to the template's host list and only enable on divergence.
+  const hasTemplate = detail.app.templateId !== null
+
+  return (
+    <Modal title={`Edit ${detail.app.name}`} onClose={onClose}>
+      <form onSubmit={submit} className="space-y-5">
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-2">
+            {error}
+          </div>
+        )}
+        <Field label="Name" required>
+          <input
+            type="text" value={form.name} required
+            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500"
+          />
+        </Field>
+        <Field label="Icon (emoji, optional)">
+          <input
+            type="text" value={form.icon}
+            onChange={e => setForm(f => ({ ...f, icon: e.target.value }))}
+            placeholder="📺"
+            maxLength={4}
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white focus:outline-none focus:border-emerald-500"
+          />
+        </Field>
+        <Field label="Hosts">
+          <div className="flex flex-wrap gap-2 mb-3 min-h-[2rem]" data-testid="hosts-chips">
+            {form.hosts.length === 0 && (
+              <span className="text-xs text-gray-500 italic">No hosts yet.</span>
+            )}
+            {form.hosts.map(h => (
+              <span key={h} className="inline-flex items-center gap-1 bg-gray-800 text-emerald-300 text-xs font-mono px-2.5 py-1 rounded-lg">
+                {h}
+                <button
+                  type="button"
+                  onClick={() => removeHost(h)}
+                  aria-label={`Remove ${h}`}
+                  className="text-gray-500 hover:text-red-400 transition-colors leading-none"
+                >×</button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newHost}
+              onChange={e => setNewHost(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  addHosts()
+                }
+              }}
+              placeholder="example.com or *.example.com"
+              className="flex-1 bg-gray-950 border border-gray-700 rounded-xl px-4 py-2 text-white font-mono text-sm focus:outline-none focus:border-emerald-500"
+            />
+            <button
+              type="button"
+              onClick={addHosts}
+              className="px-4 py-2 rounded-xl bg-gray-800 text-gray-200 hover:bg-gray-700 text-sm font-medium"
+            >Add</button>
+          </div>
+        </Field>
+
+        {hasTemplate && (
+          <button
+            type="button"
+            disabled
+            title="Reset to template will be enabled once the starter library (#768) ships."
+            className="w-full py-2 rounded-xl bg-gray-800/60 text-gray-500 text-sm font-medium cursor-not-allowed"
+          >
+            Reset to template (requires #768)
+          </button>
+        )}
+
+        <div className="border-t border-gray-800 pt-4 space-y-3">
+          <p className="text-xs text-gray-500">
+            Used by {assignedProfiles.length === 0
+              ? <span className="text-gray-400">no profiles</span>
+              : <span className="text-gray-300">{assignedProfiles.join(', ')}</span>}.
+          </p>
+          {!confirmingDelete
+            ? (
+                <button
+                  type="button"
+                  onClick={() => setConfirmingDelete(true)}
+                  className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
+                >Delete app…</button>
+              )
+            : (
+                <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-3 space-y-3">
+                  {assignedProfiles.length > 0
+                    ? (
+                        <p className="text-sm text-red-200">
+                          This app is currently assigned to{' '}
+                          <strong>{assignedProfiles.length} profile{assignedProfiles.length === 1 ? '' : 's'}</strong>
+                          {' '}({assignedProfiles.join(', ')}).
+                          Deleting it will remove those assignments. Continue?
+                        </p>
+                      )
+                    : (
+                        <p className="text-sm text-red-200">
+                          Delete <strong>{detail.app.name}</strong>? This cannot be undone.
+                        </p>
+                      )}
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingDelete(false)}
+                      disabled={saving}
+                      className="flex-1 py-2 rounded-lg bg-gray-800 text-gray-300 text-sm font-medium disabled:opacity-50"
+                    >Cancel</button>
+                    <button
+                      type="button"
+                      onClick={performDelete}
+                      disabled={saving}
+                      className="flex-1 py-2 rounded-lg bg-red-500 text-white text-sm font-semibold disabled:opacity-50"
+                    >{saving ? 'Deleting…' : 'Delete'}</button>
+                  </div>
+                </div>
+              )}
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button type="button" onClick={onClose} disabled={saving}
+            className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
+            Close
+          </button>
+          <button type="submit" disabled={saving}
+            className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold disabled:opacity-50">
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+
+function Field({ label, required, children }: {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        {label} {required && <span className="text-red-400">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto" onClick={onClose}>
+      <div
+        className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-lg my-8 p-6 space-y-5 max-h-[90vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-white">{title}</h3>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -532,3 +532,49 @@ export interface CreateRouterResponse {
   name: string
   enrollmentToken: string
 }
+
+// ── Apps (#761/#762/#765) ──────────────────────────────────────────────────
+
+export type AppMode = 'blocked' | 'allowed' | 'time_limited'
+
+export interface App {
+  id: number
+  name: string
+  slug: string
+  templateId: number | null
+  icon: string | null
+  createdAt: string
+}
+
+export interface AppPolicyAssignment {
+  id: number
+  appId: number
+  profileId: number
+  mode: AppMode
+  dailyMinutes: number | null
+  exemptFromDaily: boolean
+}
+
+export interface AppDetail {
+  app: App
+  hosts: string[]
+  assignments: AppPolicyAssignment[]
+}
+
+export interface CreateAppRequest {
+  name: string
+  slug?: string
+  icon?: string | null
+  templateId?: number | null
+  hosts: string[]
+}
+
+export interface UpdateAppRequest {
+  name: string
+  icon?: string | null
+  templateId?: number | null
+}
+
+export interface SetAppHostsRequest {
+  hosts: string[]
+}


### PR DESCRIPTION
## Summary

- New admin-only `/apps` route (under the Advanced settings dropdown) that lists household apps with name, icon, host count, and number of profiles assigning each app. Click a row → edit. CTA opens a create modal.
- Create flow: name + emoji icon + initial hosts (comma/newline-separated text; the dedicated picker arrives in #766). Edit flow renames, changes icon, and edits the host set as removable chips (round-trips through `PUT /apps/:id` + `PUT /apps/:id/hosts`).
- Delete uses an inline confirm: when assignments exist, it names the profiles and warns they'll lose the assignment; otherwise a simpler "cannot be undone" prompt.
- Zero API / router changes — calls the CRUD endpoints that landed in #945. Wire types and `api.apps` added to the SPA client.

## Deliberately deferred

- **#766** recently-visited picker — placeholder text input today; the create/edit modals already shape data so the picker can drop in.
- **#767** per-profile assignment UI — apps still get assigned through whatever surface #767 builds; this PR only manages the apps themselves.
- **#768** starter-library template host list — "Reset to template" is rendered visible-but-disabled (with a tooltip) only when `templateId` is set; we'll wire the action once #768 publishes a template-fetch endpoint.

## Test plan

- [x] `npx vitest run AppsPage` — 6 tests, all pass (list with counts, empty state, create round-trip, edit round-trip with chip add/remove + rename, delete-with-assignments warning, delete-without-assignments confirm).
- [x] Full web suite: `npx vitest run` — 204/204 passing.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: launch in browser, walk create → edit → delete on a live API.

> Screenshots: pending — local dev server not started in this run; manual smoke recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)