### PR TITLE
polish(web+starter): Gimkit hosts + drop wildcard copy + Escape closes modals (#1005 #1006 #1008)

### DIFF
--- a/api/resources/app_templates/gimkit.yml
+++ b/api/resources/app_templates/gimkit.yml
@@ -4,3 +4,4 @@ icon: "💰"
 icon_type: emoji
 hosts:
   - gimkit.com
+  - gimkitconnect.com

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -124,6 +124,16 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       } yield assertTrue(templates.forall(_.iconType == IconType.Emoji)) &&
         assertTrue(yt.iconType == IconType.Emoji)
     },
+    test("gimkit template covers both marketing site and the school game endpoint (#1005)") {
+      for {
+        templates <- AppTemplates.loadAll()
+      } yield {
+        val gimkit = templates.find(_.slug == AppTemplateId.unsafe("gimkit")).get
+        val hosts  = gimkit.hosts.map(_.value).toSet
+        assertTrue(hosts.contains("gimkit.com")) &&
+        assertTrue(hosts.contains("gimkitconnect.com"))
+      }
+    },
     test("each template's hosts parse as apex hostnames") {
       for {
         templates <- AppTemplates.loadAll()

--- a/web/src/components/RecentApexPicker.tsx
+++ b/web/src/components/RecentApexPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import { useDevices } from '@/api/queries'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 import type { RecentApex, RecentApexesResponse } from '@/types/api'
 
 // #766: pick recently-visited apexes (PSL-collapsed FQDNs) for a device and
@@ -15,6 +16,7 @@ export function RecentApexPicker({
   onClose: () => void
   onAdd: (hosts: string[]) => void
 }) {
+  useEscapeClose(onClose)
   const { data: devices = [] } = useDevices()
   const sortedDevices = useMemo(() => {
     const copy = [...devices]

--- a/web/src/components/usage/JumpToDate.tsx
+++ b/web/src/components/usage/JumpToDate.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { localTime } from './usageHelpers'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 
 // #862 / #951 — "Jump to" picker. Re-anchors the right edge of the infinite-
 // scroll window. `value === null` = "now" (no anchor); the caller passes that
@@ -78,6 +79,7 @@ function CalendarPopover({
   onPick: (iso: string) => void
   onClose: () => void
 }) {
+  useEscapeClose(onClose)
   // Seed the visible month + the selected day from `value`, or from "now"
   // if no anchor is set yet.
   const seed = useMemo(() => (value ? new Date(value) : new Date()), [value])

--- a/web/src/hooks/useEscapeClose.ts
+++ b/web/src/hooks/useEscapeClose.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react'
+
+// Module-level stack so nested modals close one layer at a time:
+// the most recently mounted handler runs on Escape, and others stay inert
+// until it unregisters.
+const stack: Array<() => void> = []
+
+let installed = false
+function installListener() {
+  if (installed) return
+  installed = true
+  window.addEventListener('keydown', e => {
+    if (e.key !== 'Escape' || stack.length === 0) return
+    e.stopPropagation()
+    stack[stack.length - 1]()
+  })
+}
+
+export function useEscapeClose(onClose: () => void, enabled = true) {
+  useEffect(() => {
+    if (!enabled) return
+    installListener()
+    stack.push(onClose)
+    return () => {
+      const i = stack.lastIndexOf(onClose)
+      if (i >= 0) stack.splice(i, 1)
+    }
+  }, [onClose, enabled])
+}

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -163,7 +163,7 @@ describe('AppsPage — edit flow', () => {
     expect(screen.queryByText('googlevideo.com')).not.toBeInTheDocument()
     // Add a new host via the Add button
     await user.type(
-      screen.getByPlaceholderText(/example\.com or \*\.example\.com/i),
+      screen.getByPlaceholderText(/^example\.com$/i),
       '*.ytimg.com',
     )
     await user.click(screen.getByRole('button', { name: 'Add' }))
@@ -247,5 +247,51 @@ describe('AppsPage — delete flow', () => {
     await waitFor(() => {
       expect(api.apps.delete).toHaveBeenCalledWith(11)
     })
+  })
+})
+
+describe('AppsPage — host input copy (#1006)', () => {
+  it('does not surface the redundant *.example.com wildcard in placeholders or help text', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await user.click(await screen.findByRole('button', { name: /new app/i }))
+    const textarea = screen.getByPlaceholderText(/youtube\.com/i) as HTMLTextAreaElement
+    expect(textarea.placeholder).not.toContain('*.')
+    // Open edit modal too — checks the single-host input placeholder.
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+    await user.click(await screen.findByRole('button', { name: /youtube/i }))
+    const hostInput = screen.getByPlaceholderText(/^example\.com$/i) as HTMLInputElement
+    expect(hostInput.placeholder).not.toContain('*.')
+    // No visible UI string should mention *.example.com.
+    expect(screen.queryByText(/\*\.example\.com/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('AppsPage — Escape closes modals (#1008)', () => {
+  it('closes the create modal on Escape', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await screen.findByText('YouTube')
+    await user.click(screen.getByRole('button', { name: /new app/i }))
+    expect(screen.getByRole('button', { name: /create app/i })).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /create app/i })).not.toBeInTheDocument()
+    })
+  })
+
+  it('Escape on a nested picker closes only the picker, not the underlying create modal', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<AppsPage />))
+    await screen.findByText('YouTube')
+    await user.click(screen.getByRole('button', { name: /new app/i }))
+    await user.click(screen.getByRole('button', { name: /pick from recent activity/i }))
+    await screen.findByText(/top apexes a device hit/i)
+    await user.keyboard('{Escape}')
+    // Picker closes but the underlying create modal stays open.
+    await waitFor(() => {
+      expect(screen.queryByText(/top apexes a device hit/i)).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /create app/i })).toBeInTheDocument()
   })
 })

--- a/web/src/pages/AppsPage.tsx
+++ b/web/src/pages/AppsPage.tsx
@@ -4,6 +4,7 @@ import { useProfiles } from '@/api/queries'
 import type { AppDetail } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { RecentApexPicker } from '@/components/RecentApexPicker'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 
 interface EditFormState {
   name: string
@@ -205,13 +206,16 @@ function CreateAppModal({ onClose, onSaved }: {
             rows={4}
             value={hostsInput}
             onChange={e => setHostsInput(e.target.value)}
-            placeholder="youtube.com&#10;*.googlevideo.com"
+            placeholder="youtube.com&#10;googlevideo.com"
             className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white font-mono text-sm focus:outline-none focus:border-emerald-500"
           />
           <div className="flex items-center justify-between mt-2 gap-3">
-            <p className="text-xs text-gray-500">
-              One per line or comma-separated. <code>*.foo.com</code> and <code>foo.com</code>
-              both canonicalize to the apex.
+            <p
+              className="text-xs text-gray-500"
+              title="Wildcards are unnecessary — example.com automatically covers every subdomain."
+            >
+              One per line or comma-separated. Each host also covers its subdomains
+              <span className="ml-1 text-gray-600 cursor-help" aria-hidden="true">ⓘ</span>
             </p>
             <button
               type="button"
@@ -372,7 +376,8 @@ function EditAppModal({ detail, profileNameById, onClose, onSaved, onDeleted }: 
                   addHosts()
                 }
               }}
-              placeholder="example.com or *.example.com"
+              placeholder="example.com"
+              title="Wildcards are unnecessary — example.com automatically covers every subdomain."
               className="flex-1 bg-gray-950 border border-gray-700 rounded-xl px-4 py-2 text-white font-mono text-sm focus:outline-none focus:border-emerald-500"
             />
             <button
@@ -485,6 +490,7 @@ function Field({ label, required, children }: {
 }
 
 function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  useEscapeClose(onClose)
   return (
     <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto" onClick={onClose}>
       <div

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -8,6 +8,7 @@ import type {
   DeviceTimeStatusWeek, UsageBucket, UsageSeriesResponse,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 import {
   HOST_COLORS, OTHER_KEY, UsageHourlyBarChart, type ChartSeries,
 } from '@/components/usage/UsageHourlyBarChart'
@@ -369,6 +370,7 @@ interface OtherDrillInModalProps {
 }
 
 function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherDrillInModalProps) {
+  useEscapeClose(onClose)
   const tail = (data?.topHosts ?? []).filter(h => h.dayMins > 0).slice(topN)
   const otherTotal = tail.reduce((a, h) => a + h.dayMins, 0)
   const grandTotal = (data?.topHosts ?? []).reduce((a, h) => a + h.dayMins, 0)

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -4,6 +4,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useDevices, useDeviceAlerts, useProfiles, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 import { useNotificationPermission } from '@/hooks/useNotifyOnNewAlerts'
 import type { Device, DeviceAlert } from '@/types/api'
 import { PageLoader } from './DashboardPage'
@@ -39,6 +40,7 @@ export function DevicesPage() {
   const profiles = profilesQuery.data ?? []
   const loading  = devicesQuery.isPending || profilesQuery.isPending
   const [editing,  setEditing]  = useState<Device | null>(null)
+  useEscapeClose(() => setEditing(null), editing !== null)
   const [form,     setForm]     = useState({ mac: '', name: '', profileId: 0 })
   const highlightMac = useHighlightFromQuery(devices)
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -4,6 +4,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import { useProfiles, useDevices, useInvalidators } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 import type {
   AppDetail, AppMode, AppPolicyAssignment,
   BlocklistSummary, CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
@@ -107,6 +108,7 @@ export function ProfilesPage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editingUsersFor, setEditingUsersFor] = useState<number | null>(null)
+  useEscapeClose(() => setEditingUsersFor(null), editingUsersFor !== null)
   const [userPick, setUserPick] = useState<number[]>([])
   const [household, setHousehold] = useState<HouseholdSettings | null>(null)
   const [apps, setApps] = useState<AppDetail[]>([])
@@ -527,6 +529,7 @@ function ProfileEditor({
   onSave: () => void
   defaultTz: string
 }) {
+  useEscapeClose(onCancel)
   function toggleCat(c: string) {
     setForm(f => ({
       ...f,

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { api } from '@/api/client'
 import type { CreateRouterResponse, RouterSummary } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 
 export function RoutersPage() {
   const [routers, setRouters] = useState<RouterSummary[]>([])
@@ -207,6 +208,7 @@ export function RoutersPage() {
 }
 
 function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  useEscapeClose(onClose)
   return (
     <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto" onClick={onClose}>
       <div

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -14,6 +14,7 @@ import {
   useUsageSeriesProfileToday,
 } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 import type {
   HostUsage,
   ProfileTimeBucket, ProfileTimeStatus, ProfileTimeStatusWeek,
@@ -217,6 +218,7 @@ export function TimePage() {
   })
 
   const [extProfileId, setExtProfileId] = useState<number | null>(null)
+  useEscapeClose(() => setExtProfileId(null), extProfileId !== null)
   const [extMins, setExtMins]   = useState(30)
   const [extNote, setExtNote]   = useState('')
 

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import type { CreateUserRequest, ProfileDetail, User, UserRole } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+import { useEscapeClose } from '@/hooks/useEscapeClose'
 
 const ROLES: UserRole[] = ['admin', 'adult', 'child']
 
@@ -275,6 +276,7 @@ function ProfilePicker({
 }
 
 function Modal({ title, children, onClose }: { title: string; children: React.ReactNode; onClose: () => void }) {
+  useEscapeClose(onClose)
   return (
     <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto" onClick={onClose}>
       <div


### PR DESCRIPTION
## Summary

Three small operator-discovered fixes bundled into one PR:

- Gimkit starter template only blocked the marketing apex; gameplay actually runs on `gimkitconnect.com`.
- The host input UI implied `example.com` vs `*.example.com` was a choice, but they're wire-identical.
- Modals across the SPA didn't close on Escape, breaking standard muscle memory.

## Fixes

- **#1005** — `api/resources/app_templates/gimkit.yml`: add `gimkitconnect.com` alongside `gimkit.com` so the seeded template covers both. `AppTemplatesSpec` gains a regression test asserting both hosts are present after seed.
- **#1006** — `web/src/pages/AppsPage.tsx`: drop `*.example.com` / `*.googlevideo.com` from placeholders and the help paragraph; explain via tooltip that "wildcards are unnecessary — `example.com` automatically covers every subdomain." Ingest logic untouched (it already canonicalizes both forms).
- **#1008** — new `web/src/hooks/useEscapeClose.ts` with a module-level handler stack so the topmost mounted modal consumes Escape (nested modals close one layer at a time). Applied to every Modal/overlay: AppsPage, UsersPage, RoutersPage, ProfilesPage (both editors), DevicesPage, TimePage, DeviceTimelinePage, RecentApexPicker, JumpToDate.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.AppTemplatesSpec` — 12 tests pass, including new gimkit regression.
- [x] `npm test` in `web/` — full suite (233 tests) green; new RTL cases for #1006 (placeholder/help text has no `*.`) and #1008 (Escape closes create modal; nested picker Escape leaves underlying modal open).
- [x] `npm run type-check` — clean.
- [ ] Smoke in browser: open Apps create/edit, press Escape — closes; open the recent-activity picker over create, Escape — closes picker only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)