### PR TITLE
feat(api): PATCH endpoints + symmetric read/write shapes for devices/users/household/apps (#996 #997 #998 #999)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -79,6 +79,8 @@ trait UserRepo {
   def findById(id: UserId): Task[Option[DbUser]]
   def create(u: String, h: String, r: String): Task[UserId]
   def updatePassword(id: UserId, h: String): Task[Unit]
+  def updateUsername(id: UserId, u: String): Task[Unit]
+  def updateRole(id: UserId, r: String): Task[Unit]
   def clearMustChangePassword(id: UserId): Task[Unit]
   def listAll: Task[List[DbUser]]
   def delete(id: UserId): Task[Unit]
@@ -460,6 +462,10 @@ class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
       .transact(xa)
   def updatePassword(id: UserId, h: String) =
     sql"UPDATE users SET password_hash=$h WHERE id=$id".update.run.transact(xa).unit
+  def updateUsername(id: UserId, u: String) =
+    sql"UPDATE users SET username=$u WHERE id=$id".update.run.transact(xa).unit
+  def updateRole(id: UserId, r: String)     =
+    sql"UPDATE users SET role=$r WHERE id=$id".update.run.transact(xa).unit
   def clearMustChangePassword(id: UserId)   =
     sql"UPDATE users SET must_change_password=false WHERE id=$id".update.run.transact(xa).unit
   def listAll                               =

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -258,42 +258,42 @@ object AppRoutes {
         handler { (id: Long, req: Request) =>
           val aid = AppId(id)
           for {
-            _    <- requireAdmin(req, auth)
-            a    <- appRepo
+            _         <- requireAdmin(req, auth)
+            a         <- appRepo
               .findById(aid)
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
-            obj  <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
-            namePatch     <- ZIO
+            body      <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            namePatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "name"))
               .mapError(Response.badRequest(_))
-            iconPatch     <- ZIO
+            iconPatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "icon"))
               .mapError(Response.badRequest(_))
-            iconTypePatch <- ZIO
+            iconTypePatch   <- ZIO
               .fromEither(FieldPatch.from[IconType](obj, "iconType"))
               .mapError(Response.badRequest(_))
             templateIdPatch <- ZIO
               .fromEither(FieldPatch.from[AppTemplateId](obj, "templateId"))
               .mapError(Response.badRequest(_))
-            hostsPatch    <- ZIO
+            hostsPatch      <- ZIO
               .fromEither(FieldPatch.from[List[String]](obj, "hosts"))
               .mapError(Response.badRequest(_))
             newName = namePatch.applyTo(a.name).trim
-            _ <- namePatch match {
-              case FieldPatch.Cleared    => ZIO.fail(Response.badRequest("name cannot be cleared"))
+            _             <- namePatch match {
+              case FieldPatch.Cleared => ZIO.fail(Response.badRequest("name cannot be cleared"))
               case FieldPatch.Set(_) if newName.isEmpty =>
                 ZIO.fail(Response.badRequest("name is required"))
-              case _                     => ZIO.unit
+              case _                                    => ZIO.unit
             }
-            _ <- iconTypePatch match {
+            _             <- iconTypePatch match {
               case FieldPatch.Cleared =>
                 ZIO.fail(Response.badRequest("iconType cannot be cleared"))
               case _                  => ZIO.unit
             }
             hostsResolved <- hostsPatch match {
-              case FieldPatch.Cleared       =>
+              case FieldPatch.Cleared  =>
                 ZIO.fail(Response.badRequest("hosts cannot be cleared (send [] to remove all)"))
               case FieldPatch.Set(raw) =>
                 ZIO.fromEither(parseHosts(raw)).mapError(Response.badRequest(_)).map(Some(_))
@@ -305,8 +305,8 @@ object AppRoutes {
               iconType = iconTypePatch.applyTo(a.iconType),
               templateId = templateIdPatch.applyToNullable(a.templateId),
             )
-            _ <- appRepo.update(updated).mapError(ErrorMapper.dbErrorToResponse)
-            _ <- hostsResolved match {
+            _             <- appRepo.update(updated).mapError(ErrorMapper.dbErrorToResponse)
+            _             <- hostsResolved match {
               case Some(hs) => appRepo.setHosts(aid, hs).mapError(ErrorMapper.dbErrorToResponse)
               case None     => ZIO.unit
             }

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -250,6 +250,68 @@ object AppRoutes {
             d    <- detail(appRepo, app).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(d.toJson)
         },
+      // #999: field-scoped partial update. Body is a subset of the App read
+      // shape — `name`, `icon` (set/null-to-clear), `iconType`, `templateId`
+      // (set/null-to-clear), `hosts` (replace, matches today's PUT /hosts).
+      // `slug` is immutable post-create and not patchable.
+      Method.PATCH / "api" / "apps" / long("id")                                 ->
+        handler { (id: Long, req: Request) =>
+          val aid = AppId(id)
+          for {
+            _    <- requireAdmin(req, auth)
+            a    <- appRepo
+              .findById(aid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj  <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            namePatch     <- ZIO
+              .fromEither(FieldPatch.from[String](obj, "name"))
+              .mapError(Response.badRequest(_))
+            iconPatch     <- ZIO
+              .fromEither(FieldPatch.from[String](obj, "icon"))
+              .mapError(Response.badRequest(_))
+            iconTypePatch <- ZIO
+              .fromEither(FieldPatch.from[IconType](obj, "iconType"))
+              .mapError(Response.badRequest(_))
+            templateIdPatch <- ZIO
+              .fromEither(FieldPatch.from[AppTemplateId](obj, "templateId"))
+              .mapError(Response.badRequest(_))
+            hostsPatch    <- ZIO
+              .fromEither(FieldPatch.from[List[String]](obj, "hosts"))
+              .mapError(Response.badRequest(_))
+            newName = namePatch.applyTo(a.name).trim
+            _ <- namePatch match {
+              case FieldPatch.Cleared    => ZIO.fail(Response.badRequest("name cannot be cleared"))
+              case FieldPatch.Set(_) if newName.isEmpty =>
+                ZIO.fail(Response.badRequest("name is required"))
+              case _                     => ZIO.unit
+            }
+            _ <- iconTypePatch match {
+              case FieldPatch.Cleared =>
+                ZIO.fail(Response.badRequest("iconType cannot be cleared"))
+              case _                  => ZIO.unit
+            }
+            hostsResolved <- hostsPatch match {
+              case FieldPatch.Cleared       =>
+                ZIO.fail(Response.badRequest("hosts cannot be cleared (send [] to remove all)"))
+              case FieldPatch.Set(raw) =>
+                ZIO.fromEither(parseHosts(raw)).mapError(Response.badRequest(_)).map(Some(_))
+              case FieldPatch.Absent   => ZIO.succeed(None)
+            }
+            updated = a.copy(
+              name = newName,
+              icon = iconPatch.applyToNullable(a.icon),
+              iconType = iconTypePatch.applyTo(a.iconType),
+              templateId = templateIdPatch.applyToNullable(a.templateId),
+            )
+            _ <- appRepo.update(updated).mapError(ErrorMapper.dbErrorToResponse)
+            _ <- hostsResolved match {
+              case Some(hs) => appRepo.setHosts(aid, hs).mapError(ErrorMapper.dbErrorToResponse)
+              case None     => ZIO.unit
+            }
+          } yield Response.ok
+        },
       Method.DELETE / "api" / "apps" / long("id") / "policy" / long("profileId") ->
         handler { (id: Long, profileIdRaw: Long, req: Request) =>
           val aid = AppId(id)

--- a/api/src/routes/FieldPatch.scala
+++ b/api/src/routes/FieldPatch.scala
@@ -30,7 +30,9 @@ enum FieldPatch[+T] {
 }
 
 object FieldPatch {
-  def from[T](obj: Json.Obj, key: String)(using dec: JsonDecoder[T]): Either[String, FieldPatch[T]] =
+  def from[T](obj: Json.Obj, key: String)(
+      using dec: JsonDecoder[T],
+  ): Either[String, FieldPatch[T]] =
     obj.get(key) match {
       case None            => Right(Absent)
       case Some(Json.Null) => Right(Cleared)

--- a/api/src/routes/FieldPatch.scala
+++ b/api/src/routes/FieldPatch.scala
@@ -1,0 +1,47 @@
+package wifihaven.api.routes
+
+import zio.json.*
+import zio.json.ast.Json
+
+// Tri-state PATCH semantics (#996-#999). zio-json's default Option codec
+// collapses absent and JSON null, so PATCH handlers parse Json.Obj directly
+// to distinguish:
+//   - field absent  → Absent       (no change)
+//   - field == null → Cleared      (set to NULL, where the column allows)
+//   - field == v    → Set(v)       (assign)
+enum FieldPatch[+T] {
+  case Absent
+  case Cleared
+  case Set(value: T)
+
+  // Apply to a non-nullable field: only Set wins; Cleared is treated as Absent
+  // (handlers should reject Cleared earlier for non-nullable fields).
+  def applyTo[U >: T](existing: U): U = this match {
+    case Set(v) => v
+    case _      => existing
+  }
+
+  // Apply to a nullable field: Set assigns, Cleared writes NULL, Absent preserves.
+  def applyToNullable[U >: T](existing: Option[U]): Option[U] = this match {
+    case Absent  => existing
+    case Cleared => None
+    case Set(v)  => Some(v)
+  }
+}
+
+object FieldPatch {
+  def from[T](obj: Json.Obj, key: String)(using dec: JsonDecoder[T]): Either[String, FieldPatch[T]] =
+    obj.get(key) match {
+      case None            => Right(Absent)
+      case Some(Json.Null) => Right(Cleared)
+      case Some(j)         => dec.fromJsonAST(j).map(Set(_))
+    }
+
+  // Parse a PATCH request body string to a Json.Obj, or return a decode error
+  // suitable for a 400 response.
+  def parseObj(body: String): Either[String, Json.Obj] =
+    body.fromJson[Json].flatMap {
+      case obj: Json.Obj => Right(obj)
+      case _             => Left("expected JSON object")
+    }
+}

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -9,7 +9,9 @@ import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
 
-import java.time.LocalDate
+import java.time.{LocalDate, LocalTime, ZoneId}
+
+import zio.json.ast.Json
 
 // ── Auth routes ────────────────────────────────────────────────────────────
 
@@ -119,6 +121,56 @@ object AuthRoutes {
           requireAdmin(req, auth) *>
             userRepo.delete(UserId(id)).mapError(ErrorMapper.dbErrorToResponse) *>
             ZIO.succeed(Response.ok)
+        },
+      // #997: field-scoped partial update. Body is a subset of the User read
+      // shape — `username`, `role`, `profileIds` (replace-set, matches the
+      // existing PUT /profiles semantics). Password changes stay on the
+      // dedicated change-password endpoint.
+      Method.PATCH / "api" / "users" / long("id")            ->
+        handler { (id: Long, req: Request) =>
+          val uid = UserId(id)
+          for {
+            _    <- requireAdmin(req, auth)
+            _    <- userRepo
+              .findById(uid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("User not found")))
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj  <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            usernamePatch <- ZIO
+              .fromEither(FieldPatch.from[String](obj, "username"))
+              .mapError(Response.badRequest(_))
+            rolePatch     <- ZIO
+              .fromEither(FieldPatch.from[UserRole](obj, "role"))
+              .mapError(Response.badRequest(_))
+            profilesPatch <- ZIO
+              .fromEither(FieldPatch.from[List[ProfileId]](obj, "profileIds"))
+              .mapError(Response.badRequest(_))
+            _ <- (usernamePatch, rolePatch, profilesPatch) match {
+              case (FieldPatch.Cleared, _, _) =>
+                ZIO.fail(Response.badRequest("username cannot be cleared"))
+              case (_, FieldPatch.Cleared, _) =>
+                ZIO.fail(Response.badRequest("role cannot be cleared"))
+              case (_, _, FieldPatch.Cleared) =>
+                ZIO.fail(Response.badRequest("profileIds cannot be cleared (send [] to unassign all)"))
+              case _                          => ZIO.unit
+            }
+            _ <- usernamePatch match {
+              case FieldPatch.Set(u) =>
+                userRepo.updateUsername(uid, u).mapError(ErrorMapper.dbErrorToResponse)
+              case _                 => ZIO.unit
+            }
+            _ <- rolePatch match {
+              case FieldPatch.Set(r) =>
+                userRepo.updateRole(uid, UserRole.asString(r)).mapError(ErrorMapper.dbErrorToResponse)
+              case _                 => ZIO.unit
+            }
+            _ <- profilesPatch match {
+              case FieldPatch.Set(pids) =>
+                userProfileRepo.setProfilesForUser(uid, pids).mapError(ErrorMapper.dbErrorToResponse)
+              case _                    => ZIO.unit
+            }
+          } yield Response.ok
         },
     )
 }
@@ -369,6 +421,47 @@ object DeviceRoutes {
             _        <- deviceRepo.delete(normalized).mapError(ErrorMapper.dbErrorToResponse)
             // #481: same rationale as PUT — make the next CI failure diagnostic.
             _        <- ZIO.logInfo(s"device deleted: mac=${normalized.value}")
+          } yield Response.ok
+        },
+      // #996: field-scoped partial update. Body is a subset of the Device read
+      // shape — `name` (set), `profileId` (set/null-to-clear). Absent fields
+      // preserve their current value. Same auth as DELETE: writer + access to
+      // the device's current profile, plus access to the destination profile
+      // if `profileId` is being reassigned.
+      Method.PATCH / "api" / "devices" / string("mac")  ->
+        handler { (mac: String, req: Request) =>
+          for {
+            claims <- requireWriter(req, auth)
+            normalized = MacAddress.unsafe(normalizeMac(mac))
+            existing <- deviceRepo
+              .findByMac(normalized)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+            _    <- requireProfileAccess(claims, existing.profileId, userProfileRepo)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj  <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            namePatch <- ZIO
+              .fromEither(FieldPatch.from[String](obj, "name"))
+              .mapError(Response.badRequest(_))
+            pidPatch  <- ZIO
+              .fromEither(FieldPatch.from[ProfileId](obj, "profileId"))
+              .mapError(Response.badRequest(_))
+            _ <- namePatch match {
+              case FieldPatch.Cleared => ZIO.fail(Response.badRequest("name cannot be cleared"))
+              case _                  => ZIO.unit
+            }
+            _ <- pidPatch match {
+              case FieldPatch.Set(pid) => requireProfileAccess(claims, pid, userProfileRepo)
+              case _                   => ZIO.unit
+            }
+            newName = namePatch.applyTo(existing.name)
+            newPid  = pidPatch.applyToNullable(existing.profileId)
+            _       <- deviceRepo
+              .upsert(normalized, newName, newPid, "")
+              .mapError(ErrorMapper.dbErrorToResponse)
+            _       <- ZIO.logInfo(
+              s"device patched: mac=${normalized.value} name=$newName profileId=${newPid.map(_.value.toString).getOrElse("-")}",
+            )
           } yield Response.ok
         },
     )
@@ -1376,6 +1469,79 @@ object HouseholdSettingsRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
+      // #998: field-scoped partial update. Body is a subset of HouseholdSettings.
+      // Top-level fields (dailyResetTime, dailyResetTz) follow standard PATCH
+      // semantics. `heartbeatFilter` is deep-merged when present so the SPA can
+      // autosave a single inner toggle without resending the threshold and
+      // patterns alongside it.
+      Method.PATCH / "api" / "household" / "settings" ->
+        handler { (req: Request) =>
+          for {
+            _        <- requireAdmin(req, auth)
+            existing <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
+            body     <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj      <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            timePatch <- ZIO
+              .fromEither(FieldPatch.from[LocalTime](obj, "dailyResetTime"))
+              .mapError(Response.badRequest(_))
+            tzPatch   <- ZIO
+              .fromEither(FieldPatch.from[ZoneId](obj, "dailyResetTz"))
+              .mapError(Response.badRequest(_))
+            _ <- timePatch match {
+              case FieldPatch.Cleared =>
+                ZIO.fail(Response.badRequest("dailyResetTime cannot be cleared"))
+              case _                  => ZIO.unit
+            }
+            _ <- tzPatch match {
+              case FieldPatch.Cleared =>
+                ZIO.fail(Response.badRequest("dailyResetTz cannot be cleared"))
+              case _                  => ZIO.unit
+            }
+            mergedFilter <- obj.get("heartbeatFilter") match {
+              case None            => ZIO.succeed(existing.heartbeatFilter)
+              case Some(Json.Null) =>
+                ZIO.fail(Response.badRequest("heartbeatFilter cannot be cleared"))
+              case Some(j: Json.Obj) => mergeHeartbeatFilter(existing.heartbeatFilter, j)
+              case Some(_)         =>
+                ZIO.fail(Response.badRequest("heartbeatFilter must be a JSON object"))
+            }
+            merged = HouseholdSettings(
+              dailyResetTime = timePatch.applyTo(existing.dailyResetTime),
+              dailyResetTz = tzPatch.applyTo(existing.dailyResetTz),
+              heartbeatFilter = mergedFilter,
+            )
+            _ <- repo.update(merged).mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+    )
+
+  private def mergeHeartbeatFilter(
+      existing: HeartbeatFilter,
+      obj: Json.Obj,
+  ): IO[Response, HeartbeatFilter] =
+    for {
+      enabledP <- ZIO
+        .fromEither(FieldPatch.from[Boolean](obj, "enabled"))
+        .mapError(Response.badRequest(_))
+      bytesP   <- ZIO
+        .fromEither(FieldPatch.from[Int](obj, "bytesThreshold"))
+        .mapError(Response.badRequest(_))
+      hostsP   <- ZIO
+        .fromEither(FieldPatch.from[List[String]](obj, "heartbeatHostPatterns"))
+        .mapError(Response.badRequest(_))
+      _ <- (enabledP, bytesP, hostsP) match {
+        case (FieldPatch.Cleared, _, _) =>
+          ZIO.fail(Response.badRequest("heartbeatFilter.enabled cannot be cleared"))
+        case (_, FieldPatch.Cleared, _) =>
+          ZIO.fail(Response.badRequest("heartbeatFilter.bytesThreshold cannot be cleared"))
+        case (_, _, FieldPatch.Cleared) =>
+          ZIO.fail(Response.badRequest("heartbeatFilter.heartbeatHostPatterns cannot be cleared"))
+        case _                          => ZIO.unit
+      }
+    } yield HeartbeatFilter(
+      enabled = enabledP.applyTo(existing.enabled),
+      bytesThreshold = bytesP.applyTo(existing.bytesThreshold),
+      heartbeatHostPatterns = hostsP.applyTo(existing.heartbeatHostPatterns),
     )
 }
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -146,28 +146,34 @@ object AuthRoutes {
             profilesPatch <- ZIO
               .fromEither(FieldPatch.from[List[ProfileId]](obj, "profileIds"))
               .mapError(Response.badRequest(_))
-            _ <- (usernamePatch, rolePatch, profilesPatch) match {
+            _             <- (usernamePatch, rolePatch, profilesPatch) match {
               case (FieldPatch.Cleared, _, _) =>
                 ZIO.fail(Response.badRequest("username cannot be cleared"))
               case (_, FieldPatch.Cleared, _) =>
                 ZIO.fail(Response.badRequest("role cannot be cleared"))
               case (_, _, FieldPatch.Cleared) =>
-                ZIO.fail(Response.badRequest("profileIds cannot be cleared (send [] to unassign all)"))
+                ZIO.fail(
+                  Response.badRequest("profileIds cannot be cleared (send [] to unassign all)"),
+                )
               case _                          => ZIO.unit
             }
-            _ <- usernamePatch match {
+            _             <- usernamePatch match {
               case FieldPatch.Set(u) =>
                 userRepo.updateUsername(uid, u).mapError(ErrorMapper.dbErrorToResponse)
               case _                 => ZIO.unit
             }
-            _ <- rolePatch match {
+            _             <- rolePatch match {
               case FieldPatch.Set(r) =>
-                userRepo.updateRole(uid, UserRole.asString(r)).mapError(ErrorMapper.dbErrorToResponse)
+                userRepo
+                  .updateRole(uid, UserRole.asString(r))
+                  .mapError(ErrorMapper.dbErrorToResponse)
               case _                 => ZIO.unit
             }
-            _ <- profilesPatch match {
+            _             <- profilesPatch match {
               case FieldPatch.Set(pids) =>
-                userProfileRepo.setProfilesForUser(uid, pids).mapError(ErrorMapper.dbErrorToResponse)
+                userProfileRepo
+                  .setProfilesForUser(uid, pids)
+                  .mapError(ErrorMapper.dbErrorToResponse)
               case _                    => ZIO.unit
             }
           } yield Response.ok
@@ -433,33 +439,33 @@ object DeviceRoutes {
           for {
             claims <- requireWriter(req, auth)
             normalized = MacAddress.unsafe(normalizeMac(mac))
-            existing <- deviceRepo
+            existing  <- deviceRepo
               .findByMac(normalized)
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _    <- requireProfileAccess(claims, existing.profileId, userProfileRepo)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
-            obj  <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            _         <- requireProfileAccess(claims, existing.profileId, userProfileRepo)
+            body      <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
             namePatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "name"))
               .mapError(Response.badRequest(_))
             pidPatch  <- ZIO
               .fromEither(FieldPatch.from[ProfileId](obj, "profileId"))
               .mapError(Response.badRequest(_))
-            _ <- namePatch match {
+            _         <- namePatch match {
               case FieldPatch.Cleared => ZIO.fail(Response.badRequest("name cannot be cleared"))
               case _                  => ZIO.unit
             }
-            _ <- pidPatch match {
+            _         <- pidPatch match {
               case FieldPatch.Set(pid) => requireProfileAccess(claims, pid, userProfileRepo)
               case _                   => ZIO.unit
             }
             newName = namePatch.applyTo(existing.name)
-            newPid  = pidPatch.applyToNullable(existing.profileId)
-            _       <- deviceRepo
+            newPid = pidPatch.applyToNullable(existing.profileId)
+            _ <- deviceRepo
               .upsert(normalized, newName, newPid, "")
               .mapError(ErrorMapper.dbErrorToResponse)
-            _       <- ZIO.logInfo(
+            _ <- ZIO.logInfo(
               s"device patched: mac=${normalized.value} name=$newName profileId=${newPid.map(_.value.toString).getOrElse("-")}",
             )
           } yield Response.ok
@@ -1449,14 +1455,14 @@ object HouseholdSettingsRoutes {
       repo: HouseholdSettingsRepo,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "household" / "settings" ->
+      Method.GET / "api" / "household" / "settings"   ->
         handler { (req: Request) =>
           for {
             _ <- requireAuth(req, auth)
             s <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(s.toJson)
         },
-      Method.PUT / "api" / "household" / "settings" ->
+      Method.PUT / "api" / "household" / "settings"   ->
         handler { (req: Request) =>
           for {
             _    <- requireAdmin(req, auth)
@@ -1477,32 +1483,32 @@ object HouseholdSettingsRoutes {
       Method.PATCH / "api" / "household" / "settings" ->
         handler { (req: Request) =>
           for {
-            _        <- requireAdmin(req, auth)
-            existing <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
-            body     <- req.body.asString.orElseFail(Response.badRequest(""))
-            obj      <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+            _         <- requireAdmin(req, auth)
+            existing  <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
+            body      <- req.body.asString.orElseFail(Response.badRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
             timePatch <- ZIO
               .fromEither(FieldPatch.from[LocalTime](obj, "dailyResetTime"))
               .mapError(Response.badRequest(_))
             tzPatch   <- ZIO
               .fromEither(FieldPatch.from[ZoneId](obj, "dailyResetTz"))
               .mapError(Response.badRequest(_))
-            _ <- timePatch match {
+            _         <- timePatch match {
               case FieldPatch.Cleared =>
                 ZIO.fail(Response.badRequest("dailyResetTime cannot be cleared"))
               case _                  => ZIO.unit
             }
-            _ <- tzPatch match {
+            _         <- tzPatch match {
               case FieldPatch.Cleared =>
                 ZIO.fail(Response.badRequest("dailyResetTz cannot be cleared"))
               case _                  => ZIO.unit
             }
             mergedFilter <- obj.get("heartbeatFilter") match {
-              case None            => ZIO.succeed(existing.heartbeatFilter)
-              case Some(Json.Null) =>
+              case None              => ZIO.succeed(existing.heartbeatFilter)
+              case Some(Json.Null)   =>
                 ZIO.fail(Response.badRequest("heartbeatFilter cannot be cleared"))
               case Some(j: Json.Obj) => mergeHeartbeatFilter(existing.heartbeatFilter, j)
-              case Some(_)         =>
+              case Some(_)           =>
                 ZIO.fail(Response.badRequest("heartbeatFilter must be a JSON object"))
             }
             merged = HouseholdSettings(
@@ -1510,7 +1516,7 @@ object HouseholdSettingsRoutes {
               dailyResetTz = tzPatch.applyTo(existing.dailyResetTz),
               heartbeatFilter = mergedFilter,
             )
-            _ <- repo.update(merged).mapError(ErrorMapper.dbErrorToResponse)
+            _            <- repo.update(merged).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
     )
@@ -1529,7 +1535,7 @@ object HouseholdSettingsRoutes {
       hostsP   <- ZIO
         .fromEither(FieldPatch.from[List[String]](obj, "heartbeatHostPatterns"))
         .mapError(Response.badRequest(_))
-      _ <- (enabledP, bytesP, hostsP) match {
+      _        <- (enabledP, bytesP, hostsP) match {
         case (FieldPatch.Cleared, _, _) =>
           ZIO.fail(Response.badRequest("heartbeatFilter.enabled cannot be cleared"))
         case (_, FieldPatch.Cleared, _) =>

--- a/api/test/src/feature/AppPatchApiSpec.scala
+++ b/api/test/src/feature/AppPatchApiSpec.scala
@@ -1,0 +1,169 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+// #999: PATCH /api/apps/:id — partial update of mutable App fields (name,
+// icon, iconType, templateId, hosts). slug is immutable post-create.
+object AppPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def setupApp(
+      name: String = "Original",
+      icon: Option[String] = Some("📺"),
+      templateId: Option[AppTemplateId] = Some(AppTemplateId.unsafe("youtube")),
+  ) =
+    for {
+      _       <- cleanDb
+      appRepo <- ZIO.service[AppRepo]
+      id      <- appRepo.create(name, "original", templateId, icon)
+      _       <- appRepo.setHosts(id, List(Hostname.unsafe("youtube.com")))
+    } yield id
+
+  private def routesAndToken =
+    for {
+      auth        <- makeAuth
+      appRepo     <- ZIO.service[AppRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      upRepo      <- ZIO.service[UserProfileRepo]
+      tk          <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (AppRoutes.routes(auth, appRepo, profileRepo, upRepo), tk)
+
+  private def patch(routes: Routes[Any, Response], token: String, id: AppId, body: String) =
+    routes.runZIO(
+      Request
+        .patch(url(s"/api/apps/${id.value}"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  def spec = suite("PATCH /api/apps/:id (#999)")(
+    test("single-field patch updates name only") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"name":"Renamed"}""")
+        appRepo      <- ZIO.service[AppRepo]
+        after        <- appRepo.findById(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "Renamed")) &&
+        assertTrue(after.exists(_.icon.contains("📺"))) &&
+        assertTrue(after.exists(_.templateId.contains(AppTemplateId.unsafe("youtube"))))
+    },
+    test("multi-field patch updates name + iconType together") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"name":"X","iconType":"url"}""")
+        appRepo      <- ZIO.service[AppRepo]
+        after        <- appRepo.findById(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "X")) &&
+        assertTrue(after.exists(_.iconType == IconType.Url))
+    },
+    test("hosts replaces the host set with canonicalized values") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"hosts":["*.youtube.com","ytimg.com"]}""")
+        appRepo      <- ZIO.service[AppRepo]
+        hosts        <- appRepo.getHosts(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(hosts.toSet == Set(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+    },
+    test("hosts=[] empties the host set") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"hosts":[]}""")
+        appRepo      <- ZIO.service[AppRepo]
+        hosts        <- appRepo.getHosts(id)
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(hosts.isEmpty)
+    },
+    test("absent fields preserve existing values + hosts") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, "{}")
+        appRepo      <- ZIO.service[AppRepo]
+        after        <- appRepo.findById(id)
+        hosts        <- appRepo.getHosts(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "Original")) &&
+        assertTrue(after.exists(_.icon.contains("📺"))) &&
+        assertTrue(after.exists(_.templateId.contains(AppTemplateId.unsafe("youtube")))) &&
+        assertTrue(hosts == List(Hostname.unsafe("youtube.com")))
+    },
+    test("null on icon clears the icon (nullable)") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"icon":null}""")
+        appRepo      <- ZIO.service[AppRepo]
+        after        <- appRepo.findById(id)
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(after.exists(_.icon.isEmpty))
+    },
+    test("null on templateId clears it (nullable)") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"templateId":null}""")
+        appRepo      <- ZIO.service[AppRepo]
+        after        <- appRepo.findById(id)
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(after.exists(_.templateId.isEmpty))
+    },
+    test("null on non-nullable name returns 400") {
+      for {
+        id           <- setupApp()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"name":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("404 when app is missing") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, AppId(999999L), """{"name":"X"}""")
+      } yield assertTrue(resp.status == Status.NotFound)
+    },
+    test("403 when non-admin (adult) tries to PATCH") {
+      for {
+        id          <- setupApp()
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        appRepo     <- ZIO.service[AppRepo]
+        profileRepo <- ZIO.service[ProfileRepo]
+        auth        <- makeAuth
+        hash        <- auth.hashPassword("pass")
+        uid         <- userRepo.create("mom", hash, "adult")
+        _           <- userRepo.clearMustChangePassword(uid)
+        token       <- auth.login("mom", "pass").map(_.token.value)
+        routes      = AppRoutes.routes(auth, appRepo, profileRepo, upRepo)
+        resp        <- patch(routes, token, id, """{"name":"X"}""")
+      } yield assertTrue(resp.status == Status.Forbidden)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/AppPatchApiSpec.scala
+++ b/api/test/src/feature/AppPatchApiSpec.scala
@@ -20,13 +20,13 @@ object AppPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
     for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
   private def url(p: String) = URL.decode(p).toOption.get
@@ -161,8 +161,8 @@ object AppPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
         uid         <- userRepo.create("mom", hash, "adult")
         _           <- userRepo.clearMustChangePassword(uid)
         token       <- auth.login("mom", "pass").map(_.token.value)
-        routes      = AppRoutes.routes(auth, appRepo, profileRepo, upRepo)
-        resp        <- patch(routes, token, id, """{"name":"X"}""")
+        routes = AppRoutes.routes(auth, appRepo, profileRepo, upRepo)
+        resp <- patch(routes, token, id, """{"name":"X"}""")
       } yield assertTrue(resp.status == Status.Forbidden)
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/DevicePatchApiSpec.scala
+++ b/api/test/src/feature/DevicePatchApiSpec.scala
@@ -1,0 +1,167 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+// #996: PATCH /api/devices/:mac — partial, field-scoped updates with
+// symmetric read/write shapes (web client posts Partial<Device>).
+object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private val Mac = MacAddress.unsafe("aa:bb:cc:dd:ee:01")
+
+  private def setupDevice(initialName: String = "OldName", profileName: String = "Kids") =
+    for {
+      _           <- cleanDb
+      profileRepo <- ZIO.service[ProfileRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      profiles    <- profileRepo.listAll
+      pid = profiles.find(_.name == profileName).get.id
+      _ <- deviceRepo.upsert(Mac, initialName, Some(pid), "")
+    } yield pid
+
+  private def routesAndToken =
+    for {
+      auth            <- makeAuth
+      deviceRepo      <- ZIO.service[DeviceRepo]
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      token           <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (DeviceRoutes.routes(auth, deviceRepo, userProfileRepo), token)
+
+  private def patch(routes: Routes[Any, Response], token: String, body: String) =
+    routes.runZIO(
+      Request
+        .patch(url(s"/api/devices/${Mac.value}"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  def spec = suite("PATCH /api/devices/:mac (#996)")(
+    test("single-field patch updates only that field") {
+      for {
+        pid          <- setupDevice()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"name":"NewName"}""")
+        deviceRepo   <- ZIO.service[DeviceRepo]
+        after        <- deviceRepo.findByMac(Mac)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "NewName")) &&
+        assertTrue(after.exists(_.profileId.contains(pid)))
+    },
+    test("multi-field patch updates all supplied fields") {
+      for {
+        _            <- setupDevice()
+        profileRepo  <- ZIO.service[ProfileRepo]
+        profiles     <- profileRepo.listAll
+        adultsId     = profiles.find(_.name == "Adults").get.id
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, s"""{"name":"Tablet","profileId":${adultsId.value}}""")
+        deviceRepo   <- ZIO.service[DeviceRepo]
+        after        <- deviceRepo.findByMac(Mac)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "Tablet")) &&
+        assertTrue(after.exists(_.profileId.contains(adultsId)))
+    },
+    test("absent field preserves existing value") {
+      for {
+        pid          <- setupDevice(initialName = "Keep")
+        (routes, tk) <- routesAndToken
+        // Empty patch — change nothing.
+        resp         <- patch(routes, tk, "{}")
+        deviceRepo   <- ZIO.service[DeviceRepo]
+        after        <- deviceRepo.findByMac(Mac)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.name == "Keep")) &&
+        assertTrue(after.exists(_.profileId.contains(pid)))
+    },
+    test("null on nullable profileId clears the assignment") {
+      for {
+        _            <- setupDevice()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"profileId":null}""")
+        deviceRepo   <- ZIO.service[DeviceRepo]
+        after        <- deviceRepo.findByMac(Mac)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.profileId.isEmpty))
+    },
+    test("null on non-nullable name returns 400") {
+      for {
+        _            <- setupDevice()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"name":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("404 when device is missing") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"name":"X"}""")
+      } yield assertTrue(resp.status == Status.NotFound)
+    },
+    test("401 without token") {
+      for {
+        _      <- setupDevice()
+        routes <- routesAndToken.map(_._1)
+        resp   <- routes.runZIO(
+          Request
+            .patch(url(s"/api/devices/${Mac.value}"), Body.fromString("""{"name":"X"}"""))
+            .addHeader(Header.ContentType(MediaType.application.json)),
+        )
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+    test("403 when adult tries to move device to a profile they don't have access to") {
+      for {
+        _            <- setupDevice()
+        profileRepo  <- ZIO.service[ProfileRepo]
+        userRepo     <- ZIO.service[UserRepo]
+        upRepo       <- ZIO.service[UserProfileRepo]
+        deviceRepo   <- ZIO.service[DeviceRepo]
+        auth         <- makeAuth
+        profiles     <- profileRepo.listAll
+        kidsId       = profiles.find(_.name == "Kids").get.id
+        adultsId     = profiles.find(_.name == "Adults").get.id
+        hash         <- auth.hashPassword("pass")
+        momId        <- userRepo.create("mom", hash, "adult")
+        _            <- userRepo.clearMustChangePassword(momId)
+        _            <- upRepo.setProfilesForUser(momId, List(kidsId))
+        token        <- auth.login("mom", "pass").map(_.token.value)
+        routes       = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        resp         <- routes.runZIO(
+          Request
+            .patch(
+              url(s"/api/devices/${Mac.value}"),
+              Body.fromString(s"""{"profileId":${adultsId.value}}"""),
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json)),
+        )
+        after <- deviceRepo.findByMac(Mac)
+      } yield assertTrue(resp.status == Status.Forbidden) &&
+        assertTrue(after.exists(_.profileId.contains(kidsId)))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/DevicePatchApiSpec.scala
+++ b/api/test/src/feature/DevicePatchApiSpec.scala
@@ -20,13 +20,13 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
     for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
@@ -74,10 +74,10 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     },
     test("multi-field patch updates all supplied fields") {
       for {
-        _            <- setupDevice()
-        profileRepo  <- ZIO.service[ProfileRepo]
-        profiles     <- profileRepo.listAll
-        adultsId     = profiles.find(_.name == "Adults").get.id
+        _           <- setupDevice()
+        profileRepo <- ZIO.service[ProfileRepo]
+        profiles    <- profileRepo.listAll
+        adultsId = profiles.find(_.name == "Adults").get.id
         (routes, tk) <- routesAndToken
         resp         <- patch(routes, tk, s"""{"name":"Tablet","profileId":${adultsId.value}}""")
         deviceRepo   <- ZIO.service[DeviceRepo]
@@ -135,22 +135,22 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     },
     test("403 when adult tries to move device to a profile they don't have access to") {
       for {
-        _            <- setupDevice()
-        profileRepo  <- ZIO.service[ProfileRepo]
-        userRepo     <- ZIO.service[UserRepo]
-        upRepo       <- ZIO.service[UserProfileRepo]
-        deviceRepo   <- ZIO.service[DeviceRepo]
-        auth         <- makeAuth
-        profiles     <- profileRepo.listAll
-        kidsId       = profiles.find(_.name == "Kids").get.id
-        adultsId     = profiles.find(_.name == "Adults").get.id
-        hash         <- auth.hashPassword("pass")
-        momId        <- userRepo.create("mom", hash, "adult")
-        _            <- userRepo.clearMustChangePassword(momId)
-        _            <- upRepo.setProfilesForUser(momId, List(kidsId))
-        token        <- auth.login("mom", "pass").map(_.token.value)
-        routes       = DeviceRoutes.routes(auth, deviceRepo, upRepo)
-        resp         <- routes.runZIO(
+        _           <- setupDevice()
+        profileRepo <- ZIO.service[ProfileRepo]
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        auth        <- makeAuth
+        profiles    <- profileRepo.listAll
+        kidsId   = profiles.find(_.name == "Kids").get.id
+        adultsId = profiles.find(_.name == "Adults").get.id
+        hash  <- auth.hashPassword("pass")
+        momId <- userRepo.create("mom", hash, "adult")
+        _     <- userRepo.clearMustChangePassword(momId)
+        _     <- upRepo.setProfilesForUser(momId, List(kidsId))
+        token <- auth.login("mom", "pass").map(_.token.value)
+        routes = DeviceRoutes.routes(auth, deviceRepo, upRepo)
+        resp  <- routes.runZIO(
           Request
             .patch(
               url(s"/api/devices/${Mac.value}"),

--- a/api/test/src/feature/HouseholdPatchApiSpec.scala
+++ b/api/test/src/feature/HouseholdPatchApiSpec.scala
@@ -21,13 +21,13 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
     for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
   private def url(p: String) = URL.decode(p).toOption.get
@@ -35,7 +35,11 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
   private val Seed = HouseholdSettings(
     dailyResetTime = LocalTime.of(0, 0),
     dailyResetTz = ZoneId.of("America/Los_Angeles"),
-    heartbeatFilter = HeartbeatFilter(enabled = false, bytesThreshold = 1024, heartbeatHostPatterns = List("foo.com")),
+    heartbeatFilter = HeartbeatFilter(
+      enabled = false,
+      bytesThreshold = 1024,
+      heartbeatHostPatterns = List("foo.com"),
+    ),
   )
 
   private def setupHousehold =
@@ -98,10 +102,11 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       for {
         _            <- setupHousehold
         (routes, tk) <- routesAndToken
-        body = """{"dailyResetTz":"America/New_York","heartbeatFilter":{"bytesThreshold":4096,"heartbeatHostPatterns":["bar.com"]}}"""
-        resp         <- patch(routes, tk, body)
-        repo         <- ZIO.service[HouseholdSettingsRepo]
-        after        <- repo.get
+        body =
+          """{"dailyResetTz":"America/New_York","heartbeatFilter":{"bytesThreshold":4096,"heartbeatHostPatterns":["bar.com"]}}"""
+        resp  <- patch(routes, tk, body)
+        repo  <- ZIO.service[HouseholdSettingsRepo]
+        after <- repo.get
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(after.dailyResetTz == ZoneId.of("America/New_York")) &&
         assertTrue(after.heartbeatFilter.enabled == false) && // preserved
@@ -132,8 +137,8 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         id       <- userRepo.create("mom", hash, "adult")
         _        <- userRepo.clearMustChangePassword(id)
         token    <- auth.login("mom", "pass").map(_.token.value)
-        routes   = HouseholdSettingsRoutes.routes(auth, repo)
-        resp     <- patch(routes, token, """{"dailyResetTime":"05:00:00"}""")
+        routes = HouseholdSettingsRoutes.routes(auth, repo)
+        resp <- patch(routes, token, """{"dailyResetTime":"05:00:00"}""")
       } yield assertTrue(resp.status == Status.Forbidden)
     },
     test("401 without token") {
@@ -142,7 +147,10 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         routes <- routesAndToken.map(_._1)
         resp   <- routes.runZIO(
           Request
-            .patch(url("/api/household/settings"), Body.fromString("""{"dailyResetTime":"05:00:00"}"""))
+            .patch(
+              url("/api/household/settings"),
+              Body.fromString("""{"dailyResetTime":"05:00:00"}"""),
+            )
             .addHeader(Header.ContentType(MediaType.application.json)),
         )
       } yield assertTrue(resp.status == Status.Unauthorized)

--- a/api/test/src/feature/HouseholdPatchApiSpec.scala
+++ b/api/test/src/feature/HouseholdPatchApiSpec.scala
@@ -1,0 +1,151 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+import java.time.{LocalTime, ZoneId}
+
+// #998: PATCH /api/household/settings — top-level field-scoped PATCH plus
+// deep-merge of the nested heartbeatFilter object.
+object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private val Seed = HouseholdSettings(
+    dailyResetTime = LocalTime.of(0, 0),
+    dailyResetTz = ZoneId.of("America/Los_Angeles"),
+    heartbeatFilter = HeartbeatFilter(enabled = false, bytesThreshold = 1024, heartbeatHostPatterns = List("foo.com")),
+  )
+
+  private def setupHousehold =
+    for {
+      _    <- cleanDb
+      repo <- ZIO.service[HouseholdSettingsRepo]
+      _    <- repo.update(Seed)
+    } yield ()
+
+  private def routesAndToken =
+    for {
+      auth <- makeAuth
+      repo <- ZIO.service[HouseholdSettingsRepo]
+      tk   <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (HouseholdSettingsRoutes.routes(auth, repo), tk)
+
+  private def patch(routes: Routes[Any, Response], token: String, body: String) =
+    routes.runZIO(
+      Request
+        .patch(url("/api/household/settings"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  def spec = suite("PATCH /api/household/settings (#998)")(
+    test("single top-level field patch") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"dailyResetTime":"03:30:00"}""")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.dailyResetTime == LocalTime.of(3, 30)) &&
+        assertTrue(after.dailyResetTz == Seed.dailyResetTz) &&
+        assertTrue(after.heartbeatFilter == Seed.heartbeatFilter)
+    },
+    test("nested heartbeatFilter deep-merges (enabled toggle preserves threshold + patterns)") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"heartbeatFilter":{"enabled":true}}""")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.heartbeatFilter.enabled) &&
+        assertTrue(after.heartbeatFilter.bytesThreshold == 1024) &&
+        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == List("foo.com"))
+    },
+    test("absent fields preserve existing values") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, "{}")
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(after == Seed)
+    },
+    test("multi-field patch (top-level + nested) applied together") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        body = """{"dailyResetTz":"America/New_York","heartbeatFilter":{"bytesThreshold":4096,"heartbeatHostPatterns":["bar.com"]}}"""
+        resp         <- patch(routes, tk, body)
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.dailyResetTz == ZoneId.of("America/New_York")) &&
+        assertTrue(after.heartbeatFilter.enabled == false) && // preserved
+        assertTrue(after.heartbeatFilter.bytesThreshold == 4096) &&
+        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == List("bar.com"))
+    },
+    test("null on non-nullable field returns 400") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"dailyResetTime":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("null on heartbeatFilter object returns 400") {
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, """{"heartbeatFilter":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("403 when non-admin (adult) tries to PATCH") {
+      for {
+        _        <- setupHousehold
+        userRepo <- ZIO.service[UserRepo]
+        repo     <- ZIO.service[HouseholdSettingsRepo]
+        auth     <- makeAuth
+        hash     <- auth.hashPassword("pass")
+        id       <- userRepo.create("mom", hash, "adult")
+        _        <- userRepo.clearMustChangePassword(id)
+        token    <- auth.login("mom", "pass").map(_.token.value)
+        routes   = HouseholdSettingsRoutes.routes(auth, repo)
+        resp     <- patch(routes, token, """{"dailyResetTime":"05:00:00"}""")
+      } yield assertTrue(resp.status == Status.Forbidden)
+    },
+    test("401 without token") {
+      for {
+        _      <- setupHousehold
+        routes <- routesAndToken.map(_._1)
+        resp   <- routes.runZIO(
+          Request
+            .patch(url("/api/household/settings"), Body.fromString("""{"dailyResetTime":"05:00:00"}"""))
+            .addHeader(Header.ContentType(MediaType.application.json)),
+        )
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/UserPatchApiSpec.scala
+++ b/api/test/src/feature/UserPatchApiSpec.scala
@@ -20,13 +20,13 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
   private def makeAuth =
     for {
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
@@ -74,21 +74,21 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     },
     test("multi-field patch updates username + role + profileIds together") {
       for {
-        id           <- setupUser(role = "adult")
-        profileRepo  <- ZIO.service[ProfileRepo]
-        profiles     <- profileRepo.listAll
-        kidsId       = profiles.find(_.name == "Kids").get.id
+        id          <- setupUser(role = "adult")
+        profileRepo <- ZIO.service[ProfileRepo]
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
         (routes, tk) <- routesAndToken
-        resp <- patch(
+        resp         <- patch(
           routes,
           tk,
           id,
           s"""{"username":"junior","role":"child","profileIds":[${kidsId.value}]}""",
         )
-        userRepo <- ZIO.service[UserRepo]
-        upRepo   <- ZIO.service[UserProfileRepo]
-        after    <- userRepo.findById(id)
-        pids     <- upRepo.listProfilesForUser(id)
+        userRepo     <- ZIO.service[UserRepo]
+        upRepo       <- ZIO.service[UserProfileRepo]
+        after        <- userRepo.findById(id)
+        pids         <- upRepo.listProfilesForUser(id)
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(after.exists(_.username == "junior")) &&
         assertTrue(after.exists(_.role == UserRole.Child)) &&
@@ -96,24 +96,19 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     },
     test("absent field preserves existing value") {
       for {
-        _            <- ZIO.unit
-        profileRepo  <- ZIO.service[ProfileRepo]
-        profiles0    <- ZIO.unit *> profileRepo.listAll.flatMap(_ => ZIO.succeed(())) // warm up cleanDb later
-        _            <- ZIO.unit
-        userRepo     <- ZIO.service[UserRepo]
-        // proper setup:
-        _ <- cleanDb
-        auth <- makeAuth
-        hash <- auth.hashPassword("secret")
-        id   <- userRepo.create("alice", hash, "adult")
-        _    <- userRepo.clearMustChangePassword(id)
-        profileRepo2 <- ZIO.service[ProfileRepo]
-        profiles     <- profileRepo2.listAll
-        kidsId       = profiles.find(_.name == "Kids").get.id
-        upRepo       <- ZIO.service[UserProfileRepo]
-        _            <- upRepo.setProfilesForUser(id, List(kidsId))
-        token        <- auth.login("admin", "changeme").map(_.token.value)
-        routes       = AuthRoutes.routes(auth, userRepo, upRepo)
+        _           <- cleanDb
+        userRepo    <- ZIO.service[UserRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        profileRepo <- ZIO.service[ProfileRepo]
+        auth        <- makeAuth
+        hash        <- auth.hashPassword("secret")
+        id          <- userRepo.create("alice", hash, "adult")
+        _           <- userRepo.clearMustChangePassword(id)
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        _     <- upRepo.setProfilesForUser(id, List(kidsId))
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        routes = AuthRoutes.routes(auth, userRepo, upRepo)
         // Empty body — change nothing.
         resp  <- patch(routes, token, id, "{}")
         after <- userRepo.findById(id)
@@ -136,12 +131,12 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         _            <- userRepo.clearMustChangePassword(id)
         profileRepo2 <- ZIO.service[ProfileRepo]
         profiles     <- profileRepo2.listAll
-        kidsId       = profiles.find(_.name == "Kids").get.id
-        _            <- upRepo.setProfilesForUser(id, List(kidsId))
-        token        <- auth.login("admin", "changeme").map(_.token.value)
-        routes       = AuthRoutes.routes(auth, userRepo, upRepo)
-        resp         <- patch(routes, token, id, """{"profileIds":[]}""")
-        pids         <- upRepo.listProfilesForUser(id)
+        kidsId = profiles.find(_.name == "Kids").get.id
+        _     <- upRepo.setProfilesForUser(id, List(kidsId))
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        routes = AuthRoutes.routes(auth, userRepo, upRepo)
+        resp <- patch(routes, token, id, """{"profileIds":[]}""")
+        pids <- upRepo.listProfilesForUser(id)
       } yield assertTrue(resp.status == Status.Ok) && assertTrue(pids.isEmpty)
     },
     test("null on non-nullable username returns 400") {
@@ -172,9 +167,9 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         upRepo   <- ZIO.service[UserProfileRepo]
         auth     <- makeAuth
         // alice is the seeded adult; she shouldn't be able to PATCH herself.
-        token <- auth.login("alice", "secret").map(_.token.value)
+        token    <- auth.login("alice", "secret").map(_.token.value)
         routes = AuthRoutes.routes(auth, userRepo, upRepo)
-        resp  <- patch(routes, token, id, """{"username":"alice2"}""")
+        resp <- patch(routes, token, id, """{"username":"alice2"}""")
       } yield assertTrue(resp.status == Status.Forbidden)
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/UserPatchApiSpec.scala
+++ b/api/test/src/feature/UserPatchApiSpec.scala
@@ -1,0 +1,181 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+// #997: PATCH /api/users/:id — partial update of username/role/profileIds.
+// Password changes stay on the dedicated change-password endpoint.
+object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def setupUser(role: String = "adult", profileIds: List[ProfileId] = Nil) =
+    for {
+      _        <- cleanDb
+      userRepo <- ZIO.service[UserRepo]
+      upRepo   <- ZIO.service[UserProfileRepo]
+      auth     <- makeAuth
+      hash     <- auth.hashPassword("secret")
+      id       <- userRepo.create("alice", hash, role)
+      _        <- userRepo.clearMustChangePassword(id)
+      _        <- upRepo.setProfilesForUser(id, profileIds)
+    } yield id
+
+  private def routesAndToken =
+    for {
+      auth     <- makeAuth
+      userRepo <- ZIO.service[UserRepo]
+      upRepo   <- ZIO.service[UserProfileRepo]
+      token    <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (AuthRoutes.routes(auth, userRepo, upRepo), token)
+
+  private def patch(routes: Routes[Any, Response], token: String, id: UserId, body: String) =
+    routes.runZIO(
+      Request
+        .patch(url(s"/api/users/${id.value}"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  def spec = suite("PATCH /api/users/:id (#997)")(
+    test("single-field patch updates username only") {
+      for {
+        id           <- setupUser()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"username":"alice2"}""")
+        userRepo     <- ZIO.service[UserRepo]
+        after        <- userRepo.findById(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.username == "alice2")) &&
+        assertTrue(after.exists(_.role == UserRole.Adult))
+    },
+    test("multi-field patch updates username + role + profileIds together") {
+      for {
+        id           <- setupUser(role = "adult")
+        profileRepo  <- ZIO.service[ProfileRepo]
+        profiles     <- profileRepo.listAll
+        kidsId       = profiles.find(_.name == "Kids").get.id
+        (routes, tk) <- routesAndToken
+        resp <- patch(
+          routes,
+          tk,
+          id,
+          s"""{"username":"junior","role":"child","profileIds":[${kidsId.value}]}""",
+        )
+        userRepo <- ZIO.service[UserRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        after    <- userRepo.findById(id)
+        pids     <- upRepo.listProfilesForUser(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.username == "junior")) &&
+        assertTrue(after.exists(_.role == UserRole.Child)) &&
+        assertTrue(pids == List(kidsId))
+    },
+    test("absent field preserves existing value") {
+      for {
+        _            <- ZIO.unit
+        profileRepo  <- ZIO.service[ProfileRepo]
+        profiles0    <- ZIO.unit *> profileRepo.listAll.flatMap(_ => ZIO.succeed(())) // warm up cleanDb later
+        _            <- ZIO.unit
+        userRepo     <- ZIO.service[UserRepo]
+        // proper setup:
+        _ <- cleanDb
+        auth <- makeAuth
+        hash <- auth.hashPassword("secret")
+        id   <- userRepo.create("alice", hash, "adult")
+        _    <- userRepo.clearMustChangePassword(id)
+        profileRepo2 <- ZIO.service[ProfileRepo]
+        profiles     <- profileRepo2.listAll
+        kidsId       = profiles.find(_.name == "Kids").get.id
+        upRepo       <- ZIO.service[UserProfileRepo]
+        _            <- upRepo.setProfilesForUser(id, List(kidsId))
+        token        <- auth.login("admin", "changeme").map(_.token.value)
+        routes       = AuthRoutes.routes(auth, userRepo, upRepo)
+        // Empty body — change nothing.
+        resp  <- patch(routes, token, id, "{}")
+        after <- userRepo.findById(id)
+        pids  <- upRepo.listProfilesForUser(id)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.exists(_.username == "alice")) &&
+        assertTrue(after.exists(_.role == UserRole.Adult)) &&
+        assertTrue(pids == List(kidsId))
+    },
+    test("profileIds=[] unassigns all profiles") {
+      for {
+        _            <- ZIO.unit
+        profileRepo  <- ZIO.service[ProfileRepo]
+        _            <- cleanDb
+        userRepo     <- ZIO.service[UserRepo]
+        upRepo       <- ZIO.service[UserProfileRepo]
+        auth         <- makeAuth
+        hash         <- auth.hashPassword("secret")
+        id           <- userRepo.create("alice", hash, "adult")
+        _            <- userRepo.clearMustChangePassword(id)
+        profileRepo2 <- ZIO.service[ProfileRepo]
+        profiles     <- profileRepo2.listAll
+        kidsId       = profiles.find(_.name == "Kids").get.id
+        _            <- upRepo.setProfilesForUser(id, List(kidsId))
+        token        <- auth.login("admin", "changeme").map(_.token.value)
+        routes       = AuthRoutes.routes(auth, userRepo, upRepo)
+        resp         <- patch(routes, token, id, """{"profileIds":[]}""")
+        pids         <- upRepo.listProfilesForUser(id)
+      } yield assertTrue(resp.status == Status.Ok) && assertTrue(pids.isEmpty)
+    },
+    test("null on non-nullable username returns 400") {
+      for {
+        id           <- setupUser()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"username":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("invalid role value returns 400") {
+      for {
+        id           <- setupUser()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, id, """{"role":"superuser"}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("404 when user is missing") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, UserId(999999L), """{"username":"x"}""")
+      } yield assertTrue(resp.status == Status.NotFound)
+    },
+    test("403 when non-admin (adult) tries to PATCH") {
+      for {
+        id       <- setupUser()
+        userRepo <- ZIO.service[UserRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        // alice is the seeded adult; she shouldn't be able to PATCH herself.
+        token <- auth.login("alice", "secret").map(_.token.value)
+        routes = AuthRoutes.routes(auth, userRepo, upRepo)
+        resp  <- patch(routes, token, id, """{"username":"alice2"}""")
+      } yield assertTrue(resp.status == Status.Forbidden)
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary
- Adds field-scoped `PATCH` endpoints for **devices**, **users**, **household settings**, and **apps**. SPA can now build a `Partial<Resource>` and post it directly — read shape and write shape match modulo `Partial<>`.
- Introduces `FieldPatch` tri-state (`Absent` / `Cleared` / `Set`) parsed from the zio-json AST so PATCH bodies distinguish absent (no change), `null` (clear, where the column is nullable), and explicit value (assign). zio-json's default Option codec collapses absent vs null, hence the AST walk.
- Existing `PUT`/`POST` endpoints + `setHosts` / `setProfiles` semantics unchanged. Auth boundaries on each PATCH match the resource's existing write rules.

## Per-resource

### #996 — `PATCH /api/devices/:mac`
- Fields: `name` (set), `profileId` (set / `null` = unassign).
- Auth: `requireWriter` + access to current profile; assigning to a new profile re-checks access on the destination.

### #997 — `PATCH /api/users/:id`
- Fields: `username` (set), `role` (set, validated against `UserRole`), `profileIds` (replace-set; send `[]` to unassign all).
- Auth: admin-only. Password changes intentionally stay on the dedicated `change-password` endpoint.

### #998 — `PATCH /api/household/settings`
- Top-level: `dailyResetTime`, `dailyResetTz`.
- Nested `heartbeatFilter` is **deep-merged**: PATCH `{ "heartbeatFilter": { "enabled": true } }` flips one flag and preserves `bytesThreshold` + `heartbeatHostPatterns`. This is what the autosave form needs.
- TZ field for #1010 will follow when that lands; no speculative scaffolding here.
- Auth: admin-only.

### #999 — `PATCH /api/apps/:id`
- Fields: `name`, `icon` (set / `null` = clear), `iconType`, `templateId` (set / `null` = clear), `hosts` (replace-list; send `[]` to remove all). `slug` stays immutable post-create.
- Auth: admin-only.

## Repo additions
- `UserRepo.updateUsername` / `updateRole` (admin can rename / re-role without rewriting the password hash).
- No schema migration needed — PATCH is a JSON-shape concern, not a DB change.

## Test plan
- [x] `mill api.test` — 34 new PATCH tests across 4 specs (single-field, multi-field, absent-preserves, `null`-clears on nullable, `null`-rejects on non-nullable, 404, 401, 403). Full api suite green (66 + downstream specs).
- [x] `mill shared.test` — green.
- [ ] SPA: per-form autosave (#995 + #1000-#1003) can ride on top.

## Notes
- ZERO router-side changes; `shared/contract/api-to-router/policy_snapshot.json` untouched.
- No backwards-compat shims — per project convention, SPA + API deploy atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)