### PR TITLE
fix(openwrt): skip 0/0/0 usage records (#1032)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -335,22 +335,28 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
     else
       active_seconds = 0
     end
-    local rec = {
-      mac           = c.mac,
-      host          = host,
-      activeSeconds = active_seconds,
-      -- Wire semantics (#905): bytesIn is from the device's POV — traffic
-      -- arriving from the internet (rx counter). bytesOut is traffic leaving
-      -- the device toward the internet (tx counter). The internal record
-      -- fields here are named for their nft-set source (bytes = tx,
-      -- bytes_out = rx) and the swap happens only at the wire boundary.
-      bytesIn       = c.bytes_out or 0,
-      bytesOut      = c.bytes     or 0,
-    }
-    if leases then
-      rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table
+    -- mac_ip_tracking set elements live for 6h after their last packet (#1032);
+    -- skip flows with no traffic this bucket rather than emit 0/0/0 records
+    -- that inflated bucket bodies past the zio-http cap in #1017. The
+    -- bytes>0/no-sample branch above still emits because active_seconds > 0.
+    if active_seconds > 0 or (c.bytes or 0) > 0 or (c.bytes_out or 0) > 0 then
+      local rec = {
+        mac           = c.mac,
+        host          = host,
+        activeSeconds = active_seconds,
+        -- Wire semantics (#905): bytesIn is from the device's POV — traffic
+        -- arriving from the internet (rx counter). bytesOut is traffic leaving
+        -- the device toward the internet (tx counter). The internal record
+        -- fields here are named for their nft-set source (bytes = tx,
+        -- bytes_out = rx) and the swap happens only at the wire boundary.
+        bytesIn       = c.bytes_out or 0,
+        bytesOut      = c.bytes     or 0,
+      }
+      if leases then
+        rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table
+      end
+      records[#records + 1] = rec
     end
-    records[#records + 1] = rec
   end
 
   return {

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -447,6 +447,47 @@ describe("usage.build_report", function()
     assert.equal(0, #r.records)
   end)
 
+  -- #1032: mac_ip_tracking set elements live for 6h after their last packet, so
+  -- post-bucket-reset the agent sees a counters entry for every flow seen in
+  -- the last 6h — most with bytes=0 and no active samples. Emitting them
+  -- inflated bucket bodies past the zio-http cap (#1017). Drop the all-zero
+  -- records at build time.
+  it("drops counters with no traffic and no active samples (#1032)", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 50000, packets = 100 },
+      { mac = "de:ad:be:ef:00:01", dst_ip = "8.8.8.8", bytes = 0,     packets = 0   },
+      { mac = "fa:ce:b0:0c:00:01", dst_ip = "9.9.9.9", bytes = 0,     packets = 0   },
+    }
+    local t = usage.new_tracker()
+    t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"] = BUCKET_S / SAMPLE_S
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, t, SAMPLE_S, BUCKET_S)
+    assert.equal(1, #r.records)
+    assert.equal("aa:bb:cc:11:22:33", r.records[1].mac)
+    assert.equal(50000,               r.records[1].bytesOut)
+    assert.equal(BUCKET_S,            r.records[1].activeSeconds)
+  end)
+
+  -- #1032 regression guard: a flow that appeared *after* the last sample tick
+  -- has no tracker samples but bytes > 0 — the post-tick branch credits one
+  -- sample of activeSeconds and must still emit a record.
+  it("still emits a record when bytes>0 but no active sample was caught (#1032)", function()
+    local counters = {
+      { mac = "aa:bb:cc:11:22:33", dst_ip = "1.2.3.4", bytes = 100, packets = 2 },
+      { mac = "de:ad:be:ef:00:01", dst_ip = "8.8.8.8", bytes = 0,   packets = 0,
+        bytes_out = 250, packets_out = 3 },
+    }
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, usage.new_tracker(), SAMPLE_S, BUCKET_S)
+    assert.equal(2, #r.records)
+    local by_mac = {}
+    for _, rec in ipairs(r.records) do by_mac[rec.mac] = rec end
+    assert.equal(SAMPLE_S, by_mac["aa:bb:cc:11:22:33"].activeSeconds)
+    assert.equal(100,      by_mac["aa:bb:cc:11:22:33"].bytesOut)
+    assert.equal(SAMPLE_S, by_mac["de:ad:be:ef:00:01"].activeSeconds)
+    assert.equal(250,      by_mac["de:ad:be:ef:00:01"].bytesIn)
+  end)
+
 end)
 
 -- ── tracker (sub-minute activity sampler, #295, #516) ────────────────────
@@ -614,12 +655,14 @@ describe("usage.build_report with tracker", function()
     assert.equal(SAMPLE_S, r.records[1].activeSeconds)
   end)
 
-  it("activeSeconds = 0 when tracker has no entry and bytes = 0", function()
+  -- #1032: previously emitted a 0/0/0 record; now dropped to keep bucket
+  -- bodies from inflating with dead mac_ip_tracking elements (see #1017).
+  it("drops the record entirely when tracker has no entry and bytes = 0 (#1032)", function()
     local t = usage.new_tracker()
     local r = usage.build_report(
       { s("aa:bb:cc:11:22:33", "1.2.3.4", 0) },
       NF_SETS, P_START, P_END, ROUTER, nil, nil, t, SAMPLE_S, BUCKET_S)
-    assert.equal(0, r.records[1].activeSeconds)
+    assert.equal(0, #r.records)
   end)
 
   it("assigns activeSeconds per (mac, dst_ip) independently from the same tracker", function()


### PR DESCRIPTION
## Summary

Closes #1032. Agent-side complement to the server-side cap raise that shipped for #1017.

The `mac_ip_tracking` nftables set keeps `(mac, remote_ip)` elements alive for 6h after their last packet, so the agent's per-bucket counters list contains an entry for every flow seen in the last six hours — most with no traffic in the current bucket. On the prod router this meant ~95% of records in each bucket body were `activeSeconds=0, bytesIn=0, bytesOut=0`, which was what inflated the POST past zio-http's 100 KiB cap and triggered #1017.

This change drops counters with no activity and no bytes at `build_report` time, in `openwrt/files/usr/lib/lua/wifihaven/usage.lua`.

## Safety argument

`build_report` has three branches for `active_seconds` per counter:

1. **`samples > 0`** — tracker observed counter growth. Always emits (`active_seconds` is positive). Unaffected.
2. **`samples == 0` but `bytes + bytes_out > 0`** — flow appeared after the final sample tick. Sets `active_seconds = sample_seconds` (positive). Still emits — the new guard short-circuits only when all three are zero.
3. **`samples == 0` and `bytes + bytes_out == 0`** — flow's set element is alive only because of the 6h timeout. **Now dropped.** This is consistent with `docs/resilience.md §1` (usage is best-effort).

Test coverage in `openwrt/test/usage_spec.lua`:
- Mixed zero/non-zero counters list → assert zero entries dropped, non-zero entries preserved with correct fields.
- `bytes>0` / `bytes_out>0` with no active sample → assert record IS still emitted with `activeSeconds = sample_seconds`.
- Updated the existing "all-zero" test (previously asserted `activeSeconds == 0`) to assert the record is dropped entirely.

Full openwrt test suite passes locally (`sh openwrt/test/run_tests.sh`).

## Rollback path

Pure agent-side filter, no API/wire/schema change. Revert the commit — server happily accepts the 0/0/0 records it accepted before.

## Related

- #1032 (this fix)
- #1017 (root incident; server-side 4 MiB cap raise already shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)