### PR TITLE
feat: router agent reports version on each checkin; admin surface (#771)

### DIFF
--- a/api/resources/db/migration/V39__router_agent_version.sql
+++ b/api/resources/db/migration/V39__router_agent_version.sql
@@ -1,0 +1,4 @@
+-- #771: router agent reports its package version on each policy fetch.
+-- Optional field — legacy routers (and a router that just enrolled but
+-- hasn't polled yet) leave this NULL.
+ALTER TABLE routers ADD COLUMN agent_version TEXT NULL;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -364,7 +364,7 @@ trait RouterRepo {
   def findByTokenHash(h: Sha256Hex): Task[Option[Router]]
   def create(name: String, enrollmentTokenHash: Sha256Hex): Task[RouterId]
   def completeEnrollment(id: RouterId, tokenHash: Sha256Hex): Task[Unit]
-  def touch(id: RouterId, etag: Option[ETag]): Task[Unit]
+  def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]): Task[Unit]
 
   def delete(id: RouterId): Task[Unit]
 }
@@ -1229,8 +1229,9 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
         Option[Instant],
         Option[ETag],
         Instant,
+        Option[String],
     )
-  private def toR(r: R)                                      =
+  private def toR(r: R)                                                     =
     Router(
       r._1,
       r._2,
@@ -1239,47 +1240,52 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
       r._5.map(_.toString),
       r._6,
       r._7.toString,
+      r._8,
     )
-  private val cols                                           =
-    fr"id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at"
-  def listAll                                                =
+  private val cols                                                          =
+    fr"id,name,enrollment_token_hash,token_hash,last_seen_at,last_etag,created_at,agent_version"
+  def listAll                                                               =
     (fr"SELECT " ++ cols ++ fr" FROM routers ORDER BY created_at")
       .query[R]
       .map(toR)
       .to[List]
       .transact(xa)
-  def findById(id: RouterId)                                 =
+  def findById(id: RouterId)                                                =
     (fr"SELECT " ++ cols ++ fr" FROM routers WHERE id=$id")
       .query[R]
       .map(toR)
       .option
       .transact(xa)
-  def findByEnrollmentTokenHash(h: Sha256Hex)                =
+  def findByEnrollmentTokenHash(h: Sha256Hex)                               =
     (fr"SELECT " ++ cols ++ fr" FROM routers WHERE enrollment_token_hash=$h")
       .query[R]
       .map(toR)
       .option
       .transact(xa)
-  def findByTokenHash(h: Sha256Hex)                          =
+  def findByTokenHash(h: Sha256Hex)                                         =
     (fr"SELECT " ++ cols ++ fr" FROM routers WHERE token_hash=$h")
       .query[R]
       .map(toR)
       .option
       .transact(xa)
-  def create(name: String, enrollmentTokenHash: Sha256Hex)   =
+  def create(name: String, enrollmentTokenHash: Sha256Hex)                  =
     sql"INSERT INTO routers(name,enrollment_token_hash) VALUES($name,$enrollmentTokenHash) RETURNING id"
       .query[RouterId]
       .unique
       .transact(xa)
-  def completeEnrollment(id: RouterId, tokenHash: Sha256Hex) =
+  def completeEnrollment(id: RouterId, tokenHash: Sha256Hex)                =
     sql"UPDATE routers SET token_hash=$tokenHash, enrollment_token_hash=NULL, last_seen_at=NOW() WHERE id=$id".update.run
       .transact(xa)
       .unit
-  def touch(id: RouterId, etag: Option[ETag])                =
-    sql"UPDATE routers SET last_seen_at=NOW(), last_etag=COALESCE($etag,last_etag) WHERE id=$id".update.run
+  def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]) =
+    sql"""UPDATE routers
+          SET last_seen_at=NOW(),
+              last_etag=COALESCE($etag,last_etag),
+              agent_version=COALESCE($agentVersion,agent_version)
+          WHERE id=$id""".update.run
       .transact(xa)
       .unit
-  def delete(id: RouterId)                                   =
+  def delete(id: RouterId)                                                  =
     sql"DELETE FROM routers WHERE id=$id".update.run.transact(xa).unit
 }
 

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -63,7 +63,7 @@ object RouterIngestRoutes {
               timeUsageRepo,
               deviceRepo,
             )
-            _        <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
+            _ <- routerRepo.touch(router.id, None, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
       Method.POST / "api" / "router" / "events" ->
@@ -97,7 +97,7 @@ object RouterIngestRoutes {
               ),
             )
             _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo, alertRepo)
-            _      <- routerRepo.touch(router.id, None).mapError(ErrorMapper.dbErrorToResponse)
+            _ <- routerRepo.touch(router.id, None, None).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
           handle.tapError(r => ZIO.logInfo(s"router events: returning status=${r.status.code}"))
         },

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -54,12 +54,19 @@ object RouterRoutes {
           for {
             router <- routerAuth.authenticate(req)
             snap   <- policy.snapshot.mapError(ErrorMapper.dbErrorToResponse)
-            ifNoneMatch = req
+            ifNoneMatch  = req
               .header(Header.IfNoneMatch)
               .map(_.renderedValue)
               .orElse(req.url.queryParam("since"))
+            // #771: agents post their baked PKG_VERSION on every policy
+            // fetch. Optional — legacy agents omit the header and the
+            // stored value is preserved via COALESCE.
+            agentVersion = req.headers
+              .get("X-WifiHaven-Agent-Version")
+              .map(_.trim)
+              .filter(_.nonEmpty)
             _ <- routerRepo
-              .touch(router.id, Some(snap.etag))
+              .touch(router.id, Some(snap.etag), agentVersion)
               .mapError(ErrorMapper.dbErrorToResponse)
             notMod = ifNoneMatch.exists(etagWeakEquals(_, snap.etag.value))
             // #481: 200s (etag changed) are diagnostic gold for snapshot-propagation
@@ -212,6 +219,7 @@ object AdminRouterRoutes {
       lastSeenAt = r.lastSeenAt,
       lastEtag = r.lastEtag,
       createdAt = r.createdAt,
+      agentVersion = r.agentVersion,
     )
 
   private def newEnrollmentToken(): String = {

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -57,14 +57,14 @@ object DbFailureSpec extends ZIOSpecDefault {
   private def throwing[A]: Task[A] = ZIO.fail(new SQLException(secretMsg))
 
   private def brokenRouterRepo: RouterRepo = new RouterRepo {
-    def listAll                                        = throwing
-    def findById(id: RouterId)                         = throwing
-    def findByEnrollmentTokenHash(h: Sha256Hex)        = throwing
-    def findByTokenHash(h: Sha256Hex)                  = throwing
-    def create(n: String, h: Sha256Hex)                = throwing
-    def completeEnrollment(id: RouterId, h: Sha256Hex) = throwing
-    def touch(id: RouterId, etag: Option[ETag])        = throwing
-    def delete(id: RouterId)                           = throwing
+    def listAll                                                               = throwing
+    def findById(id: RouterId)                                                = throwing
+    def findByEnrollmentTokenHash(h: Sha256Hex)                               = throwing
+    def findByTokenHash(h: Sha256Hex)                                         = throwing
+    def create(n: String, h: Sha256Hex)                                       = throwing
+    def completeEnrollment(id: RouterId, h: Sha256Hex)                        = throwing
+    def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]) = throwing
+    def delete(id: RouterId)                                                  = throwing
   }
 
   private def brokenTrafficRepo: TrafficReportRepo = new TrafficReportRepo {

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -328,6 +328,78 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
         assertTrue(r3.status == Status.Ok) &&
         assertTrue(s1.etag != s3.etag)
     },
+    test(
+      "#771: policy fetch with X-WifiHaven-Agent-Version header stores agentVersion on row",
+    ) {
+      for {
+        _       <- cleanDb
+        rr      <- ZIO.service[RouterRepo]
+        ber     <- ZIO.service[BlockEventRepo]
+        ps      <- makePolicyService
+        (_, et) <- seedRouter("gw-agentver")
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
+        regResp <- doRegister(routes, et)
+        regBody <- regResp.body.asString
+        reg     <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        // First poll with version header — populates agent_version.
+        _       <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken.value))
+            .addHeader("X-WifiHaven-Agent-Version", "0.1.0"),
+        )
+        row1    <- rr.findById(reg.routerId).map(_.get)
+        // Subsequent poll with a newer version updates the column.
+        _       <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken.value))
+            .addHeader("X-WifiHaven-Agent-Version", "0.2.0"),
+        )
+        row2    <- rr.findById(reg.routerId).map(_.get)
+        // Poll without the header (legacy agent) preserves the last known
+        // version — additive field, no clobber.
+        _       <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken.value)),
+        )
+        row3    <- rr.findById(reg.routerId).map(_.get)
+      } yield assertTrue(row1.agentVersion.contains("0.1.0")) &&
+        assertTrue(row2.agentVersion.contains("0.2.0")) &&
+        assertTrue(row3.agentVersion.contains("0.2.0"))
+    },
+    test("#771: GET /api/admin/routers includes agentVersion in RouterSummary") {
+      for {
+        _          <- cleanDb
+        auth       <- makeAuth
+        rr         <- ZIO.service[RouterRepo]
+        ber        <- ZIO.service[BlockEventRepo]
+        ps         <- makePolicyService
+        (_, et)    <- seedRouter("gw-summary")
+        adminLogin <- auth.login("admin", "changeme")
+        agentRoutes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
+        adminRoutes = AdminRouterRoutes.routes(auth, rr)
+        regResp   <- doRegister(agentRoutes, et)
+        regBody   <- regResp.body.asString
+        reg       <- ZIO.fromEither(regBody.fromJson[RegisterRouterResponse])
+        _         <- agentRoutes.runZIO(
+          Request
+            .get(URL.decode("/api/router/policy").toOption.get)
+            .addHeader(Header.Authorization.Bearer(reg.routerToken.value))
+            .addHeader("X-WifiHaven-Agent-Version", "0.3.1"),
+        )
+        listResp  <- adminRoutes.runZIO(
+          Request
+            .get(URL.decode("/api/admin/routers").toOption.get)
+            .addHeader(Header.Authorization.Bearer(adminLogin.token.value)),
+        )
+        listBody  <- listResp.body.asString
+        summaries <- ZIO.fromEither(listBody.fromJson[List[RouterSummary]])
+      } yield assertTrue(listResp.status == Status.Ok) &&
+        assertTrue(summaries.size == 1) &&
+        assertTrue(summaries.head.agentVersion.contains("0.3.1"))
+    },
     test("blocklist (plain-text): 200 with version comment + hosts, 401 unauth, 404 unknown") {
       for {
         _       <- cleanDb

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -57,9 +57,9 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           repo <- ZIO.service[RouterRepo]
           id   <- repo.create("r1", Sha256Hex.unsafe("e" * 64))
           _    <- repo.completeEnrollment(id, Sha256Hex.unsafe("f" * 64))
-          _    <- repo.touch(id, Some(ETag.unsafe("\"etag-A\"")))
+          _    <- repo.touch(id, Some(ETag.unsafe("\"etag-A\"")), None)
           a    <- repo.findById(id)
-          _    <- repo.touch(id, None) // last_etag must remain "etag-A"
+          _    <- repo.touch(id, None, None) // last_etag must remain "etag-A"
           b    <- repo.findById(id)
         } yield assertTrue(a.flatMap(_.lastEtag).contains(ETag.unsafe("\"etag-A\""))) &&
           assertTrue(b.flatMap(_.lastEtag).contains(ETag.unsafe("\"etag-A\""))) &&

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -57,6 +57,9 @@ define Package/wifihaven/install
 
 	$(INSTALL_DIR) $(1)/usr/lib/wifihaven
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh $(1)/usr/lib/wifihaven/
+	# #771: bake PKG_VERSION into a file the lua agent reads at startup so it
+	# can report itself to the API on every checkin (X-WifiHaven-Agent-Version).
+	echo $(PKG_VERSION) > $(1)/usr/lib/wifihaven/VERSION
 
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/uci-defaults/95-wifihaven-uhttpd $(1)/etc/uci-defaults/

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -73,6 +73,11 @@ trap 'rm -rf "$WORK"' EXIT
 mkdir "$WORK/data"
 cp -r "$SCRIPT_DIR/files/." "$WORK/data/"
 
+# #771: bake PKG_VERSION into a file the lua agent reads at startup so it can
+# report itself on every API checkin (X-WifiHaven-Agent-Version header).
+mkdir -p "$WORK/data/usr/lib/wifihaven"
+echo "$PKG_VERSION" > "$WORK/data/usr/lib/wifihaven/VERSION"
+
 find "$WORK/data/usr/sbin"            -type f -exec chmod 0755 {} \;
 find "$WORK/data/etc/init.d"          -type f -exec chmod 0755 {} \;
 find "$WORK/data/usr/lib/lua/wifihaven" -type f -exec chmod 0644 {} \; 2>/dev/null || true

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -68,6 +68,11 @@ CONFFILES
 mkdir "$WORK/data"
 cp -r "$SCRIPT_DIR/files/." "$WORK/data/"
 
+# #771: bake PKG_VERSION into a file the lua agent reads at startup so it can
+# report itself on every API checkin (X-WifiHaven-Agent-Version header).
+mkdir -p "$WORK/data/usr/lib/wifihaven"
+echo "$PKG_VERSION" > "$WORK/data/usr/lib/wifihaven/VERSION"
+
 # Fix permissions
 find "$WORK/data/usr/sbin"            -type f -exec chmod 0755 {} \;
 find "$WORK/data/etc/init.d"          -type f -exec chmod 0755 {} \;

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -1,10 +1,15 @@
 -- policy.lua — policy snapshot fetcher and atomic config applier
 --
 -- Public API:
---   policy.fetch(api_url, router_token, etag, http_get_fn)
+--   policy.fetch(api_url, router_token, etag, http_get_fn, log, opts)
 --     → snapshot_table|nil, etag|nil
 --     http_get_fn(url, headers) → status_code, body, response_headers
 --     Returns (nil, etag) on 304, (nil, nil) on error, (snapshot, etag) on 200.
+--     opts (optional table):
+--       opts.agent_version → string sent as `X-WifiHaven-Agent-Version`
+--                            header so the API can record which package
+--                            version this router is running (#771). Absent
+--                            on legacy callers — the header is just omitted.
 --
 --   policy.apply(snapshot, write_fn, reload_fn, log, opts)
 --     → bool (true on success)
@@ -68,8 +73,9 @@ end
 -- ---------------------------------------------------------------------------
 -- policy.fetch
 -- ---------------------------------------------------------------------------
-function M.fetch(api_url, router_token, etag, http_get_fn, log)
+function M.fetch(api_url, router_token, etag, http_get_fn, log, opts)
   log = log or default_log()
+  opts = opts or {}
   local url = api_url .. "/api/router/policy"
   if etag then
     url = url .. "?since=" .. urlencode(etag)
@@ -78,6 +84,11 @@ function M.fetch(api_url, router_token, etag, http_get_fn, log)
   local hdrs = { ["Authorization"] = "Bearer " .. router_token }
   if etag then
     hdrs["If-None-Match"] = etag
+  end
+  -- #771: report the agent's baked PKG_VERSION on every checkin so the
+  -- API can slice telemetry by version. Optional — older callers omit it.
+  if opts.agent_version and opts.agent_version ~= "" then
+    hdrs["X-WifiHaven-Agent-Version"] = opts.agent_version
   end
 
   log.debug("policy.fetch: GET url=%s etag=%s", url, tostring(etag))

--- a/openwrt/files/usr/lib/lua/wifihaven/version.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/version.lua
@@ -1,0 +1,28 @@
+-- version.lua — read the baked-in agent package version (#771).
+--
+-- The OpenWRT Makefile writes `PKG_VERSION` into /usr/lib/wifihaven/VERSION
+-- at install time. The agent reads it once at startup and sends it on every
+-- /api/router/policy checkin via the `X-WifiHaven-Agent-Version` header so
+-- the API can record which version each router is running.
+--
+-- Returns nil if the file is missing or empty (older installs predating the
+-- bake step). Callers must treat nil as "unknown" and omit the header.
+
+local M = {}
+
+local DEFAULT_PATH = "/usr/lib/wifihaven/VERSION"
+
+function M.read(path, open_fn)
+  path = path or DEFAULT_PATH
+  open_fn = open_fn or io.open
+  local f = open_fn(path, "r")
+  if not f then return nil end
+  local s = f:read("*a")
+  f:close()
+  if not s then return nil end
+  s = s:gsub("%s+$", ""):gsub("^%s+", "")
+  if s == "" then return nil end
+  return s
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -23,6 +23,7 @@ local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
 local paths      = require("wifihaven.paths")
 local selfheal   = require("wifihaven.selfheal")
+local version    = require("wifihaven.version")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -43,8 +44,12 @@ local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
 log.init({ debug = debug_opt })
-log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds activity_sample_int=%ds",
-         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, activity_sample_int)
+-- #771: PKG_VERSION baked at install time into /usr/lib/wifihaven/VERSION.
+-- nil on a checkout / older install — header is then simply omitted.
+local agent_version = version.read()
+local policy_opts   = { agent_version = agent_version }
+log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds activity_sample_int=%ds agent_version=%s",
+         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, activity_sample_int, tostring(agent_version))
 
 -- activity_sample_int should evenly divide usage_report_interval, or the last
 -- partial bucket at report flush time is shorter than the others. Warn and
@@ -281,7 +286,7 @@ local last_usage_wall_ts = os.time()
 
 do
   log.debug("startup: initial policy fetch")
-  local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log)
+  local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log, policy_opts)
   if snap then
     if policy.apply(snap, write_file, run_cmd, log) then
       render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
@@ -415,7 +420,7 @@ conntrack.watch({
     -- Policy timer
     if (mono - last_policy_run) >= policy_int then
       last_policy_run = mono
-      local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log)
+      local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log, policy_opts)
       local fetch_ok
       if snap then
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.

--- a/openwrt/test/policy_spec.lua
+++ b/openwrt/test/policy_spec.lua
@@ -114,6 +114,28 @@ describe("policy.fetch", function()
     assert.is_nil(etag)
   end)
 
+  it("sends X-WifiHaven-Agent-Version header when opts.agent_version is set (#771)", function()
+    local sent_hdrs
+    local function get_fn(_url, hdrs)
+      sent_hdrs = hdrs
+      return 200, SNAPSHOT_JSON, {}
+    end
+    policy.fetch("http://api:8080", "rt_tok", nil, get_fn, nil, { agent_version = "0.1.0" })
+    assert.equal("0.1.0", sent_hdrs["X-WifiHaven-Agent-Version"])
+  end)
+
+  it("omits the version header when opts.agent_version is nil/empty (#771)", function()
+    local sent_hdrs
+    local function get_fn(_url, hdrs)
+      sent_hdrs = hdrs
+      return 200, SNAPSHOT_JSON, {}
+    end
+    policy.fetch("http://api:8080", "rt_tok", nil, get_fn, nil, { agent_version = "" })
+    assert.is_nil(sent_hdrs["X-WifiHaven-Agent-Version"])
+    policy.fetch("http://api:8080", "rt_tok", nil, get_fn)
+    assert.is_nil(sent_hdrs["X-WifiHaven-Agent-Version"])
+  end)
+
   it("requests /api/router/policy endpoint", function()
     local called_url
     local function get_fn(url, _hdrs)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -19,6 +19,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/block_page_spec.lua \
          test/contract_spec.lua \
          test/selfheal_spec.lua \
+         test/version_spec.lua \
          "$@"
 
 echo ""

--- a/openwrt/test/version_spec.lua
+++ b/openwrt/test/version_spec.lua
@@ -1,0 +1,40 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/version.lua (#771).
+-- Run as part of openwrt/test/run_tests.sh.
+
+local version = require("version")
+
+local function fake_open(contents)
+  return function(_path, _mode)
+    if contents == nil then return nil end
+    local pos = 1
+    return {
+      read = function(_self, _fmt)
+        local out = contents:sub(pos)
+        pos = #contents + 1
+        return out
+      end,
+      close = function() end,
+    }
+  end
+end
+
+describe("version.read", function()
+
+  it("returns the trimmed contents of the VERSION file", function()
+    assert.equal("0.1.0", version.read("/x", fake_open("0.1.0\n")))
+  end)
+
+  it("strips leading and trailing whitespace", function()
+    assert.equal("1.2.3", version.read("/x", fake_open("  1.2.3  \n")))
+  end)
+
+  it("returns nil when the file is missing", function()
+    assert.is_nil(version.read("/x", fake_open(nil)))
+  end)
+
+  it("returns nil when the file is empty / whitespace only", function()
+    assert.is_nil(version.read("/x", fake_open("")))
+    assert.is_nil(version.read("/x", fake_open("   \n")))
+  end)
+
+end)

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1007,6 +1007,10 @@ case class Router(
     lastSeenAt: Option[String],
     lastEtag: Option[ETag],
     createdAt: String,
+    // #771: agent package version posted on each policy fetch via the
+    // `X-WifiHaven-Agent-Version` header. NULL until the router upgrades to
+    // an agent that reports it.
+    agentVersion: Option[String] = None,
 ) derives JsonCodec
 
 case class TrafficReport(
@@ -1108,6 +1112,9 @@ case class RouterSummary(
     lastSeenAt: Option[String],
     lastEtag: Option[ETag],
     createdAt: String,
+    // #771: agent package version reported on the most recent policy fetch
+    // (or NULL for routers that haven't polled with a version-aware agent).
+    agentVersion: Option[String] = None,
 ) derives JsonCodec
 
 case class RegisterRouterRequest(

--- a/web/src/pages/RoutersPage.test.tsx
+++ b/web/src/pages/RoutersPage.test.tsx
@@ -19,6 +19,7 @@ import { RoutersPage } from './RoutersPage'
 const existing: RouterSummary = {
   id: 'r1', name: 'home-gw', enrolled: false,
   lastSeenAt: null, lastEtag: null, createdAt: '2026-05-11T00:00:00Z',
+  agentVersion: null,
 }
 
 const createResp: CreateRouterResponse = {
@@ -93,6 +94,24 @@ describe('RoutersPage — copy to clipboard', () => {
     const input = screen.getByDisplayValue(createResp.enrollmentToken) as HTMLInputElement
     expect(input.tagName).toBe('INPUT')
     expect(input.readOnly).toBe(true)
+  })
+})
+
+describe('RoutersPage — #771 agent version', () => {
+  it('renders the reported agent version as a v-prefixed chip when present', async () => {
+    const withVersion: RouterSummary = {
+      ...existing, id: 'r3', name: 'gw-with-ver', agentVersion: '0.2.1',
+    }
+    ;(api.routers.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([withVersion])
+    render(<RoutersPage />)
+    const chip = await screen.findByTestId('router-agent-version')
+    expect(chip).toHaveTextContent('v0.2.1')
+  })
+
+  it('omits the version chip when agentVersion is null (legacy router)', async () => {
+    render(<RoutersPage />)
+    await screen.findByText('home-gw')
+    expect(screen.queryByTestId('router-agent-version')).toBeNull()
   })
 })
 

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -105,6 +105,14 @@ export function RoutersPage() {
                         ? <span>last seen {new Date(r.lastSeenAt).toLocaleString()}</span>
                         : <span>never seen</span>
                       }
+                      {r.agentVersion && (
+                        <span
+                          data-testid="router-agent-version"
+                          className="inline-block px-2 py-0.5 rounded font-mono bg-gray-800 text-gray-300"
+                        >
+                          v{r.agentVersion}
+                        </span>
+                      )}
                     </p>
                   </div>
                   <button

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -607,6 +607,10 @@ export interface RouterSummary {
   lastSeenAt: string | null
   lastEtag: string | null
   createdAt: string
+  // #771: package version reported by the agent on its most recent
+  // policy fetch. NULL for pre-#771 routers and routers that have not
+  // polled yet.
+  agentVersion: string | null
 }
 
 export interface CreateRouterRequest {


### PR DESCRIPTION
## Summary
- Add `agent_version` column on `routers`; backfilled `null` for existing rows
- Lua agent posts baked `PKG_VERSION` on every policy fetch via `X-WifiHaven-Agent-Version` header
- API stores it alongside `last_seen_at`; returned in admin router summaries
- Admin UI shows the version per router

## Test plan
- [ ] Existing routers continue to register with no `agentVersion` field (backward compat)
- [ ] Upgraded routers populate the column on first checkin
- [ ] Admin UI shows current version per router
- [ ] vitest passes (`nvm use 22 && pnpm -C web test`)
- [ ] `mill scalafmtCheckAll` clean

Closes #771. Unblocks #1132 phase 2 (post-publish prod validation) and #921 (e2e assertion of version after install).