### PR TITLE
feat(web): surface apps in per-profile limit UI (#767)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,7 +5,7 @@ import type {
   ConnectionEventSeriesPage, QueryLogPage,
   RouterSummary, SetAppHostsRequest, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
-  UpdateAppRequest, UpdateHouseholdSettingsRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
+  UpdateAppRequest, UpdateHouseholdSettingsRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
 } from '@/types/api'
 
@@ -300,6 +300,10 @@ export const api = {
     delete: (id: number) => req<void>('DELETE', `/apps/${id}`),
     setHosts: (id: number, hosts: string[]) =>
       req<void>('PUT', `/apps/${id}/hosts`, { hosts } as SetAppHostsRequest),
+    setPolicy: (id: number, profileId: number, data: UpsertAppAssignmentRequest) =>
+      req<void>('PUT', `/apps/${id}/policy/${profileId}`, data),
+    deletePolicy: (id: number, profileId: number) =>
+      req<void>('DELETE', `/apps/${id}/policy/${profileId}`),
   },
 
   // ── Routers (admin) ────────────────────────────────────────────────────

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -26,6 +26,11 @@ vi.mock('@/api/client', () => ({
     household: {
       get: vi.fn(),
     },
+    apps: {
+      list: vi.fn(),
+      setPolicy: vi.fn(),
+      deletePolicy: vi.fn(),
+    },
   },
 }))
 
@@ -114,6 +119,9 @@ beforeEach(() => {
     dailyResetTime: '00:00',
     dailyResetTz: 'America/Los_Angeles',
   })
+  ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  ;(api.apps.setPolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.apps.deletePolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 })
 
 describe('ProfilesPage — list', () => {
@@ -482,5 +490,125 @@ describe('ProfilesPage — highlight from ?id= (#298)', () => {
     renderPage()
     const card = await screen.findByTestId('profile-card-1')
     expect(card.className).not.toContain('ring-emerald-500')
+  })
+})
+
+describe('ProfilesPage — apps section (#767)', () => {
+  const youtube = {
+    app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '📺', createdAt: '2026-01-01' },
+    hosts: ['youtube.com'],
+    assignments: [] as { id: number; appId: number; profileId: number; mode: 'blocked'|'allowed'|'time_limited'; dailyMinutes: number|null; exemptFromDaily: boolean }[],
+  }
+  const tiktok = {
+    app: { id: 51, name: 'TikTok', slug: 'tiktok', templateId: null, icon: '🎵', createdAt: '2026-01-01' },
+    hosts: ['tiktok.com', 'www.tiktok.com'],
+    assignments: [
+      { id: 1, appId: 51, profileId: 1, mode: 'blocked' as const, dailyMinutes: null, exemptFromDaily: true },
+    ],
+  }
+
+  it('empty state with link to /apps when no apps exist', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const section = await screen.findByTestId('apps-section')
+    expect(within(section).getByText(/No apps yet/i)).toBeInTheDocument()
+    expect(within(section).getByTestId('apps-section-empty-link')).toHaveAttribute('href', '/apps')
+  })
+
+  it('renders one row per app and reflects current assignment', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube, tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await screen.findByTestId('app-row-50')
+    expect(screen.getByTestId('app-row-51')).toBeInTheDocument()
+    // TikTok is currently blocked for profile 1; the block button shows checked state.
+    const tiktokBlock = screen.getByTestId('app-row-51-block')
+    expect(tiktokBlock.textContent).toMatch(/✓/)
+  })
+
+  it('clicking block calls setPolicy with mode=blocked', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(await screen.findByTestId('app-row-50-block'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'blocked', dailyMinutes: null }),
+    )
+  })
+
+  it('clicking allow calls setPolicy with mode=allowed', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(await screen.findByTestId('app-row-50-allow'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'allowed', dailyMinutes: null }),
+    )
+  })
+
+  it('time-limit requires positive minutes; rejects empty', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(await screen.findByTestId('app-row-50-time-limit'))
+    expect(api.apps.setPolicy).not.toHaveBeenCalled()
+    expect(await screen.findByTestId('app-row-50-error')).toHaveTextContent(/minutes > 0/i)
+  })
+
+  it('time-limit with minutes calls setPolicy with mode=time_limited + dailyMinutes', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const input = await screen.findByTestId('app-row-50-minutes')
+    await user.type(input, '45')
+    await user.click(screen.getByTestId('app-row-50-time-limit'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'time_limited', dailyMinutes: 45 }),
+    )
+  })
+
+  it('clearing an assigned app calls deletePolicy', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await user.click(await screen.findByTestId('app-row-51-clear'))
+    await waitFor(() =>
+      expect(api.apps.deletePolicy).toHaveBeenCalledWith(51, 1),
+    )
+  })
+
+  it('for a brand-new profile, shows save-first hint instead of rows', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByText('Kids')
+    await user.click(screen.getByRole('button', { name: /\+ New Profile/ }))
+    const section = await screen.findByTestId('apps-section')
+    expect(within(section).getByText(/Save this profile first to assign apps/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('app-row-50')).not.toBeInTheDocument()
+  })
+
+  it('Manage apps link points at /apps', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    expect(await screen.findByTestId('apps-section-manage-link')).toHaveAttribute('href', '/apps')
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useProfiles, useDevices, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import type {
+  AppDetail, AppMode, AppPolicyAssignment,
   CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
   ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
 } from '@/types/api'
@@ -108,6 +109,7 @@ export function ProfilesPage() {
   const [editingUsersFor, setEditingUsersFor] = useState<number | null>(null)
   const [userPick, setUserPick] = useState<number[]>([])
   const [household, setHousehold] = useState<HouseholdSettings | null>(null)
+  const [apps, setApps] = useState<AppDetail[]>([])
 
   // #298: LogsPage links to `/profiles?id=...`; scroll + highlight the
   // matching profile card so the parent sees what they clicked from logs.
@@ -149,14 +151,21 @@ export function ProfilesPage() {
   }, [allUsers])
 
   async function loadAux() {
-    const [cats, users, hs] = await Promise.all([
+    const [cats, users, hs, appsList] = await Promise.all([
       api.blocklists.counts().catch(() => []),
       isAdmin ? api.users.list().catch(() => [] as User[]) : Promise.resolve([] as User[]),
       api.household.get().catch(() => null),
+      api.apps.list().catch(() => [] as AppDetail[]),
     ])
     setCategories(cats.map(c => c.category))
     setAllUsers(users)
     setHousehold(hs)
+    setApps([...appsList].sort((a, b) => a.app.name.localeCompare(b.app.name)))
+  }
+
+  async function reloadApps() {
+    const list = await api.apps.list().catch(() => [] as AppDetail[])
+    setApps([...list].sort((a, b) => a.app.name.localeCompare(b.app.name)))
   }
 
   useEffect(() => {
@@ -484,9 +493,12 @@ export function ProfilesPage() {
       {editingId !== null && (
         <ProfileEditor
           isNew={editingId === 'new'}
+          profileId={typeof editingId === 'number' ? editingId : null}
           form={form}
           setForm={setForm}
           categories={categories}
+          apps={apps}
+          onAppsChanged={reloadApps}
           saving={saving}
           error={error}
           onCancel={() => setEditingId(null)}
@@ -499,12 +511,16 @@ export function ProfilesPage() {
 }
 
 function ProfileEditor({
-  isNew, form, setForm, categories, saving, error, onCancel, onSave, defaultTz,
+  isNew, profileId, form, setForm, categories, apps, onAppsChanged,
+  saving, error, onCancel, onSave, defaultTz,
 }: {
   isNew: boolean
+  profileId: number | null
   form: FormState
   setForm: (updater: (f: FormState) => FormState) => void
   categories: string[]
+  apps: AppDetail[]
+  onAppsChanged: () => void | Promise<void>
   saving: boolean
   error: string | null
   onCancel: () => void
@@ -862,6 +878,16 @@ function ProfileEditor({
           </div>
         </div>
 
+        {/* #767 — apps picker. Lives alongside the legacy extraBlocked /
+            extraAllowed / siteTimeLimits inputs above; #764 will remove the
+            legacy fields once apps cover everything. */}
+        <AppsSection
+          profileId={profileId}
+          isNew={isNew}
+          apps={apps}
+          onChanged={onAppsChanged}
+        />
+
         <div className="flex gap-3 pt-2 sticky bottom-0 bg-gray-900">
           <button onClick={onCancel} disabled={saving}
             className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium disabled:opacity-50">
@@ -873,6 +899,194 @@ function ProfileEditor({
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function findAssignment(app: AppDetail, profileId: number | null): AppPolicyAssignment | null {
+  if (profileId == null) return null
+  return app.assignments.find(a => a.profileId === profileId) ?? null
+}
+
+function AppsSection({ profileId, isNew, apps, onChanged }: {
+  profileId: number | null
+  isNew: boolean
+  apps: AppDetail[]
+  onChanged: () => void | Promise<void>
+}) {
+  return (
+    <div data-testid="apps-section">
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          Apps
+        </label>
+        <Link
+          to="/apps"
+          data-testid="apps-section-manage-link"
+          className="text-xs text-emerald-400 hover:text-emerald-300"
+        >
+          Manage apps →
+        </Link>
+      </div>
+      {isNew || profileId == null
+        ? (
+            <p className="text-xs text-gray-500">
+              Save this profile first to assign apps.
+            </p>
+          )
+        : apps.length === 0
+          ? (
+              <p className="text-xs text-gray-500">
+                No apps yet.{' '}
+                <Link
+                  to="/apps"
+                  data-testid="apps-section-empty-link"
+                  className="text-emerald-400 hover:text-emerald-300 underline"
+                >
+                  Create one
+                </Link>
+                {' '}to block, allow, or time-limit a group of hosts.
+              </p>
+            )
+          : (
+              <div className="space-y-2">
+                {apps.map(a => (
+                  <AppRow
+                    key={a.app.id}
+                    app={a}
+                    profileId={profileId}
+                    onChanged={onChanged}
+                  />
+                ))}
+              </div>
+            )
+      }
+    </div>
+  )
+}
+
+function AppRow({ app, profileId, onChanged }: {
+  app: AppDetail
+  profileId: number
+  onChanged: () => void | Promise<void>
+}) {
+  const current = findAssignment(app, profileId)
+  const [minutesDraft, setMinutesDraft] = useState<string>(() =>
+    current?.mode === 'time_limited' && current.dailyMinutes != null
+      ? String(current.dailyMinutes)
+      : '',
+  )
+  const [busy, setBusy] = useState(false)
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  async function apply(mode: AppMode, dailyMinutes: number | null) {
+    setBusy(true)
+    setLocalError(null)
+    try {
+      await api.apps.setPolicy(app.app.id, profileId, {
+        mode,
+        dailyMinutes,
+      })
+      await onChanged()
+    } catch (e) {
+      setLocalError(e instanceof Error ? e.message : 'Failed to update')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function clear() {
+    setBusy(true)
+    setLocalError(null)
+    try {
+      await api.apps.deletePolicy(app.app.id, profileId)
+      setMinutesDraft('')
+      await onChanged()
+    } catch (e) {
+      setLocalError(e instanceof Error ? e.message : 'Failed to clear')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function applyTimeLimited() {
+    const n = Number(minutesDraft)
+    if (!Number.isFinite(n) || n <= 0) {
+      setLocalError('Enter minutes > 0')
+      return
+    }
+    await apply('time_limited', n)
+  }
+
+  const mode = current?.mode ?? null
+  const baseBtn = 'text-xs px-2.5 py-1 rounded-lg border transition-colors disabled:opacity-50'
+  const off = 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-600'
+  const onBlocked = 'bg-red-500/20 text-red-300 border-red-500/40'
+  const onAllowed = 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40'
+  const onTimeLimited = 'bg-amber-500/20 text-amber-300 border-amber-500/40'
+
+  return (
+    <div
+      data-testid={`app-row-${app.app.id}`}
+      className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2"
+    >
+      <div className="flex items-center gap-3">
+        <span className="text-xl w-7 text-center" aria-hidden>{app.app.icon || '◳'}</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-white font-medium truncate">{app.app.name}</p>
+          <p className="text-xs text-gray-500 font-mono truncate">{app.hosts.length} host{app.hosts.length === 1 ? '' : 's'}</p>
+        </div>
+        {mode != null && (
+          <button
+            type="button"
+            data-testid={`app-row-${app.app.id}-clear`}
+            disabled={busy}
+            onClick={clear}
+            className={`${baseBtn} ${off}`}
+          >Clear</button>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2 items-center">
+        <button
+          type="button"
+          data-testid={`app-row-${app.app.id}-block`}
+          disabled={busy}
+          onClick={() => apply('blocked', null)}
+          className={`${baseBtn} ${mode === 'blocked' ? onBlocked : off}`}
+        >{mode === 'blocked' ? '✓ ' : ''}Block</button>
+        <button
+          type="button"
+          data-testid={`app-row-${app.app.id}-allow`}
+          disabled={busy}
+          onClick={() => apply('allowed', null)}
+          className={`${baseBtn} ${mode === 'allowed' ? onAllowed : off}`}
+        >{mode === 'allowed' ? '✓ ' : ''}Allow</button>
+        <div className="flex items-center gap-1">
+          <input
+            type="number"
+            min={1}
+            value={minutesDraft}
+            onChange={e => setMinutesDraft(e.target.value)}
+            placeholder="min"
+            data-testid={`app-row-${app.app.id}-minutes`}
+            className="w-16 bg-gray-900 border border-gray-700 rounded-lg px-2 py-1 text-white text-xs"
+          />
+          <button
+            type="button"
+            data-testid={`app-row-${app.app.id}-time-limit`}
+            disabled={busy}
+            onClick={applyTimeLimited}
+            className={`${baseBtn} ${mode === 'time_limited' ? onTimeLimited : off}`}
+          >
+            {mode === 'time_limited' && current?.dailyMinutes != null
+              ? `✓ ${current.dailyMinutes}m / day`
+              : 'Time-limit'}
+          </button>
+        </div>
+      </div>
+      {localError && (
+        <p className="text-xs text-red-400" data-testid={`app-row-${app.app.id}-error`}>{localError}</p>
+      )}
     </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -606,3 +606,9 @@ export interface UpdateAppRequest {
 export interface SetAppHostsRequest {
   hosts: string[]
 }
+
+export interface UpsertAppAssignmentRequest {
+  mode: AppMode
+  dailyMinutes?: number | null
+  exemptFromDaily?: boolean
+}


### PR DESCRIPTION
## Summary
- Adds an Apps section to the profile edit modal: one row per household app with block / allow / time-limit (with minutes) controls. Selecting a mode calls `PUT /api/apps/:id/policy/:profileId`; clearing calls `DELETE`.
- Empty / no-apps state and a "Manage apps →" link both deep-link to `/apps`. For a brand-new profile (not yet saved) the section shows a "save first to assign apps" hint, since there's no profile id to bind to.
- New `api.apps.setPolicy` / `api.apps.deletePolicy` client helpers + `UpsertAppAssignmentRequest` type wired against the existing `AppRoutes.scala` endpoints from #762.

## Notes
- Legacy `extraBlocked` / `extraAllowed` / `siteTimeLimits` inputs are preserved alongside the apps picker; removing them is #764's job.
- Diff is scoped to the form's contents, not the modal's structure — keeps conflicts low when #965 lifts this form to the merged Profile+Screen Time inline edit.
- Zero router-side changes; no edits to `policy_snapshot.json` (#763 already expands the snapshot at build time).

## Test plan
- [x] `mill api.test` — 190 tests pass.
- [x] `mill shared.test` — 138 tests pass.
- [x] `npm run test` (web) — 221 tests pass (9 new for apps section + 22 existing ProfilesPage).
- [x] `npm run lint`, `npm run type-check` — clean.
- [ ] Manual: open a profile, assign starter app YouTube as time-limited 30m, verify policy assignment shows up at /apps and on the profile after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)