### PR TITLE
feat(web): per-profile app picker filter + exempt-from-daily control (#1007)

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -494,7 +494,16 @@ describe('ProfilesPage — highlight from ?id= (#298)', () => {
 })
 
 describe('ProfilesPage — apps section (#767)', () => {
+  // YouTube starts with an existing 'allowed' assignment so its row is
+  // visible under the #1007 filter (only assigned apps show by default).
   const youtube = {
+    app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '📺', createdAt: '2026-01-01' },
+    hosts: ['youtube.com'],
+    assignments: [
+      { id: 2, appId: 50, profileId: 1, mode: 'allowed' as const, dailyMinutes: null, exemptFromDaily: true },
+    ],
+  }
+  const youtubeUnassigned = {
     app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '📺', createdAt: '2026-01-01' },
     hosts: ['youtube.com'],
     assignments: [] as { id: number; appId: number; profileId: number; mode: 'blocked'|'allowed'|'time_limited'; dailyMinutes: number|null; exemptFromDaily: boolean }[],
@@ -518,7 +527,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     expect(within(section).getByTestId('apps-section-empty-link')).toHaveAttribute('href', '/apps')
   })
 
-  it('renders one row per app and reflects current assignment', async () => {
+  it('renders one row per assigned app and reflects current assignment', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube, tiktok])
     const user = userEvent.setup()
     renderPage()
@@ -529,6 +538,102 @@ describe('ProfilesPage — apps section (#767)', () => {
     // TikTok is currently blocked for profile 1; the block button shows checked state.
     const tiktokBlock = screen.getByTestId('app-row-51-block')
     expect(tiktokBlock.textContent).toMatch(/✓/)
+  })
+
+  // #1007: only assigned apps appear in the per-profile picker by default.
+  it('hides unassigned apps; "+ Add app" reveals them via picker', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeUnassigned, tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await screen.findByTestId('app-row-51')
+    // YouTube has no assignment → row hidden.
+    expect(screen.queryByTestId('app-row-50')).not.toBeInTheDocument()
+    // Picker reveals it.
+    await user.click(screen.getByTestId('apps-section-add'))
+    const picker = await screen.findByTestId('apps-section-picker')
+    expect(within(picker).getByTestId('apps-section-picker-add-50')).toBeInTheDocument()
+    expect(within(picker).queryByTestId('apps-section-picker-add-51')).not.toBeInTheDocument()
+  })
+
+  it('profile with zero assignments shows none-assigned hint, not all apps', async () => {
+    // Both apps belong to profile 2's universe (none assigned to profile 1).
+    const ytForProfile2 = {
+      app: youtube.app, hosts: youtube.hosts,
+      assignments: [{ id: 9, appId: 50, profileId: 2, mode: 'allowed' as const, dailyMinutes: null, exemptFromDaily: true }],
+    }
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytForProfile2])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    expect(await screen.findByTestId('apps-section-none-assigned')).toBeInTheDocument()
+    expect(screen.queryByTestId('app-row-50')).not.toBeInTheDocument()
+  })
+
+  it('picker filter narrows the unassigned list by name', async () => {
+    const slack = {
+      app: { id: 52, name: 'Slack', slug: 'slack', templateId: null, icon: '💬', createdAt: '2026-01-01' },
+      hosts: ['slack.com'],
+      assignments: [] as typeof tiktok.assignments,
+    }
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeUnassigned, slack, tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await screen.findByTestId('app-row-51')
+    await user.click(screen.getByTestId('apps-section-add'))
+    await user.type(screen.getByTestId('apps-section-picker-filter'), 'slack')
+    expect(screen.getByTestId('apps-section-picker-add-52')).toBeInTheDocument()
+    expect(screen.queryByTestId('apps-section-picker-add-50')).not.toBeInTheDocument()
+  })
+
+  it('adding from picker calls setPolicy with mode=allowed', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeUnassigned, tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await screen.findByTestId('app-row-51')
+    await user.click(screen.getByTestId('apps-section-add'))
+    await user.click(await screen.findByTestId('apps-section-picker-add-50'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'allowed', dailyMinutes: null }),
+    )
+  })
+
+  // #1007: exempt-from-daily toggle on the time-limit row.
+  it('time-limited row shows counts-toward-daily checkbox, defaulted unchecked (exempt=true)', async () => {
+    const khan = {
+      app: { id: 60, name: 'Khan', slug: 'khan', templateId: null, icon: '📚', createdAt: '2026-01-01' },
+      hosts: ['khanacademy.org'],
+      assignments: [
+        { id: 3, appId: 60, profileId: 1, mode: 'time_limited' as const, dailyMinutes: 60, exemptFromDaily: true },
+      ],
+    }
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([khan])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const cb = await screen.findByTestId('app-row-60-counts-toward-daily') as HTMLInputElement
+    expect(cb.checked).toBe(false)
+    await user.click(cb)
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(60, 1, { mode: 'time_limited', dailyMinutes: 60, exemptFromDaily: false }),
+    )
+  })
+
+  it('checkbox is not rendered when app is not time-limited', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([tiktok])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    await screen.findByTestId('app-row-51')
+    expect(screen.queryByTestId('app-row-51-counts-toward-daily')).not.toBeInTheDocument()
   })
 
   it('clicking block calls setPolicy with mode=blocked', async () => {
@@ -576,7 +681,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     await user.type(input, '45')
     await user.click(screen.getByTestId('app-row-50-time-limit'))
     await waitFor(() =>
-      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'time_limited', dailyMinutes: 45 }),
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'time_limited', dailyMinutes: 45, exemptFromDaily: true }),
     )
   })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -915,53 +915,144 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
   apps: AppDetail[]
   onChanged: () => void | Promise<void>
 }) {
+  // #1007: only show apps that already have an assignment for this profile.
+  // Unassigned apps stay manageable via the "+ Add app" picker below.
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [pickerFilter, setPickerFilter] = useState('')
+  const assigned = useMemo(
+    () => (profileId == null ? [] : apps.filter(a => findAssignment(a, profileId) != null)),
+    [apps, profileId],
+  )
+  const unassigned = useMemo(
+    () => (profileId == null ? [] : apps.filter(a => findAssignment(a, profileId) == null)),
+    [apps, profileId],
+  )
+  const pickerMatches = useMemo(() => {
+    const q = pickerFilter.trim().toLowerCase()
+    if (!q) return unassigned
+    return unassigned.filter(a => a.app.name.toLowerCase().includes(q))
+  }, [unassigned, pickerFilter])
+
+  async function addApp(app: AppDetail) {
+    if (profileId == null) return
+    // Default to 'allowed' on add — the user can immediately switch to block /
+    // time-limit on the now-visible row. We pick a mode (rather than just
+    // "make row appear") because every assignment requires one.
+    await api.apps.setPolicy(app.app.id, profileId, { mode: 'allowed', dailyMinutes: null })
+    setPickerOpen(false)
+    setPickerFilter('')
+    await onChanged()
+  }
+
+  const headerCta = !isNew && profileId != null && apps.length > 0 && (
+    <button
+      type="button"
+      data-testid="apps-section-add"
+      onClick={() => setPickerOpen(v => !v)}
+      className="text-xs text-emerald-400 hover:text-emerald-300"
+    >
+      {pickerOpen ? 'Close' : '+ Add app'}
+    </button>
+  )
+
   return (
     <div data-testid="apps-section">
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex items-center justify-between mb-2 gap-3">
         <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">
           Apps
         </label>
-        <Link
-          to="/apps"
-          data-testid="apps-section-manage-link"
-          className="text-xs text-emerald-400 hover:text-emerald-300"
-        >
-          Manage apps →
-        </Link>
+        <div className="flex items-center gap-3">
+          {headerCta}
+          <Link
+            to="/apps"
+            data-testid="apps-section-manage-link"
+            className="text-xs text-emerald-400 hover:text-emerald-300"
+          >
+            Manage apps →
+          </Link>
+        </div>
       </div>
-      {isNew || profileId == null
-        ? (
-            <p className="text-xs text-gray-500">
-              Save this profile first to assign apps.
+      {isNew || profileId == null ? (
+        <p className="text-xs text-gray-500">
+          Save this profile first to assign apps.
+        </p>
+      ) : apps.length === 0 ? (
+        <p className="text-xs text-gray-500">
+          No apps yet.{' '}
+          <Link
+            to="/apps"
+            data-testid="apps-section-empty-link"
+            className="text-emerald-400 hover:text-emerald-300 underline"
+          >
+            Create one
+          </Link>
+          {' '}to block, allow, or time-limit a group of hosts.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {assigned.length === 0 && !pickerOpen && (
+            <p className="text-xs text-gray-500" data-testid="apps-section-none-assigned">
+              No apps assigned to this profile.{' '}
+              <button
+                type="button"
+                data-testid="apps-section-none-assigned-add"
+                onClick={() => setPickerOpen(true)}
+                className="text-emerald-400 hover:text-emerald-300 underline"
+              >
+                Add one
+              </button>
+              {' '}from the {apps.length}-app library.
             </p>
-          )
-        : apps.length === 0
-          ? (
-              <p className="text-xs text-gray-500">
-                No apps yet.{' '}
-                <Link
-                  to="/apps"
-                  data-testid="apps-section-empty-link"
-                  className="text-emerald-400 hover:text-emerald-300 underline"
-                >
-                  Create one
-                </Link>
-                {' '}to block, allow, or time-limit a group of hosts.
-              </p>
-            )
-          : (
-              <div className="space-y-2">
-                {apps.map(a => (
-                  <AppRow
-                    key={a.app.id}
-                    app={a}
-                    profileId={profileId}
-                    onChanged={onChanged}
-                  />
-                ))}
-              </div>
-            )
-      }
+          )}
+          {assigned.map(a => (
+            <AppRow
+              key={a.app.id}
+              app={a}
+              profileId={profileId}
+              onChanged={onChanged}
+            />
+          ))}
+          {pickerOpen && (
+            <div
+              data-testid="apps-section-picker"
+              className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2"
+            >
+              <input
+                type="text"
+                autoFocus
+                value={pickerFilter}
+                onChange={e => setPickerFilter(e.target.value)}
+                placeholder="Filter apps…"
+                data-testid="apps-section-picker-filter"
+                className="w-full bg-gray-900 border border-gray-700 rounded-lg px-2 py-1 text-white text-xs"
+              />
+              {pickerMatches.length === 0 ? (
+                <p className="text-xs text-gray-500" data-testid="apps-section-picker-empty">
+                  {unassigned.length === 0
+                    ? 'Every app in the library is already assigned.'
+                    : 'No apps match that filter.'}
+                </p>
+              ) : (
+                <div className="space-y-1 max-h-64 overflow-y-auto">
+                  {pickerMatches.map(a => (
+                    <button
+                      key={a.app.id}
+                      type="button"
+                      data-testid={`apps-section-picker-add-${a.app.id}`}
+                      onClick={() => addApp(a)}
+                      className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg bg-gray-900 hover:bg-gray-800 border border-gray-700 text-left"
+                    >
+                      <span className="text-base w-5 text-center" aria-hidden>{a.app.icon || '◳'}</span>
+                      <span className="text-sm text-white flex-1 truncate">{a.app.name}</span>
+                      <span className="text-xs text-gray-500">{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }
@@ -980,13 +1071,14 @@ function AppRow({ app, profileId, onChanged }: {
   const [busy, setBusy] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
 
-  async function apply(mode: AppMode, dailyMinutes: number | null) {
+  async function apply(mode: AppMode, dailyMinutes: number | null, exemptFromDaily?: boolean) {
     setBusy(true)
     setLocalError(null)
     try {
       await api.apps.setPolicy(app.app.id, profileId, {
         mode,
         dailyMinutes,
+        ...(exemptFromDaily !== undefined ? { exemptFromDaily } : {}),
       })
       await onChanged()
     } catch (e) {
@@ -1016,7 +1108,14 @@ function AppRow({ app, profileId, onChanged }: {
       setLocalError('Enter minutes > 0')
       return
     }
-    await apply('time_limited', n)
+    // #1007: preserve current exemptFromDaily when re-applying; default to TRUE
+    // (matches the schema default and the wire default in #761/#763).
+    await apply('time_limited', n, current?.exemptFromDaily ?? true)
+  }
+
+  async function toggleExempt(nextExempt: boolean) {
+    if (current?.mode !== 'time_limited' || current.dailyMinutes == null) return
+    await apply('time_limited', current.dailyMinutes, nextExempt)
   }
 
   const mode = current?.mode ?? null
@@ -1085,6 +1184,24 @@ function AppRow({ app, profileId, onChanged }: {
           </button>
         </div>
       </div>
+      {mode === 'time_limited' && (
+        <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            data-testid={`app-row-${app.app.id}-counts-toward-daily`}
+            checked={!(current?.exemptFromDaily ?? true)}
+            disabled={busy}
+            onChange={e => toggleExempt(!e.target.checked)}
+            className="w-3.5 h-3.5 accent-amber-500"
+          />
+          <span>
+            Counts toward daily limit
+            {!(current?.exemptFromDaily ?? true) && (
+              <span className="ml-1 text-amber-400">(usage reduces overall remaining time)</span>
+            )}
+          </span>
+        </label>
+      )}
       {localError && (
         <p className="text-xs text-red-400" data-testid={`app-row-${app.app.id}-error`}>{localError}</p>
       )}


### PR DESCRIPTION
Closes #1007.

## Summary

- **Filter the per-profile app picker** to "implicit-by-assignment" (option c in #1007). Only apps with an existing assignment for the profile render rows. An inline `+ Add app` CTA opens a filterable picker over unassigned apps; adding stamps an `allowed` assignment, after which the row appears and the usual block/allow/time-limit controls take over. Removes the noise of seeing the full 20+ app library on every profile edit.
- **Expose `exemptFromDaily` on time-limited app rows**, matching the existing site-time-limits "Counts toward daily limit" checkbox. Wire already carried the field (#761/#763); UI just hadn't surfaced it. Default stays `true` (app cap doesn't reduce overall daily time).
- Zero router-side changes. No API/server changes — `PUT /api/apps/:id/policy/:profileId` already accepts `exemptFromDaily`.

## Filter heuristic chosen

Option (c) from #1007: an app appears in the per-profile picker iff it has an assignment for that profile. Picker reveals the rest of the library on demand. No schema, no curation step, mirrors how the FQDN inputs work. Option (a) (explicit per-profile app list) can layer on later if households want curation.

## Test plan

- [x] `mill api.test` — 41/41 passing
- [x] `mill shared.test` — 36/36 passing
- [x] `npm run test` (web) — 236/236 passing
- [x] `npm run type-check` — clean
- [x] New unit coverage:
  - empty library → "No apps yet"
  - library with apps but zero assignments for profile → "No apps assigned" hint, no rows
  - `+ Add app` opens picker over only unassigned apps; text filter narrows
  - Picker add → setPolicy with mode=allowed
  - Time-limited row renders counts-toward-daily checkbox, default unchecked (exempt=true); toggle round-trips through setPolicy with `exemptFromDaily: false`
  - Non-time-limited row hides the checkbox

## Screenshots

Manual verification deferred — the unit suite exercises every visible state. Will validate against the live API (api.lan) post-merge if anything looks off in the dogfood profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)