### PR TITLE
ci: bump keep-warm HTTP timeout to 60s for cold-start tolerance (#1025)

### DIFF
--- a/.github/workflows/keep-warm.yml
+++ b/.github/workflows/keep-warm.yml
@@ -27,4 +27,4 @@ jobs:
     steps:
       - name: Hit ${{ matrix.env }} health endpoint
         run: |
-          curl -fsS --max-time 30 ${{ matrix.url }}
+          curl -fsS --max-time 60 -w "took %{time_total}s\n" ${{ matrix.url }}


### PR DESCRIPTION
## Summary
- Bump `curl --max-time` from 30s → 60s in `.github/workflows/keep-warm.yml` so the keep-warm ping waits through Render cold-starts (mainly staging) instead of timing out and defeating its own purpose.
- Add `-w "took %{time_total}s\n"` to log request duration so we can spot when cold-starts trend alarmingly slow.
- Applies uniformly to both staging and prod (single matrix step), so prod is equally robust.

Fixes #1025.

## Exact diff
```diff
-          curl -fsS --max-time 30 ${{ matrix.url }}
+          curl -fsS --max-time 60 -w "took %{time_total}s\n" ${{ matrix.url }}
```

## Test plan
- [ ] After merge, trigger the workflow manually via `gh workflow run "Keep environments warm"` (or the Actions UI — it has `workflow_dispatch`).
- [ ] Confirm both `staging` and `prod` matrix jobs succeed and the log line shows `took <N>s` for each.
- [ ] Let the next scheduled cron fire (every 10 min, offset by 3) and confirm no timeout failures over a few hours, including a period where staging has been idle long enough to cold-start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)