### PR TITLE
fix(ci): e2e scripts read typed BlockReason .kind on event rows (#1153)

### DIFF
--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -43,6 +43,10 @@ step() { echo; echo "▶ $*"; }
 # legitimate zero/empty value.
 _py() { python3 -c "$1"; }
 
+# Importable e2e helpers (shared with the unit tests). Used by the #1122
+# read-back so the typed-BlockReason wire contract has one source of truth.
+E2E_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/e2e/lib" && pwd)"
+
 # ── Admin login ────────────────────────────────────────────────────────────
 step "Admin login"
 LOGIN=$(curl -fsS -X POST "$BASE/api/auth/login" \
@@ -305,14 +309,17 @@ while (( $(date +%s) < deadline )); do
   curl -fsS "${AUTH[@]}" \
     "$BASE/api/logs?mac=$MAC&blocked=true&hours=1" >"$TMP/nflog_logs.json"
   LOGS_OK=$(_py "
-import json
+import json, sys
+sys.path.insert(0, '$E2E_LIB')
+from log_reason import blocked_reason_kinds
 page = json.load(open('$TMP/nflog_logs.json'))
 rows = page.get('rows', [])
 # Only consider the rows we just posted (filter to the dst-IP prefix used
 # above so prior runs against staging don't contaminate the check).
 ours = [r for r in rows if (r.get('host') or {}).get('value', '').startswith('198.51.100.1')]
-reasons = sorted({r.get('reason') for r in ours if r.get('blocked')})
-want = ['Manual', 'Paused', 'Schedule', 'TimeLimit', 'Unmanaged']
+# /api/logs reason is a kind-tagged object since #1147 (#962) — key on .kind.
+reasons = blocked_reason_kinds(ours)
+want = ['manual', 'paused', 'schedule', 'timeLimit', 'unmanaged']
 print('ok' if reasons == want else f'have={reasons}')
 ")
   [ "$LOGS_OK" = "ok" ] && break

--- a/scripts/e2e/lib/log_reason.py
+++ b/scripts/e2e/lib/log_reason.py
@@ -1,0 +1,20 @@
+"""Reason extraction for /api/logs (and /api/connection-events/*) rows.
+
+Single source of truth shared by the bash router e2e (`scripts/e2e-router.sh`
+#1122 read-back) and its unit test, so the wire-shape contract can't drift
+between them.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def blocked_reason_kinds(rows: list[dict[str, Any]]) -> list[str]:
+    """Sorted, de-duplicated reason discriminators for the blocked rows.
+
+    `/api/logs` rows carry `reason` as a kind-tagged object (#1147/#962),
+    e.g. {"kind": "paused"} or {"kind": "category", "slug": "ads"}. The
+    low-cardinality `kind` is the discriminator (mirror of the SPA's
+    `web/src/types/blockReason.ts`).
+    """
+    return sorted({r.get("reason") for r in rows if r.get("blocked")})

--- a/scripts/e2e/lib/log_reason.py
+++ b/scripts/e2e/lib/log_reason.py
@@ -17,4 +17,4 @@ def blocked_reason_kinds(rows: list[dict[str, Any]]) -> list[str]:
     low-cardinality `kind` is the discriminator (mirror of the SPA's
     `web/src/types/blockReason.ts`).
     """
-    return sorted({r.get("reason") for r in rows if r.get("blocked")})
+    return sorted({r["reason"]["kind"] for r in rows if r.get("blocked")})

--- a/scripts/e2e/lib/test_log_reason.py
+++ b/scripts/e2e/lib/test_log_reason.py
@@ -1,0 +1,34 @@
+"""Unit cover for the #1153 fix: /api/logs `reason` is a kind-tagged object
+(#1147/#962), so the router-e2e read-back must key on `reason.kind`, not treat
+`reason` as a hashable string. Run standalone:
+
+    python3 -m pytest scripts/e2e/lib/test_log_reason.py
+"""
+from __future__ import annotations
+
+from log_reason import blocked_reason_kinds
+
+# The five MacBlockReason kinds the #1122 round-trip posts, as encoded by the
+# shared BlockReason zio-json codec (camelCase `kind`, mirror of the SPA's
+# web/src/types/blockReason.ts).
+_KIND_TAGGED_ROWS = [
+    {"blocked": True, "host": {"value": "198.51.100.10"}, "reason": {"kind": "paused"}},
+    {"blocked": True, "host": {"value": "198.51.100.11"}, "reason": {"kind": "schedule"}},
+    {"blocked": True, "host": {"value": "198.51.100.12"}, "reason": {"kind": "timeLimit"}},
+    {"blocked": True, "host": {"value": "198.51.100.13"}, "reason": {"kind": "manual"}},
+    {"blocked": True, "host": {"value": "198.51.100.14"}, "reason": {"kind": "unmanaged"}},
+    # An allowed row must not contribute a kind.
+    {"blocked": False, "host": {"value": "8.8.8.8"}, "reason": {"kind": "allow"}},
+]
+
+
+def test_blocked_reason_kinds_keys_on_kind():
+    assert blocked_reason_kinds(_KIND_TAGGED_ROWS) == [
+        "manual", "paused", "schedule", "timeLimit", "unmanaged",
+    ]
+
+
+def test_parametrized_kind_with_slug_uses_discriminator():
+    # category(+slug) etc. still reduce to the bare `kind` discriminator.
+    rows = [{"blocked": True, "reason": {"kind": "category", "slug": "ads"}}]
+    assert blocked_reason_kinds(rows) == ["category"]


### PR DESCRIPTION
## Summary
- `/api/logs` (and `/api/connection-events/*`) row `reason` became a kind-tagged object in #1147 (#962). The router e2e #1122 read-back still built a `set` over the raw `reason` dict, crashing the live-e2e suite with `TypeError: unhashable type: 'dict'`.
- Updated `scripts/e2e-router.sh` #1122 read-back to key on `reason.kind` via a shared `scripts/e2e/lib/log_reason.py` helper, comparing against the camelCase kinds the encoder emits (`manual/paused/schedule/timeLimit/unmanaged`).
- Audited the rest of the e2e consumers: the only real-API event-row `reason` read was the #1122 step. The fake-client / conftest reads (`scripts/e2e/lib/fake_client.py`, `scenarios_fake/conftest.py`) are router-emission side, where `reason` is still the wire string the router posts — left untouched. `events_for_mac_filtered` in `api_debug.py` has no callers (dead path), left untouched.
- Snapshot/decision `blockReason` (MacBlockReason, still serialized as a plain `String`) is deliberately left alone — only the event-table `reason` became kind-tagged.

## TDD
Used the lighter unit-test path (full compose stack run was unnecessary to prove the contract). The read-back was extracted into `scripts/e2e/lib/log_reason.py` so the bash and the test share one source of truth:
- Commit 1 (red): helper mirrors current-main behavior (`set` over `reason`); `test_log_reason.py` feeds kind-tagged rows and fails with the exact `TypeError: unhashable type: 'dict'`.
- Commit 2 (green): helper keys on `reason.kind`; bash wired to import it; tests pass.

Also smoke-tested the exact bash read-back snippet against a representative `/api/logs` payload (5 kinds round-trip → `ok`), and ran `shellcheck` clean.

## Test plan
- [ ] Live-e2e router tests pass; #1122 round-trips all 5 MacBlockReason kinds
- [ ] No other e2e consumer assumes string `reason` on event/log rows

Closes #1153.