### PR TITLE
fix(web): gate empty-state behind !isLoading on Traffic Usage + Connection Events (#968)

### DIFF
--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -86,6 +86,22 @@ describe('LogsPage (Connection Events) — raw view', () => {
     renderAt()
     expect(await screen.findByText('No events in window.')).toBeInTheDocument()
   })
+
+  // #968: while a fetch is in flight, the empty-state copy must not appear
+  // above the loading spinner. Gate empty-state on !loading.
+  it('does not render empty-state copy while loading', async () => {
+    let resolve: (v: { rows: QueryLog[]; nextCursor: string | null }) => void = () => {}
+    ;(api.logs.query as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      new Promise<{ rows: QueryLog[]; nextCursor: string | null }>(r => { resolve = r }),
+    )
+    renderAt()
+    await waitFor(() => expect(api.logs.query).toHaveBeenCalled())
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+    expect(screen.queryByText('No events in window.')).not.toBeInTheDocument()
+    resolve({ rows: [], nextCursor: null })
+    await waitFor(() => expect(screen.getByText('No events in window.')).toBeInTheDocument())
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
+  })
 })
 
 describe('LogsPage — aggregation', () => {

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -265,7 +265,7 @@ function RawEventsView({
           </tr>
         </thead>
         <tbody className="text-gray-300">
-          {logs.length === 0 && (
+          {logs.length === 0 && !loading && (
             <tr>
               <td colSpan={7} className="text-center text-gray-500 py-4">
                 No events in window.
@@ -487,7 +487,7 @@ function AggregatedEventsView({
           </tr>
         </thead>
         <tbody className="text-gray-300">
-          {rows.length === 0 && (
+          {rows.length === 0 && !loading && (
             <tr>
               <td colSpan={8} className="text-center text-gray-500 py-4">
                 No events in window.

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -225,6 +225,24 @@ describe('TrafficUsagePage', () => {
     expect(outbound.className).toMatch(/hidden sm:table-cell/)
   })
 
+  // #968: while a fetch is in flight, the "No rows in window." empty-state
+  // must not render above the spinner. Gate empty-state on !loading.
+  it('does not render empty-state copy while loading', async () => {
+    const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
+    let resolve: (v: TrafficUsageResponse) => void = () => {}
+    trafficMock.mockReturnValueOnce(new Promise<TrafficUsageResponse>(r => { resolve = r }))
+    renderPage()
+    await waitFor(() => expect(api.usage.traffic).toHaveBeenCalled())
+    // Spinner is shown, empty-state copy is NOT.
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+    expect(screen.queryByText('No rows in window.')).not.toBeInTheDocument()
+    // Once the fetch resolves with no rows, the empty-state appears and the
+    // spinner clears.
+    resolve({ ...rawResp, rawRows: [] })
+    await waitFor(() => expect(screen.getByText('No rows in window.')).toBeInTheDocument())
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
+  })
+
   it('surfaces server error', async () => {
     const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
     trafficMock.mockRejectedValueOnce(new Error('window_too_large'))

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -172,6 +172,7 @@ export function TrafficUsagePage() {
       {bucket === 'raw' && (
         <RawTable
           rows={rawRows}
+          loading={loading}
           devices={devices}
           profiles={profiles}
           macs={macs}
@@ -192,6 +193,7 @@ export function TrafficUsagePage() {
       {bucket !== 'raw' && !(groupBy.includes('app') && appCount === 0) && (
         <AggregateTable
           rows={aggRows}
+          loading={loading}
           groupBy={groupBy}
           onToggleGroup={toggleGroup}
           devices={devices}
@@ -400,10 +402,11 @@ function ProfileHeaderCell({
 
 interface RawTableProps extends FilterHeaderProps {
   rows: TrafficUsageRawRow[]
+  loading: boolean
 }
 
 function RawTable({
-  rows, devices, profiles, macs, profileIds, onMacsChange, onProfileIdsChange,
+  rows, loading, devices, profiles, macs, profileIds, onMacsChange, onProfileIdsChange,
 }: RawTableProps) {
   return (
     <div className="overflow-x-auto" data-testid="raw-table">
@@ -436,7 +439,7 @@ function RawTable({
           </tr>
         </thead>
         <tbody className="text-gray-300">
-          {rows.length === 0 && (
+          {rows.length === 0 && !loading && (
             <tr>
               <td colSpan={7} className="text-center text-gray-500 py-4">
                 No rows in window.
@@ -462,6 +465,7 @@ function RawTable({
 
 interface AggProps extends FilterHeaderProps {
   rows: TrafficUsageAggregateRow[]
+  loading: boolean
   groupBy: TrafficUsageGroupBy[]
   onToggleGroup: (key: string) => void
 }
@@ -516,7 +520,7 @@ function NonGroupedCell({
 }
 
 function AggregateTable({
-  rows, groupBy, onToggleGroup,
+  rows, loading, groupBy, onToggleGroup,
   devices, profiles, macs, profileIds, onMacsChange, onProfileIdsChange,
 }: AggProps) {
   return (
@@ -586,7 +590,7 @@ function AggregateTable({
           </tr>
         </thead>
         <tbody className="text-gray-300">
-          {rows.length === 0 && (
+          {rows.length === 0 && !loading && (
             <tr>
               <td colSpan={8} className="text-center text-gray-500 py-4">
                 No rows in window.


### PR DESCRIPTION
## Summary
- Traffic Usage and Connection Events rendered the empty-state row ("No rows in window." / "No events in window.") inside the table body during the initial fetch — showing above the loading spinner and implying "we already know it's empty, but we're still checking."
- Chose the **gate** approach (`rows.length === 0 && !loading`) over reorder: the empty-state is a `<tr>` inside the same `<table>` as the data rows, so threading `loading` into the table is the minimal change. The spinner already sits below the table, so once empty-state is gated the order is correct.
- Applied identically to TrafficUsagePage raw + aggregate tables and LogsPage raw + aggregate tables.

## Notes
- Out-of-scope follow-up: a quick scan suggests the same anti-pattern may also exist on the Dashboard NOW panel and screen-time drilldown — worth a separate audit pass under #828 (standardize empty/idle states across pages).

## Test plan
- [x] `npm test` — 214 passed
- [x] `npm run type-check` — clean
- [x] New RTL regression: while a fetch is pending, empty-state copy is NOT in the DOM; spinner IS
- [x] New RTL regression: after the fetch resolves with empty data, empty-state IS in the DOM, spinner is gone

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)