### PR TITLE
ui(web): label per-host screen-time numbers (attention vs presence) (#957)

### DIFF
--- a/web/src/pages/TimePage.test.tsx
+++ b/web/src/pages/TimePage.test.tsx
@@ -47,7 +47,8 @@ const limited: ProfileTimeStatus = {
   hostUsage: [
     { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 35, proportionalMins: 30 },
     { host: { type: 'fqdn', value: 'khan-academy.org' }, usedMins: 10, proportionalMins: 8 },
-    { host: { type: 'ipv4', value: '192.0.2.1' }, usedMins: 5, proportionalMins: 2 },
+    // #957 — equal proportional/presence (within rounding) → collapse to one number.
+    { host: { type: 'ipv4', value: '192.0.2.1' }, usedMins: 5, proportionalMins: 5 },
   ],
 }
 
@@ -228,9 +229,19 @@ describe('TimePage — expanded card content', () => {
     expect(screen.getAllByText('30m left').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('YouTube')).toBeInTheDocument()
     expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('youtube.com')
-    // #715: row shows proportional (wall-clock attention) first, presence in parens.
-    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('30m')
-    expect(screen.getByTestId('time-host-1-youtube.com')).toHaveTextContent('(35m)')
+    // #957: row shows two labeled numbers — Attention (proportional, #715) and Seen (presence).
+    // youtube.com has proportionalMins=30, usedMins=35 → distinct labels both render.
+    const ytRow = screen.getByTestId('time-host-1-youtube.com')
+    expect(ytRow).toHaveTextContent('30m')
+    expect(ytRow).toHaveTextContent('35m')
+    expect(ytRow).not.toHaveTextContent('(35m)')
+    // Column header labels are visible without hover.
+    expect(screen.getAllByText('Attention').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Seen').length).toBeGreaterThan(0)
+    // #957: when attention and seen round to the same number, the Seen cell is blank
+    // so the row renders only one figure (no `5m 5m` duplication).
+    const ipRow = screen.getByTestId('time-host-1-192.0.2.1')
+    expect((ipRow.textContent ?? '').replace('192.0.2.1', '')).toBe('5m')
   })
 
   it('over-limit and no-limit details render when expanded', async () => {
@@ -348,9 +359,11 @@ describe('TimePage — week toggle (#723)', () => {
     expect(await screen.findByTestId('time-week-card-1')).toBeInTheDocument()
     expect(screen.getByText('3:30 used this week')).toBeInTheDocument()
     expect(screen.getByTestId('time-week-chart-1')).toBeInTheDocument()
-    // Weekly host row shows proportional (1:20 = 80m) first, then presence in parens (1:30 = 90m).
-    expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('1:20')
-    expect(screen.getByTestId('time-week-host-1-youtube.com')).toHaveTextContent('(1:30)')
+    // #957: weekly host row shows two labeled numbers — Attention (1:20 = 80m) and Seen (1:30 = 90m).
+    const ytWeekRow = screen.getByTestId('time-week-host-1-youtube.com')
+    expect(ytWeekRow).toHaveTextContent('1:20')
+    expect(ytWeekRow).toHaveTextContent('1:30')
+    expect(ytWeekRow).not.toHaveTextContent('(1:30)')
     expect(screen.getByTestId('time-week-device-link-aa:bb:cc:dd:ee:01'))
       .toHaveAttribute('href', '/devices/aa%3Abb%3Acc%3Add%3Aee%3A01/timeline')
   })

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import type {
+  HostUsage,
   ProfileTimeBucket, ProfileTimeStatus, ProfileTimeStatusWeek,
   ProfileTimeSummary, ProfileTimeSummaryWeek,
 } from '@/types/api'
@@ -88,6 +89,48 @@ export function groupBucketsByLocalDay(
     })
   }
   return out
+}
+
+// #957 — per-host row shows two labeled numbers: byte-share attention (#715)
+// and the count of 5-min buckets where the host appeared at all. Column headers
+// make the distinction visible without hover; when both round to the same
+// formatted value we collapse to a single number to avoid noise.
+function HostUsageList({ rows, testidPrefix }: { rows: HostUsage[]; testidPrefix: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center text-[10px] font-semibold text-gray-500 uppercase tracking-wider gap-3 px-3">
+        <p className="flex-1">Top Sites</p>
+        <span
+          className="w-14 text-right"
+          title="Byte-share of each 5-min window — wall-clock attention this host got (#715)."
+        >
+          Attention
+        </span>
+        <span
+          className="w-14 text-right"
+          title="Count of 5-min buckets where this host appeared at all, regardless of share."
+        >
+          Seen
+        </span>
+      </div>
+      {rows.map(hu => {
+        const attention = formatMins(hu.proportionalMins)
+        const seen = formatMins(hu.usedMins)
+        const same = attention === seen
+        return (
+          <div
+            key={hu.host.value}
+            data-testid={`${testidPrefix}-${hu.host.value}`}
+            className="flex items-center text-xs bg-gray-800/50 rounded-lg px-3 py-2 gap-3"
+          >
+            <span className="text-gray-300 font-mono truncate flex-1" title={hu.host.value}>{hu.host.value}</span>
+            <span className="text-gray-500 font-mono shrink-0 w-14 text-right">{attention}</span>
+            <span className="text-gray-600 font-mono shrink-0 w-14 text-right">{same ? '' : seen}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 export function formatMins(n: number): string {
@@ -432,30 +475,7 @@ function ProfileTimeCard({ status }: { status: ProfileTimeStatus }) {
       )}
 
       {status.hostUsage.length > 0 && (
-        <div className="space-y-1">
-          <p
-            className="text-xs font-semibold text-gray-500 uppercase tracking-wider"
-            title="Per-host minutes are a byte-share of each 5-min window (wall-clock attention, #715). The presence number — how many 5-min windows the host appeared in at all — shows in parentheses."
-          >
-            Top Sites
-          </p>
-          {status.hostUsage.map(hu => (
-            <div
-              key={hu.host.value}
-              data-testid={`time-host-${status.profileId}-${hu.host.value}`}
-              className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
-            >
-              <span className="text-gray-300 font-mono truncate" title={hu.host.value}>{hu.host.value}</span>
-              <span
-                className="text-gray-500 font-mono shrink-0 ml-2"
-                title={`presence ${formatMins(hu.usedMins)} (every bucket this host appeared in)`}
-              >
-                {formatMins(hu.proportionalMins)}
-                <span className="text-gray-600"> ({formatMins(hu.usedMins)})</span>
-              </span>
-            </div>
-          ))}
-        </div>
+        <HostUsageList rows={status.hostUsage} testidPrefix={`time-host-${status.profileId}`} />
       )}
 
       {status.siteUsage.length > 0 && (
@@ -687,30 +707,7 @@ function ProfileTimeWeekCard({ status }: { status: ProfileTimeStatusWeek }) {
       )}
 
       {status.hostUsage.length > 0 && (
-        <div className="space-y-1">
-          <p
-            className="text-xs font-semibold text-gray-500 uppercase tracking-wider"
-            title="Per-host minutes are byte-share of each 5-min window (wall-clock attention, #715). Presence in parens is how many windows the host appeared in at all."
-          >
-            Top Sites
-          </p>
-          {status.hostUsage.map(hu => (
-            <div
-              key={hu.host.value}
-              data-testid={`time-week-host-${status.profileId}-${hu.host.value}`}
-              className="flex justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
-            >
-              <span className="text-gray-300 font-mono truncate" title={hu.host.value}>{hu.host.value}</span>
-              <span
-                className="text-gray-500 font-mono shrink-0 ml-2"
-                title={`presence ${formatMins(hu.usedMins)} (every bucket this host appeared in)`}
-              >
-                {formatMins(hu.proportionalMins)}
-                <span className="text-gray-600"> ({formatMins(hu.usedMins)})</span>
-              </span>
-            </div>
-          ))}
-        </div>
+        <HostUsageList rows={status.hostUsage} testidPrefix={`time-week-host-${status.profileId}`} />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Closes #957 — per-host rows on the Time page now render two labeled numbers under explicit `Attention` / `Seen` column headers instead of the cryptic `7m (8m)` form.
- Column-header tooltips explain the semantics (byte-share attention from #715 vs. count of 5-min buckets the host appeared in at all). Per-row title fallbacks are gone — meaning is visible without hover.
- When attention and presence round to the same value, the `Seen` cell is blank so the row shows a single number (no `5m 5m` noise).

## Design choice
Picked the column-header option (#957 option 2) over inline labels (`7m attention · 8m present`): with multiple rows stacked, header labels are read once and the rows stay scannable as two right-aligned numeric columns. Inline labels would double the text per row and crowd small screens. Applies identically to Today and Week views.

## Test plan
- [x] `web/src/pages/TimePage.test.tsx` updated: row no longer matches `(35m)`; column headers `Attention` and `Seen` render; equal-value row collapses to a single figure.
- [x] `npx vitest run` — 212 passing.
- [x] `npm run type-check` — clean.
- [ ] Visual check on the deployed dev SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)