### PR TITLE
fix(ci): live-e2e #1105 reads app id from nested AppDetail

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -292,7 +292,7 @@ step "#1105: exempt time_limited app folds host into extraAllowed under MAC bloc
 APP_BODY='{"name":"e2e-khan-'"$RUN_ID"'","hosts":["khan.example.com"]}'
 APP_JSON=$(curl -fsS -X POST "$BASE/api/apps" "${AUTH[@]}" \
   -H 'content-type: application/json' -d "$APP_BODY")
-APP_ID=$(_py "import json; print(json.loads('''$APP_JSON''')['id'])")
+APP_ID=$(_py "import json; print(json.loads('''$APP_JSON''')['app']['id'])")
 curl -fsS -X PUT "$BASE/api/apps/$APP_ID/policy/$PID" "${AUTH[@]}" \
   -H 'content-type: application/json' \
   -d '{"mode":"time_limited","dailyMinutes":60,"exemptFromDaily":true}' >/dev/null


### PR DESCRIPTION
## Summary

- `scripts/e2e-router.sh` scenario #1105 (`exempt time_limited app folds host into extraAllowed under MAC block`) was reading `json['id']` from the response of `POST /api/apps`, but that endpoint returns `AppDetail = {app, hosts, assignments}` — the id lives at `json['app']['id']`.
- Test-side fix only. The API shape is correct; per repo convention we don't add compat shims.

## Why this matters (unblocker chain)

This has been failing Gate 2 ("Live e2e against staging stack") on every push to `main` since #1106 landed. While Gate 2 is red, master CD never reaches Gate 3b, so we have no way to observe Gate 3b green long enough to flip it from `continue-on-error: true` to a hard gate. This PR is the prerequisite for that flip.

Fixes #1128

Failing run before fix: https://github.com/wifihaven/wifihaven/actions/runs/26528795580

## Test plan

- [ ] Master CD on `main` after merge — "Live e2e against staging stack" job passes through scenario #1105 to completion.
- [ ] Once green, follow-up PR flips Gate 3b to a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)