### PR TITLE
feat(web): inline schedule subsection with autosave (#974)

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -204,14 +204,16 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
-    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    expect(within(kidsCard).queryByText('120 min')).not.toBeInTheDocument()
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
-    expect(within(kidsCard).getByText('Bedtime')).toBeInTheDocument()
+    // #974 — schedule subsection is collapsible (closed by default); the
+    // header always shows the schedule count summary when expanded.
+    expect(within(kidsCard).getByTestId('profile-schedule-section-1')).toBeInTheDocument()
+    expect(within(kidsCard).getByText('1 schedule')).toBeInTheDocument()
     expect(within(kidsCard).getByText('120 min')).toBeInTheDocument()
     expect(within(kidsCard).getByText('YouTube')).toBeInTheDocument()
-    expect(within(kidsCard).getByText('21:00 → 07:00')).toBeInTheDocument()
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
-    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    expect(within(kidsCard).queryByText('120 min')).not.toBeInTheDocument()
   })
 })
 
@@ -836,5 +838,133 @@ describe('ProfilesPage — apps section (#767)', () => {
     await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     expect(await screen.findByTestId('apps-section-manage-link')).toHaveAttribute('href', '/apps')
+  })
+})
+
+describe('ProfilesPage — inline schedule subsection (#974)', () => {
+  async function openScheduleSection(pid: number, user: ReturnType<typeof userEvent.setup>) {
+    await expand(pid, user)
+    await user.click(screen.getByTestId(`profile-schedule-toggle-${pid}`))
+  }
+
+  it('section is collapsed by default and toggles open', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    // Subsection header is visible, but rows are not until opened.
+    expect(within(kidsCard).getByTestId('profile-schedule-section-1')).toBeInTheDocument()
+    expect(within(kidsCard).queryByTestId('profile-schedule-row-1-0')).not.toBeInTheDocument()
+    await user.click(within(kidsCard).getByTestId('profile-schedule-toggle-1'))
+    expect(within(kidsCard).getByTestId('profile-schedule-row-1-0')).toBeInTheDocument()
+    // Existing schedule round-tripped into the editor's input.
+    expect(within(kidsCard).getByTestId('profile-schedule-1-0-name')).toHaveValue('Bedtime')
+  })
+
+  it('autosaves a debounced PUT on schedule rename', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await openScheduleSection(1, user)
+    const nameInput = screen.getByTestId('profile-schedule-1-0-name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Nightly')
+
+    await waitFor(
+      () => expect(api.profiles.update).toHaveBeenCalledTimes(1),
+      { timeout: 2000 },
+    )
+    const [pid, body] = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(pid).toBe(1)
+    expect(body.schedules).toEqual([
+      { name: 'Nightly', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
+    ])
+    // Other fields round-trip unchanged (PUT carries the full profile).
+    expect(body.name).toBe('Kids')
+    expect(body.failureMode).toBe('block-all')
+  })
+
+  it('coalesces a burst of edits into a single PUT', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await openScheduleSection(1, user)
+    await user.click(screen.getByTestId('profile-schedule-1-0-day-wed'))
+    await user.click(screen.getByTestId('profile-schedule-1-0-day-thu'))
+    await user.click(screen.getByTestId('profile-schedule-1-0-day-fri'))
+    await waitFor(
+      () => expect(api.profiles.update).toHaveBeenCalledTimes(1),
+      { timeout: 2000 },
+    )
+    const body = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1]
+    expect([...body.schedules[0].days].sort()).toEqual(['fri', 'mon', 'thu', 'tue', 'wed'])
+  })
+
+  it('adding then removing a schedule via the section autosaves', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await openScheduleSection(1, user)
+    await user.click(screen.getByTestId('profile-schedule-add-1'))
+    await waitFor(
+      () => expect(api.profiles.update).toHaveBeenCalledTimes(1),
+      { timeout: 2000 },
+    )
+    let body = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1]
+    expect(body.schedules).toHaveLength(2)
+
+    await user.click(screen.getByTestId('profile-schedule-1-1-remove'))
+    await waitFor(
+      () => expect(api.profiles.update).toHaveBeenCalledTimes(2),
+      { timeout: 2000 },
+    )
+    body = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls[1][1]
+    expect(body.schedules).toHaveLength(1)
+    expect(body.schedules[0].name).toBe('Bedtime')
+  })
+
+  it('shows Saving… then Saved on a successful autosave', async () => {
+    let resolveUpdate: () => void = () => {}
+    ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise<void>(res => { resolveUpdate = res }),
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await openScheduleSection(1, user)
+    await user.click(screen.getByTestId('profile-schedule-1-0-day-wed'))
+    await waitFor(
+      () => expect(screen.getByTestId('profile-schedule-status-1')).toHaveTextContent('Saving'),
+      { timeout: 2000 },
+    )
+    resolveUpdate()
+    await waitFor(
+      () => expect(screen.getByTestId('profile-schedule-status-1')).toHaveTextContent('Saved'),
+      { timeout: 2000 },
+    )
+  })
+
+  it('shows Save failed when the autosave PUT rejects', async () => {
+    ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'))
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await openScheduleSection(1, user)
+    await user.click(screen.getByTestId('profile-schedule-1-0-day-wed'))
+    await waitFor(
+      () => expect(screen.getByTestId('profile-schedule-status-1')).toHaveTextContent('Save failed'),
+      { timeout: 2000 },
+    )
+    expect(screen.getByText('boom')).toBeInTheDocument()
+  })
+
+  it('non-admins see a read-only schedule summary, no editor', async () => {
+    mockAuth = { isAdmin: false }
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    expect(within(kidsCard).queryByTestId('profile-schedule-section-1')).not.toBeInTheDocument()
+    expect(within(kidsCard).getByText('Bedtime')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
@@ -416,6 +416,7 @@ export function ProfilesPage() {
             isAdmin={isAdmin}
             expanded={expanded.has(pd.profile.id)}
             highlight={highlightId === pd.profile.id}
+            defaultTz={household?.dailyResetTz ?? browserTimezone()}
             onToggle={() => toggleExpanded(pd.profile.id)}
             onEdit={() => startEdit(pd)}
             onEditUsers={() => startEditUsers(pd.profile.id)}
@@ -564,7 +565,7 @@ export function ProfilesPage() {
 // the existing card content + escape-hatch buttons (Edit, Edit users, Pause,
 // Delete) that subsections #973-#977 will replace with inline editors.
 function ProfileShellRow({
-  pd, summary, devices, users, isAdmin, expanded, highlight,
+  pd, summary, devices, users, isAdmin, expanded, highlight, defaultTz,
   onToggle, onEdit, onEditUsers, onDelete, onTogglePause, onGrantTime,
 }: {
   pd: ProfileDetail
@@ -574,6 +575,7 @@ function ProfileShellRow({
   isAdmin: boolean
   expanded: boolean
   highlight: boolean
+  defaultTz: string
   onToggle: () => void
   onEdit: () => void
   onEditUsers: () => void
@@ -714,7 +716,11 @@ function ProfileShellRow({
             </p>
           )}
 
-          {pd.schedules.length > 0 && (
+          {/* #974 — inline schedule subsection with debounced autosave.
+              Admins get the editor; non-admins see a read-only list. */}
+          {isAdmin ? (
+            <ProfileScheduleSection pd={pd} defaultTz={defaultTz} />
+          ) : pd.schedules.length > 0 && (
             <div>
               <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Schedules</p>
               {pd.schedules.map(s => (
@@ -792,6 +798,211 @@ function ProfileShellRow({
               ))}
             </div>
           )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// #974 — inline schedule editor mounted in the expanded profile card.
+// Collapsible (closed by default per design doc); debounced autosave PUTs
+// the full profile on every edit. PATCH (#423) would be tighter but PUT
+// is what's wired today, so we stay endpoint-compatible until #423 lands.
+// Per operator preference: autosave, not per-section Save buttons.
+function ProfileScheduleSection({ pd, defaultTz }: {
+  pd: ProfileDetail
+  defaultTz: string
+}) {
+  const invalidators = useInvalidators()
+  const [open, setOpen] = useState(false)
+  // Local draft; reseeds from `pd` when the server snapshot changes and we
+  // have no pending edits in flight (no in-flight debounce, no error).
+  const [schedules, setSchedules] = useState<ScheduleRequest[]>(() =>
+    pd.schedules.map(s => ({
+      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
+    })),
+  )
+  const [status, setStatus] = useState<'idle' | 'dirty' | 'saving' | 'saved' | 'error'>('idle')
+  const [errMsg, setErrMsg] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const dirtyRef = useRef(false)
+
+  // Reseed from server when we're not mid-edit. Comparing JSON keeps this
+  // a no-op when the round-trip echoes back identical schedules.
+  const serverJson = useMemo(() => JSON.stringify(
+    pd.schedules.map(s => ({ name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz })),
+  ), [pd.schedules])
+  useEffect(() => {
+    if (dirtyRef.current) return
+    setSchedules(JSON.parse(serverJson))
+  }, [serverJson])
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+  }, [])
+
+  function mutate(next: ScheduleRequest[]) {
+    dirtyRef.current = true
+    setSchedules(next)
+    setStatus('dirty')
+    setErrMsg(null)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    if (savedTimerRef.current) { clearTimeout(savedTimerRef.current); savedTimerRef.current = null }
+    timerRef.current = setTimeout(() => void flush(next), 500)
+  }
+
+  async function flush(next: ScheduleRequest[]) {
+    setStatus('saving')
+    try {
+      const body = formToRequest({ ...detailToForm(pd), schedules: next })
+      await api.profiles.update(pd.profile.id, body)
+      dirtyRef.current = false
+      setStatus('saved')
+      await invalidators.profileMutated()
+      savedTimerRef.current = setTimeout(() => setStatus(s => s === 'saved' ? 'idle' : s), 2000)
+    } catch (e) {
+      setStatus('error')
+      setErrMsg(e instanceof Error ? e.message : 'Failed to save')
+    }
+  }
+
+  function addSchedule() {
+    mutate([...schedules, { name: 'Bedtime', days: [...DAYS], startLocal: '21:00', endLocal: '07:00', tz: defaultTz }])
+  }
+  function updateSchedule(i: number, patch: Partial<ScheduleRequest>) {
+    mutate(schedules.map((s, idx) => idx === i ? { ...s, ...patch } : s))
+  }
+  function removeSchedule(i: number) {
+    mutate(schedules.filter((_, idx) => idx !== i))
+  }
+  function toggleDay(i: number, d: string) {
+    mutate(schedules.map((s, idx) => idx !== i ? s : {
+      ...s,
+      days: s.days.includes(d) ? s.days.filter(x => x !== d) : [...s.days, d],
+    }))
+  }
+
+  const statusLabel = status === 'saving' ? 'Saving…'
+    : status === 'saved' ? 'Saved'
+    : status === 'dirty' ? 'Unsaved…'
+    : status === 'error' ? 'Save failed'
+    : ''
+  const statusClass = status === 'error' ? 'text-red-400'
+    : status === 'saved' ? 'text-emerald-400'
+    : 'text-gray-500'
+
+  return (
+    <div data-testid={`profile-schedule-section-${pd.profile.id}`} className="border border-gray-800 rounded-xl">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        data-testid={`profile-schedule-toggle-${pd.profile.id}`}
+        className="w-full flex items-center gap-3 px-3 py-2 text-left"
+      >
+        <span className={`text-gray-500 transition-transform ${open ? 'rotate-90' : ''}`}>▸</span>
+        <span className="text-xs font-semibold text-gray-300 uppercase tracking-wider">Schedules</span>
+        <span className="text-xs text-gray-500">
+          {schedules.length === 0 ? 'none' : `${schedules.length} schedule${schedules.length === 1 ? '' : 's'}`}
+        </span>
+        <span className="ml-auto flex items-center gap-2">
+          {statusLabel && (
+            <span
+              data-testid={`profile-schedule-status-${pd.profile.id}`}
+              className={`text-xs ${statusClass}`}
+            >{statusLabel}</span>
+          )}
+        </span>
+      </button>
+
+      {open && (
+        <div className="px-3 pb-3 space-y-3 border-t border-gray-800 pt-3">
+          {errMsg && (
+            <div className="bg-red-500/10 border border-red-500/30 text-red-300 text-xs rounded-lg px-3 py-2">
+              {errMsg}
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={addSchedule}
+              data-testid={`profile-schedule-add-${pd.profile.id}`}
+              className="text-xs text-emerald-400 hover:text-emerald-300"
+            >+ Add schedule</button>
+          </div>
+
+          {schedules.length === 0 && (
+            <p className="text-xs text-gray-500">No schedules.</p>
+          )}
+
+          <div className="space-y-3">
+            {schedules.map((s, i) => (
+              <div
+                key={i}
+                data-testid={`profile-schedule-row-${pd.profile.id}-${i}`}
+                className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2"
+              >
+                <div className="flex gap-2">
+                  <input
+                    type="text" value={s.name}
+                    onChange={e => updateSchedule(i, { name: e.target.value })}
+                    placeholder="Bedtime"
+                    data-testid={`profile-schedule-${pd.profile.id}-${i}-name`}
+                    className="flex-1 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeSchedule(i)}
+                    data-testid={`profile-schedule-${pd.profile.id}-${i}-remove`}
+                    className="text-xs text-red-400 hover:text-red-300 bg-red-500/10 px-3 rounded-lg"
+                  >Remove</button>
+                </div>
+                <div className="flex gap-2 items-center text-sm">
+                  <input
+                    type="time" value={s.startLocal}
+                    onChange={e => updateSchedule(i, { startLocal: e.target.value })}
+                    data-testid={`profile-schedule-${pd.profile.id}-${i}-start`}
+                    className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white"
+                  />
+                  <span className="text-gray-500">→</span>
+                  <input
+                    type="time" value={s.endLocal}
+                    onChange={e => updateSchedule(i, { endLocal: e.target.value })}
+                    data-testid={`profile-schedule-${pd.profile.id}-${i}-end`}
+                    className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white"
+                  />
+                </div>
+                <div className="text-xs text-gray-400">
+                  Timezone (the same wall-clock window applies every day, even across DST)
+                </div>
+                <TimezonePicker
+                  value={s.tz}
+                  onChange={tz => updateSchedule(i, { tz })}
+                  testId={`profile-schedule-${pd.profile.id}-${i}-tz`}
+                />
+                <div className="flex flex-wrap gap-1">
+                  {DAYS.map(d => {
+                    const on = s.days.includes(d)
+                    return (
+                      <button
+                        key={d} type="button"
+                        onClick={() => toggleDay(i, d)}
+                        data-testid={`profile-schedule-${pd.profile.id}-${i}-day-${d}`}
+                        className={`text-xs px-2.5 py-1 rounded-lg border ${
+                          on
+                            ? 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40'
+                            : 'bg-gray-800 text-gray-500 border-gray-700'
+                        }`}
+                      >{d}</button>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #974 (sub-3 of the #965 merged /profiles plan).

## Summary
- Lift the schedule editor from the modal `ProfileEditor` into a collapsible subsection inside the expanded profile card (admin-only; non-admins keep the read-only summary).
- **Autosave** with a 500ms debounce, surfaced via a `Saving…` / `Saved` / `Save failed` status in the section header — per [feedback_autosave_default](../memory/feedback_autosave_default.md), this overrides the per-section Save button mentioned in the #965 design doc Q2.
- Subsection is **collapsed by default** when the card first expands (design doc Q3).
- Server-side PATCH (#423) isn't wired yet, so autosave PUTs the full profile via the existing `api.profiles.update`; once #423 lands, only the transport changes.
- Modal `ProfileEditor` stays as today's escape hatch; #978 deletes it.

## Out of scope (other sub-lanes)
- #973 — name / icon / color + devices subsections
- #975 — time-limit subsection
- #976 — rules / blocked categories subsection
- #977 — users subsection
- #978 — modal cleanup

## Wire / API
- **Zero** API or router-side changes. `shared/contract/api-to-router/policy_snapshot.json` untouched.
- Uses the existing `PUT /api/profiles/:id` endpoint (idempotent full-profile upsert).

## Test plan
- [x] `web/`: `nvm use 22 && npx vitest run` — 257/257 pass (added 7 new tests for the schedule subsection: collapsed-by-default, debounced PUT, burst coalescing, add+remove, Saving/Saved status, error path, non-admin read-only).
- [x] `web/`: `npx tsc --noEmit` clean.
- [ ] Manual smoke on dev API: rename a schedule and watch one PUT fire ~500ms after the last keystroke; revert by editing back.
- [ ] Manual smoke: add a schedule, toggle a couple of days quickly, confirm one PUT carries the final state.
- [ ] Manual smoke: kill the API, edit a day, confirm "Save failed" surfaces with the underlying error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)