### PR TITLE
feat(ci): Gate 3 — thin qemu integration smoke against real staging (#655)

### DIFF
--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -1,0 +1,167 @@
+name: VM e2e (Gate 3a — router-side staging smoke)
+
+# Gate 3a of the three-gate plan (#652/#655). Boots qemu OpenWRT + Alpine
+# client on the self-hosted KVM runner with the router image built *from
+# this PR's router code*, enrolls it against the current staging API
+# (`:staging` Render service, NOT freshly redeployed — Gate 3a runs in the
+# router pipeline, which doesn't touch the API), and runs the gate3 smoke
+# scenario.
+#
+# Answers: "does this router image still talk to the current prod API
+# contract?" Red here blocks publish-openwrt.
+#
+# Gate 3b's mirror lives in e2e-vm-gate3b.yml — same scenario, opposite
+# inputs (last-published router image + freshly-deployed staging API).
+#
+# Triggers:
+#   - workflow_call    — invoked from master-router.yml as a needs: of
+#                        approve-production (parallel to gate-2-router-fake-api)
+#   - workflow_dispatch — manual debugging from the Actions tab
+#
+# Concurrency: shares the e2e-vm group with Gate 2 and the live-mode VM
+# e2e workflow. Per the e2e-vm group convention, runs on this host
+# serialize. The capacity headroom this consumes is tracked in #657.
+
+on:
+  workflow_call:
+    inputs:
+      consume_vm_image_artifact:
+        description: "Download the VM image from a sibling build-vm-image job artifact instead of building locally. Master Router CD sets this true so the .img is built once per run."
+        type: boolean
+        default: false
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-vm
+  cancel-in-progress: false
+
+jobs:
+  e2e-gate3a:
+    name: Gate 3a (router-side staging) — ${{ matrix.pkg_format }}
+    # Block fork PRs on the self-hosted runner; same guard as e2e-vm.yml /
+    # e2e-vm-fake.yml. workflow_call + workflow_dispatch are always allowed.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, kvm]
+    # Local dry-run wall time per arm: ~72s end-to-end (#655 checkpoint 3).
+    # 20m budget covers cold-image build + image-extract + apk arm headroom.
+    timeout-minutes: 20
+    # Matrix over ipk-23.05 and apk-25.12 (#532). fail-fast=false so a
+    # regression in one flavor still reports the other arm's status.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg_format: ipk
+            port_base: 2422
+          - pkg_format: apk
+            port_base: 2522
+
+    env:
+      PKG_FORMAT: ${{ matrix.pkg_format }}
+      # Distinct host-port bases from Gate 2's 2222/2322 so a stale Gate 2
+      # state on the runner can't collide with Gate 3a's qemu hostfwds —
+      # even though the e2e-vm concurrency group serializes them, the
+      # safety margin is free.
+      WH_PORT_BASE: ${{ matrix.port_base }}
+      # Same WH_RUN_ID conventions as Gate 2 — short enough to keep
+      # .run/<id>/router/monitor.sock under the 108-byte Unix-socket path
+      # limit. Sequential matrix arms (today's reality on a single
+      # runner) safely reuse the same id because teardown completes
+      # between arms.
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      WH_API_URL: https://api-staging.wifihaven.net
+      WH_GATE3_SIDE: 3a
+
+    steps:
+      # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
+      # can leave root-owned files under scripts/vm/.cache/imagebuilder/.
+      # Same pattern as e2e-vm-fake.yml.
+      - name: Reclaim root-owned cache files (pre-checkout)
+        run: |
+          docker rm -f wh-imagebuilder 2>/dev/null || true
+          CACHE="${{ github.workspace }}/scripts/vm/.cache"
+          if [ -d "$CACHE" ]; then
+            docker run --rm -v "$CACHE":/c alpine sh -c '
+              chmod -R u+rwX,a+rX /c 2>/dev/null
+              chown -R '"$(id -u):$(id -g)"' /c 2>/dev/null
+            ' || true
+          fi
+
+      - uses: actions/checkout@v6
+
+      - name: Preflight (kvm/qemu)
+        run: |
+          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
+            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          qemu-system-x86_64 --version | head -n1
+
+      - name: Resolve router image path
+        id: image
+        run: |
+          # Match the path build-router-image.sh writes to and that
+          # e2e-vm-fake.yml resolves; PKG_FORMAT scopes OPENWRT_VERSION_SHORT.
+          . scripts/vm/versions.sh
+          IMG="$GITHUB_WORKSPACE/scripts/vm/.cache/openwrt-wifihaven-${PKG_FORMAT}-${OPENWRT_VERSION_SHORT}.img"
+          echo "path=$IMG" >> "$GITHUB_OUTPUT"
+          echo "Resolved image: $IMG"
+
+      # Reuse the sibling build-vm-image artifact when invoked from
+      # master-router.yml (consume_vm_image_artifact=true). Today
+      # build-vm-image only matrix-builds .ipk; the .apk arm's download is
+      # a no-op and the next step falls through to a local build.
+      - name: Download VM image artifact (from build-vm-image)
+        if: inputs.consume_vm_image_artifact
+        continue-on-error: true
+        uses: actions/download-artifact@v6
+        with:
+          pattern: openwrt-wifihaven-${{ matrix.pkg_format }}-*-${{ github.sha }}
+          path: scripts/vm/.cache
+          merge-multiple: true
+
+      - name: Build router image (if not cached / not downloaded)
+        run: |
+          if [[ -f "${{ steps.image.outputs.path }}" ]]; then
+            echo "router image present, skipping build"
+          else
+            scripts/vm/build-router-image.sh
+          fi
+
+      - name: Build client base (if not cached)
+        run: scripts/vm/build-client-base.sh
+
+      - name: Pre-flight kill of stale wh VMs (this WH_RUN_ID only)
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+
+      - name: Run Gate 3a smoke against staging
+        env:
+          WH_ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
+        run: scripts/e2e-vm.sh --mode=gate3
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-vm-gate3a-failure-${{ matrix.pkg_format }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            scripts/vm/.run/**
+            !scripts/vm/.run/**/*.qcow2
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Tear down VMs
+        if: always()
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+          # Backstop: kill anything tagged with *this* run's id that the
+          # pidfile-driven down scripts missed. Scoped via WH_RUN_ID so a
+          # sibling concurrent run is never touched.
+          pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}" || true

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -1,0 +1,156 @@
+name: VM e2e (Gate 3b — API/UI-side staging smoke)
+
+# Gate 3b of the three-gate plan (#652/#655). Mirror of Gate 3a, opposite
+# inputs: boots the *last published* qemu OpenWRT router image (downloaded
+# from the rolling openwrt-latest GitHub Release per #893) against the
+# *freshly-deployed* staging API.
+#
+# Answers: "does this API/UI build still work for routers that are
+# actually deployed in the field?" The router under test is the
+# known-good last-published image — what customers are running. Red here
+# blocks API/UI prod publish (retag-latest / deploy-prod-render /
+# deploy-spa-prod), even when Gate 1's contract goldens are green —
+# that's the whole point of running against the last-published router.
+#
+# Bootstrapping: first time #893 lands, there's no "last published" qemu
+# image yet. Caller (master-api-ui.yml) currently invokes this job with
+# `continue-on-error: true` until a seed asset exists; see #655 PR body
+# for the flip plan.
+#
+# Triggers:
+#   - workflow_call    — invoked from master-api-ui.yml as a needs: of
+#                        approve-production (alongside smoke-staging +
+#                        api-smoke-staging)
+#   - workflow_dispatch — manual debugging from the Actions tab
+#
+# Concurrency: shares the e2e-vm group with Gates 2 + 3a + live-mode e2e.
+# Capacity tracked in #657.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-vm
+  cancel-in-progress: false
+
+jobs:
+  e2e-gate3b:
+    name: Gate 3b (API/UI-side staging) — ${{ matrix.pkg_format }}
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, linux, kvm]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg_format: ipk
+            port_base: 2622
+          - pkg_format: apk
+            port_base: 2722
+
+    env:
+      PKG_FORMAT: ${{ matrix.pkg_format }}
+      WH_PORT_BASE: ${{ matrix.port_base }}
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      WH_API_URL: https://api-staging.wifihaven.net
+      WH_GATE3_SIDE: 3b
+
+    steps:
+      # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh
+      # can leave root-owned files under scripts/vm/.cache/. Same pattern
+      # as e2e-vm-fake.yml / e2e-vm-gate3a.yml.
+      - name: Reclaim root-owned cache files (pre-checkout)
+        run: |
+          docker rm -f wh-imagebuilder 2>/dev/null || true
+          CACHE="${{ github.workspace }}/scripts/vm/.cache"
+          if [ -d "$CACHE" ]; then
+            docker run --rm -v "$CACHE":/c alpine sh -c '
+              chmod -R u+rwX,a+rX /c 2>/dev/null
+              chown -R '"$(id -u):$(id -g)"' /c 2>/dev/null
+            ' || true
+          fi
+
+      - uses: actions/checkout@v6
+
+      - name: Preflight (kvm/qemu/gh)
+        run: |
+          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
+            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          qemu-system-x86_64 --version | head -n1
+          gh --version
+
+      # Download the last-published router image asset from
+      # openwrt-latest. Asset filenames follow the #893 pattern:
+      #   wifihaven-router-openwrt-<VERSION_SHORT>-<flavor>.tar.gz
+      #   wifihaven-router-images.sha256
+      # `gh release download -p '...'` resolves the asset by glob, so a
+      # future OPENWRT_VERSION_SHORT bump in the published asset doesn't
+      # need a workflow edit here.
+      - name: Download last-published router image
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p release
+          cd release
+          # Single-arm download — only fetch the tarball this matrix arm
+          # needs, plus the shared checksum manifest.
+          gh release download openwrt-latest \
+            --repo "$GITHUB_REPOSITORY" \
+            -p "wifihaven-router-openwrt-*-${PKG_FORMAT}.tar.gz" \
+            -p "wifihaven-router-images.sha256"
+          # Verify the tarball checksum. sha256sum -c short-circuits on
+          # missing files; restrict the manifest to lines we have.
+          tarball=$(ls wifihaven-router-openwrt-*-${PKG_FORMAT}.tar.gz)
+          grep -F "${tarball}" wifihaven-router-images.sha256 > expected.sha256
+          sha256sum -c expected.sha256
+
+      - name: Extract router .img
+        id: image
+        run: |
+          set -euo pipefail
+          cd release
+          tarball=$(ls wifihaven-router-openwrt-*-${PKG_FORMAT}.tar.gz)
+          tar -xzf "$tarball"
+          img=$(ls openwrt-wifihaven-${PKG_FORMAT}-*.img | head -n1)
+          path="$GITHUB_WORKSPACE/release/$img"
+          echo "path=$path" >> "$GITHUB_OUTPUT"
+          ls -lh "$path"
+
+      - name: Build client base (if not cached)
+        run: scripts/vm/build-client-base.sh
+
+      - name: Pre-flight kill of stale wh VMs (this WH_RUN_ID only)
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+
+      - name: Run Gate 3b smoke against freshly-deployed staging
+        env:
+          WH_ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
+        run: scripts/e2e-vm.sh --mode=gate3
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-vm-gate3b-failure-${{ matrix.pkg_format }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            scripts/vm/.run/**
+            !scripts/vm/.run/**/*.qcow2
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Tear down VMs
+        if: always()
+        run: |
+          scripts/vm/router-down.sh || true
+          scripts/vm/client-down.sh || true
+          pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}" || true

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -14,6 +14,9 @@ name: Master API/UI CD
 #     → smoke-staging                (lightweight curl checks against api-staging.wifihaven.net
 #                                     AND staging.wifihaven.net SPA)
 #     → api-smoke-staging            (Gate 1 — admin + router API contract smoke against staging)
+#     → gate-3b-api-staging          (Gate 3b — last-published qemu router + freshly-deployed
+#                                     staging API; #655. continue-on-error until #893's seed
+#                                     image is published — see the job's comment.)
 #     → approve-production           (manual-approval gate — GitHub `production`
 #                                     environment; required reviewer must click
 #                                     "Approve and deploy" before the deploy-production
@@ -46,6 +49,7 @@ on:
       - 'scripts/**'
       - 'shared/**'
       - '.github/workflows/master-api-ui.yml'
+      - '.github/workflows/e2e-vm-gate3b.yml'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
@@ -378,8 +382,35 @@ jobs:
   # approval prompts across the two pipelines when shared/** changes fire
   # both sides.
 
+  # ── 5c. Gate 3b — last-published router vs freshly-deployed staging ────
+  # Boots the *last published* qemu OpenWRT router image (from the
+  # openwrt-latest GitHub Release, per #893) against the staging API this
+  # PR just deployed. Catches API/UI changes that break forward
+  # compatibility with routers customers are actually running — a class
+  # of regression Gate 1's current-contract goldens cannot see.
+  #
+  # Bootstrap caveat: #893 lands the publish path but doesn't pre-seed
+  # the release. Until the first post-#893 publish-openwrt fires, the
+  # `gh release download` step in this caller will fail. We wire the job
+  # in with `continue-on-error: true` so the gate is observable in the UI
+  # but cannot block prod. Flip to a hard gate in a follow-up PR after
+  # the seed asset exists; tracked in the #655 PR body.
+  gate-3b-api-staging:
+    name: Gate 3b — last-published router + staging API
+    needs: [deploy-staging]
+    continue-on-error: true
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-vm-gate3b.yml
+    secrets: inherit
+
   approve-production:
     name: Manual approval (production gate)
+    # Gate 3b is *not* in `needs:` while continue-on-error is true — a
+    # bootstrap-skipped run shouldn't pause approve-production waiting on
+    # a job that's reporting "skipped" rather than "success". Once
+    # #655's bootstrap follow-up flips continue-on-error off, add
+    # `gate-3b-api-staging` to this `needs:` list.
     needs: [smoke-staging, api-smoke-staging]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -11,8 +11,13 @@ name: Master Router CD
 # Flow:
 #   ci-tests                    (full matrix; ci.yml self-filters by path)
 #     → gate-2-router-fake-api  (qemu OpenWRT + Alpine + fake API on KVM)
+#     ‖ gate-3a-router-staging  (qemu OpenWRT + Alpine + real staging API)
 #       → approve-production    (manual gate, `production` environment)
 #         → publish-openwrt     (rolling openwrt-latest GitHub Release)
+#
+# Gates 2 and 3a both share the e2e-vm self-hosted-runner concurrency
+# group (#657 capacity follow-up), so in practice they serialize on the
+# host even though the workflow graph runs them in parallel.
 #
 # Path scope: see `on.push.paths` below. shared/contract/** (wire-format
 # goldens) triggers BOTH pipelines for tandem releases until #597 lands.
@@ -33,6 +38,7 @@ on:
       - '.github/workflows/master-router.yml'
       - '.github/workflows/openwrt-build.yml'
       - '.github/workflows/e2e-vm-fake.yml'
+      - '.github/workflows/e2e-vm-gate3a.yml'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
@@ -86,6 +92,23 @@ jobs:
       consume_vm_image_artifact: true
     secrets: inherit
 
+  # Gate 3a (#655): the same router image, but enrolled against the real
+  # staging API. Confirms the freshly-built router agent talks to the
+  # current production API contract — catching the class of regression
+  # that's invisible against the fake-API snapshot fixtures (i.e. the
+  # snapshot golden has drifted from what the API actually emits).
+  # Shares the e2e-vm concurrency group with Gate 2 and the live-mode VM
+  # e2e workflow.
+  gate-3a-router-staging:
+    name: Gate 3a — router staging smoke
+    needs: [ci-tests, build-vm-image]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-vm-gate3a.yml
+    with:
+      consume_vm_image_artifact: true
+    secrets: inherit
+
   # Manual-approval gate. Carries `environment: production` so GitHub pauses
   # the run for an approval click before the rolling release is touched.
   # API/UI prod approval lives on its own gate in master-api-ui.yml; both
@@ -93,7 +116,7 @@ jobs:
   # approval prompts across the two pipelines.
   approve-production:
     name: Manual approval (router production gate)
-    needs: [gate-2-router-fake-api]
+    needs: [gate-2-router-fake-api, gate-3a-router-staging]
     runs-on: ubuntu-latest
     permissions: {}
     environment:

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -10,6 +10,7 @@
 # Usage:
 #   scripts/e2e-vm.sh                            # run live-mode scenarios (default)
 #   scripts/e2e-vm.sh --mode=fake                # run fake-API mode scenarios (#683)
+#   scripts/e2e-vm.sh --mode=gate3               # run gate3 smoke against real staging (#655)
 #   scripts/e2e-vm.sh --only blocked-domain      # run a single scenario
 #   scripts/e2e-vm.sh --keep                     # leave VMs + stack up after run
 #   scripts/e2e-vm.sh -- -k allowed              # passthrough to pytest
@@ -18,6 +19,9 @@
 #   live  (default) — boot docker-compose API stack, exercise live scenarios.
 #   fake            — boot in-process fake API shim, exercise fake-mode
 #                     scenarios under scripts/e2e/scenarios_fake/ (Gate 2).
+#   gate3           — boot router VM against a remote staging API (no local
+#                     stack, no fake), exercise scripts/e2e/gate3/. Requires
+#                     WH_API_URL + WH_ADMIN_PASS + WH_ROUTER_IMAGE_PATH.
 #
 # Environment overrides (read by conftest.py / conftest_fake.py):
 #   E2E_VM_API_PORT         API stack host port (default 18080; live mode)
@@ -78,8 +82,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "${MODE}" in
-  live|fake) ;;
-  *) echo "unknown --mode: ${MODE} (valid: live, fake)" >&2; exit 2 ;;
+  live|fake|gate3) ;;
+  *) echo "unknown --mode: ${MODE} (valid: live, fake, gate3)" >&2; exit 2 ;;
 esac
 
 # --only <name> maps to pytest's marker selection. Supported names match the
@@ -196,8 +200,9 @@ cd "${E2E_DIR}"
 
 CMD=( "${VENV_DIR}/bin/pytest" )
 case "${MODE}" in
-  live) CMD+=( "scenarios" ) ;;
-  fake) CMD+=( "scenarios_fake" ) ;;
+  live)  CMD+=( "scenarios" ) ;;
+  fake)  CMD+=( "scenarios_fake" ) ;;
+  gate3) CMD+=( "gate3" ) ;;
 esac
 if [[ -n "${MARK}" ]]; then
   CMD+=( -m "${MARK}" )

--- a/scripts/e2e/gate3/conftest.py
+++ b/scripts/e2e/gate3/conftest.py
@@ -1,0 +1,207 @@
+"""Gate 3 fixtures — drives the real staging API via the public admin
+surface only (no /api/debug/* — staging doesn't expose it).
+
+Reuses lib/vm + lib/enrollment primitives + lib/wait verbatim. Skips
+lib/stack and lib/api_debug (Gate 3 talks to a remote API, not a local
+docker stack, and asserts behavior via the public surface).
+
+Namespacing — every artifact written to the shared staging instance is
+suffixed with WH_RUN_ID-PKG_FORMAT-SIDE so concurrent PRs on the same
+staging do not collide. Teardown is best-effort in finally blocks; if a
+run aborts hard, a periodic cleanup job (filed separately) would scrub
+orphans.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+import pytest
+
+from lib.api_admin import AdminAPI
+from lib.enrollment import exchange_enrollment_token, provision_router_uci
+from lib.vm import Client, client_down, client_up, router_down, router_up
+from lib.wait import wait_for_client_dns, wait_for_etag_change, wait_for_router_active
+
+log = logging.getLogger(__name__)
+
+
+WH_API_URL = os.environ.get("WH_API_URL")  # e.g. https://api-staging.wifihaven.net
+WH_ADMIN_USER = os.environ.get("WH_ADMIN_USER", "admin")
+WH_ADMIN_PASS = os.environ.get("WH_ADMIN_PASS")
+WH_RUN_ID = os.environ.get("WH_RUN_ID", "local")
+WH_GATE3_SIDE = os.environ.get("WH_GATE3_SIDE", "3a")  # 3a (router-side) or 3b (api-side)
+PKG_FORMAT = os.environ.get("PKG_FORMAT", "ipk")
+ROUTER_IMAGE_PATH = os.environ.get("WH_ROUTER_IMAGE_PATH")
+KEEP_VMS = os.environ.get("E2E_VM_KEEP", "0") == "1"
+
+
+def _suffix() -> str:
+    # Short, filesystem/DB-safe. 'gate3-<run>-<arm>-<side>' keeps profile
+    # names readable at a glance and stays well under the API's name length
+    # cap (typically 64 chars).
+    return f"{WH_RUN_ID}-{PKG_FORMAT}-{WH_GATE3_SIDE}"
+
+
+def _suffix_mac() -> str:
+    """Deterministic locally-administered MAC keyed on the run suffix.
+
+    Two PRs racing on staging get distinct MACs; a retry of the same run
+    re-uses the same MAC (which is fine because teardown runs in finally
+    and we PUT, not POST, the device record).
+    """
+    h = hashlib.sha256(_suffix().encode()).hexdigest()
+    # 02:e2:e3:xx:xx:xx — bit 0x02 set marks it locally-administered, unicast.
+    # Distinct from the 02:e2:e2:* range used by the live-mode harness.
+    return "02:e2:e3:" + ":".join(h[i:i+2] for i in (0, 2, 4))
+
+
+# ── session-scoped infrastructure ────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def admin() -> AdminAPI:
+    if not WH_API_URL:
+        pytest.fail("WH_API_URL not set (e.g. https://api-staging.wifihaven.net)")
+    if not WH_ADMIN_PASS:
+        pytest.fail("WH_ADMIN_PASS not set")
+    a = AdminAPI(WH_API_URL, username=WH_ADMIN_USER, password=WH_ADMIN_PASS)
+    a.login()
+    return a
+
+
+@pytest.fixture(scope="session")
+def enrolled_router(admin):
+    """Boot the router VM, enroll it against staging, leave it running.
+
+    Single boot, no snapshot/restore loop — Gate 3 has one scenario.
+    """
+    if not ROUTER_IMAGE_PATH:
+        pytest.fail("WH_ROUTER_IMAGE_PATH not set")
+
+    name = f"gate3-{_suffix()}"
+    router_up(image_path=ROUTER_IMAGE_PATH)
+
+    created = admin.create_router(name=name)
+    router_id = created["routerId"]
+    enrollment_token = created["enrollmentToken"]
+
+    register_url = f"{WH_API_URL.rstrip('/')}/api/router/register"
+    rid, rtoken = exchange_enrollment_token(
+        register_url=register_url, enrollment_token=enrollment_token,
+    )
+    assert rid == router_id, f"register returned {rid!r}, admin issued {router_id!r}"
+
+    # Point the agent at staging directly. The router's WAN reaches the
+    # internet through SLIRP (see wait_for_router_slirp_ready's probe (b)),
+    # so HTTPS to api-staging.wifihaven.net works without any host-side
+    # proxying.
+    provision_router_uci(router_id=router_id, router_token=rtoken, api_url=WH_API_URL)
+
+    # Confirm the agent's first poll landed.
+    wait_for_router_active(admin, router_id, timeout_s=180)
+
+    yield {"router_id": router_id, "router_token": rtoken, "name": name}
+
+    if not KEEP_VMS:
+        try:
+            router_down()
+        except Exception as e:  # noqa: BLE001
+            log.warning("router_down failed: %s", e)
+    try:
+        admin.delete_router(router_id)
+    except Exception as e:  # noqa: BLE001
+        log.warning("delete_router(%s) failed: %s", router_id, e)
+
+
+# ── function-scoped lifecycle ────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client_vm() -> Client:
+    mac = _suffix_mac()
+    name = "client1"
+    c = client_up(mac=mac, name=name)
+    try:
+        wait_for_client_dns(c, host="example.com", timeout_s=60)
+        yield c
+    finally:
+        if not KEEP_VMS:
+            try:
+                client_down(name)
+            except Exception as e:  # noqa: BLE001
+                log.warning("client_down failed: %s", e)
+
+
+@pytest.fixture()
+def scratch_profile_and_device(admin, enrolled_router, client_vm):
+    """Create a namespaced profile + device + blocked/allowed apps; yield
+    the relevant ids; delete on teardown.
+
+    Post-#764, extraBlocked / extraAllowed are no longer profile fields —
+    they come from app_policy_assignments. The Apps API is:
+      POST   /api/apps {name, slug, hosts}                   → create
+      PUT    /api/apps/{aid}/policy/{pid} {mode: "blocked"}  → assign
+      DELETE /api/apps/{aid}                                 → cascades the
+                                                              assignment
+    """
+    suffix = _suffix()
+    blocked_host = "example.com"
+    allowed_host = "example.org"
+
+    pname = f"gate3-{suffix}"
+    p = admin.create_profile(name=pname)
+    pid = (p.get("profile") or p)["id"]
+
+    blocked_app = admin.create_app(
+        name=f"gate3-blk-{suffix}", slug=f"gate3-blk-{suffix}",
+        hosts=[blocked_host],
+    )
+    allowed_app = admin.create_app(
+        name=f"gate3-alw-{suffix}", slug=f"gate3-alw-{suffix}",
+        hosts=[allowed_host],
+    )
+    blocked_app_id = blocked_app["app"]["id"]
+    allowed_app_id = allowed_app["app"]["id"]
+    admin.assign_app_policy(app_id=blocked_app_id, profile_id=pid, mode="blocked")
+    admin.assign_app_policy(app_id=allowed_app_id, profile_id=pid, mode="allowed")
+
+    mac = client_vm.mac
+    admin.upsert_device(
+        mac=mac,
+        name=f"gate3-dev-{suffix}",
+        profile_id=pid,
+    )
+
+    # Wait for the agent to pick up the snapshot that includes this device
+    # + the app assignments. PolicyApply restarts dnsmasq (#341); re-gate
+    # the client on a fresh resolver answer before the test starts
+    # probing traffic.
+    wait_for_etag_change(admin, enrolled_router["router_id"], timeout_s=180)
+    wait_for_client_dns(client_vm, host=blocked_host, timeout_s=30)
+
+    yield {
+        "profile_id": pid,
+        "mac": mac,
+        "blocked_host": blocked_host,
+        "allowed_host": allowed_host,
+        "blocked_app_id": blocked_app_id,
+        "allowed_app_id": allowed_app_id,
+    }
+
+    # Teardown — DELETE app cascades its assignment, so order is:
+    # device → apps (cascades assignments) → profile.
+    try:
+        admin.delete_device(mac)
+    except Exception as e:  # noqa: BLE001
+        log.warning("delete_device(%s) failed: %s", mac, e)
+    for aid in (blocked_app_id, allowed_app_id):
+        try:
+            admin.delete_app(aid)
+        except Exception as e:  # noqa: BLE001
+            log.warning("delete_app(%s) failed: %s", aid, e)
+    try:
+        admin.delete_profile(pid)
+    except Exception as e:  # noqa: BLE001
+        log.warning("delete_profile(%s) failed: %s", pid, e)

--- a/scripts/e2e/gate3/test_smoke.py
+++ b/scripts/e2e/gate3/test_smoke.py
@@ -1,0 +1,153 @@
+"""Gate 3 smoke — single scenario covering the contract surface between
+the router agent and the API:
+
+  1. Router boots, enrolls against staging (session fixture).
+  2. Profile + device provisioned with extraBlocked + extraAllowed.
+  3. Agent fetches the new policy (etag advances).
+  4. Client traffic — blocked host is intercepted (block page body),
+     allowed host returns upstream content.
+  5. Usage report — staging /api/logs has a row attributed to this MAC,
+     and /api/time/status surfaces the device under its profile.
+
+Either side of the contract drifting (snapshot field rename consumed by
+render.lua, or events POST shape rename) turns this red. Behavior depth
+beyond this lives in Gate 2 (#654); the deliberately narrow scope is the
+point.
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+from lib.traffic import http_get
+from lib.wait import wait_until
+
+log = logging.getLogger(__name__)
+
+
+# Window for /api/logs lookback. Generous enough to absorb the agent's
+# usage-report flush cadence (default 60s) without flaking.
+LOGS_LOOKBACK_HOURS = 1
+
+
+def test_gate3_smoke(admin, enrolled_router, client_vm, scratch_profile_and_device):
+    mac = scratch_profile_and_device["mac"]
+    profile_id = scratch_profile_and_device["profile_id"]
+    blocked_host = scratch_profile_and_device["blocked_host"]
+    allowed_host = scratch_profile_and_device["allowed_host"]
+
+    log.info("gate3: probing blocked=%s allowed=%s from mac=%s",
+             blocked_host, allowed_host, mac)
+
+    # ── blocked path ─────────────────────────────────────────────────────
+    # Per #351 / #429 / render.lua: extraBlocked HTTP/80 is DNAT'd to the
+    # local block page (uhttpd on 127.0.0.1:8081). dnsmasq must first
+    # populate the per-host nft set from a real upstream answer, so the
+    # very first request after policy apply may still race to upstream —
+    # poll until the block page lands.
+    probe = wait_until(
+        lambda: _block_page_probe(client_vm, blocked_host),
+        timeout_s=120, interval_s=3,
+        description=f"block page response for {blocked_host}",
+    )
+    assert probe.http_code == 200
+    log.info("gate3: block page hit for %s (%d bytes)", blocked_host, len(probe.body))
+
+    # ── allowed path ─────────────────────────────────────────────────────
+    # example.org is in extraAllowed but no category blocks it either, so
+    # this asserts the negative — agent did NOT over-block. Genuine
+    # upstream content is expected (no block-page markers).
+    allowed = wait_until(
+        lambda: _upstream_probe(client_vm, allowed_host),
+        timeout_s=60, interval_s=3,
+        description=f"upstream response for {allowed_host}",
+    )
+    log.info("gate3: upstream OK for %s (code=%s, %d bytes)",
+             allowed_host, allowed.http_code, len(allowed.body))
+
+    # ── generate a few more probes to give the agent's usage flush
+    # something to ship. The agent batches connection events; one probe
+    # may not survive the flush cadence before the test's wait expires.
+    for _ in range(3):
+        http_get(client_vm, f"http://{allowed_host}/", timeout_s=8)
+        time.sleep(1)
+
+    # ── usage cross-check: /api/logs sees rows attributed to our MAC ────
+    # Per scenarios/test_05_usage_in_api.py the canonical assertion is
+    # "MAC attribution lands" — host-string matching is brittle because
+    # what the agent emits depends on dnsmasq log timing and packet
+    # batching. The wire-end-to-wire-end signal we care about is
+    # "events POST round-tripped → API attributed → /api/logs surfaces".
+    rows = wait_until(
+        lambda: _logs_for_mac(admin, mac) or None,
+        timeout_s=240, interval_s=5,
+        description=f"/api/logs row for mac={mac}",
+    )
+    assert any((_row_mac(r) or "").lower() == mac.lower() for r in rows), (
+        f"no /api/logs row attributed to mac={mac}; "
+        f"saw {len(rows)} row(s), macs={sorted({_row_mac(r) for r in rows if _row_mac(r)})}"
+    )
+    log.info("gate3: %d /api/logs rows attributed to %s", len(rows), mac)
+
+    # ── /api/time/status cross-check ─────────────────────────────────────
+    # Second public-surface endpoint the API/UI ships. A rename of the
+    # device-summary shape (deviceMac, deviceName) breaks the SPA today;
+    # a Gate 3b run against the last-published router would still expect
+    # this field to be present.
+    statuses = admin.time_status()
+    summaries = [d for prof in statuses for d in prof.get("devices", [])]
+    matched = [
+        d for d in summaries
+        if (d.get("deviceMac") or "").lower() == mac.lower()
+    ]
+    assert matched, (
+        f"no /api/time/status summary for {mac} under profile {profile_id}; "
+        f"saw {len(summaries)} summaries across {len(statuses)} profile(s)"
+    )
+    log.info("gate3: time_status summary present for %s: %s", mac, matched[0])
+
+
+# ── probes ───────────────────────────────────────────────────────────────
+
+
+_BLOCK_MARKERS = ("wifihaven", "/blocked", "blocked by", "blocked.html")
+
+
+def _block_page_probe(client, host: str):
+    """Return the HttpProbe iff the response looks like the wifihaven block
+    page (200 + marker substring in body). None otherwise — caller polls."""
+    p = http_get(client, f"http://{host}/", timeout_s=8)
+    if p.http_code != 200 or not p.body:
+        return None
+    body_lc = p.body.lower()
+    if any(m in body_lc for m in _BLOCK_MARKERS):
+        return p
+    return None
+
+
+def _upstream_probe(client, host: str):
+    """Return the HttpProbe iff the response is a genuine 2xx/3xx from
+    upstream with NO block-page markers. None otherwise — caller polls."""
+    p = http_get(client, f"http://{host}/", timeout_s=8)
+    if not p.ok or p.http_code is None:
+        return None
+    if not (200 <= p.http_code < 400):
+        return None
+    body_lc = (p.body or "").lower()
+    if any(m in body_lc for m in _BLOCK_MARKERS):
+        return None
+    return p
+
+
+def _logs_for_mac(admin, mac: str) -> list[dict]:
+    # /api/logs shape changed at some point; older scenarios assert
+    # isinstance(logs, list) (test_05_usage_in_api.py) but staging today
+    # returns {"rows": [...]}. Handle both.
+    res = admin.logs(mac=mac, hours=LOGS_LOOKBACK_HOURS)
+    if isinstance(res, dict):
+        return res.get("rows") or []
+    return res or []
+
+
+def _row_mac(row: dict) -> str | None:
+    return row.get("mac") or row.get("deviceMac")

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -157,6 +157,51 @@ class AdminAPI:
     def delete_device(self, mac: str) -> None:
         self._request("DELETE", f"/api/devices/{mac}")
 
+    # ── apps (#761/#764) ──────────────────────────────────────────────────
+    # Post-#764, extraAllowed/extraBlocked are sourced exclusively from
+    # app_policy_assignments — the legacy `extraBlocked`/`extraAllowed`
+    # fields on profile POST/PUT are silently dropped. To exercise the
+    # block/allow planes against a real API, callers must use the Apps
+    # surface: create an app with hosts, then assign it to a profile with
+    # a mode.
+
+    def create_app(self, *, name: str, slug: str | None = None,
+                   hosts: list[str] | None = None,
+                   template_id: str | None = None,
+                   icon: str | None = None,
+                   icon_type: str | None = None) -> dict[str, Any]:
+        """POST /api/apps. Returns the app-detail body
+        ({app: {id, name, ...}, hosts: [...], assignments: [...]})."""
+        body: dict[str, Any] = {"name": name}
+        if slug is not None:
+            body["slug"] = slug
+        if hosts is not None:
+            body["hosts"] = hosts
+        if template_id is not None:
+            body["templateId"] = template_id
+        if icon is not None:
+            body["icon"] = icon
+        if icon_type is not None:
+            body["iconType"] = icon_type
+        return self._request("POST", "/api/apps", body=body)
+
+    def assign_app_policy(self, *, app_id: int, profile_id: int, mode: str,
+                          daily_minutes: int | None = None,
+                          exempt_from_daily: bool | None = None) -> None:
+        """PUT /api/apps/{app_id}/policy/{profile_id}. mode is one of
+        'blocked' | 'allowed' | 'time_limited' (per shared/Models.scala
+        AppMode.asString)."""
+        body: dict[str, Any] = {"mode": mode}
+        if daily_minutes is not None:
+            body["dailyMinutes"] = daily_minutes
+        if exempt_from_daily is not None:
+            body["exemptFromDaily"] = exempt_from_daily
+        self._request("PUT", f"/api/apps/{app_id}/policy/{profile_id}", body=body)
+
+    def delete_app(self, app_id: int) -> None:
+        """DELETE /api/apps/{id}. Cascades app_policy_assignments."""
+        self._request("DELETE", f"/api/apps/{app_id}")
+
     # ── logs / sessions / stats ───────────────────────────────────────────
 
     def logs(self, **params: Any) -> list[dict[str, Any]]:


### PR DESCRIPTION
Closes #655.

Implements Gate 3 of the three-gate plan (#652), split into 3a (router-side) and 3b (API/UI-side). Both halves run the same narrow scenario against real staging — Gate 2 still owns enforcement depth.

## Summary

- **Gate 3a** — freshly-built qemu router image vs current staging API. Wired into `master-router.yml` as a `needs:` of `approve-production` alongside Gate 2.
- **Gate 3b** — last-published qemu router image (per #893's release assets) vs freshly-deployed staging. Wired into `master-api-ui.yml` parallel to `approve-production`. **`continue-on-error: true`** until #1096 + a first publish-openwrt seed the asset; flip in a follow-up PR.
- Shared `scripts/e2e/gate3/` harness. One pytest module, one test. ~75–105s per arm.
- `lib/api_admin.py` — added `create_app` / `assign_app_policy` / `delete_app` methods (post-#764, extra_blocked/extra_allowed are sourced exclusively from `app_policy_assignments`; the legacy profile fields are silently dropped).

## Scenario shape

1. Boot router VM, enroll against staging via `/api/router/register`.
2. Provision: one profile + one blocked App (`example.com`) + one allowed App (`example.org`) + one device assigned to the profile.
3. Wait for the agent's policy etag to advance.
4. From the Alpine client: `http://example.com/` → assert block-page body; `http://example.org/` → assert upstream content.
5. Poll `/api/logs?mac=…` until a row is attributed to the test MAC.
6. Assert `/api/time/status` includes the device's `deviceMac` under its profile.
7. `finally`: delete device → delete apps → delete profile → delete router record.

State isolation against shared staging: artifact names suffixed with `${WH_RUN_ID}-${PKG_FORMAT}-${SIDE}`. Concurrent PR runs don't collide; teardown reliable in normal completion + on the session fixture's finalizer for setup-time errors.

## Stability — 12/12 PASS, mean 84s

| Side | Arm | Run 1 | Run 2 | Run 3 |
|------|-----|-------|-------|-------|
| 3a | ipk | 103s | 102s | 102s |
| 3a | apk | 71s | 74s | 72s |
| 3b | ipk | 74s | 78s | 107s |
| 3b | apk | 75s | 76s | 73s |

3a-ipk is reproducibly slower than apk by ~30s, likely the 23.05 boot/init path. One 3b-ipk outlier at 107s — slow staging CDN response on that run; comfortably under the 20m job budget. No fragility seen.

## Simulated regression — router-side contract break (Gate 3 turns red)

Applied: rename `snapshot.devices` → `snapshot.devicesXX` in `openwrt/files/usr/lib/lua/wifihaven/render.lua` (5 sites). Agent sees zero devices, emits no per-MAC rules.

Result:
```
FAILED gate3/test_smoke.py::test_gate3_smoke
  TimeoutError: timed out waiting for block page response for example.com
Agent log: dns-tail: ingested=819 cache_size=8 bio_adds=0 eb_adds=0
```

\`eb_adds=0\` is the diagnostic signature — extra-blocked sets never populated because the agent saw no devices to enforce against. Reverted + rebuilt + sanity-passed in 77s.

## Simulated regression — API-side contract break (Gate 3b's value-add — described, not run)

A safe 3b-exclusive demo requires deploying an API change to shared staging that renames a field current router code reads, then running the test against a "last published" router image that predates the rename. Since (a) we can't safely mutate shared staging from a PR and (b) #1096's seed image doesn't exist yet, this isn't demonstrable end-to-end pre-merge.

The mechanism manifests as:
- Gate 1 (current-contract goldens) — **green** (current code agrees with itself).
- Gate 3a (fresh router → current staging) — **green** (both sides updated together).
- Gate 3b (last-published router → current staging) — **red** (old router's parser doesn't know the new field name).

This is precisely why 3b exists: forward-incompatibility for routers that haven't auto-updated is invisible to Gate 1 alone.

## Bootstrap plan for Gate 3b

Per #1096's body, the first post-#893 publish-openwrt run becomes the seed. Until then `gh release download` in `e2e-vm-gate3b.yml` will fail — `continue-on-error: true` keeps the gate visible in the UI without blocking prod. Once a seed exists:

1. Confirm the asset is downloadable via `gh release download openwrt-latest -p 'wifihaven-router-openwrt-*.tar.gz'`.
2. Single small follow-up PR: drop `continue-on-error: true` and add `gate-3b-api-staging` to `approve-production.needs:` in `master-api-ui.yml`.

## Concurrency note

Gate 3a + 3b share \`concurrency: e2e-vm\` with Gate 2 and the legacy live-mode VM e2e workflow. A cross-cutting push to \`shared/contract/**\` (fires both pipelines) now potentially queues 6 sequential qemu arms (Gate 2 × 2 + Gate 3a × 2 + Gate 3b × 2) on one runner. Acceptable for now; tracked at #657 — see new comment there.

## Follow-ups

- **#1102** — rename \`STAGING_ADMIN_PASS\` → \`WH_STAGING_ADMIN_PASS\` (per WH_ env-var convention).
- **#1107** — \`docs/testing.md\` decision tree so contributors know where to add new tests (Gate 1 vs 2 vs 3).
- **#657** — capacity headroom comment.
- After #1096 lands + first publish seeds: flip 3b to a hard gate (described above).

## Test plan

- [x] 12× stability sweep (3a-ipk × 3, 3a-apk × 3, 3b-ipk × 3, 3b-apk × 3) — all green
- [x] Simulated router-side break → Gate 3 red, expected diagnostic signature in agent log
- [x] Revert + rebuild + sanity-pass
- [x] Staging cleanup verified after every run (routers / profiles / devices / apps lists empty)
- [ ] Gate 3a fires on Master Router CD after this lands (next push to \`openwrt/**\` or \`shared/contract/**\`)
- [ ] Gate 3b workflow_dispatch dry-run once #1096 lands + seed asset exists, then flip continue-on-error follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)