### PR TITLE
feat(web+api): screen-time drill-down — per-profile group-by + 'other' breakdown (#964)

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -72,7 +72,9 @@ object UsageRoutes {
               .flatMap(_.toIntOption)
               .getOrElse(5)
               .max(1)
-              .min(20)
+              // #964: cap bumped from 20 → 500 so the per-device 'other'
+              // drill-in can request the full long-tail of hosts in one shot.
+              .min(500)
             resp <- (macOpt, profileIdOpt) match {
               case (Some(mac), _) =>
                 buildForDevice(

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -207,6 +207,36 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(h10.perHost.length == 2) &&
           assertTrue(h10.otherMins == 25) // 5 hosts × 5 min
       },
+      test("topN=500 returns the full long-tail unaggregated (#964 drill-in)") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // 30 distinct hosts — comfortably more than the prior cap of 20 and
+          // well below the new cap of 500. With topN=500 every host should be
+          // surfaced in topHosts (the prior 20-cap would have truncated to 20).
+          _  <- ZIO.foreachDiscard(0 until 30) { i =>
+            insertRow(routerId, testMac, s"host$i.com", today, 10, (i % 12) * 5)
+          }
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today&topN=500").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Prior cap (.min(20)) would have capped this at 20 — the bump to 500
+          // is what enables the per-device 'other' drill-in to see the full tail.
+          assertTrue(out.topHosts.length == 30)
+      },
       test("tz parameter buckets by local-hour") {
         for {
           _           <- cleanDb

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -273,13 +273,6 @@ export const api = {
     now: () => req<DashboardNow>('GET', '/dashboard/now'),
   },
 
-  // ── Apps (#769 surfaces the empty-state on group-by=app) ───────────────
-  // Minimal client: just enough to detect "no apps exist yet" so the
-  // group-by=app empty-state can point the operator at #765's /apps screen.
-  apps: {
-    list: () => req<Array<{ app: { id: number; name: string; slug: string } }>>('GET', '/apps'),
-  },
-
   // ── Blocklists ─────────────────────────────────────────────────────────
   blocklists: {
     counts: () => req<{ category: string; count: number }[]>('GET', '/blocklists'),

--- a/web/src/components/usage/UsageHourlyBarChart.tsx
+++ b/web/src/components/usage/UsageHourlyBarChart.tsx
@@ -41,10 +41,16 @@ interface Props {
   series: ChartSeries[]   // named stacks (top-N). "Other" is rendered as a final stack if any row has __other > 0.
   showLegend?: boolean
   legendFormatter?: (name: string) => string
+  // #964 — when set, the "Other" bar + legend entry become click targets
+  // (cursor=pointer, dotted underline) so the per-device page can pop a
+  // drill-in showing what's in the long-tail bucket.
+  onOtherClick?: () => void
   testId?: string
 }
 
-export function UsageHourlyBarChart({ rows, series, showLegend = false, legendFormatter, testId }: Props) {
+export function UsageHourlyBarChart({ rows, series, showLegend = false, legendFormatter, onOtherClick, testId }: Props) {
+  const hasOther = rows.some(r => Number(r[OTHER_KEY] ?? 0) > 0)
+  const otherClickable = !!onOtherClick && hasOther
   return (
     <div data-testid={testId} className="h-72 -ml-2">
       <ResponsiveContainer width="100%" height="100%">
@@ -84,13 +90,35 @@ export function UsageHourlyBarChart({ rows, series, showLegend = false, legendFo
             <Legend
               iconType="square"
               wrapperStyle={{ fontSize: 12, color: '#9ca3af', paddingTop: 8 }}
-              formatter={(n: string) => (n === OTHER_KEY ? 'Other' : (legendFormatter ? legendFormatter(n) : n))}
+              formatter={(n: string) => {
+                if (n === OTHER_KEY) {
+                  return otherClickable ? (
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      data-testid="usage-chart-other-legend"
+                      onClick={(e) => { e.stopPropagation(); onOtherClick?.() }}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onOtherClick?.() } }}
+                      className="cursor-pointer underline decoration-dotted underline-offset-2"
+                      title="See the hosts inside the Other bucket"
+                    >Other ↗</span>
+                  ) : 'Other'
+                }
+                return legendFormatter ? legendFormatter(n) : n
+              }}
             />
           )}
           {series.map(s => (
             <Bar key={s.key} dataKey={s.key} stackId="stacks" fill={s.color} name={s.name} />
           ))}
-          <Bar dataKey={OTHER_KEY} stackId="stacks" fill={OTHER_COLOR} name="Other" />
+          <Bar
+            dataKey={OTHER_KEY}
+            stackId="stacks"
+            fill={OTHER_COLOR}
+            name="Other"
+            cursor={otherClickable ? 'pointer' : undefined}
+            onClick={otherClickable ? () => onOtherClick?.() : undefined}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/web/src/pages/DeviceTimelinePage.test.tsx
+++ b/web/src/pages/DeviceTimelinePage.test.tsx
@@ -127,6 +127,92 @@ describe('DeviceTimelinePage', () => {
     expect(mock.mock.calls[0][0]).toMatchObject({ mac: MAC, date: '2026-05-15' })
   })
 
+  describe('"Other" drill-in (#964)', () => {
+    function withOtherResponse(date: string): UsageSeriesResponse {
+      // Top-5 covers the first 5 hosts; the long-tail (hosts 6-9) gets
+      // folded into otherMins on the chart. A drill-in fetch with topN=500
+      // should return all 9 hosts.
+      const top5 = Array.from({ length: 5 }, (_, i) => ({
+        host: { type: 'fqdn' as const, value: `top${i}.com` },
+        dayMins: 50 - i,
+      }))
+      return {
+        deviceMac: MAC,
+        deviceName: "Kid's iPad",
+        date,
+        tz: 'UTC',
+        topHosts: top5,
+        buckets: Array.from({ length: 24 }, (_, hour) => ({
+          hour,
+          totalMins: hour === 14 ? 50 : 0,
+          perHost: hour === 14 ? top5.map(h => ({ host: h.host, mins: 8 })) : [],
+          // Force a non-zero Other bucket so the drill-in affordance renders.
+          otherMins: hour === 14 ? 10 : 0,
+        })),
+      }
+    }
+    function withAllHostsResponse(date: string): UsageSeriesResponse {
+      const all = [
+        ...Array.from({ length: 5 }, (_, i) => ({
+          host: { type: 'fqdn' as const, value: `top${i}.com` },
+          dayMins: 50 - i,
+        })),
+        ...Array.from({ length: 4 }, (_, i) => ({
+          host: { type: 'fqdn' as const, value: `tail${i}.com` },
+          dayMins: 6 - i, // 6, 5, 4, 3 — sorted desc
+        })),
+      ]
+      return {
+        deviceMac: MAC,
+        deviceName: "Kid's iPad",
+        date,
+        tz: 'UTC',
+        topHosts: all,
+        buckets: Array.from({ length: 24 }, (_, hour) => ({
+          hour, totalMins: 0, perHost: [], otherMins: 0,
+        })),
+      }
+    }
+
+    it('shows the affordance only when Other > 0 and opens a modal with the long-tail', async () => {
+      const mock = api.usage.series as unknown as ReturnType<typeof vi.fn>
+      // First call (initial render): top-5 + otherMins. Second call (drill-in
+      // fetch with topN=500): the full unaggregated list.
+      mock
+        .mockResolvedValueOnce(withOtherResponse('2026-05-20'))
+        .mockResolvedValueOnce(withAllHostsResponse('2026-05-20'))
+
+      const user = userEvent.setup()
+      renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+      const button = await screen.findByTestId('device-timeline-other-button')
+
+      await user.click(button)
+
+      expect(screen.getByTestId('device-timeline-other-modal')).toBeInTheDocument()
+      // Second fetch goes out with the higher topN.
+      await waitFor(() => expect(mock).toHaveBeenCalledTimes(2))
+      expect(mock.mock.calls[1][0]).toMatchObject({ mac: MAC, date: '2026-05-20', topN: 500 })
+
+      // Long-tail rows render, top-5 do not.
+      await waitFor(() =>
+        expect(screen.getByTestId('device-timeline-other-host-tail0.com')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('device-timeline-other-host-tail3.com')).toBeInTheDocument()
+      expect(screen.queryByTestId('device-timeline-other-host-top0.com')).toBeNull()
+    })
+
+    it('hides the affordance when there is no Other bucket on any hour', async () => {
+      (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        emptyDayResponse('2026-05-20'),
+      )
+      renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+      await waitFor(() =>
+        expect(screen.getByTestId('device-timeline-empty')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('device-timeline-other-button')).toBeNull()
+    })
+  })
+
   describe('week toggle (#723)', () => {
     function richWeek(to: string): DeviceTimeStatusWeek {
       return {

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -19,6 +19,9 @@ import { groupBucketsByLocalDay, formatMins, localBucketOffsetMin } from './Time
 // the `to` anchor in Week mode.
 
 const TOP_N = 5
+// #964 — when the operator clicks the chart's "Other" bucket we refetch with
+// a much larger topN to surface the full long-tail. Server caps topN at 500.
+const DRILL_IN_TOP_N = 500
 const DEFAULT_TZ =
   Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
@@ -70,6 +73,10 @@ export function DeviceTimelinePage() {
   const [weekData, setWeekData] = useState<DeviceTimeStatusWeek | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [otherOpen, setOtherOpen] = useState(false)
+  const [otherLoading, setOtherLoading] = useState(false)
+  const [otherError, setOtherError] = useState<string | null>(null)
+  const [otherData, setOtherData] = useState<UsageSeriesResponse | null>(null)
 
   useEffect(() => {
     setLoading(true)
@@ -88,6 +95,21 @@ export function DeviceTimelinePage() {
   }
   function setDateAndPush(next: string)     { setDate(next);     pushParams({ date: next }) }
   function setWindowAndPush(next: Window)   { setWindow(next);   pushParams({ window: next }) }
+
+  function openOtherDrillIn() {
+    setOtherOpen(true)
+    setOtherError(null)
+    // Refetch with a high topN so every host (including the long-tail that
+    // got folded into "Other" at TOP_N=5) comes back unaggregated. The chart
+    // payload itself is left unchanged — we want the modal to be additive,
+    // not to swap the chart underneath the operator.
+    setOtherLoading(true)
+    api.usage
+      .series({ mac, date, tz: DEFAULT_TZ, topN: DRILL_IN_TOP_N })
+      .then(setOtherData)
+      .catch(e => setOtherError(e.message ?? 'Failed to load'))
+      .finally(() => setOtherLoading(false))
+  }
 
   const dayChart = useMemo(() => {
     if (!dayData) return { rows: [], series: [] as ChartSeries[] }
@@ -196,12 +218,28 @@ export function DeviceTimelinePage() {
               No usage recorded on {date}.
             </div>
           ) : (
-            <UsageHourlyBarChart
-              rows={dayChart.rows}
-              series={dayChart.series}
-              showLegend
-              testId="device-timeline-chart"
-            />
+            <>
+              <UsageHourlyBarChart
+                rows={dayChart.rows}
+                series={dayChart.series}
+                showLegend
+                onOtherClick={openOtherDrillIn}
+                testId="device-timeline-chart"
+              />
+              {dayChart.rows.some(r => Number(r[OTHER_KEY] ?? 0) > 0) && (
+                <div className="mt-2 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={openOtherDrillIn}
+                    data-testid="device-timeline-other-button"
+                    className="text-[11px] text-gray-500 hover:text-emerald-400 underline decoration-dotted underline-offset-2"
+                    title="See the hosts inside the Other bucket for this day"
+                  >
+                    Inside “Other” ↗
+                  </button>
+                </div>
+              )}
+            </>
           )
         ) : (
           weekEmpty ? (
@@ -302,6 +340,129 @@ export function DeviceTimelinePage() {
           </p>
         </div>
       )}
+
+      {otherOpen && (
+        <OtherDrillInModal
+          date={date}
+          loading={otherLoading}
+          error={otherError}
+          data={otherData}
+          topN={TOP_N}
+          onClose={() => setOtherOpen(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+// #964 — "Other" drill-in modal. Lists the long-tail hosts that the top-N
+// chart folded into the Other bucket for the selected day. Reuses the same
+// /api/usage/series endpoint with a much larger topN so the SPA can subtract
+// the displayed top-N off the front and show the rest, sorted by minutes desc.
+interface OtherDrillInModalProps {
+  date: string
+  loading: boolean
+  error: string | null
+  data: UsageSeriesResponse | null
+  topN: number
+  onClose: () => void
+}
+
+function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherDrillInModalProps) {
+  const tail = (data?.topHosts ?? []).filter(h => h.dayMins > 0).slice(topN)
+  const otherTotal = tail.reduce((a, h) => a + h.dayMins, 0)
+  const grandTotal = (data?.topHosts ?? []).reduce((a, h) => a + h.dayMins, 0)
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="other-drillin-title"
+      data-testid="device-timeline-other-modal"
+      className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-lg p-6 space-y-4 max-h-[80vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 id="other-drillin-title" className="text-lg font-bold text-white">
+              Inside the “Other” bucket
+            </h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Hosts below the top {topN} on {date}.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 text-xl leading-none"
+            aria-label="Close"
+          >×</button>
+        </div>
+
+        {loading && (
+          <div className="text-sm text-gray-500" data-testid="device-timeline-other-loading">
+            Loading the long-tail…
+          </div>
+        )}
+        {error && (
+          <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-sm rounded-xl px-4 py-3">
+            {error}
+          </div>
+        )}
+        {!loading && !error && tail.length === 0 && (
+          <div
+            data-testid="device-timeline-other-empty"
+            className="text-sm text-gray-500"
+          >
+            Nothing else recorded for this day — the top {topN} already cover everything.
+          </div>
+        )}
+        {!loading && !error && tail.length > 0 && (
+          <ul className="space-y-1 overflow-y-auto pr-1 -mr-1">
+            {tail.map(h => {
+              const isIp = h.host.type !== 'fqdn'
+              const shareOther = otherTotal > 0 ? (h.dayMins / otherTotal) * 100 : 0
+              const shareTotal = grandTotal > 0 ? (h.dayMins / grandTotal) * 100 : 0
+              return (
+                <li
+                  key={`${h.host.type}:${h.host.value}`}
+                  data-testid={`device-timeline-other-host-${h.host.value}`}
+                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2 gap-2"
+                >
+                  <span
+                    className={`font-mono truncate min-w-0 ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
+                    title={h.host.value}
+                  >
+                    {h.host.value}
+                    {isIp && (
+                      <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
+                        {h.host.type}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-gray-500 font-mono shrink-0 tabular-nums">
+                    {formatMins(h.dayMins)}
+                    <span className="text-gray-600 ml-2">
+                      {shareOther.toFixed(0)}% of Other · {shareTotal.toFixed(0)}% of day
+                    </span>
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        <div className="pt-2">
+          <button
+            onClick={onClose}
+            className="w-full py-2.5 rounded-xl bg-gray-800 text-gray-300 text-sm font-medium hover:bg-gray-700 transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/ProfileTimelinePage.test.tsx
+++ b/web/src/pages/ProfileTimelinePage.test.tsx
@@ -117,7 +117,7 @@ describe('ProfileTimelinePage', () => {
     expect(screen.getByTestId('profile-timeline-name')).toHaveTextContent('Kids')
   })
 
-  it('renders host stack by default, switches to device stack on toggle', async () => {
+  it('defaults to Total (no drill-down): chart visible, devices listed, no hosts panel', async () => {
     (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       richResponse('2026-05-20'),
     )
@@ -125,17 +125,46 @@ describe('ProfileTimelinePage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
     )
-    // Default: host stack visible, top-hosts list shown.
-    expect(screen.getByTestId('profile-timeline-host-youtube.com')).toBeInTheDocument()
+    // Total default: device list still visible (useful for drill-in), but the
+    // host breakdown panel is hidden because the chart is not stacked by host.
+    expect(screen.getByTestId('profile-timeline-stack-total')).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument()
+    expect(screen.queryByTestId('profile-timeline-host-youtube.com')).toBeNull()
+  })
+
+  it('toggles between Total, Host, and Device; updates the visible breakdown', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/time/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
+    )
+
+    fireEvent.click(screen.getByTestId('profile-timeline-stack-host'))
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-host-youtube.com')).toBeInTheDocument(),
+    )
     expect(screen.queryByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeNull()
 
     fireEvent.click(screen.getByTestId('profile-timeline-stack-device'))
-
-    // After toggle: device list visible, host list gone.
     await waitFor(() =>
       expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument(),
     )
     expect(screen.queryByTestId('profile-timeline-host-youtube.com')).toBeNull()
+  })
+
+  it('disables the App toggle with a tooltip until #769 lands', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/time/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
+    )
+    const appBtn = screen.getByTestId('profile-timeline-stack-app')
+    expect(appBtn).toBeDisabled()
+    expect(appBtn).toHaveAttribute('title')
   })
 
   it('reads stackBy=device from URL', async () => {

--- a/web/src/pages/ProfileTimelinePage.tsx
+++ b/web/src/pages/ProfileTimelinePage.tsx
@@ -10,16 +10,46 @@ import {
 } from '@/components/usage/UsageHourlyBarChart'
 
 // #722 — per-profile daily timeline. Hourly stacked-bar chart of minutes-of-use
-// across all of a profile's devices, with a stack-by toggle (device | host)
-// that switches which dimension drives the stacks. Colors are derived from a
-// stable index of the top-N entries so the same host (or device) keeps its
-// color across re-renders.
+// across all of a profile's devices, with a stack-by toggle that switches which
+// dimension drives the stacks. Colors are derived from a stable index of the
+// top-N entries so the same host (or device) keeps its color across re-renders.
+//
+// #964 — group-by options expanded to {total, host, device, app}. Default is
+// `total` (no drill-down, single bar per hour = profile total) to match the
+// strictly-additive aggregation model from #917. `app` is gated until the apps
+// chain (#769) extends /api/usage/series; rendered as disabled with a tooltip.
 
 const TOP_N = 5
 const DEFAULT_TZ =
   Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
-type StackBy = 'host' | 'device'
+type StackBy = 'total' | 'host' | 'device' | 'app'
+
+const STACK_BY_OPTIONS: ReadonlyArray<{
+  key: StackBy
+  label: string
+  disabled?: boolean
+  title?: string
+}> = [
+  { key: 'total',  label: 'Total' },
+  { key: 'host',   label: 'Host' },
+  { key: 'device', label: 'Device' },
+  {
+    key: 'app',
+    label: 'App',
+    disabled: true,
+    title: 'Grouping by app requires the apps chain (#769) — coming soon.',
+  },
+]
+
+function parseStackBy(s: string | null): StackBy {
+  switch (s) {
+    case 'host':   return 'host'
+    case 'device': return 'device'
+    // 'app' isn't selectable yet — fall through to total.
+    default:       return 'total'
+  }
+}
 
 function todayISO(): string {
   const d = new Date()
@@ -70,7 +100,7 @@ export function ProfileTimelinePage() {
   const [params, setParams] = useSearchParams()
 
   const initialDate = params.get('date') ?? todayISO()
-  const initialStack = (params.get('stackBy') === 'device' ? 'device' : 'host') as StackBy
+  const initialStack = parseStackBy(params.get('stackBy'))
   const [date, setDate]       = useState<string>(initialDate)
   const [stackBy, setStackBy] = useState<StackBy>(initialStack)
   const [data, setData]       = useState<UsageSeriesResponse | null>(null)
@@ -110,7 +140,7 @@ export function ProfileTimelinePage() {
         key: k, name: k, color: HOST_COLORS[i % HOST_COLORS.length],
       }))
       return { rows: buildHostRows(data.buckets, keys), series }
-    } else {
+    } else if (stackBy === 'device') {
       const top = (data.topDevices ?? []).filter(d => d.dayMins > 0)
       const keys = top.map(d => d.deviceMac)
       const series: ChartSeries[] = top.map((d, i) => ({
@@ -118,12 +148,26 @@ export function ProfileTimelinePage() {
       }))
       const rows = buildDeviceRows(data.bucketsByDevice ?? [], keys)
       return { rows, series }
+    } else {
+      // total — single stack per hour = profile total, no drill-down. Reuse
+      // the host-mode buckets (totalMins is identical across both bucket
+      // arrays since they're aggregations of the same source rows).
+      const rows = data.buckets.map(b => ({
+        hour: String(b.hour).padStart(2, '0'),
+        total: b.totalMins,
+        __total: b.totalMins,
+        [OTHER_KEY]: 0,
+      })) as { hour: string; total: number; [k: string]: number | string }[]
+      const series: ChartSeries[] = [
+        { key: '__total', name: 'Total', color: HOST_COLORS[0] },
+      ]
+      return { rows, series }
     }
   }, [data, stackBy])
 
   if (loading && !data) return <PageLoader />
 
-  const buckets = stackBy === 'host' ? data?.buckets : data?.bucketsByDevice
+  const buckets = stackBy === 'device' ? data?.bucketsByDevice : data?.buckets
   const dayTotal = buckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
   const isEmpty  = dayTotal === 0
 
@@ -172,20 +216,25 @@ export function ProfileTimelinePage() {
           </h2>
           <div className="flex items-center gap-3">
             <div className="inline-flex rounded-lg bg-gray-800 p-0.5 text-xs" role="tablist" aria-label="Stack by">
-              {(['host', 'device'] as StackBy[]).map(opt => (
+              {STACK_BY_OPTIONS.map(opt => (
                 <button
-                  key={opt}
+                  key={opt.key}
                   role="tab"
-                  aria-selected={stackBy === opt}
-                  data-testid={`profile-timeline-stack-${opt}`}
-                  onClick={() => setStackAndPush(opt)}
+                  aria-selected={stackBy === opt.key}
+                  aria-disabled={opt.disabled || undefined}
+                  disabled={opt.disabled}
+                  title={opt.title}
+                  data-testid={`profile-timeline-stack-${opt.key}`}
+                  onClick={() => { if (!opt.disabled) setStackAndPush(opt.key) }}
                   className={`px-3 py-1.5 rounded-md font-medium transition-colors ${
-                    stackBy === opt
+                    stackBy === opt.key
                       ? 'bg-emerald-500 text-black'
-                      : 'text-gray-400 hover:text-gray-200'
+                      : opt.disabled
+                        ? 'text-gray-600 cursor-not-allowed'
+                        : 'text-gray-400 hover:text-gray-200'
                   }`}
                 >
-                  {opt === 'host' ? 'Host' : 'Device'}
+                  {opt.label}
                 </button>
               ))}
             </div>
@@ -206,7 +255,7 @@ export function ProfileTimelinePage() {
           <UsageHourlyBarChart
             rows={chart.rows}
             series={chart.series}
-            showLegend
+            showLegend={stackBy !== 'total'}
             // The chart receives device-mac keys when stack-by=device; map them
             // back to friendly names so the legend reads "Kid's iPad" not the mac.
             legendFormatter={stackBy === 'device'
@@ -267,7 +316,7 @@ export function ProfileTimelinePage() {
         </div>
       )}
 
-      {data && stackBy === 'device' && (data.topDevices ?? []).length > 0 && (
+      {data && (stackBy === 'device' || stackBy === 'total') && (data.topDevices ?? []).length > 0 && (
         <div className="bg-gray-900 rounded-2xl border border-gray-800 p-5">
           <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
             Devices


### PR DESCRIPTION
Closes #964.

## Summary
- **Per-profile timeline**: stack-by toggle gains **Total** (new default = no drill-down, single bar per hour = profile total) and **App** (disabled with tooltip until #769 extends `/api/usage/series`). Host and Device still work. Matches the strictly-additive aggregation model from #917.
- **Per-device timeline**: the chart's **Other** bucket is now drillable. The Other legend entry + bar are click targets, and a small \"Inside Other ↗\" button renders below the chart whenever any hour has Other > 0. Opens a modal that refetches `/api/usage/series` with `topN=500`, then lists the long-tail hosts sorted by minutes desc with share-of-Other and share-of-day.
- **API**: `/api/usage/series` `topN` cap raised 20 → 500 so the drill-in can pull the full long-tail in one request — no new endpoint surface.
- **Drive-by fix**: removed a duplicate `api.apps` block in `web/src/api/client.ts` left behind by the #769/#765 merge collision (`tsc --noEmit` was failing on main for every branch).

## API endpoints touched
- `GET /api/usage/series` — `topN` max bumped 20 → 500. Default unchanged (5). No wire-shape change otherwise.

## Design decisions
- **Modal, not expand**, for the Other drill-in: matches the household app's existing modal pattern (TimePage extension modal, AppsPage edit dialog). Expanding a row would have to live on the per-host list which is the *displayed* top-N, not the long-tail — semantically off.
- **Reuse `groupBy=host`-equivalent path with high `topN`** rather than adding `/api/usage/other-hosts`: smaller surface area, exact same data, server already aggregates correctly for any topN.
- **Total mode reuses `data.buckets[].totalMins`** rather than a separate API call — `totalMins` is identical across `buckets` and `bucketsByDevice` for the same day.
- **Device list panel renders in Total mode too** — the operator's natural drill-in path from a Total view is \"which device contributed this?\" so keep the device links visible.

## Coordination
- **#917 (additive aggregation)**: Total is now the explicit identity element — toggling Host or Device drills in (more rows), toggling back collapses. Matches the column-toggle model on Traffic Usage / Connection Events.
- **#769 (apps chain)**: `/api/usage/series` doesn't yet accept `groupBy=app`. The App button is rendered but `disabled` with a tooltip pointing at #769. When #769 lands, drop the `disabled` flag in `STACK_BY_OPTIONS` and wire the request branch.
- **#778 (Other threshold)**: complementary, not blocked by — #778 should still tune top-N; this PR adds visibility into whatever falls below it.

## Test plan
- [x] `mill api.test` — 54 tests pass, includes new UsageApiSpec case asserting `topN=500` returns 30 distinct hosts (prior 20 cap would have truncated).
- [x] `mill shared.test` — 36 tests pass.
- [x] `web` vitest (focused: ProfileTimelinePage + DeviceTimelinePage) — 13 tests pass, including 3 new ProfileTimelinePage cases (Total default, full toggle cycle, disabled App) and 2 new DeviceTimelinePage cases (drill-in opens + refetches with topN=500, affordance hidden when no Other).
- [x] Full `web` vitest run — 210 tests, all green.
- [x] `tsc --noEmit` clean (after the drive-by client.ts dedup).
- [ ] **Manual prod-shape walkthrough deferred to operator**: I did not run the Chrome connector against `wifihaven.net` for before/after screenshots — operator should spot-check the dev SPA once this lands and confirm the drill-in modal layout on a profile with a fat Other bucket (Kids profile, school day).

## Out of scope
- Per-host drill into *specific hour windows* (this PR drills into the full day; per-hour click-through is a separate UX).
- Migrating to `groupBy=` query param on `/api/usage/series` (different wire model than `/api/usage/traffic`; consolidation can come with #769).

🤖 Generated with [Claude Code](https://claude.com/claude-code)