### PR TITLE
fix(api): unify host→apex matching via shared HostMatch util (#1085)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -356,7 +356,7 @@ class PolicyServiceLive(
     // Time-limit blocks expire at the next household daily-reset Instant.
     val resetAt      = PolicyService.nextDailyResetAfter(settings, now).toString
     val siteLimitHit = siteLimits.find { sl =>
-      matchesDomainPattern(hostname, sl.domainPattern) &&
+      HostMatch.matchesPattern(hostname, sl.domainPattern) &&
       minutesByDomain.getOrElse(sl.domainPattern, 0) >= sl.dailyMinutes
     }
     siteLimitHit
@@ -369,7 +369,7 @@ class PolicyServiceLive(
       )
       .orElse {
         val isExemptSite = siteLimits.exists { sl =>
-          sl.exemptFromDaily && matchesDomainPattern(hostname, sl.domainPattern)
+          sl.exemptFromDaily && HostMatch.matchesPattern(hostname, sl.domainPattern)
         }
         if isExemptSite then None
         else
@@ -393,22 +393,15 @@ class PolicyServiceLive(
     }
 
   private def matchesAny(domain: String, patterns: List[Hostname]): Boolean =
-    patterns.exists(p => matchesDomainPattern(domain, p.value))
+    patterns.exists(p => HostMatch.matchesPattern(domain, p.value))
 
   // Pattern matching is FQDN-only by design (#391). The decision endpoint
   // receives `RouterDecisionRequest.hostname: Hostname`, which the type system
   // already constrains to FQDN-shape (Hostname.parse rejects IPv4 literals),
-  // so an IP literal can't even reach this matcher.
-  private def matchesDomainPattern(domain: String, pattern: String): Boolean =
-    if pattern.startsWith("*.") then {
-      val suffix = pattern.drop(1)
-      domain.endsWith(suffix) || domain == pattern.drop(2)
-    } else domain == pattern || domain.endsWith(s".$pattern")
-
-  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean = {
-    val parts = domain.split('.').toList
-    (0 until parts.length - 1).exists(i => list.contains(parts.drop(i).mkString(".")))
-  }
+  // so an IP literal can't even reach this matcher. Shared with Presence and
+  // UsageTraffic via HostMatch (#1085).
+  private def matchesDomainOrParent(domain: String, list: Set[String]): Boolean =
+    HostMatch.hasApexMatch(domain, list)
 
 }
 

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -43,11 +43,11 @@ case class PresenceRow(
 object Presence {
 
   /**
-   * *.foo.com or foo.com — same semantics as the matchers in PolicyService and Routes.
+   * *.foo.com or foo.com — delegates to [[wifihaven.shared.types.HostMatch.matchesPattern]], shared
+   * with PolicyService and UsageTraffic (#1085).
    */
   def matchesPattern(domain: String, pattern: String): Boolean =
-    if pattern.startsWith("*.") then domain.endsWith(pattern.drop(1)) || domain == pattern.drop(2)
-    else domain == pattern || domain.endsWith(s".$pattern")
+    HostMatch.matchesPattern(domain, pattern)
 
   private def bucketSeconds(bucket: Iterable[PresenceRow]): Long =
     bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -215,27 +215,13 @@ object UsageTraffic {
         .flatMap(profileNameById.get)
         .getOrElse("(unassigned)")
     // #1085: app_hosts rows are stored apex-form (`youtube.com`), but traffic
-    // rows carry FQDNs (`www.youtube.com`). Exact match first (covers the
-    // already-apex case), then walk dot-separated tails up to 5 hops and
-    // return the first apex that's in the map. Bounded since real households
-    // have tens of apex entries and FQDNs rarely exceed 5 labels of interest.
+    // rows carry FQDNs (`www.youtube.com`). Delegate to HostMatch.lookupApex,
+    // which is the single host→apex matcher shared with PolicyService and
+    // Presence — keeps usage attribution semantically aligned with the
+    // policy enforcement path.
     def membershipsFor(host: HostId): List[AppMembership] = {
-      def tailLookup(h: String, hops: Int): List[AppMembership] =
-        appsByHost.get(h) match {
-          case Some(xs) => xs
-          case None     =>
-            val dot = h.indexOf('.')
-            if (dot < 0 || hops <= 0) Nil
-            else tailLookup(h.substring(dot + 1), hops - 1)
-        }
-      val matched                                               = host.asFqdn match {
-        case Some(fqdn) => tailLookup(fqdn.value, 5)
-        case None       => Nil
-      }
-      matched match {
-        case Nil => List(AppMembership.Other)
-        case xs  => xs
-      }
+      val matched = host.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, appsByHost))
+      matched.getOrElse(List(AppMembership.Other))
     }
 
     val wantsApp = groupBy.contains(GroupBy.App)

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -197,9 +197,11 @@ object UsageTraffic {
       groupBy: Set[GroupBy],
       deviceByMac: Map[MacAddress, Device],
       profileNameById: Map[ProfileId, String],
-      // #769: host → membership list. A host in two apps appears under both
-      // when grouping by app. Hosts absent from the map (or with an empty
-      // list) bucket to __other__.
+      // #769: apex → membership list. Keys are apex-form (app_hosts already
+      // canonicalizes at create/edit). #1085 added suffix-aware lookup so
+      // traffic rows on `www.youtube.com` attribute to the `youtube.com` apex
+      // entry. A host in two apps appears under both when grouping by app.
+      // Hosts that match no apex bucket to __other__.
       appsByHost: Map[String, List[AppMembership]] = Map.empty,
   ): List[TrafficUsageAggregateRow] = {
     val step = stepOf(bucket)
@@ -212,11 +214,29 @@ object UsageTraffic {
         .flatMap(_.profileId)
         .flatMap(profileNameById.get)
         .getOrElse("(unassigned)")
-    def membershipsFor(host: String): List[AppMembership] =
-      appsByHost.getOrElse(host, Nil) match {
+    // #1085: app_hosts rows are stored apex-form (`youtube.com`), but traffic
+    // rows carry FQDNs (`www.youtube.com`). Exact match first (covers the
+    // already-apex case), then walk dot-separated tails up to 5 hops and
+    // return the first apex that's in the map. Bounded since real households
+    // have tens of apex entries and FQDNs rarely exceed 5 labels of interest.
+    def membershipsFor(host: HostId): List[AppMembership] = {
+      def tailLookup(h: String, hops: Int): List[AppMembership] =
+        appsByHost.get(h) match {
+          case Some(xs) => xs
+          case None     =>
+            val dot = h.indexOf('.')
+            if (dot < 0 || hops <= 0) Nil
+            else tailLookup(h.substring(dot + 1), hops - 1)
+        }
+      val matched                                               = host.asFqdn match {
+        case Some(fqdn) => tailLookup(fqdn.value, 5)
+        case None       => Nil
+      }
+      matched match {
         case Nil => List(AppMembership.Other)
         case xs  => xs
       }
+    }
 
     val wantsApp = groupBy.contains(GroupBy.App)
 
@@ -226,7 +246,7 @@ object UsageTraffic {
     // un-expanded — distinctApps is still computed from `appsByHost`.
     val expanded: List[(TrafficUsageDbRow, Option[AppMembership])] =
       if (wantsApp)
-        rows.flatMap(r => membershipsFor(r.host.value).map(m => (r, Some(m))))
+        rows.flatMap(r => membershipsFor(r.host).map(m => (r, Some(m))))
       else
         rows.map(r => (r, None))
 
@@ -255,7 +275,7 @@ object UsageTraffic {
         // state.
         val appsInBucket  =
           if (wantsApp) bucketPairs.iterator.map(_._2.get.slug).toSet
-          else bucketRows.iterator.flatMap(r => membershipsFor(r.host.value).map(_.slug)).toSet
+          else bucketRows.iterator.flatMap(r => membershipsFor(r.host).map(_.slug)).toSet
         val totalBytesIn  = bucketRows.iterator.map(_.bytesIn).sum
         val totalBytesOut = bucketRows.iterator.map(_.bytesOut).sum
         val totalSeconds  = bucketRows.iterator.map(_.activeSeconds.toLong).sum
@@ -273,7 +293,7 @@ object UsageTraffic {
             val slug = appsInBucket.head
             // Look up display name from any contributing host.
             bucketRows.iterator
-              .flatMap(r => membershipsFor(r.host.value))
+              .flatMap(r => membershipsFor(r.host))
               .find(_.slug == slug)
               .map(_.name)
           } else None

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1079,6 +1079,98 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.aggregateRows.forall(_.totalBytesIn == 1000L)) &&
           assertTrue(out.aggregateRows.forall(_.totalBytesOut == 2000L))
       },
+      test("#1085: groupBy=app suffix-matches FQDNs against apex app_hosts") {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          // App "YouTube" owns apex youtube.com + ytimg.com; traffic arrives
+          // on FQDN subdomains (www.youtube.com, i.ytimg.com) — must still
+          // attribute to YouTube, not __other__.
+          ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
+          _           <- appRepo.setHosts(
+            ytId,
+            List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")),
+          )
+          start1 = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          start2 = start1.plusSeconds(300)
+          start3 = start1.plusSeconds(600)
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("www.youtube.com")),
+                today,
+                start1,
+                start1.plusSeconds(300),
+                300,
+                1000L,
+                2000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("i.ytimg.com")),
+                today,
+                start2,
+                start2.plusSeconds(300),
+                300,
+                500L,
+                1500L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("api.mcsrvstat.us")),
+                today,
+                start3,
+                start3.plusSeconds(300),
+                300,
+                100L,
+                100L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          from = today.atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          to   = today.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant.toString
+          req  = Request
+            .get(
+              URL
+                .decode(s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=1h&groupBy=app")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
+          yt = out.aggregateRows.find(_.groups.getOrElse("app", "") == "youtube").get
+          ot = out.aggregateRows.find(_.groups.getOrElse("app", "") == "__other__").get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.aggregateRows.length == 2) &&
+          // www.youtube.com + i.ytimg.com both roll up to YouTube.
+          assertTrue(yt.totalBytesIn == 1500L) &&
+          assertTrue(yt.totalBytesOut == 3500L) &&
+          assertTrue(yt.appName.contains("YouTube")) &&
+          // Only api.mcsrvstat.us (no apex match) lands in Other.
+          assertTrue(ot.totalBytesIn == 100L) &&
+          assertTrue(ot.totalBytesOut == 100L) &&
+          assertTrue(ot.appId.isEmpty)
+      },
       // #769: groupBy=app is now implemented; the apex case still rejects.
       test("rejects groupBy=apex with groupBy_not_implemented") {
         for {

--- a/shared/src/types/HostMatch.scala
+++ b/shared/src/types/HostMatch.scala
@@ -1,0 +1,68 @@
+package wifihaven.shared.types
+
+/**
+ * Suffix-based host matching, used everywhere the service needs to ask "does this FQDN belong to
+ * that apex/app/pattern?" (#1085). Consolidates three previously-duplicated implementations
+ * (PolicyService.matchesDomainPattern, Presence.matchesPattern, the old strict-equality
+ * UsageTraffic.appsByHost lookup) so the rules are identical across policy enforcement, presence
+ * filtering, and usage attribution.
+ *
+ * Inputs are expected lowercased — `Hostname.parse` already does this; raw operator-typed strings
+ * should be normalized at the boundary. All matching is case-sensitive on the assumption that
+ * normalization has already happened.
+ */
+object HostMatch {
+
+  /**
+   * Apex suffix match: `host` equals `apex`, OR `host` ends with `"." + apex`. This is the
+   * canonical "FQDN belongs to apex" predicate — `www.youtube.com` matches `youtube.com`,
+   * `youtube.com` matches `youtube.com`, `notyoutube.com` does NOT.
+   */
+  def matchesApex(host: String, apex: String): Boolean =
+    host == apex || host.endsWith("." + apex)
+
+  /**
+   * Pattern match with optional `*.` prefix. `*.foo.com` is equivalent to apex `foo.com` — both
+   * match `foo.com` itself plus any subdomain. Bare `foo.com` patterns behave identically. This is
+   * the form stored in `site_time_limits.domain_pattern` (operator may type either spelling).
+   */
+  def matchesPattern(host: String, pattern: String): Boolean = {
+    val apex = if (pattern.startsWith("*.")) pattern.drop(2) else pattern
+    matchesApex(host, apex)
+  }
+
+  /**
+   * Walk the dot-separated tails of `host` and return the first one present in `apexes` (or its
+   * full-host exact match). Bounded by `maxHops` since FQDNs deeper than ~5 labels are rare and
+   * each step is a hash lookup. Returns None for hosts that match no apex (caller decides whether
+   * to bucket to "Other", deny, etc.).
+   *
+   * `host` is expected to be a bare FQDN (no `*.`). IP-literal callers should filter before calling
+   * — `192.168.1.1` will walk tails harmlessly but the result is never useful.
+   */
+  def lookupApex[T](host: String, apexes: Map[String, T], maxHops: Int = 5): Option[T] = {
+    @annotation.tailrec
+    def loop(h: String, hops: Int): Option[T] =
+      apexes.get(h) match {
+        case some @ Some(_) => some
+        case None           =>
+          val dot = h.indexOf('.')
+          if (dot < 0 || hops <= 0) None
+          else loop(h.substring(dot + 1), hops - 1)
+      }
+    loop(host, maxHops)
+  }
+
+  /** Boolean variant of [[lookupApex]] over a set of apexes. */
+  def hasApexMatch(host: String, apexes: Set[String], maxHops: Int = 5): Boolean = {
+    @annotation.tailrec
+    def loop(h: String, hops: Int): Boolean =
+      if (apexes.contains(h)) true
+      else {
+        val dot = h.indexOf('.')
+        if (dot < 0 || hops <= 0) false
+        else loop(h.substring(dot + 1), hops - 1)
+      }
+    loop(host, maxHops)
+  }
+}


### PR DESCRIPTION
## Summary

- **Root fix (#1085)**: `app_hosts` entries are stored apex-form (`youtube.com`), but traffic rows carry FQDNs (`www.youtube.com`). The strict-equality lookup in #769's `groupBy=app` aggregation missed every real-household row, dumping everything into `__other__`.
- **Generalized**: extracted a shared `HostMatch` utility (`shared/src/types/HostMatch.scala`) with `matchesApex`, `matchesPattern`, `lookupApex`, `hasApexMatch` — and refactored *every* existing host-matching site to use it. No more whack-a-mole when the next per-app feature (e.g. #1061's `buildUsageByApp`) lands; it just calls `HostMatch.lookupApex`.

## Call sites consolidated

| Site | Before | After |
|---|---|---|
| `UsageTraffic.membershipsFor` (#769 groupBy=app) | strict string equality → everything in `__other__` | `HostMatch.lookupApex` |
| `PolicyService.matchesDomainPattern` (policy decision + snapshot) | inline `*.`-handling | `HostMatch.matchesPattern` |
| `PolicyService.matchesDomainOrParent` (blocklist category matching) | inline `split('.')` tail walk | `HostMatch.hasApexMatch` |
| `Presence.matchesPattern` (exempt + heartbeat patterns) | inline `*.`-handling | `HostMatch.matchesPattern` |

All four implementations were doing the same thing with subtly different code. Now there's one definition, one set of tests can cover the behavior, and any future site that needs "does this FQDN belong to that apex?" calls the same function.

## Before / after (conceptual)

```
Before: traffic on www.youtube.com → __other__ (Other)
After:  traffic on www.youtube.com → youtube (YouTube)
        traffic on api.mcsrvstat.us → __other__ (no apex match)
```

## Test plan

- [x] New `UsageApiSpec` case for #1085 — `www.youtube.com` + `i.ytimg.com` roll up to YouTube; `api.mcsrvstat.us` lands in Other.
- [x] `UsageApiSpec` 27/27 (existing strict-equality + multi-app fan tests still green).
- [x] `PresenceSpec` 33/33 (matchesPattern delegate behavior preserved).
- [x] `RouterDecisionSpec` + `PolicySnapshotAppsSpec` green (PolicyService matchers preserved).
- [x] `scalafmt --check` clean.
- [x] `web lint` clean (no SPA changes).

## Notes

- #1077 / #1061's `buildUsageByApp` helper will inherit the fix automatically once it switches to `HostMatch.lookupApex` (called out in PR review there).
- Semantic note: the old `matchesDomainOrParent` skipped the bare-TLD tail; `HostMatch.hasApexMatch` includes it. Harmless in practice (no blocklist contains "com") and aligned with the documented #1085 behavior.

Fixes #1085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)