### PR TITLE
fix(ci): use APK_TOOLS_PREFIX in build-router-image.sh (#1058)

### DIFF
--- a/scripts/vm/build-router-image.sh
+++ b/scripts/vm/build-router-image.sh
@@ -223,9 +223,10 @@ case "$PKG_FORMAT" in
         # not found (try 'apk update')". Read the version straight from
         # the .apk's ADB metadata so this stays consistent if PKG_RELEASE
         # ever bumps.
-        apk_name="$(/home/sameer/.cache/wifihaven-apk-tools/build/src/apk \
+        : "${APK_TOOLS_PREFIX:=$HOME/.cache/wifihaven-apk-tools}"
+        apk_name="$("$APK_TOOLS_PREFIX/build/src/apk" \
             adbdump "$PKG_FILE" 2>/dev/null \
-            | awk '/^  name:/ {n=$2} /^  version:/ {print n"-"$2; exit}')"
+            | awk '/^  name:/ {n=$2} /^  version:/ {print n"-"$2; exit}')" || apk_name=""
         if [ -z "$apk_name" ]; then
             # Fallback: parse from filename (wifihaven_0.1.0-1_all.apk ->
             # wifihaven-0.1.0-r1). Triggers if adbdump fails for any reason.


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/sameer/.cache/wifihaven-apk-tools/build/src/apk` with `$APK_TOOLS_PREFIX` (same convention as `openwrt/build-apk.sh`), defaulting to `$HOME/.cache/wifihaven-apk-tools`.
- Append `|| apk_name=""` so when exec fails (e.g. CI runner where the path doesn't exist), `set -e` + pipefail no longer abort the build before the existing filename-parsing fallback at lines 230-233 can run.

Fixes #1058. Unblocks Gate 2's `.apk` arm.

## Test plan
- [x] Baseline: `PKG_FORMAT=apk scripts/vm/build-router-image.sh` with apk-tools present → builds image successfully (ADB-name path).
- [x] Fallback: move apk binary aside, rerun → builds image successfully (filename-parse path, proving `|| apk_name=""` defuses pipefail).
- [ ] CI: Gate 2 apk arm green on next Master Router CD run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)