### PR TITLE
ci: shellcheck-clean inline run: scripts, drop actionlint severity override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,12 +437,6 @@ jobs:
           bash <(curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash") "$ACTIONLINT_VERSION"
 
       - name: Run actionlint
-        env:
-          # actionlint runs shellcheck on inline `run:` scripts. Gate on
-          # correctness (warning+), not style nits — existing release scripts
-          # carry info-level SC2086/SC2012 findings (unquoted vars inside
-          # globs, `ls` vs `find`) that aren't worth failing CI over.
-          SHELLCHECK_OPTS: --severity=warning
         run: ./actionlint -color
 
   # ── Frontend: type-check, lint, build ────────────────────────────────────

--- a/.github/workflows/e2e-kvm-sanity.yml
+++ b/.github/workflows/e2e-kvm-sanity.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Verify /dev/kvm
         run: |
           test -e /dev/kvm || { echo "/dev/kvm missing"; exit 1; }
-          test -r /dev/kvm && test -w /dev/kvm \
-            || { echo "/dev/kvm not r/w for runner user"; ls -l /dev/kvm; exit 1; }
+          if ! { test -r /dev/kvm && test -w /dev/kvm; }; then
+            echo "/dev/kvm not r/w for runner user"
+            ls -l /dev/kvm
+            exit 1
+          fi
           echo "ok /dev/kvm"
 
       - name: Verify qemu

--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -130,8 +130,11 @@ jobs:
 
       - name: Preflight (kvm/qemu/docker)
         run: |
-          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
-            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          if ! { test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm; }; then
+            echo "/dev/kvm missing or not r/w"
+            ls -l /dev/kvm || true
+            exit 1
+          fi
           qemu-system-x86_64 --version | head -n1
           docker --version
 

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -111,8 +111,11 @@ jobs:
 
       - name: Preflight (kvm/qemu)
         run: |
-          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
-            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          if ! { test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm; }; then
+            echo "/dev/kvm missing or not r/w"
+            ls -l /dev/kvm || true
+            exit 1
+          fi
           qemu-system-x86_64 --version | head -n1
 
       - name: Resolve router image path

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -93,8 +93,11 @@ jobs:
 
       - name: Preflight (kvm/qemu/gh)
         run: |
-          test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm \
-            || { echo "/dev/kvm missing or not r/w"; ls -l /dev/kvm || true; exit 1; }
+          if ! { test -e /dev/kvm && test -r /dev/kvm && test -w /dev/kvm; }; then
+            echo "/dev/kvm missing or not r/w"
+            ls -l /dev/kvm || true
+            exit 1
+          fi
           qemu-system-x86_64 --version | head -n1
           gh --version
 

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -120,7 +120,9 @@ jobs:
             -p "wifihaven-router-images.sha256"
           # Verify the tarball checksum. sha256sum -c short-circuits on
           # missing files; restrict the manifest to lines we have.
-          tarball=$(ls wifihaven-router-openwrt-*-${PKG_FORMAT}.tar.gz)
+          shopt -s nullglob
+          tarballs=(wifihaven-router-openwrt-*-"${PKG_FORMAT}".tar.gz)
+          tarball="${tarballs[0]}"
           grep -F "${tarball}" wifihaven-router-images.sha256 > expected.sha256
           sha256sum -c expected.sha256
 
@@ -129,9 +131,12 @@ jobs:
         run: |
           set -euo pipefail
           cd release
-          tarball=$(ls wifihaven-router-openwrt-*-${PKG_FORMAT}.tar.gz)
+          shopt -s nullglob
+          tarballs=(wifihaven-router-openwrt-*-"${PKG_FORMAT}".tar.gz)
+          tarball="${tarballs[0]}"
           tar -xzf "$tarball"
-          img=$(ls openwrt-wifihaven-${PKG_FORMAT}-*.img | head -n1)
+          imgs=(openwrt-wifihaven-"${PKG_FORMAT}"-*.img)
+          img="${imgs[0]}"
           path="$GITHUB_WORKSPACE/release/$img"
           echo "path=$path" >> "$GITHUB_OUTPUT"
           ls -lh "$path"

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -211,7 +211,9 @@ jobs:
           IPK_SOURCE: path
         run: |
           set -euo pipefail
-          IPK_PATH="$(ls "$PWD"/openwrt/wifihaven_*.ipk | head -n1)"
+          shopt -s nullglob
+          ipks=("$PWD"/openwrt/wifihaven_*.ipk)
+          IPK_PATH="${ipks[0]}"
           export IPK_PATH
           chmod +x scripts/vm/build-router-image.sh
           scripts/vm/build-router-image.sh
@@ -223,7 +225,9 @@ jobs:
           APK_SOURCE: path
         run: |
           set -euo pipefail
-          APK_PATH="$(ls "$PWD"/openwrt/wifihaven_*.apk | head -n1)"
+          shopt -s nullglob
+          apks=("$PWD"/openwrt/wifihaven_*.apk)
+          APK_PATH="${apks[0]}"
           export APK_PATH
           scripts/vm/build-router-image.sh
 


### PR DESCRIPTION
## Summary

Follow-up to #1141 (merged), which introduced the `actionlint` CI job but ran shellcheck at `--severity=warning` to keep the gate green over pre-existing info-level findings in inline `run:` scripts. This PR fixes all of those findings and removes the override so the gate runs at full (info) strictness.

**SC2086 / SC2012** (the documented 6 — unquoted vars in globs, `ls` vs `find`):
- `e2e-vm-gate3b.yml` — "Download last-published router image" and "Extract router .img" steps → quoted nullglob arrays.
- `openwrt-build.yml` — both "Build qemu VM image" steps → nullglob arrays.

**SC2015** (5 more the override was also masking — `A && B || C is not if-then-else`):
- The `/dev/kvm` preflight ternary in `e2e-kvm-sanity.yml`, `e2e-vm-fake.yml`, `e2e-vm-gate3a.yml`, `e2e-vm-gate3b.yml`, `e2e-vm.yml` → rewritten as explicit `if ! { ...; }; then ...; fi`.

**`ci.yml`** — removed `SHELLCHECK_OPTS: --severity=warning` from the "Run actionlint" step.

Globs still resolve to the single built artifact (`arr=(glob); x="${arr[0]}"`) and the preflight handler still runs + exits 1 iff any test fails, so release-pipeline and gate behavior are unchanged.

## Dependency

Follows #1141 (merged). Base is `main`.

## Test plan

- [x] `actionlint` v1.7.12 against **shellcheck 0.10.0** (the version that emits SC2015, matching CI's ubuntu-latest), no severity override → exit 0, fully clean. (Local shellcheck 0.11.0 no longer emits SC2015, which is why the first push was a false green.)
- [ ] CI `Actionlint` job green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)