### PR TITLE
feat(api): filter multicast destinations from Connection Events default view (#969)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -44,6 +44,11 @@ case class LogFilter(
     cursorId: Option[Long] = None,
     cursorWs: Option[String] = None,
     cursorKey: Option[String] = None,
+    // #969: when false (default), drop rows whose destination is IPv4 multicast
+    // (224.0.0.0/4), IPv4 broadcast (255.255.255.255), or IPv6 multicast
+    // (ff00::/8) from both the raw and aggregated views. Operators can pass
+    // ?includeMulticast=true to see them for diagnostics.
+    includeMulticast: Boolean = false,
 )
 
 case class TrafficRollupFilter(
@@ -1398,6 +1403,26 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
 
   // ── Dashboard / log API ──────────────────────────────────────────────────
 
+  // #969: SSDP / UPnP discovery (239.255.255.250) and the rest of the IPv4
+  // multicast range, IPv4 broadcast, and IPv6 multicast aren't real per-device
+  // connections an operator can act on. Filter pre-aggregation in both /api/logs
+  // and /series so counts stay correct. The router-side fix is deferred behind
+  // Gate 2 (#654); until then, this read-side filter is the floor.
+  //
+  // host_type is a strict enum ('fqdn'|'ipv4'|'ipv6') so the regex/literal
+  // checks only run on the relevant variant — fqdn rows short-circuit cheaply.
+  // We filter on the raw ce.host_value (the actual destination on the wire),
+  // not the resolved FQDN: a multicast IP that somehow got a resolved name is
+  // still a multicast packet.
+  private val multicastFilterSql: Fragment =
+    fr"""AND NOT (
+           (ce.host_type = 'ipv4' AND (
+             ce.host_value ~ '^(22[4-9]|23[0-9])\.'
+             OR ce.host_value = '255.255.255.255'
+           ))
+           OR (ce.host_type = 'ipv6' AND ce.host_value ~* '^ff')
+         )"""
+
   def query(f: LogFilter) = {
     // location is sourced from routers.name until routers.location lands (#136)
     // #720: coalesce resolved_host_value into the returned host tuple so
@@ -1441,7 +1466,8 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       fr"AND COALESCE(ce.resolved_host_value, ce.host_value) ILIKE ${s"%$d%"}",
     )
     val byLoc  = f.location.fold(fr"")(l => fr"AND r.name = $l")
-    (base ++ window ++ byCur ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++
+    val byMc   = if (f.includeMulticast) fr"" else multicastFilterSql
+    (base ++ window ++ byCur ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++ byMc ++
       fr"ORDER BY ce.ts DESC, ce.id DESC LIMIT ${f.limit}")
       .query[
         (
@@ -1607,6 +1633,7 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       fr"AND COALESCE(ce.resolved_host_value, ce.host_value) ILIKE ${s"%$d%"}",
     )
     val byLoc   = f.location.fold(fr"")(l => fr"AND r.name = $l")
+    val byMc    = if (f.includeMulticast) fr"" else multicastFilterSql
     // #862: keyset cursor on (window_start DESC, group_key ASC). HAVING uses
     // the full window/groupkey expressions (PG doesn't allow SELECT aliases
     // in HAVING).
@@ -1628,7 +1655,7 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     val orderBy =
       if (groupKeyParts.isEmpty) fr"ORDER BY window_start DESC"
       else fr"ORDER BY window_start DESC, " ++ groupKeyExpr ++ fr" ASC"
-    (base ++ window ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++
+    (base ++ window ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++ byMc ++
       fr"GROUP BY " ++ groupByCols ++ fr" " ++ having ++
       orderBy ++ fr"LIMIT ${f.limit}")
       .query[

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1162,6 +1162,7 @@ object LogRoutes {
               until = untilOpt,
               cursorTs = cursorOpt.map(_.ts),
               cursorId = cursorOpt.map(_.id),
+              includeMulticast = req.url.queryParam("includeMulticast").contains("true"),
             )
             logs    <- connRepo.query(filter).mapError(ErrorMapper.dbErrorToResponse)
             visible <- filterLogs(claims, logs, userProfileRepo)
@@ -1240,6 +1241,7 @@ object LogRoutes {
               until = untilOpt,
               cursorWs = cursorOpt.map(_.ws),
               cursorKey = cursorOpt.map(_.key),
+              includeMulticast = req.url.queryParam("includeMulticast").contains("true"),
             )
             rows <- connRepo
               .querySeries(filter, bucket.seconds, groupByCodes)

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -1212,5 +1212,137 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
         assertTrue(domains.distinct.length == 5) &&
         assertTrue(domains == domains.sorted) // group_key ASC ordering
     },
+    test("#969: GET /api/logs filters multicast/broadcast destinations by default") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:dd:ee:ff")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv4(IpAddress.unsafe("239.255.255.250")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv4(IpAddress.unsafe("224.0.0.251")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv4(IpAddress.unsafe("255.255.255.255")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv6(IpAddress.unsafe("ff02::fb")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        respDef <- getJson(routes, "/api/logs", token)
+        bodyDef <- respDef.body.asString
+        pageDef <- ZIO.fromEither(bodyDef.fromJson[QueryLogPage])
+        respInc <- getJson(routes, "/api/logs?includeMulticast=true", token)
+        bodyInc <- respInc.body.asString
+        pageInc <- ZIO.fromEither(bodyInc.fromJson[QueryLogPage])
+      } yield assertTrue(pageDef.rows.length == 1) &&
+        assertTrue(pageDef.rows.head.host.value == "youtube.com") &&
+        assertTrue(pageInc.rows.length == 5) &&
+        assertTrue(pageInc.rows.exists(_.host.value == "239.255.255.250")) &&
+        assertTrue(pageInc.rows.exists(_.host.value == "224.0.0.251")) &&
+        assertTrue(pageInc.rows.exists(_.host.value == "255.255.255.255")) &&
+        assertTrue(pageInc.rows.exists(_.host.value == "ff02::fb"))
+    },
+    test("#969: GET /api/connection-events/series filters multicast pre-aggregation by default") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(MacAddress.unsafe("aa:bb:cc:dd:ee:ff")),
+              HostId.Fqdn(Hostname.unsafe("youtube.com")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv4(IpAddress.unsafe("239.255.255.250")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+            ConnectionEventInsert(
+              routerId,
+              None,
+              HostId.IPv4(IpAddress.unsafe("239.255.255.250")),
+              None,
+              true,
+              "allowed",
+              recentTs,
+            ),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        respDef <- getJson(routes, "/api/connection-events/series?bucket=1h&groupBy=domain", token)
+        bodyDef <- respDef.body.asString
+        pageDef <- ZIO.fromEither(bodyDef.fromJson[ConnectionEventSeriesPage])
+        respInc <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1h&groupBy=domain&includeMulticast=true",
+          token,
+        )
+        bodyInc <- respInc.body.asString
+        pageInc <- ZIO.fromEither(bodyInc.fromJson[ConnectionEventSeriesPage])
+        defDomains = pageDef.rows.flatMap(_.groups.get("domain"))
+        incDomains = pageInc.rows.flatMap(_.groups.get("domain"))
+      } yield assertTrue(defDomains == List("youtube.com")) &&
+        assertTrue(incDomains.toSet == Set("youtube.com", "239.255.255.250")) &&
+        assertTrue(
+          pageInc.rows
+            .find(_.groups.get("domain").contains("239.255.255.250"))
+            .exists(_.countSucceeded == 2),
+        )
+    },
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
## Summary

- Connection Events was surfacing `(unassigned) → 239.255.255.250` rows (SSDP/UPnP discovery) and other multicast/broadcast destinations — noise that doesn't represent any household activity an operator can act on.
- Read-side filter applied pre-aggregation in both `/api/logs` and `/api/connection-events/series`, so aggregated counts also stay correct.
- Default-on; opt-out via `?includeMulticast=true` for diagnostics.

## Filtered ranges

The filter drops rows whose raw destination (`host_type` + `host_value`) is:
- IPv4 multicast: `224.0.0.0/4` (first octet 224–239), e.g. `239.255.255.250` SSDP, `224.0.0.251` mDNS
- IPv4 broadcast: `255.255.255.255`
- IPv6 multicast: `ff00::/8` (any address starting with `ff`)

Filter applied on `ce.host_value` (the wire destination), not on `resolved_host_value` — a multicast IP that somehow got a resolved name is still a multicast packet.

Implementation uses cheap regex/equality predicates on the TEXT column. `host_type` is a strict enum so FQDN rows short-circuit without touching the regex.

## Before / after (synthetic, the new test case in LogApiSpec)

Seed one FQDN row (`youtube.com`) plus four multicast/broadcast rows (`239.255.255.250`, `224.0.0.251`, `255.255.255.255`, `ff02::fb`).

| Query | Rows |
|---|---|
| `GET /api/logs` | 1 (only `youtube.com`) |
| `GET /api/logs?includeMulticast=true` | 5 (all of them) |
| `GET /api/connection-events/series?bucket=1h&groupBy=domain` | 1 domain (`youtube.com`) |
| `…&includeMulticast=true` | 2 domains, multicast group has `countSucceeded=2` |

## Opt-out

`?includeMulticast=true` on either endpoint bypasses the filter entirely.

## Router-side follow-up

A router-side filter (stop emitting conntrack events for multicast destinations) would shrink ingest volume but is **blocked on Gate 2 (#654)** per the router-freeze rule. Follow-up issue to be filed against this PR; will be commented onto #969.

## Test plan

- [x] `mill api.test` — 67 tests pass including the two new `#969` tests
- [x] `mill shared.test` — 36 tests pass
- [x] New: `#969: GET /api/logs filters multicast/broadcast destinations by default`
- [x] New: `#969: GET /api/connection-events/series filters multicast pre-aggregation by default`
- [x] FQDN rows (`youtube.com`) unaffected — covered by all pre-existing `/api/logs` and `/series` tests still passing
- [ ] Web tests skipped: pre-existing local-env vitest/vite ESM loader failure reproduces on `main` without my changes; no web files touched in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)