### PR TITLE
fix(api): daily screen-time reset uses household-local TZ (#1010)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -160,6 +160,7 @@ object Main extends ZIOAppDefault {
         deviceRepo,
         connRepo,
         alertRepo,
+        hsRepo,
       ) ++
       DeviceAlertRoutes.routes(auth, alertRepo, clock) ++
       AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates) ++

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -8,7 +8,7 @@ import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 
 import java.security.MessageDigest
-import java.time.{DayOfWeek, Instant}
+import java.time.{DayOfWeek, Instant, LocalDate}
 
 trait PolicyService {
   def snapshot: Task[PolicySnapshot]
@@ -58,7 +58,7 @@ class PolicyServiceLive(
     for {
       settings <- householdSettingsRepo.get
       now      <- clock.instant
-      today = now.atZone(settings.dailyResetTz).toLocalDate
+      today = PolicyService.householdLocalDate(now, settings)
       profiles <- profileRepo.listAll
       devices  <- deviceRepo.listAll
       scheds   <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
@@ -216,7 +216,7 @@ class PolicyServiceLive(
     for {
       settings <- householdSettingsRepo.get
       now      <- clock.instant
-      today = now.atZone(settings.dailyResetTz).toLocalDate
+      today = PolicyService.householdLocalDate(now, settings)
       device <- deviceRepo.listAll.map(_.find(_.mac.value.equalsIgnoreCase(mac)))
       result <- device.flatMap(_.profileId) match {
         case None      =>
@@ -572,6 +572,21 @@ object PolicyService {
       if isOvernight && !zdt.toLocalTime.isBefore(s.startLocal) then today.plusDays(1)
       else today
     endDate.atTime(s.endLocal).atZone(s.tz).toInstant
+  }
+
+  /**
+   * #1010: the "logical day" bucket for `instant` under the household's daily-reset configuration.
+   * Projects into `dailyResetTz`; if the wall-clock time is before `dailyResetTime`, the bucket is
+   * the previous calendar date (the prior day's reset is still in force). For the default
+   * `daily_reset_time = '00:00'` this collapses to plain calendar date in the household zone.
+   *
+   * This is the canonical "what date does this Instant belong to" function — used both to write
+   * `time_usage.date` and to read today's cap/usage on the policy snapshot path.
+   */
+  def householdLocalDate(instant: Instant, settings: HouseholdSettings): LocalDate = {
+    val zdt = instant.atZone(settings.dailyResetTz)
+    if (zdt.toLocalTime.isBefore(settings.dailyResetTime)) zdt.toLocalDate.minusDays(1)
+    else zdt.toLocalDate
   }
 
   /**

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -33,27 +33,27 @@ object RouterIngestRoutes {
       Method.POST / "api" / "router" / "usage"  ->
         handler { (req: Request) =>
           for {
-            router <- auth.authenticate(req)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
-            rep    <- ZIO
+            router   <- auth.authenticate(req)
+            body     <- req.body.asString.orElseFail(Response.badRequest(""))
+            rep      <- ZIO
               .fromEither(body.fromJson[UsageReport])
               .mapError(e => Response.badRequest(e))
-            _      <- ZIO
+            _        <- ZIO
               .fail(Response.badRequest("router_id mismatch"))
               .when(rep.routerId != router.id)
-            ps     <- parseInstant(rep.periodStart)
-            pe     <- parseInstant(rep.periodEnd)
-            _      <- ZIO.logDebug(
+            ps       <- parseInstant(rep.periodStart)
+            pe       <- parseInstant(rep.periodEnd)
+            _        <- ZIO.logDebug(
               s"router usage: router=${router.id} period=$ps..$pe records=${rep.records.size}",
             )
-            _      <- ZIO.foreachDiscard(rep.records)(r =>
+            _        <- ZIO.foreachDiscard(rep.records)(r =>
               ZIO.logDebug(
                 s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
                   s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
               ),
             )
             settings <- householdSettingsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
-            _ <- handleUsage(
+            _        <- handleUsage(
               router.id,
               ps,
               pe,
@@ -63,7 +63,7 @@ object RouterIngestRoutes {
               timeUsageRepo,
               deviceRepo,
             )
-            _ <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
+            _        <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
       Method.POST / "api" / "router" / "events" ->

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -1,13 +1,14 @@
 package wifihaven.api.routes
 
 import wifihaven.api.db.*
+import wifihaven.api.policy.PolicyService
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
 
-import java.time.{Duration, Instant, ZoneOffset}
+import java.time.{Duration, Instant}
 
 /**
  * Router-side ingest endpoints. See docs/architecture-openwrt.md §5.4 / §5.5.
@@ -26,6 +27,7 @@ object RouterIngestRoutes {
       deviceRepo: DeviceRepo,
       connEventRepo: ConnectionEventRepo,
       deviceAlertRepo: DeviceAlertRepo,
+      householdSettingsRepo: HouseholdSettingsRepo,
   ): Routes[Any, Response] =
     Routes(
       Method.POST / "api" / "router" / "usage"  ->
@@ -50,7 +52,17 @@ object RouterIngestRoutes {
                   s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
               ),
             )
-            _ <- handleUsage(router.id, ps, pe, rep.records, trafficRepo, timeUsageRepo, deviceRepo)
+            settings <- householdSettingsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            _ <- handleUsage(
+              router.id,
+              ps,
+              pe,
+              rep.records,
+              settings,
+              trafficRepo,
+              timeUsageRepo,
+              deviceRepo,
+            )
             _ <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
@@ -99,11 +111,14 @@ object RouterIngestRoutes {
       periodStart: Instant,
       periodEnd: Instant,
       records: List[UsageRecord],
+      settings: HouseholdSettings,
       trafficRepo: TrafficReportRepo,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
   ): IO[Response, Unit] = {
-    val date    = periodStart.atZone(ZoneOffset.UTC).toLocalDate
+    // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
+    // reset_time), matching the read-side date used by PolicyService.snapshot.
+    val date    = PolicyService.householdLocalDate(periodStart, settings)
     val inserts = records.map(r =>
       TrafficReportInsert(
         routerId,
@@ -123,7 +138,7 @@ object RouterIngestRoutes {
       // Only those rows should drive time_usage / device updates; replays return 0.
       newCount <- trafficRepo.insertBatch(inserts).mapError(ErrorMapper.dbErrorToResponse)
       _        <- ZIO.when(newCount > 0)(
-        applyDelta(routerId, periodEnd, records, timeUsageRepo, deviceRepo),
+        applyDelta(routerId, periodEnd, records, settings, timeUsageRepo, deviceRepo),
       )
     } yield ()
   }
@@ -143,10 +158,14 @@ object RouterIngestRoutes {
       @scala.annotation.unused routerId: RouterId,
       periodEnd: Instant,
       records: List[UsageRecord],
+      settings: HouseholdSettings,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
   ): IO[Response, Unit] = {
-    val date      = periodEnd.atZone(ZoneOffset.UTC).toLocalDate
+    // #1010: bucket time_usage by the household's logical "today" so the
+    // cap-tracking read path (which uses the same household-local date) lines
+    // up with the rows we wrote.
+    val date      = PolicyService.householdLocalDate(periodEnd, settings)
     // A batch carries one record per (mac, dst_ip) but time_usage is keyed
     // by (mac, hostname, date), and activeSeconds is the bucket duration
     // (the report window, ~60 s — same value on every record that saw bytes>0). Two

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -724,7 +724,11 @@ object TimeRoutes {
               .fromEither(body.fromJson[GrantExtensionRequest])
               .mapError(e => Response.badRequest(e))
             _      <- requireProfileAccess(claims, ger.profileId, userProfileRepo)
-            today  <- clock.today
+            // #1010: bucket the grant under the household-local "today" so the
+            // policy-snapshot read path (also household-local) finds it.
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            today    = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             id     <- extRepo
               .grantForProfile(ger.profileId, today, ger.extraMinutes, claims.sub, ger.note)
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -739,7 +743,10 @@ object TimeRoutes {
           for {
             claims <- requireAuth(req, auth)
             _      <- requireProfileAccess(claims, pid, userProfileRepo)
-            date   <- clock.today
+            // #1010: same household-local "today" as the grant path.
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            date     = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             exts   <- extRepo
               .listForProfile(pid, date)
               .mapError(ErrorMapper.dbErrorToResponse)

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -718,36 +718,36 @@ object TimeRoutes {
       Method.POST / "api" / "time" / "extend"                           ->
         handler { (req: Request) =>
           for {
-            claims <- requireWriter(req, auth)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
-            ger    <- ZIO
+            claims   <- requireWriter(req, auth)
+            body     <- req.body.asString.orElseFail(Response.badRequest(""))
+            ger      <- ZIO
               .fromEither(body.fromJson[GrantExtensionRequest])
               .mapError(e => Response.badRequest(e))
-            _      <- requireProfileAccess(claims, ger.profileId, userProfileRepo)
+            _        <- requireProfileAccess(claims, ger.profileId, userProfileRepo)
             // #1010: bucket the grant under the household-local "today" so the
             // policy-snapshot read path (also household-local) finds it.
             settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             now      <- clock.instant
-            today    = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
-            id     <- extRepo
+            today = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
+            id <- extRepo
               .grantForProfile(ger.profileId, today, ger.extraMinutes, claims.sub, ger.note)
               .mapError(ErrorMapper.dbErrorToResponse)
             // #946: bust the cached ProfileTimeStatus for this profile so the SPA's next
             // refetch reflects the new cap immediately instead of waiting up to todayTtl.
-            _      <- cache.invalidateProfile(ger.profileId)
+            _  <- cache.invalidateProfile(ger.profileId)
           } yield Response.json(s"""{"id":${id.value},"grantedMinutes":${ger.extraMinutes}}""")
         },
       Method.GET / "api" / "time" / "extensions" / long("profileId")    ->
         handler { (profileId: Long, req: Request) =>
           val pid = ProfileId(profileId)
           for {
-            claims <- requireAuth(req, auth)
-            _      <- requireProfileAccess(claims, pid, userProfileRepo)
+            claims   <- requireAuth(req, auth)
+            _        <- requireProfileAccess(claims, pid, userProfileRepo)
             // #1010: same household-local "today" as the grant path.
             settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             now      <- clock.instant
-            date     = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
-            exts   <- extRepo
+            date = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
+            exts <- extRepo
               .listForProfile(pid, date)
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(exts.toJson)

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -129,6 +129,12 @@ object DbFailureSpec extends ZIOSpecDefault {
     def dismiss(id: DeviceAlertId, at: Instant)      = throwing
   }
 
+  private def brokenHouseholdSettingsRepo: HouseholdSettingsRepo = new HouseholdSettingsRepo {
+    def get                                       = throwing
+    def update(s: HouseholdSettings)              = throwing
+    def ensureDefault(z: java.time.ZoneId)        = throwing
+  }
+
   private def brokenConnectionEventRepo: ConnectionEventRepo = new ConnectionEventRepo {
     def insertBatch(es: List[ConnectionEventInsert])                                    = throwing
     def recent(l: Int)                                                                  = throwing
@@ -179,6 +185,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenDeviceRepo,
         brokenConnectionEventRepo,
         brokenDeviceAlertRepo,
+        brokenHouseholdSettingsRepo,
       )
       val req    = Request
         .post(URL.decode("/api/router/usage").toOption.get, Body.fromString("{}"))
@@ -203,6 +210,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenDeviceRepo,
         brokenConnectionEventRepo,
         brokenDeviceAlertRepo,
+        brokenHouseholdSettingsRepo,
       )
       val req    = Request
         .post(URL.decode("/api/router/usage").toOption.get, Body.fromString("not json"))
@@ -223,6 +231,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenDeviceRepo,
         brokenConnectionEventRepo,
         brokenDeviceAlertRepo,
+        brokenHouseholdSettingsRepo,
       )
       val req    = Request.post(URL.decode("/api/router/usage").toOption.get, Body.fromString("{}"))
       for {

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -130,9 +130,9 @@ object DbFailureSpec extends ZIOSpecDefault {
   }
 
   private def brokenHouseholdSettingsRepo: HouseholdSettingsRepo = new HouseholdSettingsRepo {
-    def get                                       = throwing
-    def update(s: HouseholdSettings)              = throwing
-    def ensureDefault(z: java.time.ZoneId)        = throwing
+    def get                                = throwing
+    def update(s: HouseholdSettings)       = throwing
+    def ensureDefault(z: java.time.ZoneId) = throwing
   }
 
   private def brokenConnectionEventRepo: ConnectionEventRepo = new ConnectionEventRepo {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -58,8 +58,9 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       dRepo <- ZIO.service[DeviceRepo]
       cRepo <- ZIO.service[ConnectionEventRepo]
       aRepo <- ZIO.service[DeviceAlertRepo]
+      hsr   <- ZIO.service[HouseholdSettingsRepo]
       auth = new RouterAuthLive(rRepo)
-    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo)
+    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
 
   private def makePolicyService =
     for {
@@ -1116,6 +1117,88 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         _      <- post(routes, "/api/router/events", body, Some(tk))
         alerts <- aRepo.listAll(includeDismissed = true)
       } yield assertTrue(alerts.size == 1)
+    },
+    // ── #1010: time_usage bucket follows household-local TZ, not UTC ─────────
+    test(
+      "#1010: usage at 22:00 PT (05:00 UTC next day) buckets to LA-local date, not UTC date",
+    ) {
+      // Household configured for LA. A usage period centered at 22:00 PDT on
+      // 2026-05-07 (= 05:00 UTC on 2026-05-08) must bucket into 2026-05-07,
+      // not the UTC date 2026-05-08 — otherwise a kid hitting cap at 15:00 PT
+      // would see their cap reset at 17:00 PT (UTC midnight) instead of
+      // 00:00 PT.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        hsr      <- ZIO.service[HouseholdSettingsRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        _        <- hsr.update(
+          HouseholdSettings(
+            java.time.LocalTime.of(0, 0),
+            java.time.ZoneId.of("America/Los_Angeles"),
+            HeartbeatFilter.Off,
+          ),
+        )
+        // 2026-05-08T05:00:00Z = 2026-05-07T22:00 PDT → LA-local date 2026-05-07.
+        laEveningStart = Instant.parse("2026-05-08T04:55:00Z")
+        laEveningEnd   = Instant.parse("2026-05-08T05:00:00Z")
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          None,
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          120L,
+          800L,
+          400L,
+        )
+        body = UsageReport(id, laEveningStart.toString, laEveningEnd.toString, List(rec)).toJson
+        resp <- post(routes, "/api/router/usage", body, Some(tk))
+        // Expected bucket: LA-local 2026-05-07. Wrong-bucket (UTC) would be 2026-05-08.
+        laBucket  <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          java.time.LocalDate.of(2026, 5, 7),
+        )
+        utcBucket <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          java.time.LocalDate.of(2026, 5, 8),
+        )
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(laBucket == ((120L, 800L, 400L))) &&
+        assertTrue(utcBucket == ((0L, 0L, 0L)))
+    },
+    test("#1010: usage in default UTC household keeps UTC-date bucketing (regression)") {
+      // No TZ change: default daily_reset_tz='UTC'. Behavior unchanged from pre-#1010.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          None,
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          60L,
+          100L,
+          50L,
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        _    <- post(routes, "/api/router/usage", body, Some(tk))
+        sb   <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+      } yield assertTrue(sb == ((60L, 100L, 50L)))
     },
     test("events: dhcp_lease for a known MAC does NOT raise an alert") {
       for {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -1147,7 +1147,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         // 2026-05-08T05:00:00Z = 2026-05-07T22:00 PDT → LA-local date 2026-05-07.
         laEveningStart = Instant.parse("2026-05-08T04:55:00Z")
         laEveningEnd   = Instant.parse("2026-05-08T05:00:00Z")
-        rec  = UsageRecord(
+        rec            = UsageRecord(
           MacAddress.unsafe(knownMac),
           None,
           HostId.Fqdn(Hostname.unsafe("youtube.com")),
@@ -1156,7 +1156,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           400L,
         )
         body = UsageReport(id, laEveningStart.toString, laEveningEnd.toString, List(rec)).toJson
-        resp <- post(routes, "/api/router/usage", body, Some(tk))
+        resp      <- post(routes, "/api/router/usage", body, Some(tk))
         // Expected bucket: LA-local 2026-05-07. Wrong-bucket (UTC) would be 2026-05-08.
         laBucket  <- tu.getSecondsAndBytes(
           MacAddress.unsafe(knownMac),
@@ -1192,8 +1192,8 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           50L,
         )
         body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
-        _    <- post(routes, "/api/router/usage", body, Some(tk))
-        sb   <- tu.getSecondsAndBytes(
+        _  <- post(routes, "/api/router/usage", body, Some(tk))
+        sb <- tu.getSecondsAndBytes(
           MacAddress.unsafe(knownMac),
           HostId.Fqdn(Hostname.unsafe("youtube.com")),
           testDate,

--- a/api/test/src/unit/SchedulingSpec.scala
+++ b/api/test/src/unit/SchedulingSpec.scala
@@ -178,5 +178,60 @@ object SchedulingSpec extends ZIOSpecDefault {
         assertTrue(PolicyService.nextDailyResetAfter(settings, now) == expected)
       },
     ),
+    suite("householdLocalDate — #1010")(
+      test("default UTC household: calendar date is the UTC date") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), UTC, HeartbeatFilter.Off)
+        val now      = Instant.parse("2026-05-13T15:30:00Z")
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 13),
+        )
+      },
+      test("LA household at 20:00 PDT: bucket is the local date (still yesterday in UTC)") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
+        // 2026-05-07 20:00 PDT = 2026-05-08 03:00 UTC. UTC date has rolled but LA hasn't.
+        val now      = Instant.parse("2026-05-08T03:00:00Z")
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 7),
+        )
+      },
+      test("LA household at 22:00 PT: still 'today' in LA, even though UTC says tomorrow") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
+        // 22:00 PDT on 2026-05-13 = 05:00 UTC 2026-05-14. The kid in LA is still on 2026-05-13.
+        val now      = Instant.parse("2026-05-14T05:00:00Z")
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 13),
+        )
+      },
+      test("LA household one minute past local midnight: bucket flips to the new day") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
+        // 00:01 PDT 2026-05-14 = 07:01 UTC 2026-05-14
+        val now      = Instant.parse("2026-05-14T07:01:00Z")
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 14),
+        )
+      },
+      test("non-midnight reset_time: 02:00 local before reset stays on prior day's bucket") {
+        // Reset at 04:00 LA. At 03:30 LA the day-bucket should still be the previous date.
+        val settings = HouseholdSettings(LocalTime.of(4, 0), LA, HeartbeatFilter.Off)
+        val now      = instantAt(2026, 5, 14, 3, 30, LA)
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 13),
+        )
+      },
+      test("non-midnight reset_time: just after reset flips to the new bucket") {
+        val settings = HouseholdSettings(LocalTime.of(4, 0), LA, HeartbeatFilter.Off)
+        val now      = instantAt(2026, 5, 14, 4, 1, LA)
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 5, 14),
+        )
+      },
+      test("DST spring-forward: 06:30 LA on 2026-03-08 is still that calendar date") {
+        val settings = HouseholdSettings(LocalTime.of(0, 0), LA, HeartbeatFilter.Off)
+        val now      = instantAt(2026, 3, 8, 6, 30, LA)
+        assertTrue(
+          PolicyService.householdLocalDate(now, settings) == java.time.LocalDate.of(2026, 3, 8),
+        )
+      },
+    ),
   )
 }


### PR DESCRIPTION
Closes #1010.

## Summary

- **Path A** (households already had a TZ field — `household_settings.daily_reset_tz`, added in V16 for #334). No migration; default zone unchanged (`UTC`).
- Root bug: `RouterIngestRoutes.handleUsage` / `applyDelta` bucketed `time_usage.date` and `traffic_reports.date` by **UTC** (hardcoded `ZoneOffset.UTC`), but `PolicyService.snapshot` / `decide` read by `dailyResetTz` calendar date. In a non-UTC household the keys diverged — a kid hitting cap at 15:00 PT saw it reset at 17:00 PT (UTC midnight) instead of 00:00 PT.
- Fix: introduce `PolicyService.householdLocalDate(instant, settings)` as the canonical "what logical day does this Instant belong to" function (respects both `daily_reset_tz` and `daily_reset_time`; collapses to plain calendar-zone date for the default `00:00`). Apply at both sides of the date-key channel — ingest (writes) and snapshot/decide (reads).

## Audit scope

| Item | Status |
| --- | --- |
| Router ingest → `time_usage.date` | **Fixed in PR** — uses `householdLocalDate(periodEnd, settings)`. |
| Router ingest → `traffic_reports.date` | **Fixed in PR** — uses `householdLocalDate(periodStart, settings)`. |
| `PolicyService.snapshot` / `decide` today calc | **Fixed in PR** — uses helper (was already TZ-aware but did not respect non-midnight reset_time). |
| `POST /api/time/extend`, `GET /api/time/extensions/{pid}` | **Fixed in PR** — was `clock.today` (JVM zone); now uses helper so grants land in the same bucket the cap read consults. |
| Week-chart day buckets (#794) | Already correct post-#797 — SPA passes explicit `tz` query param to `UsageRoutes`. |
| Sessions stitching midnight (#817 finding 2) | Per-schedule `tz` is already applied in `scheduleActiveAt`. No change needed. |
| Schedule application HH:MM | Already TZ-aware via per-row `schedules.tz` (#334). |
| Connection Events / Traffic Usage aggregation | Bucket keys are Instants, not dates. Already correct. |
| Other `clock.today` defaults in `Routes.scala` / `UsageRoutes.scala` | **Filed as [#1013](https://github.com/wifihaven/wifihaven/issues/1013)** — long tail; SPA always passes `?date=`, so impact is limited to non-SPA callers in non-UTC households. |

## Test plan

- [x] Unit: `PolicyService.householdLocalDate` covers default UTC, LA at 22:00 PT (UTC has rolled, LA hasn't), LA just past local midnight, non-midnight `reset_time` (04:00 LA) before/after reset, DST spring-forward (06:30 PDT on 2026-03-08).
- [x] Integration: `RouterIngestSpec` — LA household, a usage period at 2026-05-08T04:55..05:00Z (= 21:55..22:00 PDT 2026-05-07) buckets to LA-local 2026-05-07, not the UTC date 2026-05-08.
- [x] Regression: a usage POST in a default-UTC household still buckets to the UTC date (existing tests pass; new explicit assertion in `RouterIngestSpec`).
- [x] `mill api.test` — 190 tests pass (72 in TimeApiSpec, 34 in RouterIngestSpec including the two new #1010 cases, all SchedulingSpec).
- [x] `mill shared.test` — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)