### PR TITLE
fix(openwrt): rotate wifihaven-dnsmasq.log to prevent tmpfs exhaustion

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -34,6 +34,7 @@ define Package/wifihaven/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-agent $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-dns-tail $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-update $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-rotate-dnsmasq-log $(1)/usr/sbin/
 
 	$(INSTALL_DIR) $(1)/usr/lib/lua/wifihaven
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/usr/lib/lua/wifihaven/*.lua $(1)/usr/lib/lua/wifihaven/
@@ -77,12 +78,13 @@ define Package/wifihaven/postinst
 # at first boot — postinst runs during offline-install before procd/uhttpd
 # are up, so a uci-defaults stub is the right idiom here. Nothing for
 # postinst to do for the block-page handler.
-# Install cron entry for the auto-updater (daily, 04:00 router-local).
-# Replace any existing wifihaven-update entry so upgrades migrate the
-# cadence — older packages installed it at "0 */6 * * *".
+# Install cron entries. Replace any existing wifihaven entries so upgrades
+# migrate the cadence. Kept in sync with build-ipk.sh, build-apk.sh.
 mkdir -p /etc/crontabs
 [ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-rotate-dnsmasq-log/d' /etc/crontabs/root
 echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+echo '*/10 * * * * /usr/sbin/wifihaven-rotate-dnsmasq-log' >> /etc/crontabs/root
 /etc/init.d/cron enable 2>/dev/null || true
 /etc/init.d/cron restart 2>/dev/null || true
 endef

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -96,13 +96,14 @@ cat > "$WORK/post-install" <<'POSTINSTALL'
 # #542: uhttpd block-page wire-up runs at first boot from
 # /etc/uci-defaults/95-wifihaven-uhttpd (shipped in data/).
 
-# #869: Install cron entry for the auto-updater (daily, 04:00 router-local).
-# Replace any existing wifihaven-update entry so upgrades migrate the
-# cadence — older packages installed it at "0 */6 * * *".
-# Kept in sync with the trigger script below and openwrt/Makefile postinst.
+# #869: Install cron entries. Replace any existing wifihaven entries so
+# upgrades migrate the cadence. Kept in sync with trigger below and
+# openwrt/Makefile postinst, build-ipk.sh.
 mkdir -p /etc/crontabs
 [ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-rotate-dnsmasq-log/d' /etc/crontabs/root
 echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+echo '*/10 * * * * /usr/sbin/wifihaven-rotate-dnsmasq-log' >> /etc/crontabs/root
 /etc/init.d/cron enable 2>/dev/null || true
 /etc/init.d/cron restart 2>/dev/null || true
 POSTINSTALL
@@ -122,7 +123,9 @@ cat > "$WORK/trigger" <<'TRIGGER'
 #!/bin/sh
 mkdir -p /etc/crontabs
 [ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-rotate-dnsmasq-log/d' /etc/crontabs/root
 echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+echo '*/10 * * * * /usr/sbin/wifihaven-rotate-dnsmasq-log' >> /etc/crontabs/root
 /etc/init.d/cron enable 2>/dev/null || true
 /etc/init.d/cron restart 2>/dev/null || true
 TRIGGER

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -44,12 +44,13 @@ cat > "$WORK/ctrl/postinst" <<'POSTINST'
 /etc/init.d/wifihaven-boot start 2>/dev/null || true
 # #542: uhttpd block-page wire-up runs at first boot from
 # /etc/uci-defaults/95-wifihaven-uhttpd (shipped in data/).
-# Install cron entry for the auto-updater (daily, 04:00 router-local).
-# Replace any existing wifihaven-update entry so upgrades migrate the
-# cadence — older packages installed it at "0 */6 * * *".
+# Install cron entries. Replace any existing wifihaven entries so upgrades
+# migrate the cadence. Kept in sync with Makefile postinst, build-apk.sh.
 mkdir -p /etc/crontabs
 [ -f /etc/crontabs/root ] && sed -i '/wifihaven-update/d' /etc/crontabs/root
+[ -f /etc/crontabs/root ] && sed -i '/wifihaven-rotate-dnsmasq-log/d' /etc/crontabs/root
 echo '0 4 * * * /usr/sbin/wifihaven-update' >> /etc/crontabs/root
+echo '*/10 * * * * /usr/sbin/wifihaven-rotate-dnsmasq-log' >> /etc/crontabs/root
 /etc/init.d/cron enable 2>/dev/null || true
 /etc/init.d/cron restart 2>/dev/null || true
 POSTINST

--- a/openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log
+++ b/openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log
@@ -1,0 +1,36 @@
+#!/bin/sh
+# wifihaven-rotate-dnsmasq-log — cap /tmp/wifihaven-dnsmasq.log at 20 MB.
+#
+# Run from cron every 10 minutes. When the log exceeds MAX_BYTES, it is
+# rotated in place: the previous rotation is discarded, the current file is
+# copied to *.1, and the original is truncated to zero.
+#
+# Truncating the original (rather than renaming it) is the "copytruncate"
+# pattern. dnsmasq holds the log fd open for the lifetime of the process and
+# does not reopen it on SIGHUP when logfacility is a file path — so a rename
+# would leave dnsmasq writing to an invisible, unrotated inode. Truncating
+# leaves dnsmasq on the same inode; it continues writing from offset 0.
+#
+# wifihaven-dns-tail runs `tail -n 0 -F` (follow by name). BusyBox tail -F
+# polls the file by name and detects the truncation within its next stat
+# interval; it reseeks to the beginning and resumes from there. Lines written
+# by dnsmasq between the copy and the truncate are present in *.1 and will be
+# missed by the tailer — this is acceptable and bounded: at 10-minute cron
+# cadence, the window is tiny and the tailer's hostname cache fills back up
+# within seconds of the next resolved query.
+
+set -eu
+
+LOG=/tmp/wifihaven-dnsmasq.log
+LOG_PREV="${LOG}.1"
+# 20 MB in bytes — two rotations consume at most ~40 MB + the live file's
+# headroom before the next rotation, so worst-case /tmp usage is ~60 MB.
+MAX_BYTES=20971520
+
+[ -f "$LOG" ] || exit 0
+
+size=$(wc -c < "$LOG" 2>/dev/null) || exit 0
+[ "$size" -ge "$MAX_BYTES" ] || exit 0
+
+cp -f "$LOG" "$LOG_PREV"
+: > "$LOG"

--- a/openwrt/test/rotate_dnsmasq_log_spec.sh
+++ b/openwrt/test/rotate_dnsmasq_log_spec.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+# Tests for openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log and its
+# integration into the package build / install plumbing.
+# Run from the openwrt/ directory:  sh test/rotate_dnsmasq_log_spec.sh
+set -e
+
+PASS=0; FAIL=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/files/usr/sbin/wifihaven-rotate-dnsmasq-log"
+MAKEFILE="$ROOT/Makefile"
+BUILDER_IPK="$ROOT/build-ipk.sh"
+BUILDER_APK="$ROOT/build-apk.sh"
+
+check() {
+  if [ "$2" = "ok" ]; then
+    printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "$1" "$2"; FAIL=$((FAIL + 1))
+  fi
+}
+
+[ -f "$SCRIPT" ] || { printf "MISSING: %s\n" "$SCRIPT"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. Static checks on the rotation script itself
+# ---------------------------------------------------------------------------
+
+[ -x "$SCRIPT" ] \
+  && check "rotation script is executable" ok \
+  || check "rotation script is executable" "missing +x bit"
+
+grep -q '/tmp/wifihaven-dnsmasq.log' "$SCRIPT" \
+  && check "rotation script targets /tmp/wifihaven-dnsmasq.log" ok \
+  || check "rotation script targets /tmp/wifihaven-dnsmasq.log" "wrong log path"
+
+# Must use in-place truncation (: > "$LOG") so dnsmasq's open fd stays on the
+# same inode. A rename would send dnsmasq's writes to an invisible inode.
+grep -q ': > ' "$SCRIPT" \
+  && check "rotation script truncates in place (copytruncate pattern)" ok \
+  || check "rotation script truncates in place (copytruncate pattern)" \
+           "missing in-place truncation — rename would orphan dnsmasq's fd"
+
+# Size cap must be referenced.
+grep -q 'MAX_BYTES\|20971520' "$SCRIPT" \
+  && check "rotation script enforces a size cap (MAX_BYTES)" ok \
+  || check "rotation script enforces a size cap (MAX_BYTES)" "no size cap found"
+
+# ---------------------------------------------------------------------------
+# 2. Package install plumbing: cron entry registered in all three producers
+# ---------------------------------------------------------------------------
+
+grep -q 'wifihaven-rotate-dnsmasq-log' "$MAKEFILE" \
+  && check "Makefile installs wifihaven-rotate-dnsmasq-log" ok \
+  || check "Makefile installs wifihaven-rotate-dnsmasq-log" \
+           "missing from Makefile Package/wifihaven/install"
+
+grep -q 'wifihaven-rotate-dnsmasq-log' "$MAKEFILE" \
+  && grep -q '/etc/crontabs' "$MAKEFILE" \
+  && check "Makefile postinst adds rotation cron entry" ok \
+  || check "Makefile postinst adds rotation cron entry" \
+           "cron install missing in Makefile postinst"
+
+grep -q 'wifihaven-rotate-dnsmasq-log' "$BUILDER_IPK" \
+  && check "build-ipk.sh postinst adds rotation cron entry" ok \
+  || check "build-ipk.sh postinst adds rotation cron entry" \
+           "missing rotation cron entry in build-ipk.sh"
+
+grep -q 'wifihaven-rotate-dnsmasq-log' "$BUILDER_APK" \
+  && check "build-apk.sh post-install adds rotation cron entry" ok \
+  || check "build-apk.sh post-install adds rotation cron entry" \
+           "missing rotation cron entry in build-apk.sh post-install"
+
+# #898: the apk trigger script (fires on reinstall) must also carry the entry
+# so force-reinstall repairs a missing cron line.
+awk '/cat > "\$WORK\/trigger"/,/^TRIGGER$/' "$BUILDER_APK" \
+  | grep -q 'wifihaven-rotate-dnsmasq-log' \
+  && check "build-apk.sh trigger script adds rotation cron entry" ok \
+  || check "build-apk.sh trigger script adds rotation cron entry" \
+           "trigger heredoc missing wifihaven-rotate-dnsmasq-log"
+
+# Cron expression: every 10 minutes.
+grep -q '\*/10 \* \* \* \* /usr/sbin/wifihaven-rotate-dnsmasq-log' "$MAKEFILE" \
+  && check "Makefile rotation cron runs every 10 minutes" ok \
+  || check "Makefile rotation cron runs every 10 minutes" "wrong cron expression"
+
+grep -q '\*/10 \* \* \* \* /usr/sbin/wifihaven-rotate-dnsmasq-log' "$BUILDER_IPK" \
+  && check "build-ipk.sh rotation cron runs every 10 minutes" ok \
+  || check "build-ipk.sh rotation cron runs every 10 minutes" "wrong cron expression"
+
+grep -q '\*/10 \* \* \* \* /usr/sbin/wifihaven-rotate-dnsmasq-log' "$BUILDER_APK" \
+  && check "build-apk.sh rotation cron runs every 10 minutes" ok \
+  || check "build-apk.sh rotation cron runs every 10 minutes" "wrong cron expression"
+
+# ---------------------------------------------------------------------------
+# 3. Behavioural simulation: run the script with a fake LOG path
+# ---------------------------------------------------------------------------
+
+TESTDIR=$(mktemp -d)
+trap 'rm -rf "$TESTDIR"' EXIT
+
+FAKE_LOG="$TESTDIR/wifihaven-dnsmasq.log"
+FAKE_LOG_PREV="${FAKE_LOG}.1"
+
+# Rewrite the LOG variable in a copy of the script so it targets our tmpdir.
+PATCHED="$TESTDIR/wifihaven-rotate-dnsmasq-log"
+sed "s|^LOG=/tmp/wifihaven-dnsmasq.log|LOG=$FAKE_LOG|" "$SCRIPT" > "$PATCHED"
+chmod +x "$PATCHED"
+
+# Case A: file absent — script exits 0, no .1 created.
+"$PATCHED"
+[ ! -f "$FAKE_LOG_PREV" ] \
+  && check "[no file] exits cleanly when log is absent" ok \
+  || check "[no file] exits cleanly when log is absent" ".1 unexpectedly created"
+
+# Case B: file present but small — no rotation.
+printf 'small content\n' > "$FAKE_LOG"
+"$PATCHED"
+[ -f "$FAKE_LOG" ] \
+  && check "[small file] log still present after no-op run" ok \
+  || check "[small file] log still present after no-op run" "log was removed"
+[ ! -f "$FAKE_LOG_PREV" ] \
+  && check "[small file] no .1 created for small log" ok \
+  || check "[small file] no .1 created for small log" ".1 unexpectedly created"
+
+# Case C: file at or above threshold — rotation fires.
+# Write exactly MAX_BYTES + 1 bytes (21 MB + 1 byte) to trigger rotation.
+python3 -c "
+import os, sys
+path = sys.argv[1]
+with open(path, 'wb') as f:
+    f.write(b'A' * (20 * 1024 * 1024 + 1))
+" "$FAKE_LOG"
+
+"$PATCHED"
+
+[ -f "$FAKE_LOG_PREV" ] \
+  && check "[large file] .1 backup created" ok \
+  || check "[large file] .1 backup created" ".1 not created"
+
+[ -f "$FAKE_LOG" ] \
+  && check "[large file] original log still exists after rotation" ok \
+  || check "[large file] original log still exists after rotation" "log was deleted"
+
+actual_size=$(wc -c < "$FAKE_LOG" 2>/dev/null)
+[ "$actual_size" -eq 0 ] \
+  && check "[large file] original log truncated to zero bytes" ok \
+  || check "[large file] original log truncated to zero bytes" \
+           "expected 0 bytes, got $actual_size"
+
+prev_size=$(wc -c < "$FAKE_LOG_PREV" 2>/dev/null)
+[ "$prev_size" -gt 0 ] \
+  && check "[large file] .1 backup contains the original content" ok \
+  || check "[large file] .1 backup contains the original content" ".1 is empty"
+
+# Case D: simulate tail -F behaviour across rotation.
+# After rotation, new content appended to the (now-empty) original is
+# independent of .1. wifihaven-dns-tail uses `tail -n 0 -F` which follows
+# by name; it detects the truncation within its next stat interval and
+# reseeks to 0. Verify that the rotated .1 holds exactly the pre-rotation
+# content and the live log is writable.
+printf 'post-rotation line\n' >> "$FAKE_LOG"
+grep -q 'post-rotation line' "$FAKE_LOG" \
+  && check "[tail-F compat] new writes go to truncated original" ok \
+  || check "[tail-F compat] new writes go to truncated original" "write to live log failed"
+! grep -q 'post-rotation line' "$FAKE_LOG_PREV" \
+  && check "[tail-F compat] pre-rotation content stays in .1" ok \
+  || check "[tail-F compat] pre-rotation content stays in .1" ".1 was modified after rotation"
+
+# Case E: second rotation discards the old .1 (no unbounded accumulation).
+python3 -c "
+import os, sys
+path = sys.argv[1]
+with open(path, 'wb') as f:
+    f.write(b'B' * (20 * 1024 * 1024 + 1))
+" "$FAKE_LOG"
+"$PATCHED"
+
+# .1 must now contain B's, not A's — the old .1 was overwritten.
+old_prev=$(python3 -c "
+import sys
+with open(sys.argv[1], 'rb') as f:
+    sample = f.read(4)
+print('B' if sample == b'BBBB' else 'other')
+" "$FAKE_LOG_PREV" 2>/dev/null || echo 'error')
+[ "$old_prev" = "B" ] \
+  && check "[second rotation] .1 overwritten with latest rotation" ok \
+  || check "[second rotation] .1 overwritten with latest rotation" \
+           "expected B content in .1, got: $old_prev"
+
+printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -28,3 +28,4 @@ sh test/boot_skeleton_spec.sh
 sh test/update_spec.sh
 sh test/install_spec.sh
 sh test/agent_spec.sh
+sh test/rotate_dnsmasq_log_spec.sh


### PR DESCRIPTION
## Bug

`/tmp/wifihaven-dnsmasq.log` grows without bound and fills the router's 493 MB tmpfs in ~4 days. When tmpfs is full, dnsmasq can no longer write to the log and returns REFUSED to all DNS queries, killing internet for every device on the LAN. Observed live: the file hit 490 MB, dnsmasq stopped writing mid-line, manual truncation was required.

Closes #1030

## Root cause

`install.sh` sets `logfacility=/tmp/wifihaven-dnsmasq.log` via UCI. dnsmasq holds the file open and appends to it indefinitely. No rotation was configured.

## Design

**Cron-based copytruncate** (`wifihaven-rotate-dnsmasq-log`, runs every 10 minutes via `/etc/crontabs/root`):

1. If the log is `< 20 MB` — exit immediately (no-op).
2. Otherwise: `cp -f $LOG $LOG.1` then `: > $LOG` (truncate in place).

**Why copytruncate instead of rename?** dnsmasq holds the log fd open for its lifetime and does not reopen it on SIGHUP when `logfacility` is a file path. A rename would redirect dnsmasq's writes to an invisible inode that never gets read or rotated again. Truncating the original leaves dnsmasq's fd on the same inode; it continues writing from offset 0.

**Why cron instead of logrotate?** `logrotate` is not a stock OpenWRT package and is not used anywhere in this project. The cron pattern (`/etc/crontabs/root`) is the established idiom here (see `wifihaven-update`). No additional package dependencies needed.

**Why not option (b) — dns_log.lua self-truncates?** `wifihaven-dns-tail` uses `tail -n 0 -F`, which already handles rotation safely by following the file by name. There is no byte-offset tracking in dns_log.lua to worry about. The tailer sees the truncation within its next stat interval, reseeks to 0, and resumes. No changes to dns_log.lua were needed.

## Rotation parameters

- Size cap: 20 MB (`MAX_BYTES=20971520`)
- Rotations kept: 1 (`.log.1`)
- Worst-case `/tmp` usage: ~40 MB (`.1` + live file before next rotation tick)
- Cron cadence: every 10 minutes — so a 20 MB file generates at most ~2–3 MB of data in one cron window at typical household traffic rates, and the worst-case gap between dnsmasq writing past 20 MB and the truncation firing is 10 minutes

## Loss bound

Lines written by dnsmasq between the `cp` and the `: > $LOG` are present in `.1` and missed by the tailer on the live file. At cron cadence the window is a few milliseconds. The tailer's hostname cache refills within seconds of the next resolved query. Documented in a comment in the rotation script.

## What changed

- `openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log` — new rotation script
- `openwrt/Makefile` — installs script; postinst registers cron entry
- `openwrt/build-ipk.sh` — postinst registers cron entry
- `openwrt/build-apk.sh` — post-install + trigger script register cron entry
- `openwrt/test/rotate_dnsmasq_log_spec.sh` — 22 new tests (static + behavioural simulation)
- `openwrt/test/run_tests.sh` — wires the new spec into the full suite

## Test results

```
sh openwrt/test/run_tests.sh
421 successes / 0 failures / 0 errors  (Lua busted)
+ 99 shell spec assertions (all existing specs)
+ 22 shell spec assertions (rotate_dnsmasq_log_spec.sh)
0 failures total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)