### PR TITLE
test(web): add blocked-today component test for time-status UI (#1109)

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -246,6 +246,36 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
     expect(chip).toHaveAttribute('data-chip', 'time-exceeded')
   })
 
+  // #1109 — follow-up to #1104. Locks in that a blocked-today time-status
+  // payload (usedMins == dailyLimitMins, remainingMins == 0) reaches the
+  // operator-visible summary row: chip copy reads "Time exceeded", the
+  // burn renders as "30m / 30m", and the date comes from the mock — no
+  // hard-coded UTC date that would silently rot when run in non-UTC tz.
+  //
+  // Scope note: the issue mentions /api/time/status/{mac} (DeviceTimeStatus),
+  // but no SPA surface consumes statusDevice today. The blocked-today UI
+  // lives on the profile summary chip, fed by /api/time/status/summary
+  // (ProfileTimeSummary). Same set of burn fields, same #1104 fix path.
+  it('blocked-today profile surfaces "Time exceeded" copy with used/limit burn (#1109)', async () => {
+    const blockedDate = '2026-05-26'
+    const blockedSummary: ProfileTimeSummary = {
+      profileId: 1, profileName: 'Kids', date: blockedDate,
+      dailyLimitMins: 30, usedMins: 30, extensionMins: 0, remainingMins: 0,
+    }
+    ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
+      blockedSummary, adultsSummary,
+    ])
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    const chip = within(kidsCard).getByTestId('profile-pause-chip-1')
+    expect(chip).toHaveAttribute('data-chip', 'time-exceeded')
+    expect(chip).toHaveTextContent(/Time exceeded/i)
+    const time = within(kidsCard).getByTestId('profile-summary-time-1')
+    expect(time).toHaveTextContent('30m')
+    expect(time).toHaveTextContent(/30m\s*\/\s*30m/)
+    expect(time).not.toHaveTextContent('(+')
+  })
+
   it('no +Time button for profiles without a daily limit', async () => {
     renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')


### PR DESCRIPTION
## Summary

- Adds a vitest component test that locks in the post-#1104 blocked-today
  rendering on `ProfilesPage`: at-cap profiles surface the "Time exceeded"
  chip copy and the burn (used/limit) text, sourced from a mocked
  `/api/time/status/summary` payload whose `date` is read from the mock —
  no hard-coded UTC date in the assertion.

## Scope note

The issue references `/api/time/status/{mac}` (`DeviceTimeStatus`), but
no SPA surface consumes `api.time.statusDevice` today (defined in the
client, no callers). The blocked-today UI is the profile summary chip
on `ProfilesPage`, fed by `/api/time/status/summary` (`ProfileTimeSummary`),
which carries the same `usedMins`/`dailyLimitMins`/`remainingMins`/`date`
fields and the same #1104 fix path. Test is sited there; a comment in
the test body documents this.

## Test plan

- [x] `nvm use 22 && cd web && npx vitest run src/pages/ProfilesPage.test.tsx`
      → 57 passed (1 new).
- [x] Existing time-exceeded test still passes (this PR adds a deeper
      assertion alongside it, doesn't replace it).

Closes #1109