### PR TITLE
fix(hooks): scope pre-push scalafmt to api/ + shared/

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,11 +11,20 @@ cd "$ROOT"
 fail=0
 
 # ── Scala: scalafmt check across the whole repo ───────────────────────────
+# Pass explicit source roots so the recursive walk doesn't descend into
+# sibling git worktrees under .claude/worktrees/ — an unformatted file
+# in another branch's worktree must not block this push.
 if command -v scalafmt >/dev/null 2>&1; then
-  echo "pre-push: scalafmt --check (all .scala)"
-  if ! scalafmt --check --non-interactive; then
-    echo "pre-push: scalafmt failed. Run: scalafmt" >&2
-    fail=1
+  scala_roots=()
+  for d in api shared mill-build .mill-build; do
+    [[ -d "$d" ]] && scala_roots+=("$d")
+  done
+  if (( ${#scala_roots[@]} > 0 )); then
+    echo "pre-push: scalafmt --check (${scala_roots[*]})"
+    if ! scalafmt --check --non-interactive "${scala_roots[@]}"; then
+      echo "pre-push: scalafmt failed. Run: scalafmt ${scala_roots[*]}" >&2
+      fail=1
+    fi
   fi
 else
   echo "pre-push: scalafmt not on PATH — skipping" >&2


### PR DESCRIPTION
## Summary
- `scalafmt --check` with no path args recurses from the repo root, walking into sibling `.claude/worktrees/<branch>/` checkouts. An unformatted file in any concurrent worktree blocks unrelated pushes.
- Pass explicit source roots (`api/`, `shared/`, optional `mill-build/`) so the walk stays inside the current branch's tree.
- Hit while pushing [#1100](https://github.com/wifihaven/wifihaven/pull/1100) — a sibling worktree's half-formatted Scala file failed the push for a one-line workflow change.

## Test plan
- [ ] In a repo with multiple worktrees containing unformatted Scala, `git push` from the main checkout no longer trips on sibling files.
- [ ] `scalafmt --check api shared` still catches real formatting issues in the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)