### PR TITLE
ci: gate Master CD jobs to main so branch pushes don't log failures (#1136)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -79,11 +79,18 @@ jobs:
   # ── 1. Full CI test matrix (unit, lint, lua, python, shell, frontend) ─────
   ci-tests:
     name: CI
+    # Gate every job to main: the broad `paths:` filter above lets feature-
+    # branch pushes create a run, but on a non-main ref no job is eligible
+    # and GitHub records a 0-job `failure`. Skipping (not failing) the jobs
+    # turns that spurious red run neutral. `workflow_dispatch` on main still
+    # satisfies this; dispatch on a non-main ref is intentionally skipped. (#1136)
+    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/ci.yml
 
   # ── 2. E2E + smoke tests (unconditional) ──────────────────────────────────
   bootstrap-smoke:
     name: bootstrap-host.sh smoke (Ubuntu container)
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -94,6 +101,7 @@ jobs:
 
   e2e:
     name: Live e2e against staging stack
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -121,6 +129,7 @@ jobs:
 
   prod-stack-smoke:
     name: deploy/docker-compose.prod.yml smoke
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -137,6 +146,7 @@ jobs:
   # simpler option; we did).
   build-image:
     name: Build Docker image to ghcr.io (sha + staging tags)
+    if: github.ref == 'refs/heads/main'
     needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
     runs-on: ubuntu-latest
     permissions:
@@ -209,6 +219,7 @@ jobs:
   # (which the build-image job just pushed) and roll the service.
   deploy-staging:
     name: Deploy staging (Render)
+    if: github.ref == 'refs/heads/main'
     needs: [build-image]
     runs-on: ubuntu-latest
     steps:
@@ -250,6 +261,7 @@ jobs:
   # live at staging.wifihaven.net before the cross-origin CORS checks run.
   deploy-spa-staging:
     name: Deploy SPA to Cloudflare Pages (staging)
+    if: github.ref == 'refs/heads/main'
     needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
     runs-on: ubuntu-latest
     steps:
@@ -298,6 +310,7 @@ jobs:
   # SPA cross-origin contract.
   smoke-staging:
     name: Smoke-test staging
+    if: github.ref == 'refs/heads/main'
     needs: [deploy-staging, deploy-spa-staging]
     runs-on: ubuntu-latest
     steps:
@@ -368,6 +381,7 @@ jobs:
   # deploy by sitting on `approve-production`'s `needs:`.
   api-smoke-staging:
     name: Gate 1 — API contract smoke (staging)
+    if: github.ref == 'refs/heads/main'
     # Runs in parallel with smoke-staging — both `needs: [deploy-staging]`,
     # both feed approve-production. smoke-staging covers the SPA bundle +
     # CORS plane; this job covers the admin + router API plane. Either
@@ -415,6 +429,7 @@ jobs:
   # of regression Gate 1's current-contract goldens cannot see.
   gate-3b-api-staging:
     name: Gate 3b — last-published router + staging API
+    if: github.ref == 'refs/heads/main'
     needs: [deploy-staging]
     permissions:
       contents: read
@@ -423,6 +438,7 @@ jobs:
 
   approve-production:
     name: Manual approval (production gate)
+    if: github.ref == 'refs/heads/main'
     needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]
     runs-on: ubuntu-latest
     environment:
@@ -439,6 +455,7 @@ jobs:
   # in another tool; buildx is already set up on github-hosted runners.
   retag-latest:
     name: Promote sha → :latest (deploy-production)
+    if: github.ref == 'refs/heads/main'
     needs: [approve-production]
     runs-on: ubuntu-latest
     permissions:
@@ -470,6 +487,7 @@ jobs:
   # whichever pipeline finishes first wins, the other no-ops.
   cut-release-tag:
     name: Cut v<X.Y.Z> release tag (#499)
+    if: github.ref == 'refs/heads/main'
     needs: [approve-production, retag-latest]
     runs-on: ubuntu-latest
     permissions:
@@ -510,6 +528,7 @@ jobs:
   # depend on retag-latest to enforce ordering.
   deploy-prod-render:
     name: Deploy production (Render)
+    if: github.ref == 'refs/heads/main'
     needs: [approve-production, retag-latest]
     runs-on: ubuntu-latest
     steps:
@@ -541,6 +560,7 @@ jobs:
   # deploy-prod-render is bounded to the duration of either job.
   deploy-spa-prod:
     name: Deploy SPA to Cloudflare Pages (prod) (deploy-production)
+    if: github.ref == 'refs/heads/main'
     needs: [approve-production]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -64,6 +64,12 @@ env:
 jobs:
   ci-tests:
     name: CI
+    # Gate every job to main: the broad `paths:` filter above lets feature-
+    # branch pushes create a run, but on a non-main ref no job is eligible
+    # and GitHub records a 0-job `failure`. Skipping (not failing) the jobs
+    # turns that spurious red run neutral. `workflow_dispatch` on main still
+    # satisfies this; dispatch on a non-main ref is intentionally skipped. (#1136)
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
     uses: ./.github/workflows/ci.yml
@@ -75,6 +81,7 @@ jobs:
   # .ipk/.apk packages from publish-openwrt are).
   build-vm-image:
     name: Build OpenWRT VM image
+    if: github.ref == 'refs/heads/main'
     needs: [ci-tests]
     permissions:
       contents: read
@@ -86,6 +93,7 @@ jobs:
   # serializes against the live-mode VM e2e workflow on the same host.
   gate-2-router-fake-api:
     name: Gate 2 — router fake-API e2e
+    if: github.ref == 'refs/heads/main'
     needs: [ci-tests, build-vm-image]
     permissions:
       contents: read
@@ -103,6 +111,7 @@ jobs:
   # e2e workflow.
   gate-3a-router-staging:
     name: Gate 3a — router staging smoke
+    if: github.ref == 'refs/heads/main'
     needs: [ci-tests, build-vm-image]
     permissions:
       contents: read
@@ -118,6 +127,7 @@ jobs:
   # approval prompts across the two pipelines.
   approve-production:
     name: Manual approval (router production gate)
+    if: github.ref == 'refs/heads/main'
     needs: [gate-2-router-fake-api, gate-3a-router-staging]
     runs-on: ubuntu-latest
     permissions: {}
@@ -134,6 +144,7 @@ jobs:
   # completion regardless of any later main push.
   publish-openwrt:
     name: Publish OpenWRT release
+    if: github.ref == 'refs/heads/main'
     needs: [approve-production]
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

`.github/workflows/master-api-ui.yml` declares `on.push.branches: [main]` but pairs it with a broad `paths:` filter (`scripts/**`, `shared/**`, `.github/workflows/ci.yml`, …). A push to *any* feature branch touching one of those paths makes GitHub create a workflow run — but on a non-main ref none of the jobs are eligible, so GitHub records the run as a **0-job, 0s `failure`** ("This run likely failed because of a workflow file issue").

Concrete evidence: [run 26548764865](https://github.com/wifihaven/wifihaven/actions/runs/26548764865) — `event=push`, `head_branch=nflog-1122`, `conclusion=failure`, 0 jobs.

It is **not** a PR blocker (branch protection on `main` only requires the `CI` context, and this run doesn't appear in the PR rollup). It's pure noise on the Actions tab that makes real failures harder to spot.

## What changed

Added `if: github.ref == 'refs/heads/main'` to **every top-level job** in both Master CD workflows:

- **master-api-ui.yml** — all 15 jobs guarded (including the reusable-workflow jobs `ci-tests` and `gate-3b-api-staging`, which accept a job-level `if:`).
- **master-router.yml** — audited and found to have the identical shape (same `branches: [main]` + broad-paths pattern, split from the unified CD in #871). All 6 jobs guarded.

The run is still *created* on branch pushes, but every job is explicitly **skipped** rather than failing — GitHub reports a fully-skipped run as neutral, not `failure`, which kills the red-X noise.

Notes:
- The `on:` blocks are **unchanged**. The branch/path filters were already correctly nested (no indentation slip) — this is purely the job-guard layer.
- `paths:` filters were deliberately **not** narrowed (the lossy approach rejected in the issue).
- `workflow_dispatch` on `main` still satisfies `github.ref == 'refs/heads/main'`, so manual dispatch against main runs the full pipeline. Dispatch on a non-main ref is intentionally skipped (stricter form; no evidence non-main debug dispatch is intended).
- A needed job being skipped cascades correctly to its dependents, so guarding all top-level jobs is sufficient.

## Test plan

- [x] `actionlint` clean on both workflows.
- [x] Guard count matches top-level job count: 15/15 (api-ui), 6/6 (router).
- [ ] Cannot be fully validated until merged to main — the fix is about what does **not** happen on branch pushes (no more `failure` run). After merge, a feature-branch push touching `scripts/**` / `shared/**` should produce either no run or a neutral skipped/success run for Master CD, and a push to `main` should still run the full pipeline unchanged.

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)