### PR TITLE
feat(web): inline rules (apps + legacy) subsection (#976)

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -980,11 +980,14 @@ describe('ProfilesPage — apps section (#767)', () => {
   })
 })
 
-// #976 — rules subsection inside the expanded card (apps editor + legacy
-// extraBlocked/extraAllowed). Default collapsed; opening reveals the same
-// AppsSection the modal uses, scoped to a profile-specific testid prefix.
-describe('ProfilesPage — rules subsection (#976)', () => {
-  it('subsection summary reflects assigned-app count and legacy domain counts', async () => {
+// #976 — apps subsection inside the expanded card (per-app policy editor
+// + transitional extraBlocked/extraAllowed). Default collapsed; opening
+// reveals the same AppsSection the modal uses, scoped to a profile-
+// specific testid prefix. Labelled "Apps" (not "Rules") because time
+// limits live in their own subsection (#975) and domain blocklists are
+// on their way out (#764).
+describe('ProfilesPage — apps subsection (#976)', () => {
+  it('subsection summary reports the assigned-app count', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
         app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '▶', createdAt: '2026-01-01' },
@@ -998,11 +1001,9 @@ describe('ProfilesPage — rules subsection (#976)', () => {
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await expand(1, user)
-    const toggle = await screen.findByTestId('profile-rules-toggle-1')
-    // kids has 2 extraBlocked + 1 extraAllowed (from the seeded profile) + 1 assigned app.
-    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/1 app/)
-    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/2 blocked/)
-    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/1 allowed/)
+    const toggle = await screen.findByTestId('profile-apps-toggle-1')
+    expect(within(kidsCard).getByTestId('profile-apps-subsection-1')).toHaveTextContent(/Apps/)
+    expect(within(kidsCard).getByTestId('profile-apps-subsection-1')).toHaveTextContent(/1 assigned/)
     // Body collapsed: inline AppsSection not mounted yet.
     expect(screen.queryByTestId('profile-1-apps-section')).not.toBeInTheDocument()
     await user.click(toggle)
@@ -1011,14 +1012,14 @@ describe('ProfilesPage — rules subsection (#976)', () => {
     expect(screen.getByTestId('app-row-50')).toBeInTheDocument()
   })
 
-  it('legacy textareas seed from profile and debounce-autosave via PUT', async () => {
+  it('legacy domain textareas seed from profile and debounce-autosave via PUT', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
       renderPage()
       await screen.findByTestId('profile-card-1')
       await expand(1, user)
-      await user.click(screen.getByTestId('profile-rules-toggle-1'))
+      await user.click(screen.getByTestId('profile-apps-toggle-1'))
       const blocked = await screen.findByTestId('profile-legacy-blocked-1') as HTMLTextAreaElement
       const allowed = screen.getByTestId('profile-legacy-allowed-1') as HTMLTextAreaElement
       expect(blocked.value).toBe('bad.com\nevil.com')
@@ -1043,12 +1044,12 @@ describe('ProfilesPage — rules subsection (#976)', () => {
     }
   })
 
-  it('subsection survives without admin gating only for admins', async () => {
+  it('subsection hidden for non-admins', async () => {
     mockAuth = { isAdmin: false }
     const user = userEvent.setup()
     renderPage()
     await screen.findByTestId('profile-card-1')
     await expand(1, user)
-    expect(screen.queryByTestId('profile-rules-toggle-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('profile-apps-toggle-1')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -918,19 +918,37 @@ describe('ProfilesPage — apps section (#767)', () => {
     )
   })
 
-  it('time-limit requires positive minutes; rejects empty', async () => {
+  it('typing a positive value into the minutes input then blurring saves as time_limited', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
-    await user.click(await screen.findByTestId('app-row-50-time-limit'))
+    const input = await screen.findByTestId('app-row-50-minutes') as HTMLInputElement
+    await user.type(input, '45')
+    // Tab away — the input IS the time-limit control, no separate button.
+    await user.tab()
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'time_limited', dailyMinutes: 45, exemptFromDaily: true }),
+    )
+  })
+
+  it('zero/negative minutes shows inline error and does not save', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const input = await screen.findByTestId('app-row-50-minutes') as HTMLInputElement
+    await user.type(input, '0')
+    await user.tab()
     expect(api.apps.setPolicy).not.toHaveBeenCalled()
     expect(await screen.findByTestId('app-row-50-error')).toHaveTextContent(/minutes > 0/i)
   })
 
-  it('time-limit with minutes calls setPolicy with mode=time_limited + dailyMinutes', async () => {
+  it('blank minutes on blur is a no-op (no save, no error)', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
     const user = userEvent.setup()
     renderPage()
@@ -938,11 +956,10 @@ describe('ProfilesPage — apps section (#767)', () => {
     await expand(1, user)
     await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
     const input = await screen.findByTestId('app-row-50-minutes')
-    await user.type(input, '45')
-    await user.click(screen.getByTestId('app-row-50-time-limit'))
-    await waitFor(() =>
-      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'time_limited', dailyMinutes: 45, exemptFromDaily: true }),
-    )
+    await user.click(input)
+    await user.tab()
+    expect(api.apps.setPolicy).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('app-row-50-error')).not.toBeInTheDocument()
   })
 
   it('clearing an assigned app calls deletePolicy', async () => {

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -948,7 +948,7 @@ describe('ProfilesPage — apps section (#767)', () => {
     expect(await screen.findByTestId('app-row-50-error')).toHaveTextContent(/minutes > 0/i)
   })
 
-  it('blank minutes on blur is a no-op (no save, no error)', async () => {
+  it('blank minutes on blur is a no-op when the app is not time-limited', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtube])
     const user = userEvent.setup()
     renderPage()
@@ -960,6 +960,29 @@ describe('ProfilesPage — apps section (#767)', () => {
     await user.tab()
     expect(api.apps.setPolicy).not.toHaveBeenCalled()
     expect(screen.queryByTestId('app-row-50-error')).not.toBeInTheDocument()
+  })
+
+  it('clearing the minutes input on a time-limited app reverts to Allow', async () => {
+    const khan = {
+      app: { id: 60, name: 'Khan', slug: 'khan', templateId: null, icon: '📚', createdAt: '2026-01-01' },
+      hosts: ['khanacademy.org'],
+      assignments: [
+        { id: 3, appId: 60, profileId: 1, mode: 'time_limited' as const, dailyMinutes: 60, exemptFromDaily: true },
+      ],
+    }
+    ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([khan])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(within(kidsCard).getByRole('button', { name: /^Edit$/ }))
+    const input = await screen.findByTestId('app-row-60-minutes') as HTMLInputElement
+    expect(input.value).toBe('60')
+    await user.clear(input)
+    await user.tab()
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(60, 1, { mode: 'allowed', dailyMinutes: null }),
+    )
   })
 
   it('clearing an assigned app calls deletePolicy', async () => {

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -838,3 +838,76 @@ describe('ProfilesPage — apps section (#767)', () => {
     expect(await screen.findByTestId('apps-section-manage-link')).toHaveAttribute('href', '/apps')
   })
 })
+
+// #976 — rules subsection inside the expanded card (apps editor + legacy
+// extraBlocked/extraAllowed). Default collapsed; opening reveals the same
+// AppsSection the modal uses, scoped to a profile-specific testid prefix.
+describe('ProfilesPage — rules subsection (#976)', () => {
+  it('subsection summary reflects assigned-app count and legacy domain counts', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '▶', createdAt: '2026-01-01' },
+        hosts: ['youtube.com'],
+        assignments: [
+          { id: 1, appId: 50, profileId: 1, mode: 'allowed' as const, dailyMinutes: null, exemptFromDaily: true },
+        ],
+      },
+    ])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    const toggle = await screen.findByTestId('profile-rules-toggle-1')
+    // kids has 2 extraBlocked + 1 extraAllowed (from the seeded profile) + 1 assigned app.
+    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/1 app/)
+    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/2 blocked/)
+    expect(within(kidsCard).getByTestId('profile-rules-subsection-1')).toHaveTextContent(/1 allowed/)
+    // Body collapsed: inline AppsSection not mounted yet.
+    expect(screen.queryByTestId('profile-1-apps-section')).not.toBeInTheDocument()
+    await user.click(toggle)
+    expect(await screen.findByTestId('profile-1-apps-section')).toBeInTheDocument()
+    // Inline app row rendered.
+    expect(screen.getByTestId('app-row-50')).toBeInTheDocument()
+  })
+
+  it('legacy textareas seed from profile and debounce-autosave via PUT', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      renderPage()
+      await screen.findByTestId('profile-card-1')
+      await expand(1, user)
+      await user.click(screen.getByTestId('profile-rules-toggle-1'))
+      const blocked = await screen.findByTestId('profile-legacy-blocked-1') as HTMLTextAreaElement
+      const allowed = screen.getByTestId('profile-legacy-allowed-1') as HTMLTextAreaElement
+      expect(blocked.value).toBe('bad.com\nevil.com')
+      expect(allowed.value).toBe('school.com')
+
+      await user.clear(blocked)
+      await user.type(blocked, 'newbad.com')
+      // Not yet saved before debounce.
+      expect(api.profiles.update).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(900)
+      await waitFor(() =>
+        expect(api.profiles.update).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({
+            extraBlocked: ['newbad.com'],
+            extraAllowed: ['school.com'],
+          }),
+        ),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('subsection survives without admin gating only for admins', async () => {
+    mockAuth = { isAdmin: false }
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    expect(screen.queryByTestId('profile-rules-toggle-1')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -671,12 +671,13 @@ function ProfileShellRow({
             </div>
           )}
 
-          {/* #976: rules subsection — inline app-policy editor + legacy
-              extraAllowed/extraBlocked textareas. Replaces the read-only
-              summary that used to live here; the modal Edit still works
-              while #978 cleans it up. */}
+          {/* #976: apps subsection — inline app-policy editor (with the
+              transitional extraAllowed/extraBlocked textareas tucked
+              underneath until #764 migrates them off the schema).
+              Replaces the read-only summary that used to live here; the
+              modal Edit still works while #978 cleans it up. */}
           {isAdmin && (
-            <RulesSubsection
+            <AppsRulesSubsection
               pd={pd}
               apps={apps}
               onAppsChanged={onAppsChanged}
@@ -1526,14 +1527,16 @@ function ProfileEditor({
   )
 }
 
-// #976 — rules subsection of the merged /profiles expanded card.
+// #976 — apps subsection of the merged /profiles expanded card.
 // Default collapsed; opening reveals the same `<AppsSection>` the modal
-// shows, followed by legacy extraBlocked/extraAllowed textareas with
-// debounced autosave (1s after last keystroke). The legacy textareas
-// disappear once #764 migrates those fields onto apps; PATCH support
-// (#423) would let us send only the changed fields instead of a full
-// PUT body, but the textareas are short-lived enough that PUT is fine.
-function RulesSubsection({
+// shows, plus the transitional extraBlocked/extraAllowed textareas with
+// debounced autosave. The textareas disappear once #764 migrates those
+// fields onto apps; PATCH support (#423) would let us send only the
+// changed fields instead of a full PUT body, but the textareas are
+// short-lived enough that PUT is fine. Subsection is labelled "Apps"
+// (not "Rules") because time limits are their own subsection (#975)
+// and domain blocklists are on their way out.
+function AppsRulesSubsection({
   pd, apps, onAppsChanged, onProfileChanged, updateProfile,
 }: {
   pd: ProfileDetail
@@ -1547,29 +1550,25 @@ function RulesSubsection({
     () => apps.filter(a => a.assignments.some(x => x.profileId === pd.profile.id)).length,
     [apps, pd.profile.id],
   )
-  const blockedCount = pd.profile.extraBlocked.length
-  const allowedCount = pd.profile.extraAllowed.length
-  const summaryParts: string[] = []
-  if (assignedAppCount > 0) summaryParts.push(`${assignedAppCount} app${assignedAppCount === 1 ? '' : 's'}`)
-  if (blockedCount > 0) summaryParts.push(`${blockedCount} blocked`)
-  if (allowedCount > 0) summaryParts.push(`${allowedCount} allowed`)
-  const summary = summaryParts.length > 0 ? summaryParts.join(' · ') : 'No rules'
+  const summary = assignedAppCount > 0
+    ? `${assignedAppCount} assigned`
+    : 'None assigned'
 
   return (
     <div
-      data-testid={`profile-rules-subsection-${pd.profile.id}`}
+      data-testid={`profile-apps-subsection-${pd.profile.id}`}
       className="bg-gray-950/40 border border-gray-800 rounded-xl"
     >
       <button
         type="button"
         aria-expanded={open}
         onClick={() => setOpen(v => !v)}
-        data-testid={`profile-rules-toggle-${pd.profile.id}`}
+        data-testid={`profile-apps-toggle-${pd.profile.id}`}
         className="w-full flex items-center justify-between px-4 py-3 text-left"
       >
         <span className="flex items-center gap-2">
           <span className={`text-gray-500 transition-transform ${open ? 'rotate-90' : ''}`}>▸</span>
-          <span className="text-sm font-semibold text-white">Rules</span>
+          <span className="text-sm font-semibold text-white">Apps</span>
         </span>
         <span className="text-xs text-gray-400">{summary}</span>
       </button>

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1930,11 +1930,15 @@ function AppRow({ app, profileId, onChanged }: {
   async function commitMinutes() {
     const trimmed = minutesDraft.trim()
     if (trimmed === '') {
-      // Restore to the persisted value so the input doesn't sit empty
-      // looking unsaved. Doesn't clear the policy — operator must use
-      // Clear / Block / Allow for that.
-      setMinutesDraft(currentMinutes != null ? String(currentMinutes) : '')
       setLocalError(null)
+      // Clearing the input on a time-limited app removes the limit by
+      // switching the app to plain Allow (keeps it assigned to the
+      // profile so the row stays visible — use the Clear button to drop
+      // the assignment entirely). For apps that weren't time-limited in
+      // the first place this is a no-op.
+      if (isTimeLimited) {
+        await apply('allowed', null)
+      }
       return
     }
     const n = Number(trimmed)

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -413,6 +413,7 @@ export function ProfilesPage() {
             summary={summaryByProfile.get(pd.profile.id)}
             devices={devicesByProfile.get(pd.profile.id) ?? []}
             users={usersByProfile.get(pd.profile.id) ?? []}
+            apps={apps}
             isAdmin={isAdmin}
             expanded={expanded.has(pd.profile.id)}
             highlight={highlightId === pd.profile.id}
@@ -422,6 +423,9 @@ export function ProfilesPage() {
             onDelete={() => del(pd.profile.id, pd.profile.name)}
             onTogglePause={() => togglePause(pd)}
             onGrantTime={() => setExtProfileId(pd.profile.id)}
+            onAppsChanged={reloadApps}
+            onProfileChanged={() => invalidators.profileMutated()}
+            updateProfile={(body) => updateMutation.mutateAsync({ id: pd.profile.id, body })}
           />
         ))}
       </div>
@@ -564,13 +568,15 @@ export function ProfilesPage() {
 // the existing card content + escape-hatch buttons (Edit, Edit users, Pause,
 // Delete) that subsections #973-#977 will replace with inline editors.
 function ProfileShellRow({
-  pd, summary, devices, users, isAdmin, expanded, highlight,
+  pd, summary, devices, users, apps, isAdmin, expanded, highlight,
   onToggle, onEdit, onEditUsers, onDelete, onTogglePause, onGrantTime,
+  onAppsChanged, onProfileChanged, updateProfile,
 }: {
   pd: ProfileDetail
   summary: ProfileTimeSummary | undefined
   devices: Device[]
   users: User[]
+  apps: AppDetail[]
   isAdmin: boolean
   expanded: boolean
   highlight: boolean
@@ -580,6 +586,9 @@ function ProfileShellRow({
   onDelete: () => void
   onTogglePause: () => void
   onGrantTime: () => void
+  onAppsChanged: () => void | Promise<void>
+  onProfileChanged: () => void | Promise<unknown>
+  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
 }) {
   const chip = computeChip(pd, summary)
   const hasLimit = summary?.dailyLimitMins != null
@@ -691,21 +700,18 @@ function ProfileShellRow({
             </div>
           )}
 
-          {(pd.profile.extraBlocked.length > 0 || pd.profile.extraAllowed.length > 0) && (
-            <div className="grid grid-cols-2 gap-3">
-              {pd.profile.extraBlocked.length > 0 && (
-                <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Blocked domains</p>
-                  <p className="text-xs text-gray-400 font-mono">{pd.profile.extraBlocked.length} entr{pd.profile.extraBlocked.length === 1 ? 'y' : 'ies'}</p>
-                </div>
-              )}
-              {pd.profile.extraAllowed.length > 0 && (
-                <div>
-                  <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Allowed domains</p>
-                  <p className="text-xs text-gray-400 font-mono">{pd.profile.extraAllowed.length} entr{pd.profile.extraAllowed.length === 1 ? 'y' : 'ies'}</p>
-                </div>
-              )}
-            </div>
+          {/* #976: rules subsection — inline app-policy editor + legacy
+              extraAllowed/extraBlocked textareas. Replaces the read-only
+              summary that used to live here; the modal Edit still works
+              while #978 cleans it up. */}
+          {isAdmin && (
+            <RulesSubsection
+              pd={pd}
+              apps={apps}
+              onAppsChanged={onAppsChanged}
+              onProfileChanged={onProfileChanged}
+              updateProfile={updateProfile}
+            />
           )}
 
           {pd.timeLimit && (
@@ -1191,16 +1197,197 @@ function ProfileEditor({
   )
 }
 
+// #976 — rules subsection of the merged /profiles expanded card.
+// Default collapsed; opening reveals the same `<AppsSection>` the modal
+// shows, followed by legacy extraBlocked/extraAllowed textareas with
+// debounced autosave (1s after last keystroke). The legacy textareas
+// disappear once #764 migrates those fields onto apps; PATCH support
+// (#423) would let us send only the changed fields instead of a full
+// PUT body, but the textareas are short-lived enough that PUT is fine.
+function RulesSubsection({
+  pd, apps, onAppsChanged, onProfileChanged, updateProfile,
+}: {
+  pd: ProfileDetail
+  apps: AppDetail[]
+  onAppsChanged: () => void | Promise<void>
+  onProfileChanged: () => void | Promise<unknown>
+  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
+}) {
+  const [open, setOpen] = useState(false)
+  const assignedAppCount = useMemo(
+    () => apps.filter(a => a.assignments.some(x => x.profileId === pd.profile.id)).length,
+    [apps, pd.profile.id],
+  )
+  const blockedCount = pd.profile.extraBlocked.length
+  const allowedCount = pd.profile.extraAllowed.length
+  const summaryParts: string[] = []
+  if (assignedAppCount > 0) summaryParts.push(`${assignedAppCount} app${assignedAppCount === 1 ? '' : 's'}`)
+  if (blockedCount > 0) summaryParts.push(`${blockedCount} blocked`)
+  if (allowedCount > 0) summaryParts.push(`${allowedCount} allowed`)
+  const summary = summaryParts.length > 0 ? summaryParts.join(' · ') : 'No rules'
+
+  return (
+    <div
+      data-testid={`profile-rules-subsection-${pd.profile.id}`}
+      className="bg-gray-950/40 border border-gray-800 rounded-xl"
+    >
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen(v => !v)}
+        data-testid={`profile-rules-toggle-${pd.profile.id}`}
+        className="w-full flex items-center justify-between px-4 py-3 text-left"
+      >
+        <span className="flex items-center gap-2">
+          <span className={`text-gray-500 transition-transform ${open ? 'rotate-90' : ''}`}>▸</span>
+          <span className="text-sm font-semibold text-white">Rules</span>
+        </span>
+        <span className="text-xs text-gray-400">{summary}</span>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4 space-y-4 border-t border-gray-800 pt-3">
+          <AppsSection
+            profileId={pd.profile.id}
+            isNew={false}
+            apps={apps}
+            onChanged={onAppsChanged}
+            testIdPrefix={`profile-${pd.profile.id}-apps-section`}
+          />
+          <LegacyDomainListsEditor
+            pd={pd}
+            updateProfile={updateProfile}
+            onSaved={onProfileChanged}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function profileDetailToUpsert(pd: ProfileDetail): UpsertProfileRequest {
+  return {
+    name: pd.profile.name,
+    blockedCategories: pd.profile.blockedCategories,
+    extraBlocked: pd.profile.extraBlocked,
+    extraAllowed: pd.profile.extraAllowed,
+    paused: pd.profile.paused,
+    timeLimit: pd.timeLimit ? pd.timeLimit.dailyMinutes : null,
+    schedules: pd.schedules.map(s => ({
+      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
+    })),
+    siteTimeLimits: pd.siteTimeLimits.map(s => ({
+      domainPattern: s.domainPattern,
+      dailyMinutes: s.dailyMinutes,
+      label: s.label,
+      exemptFromDaily: s.exemptFromDaily,
+    })),
+    failureMode: pd.profile.failureMode,
+    crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
+  }
+}
+
+function LegacyDomainListsEditor({
+  pd, updateProfile, onSaved,
+}: {
+  pd: ProfileDetail
+  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
+  onSaved: () => void | Promise<unknown>
+}) {
+  const [blocked, setBlocked] = useState(pd.profile.extraBlocked.join('\n'))
+  const [allowed, setAllowed] = useState(pd.profile.extraAllowed.join('\n'))
+  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
+  const [errMsg, setErrMsg] = useState<string | null>(null)
+  // Track the persisted values so we can detect dirty state and re-seed
+  // when an external mutation lands (e.g. modal Save). Comparing against
+  // the raw join lets us avoid stomping in-flight edits.
+  const persistedBlocked = pd.profile.extraBlocked.join('\n')
+  const persistedAllowed = pd.profile.extraAllowed.join('\n')
+  useEffect(() => {
+    if (status === 'saving') return
+    setBlocked(persistedBlocked)
+    setAllowed(persistedAllowed)
+  }, [persistedBlocked, persistedAllowed])
+
+  const splitLines = (s: string) => s.split('\n').map(x => x.trim()).filter(Boolean)
+
+  useEffect(() => {
+    if (blocked === persistedBlocked && allowed === persistedAllowed) return
+    const t = setTimeout(async () => {
+      setStatus('saving')
+      setErrMsg(null)
+      try {
+        const body = profileDetailToUpsert(pd)
+        body.extraBlocked = splitLines(blocked)
+        body.extraAllowed = splitLines(allowed)
+        await updateProfile(body)
+        await onSaved()
+        setStatus('saved')
+      } catch (e) {
+        setStatus('error')
+        setErrMsg(e instanceof Error ? e.message : 'Failed to save')
+      }
+    }, 800)
+    return () => clearTimeout(t)
+  }, [blocked, allowed])
+
+  return (
+    <div data-testid={`profile-legacy-domains-${pd.profile.id}`}>
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          Extra domains <span className="normal-case text-gray-600">(legacy — migrating to apps in #764)</span>
+        </label>
+        <span
+          data-testid={`profile-legacy-domains-status-${pd.profile.id}`}
+          className={`text-xs ${
+            status === 'saving' ? 'text-gray-400'
+              : status === 'saved' ? 'text-emerald-400'
+              : status === 'error' ? 'text-red-400'
+              : 'text-transparent'
+          }`}
+        >
+          {status === 'saving' ? 'Saving…' : status === 'saved' ? 'Saved' : status === 'error' ? (errMsg ?? 'Save failed') : '·'}
+        </span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div>
+          <p className="text-xs text-gray-500 mb-1">Blocked domains</p>
+          <textarea
+            value={blocked}
+            onChange={e => setBlocked(e.target.value)}
+            placeholder="One domain per line"
+            rows={3}
+            data-testid={`profile-legacy-blocked-${pd.profile.id}`}
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
+          />
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 mb-1">Allowed domains</p>
+          <textarea
+            value={allowed}
+            onChange={e => setAllowed(e.target.value)}
+            placeholder="One domain per line"
+            rows={3}
+            data-testid={`profile-legacy-allowed-${pd.profile.id}`}
+            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function findAssignment(app: AppDetail, profileId: number | null): AppPolicyAssignment | null {
   if (profileId == null) return null
   return app.assignments.find(a => a.profileId === profileId) ?? null
 }
 
-function AppsSection({ profileId, isNew, apps, onChanged }: {
+function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-section' }: {
   profileId: number | null
   isNew: boolean
   apps: AppDetail[]
   onChanged: () => void | Promise<void>
+  testIdPrefix?: string
 }) {
   // #1007: only show apps that already have an assignment for this profile.
   // Unassigned apps stay manageable via the "+ Add app" picker below.
@@ -1234,7 +1421,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
   const headerCta = !isNew && profileId != null && apps.length > 0 && (
     <button
       type="button"
-      data-testid="apps-section-add"
+      data-testid={`${testIdPrefix}-add`}
       onClick={() => setPickerOpen(v => !v)}
       className="text-xs text-emerald-400 hover:text-emerald-300"
     >
@@ -1243,7 +1430,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
   )
 
   return (
-    <div data-testid="apps-section">
+    <div data-testid={testIdPrefix}>
       <div className="flex items-center justify-between mb-2 gap-3">
         <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">
           Apps
@@ -1252,7 +1439,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
           {headerCta}
           <Link
             to="/apps"
-            data-testid="apps-section-manage-link"
+            data-testid={`${testIdPrefix}-manage-link`}
             className="text-xs text-emerald-400 hover:text-emerald-300"
           >
             Manage apps →
@@ -1268,7 +1455,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
           No apps yet.{' '}
           <Link
             to="/apps"
-            data-testid="apps-section-empty-link"
+            data-testid={`${testIdPrefix}-empty-link`}
             className="text-emerald-400 hover:text-emerald-300 underline"
           >
             Create one
@@ -1278,11 +1465,11 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
       ) : (
         <div className="space-y-2">
           {assigned.length === 0 && !pickerOpen && (
-            <p className="text-xs text-gray-500" data-testid="apps-section-none-assigned">
+            <p className="text-xs text-gray-500" data-testid={`${testIdPrefix}-none-assigned`}>
               No apps assigned to this profile.{' '}
               <button
                 type="button"
-                data-testid="apps-section-none-assigned-add"
+                data-testid={`${testIdPrefix}-none-assigned-add`}
                 onClick={() => setPickerOpen(true)}
                 className="text-emerald-400 hover:text-emerald-300 underline"
               >
@@ -1301,7 +1488,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
           ))}
           {pickerOpen && (
             <div
-              data-testid="apps-section-picker"
+              data-testid={`${testIdPrefix}-picker`}
               className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2"
             >
               <input
@@ -1310,11 +1497,11 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
                 value={pickerFilter}
                 onChange={e => setPickerFilter(e.target.value)}
                 placeholder="Filter apps…"
-                data-testid="apps-section-picker-filter"
+                data-testid={`${testIdPrefix}-picker-filter`}
                 className="w-full bg-gray-900 border border-gray-700 rounded-lg px-2 py-1 text-white text-xs"
               />
               {pickerMatches.length === 0 ? (
-                <p className="text-xs text-gray-500" data-testid="apps-section-picker-empty">
+                <p className="text-xs text-gray-500" data-testid={`${testIdPrefix}-picker-empty`}>
                   {unassigned.length === 0
                     ? 'Every app in the library is already assigned.'
                     : 'No apps match that filter.'}
@@ -1325,7 +1512,7 @@ function AppsSection({ profileId, isNew, apps, onChanged }: {
                     <button
                       key={a.app.id}
                       type="button"
-                      data-testid={`apps-section-picker-add-${a.app.id}`}
+                      data-testid={`${testIdPrefix}-picker-add-${a.app.id}`}
                       onClick={() => addApp(a)}
                       className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg bg-gray-900 hover:bg-gray-800 border border-gray-700 text-left"
                     >

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1872,6 +1872,15 @@ function AppRow({ app, profileId, onChanged }: {
   )
   const [busy, setBusy] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
+  // Re-seed the input when the persisted policy changes from outside
+  // (e.g. another tab, or after our own setPolicy round-trip lands).
+  // Without this the input keeps stale values once `current` updates.
+  useEffect(() => {
+    if (busy) return
+    const next = current?.mode === 'time_limited' && current.dailyMinutes != null
+      ? String(current.dailyMinutes) : ''
+    setMinutesDraft(next)
+  }, [current?.mode, current?.dailyMinutes])
 
   async function apply(mode: AppMode, dailyMinutes: number | null, exemptFromDaily?: boolean) {
     setBusy(true)
@@ -1904,28 +1913,48 @@ function AppRow({ app, profileId, onChanged }: {
     }
   }
 
-  async function applyTimeLimited() {
-    const n = Number(minutesDraft)
-    if (!Number.isFinite(n) || n <= 0) {
-      setLocalError('Enter minutes > 0')
-      return
-    }
-    // #1007: preserve current exemptFromDaily when re-applying; default to TRUE
-    // (matches the schema default and the wire default in #761/#763).
-    await apply('time_limited', n, current?.exemptFromDaily ?? true)
-  }
-
   async function toggleExempt(nextExempt: boolean) {
     if (current?.mode !== 'time_limited' || current.dailyMinutes == null) return
     await apply('time_limited', current.dailyMinutes, nextExempt)
   }
 
   const mode = current?.mode ?? null
+  const isTimeLimited = mode === 'time_limited'
+  const currentMinutes = isTimeLimited ? current?.dailyMinutes ?? null : null
+
+  // Operator feedback: the old UX made you type minutes AND click a
+  // separate "Time-limit" button, then showed the duration twice. Now
+  // the minutes input IS the time-limit control: editing it and tabbing
+  // away (or pressing Enter) saves the policy. Empty input is a no-op
+  // (we revert to the current value); 0/negative shows an inline error.
+  async function commitMinutes() {
+    const trimmed = minutesDraft.trim()
+    if (trimmed === '') {
+      // Restore to the persisted value so the input doesn't sit empty
+      // looking unsaved. Doesn't clear the policy — operator must use
+      // Clear / Block / Allow for that.
+      setMinutesDraft(currentMinutes != null ? String(currentMinutes) : '')
+      setLocalError(null)
+      return
+    }
+    const n = Number(trimmed)
+    if (!Number.isFinite(n) || n <= 0) {
+      setLocalError('Enter minutes > 0')
+      return
+    }
+    setLocalError(null)
+    // No-op if the policy is already time_limited at exactly this value.
+    if (isTimeLimited && currentMinutes === n) return
+    // #1007: preserve current exemptFromDaily when re-applying; default
+    // to TRUE (matches the schema default and the wire default in
+    // #761/#763) when transitioning into time_limited.
+    await apply('time_limited', n, current?.exemptFromDaily ?? true)
+  }
+
   const baseBtn = 'text-xs px-2.5 py-1 rounded-lg border transition-colors disabled:opacity-50'
   const off = 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-600'
   const onBlocked = 'bg-red-500/20 text-red-300 border-red-500/40'
   const onAllowed = 'bg-emerald-500/20 text-emerald-300 border-emerald-500/40'
-  const onTimeLimited = 'bg-amber-500/20 text-amber-300 border-amber-500/40'
 
   return (
     <div
@@ -1971,21 +2000,24 @@ function AppRow({ app, profileId, onChanged }: {
             min={1}
             value={minutesDraft}
             onChange={e => setMinutesDraft(e.target.value)}
-            placeholder="min"
-            data-testid={`app-row-${app.app.id}-minutes`}
-            className="w-16 bg-gray-900 border border-gray-700 rounded-lg px-2 py-1 text-white text-xs"
-          />
-          <button
-            type="button"
-            data-testid={`app-row-${app.app.id}-time-limit`}
+            onBlur={commitMinutes}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                (e.currentTarget as HTMLInputElement).blur()
+              }
+            }}
             disabled={busy}
-            onClick={applyTimeLimited}
-            className={`${baseBtn} ${mode === 'time_limited' ? onTimeLimited : off}`}
-          >
-            {mode === 'time_limited' && current?.dailyMinutes != null
-              ? `✓ ${current.dailyMinutes}m / day`
-              : 'Time-limit'}
-          </button>
+            placeholder="min"
+            aria-label="Daily time-limit minutes"
+            data-testid={`app-row-${app.app.id}-minutes`}
+            className={`w-16 rounded-lg px-2 py-1 text-white text-xs border transition-colors disabled:opacity-50 ${
+              isTimeLimited
+                ? 'bg-amber-500/10 border-amber-500/40 text-amber-200 placeholder-amber-200/40'
+                : 'bg-gray-900 border-gray-700'
+            }`}
+          />
+          <span className="text-xs text-gray-500">min/day</span>
         </div>
       </div>
       {mode === 'time_limited' && (


### PR DESCRIPTION
## Summary
- Lift the per-app policy editor (#767/#988) and the legacy `extraBlocked`/`extraAllowed` textareas out of the modal `ProfileEditor` and mount them as a collapsible **Rules** subsection inside the expanded profile card (sub-5 of the /profiles merge per #976).
- Subsection is collapsed by default; the header shows assigned-app count and legacy blocked/allowed counts so admins can skim without opening it.
- App rows continue to autosave per row via `PUT/DELETE /api/apps/:id/policy/:profileId` (#767/#988); legacy textareas debounce-autosave (~800ms) via the existing `PUT /api/profiles/:id` full-body update.
- Modal editor is intentionally left in place — #978 removes it.

## Notes
- Legacy `extraBlocked` / `extraAllowed` textareas are temporary: they disappear from this subsection once #764 migrates those fields onto apps. Until then they live below the apps editor and autosave on edit.
- `<AppsSection>` gained an optional `testIdPrefix` prop so the modal copy and the new inline copy can coexist without testid clashes. Existing modal testids are unchanged (`apps-section`, `app-row-N`, etc.); the inline copy uses `profile-{id}-apps-section-*`.
- PATCH for `/api/profiles/:id` (#423) would let us send only the changed fields instead of the full body, but the textareas are short-lived enough that the full PUT is fine.
- Subsection is admin-only; non-admins still see the rest of the expanded card.

## Screenshot
(captured locally — rendering only differs from prior expanded card by the new collapsible "Rules" block between the admin buttons and the Devices list)

## Test plan
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean.
- [x] `npx vitest run` — 253 tests pass (existing 43 ProfilesPage tests still green; 3 new tests for the subsection).
- [ ] Manual: load /profiles as admin, expand a profile, click "Rules", verify the apps editor (block/allow/time-limit + picker filter) and legacy textareas both work and persist on reload.
- [ ] Manual: edit the legacy textareas, confirm "Saving…" → "Saved" status appears and the next reload shows the new values.
- [ ] Manual: verify the modal Edit flow still works for the rules section while #978 hasn't landed.

Refs: #976, #965, #767, #988, #1021, #764 (follow-up), #978 (modal cleanup), #423 (PATCH follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)