### PR TITLE
migrate(api): legacy extra_blocked/extra_allowed/site_time_limits → apps; drop columns (#764)

### DIFF
--- a/api/resources/db/migration/V35__migrate_legacy_into_apps.sql
+++ b/api/resources/db/migration/V35__migrate_legacy_into_apps.sql
@@ -1,0 +1,132 @@
+-- V35__migrate_legacy_into_apps.sql
+-- #764: backfill legacy profiles.extra_blocked / profiles.extra_allowed /
+-- site_time_limits into the apps schema (#761/#762/#763), then drop the legacy
+-- columns and table.
+--
+-- Wire-shape continuity is provided by #763, which already expands app
+-- assignments into the same per-profile extraBlocked / extraAllowed /
+-- siteTimeLimits snapshot buckets the legacy fields used to feed. Once this
+-- migration runs the router-facing snapshot is byte-identical for any
+-- household whose policy lived entirely in the legacy fields.
+--
+-- This is single-household — `apps.slug` is uniquely scoped to the implicit
+-- household, so we key on the host string itself (apex form, leading "*."
+-- stripped).
+
+-- ── 1. site_time_limits → time_limited apps ──────────────────────────────────
+
+INSERT INTO apps (name, slug, template_id, icon)
+SELECT DISTINCT
+  CASE WHEN domain_pattern LIKE '*.%' THEN substr(domain_pattern, 3) ELSE domain_pattern END,
+  CASE WHEN domain_pattern LIKE '*.%' THEN substr(domain_pattern, 3) ELSE domain_pattern END,
+  NULL, NULL
+FROM site_time_limits
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO app_hosts (app_id, host)
+SELECT DISTINCT a.id, a.slug
+FROM apps a
+WHERE a.slug IN (
+  SELECT
+    CASE WHEN domain_pattern LIKE '*.%' THEN substr(domain_pattern, 3) ELSE domain_pattern END
+  FROM site_time_limits
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO app_policy_assignments (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
+SELECT
+  a.id,
+  stl.profile_id,
+  'time_limited',
+  stl.daily_minutes,
+  stl.exempt_from_daily
+FROM site_time_limits stl
+JOIN apps a ON a.slug = CASE
+  WHEN stl.domain_pattern LIKE '*.%' THEN substr(stl.domain_pattern, 3)
+  ELSE stl.domain_pattern
+END
+ON CONFLICT (app_id, profile_id) DO NOTHING;
+
+-- ── 2. profiles.extra_blocked → blocked apps ─────────────────────────────────
+
+INSERT INTO apps (name, slug, template_id, icon)
+SELECT DISTINCT
+  CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END,
+  CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END,
+  NULL, NULL
+FROM profiles p, unnest(p.extra_blocked) AS entry
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO app_hosts (app_id, host)
+SELECT DISTINCT a.id, a.slug
+FROM apps a
+WHERE a.slug IN (
+  SELECT
+    CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END
+  FROM profiles p, unnest(p.extra_blocked) AS entry
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO app_policy_assignments (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
+SELECT
+  a.id,
+  p.id,
+  'blocked',
+  NULL,
+  TRUE
+FROM profiles p
+CROSS JOIN LATERAL unnest(p.extra_blocked) AS entry
+JOIN apps a ON a.slug = CASE
+  WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry
+END
+ON CONFLICT (app_id, profile_id) DO NOTHING;
+
+-- ── 3. profiles.extra_allowed → allowed apps ─────────────────────────────────
+
+INSERT INTO apps (name, slug, template_id, icon)
+SELECT DISTINCT
+  CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END,
+  CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END,
+  NULL, NULL
+FROM profiles p, unnest(p.extra_allowed) AS entry
+ON CONFLICT (slug) DO NOTHING;
+
+INSERT INTO app_hosts (app_id, host)
+SELECT DISTINCT a.id, a.slug
+FROM apps a
+WHERE a.slug IN (
+  SELECT
+    CASE WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry END
+  FROM profiles p, unnest(p.extra_allowed) AS entry
+)
+ON CONFLICT DO NOTHING;
+
+-- A host present in both extra_blocked and extra_allowed for the same profile
+-- can't be expressed as two separate assignments (UNIQUE (app_id, profile_id)).
+-- Allowed wins — the wire's `extraAllowed` already beats `extraBlocked` at the
+-- router (feedback_extraallowed_beats_blocked / #421). Upsert mode to 'allowed'
+-- if a blocked assignment was already written in step 2.
+INSERT INTO app_policy_assignments (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
+SELECT
+  a.id,
+  p.id,
+  'allowed',
+  NULL,
+  TRUE
+FROM profiles p
+CROSS JOIN LATERAL unnest(p.extra_allowed) AS entry
+JOIN apps a ON a.slug = CASE
+  WHEN entry LIKE '*.%' THEN substr(entry, 3) ELSE entry
+END
+ON CONFLICT (app_id, profile_id) DO UPDATE SET
+  mode = 'allowed',
+  daily_minutes = NULL,
+  exempt_from_daily = TRUE;
+
+-- ── 4. Drop legacy storage ──────────────────────────────────────────────────
+
+DROP TABLE site_time_limits;
+
+ALTER TABLE profiles
+  DROP COLUMN extra_blocked,
+  DROP COLUMN extra_allowed;

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -134,7 +134,7 @@ object Main extends ZIOAppDefault {
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield HealthRoutes.routes(dbHealthCheck) ++
       AuthRoutes.routes(auth, userRepo, upRepo) ++
-      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, stlRepo, upRepo, userRepo) ++
+      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
       HouseholdSettingsRoutes.routes(auth, hsRepo) ++
       DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
       TimeRoutes.routes(

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -128,10 +128,15 @@ trait TimeLimitRepo {
   def listAll: Task[List[TimeLimit]]
 }
 
+/**
+ * Post-#764 the `site_time_limits` table is dropped. This repo now synthesizes the legacy
+ * `SiteTimeLimit` shape from `app_policy_assignments` rows with mode='time_limited', emitting one
+ * row per (assignment × host) — mirroring the snapshot expansion in `PolicyService`. Synthetic ids
+ * are 0L; callers that need stable ids should switch to AppRepo directly.
+ */
 trait SiteTimeLimitRepo {
   def listForProfile(pid: ProfileId): Task[List[SiteTimeLimit]]
   def listAll: Task[List[SiteTimeLimit]]
-  def replaceForProfile(pid: ProfileId, limits: List[SiteTimeLimitRequest]): Task[Unit]
 }
 
 trait DeviceRepo {
@@ -533,8 +538,6 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       ProfileId,
       String,
       List[String],
-      List[String],
-      List[String],
       Boolean,
       String,
       Boolean,
@@ -544,21 +547,19 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     r._1,
     r._2,
     r._3.map(BlocklistId.unsafe),
-    r._4.map(Hostname.unsafe),
-    r._5.map(Hostname.unsafe),
+    r._4,
+    FailureMode.parse(r._5).getOrElse(FailureMode.LastKnownGood),
     r._6,
-    FailureMode.parse(r._7).getOrElse(FailureMode.LastKnownGood),
-    r._8,
-    CrossDeviceOverlapMode.parse(r._9).getOrElse(CrossDeviceOverlapMode.Sum),
+    CrossDeviceOverlapMode.parse(r._7).getOrElse(CrossDeviceOverlapMode.Sum),
   )
   def listAll                                       =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
+    sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
       .query[R]
       .map(toP)
       .to[List]
       .transact(xa)
   def findById(id: ProfileId)                       =
-    sql"SELECT id,name,blocked_categories,extra_blocked,extra_allowed,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
+    sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
       .query[R]
       .map(toP)
       .option
@@ -572,8 +573,6 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     sql"""UPDATE profiles SET
             name=${p.name},
             blocked_categories=${p.blockedCategories.map(_.value).toArray},
-            extra_blocked=${p.extraBlocked.map(_.value).toArray},
-            extra_allowed=${p.extraAllowed.map(_.value).toArray},
             paused=${p.paused},
             failure_mode=${FailureMode.asString(p.failureMode)},
             block_ip_only=${p.blockIpOnly},
@@ -668,27 +667,34 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
 }
 
 class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
-  private type R = (SiteTimeLimitId, ProfileId, String, Int, String, Boolean)
-  private def toS(r: R)              = SiteTimeLimit(r._1, r._2, r._3, r._4, r._5, r._6)
+  // (profileId, host, dailyMinutes, slug, exemptFromDaily)
+  private type R = (ProfileId, String, Int, String, Boolean)
+  private def toS(r: R) =
+    SiteTimeLimit(SiteTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5)
+
   def listForProfile(pid: ProfileId) =
-    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label,exempt_from_daily FROM site_time_limits WHERE profile_id=$pid ORDER BY id"
+    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
+            FROM app_policy_assignments apa
+            JOIN apps a       ON a.id = apa.app_id
+            JOIN app_hosts ah ON ah.app_id = apa.app_id
+           WHERE apa.profile_id = $pid AND apa.mode = 'time_limited'
+           ORDER BY apa.id, ah.host"""
       .query[R]
       .map(toS)
       .to[List]
       .transact(xa)
-  def listAll                        =
-    sql"SELECT id,profile_id,domain_pattern,daily_minutes,label,exempt_from_daily FROM site_time_limits ORDER BY id"
+
+  def listAll =
+    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
+            FROM app_policy_assignments apa
+            JOIN apps a       ON a.id = apa.app_id
+            JOIN app_hosts ah ON ah.app_id = apa.app_id
+           WHERE apa.mode = 'time_limited'
+           ORDER BY apa.id, ah.host"""
       .query[R]
       .map(toS)
       .to[List]
       .transact(xa)
-  def replaceForProfile(pid: ProfileId, ls: List[SiteTimeLimitRequest]) = {
-    val del = sql"DELETE FROM site_time_limits WHERE profile_id=$pid".update.run
-    val ins = ls.map(l =>
-      sql"INSERT INTO site_time_limits(profile_id,domain_pattern,daily_minutes,label,exempt_from_daily) VALUES($pid,${l.domainPattern},${l.dailyMinutes},${l.label},${l.exemptFromDaily})".update.run,
-    )
-    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
-  }
 }
 
 class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -77,7 +77,6 @@ class PolicyServiceLive(
       )
       appHostsMap = appHostsRaw.toMap
       appAssignsMap = appAssigns.toMap
-      appSlugById   = apps.iterator.map(a => a.id -> a.slug).toMap
       schedMap      = scheds.toMap
       tlMap         = tlims.toMap
       stlMap        = stlims.toMap
@@ -86,50 +85,29 @@ class PolicyServiceLive(
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
 
       val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
-        val pSched     = schedMap.getOrElse(p.id, Nil)
-        val pSiteLims0 = stlMap.getOrElse(p.id, Nil)
+        val pSched    = schedMap.getOrElse(p.id, Nil)
+        val pSiteLims = stlMap.getOrElse(p.id, Nil)
 
-        // #763: expand this profile's app assignments into wire-shape buckets.
-        // - allowed-mode apps → union into extraAllowed (passed via ProfileInputs)
-        // - blocked-mode apps → union into extraBlocked
-        // - time_limited apps → synthesize one SiteTimeLimit row per host. The
-        //   wire's SiteTimeLimit carries a single domainPattern + budget, so
-        //   "one shared budget across N hosts" can't be expressed natively;
-        //   stop-gap is per-host independent budgets (each host gets its own
-        //   N-minute budget). Tracked separately (see PR description for #763).
-        val pAssigns                           = appAssignsMap.getOrElse(p.id, Nil)
-        val appAllowedHosts: List[Hostname]    = pAssigns
+        // #763/#764: expand this profile's app assignments into wire-shape
+        // buckets. Post-#764, time_limited apps are surfaced via
+        // SiteTimeLimitRepo (which itself synthesizes from app tables), so
+        // here we only handle allowed/blocked modes.
+        val pAssigns                        = appAssignsMap.getOrElse(p.id, Nil)
+        val appAllowedHosts: List[Hostname] = pAssigns
           .collect {
             case a if a.mode == AppMode.Allowed =>
               appHostsMap.getOrElse(a.appId, Nil)
           }
           .flatten
           .distinct
-        val appBlockedHosts: List[Hostname]    = pAssigns
+        val appBlockedHosts: List[Hostname] = pAssigns
           .collect {
             case a if a.mode == AppMode.Blocked =>
               appHostsMap.getOrElse(a.appId, Nil)
           }
           .flatten
           .distinct
-        val appSiteLimits: List[SiteTimeLimit] = pAssigns.collect {
-          case a if a.mode == AppMode.TimeLimited =>
-            val mins   = a.dailyMinutes.getOrElse(0)
-            val exempt = a.exemptFromDaily
-            val slug   = appSlugById.getOrElse(a.appId, a.appId.value.toString)
-            appHostsMap.getOrElse(a.appId, Nil).map { h =>
-              SiteTimeLimit(
-                id = SiteTimeLimitId(0L),
-                profileId = p.id,
-                domainPattern = h.value,
-                dailyMinutes = mins,
-                label = s"app:$slug",
-                exemptFromDaily = exempt,
-              )
-            }
-        }.flatten
 
-        val pSiteLims  = pSiteLims0 ++ appSiteLimits
         val devicesIn  = devsByProfile.getOrElse(p.id, Nil)
         val deviceMacs = devicesIn.map(_.mac).toSet
         val pPresence  = presence.filter(r => deviceMacs.contains(r.mac))
@@ -235,8 +213,8 @@ class PolicyServiceLive(
   /**
    * Per-host fallback decision. Reads DB rows directly rather than going through the snapshot,
    * since the snapshot's collapsed BlockRules no longer carries the raw schedule / site-limit /
-   * category state needed to make a per-host decision. Precedence: paused > schedule > extraAllowed
-   * > extraBlocked > site_time_limit > time_limit > category > allow.
+   * category state needed to make a per-host decision. Precedence: paused > schedule > allowed-app
+   * > blocked-app > site_time_limit > time_limit > category > allow.
    */
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
     for {
@@ -249,12 +227,32 @@ class PolicyServiceLive(
           ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
         case Some(pid) =>
           for {
-            pOpt   <- profileRepo.findById(pid)
-            scheds <- scheduleRepo.listForProfile(pid)
-            tl     <- timeLimitRepo.findForProfile(pid)
-            stlims <- siteTimeLimitRepo.listForProfile(pid)
+            pOpt          <- profileRepo.findById(pid)
+            scheds        <- scheduleRepo.listForProfile(pid)
+            tl            <- timeLimitRepo.findForProfile(pid)
+            stlims        <- siteTimeLimitRepo.listForProfile(pid)
+            // #764: post-migration, extraAllowed/extraBlocked are sourced
+            // exclusively from app_policy_assignments. Mirror the snapshot
+            // expansion (allowed/blocked modes) here so the per-host
+            // fallback agrees with the snapshot's precedence.
+            appAssigns    <- appRepo.listAssignmentsForProfile(pid)
+            appHostsByApp <- ZIO
+              .foreach(appAssigns.map(_.appId).distinct)(aid => appRepo.getHosts(aid).map(aid -> _))
+              .map(_.toMap)
+            appAllowed = appAssigns
+              .collect {
+                case a if a.mode == AppMode.Allowed => appHostsByApp.getOrElse(a.appId, Nil)
+              }
+              .flatten
+              .distinct
+            appBlocked = appAssigns
+              .collect {
+                case a if a.mode == AppMode.Blocked => appHostsByApp.getOrElse(a.appId, Nil)
+              }
+              .flatten
+              .distinct
             // Reuse the same per-profile usage calc used by snapshot, scoped to this profile.
-            devs   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(pid)))
+            devs          <- deviceRepo.listAll.map(_.filter(_.profileId.contains(pid)))
             macs = devs.map(_.mac).toSet
             pres <- trafficRepo.listPresenceRows(devs.map(_.mac), today)
             exts <- extRepo.snapshotAllByProfile(today).map(_.getOrElse(pid, 0))
@@ -269,11 +267,11 @@ class PolicyServiceLive(
                   scheduleBlock(scheds, now) match {
                     case Some(r) => ZIO.succeed(r)
                     case None    =>
-                      if matchesAny(h, p.extraAllowed) then
+                      if matchesAny(h, appAllowed) then
                         ZIO.succeed(
                           RouterDecisionResponse(ConnectionDecision.Allow, "extra_allowed", None),
                         )
-                      else if matchesAny(h, p.extraBlocked) then
+                      else if matchesAny(h, appBlocked) then
                         ZIO.succeed(
                           RouterDecisionResponse(ConnectionDecision.Block, "extra_blocked", None),
                         )
@@ -539,16 +537,16 @@ object PolicyService {
     BlockRules(
       blocked = blocked,
       blockReason = reason,
-      extraBlocked = (p.extraBlocked ++ in.appExtraBlocked ++ siteLimitExtraBlocked).distinct,
+      extraBlocked = (in.appExtraBlocked ++ siteLimitExtraBlocked).distinct,
       // #944: union the deployment's UI hosts into per-profile extraAllowed so
       // a household device can always reach the admin UI even when this
-      // profile is paused or lists one of these hosts in extraBlocked (allow
-      // beats block at the router). Configured via wifihaven.policy
+      // profile is paused or lists one of these hosts in a blocked-mode app
+      // (allow beats block at the router). Configured via wifihaven.policy
       // .uiAllowedHosts per-deployment so prod doesn't allow staging through
       // and vice versa. Will become DB-backed per #937.
-      extraAllowed = (p.extraAllowed ++ in.appExtraAllowed ++ uiAllowedHosts).distinct,
+      extraAllowed = (in.appExtraAllowed ++ uiAllowedHosts).distinct,
       blocklistIds = p.blockedCategories,
-      blockIpOnly = p.blockIpOnly, // #424: per-profile toggle (router enforcement #353)
+      blockIpOnly = p.blockIpOnly,
     )
   }
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -189,7 +189,6 @@ object ProfileRoutes {
       profileRepo: ProfileRepo,
       scheduleRepo: ScheduleRepo,
       timeLimitRepo: TimeLimitRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
       userProfileRepo: UserProfileRepo,
       userRepo: UserRepo,
   ): Routes[Any, Response] =
@@ -205,8 +204,7 @@ object ProfileRoutes {
                 for {
                   scheds <- scheduleRepo.listForProfile(p.id)
                   tl     <- timeLimitRepo.findForProfile(p.id)
-                  stls   <- siteTimeLimitRepo.listForProfile(p.id)
-                } yield ProfileDetail(p, scheds, tl, stls)
+                } yield ProfileDetail(p, scheds, tl)
               }
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(details.toJson)
@@ -223,10 +221,7 @@ object ProfileRoutes {
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
             scheds <- scheduleRepo.listForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
             tl     <- timeLimitRepo.findForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
-            stls   <- siteTimeLimitRepo
-              .listForProfile(pid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-          } yield Response.json(ProfileDetail(p, scheds, tl, stls).toJson)
+          } yield Response.json(ProfileDetail(p, scheds, tl).toJson)
         },
       Method.POST / "api" / "profiles"                       ->
         handler { (req: Request) =>
@@ -245,8 +240,6 @@ object ProfileRoutes {
                   id,
                   upr.name,
                   upr.blockedCategories,
-                  upr.extraBlocked,
-                  upr.extraAllowed,
                   upr.paused,
                   // #385: missing failureMode → LastKnownGood (preserves
                   // cached-snapshot enforcement; matches DB column default).
@@ -269,9 +262,6 @@ object ProfileRoutes {
             _    <- ZIO
               .foreachDiscard(upr.timeLimit)(mins => timeLimitRepo.upsert(id, mins))
               .mapError(ErrorMapper.dbErrorToResponse)
-            _    <- siteTimeLimitRepo
-              .replaceForProfile(id, upr.siteTimeLimits)
-              .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(s"""{"id":${id.value}}""")
         },
       Method.PUT / "api" / "profiles" / long("id")           ->
@@ -293,8 +283,6 @@ object ProfileRoutes {
                 p.copy(
                   name = upr.name,
                   blockedCategories = upr.blockedCategories,
-                  extraBlocked = upr.extraBlocked,
-                  extraAllowed = upr.extraAllowed,
                   paused = upr.paused,
                   // #385: if the caller omits failureMode, preserve the
                   // existing value rather than resetting to the column default.
@@ -309,12 +297,9 @@ object ProfileRoutes {
               )
               .mapError(ErrorMapper.dbErrorToResponse)
             // #481: log mutations that should bump the policy snapshot etag.
-            // Without this the only evidence of "did the API even receive the
-            // pause flip?" was the absence of logs, which was useless.
             _      <- ZIO.logInfo(
               s"profile updated: id=${pid.value} paused=${p.paused}→${upr.paused} " +
-                s"name=${upr.name} extraBlockedCount=${upr.extraBlocked.size} " +
-                s"extraAllowedCount=${upr.extraAllowed.size}",
+                s"name=${upr.name}",
             )
             _      <- scheduleRepo
               .replaceForProfile(pid, upr.schedules)
@@ -323,9 +308,6 @@ object ProfileRoutes {
               case Some(mins) => timeLimitRepo.upsert(pid, mins)
               case None       => timeLimitRepo.delete(pid)
             }).mapError(ErrorMapper.dbErrorToResponse)
-            _      <- siteTimeLimitRepo
-              .replaceForProfile(pid, upr.siteTimeLimits)
-              .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
       Method.DELETE / "api" / "profiles" / long("id")        ->

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -162,4 +162,30 @@ object TestLayers {
       profileId: ProfileId,
   ): Task[DeviceId] =
     deviceRepo.upsert(MacAddress.unsafe(mac), name, Some(profileId), "192.168.1.100")
+
+  /**
+   * Post-#764: ensure a single-host app exists with `slug = host` (creating it if missing) and
+   * upsert an assignment for `(app, profileId)` with the given mode. Used by tests that previously
+   * wrote to legacy profiles.extra_blocked/extra_allowed/site_time_limits columns.
+   */
+  def seedAppAssignment(
+      appRepo: AppRepo,
+      profileId: ProfileId,
+      host: String,
+      mode: wifihaven.shared.AppMode,
+      dailyMinutes: Option[Int] = None,
+      exemptFromDaily: Boolean = true,
+  ): Task[Unit] =
+    for {
+      existing <- appRepo.findBySlug(host)
+      appId    <- existing match {
+        case Some(a) => ZIO.succeed(a.id)
+        case None    =>
+          for {
+            id <- appRepo.create(host, host, None, None)
+            _  <- appRepo.setHosts(id, List(wifihaven.shared.types.Hostname.unsafe(host)))
+          } yield id
+      }
+      _        <- appRepo.upsertAssignment(appId, profileId, mode, dailyMinutes, exemptFromDaily)
+    } yield ()
 }

--- a/api/test/src/feature/LegacyAppMigrationSpec.scala
+++ b/api/test/src/feature/LegacyAppMigrationSpec.scala
@@ -1,0 +1,154 @@
+package wifihaven.api.feature
+
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import org.flywaydb.core.Flyway
+import zio.*
+import zio.test.*
+
+/**
+ * #764: verify that V35 backfills legacy profiles.extra_blocked / profiles.extra_allowed /
+ * site_time_limits into the apps schema, then drops the legacy storage.
+ *
+ * Strategy: wipe the DB, run Flyway up to V34 (legacy columns/table still present), seed legacy
+ * rows directly via JDBC, then run Flyway again to pick up V35 and assert the apps schema reflects
+ * the legacy data + the legacy columns/table are gone. V33/V34 are unrelated migrations
+ * (fakenews-blocklist removal, unmanaged-mac policy) that landed on main between branching and
+ * merging.
+ *
+ * EmbeddedPostgres is shared across the JVM (see TestDatabase) so we drop + recreate `public`
+ * between steps to isolate this spec from sibling specs.
+ */
+object LegacyAppMigrationSpec extends ZIOSpec[EmbeddedPostgres] {
+
+  override val bootstrap: ZLayer[Any, Throwable, EmbeddedPostgres] = TestDatabase.embeddedPg
+
+  private def dropPublic(pg: EmbeddedPostgres): Task[Unit] = ZIO.attempt {
+    val conn = pg.getPostgresDatabase.getConnection
+    try {
+      val st = conn.createStatement()
+      st.execute("DROP SCHEMA public CASCADE")
+      st.execute("CREATE SCHEMA public")
+      ()
+    } finally conn.close()
+  }
+
+  private def migrateTo(pg: EmbeddedPostgres, target: String): Task[Unit] = ZIO.attempt {
+    Flyway
+      .configure()
+      .dataSource(pg.getPostgresDatabase)
+      .locations("classpath:db/migration")
+      .target(target)
+      .baselineOnMigrate(true)
+      .load()
+      .migrate()
+    ()
+  }
+
+  private def exec(pg: EmbeddedPostgres, sql: String): Task[Unit] = ZIO.attempt {
+    val conn = pg.getPostgresDatabase.getConnection
+    try {
+      val _ = conn.createStatement().execute(sql)
+    } finally conn.close()
+  }
+
+  private def query[A](pg: EmbeddedPostgres, sql: String)(extract: java.sql.ResultSet => A) =
+    ZIO.attempt {
+      val conn = pg.getPostgresDatabase.getConnection
+      try {
+        val rs  = conn.createStatement().executeQuery(sql)
+        val out = scala.collection.mutable.ArrayBuffer.empty[A]
+        while (rs.next()) out += extract(rs)
+        out.toList
+      } finally conn.close()
+    }
+
+  def spec = suite("V35 legacy-to-apps migration (#764)")(
+    test("backfills extra_blocked / extra_allowed / site_time_limits into apps, then drops them") {
+      for {
+        pg          <- ZIO.service[EmbeddedPostgres]
+        _           <- dropPublic(pg)
+        _           <- migrateTo(pg, "34")
+        // Seed a profile with one entry of each kind of legacy policy.
+        _           <- exec(
+          pg,
+          """INSERT INTO profiles (id, name, blocked_categories, extra_blocked, extra_allowed)
+             VALUES (99, 'TestKids', ARRAY[]::TEXT[],
+                     ARRAY['ads.example']::TEXT[],
+                     ARRAY['edu.example']::TEXT[])""",
+        )
+        _           <- exec(
+          pg,
+          """INSERT INTO site_time_limits (profile_id, domain_pattern, daily_minutes, label, exempt_from_daily)
+             VALUES (99, 'youtube.com', 45, 'YouTube', true)""",
+        )
+        // Apply V35 — the migration under test.
+        _           <- migrateTo(pg, "35")
+        // Apps were created with slug = host apex.
+        slugs       <- query(pg, "SELECT slug FROM apps ORDER BY slug")(_.getString(1))
+        // Each app has the corresponding single host.
+        hosts       <- query(
+          pg,
+          "SELECT a.slug, ah.host FROM apps a JOIN app_hosts ah ON ah.app_id = a.id ORDER BY a.slug",
+        )(rs => (rs.getString(1), rs.getString(2)))
+        // Assignments link back to profile 99 with the expected mode.
+        assigns     <- query(
+          pg,
+          """SELECT a.slug, apa.mode, COALESCE(apa.daily_minutes, 0), apa.exempt_from_daily
+               FROM app_policy_assignments apa
+               JOIN apps a ON a.id = apa.app_id
+              WHERE apa.profile_id = 99
+              ORDER BY a.slug""",
+        )(rs => (rs.getString(1), rs.getString(2), rs.getInt(3), rs.getBoolean(4)))
+        // Legacy columns + table are gone.
+        colExists   <- query(
+          pg,
+          """SELECT column_name FROM information_schema.columns
+              WHERE table_name='profiles'
+                AND column_name IN ('extra_blocked','extra_allowed')""",
+        )(_.getString(1))
+        tableExists <- query(
+          pg,
+          "SELECT table_name FROM information_schema.tables WHERE table_name='site_time_limits'",
+        )(_.getString(1))
+      } yield assertTrue(slugs == List("ads.example", "edu.example", "youtube.com")) &&
+        assertTrue(
+          hosts.toSet == Set(
+            "ads.example" -> "ads.example",
+            "edu.example" -> "edu.example",
+            "youtube.com" -> "youtube.com",
+          ),
+        ) &&
+        assertTrue(
+          assigns == List(
+            ("ads.example", "blocked", 0, true),
+            ("edu.example", "allowed", 0, true),
+            ("youtube.com", "time_limited", 45, true),
+          ),
+        ) &&
+        assertTrue(colExists.isEmpty) &&
+        assertTrue(tableExists.isEmpty)
+    },
+    test("a host present in both extra_blocked and extra_allowed → allowed wins") {
+      for {
+        pg    <- ZIO.service[EmbeddedPostgres]
+        _     <- dropPublic(pg)
+        _     <- migrateTo(pg, "34")
+        _     <- exec(
+          pg,
+          """INSERT INTO profiles (id, name, blocked_categories, extra_blocked, extra_allowed)
+             VALUES (88, 'Conflict', ARRAY[]::TEXT[],
+                     ARRAY['both.example']::TEXT[],
+                     ARRAY['both.example']::TEXT[])""",
+        )
+        _     <- migrateTo(pg, "35")
+        modes <- query(
+          pg,
+          """SELECT apa.mode FROM app_policy_assignments apa
+               JOIN apps a ON a.id = apa.app_id
+              WHERE apa.profile_id = 88 AND a.slug = 'both.example'""",
+        )(_.getString(1))
+      } yield assertTrue(modes == List("allowed"))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -54,25 +54,21 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
     ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Kids").get.id))
 
   def spec = suite("PolicySnapshot — app expansion (#763)")(
-    test("allowed-mode app: hosts unioned into extraAllowed (alongside profile's own list)") {
+    test("allowed-mode app: hosts unioned into extraAllowed") {
       for {
-        _           <- cleanDb
-        pr          <- ZIO.service[ProfileRepo]
-        ar          <- ZIO.service[AppRepo]
-        kids        <- kidsId
-        // Profile keeps an existing per-profile extraAllowed entry.
-        kidsProfile <- pr.findById(kids).map(_.get)
-        _           <- pr.update(
-          kidsProfile.copy(extraAllowed = List(Hostname.unsafe("khan-own.org"))),
-        )
-        appId       <- ar.create("Khan", "khan", None, None)
-        _           <- ar.setHosts(
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        // A second allowed-mode app contributes a host alongside the multi-host one.
+        _     <- TestLayers.seedAppAssignment(ar, kids, "khan-own.org", AppMode.Allowed)
+        appId <- ar.create("Khan", "khan", None, None)
+        _     <- ar.setHosts(
           appId,
           List(Hostname.unsafe("khanacademy.org"), Hostname.unsafe("kastatic.org")),
         )
-        _           <- ar.upsertAssignment(appId, kids, AppMode.Allowed, None, true)
-        svc         <- makePs
-        snap        <- svc.snapshot
+        _     <- ar.upsertAssignment(appId, kids, AppMode.Allowed, None, true)
+        svc   <- makePs
+        snap  <- svc.snapshot
       } yield {
         val ea = snap.profiles(kids).rules.extraAllowed.map(_.value).toSet
         assertTrue(ea.contains("khan-own.org")) &&

--- a/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
@@ -100,7 +100,6 @@ object PolicySnapshotBlockIpOnlySpec
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         auth        <- makeAuth
         token       <- auth.login("admin", "changeme").map(_.token.value)
         profiles0   <- profileRepo.listAll
@@ -112,7 +111,6 @@ object PolicySnapshotBlockIpOnlySpec
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           userProfileRepo,
           userRepoSvc,
         )
@@ -120,12 +118,9 @@ object PolicySnapshotBlockIpOnlySpec
           val body = UpsertProfileRequest(
             name = "Kids",
             blockedCategories = Nil,
-            extraBlocked = Nil,
-            extraAllowed = Nil,
             paused = false,
             schedules = Nil,
             timeLimit = None,
-            siteTimeLimits = Nil,
             blockIpOnly = ipOnly,
           ).toJson
           Request
@@ -158,7 +153,6 @@ object PolicySnapshotBlockIpOnlySpec
         profileRepo     <- ZIO.service[ProfileRepo]
         schedRepo       <- ZIO.service[ScheduleRepo]
         tlRepo          <- ZIO.service[TimeLimitRepo]
-        stlRepo         <- ZIO.service[SiteTimeLimitRepo]
         auth            <- makeAuth
         token           <- auth.login("admin", "changeme").map(_.token.value)
         userProfileRepo <- ZIO.service[UserProfileRepo]
@@ -168,7 +162,6 @@ object PolicySnapshotBlockIpOnlySpec
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           userProfileRepo,
           userRepoSvc,
         )
@@ -176,12 +169,9 @@ object PolicySnapshotBlockIpOnlySpec
           val body = UpsertProfileRequest(
             name = name,
             blockedCategories = Nil,
-            extraBlocked = Nil,
-            extraAllowed = Nil,
             paused = false,
             schedules = Nil,
             timeLimit = None,
-            siteTimeLimits = Nil,
             blockIpOnly = ipOnly,
           ).toJson
           Request

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -60,7 +60,7 @@ object PolicySnapshotGlobalAllowSpec
   private val expected: Set[String] = uiHosts.map(_.value).toSet
 
   def spec = suite("policy snapshot — global allow hosts (#944)")(
-    test("empty uiAllowedHosts → snapshot extraAllowed is just the profile's own list") {
+    test("empty uiAllowedHosts → snapshot extraAllowed is just the app-derived list") {
       for {
         _    <- cleanDb
         pr   <- ZIO.service[ProfileRepo]
@@ -76,7 +76,7 @@ object PolicySnapshotGlobalAllowSpec
         clk  <- ZIO.service[Clock]
         ps0  <- pr.listAll
         kids = ps0.find(_.name == "Kids").get
-        _ <- pr.update(kids.copy(extraAllowed = List(Hostname.unsafe("user.example"))))
+        _ <- TestLayers.seedAppAssignment(ar, kids.id, "user.example", AppMode.Allowed)
         svc = PolicyServiceLive(
           pr,
           sr,
@@ -99,10 +99,10 @@ object PolicySnapshotGlobalAllowSpec
       for {
         _         <- cleanDb
         pr        <- ZIO.service[ProfileRepo]
-        // Seed an existing user-configured extraAllowed entry on one profile.
+        ar        <- ZIO.service[AppRepo]
         profiles0 <- pr.listAll
         kids = profiles0.find(_.name == "Kids").get
-        _    <- pr.update(kids.copy(extraAllowed = List(Hostname.unsafe("already-in.example"))))
+        _    <- TestLayers.seedAppAssignment(ar, kids.id, "already-in.example", AppMode.Allowed)
         ps   <- makePs
         snap <- ps.snapshot
       } yield {
@@ -141,9 +141,10 @@ object PolicySnapshotGlobalAllowSpec
       for {
         _   <- cleanDb
         pr  <- ZIO.service[ProfileRepo]
+        ar  <- ZIO.service[AppRepo]
         ps0 <- pr.listAll
         kids = ps0.find(_.name == "Kids").get
-        _    <- pr.update(kids.copy(extraBlocked = List(Hostname.unsafe("wifihaven.net"))))
+        _    <- TestLayers.seedAppAssignment(ar, kids.id, "wifihaven.net", AppMode.Blocked)
         svc  <- makePs
         snap <- svc.snapshot
       } yield {

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -20,6 +20,9 @@ import zio.test.Assertion.*
  *
  * These exercise the full stack: HTTP handler → service → real Postgres. No mocks except Clock and
  * upstream DNS socket.
+ *
+ * Post-#764: profile-side `extraBlocked`/`extraAllowed`/`siteTimeLimits` were migrated into the
+ * apps schema and dropped from the wire — those concerns are exercised via app endpoints/specs.
  */
 object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
@@ -38,30 +41,27 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
   )
 
+  private def mkRoutes =
+    for {
+      profileRepo     <- ZIO.service[ProfileRepo]
+      schedRepo       <- ZIO.service[ScheduleRepo]
+      tlRepo          <- ZIO.service[TimeLimitRepo]
+      auth            <- makeAuth
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      userRepoSvc     <- ZIO.service[UserRepo]
+    } yield (
+      auth,
+      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, userProfileRepo, userRepoSvc),
+    )
+
   def spec = suite("Profile API")(
     suite("GET /api/profiles")(
       test("returns seeded default profiles") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          auth            <- makeAuth
-          userRepo        <- ZIO.service[UserRepo]
-          token           <- auth.login("admin", "changeme").map(_.token.value)
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          req    = Request
+          _              <- cleanDb
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
             .get(URL.decode("/api/profiles").toOption.get)
             .addHeader(Header.Authorization.Bearer(token))
           resp    <- routes.runZIO(req)
@@ -74,23 +74,8 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("returns 401 without token") {
         for {
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          auth            <- makeAuth
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          req    = Request.get(URL.decode("/api/profiles").toOption.get)
+          (_, routes) <- mkRoutes
+          req = Request.get(URL.decode("/api/profiles").toOption.get)
           resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.Unauthorized)
       },
@@ -98,29 +83,15 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     suite("POST /api/profiles")(
       test("admin can create a profile with schedules and time limits") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          auth            <- makeAuth
-          token           <- auth.login("admin", "changeme").map(_.token.value)
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          body   = UpsertProfileRequest(
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          tlRepo         <- ZIO.service[TimeLimitRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          body = UpsertProfileRequest(
             name = "Teenager",
             blockedCategories = List(BlocklistId.unsafe("adult"), BlocklistId.unsafe("gambling")),
-            extraBlocked = List(Hostname.unsafe("tiktok.com")),
-            extraAllowed = List(Hostname.unsafe("khanacademy.org")),
             paused = false,
             schedules = List(
               ScheduleRequest(
@@ -132,58 +103,33 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
               ),
             ),
             timeLimit = Some(180),
-            siteTimeLimits = List(
-              SiteTimeLimitRequest("*.youtube.com", 45, "YouTube"),
-            ),
           ).toJson
-          req    = Request
+          req  = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
           resp     <- routes.runZIO(req)
-          // Verify everything was persisted
           profiles <- profileRepo.listAll
           teen     <- ZIO
             .fromOption(profiles.find(_.name == "Teenager"))
             .orElseFail(new Exception("Profile not found"))
           scheds   <- schedRepo.listForProfile(teen.id)
           tl       <- tlRepo.findForProfile(teen.id)
-          stls     <- stlRepo.listForProfile(teen.id)
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(teen.blockedCategories.contains(BlocklistId.unsafe("adult"))) &&
-          assertTrue(teen.extraBlocked.contains(Hostname.unsafe("tiktok.com"))) &&
-          assertTrue(teen.extraAllowed.contains(Hostname.unsafe("khanacademy.org"))) &&
           assertTrue(scheds.length == 1) &&
           assertTrue(scheds.head.startLocal == java.time.LocalTime.of(22, 0)) &&
-          assertTrue(tl.exists(_.dailyMinutes == 180)) &&
-          assertTrue(stls.length == 1) &&
-          assertTrue(stls.head.label == "YouTube") &&
-          assertTrue(stls.head.dailyMinutes == 45)
+          assertTrue(tl.exists(_.dailyMinutes == 180))
       },
       test("failureMode defaults to LastKnownGood when omitted from create request (#385)") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          auth            <- makeAuth
-          token           <- auth.login("admin", "changeme").map(_.token.value)
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          // Send create body with no failureMode field at all.
-          body   =
-            """{"name":"Defaulted","blockedCategories":[],"extraBlocked":[],"extraAllowed":[],"paused":false,"schedules":[],"timeLimit":null,"siteTimeLimits":[]}"""
-          req    = Request
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          body =
+            """{"name":"Defaulted","blockedCategories":[],"paused":false,"schedules":[],"timeLimit":null}"""
+          req  = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
@@ -194,36 +140,19 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("failureMode=AllowAll in create request persists AllowAll (#385 admin override)") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          auth            <- makeAuth
-          token           <- auth.login("admin", "changeme").map(_.token.value)
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          body   = UpsertProfileRequest(
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          body = UpsertProfileRequest(
             name = "AdultsAllowAll",
             blockedCategories = Nil,
-            extraBlocked = Nil,
-            extraAllowed = Nil,
             paused = false,
             schedules = Nil,
             timeLimit = None,
-            siteTimeLimits = Nil,
             failureMode = Some(FailureMode.AllowAll),
           ).toJson
-          req    = Request
+          req  = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
             .addHeader(Header.ContentType(MediaType.application.json))
@@ -234,35 +163,18 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("PUT /api/profiles/:id updates failureMode") {
         for {
-          _           <- cleanDb
-          profileRepo <- ZIO.service[ProfileRepo]
-          schedRepo   <- ZIO.service[ScheduleRepo]
-          tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-          auth        <- makeAuth
-          token       <- auth.login("admin", "changeme").map(_.token.value)
-          profiles0   <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          profiles0      <- profileRepo.listAll
           kidsId = profiles0.find(_.name == "Kids").get.id
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
           body   = UpsertProfileRequest(
             name = "Kids",
             blockedCategories = Nil,
-            extraBlocked = Nil,
-            extraAllowed = Nil,
             paused = false,
             schedules = Nil,
             timeLimit = None,
-            siteTimeLimits = Nil,
             failureMode = Some(FailureMode.AllowAll),
           ).toJson
           req    = Request
@@ -276,29 +188,14 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("child user cannot create profiles") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          userRepo        <- ZIO.service[UserRepo]
-          auth            <- makeAuth
-          hash            <- auth.hashPassword("readpass")
-          _               <- userRepo.create("reader", hash, "child")
-          token           <- auth.login("reader", "readpass").map(_.token.value)
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
-          body   = UpsertProfileRequest("Test", Nil, Nil, Nil, false, Nil, None, Nil).toJson
-          req    = Request
+          _              <- cleanDb
+          userRepo       <- ZIO.service[UserRepo]
+          (auth, routes) <- mkRoutes
+          hash           <- auth.hashPassword("readpass")
+          _              <- userRepo.create("reader", hash, "child")
+          token          <- auth.login("reader", "readpass").map(_.token.value)
+          body = UpsertProfileRequest("Test", Nil, false, Nil, None).toJson
+          req  = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
           resp <- routes.runZIO(req)
@@ -308,32 +205,17 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     suite("PUT /api/profiles/:id")(
       test("update profile name, categories, and time limit") {
         for {
-          _           <- cleanDb
-          profileRepo <- ZIO.service[ProfileRepo]
-          schedRepo   <- ZIO.service[ScheduleRepo]
-          tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-          auth        <- makeAuth
-          token       <- auth.login("admin", "changeme").map(_.token.value)
-          // Get the Kids profile id
-          profiles    <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          tlRepo         <- ZIO.service[TimeLimitRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          profiles       <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
           body   = UpsertProfileRequest(
             name = "Kids Updated",
             blockedCategories = List(BlocklistId.unsafe("adult")),
-            extraBlocked = Nil,
-            extraAllowed = List(Hostname.unsafe("pbs.org")),
             paused = false,
             schedules = List(
               ScheduleRequest(
@@ -345,7 +227,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
               ),
             ),
             timeLimit = Some(120),
-            siteTimeLimits = Nil,
           ).toJson
           req    = Request
             .put(
@@ -360,7 +241,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           scheds  <- schedRepo.listForProfile(kidsId)
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(updated.exists(_.name == "Kids Updated")) &&
-          assertTrue(updated.exists(_.extraAllowed.contains(Hostname.unsafe("pbs.org")))) &&
           assertTrue(tl.exists(_.dailyMinutes == 120)) &&
           assertTrue(scheds.exists(_.startLocal == java.time.LocalTime.of(20, 0)))
       },
@@ -372,36 +252,19 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       // via the full PUT, which is idempotent by construction.
       test("two consecutive PUT(paused=true) leave state at paused=true") {
         for {
-          _           <- cleanDb
-          profileRepo <- ZIO.service[ProfileRepo]
-          schedRepo   <- ZIO.service[ScheduleRepo]
-          tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-          auth        <- makeAuth
-          token       <- auth.login("admin", "changeme").map(_.token.value)
-          profiles    <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          profiles       <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
           mkReq  = (paused: Boolean) => {
             val body = UpsertProfileRequest(
               name = "Kids",
               blockedCategories = Nil,
-              extraBlocked = Nil,
-              extraAllowed = Nil,
               paused = paused,
               schedules = Nil,
               timeLimit = None,
-              siteTimeLimits = Nil,
             ).toJson
             Request
               .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
@@ -423,26 +286,12 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("legacy POST /api/profiles/:id/pause is removed (404)") {
         for {
-          _           <- cleanDb
-          profileRepo <- ZIO.service[ProfileRepo]
-          schedRepo   <- ZIO.service[ScheduleRepo]
-          tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-          auth        <- makeAuth
-          token       <- auth.login("admin", "changeme").map(_.token.value)
-          profiles    <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          profiles       <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          userRepoSvc     <- ZIO.service[UserRepo]
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepoSvc,
-          )
           req    = Request
             .post(URL.decode(s"/api/profiles/$kidsId/pause").toOption.get, Body.empty)
             .addHeader(Header.Authorization.Bearer(token))
@@ -453,29 +302,16 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     suite("Profile ↔ user linking")(
       test("PUT /api/profiles/:id/users sets the link set; GET returns those users") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          userRepo        <- ZIO.service[UserRepo]
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          auth            <- makeAuth
-          token           <- auth.login("admin", "changeme").map(_.token.value)
-          hash            <- auth.hashPassword("pw")
-          aliceId         <- userRepo.create("alice", hash, "child")
-          bobId           <- userRepo.create("bob", hash, "adult")
-          profiles        <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          userRepo       <- ZIO.service[UserRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          hash           <- auth.hashPassword("pw")
+          aliceId        <- userRepo.create("alice", hash, "child")
+          bobId          <- userRepo.create("bob", hash, "adult")
+          profiles       <- profileRepo.listAll
           kidsId  = profiles.find(_.name == "Kids").get.id
-          routes  = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepo,
-          )
           putBody = SetProfileUsersRequest(List(aliceId, bobId)).toJson
           putReq  = Request
             .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(putBody))
@@ -496,30 +332,16 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
           userRepo        <- ZIO.service[UserRepo]
           userProfileRepo <- ZIO.service[UserProfileRepo]
-          auth            <- makeAuth
+          (auth, routes)  <- mkRoutes
           token           <- auth.login("admin", "changeme").map(_.token.value)
           hash            <- auth.hashPassword("pw")
           aliceId         <- userRepo.create("alice", hash, "child")
           profiles        <- profileRepo.listAll
           kidsId   = profiles.find(_.name == "Kids").get.id
           adultsId = profiles.find(_.name == "Adults").get.id
-          // Alice is linked to BOTH profiles.
           _ <- userProfileRepo.setProfilesForUser(aliceId, List(kidsId, adultsId))
-          routes  = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepo,
-          )
-          // Remove alice from Kids by setting empty user list for Kids.
           putBody = SetProfileUsersRequest(Nil).toJson
           putReq  = Request
             .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(putBody))
@@ -531,28 +353,15 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
       test("non-admin gets 403 on PUT /api/profiles/:id/users") {
         for {
-          _               <- cleanDb
-          profileRepo     <- ZIO.service[ProfileRepo]
-          schedRepo       <- ZIO.service[ScheduleRepo]
-          tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
-          userRepo        <- ZIO.service[UserRepo]
-          userProfileRepo <- ZIO.service[UserProfileRepo]
-          auth            <- makeAuth
-          hash            <- auth.hashPassword("pw")
-          _               <- userRepo.create("adult1", hash, "adult")
-          token           <- auth.login("adult1", "pw").map(_.token.value)
-          profiles        <- profileRepo.listAll
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          userRepo       <- ZIO.service[UserRepo]
+          (auth, routes) <- mkRoutes
+          hash           <- auth.hashPassword("pw")
+          _              <- userRepo.create("adult1", hash, "adult")
+          token          <- auth.login("adult1", "pw").map(_.token.value)
+          profiles       <- profileRepo.listAll
           kidsId = profiles.find(_.name == "Kids").get.id
-          routes = ProfileRoutes.routes(
-            auth,
-            profileRepo,
-            schedRepo,
-            tlRepo,
-            stlRepo,
-            userProfileRepo,
-            userRepo,
-          )
           body   = SetProfileUsersRequest(Nil).toJson
           req    = Request
             .put(URL.decode(s"/api/profiles/$kidsId/users").toOption.get, Body.fromString(body))

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -64,7 +64,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -77,7 +76,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
@@ -97,7 +95,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -111,7 +108,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
@@ -127,7 +123,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -140,11 +135,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
-        body   = UpsertProfileRequest("Hacked", Nil, Nil, Nil, false, Nil, None, Nil).toJson
+        body   = UpsertProfileRequest("Hacked", Nil, false, Nil, None).toJson
         req    = Request
           .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
           .addHeader(Header.Authorization.Bearer(token))
@@ -158,7 +152,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -179,19 +172,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
         body   = UpsertProfileRequest(
           "Kids Renamed",
           List(BlocklistId.unsafe("adult")),
-          Nil,
-          Nil,
           false,
           Nil,
           None,
-          Nil,
         ).toJson
         req    = Request
           .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
@@ -208,7 +197,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -222,19 +210,15 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
         body   = UpsertProfileRequest(
           "Pwned",
           Nil,
-          Nil,
-          Nil,
           false,
           Nil,
           None,
-          Nil,
         ).toJson
         req    = Request
           .put(URL.decode(s"/api/profiles/$otherId").toOption.get, Body.fromString(body))
@@ -249,7 +233,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -260,11 +243,10 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
-        body   = UpsertProfileRequest("New", Nil, Nil, Nil, false, Nil, None, Nil).toJson
+        body   = UpsertProfileRequest("New", Nil, false, Nil, None).toJson
         req    = Request
           .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
           .addHeader(Header.Authorization.Bearer(token))
@@ -293,7 +275,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -319,7 +300,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
@@ -398,7 +378,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -411,7 +390,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )
@@ -430,7 +408,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         profileRepo <- ZIO.service[ProfileRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
         userRepo    <- ZIO.service[UserRepo]
         upRepo      <- ZIO.service[UserProfileRepo]
         auth        <- makeAuth
@@ -444,7 +421,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
           upRepo,
           userRepo,
         )

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -211,15 +211,19 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         pr        <- ZIO.service[ProfileRepo]
         sr        <- ZIO.service[ScheduleRepo]
         tlr       <- ZIO.service[TimeLimitRepo]
-        stlr      <- ZIO.service[SiteTimeLimitRepo]
         dr        <- ZIO.service[DeviceRepo]
         blr       <- ZIO.service[BlocklistRepo]
         rr        <- ZIO.service[RouterRepo]
+        ar        <- ZIO.service[AppRepo]
         kid       <- TestLayers.seedKidsProfile(pr, sr)
         _         <- tlr.upsert(kid, 120)
-        _         <- stlr.replaceForProfile(
+        _         <- TestLayers.seedAppAssignment(
+          ar,
           kid,
-          List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")), // default exemptFromDaily=true
+          "youtube.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(30),
+          exemptFromDaily = true,
         )
         adult     <- TestLayers.seedAdultsProfile(pr)
         _         <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -410,10 +410,10 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         pr  <- ZIO.service[ProfileRepo]
         dr  <- ZIO.service[DeviceRepo]
         sr  <- ZIO.service[ScheduleRepo]
+        ar  <- ZIO.service[AppRepo]
         ber <- ZIO.service[BlockEventRepo]
         kid <- pr.create("Kids", List.empty)
-        p   <- pr.findById(kid).map(_.get)
-        _   <- pr.update(p.copy(extraBlocked = List(Hostname.unsafe("badsite.com"))))
+        _   <- TestLayers.seedAppAssignment(ar, kid, "badsite.com", AppMode.Blocked)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
         ps  <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
@@ -447,24 +447,28 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       // Site cap is 200 (not hit). Daily cap is 120. 121 min of YouTube usage.
       // With exemptFromDaily=false the 121 min counts toward the 120 daily cap → time_limit.
       for
-        _    <- cleanDb
-        rr   <- ZIO.service[RouterRepo]
-        pr   <- ZIO.service[ProfileRepo]
-        dr   <- ZIO.service[DeviceRepo]
-        sr   <- ZIO.service[ScheduleRepo]
-        tlr  <- ZIO.service[TimeLimitRepo]
-        stlr <- ZIO.service[SiteTimeLimitRepo]
-        ber  <- ZIO.service[BlockEventRepo]
-        kid  <- TestLayers.seedKidsProfile(pr, sr)
-        _    <- tlr.upsert(kid, 120)
-        _    <- stlr.replaceForProfile(
+        _   <- cleanDb
+        rr  <- ZIO.service[RouterRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ber <- ZIO.service[BlockEventRepo]
+        ar  <- ZIO.service[AppRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 120)
+        _   <- TestLayers.seedAppAssignment(
+          ar,
           kid,
-          List(SiteTimeLimitRequest("youtube.com", 200, "YouTube", exemptFromDaily = false)),
+          "youtube.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(200),
+          exemptFromDaily = false,
         )
-        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        rid  <- seedRouterRow
-        _    <- seedTraffic(rid, "aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 125)
-        ps   <- makePsDefault
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 125)
+        ps  <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
         tok  <- seedAndEnrollRouter(rr, routes)
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "youtube.com")
@@ -479,27 +483,28 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       // Daily cap is 120. 121 min of YouTube usage, but YouTube is exempt from daily cap.
       // YouTube site cap is 200 (not hit either) → should allow.
       for
-        _    <- cleanDb
-        rr   <- ZIO.service[RouterRepo]
-        pr   <- ZIO.service[ProfileRepo]
-        dr   <- ZIO.service[DeviceRepo]
-        sr   <- ZIO.service[ScheduleRepo]
-        tlr  <- ZIO.service[TimeLimitRepo]
-        stlr <- ZIO.service[SiteTimeLimitRepo]
-        ber  <- ZIO.service[BlockEventRepo]
-        kid  <- TestLayers.seedKidsProfile(pr, sr)
-        _    <- tlr.upsert(kid, 120)
-        _    <- stlr.replaceForProfile(
+        _   <- cleanDb
+        rr  <- ZIO.service[RouterRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ber <- ZIO.service[BlockEventRepo]
+        ar  <- ZIO.service[AppRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 120)
+        _   <- TestLayers.seedAppAssignment(
+          ar,
           kid,
-          List(
-            // exemptFromDaily=true (default): YouTube time does NOT eat into 120-min daily cap
-            SiteTimeLimitRequest("youtube.com", 200, "YouTube", exemptFromDaily = true),
-          ),
+          "youtube.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(200),
+          exemptFromDaily = true,
         )
-        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        rid  <- seedRouterRow
-        _    <- seedTraffic(rid, "aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 125)
-        ps   <- makePsDefault
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "aa:bb:cc:11:22:33", "youtube.com", LocalDate.of(2025, 1, 6), 125)
+        ps  <- makePsDefault
         routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
         tok  <- seedAndEnrollRouter(rr, routes)
         resp <- callDecide(routes, tok, "aa:bb:cc:11:22:33", "youtube.com")

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -189,12 +189,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           token       <- auth.login("admin", "changeme").map(_.token.value)
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 120)
-          _           <- stlRepo.replaceForProfile(
+          appRepo     <- ZIO.service[AppRepo]
+          _           <- TestLayers.seedAppAssignment(
+            appRepo,
             kidsId,
-            List(
-              // default exemptFromDaily = true → does NOT count toward 120-min cap
-              SiteTimeLimitRequest("*.youtube.com", 30, "YouTube"),
-            ),
+            "*.youtube.com",
+            AppMode.TimeLimited,
+            dailyMinutes = Some(30),
+            exemptFromDaily = true,
           )
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           routerId    <- seedRouter
@@ -227,7 +229,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(status.remainingMins.contains(60)) &&
           assertTrue(
             status.siteUsage.exists(su =>
-              su.label == "YouTube" && su.usedMins == 20 && su.remainingMins == 10,
+              su.label == "app:*.youtube.com" && su.usedMins == 20 && su.remainingMins == 10,
             ),
           )
       },
@@ -245,12 +247,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           token       <- auth.login("admin", "changeme").map(_.token.value)
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 120)
-          _           <- stlRepo.replaceForProfile(
+          appRepo     <- ZIO.service[AppRepo]
+          _           <- TestLayers.seedAppAssignment(
+            appRepo,
             kidsId,
-            List(
-              // exemptFromDaily=false → YouTube minutes count against the 120-min daily cap
-              SiteTimeLimitRequest("*.youtube.com", 60, "YouTube", exemptFromDaily = false),
-            ),
+            "*.youtube.com",
+            AppMode.TimeLimited,
+            dailyMinutes = Some(60),
+            exemptFromDaily = false,
           )
           _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
           routerId    <- seedRouter
@@ -282,7 +286,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(status.remainingMins.contains(60)) && // 120 - 60 = 60
           assertTrue(
             status.siteUsage.exists(su =>
-              su.label == "YouTube" && su.usedMins == 60 && su.remainingMins == 0,
+              su.label == "app:*.youtube.com" && su.usedMins == 60 && su.remainingMins == 0,
             ),
           )
       },
@@ -538,8 +542,6 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
                   Profile(
                     pid,
                     "Adults",
-                    Nil,
-                    Nil,
                     Nil,
                     paused = false,
                     FailureMode.LastKnownGood,
@@ -809,9 +811,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           token       <- auth.login("admin", "changeme").map(_.token.value)
           kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
           _           <- tlRepo.upsert(kidsId, 120)
-          _           <- stlRepo.replaceForProfile(
+          appRepo     <- ZIO.service[AppRepo]
+          _           <- TestLayers.seedAppAssignment(
+            appRepo,
             kidsId,
-            List(SiteTimeLimitRequest("youtube.com", 30, "YouTube")),
+            "youtube.com",
+            AppMode.TimeLimited,
+            dailyMinutes = Some(30),
+            exemptFromDaily = true,
           )
           mac1 = "aa:bb:cc:dd:ee:01"
           mac2 = "aa:bb:cc:dd:ee:02"
@@ -844,7 +851,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
-          yt   = kids.siteUsage.find(_.label == "YouTube").get
+          yt   = kids.siteUsage.find(_.label == "app:youtube.com").get
         } yield assertTrue(yt.usedMins == 40) && // both devices summed
           assertTrue(yt.limitMins == 30) &&
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
@@ -1220,8 +1227,6 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
                     pid,
                     "Adults",
                     Nil,
-                    Nil,
-                    Nil,
                     paused = false,
                     FailureMode.LastKnownGood,
                     blockIpOnly = false,
@@ -1418,8 +1423,6 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
                   Profile(
                     pid,
                     "Adults",
-                    Nil,
-                    Nil,
                     Nil,
                     paused = false,
                     FailureMode.LastKnownGood,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -128,8 +128,6 @@ case class Profile(
     id: ProfileId,
     name: String,
     blockedCategories: List[BlocklistId],
-    extraBlocked: List[Hostname],
-    extraAllowed: List[Hostname],
     paused: Boolean,
     failureMode: FailureMode = FailureMode.LastKnownGood,
     blockIpOnly: Boolean = false,
@@ -381,12 +379,9 @@ case class SetProfileUsersRequest(userIds: List[UserId]) derives JsonCodec
 case class UpsertProfileRequest(
     name: String,
     blockedCategories: List[BlocklistId],
-    extraBlocked: List[Hostname],
-    extraAllowed: List[Hostname],
     paused: Boolean,
     schedules: List[ScheduleRequest],
     timeLimit: Option[Int],
-    siteTimeLimits: List[SiteTimeLimitRequest],
     failureMode: Option[FailureMode] = None,
     blockIpOnly: Option[Boolean] = None,
     crossDeviceOverlapMode: Option[CrossDeviceOverlapMode] = None,
@@ -469,13 +464,6 @@ case class HeartbeatExplainRow(
     bytes: Long,
     classified: String,
     reasons: List[String],
-) derives JsonCodec
-
-case class SiteTimeLimitRequest(
-    domainPattern: String,
-    dailyMinutes: Int,
-    label: String,
-    exemptFromDaily: Boolean = true,
 ) derives JsonCodec
 
 case class UpsertDeviceRequest(
@@ -706,7 +694,6 @@ case class ProfileDetail(
     profile: Profile,
     schedules: List[Schedule],
     timeLimit: Option[TimeLimit],
-    siteTimeLimits: List[SiteTimeLimit],
 ) derives JsonCodec
 
 // #716 / #721 — per-device hourly usage timeline. The endpoint returns 24
@@ -863,17 +850,10 @@ case class DashboardNow(
     profiles: List[DashboardNowProfile],
 ) derives JsonCodec
 
-case class CachedProfile(
-    profile: Profile,
-    schedules: List[Schedule],
-    timeLimit: Option[Int],
-    siteTimeLimits: List[SiteTimeLimit],
-)
-
 case class DnsCache(
-    deviceProfiles: Map[MacAddress, CachedProfile],
+    deviceProfiles: Map[MacAddress, Profile],
     blocklists: Map[BlocklistId, Set[Hostname]],
-    defaultProfile: Option[CachedProfile],
+    defaultProfile: Option[Profile],
 )
 
 object DnsCache {

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -90,7 +90,7 @@ describe('SWR caching (#803)', () => {
     const qc = freshClient(0)
     const wrapper = makeWrapper(qc)
     ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all' as const, crossDeviceOverlapMode: 'sum' as const }, schedules: [], timeLimit: null, siteTimeLimits: [] },
+      { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all' as const, crossDeviceOverlapMode: 'sum' as const }, schedules: [], timeLimit: null },
     ])
     const hook = renderHook(() => useProfiles(), { wrapper })
     await waitFor(() => expect(hook.result.current.isSuccess).toBe(true))

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -31,15 +31,15 @@ function makeProfile(id: number, name: string): ProfileDetail {
     profile: {
       id, name,
       blockedCategories: [],
-      extraBlocked: [],
-      extraAllowed: [],
+      
+      
       paused: false,
       failureMode: 'last-known-good',
       crossDeviceOverlapMode: 'sum',
     },
     schedules: [],
     timeLimit: null,
-    siteTimeLimits: [],
+    
   }
 }
 

--- a/web/src/pages/BlocklistsPage.tsx
+++ b/web/src/pages/BlocklistsPage.tsx
@@ -9,7 +9,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { api } from '@/api/client'
 import { useProfiles, useInvalidators } from '@/api/queries'
-import type { BlocklistSummary, ProfileDetail, ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest } from '@/types/api'
+import type { BlocklistSummary, ProfileDetail, ScheduleRequest, UpsertProfileRequest } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
 const HOSTS_PER_PAGE = 50
@@ -54,8 +54,6 @@ export function BlocklistsPage() {
       const body: UpsertProfileRequest = {
         name: profile.profile.name,
         blockedCategories: nextCats,
-        extraBlocked: profile.profile.extraBlocked,
-        extraAllowed: profile.profile.extraAllowed,
         paused: profile.profile.paused,
         schedules: profile.schedules.map<ScheduleRequest>(s => ({
           name: s.name,
@@ -65,12 +63,6 @@ export function BlocklistsPage() {
           tz: s.tz,
         })),
         timeLimit: profile.timeLimit?.dailyMinutes ?? null,
-        siteTimeLimits: profile.siteTimeLimits.map<SiteTimeLimitRequest>(s => ({
-          domainPattern: s.domainPattern,
-          dailyMinutes: s.dailyMinutes,
-          label: s.label,
-          exemptFromDaily: s.exemptFromDaily,
-        })),
         failureMode: profile.profile.failureMode,
         crossDeviceOverlapMode: profile.profile.crossDeviceOverlapMode,
       }

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -54,12 +54,12 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' },
-  schedules: [], timeLimit: null, siteTimeLimits: [],
+  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' },
+  schedules: [], timeLimit: null,
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum' },
-  schedules: [], timeLimit: null, siteTimeLimits: [],
+  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum' },
+  schedules: [], timeLimit: null,
 }
 
 beforeEach(() => {

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -39,7 +39,7 @@ const devices: Device[] = [
   { id: 10, mac: 'aa:bb:cc:dd:ee:01', name: "Kid's iPad", profileId: 1, profileName: 'Kids', lastSeenIp: null, lastSeenAt: null },
 ]
 const profileDetails: ProfileDetail[] = [
-  { profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' }, schedules: [], timeLimit: null, siteTimeLimits: [] },
+  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' }, schedules: [], timeLimit: null },
 ]
 
 function renderAt(path = '/usage/events') {

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -61,8 +61,6 @@ const kidsProfile: ProfileDetail = {
     id: 1,
     name: 'Kids',
     blockedCategories: ['adult', 'gambling'],
-    extraBlocked: ['bad.com', 'evil.com'],
-    extraAllowed: ['school.com'],
     paused: false,
     failureMode: 'block-all',
     crossDeviceOverlapMode: 'sum',
@@ -71,9 +69,6 @@ const kidsProfile: ProfileDetail = {
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
   ],
   timeLimit: { id: 5, profileId: 1, dailyMinutes: 120 },
-  siteTimeLimits: [
-    { id: 7, profileId: 1, domainPattern: 'youtube.com', dailyMinutes: 30, label: 'YouTube', exemptFromDaily: true },
-  ],
 }
 
 const adultsProfile: ProfileDetail = {
@@ -81,15 +76,12 @@ const adultsProfile: ProfileDetail = {
     id: 2,
     name: 'Adults',
     blockedCategories: [],
-    extraBlocked: [],
-    extraAllowed: [],
     paused: true,
     failureMode: 'last-known-good',
     crossDeviceOverlapMode: 'sum',
   },
   schedules: [],
   timeLimit: null,
-  siteTimeLimits: [],
 }
 
 const phoneDevice: Device = {
@@ -228,7 +220,6 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
     expect(within(kidsCard).getByText('Bedtime')).toBeInTheDocument()
     expect(within(kidsCard).getByText('120 min')).toBeInTheDocument()
-    expect(within(kidsCard).getByText('YouTube')).toBeInTheDocument()
     expect(within(kidsCard).getByText('21:00 → 07:00')).toBeInTheDocument()
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
     expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
@@ -330,12 +321,6 @@ describe('ProfilesPage — create', () => {
     // toggle category "social" (label uses display name)
     await user.click(screen.getByRole('button', { name: 'Social' }))
 
-    // extra blocked / allowed (split lines, trim)
-    const blockedTa = screen.getAllByPlaceholderText('One domain per line')[0]
-    const allowedTa = screen.getAllByPlaceholderText('One domain per line')[1]
-    await user.type(blockedTa, '  tiktok.com  \n  insta.com  ')
-    await user.type(allowedTa, 'khan.org')
-
     // daily limit
     await user.type(screen.getByPlaceholderText('Leave blank for unlimited'), '90')
 
@@ -343,26 +328,16 @@ describe('ProfilesPage — create', () => {
     await user.click(screen.getByRole('button', { name: /\+ Add schedule/ }))
     await user.click(screen.getByRole('button', { name: 'sun' }))
 
-    // add site limit
-    await user.click(screen.getByRole('button', { name: /\+ Add site limit/ }))
-    await user.type(screen.getByPlaceholderText('YouTube'), 'YouTube')
-    await user.type(screen.getByPlaceholderText('youtube.com'), 'youtube.com')
-
     await user.click(screen.getByRole('button', { name: /^Save$/ }))
 
     await waitFor(() => expect(api.profiles.create).toHaveBeenCalledTimes(1))
     expect(api.profiles.create).toHaveBeenCalledWith({
       name: 'Teens',
       blockedCategories: ['social'],
-      extraBlocked: ['tiktok.com', 'insta.com'],
-      extraAllowed: ['khan.org'],
       paused: false,
       timeLimit: 90,
       schedules: [
         { name: 'Bedtime', days: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat'], startLocal: '21:00', endLocal: '07:00', tz: 'America/Los_Angeles' },
-      ],
-      siteTimeLimits: [
-        { label: 'YouTube', domainPattern: 'youtube.com', dailyMinutes: 30, exemptFromDaily: true },
       ],
       // #385: form default for a brand-new profile is LastKnownGood
       // (matches DB column default; UI copy steers admins towards BlockAll
@@ -384,14 +359,14 @@ describe('ProfilesPage — create', () => {
 //   - timeLimit /
 //     schedules /
 //     crossDeviceOverlapMode → "ProfilesPage — inline time-limit subsection (#975)"
-//   - blockedCategories /
-//     extraBlocked /
-//     extraAllowed    → "ProfilesPage — apps subsection (#976)"
+//   - blockedCategories → "ProfilesPage — apps subsection (#976)"
 //   - paused          → "ProfilesPage — pause / delete" + inline subsection sync
 //   - app policies   → "ProfilesPage — apps section (#767)" exercises the
 //                      inline subsection's AppsSection (post-#976).
 //   - failureMode    → only reachable from "+ New Profile" until the inline
 //                      subsection follow-up lands; see the #385 describe below.
+// Post-#764 the legacy extraBlocked/extraAllowed/siteTimeLimits fields are
+// gone — per-host policy lives in apps, exercised by the apps subsection.
 
 describe('ProfilesPage — inline time-limit subsection (#975)', () => {
   it('collapsed-by-default subsection shows daily-limit + schedule summary', async () => {
@@ -949,12 +924,10 @@ describe('ProfilesPage — apps section (#767)', () => {
   })
 })
 
-// #976 — apps subsection inside the expanded card (per-app policy editor
-// + transitional extraBlocked/extraAllowed). Default collapsed; opening
-// reveals the same AppsSection the modal uses, scoped to a profile-
-// specific testid prefix. Labelled "Apps" (not "Rules") because time
-// limits live in their own subsection (#975) and domain blocklists are
-// on their way out (#764).
+// #976 — apps subsection inside the expanded card (per-app policy
+// editor). Default collapsed; opening reveals the same AppsSection the
+// modal uses, scoped to a profile-specific testid prefix. Post-#764 the
+// transitional legacy extraBlocked/extraAllowed textareas are gone.
 describe('ProfilesPage — apps subsection (#976)', () => {
   it('subsection summary reports the assigned-app count', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
@@ -979,38 +952,6 @@ describe('ProfilesPage — apps subsection (#976)', () => {
     expect(await screen.findByTestId('profile-1-apps-section')).toBeInTheDocument()
     // Inline app row rendered.
     expect(screen.getByTestId('app-row-50')).toBeInTheDocument()
-  })
-
-  it('legacy domain textareas seed from profile and debounce-autosave via PUT', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-      renderPage()
-      await screen.findByTestId('profile-card-1')
-      await expand(1, user)
-      await user.click(screen.getByTestId('profile-apps-toggle-1'))
-      const blocked = await screen.findByTestId('profile-legacy-blocked-1') as HTMLTextAreaElement
-      const allowed = screen.getByTestId('profile-legacy-allowed-1') as HTMLTextAreaElement
-      expect(blocked.value).toBe('bad.com\nevil.com')
-      expect(allowed.value).toBe('school.com')
-
-      await user.clear(blocked)
-      await user.type(blocked, 'newbad.com')
-      // Not yet saved before debounce.
-      expect(api.profiles.update).not.toHaveBeenCalled()
-      vi.advanceTimersByTime(900)
-      await waitFor(() =>
-        expect(api.profiles.update).toHaveBeenCalledWith(
-          1,
-          expect.objectContaining({
-            extraBlocked: ['newbad.com'],
-            extraAllowed: ['school.com'],
-          }),
-        ),
-      )
-    } finally {
-      vi.useRealTimers()
-    }
   })
 
   it('subsection hidden for non-admins', async () => {
@@ -1054,7 +995,7 @@ describe('ProfilesPage — #973 inline name subsection (autosave)', () => {
             paused: false,
             failureMode: 'block-all',
             crossDeviceOverlapMode: 'sum',
-            // round-trips schedules + siteTimeLimits + timeLimit unchanged
+            // round-trips schedules + timeLimit unchanged
             timeLimit: 120,
           }),
         ),

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -10,7 +10,7 @@ import type {
   AppDetail, AppMode, AppPolicyAssignment,
   BlocklistSummary, CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
   ProfileTimeSummary,
-  ScheduleRequest, SiteTimeLimitRequest, UpsertProfileRequest, User,
+  ScheduleRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { AppIcon } from '@/components/AppIcon'
@@ -22,12 +22,9 @@ const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
 interface FormState {
   name: string
   blockedCategories: string[]
-  extraBlocked: string
-  extraAllowed: string
   paused: boolean
   timeLimit: string
   schedules: ScheduleRequest[]
-  siteTimeLimits: SiteTimeLimitRequest[]
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
 }
@@ -36,12 +33,9 @@ function emptyForm(): FormState {
   return {
     name: '',
     blockedCategories: [],
-    extraBlocked: '',
-    extraAllowed: '',
     paused: false,
     timeLimit: '',
     schedules: [],
-    siteTimeLimits: [],
     // #385: safe default for a brand-new profile is LastKnownGood
     // (matches the DB column default). The editor calls out the
     // BlockAll-for-kids recommendation in copy; admins still have to
@@ -58,18 +52,10 @@ function detailToForm(pd: ProfileDetail): FormState {
   return {
     name: pd.profile.name,
     blockedCategories: pd.profile.blockedCategories,
-    extraBlocked: pd.profile.extraBlocked.join('\n'),
-    extraAllowed: pd.profile.extraAllowed.join('\n'),
     paused: pd.profile.paused,
     timeLimit: pd.timeLimit ? String(pd.timeLimit.dailyMinutes) : '',
     schedules: pd.schedules.map(s => ({
       name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-    })),
-    siteTimeLimits: pd.siteTimeLimits.map(s => ({
-      domainPattern: s.domainPattern,
-      dailyMinutes: s.dailyMinutes,
-      label: s.label,
-      exemptFromDaily: s.exemptFromDaily,
     })),
     failureMode: pd.profile.failureMode,
     crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
@@ -77,17 +63,13 @@ function detailToForm(pd: ProfileDetail): FormState {
 }
 
 function formToRequest(f: FormState): UpsertProfileRequest {
-  const splitLines = (s: string) => s.split('\n').map(x => x.trim()).filter(Boolean)
   const tl = f.timeLimit.trim() === '' ? null : Number(f.timeLimit)
   return {
     name: f.name.trim(),
     blockedCategories: f.blockedCategories,
-    extraBlocked: splitLines(f.extraBlocked),
-    extraAllowed: splitLines(f.extraAllowed),
     paused: f.paused,
     timeLimit: tl !== null && Number.isFinite(tl) ? tl : null,
     schedules: f.schedules,
-    siteTimeLimits: f.siteTimeLimits,
     failureMode: f.failureMode,
     crossDeviceOverlapMode: f.crossDeviceOverlapMode,
   }
@@ -581,18 +563,10 @@ function ProfileShellRow({
       await updateProfile({
         name: trimmed,
         blockedCategories: pd.profile.blockedCategories,
-        extraBlocked: pd.profile.extraBlocked,
-        extraAllowed: pd.profile.extraAllowed,
         paused: pd.profile.paused,
         timeLimit: pd.timeLimit ? pd.timeLimit.dailyMinutes : null,
         schedules: pd.schedules.map(s => ({
           name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-        })),
-        siteTimeLimits: pd.siteTimeLimits.map(s => ({
-          domainPattern: s.domainPattern,
-          dailyMinutes: s.dailyMinutes,
-          label: s.label,
-          exemptFromDaily: s.exemptFromDaily,
         })),
         failureMode: pd.profile.failureMode,
         crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
@@ -734,11 +708,9 @@ function ProfileShellRow({
             </div>
           )}
 
-          {/* #976: apps subsection — inline app-policy editor (with the
-              transitional extraAllowed/extraBlocked textareas tucked
-              underneath until #764 migrates them off the schema).
-              Replaces the read-only summary that used to live here; the
-              modal Edit still works while #978 cleans it up. */}
+          {/* #976: apps subsection — inline app-policy editor. Post-#764 the
+              legacy extraAllowed/extraBlocked textareas are gone; this owns
+              the per-host policy surface end-to-end. */}
           {isAdmin && (
             <AppsRulesSubsection
               pd={pd}
@@ -751,10 +723,7 @@ function ProfileShellRow({
 
           {/* #975 — inline time-limit + cross-device overlap subsection.
               Replaces the modal's daily-cap + schedules + overlap blocks for
-              this profile. Autosave-default; the subsection itself is
-              collapsed-by-default and its header carries the at-a-glance
-              summary (limit + schedule list) so the collapsed view still
-              reads "Daily limit: 120 min", "Bedtime · 21:00 → 07:00". */}
+              this profile. */}
           <TimeSubsection pd={pd} isAdmin={isAdmin} defaultTz={defaultTz} />
 
           {/* #973: read-only Devices listing for non-admins. Admins get the
@@ -829,26 +798,6 @@ function ProfileShellRow({
             </div>
           )}
 
-          {pd.siteTimeLimits.length > 0 && (
-            <div>
-              <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Site Limits</p>
-              {pd.siteTimeLimits.map(s => (
-                <div key={s.id} className="flex justify-between items-center text-sm bg-gray-800/50 rounded-lg px-3 py-2 mb-1">
-                  <span className="text-gray-300">{s.label}</span>
-                  <div className="flex items-center gap-2">
-                    <span className="text-emerald-400 text-xs font-mono">{s.dailyMinutes}m · {s.domainPattern}</span>
-                    <span className={`text-xs px-1.5 py-0.5 rounded font-mono ${
-                      s.exemptFromDaily
-                        ? 'bg-gray-700 text-gray-400'
-                        : 'bg-amber-500/20 text-amber-400'
-                    }`}>
-                      {s.exemptFromDaily ? 'exempt' : 'counts'}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
       )}
     </div>
@@ -1261,27 +1210,6 @@ function ProfileEditor({
     }))
   }
 
-  function addSiteLimit() {
-    setForm(f => ({
-      ...f,
-      siteTimeLimits: [
-        ...f.siteTimeLimits,
-        { label: '', domainPattern: '', dailyMinutes: 30, exemptFromDaily: true },
-      ],
-    }))
-  }
-
-  function updateSiteLimit(i: number, patch: Partial<SiteTimeLimitRequest>) {
-    setForm(f => ({
-      ...f,
-      siteTimeLimits: f.siteTimeLimits.map((s, idx) => idx === i ? { ...s, ...patch } : s),
-    }))
-  }
-
-  function removeSiteLimit(i: number) {
-    setForm(f => ({ ...f, siteTimeLimits: f.siteTimeLimits.filter((_, idx) => idx !== i) }))
-  }
-
   return (
     <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4 overflow-y-auto">
       <div className="bg-gray-900 rounded-2xl border border-gray-700 w-full max-w-2xl my-8 p-6 space-y-5 max-h-[90vh] overflow-y-auto">
@@ -1445,25 +1373,6 @@ function ProfileEditor({
           )}
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Extra blocked domains</label>
-            <textarea value={form.extraBlocked}
-              onChange={e => setForm(f => ({ ...f, extraBlocked: e.target.value }))}
-              placeholder="One domain per line"
-              rows={4}
-              className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500" />
-          </div>
-          <div>
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Extra allowed domains</label>
-            <textarea value={form.extraAllowed}
-              onChange={e => setForm(f => ({ ...f, extraAllowed: e.target.value }))}
-              placeholder="One domain per line"
-              rows={4}
-              className="w-full bg-gray-950 border border-gray-700 rounded-xl px-4 py-3 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500" />
-          </div>
-        </div>
-
         <div>
           <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Daily time limit (minutes)</label>
           <input type="number" min={0} value={form.timeLimit}
@@ -1527,53 +1436,8 @@ function ProfileEditor({
           </div>
         </div>
 
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">Site time limits</label>
-            <button type="button" onClick={addSiteLimit}
-              className="text-xs text-emerald-400 hover:text-emerald-300">+ Add site limit</button>
-          </div>
-          {form.siteTimeLimits.length === 0 && <p className="text-xs text-gray-500">No site-specific limits.</p>}
-          <div className="space-y-2">
-            {form.siteTimeLimits.map((s, i) => (
-              <div key={i} className="bg-gray-950 border border-gray-700 rounded-xl p-3 space-y-2">
-                <div className="grid grid-cols-12 gap-2">
-                  <input type="text" value={s.label}
-                    onChange={e => updateSiteLimit(i, { label: e.target.value })}
-                    placeholder="YouTube"
-                    className="col-span-4 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
-                  <input type="text" value={s.domainPattern}
-                    onChange={e => updateSiteLimit(i, { domainPattern: e.target.value })}
-                    placeholder="youtube.com"
-                    className="col-span-5 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm font-mono" />
-                  <input type="number" min={0} value={s.dailyMinutes}
-                    onChange={e => updateSiteLimit(i, { dailyMinutes: Number(e.target.value) || 0 })}
-                    className="col-span-2 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-white text-sm" />
-                  <button type="button" onClick={() => removeSiteLimit(i)}
-                    className="col-span-1 text-xs text-red-400 hover:text-red-300 bg-red-500/10 rounded-lg">×</button>
-                </div>
-                <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={!s.exemptFromDaily}
-                    onChange={e => updateSiteLimit(i, { exemptFromDaily: !e.target.checked })}
-                    className="w-3.5 h-3.5 accent-amber-500"
-                  />
-                  <span>
-                    Counts toward daily limit
-                    {!s.exemptFromDaily && (
-                      <span className="ml-1 text-amber-400">(usage reduces overall remaining time)</span>
-                    )}
-                  </span>
-                </label>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* #767 — apps picker. Lives alongside the legacy extraBlocked /
-            extraAllowed / siteTimeLimits inputs above; #764 will remove the
-            legacy fields once apps cover everything. */}
+        {/* #764: per-host policy lives in apps. Blocked / allowed / time-limited
+            single-host or multi-host apps are managed via AppsSection below. */}
         <AppsSection
           profileId={profileId}
           isNew={isNew}
@@ -1598,15 +1462,10 @@ function ProfileEditor({
 
 // #976 — apps subsection of the merged /profiles expanded card.
 // Default collapsed; opening reveals the same `<AppsSection>` the modal
-// shows, plus the transitional extraBlocked/extraAllowed textareas with
-// debounced autosave. The textareas disappear once #764 migrates those
-// fields onto apps; PATCH support (#423) would let us send only the
-// changed fields instead of a full PUT body, but the textareas are
-// short-lived enough that PUT is fine. Subsection is labelled "Apps"
-// (not "Rules") because time limits are their own subsection (#975)
-// and domain blocklists are on their way out.
+// shows. Post-#764 the legacy extraBlocked/extraAllowed textareas are
+// gone — per-host policy is owned end-to-end by app assignments.
 function AppsRulesSubsection({
-  pd, apps, onAppsChanged, onProfileChanged, updateProfile,
+  pd, apps, onAppsChanged, onProfileChanged: _onProfileChanged, updateProfile: _updateProfile,
 }: {
   pd: ProfileDetail
   apps: AppDetail[]
@@ -1651,125 +1510,8 @@ function AppsRulesSubsection({
             onChanged={onAppsChanged}
             testIdPrefix={`profile-${pd.profile.id}-apps-section`}
           />
-          <LegacyDomainListsEditor
-            pd={pd}
-            updateProfile={updateProfile}
-            onSaved={onProfileChanged}
-          />
         </div>
       )}
-    </div>
-  )
-}
-
-function profileDetailToUpsert(pd: ProfileDetail): UpsertProfileRequest {
-  return {
-    name: pd.profile.name,
-    blockedCategories: pd.profile.blockedCategories,
-    extraBlocked: pd.profile.extraBlocked,
-    extraAllowed: pd.profile.extraAllowed,
-    paused: pd.profile.paused,
-    timeLimit: pd.timeLimit ? pd.timeLimit.dailyMinutes : null,
-    schedules: pd.schedules.map(s => ({
-      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-    })),
-    siteTimeLimits: pd.siteTimeLimits.map(s => ({
-      domainPattern: s.domainPattern,
-      dailyMinutes: s.dailyMinutes,
-      label: s.label,
-      exemptFromDaily: s.exemptFromDaily,
-    })),
-    failureMode: pd.profile.failureMode,
-    crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
-  }
-}
-
-function LegacyDomainListsEditor({
-  pd, updateProfile, onSaved,
-}: {
-  pd: ProfileDetail
-  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
-  onSaved: () => void | Promise<unknown>
-}) {
-  const [blocked, setBlocked] = useState(pd.profile.extraBlocked.join('\n'))
-  const [allowed, setAllowed] = useState(pd.profile.extraAllowed.join('\n'))
-  const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const [errMsg, setErrMsg] = useState<string | null>(null)
-  // Track the persisted values so we can detect dirty state and re-seed
-  // when an external mutation lands (e.g. modal Save). Comparing against
-  // the raw join lets us avoid stomping in-flight edits.
-  const persistedBlocked = pd.profile.extraBlocked.join('\n')
-  const persistedAllowed = pd.profile.extraAllowed.join('\n')
-  useEffect(() => {
-    if (status === 'saving') return
-    setBlocked(persistedBlocked)
-    setAllowed(persistedAllowed)
-  }, [persistedBlocked, persistedAllowed])
-
-  const splitLines = (s: string) => s.split('\n').map(x => x.trim()).filter(Boolean)
-
-  useEffect(() => {
-    if (blocked === persistedBlocked && allowed === persistedAllowed) return
-    const t = setTimeout(async () => {
-      setStatus('saving')
-      setErrMsg(null)
-      try {
-        const body = profileDetailToUpsert(pd)
-        body.extraBlocked = splitLines(blocked)
-        body.extraAllowed = splitLines(allowed)
-        await updateProfile(body)
-        await onSaved()
-        setStatus('saved')
-      } catch (e) {
-        setStatus('error')
-        setErrMsg(e instanceof Error ? e.message : 'Failed to save')
-      }
-    }, 800)
-    return () => clearTimeout(t)
-  }, [blocked, allowed])
-
-  return (
-    <div data-testid={`profile-legacy-domains-${pd.profile.id}`}>
-      <div className="flex items-center justify-between mb-2">
-        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider">
-          Extra domains <span className="normal-case text-gray-600">(legacy — migrating to apps in #764)</span>
-        </label>
-        <span
-          data-testid={`profile-legacy-domains-status-${pd.profile.id}`}
-          className={`text-xs ${
-            status === 'saving' ? 'text-gray-400'
-              : status === 'saved' ? 'text-emerald-400'
-              : status === 'error' ? 'text-red-400'
-              : 'text-transparent'
-          }`}
-        >
-          {status === 'saving' ? 'Saving…' : status === 'saved' ? 'Saved' : status === 'error' ? (errMsg ?? 'Save failed') : '·'}
-        </span>
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div>
-          <p className="text-xs text-gray-500 mb-1">Blocked domains</p>
-          <textarea
-            value={blocked}
-            onChange={e => setBlocked(e.target.value)}
-            placeholder="One domain per line"
-            rows={3}
-            data-testid={`profile-legacy-blocked-${pd.profile.id}`}
-            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
-          />
-        </div>
-        <div>
-          <p className="text-xs text-gray-500 mb-1">Allowed domains</p>
-          <textarea
-            value={allowed}
-            onChange={e => setAllowed(e.target.value)}
-            placeholder="One domain per line"
-            rows={3}
-            data-testid={`profile-legacy-allowed-${pd.profile.id}`}
-            className="w-full bg-gray-950 border border-gray-700 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
-          />
-        </div>
-      </div>
     </div>
   )
 }

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -21,13 +21,13 @@ import { api } from '@/api/client'
 import { UsersPage } from './UsersPage'
 
 const kidsProfile = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false },
-  schedules: [], siteTimeLimits: [], timeLimit: null,
+  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false },
+  schedules: [], timeLimit: null,
 } as unknown as ProfileDetail
 
 const adultsProfile = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], extraBlocked: [], extraAllowed: [], paused: false },
-  schedules: [], siteTimeLimits: [], timeLimit: null,
+  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false },
+  schedules: [], timeLimit: null,
 } as unknown as ProfileDetail
 
 const aliceUser: User = { id: 10, username: 'alice', role: 'admin', profileIds: [] }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -14,8 +14,6 @@ export interface Profile {
   id: number
   name: string
   blockedCategories: string[]
-  extraBlocked: string[]
-  extraAllowed: string[]
   paused: boolean
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
@@ -82,7 +80,6 @@ export interface ProfileDetail {
   profile: Profile
   schedules: Schedule[]
   timeLimit: TimeLimit | null
-  siteTimeLimits: SiteTimeLimit[]
 }
 
 export interface Device {
@@ -518,22 +515,12 @@ export interface ScheduleRequest {
   tz: string
 }
 
-export interface SiteTimeLimitRequest {
-  domainPattern: string
-  dailyMinutes: number
-  label: string
-  exemptFromDaily: boolean
-}
-
 export interface UpsertProfileRequest {
   name: string
   blockedCategories: string[]
-  extraBlocked: string[]
-  extraAllowed: string[]
   paused: boolean
   schedules: ScheduleRequest[]
   timeLimit: number | null
-  siteTimeLimits: SiteTimeLimitRequest[]
   failureMode: FailureMode
   // #751: omit to preserve existing value on update; defaults to 'sum' on create.
   crossDeviceOverlapMode?: CrossDeviceOverlapMode


### PR DESCRIPTION
## Summary

- V33 backfills every `site_time_limits` row + every `profiles.extra_blocked`/`extra_allowed` entry into the apps schema (single-host app keyed by apex slug + per-profile assignment), then drops the legacy columns and table.
- All API code paths now source per-host policy from `app_policy_assignments` only. `SiteTimeLimitRepo` stays as a thin in-memory synthesizer over the apps tables so TimeRoutes / Presence / decide() keep working unchanged.
- SPA loses its `extraBlocked` / `extraAllowed` textareas and site-time-limit editor — apps now own that surface.

## Migration sketch

For each row in `site_time_limits` and each entry in `profiles.extra_blocked` / `profiles.extra_allowed`:

1. Apex = `domain_pattern` (or list entry) with any leading `*.` stripped.
2. `INSERT INTO apps (name, slug) VALUES (apex, apex) ON CONFLICT (slug) DO NOTHING`.
3. `INSERT INTO app_hosts` for that single host (idempotent).
4. `INSERT INTO app_policy_assignments` with mode `time_limited` / `blocked` / `allowed`, copying `daily_minutes` + `exempt_from_daily` from the source row, `ON CONFLICT (app_id, profile_id) DO NOTHING`. Allowed wins over blocked for the same (host, profile) — already mirrors router precedence ([feedback_extraallowed_beats_blocked](https://github.com/wifihaven/wifihaven/issues/421)).
5. `DROP TABLE site_time_limits; ALTER TABLE profiles DROP COLUMN extra_blocked, DROP COLUMN extra_allowed`.

Re-running the data inserts is a no-op (every step has `ON CONFLICT DO NOTHING`); the schema drops are owned by Flyway's `flyway_schema_history`, so V33 never runs twice.

## Snapshot continuity proof

PolicyService.snapshot was already routing app assignments into BlockRules.extraBlocked / extraAllowed / siteTimeLimits (per [#763 / PR #949](https://github.com/wifihaven/wifihaven/pull/949)). For a household whose policy lived entirely in legacy fields:

**Before V33** (one profile, `extra_blocked=['ads.example']`, `extra_allowed=['edu.example']`, site limit `youtube.com` 45m exempt):
- BlockRules.extraBlocked  = `[ads.example]`     (from profile column)
- BlockRules.extraAllowed  = `[edu.example]`     (from profile column)
- BlockRules.siteTimeLimits emits `{youtube.com, 45m, exempt}` (from site_time_limits)

**After V33** (three single-host apps created, one assignment each):
- BlockRules.extraBlocked  = `[ads.example]`     (allowed-mode app → snapshot expansion)
- BlockRules.extraAllowed  = `[edu.example]`     (blocked-mode app → snapshot expansion)
- BlockRules.siteTimeLimits emits `{youtube.com, 45m, exempt}` (time_limited app → SiteTimeLimitRepo synthesis with label `app:youtube.com`)

Only difference is `label` on the time_limited rows (`"YouTube"` → `"app:<slug>"`). The router doesn't read `label`; it's UI-only and reflected in the SPA's per-site usage strip.

## Test plan

- [x] `mill api.test` (190 tests) + `mill shared.test`
- [x] New `LegacyAppMigrationSpec` runs Flyway up to V32, seeds legacy rows, runs V33, asserts apps/hosts/assignments + dropped columns/table + allowed-beats-blocked conflict resolution.
- [x] Existing `PolicySnapshotAppsSpec` / `RouterDecisionSpec` / `TimeApiSpec` rewritten to seed via apps (new `TestLayers.seedAppAssignment` helper) — exercises the same snapshot/decide paths that legacy storage used to feed.
- [x] `policy_snapshot.json` golden file untouched — wire shape preserved.

## Coordination

[#976](https://github.com/wifihaven/wifihaven/issues/976) (rules subsection) has the legacy textareas in its lane. This PR removes them outright from `ProfilesPage.tsx` since policy moved to apps; #976 can drop its leftover wiring once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)