### PR TITLE
fix(e2e): update events_for_mac_filtered reason filter for typed BlockReason shape

### DIFF
--- a/scripts/e2e/lib/api_debug.py
+++ b/scripts/e2e/lib/api_debug.py
@@ -61,7 +61,8 @@ class DebugAPI:
                     continue
             if allowed is not None and e.get("allowed") is not allowed:
                 continue
-            if reason is not None and e.get("reason") != reason:
+            r = e.get("reason")
+            if reason is not None and (not isinstance(r, dict) or r.get("kind") != reason):
                 continue
             out.append(e)
         return out


### PR DESCRIPTION
## Summary

- `events_for_mac_filtered` had a `reason` filter that compared `e.get("reason") != reason` against a plain string
- As of #1147 / #962, event rows from `/api/debug/events` carry `reason` as a kind-tagged object `{"kind": "paused"}` — the old string comparison silently never matched
- Updated the guard to extract `reason["kind"]` with a None/non-dict safety check, matching the actual wire shape
- Method has no callers (latent helper), so no runtime impact — this is cleanup following #1153 which fixed a sibling crash with the same root cause

## Test plan

- [ ] `py_compile` passes (confirmed locally)
- [ ] `grep -rn events_for_mac_filtered scripts/` shows no callers (confirmed)
- [ ] No Scala changes; scalafmt pre-push hook passed

Follows up #1153. Closes the last `reason`-shape inconsistency introduced by #1147 / #962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)