### PR TITLE
web: gate usage date-picker granularity on retention horizon (#814)

### DIFF
--- a/web/src/components/usage/BucketSelector.test.tsx
+++ b/web/src/components/usage/BucketSelector.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BucketSelector } from './BucketSelector'
+import { bucketAvailability } from './retentionGating'
+
+const NOW = new Date('2026-05-29T12:00:00.000Z')
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86400000)
+
+describe('BucketSelector — retention gating', () => {
+  it('greys out swept buckets and surfaces the retention reason as a tooltip', () => {
+    // 45d back: raw (30d) swept, hourly/daily retained.
+    const gates = bucketAvailability(daysAgo(45), NOW)
+    render(<BucketSelector value="1h" onChange={() => {}} gates={gates} />)
+
+    const raw = screen.getByTestId('bucket-raw')
+    expect(raw).toBeDisabled()
+    expect(raw).toHaveAttribute('title', expect.stringMatching(/30 days/))
+
+    expect(screen.getByTestId('bucket-1h')).toBeEnabled()
+    expect(screen.getByTestId('bucket-1d')).toBeEnabled()
+  })
+
+  it('does not fire onChange when a disabled bucket is clicked', async () => {
+    const onChange = vi.fn()
+    const gates = bucketAvailability(daysAgo(45), NOW)
+    render(<BucketSelector value="1h" onChange={onChange} gates={gates} />)
+
+    await userEvent.click(screen.getByTestId('bucket-raw'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('without gates, all buckets are enabled (backwards-compatible)', () => {
+    render(<BucketSelector value="raw" onChange={() => {}} />)
+    expect(screen.getByTestId('bucket-raw')).toBeEnabled()
+    expect(screen.getByTestId('bucket-1w')).toBeEnabled()
+  })
+})

--- a/web/src/components/usage/BucketSelector.tsx
+++ b/web/src/components/usage/BucketSelector.tsx
@@ -1,10 +1,9 @@
 import type { TrafficUsageBucket } from '@/types/api'
+import type { BucketGate } from './retentionGating'
 
 interface BucketOption {
   value: TrafficUsageBucket
   label: string
-  disabled?: boolean
-  disabledReason?: string
 }
 
 // Raw period is whatever the router agent emits — typically 1m in prod,
@@ -26,33 +25,41 @@ interface Props {
   // Hide "Raw" when the consumer endpoint doesn't support it (events agg
   // requires a bucket — there's a separate raw view at /api/logs).
   hideRaw?: boolean
+  // #814: per-bucket enable/disable derived from the retention horizon for
+  // the chosen date range. A disabled bucket is greyed (not hidden) and its
+  // `reason` is surfaced as the tooltip.
+  gates?: Partial<Record<TrafficUsageBucket, BucketGate>>
 }
 
-export function BucketSelector({ value, onChange, hideRaw }: Props) {
+export function BucketSelector({ value, onChange, hideRaw, gates }: Props) {
   const buckets = hideRaw ? BUCKETS.filter(b => b.value !== 'raw') : BUCKETS
   return (
     <div className="flex flex-wrap gap-2" role="group" aria-label="bucket-selector">
-      {buckets.map(b => (
-        <button
-          key={b.value}
-          type="button"
-          disabled={b.disabled}
-          data-testid={`bucket-${b.value}`}
-          onClick={() => {
-            if (!b.disabled) onChange(b.value)
-          }}
-          title={b.disabledReason ?? ''}
-          className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
-            b.disabled
-              ? 'bg-gray-900 text-gray-600 cursor-not-allowed'
-              : value === b.value
-              ? 'bg-emerald-600 text-white'
-              : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
-          }`}
-        >
-          {b.label}
-        </button>
-      ))}
+      {buckets.map(b => {
+        const gate = gates?.[b.value]
+        const disabled = gate ? !gate.enabled : false
+        return (
+          <button
+            key={b.value}
+            type="button"
+            disabled={disabled}
+            data-testid={`bucket-${b.value}`}
+            onClick={() => {
+              if (!disabled) onChange(b.value)
+            }}
+            title={disabled ? gate?.reason ?? '' : ''}
+            className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+              disabled
+                ? 'bg-gray-900 text-gray-600 cursor-not-allowed'
+                : value === b.value
+                ? 'bg-emerald-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            {b.label}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/web/src/components/usage/retentionGating.test.ts
+++ b/web/src/components/usage/retentionGating.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import type { TrafficUsageBucket } from '@/types/api'
+import {
+  DEFAULT_RETENTION_HORIZONS,
+  bucketAvailability,
+} from './retentionGating'
+
+// Anchor "now" to a fixed instant so day-offset arithmetic is deterministic.
+const NOW = new Date('2026-05-29T12:00:00.000Z')
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000)
+}
+
+function enabledBuckets(until: Date | null): TrafficUsageBucket[] {
+  const gates = bucketAvailability(until, NOW, DEFAULT_RETENTION_HORIZONS)
+  return (Object.keys(gates) as TrafficUsageBucket[]).filter(b => gates[b].enabled)
+}
+
+describe('bucketAvailability — gate granularity on retention horizon', () => {
+  // Mirrors RetentionSweepJob: raw 30d / hourly 90d / daily 180d, and the
+  // bucket→tier grouping from UsageRoutes (sub-hourly→raw, 1h/12h→hourly,
+  // 1d/1w→daily).
+  it('exposes the server retention constants', () => {
+    expect(DEFAULT_RETENTION_HORIZONS).toEqual({
+      rawDays: 30,
+      hourlyDays: 90,
+      dailyDays: 180,
+    })
+  })
+
+  it('until=null (now) → every bucket enabled', () => {
+    expect(enabledBuckets(null)).toEqual(['raw', '1m', '10m', '1h', '12h', '1d', '1w'])
+  })
+
+  it('range within last 30d → raw / hourly / daily all available', () => {
+    expect(enabledBuckets(daysAgo(10))).toEqual(['raw', '1m', '10m', '1h', '12h', '1d', '1w'])
+  })
+
+  it('exactly at the 30d edge → raw still available', () => {
+    const gates = bucketAvailability(daysAgo(30), NOW, DEFAULT_RETENTION_HORIZONS)
+    expect(gates.raw.enabled).toBe(true)
+  })
+
+  it('older than 30d (within 3mo) → raw swept, hourly+daily only', () => {
+    expect(enabledBuckets(daysAgo(45))).toEqual(['1h', '12h', '1d', '1w'])
+  })
+
+  it('older than 3mo (within 6mo) → daily only', () => {
+    expect(enabledBuckets(daysAgo(120))).toEqual(['1d', '1w'])
+  })
+
+  it('older than 6mo → nothing retained', () => {
+    expect(enabledBuckets(daysAgo(200))).toEqual([])
+  })
+
+  it('disabled sub-hourly buckets carry a retention reason mentioning 30 days', () => {
+    const gates = bucketAvailability(daysAgo(45), NOW, DEFAULT_RETENTION_HORIZONS)
+    expect(gates.raw.enabled).toBe(false)
+    expect(gates.raw.reason).toMatch(/30 days/)
+    expect(gates['10m'].reason).toMatch(/30 days/)
+  })
+
+  it('disabled hourly buckets mention the 3-month horizon', () => {
+    const gates = bucketAvailability(daysAgo(120), NOW, DEFAULT_RETENTION_HORIZONS)
+    expect(gates['1h'].enabled).toBe(false)
+    expect(gates['1h'].reason).toMatch(/90 days|3 months/)
+  })
+
+  it('disabled daily buckets mention the 6-month horizon', () => {
+    const gates = bucketAvailability(daysAgo(200), NOW, DEFAULT_RETENTION_HORIZONS)
+    expect(gates['1d'].enabled).toBe(false)
+    expect(gates['1d'].reason).toMatch(/180 days|6 months/)
+  })
+
+  it('honours custom horizons (operator-tuned retention)', () => {
+    const custom = { rawDays: 7, hourlyDays: 14, dailyDays: 28 }
+    const gates = bucketAvailability(daysAgo(10), NOW, custom)
+    expect(gates.raw.enabled).toBe(false)
+    expect(gates['1h'].enabled).toBe(true)
+    expect(gates['1d'].enabled).toBe(true)
+  })
+})

--- a/web/src/components/usage/retentionGating.ts
+++ b/web/src/components/usage/retentionGating.ts
@@ -1,0 +1,85 @@
+import type { TrafficUsageBucket } from '@/types/api'
+
+// Retention horizons, mirrored from the server. The sweep job
+// (api/src/usage/RetentionSweepJob.scala) drops raw rows after 30d, hourly
+// rollups after 90d, daily rollups after 180d. We hard-code the same values
+// here so the date-picker never offers a granularity whose source table has
+// already been swept. Operator-tunable horizons (GET /api/usage/horizons) are
+// a follow-up; until then these constants must track RetentionSweepJob.
+export interface RetentionHorizons {
+  rawDays: number
+  hourlyDays: number
+  dailyDays: number
+}
+
+export const DEFAULT_RETENTION_HORIZONS: RetentionHorizons = {
+  rawDays: 30,
+  hourlyDays: 90,
+  dailyDays: 180,
+}
+
+type SourceTier = 'raw' | 'hourly' | 'daily'
+
+// Which source tier backs each display bucket — mirrors the bucket→tier
+// grouping in UsageRoutes.scala (minBucketFor / bucketRank): sub-hourly
+// buckets can only come from raw 5-min rows; 1h/12h come from the hourly
+// rollup (or finer); 1d/1w come from the daily rollup (or finer). A bucket is
+// retained as far back as the *coarsest* tier that can produce it, which is
+// exactly the tier named here.
+const BUCKET_TIER: Record<TrafficUsageBucket, SourceTier> = {
+  raw: 'raw',
+  '1m': 'raw',
+  '10m': 'raw',
+  '1h': 'hourly',
+  '12h': 'hourly',
+  '1d': 'daily',
+  '1w': 'daily',
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface BucketGate {
+  enabled: boolean
+  reason?: string
+}
+
+function horizonFor(tier: SourceTier, h: RetentionHorizons): number {
+  switch (tier) {
+    case 'raw':
+      return h.rawDays
+    case 'hourly':
+      return h.hourlyDays
+    case 'daily':
+      return h.dailyDays
+  }
+}
+
+function reasonFor(tier: SourceTier, h: RetentionHorizons): string {
+  switch (tier) {
+    case 'raw':
+      return `5-minute resolution is kept for ${h.rawDays} days. Switch to a coarser bucket to see older data.`
+    case 'hourly':
+      return `Hourly resolution is kept for ${h.hourlyDays} days. Switch to a daily bucket to see older data.`
+    case 'daily':
+      return `Daily resolution is kept for ${h.dailyDays} days; no data is retained beyond that.`
+  }
+}
+
+// Given the right-edge anchor of the viewing window (`until`; null = now),
+// return the enable/disable state for every granularity bucket. A bucket is
+// disabled when its newest visible point is already older than its source
+// tier's retention horizon — i.e. the whole window has been swept.
+export function bucketAvailability(
+  until: Date | null,
+  now: Date,
+  horizons: RetentionHorizons = DEFAULT_RETENTION_HORIZONS,
+): Record<TrafficUsageBucket, BucketGate> {
+  const daysAgo = until === null ? 0 : (now.getTime() - until.getTime()) / DAY_MS
+  const gates = {} as Record<TrafficUsageBucket, BucketGate>
+  for (const bucket of Object.keys(BUCKET_TIER) as TrafficUsageBucket[]) {
+    const tier = BUCKET_TIER[bucket]
+    const enabled = daysAgo <= horizonFor(tier, horizons)
+    gates[bucket] = enabled ? { enabled } : { enabled, reason: reasonFor(tier, horizons) }
+  }
+  return gates
+}

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -16,6 +16,10 @@ import { GroupableHeader } from '@/components/usage/GroupableHeader'
 import { HeaderFilter } from '@/components/usage/HeaderFilter'
 import { JumpToDate } from '@/components/usage/JumpToDate'
 import {
+  bucketAvailability,
+  type BucketGate,
+} from '@/components/usage/retentionGating'
+import {
   fmtBytes,
   fmtDuration,
   localTime,
@@ -92,6 +96,25 @@ export function TrafficUsagePage() {
     else sp.delete('until')
     setSearchParams(sp, { replace: true })
   }
+
+  // #814: which granularity buckets still have retained data for the chosen
+  // anchor. When the user jumps to a date older than the raw/hourly horizon,
+  // those buckets grey out (BucketSelector) and we auto-promote the current
+  // selection to the finest still-available bucket so we never request a
+  // swept tier.
+  const bucketGates = useMemo<Record<TrafficUsageBucket, BucketGate>>(
+    () => bucketAvailability(until ? new Date(until) : null, new Date()),
+    [until],
+  )
+
+  useEffect(() => {
+    if (bucketGates[bucket]?.enabled === false) {
+      const finest = (Object.keys(bucketGates) as TrafficUsageBucket[]).find(
+        b => bucketGates[b].enabled,
+      )
+      if (finest) setBucket(finest)
+    }
+  }, [bucketGates, bucket])
 
   const load = useCallback(
     async (curs: string | null) => {
@@ -175,6 +198,7 @@ export function TrafficUsagePage() {
         profileIds={profileIds}
         bucket={bucket}
         until={until}
+        bucketGates={bucketGates}
         onMacsChange={setMacs}
         onProfileIdsChange={setProfileIds}
         onBucketChange={setBucket}
@@ -249,6 +273,9 @@ interface ShelfProps {
   profileIds: number[]
   bucket: TrafficUsageBucket
   until: string | null
+  // #814: per-bucket retention gating. Omitted by consumers (e.g. the
+  // connection-events log) whose source has a single flat retention horizon.
+  bucketGates?: Record<TrafficUsageBucket, BucketGate>
   onMacsChange: (v: string[]) => void
   onProfileIdsChange: (v: number[]) => void
   onBucketChange: (b: TrafficUsageBucket) => void
@@ -261,7 +288,7 @@ interface ShelfProps {
 // #951: Jump-to-Date sits next to the bucket selector — re-anchors the
 // infinite-scroll cursor at the chosen instant (cleared = "now").
 export function FilterShelf({
-  devices, profiles, macs, profileIds, bucket, until,
+  devices, profiles, macs, profileIds, bucket, until, bucketGates,
   onMacsChange, onProfileIdsChange, onBucketChange, onUntilChange,
 }: ShelfProps) {
   const deviceLabel = (m: string) => devices.find(d => d.mac === m)?.name ?? m
@@ -271,7 +298,7 @@ export function FilterShelf({
   return (
     <div className="space-y-3 bg-gray-900/40 rounded p-3 border border-gray-800">
       <div className="flex flex-wrap items-end gap-4">
-        <BucketSelector value={bucket} onChange={onBucketChange} />
+        <BucketSelector value={bucket} onChange={onBucketChange} gates={bucketGates} />
         <JumpToDate value={until} onChange={onUntilChange} />
       </div>
       {hasChips && (


### PR DESCRIPTION
## Summary
- Date-picker only offers granularities with retained data for the chosen range (raw 30d / hourly 90d / daily 180d)
- Mirrors the server-side granularity routing from #1083 (bucket→source-tier grouping) and the retention horizons in `RetentionSweepJob` so SPA + API agree
- Disabled (greyed, not hidden) buckets carry a tooltip explaining the retention horizon; older-than-retention ranges disable everything
- `TrafficUsagePage` auto-promotes the selected bucket to the finest still-retained tier when the anchor jumps past a horizon, so the SPA never requests a swept bucket

## Notes
- Web only; no API change. Horizons are hard-coded to track `RetentionSweepJob` constants — an operator-tunable `GET /api/usage/horizons` endpoint remains a follow-up (per #814).
- `FilterShelf` `bucketGates` is optional; the connection-events log (flat 30d retention) opts out.

## Test plan
- [x] vitest: `bucketAvailability` enable/disable matches retention horizons for representative ranges (within 30d / 30-90d / 90-180d / >180d, edge, custom horizons)
- [x] vitest: `BucketSelector` greys swept buckets, surfaces the tooltip, ignores disabled clicks
- [x] `nvm use 22 && npm test` green (281 tests)

Closes #814.