### PR TITLE
web: shared EmptyState component + rollout (#828)

### DIFF
--- a/web/src/components/EmptyState.test.tsx
+++ b/web/src/components/EmptyState.test.tsx
@@ -1,0 +1,45 @@
+// Tests for EmptyState — the shared placeholder for "nothing here yet" / "no
+// data" surfaces across the SPA (#828). Centralizes the scattered ad-hoc
+// `<p>No X yet</p>` strings so empty states look and read consistently.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    render(<EmptyState title="No devices yet." />)
+    expect(screen.getByText('No devices yet.')).toBeInTheDocument()
+  })
+
+  it('renders an optional hint/subtitle', () => {
+    render(<EmptyState title="No apps yet." hint="Create one to start grouping hosts." />)
+    expect(screen.getByText('Create one to start grouping hosts.')).toBeInTheDocument()
+  })
+
+  it('does not render a hint when none is given', () => {
+    const { container } = render(<EmptyState title="No users yet." />)
+    // only the title paragraph, no second line
+    expect(container.querySelectorAll('p')).toHaveLength(1)
+  })
+
+  it('renders an optional action / CTA', () => {
+    render(<EmptyState title="No routers enrolled yet." action={<button>Enroll</button>} />)
+    expect(screen.getByRole('button', { name: 'Enroll' })).toBeInTheDocument()
+  })
+
+  it('exposes a status role for assistive tech', () => {
+    render(<EmptyState title="No blocked queries yet" />)
+    expect(screen.getByRole('status')).toHaveTextContent('No blocked queries yet')
+  })
+
+  it('forwards a data-testid', () => {
+    render(<EmptyState title="No profiles configured yet." data-testid="now-empty" />)
+    expect(screen.getByTestId('now-empty')).toBeInTheDocument()
+  })
+
+  it('supports an inline variant for sub-sections', () => {
+    render(<EmptyState title="No activity in the last 5 minutes" variant="inline" />)
+    expect(screen.getByText('No activity in the last 5 minutes')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react'
+
+// Shared empty / idle-state placeholder (#828). Use instead of ad-hoc
+// `<p>No X yet</p>` strings so "nothing here" surfaces read and look the same
+// everywhere.
+//
+//  - variant="page"   — for an empty list card (centered, roomy).
+//  - variant="inline" — for an empty sub-section inside a populated card
+//    (left-aligned, compact).
+
+type EmptyStateVariant = 'page' | 'inline'
+
+interface EmptyStateProps {
+  title: string
+  hint?: ReactNode
+  action?: ReactNode
+  icon?: ReactNode
+  variant?: EmptyStateVariant
+  'data-testid'?: string
+}
+
+export function EmptyState({
+  title,
+  hint,
+  action,
+  icon,
+  variant = 'page',
+  'data-testid': testId,
+}: EmptyStateProps) {
+  const isPage = variant === 'page'
+  return (
+    <div
+      role="status"
+      data-testid={testId}
+      className={
+        isPage
+          ? 'flex flex-col items-center justify-center gap-2 px-6 py-12 text-center'
+          : 'flex flex-col items-start gap-1 px-1 py-2'
+      }
+    >
+      {icon && (
+        <div className={isPage ? 'text-gray-600 text-2xl' : 'text-gray-600 text-base'} aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <p className="text-gray-500 text-sm">{title}</p>
+      {hint && <p className="text-gray-600 text-xs">{hint}</p>}
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  )
+}

--- a/web/src/pages/AppsPage.tsx
+++ b/web/src/pages/AppsPage.tsx
@@ -6,6 +6,7 @@ import { PageLoader } from './DashboardPage'
 import { RecentApexPicker } from '@/components/RecentApexPicker'
 import { IconPicker, type IconValue } from '@/components/IconPicker'
 import { AppIcon } from '@/components/AppIcon'
+import { EmptyState } from '@/components/EmptyState'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 
 interface EditFormState {
@@ -87,7 +88,7 @@ export function AppsPage() {
 
       <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
         {apps.length === 0
-          ? <p className="p-6 text-gray-500 text-sm">No apps yet. Create one to start grouping hosts.</p>
+          ? <EmptyState title="No apps yet." hint="Create one to start grouping hosts." />
           : apps.map(a => {
               const assignProfiles = new Set(a.assignments.map(x => x.profileId))
               return (

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import type {
   QueryLog,
 } from '@/types/api'
 import { HostCell } from '@/components/HostCell'
+import { EmptyState } from '@/components/EmptyState'
 import { AccessRequestsBanner, NewDevicesHint } from '@/components/AlertsPanel'
 import { blockReasonText } from '@/types/blockReason'
 
@@ -49,7 +50,7 @@ export function DashboardPage() {
                 Top Blocked (24h)
               </h2>
               {stats.topBlocked.length === 0
-                ? <p className="text-gray-600 text-sm">No blocked queries yet</p>
+                ? <EmptyState variant="inline" title="No blocked queries yet" />
                 : stats.topBlocked.map(d => (
                     <div key={`${d.host.type}:${d.host.value}`} className="flex justify-between items-center py-2 border-b border-gray-800 last:border-0">
                       <span className="font-mono text-sm text-gray-300 truncate"><HostCell host={d.host} /></span>
@@ -107,7 +108,7 @@ export function NowSection() {
       {data === null
         ? <p className="text-gray-600 text-sm">Loading live activity…</p>
         : data.profiles.length === 0
-          ? <p className="text-gray-600 text-sm">No profiles configured yet.</p>
+          ? <EmptyState variant="inline" title="No profiles configured yet." />
           : (
             <div className="grid md:grid-cols-2 gap-4">
               {data.profiles.map(p => <NowProfileCard key={p.id} profile={p} />)}
@@ -134,7 +135,7 @@ function NowProfileCard({ profile }: { profile: DashboardNowProfile }) {
         )}
       </div>
       {idle
-        ? <p className="text-gray-600 text-xs">No activity in the last 5 minutes</p>
+        ? <EmptyState variant="inline" title="No activity in the last 5 minutes" />
         : (
           <div className="space-y-3">
             {profile.activeDevices.map(d => <NowDeviceRow key={d.mac} device={d} />)}

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -6,6 +6,7 @@ import { useAlerts, useDevices, useHouseholdSettings, useProfiles, useInvalidato
 import { useAuth } from '@/hooks/useAuth'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 import { useNotificationPermission } from '@/hooks/useNotifyOnNewAlerts'
+import { EmptyState } from '@/components/EmptyState'
 import type { Alert, Device, PatchDeviceRequest, ProfileDetail } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
@@ -97,7 +98,7 @@ export function DevicesPage() {
 
       <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
         {knownDevices.length === 0
-          ? <p className="p-6 text-gray-500 text-sm">No devices yet.</p>
+          ? <EmptyState title="No devices yet." />
           : knownDevices.map(d => (
               <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-emerald-500/60 ring-inset' : ''}`}>
                 <Link to={`/devices/${encodeURIComponent(d.mac)}/timeline`} className="flex-1 min-w-0 hover:text-emerald-400 transition-colors" data-testid={`device-timeline-link-${d.mac}`}>

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -14,6 +14,7 @@ import type {
 import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { AppIcon } from '@/components/AppIcon'
 import { ProfileTimelineChart } from '@/components/usage/ProfileTimelineChart'
+import { EmptyState } from '@/components/EmptyState'
 import { PageLoader } from './DashboardPage'
 import { formatMins } from '@/lib/timeFormat'
 
@@ -809,7 +810,7 @@ function ProfileShellRow({
                 </p>
               )}
               {allUsers.length === 0
-                ? <p className="text-xs text-gray-600">No users in this household yet.</p>
+                ? <EmptyState variant="inline" title="No users in this household yet." />
                 : (
                   <div className="flex flex-wrap gap-2">
                     {allUsers.map(u => {
@@ -1353,17 +1354,22 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
           Save this profile first to assign apps.
         </p>
       ) : apps.length === 0 ? (
-        <p className="text-xs text-gray-500">
-          No apps yet.{' '}
-          <Link
-            to="/apps"
-            data-testid={`${testIdPrefix}-empty-link`}
-            className="text-emerald-400 hover:text-emerald-300 underline"
-          >
-            Create one
-          </Link>
-          {' '}to block, allow, or time-limit a group of hosts.
-        </p>
+        <EmptyState
+          variant="inline"
+          title="No apps yet."
+          hint={
+            <>
+              <Link
+                to="/apps"
+                data-testid={`${testIdPrefix}-empty-link`}
+                className="text-emerald-400 hover:text-emerald-300 underline"
+              >
+                Create one
+              </Link>
+              {' '}to block, allow, or time-limit a group of hosts.
+            </>
+          }
+        />
       ) : (
         <div className="space-y-2">
           {assigned.length === 0 && !pickerOpen && (

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -3,6 +3,7 @@ import { api } from '@/api/client'
 import type { CreateRouterResponse, RouterSummary } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
+import { EmptyState } from '@/components/EmptyState'
 
 export function RoutersPage() {
   const [routers, setRouters] = useState<RouterSummary[]>([])
@@ -89,7 +90,7 @@ export function RoutersPage() {
 
       <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
         {routers.length === 0
-          ? <p className="p-6 text-gray-500 text-sm">No routers enrolled yet.</p>
+          ? <EmptyState title="No routers enrolled yet." />
           : routers.map(r => (
               <div key={r.id} className="border-b border-gray-800 last:border-0">
                 <div className="flex items-center gap-4 px-5 py-4">

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -3,6 +3,7 @@ import { api } from '@/api/client'
 import type { CreateUserRequest, ProfileDetail, User, UserRole } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
+import { EmptyState } from '@/components/EmptyState'
 
 const ROLES: UserRole[] = ['admin', 'adult', 'child']
 
@@ -119,7 +120,7 @@ export function UsersPage() {
 
       <div className="bg-gray-900 rounded-2xl border border-gray-800 overflow-hidden">
         {users.length === 0
-          ? <p className="p-6 text-gray-500 text-sm">No users yet.</p>
+          ? <EmptyState title="No users yet." />
           : users.map(u => (
               <div key={u.id} data-testid={`user-row-${u.id}`} className="flex items-center gap-4 px-5 py-4 border-b border-gray-800 last:border-0">
                 <div className="flex-1 min-w-0">
@@ -252,7 +253,7 @@ function ProfilePicker({
     <div>
       <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Linked profiles</label>
       {profiles.length === 0
-        ? <p className="text-sm text-gray-500">No profiles available.</p>
+        ? <EmptyState variant="inline" title="No profiles available." />
         : (
           <div className="flex flex-wrap gap-2">
             {profiles.map(p => {


### PR DESCRIPTION
## Summary
- Add a shared EmptyState component (consistent icon/title/subtitle/CTA + muted styling, `role="status"`, `page` + `inline` variants)
- Replace ad-hoc 'No X yet' strings across dashboard, devices, users, routers, apps, and profiles
- Dashboard: empty-state swap only — no layout changes (those belong to redesign umbrella #1148)

## Test plan
- [x] vitest covers EmptyState rendering + a11y
- [x] `nvm use 22 && npm test` green (274 passed)
- [ ] Visual check: empty states consistent across profiles/devices/logs/apps/users

## Notes
- LogsPage empty-states live inside `<td colSpan>` table cells and overlap with the bare-IP-row standardization effort (#826), so they were left untouched here to avoid file collisions.

Closes #828.