### PR TITLE
ci: allow up to 3 concurrent e2e-vm runs on the self-hosted host (#895)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -14,11 +14,26 @@ name: VM e2e (fake API — Gate 2)
 #   - workflow_call    — invoked from master-router.yml as a needs: of publish-openwrt
 #   - workflow_dispatch — manual debugging from the Actions tab
 #
-# Concurrency: shares the e2e-vm group with the live-mode VM e2e workflow
-# so cross-workflow runs serialize on the self-hosted KVM runner. #891
-# parameterized bridge/ports/MACs so two qemu pairs can share a host,
-# but the group stays until two concurrent runs are observed clean on
-# the runner (per #891's follow-up note).
+# Concurrency / host capacity (#895):
+#   The old `group: e2e-vm` serialized *every* VM e2e workflow run on the
+#   host. #891 parameterized bridge/ports/MACs so multiple qemu pairs can
+#   share the host, so we now scope the group per workflow-run — distinct
+#   runs no longer serialize at the GitHub queue level. Per-run isolation on
+#   the host comes from WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge
+#   pool pick (lib.sh::wh_pick_lan_bridge, #891).
+#
+#   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
+#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
+#   and each VM pair (router + client) consumes one — so 4 concurrent pairs
+#   is the absolute max. We cap CI matrix fan-out at `max-parallel: 3`
+#   (below) to leave one bridge free for ad-hoc manual runs,
+#   scripts/e2e-kvm-sanity, and the keep-staging-warm cron, so none of those
+#   ever queue behind CI. Bumping to 4 is a one-line change if pressure
+#   justifies giving up the headroom slot.
+#
+#   When all 4 bridges are taken, wh_pick_lan_bridge fails loud with
+#   "LAN bridge pool exhausted" (exit 1) rather than queueing forever — see
+#   scripts/vm/test-lan-bridge-pick.sh. Broader capacity plan: #657.
 
 on:
   workflow_call:
@@ -33,7 +48,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: e2e-vm
+  group: e2e-vm-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -52,12 +67,15 @@ jobs:
     # #685: matrix over ipk-23.05 and apk-25.12 router images. fail-fast=false
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).
-    # No max-parallel: with #891's bridge/port/MAC parameterization the two
-    # arms can share a host. In practice today the single self-hosted kvm
-    # runner still serializes them via runner availability; once a second
-    # runner is added the arms parallelize automatically.
+    # max-parallel: 3 (#895) — with #891's bridge/port/MAC parameterization
+    # the arms can share a host, bounded by the 4-bridge pool minus one
+    # headroom slot (see the concurrency note at the top of this file). Today
+    # the single self-hosted kvm runner still serializes the arms via runner
+    # availability; once a second runner is added they parallelize up to the
+    # cap automatically.
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - pkg_format: ipk
@@ -75,15 +93,19 @@ jobs:
       WH_PORT_BASE: ${{ matrix.port_base }}
       # Per-job scope for the qemu `-name wh-*-${WH_RUN_ID}` suffix and the
       # .run/<id>/ state dir (config.sh:91,145,40-44). Lets teardown's
-      # pkill backstop match only this run's qemu, never a sibling's, and
-      # is a prerequisite for relaxing the e2e-vm concurrency group (#895).
-      # Kept short so .run/<id>/router/monitor.sock fits the 108-byte Linux
-      # Unix-socket-path limit in deep workspace paths (cf. #907 bug 4 —
-      # acceptance: WH_RUN_ID ≤ 18 chars in the CI runner workspace).
-      # Sequential matrix arms (today's reality) reuse the same id safely
-      # because teardown completes between arms; a per-arm suffix would
-      # overrun the path budget.
-      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      # pkill backstop match only this run's qemu, never a sibling's.
+      # Now that #895 lets matrix arms run in parallel (max-parallel: 3),
+      # the id MUST be unique per arm — two concurrently-booting arms sharing
+      # one .run/<id>/ would clobber each other's overlay/pid/monitor.sock —
+      # so we append the pkg_format. github.run_id already makes it unique
+      # across concurrent *workflow* runs (fake / gate3a / gate3b each get a
+      # distinct run_id).
+      # Path budget: .run/<id>/router/monitor.sock must fit the 108-byte
+      # Linux Unix-socket-path limit (#907 bug 4). On the runner workspace
+      # (/home/runner/actions-runner/_work/wifihaven/wifihaven) the fixed
+      # prefix+suffix leaves room for a 17-char id; "<11-digit run_id>-<attempt>-ipk"
+      # = 17 chars fits exactly. Keep any future suffix additions within that.
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.pkg_format }}
 
     steps:
       # Self-hosted runner: a prior run of scripts/vm/build-router-image.sh

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -18,9 +18,20 @@ name: VM e2e (Gate 3a — router-side staging smoke)
 #                        approve-production (parallel to gate-2-router-fake-api)
 #   - workflow_dispatch — manual debugging from the Actions tab
 #
-# Concurrency: shares the e2e-vm group with Gate 2 and the live-mode VM
-# e2e workflow. Per the e2e-vm group convention, runs on this host
-# serialize. The capacity headroom this consumes is tracked in #657.
+# Concurrency / host capacity (#895):
+#   The old `group: e2e-vm` serialized every VM e2e workflow run on the host.
+#   #891 parameterized bridge/ports/MACs so multiple qemu pairs can share the
+#   host, so we now scope the group per workflow-run — distinct runs no longer
+#   serialize at the GitHub queue level. Per-run host isolation comes from
+#   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
+#
+#   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
+#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
+#   each VM pair consumes one → 4 concurrent pairs max. CI matrix fan-out is
+#   capped at `max-parallel: 3` (below), leaving one bridge for ad-hoc runs,
+#   scripts/e2e-kvm-sanity, and keep-staging-warm. When all 4 are taken,
+#   wh_pick_lan_bridge fails loud ("LAN bridge pool exhausted", exit 1)
+#   instead of queueing forever. Broader capacity plan: #657.
 
 on:
   workflow_call:
@@ -35,7 +46,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: e2e-vm
+  group: e2e-vm-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -52,8 +63,11 @@ jobs:
     timeout-minutes: 20
     # Matrix over ipk-23.05 and apk-25.12 (#532). fail-fast=false so a
     # regression in one flavor still reports the other arm's status.
+    # max-parallel: 3 (#895) — bounded by the 4-bridge pool minus one
+    # headroom slot (see the concurrency note at the top of this file).
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - pkg_format: ipk
@@ -68,12 +82,13 @@ jobs:
       # even though the e2e-vm concurrency group serializes them, the
       # safety margin is free.
       WH_PORT_BASE: ${{ matrix.port_base }}
-      # Same WH_RUN_ID conventions as Gate 2 — short enough to keep
-      # .run/<id>/router/monitor.sock under the 108-byte Unix-socket path
-      # limit. Sequential matrix arms (today's reality on a single
-      # runner) safely reuse the same id because teardown completes
-      # between arms.
-      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      # Same WH_RUN_ID convention as Gate 2 (#895): per-arm pkg_format suffix
+      # so concurrently-booting matrix arms (max-parallel: 3) don't share a
+      # .run/<id>/ state dir; github.run_id keeps it unique across concurrent
+      # workflow runs (gate3a / gate3b / fake each get a distinct run_id, and
+      # the per-workflow WH_PORT_BASE ranges below never overlap either).
+      # 17-char budget: see the WH_RUN_ID note in e2e-vm-fake.yml.
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.pkg_format }}
       WH_API_URL: https://api-staging.wifihaven.net
       WH_GATE3_SIDE: 3a
 

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -18,8 +18,20 @@ name: VM e2e (Gate 3b — API/UI-side staging smoke)
 #                        api-smoke-staging)
 #   - workflow_dispatch — manual debugging from the Actions tab
 #
-# Concurrency: shares the e2e-vm group with Gates 2 + 3a + live-mode e2e.
-# Capacity tracked in #657.
+# Concurrency / host capacity (#895):
+#   The old `group: e2e-vm` serialized every VM e2e workflow run on the host.
+#   #891 parameterized bridge/ports/MACs so multiple qemu pairs can share the
+#   host, so we now scope the group per workflow-run — distinct runs no longer
+#   serialize at the GitHub queue level. Per-run host isolation comes from
+#   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
+#
+#   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
+#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
+#   each VM pair consumes one → 4 concurrent pairs max. CI matrix fan-out is
+#   capped at `max-parallel: 3` (below), leaving one bridge for ad-hoc runs,
+#   scripts/e2e-kvm-sanity, and keep-staging-warm. When all 4 are taken,
+#   wh_pick_lan_bridge fails loud ("LAN bridge pool exhausted", exit 1)
+#   instead of queueing forever. Broader capacity plan: #657.
 
 on:
   workflow_call:
@@ -29,7 +41,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: e2e-vm
+  group: e2e-vm-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -40,8 +52,11 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 20
+    # max-parallel: 3 (#895) — bounded by the 4-bridge pool minus one headroom
+    # slot (see the concurrency note at the top of this file).
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - pkg_format: ipk
@@ -52,7 +67,10 @@ jobs:
     env:
       PKG_FORMAT: ${{ matrix.pkg_format }}
       WH_PORT_BASE: ${{ matrix.port_base }}
-      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      # Per-arm pkg_format suffix (#895) so concurrent matrix arms don't share
+      # a .run/<id>/ state dir; github.run_id keeps it unique across concurrent
+      # workflow runs. 17-char budget: see e2e-vm-fake.yml's WH_RUN_ID note.
+      WH_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.pkg_format }}
       WH_API_URL: https://api-staging.wifihaven.net
       WH_GATE3_SIDE: 3b
 

--- a/.github/workflows/e2e-vm.yml
+++ b/.github/workflows/e2e-vm.yml
@@ -28,8 +28,19 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Concurrency / host capacity (#895): scope the group per workflow-run so
+# distinct runs of this (legacy, single-job) workflow no longer serialize at
+# the GitHub queue level. Host isolation comes from WH_RUN_ID (below, unique
+# per run) + the wh-lan* bridge pool pick (#891). The hard ceiling on
+# concurrent VM pairs is the bridge pool, not this group: api.lan's
+# /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3), each pair consumes
+# one. This workflow has no matrix fan-out (single job), so it has no
+# max-parallel cap; the sibling fan-out workflows (e2e-vm-fake / gate3a /
+# gate3b) cap at 3 to leave one bridge of headroom. When the pool is
+# exhausted, wh_pick_lan_bridge fails loud ("LAN bridge pool exhausted").
+# Broader capacity plan: #657.
 concurrency:
-  group: e2e-vm
+  group: e2e-vm-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -45,8 +56,8 @@ jobs:
     # test_pause but was killed mid-test_time_limit, which sleeps 330s
     # waiting for the agent's usage-report flush. The full suite needs
     # ~80–100m wall clock. 120m gives one slow scenario's worth of slack
-    # without masking real regressions; concurrency=e2e-vm keeps the
-    # queue serialized so a slow run doesn't pile up.
+    # without masking real regressions. Per-run concurrency (#895) no longer
+    # serializes the queue; the bridge pool bounds host contention instead.
     timeout-minutes: 120
 
     env:

--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -112,6 +112,11 @@ router_is_running() {
 # lan-bridge-pool-bootstrap.sh so non-root pickers can write reservations.
 WH_BRIDGE_RESERVATION_DIR="${WH_BRIDGE_RESERVATION_DIR:-/run/wh-lan-bridge}"
 
+# Host paths the bridge picker reads. Overridable so tests can simulate a
+# bridge pool without root / dummy netdevs.
+WH_QEMU_BRIDGE_CONF="${WH_QEMU_BRIDGE_CONF:-/etc/qemu/bridge.conf}"
+WH_SYS_CLASS_NET="${WH_SYS_CLASS_NET:-/sys/class/net}"
+
 # Atomically (re)write the reservation marker for ${1}=bridge to ${2}=pid,
 # tagging it with WH_RUN_ID for human debugging. Silently no-ops if the
 # reservation dir does not exist (un-bootstrapped host).
@@ -183,14 +188,14 @@ wh_pick_lan_bridge() {
   # experiment forgot to clean up — qemu-bridge-helper would refuse to attach
   # to such a leftover anyway.
   local pool=()
-  if [[ -f /etc/qemu/bridge.conf ]]; then
+  if [[ -f "${WH_QEMU_BRIDGE_CONF}" ]]; then
     local br
     while IFS= read -r br; do
       [[ -n "${br}" ]] || continue
       [[ "${br}" =~ ^wh-lan[0-9]+$ ]] || continue
-      [[ -d "/sys/class/net/${br}" ]] || continue
+      [[ -d "${WH_SYS_CLASS_NET}/${br}" ]] || continue
       pool+=("${br}")
-    done < <(awk '/^[[:space:]]*allow[[:space:]]+/ {print $2}' /etc/qemu/bridge.conf)
+    done < <(awk '/^[[:space:]]*allow[[:space:]]+/ {print $2}' "${WH_QEMU_BRIDGE_CONF}")
   fi
   # No pool bridges exist → fall back to today's behavior (config.sh default).
   if (( ${#pool[@]} == 0 )); then
@@ -212,7 +217,7 @@ wh_pick_lan_bridge() {
   local br
   while IFS= read -r br; do
     local attached
-    attached=$(ls "/sys/class/net/${br}/brif" 2>/dev/null | wc -l)
+    attached=$(ls "${WH_SYS_CLASS_NET}/${br}/brif" 2>/dev/null | wc -l)
     local res="none"
     if [[ -f "${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation" ]]; then
       res="$(awk -F= '$1=="pid"{print $2; exit}' "${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation" 2>/dev/null)"

--- a/scripts/vm/test-lan-bridge-pick.sh
+++ b/scripts/vm/test-lan-bridge-pick.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Smoke test for scripts/vm/lib.sh::wh_pick_lan_bridge (#895).
+#
+# Substitutes for a true red-green on the workflow YAML change in #895: the
+# concurrency relaxation relies on the picker failing fast and loud when every
+# pool bridge is already in use, so that a fourth concurrent VM run cannot
+# silently wedge waiting on a slot that will never come free.
+#
+# Two cases:
+#   1. Empty pool (no reservations) → picks the lowest-numbered bridge.
+#   2. Every pool bridge reserved   → exits non-zero with a "pool exhausted"
+#      message on stderr.
+#
+# Runs anywhere; no root, no real bridges, no qemu. Uses tmpdirs for
+# /etc/qemu/bridge.conf, /sys/class/net/<br>, and the reservation dir via the
+# WH_QEMU_BRIDGE_CONF / WH_SYS_CLASS_NET / WH_BRIDGE_RESERVATION_DIR overrides.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+# `flock(1)` ships with util-linux on Linux but is not present by default on
+# macOS. The picker itself can't run without it either, so this test is only
+# meaningful on the same hosts that run the VM e2e workflows (the self-hosted
+# KVM runner). Skip cleanly elsewhere so `bash scripts/vm/test-lan-bridge-pick.sh`
+# from a dev laptop is a no-op rather than a spurious failure.
+if ! command -v flock >/dev/null 2>&1; then
+  echo "test-lan-bridge-pick: SKIP (no flock(1) on PATH — Linux-only test)"
+  exit 0
+fi
+
+setup_tmp() {
+  TMP="$(mktemp -d)"
+  export WH_QEMU_BRIDGE_CONF="${TMP}/bridge.conf"
+  export WH_SYS_CLASS_NET="${TMP}/sys-class-net"
+  export WH_BRIDGE_RESERVATION_DIR="${TMP}/reservations"
+  export WH_RUN_ID="t-$$"
+  # WH_RUN_DIR is derived from WH_RUN_ID under WH_VM_DIR; point it at the tmp.
+  export WH_VM_DIR_OVERRIDE_TMP="${TMP}/vmdir"
+  mkdir -p "${WH_SYS_CLASS_NET}" "${WH_BRIDGE_RESERVATION_DIR}" "${WH_VM_DIR_OVERRIDE_TMP}/.run"
+  # Pool of 4 bridges, mirroring the real api.lan layout.
+  {
+    echo "allow wh-lan0"
+    echo "allow wh-lan1"
+    echo "allow wh-lan2"
+    echo "allow wh-lan3"
+  } > "${WH_QEMU_BRIDGE_CONF}"
+  for i in 0 1 2 3; do
+    mkdir -p "${WH_SYS_CLASS_NET}/wh-lan${i}/brif"
+  done
+}
+
+cleanup_tmp() {
+  rm -rf "${TMP}"
+  unset WH_LAN_BRIDGE WH_LAN_BRIDGE_PICKED
+}
+
+# Run wh_pick_lan_bridge in a subshell so we can capture stdout/stderr/rc and
+# isolate any exports/exit calls (die uses `exit 1`). We *want* die→exit to
+# count as a non-zero rc here, so we wrap the call in `||` to keep the
+# subshell alive long enough to emit the trailer.
+run_pick() {
+  local rc=0
+  local stdout_stderr
+  stdout_stderr="$(
+    exec 2>&1
+    set +e
+    # shellcheck source=lib.sh
+    source "${HERE}/lib.sh"
+    # Force the run dir into the tmp so the picker writes its marker safely
+    # without touching the real .run tree.
+    WH_RUN_DIR="${WH_VM_DIR_OVERRIDE_TMP}/.run"
+    WH_VM_DIR="${WH_VM_DIR_OVERRIDE_TMP}"
+    wh_pick_lan_bridge
+    inner_rc=$?
+    echo "RC=${inner_rc}"
+    echo "WH_LAN_BRIDGE=${WH_LAN_BRIDGE:-}"
+  )" || rc=$?
+  printf '%s\nRC=%s\n' "${stdout_stderr}" "${rc}"
+}
+
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${actual}" == *"${expected}"* ]]; then
+    echo "  ok: ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${name}"
+    echo "    expected substring: ${expected}"
+    echo "    actual: ${actual}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+set +e
+echo "test-lan-bridge-pick: case 1 — empty pool picks wh-lan0"
+setup_tmp
+out="$(run_pick)"
+assert "rc=0" "RC=0" "${out}"
+assert "picked wh-lan0" "WH_LAN_BRIDGE=wh-lan0" "${out}"
+cleanup_tmp
+
+echo "test-lan-bridge-pick: case 2 — pool exhausted exits non-zero"
+setup_tmp
+# Reserve every bridge with this shell's PID (guaranteed live → not reaped).
+for i in 0 1 2 3; do
+  printf 'pid=%s\nrun_id=test\n' "$$" \
+    > "${WH_BRIDGE_RESERVATION_DIR}/wh-lan${i}.reservation"
+done
+out="$(run_pick)"
+assert "non-zero rc" "RC=1" "${out}"
+assert "pool-exhausted message" "LAN bridge pool exhausted" "${out}"
+cleanup_tmp
+set -e
+
+echo
+echo "test-lan-bridge-pick: passed=${PASS} failed=${FAIL}"
+if (( FAIL > 0 )); then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Replace the workflow-level serial gate (`concurrency: { group: e2e-vm }`) on the VM e2e workflows with a per-run group (`e2e-vm-${{ github.workflow }}-${{ github.run_id }}`), so distinct runs no longer queue behind one another.
- Add `max-parallel: 3` to the matrix-fan-out jobs (e2e-vm-fake, gate3a, gate3b). The bridge pool on api.lan has 4 slots; cap CI at 3 to leave one for ad-hoc / cron.
- Make `WH_RUN_ID` unique per matrix arm (append `pkg_format`) so concurrently-booting arms don't clobber each other's `.run/<id>/` state dir. `github.run_id` already keeps it unique across concurrent workflow runs; per-workflow `WH_PORT_BASE` ranges (2222/2322, 2422/2522, 2622/2722) never overlap either.
- Bridge-pool picker fails fast when the pool is exhausted (verified with a new shell test).

## Hard cap rationale
`/etc/qemu/bridge.conf` on api.lan: `wh-lan0..wh-lan3` = 4 bridges. Each VM pair (router + client) consumes one. Capping CI at 3 leaves one slot of headroom for ad-hoc runs, `scripts/e2e-kvm-sanity`, and `keep-staging-warm` without queueing CI. Bumping to 4 later is a one-line change.

We rely on the bridge-pool picker (`lib.sh::wh_pick_lan_bridge`) to **fail loud** ("LAN bridge pool exhausted", exit 1) when no slot is free, rather than a cross-workflow global concurrency group — failing fast with a clear message beats indefinite queueing, and avoids the brittle round-robin `concurrency` slot trick.

## Path-budget note
`WH_RUN_ID` feeds `.run/<id>/router/monitor.sock`, which must fit the 108-byte Linux Unix-socket-path limit (#907 bug 4). On the runner workspace the fixed prefix+suffix leaves room for a 17-char id; `"<11-digit run_id>-<attempt>-ipk"` = 17 chars fits exactly (measured the full path at 107 bytes on the runner). The inline comments document this so future suffix additions stay within budget.

## Why the test substitutes for red-green on the YAML
Workflow-config changes have no clean unit-test path. `scripts/vm/test-lan-bridge-pick.sh` instead proves the failure mode the new concurrency model depends on: (1) an empty pool picks the lowest-numbered bridge, (2) an exhausted pool exits non-zero with a clear message. It passes on current `main` (committed first), runs with no root / no real bridges via tmpdir path overrides, and skips cleanly where `flock(1)` is absent (macOS).

## Test plan
- [ ] Two concurrent `e2e-vm-fake` runs go green with overlapping wall times
- [ ] Each picks a distinct pool bridge (`picked LAN bridge from pool: wh-lanN`)
- [ ] A forced fourth concurrent attempt either fails-fast with a clear pool-exhausted message or queues without flaking
- [x] Bridge-picker test passes (`bash scripts/vm/test-lan-bridge-pick.sh` on the Linux runner: `passed=4 failed=0`)

Closes #895. Feeds data into #657 capacity planning.