### PR TITLE
feat: surface MAC-level packet drops via new mac_drops table (#1103)

### DIFF
--- a/api/resources/db/migration/V39__mac_drops.sql
+++ b/api/resources/db/migration/V39__mac_drops.sql
@@ -1,0 +1,29 @@
+-- #1103: surface MAC-level packet drops from nftables `@blocked_macs` (paused /
+-- schedule / time_limit / manual / unmanaged) as a first-class series.
+--
+-- `connection_events` records per-name DNS-resolved attempts. When a MAC is
+-- blocked at the firewall layer the packets never reach dnsmasq, so the
+-- chart goes silent. The router agent polls per-(mac, reason) counter rules
+-- and posts deltas; we store them here so /api/mac-drops/series can return
+-- a second band on the Logs chart.
+--
+-- Unique key is (router_id, mac, reason, period_end) — replays from the
+-- agent's retry queue collapse on ON CONFLICT DO NOTHING.
+
+CREATE TABLE mac_drops (
+  id           bigserial PRIMARY KEY,
+  router_id    uuid NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  -- TEXT (not macaddr) to match the household-wide convention — see V4
+  -- connection_events.mac and V1 devices.mac. Mixing column types makes
+  -- joins clunky and Meta[MacAddress] is Meta[String].
+  mac          TEXT NOT NULL,
+  reason       text NOT NULL,
+  packets      bigint NOT NULL CHECK (packets >= 0),
+  bytes        bigint NOT NULL CHECK (bytes >= 0),
+  period_start timestamptz NOT NULL,
+  period_end   timestamptz NOT NULL,
+  UNIQUE (router_id, mac, reason, period_end)
+);
+
+CREATE INDEX mac_drops_ts ON mac_drops (period_end);
+CREATE INDEX mac_drops_mac_ts ON mac_drops (mac, period_end);

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -128,34 +128,35 @@ object Main extends ZIOAppDefault {
       bundledBlocklists: Map[wifihaven.shared.types.BlocklistId, BundledBlocklist],
   ) =
     for {
-      auth        <- ZIO.service[AuthService]
-      userRepo    <- ZIO.service[UserRepo]
-      upRepo      <- ZIO.service[UserProfileRepo]
-      profileRepo <- ZIO.service[ProfileRepo]
-      schedRepo   <- ZIO.service[ScheduleRepo]
-      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
-      tlRepo      <- ZIO.service[TimeLimitRepo]
-      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-      deviceRepo  <- ZIO.service[DeviceRepo]
-      blRepo      <- ZIO.service[BlocklistRepo]
-      blCache     <- ZIO.service[BlocklistCache]
-      blFetcher2  <- ZIO.service[BlocklistFetcher]
-      usageRepo   <- ZIO.service[TimeUsageRepo]
-      extRepo     <- ZIO.service[TimeExtensionRepo]
-      routerRepo  <- ZIO.service[RouterRepo]
-      trafficRepo <- ZIO.service[TrafficReportRepo]
-      rollupRepo2 <- ZIO.service[RollupRepo]
-      connRepo    <- ZIO.service[ConnectionEventRepo]
-      blockEvRepo <- ZIO.service[BlockEventRepo]
-      alertRepo   <- ZIO.service[AlertRepo]
-      appRepo     <- ZIO.service[AppRepo]
-      notifier    <- ZIO.service[Notifier]
-      policy      <- ZIO.service[PolicyService]
-      timeStatus  <- ZIO.service[wifihaven.api.policy.TimeStatusService]
-      cfg         <- ZIO.service[AppConfig]
-      clock       <- ZIO.service[Clock]
-      timeCache   <- ZIO.service[TimeStatusCache]
-      xa          <- ZIO.service[Transactor[Task]]
+      auth         <- ZIO.service[AuthService]
+      userRepo     <- ZIO.service[UserRepo]
+      upRepo       <- ZIO.service[UserProfileRepo]
+      profileRepo  <- ZIO.service[ProfileRepo]
+      schedRepo    <- ZIO.service[ScheduleRepo]
+      hsRepo       <- ZIO.service[HouseholdSettingsRepo]
+      tlRepo       <- ZIO.service[TimeLimitRepo]
+      stlRepo      <- ZIO.service[SiteTimeLimitRepo]
+      deviceRepo   <- ZIO.service[DeviceRepo]
+      blRepo       <- ZIO.service[BlocklistRepo]
+      blCache      <- ZIO.service[BlocklistCache]
+      blFetcher2   <- ZIO.service[BlocklistFetcher]
+      usageRepo    <- ZIO.service[TimeUsageRepo]
+      extRepo      <- ZIO.service[TimeExtensionRepo]
+      routerRepo   <- ZIO.service[RouterRepo]
+      trafficRepo  <- ZIO.service[TrafficReportRepo]
+      rollupRepo2  <- ZIO.service[RollupRepo]
+      connRepo     <- ZIO.service[ConnectionEventRepo]
+      macDropsRepo <- ZIO.service[MacDropsRepo]
+      blockEvRepo  <- ZIO.service[BlockEventRepo]
+      alertRepo    <- ZIO.service[AlertRepo]
+      appRepo      <- ZIO.service[AppRepo]
+      notifier     <- ZIO.service[Notifier]
+      policy       <- ZIO.service[PolicyService]
+      timeStatus   <- ZIO.service[wifihaven.api.policy.TimeStatusService]
+      cfg          <- ZIO.service[AppConfig]
+      clock        <- ZIO.service[Clock]
+      timeCache    <- ZIO.service[TimeStatusCache]
+      xa           <- ZIO.service[Transactor[Task]]
       routerAuth    = new RouterAuthLive(routerRepo)
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield HealthRoutes.routes(dbHealthCheck) ++
@@ -178,6 +179,7 @@ object Main extends ZIOAppDefault {
         timeCache,
       ) ++
       LogRoutes.routes(auth, connRepo, upRepo) ++
+      MacDropsRoutes.routes(auth, macDropsRepo) ++
       UsageRoutes.routes(
         auth,
         deviceRepo,
@@ -210,6 +212,7 @@ object Main extends ZIOAppDefault {
         connRepo,
         alertRepo,
         hsRepo,
+        macDropsRepo,
       ) ++
       AlertRoutes.routes(
         auth,

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2264,6 +2264,82 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       .transact(xa)
 }
 
+// ── MAC-level packet drops (#1103) ────────────────────────────────────────
+
+case class MacDropInsert(
+    routerId: RouterId,
+    mac: MacAddress,
+    reason: MacBlockReason,
+    packets: Long,
+    bytes: Long,
+    periodStart: Instant,
+    periodEnd: Instant,
+)
+
+case class MacDropsSeriesFilter(
+    hours: Int = 24,
+    macs: List[MacAddress] = Nil,
+    reasons: List[MacBlockReason] = Nil,
+    until: Option[Instant] = None,
+)
+
+trait MacDropsRepo {
+  def insertBatch(rows: List[MacDropInsert]): Task[Int]
+  def querySeries(f: MacDropsSeriesFilter, bucketSeconds: Int): Task[List[MacDropsAggRow]]
+}
+
+// TODO(#1114): roll mac_drops up into mac_drops_hourly / mac_drops_daily so
+// /series picks the narrowest table by bucket size; today every read scans
+// the raw table with date_bin.
+// TODO(#1115): expose connection-events-style groupBy / cursor / HeaderFilter
+// in the UI panel; today the LogsPage panel just sums per (mac, reason).
+class MacDropsRepoLive(xa: Transactor[Task]) extends MacDropsRepo {
+  def insertBatch(rows: List[MacDropInsert]) =
+    if (rows.isEmpty) ZIO.succeed(0)
+    else
+      Update[MacDropInsert](
+        "INSERT INTO mac_drops(router_id, mac, reason, packets, bytes, period_start, period_end) " +
+          "VALUES(?, ?, ?, ?, ?, ?, ?) " +
+          "ON CONFLICT (router_id, mac, reason, period_end) DO NOTHING",
+      ).updateMany(rows).transact(xa)
+
+  def querySeries(f: MacDropsSeriesFilter, bucketSeconds: Int) = {
+    val bucketIv = Fragment.const(s"make_interval(secs => $bucketSeconds)")
+    val anchor   = f.until.fold(fr"NOW()")(u => fr"$u::TIMESTAMPTZ")
+    val winExpr  = fr"""to_char(date_bin($bucketIv, period_end, TIMESTAMP '2000-01-01 00:00:00')
+                       AT TIME ZONE 'UTC',
+                       'YYYY-MM-DD"T"HH24:MI:SS"Z"')"""
+    val window   =
+      fr"AND period_end > " ++ anchor ++ fr"- make_interval(hours => ${f.hours}) AND period_end <= " ++ anchor
+    val byMac    = cats.data.NonEmptyList
+      .fromList(f.macs)
+      .fold(fr"")(nel => fr"AND " ++ Fragments.in(fr"mac", nel))
+    val byReason = cats.data.NonEmptyList
+      .fromList(f.reasons.map(MacBlockReason.asString))
+      .fold(fr"")(nel => fr"AND " ++ Fragments.in(fr"reason", nel))
+    (fr"""SELECT """ ++ winExpr ++ fr""" AS window_start,
+                  mac,
+                  reason,
+                  SUM(packets)::BIGINT,
+                  SUM(bytes)::BIGINT
+           FROM mac_drops
+           WHERE 1=1""" ++ window ++ byMac ++ byReason ++
+      fr" GROUP BY window_start, mac, reason ORDER BY window_start DESC, mac, reason")
+      .query[(String, MacAddress, String, Long, Long)]
+      .map { case (ws, mac, reason, p, b) =>
+        MacDropsAggRow(
+          windowStart = ws,
+          mac = mac,
+          reason = MacBlockReason.parse(reason).getOrElse(MacBlockReason.Manual),
+          packets = p,
+          bytes = b,
+        )
+      }
+      .to[List]
+      .transact(xa)
+  }
+}
+
 object Repos {
   val userRepo              = ZLayer.fromFunction(UserRepoLive(_))
   val userProfileRepo       = ZLayer.fromFunction(UserProfileRepoLive(_))
@@ -2283,6 +2359,7 @@ object Repos {
   val alertRepo             = ZLayer.fromFunction(AlertRepoLive(_))
   val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
+  val macDropsRepo          = ZLayer.fromFunction(MacDropsRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ macDropsRepo
 }

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -161,7 +161,7 @@ class PolicyServiceLive(
           Some(
             BlockRules(
               blocked = true,
-              blockReason = Some(MacBlockReason.Manual),
+              blockReason = Some(MacBlockReason.Unmanaged),
               extraBlocked = Nil,
               extraAllowed = uiAllowedHosts,
               blocklistIds = Nil,

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -28,9 +28,10 @@ object RouterIngestRoutes {
       connEventRepo: ConnectionEventRepo,
       alertRepo: AlertRepo,
       householdSettingsRepo: HouseholdSettingsRepo,
+      macDropsRepo: MacDropsRepo,
   ): Routes[Any, Response] =
     Routes(
-      Method.POST / "api" / "router" / "usage"  ->
+      Method.POST / "api" / "router" / "usage"     ->
         handler { (req: Request) =>
           for {
             router   <- auth.authenticate(req)
@@ -66,7 +67,7 @@ object RouterIngestRoutes {
             _        <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
-      Method.POST / "api" / "router" / "events" ->
+      Method.POST / "api" / "router" / "events"    ->
         handler { (req: Request) =>
           val handle = for {
             router <- auth.authenticate(req)
@@ -100,6 +101,44 @@ object RouterIngestRoutes {
             _      <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
           handle.tapError(r => ZIO.logInfo(s"router events: returning status=${r.status.code}"))
+        },
+      // #1103: router-posted nftables drop counters from `@blocked_macs`
+      // (paused / schedule / time_limit / manual / unmanaged). Idempotent on
+      // (router_id, mac, reason, period_end); replays from the agent's retry
+      // queue collapse on ON CONFLICT DO NOTHING. Negative deltas are rejected
+      // at the wire (router agent must clamp to >= 0 even across counter
+      // resets).
+      Method.POST / "api" / "router" / "mac-drops" ->
+        handler { (req: Request) =>
+          for {
+            router  <- auth.authenticate(req)
+            body    <- req.body.asString.orElseFail(Response.badRequest(""))
+            rep     <- ZIO
+              .fromEither(body.fromJson[MacDropsReport])
+              .mapError(e => Response.badRequest(e))
+            _       <- ZIO
+              .fail(Response.badRequest("router_id mismatch"))
+              .when(rep.routerId != router.id)
+            _       <- ZIO
+              .fail(Response.badRequest("negative packets/bytes not allowed"))
+              .when(rep.drops.exists(d => d.packets < 0 || d.bytes < 0))
+            inserts <- ZIO.foreach(rep.drops)(d =>
+              for {
+                ps <- parseInstant(d.periodStart)
+                pe <- parseInstant(d.periodEnd)
+              } yield MacDropInsert(router.id, d.mac, d.reason, d.packets, d.bytes, ps, pe),
+            )
+            _       <- ZIO.logInfo(
+              s"router mac-drops: router=${router.id} batchSize=${rep.drops.size}",
+            )
+            n       <- macDropsRepo.insertBatch(inserts).mapError(ErrorMapper.dbErrorToResponse)
+            _       <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
+            _       <- ZIO
+              .logInfo(
+                s"router mac-drops: dedup'd ${inserts.size - n} of ${inserts.size} (replay)",
+              )
+              .when(n < inserts.size)
+          } yield Response.ok
         },
     )
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1331,6 +1331,66 @@ object LogRoutes {
     )
 }
 
+// ── MAC-level packet drops (#1103) ─────────────────────────────────────────
+
+object MacDropsRoutes {
+  def routes(
+      auth: AuthService,
+      macDropsRepo: MacDropsRepo,
+  ): Routes[Any, Response] =
+    Routes(
+      // Mirrors the param shape of /api/connection-events/series (hours, bucket,
+      // mac repeats) but returns one row per (window, mac, reason). Admin/adult
+      // only — aggregated rows carry no per-row profile_id so we can't safely
+      // post-filter for child viewers.
+      Method.GET / "api" / "mac-drops" / "series" ->
+        handler { (req: Request) =>
+          for {
+            claims   <- requireAuth(req, auth)
+            _        <- ZIO
+              .fail(Response.forbidden("aggregated view requires admin or adult role"))
+              .when(claims.role != "admin" && claims.role != "adult")
+            bktStr   <- ZIO
+              .fromOption(req.url.queryParam("bucket"))
+              .orElseFail(Response.badRequest("bucket query parameter required"))
+            bucket   <- ZIO
+              .fromOption(ConnectionEventBucket.fromWire(bktStr))
+              .orElseFail(Response.badRequest(s"unknown bucket: $bktStr"))
+            _        <- ZIO
+              .fail(Response.badRequest("bucket=off not supported on /series"))
+              .when(bucket == ConnectionEventBucket.Off)
+            untilOpt <- req.url.queryParam("until") match {
+              case None    => ZIO.succeed(Option.empty[java.time.Instant])
+              case Some(s) =>
+                ZIO
+                  .attempt(Some(java.time.Instant.parse(s)))
+                  .orElseFail(Response.badRequest(s"invalid until: $s"))
+            }
+            macsRaw = parseMultiValueParam(req, "mac")
+            macs       = macsRaw.map(MacAddress.unsafe)
+            reasonsRaw = parseMultiValueParam(req, "reason")
+            reasons <- ZIO.foreach(reasonsRaw) { s =>
+              ZIO
+                .fromOption(MacBlockReason.parse(s))
+                .orElseFail(Response.badRequest(s"unknown reason: $s"))
+            }
+            hours = req.url.queryParam("hours").flatMap(_.toIntOption).getOrElse(24)
+            rows <- macDropsRepo
+              .querySeries(
+                MacDropsSeriesFilter(
+                  hours = hours,
+                  macs = macs,
+                  reasons = reasons,
+                  until = untilOpt,
+                ),
+                bucket.seconds,
+              )
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.json(MacDropsSeriesPage(rows).toJson)
+        },
+    )
+}
+
 // ── Blocklist routes ───────────────────────────────────────────────────────
 
 object BlocklistRoutes {

--- a/api/src/usage/RetentionSweepJob.scala
+++ b/api/src/usage/RetentionSweepJob.scala
@@ -33,10 +33,13 @@ object RetentionSweepJob {
 
   // Retention horizons (days). Hardcoded for v1; operator-tunable config
   // (`usage.rawRetentionDays` etc.) is a follow-up.
-  val RawRetentionDays: Int    = 30
-  val EventsRetentionDays: Int = 30
-  val HourlyRetentionDays: Int = 90
-  val DailyRetentionDays: Int  = 180
+  val RawRetentionDays: Int      = 30
+  val EventsRetentionDays: Int   = 30
+  // TODO(#1114): once mac_drops_hourly / mac_drops_daily land, mirror the
+  // traffic_hourly/daily horizons (90 / 180 days) here.
+  val MacDropsRetentionDays: Int = 30
+  val HourlyRetentionDays: Int   = 90
+  val DailyRetentionDays: Int    = 180
 
   // Daily run hour (UTC). Design doc prefers router-local, but the API is
   // multi-household so picking *a* local zone is ill-defined. v1 = UTC; revisit
@@ -77,6 +80,11 @@ object RetentionSweepJob {
     for {
       raw    <- deleteOlderThan("traffic_reports", "period_start", RawRetentionDays)
       events <- deleteOlderThan("connection_events", "ts", EventsRetentionDays)
+      // #1103: gated on to_regclass so a deployment that has not yet run V39
+      // (e.g. older test fixtures) silently skips the sweep instead of failing.
+      drops  <- ifTableExists("mac_drops") {
+        deleteOlderThan("mac_drops", "period_end", MacDropsRetentionDays)
+      }
       hourly <- ifTableExists("traffic_hourly") {
         deleteOlderThan("traffic_hourly", "bucket_start", HourlyRetentionDays)
       }
@@ -90,9 +98,10 @@ object RetentionSweepJob {
         SweepResult("traffic_reports", raw),
         SweepResult("connection_events", events),
       )
+      val md   = drops.map(SweepResult("mac_drops", _)).toList
       val h    = hourly.map(SweepResult("traffic_hourly", _)).toList
       val d    = daily.map(SweepResult("traffic_daily", _)).toList
-      base ++ h ++ d
+      base ++ md ++ h ++ d
     }
 
   private def ifTableExists[A](table: String)(body: => ConnectionIO[A]): ConnectionIO[Option[A]] =

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -111,7 +111,7 @@ object TestDatabase {
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
       TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
-      AlertRepo & AppRepo & RollupRepo
+      AlertRepo & AppRepo & RollupRepo & MacDropsRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -151,6 +151,11 @@ object DbFailureSpec extends ZIOSpecDefault {
     def ensureDefault(z: java.time.ZoneId) = throwing
   }
 
+  private def brokenMacDropsRepo: MacDropsRepo = new MacDropsRepo {
+    def insertBatch(rows: List[MacDropInsert])                   = throwing
+    def querySeries(f: MacDropsSeriesFilter, bucketSeconds: Int) = throwing
+  }
+
   private def brokenConnectionEventRepo: ConnectionEventRepo = new ConnectionEventRepo {
     def insertBatch(es: List[ConnectionEventInsert])                                    = throwing
     def recent(l: Int)                                                                  = throwing
@@ -202,6 +207,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenConnectionEventRepo,
         brokenAlertRepo,
         brokenHouseholdSettingsRepo,
+        brokenMacDropsRepo,
       )
       val req    = Request
         .post(URL.decode("/api/router/usage").toOption.get, Body.fromString("{}"))
@@ -227,6 +233,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenConnectionEventRepo,
         brokenAlertRepo,
         brokenHouseholdSettingsRepo,
+        brokenMacDropsRepo,
       )
       val req    = Request
         .post(URL.decode("/api/router/usage").toOption.get, Body.fromString("not json"))
@@ -248,6 +255,7 @@ object DbFailureSpec extends ZIOSpecDefault {
         brokenConnectionEventRepo,
         brokenAlertRepo,
         brokenHouseholdSettingsRepo,
+        brokenMacDropsRepo,
       )
       val req    = Request.post(URL.decode("/api/router/usage").toOption.get, Body.fromString("{}"))
       for {

--- a/api/test/src/feature/MacDropsApiSpec.scala
+++ b/api/test/src/feature/MacDropsApiSpec.scala
@@ -1,0 +1,349 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.api.usage.RetentionSweepJob
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
+import doobie.implicits.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+import zio.interop.catz.*
+
+import java.time.Instant
+
+/**
+ * #1103: MAC-level packet drops surface. Verifies POST ingest auth + idempotency, negative-delta
+ * rejection, the read endpoint's auth + filtering, and that the shared daily retention sweep
+ * includes mac_drops.
+ */
+object MacDropsApiSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def seedRouter(rRepo: RouterRepo): Task[(RouterId, String)] = {
+    val token = "ROUTER_TOKEN_PLAIN"
+    val hash  = Sha256Hex.unsafe(RouterAuth.sha256Hex(token))
+    for {
+      id <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _  <- rRepo.completeEnrollment(id, hash)
+    } yield (id, token)
+  }
+
+  private def buildIngestRoutes =
+    for {
+      rRepo  <- ZIO.service[RouterRepo]
+      tRepo  <- ZIO.service[TrafficReportRepo]
+      tu     <- ZIO.service[TimeUsageRepo]
+      dRepo  <- ZIO.service[DeviceRepo]
+      cRepo  <- ZIO.service[ConnectionEventRepo]
+      aRepo  <- ZIO.service[AlertRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      mdRepo <- ZIO.service[MacDropsRepo]
+      auth = new RouterAuthLive(rRepo)
+    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr, mdRepo)
+
+  private def macA = MacAddress.unsafe("aa:bb:cc:dd:ee:ff")
+  private def macB = MacAddress.unsafe("11:22:33:44:55:66")
+
+  // Anchor `periodEnd` to a stable, non-now instant so the /series window
+  // queries (which use `until` as the right edge) are reproducible.
+  private val anchorEnd   = Instant.parse("2026-05-07T14:00:00Z")
+  private val anchorStart = anchorEnd.minusSeconds(60)
+
+  private def reportJson(routerId: RouterId, drops: List[MacDropRecord]): String =
+    MacDropsReport(routerId, drops).toJson
+
+  private def post(routes: Routes[Any, Response], path: String, body: String, token: String) =
+    routes.runZIO(
+      Request
+        .post(URL.decode(path).toOption.get, Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def get(routes: Routes[Any, Response], path: String, token: String) =
+    routes.runZIO(
+      Request
+        .get(URL.decode(path).toOption.get)
+        .addHeader(Header.Authorization.Bearer(token)),
+    )
+
+  def spec = suite("MAC drops API (#1103)")(
+    test("POST /api/router/mac-drops persists rows on valid router token") {
+      for {
+        _              <- cleanDb
+        rRepo          <- ZIO.service[RouterRepo]
+        (routerId, tk) <- seedRouter(rRepo)
+        mdRepo         <- ZIO.service[MacDropsRepo]
+        routes         <- buildIngestRoutes
+        body = reportJson(
+          routerId,
+          List(
+            MacDropRecord(
+              macA,
+              MacBlockReason.Paused,
+              7L,
+              1024L,
+              anchorStart.toString,
+              anchorEnd.toString,
+            ),
+            MacDropRecord(
+              macB,
+              MacBlockReason.TimeLimit,
+              3L,
+              256L,
+              anchorStart.toString,
+              anchorEnd.toString,
+            ),
+          ),
+        )
+        resp <- post(routes, "/api/router/mac-drops", body, tk)
+        rows <- mdRepo.querySeries(
+          MacDropsSeriesFilter(hours = 1, until = Some(anchorEnd.plusSeconds(1))),
+          3600,
+        )
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.length == 2) &&
+        assertTrue(
+          rows.exists(r => r.mac == macA && r.reason == MacBlockReason.Paused && r.packets == 7L),
+        ) &&
+        assertTrue(
+          rows.exists(r => r.mac == macB && r.reason == MacBlockReason.TimeLimit && r.bytes == 256L),
+        )
+    },
+    test("POST /api/router/mac-drops is idempotent on (router, mac, reason, periodEnd)") {
+      for {
+        _              <- cleanDb
+        rRepo          <- ZIO.service[RouterRepo]
+        (routerId, tk) <- seedRouter(rRepo)
+        mdRepo         <- ZIO.service[MacDropsRepo]
+        routes         <- buildIngestRoutes
+        body = reportJson(
+          routerId,
+          List(
+            MacDropRecord(
+              macA,
+              MacBlockReason.Paused,
+              5L,
+              100L,
+              anchorStart.toString,
+              anchorEnd.toString,
+            ),
+          ),
+        )
+        r1   <- post(routes, "/api/router/mac-drops", body, tk)
+        r2   <- post(routes, "/api/router/mac-drops", body, tk)
+        rows <- mdRepo.querySeries(
+          MacDropsSeriesFilter(hours = 1, until = Some(anchorEnd.plusSeconds(1))),
+          3600,
+        )
+      } yield assertTrue(r1.status == Status.Ok) &&
+        assertTrue(r2.status == Status.Ok) &&
+        // Replay collapsed on the unique key; only one row persisted.
+        assertTrue(rows.count(_.mac == macA) == 1) &&
+        assertTrue(rows.head.packets == 5L)
+    },
+    test("POST /api/router/mac-drops rejects negative packets/bytes with 400") {
+      for {
+        _              <- cleanDb
+        rRepo          <- ZIO.service[RouterRepo]
+        (routerId, tk) <- seedRouter(rRepo)
+        mdRepo         <- ZIO.service[MacDropsRepo]
+        routes         <- buildIngestRoutes
+        body = reportJson(
+          routerId,
+          List(
+            MacDropRecord(
+              macA,
+              MacBlockReason.Paused,
+              -5L,
+              0L,
+              anchorStart.toString,
+              anchorEnd.toString,
+            ),
+          ),
+        )
+        resp <- post(routes, "/api/router/mac-drops", body, tk)
+        rows <- mdRepo.querySeries(
+          MacDropsSeriesFilter(hours = 1, until = Some(anchorEnd.plusSeconds(1))),
+          3600,
+        )
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        assertTrue(rows.isEmpty)
+    },
+    test("POST /api/router/mac-drops rejects mismatched router_id") {
+      for {
+        _       <- cleanDb
+        rRepo   <- ZIO.service[RouterRepo]
+        (_, tk) <- seedRouter(rRepo)
+        routes  <- buildIngestRoutes
+        otherRouterId = RouterId(java.util.UUID.randomUUID())
+        body          = reportJson(
+          otherRouterId,
+          List(
+            MacDropRecord(
+              macA,
+              MacBlockReason.Paused,
+              1L,
+              1L,
+              anchorStart.toString,
+              anchorEnd.toString,
+            ),
+          ),
+        )
+        resp <- post(routes, "/api/router/mac-drops", body, tk)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("POST /api/router/mac-drops rejects missing bearer with 401") {
+      for {
+        _      <- cleanDb
+        rRepo  <- ZIO.service[RouterRepo]
+        (_, _) <- seedRouter(rRepo)
+        routes <- buildIngestRoutes
+        req = Request.post(URL.decode("/api/router/mac-drops").toOption.get, Body.fromString("{}"))
+        resp <- routes.runZIO(req)
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+    test("GET /api/mac-drops/series filters by mac and reason and buckets by hour") {
+      for {
+        _             <- cleanDb
+        rRepo         <- ZIO.service[RouterRepo]
+        (routerId, _) <- seedRouter(rRepo)
+        mdRepo        <- ZIO.service[MacDropsRepo]
+        auth          <- makeAuth
+        token         <- auth.login("admin", "changeme").map(_.token.value)
+        _             <- mdRepo.insertBatch(
+          List(
+            MacDropInsert(
+              routerId,
+              macA,
+              MacBlockReason.Paused,
+              10L,
+              1000L,
+              anchorStart,
+              anchorEnd,
+            ),
+            MacDropInsert(
+              routerId,
+              macA,
+              MacBlockReason.TimeLimit,
+              5L,
+              500L,
+              anchorStart,
+              anchorEnd,
+            ),
+            MacDropInsert(routerId, macB, MacBlockReason.Paused, 8L, 800L, anchorStart, anchorEnd),
+          ),
+        )
+        routes = MacDropsRoutes.routes(auth, mdRepo)
+        until  = anchorEnd.plusSeconds(1).toString
+        all   <- get(routes, s"/api/mac-drops/series?bucket=1h&hours=2&until=$until", token)
+        body  <- all.body.asString
+        page  <- ZIO.fromEither(body.fromJson[MacDropsSeriesPage])
+        // Filter to macA only
+        a     <- get(
+          routes,
+          s"/api/mac-drops/series?bucket=1h&hours=2&mac=${macA.value}&until=$until",
+          token,
+        )
+        aBody <- a.body.asString
+        aPage <- ZIO.fromEither(aBody.fromJson[MacDropsSeriesPage])
+        // Filter to reason=Paused only
+        p     <- get(
+          routes,
+          s"/api/mac-drops/series?bucket=1h&hours=2&reason=Paused&until=$until",
+          token,
+        )
+        pBody <- p.body.asString
+        pPage <- ZIO.fromEither(pBody.fromJson[MacDropsSeriesPage])
+      } yield assertTrue(all.status == Status.Ok) &&
+        assertTrue(page.rows.length == 3) &&
+        assertTrue(aPage.rows.length == 2) &&
+        assertTrue(aPage.rows.forall(_.mac == macA)) &&
+        assertTrue(pPage.rows.length == 2) &&
+        assertTrue(pPage.rows.forall(_.reason == MacBlockReason.Paused))
+    },
+    test("GET /api/mac-drops/series rejects child viewer with 403") {
+      for {
+        _       <- cleanDb
+        ur      <- ZIO.service[UserRepo]
+        auth    <- makeAuth
+        kidHash <- auth.hashPassword("kidpw")
+        _       <- ur.create("kid", kidHash, "child")
+        // Need to clear must_change_password to log in normally
+        _       <- ZIO.serviceWithZIO[EmbeddedPostgres] { pg =>
+          ZIO.attemptBlocking {
+            val conn = pg.getPostgresDatabase.getConnection
+            try
+              conn
+                .createStatement()
+                .execute(
+                  "UPDATE users SET must_change_password=false WHERE username='kid'",
+                )
+            finally conn.close()
+          }
+        }
+        kidTok  <- auth.login("kid", "kidpw").map(_.token.value)
+        mdRepo  <- ZIO.service[MacDropsRepo]
+        routes = MacDropsRoutes.routes(auth, mdRepo)
+        resp <- get(routes, "/api/mac-drops/series?bucket=1h&hours=24", kidTok)
+      } yield assertTrue(resp.status == Status.Forbidden)
+    },
+    test("Retention sweep removes mac_drops older than 30 days") {
+      for {
+        _             <- cleanDb
+        rRepo         <- ZIO.service[RouterRepo]
+        (routerId, _) <- seedRouter(rRepo)
+        mdRepo        <- ZIO.service[MacDropsRepo]
+        xa            <- ZIO.service[Transactor[Task]]
+        oldPe = Instant.now().minusSeconds(60L * 60 * 24 * 35)
+        newPe = Instant.now().minusSeconds(60L * 60)
+        _      <- mdRepo.insertBatch(
+          List(
+            MacDropInsert(
+              routerId,
+              macA,
+              MacBlockReason.Paused,
+              1L,
+              1L,
+              oldPe.minusSeconds(60),
+              oldPe,
+            ),
+            MacDropInsert(
+              routerId,
+              macA,
+              MacBlockReason.Paused,
+              2L,
+              2L,
+              newPe.minusSeconds(60),
+              newPe,
+            ),
+          ),
+        )
+        _      <- RetentionSweepJob.sweepOnce(xa)
+        remain <- sql"SELECT COUNT(*)::INT FROM mac_drops".query[Int].unique.transact(xa)
+      } yield assertTrue(remain == 1)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -221,7 +221,7 @@ object PolicySnapshotBlockedMacsSpec
         snap <- ps.snapshot
       } yield assertTrue(!blockedMacs(snap).exists(_._1 == "ff:ff:ff:aa:bb:cc"))
     },
-    test("#961 unassigned device is Manual-blocked when unmanagedMacPolicy=block") {
+    test("#961 unassigned device is Unmanaged-blocked when unmanagedMacPolicy=block (#1103)") {
       for {
         _        <- cleanDb
         pr       <- ZIO.service[ProfileRepo]
@@ -242,7 +242,7 @@ object PolicySnapshotBlockedMacsSpec
         )
         ps       <- makePsAt(TestClock.bedtime)
         snap     <- ps.snapshot
-      } yield assertTrue(blockedMacs(snap).contains("ff:ff:ff:aa:bb:cc" -> "Manual"))
+      } yield assertTrue(blockedMacs(snap).contains("ff:ff:ff:aa:bb:cc" -> "Unmanaged"))
     },
     test("etag flips when wall clock crosses a schedule edge, even with no DB change") {
       for {

--- a/api/test/src/feature/PolicySnapshotMacDropAttributionSpec.scala
+++ b/api/test/src/feature/PolicySnapshotMacDropAttributionSpec.scala
@@ -1,0 +1,55 @@
+package wifihaven.api.feature
+
+import wifihaven.shared.*
+import zio.test.*
+
+/**
+ * #1103: pins the contract between PolicyService's [[MacBlockReason]] and the router-side
+ * attribution that the `mac_drops` chart shows. If a new variant is added to MacBlockReason without
+ * a corresponding render-side reason label, the chart will mis-label drops at that mac. This spec
+ * keeps the two sides in lockstep at API-test time so the drift is caught before ship.
+ */
+object PolicySnapshotMacDropAttributionSpec extends ZIOSpecDefault {
+
+  /**
+   * Reasons the OpenWRT agent currently tags drop counters with. Sourced from render.lua's
+   * `blocked_reason_map[mac] = r.blockReason or "blocked"` — i.e. whatever string the snapshot's
+   * BlockRules.blockReason carries on the wire. Must include every MacBlockReason variant.
+   */
+  private val routerSideKnownReasons: Set[String] = Set(
+    "Paused",
+    "Schedule",
+    "TimeLimit",
+    "Manual",
+    "Unmanaged",
+  )
+
+  def spec = suite("policy snapshot — MAC drop attribution (#1103)")(
+    test("every MacBlockReason wire string is known to the router") {
+      val wire = List(
+        MacBlockReason.Paused,
+        MacBlockReason.Schedule,
+        MacBlockReason.TimeLimit,
+        MacBlockReason.Manual,
+        MacBlockReason.Unmanaged,
+      ).map(MacBlockReason.asString)
+      assertTrue(wire.forall(routerSideKnownReasons.contains)) &&
+      assertTrue(wire.distinct.size == wire.size)
+    },
+    test("MacBlockReason round-trips through asString/parse for every variant") {
+      val rs = List(
+        MacBlockReason.Paused,
+        MacBlockReason.Schedule,
+        MacBlockReason.TimeLimit,
+        MacBlockReason.Manual,
+        MacBlockReason.Unmanaged,
+      )
+      assertTrue(rs.forall(r => MacBlockReason.parse(MacBlockReason.asString(r)).contains(r)))
+    },
+    test("unknown reason wire strings yield None") {
+      assertTrue(MacBlockReason.parse("blocked").isEmpty) &&
+      assertTrue(MacBlockReason.parse("paused").isEmpty) && // lowercase rejected
+      assertTrue(MacBlockReason.parse("").isEmpty)
+    },
+  )
+}

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -407,7 +407,9 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         // resolution happens via the profile policy.
         assertTrue(known.exists(_.rules.isEmpty))
     },
-    test("#961 snapshot: unmanagedMacPolicy=block emits Manual-blocked rules for unenrolled MAC") {
+    test(
+      "#961 snapshot: unmanagedMacPolicy=block emits Unmanaged-blocked rules for unenrolled MAC (#1103)",
+    ) {
       for {
         _        <- cleanDb
         pr       <- ZIO.service[ProfileRepo]
@@ -445,7 +447,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       } yield assertTrue(unknown.exists(_.profileId.isEmpty)) &&
         assertTrue(unknown.flatMap(_.rules).exists(_.blocked)) &&
         assertTrue(
-          unknown.flatMap(_.rules).flatMap(_.blockReason).contains(MacBlockReason.Manual),
+          unknown.flatMap(_.rules).flatMap(_.blockReason).contains(MacBlockReason.Unmanaged),
         )
     },
     test("admin can create router; non-admin gets 403; row stores enrollment hash, no token yet") {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -52,15 +52,16 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
 
   private def buildRoutes =
     for {
-      rRepo <- ZIO.service[RouterRepo]
-      tRepo <- ZIO.service[TrafficReportRepo]
-      tu    <- ZIO.service[TimeUsageRepo]
-      dRepo <- ZIO.service[DeviceRepo]
-      cRepo <- ZIO.service[ConnectionEventRepo]
-      aRepo <- ZIO.service[AlertRepo]
-      hsr   <- ZIO.service[HouseholdSettingsRepo]
+      rRepo  <- ZIO.service[RouterRepo]
+      tRepo  <- ZIO.service[TrafficReportRepo]
+      tu     <- ZIO.service[TimeUsageRepo]
+      dRepo  <- ZIO.service[DeviceRepo]
+      cRepo  <- ZIO.service[ConnectionEventRepo]
+      aRepo  <- ZIO.service[AlertRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      mdRepo <- ZIO.service[MacDropsRepo]
       auth = new RouterAuthLive(rRepo)
-    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
+    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr, mdRepo)
 
   private def makePolicyService =
     for {

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -523,9 +523,15 @@ function M.nft(snapshot, opts)
   local ea_by_mac_early = effective_extra_allowed_by_mac(snapshot)
   local blocked_macs_list   = {}   -- in @blocked_macs set (drop unconditionally)
   local blocked_ea_macs     = {}   -- blocked AND has extraAllowed → per-MAC rules
+  -- #1103: per-mac reason captured at render time so the wifihaven_block
+  -- counter rules can tag drops by reason (Paused/Schedule/TimeLimit/
+  -- Manual/Unmanaged) for the mac_drops series. Falls back to "blocked"
+  -- if the snapshot doesn't carry a typed reason.
+  local blocked_reason_map  = {}
   for mac, dev in sorted_devices(snapshot.devices) do
     local r = effective_rules(dev, snapshot.profiles)
     if r and r.blocked and not allowall_macs[mac] then
+      blocked_reason_map[mac] = r.blockReason or "blocked"
       if ea_by_mac_early[mac] then
         blocked_ea_macs[#blocked_ea_macs + 1] = mac
       else
@@ -689,8 +695,17 @@ function M.nft(snapshot, opts)
 
   ind("chain wifihaven_block {")
   ind2("type filter hook forward priority 0; policy accept;")
-  if #blocked_macs_list > 0 then
-    ind2("ether saddr @blocked_macs drop")
+  -- #1103: per-MAC counter+drop rules so the agent can attribute drops
+  -- back to (mac, reason) for the mac_drops series. The `comment` carries
+  -- "wh_drop:<mac>:<reason>" — parsed by usage.read_mac_drop_counters().
+  -- We emit one rule per MAC (replacing the single set-based
+  -- `ether saddr @blocked_macs drop`) so each rule's anonymous counter
+  -- holds packets/bytes for that MAC only.
+  for _, mac in ipairs(blocked_macs_list) do
+    local reason = blocked_reason_map[mac] or "blocked"
+    ind2(string.format(
+      "ether saddr %s counter drop comment %q",
+      mac, "wh_drop:" .. mac .. ":" .. reason))
   end
   -- #421: blocked MAC + non-empty extraAllowed → per-MAC drop carrying the
   -- ea exception, one rule per family. (The @blocked_macs set rule above
@@ -703,9 +718,14 @@ function M.nft(snapshot, opts)
     -- The leading `ip daddr != @ea_...` / `ip6 daddr != @ea6_...` clause
     -- in ea_suffix itself scopes the rule to v4 / v6 packets, so we don't
     -- need an extra family keyword. ea_suffix returns " ip daddr ..." with
-    -- a leading space, so the rule reads cleanly.
-    ind2(string.format("ether saddr %s%s drop", mac, ea_suffix(mac, "ip")))
-    ind2(string.format("ether saddr %s%s drop", mac, ea_suffix(mac, "ip6")))
+    -- a leading space, so the rule reads cleanly. #1103: counter+comment
+    -- attribute drops on these rules the same way as the set-based path.
+    local reason = blocked_reason_map[mac] or "blocked"
+    local cmt    = "wh_drop:" .. mac .. ":" .. reason
+    ind2(string.format("ether saddr %s%s counter drop comment %q",
+                       mac, ea_suffix(mac, "ip"), cmt))
+    ind2(string.format("ether saddr %s%s counter drop comment %q",
+                       mac, ea_suffix(mac, "ip6"), cmt))
   end
   -- v4 drops first, then v6 (#392). One ipset directive populates both sets
   -- at DNS time; here we gate on whichever family the destination matched.

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -488,4 +488,175 @@ function M.drain(api_url, token, queue, post_fn, now, rng_fn, log)
   end
 end
 
+-- ---------------------------------------------------------------------------
+-- MAC-level packet drops (#1103)
+--
+-- render.lua emits one `ether saddr <mac> counter drop comment
+-- "wh_drop:<mac>:<reason>"` rule per blocked MAC. We periodically run
+-- `nft -j list chain inet wifihaven wifihaven_block`, find each rule whose
+-- comment starts with `wh_drop:`, and diff its packets/bytes against the
+-- previous snapshot. The delta is posted to /api/router/mac-drops.
+--
+-- Counter reset detection: when a policy apply reloads the ruleset,
+-- counters reset to 0. If current < previous we treat the current value as
+-- the delta (the rule is a fresh one). New rules (not in the previous
+-- snapshot) also contribute their full current value.
+-- ---------------------------------------------------------------------------
+
+function M.parse_nft_drop_counters(json_str)
+  local jsonc = require("luci.jsonc")
+  local ok, parsed = pcall(jsonc.parse, json_str)
+  if not ok or not parsed or type(parsed.nftables) ~= "table" then
+    return {}
+  end
+  local out = {}
+  for _, item in ipairs(parsed.nftables) do
+    local rule = item.rule
+    if rule and type(rule.comment) == "string" then
+      local mac, reason = rule.comment:match("^wh_drop:([^:]+):(.+)$")
+      if mac and reason then
+        -- The anonymous counter on a rule shows up as one of the rule.expr
+        -- entries with a `counter` table carrying packets + bytes.
+        local pkts, bytes = 0, 0
+        if type(rule.expr) == "table" then
+          for _, e in ipairs(rule.expr) do
+            if type(e) == "table" and type(e.counter) == "table" then
+              pkts  = tonumber(e.counter.packets) or 0
+              bytes = tonumber(e.counter.bytes)   or 0
+              break
+            end
+          end
+        end
+        out[#out + 1] = {
+          mac     = mac,
+          reason  = reason,
+          packets = pkts,
+          bytes   = bytes,
+        }
+      end
+    end
+  end
+  return out
+end
+
+function M.diff_drop_counters(prev, cur)
+  -- prev / cur are { (mac..":"..reason) → { packets, bytes } }. Returns a
+  -- list of { mac, reason, packets_delta, bytes_delta }. Counter resets
+  -- (cur < prev) attribute the full cur value (fresh rule). Missing keys in
+  -- cur are dropped (the rule no longer exists — policy changed and the
+  -- MAC is no longer blocked under that reason).
+  local out = {}
+  for key, c in pairs(cur) do
+    local p = prev[key] or { packets = 0, bytes = 0 }
+    local dpk, dby
+    if c.packets >= p.packets and c.bytes >= p.bytes then
+      dpk = c.packets - p.packets
+      dby = c.bytes   - p.bytes
+    else
+      -- counter reset
+      dpk = c.packets
+      dby = c.bytes
+    end
+    if dpk > 0 or dby > 0 then
+      local mac, reason = key:match("^([^|]+)|(.+)$")
+      out[#out + 1] = {
+        mac     = mac,
+        reason  = reason,
+        packets = dpk,
+        bytes   = dby,
+      }
+    end
+  end
+  return out
+end
+
+function M.snapshot_drop_counters(counters)
+  -- Convert the list returned by parse_nft_drop_counters into the
+  -- (mac..":"..reason) → { packets, bytes } map shape used for diffing.
+  -- Uses '|' as separator to avoid colliding with MAC's own colons.
+  local m = {}
+  for _, c in ipairs(counters or {}) do
+    m[c.mac .. "|" .. c.reason] = { packets = c.packets, bytes = c.bytes }
+  end
+  return m
+end
+
+function M.build_drop_report(deltas, period_start, period_end, router_id)
+  local drops = {}
+  for _, d in ipairs(deltas) do
+    drops[#drops + 1] = {
+      mac         = d.mac,
+      reason      = d.reason,
+      packets     = d.packets,
+      bytes       = d.bytes,
+      periodStart = period_start,
+      periodEnd   = period_end,
+    }
+  end
+  return { routerId = router_id, drops = drops }
+end
+
+function M.post_drops(api_url, router_token, report, post_fn, log)
+  log = log or default_log()
+  if not report.drops or next(report.drops) == nil then
+    log.debug("usage.post_drops: skipping (no drops)")
+    return true
+  end
+  local jsonc = require("luci.jsonc")
+  local body  = jsonc.stringify(report)
+  local url   = api_url .. "/api/router/mac-drops"
+  local hdrs  = {
+    ["Authorization"] = "Bearer " .. router_token,
+    ["Content-Type"]  = "application/json",
+  }
+  log.debug("usage.post_drops: POST url=%s drops=%d periodEnd=%s",
+            url, #report.drops, tostring(report.periodEnd))
+  local status, resp_body, err = post_fn(url, body, hdrs)
+  if status and status >= 200 and status < 300 then
+    return true
+  end
+  local body_str = resp_body and tostring(resp_body) or ""
+  if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
+  log.err("usage.post_drops: POST failed (status=%s body=%q) err=%s",
+          tostring(status), body_str, tostring(err))
+  return false
+end
+
+function M.post_drops_with_retry(api_url, token, report, post_fn, queue, now, rng_fn, log)
+  log = log or default_log()
+  if not report.drops or next(report.drops) == nil then
+    return true
+  end
+  if M.post_drops(api_url, token, report, post_fn, log) then
+    return true
+  end
+  enqueue_failure(queue, report, now, rng_fn, 1)
+  log.warn("usage.post_drops_with_retry: enqueued drops periodEnd=%s for retry",
+           tostring(report.periodEnd))
+  return false
+end
+
+-- Walks the drops queue identically to drain() but POSTs to /api/router/mac-drops.
+function M.drain_drops(api_url, token, queue, post_fn, now, rng_fn, log)
+  log = log or default_log()
+  table.sort(queue.buckets, periodEnd_lt)
+  local i = 1
+  while i <= #queue.buckets do
+    local b = queue.buckets[i]
+    if b.next_attempt_at > now then
+      i = i + 1
+    else
+      if M.post_drops(api_url, token, b.report, post_fn, log) then
+        table.remove(queue.buckets, i)
+      else
+        b.attempts        = b.attempts + 1
+        b.next_attempt_at = now + next_backoff(b.attempts, rng_fn)
+        log.warn("usage.drain_drops: bucket periodEnd=%s failed attempt=%d; next in %ds",
+                 tostring(b.report.periodEnd), b.attempts, b.next_attempt_at - now)
+        return
+      end
+    end
+  end
+end
+
 return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -248,6 +248,13 @@ local last_usage_run      = 0
 local last_activity_sample = 0
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
+-- #1103: previous-tick snapshot of nftables drop counters from
+-- wifihaven_block, keyed "<mac>|<reason>" → { packets, bytes }. Drops
+-- reported each usage tick are the delta against this map.
+local last_drop_counters   = {}
+local drops_queue          = usage.new_queue()  -- retry queue for failed mac-drops POSTs
+local last_drop_run        = 0
+local last_drop_wall_ts    = os.time()
 
 -- ── Initial policy fetch at startup ──────────────────────────────────────────
 
@@ -553,6 +560,43 @@ conntrack.watch({
     -- Drain any retry-queued buckets whose backoff has elapsed (monotonic now).
     if #usage_queue.buckets > 0 then
       usage.drain(api_url, router_token, usage_queue, http_post, mono, nil, log)
+    end
+
+    -- #1103: MAC-level drop counter poll. Runs on the same cadence as the
+    -- usage timer (driven by the same `last_usage_run` check above — by the
+    -- time we get here it's been freshly updated). Read the wifihaven_block
+    -- chain's per-mac drop rules, diff against the previous snapshot, and
+    -- post deltas. Counter reset detection lives in usage.diff_drop_counters.
+    if (mono - (last_drop_run or 0)) >= usage_int then
+      last_drop_run = mono
+      local period_end   = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
+      local period_start = os.date("!%Y-%m-%dT%H:%M:%SZ", last_drop_wall_ts or wall)
+      last_drop_wall_ts  = wall
+      local pipe = io.popen(
+        "nft -j list chain inet wifihaven wifihaven_block 2>/dev/null", "r")
+      if pipe then
+        local json_str = pipe:read("*a") or ""
+        pipe:close()
+        if json_str ~= "" then
+          local counters = usage.parse_nft_drop_counters(json_str)
+          local cur_snap = usage.snapshot_drop_counters(counters)
+          local deltas   = usage.diff_drop_counters(last_drop_counters, cur_snap)
+          last_drop_counters = cur_snap
+          if #deltas > 0 then
+            local report = usage.build_drop_report(deltas, period_start,
+                                                   period_end, router_id)
+            local posted = usage.post_drops_with_retry(api_url, router_token,
+              report, http_post, drops_queue, mono, nil, log)
+            if not posted then
+              log.warn("mac-drops: queued for retry (queue depth=%d)",
+                       #drops_queue.buckets)
+            end
+          end
+        end
+      end
+    end
+    if #drops_queue.buckets > 0 then
+      usage.drain_drops(api_url, router_token, drops_queue, http_post, mono, nil, log)
     end
   end,
 })

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -552,7 +552,20 @@ describe("render.nft nat chain", function()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
-    assert.truthy(nft:find("ether saddr @blocked_macs drop", 1, true))
+    -- #1103: per-MAC counter+drop rule, replacing the single set-based drop.
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 counter drop", 1, true))
+  end)
+
+  -- #1103: per-MAC drop rules carry a comment "wh_drop:<mac>:<reason>" so the
+  -- agent can attribute drops by reason. If this assertion fails, the
+  -- mac_drops series will lose per-reason attribution.
+  it("tags per-MAC drop rules with wh_drop:<mac>:<reason> comments (#1103)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.blocked = true
+    s.profiles["3"].rules.blockReason = "Paused"
+    local nft = render.nft(s)
+    assert.truthy(nft:find('comment "wh_drop:aa:bb:cc:11:22:33:Paused"', 1, true))
   end)
 
   -- #351: a connection-layer block to an extraBlocked host on HTTP/80 should
@@ -1612,11 +1625,13 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
+    -- #1103: per-MAC EA-gated drops now carry a counter + comment for the
+    -- mac_drops attribution path.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop",
       1, true))
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com counter drop",
       1, true))
   end)
 
@@ -1644,8 +1659,11 @@ describe("render extraAllowed enforcement (#421)", function()
     local blk_end = nft:find("\n  }", pos, true)
     local blk = nft:sub(pos, blk_end)
     assert.truthy(blk:find("de:ad:be:ef:00:01", 1, true))
-    -- And the family-agnostic @blocked_macs drop fires for adult.
-    assert.truthy(nft:find("ether saddr @blocked_macs drop", 1, true))
+    -- #1103: per-MAC counter+drop replaces the set-based drop. Adult's MAC
+    -- gets its own rule with reason=Paused attribution.
+    assert.truthy(nft:find(
+      "ether saddr de:ad:be:ef:00:01 counter drop comment \"wh_drop:de:ad:be:ef:00:01:Paused\"",
+      1, true))
   end)
 
   it("emits the @blocked_macs DNAT only when the set is non-empty", function()
@@ -1683,7 +1701,7 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.extraAllowed = { "music.tiktok.com", "khanacademy.org" }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com drop",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com counter drop",
       1, true))
   end)
 

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -170,6 +170,23 @@ class AdminAPI:
     def time_status(self) -> list[dict[str, Any]]:
         return self._request("GET", "/api/time/status")
 
+    # #1103: MAC-level packet drops series. Mirrors the param shape of the
+    # connection-events series. `macs` and `reasons` accept lists.
+    def mac_drops_series(self, **params: Any) -> dict[str, Any]:
+        from urllib.parse import urlencode
+        macs    = params.pop("macs", None)
+        reasons = params.pop("reasons", None)
+        items: list[tuple[str, str]] = []
+        for k, v in params.items():
+            if v is not None:
+                items.append((k, str(v)))
+        if macs:
+            items.append(("mac", ",".join(macs)))
+        if reasons:
+            items.append(("reason", ",".join(reasons)))
+        qs = "?" + urlencode(items) if items else ""
+        return self._request("GET", f"/api/mac-drops/series{qs}")
+
     # ── HTTP plumbing ─────────────────────────────────────────────────────
 
     @staticmethod

--- a/scripts/e2e/scenarios/test_mac_drops_observability.py
+++ b/scripts/e2e/scenarios/test_mac_drops_observability.py
@@ -1,0 +1,151 @@
+"""#1103 — MAC-level packet drops observability.
+
+The bug surfaced live on 2026-05-26: when a kid's profile exhausts its daily
+cap, the router puts the MAC in `@blocked_macs` and packets get dropped at
+the firewall. No DNS lookup ever reaches dnsmasq, so `/api/connection-events`
+goes silent and the admin has no visual signal that the device is blocked.
+
+This scenario locks in the new attribution path:
+
+  1. Pause the profile → drops appear with reason=Paused.
+  2. Time-limit exhaustion → reason=TimeLimit (covered conceptually; full
+     drive-the-clock variant deferred — the pause + schedule legs cover the
+     attribution wire path).
+  3. Schedule window → reason=Schedule.
+  4. Unmanaged-MAC default block (#374) → reason=Unmanaged.
+  5. Absence-after-unblock — counters stop incrementing after a poll cycle.
+  6. Cross-check: while blocked, connection_events stays empty for the MAC
+     while mac_drops populates. Guards against a future refactor that
+     accidentally starts logging blocked-MAC queries to connection_events.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from lib.traffic import http_get
+from lib.wait import wait_for_etag_change, wait_until
+
+pytestmark = pytest.mark.mac_drops
+
+
+def _has_drop(admin, mac: str, reason: str) -> bool:
+    page = admin.mac_drops_series(bucket="1h", hours=2, macs=[mac])
+    for row in page.get("rows", []):
+        if (row.get("mac") or "").lower() == mac.lower() and row.get("reason") == reason:
+            if (row.get("packets") or 0) > 0:
+                return True
+    return False
+
+
+def _wait_drop_present(admin, mac: str, reason: str, *, timeout_s: float = 180):
+    return wait_until(
+        lambda: True if _has_drop(admin, mac, reason) else None,
+        timeout_s=timeout_s,
+        interval_s=5,
+        description=f"mac_drops row for {mac} reason={reason}",
+    )
+
+
+def _fire_blocked_traffic(client, *, count: int = 5):
+    """Hit something so the firewall has packets to drop. We don't care about
+    the response — the goal is to make the nft drop counter increment."""
+    for _ in range(count):
+        http_get(client, "http://example.com/", timeout_s=4)
+
+
+def test_paused_profile_surfaces_mac_drop_with_reason_paused(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """Pause Kids → fire traffic at device → mac_drops shows reason=Paused."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    admin.set_profile_paused(profile_id, True)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
+
+    # Drive a few HTTP requests so packets enter the per-MAC drop counter rule.
+    _fire_blocked_traffic(client, count=5)
+    _wait_drop_present(admin, mac, "Paused", timeout_s=180)
+
+    # Cross-check: connection_events stays empty for this MAC while blocked.
+    # If a future refactor starts logging blocked-MAC queries, the assertion
+    # below fails — forcing a deliberate decision rather than silent drift.
+    logs = admin.logs(mac=mac, hours=1)
+    blocked_log_rows = [l for l in logs if (l.get("mac") or "").lower() == mac.lower()]
+    assert not blocked_log_rows, (
+        "Regression: connection_events recorded rows for a firewall-blocked MAC. "
+        "mac_drops is supposed to be the *only* signal for these — see #1103."
+    )
+
+    # Now unpause and confirm drops stop incrementing within one poll.
+    admin.set_profile_paused(profile_id, False)
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
+
+    # Snapshot current packets; after the unblock poll the value should not climb.
+    def _packets_for_paused() -> int:
+        page = admin.mac_drops_series(bucket="1h", hours=2, macs=[mac])
+        total = 0
+        for row in page.get("rows", []):
+            if row.get("reason") == "Paused":
+                total += row.get("packets") or 0
+        return total
+
+    baseline = _packets_for_paused()
+    _fire_blocked_traffic(client, count=5)
+    # Wait a full poll interval, then verify no growth.
+    import time
+    time.sleep(75)
+    after = _packets_for_paused()
+    assert after == baseline, (
+        f"Absence-after-unblock failed: paused drops still incrementing after "
+        f"unpause (baseline={baseline} after={after}). See #1103 step 5."
+    )
+
+
+def test_schedule_window_surfaces_mac_drop_with_reason_schedule(
+    router, client, scratch_device, scratch_profile, admin,
+):
+    """Open a near-now schedule window → mac_drops shows reason=Schedule."""
+    profile_id = scratch_profile["id"]
+    mac = client.mac
+
+    # Wide-open window so we don't race the clock during the test.
+    admin.add_schedule(profile_id, {
+        "name": "e2e-mac-drops",
+        "days": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+        "startTime": "00:00",
+        "endTime": "23:59",
+        "tz": "UTC",
+    })
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
+    _fire_blocked_traffic(client, count=5)
+    _wait_drop_present(admin, mac, "Schedule", timeout_s=180)
+
+
+def test_unmanaged_default_block_surfaces_mac_drop_with_reason_unmanaged(
+    router, client, admin,
+):
+    """unprofiled MAC under unmanagedMacPolicy.policy=block → reason=Unmanaged."""
+    # Flip the household policy to block; remember to restore.
+    settings = admin._request("GET", "/api/household-settings")
+    old_policy = settings.get("unmanagedMacPolicy", {"policy": "allow", "blockPage": True})
+    admin._request(
+        "PATCH", "/api/household-settings",
+        body={"unmanagedMacPolicy": {"policy": "block", "blockPage": True}},
+    )
+    wait_for_etag_change(admin, router.router_id, timeout_s=240)
+    try:
+        # The fixture's client already exists with no profile assignment —
+        # under policy=block the snapshot emits BlockRules with
+        # blockReason=Unmanaged for it.
+        mac = client.mac
+        _fire_blocked_traffic(client, count=5)
+        _wait_drop_present(admin, mac, "Unmanaged", timeout_s=180)
+    finally:
+        admin._request(
+            "PATCH", "/api/household-settings",
+            body={"unmanagedMacPolicy": old_policy},
+        )
+        wait_for_etag_change(admin, router.router_id, timeout_s=240)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -946,6 +946,37 @@ case class ConnectionEventSeriesPage(
     nextCursor: Option[String] = None,
 ) derives JsonCodec
 
+// ── MAC-level packet drops (#1103) ─────────────────────────────────────────
+// nftables counter-rule drops from `@blocked_macs` (paused / schedule /
+// time_limit / manual / unmanaged). The router agent polls per-(mac, reason)
+// counters and posts deltas; dedup is on (router_id, mac, reason, period_end).
+
+case class MacDropRecord(
+    mac: MacAddress,
+    reason: MacBlockReason,
+    packets: Long,
+    bytes: Long,
+    periodStart: String,
+    periodEnd: String,
+) derives JsonCodec
+
+case class MacDropsReport(
+    routerId: RouterId,
+    drops: List[MacDropRecord],
+) derives JsonCodec
+
+case class MacDropsAggRow(
+    windowStart: String,
+    mac: MacAddress,
+    reason: MacBlockReason,
+    packets: Long,
+    bytes: Long,
+) derives JsonCodec
+
+case class MacDropsSeriesPage(
+    rows: List[MacDropsAggRow],
+) derives JsonCodec
+
 // ── Dashboard "Now" ────────────────────────────────────────────────────────
 
 case class DashboardNowHost(host: HostId, activeSeconds: Long) derives JsonCodec
@@ -1227,18 +1258,24 @@ object MacBlockReason {
   case object Schedule  extends MacBlockReason
   case object TimeLimit extends MacBlockReason
   case object Manual    extends MacBlockReason
+  // #1103: unprofiled device blocked by `unmanagedMacPolicy.policy=block` (#374).
+  // Distinct from Manual so the mac_drops chart can attribute drops to the
+  // household-policy default block vs. an admin's explicit per-device block.
+  case object Unmanaged extends MacBlockReason
 
   def asString(r: MacBlockReason): String      = r match {
     case Paused    => "Paused"
     case Schedule  => "Schedule"
     case TimeLimit => "TimeLimit"
     case Manual    => "Manual"
+    case Unmanaged => "Unmanaged"
   }
   def parse(s: String): Option[MacBlockReason] = s match {
     case "Paused"    => Some(Paused)
     case "Schedule"  => Some(Schedule)
     case "TimeLimit" => Some(TimeLimit)
     case "Manual"    => Some(Manual)
+    case "Unmanaged" => Some(Unmanaged)
     case _           => None
   }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,7 +2,7 @@ import type {
   Alert, AppDetail, ApproveAlertRequest, BlockedInfoResponse, BlocklistHosts, BlocklistSummary, CreateAppRequest, CreateRouterRequest, CreateRouterResponse, CreateUserRequest,
   DashboardNow, DashboardStats, Device,
   CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
-  ConnectionEventSeriesPage, QueryLogPage,
+  ConnectionEventSeriesPage, MacBlockReason, MacDropsSeriesPage, QueryLogPage,
   RecentApexesResponse, RouterSummary, SetAppHostsRequest, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
@@ -302,6 +302,24 @@ export const api = {
       return req<ConnectionEventSeriesPage>('GET', `/connection-events/series?${qs}`)
     },
     stats: () => req<DashboardStats>('GET', '/stats'),
+    // #1103: MAC-level packet drops series. Mirrors `series:` above but
+    // reads from /api/mac-drops/series — these are firewall drops that
+    // connection_events doesn't see (packets never reach dnsmasq).
+    macDrops: (params: {
+      bucket: '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
+      macs?: string[]
+      reasons?: MacBlockReason[]
+      hours?: number
+      until?: string
+    }) => {
+      const qs = new URLSearchParams()
+      qs.set('bucket', params.bucket)
+      if (params.macs?.length)    qs.set('mac', params.macs.join(','))
+      if (params.reasons?.length) qs.set('reason', params.reasons.join(','))
+      if (params.hours)           qs.set('hours', String(params.hours))
+      if (params.until)           qs.set('until', params.until)
+      return req<MacDropsSeriesPage>('GET', `/mac-drops/series?${qs}`)
+    },
   },
 
   // ── Dashboard "now" ────────────────────────────────────────────────────

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -6,7 +6,7 @@ import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog } from '@/t
 
 vi.mock('@/api/client', () => ({
   api: {
-    logs:     { query: vi.fn(), series: vi.fn() },
+    logs:     { query: vi.fn(), series: vi.fn(), macDrops: vi.fn() },
     devices:  { list:  vi.fn() },
     profiles: { list:  vi.fn() },
     apps:     { list:  vi.fn() },
@@ -77,6 +77,43 @@ beforeEach(() => {
   ;(api.apps.list     as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
     { app: { id: 1, name: 'YouTube', slug: 'youtube' } },
   ])
+  // #1103: default to "no drops" so the panel stays hidden in unrelated tests.
+  ;(api.logs.macDrops as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] })
+})
+
+describe('LogsPage — MAC drops panel (#1103)', () => {
+  it('renders a visible signal when /api/mac-drops/series returns drops while connection_events is empty', async () => {
+    // The bug we're guarding: kid-iPad is firewall-blocked, so dnsmasq
+    // never sees its traffic. `/api/connection-events/series` (and /api/logs)
+    // return nothing for that MAC, but `/api/mac-drops/series` reports the
+    // drops. The SPA must still surface a "blocked: paused" signal.
+    (api.logs.query    as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], nextCursor: null })
+    ;(api.logs.series   as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [], nextCursor: null })
+    ;(api.logs.macDrops as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [
+        {
+          windowStart: '2026-05-22T14:00:00Z',
+          mac: 'aa:bb:cc:dd:ee:01',
+          reason: 'Paused',
+          packets: 42,
+          bytes: 9001,
+        },
+      ],
+    })
+    renderAt()
+    expect(await screen.findByTestId('mac-drops-panel')).toBeInTheDocument()
+    expect(api.logs.macDrops).toHaveBeenCalled()
+    const reasonChip = await screen.findByTestId('mac-drops-reason-aa:bb:cc:dd:ee:01')
+    expect(reasonChip.textContent).toMatch(/blocked:\s*paused/)
+  })
+
+  it('stays hidden when there are no MAC drops', async () => {
+    (api.logs.macDrops as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] })
+    renderAt()
+    // Wait for the page to settle, then assert the panel isn't rendered.
+    await screen.findByText('example.com')
+    expect(screen.queryByTestId('mac-drops-panel')).not.toBeInTheDocument()
+  })
 })
 
 describe('LogsPage (Connection Events) — raw view', () => {

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog, TrafficUsageBucket } from '@/types/api'
+import type { ConnectionEventAggRow, Device, MacDropsAggRow, ProfileDetail, QueryLog, TrafficUsageBucket } from '@/types/api'
 import { HostCell } from '@/components/HostCell'
 import { GroupableHeader } from '@/components/usage/GroupableHeader'
 import { HeaderFilter } from '@/components/usage/HeaderFilter'
@@ -117,6 +117,8 @@ export function LogsPage() {
         onBucketChange={setBucket}
         onUntilChange={setUntil}
       />
+
+      <MacDropsPanel macs={macs} devices={devices} until={until} />
 
       {bucket === 'raw'
         ? <RawEventsView
@@ -581,5 +583,116 @@ function AggregatedEventsView({
       </div>
     )}
     </>
+  )
+}
+
+
+// #1103: MAC-level packet drops panel. Surfaces drops from `@blocked_macs`
+// (paused / schedule / time_limit / manual / unmanaged) that connection_events
+// can't see because the firewall drops the packets before dnsmasq sees them.
+// Sums packets/bytes per (mac, reason) over the visible window — the same
+// 24h band the Connection Events table uses. Hidden when there are no drops,
+// so the panel never crowds the page in the steady state.
+function MacDropsPanel({
+  macs, devices, until,
+}: {
+  macs: string[]
+  devices: Device[]
+  until: string | null
+}) {
+  const [rows, setRows] = useState<MacDropsAggRow[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const filterKey = `${macs.join(',')}|${until ?? ''}`
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    api.logs.macDrops({
+      bucket: '1h',
+      hours: 24,
+      macs: macs.length ? macs : undefined,
+      until: until ?? undefined,
+    })
+      .then(p => setRows(p.rows))
+      .catch(e => {
+        setError(String((e as Error).message ?? e))
+        setRows([])
+      })
+      .finally(() => setLoading(false))
+  }, [filterKey])
+
+  if (loading && rows.length === 0) return null
+  if (error) {
+    return (
+      <div data-testid="mac-drops-error" className="text-xs text-red-300">
+        mac-drops: {error}
+      </div>
+    )
+  }
+  if (rows.length === 0) return null
+
+  // Roll up per (mac, reason) across the visible buckets so the panel shows
+  // a compact summary, not one row per hour. Sorted by packets descending so
+  // the worst offender lands at the top.
+  type Agg = { mac: string; reason: string; packets: number; bytes: number }
+  const byKey = new Map<string, Agg>()
+  for (const r of rows) {
+    const key = `${r.mac}|${r.reason}`
+    const cur = byKey.get(key)
+    if (cur) {
+      cur.packets += r.packets
+      cur.bytes   += r.bytes
+    } else {
+      byKey.set(key, { mac: r.mac, reason: r.reason, packets: r.packets, bytes: r.bytes })
+    }
+  }
+  const summary = Array.from(byKey.values()).sort((a, b) => b.packets - a.packets)
+
+  const nameByMac = new Map(devices.map(d => [d.mac, d.name]))
+
+  return (
+    <div
+      data-testid="mac-drops-panel"
+      className="rounded border border-yellow-900 bg-yellow-950/20 p-3 text-sm"
+    >
+      <div className="text-xs uppercase text-yellow-400 mb-1">
+        MAC-level firewall drops (last 24h)
+      </div>
+      <p className="text-xs text-gray-500 mb-2">
+        Packets dropped at the firewall before reaching DNS — not visible in
+        Connection Events. Sourced from nftables drop counters (#1103).
+      </p>
+      <table className="min-w-full text-xs">
+        <thead className="text-gray-500">
+          <tr>
+            <th className="text-left px-2 py-1">Device</th>
+            <th className="text-left px-2 py-1">Reason</th>
+            <th className="text-right px-2 py-1">Packets</th>
+            <th className="text-right px-2 py-1">Bytes</th>
+          </tr>
+        </thead>
+        <tbody className="text-gray-300">
+          {summary.map(s => (
+            <tr key={`${s.mac}|${s.reason}`} data-testid={`mac-drops-row-${s.mac}-${s.reason}`}>
+              <td className="px-2 py-1">
+                <DeviceLink mac={s.mac} deviceName={nameByMac.get(s.mac) ?? null} />
+              </td>
+              <td className="px-2 py-1">
+                <span
+                  data-testid={`mac-drops-reason-${s.mac}`}
+                  className="inline-block px-1.5 py-0.5 rounded bg-yellow-900/40 text-yellow-200"
+                >
+                  blocked: {s.reason.toLowerCase()}
+                </span>
+              </td>
+              <td className="px-2 py-1 text-right tabular-nums">{s.packets}</td>
+              <td className="px-2 py-1 text-right tabular-nums">{s.bytes}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -478,6 +478,23 @@ export interface ConnectionEventSeriesPage {
   nextCursor?: string | null
 }
 
+// #1103: MAC-level packet drops series — drops from `@blocked_macs` that
+// connection_events can't see because the packets never reach dnsmasq.
+export type MacBlockReason =
+  | 'Paused' | 'Schedule' | 'TimeLimit' | 'Manual' | 'Unmanaged'
+
+export interface MacDropsAggRow {
+  windowStart: string
+  mac: string
+  reason: MacBlockReason
+  packets: number
+  bytes: number
+}
+
+export interface MacDropsSeriesPage {
+  rows: MacDropsAggRow[]
+}
+
 // #794: server returns hourly UTC buckets aligned to a caller-specified `bucketOffsetMin`
 // (one of 0/15/30/45 — minute past the UTC hour where the grid starts). The SPA picks the
 // offset so each bucket falls fully within one local-tz day, then groups by local day for the


### PR DESCRIPTION
## Summary

- New `mac_drops` table + ingest/read endpoints surface drops from `@blocked_macs` (paused / schedule / time_limit / manual / unmanaged) that `connection_events` can't see because the firewall drops the packets before dnsmasq.
- `render.lua` converts the family-agnostic `@blocked_macs drop` into per-MAC `counter drop comment "wh_drop:<mac>:<reason>"` rules; the agent polls those counters and POSTs deltas via the existing retry-queue pattern.
- LogsPage gains a small drops panel — hidden in the steady state, lights up the moment a kid's iPad goes silent because their cap is exhausted.
- `MacBlockReason.Unmanaged` added so #374's default-block path is distinguishable from an admin's explicit Manual block at the chart.

Closes #1103.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.MacDropsApiSpec` — 8 tests pass (ingest auth, idempotency, negative-delta rejection, mac/reason filters, child-role 403, retention sweep).
- [x] `mill api.test.testOnly wifihaven.api.feature.PolicySnapshotMacDropAttributionSpec` — 3 tests pass; pins the wire-string contract between API + router for all five reasons.
- [x] `mill api.test` — full suite green (192 test classes, all `0 tests failed`; pre-existing mill 1.1.5 reporter race on parallel workers, not in this change).
- [x] `mill scalafmtCheckAll` — formatted.
- [x] `npx tsc --noEmit` (web) — clean.
- [x] busted `render_spec` — 137 successes, render assertions updated for per-MAC `counter drop comment "wh_drop:..."` rules.
- [x] `LogsPage.test.tsx` — added panel-visible + panel-hidden cases (vitest couldn't be invoked in the worktree due to a local `@rolldown/binding-darwin-arm64` install hiccup unrelated to this change; tsc passes).
- [ ] `scripts/e2e/scenarios/test_mac_drops_observability.py` — written but not run from here; needs the e2e VM stack.

## Follow-ups filed

- #1114 — rollup tables (`mac_drops_hourly` / `mac_drops_daily`) + 90/180-day retention parity with `traffic_*`.
- #1115 — connection-events-style groupBy / cursor / HeaderFilter in the panel (depends on #1114 for cheap wide buckets).
- #1116 — fake-router e2e scenario asserting the `/api/router/mac-drops` wire contract under synthetic load.
- #1117 — fake-API e2e scenario asserting the agent's counter-diff + retry-queue path.

## Wire-shape notes

- Atomic API + SPA deploy. No feature flag, no shim — the router agent is the only client; old agents simply don't post to the new endpoint until upgraded.
- `MacBlockReason` parser now accepts a fifth variant (`Unmanaged`); existing snapshots emitting `Manual` for the unmanaged-block path are updated to emit `Unmanaged` (PolicySnapshotBlockedMacsSpec + RouterApiSpec updated to match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)