### PR TITLE
fix(web): +Time extension immediately reflects in UI (#946)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,16 @@ jobs:
         # Mill caches `out/` across runs but does NOT drop stale `.class` files when their `.scala`
         # sources are deleted, so old test classes can still be discovered by the test framework
         # (#845 hit this: SessionApiSpec was deleted but its cached class file persisted and
-        # failed with NoClassDefFoundError for the also-deleted SessionPage). Wipe the per-module
-        # `classes` dirs so Zinc rebuilds against the current source set; everything else in
-        # `out/` (Zinc analysis, downloaded deps) stays cached.
+        # failed with NoClassDefFoundError for the also-deleted SessionPage). Wipe just the *test*
+        # `classes` dirs so Zinc rebuilds tests against the current source set; everything else in
+        # `out/` (main module classes, Zinc analysis, downloaded deps) stays cached.
+        #
+        # NB: do NOT also `rm -rf out/*/compile.dest/classes`. That would wipe shared/api main
+        # classes while Mill's task-state still treats those compile tasks as up-to-date from the
+        # restored cache — so they get skipped, downstream modules can't resolve their symbols, and
+        # `api.compile` fails with "value shared is not a member of wifihaven" (#946).
         run: |
-          rm -rf out/*/test/compile.dest/classes out/*/compile.dest/classes 2>/dev/null || true
+          rm -rf out/*/test/compile.dest/classes 2>/dev/null || true
           mill __.compile
 
       - name: Run all tests (sequential to avoid embedded-pg lock contention)

--- a/api/src/cache/TimeStatusCache.scala
+++ b/api/src/cache/TimeStatusCache.scala
@@ -189,11 +189,11 @@ object TimeStatusCache {
 
     def invalidateProfile(profileId: ProfileId): UIO[Unit] = ZIO.succeed {
       def matches(k: Key): Boolean = k match {
-        case DailyKey(pid, _)         => pid == profileId
-        case WeeklyKey(pid, _, _, _)  => pid == profileId
+        case DailyKey(pid, _)        => pid == profileId
+        case WeeklyKey(pid, _, _, _) => pid == profileId
       }
-      val _ = todayCache.asMap().keySet().removeIf(matches(_))
-      val _ = pastCache.asMap().keySet().removeIf(matches(_))
+      val _                        = todayCache.asMap().keySet().removeIf(matches(_))
+      val _                        = pastCache.asMap().keySet().removeIf(matches(_))
     }
 
     def snapshot: UIO[StatsSnapshot] = ZIO.succeed {

--- a/api/src/cache/TimeStatusCache.scala
+++ b/api/src/cache/TimeStatusCache.scala
@@ -49,6 +49,13 @@ trait TimeStatusCache {
   /** Drop everything — exposed for tests and the debug endpoint. */
   def invalidateAll: UIO[Unit]
 
+  /**
+   * Drop every cached entry for this profile across both daily and weekly sub-caches (#946). Called
+   * by mutating endpoints (`POST /api/time/extend`) so the next read reflects the write within the
+   * same tick rather than waiting up to `todayTtl` for the entry to expire.
+   */
+  def invalidateProfile(profileId: ProfileId): UIO[Unit]
+
   def snapshot: UIO[TimeStatusCache.StatsSnapshot]
 }
 
@@ -178,6 +185,15 @@ object TimeStatusCache {
       pastCache.invalidateAll()
       hits.reset()
       misses.reset()
+    }
+
+    def invalidateProfile(profileId: ProfileId): UIO[Unit] = ZIO.succeed {
+      def matches(k: Key): Boolean = k match {
+        case DailyKey(pid, _)         => pid == profileId
+        case WeeklyKey(pid, _, _, _)  => pid == profileId
+      }
+      val _ = todayCache.asMap().keySet().removeIf(matches(_))
+      val _ = pastCache.asMap().keySet().removeIf(matches(_))
     }
 
     def snapshot: UIO[StatsSnapshot] = ZIO.succeed {

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -728,6 +728,9 @@ object TimeRoutes {
             id     <- extRepo
               .grantForProfile(ger.profileId, today, ger.extraMinutes, claims.sub, ger.note)
               .mapError(ErrorMapper.dbErrorToResponse)
+            // #946: bust the cached ProfileTimeStatus for this profile so the SPA's next
+            // refetch reflects the new cap immediately instead of waiting up to todayTtl.
+            _      <- cache.invalidateProfile(ger.profileId)
           } yield Response.json(s"""{"id":${id.value},"grantedMinutes":${ger.extraMinutes}}""")
         },
       Method.GET / "api" / "time" / "extensions" / long("profileId")    ->

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -220,6 +220,64 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         afterP.head.usedMins == 55, // 25 + 30 after invalidation re-queries
       )
     },
+    test("POST /api/time/extend invalidates the cached daily status for that profile (#946)") {
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        tlRepo      <- ZIO.service[TimeLimitRepo]
+        schedRepo   <- ZIO.service[ScheduleRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        trafficRepo <- ZIO.service[TrafficReportRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+        adultsId    <- TestLayers.seedAdultsProfile(profileRepo)
+        _           <- tlRepo.upsert(kidsId, 30) // tight cap so the kid is over limit at 25m used + buffer
+        _           <- tlRepo.upsert(adultsId, 120)
+        _           <- TestLayers.seedDevice(deviceRepo, macKid, "iPad-Kid", kidsId)
+        _           <- TestLayers.seedDevice(deviceRepo, macAdult, "iPad-Adult", adultsId)
+        routerId    <- seedRouter
+        today = TestClock.schoolDayAfternoon.toLocalDate
+        _      <- seedTraffic(routerId, macKid, "minecraft.net", today, 25)
+        _      <- seedTraffic(routerId, macAdult, "wsj.com", today, 40)
+        cache  <- TimeStatusCache.make()
+        routes <- buildRoutes(cache)
+        kidsPath  = s"/api/time/status?profileId=${kidsId.value}&date=$today"
+        adultPath = s"/api/time/status?profileId=${adultsId.value}&date=$today"
+        // Prime both profiles' cache entries.
+        primedKids  <- get(routes, kidsPath, token).flatMap(_.body.asString)
+        primedAdult <- get(routes, adultPath, token).flatMap(_.body.asString)
+        kidsBefore  <- ZIO.fromEither(primedKids.fromJson[List[ProfileTimeStatus]])
+        adultBefore <- ZIO.fromEither(primedAdult.fromJson[List[ProfileTimeStatus]])
+        // Grant 15 extra minutes to kids; cache for kids must drop, cache for adults must stay.
+        grantBody    = GrantExtensionRequest(kidsId, 15, None).toJson
+        grantResp   <- routes.runZIO(
+          Request
+            .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(grantBody))
+            .addHeader(Header.Authorization.Bearer(token)),
+        )
+        statsAfterGrant <- cache.snapshot
+        // Refetch — kids should hit the DB again and reflect the new cap; adults should hit the cache.
+        refetchKids  <- get(routes, kidsPath, token).flatMap(_.body.asString)
+        refetchAdult <- get(routes, adultPath, token).flatMap(_.body.asString)
+        kidsAfter    <- ZIO.fromEither(refetchKids.fromJson[List[ProfileTimeStatus]])
+        adultAfter   <- ZIO.fromEither(refetchAdult.fromJson[List[ProfileTimeStatus]])
+        finalStats   <- cache.snapshot
+      } yield assertTrue(
+        grantResp.status == Status.Ok,
+        // Before the grant: 30m cap, 0 extension.
+        kidsBefore.head.dailyLimitMins.contains(30),
+        kidsBefore.head.extensionMins == 0,
+        // After the grant + refetch: extension shows up immediately (not after 30s).
+        kidsAfter.head.extensionMins == 15,
+        kidsAfter.head.remainingMins.contains(20), // 30 + 15 - 25
+        // Adults entry survives — invalidation is profile-scoped, not global.
+        adultBefore == adultAfter,
+        // The kids refetch was a miss (cache was invalidated); the adult refetch was a hit.
+        finalStats.misses == statsAfterGrant.misses + 1L,
+        finalStats.hits == statsAfterGrant.hits + 1L,
+      )
+    },
     test("Cache-Control: max-age=30 for today, max-age=3600 for past") {
       for {
         _           <- cleanDb

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -232,11 +232,11 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         token       <- auth.login("admin", "changeme").map(_.token.value)
         kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
         adultsId    <- TestLayers.seedAdultsProfile(profileRepo)
-        _           <- tlRepo.upsert(kidsId, 30) // tight cap so the kid is over limit at 25m used + buffer
-        _           <- tlRepo.upsert(adultsId, 120)
-        _           <- TestLayers.seedDevice(deviceRepo, macKid, "iPad-Kid", kidsId)
-        _           <- TestLayers.seedDevice(deviceRepo, macAdult, "iPad-Adult", adultsId)
-        routerId    <- seedRouter
+        _ <- tlRepo.upsert(kidsId, 30) // tight cap so the kid is over limit at 25m used + buffer
+        _ <- tlRepo.upsert(adultsId, 120)
+        _ <- TestLayers.seedDevice(deviceRepo, macKid, "iPad-Kid", kidsId)
+        _ <- TestLayers.seedDevice(deviceRepo, macAdult, "iPad-Adult", adultsId)
+        routerId <- seedRouter
         today = TestClock.schoolDayAfternoon.toLocalDate
         _      <- seedTraffic(routerId, macKid, "minecraft.net", today, 25)
         _      <- seedTraffic(routerId, macAdult, "wsj.com", today, 40)
@@ -250,19 +250,19 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         kidsBefore  <- ZIO.fromEither(primedKids.fromJson[List[ProfileTimeStatus]])
         adultBefore <- ZIO.fromEither(primedAdult.fromJson[List[ProfileTimeStatus]])
         // Grant 15 extra minutes to kids; cache for kids must drop, cache for adults must stay.
-        grantBody    = GrantExtensionRequest(kidsId, 15, None).toJson
-        grantResp   <- routes.runZIO(
+        grantBody = GrantExtensionRequest(kidsId, 15, None).toJson
+        grantResp       <- routes.runZIO(
           Request
             .post(URL.decode("/api/time/extend").toOption.get, Body.fromString(grantBody))
             .addHeader(Header.Authorization.Bearer(token)),
         )
         statsAfterGrant <- cache.snapshot
         // Refetch — kids should hit the DB again and reflect the new cap; adults should hit the cache.
-        refetchKids  <- get(routes, kidsPath, token).flatMap(_.body.asString)
-        refetchAdult <- get(routes, adultPath, token).flatMap(_.body.asString)
-        kidsAfter    <- ZIO.fromEither(refetchKids.fromJson[List[ProfileTimeStatus]])
-        adultAfter   <- ZIO.fromEither(refetchAdult.fromJson[List[ProfileTimeStatus]])
-        finalStats   <- cache.snapshot
+        refetchKids     <- get(routes, kidsPath, token).flatMap(_.body.asString)
+        refetchAdult    <- get(routes, adultPath, token).flatMap(_.body.asString)
+        kidsAfter       <- ZIO.fromEither(refetchKids.fromJson[List[ProfileTimeStatus]])
+        adultAfter      <- ZIO.fromEither(refetchAdult.fromJson[List[ProfileTimeStatus]])
+        finalStats      <- cache.snapshot
       } yield assertTrue(
         grantResp.status == Status.Ok,
         // Before the grant: 30m cap, 0 extension.


### PR DESCRIPTION
## Summary

- Server-side bug: `POST /api/time/extend` wrote the grant but didn't invalidate the in-process `TimeStatusCache` (#802), so the SPA's post-mutation refetch served the prior render for up to 30s. UI continued to show the original cap + "limit reached" badge.
- Add `TimeStatusCache.invalidateProfile(profileId)` (drops daily + weekly entries for the profile across both today and past sub-caches) and call it from the extend handler.
- SPA was already invalidating its React Query cache correctly — no client-side change needed.

## Which side was broken

Server. The SPA's `grantMutation.onSuccess` calls `invalidators.timeStatus()` which refetches `/api/time/status`; that endpoint then returned a stale cached `ProfileTimeStatus` because the write path skipped cache busting.

## Root cause

`TimeStatusCache` is keyed by `(profileId, date)` with a 30s todayTtl. The cache exposed only `invalidateAll`, used by the debug endpoint — not by mutating routes. Added a scoped `invalidateProfile` and called it from `POST /api/time/extend`.

Closes #946.

## Test plan

- [x] `mill api.test` (87 tests, including new `POST /api/time/extend invalidates the cached daily status for that profile (#946)`)
- [x] `mill shared.test` (36 tests)
- [x] `npm test` in `web/` (212 tests)
- [x] `npm run type-check` + `npm run lint`
- [ ] Manual: against `api.lan:8080`, grant +15m to a profile near its cap → status endpoint reflects new cap immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)