### PR TITLE
refactor: consolidate time-status into single TimeStatusService used by snapshot + UI (#1104)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -116,6 +116,7 @@ object Main extends ZIOAppDefault {
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.jwt)) >+>
       Clock.live >+>
       AuthService.layer >+>
+      TimeStatusService.layer >+>
       PolicyService.layer >+>
       TimeStatusCache.live() >+>
       BlocklistCache.live >+>
@@ -150,6 +151,7 @@ object Main extends ZIOAppDefault {
       appRepo     <- ZIO.service[AppRepo]
       notifier    <- ZIO.service[Notifier]
       policy      <- ZIO.service[PolicyService]
+      timeStatus  <- ZIO.service[wifihaven.api.policy.TimeStatusService]
       cfg         <- ZIO.service[AppConfig]
       clock       <- ZIO.service[Clock]
       timeCache   <- ZIO.service[TimeStatusCache]
@@ -171,6 +173,7 @@ object Main extends ZIOAppDefault {
         profileRepo,
         upRepo,
         hsRepo,
+        timeStatus,
         clock,
         timeCache,
       ) ++

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -16,28 +16,54 @@ trait PolicyService {
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse]
 }
 
-/**
- * Inputs needed to evaluate a single profile's effective BlockRules. Pulled from the per-profile
- * repos by `snapshot` and fed into the pure `computeBlockRules` function below.
- */
-private[policy] case class ProfileInputs(
-    profile: Profile,
-    schedules: List[DbSchedule],
-    dailyMinutes: Option[Int],
-    siteLimits: List[SiteTimeLimit],
-    /**
-     * total active minutes today summed across all devices in the profile, excluding minutes spent
-     * on exempt site-limited domains.
-     */
-    totalMinutesUsed: Int,
-    /** active minutes per site-limit domain, summed across all devices in the profile. */
-    minutesByDomain: Map[String, Int],
-    extensionsMinutes: Int,
-    // #763: hosts contributed by apps assigned to this profile (allowed / blocked modes).
-    // time_limited apps are folded into `siteLimits` above as one synthesized row per host.
-    appExtraAllowed: List[Hostname] = Nil,
-    appExtraBlocked: List[Hostname] = Nil,
-)
+object PolicyServiceLive {
+
+  /**
+   * #1104: test-friendly factory that wires a default `TimeStatusServiceLive` over the same repos.
+   * Lets the existing PolicySnapshot* specs and Router* specs continue passing the old positional
+   * args; production wiring still goes through `PolicyService.layer`, which injects an explicit
+   * `TimeStatusService` (so a per-deployment instance can be swapped in).
+   */
+  def apply(
+      profileRepo: ProfileRepo,
+      scheduleRepo: ScheduleRepo,
+      householdSettingsRepo: HouseholdSettingsRepo,
+      timeLimitRepo: TimeLimitRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      deviceRepo: DeviceRepo,
+      blocklistRepo: BlocklistRepo,
+      trafficRepo: TrafficReportRepo,
+      extRepo: TimeExtensionRepo,
+      appRepo: AppRepo,
+      clock: Clock,
+      uiAllowedHosts: List[Hostname] = Nil,
+  ): PolicyServiceLive = {
+    val tss = new TimeStatusServiceLive(
+      profileRepo,
+      scheduleRepo,
+      timeLimitRepo,
+      siteTimeLimitRepo,
+      deviceRepo,
+      trafficRepo,
+      extRepo,
+    )
+    new PolicyServiceLive(
+      profileRepo,
+      scheduleRepo,
+      householdSettingsRepo,
+      timeLimitRepo,
+      siteTimeLimitRepo,
+      deviceRepo,
+      blocklistRepo,
+      trafficRepo,
+      extRepo,
+      appRepo,
+      tss,
+      clock,
+      uiAllowedHosts,
+    )
+  }
+}
 
 class PolicyServiceLive(
     profileRepo: ProfileRepo,
@@ -50,6 +76,7 @@ class PolicyServiceLive(
     trafficRepo: TrafficReportRepo,
     extRepo: TimeExtensionRepo,
     appRepo: AppRepo,
+    timeStatusService: TimeStatusService,
     clock: Clock,
     uiAllowedHosts: List[Hostname] = Nil,
 ) extends PolicyService {
@@ -59,14 +86,13 @@ class PolicyServiceLive(
       settings <- householdSettingsRepo.get
       now      <- clock.instant
       today = PolicyService.householdLocalDate(now, settings)
-      profiles <- profileRepo.listAll
-      devices  <- deviceRepo.listAll
-      scheds   <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
-      tlims    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
-      stlims   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
-      presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-      exts     <- extRepo.snapshotAllByProfile(today)
-      cats     <- blocklistRepo.listCategories
+      // #1104: today's cap/block state for every profile in one batched read. Same call the
+      // /api/time/status/... endpoints use — keeps the snapshot and the UI in lockstep.
+      dayStates <- timeStatusService.dayStateAll(now, today, settings)
+      profiles  <- profileRepo.listAll
+      devices   <- deviceRepo.listAll
+      stlims    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      cats      <- blocklistRepo.listCategories
       catDomains  <- ZIO.foreach(cats)(c => blocklistRepo.loadCategory(c).map(c -> _))
       // #763: load apps + per-app hosts + per-profile assignments so we can
       // expand app modes into the per-profile BlockRules buckets below.
@@ -77,15 +103,9 @@ class PolicyServiceLive(
       )
       appHostsMap = appHostsRaw.toMap
       appAssignsMap = appAssigns.toMap
-      schedMap      = scheds.toMap
-      tlMap         = tlims.toMap
       stlMap        = stlims.toMap
     } yield {
-      val devsByProfile =
-        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
-
       val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
-        val pSched    = schedMap.getOrElse(p.id, Nil)
         val pSiteLims = stlMap.getOrElse(p.id, Nil)
 
         // #763/#764: expand this profile's app assignments into wire-shape
@@ -108,40 +128,19 @@ class PolicyServiceLive(
           .flatten
           .distinct
 
-        val devicesIn  = devsByProfile.getOrElse(p.id, Nil)
-        val deviceMacs = devicesIn.map(_.mac).toSet
-        val pPresence  = presence.filter(r => deviceMacs.contains(r.mac))
-        val patterns   = pSiteLims.map(_.domainPattern)
-        val perPat     = Presence.patternMinutesByMac(pPresence, patterns)
-        val byDomain   = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
-          val mins = devicesIn.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
-          if mins == 0 then acc else acc.updated(pat, mins)
-        }
-        val exemptPats = pSiteLims.filter(_.exemptFromDaily).map(_.domainPattern)
-        val perMacTot  = Presence.totalMinutesByMac(pPresence, exemptPats, settings.heartbeatFilter)
-        // #751: cap-enforcement reads the same Sum/Dedup branch as the
-        // /api/time/status surface so the policy snapshot agrees with what
-        // the screen-time UI shows.
-        val totalMins  = p.crossDeviceOverlapMode match {
-          case CrossDeviceOverlapMode.Sum   =>
-            devicesIn.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
-          case CrossDeviceOverlapMode.Dedup =>
-            Presence.dedupedTotalMinutes(pPresence, exemptPats, settings.heartbeatFilter)
-        }
-        val extMins    = exts.getOrElse(p.id, 0)
-
-        val inputs = ProfileInputs(
+        // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
+        val state = dayStates.getOrElse(
+          p.id,
+          ProfileDayState(p.id, today, None, 0, 0, None, blocked = false, None, Nil),
+        )
+        val rules = PolicyService.computeBlockRules(
           profile = p,
-          schedules = pSched,
-          dailyMinutes = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
+          state = state,
           siteLimits = pSiteLims,
-          totalMinutesUsed = totalMins,
-          minutesByDomain = byDomain,
-          extensionsMinutes = extMins,
           appExtraAllowed = appAllowedHosts,
           appExtraBlocked = appBlockedHosts,
+          uiAllowedHosts = uiAllowedHosts,
         )
-        val rules  = PolicyService.computeBlockRules(inputs, now, uiAllowedHosts)
 
         p.id -> ProfilePolicy(name = p.name, rules = rules, failureMode = p.failureMode)
       }.toMap
@@ -415,7 +414,7 @@ object PolicyService {
   val layer: ZLayer[
     AppConfig & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo &
       SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo &
-      AppRepo & Clock,
+      AppRepo & TimeStatusService & Clock,
     Nothing,
     PolicyService,
   ] = ZLayer.fromFunction {
@@ -431,9 +430,10 @@ object PolicyService {
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
         ar: AppRepo,
+        tss: TimeStatusService,
         clk: Clock,
     ) =>
-      PolicyServiceLive(
+      new PolicyServiceLive(
         pr,
         sr,
         hsr,
@@ -444,6 +444,7 @@ object PolicyService {
         trr,
         er,
         ar,
+        tss,
         clk,
         cfg.policy.uiAllowedHostsParsed,
       )
@@ -488,39 +489,31 @@ object PolicyService {
   }
 
   /**
-   * #354: pure function that collapses a profile's raw inputs into the effective BlockRules served
-   * in the snapshot. Precedence for `blockReason` when multiple block conditions hold: Paused >
-   * Schedule > TimeLimit.
+   * #354 / #1104: collapse a profile's `ProfileDayState` plus its app & site-limit context into the
+   * effective `BlockRules` served in the snapshot. `state` carries the canonical `blocked` and
+   * `blockReason` already evaluated by `TimeStatusService.fold` (same precedence Paused > Schedule
+   * > TimeLimit). This function only adds the app/site-limit/UI-host wiring around it.
    */
   private[policy] def computeBlockRules(
-      in: ProfileInputs,
-      now: Instant,
+      profile: Profile,
+      state: ProfileDayState,
+      siteLimits: List[SiteTimeLimit],
+      appExtraAllowed: List[Hostname] = Nil,
+      appExtraBlocked: List[Hostname] = Nil,
       uiAllowedHosts: List[Hostname] = Nil,
   ): BlockRules = {
-    val p = in.profile
-
     // Per-site limits exhausted today → host appears in extraBlocked too.
     // domainPattern is a glob string, not a Hostname — we keep it as-is in the
     // extraBlocked list so the router agent can match it. We do NOT wrap with
     // Hostname here because glob patterns like *.youtube.com are not hostnames.
     // Instead, we pass them as raw strings and convert via Hostname.unsafe for
     // the typed list (the router treats these as patterns, so validation is relaxed).
-    val siteLimitExtraBlocked: List[Hostname] = in.siteLimits.collect {
-      case sl if in.minutesByDomain.getOrElse(sl.domainPattern, 0) >= sl.dailyMinutes =>
+    val siteUsedByPattern: Map[String, Int]   =
+      state.perSite.iterator.map(s => s.domainPattern -> s.usedMinutes).toMap
+    val siteLimitExtraBlocked: List[Hostname] = siteLimits.collect {
+      case sl if siteUsedByPattern.getOrElse(sl.domainPattern, 0) >= sl.dailyMinutes =>
         Hostname.unsafe(sl.domainPattern)
     }
-
-    val (blocked, reason) =
-      if p.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
-      else if in.schedules.exists(s => scheduleActiveAt(s, now)) then
-        (true, Some(MacBlockReason.Schedule: MacBlockReason))
-      else
-        in.dailyMinutes match {
-          case Some(limit) if in.totalMinutesUsed >= limit + in.extensionsMinutes =>
-            (true, Some(MacBlockReason.TimeLimit: MacBlockReason))
-          case _                                                                  =>
-            (false, None)
-        }
 
     // #763: app expansion is additive. A host in both an allowed-mode app and
     // a blocked-mode app will appear in both lists; the router's
@@ -528,18 +521,18 @@ object PolicyService {
     // semantics it already applies to the per-profile own lists (see
     // feedback_extraallowed_beats_blocked).
     BlockRules(
-      blocked = blocked,
-      blockReason = reason,
-      extraBlocked = (in.appExtraBlocked ++ siteLimitExtraBlocked).distinct,
+      blocked = state.blocked,
+      blockReason = state.blockReason,
+      extraBlocked = (appExtraBlocked ++ siteLimitExtraBlocked).distinct,
       // #944: union the deployment's UI hosts into per-profile extraAllowed so
       // a household device can always reach the admin UI even when this
       // profile is paused or lists one of these hosts in a blocked-mode app
       // (allow beats block at the router). Configured via wifihaven.policy
       // .uiAllowedHosts per-deployment so prod doesn't allow staging through
       // and vice versa. Will become DB-backed per #937.
-      extraAllowed = (in.appExtraAllowed ++ uiAllowedHosts).distinct,
-      blocklistIds = p.blockedCategories,
-      blockIpOnly = p.blockIpOnly,
+      extraAllowed = (appExtraAllowed ++ uiAllowedHosts).distinct,
+      blocklistIds = profile.blockedCategories,
+      blockIpOnly = profile.blockIpOnly,
     )
   }
 

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -1,0 +1,272 @@
+package wifihaven.api.policy
+
+import wifihaven.api.db.*
+import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.shared.{Schedule as DbSchedule, *}
+import wifihaven.shared.types.*
+import zio.{Clock as _, *}
+
+import java.time.{Instant, LocalDate}
+
+/**
+ * Canonical per-profile cap/block state for a single household-local date. Returned by
+ * [[TimeStatusService.todaysState]] / [[TimeStatusService.dayState]] and consumed by both the
+ * policy snapshot ([[PolicyService.snapshot]]) and the seven `/api/time/status/...` endpoints.
+ * Having one function emit this means the snapshot's `blocked` / `blockReason` cannot drift from
+ * the UI's `usedMinutes` / `extensionMinutes` — they read the same fields off the same case class
+ * (#1104).
+ */
+final case class ProfileDayState(
+    profileId: ProfileId,
+    date: LocalDate,
+    dailyLimitMinutes: Option[Int],
+    usedMinutes: Int,
+    extensionMinutes: Int,
+    remainingMinutes: Option[Int],
+    blocked: Boolean,
+    blockReason: Option[MacBlockReason],
+    perSite: List[SiteDayState],
+)
+
+/**
+ * Per-site (site_time_limits) usage breakdown for a profile-day. `usedMinutes` is the
+ * bucket-counted active minutes against this site's domain pattern, summed across the profile's
+ * devices, computed the same way regardless of whether the consumer is the snapshot (deciding which
+ * sites land in extraBlocked) or a route (rendering the per-site bars in the UI).
+ */
+final case class SiteDayState(
+    label: String,
+    domainPattern: String,
+    dailyLimitMinutes: Int,
+    usedMinutes: Int,
+    exemptFromDaily: Boolean,
+)
+
+trait TimeStatusService {
+
+  /**
+   * The canonical per-profile day state for the household-local date containing `now`. Returns
+   * `None` if no such profile exists. Use this on the snapshot/grant/ingestion side and for
+   * `/api/time/status/...` reads against today.
+   */
+  def todaysState(
+      now: Instant,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]]
+
+  /**
+   * Same as [[todaysState]] but for an explicit date. Used by the `?date=` query-param override on
+   * the seven `/api/time/status/...` endpoints so the UI can scroll back to a historical day; the
+   * date is treated as the canonical bucket date (no tz reprojection — `time_usage` /
+   * `traffic_reports` are already bucketed under household-local dates).
+   *
+   * `now` is still needed so the schedule/paused arm of the block evaluation has a wall-clock
+   * instant to test windows against. For historical dates the schedule arm will generally not be
+   * active (today's wall clock is not in yesterday's schedule window), but pinning `now` here keeps
+   * the function total.
+   */
+  def dayState(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]]
+
+  /**
+   * Batched form for [[PolicyService.snapshot]] and the `/api/time/status/summary` route. Emits one
+   * `ProfileDayState` per profile for `date`, in a single batched presence + extensions read across
+   * all profiles' devices. `now` is still threaded through so the schedule-active evaluation has a
+   * wall-clock instant; when `date` is in the past, the schedule arm naturally won't match.
+   */
+  def dayStateAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, ProfileDayState]]
+}
+
+class TimeStatusServiceLive(
+    profileRepo: ProfileRepo,
+    scheduleRepo: ScheduleRepo,
+    timeLimitRepo: TimeLimitRepo,
+    siteTimeLimitRepo: SiteTimeLimitRepo,
+    deviceRepo: DeviceRepo,
+    trafficRepo: TrafficReportRepo,
+    extRepo: TimeExtensionRepo,
+) extends TimeStatusService {
+
+  def todaysState(
+      now: Instant,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]] =
+    dayState(now, PolicyService.householdLocalDate(now, settings), settings, profileId)
+
+  def dayState(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]] =
+    profileRepo.findById(profileId).flatMap {
+      case None    => ZIO.succeed(None)
+      case Some(p) =>
+        for {
+          schedules <- scheduleRepo.listForProfile(profileId)
+          tl        <- timeLimitRepo.findForProfile(profileId)
+          stls      <- siteTimeLimitRepo.listForProfile(profileId)
+          devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
+          presence  <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
+          extMins   <- extRepo.getProfileTotalExtension(profileId, date)
+        } yield Some(
+          TimeStatusService.fold(
+            profile = p,
+            schedules = schedules,
+            devices = devices,
+            dailyLimit = tl.map(_.dailyMinutes),
+            siteLimits = stls,
+            presence = presence,
+            extensionMinutes = extMins,
+            date = date,
+            now = now,
+            settings = settings,
+          ),
+        )
+    }
+
+  def dayStateAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, ProfileDayState]] =
+    for {
+      profiles <- profileRepo.listAll
+      devices  <- deviceRepo.listAll
+      schedsP  <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      tlsP     <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
+      stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      presence <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
+      exts     <- extRepo.snapshotAllByProfile(date)
+    } yield {
+      val schedMap = schedsP.toMap
+      val tlMap    = tlsP.toMap
+      val stlMap   = stlsP.toMap
+      val devsByP  =
+        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+      profiles.iterator.map { p =>
+        val devs    = devsByP.getOrElse(p.id, Nil)
+        val macSet  = devs.map(_.mac).toSet
+        val pPres   = presence.filter(r => macSet.contains(r.mac))
+        val extMins = exts.getOrElse(p.id, 0)
+        p.id -> TimeStatusService.fold(
+          profile = p,
+          schedules = schedMap.getOrElse(p.id, Nil),
+          devices = devs,
+          dailyLimit = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
+          siteLimits = stlMap.getOrElse(p.id, Nil),
+          presence = pPres,
+          extensionMinutes = extMins,
+          date = date,
+          now = now,
+          settings = settings,
+        )
+      }.toMap
+    }
+}
+
+object TimeStatusService {
+
+  val layer: ZLayer[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      TrafficReportRepo & TimeExtensionRepo,
+    Nothing,
+    TimeStatusService,
+  ] = ZLayer.fromFunction {
+    (
+        pr: ProfileRepo,
+        sr: ScheduleRepo,
+        tlr: TimeLimitRepo,
+        stlr: SiteTimeLimitRepo,
+        dr: DeviceRepo,
+        trr: TrafficReportRepo,
+        er: TimeExtensionRepo,
+    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+  }
+
+  /**
+   * Pure folder: collapse the per-profile inputs into the canonical day state. Same math the
+   * snapshot and the routes used to do independently — the consolidation contract (#1104) is that
+   * every consumer reads through this function.
+   *
+   * Block precedence (mirrors `PolicyService.computeBlockRules`): `Paused` > `Schedule` >
+   * `TimeLimit`.
+   */
+  def fold(
+      profile: Profile,
+      schedules: List[DbSchedule],
+      devices: List[Device],
+      dailyLimit: Option[Int],
+      siteLimits: List[SiteTimeLimit],
+      presence: List[PresenceRow],
+      extensionMinutes: Int,
+      date: LocalDate,
+      now: Instant,
+      settings: HouseholdSettings,
+  ): ProfileDayState = {
+    val patterns   = siteLimits.map(_.domainPattern)
+    val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
+    val perPat     = Presence.patternMinutesByMac(presence, patterns)
+    val perMacTot  = Presence.totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
+
+    // #751: cap-enforcement honours the profile's overlap mode (Sum vs Dedup) — the same branch the
+    // routes used to apply independently.
+    val totalMinutesUsed = profile.crossDeviceOverlapMode match {
+      case CrossDeviceOverlapMode.Sum   =>
+        devices.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+      case CrossDeviceOverlapMode.Dedup =>
+        Presence.dedupedTotalMinutes(presence, exemptPats, settings.heartbeatFilter)
+    }
+
+    val byDomain: Map[String, Int] = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
+      val mins = devices.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
+      if mins == 0 then acc else acc.updated(pat, mins)
+    }
+
+    val (blocked, reason) =
+      if profile.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
+      else if schedules.exists(s => PolicyService.scheduleActiveAt(s, now)) then
+        (true, Some(MacBlockReason.Schedule: MacBlockReason))
+      else
+        dailyLimit match {
+          case Some(limit) if totalMinutesUsed >= limit + extensionMinutes =>
+            (true, Some(MacBlockReason.TimeLimit: MacBlockReason))
+          case _                                                           =>
+            (false, None)
+        }
+
+    val remaining = dailyLimit.map(l => (l + extensionMinutes - totalMinutesUsed).max(0))
+
+    val perSite = siteLimits.map { sl =>
+      SiteDayState(
+        label = sl.label,
+        domainPattern = sl.domainPattern,
+        dailyLimitMinutes = sl.dailyMinutes,
+        usedMinutes = byDomain.getOrElse(sl.domainPattern, 0),
+        exemptFromDaily = sl.exemptFromDaily,
+      )
+    }
+
+    ProfileDayState(
+      profileId = profile.id,
+      date = date,
+      dailyLimitMinutes = dailyLimit,
+      usedMinutes = totalMinutesUsed,
+      extensionMinutes = extensionMinutes,
+      remainingMinutes = remaining,
+      blocked = blocked,
+      blockReason = reason,
+      perSite = perSite,
+    )
+  }
+}

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -477,6 +477,7 @@ object TimeRoutes {
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
       hsRepo: HouseholdSettingsRepo,
+      timeStatusService: wifihaven.api.policy.TimeStatusService,
       clock: Clock,
       cache: TimeStatusCache = TimeStatusCache.makeUnsafe(),
   ): Routes[Any, Response] =
@@ -487,62 +488,31 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status" / "summary"                ->
         handler { (req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: default to household-local "today", not UTC `clock.today`.
+            today   = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            allProfiles   <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            allDevices    <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            allLimits     <- timeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            allSiteLimits <- siteTimeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            extsByPid     <- extRepo
-              .snapshotAllByProfile(date)
+            allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            states      <- timeStatusService
+              .dayStateAll(now, date, settings)
               .mapError(ErrorMapper.dbErrorToResponse)
-            settings      <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
-            visible       <- visibleProfiles(claims, allProfiles, userProfileRepo)
-            devicesByPid = allDevices.groupBy(_.profileId)
-            allMacs      = visible.iterator
-              .flatMap(p => devicesByPid.getOrElse(Some(p.id), Nil))
-              .map(_.mac)
-              .toList
-              .distinct
-            presence <- (if allMacs.isEmpty then ZIO.succeed(Nil)
-                         else trafficRepo.listPresenceRows(allMacs, date))
-              .mapError(ErrorMapper.dbErrorToResponse)
-            limitByPid  = allLimits.iterator.map(l => l.profileId -> l.dailyMinutes).toMap
-            exemptByPid = allSiteLimits.iterator
-              .filter(_.exemptFromDaily)
-              .toList
-              .groupBy(_.profileId)
-              .view
-              .mapValues(_.map(_.domainPattern))
-              .toMap
-            summaries   = visible.map { p =>
-              val devices   = devicesByPid.getOrElse(Some(p.id), Nil)
-              val macSet    = devices.map(_.mac).toSet
-              val pRows     = presence.filter(r => macSet.contains(r.mac))
-              val exempts   = exemptByPid.getOrElse(p.id, Nil)
-              val perMac    = wifihaven.api.presence.Presence
-                .totalMinutesByMac(pRows, exempts, settings.heartbeatFilter)
-              // #751: honor the profile's overlap mode.
-              val used      = p.crossDeviceOverlapMode match {
-                case CrossDeviceOverlapMode.Sum   =>
-                  devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
-                case CrossDeviceOverlapMode.Dedup =>
-                  wifihaven.api.presence.Presence
-                    .dedupedTotalMinutes(pRows, exempts, settings.heartbeatFilter)
-              }
-              val limit     = limitByPid.get(p.id)
-              val extMins   = extsByPid.getOrElse(p.id, 0)
-              val remaining = limit.map(l => (l + extMins - used).max(0))
+            summaries = visible.map { p =>
+              val st = states.getOrElse(
+                p.id,
+                wifihaven.api.policy.ProfileDayState(p.id, date, None, 0, 0, None, false, None, Nil),
+              )
               ProfileTimeSummary(
                 p.id,
                 p.name,
-                date.toString,
-                limit,
-                used,
-                extMins,
-                remaining,
+                st.date.toString,
+                st.dailyLimitMinutes,
+                st.usedMinutes,
+                st.extensionMinutes,
+                st.remainingMinutes,
               )
             }
           } yield Response
@@ -554,15 +524,17 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status" / "summary" / "week"       ->
         handler { (req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: anchor on household-local today, not UTC today.
+            today = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             toStr = req.url.queryParam("to").getOrElse(today.toString)
             to    = LocalDate.parse(toStr)
             from  = to.minusDays(6)
             allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             allLimits   <- timeLimitRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            settings    <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visible     <- visibleProfiles(claims, allProfiles, userProfileRepo)
             devicesByPid = allDevices.groupBy(_.profileId)
             allMacs      = visible.iterator
@@ -604,8 +576,11 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status"                            ->
         handler { (req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: household-local today, not UTC.
+            today   = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
             // #795: ?profileId=N narrows the rollup to a single profile so the
@@ -615,7 +590,6 @@ object TimeRoutes {
             profileIdOpt <- parseProfileIdParam(req)
             allProfiles  <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             allDevices   <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            settings     <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visible      <- visibleProfiles(claims, allProfiles, userProfileRepo)
             scoped       = profileIdOpt match {
               case Some(pid) => visible.filter(_.id == pid)
@@ -633,11 +607,10 @@ object TimeRoutes {
                       p,
                       devicesByPid.getOrElse(Some(p.id), Nil),
                       date,
-                      timeLimitRepo,
-                      siteTimeLimitRepo,
+                      now,
+                      settings,
+                      timeStatusService,
                       trafficRepo,
-                      extRepo,
-                      settings.heartbeatFilter,
                     )
                   }
               }
@@ -650,9 +623,12 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status" / "week"                   ->
         handler { (req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
-            // ?to=YYYY-MM-DD anchors the trailing 7-day window; defaults to today (UTC).
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: household-local today (was UTC).
+            today = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
+            // ?to=YYYY-MM-DD anchors the trailing 7-day window; defaults to today (household-local).
             // ?bucketOffsetMin=N sets the minute-past-the-hour where the hourly grid starts,
             // so each bucket falls fully within one local day on the caller's side (#794).
             // Accepts 0/15/30/45; defaults to 0 (whole-hour grid, fine for UTC-aligned zones).
@@ -664,7 +640,6 @@ object TimeRoutes {
             profileIdOpt    <- parseProfileIdParam(req)
             allProfiles     <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             allDevices      <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-            settings        <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visible         <- visibleProfiles(claims, allProfiles, userProfileRepo)
             scoped       = profileIdOpt match {
               case Some(pid) => visible.filter(_.id == pid)
@@ -700,8 +675,11 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status" / string("mac") / "week"   ->
         handler { (mac: String, req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: household-local today.
+            today = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             toStr = req.url.queryParam("to").getOrElse(today.toString)
             to    = LocalDate.parse(toStr)
             from  = to.minusDays(6)
@@ -711,7 +689,6 @@ object TimeRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
             _               <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
-            settings        <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             status          <- buildDeviceTimeStatusWeek(
               device,
               from,
@@ -728,25 +705,26 @@ object TimeRoutes {
       Method.GET / "api" / "time" / "status" / string("mac")            ->
         handler { (mac: String, req: Request) =>
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: household-local today.
+            today   = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            device   <- deviceRepo
+            device <- deviceRepo
               .findByMac(MacAddress.unsafe(normalizeMac(mac)))
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _        <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
-            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
-            status   <- buildDeviceTimeStatus(
+            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            status <- buildDeviceTimeStatus(
               device,
               date,
+              now,
+              settings,
               profileRepo,
-              timeLimitRepo,
-              siteTimeLimitRepo,
+              timeStatusService,
               trafficRepo,
-              extRepo,
-              settings.heartbeatFilter,
             )
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(status.toJson)
@@ -760,17 +738,19 @@ object TimeRoutes {
           // tune `heartbeat_bytes_threshold` against this surface before flipping
           // `heartbeat_filter_enabled` on.
           for {
-            claims <- requireAuth(req, auth)
-            today  <- clock.today
+            claims   <- requireAuth(req, auth)
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            now      <- clock.instant
+            // #1104: household-local today.
+            today   = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date    = LocalDate.parse(dateStr)
-            device   <- deviceRepo
+            device <- deviceRepo
               .findByMac(MacAddress.unsafe(normalizeMac(mac)))
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
-            _        <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
-            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
-            rows     <- trafficRepo
+            _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+            rows   <- trafficRepo
               .listPresenceRows(List(device.mac), date)
               .mapError(ErrorMapper.dbErrorToResponse)
             classified = wifihaven.api.presence.Presence
@@ -857,49 +837,40 @@ object TimeRoutes {
         .unit
     }
 
+  /**
+   * #1104: builds the daily per-profile wire shape. Cap/extension/remaining/per-site numbers come
+   * from the canonical `TimeStatusService.dayState` so they cannot drift from the policy snapshot's
+   * `blocked`/`blockReason`. Per-device summaries and the top-10 host attribution are still
+   * computed from the day's presence rows here (snapshot doesn't need them).
+   */
   private def buildProfileTimeStatus(
       profile: Profile,
       devices: List[Device],
       date: LocalDate,
-      tlRepo: TimeLimitRepo,
-      stlRepo: SiteTimeLimitRepo,
+      now: java.time.Instant,
+      settings: HouseholdSettings,
+      timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
-      extRepo: TimeExtensionRepo,
-      heartbeatFilter: HeartbeatFilter,
   ): Task[ProfileTimeStatus] = {
     val macs = devices.map(_.mac)
     for {
-      tl       <- tlRepo.findForProfile(profile.id)
-      stls     <- stlRepo.listForProfile(profile.id)
+      stateOpt <- timeStatusService.dayState(now, date, settings, profile.id)
+      state = stateOpt.getOrElse(
+        wifihaven.api.policy.ProfileDayState(profile.id, date, None, 0, 0, None, false, None, Nil),
+      )
       presence <- trafficRepo.listPresenceRows(macs, date)
-      extMins  <- extRepo.getProfileTotalExtension(profile.id, date)
-      // Only exempt site domains are excluded from the daily total.
-      // Included sites (exemptFromDaily=false) count against the daily cap.
-      exemptPats      = stls.filter(_.exemptFromDaily).map(_.domainPattern)
-      perMacTotal     = wifihaven.api.presence.Presence
-        .totalMinutesByMac(presence, exemptPats, heartbeatFilter)
-      perMacPat       = wifihaven.api.presence.Presence
-        .patternMinutesByMac(presence, stls.map(_.domainPattern))
-      // #751: in Dedup mode the profile total unions per-device active buckets
-      // (one bucket → one minute, regardless of how many of this profile's
-      // devices were active in it). In Sum mode we keep the historical
-      // behaviour: per-device totals added.
-      totalUsed       = profile.crossDeviceOverlapMode match {
-        case CrossDeviceOverlapMode.Sum   =>
-          devices.iterator.map(d => perMacTotal.getOrElse(d.mac, 0)).sum
-        case CrossDeviceOverlapMode.Dedup =>
-          wifihaven.api.presence.Presence
-            .dedupedTotalMinutes(presence, exemptPats, heartbeatFilter)
+      perMacTotal     = {
+        val exemptPats = state.perSite.filter(_.exemptFromDaily).map(_.domainPattern)
+        wifihaven.api.presence.Presence
+          .totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
       }
-      remaining       = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
-      siteUsage       = stls.map { stl =>
-        val used = devices.iterator.map(d => perMacPat.getOrElse((d.mac, stl.domainPattern), 0)).sum
+      siteUsage       = state.perSite.map { s =>
         SiteUsage(
-          stl.label,
-          stl.domainPattern,
-          stl.dailyMinutes,
-          used,
-          (stl.dailyMinutes - used).max(0),
+          s.label,
+          s.domainPattern,
+          s.dailyLimitMinutes,
+          s.usedMinutes,
+          (s.dailyLimitMinutes - s.usedMinutes).max(0),
         )
       }
       deviceSummaries = devices.map { d =>
@@ -923,11 +894,11 @@ object TimeRoutes {
     } yield ProfileTimeStatus(
       profile.id,
       profile.name,
-      date.toString,
-      tl.map(_.dailyMinutes),
-      totalUsed,
-      extMins,
-      remaining,
+      state.date.toString,
+      state.dailyLimitMinutes,
+      state.usedMinutes,
+      state.extensionMinutes,
+      state.remainingMinutes,
       siteUsage,
       deviceSummaries,
       hostUsage,
@@ -1114,42 +1085,47 @@ object TimeRoutes {
       .sortBy(_.bucketStart)
   }
 
+  /**
+   * #1104: per-device daily wire shape. Cap (`dailyLimitMins`/`extensionMins`/`remainingMins`)
+   * comes from the profile-level `ProfileDayState` so the per-device view matches the per-profile
+   * view and the snapshot. Per-device active minutes and per-site bars still need this device's
+   * presence rows, but the daily cap fields read from `state`.
+   */
   private def buildDeviceTimeStatus(
       device: Device,
       date: LocalDate,
+      now: java.time.Instant,
+      settings: HouseholdSettings,
       profileRepo: ProfileRepo,
-      tlRepo: TimeLimitRepo,
-      stlRepo: SiteTimeLimitRepo,
+      timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
-      extRepo: TimeExtensionRepo,
-      heartbeatFilter: HeartbeatFilter,
   ): Task[DeviceTimeStatus] = {
     val pid = device.profileId
     for {
-      tl       <- pid.fold(ZIO.succeed(Option.empty[TimeLimit]))(tlRepo.findForProfile)
-      stls     <- pid.fold(ZIO.succeed(List.empty[SiteTimeLimit]))(stlRepo.listForProfile)
+      stateOpt <- pid.fold(ZIO.succeed(Option.empty[wifihaven.api.policy.ProfileDayState]))(p =>
+        timeStatusService.dayState(now, date, settings, p),
+      )
       presence <- trafficRepo.listPresenceRows(List(device.mac), date)
-      extMins  <- pid.fold(ZIO.succeed(0))(extRepo.getProfileTotalExtension(_, date))
       profile  <- pid.fold(ZIO.succeed("No profile"))(p =>
         profileRepo.findById(p).map(_.map(_.name).getOrElse("Unknown")),
       )
-      // Only exempt site domains are excluded from the daily total.
-      // Included sites (exemptFromDaily=false) count against the daily cap.
-      exemptPats = stls.filter(_.exemptFromDaily).map(_.domainPattern)
+      exemptPats = stateOpt.toList.flatMap(_.perSite.filter(_.exemptFromDaily).map(_.domainPattern))
       totalUsed  = wifihaven.api.presence.Presence
-        .totalMinutesByMac(presence, exemptPats, heartbeatFilter)
+        .totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
         .getOrElse(device.mac, 0)
       perPat     = wifihaven.api.presence.Presence
-        .patternMinutesByMac(presence, stls.map(_.domainPattern))
-      remaining  = tl.map(l => (l.dailyMinutes + extMins - totalUsed).max(0))
-      siteUsage  = stls.map { stl =>
-        val used = perPat.getOrElse((device.mac, stl.domainPattern), 0)
+        .patternMinutesByMac(
+          presence,
+          stateOpt.toList.flatMap(_.perSite.map(_.domainPattern)),
+        )
+      siteUsage  = stateOpt.toList.flatMap(_.perSite).map { s =>
+        val used = perPat.getOrElse((device.mac, s.domainPattern), 0)
         SiteUsage(
-          stl.label,
-          stl.domainPattern,
-          stl.dailyMinutes,
+          s.label,
+          s.domainPattern,
+          s.dailyLimitMinutes,
           used,
-          (stl.dailyMinutes - used).max(0),
+          (s.dailyLimitMinutes - used).max(0),
         )
       }
     } yield DeviceTimeStatus(
@@ -1158,10 +1134,10 @@ object TimeRoutes {
       date.toString,
       profile,
       pid,
-      tl.map(_.dailyMinutes),
+      stateOpt.flatMap(_.dailyLimitMinutes),
       totalUsed,
-      extMins,
-      remaining,
+      stateOpt.map(_.extensionMinutes).getOrElse(0),
+      stateOpt.flatMap(_.remainingMinutes),
       siteUsage,
     )
   }

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -43,7 +43,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       ar     <- ZIO.service[AppRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -55,7 +55,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       er,
       ar,
       clk,
-    )): PolicyService
+    ): PolicyService
 
   private def callBlocked(
       routes: Routes[Any, Response],

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -36,7 +36,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
       clock  <- ZIO.service[Clock]
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -48,7 +48,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       er,
       ar,
       clock,
-    )): PolicyService
+    ): PolicyService
 
   private def kidsId: ZIO[ProfileRepo, Throwable, ProfileId] =
     ZIO.serviceWithZIO[ProfileRepo](_.listAll.map(_.find(_.name == "Kids").get.id))

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -55,7 +55,7 @@ object PolicySnapshotBlockedMacsSpec
       ar     <- ZIO.service[AppRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -67,7 +67,7 @@ object PolicySnapshotBlockedMacsSpec
       er,
       ar,
       clk,
-    )): PolicyService
+    ): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", Sha256Hex.unsafe("o" * 64)))

--- a/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
+++ b/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
@@ -1,0 +1,243 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+
+/**
+ * #1104: structural lock between the snapshot's per-profile `BlockRules` and the per-profile/per-
+ * device `/api/time/status` shapes. For a fixture spanning Sum + Dedup overlap modes, multiple
+ * household timezones, cap-exhausted and not-exhausted states, with and without an extension grant
+ * — assert the three equalities the issue demands:
+ *
+ *   - `snapshot.profiles(pid).rules.blocked == todaysState(pid).blocked`
+ *   - `snapshot.profiles(pid).rules.blockReason == todaysState(pid).blockReason`
+ *   - `usedMinutes_per_profile(pid)` matches between snapshot's inputs and `todaysState`
+ *
+ * The first two are direct equalities; the third is enforced by structure (snapshot consumes the
+ * same `dayStateAll` output the UI route does). The contract is: future code changes that touch
+ * either side without going through `TimeStatusService` will break this spec.
+ */
+object PolicySnapshotConsolidationSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def settingsTz(hsr: HouseholdSettingsRepo, tz: String): Task[HouseholdSettings] =
+    for {
+      cur <- hsr.get
+      upd = cur.copy(dailyResetTz = java.time.ZoneId.of(tz), dailyResetTime = LocalTime.of(0, 0))
+      _ <- hsr.update(upd)
+    } yield upd
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-cons", Sha256Hex.unsafe("c" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  /** Build the policy service over the in-test repos, with a fixed `now`. */
+  private def buildPs(now: LocalDateTime): ZIO[
+    AllReposLite,
+    Nothing,
+    PolicyService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      hsr  <- ZIO.service[HouseholdSettingsRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      blr  <- ZIO.service[BlocklistRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ar   <- ZIO.service[AppRepo]
+      ref  <- Ref.make(now)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trr, er, ar, clk)
+
+  private def buildTss: ZIO[AllReposLite, Nothing, TimeStatusService] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+
+  private type AllReposLite =
+    ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo & SiteTimeLimitRepo &
+      DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo & AppRepo
+
+  /** One fixture row → the spec runs the equalities against every row. */
+  private final case class Fixture(
+      label: String,
+      tz: String,
+      // (mac → minutes-of-presence) for that profile's devices today
+      load: List[(String, Int)],
+      overlap: CrossDeviceOverlapMode,
+      dailyCap: Option[Int],
+      extension: Option[Int],
+      now: LocalDateTime,
+      // expected `blocked` and `reason` so a regression here is loud
+      expectBlocked: Boolean,
+      expectReason: Option[MacBlockReason],
+  )
+
+  private val today  = LocalDate.of(2025, 1, 6)           // a Monday
+  private val midDay = Clock.TestClock.schoolDayAfternoon // Mon 14:00 UTC
+
+  private val fixtures: List[Fixture] = List(
+    Fixture(
+      "under-cap, no extension, UTC, Sum",
+      "UTC",
+      List(("aa:bb:cc:00:00:01", 20)),
+      CrossDeviceOverlapMode.Sum,
+      Some(60),
+      None,
+      midDay,
+      expectBlocked = false,
+      expectReason = None,
+    ),
+    Fixture(
+      "exactly-at-cap, blocked=true, UTC, Sum",
+      "UTC",
+      List(("aa:bb:cc:00:00:02", 60)),
+      CrossDeviceOverlapMode.Sum,
+      Some(60),
+      None,
+      midDay,
+      expectBlocked = true,
+      expectReason = Some(MacBlockReason.TimeLimit),
+    ),
+    Fixture(
+      "extension restores headroom, UTC, Sum",
+      "UTC",
+      List(("aa:bb:cc:00:00:03", 60)),
+      CrossDeviceOverlapMode.Sum,
+      Some(60),
+      Some(15),
+      midDay,
+      expectBlocked = false,
+      expectReason = None,
+    ),
+    Fixture(
+      "Dedup: overlapping devices count once → under cap",
+      "UTC",
+      List(("aa:bb:cc:00:00:04", 30), ("aa:bb:cc:00:00:05", 30)),
+      CrossDeviceOverlapMode.Dedup,
+      Some(60),
+      None,
+      midDay,
+      expectBlocked = false,
+      expectReason = None,
+    ),
+    Fixture(
+      "Sum: overlapping devices double-count → blocked",
+      "UTC",
+      List(("aa:bb:cc:00:00:06", 30), ("aa:bb:cc:00:00:07", 30)),
+      CrossDeviceOverlapMode.Sum,
+      Some(60),
+      None,
+      midDay,
+      expectBlocked = true,
+      expectReason = Some(MacBlockReason.TimeLimit),
+    ),
+    Fixture(
+      "America/Denver, late-evening UTC → still today's MDT day",
+      "America/Denver",
+      List(("aa:bb:cc:00:00:08", 60)),
+      CrossDeviceOverlapMode.Sum,
+      Some(60),
+      None,
+      LocalDateTime.of(2025, 1, 6, 23, 30, 0),
+      expectBlocked = true,
+      expectReason = Some(MacBlockReason.TimeLimit),
+    ),
+  )
+
+  private def runFixture(f: Fixture) =
+    test(f.label) {
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        er   <- ZIO.service[TimeExtensionRepo]
+        s    <- settingsTz(hsr, f.tz)
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        prof <- pr.findById(kid).map(_.get)
+        // Set overlap mode + paused=false (default)
+        _    <- pr.update(prof.copy(crossDeviceOverlapMode = f.overlap))
+        // Replace seeded "bedtime" schedule with empty so it doesn't interfere with our cap-only assertions
+        _    <- sr.replaceForProfile(kid, Nil)
+        _    <- ZIO.foreachDiscard(f.load.zipWithIndex) { case ((mac, _), i) =>
+          TestLayers.seedDevice(dr, mac, s"d$i", kid)
+        }
+        _    <- f.dailyCap.fold(ZIO.unit)(c => tlr.upsert(kid, c))
+        _ <- f.extension.fold(ZIO.unit)(m => er.grantForProfile(kid, today, m, "admin", None).unit)
+        rid  <- seedRouterRow
+        _    <- ZIO.foreachDiscard(f.load) { case (mac, mins) =>
+          seedTraffic(rid, mac, "cnn.com", today, mins)
+        }
+        ps   <- buildPs(f.now)
+        tss  <- buildTss
+        snap <- ps.snapshot
+        now = f.now.toInstant(ZoneOffset.UTC)
+        stOpt <- tss.todaysState(now, s, kid)
+        state = stOpt.get
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        // The three consolidation equalities — these are the structural lock.
+        rules.blocked == state.blocked,
+        rules.blockReason == state.blockReason,
+        // Expectations as a secondary check that the test fixture itself didn't drift.
+        state.blocked == f.expectBlocked,
+        state.blockReason == f.expectReason,
+      )
+    }
+
+  def spec = suite("PolicySnapshotConsolidationSpec (#1104)")(
+    fixtures.map(runFixture)*,
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -48,7 +48,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
       clock  <- ZIO.service[Clock]
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -60,7 +60,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       er,
       ar,
       clock,
-    )): PolicyService
+    ): PolicyService
 
   /**
    * Seed `minutes/5` non-overlapping 5-min traffic_reports buckets, starting `bucketOffset` past

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -39,7 +39,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       ar     <- ZIO.service[AppRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -51,7 +51,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       er,
       ar,
       clk,
-    )): PolicyService
+    ): PolicyService
 
   private def makePsDefault = makePsAt(TestClock.schoolDayAfternoon)
 

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -75,7 +75,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
       clock  <- ZIO.service[Clock]
-    } yield (new PolicyServiceLive(
+    } yield PolicyServiceLive(
       pr,
       sr,
       hsr,
@@ -87,7 +87,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       er,
       ar,
       clock,
-    )): PolicyService
+    ): PolicyService
 
   private def post(
       routes: Routes[Any, Response],

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -108,6 +108,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -118,6 +127,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -154,6 +164,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -164,6 +183,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -207,6 +227,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -217,6 +246,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -264,6 +294,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -274,6 +313,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -313,6 +353,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss     = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes  = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -323,6 +372,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           extBody = GrantExtensionRequest(kidsId, 30, Some("Homework finished early")).toJson
@@ -359,6 +409,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -369,6 +428,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           body   = GrantExtensionRequest(kidsId, 15, Some("Good behavior")).toJson
@@ -403,6 +463,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -413,6 +482,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           body   = GrantExtensionRequest(kidsId, 30, None).toJson
@@ -440,6 +510,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -450,6 +529,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           grant  = (mins: Int) =>
@@ -494,6 +574,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -504,6 +593,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -556,6 +646,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -566,6 +665,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -612,6 +712,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -622,6 +731,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -668,6 +778,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -678,6 +797,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -722,6 +842,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -732,6 +861,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -775,6 +905,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -785,6 +924,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -832,6 +972,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -842,6 +991,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -919,6 +1069,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -929,6 +1088,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -980,6 +1140,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -990,6 +1159,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1036,6 +1206,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1046,6 +1225,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1173,6 +1353,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1183,6 +1372,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1251,6 +1441,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1261,6 +1460,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -1308,6 +1508,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1318,6 +1527,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -1363,6 +1573,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1373,6 +1592,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1436,6 +1656,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1446,6 +1675,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -1492,6 +1722,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1502,6 +1741,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1542,6 +1782,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1552,6 +1801,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           // Default window (anchor=today): outside-range traffic must NOT appear.
@@ -1607,6 +1857,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _ <- seedTraffic(routerId, testMac, "late.example", today, 5, bucketOffset = 66)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
+          tss        = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes     = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1617,6 +1876,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           expected0  = today.atStartOfDay(java.time.ZoneOffset.UTC).toInstant.plusSeconds(5 * 3600)
@@ -1653,6 +1913,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
           stlRepo         <- ZIO.service[SiteTimeLimitRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
@@ -1663,6 +1924,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           token           <- auth.login("admin", "changeme").map(_.token.value)
           userProfileRepo <- ZIO.service[UserProfileRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1673,6 +1943,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           resp <- routes.runZIO(
@@ -1714,6 +1985,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1724,6 +2004,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request
@@ -1753,6 +2034,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         for {
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
+          schedRepo       <- ZIO.service[ScheduleRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
           stlRepo         <- ZIO.service[SiteTimeLimitRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
@@ -1763,6 +2045,15 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           userProfileRepo <- ZIO.service[UserProfileRepo]
           hsRepo          <- ZIO.service[HouseholdSettingsRepo]
           clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
           routes = TimeRoutes.routes(
             auth,
             deviceRepo,
@@ -1773,6 +2064,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             userProfileRepo,
             hsRepo,
+            tss,
             clock,
           )
           req    = Request

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -92,9 +92,19 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       trafficRepo <- ZIO.service[TrafficReportRepo]
       extRepo     <- ZIO.service[TimeExtensionRepo]
       profileRepo <- ZIO.service[ProfileRepo]
+      schedRepo   <- ZIO.service[ScheduleRepo]
       upRepo      <- ZIO.service[UserProfileRepo]
       hsRepo      <- ZIO.service[HouseholdSettingsRepo]
       clock       <- ZIO.service[Clock]
+      tss = new wifihaven.api.policy.TimeStatusServiceLive(
+        profileRepo,
+        schedRepo,
+        tlRepo,
+        stlRepo,
+        deviceRepo,
+        trafficRepo,
+        extRepo,
+      )
     } yield TimeRoutes.routes(
       auth,
       deviceRepo,
@@ -105,6 +115,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       profileRepo,
       upRepo,
       hsRepo,
+      tss,
       clock,
       cache,
     )

--- a/api/test/src/feature/TimeStatusServiceSpec.scala
+++ b/api/test/src/feature/TimeStatusServiceSpec.scala
@@ -1,0 +1,257 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+
+/**
+ * #1104: canonical test surface for `TimeStatusService`. Every other consumer of cap/block state
+ * (snapshot, the 7 `/api/time/status/...` endpoints) asserts agreement with the outputs measured
+ * here.
+ */
+object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def makeService: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      TrafficReportRepo & TimeExtensionRepo,
+    Nothing,
+    TimeStatusService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-tss", Sha256Hex.unsafe("t" * 64)))
+
+  /** Seed `minutes` consecutive 5-minute buckets starting at midnight UTC on `date`. */
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def settingsWithTz(
+      hsr: HouseholdSettingsRepo,
+      tz: String,
+      resetAt: LocalTime = LocalTime.of(0, 0),
+  ): Task[HouseholdSettings] =
+    for {
+      cur <- hsr.get
+      upd = cur.copy(
+        dailyResetTz = java.time.ZoneId.of(tz),
+        dailyResetTime = resetAt,
+      )
+      _ <- hsr.update(upd)
+    } yield upd
+
+  def spec = suite("TimeStatusService (#1104)")(
+    test("west of UTC: 22:46Z under America/Denver buckets to 2026-05-26") {
+      // The exact repro from the bug: late evening UTC, household tz MDT (UTC-6).
+      // householdLocalDate must say 2026-05-26 even though UTC is already that wall-clock day,
+      // and the snapshot for 'today' uses the same date.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        s   <- settingsWithTz(hsr, "America/Denver")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:01", "kid-ipad", kid)
+        svc <- makeService
+        now = LocalDateTime.of(2026, 5, 26, 22, 46, 0).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(
+        stOpt.exists(_.date == LocalDate.of(2026, 5, 26)),
+      )
+    },
+    test("east of UTC: 13:00Z under Asia/Tokyo buckets to 2026-05-26") {
+      // Catches lazy single-direction fixes that special-case west-of-UTC.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        s   <- settingsWithTz(hsr, "Asia/Tokyo")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        svc <- makeService
+        now = LocalDateTime.of(2026, 5, 26, 13, 0, 0).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(stOpt.exists(_.date == LocalDate.of(2026, 5, 26)))
+    },
+    test("after UTC midnight but before MDT midnight, today is still the prior MDT day") {
+      // The actual prod incident: 00:30 UTC = 18:30 MDT the day before.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        s   <- settingsWithTz(hsr, "America/Denver")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        svc <- makeService
+        now = LocalDateTime.of(2026, 5, 27, 0, 30, 0).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(stOpt.exists(_.date == LocalDate.of(2026, 5, 26)))
+    },
+    test(
+      "DST spring-forward: 2025-03-09 08:00Z under America/Denver buckets to local 02:00=2025-03-09",
+    ) {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        s   <- settingsWithTz(hsr, "America/Denver")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        svc <- makeService
+        now = LocalDateTime.of(2025, 3, 9, 8, 0, 0).toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(stOpt.exists(_.date == LocalDate.of(2025, 3, 9)))
+    },
+    test("cap exhausted exactly at minute N → blocked=true with reason=TimeLimit") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 30)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:02", "kid-ipad", kid)
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:02", "cnn.com", LocalDate.of(2025, 1, 6), 30)
+        svc <- makeService
+        // 14:00 Monday — well after exhausting; no schedule conflict at this hour either
+        now = Clock.TestClock.schoolDayAfternoon.toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(
+        stOpt.exists(st => st.blocked && st.blockReason.contains(MacBlockReason.TimeLimit)),
+      ) && assertTrue(stOpt.exists(_.usedMinutes >= 30))
+    },
+    test("extension grant lifts cap-exhausted block") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        er  <- ZIO.service[TimeExtensionRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 30)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:03", "kid-ipad", kid)
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:03", "cnn.com", LocalDate.of(2025, 1, 6), 30)
+        _   <- er.grantForProfile(kid, LocalDate.of(2025, 1, 6), 15, "admin", None)
+        svc <- makeService
+        now = Clock.TestClock.schoolDayAfternoon.toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(stOpt.exists(st => !st.blocked)) &&
+        assertTrue(stOpt.exists(_.extensionMinutes == 15)) &&
+        assertTrue(stOpt.exists(_.remainingMinutes.contains(15)))
+    },
+    test("Sum vs Dedup overlap modes produce different usedMinutes for overlapping buckets") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:04", "ipadA", kid)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:05", "ipadB", kid)
+        rid <- seedRouterRow
+        // Both devices active in the SAME 30 minutes
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:04", "cnn.com", LocalDate.of(2025, 1, 6), 30)
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:05", "cnn.com", LocalDate.of(2025, 1, 6), 30)
+        svc <- makeService
+        now = Clock.TestClock.schoolDayAfternoon.toInstant(ZoneOffset.UTC)
+        // Default seedKidsProfile creates profile with overlap=Sum (verify shape)
+        sumState   <- svc.todaysState(now, s, kid)
+        profile    <- pr.findById(kid).map(_.get)
+        _          <- pr.update(profile.copy(crossDeviceOverlapMode = CrossDeviceOverlapMode.Dedup))
+        dedupState <- svc.todaysState(now, s, kid)
+      } yield assertTrue(sumState.exists(_.usedMinutes == 60)) &&
+        assertTrue(dedupState.exists(_.usedMinutes == 30))
+    },
+    test("per-site limit exempt from daily subtracts from total used") {
+      // #1105 regression guard: a fully-exempt site limit means its buckets never count
+      // toward the headline `usedMinutes`. Add a regular and an exempt site limit; only
+      // the regular site's mins should land in usedMinutes.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:06", "kid-ipad", kid)
+        _   <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          "khan.org",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(60),
+          exemptFromDaily = true,
+        )
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:06", "khan.org", LocalDate.of(2025, 1, 6), 25)
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:06", "cnn.com", LocalDate.of(2025, 1, 6), 10)
+        svc <- makeService
+        now = Clock.TestClock.schoolDayAfternoon.toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(stOpt.exists(_.usedMinutes == 10)) &&
+        assertTrue(
+          stOpt.exists(_.perSite.exists(p => p.domainPattern == "khan.org" && p.exemptFromDaily)),
+        )
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary

Extracts `TimeStatusService.{todaysState, dayState, dayStateAll}` returning a canonical `ProfileDayState`. Both `PolicyService.snapshot` and the seven `/api/time/status/*` endpoints now funnel through it, so the snapshot's `blocked`/`blockReason` and the UI's `usedMinutes`/`extensionMinutes`/`remainingMinutes` are derived from the same function. Wire shapes are byte-identical (no compat shims; atomic SPA+API deploy).

## Bug repro (now fixed)

Pre-fix: `/api/time/status/*` used `clock.today` (UTC), while the snapshot/grant/ingestion paths used `PolicyService.householdLocalDate`. West of UTC, between UTC midnight and local midnight, the UI showed the next day's empty stats while the snapshot kept enforcing the current day's exhausted cap (see the prod 2026-05-26 incident in the issue body).

## What changed

- **New file** `api/src/policy/TimeStatusService.scala` — `ProfileDayState`, `SiteDayState`, `TimeStatusService` trait + `TimeStatusServiceLive` impl + `fold` pure helper that implements the canonical day-state math.
- **`api/src/policy/PolicyService.scala`** — `snapshot` no longer re-aggregates `traffic_reports`/extensions for cap math; it calls `timeStatusService.dayStateAll(now, today, settings)` and `computeBlockRules` consumes `ProfileDayState.{blocked, blockReason}` directly. `ProfileInputs` is deleted.
- **`api/src/routes/Routes.scala`** — all seven `/api/time/status/*` endpoints replace `clock.today` with `householdLocalDate(now, settings)` and pull cap fields (`usedMinutes`/`extensionMinutes`/`remainingMinutes`/`dailyLimitMins`/per-site usage) from `TimeStatusService`. Per-device summaries and top-10 host attribution still come from the per-day presence rows (snapshot doesn't need them).
- **`api/src/Main.scala`** — wires `TimeStatusService.layer` into the env and threads it into `TimeRoutes.routes`.

## Tests

- **`TimeStatusServiceSpec`** (new) — west-of-UTC (`22:46Z` MDT → `2026-05-26`), east-of-UTC (`13:00Z` Tokyo → `2026-05-26`), post-UTC-midnight pre-local-midnight repro (`00:30Z` MDT → still `2026-05-26`), DST spring-forward boundary, exact-minute cap exhaustion + extension grant, Sum vs Dedup overlap modes, exempt-from-daily site limits (#1105 regression guard).
- **`PolicySnapshotConsolidationSpec`** (new) — structural lock: across UTC + `America/Denver` × Sum/Dedup × cap-exhausted/extension-granted fixtures, asserts `snapshot.profiles(pid).rules.blocked == todaysState(pid).blocked` and same for `blockReason`. Any future refactor that drifts one path from the other will break this.

## Test plan

- [x] `mill api.test` — 583 tests pass, 0 fail (including all pre-existing PolicySnapshot* / Time / Router specs).
- [x] `mill api.compile`, `scalafmt --check --non-interactive`.
- [ ] Web component test for blocked-today UI render — **deferred** (wire shape unchanged, so safe to add separately).
- [ ] `scripts/e2e/scenarios/test_household_tz_rollover.py` — **deferred** to a follow-up issue (needs new e2e harness scaffolding beyond this PR's scope).

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)