### PR TITLE
fix(ci): unbreak master CD — gate3b continue-on-error placement (#1124)

### DIFF
--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -40,6 +40,13 @@ concurrency:
 jobs:
   e2e-gate3b:
     name: Gate 3b (API/UI-side staging) — ${{ matrix.pkg_format }}
+    # Soft-fail until #893's seed asset exists. The `gh release download`
+    # step will fail the first run; flip to hard gate after the first
+    # publish-openwrt fires. See #655 PR body for the flip plan.
+    # (Lives here rather than on the caller in master-api-ui.yml because
+    # `continue-on-error` is not a supported key on a job that invokes a
+    # reusable workflow via `uses:` — see #1124.)
+    continue-on-error: true
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -397,14 +397,16 @@ jobs:
   #
   # Bootstrap caveat: #893 lands the publish path but doesn't pre-seed
   # the release. Until the first post-#893 publish-openwrt fires, the
-  # `gh release download` step in this caller will fail. We wire the job
-  # in with `continue-on-error: true` so the gate is observable in the UI
-  # but cannot block prod. Flip to a hard gate in a follow-up PR after
-  # the seed asset exists; tracked in the #655 PR body.
+  # `gh release download` step in this caller will fail. The soft-fail
+  # is set as `continue-on-error: true` on the `e2e-gate3b` job inside
+  # `e2e-vm-gate3b.yml` (not here — `continue-on-error` is not a
+  # supported key on a job that invokes a reusable workflow via `uses:`;
+  # putting it here rejects the whole workflow file, see #1124). Flip
+  # to a hard gate in a follow-up PR after the seed asset exists;
+  # tracked in the #655 PR body.
   gate-3b-api-staging:
     name: Gate 3b — last-published router + staging API
     needs: [deploy-staging]
-    continue-on-error: true
     permissions:
       contents: read
     uses: ./.github/workflows/e2e-vm-gate3b.yml
@@ -412,11 +414,12 @@ jobs:
 
   approve-production:
     name: Manual approval (production gate)
-    # Gate 3b is *not* in `needs:` while continue-on-error is true — a
+    # Gate 3b is *not* in `needs:` while its soft-fail is active — a
     # bootstrap-skipped run shouldn't pause approve-production waiting on
     # a job that's reporting "skipped" rather than "success". Once
-    # #655's bootstrap follow-up flips continue-on-error off, add
-    # `gate-3b-api-staging` to this `needs:` list.
+    # #655's bootstrap follow-up removes `continue-on-error` from the
+    # `e2e-gate3b` job in `e2e-vm-gate3b.yml`, add `gate-3b-api-staging`
+    # to this `needs:` list.
     needs: [smoke-staging, api-smoke-staging]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the `gate-3b-api-staging` caller job in `master-api-ui.yml` (not a supported key on reusable-workflow callers)
- Add `continue-on-error: true` to the `e2e-gate3b` job inside `e2e-vm-gate3b.yml` so the bootstrap-window soft-fail is preserved
- Update inline comments in both files

## Why this happened
GitHub Actions only allows `name / uses / with / secrets / needs / if / permissions / strategy / concurrency` on reusable-workflow caller jobs. `continue-on-error` is not on that list; the file was rejected outright with "workflow file issue" since #1121 merged. Every push to main and every merge-queue run has failed since 2026-05-27 ~15:29Z.

## TDD note
Per AGENTS.md TDD step 2 (autonomous mode), the failing artifact should land as its own commit before the fix. There's no meaningful failing-test commit for a YAML parse fix — the proof is the workflow runs after merge. Validated locally with `actionlint`; only pre-existing warnings (self-hosted `kvm` label, shellcheck nits in unchanged blocks) remain.

## Test plan
- [ ] Master API/UI CD run on this PR's merge enters jobs (not "workflow file issue")
- [ ] Gate 3b still soft-fails (skipped/failed) without blocking approve-production
- [ ] `approve-production` reachable as before

Closes #1124.