### PR TITLE
feat(ci): publish qemu router images on every OpenWRT release (#893)

### DIFF
--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -157,6 +157,65 @@ jobs:
           path: openwrt/wifihaven_*.apk
           if-no-files-found: error
 
+      # Qemu VM image build (#893) — produces the bootable router images that
+      # downstream Gate 3b (#655) fetches by stable URL to test API/UI changes
+      # against the last-published router. Gated on publish_release so PR /
+      # main-push validation runs don't pay the ~2× IB cost; this is only the
+      # release pipeline's concern. Reuses the .ipk/.apk built above via
+      # IPK_PATH/APK_PATH so we don't recompile the wifihaven package.
+      - name: Build qemu VM image (ipk / OpenWRT 23.05)
+        if: inputs.publish_release == true
+        env:
+          PKG_FORMAT: ipk
+          IPK_SOURCE: path
+        run: |
+          set -euo pipefail
+          IPK_PATH="$(ls "$PWD"/openwrt/wifihaven_*.ipk | head -n1)"
+          export IPK_PATH
+          chmod +x scripts/vm/build-router-image.sh
+          scripts/vm/build-router-image.sh
+
+      - name: Build qemu VM image (apk / OpenWRT 25.12)
+        if: inputs.publish_release == true
+        env:
+          PKG_FORMAT: apk
+          APK_SOURCE: path
+        run: |
+          set -euo pipefail
+          APK_PATH="$(ls "$PWD"/openwrt/wifihaven_*.apk | head -n1)"
+          export APK_PATH
+          scripts/vm/build-router-image.sh
+
+      # Package each VM image as a release tarball. Contents: the bootable
+      # ext4-combined .img only — scripts/vm/router-up.sh (lib.sh:ensure_openwrt_image)
+      # consumes a single raw .img and creates its own qcow2 overlay, so no
+      # kernel/initrd sidecars are needed. Asset filenames are version-derived
+      # from versions.sh so a future OPENWRT_VERSION_{IPK,APK} bump renames the
+      # asset cleanly; the .sha256 file lets downstream verify the fetch.
+      - name: Package qemu VM images as release tarballs
+        if: inputs.publish_release == true
+        run: |
+          set -euo pipefail
+          # Resolve the major.minor for each flavor (matches build-router-image.sh's
+          # OUTPUT_IMG path).
+          ipk_short="$(PKG_FORMAT=ipk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
+          apk_short="$(PKG_FORMAT=apk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
+          ipk_img="scripts/vm/.cache/openwrt-wifihaven-ipk-${ipk_short}.img"
+          apk_img="scripts/vm/.cache/openwrt-wifihaven-apk-${apk_short}.img"
+          [ -f "$ipk_img" ] || { echo "missing $ipk_img" >&2; exit 1; }
+          [ -f "$apk_img" ] || { echo "missing $apk_img" >&2; exit 1; }
+          mkdir -p release
+          ipk_tar="release/wifihaven-router-openwrt-${ipk_short}-ipk.tar.gz"
+          apk_tar="release/wifihaven-router-openwrt-${apk_short}-apk.tar.gz"
+          tar -czf "$ipk_tar" -C "$(dirname "$ipk_img")" "$(basename "$ipk_img")"
+          tar -czf "$apk_tar" -C "$(dirname "$apk_img")" "$(basename "$apk_img")"
+          ( cd release && sha256sum \
+              "$(basename "$ipk_tar")" \
+              "$(basename "$apk_tar")" \
+              > wifihaven-router-images.sha256 )
+          echo "--- release assets ---"
+          ls -lh release/
+
       # Rolling pre-release. Post-#498 this is the ONLY release path — fires
       # only when the caller passes publish_release=true (Master Router
       # CD's publish-openwrt job, after the manual-approval gate). Direct
@@ -178,3 +237,6 @@ jobs:
             openwrt/wifihaven_*.apk
             openwrt/luci/luci-app-wifihaven_*.ipk
             openwrt/luci/luci-app-wifihaven_*.apk
+            release/wifihaven-router-openwrt-*-ipk.tar.gz
+            release/wifihaven-router-openwrt-*-apk.tar.gz
+            release/wifihaven-router-images.sha256


### PR DESCRIPTION
Closes #893.

## Summary
- Adds two qemu router VM tarballs (.ipk-23.05 and .apk-25.12 flavors)
  plus a sha256 manifest to every published `openwrt-latest` release,
  unblocking #655 Gate 3b which needs to fetch the last-published
  router image by stable URL.
- Inline in `openwrt-build.yml`, gated on `inputs.publish_release`
  so PR / main-push validation runs don't pay the cost.
- Reuses already-built .ipk/.apk via `IPK_SOURCE=path` / `APK_SOURCE=path`
  (no double-compile of the wifihaven package).
- Asset filenames are derived from `versions.sh`'s `OPENWRT_VERSION_SHORT`
  so a future flavor bump renames cleanly.

## Validation

**Local:** built both flavors via `scripts/vm/build-router-image.sh`,
tarred each, extracted to a scratch dir, booted the extracted `.img`
via `scripts/vm/router-up.sh`, SSH'd in:
- ipk: `opkg list-installed | grep wifihaven` → `wifihaven - 0.1.0-1`
- apk: `apk list --installed | grep wifihaven` → `wifihaven-0.1.0-r1 noarch [installed]`
- both: agent process running, UCI defaults baked in.

**CI end-to-end:** dispatched openwrt-build.yml against a throwaway tag
via temporary `workflow_dispatch` scaffolding (not in this diff,
reverted before PR).
Run: https://github.com/wifihaven/wifihaven/actions/runs/26476803055 — all green.
The throwaway `openwrt-test-893` release/tag has been cleaned up; the
following was observed before cleanup:
- 12 MB ipk tarball, 14 MB apk tarball, 216 B sha256 manifest uploaded
- `gh release download` + `sha256sum -c` + `tar -tzf` all passed
- Each tarball contained exactly the one `.img` file as designed

## Timing delta on the publish path (GHA `ubuntu-latest`)
- Build qemu ipk: ~1:41
- Build qemu apk: ~1:59
- Package + checksum: ~3s
- Publish (gh release upload): ~4s
- **Total added: ~3:47** on top of the existing ~30s package upload
  step. Only fires on the publish_release path (master-router.yml →
  publish-openwrt), not on PRs or main pushes.

## Notes / out of scope
- The first post-merge release becomes the bootstrap seed for #655
  Gate 3b — there is no pre-seeded image shipping in this PR.
- Gate 2 (#654) is intentionally not switched over to consume the
  published artifacts (issue calls that an optional follow-up).

## Test plan
- [x] Build both qemu images locally (#532 PKG_FORMAT knob)
- [x] Tarball + extract roundtrip (sha256 match)
- [x] Boot extracted .img: wifihaven installed + agent running (both flavors)
- [x] CI dispatch uploads assets to a real release tag
- [x] `gh release download` + `sha256sum -c` from the release URL
- [ ] First post-merge master-router.yml run uploads tarballs to `openwrt-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)