### PR TITLE
db: partition traffic_reports + connection_events (weekly range) (#805 #806)

### DIFF
--- a/api/resources/db/migration/V41__partition_traffic_reports.sql
+++ b/api/resources/db/migration/V41__partition_traffic_reports.sql
@@ -1,0 +1,118 @@
+-- V41__partition_traffic_reports.sql
+-- #805 (design: docs/design/db-partitioning.md, #793): convert traffic_reports
+-- to a weekly RANGE-partitioned table on period_start. traffic_reports is the
+-- largest growth surface; every hot read predicate is a period_start/date range
+-- or a router_id lookup, and the unique key already includes period_start, so
+-- native partitioning preserves uniqueness without weakening it.
+--
+-- Technique: detach-and-reattach. Rename the existing table to become a single
+-- historical "omnibus" partition, create a new partitioned parent with an
+-- identical column set, relocate any on/after-cutover rows into freshly-created
+-- weekly partitions, then attach the historical remainder as the unbounded-below
+-- partition. ATTACH validates (full scan, no rewrite); at current volume this is
+-- seconds. Ongoing weekly-partition creation lands in #808; retention drop in
+-- #812; redundant-index cleanup in #810.
+--
+-- Two points the design doc's worked example glosses over, resolved here:
+--   1. `id BIGSERIAL PRIMARY KEY` is illegal as-is on a partitioned table — a
+--      primary key must include the partition key. Nothing references this id
+--      (no FKs, no lookups; it is a surrogate returned in read DTOs only), so we
+--      drop the PK and keep `id` as a plain sequence-backed column. The existing
+--      UNIQUE (router_id, period_start, mac, host_type, host_value) — which DOES
+--      include the partition key — becomes the row-identity constraint.
+--   2. The id sequence is detached (OWNED BY NONE) so it survives the eventual
+--      DROP of expired partitions (#812); otherwise dropping the omnibus would
+--      drop the sequence the parent still defaults from.
+--
+-- Partition seeding is anchored to CURRENT_DATE at migration time (not a
+-- hardcoded date) so the test harness — which re-runs every migration against a
+-- fresh embedded Postgres on each reset — always seeds partitions covering "now"
+-- regardless of when the suite runs, and prod seeds relative to its deploy date.
+
+-- Detach the id sequence so a future partition drop can't take it with it.
+ALTER SEQUENCE traffic_reports_id_seq OWNED BY NONE;
+
+-- Rename the existing table; it becomes the historical omnibus partition.
+ALTER TABLE traffic_reports RENAME TO traffic_reports_pre_partition;
+
+-- Strip indexes + constraints from the omnibus. Index and unique/PK-backing
+-- index names share the schema namespace, so they must be freed before the new
+-- parent re-establishes them under the canonical names. The parent re-creates
+-- the UNIQUE and FK (the FK propagates to this partition on attach) and the
+-- secondary indexes after attach. The host_type CHECK is deliberately KEPT:
+-- ATTACH PARTITION requires the child to already carry an equivalent of each of
+-- the parent's CHECK constraints, and the parent declares the same-named check,
+-- so Postgres merges them on attach.
+ALTER TABLE traffic_reports_pre_partition DROP CONSTRAINT traffic_reports_pkey;
+ALTER TABLE traffic_reports_pre_partition
+  DROP CONSTRAINT traffic_reports_router_id_period_start_mac_host_key;
+ALTER TABLE traffic_reports_pre_partition DROP CONSTRAINT traffic_reports_router_id_fkey;
+DROP INDEX idx_traffic_reports_router;
+DROP INDEX idx_traffic_reports_date;
+DROP INDEX idx_traffic_reports_mac_date;
+DROP INDEX idx_traffic_reports_period_start;
+DROP INDEX idx_traffic_reports_mac_period_start;
+
+-- New range-partitioned parent. Identical columns/types/NOT NULLs/defaults to
+-- the original; id continues monotonically from the preserved sequence.
+CREATE TABLE traffic_reports (
+  id              BIGINT      NOT NULL DEFAULT nextval('traffic_reports_id_seq'),
+  router_id       UUID        NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  mac             TEXT        NOT NULL,
+  ip              TEXT,
+  host_value      TEXT        NOT NULL,
+  date            DATE        NOT NULL,
+  period_start    TIMESTAMPTZ NOT NULL,
+  period_end      TIMESTAMPTZ NOT NULL,
+  active_seconds  INT         NOT NULL DEFAULT 0,
+  bytes_in        BIGINT      NOT NULL DEFAULT 0,
+  bytes_out       BIGINT      NOT NULL DEFAULT 0,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  host_type       TEXT        NOT NULL,
+  CONSTRAINT traffic_reports_host_type_check CHECK (host_type IN ('fqdn', 'ipv4', 'ipv6')),
+  CONSTRAINT traffic_reports_router_id_period_start_mac_host_key
+    UNIQUE (router_id, period_start, mac, host_type, host_value)
+) PARTITION BY RANGE (period_start);
+
+-- Seed weekly partitions (current ISO week + 4 ahead), relocate on/after-cutover
+-- rows into them, then attach the remainder as the unbounded-below omnibus.
+DO $$
+DECLARE
+  cutover DATE := date_trunc('week', CURRENT_DATE)::date; -- Monday of current ISO week
+  wk      DATE;
+  i       INT;
+BEGIN
+  FOR i IN 0..4 LOOP
+    wk := cutover + (i * 7);
+    EXECUTE format(
+      'CREATE TABLE traffic_reports_%s PARTITION OF traffic_reports FOR VALUES FROM (%L) TO (%L)',
+      to_char(wk, 'IYYY_IW'), wk::timestamptz, (wk + 7)::timestamptz
+    );
+  END LOOP;
+
+  INSERT INTO traffic_reports
+    (id, router_id, mac, ip, host_value, date, period_start, period_end,
+     active_seconds, bytes_in, bytes_out, created_at, host_type)
+  SELECT id, router_id, mac, ip, host_value, date, period_start, period_end,
+     active_seconds, bytes_in, bytes_out, created_at, host_type
+  FROM traffic_reports_pre_partition
+  WHERE period_start >= cutover::timestamptz;
+
+  DELETE FROM traffic_reports_pre_partition WHERE period_start >= cutover::timestamptz;
+
+  EXECUTE format(
+    'ALTER TABLE traffic_reports ATTACH PARTITION traffic_reports_pre_partition '
+    || 'FOR VALUES FROM (MINVALUE) TO (%L)',
+    cutover::timestamptz
+  );
+END $$;
+
+-- Re-establish the original secondary indexes as local partitioned indexes
+-- (CREATE INDEX on the parent propagates to every partition). Kept verbatim
+-- through the burn-in window so a rollback stays cheap; the now-redundant ones
+-- (date, mac_date, period_start) are dropped in the post-burn-in cleanup (#810).
+CREATE INDEX idx_traffic_reports_router          ON traffic_reports (router_id);
+CREATE INDEX idx_traffic_reports_date            ON traffic_reports (date);
+CREATE INDEX idx_traffic_reports_mac_date        ON traffic_reports (mac, date);
+CREATE INDEX idx_traffic_reports_period_start    ON traffic_reports (period_start DESC);
+CREATE INDEX idx_traffic_reports_mac_period_start ON traffic_reports (mac, period_start);

--- a/api/resources/db/migration/V42__partition_connection_events.sql
+++ b/api/resources/db/migration/V42__partition_connection_events.sql
@@ -1,0 +1,107 @@
+-- V42__partition_connection_events.sql
+-- #806 (design: docs/design/db-partitioning.md, #793): convert connection_events
+-- to a weekly RANGE-partitioned table on ts. One row per outbound connection
+-- attempt; every non-trivial query has a `ts > NOW() - INTERVAL …` predicate or
+-- is a bounded `ORDER BY ts DESC LIMIT N`. Retention-via-partition-drop (#812)
+-- is the obvious win. Same detach-and-reattach technique as V41.
+--
+-- DISCREPANCY WITH THE DESIGN DOC (flagged here per the worktree TDD policy):
+-- docs/design/db-partitioning.md states connection_events "has no unique
+-- constraints" and lists only the V4 + V22 indexes. That predates V15, which
+-- added UNIQUE INDEX idx_conn_events_event_id (event_id) — the dedup key for the
+-- idempotent ingest upsert (#338). A unique index on a partitioned table MUST
+-- include the partition key, so a bare UNIQUE (event_id) is illegal here. We
+-- widen it to UNIQUE (event_id, ts); the ingest upsert's ON CONFLICT target is
+-- updated to (event_id, ts) in the same PR. This preserves idempotency: a
+-- retry-queue replay (#330) carries the same router-supplied ts as the original
+-- event, so (event_id, ts) collapses replays exactly as (event_id) did. Two
+-- genuinely distinct events never share an event_id (client UUID, else
+-- gen_random_uuid()), so the widened key cannot admit a true duplicate.
+--
+-- As in V41: drop the id PRIMARY KEY (illegal without the partition key; id is a
+-- surrogate used only as a keyset-pagination tiebreaker on (ts, id), which a
+-- plain monotonic sequence still satisfies) and detach the id sequence so a
+-- future partition drop can't take it with it. Partition seeding is anchored to
+-- CURRENT_DATE at migration time (see V41 for why).
+
+ALTER SEQUENCE connection_events_id_seq OWNED BY NONE;
+
+ALTER TABLE connection_events RENAME TO connection_events_pre_partition;
+
+-- Strip indexes + constraints from the omnibus to free the canonical names. The
+-- host_type CHECK is deliberately KEPT: ATTACH PARTITION requires the child to
+-- already carry an equivalent of each of the parent's CHECK constraints, which
+-- Postgres merges with the same-named check the parent declares.
+ALTER TABLE connection_events_pre_partition DROP CONSTRAINT connection_events_pkey;
+ALTER TABLE connection_events_pre_partition DROP CONSTRAINT connection_events_router_id_fkey;
+DROP INDEX idx_conn_events_ts;
+DROP INDEX idx_conn_events_mac_ts;
+DROP INDEX idx_conn_events_allowed_ts;
+DROP INDEX idx_conn_events_router_ts;
+DROP INDEX idx_conn_events_event_id;
+DROP INDEX idx_conn_events_router_dest_ip_ts;
+DROP INDEX idx_conn_events_mac_dest_resolved;
+
+-- New range-partitioned parent. Identical columns/types/NOT NULLs/defaults to
+-- the original (logical column order); id continues from the preserved sequence.
+-- UNIQUE widened from (event_id) to (event_id, ts) to include the partition key.
+CREATE TABLE connection_events (
+  id                  BIGINT      NOT NULL DEFAULT nextval('connection_events_id_seq'),
+  router_id           UUID        NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  mac                 TEXT,
+  host_value          TEXT        NOT NULL,
+  dest_ip             TEXT,
+  allowed             BOOLEAN     NOT NULL,
+  ts                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  host_type           TEXT        NOT NULL,
+  event_id            UUID        NOT NULL DEFAULT gen_random_uuid(),
+  resolved_host_value TEXT,
+  reason              JSONB       NOT NULL,
+  CONSTRAINT connection_events_host_type_check CHECK (host_type IN ('fqdn', 'ipv4', 'ipv6')),
+  CONSTRAINT connection_events_event_id_ts_key UNIQUE (event_id, ts)
+) PARTITION BY RANGE (ts);
+
+DO $$
+DECLARE
+  cutover DATE := date_trunc('week', CURRENT_DATE)::date; -- Monday of current ISO week
+  wk      DATE;
+  i       INT;
+BEGIN
+  FOR i IN 0..4 LOOP
+    wk := cutover + (i * 7);
+    EXECUTE format(
+      'CREATE TABLE connection_events_%s PARTITION OF connection_events FOR VALUES FROM (%L) TO (%L)',
+      to_char(wk, 'IYYY_IW'), wk::timestamptz, (wk + 7)::timestamptz
+    );
+  END LOOP;
+
+  INSERT INTO connection_events
+    (id, router_id, mac, host_value, dest_ip, allowed, ts, host_type,
+     event_id, resolved_host_value, reason)
+  SELECT id, router_id, mac, host_value, dest_ip, allowed, ts, host_type,
+     event_id, resolved_host_value, reason
+  FROM connection_events_pre_partition
+  WHERE ts >= cutover::timestamptz;
+
+  DELETE FROM connection_events_pre_partition WHERE ts >= cutover::timestamptz;
+
+  EXECUTE format(
+    'ALTER TABLE connection_events ATTACH PARTITION connection_events_pre_partition '
+    || 'FOR VALUES FROM (MINVALUE) TO (%L)',
+    cutover::timestamptz
+  );
+END $$;
+
+-- Re-establish the original secondary indexes as local partitioned indexes.
+-- idx_conn_events_ts is now redundant with partition pruning and is dropped in
+-- the post-burn-in cleanup (#810); kept here so a rollback stays cheap.
+CREATE INDEX idx_conn_events_ts         ON connection_events (ts DESC);
+CREATE INDEX idx_conn_events_mac_ts     ON connection_events (mac, ts DESC);
+CREATE INDEX idx_conn_events_allowed_ts ON connection_events (allowed, ts DESC);
+CREATE INDEX idx_conn_events_router_ts  ON connection_events (router_id, ts DESC);
+CREATE INDEX idx_conn_events_router_dest_ip_ts
+  ON connection_events (router_id, dest_ip, ts DESC)
+  WHERE dest_ip IS NOT NULL;
+CREATE INDEX idx_conn_events_mac_dest_resolved
+  ON connection_events (mac, dest_ip)
+  WHERE resolved_host_value IS NOT NULL;

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1623,7 +1623,9 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     Update[ConnectionEventInsert](
       "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value) " +
         "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?) " +
-        "ON CONFLICT (event_id) DO NOTHING",
+        // #806: unique key widened to (event_id, ts) for ts-range partitioning;
+        // a replay carries the same router-supplied ts so dedup is unchanged.
+        "ON CONFLICT (event_id, ts) DO NOTHING",
     ).updateMany(events).transact(xa)
 
   // #720: read paths coalesce a populated resolved_host_value into the host

--- a/api/test/src/feature/PartitioningSpec.scala
+++ b/api/test/src/feature/PartitioningSpec.scala
@@ -173,5 +173,5 @@ object PartitioningSpec
         total  <- sql"SELECT count(*)::int FROM connection_events".query[Int].unique.transact(xa)
       } yield assertTrue(first == 1) && assertTrue(second == 0) && assertTrue(total == 1)
     },
-  )
+  ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/PartitioningSpec.scala
+++ b/api/test/src/feature/PartitioningSpec.scala
@@ -1,0 +1,177 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.db.TypeMeta.given
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import doobie.Transactor
+import doobie.implicits.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+
+import java.time.Instant
+
+/**
+ * #805 / #806: traffic_reports and connection_events are weekly range-partitioned (RANGE on
+ * period_start / ts respectively). This spec pins the post-migration structure (so the partitioning
+ * can't silently regress to a flat table), proves existing rows survive the detach-and-reattach,
+ * that inserts route across a partition boundary, and that the idempotent upserts still collapse
+ * replays under partitioning (the connection_events unique key had to grow to include `ts`).
+ */
+object PartitioningSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def seedRouter: RIO[RouterRepo, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("partition-test", Sha256Hex.unsafe("a" * 64)))
+
+  /** Is `table` a RANGE-partitioned parent? */
+  private def isRangePartitioned(xa: Transactor[Task], table: String): Task[Boolean] =
+    sql"""SELECT EXISTS (
+            SELECT 1 FROM pg_partitioned_table pt
+              JOIN pg_class c ON c.oid = pt.partrelid
+             WHERE c.relname = $table AND pt.partstrat = 'r'
+          )""".query[Boolean].unique.transact(xa)
+
+  /** Number of attached partitions of `table`. */
+  private def partitionCount(xa: Transactor[Task], table: String): Task[Int] =
+    sql"""SELECT count(*)::int FROM pg_inherits i
+            JOIN pg_class p ON p.oid = i.inhparent
+           WHERE p.relname = $table""".query[Int].unique.transact(xa)
+
+  /** Distinct partitions (by tableoid) that currently hold rows of `table`. */
+  private def distinctPartitionsWithRows(xa: Transactor[Task], table: String): Task[Int] = {
+    val frag = doobie.Fragment.const(s"SELECT count(DISTINCT tableoid)::int FROM $table")
+    frag.query[Int].unique.transact(xa)
+  }
+
+  private def insertTraffic(
+      xa: Transactor[Task],
+      routerId: RouterId,
+      mac: String,
+      offset: doobie.Fragment,
+  ): Task[Unit] =
+    (fr"""INSERT INTO traffic_reports
+            (router_id, mac, ip, host_type, host_value, date, period_start, period_end,
+             active_seconds, bytes_in, bytes_out)
+          VALUES
+            ($routerId, $mac, NULL, 'fqdn', 'example.com',
+             (NOW() """ ++ offset ++ fr""")::date,
+             NOW() """ ++ offset ++ fr""",
+             NOW() """ ++ offset ++ fr""" + INTERVAL '5 minutes',
+             1, 1, 1)""").update.run.transact(xa).unit
+
+  private def insertEvent(
+      xa: Transactor[Task],
+      routerId: RouterId,
+      mac: String,
+      offset: doobie.Fragment,
+  ): Task[Unit] =
+    (fr"""INSERT INTO connection_events
+            (router_id, mac, host_type, host_value, dest_ip, allowed, reason, ts)
+          VALUES
+            ($routerId, $mac, 'fqdn', 'example.com', NULL, true, '{"kind":"allow"}'::jsonb,
+             NOW() """ ++ offset ++ fr""")""").update.run.transact(xa).unit
+
+  private val past   = fr"- INTERVAL '40 days'" // omnibus partition
+  private val nowOff = fr"+ INTERVAL '0 days'"  // current-week partition
+  private val future = fr"+ INTERVAL '8 days'"  // next-week partition
+
+  def spec = suite("table partitioning (#805 #806)")(
+    test("traffic_reports is a RANGE-partitioned parent with seeded weekly partitions") {
+      for {
+        _    <- cleanDb
+        xa   <- ZIO.service[Transactor[Task]]
+        part <- isRangePartitioned(xa, "traffic_reports")
+        n    <- partitionCount(xa, "traffic_reports")
+      } yield assertTrue(part) && assertTrue(n >= 2)
+    },
+    test("connection_events is a RANGE-partitioned parent with seeded weekly partitions") {
+      for {
+        _    <- cleanDb
+        xa   <- ZIO.service[Transactor[Task]]
+        part <- isRangePartitioned(xa, "connection_events")
+        n    <- partitionCount(xa, "connection_events")
+      } yield assertTrue(part) && assertTrue(n >= 2)
+    },
+    test("traffic_reports rows survive and route across a partition boundary") {
+      for {
+        _      <- cleanDb
+        xa     <- ZIO.service[Transactor[Task]]
+        rid    <- seedRouter
+        _      <- insertTraffic(xa, rid, "aa:aa:aa:aa:aa:01", past)
+        _      <- insertTraffic(xa, rid, "aa:aa:aa:aa:aa:02", nowOff)
+        _      <- insertTraffic(xa, rid, "aa:aa:aa:aa:aa:03", future)
+        total  <- sql"SELECT count(*)::int FROM traffic_reports".query[Int].unique.transact(xa)
+        spread <- distinctPartitionsWithRows(xa, "traffic_reports")
+      } yield assertTrue(total == 3) && assertTrue(spread >= 3)
+    },
+    test("connection_events rows survive and route across a partition boundary") {
+      for {
+        _      <- cleanDb
+        xa     <- ZIO.service[Transactor[Task]]
+        rid    <- seedRouter
+        _      <- insertEvent(xa, rid, "bb:bb:bb:bb:bb:01", past)
+        _      <- insertEvent(xa, rid, "bb:bb:bb:bb:bb:02", nowOff)
+        _      <- insertEvent(xa, rid, "bb:bb:bb:bb:bb:03", future)
+        total  <- sql"SELECT count(*)::int FROM connection_events".query[Int].unique.transact(xa)
+        spread <- distinctPartitionsWithRows(xa, "connection_events")
+      } yield assertTrue(total == 3) && assertTrue(spread >= 3)
+    },
+    test("traffic_reports upsert stays idempotent on its business key under partitioning") {
+      for {
+        _     <- cleanDb
+        rid   <- seedRouter
+        tRepo <- ZIO.service[TrafficReportRepo]
+        xa    <- ZIO.service[Transactor[Task]]
+        ps  = Instant.now()
+        row = TrafficReportInsert(
+          rid,
+          MacAddress.unsafe("cc:cc:cc:cc:cc:01"),
+          None,
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          java.time.LocalDate.now(),
+          ps,
+          ps.plusSeconds(300),
+          240,
+          1000L,
+          500L,
+        )
+        first  <- tRepo.insertBatch(List(row))
+        second <- tRepo.insertBatch(List(row))
+        total  <- sql"SELECT count(*)::int FROM traffic_reports".query[Int].unique.transact(xa)
+      } yield assertTrue(first == 1) && assertTrue(second == 0) && assertTrue(total == 1)
+    },
+    test("connection_events upsert dedups replays on (event_id, ts) under partitioning") {
+      for {
+        _     <- cleanDb
+        rid   <- seedRouter
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        xa    <- ZIO.service[Transactor[Task]]
+        ts  = Instant.now()
+        eid = java.util.UUID.randomUUID()
+        ev  = ConnectionEventInsert(
+          rid,
+          Some(MacAddress.unsafe("dd:dd:dd:dd:dd:01")),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          None,
+          true,
+          BlockReason.fromWire("allow"),
+          ts,
+          Some(eid),
+        )
+        first  <- cRepo.insertBatch(List(ev))
+        second <- cRepo.insertBatch(List(ev))
+        total  <- sql"SELECT count(*)::int FROM connection_events".query[Int].unique.transact(xa)
+      } yield assertTrue(first == 1) && assertTrue(second == 0) && assertTrue(total == 1)
+    },
+  )
+}


### PR DESCRIPTION
## Summary
- Convert `traffic_reports` (#805) and `connection_events` (#806) to weekly RANGE-partitioned tables per [docs/design/db-partitioning.md](docs/design/db-partitioning.md)
- Detach-and-reattach preserves existing data, indexes, FK and constraints; the renamed original table becomes the unbounded-below "omnibus" partition
- Seed current ISO week + 4 ahead, **anchored to `CURRENT_DATE` at migration time** (not a hardcoded date) so the test harness — which re-runs every migration against a fresh embedded Postgres on each reset — always seeds partitions covering "now", and prod seeds relative to its deploy date. Ongoing creation lands in #808.

## Design decisions / deviations from the design doc
The design doc's worked example glosses over two things that block native partitioning; resolved here (flagging per "design doc wins, but flag the discrepancy"):

1. **`id BIGSERIAL PRIMARY KEY` is illegal on a partitioned table** — a PK must include the partition key. Nothing references these ids (no FKs, no lookups; `id` is a surrogate returned in read DTOs, plus a keyset-pagination tiebreaker on `(ts, id)` for connection_events). So the PK is dropped and `id` kept as a plain sequence-backed column; the sequence is detached (`OWNED BY NONE`) so the eventual retention partition-drop (#812) can't take it. Row identity comes from the existing business unique key (traffic_reports) / `event_id` (connection_events).

2. **The design doc says `connection_events` has no unique constraints — but V15 added `UNIQUE(event_id)`** (the doc predates it, listing only V4 + V22 indexes). A unique index on a partitioned table must include the partition key, so it is widened to `UNIQUE(event_id, ts)` and the ingest upsert's `ON CONFLICT` target follows. Idempotency is preserved: a retry-queue replay (#330) carries the same router-supplied `ts` as the original event, and two genuinely distinct events never share an `event_id`.

`traffic_reports`' `UNIQUE(router_id, period_start, mac, host_type, host_value)` already includes the partition key, so its upsert is unchanged.

Per the design doc's rollback section, all original indexes are kept (re-created as local partitioned indexes) through the burn-in window; the now-redundant ones (`idx_traffic_reports_date/mac_date/period_start`, `idx_conn_events_ts`) are dropped later in #810.

## Test plan
- [x] Migration test (`PartitioningSpec`): both tables are RANGE-partitioned post-migration; rows survive; inserts route across a partition boundary (omnibus / current-week / next-week → distinct `tableoid`s); upserts stay idempotent under partitioning
- [x] `mill api.test` green — 555 tests pass (no regression in traffic/usage/log/connection-event queries). Note: the parallel embedded-Postgres harness flakes on ARM (`Gave up waiting for server to start`); run serialized with `mill -j 1 api.test` for a clean pass
- [x] `scalafmt --check` clean on changed Scala

Red→green commit progression visible in history.

Closes #805, closes #806. Unblocks #808 (auto-create), #812 (partition-drop retention), #810 (index cleanup).