### PR TITLE
fix: per-app expansion now shows time used (#1161)

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -229,13 +229,19 @@ object UsageRoutes {
       // Deterministic host → owning-app: lowest appId wins when a host is in
       // multiple apps. Avoids double-counting one bucket of activity into two
       // apps for the per-profile screen-time view (matches #1061 acceptance).
+      //
+      // #1161: app_hosts rows are stored apex-form (`youtube.com`) but traffic
+      // rows carry FQDNs (`m.youtube.com`). Use suffix-aware lookup — same
+      // matcher as #1085's groupBy=app fix and PolicyService — so subdomain
+      // traffic attributes to the apex-form app entry instead of falling into
+      // the synthetic "Other" bucket.
       val appOfHost: HostId => Option[AppId] = {
-        val byHost = mappings
-          .groupBy(_.host)
+        val byApex = mappings
+          .groupBy(_.host.value)
           .view
-          .mapValues(ms => ms.iterator.map(_.appId).minByOption(_.value))
+          .mapValues(ms => ms.iterator.map(_.appId).minBy(_.value))
           .toMap
-        h => h.asFqdn.flatMap(fqdn => byHost.getOrElse(fqdn, None))
+        h => h.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApex))
       }
 
       val propByHost    = wifihaven.api.presence.Presence.proportionalHostSeconds(presence)

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1443,6 +1443,64 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(ot.appName == "Other") &&
           assertTrue(ot.hosts.map(_.host.value).contains("google.com"))
       },
+      test("#1161: traffic on FQDN subdomain attributes to apex-form app_hosts entry") {
+        // App is registered with apex `khanacademy.org`, but the device actually
+        // contacts `m.khanacademy.org`. Pre-fix the row falls into the synthetic
+        // "Other" bucket because the lookup is strict equality; post-fix it
+        // attributes to the Khan Academy app (same suffix rule as #1085 on the
+        // groupBy=app path).
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          kaId        <- appRepo.create("KhanAcademy", "khan", None, Some("🎓"))
+          _           <- appRepo.setHosts(kaId, List(Hostname.unsafe("khanacademy.org")))
+          start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("m.khanacademy.org")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                1000L,
+                1000L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/profiles/${kidsId.value}/usage-by-app?from=$today&to=$today")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[ProfileUsageByApp])
+          ka = out.apps.find(_.appName == "KhanAcademy")
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(ka.isDefined) &&
+          assertTrue(ka.get.proportionalSeconds == 300L) &&
+          assertTrue(ka.get.presenceSeconds == 300L) &&
+          assertTrue(ka.get.hosts.map(_.host.value).contains("m.khanacademy.org")) &&
+          assertTrue(!out.apps.exists(_.appId.isEmpty))
+      },
       test("sorted by proportionalSeconds desc") {
         val today = TestClock.schoolDayAfternoon.toLocalDate
         for {


### PR DESCRIPTION
## Root cause

Host→app attribution miss (mode 2 from #1161). `buildUsageByApp` in
`api/src/routes/UsageRoutes.scala` built a `Map[Hostname, AppId]` from
`app_hosts` rows and did strict-equality `byHost.get(fqdn)` against
traffic rows. But `app_hosts` is stored apex-form (`youtube.com`,
`khanacademy.org`) while traffic carries FQDN subdomains
(`m.khanacademy.org`, `www.youtube.com`). Every subdomain bucket missed
the join and fell into the synthetic `appId=null` "Other" bucket — so
the expanded /profiles card's per-app subsection rendered minutes under
"Other" instead of under the app the operator actually configured.

#1085 already fixed the same class of bug for `/api/usage/traffic`
`groupBy=app` via `HostMatch.lookupApex`; the #1061 per-profile endpoint
shipped just before and didn't get the same fix.

## Summary

- `buildUsageByApp` now keys the mappings by apex string and looks up
  via `HostMatch.lookupApex` — same matcher PolicyService and the
  groupBy=app path use, so usage attribution stays consistent with
  policy enforcement (the #1104 single-source-of-truth invariant).
- New feature test inserts traffic on `m.khanacademy.org` against an app
  whose `app_hosts` row is `khanacademy.org`. Pre-fix the row lands in
  "Other"; post-fix it attributes to the Khan Academy app.

## Test plan

- [x] New test fails on main, passes on this branch
- [x] mill api.test (UsageApiSpec) green — 32 tests pass
- [x] mill scalafmt check clean (pre-push hook)
- [ ] Manual against staging: expanded profile card shows minutes per
      app matching time-status

## Out of scope

Doesn't touch the rollup write path — pre-attributing `app_id` at
ingest time stays #1091's responsibility. This is the read-side fix
that unblocks the visible regression now.

Closes #1161.