### PR TITLE
dx: auto-install git hooks at compile-time; close #755, supersede #617 (#1050)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,12 @@ jobs:
           chmod +x /tmp/cs
           /tmp/cs install --install-dir /usr/local/bin --quiet scalafmt
 
+      - name: Verify git hooks configured (informational, #1050)
+        # Informational only — CI itself doesn't need hooks; this surfaces
+        # when a contributor's local hooks weren't installed so they can fix
+        # it before the next scalafmt CI failure.
+        run: bash scripts/verify-hooks-configured.sh
+
       - name: scalafmt --check
         run: scalafmt --check --non-interactive
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ installs the matching artifact. Full walkthrough: [`docs/install-openwrt.md`](do
 # Prereqs: JDK 21, Node 22, mill 1.1.5, scalafmt (cs install scalafmt)
 git clone git@github.com:wifihaven/wifihaven.git
 cd wifihaven
-scripts/install-hooks.sh         # set up pre-commit / pre-push hooks
 
-# Run all tests
+# Run all tests (also auto-installs git hooks via build.mill — see "Git hooks")
 mill __.test
 
 # Run the API locally (uses an embedded Postgres for tests; for dev you
@@ -307,19 +306,27 @@ CI (`.github/workflows/ci.yml`) runs:
 
 ## Git hooks
 
-`.githooks/` ships pre-commit and pre-push hooks. Install once per clone:
-
-```bash
-scripts/install-hooks.sh
-```
-
-This sets `core.hooksPath = .githooks`, so updates flow with the repo.
+`.githooks/` ships pre-commit and pre-push hooks. They install automatically
+the first time you run `mill` in a fresh checkout or worktree — `build.mill`
+checks `core.hooksPath` on load and runs `scripts/install-hooks.sh` if it
+isn't already pointing at `.githooks`. Idempotent and silent in the steady
+state.
 
 - **pre-commit (~5s)** — `scalafmt --check` and `eslint` on staged files only
 - **pre-push (~5s)** — `scalafmt --check`, `tsc --noEmit`, `eslint` on the
   whole tree
 
 Both can be bypassed in an emergency with `--no-verify`.
+
+### Troubleshooting
+
+If hooks aren't firing (e.g. you cloned but haven't yet run mill, or
+`core.hooksPath` was changed by another tool), run the installer manually:
+
+```bash
+scripts/install-hooks.sh
+scripts/verify-hooks-configured.sh   # confirms core.hooksPath=.githooks
+```
 
 ## License
 

--- a/build.mill
+++ b/build.mill
@@ -2,6 +2,35 @@ import mill._
 import mill.scalalib._
 import mill.javalib.Assembly
 
+// Auto-install git hooks (#1050). Idempotent: only writes `core.hooksPath`
+// when it isn't already pointing at `.githooks`. Silent in the steady state
+// — one "Hooks installed" line the first time per worktree. Skipped when
+// not in a git checkout (e.g. tarball build). Wired into every module's
+// `compile` task below so a fresh `mill <mod>.compile` (or any task that
+// transitively compiles) re-installs hooks if they were dropped.
+def ensureHooksInstalled(root: os.Path): Unit =
+  try {
+    if (os.exists(root / ".git") && os.exists(root / "scripts" / "install-hooks.sh")) {
+      val current = os
+        .proc("git", "config", "--get", "core.hooksPath")
+        .call(cwd = root, check = false, stderr = os.Pipe)
+        .out
+        .text()
+        .trim
+      if (current != ".githooks") {
+        os.proc("bash", (root / "scripts" / "install-hooks.sh").toString).call(cwd = root)
+      }
+    }
+  } catch {
+    case _: Throwable => () // never block the build on hook install
+  }
+
+// Externally invokable: `mill installHooks`. Useful in scripts and CI for
+// an explicit, no-side-effects-on-compile-cache install.
+def installHooks() = Task.Command {
+  ensureHooksInstalled(mill.api.BuildCtx.workspaceRoot)
+}
+
 val scala3Version = "3.3.3"
 
 val zioVersion         = "2.1.9"
@@ -33,6 +62,14 @@ trait CommonModule extends ScalaModule {
     "-source:future",
     "-no-indent",
   )
+
+  // #1050: auto-install git hooks when compile runs. Plain side-effecting
+  // call (not a Task dependency) so it doesn't perturb mill's cache key —
+  // it just runs whenever compile's body is evaluated.
+  override def compile = Task {
+    ensureHooksInstalled(mill.api.BuildCtx.workspaceRoot)
+    super.compile()
+  }
 }
 
 trait WifiHavenTestModule extends TestModule.ZioTest {

--- a/scripts/test-hooks-install.sh
+++ b/scripts/test-hooks-install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Smoke test for #1050: in a throwaway clone, simulate a fresh worktree and
+# confirm the build.mill auto-install sets core.hooksPath=.githooks.
+#
+# Requires `mill` on PATH. Skip the mill-bound assertion (and only assert the
+# install-hooks.sh path) if mill isn't available, so the script still runs in
+# minimal environments.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-hooks-install: staging copy in $TMP"
+git clone --quiet --no-local "$ROOT" "$TMP/repo" >/dev/null
+# Overlay any uncommitted script changes so the test reflects the working
+# tree, not just the last commit (lets you iterate without committing first).
+for f in install-hooks.sh verify-hooks-configured.sh test-hooks-install.sh; do
+  if [[ -f "$ROOT/scripts/$f" ]]; then
+    cp "$ROOT/scripts/$f" "$TMP/repo/scripts/$f"
+  fi
+done
+cp "$ROOT/build.mill" "$TMP/repo/build.mill"
+cd "$TMP/repo"
+
+# Step 1: hooks should NOT be configured in a fresh clone.
+got="$(git config --get core.hooksPath 2>/dev/null || echo "")"
+if [[ -n "$got" ]]; then
+  echo "test-hooks-install: FAIL — fresh clone already has core.hooksPath=$got" >&2
+  exit 1
+fi
+echo "test-hooks-install: fresh clone has no core.hooksPath (expected)"
+
+# Step 2: the manual installer is the source of truth — confirm it works.
+bash scripts/install-hooks.sh >/dev/null
+got="$(git config --get core.hooksPath)"
+if [[ "$got" != ".githooks" ]]; then
+  echo "test-hooks-install: FAIL — install-hooks.sh did not set core.hooksPath (got '$got')" >&2
+  exit 1
+fi
+echo "test-hooks-install: install-hooks.sh set core.hooksPath=.githooks"
+
+# Step 3: re-running is a no-op (idempotency).
+bash scripts/install-hooks.sh >/dev/null
+got="$(git config --get core.hooksPath)"
+if [[ "$got" != ".githooks" ]]; then
+  echo "test-hooks-install: FAIL — second install left core.hooksPath as '$got'" >&2
+  exit 1
+fi
+echo "test-hooks-install: re-install is idempotent"
+
+# Step 4: the verify script reports OK when configured.
+if ! bash scripts/verify-hooks-configured.sh | grep -q "^verify-hooks: OK"; then
+  echo "test-hooks-install: FAIL — verify-hooks-configured.sh did not report OK" >&2
+  exit 1
+fi
+echo "test-hooks-install: verify-hooks-configured.sh reports OK"
+
+# Step 5: unset and confirm verify warns (informational, doesn't fail).
+git config --unset core.hooksPath
+if ! bash scripts/verify-hooks-configured.sh | grep -q "^verify-hooks: WARNING"; then
+  echo "test-hooks-install: FAIL — verify did not warn when unset" >&2
+  exit 1
+fi
+echo "test-hooks-install: verify-hooks-configured.sh warns when unset"
+
+# Step 6 (optional, only if mill is on PATH): mill evaluation auto-installs.
+if command -v mill >/dev/null 2>&1; then
+  echo "test-hooks-install: invoking mill installHooks to trigger build.mill auto-install"
+  mill installHooks >/dev/null 2>&1 || true
+  got="$(git config --get core.hooksPath 2>/dev/null || echo "")"
+  if [[ "$got" != ".githooks" ]]; then
+    echo "test-hooks-install: FAIL — mill did not auto-install hooks (got '$got')" >&2
+    exit 1
+  fi
+  echo "test-hooks-install: mill auto-install restored core.hooksPath=.githooks"
+else
+  echo "test-hooks-install: mill not on PATH — skipping mill auto-install check"
+fi
+
+echo "test-hooks-install: PASS"

--- a/scripts/verify-hooks-configured.sh
+++ b/scripts/verify-hooks-configured.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Informational check: report whether this checkout has git hooks wired up
+# to .githooks. Used as a CI surface for #1050 — never fails CI; just prints
+# the state so a contributor whose hooks weren't installed sees it in the log.
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$ROOT" ]]; then
+  echo "verify-hooks: not a git checkout — skipping"
+  exit 0
+fi
+cd "$ROOT"
+
+current="$(git config --get core.hooksPath 2>/dev/null || echo "")"
+if [[ "$current" == ".githooks" ]]; then
+  echo "verify-hooks: OK (core.hooksPath=.githooks)"
+  exit 0
+fi
+
+echo "verify-hooks: WARNING — core.hooksPath is '${current:-<unset>}', expected '.githooks'."
+echo "verify-hooks: pre-commit/pre-push gates (scalafmt, tsc, eslint) will NOT fire locally."
+echo "verify-hooks: run 'mill resolve _' or 'scripts/install-hooks.sh' to install."
+exit 0


### PR DESCRIPTION
## Summary
- Wire `ensureHooksInstalled` into every `CommonModule.compile`, so any `mill <mod>.compile` (and anything that transitively compiles — tests, assemblies) re-installs `.githooks` if `core.hooksPath` isn't already pointing there. Idempotent: it runs `git config --get core.hooksPath` first and only shells out to `scripts/install-hooks.sh` when the value differs.
- Add an externally-invokable `mill installHooks` (`Task.Command`) for scripts/CI/manual runs that don't want to drag compile along.
- README: drop the manual `scripts/install-hooks.sh` step from quick-start; describe auto-install under "Git hooks" and move the manual command to a new Troubleshooting subsection.
- CI: add an informational `verify-hooks-configured.sh` step that never fails — it just surfaces in the log when a contributor pushes without hooks installed, ahead of `scalafmt --check`.

## Hook point
- `build.mill:53` — `trait CommonModule.compile` overrides to call `ensureHooksInstalled(mill.api.BuildCtx.workspaceRoot)` before `super.compile()`. Plain side-effecting call (not a Task dependency) so it doesn't perturb mill's cache key.
- `build.mill:30` — `def installHooks() = Task.Command { ... }` for direct invocation.

## Idempotency proof
- `mill installHooks` with `core.hooksPath` already set → reads config, value matches `.githooks`, returns without running the installer. No log spam.
- `mill installHooks` after `git config --unset core.hooksPath` → runs `scripts/install-hooks.sh`, which prints the one-line `Hooks installed (core.hooksPath=.githooks)` and exits 0.
- `scripts/test-hooks-install.sh` exercises both branches end-to-end (fresh clone, second-run no-op, verify-OK, unset-warn, mill auto-install) and passes locally.

## Closes / supersedes
- Closes #755 (auto-install hooks) — this is the structural fix.
- Supersedes #617 (pre-push scalafmt) — `.githooks/pre-push` already runs it; this ensures it's wired up by default.
- Closes #1050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)