### PR TITLE
chore: gitignore openwrt .apk build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ mill.??????
 .e2e-vm-artifacts/
 scripts/e2e/**/__pycache__/
 
-# OpenWRT package build artifact (produced by openwrt/build-ipk.sh and
-# scripts/vm/build-router-image.sh). Repackaged from openwrt/files/ on
-# every build; not source.
+# OpenWRT package build artifacts (produced by openwrt/build-ipk.sh,
+# openwrt/build-apk.sh, and scripts/vm/build-router-image.sh). Repackaged
+# from openwrt/files/ on every build; not source.
 openwrt/wifihaven_*.ipk
+openwrt/wifihaven_*.apk


### PR DESCRIPTION
## Summary
- Add `openwrt/wifihaven_*.apk` next to the existing `.ipk` ignore line, and update the comment to mention `openwrt/build-apk.sh` alongside `build-ipk.sh`.
- After #532 added the apk build path and #685 wired apk into Gate 2, any local run of `openwrt/build-apk.sh` (or `PKG_FORMAT=apk scripts/vm/build-router-image.sh`) leaves `openwrt/wifihaven_0.1.0-1_all.apk` untracked — noise in `git status`, `gh pr create` warnings, and risk of an accidental `git add .` committing the binary.

## Test plan
- [x] `git check-ignore -v openwrt/wifihaven_0.1.0-1_all.apk` → `.gitignore:61:openwrt/wifihaven_*.apk`
- [x] `git status` clean after touching the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)