### PR TITLE
feat(web): merged /profiles page shell — collapse cards + summary row (#972)

### DIFF
--- a/web/src/components/layout/Layout.test.tsx
+++ b/web/src/components/layout/Layout.test.tsx
@@ -42,17 +42,22 @@ function renderLayout() {
 }
 
 describe('Layout — primary nav', () => {
-  it('renders the four primary items inline for admins', () => {
+  it('renders the three primary items inline for admins', () => {
     renderLayout()
-    for (const label of ['Dashboard', 'Devices', 'Profiles', 'Screen Time']) {
+    for (const label of ['Dashboard', 'Devices', 'Profiles']) {
       expect(screen.getAllByRole('link', { name: new RegExp(label) }).length).toBeGreaterThan(0)
     }
   })
 
-  it('renders the four primary items inline for non-admins', () => {
+  it('drops the Screen Time entry (merged into /profiles in #972)', () => {
+    renderLayout()
+    expect(screen.queryByRole('link', { name: /Screen Time/ })).not.toBeInTheDocument()
+  })
+
+  it('renders the three primary items inline for non-admins', () => {
     mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
     renderLayout()
-    for (const label of ['Dashboard', 'Devices', 'Profiles', 'Screen Time']) {
+    for (const label of ['Dashboard', 'Devices', 'Profiles']) {
       expect(screen.getAllByRole('link', { name: new RegExp(label) }).length).toBeGreaterThan(0)
     }
   })
@@ -92,17 +97,17 @@ describe('Layout — Settings dropdown', () => {
 })
 
 describe('Layout — mobile bottom nav', () => {
-  it('renders exactly 4 cells regardless of role', () => {
+  it('renders exactly 3 cells regardless of role', () => {
     const { container, unmount } = renderLayout()
     const bottomNav = container.querySelector('nav.md\\:hidden')
     expect(bottomNav).not.toBeNull()
-    expect(bottomNav!.querySelectorAll('a').length).toBe(4)
+    expect(bottomNav!.querySelectorAll('a').length).toBe(3)
     unmount()
 
     mockAuth = { username: 'bob', role: 'child', isAdmin: false, logout: logoutMock }
     const { container: c2 } = renderLayout()
     const bottomNav2 = c2.querySelector('nav.md\\:hidden')
-    expect(bottomNav2!.querySelectorAll('a').length).toBe(4)
+    expect(bottomNav2!.querySelectorAll('a').length).toBe(3)
   })
 })
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -12,11 +12,13 @@ interface NavItem {
   children?: NavItem[]
 }
 
+// #972 — Screen Time merged into Profiles; the collapsed-card summary row on
+// /profiles carries the at-a-glance time view. /time still routes for one
+// release as a defensive measure (sub-7 / #978 removes it entirely).
 const primaryNav: NavItem[] = [
-  { to: '/dashboard', label: 'Dashboard',   icon: '◈' },
-  { to: '/devices',   label: 'Devices',     icon: '⬡' },
-  { to: '/profiles',  label: 'Profiles',    icon: '◉' },
-  { to: '/time',      label: 'Screen Time', icon: '◷' },
+  { to: '/dashboard', label: 'Dashboard', icon: '◈' },
+  { to: '/devices',   label: 'Devices',   icon: '⬡' },
+  { to: '/profiles',  label: 'Profiles',  icon: '◉' },
 ]
 
 const settingsNav: NavItem[] = [

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import type { Device, ProfileDetail, User } from '@/types/api'
+import type { Device, ProfileDetail, ProfileTimeSummary, User } from '@/types/api'
 import { withQuery } from '@/test/queryWrapper'
 
 vi.mock('@/api/client', () => ({
@@ -30,6 +30,10 @@ vi.mock('@/api/client', () => ({
       list: vi.fn(),
       setPolicy: vi.fn(),
       deletePolicy: vi.fn(),
+    },
+    time: {
+      summaryAll: vi.fn(),
+      grantExtension: vi.fn(),
     },
   },
 }))
@@ -96,6 +100,15 @@ const tabletDevice: Device = {
   profileName: 'Adults', lastSeenIp: null, lastSeenAt: null,
 }
 
+const kidsSummary: ProfileTimeSummary = {
+  profileId: 1, profileName: 'Kids', date: '2026-05-24',
+  dailyLimitMins: 120, usedMins: 45, extensionMins: 0, remainingMins: 75,
+}
+const adultsSummary: ProfileTimeSummary = {
+  profileId: 2, profileName: 'Adults', date: '2026-05-24',
+  dailyLimitMins: null, usedMins: 0, extensionMins: 0, remainingMins: null,
+}
+
 const aliceUser: User = { id: 10, username: 'alice', role: 'child', profileIds: [1] }
 const bobUser:   User = { id: 11, username: 'bob',   role: 'adult', profileIds: [2] }
 const carolUser: User = { id: 12, username: 'carol', role: 'admin', profileIds: [1, 2] }
@@ -122,24 +135,100 @@ beforeEach(() => {
   ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.apps.setPolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.apps.deletePolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([kidsSummary, adultsSummary])
+  ;(api.time.grantExtension as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 1, grantedMinutes: 30 })
 })
 
-describe('ProfilesPage — list', () => {
-  it('renders profile names, paused badge, blocked categories, schedules, site limits, and daily limit', async () => {
+// #972 — cards are collapse-by-default; tests that need the expanded body
+// (Edit / Delete / Pause buttons, devices, linked users) must expand first.
+async function expand(pid: number, user = userEvent.setup()) {
+  await user.click(screen.getByTestId(`profile-row-toggle-${pid}`))
+}
+
+describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
+  it('renders one collapsed card per profile with name and pause chip', async () => {
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    const adultsCard = screen.getByTestId('profile-card-2')
     expect(within(kidsCard).getByText('Kids')).toBeInTheDocument()
-    expect(screen.getByText('Adults')).toBeInTheDocument()
-    expect(screen.getByText('Paused')).toBeInTheDocument()
-    // 'adult' (the blocked category) lives inside the Kids card; the bob/admin role
-    // badges read 'adult' too, so scope this lookup to the Kids card.
-    expect(within(kidsCard).getByText('adult')).toBeInTheDocument()
-    expect(within(kidsCard).getByText('gambling')).toBeInTheDocument()
-    expect(screen.getByText('Bedtime')).toBeInTheDocument()
-    expect(screen.getByText('21:00 → 07:00')).toBeInTheDocument()
-    expect(screen.getByText('YouTube')).toBeInTheDocument()
-    expect(screen.getByText('30m · youtube.com')).toBeInTheDocument()
-    expect(screen.getByText('120 min')).toBeInTheDocument()
+    expect(within(adultsCard).getByText('Adults')).toBeInTheDocument()
+    // collapsed body is hidden — categories / schedules / limit live inside it
+    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    expect(within(kidsCard).queryByText('120 min')).not.toBeInTheDocument()
+  })
+
+  it('summary row carries used/cap, pause chip, and +Time for limited profiles', async () => {
+    // override the Kids profile to drop the schedule so the "active" chip
+    // assertion is independent of when the test happens to run.
+    (api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...kidsProfile, schedules: [] },
+      adultsProfile,
+    ])
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    // "Kids" has dailyLimitMins=120, usedMins=45 → "45m / 2:00"
+    const time = within(kidsCard).getByTestId('profile-summary-time-1')
+    expect(time).toHaveTextContent('45m')
+    expect(time).toHaveTextContent('2:00')
+    const chip = within(kidsCard).getByTestId('profile-pause-chip-1')
+    expect(chip).toHaveAttribute('data-chip', 'active')
+    expect(within(kidsCard).getByTestId('profile-row-grant-1')).toBeInTheDocument()
+  })
+
+  it('paused profile renders the Paused chip', async () => {
+    renderPage()
+    const adultsCard = await screen.findByTestId('profile-card-2')
+    const chip = within(adultsCard).getByTestId('profile-pause-chip-2')
+    expect(chip).toHaveAttribute('data-chip', 'paused-manual')
+    expect(chip).toHaveTextContent(/Paused/)
+  })
+
+  it('time-exceeded summary flips the chip and hides the bar fill at 100%', async () => {
+    (api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...kidsSummary, usedMins: 130, remainingMins: 0 },
+      adultsSummary,
+    ])
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    const chip = within(kidsCard).getByTestId('profile-pause-chip-1')
+    expect(chip).toHaveAttribute('data-chip', 'time-exceeded')
+  })
+
+  it('no +Time button for profiles without a daily limit', async () => {
+    renderPage()
+    const adultsCard = await screen.findByTestId('profile-card-2')
+    expect(within(adultsCard).queryByTestId('profile-row-grant-2')).not.toBeInTheDocument()
+  })
+
+  it('clicking the row toggles the expanded body', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
+    expect(within(kidsCard).getByText('Bedtime')).toBeInTheDocument()
+    expect(within(kidsCard).getByText('120 min')).toBeInTheDocument()
+    expect(within(kidsCard).getByText('YouTube')).toBeInTheDocument()
+    expect(within(kidsCard).getByText('21:00 → 07:00')).toBeInTheDocument()
+    await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
+    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+  })
+})
+
+describe('ProfilesPage — +Time mutation (#972 / #946)', () => {
+  it('opens the modal then submits grantExtension with the chosen minutes', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByTestId('profile-row-grant-1'))
+    // 30m is the default; pick 60m to make the assertion specific
+    await user.click(screen.getByRole('button', { name: /^60m$/ }))
+    await user.click(screen.getByRole('button', { name: /^Grant 60m$/ }))
+    await waitFor(() =>
+      expect(api.time.grantExtension).toHaveBeenCalledWith({
+        profileId: 1, extraMinutes: 60, note: null,
+      }),
+    )
   })
 })
 
@@ -150,6 +239,7 @@ describe('ProfilesPage — pause / delete', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /Pause/ }))
     await waitFor(() =>
       expect(api.profiles.update).toHaveBeenCalledWith(
@@ -164,6 +254,7 @@ describe('ProfilesPage — pause / delete', () => {
     const user = userEvent.setup()
     renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')
+    await expand(2, user)
     await user.click(within(adultsCard).getByRole('button', { name: /Resume/ }))
     await waitFor(() =>
       expect(api.profiles.update).toHaveBeenCalledWith(
@@ -178,6 +269,7 @@ describe('ProfilesPage — pause / delete', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
     expect(confirmSpy).toHaveBeenCalled()
     await waitFor(() => expect(api.profiles.delete).toHaveBeenCalledWith(1))
@@ -189,6 +281,7 @@ describe('ProfilesPage — pause / delete', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
     expect(api.profiles.delete).not.toHaveBeenCalled()
     confirmSpy.mockRestore()
@@ -269,6 +362,7 @@ describe('ProfilesPage — edit', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
 
     expect(screen.getByDisplayValue('Kids')).toBeInTheDocument()
@@ -310,6 +404,7 @@ describe('ProfilesPage — cross-device overlap toggle (#751)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
 
     expect(screen.getByTestId('profile-overlap-mode-sum')).toBeChecked()
@@ -343,9 +438,12 @@ describe('ProfilesPage — role gating', () => {
 
 describe('ProfilesPage — devices section', () => {
   it('renders devices grouped under their profile', async () => {
+    const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     const adultsCard = screen.getByTestId('profile-card-2')
+    await expand(1, user)
+    await expand(2, user)
 
     expect(within(kidsCard).getByTestId('profile-device-100')).toHaveTextContent('Kid Phone')
     expect(within(kidsCard).getByTestId('profile-device-100')).toHaveTextContent('aa:bb:cc:dd:ee:01')
@@ -357,9 +455,12 @@ describe('ProfilesPage — devices section', () => {
 
 describe('ProfilesPage — linked users section', () => {
   it('renders linked users for each profile (admin view)', async () => {
+    const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     const adultsCard = screen.getByTestId('profile-card-2')
+    await expand(1, user)
+    await expand(2, user)
 
     expect(within(kidsCard).getByTestId('profile-user-10')).toHaveTextContent('alice')
     expect(within(kidsCard).getByTestId('profile-user-12')).toHaveTextContent('carol')
@@ -382,6 +483,7 @@ describe('ProfilesPage — linked users section', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /Edit users/ }))
 
     const modal = await screen.findByTestId('edit-users-modal')
@@ -408,6 +510,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     const blockAll      = screen.getByTestId('profile-failure-mode-block-all')       as HTMLInputElement
     const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
@@ -421,6 +524,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     const user = userEvent.setup()
     renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')
+    await expand(2, user)
     await user.click(within(adultsCard).getByRole('button', { name: /^Edit$/ }))
     const lastKnownGood = screen.getByTestId('profile-failure-mode-last-known-good') as HTMLInputElement
     const blockAll      = screen.getByTestId('profile-failure-mode-block-all')       as HTMLInputElement
@@ -432,6 +536,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(screen.getByTestId('profile-failure-mode-allow-all'))
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
@@ -444,6 +549,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(screen.getByTestId('profile-failure-mode-last-known-good'))
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
@@ -465,6 +571,7 @@ describe('ProfilesPage — #385 failureMode (three modes)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     expect(
       screen.getByText(/drop all forwarded traffic for this profile's devices/i),
@@ -512,6 +619,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     const section = await screen.findByTestId('apps-section')
     expect(within(section).getByText(/No apps yet/i)).toBeInTheDocument()
@@ -523,6 +631,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await screen.findByTestId('app-row-50')
     expect(screen.getByTestId('app-row-51')).toBeInTheDocument()
@@ -536,6 +645,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(await screen.findByTestId('app-row-50-block'))
     await waitFor(() =>
@@ -548,6 +658,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(await screen.findByTestId('app-row-50-allow'))
     await waitFor(() =>
@@ -560,6 +671,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(await screen.findByTestId('app-row-50-time-limit'))
     expect(api.apps.setPolicy).not.toHaveBeenCalled()
@@ -571,6 +683,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     const input = await screen.findByTestId('app-row-50-minutes')
     await user.type(input, '45')
@@ -585,6 +698,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     await user.click(await screen.findByTestId('app-row-51-clear'))
     await waitFor(() =>
@@ -608,6 +722,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     expect(await screen.findByTestId('apps-section-manage-link')).toHaveAttribute('href', '/apps')
   })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -2,15 +2,17 @@ import { useEffect, useMemo, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import { useProfiles, useDevices, useInvalidators } from '@/api/queries'
+import { useProfiles, useDevices, useInvalidators, useTimeStatusSummary } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import type {
   AppDetail, AppMode, AppPolicyAssignment,
   BlocklistSummary, CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
+  ProfileTimeSummary,
   ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { PageLoader } from './DashboardPage'
+import { formatMins } from './TimePage'
 
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
 
@@ -88,18 +90,90 @@ function formToRequest(f: FormState): UpsertProfileRequest {
   }
 }
 
+// #972: chip states reflect the at-a-glance "what's this profile doing right
+// now" answer. Schedule-active check is approximated locally from the cached
+// ProfileDetail.schedules; subsection #973 may move this server-side.
+type PauseChip = 'active' | 'paused-manual' | 'paused-schedule' | 'time-exceeded'
+
+const WEEKDAY_SHORT_TO_KEY: Record<string, string> = {
+  Mon: 'mon', Tue: 'tue', Wed: 'wed', Thu: 'thu', Fri: 'fri', Sat: 'sat', Sun: 'sun',
+}
+
+function isScheduleActiveNow(
+  s: { days: string[]; startLocal: string; endLocal: string; tz: string },
+  now: Date = new Date(),
+): boolean {
+  let weekday = ''
+  let hh = '00'
+  let mm = '00'
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: s.tz, weekday: 'short', hour: '2-digit', minute: '2-digit', hour12: false,
+    })
+    for (const p of fmt.formatToParts(now)) {
+      if (p.type === 'weekday') weekday = WEEKDAY_SHORT_TO_KEY[p.value] ?? ''
+      else if (p.type === 'hour') hh = p.value === '24' ? '00' : p.value
+      else if (p.type === 'minute') mm = p.value
+    }
+  } catch {
+    return false
+  }
+  const minOfDay = parseInt(hh, 10) * 60 + parseInt(mm, 10)
+  const [sh, sm] = s.startLocal.split(':').map(Number)
+  const [eh, em] = s.endLocal.split(':').map(Number)
+  if ([sh, sm, eh, em].some(n => !Number.isFinite(n))) return false
+  const start = sh * 60 + sm
+  const end   = eh * 60 + em
+  if (start === end) return false
+  // Same-day window — only active if today's weekday is in the day-set.
+  if (start < end) return s.days.includes(weekday) && minOfDay >= start && minOfDay < end
+  // Wraps midnight (e.g. 21:00 → 07:00). The "before-midnight" half belongs to
+  // the start day; the "after-midnight" half belongs to the next day.
+  const prevWeekday = previousWeekday(weekday)
+  if (minOfDay >= start) return s.days.includes(weekday)
+  if (minOfDay <  end)   return s.days.includes(prevWeekday)
+  return false
+}
+
+const ORDER = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+function previousWeekday(k: string): string {
+  const i = ORDER.indexOf(k)
+  if (i < 0) return ''
+  return ORDER[(i + 6) % 7]
+}
+
+function computeChip(pd: ProfileDetail, summary: ProfileTimeSummary | undefined): PauseChip {
+  if (pd.profile.paused) return 'paused-manual'
+  if (summary && summary.remainingMins != null && summary.remainingMins <= 0) return 'time-exceeded'
+  if (pd.schedules.some(s => isScheduleActiveNow(s))) return 'paused-schedule'
+  return 'active'
+}
+
+const CHIP_LABEL: Record<PauseChip, string> = {
+  'active':          'Active',
+  'paused-manual':   'Paused',
+  'paused-schedule': 'Paused (schedule)',
+  'time-exceeded':   'Time exceeded',
+}
+
+const CHIP_CLASS: Record<PauseChip, string> = {
+  'active':          'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  'paused-manual':   'bg-yellow-500/10 text-yellow-400 border-yellow-500/20',
+  'paused-schedule': 'bg-blue-500/10 text-blue-400 border-blue-500/20',
+  'time-exceeded':   'bg-red-500/10 text-red-400 border-red-500/20',
+}
+
 export function ProfilesPage() {
   const { isAdmin } = useAuth()
   const invalidators = useInvalidators()
   const profilesQuery = useProfiles()
   const devicesQuery  = useDevices()
-  const profiles = profilesQuery.data ?? []
-  const devices  = devicesQuery.data  ?? []
+  const summariesQuery = useTimeStatusSummary()
+  const profiles  = profilesQuery.data  ?? []
+  const devices   = devicesQuery.data   ?? []
+  const summaries = summariesQuery.data ?? []
   const [categories, setCategories] = useState<BlocklistSummary[]>([])
   const [allUsers, setAllUsers] = useState<User[]>([])
-  // Aux fetches (blocklists/users/household) aren't part of the #803 hot
-  // loop — keep them as one-shot useEffect state. They only need to load
-  // once when the page mounts.
   const [auxLoading, setAuxLoading] = useState(true)
   const loading = profilesQuery.isPending || devicesQuery.isPending || auxLoading
   const [editingId, setEditingId] = useState<number | 'new' | null>(null)
@@ -110,9 +184,35 @@ export function ProfilesPage() {
   const [userPick, setUserPick] = useState<number[]>([])
   const [household, setHousehold] = useState<HouseholdSettings | null>(null)
   const [apps, setApps] = useState<AppDetail[]>([])
+  // #972 — collapse-by-default; toggle state lives in-memory only. Persistence
+  // across reloads is a deferred enhancement; the design doc calls this out.
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const toggleExpanded = (pid: number) => setExpanded(prev => {
+    const next = new Set(prev)
+    if (next.has(pid)) next.delete(pid); else next.add(pid)
+    return next
+  })
+
+  // #972 — +Time mutation reused from the screen-time page. #946-fixed pattern:
+  // invalidate the full ['time','status'] subtree so both the summary row and
+  // any expanded detail re-render with the new remaining minutes.
+  const [extProfileId, setExtProfileId] = useState<number | null>(null)
+  const [extMins, setExtMins] = useState(30)
+  const [extNote, setExtNote] = useState('')
+  const grantMutation = useMutation({
+    mutationFn: (vars: { profileId: number; extraMinutes: number; note: string | null }) =>
+      api.time.grantExtension(vars),
+    onSuccess: () => {
+      setExtProfileId(null)
+      setExtMins(30)
+      setExtNote('')
+      return invalidators.timeStatus()
+    },
+  })
 
   // #298: LogsPage links to `/profiles?id=...`; scroll + highlight the
   // matching profile card so the parent sees what they clicked from logs.
+  // Also auto-expand it so the linked content is visible immediately.
   const [params] = useSearchParams()
   const queryId = params.get('id')
   const [highlightId, setHighlightId] = useState<number | null>(null)
@@ -121,6 +221,7 @@ export function ProfilesPage() {
     const id = Number(queryId)
     if (!Number.isFinite(id) || !profiles.some(p => p.profile.id === id)) return
     setHighlightId(id)
+    setExpanded(prev => prev.has(id) ? prev : new Set(prev).add(id))
     const el = document.querySelector(`[data-testid="profile-card-${id}"]`) as HTMLElement | null
     el?.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
     const t = setTimeout(() => setHighlightId(null), 2000)
@@ -150,6 +251,12 @@ export function ProfilesPage() {
     return m
   }, [allUsers])
 
+  const summaryByProfile = useMemo(() => {
+    const m = new Map<number, ProfileTimeSummary>()
+    for (const s of summaries) m.set(s.profileId, s)
+    return m
+  }, [summaries])
+
   async function loadAux() {
     const [cats, users, hs, appsList] = await Promise.all([
       api.blocklists.list().catch(() => [] as BlocklistSummary[]),
@@ -172,8 +279,6 @@ export function ProfilesPage() {
     loadAux().finally(() => setAuxLoading(false))
   }, [])
 
-  // After a profile mutation, refetch user→profile links too so the
-  // "linked users" badges stay in sync.
   async function refetchAux() {
     if (!isAdmin) return
     const users = await api.users.list().catch(() => [] as User[])
@@ -216,9 +321,8 @@ export function ProfilesPage() {
 
   async function togglePause(pd: ProfileDetail) {
     // #406: setting `paused` explicitly via the full-profile PUT is
-    // idempotent under concurrent clicks. The old POST /pause endpoint was
-    // a server-side toggle that race-flipped under double-click / retry.
-    // #423 tracks adding PATCH so we don't have to send the whole profile.
+    // idempotent under concurrent clicks. #423 tracks adding PATCH so we
+    // don't have to send the whole profile.
     const body = formToRequest(detailToForm(pd))
     body.paused = !pd.profile.paused
     await updateMutation.mutateAsync({ id: pd.profile.id, body })
@@ -270,7 +374,19 @@ export function ProfilesPage() {
     }
   }
 
+  const granting = grantMutation.isPending
+  async function grantExtension(profileId: number) {
+    await grantMutation.mutateAsync({
+      profileId,
+      extraMinutes: extMins,
+      note: extNote || null,
+    })
+  }
+
   if (loading) return <PageLoader />
+
+  const profileName = (id: number | null) =>
+    id == null ? '' : profiles.find(p => p.profile.id === id)?.profile.name ?? ''
 
   return (
     <div className="space-y-6">
@@ -286,155 +402,24 @@ export function ProfilesPage() {
         )}
       </div>
 
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-3">
         {profiles.map(pd => (
-          <div key={pd.profile.id} data-testid={`profile-card-${pd.profile.id}`} className={`bg-gray-900 rounded-2xl border border-gray-800 p-5 space-y-4 transition-shadow ${highlightId === pd.profile.id ? 'ring-2 ring-emerald-500/60' : ''}`}>
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <h3 className="font-bold text-white text-lg">{pd.profile.name}</h3>
-                {pd.profile.paused && (
-                  <span className="text-xs text-red-400 bg-red-500/10 px-2 py-0.5 rounded mt-1 inline-block">Paused</span>
-                )}
-              </div>
-              {isAdmin && (
-                <div className="flex flex-wrap gap-2 shrink-0">
-                  <button onClick={() => togglePause(pd)}
-                    className={`text-xs px-3 py-1.5 rounded-lg border transition-colors ${
-                      pd.profile.paused
-                        ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20 hover:bg-emerald-500/20'
-                        : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20 hover:bg-yellow-500/20'
-                    }`}>
-                    {pd.profile.paused ? '▶ Resume' : '⏸ Pause'}
-                  </button>
-                  <button onClick={() => startEdit(pd)}
-                    className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
-                    Edit
-                  </button>
-                  <button onClick={() => startEditUsers(pd.profile.id)}
-                    className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
-                    Edit users
-                  </button>
-                  <button onClick={() => del(pd.profile.id, pd.profile.name)}
-                    className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors">
-                    Delete
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {pd.profile.blockedCategories.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Blocked categories</p>
-                <div className="flex flex-wrap gap-2">
-                  {pd.profile.blockedCategories.map(c => (
-                    <span key={c} className="text-xs bg-red-500/10 text-red-400 px-2 py-1 rounded-lg font-mono">{c}</span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {(pd.profile.extraBlocked.length > 0 || pd.profile.extraAllowed.length > 0) && (
-              <div className="grid grid-cols-2 gap-3">
-                {pd.profile.extraBlocked.length > 0 && (
-                  <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Blocked domains</p>
-                    <p className="text-xs text-gray-400 font-mono">{pd.profile.extraBlocked.length} entr{pd.profile.extraBlocked.length === 1 ? 'y' : 'ies'}</p>
-                  </div>
-                )}
-                {pd.profile.extraAllowed.length > 0 && (
-                  <div>
-                    <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Allowed domains</p>
-                    <p className="text-xs text-gray-400 font-mono">{pd.profile.extraAllowed.length} entr{pd.profile.extraAllowed.length === 1 ? 'y' : 'ies'}</p>
-                  </div>
-                )}
-              </div>
-            )}
-
-            {pd.timeLimit && (
-              <p className="text-sm text-gray-400">
-                Daily limit: <span className="text-white font-medium">{pd.timeLimit.dailyMinutes} min</span>
-              </p>
-            )}
-
-            {pd.schedules.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Schedules</p>
-                {pd.schedules.map(s => (
-                  <div key={s.id} className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
-                    <span className="text-gray-300">{s.name}</span>
-                    <span className="text-yellow-400 font-mono text-xs">
-                      {s.startLocal} → {s.endLocal} <span className="text-yellow-300/60">({s.tz})</span>
-                    </span>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <div data-testid={`profile-devices-${pd.profile.id}`}>
-              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Devices</p>
-              {(devicesByProfile.get(pd.profile.id) ?? []).length === 0
-                ? <p className="text-xs text-gray-600">No devices assigned.</p>
-                : (
-                  <div className="space-y-1">
-                    {(devicesByProfile.get(pd.profile.id) ?? []).map(d => (
-                      <div key={d.id} data-testid={`profile-device-${d.id}`}
-                        className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2">
-                        <span className="text-gray-300">{d.name}</span>
-                        <span className="text-gray-500 font-mono text-xs">{d.mac}</span>
-                      </div>
-                    ))}
-                  </div>
-                )
-              }
-            </div>
-
-            {isAdmin && (
-              <div data-testid={`profile-users-${pd.profile.id}`}>
-                <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Linked users</p>
-                {(usersByProfile.get(pd.profile.id) ?? []).length === 0
-                  ? <p className="text-xs text-gray-600">No users linked.</p>
-                  : (
-                    <div className="flex flex-wrap gap-2">
-                      {(usersByProfile.get(pd.profile.id) ?? []).map(u => (
-                        <span key={u.id} data-testid={`profile-user-${u.id}`}
-                          className="text-xs bg-gray-800 text-gray-300 border border-gray-700 px-2 py-1 rounded-lg">
-                          {u.username}
-                          <span className={`ml-2 font-mono px-1.5 py-0.5 rounded ${
-                            u.role === 'admin'
-                              ? 'bg-emerald-500/10 text-emerald-400'
-                              : u.role === 'adult'
-                                ? 'bg-blue-500/10 text-blue-400'
-                                : 'bg-yellow-500/10 text-yellow-400'
-                          }`}>{u.role}</span>
-                        </span>
-                      ))}
-                    </div>
-                  )
-                }
-              </div>
-            )}
-
-            {pd.siteTimeLimits.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Site Limits</p>
-                {pd.siteTimeLimits.map(s => (
-                  <div key={s.id} className="flex justify-between items-center text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
-                    <span className="text-gray-300">{s.label}</span>
-                    <div className="flex items-center gap-2">
-                      <span className="text-emerald-400 text-xs font-mono">{s.dailyMinutes}m · {s.domainPattern}</span>
-                      <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
-                        s.exemptFromDaily
-                          ? 'bg-gray-700 text-gray-400'
-                          : 'bg-amber-500/20 text-amber-400'
-                      }`}>
-                        {s.exemptFromDaily ? 'exempt' : 'counts'}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          <ProfileShellRow
+            key={pd.profile.id}
+            pd={pd}
+            summary={summaryByProfile.get(pd.profile.id)}
+            devices={devicesByProfile.get(pd.profile.id) ?? []}
+            users={usersByProfile.get(pd.profile.id) ?? []}
+            isAdmin={isAdmin}
+            expanded={expanded.has(pd.profile.id)}
+            highlight={highlightId === pd.profile.id}
+            onToggle={() => toggleExpanded(pd.profile.id)}
+            onEdit={() => startEdit(pd)}
+            onEditUsers={() => startEditUsers(pd.profile.id)}
+            onDelete={() => del(pd.profile.id, pd.profile.name)}
+            onTogglePause={() => togglePause(pd)}
+            onGrantTime={() => setExtProfileId(pd.profile.id)}
+          />
         ))}
       </div>
 
@@ -506,6 +491,306 @@ export function ProfilesPage() {
           defaultTz={household?.dailyResetTz ?? browserTimezone()}
         />
       )}
+
+      {/* #972 — +Time modal lifted from TimePage so the +Time button in the
+          collapsed summary works on /profiles too. */}
+      {extProfileId !== null && (
+        <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-sm p-6 space-y-4">
+            <h3 className="text-lg font-bold text-white">Grant Extra Time</h3>
+            <p className="text-sm text-gray-400">{profileName(extProfileId)}</p>
+
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                Extra minutes
+              </label>
+              <div className="flex gap-2">
+                {[15, 30, 45, 60].map(m => (
+                  <button
+                    key={m}
+                    onClick={() => setExtMins(m)}
+                    className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+                      extMins === m
+                        ? 'bg-emerald-500 text-black'
+                        : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                    }`}
+                  >
+                    {m}m
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+                Note (optional)
+              </label>
+              <input
+                type="text"
+                value={extNote}
+                onChange={e => setExtNote(e.target.value)}
+                placeholder="Homework finished, good behavior…"
+                className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white text-sm placeholder-gray-600 focus:outline-none focus:border-emerald-500"
+              />
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button
+                onClick={() => setExtProfileId(null)}
+                className="flex-1 py-3 rounded-xl bg-gray-800 text-gray-300 font-medium hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => grantExtension(extProfileId)}
+                disabled={granting}
+                className="flex-1 py-3 rounded-xl bg-emerald-500 text-black font-semibold hover:bg-emerald-400 disabled:opacity-50 transition-colors"
+              >
+                {granting ? 'Granting…' : `Grant ${extMins}m`}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// #972 — collapsed accordion row for the merged Profiles page. Header carries
+// the summary (name, used/cap + bar, pause chip, +Time). Expanded body shows
+// the existing card content + escape-hatch buttons (Edit, Edit users, Pause,
+// Delete) that subsections #973-#977 will replace with inline editors.
+function ProfileShellRow({
+  pd, summary, devices, users, isAdmin, expanded, highlight,
+  onToggle, onEdit, onEditUsers, onDelete, onTogglePause, onGrantTime,
+}: {
+  pd: ProfileDetail
+  summary: ProfileTimeSummary | undefined
+  devices: Device[]
+  users: User[]
+  isAdmin: boolean
+  expanded: boolean
+  highlight: boolean
+  onToggle: () => void
+  onEdit: () => void
+  onEditUsers: () => void
+  onDelete: () => void
+  onTogglePause: () => void
+  onGrantTime: () => void
+}) {
+  const chip = computeChip(pd, summary)
+  const hasLimit = summary?.dailyLimitMins != null
+  const usedMins = summary?.usedMins ?? 0
+  const limitBase = hasLimit ? (summary!.dailyLimitMins ?? 0) + (summary!.extensionMins ?? 0) : 0
+  const pct = hasLimit && limitBase > 0
+    ? Math.min(100, Math.round((usedMins / limitBase) * 100))
+    : 0
+  const overLimit = chip === 'time-exceeded'
+
+  return (
+    <div
+      data-testid={`profile-card-${pd.profile.id}`}
+      className={`bg-gray-900 rounded-2xl border transition-shadow ${
+        overLimit ? 'border-red-500/40' : 'border-gray-800'
+      } ${highlight ? 'ring-2 ring-emerald-500/60' : ''}`}
+    >
+      <div className="flex items-center gap-2 px-5 py-4">
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-expanded={expanded}
+          data-testid={`profile-row-toggle-${pd.profile.id}`}
+          className="flex-1 flex items-center gap-3 text-left min-w-0"
+        >
+          <span className={`text-gray-500 transition-transform ${expanded ? 'rotate-90' : ''}`}>▸</span>
+          <span className="font-semibold text-white text-lg truncate">{pd.profile.name}</span>
+        </button>
+
+        <div className="flex items-center gap-3 shrink-0">
+          {/* Used / cap with a thin inline progress bar */}
+          <div
+            data-testid={`profile-summary-time-${pd.profile.id}`}
+            className="hidden sm:flex flex-col items-end min-w-[7rem]"
+          >
+            <span className="text-xs font-mono text-gray-300">
+              {formatMins(usedMins)}
+              {hasLimit ? ` / ${formatMins(summary!.dailyLimitMins ?? 0)}` : ''}
+            </span>
+            {hasLimit && (
+              <div className="w-24 h-1 bg-gray-800 rounded-full overflow-hidden mt-1">
+                <div
+                  className={`h-full rounded-full ${overLimit ? 'bg-red-500' : 'bg-emerald-500'}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            )}
+          </div>
+
+          <span
+            data-testid={`profile-pause-chip-${pd.profile.id}`}
+            data-chip={chip}
+            className={`text-xs px-2 py-1 rounded-lg border ${CHIP_CLASS[chip]}`}
+          >
+            {CHIP_LABEL[chip]}
+          </span>
+
+          {isAdmin && hasLimit && (
+            <button
+              type="button"
+              onClick={onGrantTime}
+              data-testid={`profile-row-grant-${pd.profile.id}`}
+              className="text-xs bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border border-emerald-500/20 px-3 py-1.5 rounded-lg transition-colors"
+            >
+              + Time
+            </button>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="px-5 pb-5 border-t border-gray-800 pt-4 space-y-4">
+          {/* #972: stub expanded view — subsections #973-#977 replace the
+              escape-hatch buttons below with inline editors. */}
+          {isAdmin && (
+            <div className="flex flex-wrap gap-2">
+              <button onClick={onTogglePause}
+                className={`text-xs px-3 py-1.5 rounded-lg border transition-colors ${
+                  pd.profile.paused
+                    ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20 hover:bg-emerald-500/20'
+                    : 'bg-yellow-500/10 text-yellow-400 border-yellow-500/20 hover:bg-yellow-500/20'
+                }`}>
+                {pd.profile.paused ? '▶ Resume' : '⏸ Pause'}
+              </button>
+              <button onClick={onEdit}
+                data-testid={`profile-open-editor-${pd.profile.id}`}
+                className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
+                Edit
+              </button>
+              <button onClick={onEditUsers}
+                className="text-xs text-gray-300 hover:text-white bg-gray-800 px-3 py-1.5 rounded-lg transition-colors">
+                Edit users
+              </button>
+              <button onClick={onDelete}
+                className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors">
+                Delete
+              </button>
+            </div>
+          )}
+
+          {pd.profile.blockedCategories.length > 0 && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Blocked categories</p>
+              <div className="flex flex-wrap gap-2">
+                {pd.profile.blockedCategories.map(c => (
+                  <span key={c} className="text-xs bg-red-500/10 text-red-400 px-2 py-1 rounded-lg font-mono">{c}</span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {(pd.profile.extraBlocked.length > 0 || pd.profile.extraAllowed.length > 0) && (
+            <div className="grid grid-cols-2 gap-3">
+              {pd.profile.extraBlocked.length > 0 && (
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Blocked domains</p>
+                  <p className="text-xs text-gray-400 font-mono">{pd.profile.extraBlocked.length} entr{pd.profile.extraBlocked.length === 1 ? 'y' : 'ies'}</p>
+                </div>
+              )}
+              {pd.profile.extraAllowed.length > 0 && (
+                <div>
+                  <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Allowed domains</p>
+                  <p className="text-xs text-gray-400 font-mono">{pd.profile.extraAllowed.length} entr{pd.profile.extraAllowed.length === 1 ? 'y' : 'ies'}</p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {pd.timeLimit && (
+            <p className="text-sm text-gray-400">
+              Daily limit: <span className="text-white font-medium">{pd.timeLimit.dailyMinutes} min</span>
+            </p>
+          )}
+
+          {pd.schedules.length > 0 && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Schedules</p>
+              {pd.schedules.map(s => (
+                <div key={s.id} className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
+                  <span className="text-gray-300">{s.name}</span>
+                  <span className="text-yellow-400 font-mono text-xs">
+                    {s.startLocal} → {s.endLocal} <span className="text-yellow-300/60">({s.tz})</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div data-testid={`profile-devices-${pd.profile.id}`}>
+            <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Devices</p>
+            {devices.length === 0
+              ? <p className="text-xs text-gray-600">No devices assigned.</p>
+              : (
+                <div className="space-y-1">
+                  {devices.map(d => (
+                    <div key={d.id} data-testid={`profile-device-${d.id}`}
+                      className="flex justify-between text-sm bg-gray-800/50 rounded-lg px-3 py-2">
+                      <span className="text-gray-300">{d.name}</span>
+                      <span className="text-gray-500 font-mono text-xs">{d.mac}</span>
+                    </div>
+                  ))}
+                </div>
+              )
+            }
+          </div>
+
+          {isAdmin && (
+            <div data-testid={`profile-users-${pd.profile.id}`}>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Linked users</p>
+              {users.length === 0
+                ? <p className="text-xs text-gray-600">No users linked.</p>
+                : (
+                  <div className="flex flex-wrap gap-2">
+                    {users.map(u => (
+                      <span key={u.id} data-testid={`profile-user-${u.id}`}
+                        className="text-xs bg-gray-800 text-gray-300 border border-gray-700 px-2 py-1 rounded-lg">
+                        {u.username}
+                        <span className={`ml-2 font-mono px-1.5 py-0.5 rounded ${
+                          u.role === 'admin'
+                            ? 'bg-emerald-500/10 text-emerald-400'
+                            : u.role === 'adult'
+                              ? 'bg-blue-500/10 text-blue-400'
+                              : 'bg-yellow-500/10 text-yellow-400'
+                        }`}>{u.role}</span>
+                      </span>
+                    ))}
+                  </div>
+                )
+              }
+            </div>
+          )}
+
+          {pd.siteTimeLimits.length > 0 && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Site Limits</p>
+              {pd.siteTimeLimits.map(s => (
+                <div key={s.id} className="flex justify-between items-center text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
+                  <span className="text-gray-300">{s.label}</span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-emerald-400 text-xs font-mono">{s.dailyMinutes}m · {s.domainPattern}</span>
+                    <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
+                      s.exemptFromDaily
+                        ? 'bg-gray-700 text-gray-400'
+                        : 'bg-amber-500/20 text-amber-400'
+                    }`}>
+                      {s.exemptFromDaily ? 'exempt' : 'counts'}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -537,8 +822,6 @@ function ProfileEditor({
   }
 
   function addSchedule() {
-    // Default tz comes from the parent (household's daily-reset tz, or
-    // browser tz fallback). Most homes want all schedules in the same zone.
     setForm(f => ({
       ...f,
       schedules: [

--- a/web/src/pages/TimePage.tsx
+++ b/web/src/pages/TimePage.tsx
@@ -250,6 +250,21 @@ export function TimePage() {
 
   return (
     <div className="space-y-6">
+      {/* #972 — Screen Time has merged into Profiles; the at-a-glance summary
+          and +Time button now live in the collapsed cards there. This route
+          stays alive for one release for direct-link compatibility (#978
+          removes it entirely). */}
+      <div
+        data-testid="time-merged-banner"
+        className="bg-emerald-500/10 border border-emerald-500/20 text-emerald-300 text-sm rounded-xl px-4 py-3"
+      >
+        Screen Time has moved into{' '}
+        <Link to="/profiles" className="underline font-medium hover:text-emerald-200">
+          Profiles
+        </Link>
+        . The +Time button and usage chart now live on each profile card.
+      </div>
+
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-white">Screen Time</h1>
         <span className="text-xs text-gray-500 font-mono">{new Date().toLocaleDateString()}</span>


### PR DESCRIPTION
## Summary
- Sub-issue 1 of [#965](https://github.com/wifihaven/wifihaven/issues/965) (design doc PR #980): reshapes `/profiles` into a collapse-by-default accordion. Each card's always-visible summary row carries **name · used/cap (with thin progress bar) · pause-state chip · +Time** — the at-a-glance Screen-Time view that this merge absorbs.
- Pause-state chip resolves to `active`, `paused (manual)`, `paused (schedule)` (computed locally from cached schedules), or `time exceeded` (from the summary endpoint's `remainingMins`).
- Expanded body keeps the existing card content + escape-hatch buttons (Edit, Edit users, Pause, Delete). Subsections [#973](https://github.com/wifihaven/wifihaven/issues/973)–[#977](https://github.com/wifihaven/wifihaven/issues/977) will replace these with inline editors.
- Nav: drops the Screen Time entry per the design doc's Q1 decision. `/time` stays routable for one release with a banner pointing at `/profiles`; [#978](https://github.com/wifihaven/wifihaven/issues/978) deletes the route + modal entirely.
- +Time uses the existing `time.grantExtension` mutation with the [#946](https://github.com/wifihaven/wifihaven/issues/946)-fixed `invalidators.timeStatus()` so the summary row reflects the grant immediately.

## Notes
- Zero router-side changes; no schema or contract touched. The existing `/api/time/status/summary` endpoint already returns everything the summary row needs.
- The modal `ProfileEditor` stays intact — subsections #973+ depend on it during transition.
- `useTimeStatusSummary()` was added to ProfilesPage; it's the same query the Screen Time page already used, so no new API surface.

## Test plan
- [x] `npm run test` — 237 / 237 passing (added new tests for collapse/expand toggle, summary row content, chip states, +Time mutation; updated tests that previously assumed always-visible card body to expand the card first).
- [x] `npm run lint` — clean.
- [x] `npm run type-check` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: load `/profiles`, verify collapse-by-default and chevron toggle behavior.
- [ ] Manual: click +Time, grant 30m, confirm summary row updates without a hard reload (#946-fixed pattern).
- [ ] Manual: visit `/time` directly, confirm banner renders and link to `/profiles` works.

## Follow-ups
- Subsections [#973](https://github.com/wifihaven/wifihaven/issues/973) (name/icon/color + devices), [#974](https://github.com/wifihaven/wifihaven/issues/974) (schedule), [#975](https://github.com/wifihaven/wifihaven/issues/975) (time limits + overlap), [#976](https://github.com/wifihaven/wifihaven/issues/976) (rules — blocked on #767), [#977](https://github.com/wifihaven/wifihaven/issues/977) (users) layer inline editors into the expanded view. All block on [#423](https://github.com/wifihaven/wifihaven/issues/423) (PATCH) + [#581](https://github.com/wifihaven/wifihaven/issues/581) (symmetric shapes) per Q2 of the design doc.
- [#978](https://github.com/wifihaven/wifihaven/issues/978) cleanup: delete the `ProfileEditor` modal and the `/time` route entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)