### PR TITLE
feat(api): expose build version for deploy health-poll verification (#1140)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -152,6 +152,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      # #1140: surfaced so deploy-staging can assert /api/version == this SHA.
+      short_sha: ${{ steps.ver.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -163,14 +166,17 @@ jobs:
         id: ver
         run: |
           set -eu
+          short=$(echo "${GITHUB_SHA}" | cut -c1-7)
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            short=$(echo "${GITHUB_SHA}" | cut -c1-7)
             version=$(./scripts/ci/derive-version.sh --dev "$short")
           else
             version=$(./scripts/ci/derive-version.sh)
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Derived version: $version"
+          # #1140: short SHA is baked into the image and asserted by the
+          # deploy-staging health-poll to prove THIS build is serving.
+          echo "short_sha=$short" >> "$GITHUB_OUTPUT"
+          echo "Derived version: $version (sha-$short)"
 
       - name: Set up QEMU (for linux/arm64 emulation)
         uses: docker/setup-qemu-action@v3
@@ -210,6 +216,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # #1140: bake build identity so /api/version reports this build.
+          build-args: |
+            WIFIHAVEN_VERSION=${{ steps.ver.outputs.version }}
+            WIFIHAVEN_GIT_SHA=${{ steps.ver.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -233,25 +243,31 @@ jobs:
             -X POST "$RENDER_DEPLOY_HOOK_STAGING" >/dev/null
           echo "Staging deploy hook accepted."
 
-      - name: Wait for staging to be healthy
+      - name: Wait for staging to serve THIS build (#1140)
+        env:
+          EXPECTED_SHA: ${{ needs.build-image.outputs.short_sha }}
         run: |
-          # Poll /api/health until it returns 200 with db ok. Render's image
-          # rollout typically takes 30-90s; allow up to 15 minutes.
-          # We check both the HTTP status AND the body to confirm THIS run's
-          # deploy is live (not the previous image still serving while the
-          # new one is starting). The `version` field (if exposed) would be
-          # more authoritative; for now /api/health 200 + db ok is enough —
-          # the smoke-staging job that follows will catch any real breakage.
+          # Poll /api/version until the served `sha` equals the SHA we just
+          # built and pushed. This is the load-bearing check: during a Render
+          # rollover the OLD container keeps answering 200 on /api/health, so
+          # a green health-poll does NOT prove the new image is live (the
+          # #1138 false positive). Asserting the served SHA closes that blind
+          # spot. Render's rollout typically takes 30-90s; allow 15 minutes.
+          set -u
+          echo "Expecting served sha=${EXPECTED_SHA}"
           deadline=$(( $(date +%s) + 900 ))
           while (( $(date +%s) < deadline )); do
-            if curl --fail --silent --max-time 15 \
-                 "${STAGING_API_URL}/api/health" | grep -q '"db":\s*"ok"'; then
-              echo "Staging is healthy."
+            served=$(curl --fail --silent --max-time 15 \
+                       "${STAGING_API_URL}/api/version" \
+                     | grep -oE '"sha":"[^"]*"' | cut -d'"' -f4 || true)
+            if [ "$served" = "$EXPECTED_SHA" ]; then
+              echo "Staging is serving the just-deployed build (sha=${served})."
               exit 0
             fi
+            echo "Still waiting — served sha=${served:-<none>}, want ${EXPECTED_SHA}"
             sleep 10
           done
-          echo "Timed out waiting for staging /api/health." >&2
+          echo "Timed out waiting for staging to serve sha=${EXPECTED_SHA}." >&2
           exit 1
 
   # ── 4b. Deploy SPA to Cloudflare Pages (staging) ──────────────────────────

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -216,9 +216,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # #1140: bake build identity so /api/version reports this build.
+          # #1140: bake the short SHA so /api/version reports this build.
           build-args: |
-            WIFIHAVEN_VERSION=${{ steps.ver.outputs.version }}
             WIFIHAVEN_GIT_SHA=${{ steps.ver.outputs.short_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/api/src/BuildInfo.scala
+++ b/api/src/BuildInfo.scala
@@ -5,22 +5,18 @@ package wifihaven.api
  * actually serving — a green `/api/health` alone can't, since the old container keeps answering 200
  * during a Render rollover.
  *
- * `version` is the derived semver (see scripts/ci/derive-version.sh); `sha` is the git short SHA of
- * the commit the image was built from. Both are baked into the image at build time via Docker ENV
- * (see docker/Dockerfile + .github/workflows/master-api-ui.yml) and read here from the environment.
- * Local/dev runs where nothing is injected fall back to `dev` / `unknown`.
+ * `sha` is the git short SHA of the commit the image was built from. It's the only stable build
+ * identifier for the API/UI (there is no independent semver for this surface). Baked into the image
+ * at build time via Docker ENV (see docker/Dockerfile + .github/workflows/master-api-ui.yml) and
+ * read here from the environment. Local/dev runs where nothing is injected fall back to `unknown`.
  */
-final case class BuildInfo(version: String, sha: String)
+final case class BuildInfo(sha: String)
 
 object BuildInfo {
-  val DevVersion = "dev"
   val UnknownSha = "unknown"
 
   def fromEnv: BuildInfo =
-    BuildInfo(
-      version = resolve(sys.env.get("WIFIHAVEN_VERSION"), DevVersion),
-      sha = resolve(sys.env.get("WIFIHAVEN_GIT_SHA"), UnknownSha),
-    )
+    BuildInfo(resolve(sys.env.get("WIFIHAVEN_GIT_SHA"), UnknownSha))
 
   private[api] def resolve(raw: Option[String], fallback: String): String =
     raw.map(_.trim).filter(_.nonEmpty).getOrElse(fallback)

--- a/api/src/BuildInfo.scala
+++ b/api/src/BuildInfo.scala
@@ -1,0 +1,27 @@
+package wifihaven.api
+
+/**
+ * Build identity of the running image (#1140). Lets CD prove the freshly-built image is the one
+ * actually serving — a green `/api/health` alone can't, since the old container keeps answering 200
+ * during a Render rollover.
+ *
+ * `version` is the derived semver (see scripts/ci/derive-version.sh); `sha` is the git short SHA of
+ * the commit the image was built from. Both are baked into the image at build time via Docker ENV
+ * (see docker/Dockerfile + .github/workflows/master-api-ui.yml) and read here from the environment.
+ * Local/dev runs where nothing is injected fall back to `dev` / `unknown`.
+ */
+final case class BuildInfo(version: String, sha: String)
+
+object BuildInfo {
+  val DevVersion = "dev"
+  val UnknownSha = "unknown"
+
+  def fromEnv: BuildInfo =
+    BuildInfo(
+      version = resolve(sys.env.get("WIFIHAVEN_VERSION"), DevVersion),
+      sha = resolve(sys.env.get("WIFIHAVEN_GIT_SHA"), UnknownSha),
+    )
+
+  private[api] def resolve(raw: Option[String], fallback: String): String =
+    raw.map(_.trim).filter(_.nonEmpty).getOrElse(fallback)
+}

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -159,6 +159,7 @@ object Main extends ZIOAppDefault {
       routerAuth    = new RouterAuthLive(routerRepo)
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield HealthRoutes.routes(dbHealthCheck) ++
+      VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
       AuthRoutes.routes(auth, userRepo, upRepo) ++
       ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
       HouseholdSettingsRoutes.routes(auth, hsRepo) ++

--- a/api/src/routes/VersionRoutes.scala
+++ b/api/src/routes/VersionRoutes.scala
@@ -1,0 +1,20 @@
+package wifihaven.api.routes
+
+import wifihaven.api.BuildInfo
+import zio.*
+import zio.http.*
+
+/**
+ * Unauthenticated, DB-free build-identity probe (#1140). The CD staging health-poll asserts the
+ * served `sha` equals the SHA it just deployed before trusting the smoke tests, closing the
+ * Render-rollover blind spot that produced the #1138 false positive.
+ */
+object VersionRoutes {
+  def routes(info: BuildInfo): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "version" ->
+        handler { (_: Request) =>
+          Response.json(s"""{"version":"${info.version}","sha":"${info.sha}"}""")
+        },
+    )
+}

--- a/api/src/routes/VersionRoutes.scala
+++ b/api/src/routes/VersionRoutes.scala
@@ -13,8 +13,6 @@ object VersionRoutes {
   def routes(info: BuildInfo): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "version" ->
-        handler { (_: Request) =>
-          Response.json(s"""{"version":"${info.version}","sha":"${info.sha}"}""")
-        },
+        handler { (_: Request) => Response.json(s"""{"sha":"${info.sha}"}""") },
     )
 }

--- a/api/test/src/feature/VersionApiSpec.scala
+++ b/api/test/src/feature/VersionApiSpec.scala
@@ -17,21 +17,19 @@ object VersionApiSpec extends ZIOSpecDefault {
     json.asObject.flatMap(_.get(key)).flatMap(_.asString)
 
   def spec = suite("Version API")(
-    test("GET /api/version returns the injected version and sha") {
-      val routes = VersionRoutes.routes(BuildInfo("0.2.7", "abc1234"))
+    test("GET /api/version returns the injected sha") {
+      val routes = VersionRoutes.routes(BuildInfo("abc1234"))
       for {
         resp <- get(routes)
         body <- resp.body.asString
         json <- ZIO.fromEither(body.fromJson[Json])
       } yield assertTrue(resp.status == Status.Ok) &&
-        assertTrue(field(json, "version").contains("0.2.7")) &&
         assertTrue(field(json, "sha").contains("abc1234"))
     },
-    test("BuildInfo.fromEnv falls back to dev/unknown when the env var is unset or blank") {
-      assertTrue(BuildInfo.resolve(None, BuildInfo.DevVersion) == "dev") &&
+    test("BuildInfo.fromEnv falls back to unknown when the env var is unset or blank") {
+      assertTrue(BuildInfo.resolve(None, BuildInfo.UnknownSha) == "unknown") &&
       assertTrue(BuildInfo.resolve(Some(""), BuildInfo.UnknownSha) == "unknown") &&
       assertTrue(BuildInfo.resolve(Some("   "), BuildInfo.UnknownSha) == "unknown") &&
-      assertTrue(BuildInfo.resolve(Some("0.2.7"), BuildInfo.DevVersion) == "0.2.7") &&
       assertTrue(BuildInfo.resolve(Some(" abc1234 "), BuildInfo.UnknownSha) == "abc1234")
     },
   )

--- a/api/test/src/feature/VersionApiSpec.scala
+++ b/api/test/src/feature/VersionApiSpec.scala
@@ -1,0 +1,38 @@
+package wifihaven.api.feature
+
+import wifihaven.api.BuildInfo
+import wifihaven.api.routes.VersionRoutes
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+object VersionApiSpec extends ZIOSpecDefault {
+
+  private def get(routes: Routes[Any, Response]): UIO[Response] =
+    routes(Request.get("/api/version")).merge
+
+  private def field(json: Json, key: String): Option[String] =
+    json.asObject.flatMap(_.get(key)).flatMap(_.asString)
+
+  def spec = suite("Version API")(
+    test("GET /api/version returns the injected version and sha") {
+      val routes = VersionRoutes.routes(BuildInfo("0.2.7", "abc1234"))
+      for {
+        resp <- get(routes)
+        body <- resp.body.asString
+        json <- ZIO.fromEither(body.fromJson[Json])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(field(json, "version").contains("0.2.7")) &&
+        assertTrue(field(json, "sha").contains("abc1234"))
+    },
+    test("BuildInfo.fromEnv falls back to dev/unknown when the env var is unset or blank") {
+      assertTrue(BuildInfo.resolve(None, BuildInfo.DevVersion) == "dev") &&
+      assertTrue(BuildInfo.resolve(Some(""), BuildInfo.UnknownSha) == "unknown") &&
+      assertTrue(BuildInfo.resolve(Some("   "), BuildInfo.UnknownSha) == "unknown") &&
+      assertTrue(BuildInfo.resolve(Some("0.2.7"), BuildInfo.DevVersion) == "0.2.7") &&
+      assertTrue(BuildInfo.resolve(Some(" abc1234 "), BuildInfo.UnknownSha) == "abc1234")
+    },
+  )
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,16 @@ RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8080
 
+# #1140: bake the build identity into the image so /api/version can report
+# which build is serving. Defaults keep local `docker build` honest (dev/
+# unknown) without requiring the args; CI passes the derived semver + short
+# SHA (see .github/workflows/master-api-ui.yml).
+ARG WIFIHAVEN_VERSION=dev
+ARG WIFIHAVEN_GIT_SHA=unknown
+
 ENV WIFIHAVEN_HTTP_PORT=8080 \
-    WIFIHAVEN_STATIC_DIR=/app/web
+    WIFIHAVEN_STATIC_DIR=/app/web \
+    WIFIHAVEN_VERSION=$WIFIHAVEN_VERSION \
+    WIFIHAVEN_GIT_SHA=$WIFIHAVEN_GIT_SHA
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,16 +54,14 @@ RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8080
 
-# #1140: bake the build identity into the image so /api/version can report
-# which build is serving. Defaults keep local `docker build` honest (dev/
-# unknown) without requiring the args; CI passes the derived semver + short
-# SHA (see .github/workflows/master-api-ui.yml).
-ARG WIFIHAVEN_VERSION=dev
+# #1140: bake the git short SHA into the image so /api/version can report
+# which build is serving. Default keeps local `docker build` honest (unknown)
+# without requiring the arg; CI passes the short SHA (see
+# .github/workflows/master-api-ui.yml).
 ARG WIFIHAVEN_GIT_SHA=unknown
 
 ENV WIFIHAVEN_HTTP_PORT=8080 \
     WIFIHAVEN_STATIC_DIR=/app/web \
-    WIFIHAVEN_VERSION=$WIFIHAVEN_VERSION \
     WIFIHAVEN_GIT_SHA=$WIFIHAVEN_GIT_SHA
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Bake the git short SHA into the API image at build time via Docker `ARG`/`ENV`, passed from `master-api-ui.yml`.
- Surface it on a new unauthenticated, DB-free `GET /api/version` returning `{"sha":"<short-sha>"}`. Falls back to `unknown` for local runs where nothing is injected.
- Staging deploy health-poll now asserts the served `sha` == the just-pushed short SHA (polling `/api/version`), instead of only checking `/api/health` for HTTP 200 — closing the Render-rollover blind spot where the old container keeps answering 200 while the new image starts (the #1138 false positive).

SHA only — the API/UI has no independent semver (the `v<X.Y.Z>` tags are the coordinated #499/#1134 release tags, not a per-surface version), and the SHA is the only value the health-poll compares.

## Test plan
- [x] New `VersionApiSpec` committed red before the implementation commit; passes after.
- [x] `mill api.test` green (192 tests).
- [x] `scalafmt --check` clean.
- [x] Health-poll change verified against the deploy step logic: `build-image` exposes `short_sha` as a job output; `deploy-staging` consumes it via `needs.build-image.outputs.short_sha` and loops until `/api/version`'s `sha` matches.

Closes #1140.