### PR TITLE
ci: enable merge queue on main (#1094)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     # Run on PRs targeting any branch
+  merge_group:
+    # Run on gh-readonly-queue/* refs so the merge queue gates on the same
+    # check PRs do (#1094).
   workflow_call:
     # Invoked by master-api-ui.yml and master-router.yml on push to main so
     # the CD pipelines gate publish on the same test matrix PRs run. Direct


### PR DESCRIPTION
## Summary
- Add `merge_group:` trigger to `.github/workflows/ci.yml` (the only workflow whose check — `CI` — is required on `main`).
- Enable merge queue on `main` via the "Main Protection" ruleset: squash, build concurrency 2, min 1 / max 5, 5 min wait, ALLGREEN, 60 min timeout.
- Flip `required_status_checks.strict` to `false` on classic branch protection — the queue now enforces up-to-date.

Other workflows (`e2e-*`, `keep-warm`, `master-*`, `openwrt-build`, `router-image-build`) aren't required on `main`, so they're left alone.

## Test plan
- [ ] `CI` check runs on this PR via `pull_request`.
- [ ] After clicking "Merge when ready", `CI` runs on the `gh-readonly-queue/main/...` ref via `merge_group`.
- [ ] PR squash-merges via the queue.

Closes #1094.