### PR TITLE
ci: flip Gate 3b to hard gate (#1130)

### DIFF
--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -12,11 +12,6 @@ name: VM e2e (Gate 3b — API/UI-side staging smoke)
 # deploy-spa-prod), even when Gate 1's contract goldens are green —
 # that's the whole point of running against the last-published router.
 #
-# Bootstrapping: first time #893 lands, there's no "last published" qemu
-# image yet. Caller (master-api-ui.yml) currently invokes this job with
-# `continue-on-error: true` until a seed asset exists; see #655 PR body
-# for the flip plan.
-#
 # Triggers:
 #   - workflow_call    — invoked from master-api-ui.yml as a needs: of
 #                        approve-production (alongside smoke-staging +
@@ -40,13 +35,6 @@ concurrency:
 jobs:
   e2e-gate3b:
     name: Gate 3b (API/UI-side staging) — ${{ matrix.pkg_format }}
-    # Soft-fail until #893's seed asset exists. The `gh release download`
-    # step will fail the first run; flip to hard gate after the first
-    # publish-openwrt fires. See #655 PR body for the flip plan.
-    # (Lives here rather than on the caller in master-api-ui.yml because
-    # `continue-on-error` is not a supported key on a job that invokes a
-    # reusable workflow via `uses:` — see #1124.)
-    continue-on-error: true
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -17,8 +17,7 @@ name: Master API/UI CD
 #                                     AND staging.wifihaven.net SPA)
 #     → api-smoke-staging            (Gate 1 — admin + router API contract smoke against staging)
 #     → gate-3b-api-staging          (Gate 3b — last-published qemu router + freshly-deployed
-#                                     staging API; #655. continue-on-error until #893's seed
-#                                     image is published — see the job's comment.)
+#                                     staging API; #655)
 #     → approve-production           (manual-approval gate — GitHub `production`
 #                                     environment; required reviewer must click
 #                                     "Approve and deploy" before the deploy-production
@@ -394,16 +393,6 @@ jobs:
   # PR just deployed. Catches API/UI changes that break forward
   # compatibility with routers customers are actually running — a class
   # of regression Gate 1's current-contract goldens cannot see.
-  #
-  # Bootstrap caveat: #893 lands the publish path but doesn't pre-seed
-  # the release. Until the first post-#893 publish-openwrt fires, the
-  # `gh release download` step in this caller will fail. The soft-fail
-  # is set as `continue-on-error: true` on the `e2e-gate3b` job inside
-  # `e2e-vm-gate3b.yml` (not here — `continue-on-error` is not a
-  # supported key on a job that invokes a reusable workflow via `uses:`;
-  # putting it here rejects the whole workflow file, see #1124). Flip
-  # to a hard gate in a follow-up PR after the seed asset exists;
-  # tracked in the #655 PR body.
   gate-3b-api-staging:
     name: Gate 3b — last-published router + staging API
     needs: [deploy-staging]
@@ -414,13 +403,7 @@ jobs:
 
   approve-production:
     name: Manual approval (production gate)
-    # Gate 3b is *not* in `needs:` while its soft-fail is active — a
-    # bootstrap-skipped run shouldn't pause approve-production waiting on
-    # a job that's reporting "skipped" rather than "success". Once
-    # #655's bootstrap follow-up removes `continue-on-error` from the
-    # `e2e-gate3b` job in `e2e-vm-gate3b.yml`, add `gate-3b-api-staging`
-    # to this `needs:` list.
-    needs: [smoke-staging, api-smoke-staging]
+    needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
Planned follow-up to #1124. #893's qemu VM image seed assets are published to the openwrt-latest release as of 2026-05-27, and Gate 3b was observed green against the seeded release in master CD run [26532952110](https://github.com/wifihaven/wifihaven/actions/runs/26532952110) (both `ipk` and `apk` matrix arms). The bootstrap soft-fail introduced in #655 / #1124 is no longer needed.

## Changes

- `.github/workflows/e2e-vm-gate3b.yml`: drop `continue-on-error: true` from the `e2e-gate3b` job; remove the bootstrap comment block above it and the matching paragraph in the header overview.
- `.github/workflows/master-api-ui.yml`: add `gate-3b-api-staging` to `approve-production`'s `needs:` list (was `[smoke-staging, api-smoke-staging]`); drop the bootstrap caveat from the `gate-3b-api-staging` job comment and the qualifier from the header overview.

A red Gate 3b now blocks prod deploys, as originally intended in #655.

Closes #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)