### PR TITLE
web: standardize bare-IP destination row presentation (#826)

### DIFF
--- a/web/src/components/HostCell.test.tsx
+++ b/web/src/components/HostCell.test.tsx
@@ -40,4 +40,49 @@ describe('HostCell', () => {
     const outer = container.firstChild as HTMLElement
     expect(outer.textContent).toContain('2001:db8::1 ipv6')
   })
+
+  // #826: standardize bare-IP-row presentation across surfaces. Every surface
+  // that renders a HostId in a ranked/log list previously hand-rolled its own
+  // italic/muted/tag markup, drifting on the muted color (text-gray-400 vs
+  // text-gray-500) and the title tooltip. HostCell is now the single source of
+  // truth: monospace value, full-value title for truncated cells, and one
+  // canonical unresolved treatment (italic + text-gray-400 + type tag).
+  describe('#826: standardized presentation', () => {
+    it('renders the value in monospace for both fqdn and IP rows', () => {
+      const { container: fqdn } = render(<HostCell host={{ type: 'fqdn', value: 'youtube.com' }} />)
+      const { container: ip } = render(<HostCell host={{ type: 'ipv4', value: '10.0.0.5' }} />)
+      expect((fqdn.firstChild as HTMLElement).className).toContain('font-mono')
+      expect((ip.firstChild as HTMLElement).className).toContain('font-mono')
+    })
+
+    it('gives bare-IP rows the standardized unresolved treatment (italic + muted gray-400)', () => {
+      const { container } = render(<HostCell host={{ type: 'ipv4', value: '10.0.0.5' }} />)
+      const outer = container.firstChild as HTMLElement
+      expect(outer.className).toContain('italic')
+      expect(outer.className).toContain('text-gray-400')
+      // The drifted surfaces used text-gray-500; the standardized treatment must not.
+      expect(outer.className).not.toContain('text-gray-500')
+    })
+
+    it('does not italicize resolved fqdn rows', () => {
+      const { container } = render(<HostCell host={{ type: 'fqdn', value: 'youtube.com' }} />)
+      expect((container.firstChild as HTMLElement).className).not.toContain('italic')
+    })
+
+    it('sets a title tooltip with the full value so truncated cells stay inspectable', () => {
+      const { container: fqdn } = render(<HostCell host={{ type: 'fqdn', value: 'a.very.long.subdomain.example.com' }} />)
+      const { container: ip } = render(<HostCell host={{ type: 'ipv6', value: '2001:db8::dead:beef' }} />)
+      expect((fqdn.firstChild as HTMLElement).getAttribute('title')).toBe('a.very.long.subdomain.example.com')
+      expect((ip.firstChild as HTMLElement).getAttribute('title')).toBe('2001:db8::dead:beef')
+    })
+
+    it('merges a caller-supplied className onto the outer span (structural classes from the surface)', () => {
+      const { container: fqdn } = render(<HostCell host={{ type: 'fqdn', value: 'youtube.com' }} className="truncate min-w-0" />)
+      const { container: ip } = render(<HostCell host={{ type: 'ipv4', value: '10.0.0.5' }} className="truncate min-w-0" />)
+      expect((fqdn.firstChild as HTMLElement).className).toContain('truncate')
+      expect((fqdn.firstChild as HTMLElement).className).toContain('min-w-0')
+      expect((ip.firstChild as HTMLElement).className).toContain('truncate')
+      expect((ip.firstChild as HTMLElement).className).toContain('italic')
+    })
+  })
 })

--- a/web/src/components/HostCell.tsx
+++ b/web/src/components/HostCell.tsx
@@ -4,12 +4,25 @@ import type { HostId } from '@/types/api'
 // distinguishable (#391). IP rows get italic + a small "ipv4" / "ipv6" tag so
 // an admin scanning the logs sees at a glance that the row is unattributed
 // traffic (DoH, Apple Private Relay, etc.) rather than a normal browse.
-export function HostCell({ host }: { host: HostId }) {
+//
+// #826: single source of truth for destination presentation across every
+// ranked/log surface. The value is always monospace and carries a full-value
+// title so truncated cells stay inspectable; bare-IP rows get the one
+// canonical unresolved treatment (italic + text-gray-400 + type tag) instead
+// of each surface hand-rolling its own muted color. Callers pass only
+// structural classes (truncate, min-w-0, sizing) via `className`; they must
+// NOT pass a text color for IP rows, since the unresolved color is owned here.
+// A bare IP is not "blocked" — this styling never implies block state.
+export function HostCell({ host, className = '' }: { host: HostId; className?: string }) {
   if (host.type === 'fqdn') {
-    return <span>{host.value}</span>
+    return (
+      <span className={`font-mono ${className}`.trim()} title={host.value}>
+        {host.value}
+      </span>
+    )
   }
   return (
-    <span className="italic text-gray-400">
+    <span className={`font-mono italic text-gray-400 ${className}`.trim()} title={host.value}>
       {host.value}
       {' '}
       <span className="text-[10px] uppercase tracking-wide text-gray-600">

--- a/web/src/components/usage/ProfileTimelineChart.tsx
+++ b/web/src/components/usage/ProfileTimelineChart.tsx
@@ -6,6 +6,7 @@ import { api } from '@/api/client'
 import {
   useTimeStatusProfileWeek, useUsageSeriesProfileToday,
 } from '@/api/queries'
+import { HostCell } from '@/components/HostCell'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 import type {
   UsageBucket, UsageDeviceBucket, UsageSeriesResponse,
@@ -370,22 +371,13 @@ function OtherDrillInModal({
         {!loading && !error && tail.length > 0 && (
           <ul className="space-y-1 overflow-y-auto pr-1 -mr-1">
             {tail.map(h => {
-              const isIp = h.host.type !== 'fqdn'
               const shareOther = otherTotal > 0 ? (h.dayMins / otherTotal) * 100 : 0
               const shareTotal = grandTotal > 0 ? (h.dayMins / grandTotal) * 100 : 0
               return (
                 <li key={`${h.host.type}:${h.host.value}`}
                   data-testid={`${testIdPrefix}-other-host-${h.host.value}`}
-                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2 gap-2">
-                  <span className={`font-mono truncate min-w-0 ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
-                    title={h.host.value}>
-                    {h.host.value}
-                    {isIp && (
-                      <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
-                        {h.host.type}
-                      </span>
-                    )}
-                  </span>
+                  className="flex items-center justify-between text-xs text-gray-300 bg-gray-800/50 rounded-lg px-3 py-2 gap-2">
+                  <HostCell host={h.host} className="truncate min-w-0" />
                   <span className="text-gray-500 font-mono shrink-0 tabular-nums">
                     {formatMins(h.dayMins)}
                     <span className="text-gray-600 ml-2">

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -8,6 +8,7 @@ import type {
   DeviceTimeStatusWeek, UsageBucket, UsageSeriesResponse,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
+import { HostCell } from '@/components/HostCell'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 import {
   HOST_COLORS, OTHER_KEY, UsageHourlyBarChart, type ChartSeries,
@@ -294,31 +295,20 @@ export function DeviceTimelinePage() {
           </h2>
           <ul className="space-y-1.5">
             {hosts.map((h, i) => {
-              const isIp = h.host.type !== 'fqdn'
               return (
                 <li
                   key={`${h.host.type}:${h.host.value}`}
                   data-testid={`device-timeline-host-${h.host.value}`}
-                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+                  className="flex items-center justify-between text-xs text-gray-300 bg-gray-800/50 rounded-lg px-3 py-2"
                 >
                   <span className="flex items-center gap-2 min-w-0">
                     <span
                       className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                       style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
                     />
-                    {/* Per #718: bare-IP rows render but de-emphasized so the
-                        FQDN attribution gap is visible at a glance. */}
-                    <span
-                      className={`font-mono truncate ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
-                      title={h.host.value}
-                    >
-                      {h.host.value}
-                      {isIp && (
-                        <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
-                          {h.host.type}
-                        </span>
-                      )}
-                    </span>
+                    {/* Per #718: bare-IP rows render but de-emphasized (HostCell)
+                        so the FQDN attribution gap is visible at a glance. */}
+                    <HostCell host={h.host} className="truncate" />
                   </span>
                   <span
                     className="text-gray-500 font-mono shrink-0 ml-2"
@@ -424,26 +414,15 @@ function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherD
         {!loading && !error && tail.length > 0 && (
           <ul className="space-y-1 overflow-y-auto pr-1 -mr-1">
             {tail.map(h => {
-              const isIp = h.host.type !== 'fqdn'
               const shareOther = otherTotal > 0 ? (h.dayMins / otherTotal) * 100 : 0
               const shareTotal = grandTotal > 0 ? (h.dayMins / grandTotal) * 100 : 0
               return (
                 <li
                   key={`${h.host.type}:${h.host.value}`}
                   data-testid={`device-timeline-other-host-${h.host.value}`}
-                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2 gap-2"
+                  className="flex items-center justify-between text-xs text-gray-300 bg-gray-800/50 rounded-lg px-3 py-2 gap-2"
                 >
-                  <span
-                    className={`font-mono truncate min-w-0 ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
-                    title={h.host.value}
-                  >
-                    {h.host.value}
-                    {isIp && (
-                      <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
-                        {h.host.type}
-                      </span>
-                    )}
-                  </span>
+                  <HostCell host={h.host} className="truncate min-w-0" />
                   <span className="text-gray-500 font-mono shrink-0 tabular-nums">
                     {formatMins(h.dayMins)}
                     <span className="text-gray-600 ml-2">

--- a/web/src/pages/ProfileTimelinePage.tsx
+++ b/web/src/pages/ProfileTimelinePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
+import { HostCell } from '@/components/HostCell'
 import type {
   UsageBucket, UsageDeviceBucket, UsageSeriesResponse,
 } from '@/types/api'
@@ -284,29 +285,18 @@ export function ProfileTimelinePage() {
           </h2>
           <ul className="space-y-1.5">
             {data.topHosts.filter(h => h.dayMins > 0).map((h, i) => {
-              const isIp = h.host.type !== 'fqdn'
               return (
                 <li
                   key={`${h.host.type}:${h.host.value}`}
                   data-testid={`profile-timeline-host-${h.host.value}`}
-                  className="flex items-center justify-between text-xs bg-gray-800/50 rounded-lg px-3 py-2"
+                  className="flex items-center justify-between text-xs text-gray-300 bg-gray-800/50 rounded-lg px-3 py-2"
                 >
                   <span className="flex items-center gap-2 min-w-0">
                     <span
                       className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                       style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
                     />
-                    <span
-                      className={`font-mono truncate ${isIp ? 'italic text-gray-500' : 'text-gray-300'}`}
-                      title={h.host.value}
-                    >
-                      {h.host.value}
-                      {isIp && (
-                        <span className="ml-1 text-[10px] uppercase tracking-wide text-gray-600">
-                          {h.host.type}
-                        </span>
-                      )}
-                    </span>
+                    <HostCell host={h.host} className="truncate" />
                   </span>
                   <span className="text-gray-500 font-mono shrink-0 ml-2">{h.dayMins}m</span>
                 </li>


### PR DESCRIPTION
## Summary
- `HostCell` is now the single source of truth for rendering a destination host: monospace value, full-value `title` tooltip (so truncated cells stay inspectable), one canonical unresolved treatment (italic + `text-gray-400` + type tag), and a structural-only `className` passthrough.
- Rolled it out across the surfaces that hand-rolled their own italic/muted/tag markup and had drifted to `text-gray-500` + a redundant title: profile-timeline "top hosts" and "other" lists, device-timeline "top hosts" and "other" lists. The logs/dashboard/traffic surfaces already used `HostCell`.
- Rendering only — no dashboard layout changes (redesign is umbrella #1148). A bare IP is not implied to be "blocked"; unresolved-IP styling stays separate from block state.

## Notes for clean rebase
- Only `HostCell.tsx` + the four timeline render sites changed; if the empty-state work (#828) touches a shared row/table component, no overlap is expected here.

## Test plan
- [x] vitest covers hostname vs bare-IP rendering (monospace, italic+gray-400 unresolved treatment, title tooltip, className merge)
- [x] `nvm use 22 && npm test` green (272 passed); `tsc --noEmit` + eslint clean
- [ ] Visual check: bare-IP rows consistent across logs, dashboard, profile/device timelines

Closes #826.