### PR TITLE
fix(ci): force ASCII commit message for Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -259,7 +259,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: '4'
           workingDirectory: web
-          command: pages deploy --branch=main
+          command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"
 
   # ── 5. Smoke-test staging ─────────────────────────────────────────────────
   # Fast (<2 min) end-user-facing checks against the deployed staging URL.
@@ -487,4 +487,4 @@ jobs:
           # default `wrangler.toml` in web/ already targets the prod project.
           wranglerVersion: '4'
           workingDirectory: web
-          command: pages deploy --branch=main
+          command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -259,6 +259,10 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: '4'
           workingDirectory: web
+          # Pass an explicit ASCII commit message + hash. Without these
+          # wrangler auto-detects the git commit message, and the
+          # Cloudflare Pages deployments API rejects multi-byte UTF-8
+          # (e.g. `§`) with code 8000111 despite advertising UTF-8.
           command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"
 
   # ── 5. Smoke-test staging ─────────────────────────────────────────────────
@@ -487,4 +491,5 @@ jobs:
           # default `wrangler.toml` in web/ already targets the prod project.
           wranglerVersion: '4'
           workingDirectory: web
+          # See staging step for why --commit-message is forced ASCII.
           command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"


### PR DESCRIPTION
## Summary
- Cloudflare Pages' deployments API rejects multi-byte UTF-8 commit messages with code 8000111, even when the bytes are well-formed UTF-8. `wrangler-action` auto-detects the git commit message, so any commit with non-ASCII chars (e.g. `§`) breaks the deploy.
- Saw this on commit `fca69378` in run [26478981395](https://github.com/wifihaven/wifihaven/actions/runs/26478981395).
- Pass `--commit-message=<sha>` + `--commit-hash=<sha>` explicitly so wrangler skips auto-detection. Applied to both staging and prod deploy steps.

## Test plan
- [ ] Merge → next push to `main` triggers `Master API/UI CD`; staging SPA deploy step succeeds and `staging.wifihaven.net` reflects the new build.
- [ ] Prod SPA deploy (after manual approval) also succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)