### PR TITLE
ci: lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,8 @@
+# actionlint configuration. See https://github.com/rhysd/actionlint.
+#
+# Declare custom labels for our self-hosted KVM runner so actionlint doesn't
+# flag `runs-on: [self-hosted, linux, kvm]` (used by the VM e2e workflows) as
+# an unknown-runner-label error.
+self-hosted-runner:
+  labels:
+    - kvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   MILL_VERSION: "1.1.5"
+  ACTIONLINT_VERSION: "1.7.12"
   # Opt into Node.js 24 now (forced default June 2026 anyway). Silences the
   # Node 20 deprecation warnings emitted by actions/checkout@v6, setup-java@v4,
   # setup-node@v4, cache@v4, codeql-action@v4 etc.
@@ -41,6 +42,7 @@ jobs:
       migrations: ${{ steps.filter.outputs.migrations || steps.force.outputs.all }}
       contract: ${{ steps.filter.outputs.contract || steps.force.outputs.all }}
       fake-api: ${{ steps.filter.outputs.fake-api || steps.force.outputs.all }}
+      workflows: ${{ steps.filter.outputs.workflows || steps.force.outputs.all }}
     steps:
       - name: Force full matrix for non-PR triggers
         id: force
@@ -128,6 +130,9 @@ jobs:
             migrations:
               - '.github/workflows/ci.yml'
               - 'api/migrations/**'
+            workflows:
+              - '.github/workflows/**'
+              - '.github/actionlint.yaml'
 
   # ── Scala: format, compile, test ─────────────────────────────────────────
   scala:
@@ -411,6 +416,33 @@ jobs:
         # before they reach Render's blueprint importer.
         run: ruby -ryaml -e "YAML.load_file('render.yaml')"
 
+  # ── GitHub Actions workflow lint ─────────────────────────────────────────
+  # actionlint statically checks every workflow under .github/workflows/ for
+  # syntax errors, bad expressions, unknown runner labels, and (via the
+  # shellcheck preinstalled on ubuntu-latest) issues in inline `run:` scripts.
+  # The custom self-hosted `kvm` label is declared in .github/actionlint.yaml
+  # so the VM e2e workflows don't trip the unknown-runner-label check.
+  actionlint:
+    name: Actionlint
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "$ACTIONLINT_VERSION"
+
+      - name: Run actionlint
+        env:
+          # actionlint runs shellcheck on inline `run:` scripts. Gate on
+          # correctness (warning+), not style nits — existing release scripts
+          # carry info-level SC2086/SC2012 findings (unquoted vars inside
+          # globs, `ls` vs `find`) that aren't worth failing CI over.
+          SHELLCHECK_OPTS: --severity=warning
+        run: ./actionlint -color
+
   # ── Frontend: type-check, lint, build ────────────────────────────────────
   frontend:
     name: Frontend Build & Lint
@@ -464,6 +496,7 @@ jobs:
       - python-tests
       - fake-api-tests
       - render-blueprint
+      - actionlint
       - frontend
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds an `actionlint` job to the CI matrix so workflow files get static analysis on every PR that touches them — catching the class of mistake that motivated #1136 (a CD workflow that silently misbehaves) *before* merge rather than as Actions-tab noise after.

actionlint checks each workflow under `.github/workflows/` for syntax errors, bad `${{ }}` expressions, unknown runner labels, deprecated action versions, and — via the `shellcheck` preinstalled on `ubuntu-latest` — issues in inline `run:` scripts.

## What changed

- **New `actionlint` job** in `ci.yml`, gated behind a new `workflows` path filter (`.github/workflows/**` + `.github/actionlint.yaml`) so it only runs when workflow files change. Wired into the umbrella `ci` gating job, so the single required status check covers it.
- **Pinned to actionlint `v1.7.12`** via the project's official download script, with the version in an `ACTIONLINT_VERSION` env var for easy bumps — consistent with how the repo pins `MILL_VERSION`.
- **`.github/actionlint.yaml`** declares the custom self-hosted `kvm` runner label, so the VM e2e workflows (`e2e-vm*.yml`) don't trip actionlint's unknown-runner-label check. This was the only finding across the existing workflows.
- **shellcheck severity set to `warning`**: the existing release scripts (`openwrt-build.yml`, `e2e-vm-gate3b.yml`) carry a handful of `info`-level findings (SC2086 unquoted var inside a glob, SC2012 `ls` vs `find`). Those are style nits in working code, not worth failing CI over or invasively rewriting in this PR — so the gate flags correctness (warning+) but not info-level style. Cleaning up the info findings and tightening the bar can be a separate change if desired.

## Test plan

- [x] `actionlint v1.7.12` runs clean across all current workflows locally with the new `.github/actionlint.yaml` config and `SHELLCHECK_OPTS=--severity=warning`.
- [x] actionlint validates the modified `ci.yml` itself (new `needs: actionlint` resolves, `${ACTIONLINT_VERSION}` reference valid).
- [ ] On this PR, the new `Actionlint` job should run (the `workflows` filter matches) and pass; the umbrella `CI` check should stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)