### PR TITLE
docs(testing): one-page map of which e2e suite covers what (#1107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+# Where do new tests go? See docs/testing.md.
+
 on:
   pull_request:
     # Run on PRs targeting any branch

--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -1,5 +1,7 @@
 name: VM e2e (fake API — Gate 2)
 
+# Where do new tests go? See docs/testing.md.
+
 # Gate 2 of the three-gate plan (#652/#654/#686). Boots qemu OpenWRT +
 # Alpine client on the self-hosted KVM runner against the in-process fake
 # API (scripts/e2e/fake-api/), runs scripts/e2e/scenarios_fake/.

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -1,5 +1,7 @@
 name: VM e2e
 
+# Where do new tests go? See docs/testing.md — legacy track, retiring in #656.
+
 # Full VM-based e2e: boots the OpenWRT router VM + Alpine client VM and runs
 # the scenarios under scripts/e2e/scenarios/ against a disposable docker
 # compose API stack. Runs on the self-hosted KVM runner (#149).

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -1,5 +1,7 @@
 name: Master API/UI CD
 
+# Where do new tests go? See docs/testing.md (Gate 1 lives in this workflow).
+
 # API + SPA deployment pipeline. Split off from the unified Master CD in
 # #871 — see master-router.yml for the router half and the split rationale.
 #

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -1,5 +1,7 @@
 name: Master Router CD
 
+# Where do new tests go? See docs/testing.md (Gate 2 gates publish here).
+
 # Router deployment pipeline — produces the openwrt-latest rolling release.
 #
 # Split off from the unified Master CD in #871: a single workflow handling

--- a/README.md
+++ b/README.md
@@ -288,6 +288,9 @@ but you lose the auto-update property.
 
 ## Testing
 
+Where does a new test belong? See [`docs/testing.md`](docs/testing.md) for the
+suite map (unit / Gate 1 / Gate 2 / Gate 3a+3b).
+
 Tests use [zonky/embedded-postgres](https://github.com/zonkyio/embedded-postgres),
 so no external DB is required.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,120 @@
+# Where do I add this test?
+
+A one-page map of the test suites in this repo and which one a given
+behavior belongs in. Background: three-gate plan (#652), Gate 1 (#653),
+Gate 2 (#654 / #686), Gate 3a + 3b (#655). The live `e2e-vm.yml` track
+is being decommissioned (#656) — **don't add new tests there**.
+
+## 30-second decision tree
+
+Pick the lowest layer that can fail the way you care about.
+
+1. **Pure logic in one process?** → unit tests. `api/test/` (Scala),
+   `web/src/**/*.test.tsx` (Vitest), `openwrt/test/` (busted/Lua).
+2. **API contract — admin or router-API field shapes, status codes,
+   etag round-trip, 4xx/401?** → **Gate 1** (`scripts/e2e-tests.sh` +
+   `scripts/e2e-router.sh`, run as `api-smoke-staging` in
+   `master-api-ui.yml`).
+3. **Router enforcement — does blocked / allowed / scheduled / paused /
+   extra-allowed actually do the right thing on the wire?** → **Gate 2**
+   (`scripts/e2e/scenarios_fake/`, run by `e2e-vm-fake.yml`).
+4. **The seam between a real router build and a real API deploy?** →
+   **Gate 3** (`scripts/e2e/gate3/`, run by `e2e-vm-gate3a.yml` and
+   `e2e-vm-gate3b.yml`). Almost never the right answer for new tests —
+   see "Gate 3" below.
+
+Worked example — adding a new `failureMode` enum value:
+
+- New admin-API field shape / accepted values → **Gate 1**.
+- Router rendering the new mode at enforcement time → **Gate 2**.
+- Gate 3 → **no change**. Gate 3 doesn't enumerate modes; it only checks
+  that the wire still flows.
+
+## Suite scope reference
+
+### Unit tests
+
+`api/test/` · `web/src/**/*.test.tsx` · `openwrt/test/`. Run from `ci.yml`
+on every PR via `mill __.test`, `npm test`, and the Lua test job.
+
+- **Add here:** anything that can be exercised in one process with no
+  router VM, no live API, no network.
+- **Don't add here:** anything whose failure mode is "the two sides
+  disagree about the wire" — that's what the gates exist for.
+
+### Gate 1 — API contract smoke against staging
+
+Workflow: `master-api-ui.yml` job `api-smoke-staging`. Driver:
+`scripts/e2e-tests.sh` + `scripts/e2e-router.sh`. Hits a freshly-deployed
+staging API; the "router" side is the fake driver in those scripts.
+
+- **Add here:** new admin-API endpoints or fields, router-API contract
+  changes, status-code expectations, etag / If-None-Match behavior,
+  auth / 401 / 4xx surface area.
+- **Don't add here:** anything that needs a real OpenWRT image to
+  observe — that's Gate 2. Don't add deep enumeration of enforcement
+  modes; the goal here is contract surface, not depth.
+- **Template tests:** `scripts/e2e-tests.sh` covers the admin path;
+  `scripts/e2e-router.sh` covers the router-API path.
+
+### Gate 2 — router enforcement against fake API
+
+Workflow: `e2e-vm-fake.yml` (gates `publish-openwrt` in
+`master-router.yml`). Boots qemu OpenWRT + Alpine client on the
+self-hosted KVM runner, points the agent at the in-process fake API in
+`scripts/e2e/fake-api/` serving snapshot goldens.
+
+- **Add here:** every enforcement mode and combination —
+  blocked / allowed / scheduled / paused / extra-allowed,
+  daily limits, time limits, unknown-device handling, reassignment,
+  block-page rendering, etc. **Depth is Gate 2's job.**
+- **Don't add here:** API contract assertions — the fake API is by
+  construction whatever the snapshot says, so you can't catch a real
+  contract drift here. Use Gate 1.
+- **Template tests:** `scripts/e2e/scenarios_fake/test_03_blocked_domain.py`,
+  `test_extra_blocked.py`, `test_schedule.py`, `test_pause.py`.
+
+### Gate 3 — real router vs real API (two halves)
+
+Both halves share the same code under `scripts/e2e/gate3/`. The only
+difference is which side is "fresh" and which is "current released":
+
+- **Gate 3a** (`e2e-vm-gate3a.yml`, gates `publish-openwrt`): freshly-built
+  router against current staging API. "Can this router still talk to
+  prod's API?"
+- **Gate 3b** (`e2e-vm-gate3b.yml`, gates `publish-api`):
+  last-published router against freshly-deployed staging API. "Does this
+  API still work for routers customers are running?"
+
+Gate 3 is deliberately a thin smoke. Its purpose is to catch wire-protocol
+regressions across an actual published-version skew — not to retest
+behaviors either side already covers.
+
+- **Add here:** almost nothing. A new wire-level field that needs cross-
+  version compatibility evidence might qualify; talk to whoever opened
+  #655 first.
+- **Don't add here:** new enforcement modes (Gate 2). New admin-API
+  fields (Gate 1). UI behavior (web unit tests + Gate 1). Anything that
+  could be expressed without two real artifacts.
+
+### Live VM e2e (`e2e-vm.yml`) — legacy
+
+Full docker-compose API + qemu router. Not a gate. **Being retired
+(#656).** Don't add new tests under `scripts/e2e/scenarios/`; if you'd
+have put one here, it belongs in Gate 2.
+
+## Cheat sheet
+
+| If the failure is… | Add to |
+|---|---|
+| "the API would accept/return the wrong JSON" | Gate 1 |
+| "the router would block/allow the wrong packet" | Gate 2 |
+| "an old router talking to a new API would break" | Gate 3b |
+| "a new router talking to the current API would break" | Gate 3a |
+| "this function returns the wrong value" | unit test |
+
+## Out of scope here
+
+- Decommissioning `e2e-vm.yml` — tracked in #656.
+- Runner capacity — tracked in #657.
+- Wire-schema versioning framework — tracked in #376 / #597.


### PR DESCRIPTION
## Summary
- New `docs/testing.md` — 30-sec decision tree, per-gate scope + "don't add here" lists, 3a/3b distinction, template-test pointers, links to #652/#653/#654/#655/#656.
- One-line cross-link added to the header of each existing test/CD workflow (`ci.yml`, `e2e-vm.yml`, `e2e-vm-fake.yml`, `master-api-ui.yml`, `master-router.yml`).
- One-liner under README's existing Testing section pointing at the new doc. No `CONTRIBUTING.md` exists; not created.

Gate 3a/3b workflow files don't exist yet (waiting on #655) — the doc references them as planned, matching the issue body.

Closes #1107.

## Test plan
- [ ] `docs/testing.md` renders on GitHub.
- [ ] Sanity-check the acceptance scenario: reader can tell in <30s that a new `failureMode` enum value → admin field in Gate 1, router rendering in Gate 2, Gate 3 no-op.
- [ ] Workflow header comments still parse (they're just `#` lines — CI should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)