### PR TITLE
fix(api): bump zio-http request body cap to 4 MiB (#1017)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -75,8 +75,8 @@ object Main extends ZIOAppDefault {
       // Bump to 4 MiB — well above any realistic single-bucket payload and below
       // Render's edge 413 threshold.
       serverConfig = Server.Config.default
-                       .port(cfg.http.port)
-                       .disableRequestStreaming(4 * 1024 * 1024)
+        .port(cfg.http.port)
+        .disableRequestStreaming(4 * 1024 * 1024)
       _ <- Server
         .serve(withCors)
         .provide(ZLayer.succeed(serverConfig) >>> Server.live)

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -70,9 +70,16 @@ object Main extends ZIOAppDefault {
       _ <- ZIO
         .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
         .when(cfg.cors.origins.nonEmpty)
+      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
+      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
+      // Bump to 4 MiB — well above any realistic single-bucket payload and below
+      // Render's edge 413 threshold.
+      serverConfig = Server.Config.default
+                       .port(cfg.http.port)
+                       .disableRequestStreaming(4 * 1024 * 1024)
       _ <- Server
         .serve(withCors)
-        .provide(Server.defaultWithPort(cfg.http.port))
+        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
     } yield ()).provide(serverEnv)
 
   private val serverEnv =


### PR DESCRIPTION
## Summary
- zio-http 3.0.1 hard-codes a 100 KiB max request body in `RequestStreaming.Disabled` (default).
- `/api/router/usage` bodies on prod have grown past that as the agent's `mac_ip_tracking` nft set fills up (6 h timeout).
- Above the cap zio-http truncates the body silently; the handler then sees `"Unexpected end of input"` from zio-json and returns 400 — exactly what the prod agent has been logging for hours.
- This bumps the cap to 4 MiB.

Closes the read-side outage in [#1017](https://github.com/wifihaven/wifihaven/issues/1017). A separate follow-up issue will track the router-side fix (skip records with zero bytes in both directions, which today make up the bulk of every body).

## Evidence
Probed from the prod router with the live router token:

| body size | API response |
|----------:|:------------:|
|     50 KB | 200          |
|    100 KB | 200          |
|    150 KB | 413          |
|    200 KB | 413          |

The actual queued bucket on the prod router is 222,618 bytes; the agent log shows ~260 buckets stuck in the retry queue. The agent's curl reports status=400 because zio-http reads a truncated body and the handler responds 400 with `body="Unexpected end of input"`.

## Test plan
- [x] `mill api.compile` clean.
- [ ] Render deploy from main once merged; verify prod router's queue depth drops within a few drain cycles (`logread -e wifihaven` on the router; `usage.drain` should start logging `success` instead of `failed`).
- [ ] `GET /api/usage/traffic?bucket=10m&from=…&to=…` returns rows past 01:30 UTC 2026-05-25 (current cutoff).

## Rollback path
Revert this commit and redeploy; API regresses to the prior 100 KiB cap. Routers will resume failing usage POSTs but events / snapshot polling are unaffected, so the outage shape would just return to where it is now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)