### PR TITLE
fix: remove device works for devices with dependent rows (#1154)

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1725,8 +1725,17 @@ def requireProfileAccess(
     case Some(pid) => requireProfileAccess(claims, pid, upRepo)
   }
 
-def normalizeMac(mac: String): String =
-  mac.toLowerCase.replace("-", ":").trim
+def normalizeMac(mac: String): String = {
+  // Path-captured MACs arrive percent-encoded — the SPA builds the URL with
+  // encodeURIComponent, which turns ':' into '%3A', and zio-http's string(_)
+  // path codec does not decode it. Decode first so the colon form matches the
+  // stored MAC; decoding a clean MAC (query- or body-sourced) is a no-op.
+  val decoded =
+    scala.util
+      .Try(java.net.URLDecoder.decode(mac, java.nio.charset.StandardCharsets.UTF_8))
+      .getOrElse(mac)
+  decoded.toLowerCase.replace("-", ":").trim
+}
 
 // #795: parse a ?profileId=N query parameter, used by the per-profile-scoped
 // hot read endpoints. Returns None when the param is absent (callers fall back

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -15,6 +15,8 @@ import zio.json.*
 import zio.test.*
 import zio.test.Assertion.*
 
+import java.time.{Instant, LocalDate}
+
 object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
   override val bootstrap =
@@ -110,6 +112,61 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
           .addHeader(Header.Authorization.Bearer(token.value))
         delResp <- routes.runZIO(delReq)
         after   <- deviceRepo.findByMac(MacAddress.unsafe(mac))
+      } yield assertTrue(delResp.status == Status.Ok) &&
+        assertTrue(after.isEmpty)
+    },
+    test("#1154 delete device with dependent alert / usage / connection-event rows") {
+      // Operator-reported: 'Remove device' failed for real devices. Real
+      // devices accumulate dependent rows (a new-device alert, per-host usage,
+      // connection events). Deleting one must succeed and remove the row.
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        alertRepo   <- ZIO.service[AlertRepo]
+        usageRepo   <- ZIO.service[TimeUsageRepo]
+        connRepo    <- ZIO.service[ConnectionEventRepo]
+        routerRepo  <- ZIO.service[RouterRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token)
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        mac    = MacAddress.unsafe("aa:bb:cc:11:22:33")
+        host   = HostId.Fqdn(Hostname.unsafe("youtube.com"))
+        _               <- deviceRepo.upsert(mac, "Kid iPad", Some(kidsId), "192.168.1.77")
+        _               <- alertRepo.raiseNewDevice(mac, Instant.parse("2026-01-01T00:00:00Z"))
+        _               <- usageRepo.incrementSecondsAndBytes(
+          mac,
+          host,
+          LocalDate.of(2026, 1, 1),
+          60L,
+          100L,
+          200L,
+        )
+        routerId        <- routerRepo.create("r1", Sha256Hex.unsafe("m" * 64))
+        _               <- connRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId,
+              Some(mac),
+              host,
+              Some(IpAddress.unsafe("1.2.3.4")),
+              allowed = true,
+              BlockReason.Allow,
+              Instant.parse("2026-01-01T00:00:00Z"),
+            ),
+          ),
+        )
+        userProfileRepo <- ZIO.service[UserProfileRepo]
+        routes  = DeviceRoutes.routes(auth, deviceRepo, userProfileRepo)
+        // The SPA builds the path with encodeURIComponent(mac), so the colons
+        // arrive percent-encoded (de%3Aad%3A…). The route must decode them.
+        encPath = s"/api/devices/${java.net.URLEncoder.encode(mac.value, "UTF-8")}"
+        delReq  = Request
+          .delete(URL.decode(encPath).toOption.get)
+          .addHeader(Header.Authorization.Bearer(token.value))
+        delResp <- routes.runZIO(delReq)
+        after   <- deviceRepo.findByMac(mac)
       } yield assertTrue(delResp.status == Status.Ok) &&
         assertTrue(after.isEmpty)
     },


### PR DESCRIPTION
## Summary
- Root cause: **percent-encoded MAC path param**, not an FK constraint. The SPA deletes via `api.devices.delete(mac)` → `DELETE /devices/${encodeURIComponent(mac)}`, so the colons arrive as `%3A`. zio-http's `string("mac")` path codec does not percent-decode, and `normalizeMac` only handled case/dashes, so `findByMac` missed → **404 "Device not found"**, the mutation rejected, and the row stayed in the UI.
- Fix: `normalizeMac` now URL-decodes its input before lowercasing/colonizing. Decoding a clean MAC (query- or body-sourced) is a no-op, so all call sites (DELETE/PATCH/GET-by-mac, usage routes) stay correct.
- Verified the FK angle is a non-issue: deleting a device that has an `alerts` row (FK is `ON DELETE CASCADE`) plus `time_usage`/`connection_events` rows (no FK) already succeeds server-side.
- Feature test deletes a device that has alert + usage + connection-event rows **via the percent-encoded path** (mirroring the SPA) and asserts it's gone.

## Test plan
- [x] New feature test fails pre-fix (404, row persists), passes post-fix
- [x] `mill api.test` green (full suite)
- [x] `scalafmt --check` clean
- [ ] Manual: remove a real device in the SPA — it disappears without refresh

Reproduced against the dev API before fixing: raw-colon `DELETE` → 200; `encodeURIComponent` path (`de%3Aad%3A…`) → 404 with the row still present.

Closes #1154.