### PR TITLE
dx(vm): friendlier client-base-missing error + opt-in autobuild

### DIFF
--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -46,8 +46,30 @@ if [[ ! "${MAC}" =~ ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$ ]]; then
   exit 2
 fi
 if [[ ! -f "${WH_CLIENT_BASE_IMG}" ]]; then
-  echo "client-up.sh: base image missing — run scripts/vm/build-client-base.sh first" >&2
-  exit 1
+  if [[ "${WH_AUTOBUILD_CLIENT_BASE:-0}" == "1" ]]; then
+    echo "client-up.sh: base image missing — auto-building (WH_AUTOBUILD_CLIENT_BASE=1, ~5 min)" >&2
+    "${HERE}/build-client-base.sh"
+  else
+    {
+      echo "client-up.sh: base image missing."
+      echo "  Build it:    scripts/vm/build-client-base.sh   (~5 min)"
+      echo "  Auto-build:  re-run with WH_AUTOBUILD_CLIENT_BASE=1"
+      sibling=""
+      if command -v git >/dev/null 2>&1; then
+        while IFS= read -r line; do
+          [[ "${line}" == "worktree "* ]] || continue
+          cand="${line#worktree }/scripts/vm/.cache/client-base.qcow2"
+          if [[ -f "${cand}" && "${cand}" != "${WH_CLIENT_BASE_IMG}" ]]; then
+            sibling="${cand}"; break
+          fi
+        done < <(git -C "${HERE}" worktree list --porcelain 2>/dev/null)
+      fi
+      if [[ -n "${sibling}" ]]; then
+        echo "  Or reuse:    mkdir -p '${WH_CACHE_DIR}' && ln -s '${sibling}' '${WH_CLIENT_BASE_IMG}'"
+      fi
+    } >&2
+    exit 1
+  fi
 fi
 if ! ip link show "${WH_LAN_BRIDGE}" >/dev/null 2>&1; then
   echo "client-up.sh: LAN bridge '${WH_LAN_BRIDGE}' does not exist." >&2


### PR DESCRIPTION
## Summary
- `scripts/vm/client-up.sh` now prints an actionable hint instead of a dead-end when `client-base.qcow2` is missing: build command, autobuild env var, and — if a sibling git worktree already has one — a ready-to-paste `ln -s`.
- New opt-in `WH_AUTOBUILD_CLIENT_BASE=1` invokes `build-client-base.sh` in place. The build script is already idempotent and the Alpine version is pinned in `config.sh`, so sibling base images are byte-identical and safe to symlink.
- Sibling discovery uses `git worktree list --porcelain`, so it works regardless of worktree layout.

## Test plan
- [x] `bash -n scripts/vm/client-up.sh`
- [x] Run on a worktree with no `.cache/client-base.qcow2`: error lists build / autobuild / sibling-reuse options, and the sibling `ln -s` points at an actual neighbor's image.
- [ ] Verify `WH_AUTOBUILD_CLIENT_BASE=1 scripts/vm/client-up.sh --mac …` triggers the build on a clean worktree.
- [ ] Existing flow (base image already present) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)