### PR TITLE
remove: drop fakenews bundled blocklist (#1037)

### DIFF
--- a/api/resources/blocklists/_index.yml
+++ b/api/resources/blocklists/_index.yml
@@ -13,5 +13,4 @@ ids:
   - ads-extended
   - social-extended
   - adult-extended
-  - fakenews
   - malware

--- a/api/resources/blocklists/fakenews.yml
+++ b/api/resources/blocklists/fakenews.yml
@@ -1,9 +1,0 @@
-# Fake-news domains. StevenBlack publishes an "alternates/fakenews-only"
-# file (MIT-licensed) maintained against the Melissa Zimdars fake-news
-# research corpus. We refresh on every API restart.
-id: fakenews
-name: Fake News
-description: Known misinformation and fake-news sites, fetched from StevenBlack/hosts (alternates/fakenews-only) on each API restart.
-source: "https://github.com/StevenBlack/hosts/tree/master/alternates/fakenews-only (MIT)"
-url: https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-only/hosts
-format: hosts-file

--- a/api/resources/db/migration/V33__remove_fakenews_blocklist.sql
+++ b/api/resources/db/migration/V33__remove_fakenews_blocklist.sql
@@ -1,0 +1,17 @@
+-- #1037: drop the bundled `fakenews` blocklist. Editorializing on what
+-- counts as "fake news" is a value judgment that belongs to the household
+-- admin, not to the bundled set we ship.
+--
+-- Idempotent: re-running on a deployment that never had fakenews seeded
+-- (or has already had it removed) is a no-op. profiles.blocked_categories
+-- is a TEXT[]; array_remove is safe on rows that don't reference the id.
+
+DELETE FROM blocklist_domains
+WHERE category = 'fakenews';
+
+DELETE FROM blocklists
+WHERE id = 'fakenews';
+
+UPDATE profiles
+SET blocked_categories = array_remove(blocked_categories, 'fakenews')
+WHERE blocked_categories && ARRAY['fakenews']::TEXT[];

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -59,11 +59,9 @@ object BundledBlocklistsSpec
    * tiny canned response so seeding completes without network.
    */
   private val stubbedUpstreams: Map[String, List[Hostname]] = Map(
-    "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"                          ->
+    "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"                        ->
       List("ads-extended-upstream.example", "tracker.example").map(Hostname.unsafe),
-    "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/fakenews-only/hosts" ->
-      List("fakenews-upstream.example").map(Hostname.unsafe),
-    "https://urlhaus.abuse.ch/downloads/hostfile/"                                              ->
+    "https://urlhaus.abuse.ch/downloads/hostfile/"                                            ->
       List("malware-upstream.example").map(Hostname.unsafe),
     "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/social-only/hosts"   ->
       List("social-extended-upstream.example").map(Hostname.unsafe),

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -63,9 +63,9 @@ object BundledBlocklistsSpec
       List("ads-extended-upstream.example", "tracker.example").map(Hostname.unsafe),
     "https://urlhaus.abuse.ch/downloads/hostfile/"                                            ->
       List("malware-upstream.example").map(Hostname.unsafe),
-    "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/social-only/hosts"   ->
+    "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/social-only/hosts" ->
       List("social-extended-upstream.example").map(Hostname.unsafe),
-    "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/porn-only/hosts"     ->
+    "https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/porn-only/hosts"   ->
       List("adult-extended-upstream.example").map(Hostname.unsafe),
   )
 


### PR DESCRIPTION
## Summary

- Removes the bundled `fakenews` blocklist (file + `_index.yml` entry).
- V33 migration drops the `blocklists` row, its `blocklist_domains`, and scrubs `'fakenews'` from any `profiles.blocked_categories[]`. Idempotent.
- Test stub no longer mocks the StevenBlack fakenews URL — fresh API boot won't fetch it.

## Why

Deciding what counts as "fake news" is a value judgment that belongs with the household admin, not with the bundled set we ship. Caught early — before any household configured it broadly, so the subscription-scrub in V33 handles the rare case cleanly. The URL-fetcher / cache machinery stays intact for the other URL-sourced lists.

## Migration sketch

```sql
DELETE FROM blocklist_domains WHERE category = 'fakenews';
DELETE FROM blocklists         WHERE id       = 'fakenews';
UPDATE profiles
   SET blocked_categories = array_remove(blocked_categories, 'fakenews')
 WHERE blocked_categories && ARRAY['fakenews']::TEXT[];
```

## Test plan

- [x] `mill api.test` (BundledBlocklistsSpec: manifest sync, seeder, remote-fetch behavior all still pass without fakenews).
- [x] `mill shared.test`.
- [ ] On a real DB: confirm `GET /api/blocklists` no longer includes `fakenews` after migration.

Closes #1037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)