### PR TITLE
perf: materialize per-day time-used rollup with tz/heartbeat invalidation (#1160)

### DIFF
--- a/api/resources/db/migration/V43__time_used_daily.sql
+++ b/api/resources/db/migration/V43__time_used_daily.sql
@@ -1,0 +1,36 @@
+-- V43__time_used_daily.sql
+-- #1160: per-(profile, household-local date) materialization of the
+-- `usedMinutes` field on `ProfileDayState`. Today the UI computes this live
+-- on every request by re-aggregating `traffic_reports` through the presence /
+-- heartbeat-filter pipeline (`TimeStatusService.dayStateAll`). At single-
+-- household real-data sizes the per-request scan is already noticeable on
+-- /profiles (#1099) and grows with retention.
+--
+-- The rollup is a strict cache of `TimeStatusService.dayStateAll(now, date,
+-- settings)` keyed by (profile, date). The other ProfileDayState fields
+-- (`extensionMinutes`, `dailyLimitMinutes`, `blocked`, `blockReason`,
+-- `perSite`) are either cheap or depend on `now` (schedule/paused), so they
+-- stay computed live and are composed with the cached `used_minutes` at
+-- read time.
+--
+-- Invalidation: any input that changes the active-minute definition or the
+-- household-local day boundary deletes the rollup wholesale, and the
+-- scheduled rollup fiber refills on its next tick. The two triggers wired
+-- here are `household_settings.update` (covers daily_reset_tz, daily reset
+-- time, and the heartbeat filter — see HouseholdSettingsRepoLive.update).
+-- The midnight roll and routine refresh are handled by the fiber loop.
+--
+-- Retention: matches the raw `traffic_reports` retention (#811: 30 days) —
+-- once raw data is gone the rollup cannot be recomputed, so retaining
+-- longer would only hold stale numbers that disagree with a forced re-roll.
+-- A separate longer-horizon archive is a follow-up if the UI grows a
+-- multi-month trends view.
+
+CREATE TABLE time_used_daily (
+  profile_id    BIGINT       NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  date          DATE         NOT NULL,
+  used_minutes  INT          NOT NULL,
+  rolled_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (profile_id, date)
+);
+CREATE INDEX idx_time_used_daily_date ON time_used_daily (date DESC);

--- a/api/resources/db/migration/V43__time_used_daily.sql
+++ b/api/resources/db/migration/V43__time_used_daily.sql
@@ -1,36 +1,35 @@
 -- V43__time_used_daily.sql
--- #1160: per-(profile, household-local date) materialization of the
--- `usedMinutes` field on `ProfileDayState`. Today the UI computes this live
--- on every request by re-aggregating `traffic_reports` through the presence /
--- heartbeat-filter pipeline (`TimeStatusService.dayStateAll`). At single-
--- household real-data sizes the per-request scan is already noticeable on
--- /profiles (#1099) and grows with retention.
+-- #1160: per-(profile, today) cache of `ProfileDayState.usedMinutes`, stored as
+-- seconds so the rollup + live-tail decomposition is exact (truncation to
+-- minutes happens once at read time).
 --
--- The rollup is a strict cache of `TimeStatusService.dayStateAll(now, date,
--- settings)` keyed by (profile, date). The other ProfileDayState fields
--- (`extensionMinutes`, `dailyLimitMinutes`, `blocked`, `blockReason`,
--- `perSite`) are either cheap or depend on `now` (schedule/paused), so they
--- stay computed live and are composed with the cached `used_minutes` at
--- read time.
+-- Scope: today only. Past dates are not cached here — the existing live path
+-- (and the byte rollups in V38) cover historical reads. The hot path this
+-- table exists for is `/api/time/status/summary` rendering the per-profile
+-- screen-time figures, which today re-aggregates `traffic_reports` per request
+-- (#1099). Caching past days would also work but is unnecessary: the row count
+-- is small (one per profile per past day) but each row is immutable once the
+-- raw retention horizon passes, so it's not what makes the UI slow.
 --
--- Invalidation: any input that changes the active-minute definition or the
--- household-local day boundary deletes the rollup wholesale, and the
--- scheduled rollup fiber refills on its next tick. The two triggers wired
--- here are `household_settings.update` (covers daily_reset_tz, daily reset
--- time, and the heartbeat filter — see HouseholdSettingsRepoLive.update).
--- The midnight roll and routine refresh are handled by the fiber loop.
+-- Read semantics: a row covers presence rows for `date` whose
+-- `period_start < rolled_through`. The read path is
+--   rolled_seconds + live_aggregate(presence rows where period_start >= rolled_through)
+-- which gives a real-time result with the bulk of the day pre-aggregated. The
+-- decomposition is exact in seconds for both `Sum` and `Dedup` overlap modes
+-- because buckets are 5-min granular and disjoint on either side of the
+-- watermark.
 --
--- Retention: matches the raw `traffic_reports` retention (#811: 30 days) —
--- once raw data is gone the rollup cannot be recomputed, so retaining
--- longer would only hold stale numbers that disagree with a forced re-roll.
--- A separate longer-horizon archive is a follow-up if the UI grows a
--- multi-month trends view.
+-- Invalidation: wholesale `DELETE FROM time_used_daily` from
+-- `HouseholdSettingsRepoLive.update`. Any change to the heartbeat filter or
+-- the daily-reset boundary changes the active-minute definition, and the next
+-- rollup tick refills the row with the new rules in force.
 
 CREATE TABLE time_used_daily (
-  profile_id    BIGINT       NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
-  date          DATE         NOT NULL,
-  used_minutes  INT          NOT NULL,
-  rolled_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  profile_id      BIGINT       NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  date            DATE         NOT NULL,
+  used_seconds    BIGINT       NOT NULL,
+  rolled_through  TIMESTAMPTZ  NOT NULL,
+  rolled_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   PRIMARY KEY (profile_id, date)
 );
 CREATE INDEX idx_time_used_daily_date ON time_used_daily (date DESC);

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -10,6 +10,7 @@ import wifihaven.api.policy.*
 import wifihaven.api.routes.*
 import wifihaven.api.usage.RetentionSweepJob
 import wifihaven.api.usage.RollupJobs
+import wifihaven.api.usage.TimeUsedRollupJob
 import wifihaven.shared.Clock
 import zio.*
 import zio.http.*
@@ -74,7 +75,14 @@ object Main extends ZIOAppDefault {
       clockForJobs   <- ZIO.service[Clock]
       _              <- RollupJobs.hourlyLoop(rollupRepo, clockForJobs).forkDaemon
       _              <- RollupJobs.dailyLoop(rollupRepo, clockForJobs, tz).forkDaemon
-      _              <- ZIO.logInfo("rollup fibers forked (hourly + daily)")
+      // #1160: per-(profile, date) `usedMinutes` rollup. Refreshes the trailing
+      // window so /api/time/status/summary serves out of cache for past dates.
+      tssForJobs     <- ZIO.service[wifihaven.api.policy.TimeStatusService]
+      timeRollupRepo <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+      _              <- TimeUsedRollupJob
+        .loop(timeRollupRepo, rollupRepo, tssForJobs, hsRepo, clockForJobs)
+        .forkDaemon
+      _              <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
       _              <- ZIO
         .logWarning(
           "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -40,14 +40,14 @@ object Main extends ZIOAppDefault {
       // on subsequent boots because of ON CONFLICT DO NOTHING.
       hsRepo <- ZIO.service[HouseholdSettingsRepo]
       tz = java.time.ZoneId.systemDefault()
-      _              <- hsRepo.ensureDefault(tz)
-      _              <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
+      _               <- hsRepo.ensureDefault(tz)
+      _               <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       // #768: seed the starter library of app templates. Idempotent — operator
       // host edits on previously-seeded apps are preserved.
-      appRepoForSeed <- ZIO.service[AppRepo]
-      templates      <- AppTemplates.loadAll()
-      seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
-      _              <- ZIO.logInfo(
+      appRepoForSeed  <- ZIO.service[AppRepo]
+      templates       <- AppTemplates.loadAll()
+      seedSummary     <- AppTemplates.seed(appRepoForSeed, templates)
+      _               <- ZIO.logInfo(
         s"app_templates seeded (${templates.size} templates): " +
           s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
           s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated.mkString("[", ",", "]")}, " +
@@ -61,42 +61,56 @@ object Main extends ZIOAppDefault {
       // straight from YAML; remote lists fetch from the declared upstream URL
       // (cached in-memory after first success — see BlocklistCache). REPLACE
       // semantics; remote-fetch failures leave existing DB rows untouched.
-      blRepoForSeed  <- ZIO.service[BlocklistRepo]
-      blCacheForSeed <- ZIO.service[BlocklistCache]
-      blFetcher      <- ZIO.service[BlocklistFetcher]
-      bundled        <- BundledBlocklists.loadAll()
-      _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
-      _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+      blRepoForSeed   <- ZIO.service[BlocklistRepo]
+      blCacheForSeed  <- ZIO.service[BlocklistCache]
+      blFetcher       <- ZIO.service[BlocklistFetcher]
+      bundled         <- BundledBlocklists.loadAll()
+      _               <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
+      _               <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
       // #809: scheduled re-aggregation of traffic_reports into the rollup
       // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
       // re-rolls yesterday + today every hour. Both are forkDaemon so they
       // run for the lifetime of the process and never block startup.
-      rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
-      clockForJobs   <- ZIO.service[Clock]
-      _              <- RollupJobs.hourlyLoop(rollupRepo, clockForJobs).forkDaemon
-      _              <- RollupJobs.dailyLoop(rollupRepo, clockForJobs, tz).forkDaemon
-      // #1160: per-(profile, date) `usedMinutes` rollup. Refreshes the trailing
-      // window so /api/time/status/summary serves out of cache for past dates.
-      tssForJobs     <- ZIO.service[wifihaven.api.policy.TimeStatusService]
-      timeRollupRepo <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
-      _              <- TimeUsedRollupJob
-        .loop(timeRollupRepo, rollupRepo, tssForJobs, hsRepo, clockForJobs)
+      rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
+      clockForJobs    <- ZIO.service[Clock]
+      _               <- RollupJobs.hourlyLoop(rollupRepo, clockForJobs).forkDaemon
+      _               <- RollupJobs.dailyLoop(rollupRepo, clockForJobs, tz).forkDaemon
+      // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
+      // a watermarked row; the read path adds a live tail of buckets after the watermark, so
+      // /api/time/status/summary serves a rollup + small live aggregation instead of a full
+      // per-request day scan.
+      timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+      profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
+      deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
+      stlRepoForJ     <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      trafficRepoForJ <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
+      _               <- TimeUsedRollupJob
+        .loop(
+          timeRollupRepo,
+          rollupRepo,
+          profileRepoForJ,
+          deviceRepoForJ,
+          stlRepoForJ,
+          trafficRepoForJ,
+          hsRepo,
+          clockForJobs,
+        )
         .forkDaemon
-      _              <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
-      _              <- ZIO
+      _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
+      _               <- ZIO
         .logWarning(
           "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
             "Disable in production.",
         )
         .when(cfg.seedTestBlocklists)
-      _              <- BundledBlocklists
+      _               <- BundledBlocklists
         .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
         .when(cfg.seedTestBlocklists)
       // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
       // Multi-instance-safe via Postgres advisory lock — losing instances skip
       // the tick rather than racing on the same DELETE.
-      xaForJobs      <- ZIO.service[Transactor[Task]]
-      _              <- RetentionSweepJob.start(xaForJobs)
+      xaForJobs       <- ZIO.service[Transactor[Task]]
+      _               <- RetentionSweepJob.start(xaForJobs)
       templatesById = templates.map(t => t.slug -> t).toMap
       bundledById   = bundled.map(b => b.id -> b).toMap
       routes <- allRoutes(templatesById, bundledById)

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -673,16 +673,26 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
       .transact(xa)
 
   def update(s: HouseholdSettings): Task[Unit] = {
-    val ummJson = s.unmanagedMacPolicy.toJson
-    sql"""UPDATE household_settings
-            SET daily_reset_time=${s.dailyResetTime},
-                daily_reset_tz=${s.dailyResetTz},
-                heartbeat_filter_enabled=${s.heartbeatFilter.enabled},
-                heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
-                heartbeat_host_patterns=${s.heartbeatFilter.heartbeatHostPatterns.toArray},
-                unmanaged_mac_policy=${ummJson}::jsonb,
-                updated_at=NOW()
-          WHERE id=1""".update.run.transact(xa).unit
+    val ummJson    = s.unmanagedMacPolicy.toJson
+    // #1160: invalidate the time-used rollup atomically with the settings
+    // update. Any change to the daily-reset boundary (tz / reset hour) or the
+    // heartbeat filter changes the active-minute definition for every cached
+    // day; deleting the cache forces the next rollup tick to refill from
+    // first principles. The DELETE is wholesale because all three fields gate
+    // the same aggregation — fine-grained invalidation would only add risk of
+    // missing a code path that mutates the filter.
+    val upd        =
+      sql"""UPDATE household_settings
+              SET daily_reset_time=${s.dailyResetTime},
+                  daily_reset_tz=${s.dailyResetTz},
+                  heartbeat_filter_enabled=${s.heartbeatFilter.enabled},
+                  heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
+                  heartbeat_host_patterns=${s.heartbeatFilter.heartbeatHostPatterns.toArray},
+                  unmanaged_mac_policy=${ummJson}::jsonb,
+                  updated_at=NOW()
+            WHERE id=1""".update.run
+    val invalidate = sql"DELETE FROM time_used_daily".update.run
+    (upd *> invalidate).transact(xa).unit
   }
 
   def ensureDefault(defaultZone: ZoneId): Task[Unit] =
@@ -2291,6 +2301,7 @@ object Repos {
   val alertRepo             = ZLayer.fromFunction(AlertRepoLive(_))
   val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
+  val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
 }

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -405,6 +405,17 @@ trait TrafficReportRepo {
   ): Task[List[wifihaven.api.presence.PresenceRow]]
 
   /**
+   * #1160: tail-load for the rollup read path. Same row shape as [[listPresenceRows]] but with an
+   * additional `period_start >= since` filter, so the caller only pays for the slice of buckets the
+   * rollup hasn't yet absorbed.
+   */
+  def listPresenceRowsSince(
+      macs: List[MacAddress],
+      date: LocalDate,
+      since: Instant,
+  ): Task[List[wifihaven.api.presence.PresenceRow]]
+
+  /**
    * #846: raw rows in `[fromInstant, toInstant)` for the given macs. `macs = Nil` means "all macs"
    * (used by the Traffic Usage page in unfiltered mode). Returns Instants (not String date columns)
    * so callers can bucket without re-parsing.
@@ -1376,16 +1387,20 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
       .transact(xa)
 
   def listPresenceRows(macs: List[MacAddress], date: LocalDate) =
-    listPresenceRowsBetween(macs, date, date)
+    listPresenceRowsBetween(macs, date, date, None)
 
   def listPresenceRows(macs: List[MacAddress], from: LocalDate, to: LocalDate) =
-    listPresenceRowsBetween(macs, from, to)
+    listPresenceRowsBetween(macs, from, to, None)
+
+  def listPresenceRowsSince(macs: List[MacAddress], date: LocalDate, since: Instant) =
+    listPresenceRowsBetween(macs, date, date, Some(since))
 
   // TODO(#730): remove this read-side join once usage records carry dest_ip.
   private def listPresenceRowsBetween(
       macs: List[MacAddress],
       from: LocalDate,
       to: LocalDate,
+      since: Option[Instant] = None,
   ) = {
     type Row = (MacAddress, LocalDate, Instant, HostId, Int, Long, Long, Instant, Instant)
     macs match {
@@ -1412,7 +1427,8 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                ) ce ON tr.host_type IN ('ipv4','ipv6')
                WHERE tr.date BETWEEN $from AND $to
                  AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
-                 AND """ ++ Fragments.in(fr"tr.mac", nel)
+                 AND """ ++ Fragments.in(fr"tr.mac", nel) ++
+            since.fold(fr"")(s => fr"AND tr.period_start >= $s")
         q.query[Row]
           .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
             val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt

--- a/api/src/db/TimeUsedRollupRepo.scala
+++ b/api/src/db/TimeUsedRollupRepo.scala
@@ -1,0 +1,92 @@
+package wifihaven.api.db
+
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.implicits.*
+import wifihaven.api.db.TypeMeta.given
+import wifihaven.shared.types.*
+import zio.*
+import zio.interop.catz.*
+
+import java.time.LocalDate
+
+// #1160: persistent rollup of `TimeStatusService.dayStateAll(...).usedMinutes`,
+// keyed by (profile, household-local date). Read by the /api/time/status/summary
+// route (and any other consumer that wants the cached total) instead of the
+// per-request raw aggregation. Invalidation is wholesale — see the V43 migration
+// header and HouseholdSettingsRepoLive.update for the trigger.
+trait TimeUsedRollupRepo {
+
+  /** Upsert the cached `usedMinutes` for one profile/date. */
+  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit]
+
+  /**
+   * Batched upsert — one row per profile for `date`, all in a single transaction.
+   *
+   * Returns the count of rows touched.
+   */
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int]
+
+  /** Cached `usedMinutes` for a single profile/date, or None if not yet rolled. */
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]]
+
+  /** Cached `usedMinutes` keyed by profile for `date`. Missing profiles signal a cache miss. */
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]]
+
+  /**
+   * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` so any change to the
+   * household-local day boundary or the heartbeat filter forces a fresh re-roll. Cheap — the table
+   * is bounded by retention × profiles.
+   */
+  def deleteAll: Task[Unit]
+}
+
+/**
+ * No-op variant for test wiring that doesn't need cache behaviour (e.g., the `PolicyService.apply`
+ * factory used by the snapshot specs — those exercise today, which is always live). All reads miss
+ * and all writes are dropped; semantically equivalent to no rollup.
+ */
+object NoopTimeUsedRollupRepo extends TimeUsedRollupRepo {
+  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit] = ZIO.unit
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int]   = ZIO.succeed(0)
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]] = ZIO.none
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]] = ZIO.succeed(Map.empty)
+  def deleteAll: Task[Unit]                                 = ZIO.unit
+}
+
+class TimeUsedRollupRepoLive(xa: Transactor[Task]) extends TimeUsedRollupRepo {
+
+  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit] =
+    sql"""INSERT INTO time_used_daily (profile_id, date, used_minutes, rolled_at)
+          VALUES ($profileId, $date, $usedMinutes, NOW())
+          ON CONFLICT (profile_id, date) DO UPDATE
+            SET used_minutes = EXCLUDED.used_minutes,
+                rolled_at    = EXCLUDED.rolled_at""".update.run.transact(xa).unit
+
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int] =
+    if perProfile.isEmpty then ZIO.succeed(0)
+    else {
+      val sql  = "INSERT INTO time_used_daily (profile_id, date, used_minutes, rolled_at) " +
+        "VALUES (?, ?, ?, NOW()) " +
+        "ON CONFLICT (profile_id, date) DO UPDATE " +
+        "SET used_minutes = EXCLUDED.used_minutes, rolled_at = EXCLUDED.rolled_at"
+      val rows = perProfile.toList.map { case (pid, used) => (pid, date, used) }
+      Update[(ProfileId, LocalDate, Int)](sql).updateMany(rows).transact(xa)
+    }
+
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]] =
+    sql"SELECT used_minutes FROM time_used_daily WHERE profile_id=$profileId AND date=$date"
+      .query[Int]
+      .option
+      .transact(xa)
+
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]] =
+    sql"SELECT profile_id, used_minutes FROM time_used_daily WHERE date=$date"
+      .query[(ProfileId, Int)]
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
+
+  def deleteAll: Task[Unit] =
+    sql"DELETE FROM time_used_daily".update.run.transact(xa).unit
+}

--- a/api/src/db/TimeUsedRollupRepo.scala
+++ b/api/src/db/TimeUsedRollupRepo.scala
@@ -8,81 +8,93 @@ import wifihaven.shared.types.*
 import zio.*
 import zio.interop.catz.*
 
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
-// #1160: persistent rollup of `TimeStatusService.dayStateAll(...).usedMinutes`,
-// keyed by (profile, household-local date). Read by the /api/time/status/summary
-// route (and any other consumer that wants the cached total) instead of the
-// per-request raw aggregation. Invalidation is wholesale — see the V43 migration
-// header and HouseholdSettingsRepoLive.update for the trigger.
+// #1160: per-(profile, today) cache of `usedSeconds`. The row covers presence
+// buckets on `date` with `period_start < rolled_through`; readers add a live
+// aggregation of the remaining buckets (period_start >= rolled_through) to
+// recover an exact, real-time `usedMinutes`. Stored as seconds (not minutes)
+// so the rollup + tail decomposition is exact — truncation happens once at
+// read time. See `TimeStatusServiceLive` for the read path and the V43
+// migration header for invalidation semantics.
+
+/** Watermarked rollup row: aggregated seconds and the upper bound (`exclusive`) it covers. */
+final case class RolledDay(usedSeconds: Long, rolledThrough: Instant)
+
 trait TimeUsedRollupRepo {
 
-  /** Upsert the cached `usedMinutes` for one profile/date. */
-  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit]
+  /** Upsert one profile's rolled (seconds, watermark) for `date`. */
+  def upsertDay(profileId: ProfileId, date: LocalDate, row: RolledDay): Task[Unit]
 
-  /**
-   * Batched upsert — one row per profile for `date`, all in a single transaction.
-   *
-   * Returns the count of rows touched.
-   */
-  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int]
+  /** Batched upsert — one row per profile for `date`. Returns the count of rows touched. */
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, RolledDay]): Task[Int]
 
-  /** Cached `usedMinutes` for a single profile/date, or None if not yet rolled. */
-  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]]
+  /** Cached row for a single profile/date, or None if not yet rolled. */
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[RolledDay]]
 
-  /** Cached `usedMinutes` keyed by profile for `date`. Missing profiles signal a cache miss. */
-  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]]
+  /** Cached rows keyed by profile for `date`. Missing profiles signal a cache miss. */
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, RolledDay]]
 
   /**
    * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` so any change to the
-   * household-local day boundary or the heartbeat filter forces a fresh re-roll. Cheap — the table
-   * is bounded by retention × profiles.
+   * heartbeat filter or the daily-reset boundary forces the next rollup tick to refill from first
+   * principles. The table is bounded (one row per profile per active date), so the DELETE is cheap.
    */
   def deleteAll: Task[Unit]
 }
 
 /**
- * No-op variant for test wiring that doesn't need cache behaviour (e.g., the `PolicyService.apply`
- * factory used by the snapshot specs — those exercise today, which is always live). All reads miss
- * and all writes are dropped; semantically equivalent to no rollup.
+ * No-op variant for test wiring that doesn't exercise the cache (e.g., the `PolicyService.apply`
+ * factory used by snapshot specs). Reads miss; writes are dropped.
  */
 object NoopTimeUsedRollupRepo extends TimeUsedRollupRepo {
-  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit] = ZIO.unit
-  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int]   = ZIO.succeed(0)
-  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]] = ZIO.none
-  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]] = ZIO.succeed(Map.empty)
-  def deleteAll: Task[Unit]                                 = ZIO.unit
+  def upsertDay(profileId: ProfileId, date: LocalDate, row: RolledDay): Task[Unit]     = ZIO.unit
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, RolledDay]): Task[Int]   =
+    ZIO.succeed(0)
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[RolledDay]] = ZIO.none
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, RolledDay]] = ZIO.succeed(Map.empty)
+  def deleteAll: Task[Unit]                                       = ZIO.unit
 }
 
 class TimeUsedRollupRepoLive(xa: Transactor[Task]) extends TimeUsedRollupRepo {
 
-  def upsertDay(profileId: ProfileId, date: LocalDate, usedMinutes: Int): Task[Unit] =
-    sql"""INSERT INTO time_used_daily (profile_id, date, used_minutes, rolled_at)
-          VALUES ($profileId, $date, $usedMinutes, NOW())
+  def upsertDay(profileId: ProfileId, date: LocalDate, row: RolledDay): Task[Unit] =
+    sql"""INSERT INTO time_used_daily (profile_id, date, used_seconds, rolled_through, rolled_at)
+          VALUES ($profileId, $date, ${row.usedSeconds}, ${row.rolledThrough}, NOW())
           ON CONFLICT (profile_id, date) DO UPDATE
-            SET used_minutes = EXCLUDED.used_minutes,
-                rolled_at    = EXCLUDED.rolled_at""".update.run.transact(xa).unit
+            SET used_seconds   = EXCLUDED.used_seconds,
+                rolled_through = EXCLUDED.rolled_through,
+                rolled_at      = EXCLUDED.rolled_at""".update.run.transact(xa).unit
 
-  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, Int]): Task[Int] =
+  def upsertBatch(date: LocalDate, perProfile: Map[ProfileId, RolledDay]): Task[Int] =
     if perProfile.isEmpty then ZIO.succeed(0)
     else {
-      val sql  = "INSERT INTO time_used_daily (profile_id, date, used_minutes, rolled_at) " +
-        "VALUES (?, ?, ?, NOW()) " +
-        "ON CONFLICT (profile_id, date) DO UPDATE " +
-        "SET used_minutes = EXCLUDED.used_minutes, rolled_at = EXCLUDED.rolled_at"
-      val rows = perProfile.toList.map { case (pid, used) => (pid, date, used) }
-      Update[(ProfileId, LocalDate, Int)](sql).updateMany(rows).transact(xa)
+      val sql  =
+        "INSERT INTO time_used_daily (profile_id, date, used_seconds, rolled_through, rolled_at) " +
+          "VALUES (?, ?, ?, ?, NOW()) " +
+          "ON CONFLICT (profile_id, date) DO UPDATE " +
+          "SET used_seconds = EXCLUDED.used_seconds, " +
+          "    rolled_through = EXCLUDED.rolled_through, " +
+          "    rolled_at = EXCLUDED.rolled_at"
+      val rows = perProfile.toList.map { case (pid, r) =>
+        (pid, date, r.usedSeconds, r.rolledThrough)
+      }
+      Update[(ProfileId, LocalDate, Long, Instant)](sql).updateMany(rows).transact(xa)
     }
 
-  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[Int]] =
-    sql"SELECT used_minutes FROM time_used_daily WHERE profile_id=$profileId AND date=$date"
-      .query[Int]
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Option[RolledDay]] =
+    sql"""SELECT used_seconds, rolled_through
+          FROM time_used_daily WHERE profile_id=$profileId AND date=$date"""
+      .query[(Long, Instant)]
+      .map { case (s, t) => RolledDay(s, t) }
       .option
       .transact(xa)
 
-  def getDayMap(date: LocalDate): Task[Map[ProfileId, Int]] =
-    sql"SELECT profile_id, used_minutes FROM time_used_daily WHERE date=$date"
-      .query[(ProfileId, Int)]
+  def getDayMap(date: LocalDate): Task[Map[ProfileId, RolledDay]] =
+    sql"""SELECT profile_id, used_seconds, rolled_through
+          FROM time_used_daily WHERE date=$date"""
+      .query[(ProfileId, Long, Instant)]
+      .map { case (p, s, t) => p -> RolledDay(s, t) }
       .to[List]
       .transact(xa)
       .map(_.toMap)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -46,6 +46,9 @@ object PolicyServiceLive {
       deviceRepo,
       trafficRepo,
       extRepo,
+      // Snapshot specs only exercise today; today is always live. A real rollup repo would be
+      // ignored on this path, so wire a noop and avoid threading the repo through every test.
+      NoopTimeUsedRollupRepo,
     )
     new PolicyServiceLive(
       profileRepo,

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -61,6 +61,11 @@ trait TimeStatusService {
    * date is treated as the canonical bucket date (no tz reprojection — `time_usage` /
    * `traffic_reports` are already bucketed under household-local dates).
    *
+   * For past dates this reads `usedMinutes` from the `time_used_daily` rollup (#1160) when
+   * available, falling back to a live aggregation on miss. Today is always live so enforcement
+   * (which threads through [[dayStateAllLive]] on the snapshot path) and the UI never disagree on
+   * the current cap.
+   *
    * `now` is still needed so the schedule/paused arm of the block evaluation has a wall-clock
    * instant to test windows against. For historical dates the schedule arm will generally not be
    * active (today's wall clock is not in yesterday's schedule window), but pinning `now` here keeps
@@ -75,11 +80,29 @@ trait TimeStatusService {
 
   /**
    * Batched form for [[PolicyService.snapshot]] and the `/api/time/status/summary` route. Emits one
-   * `ProfileDayState` per profile for `date`, in a single batched presence + extensions read across
-   * all profiles' devices. `now` is still threaded through so the schedule-active evaluation has a
-   * wall-clock instant; when `date` is in the past, the schedule arm naturally won't match.
+   * `ProfileDayState` per profile for `date`. For past dates this is served from the
+   * `time_used_daily` rollup; today is computed live.
    */
   def dayStateAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, ProfileDayState]]
+
+  /**
+   * Always-live variant of [[dayState]] — recomputes from raw `traffic_reports` regardless of cache
+   * state. The rollup fiber writes through this so the cache cannot drift from the live computation
+   * (#1160's source-of-truth invariant).
+   */
+  def dayStateLive(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]]
+
+  /** Always-live batched variant of [[dayStateAll]] — see [[dayStateLive]]. */
+  def dayStateAllLive(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
@@ -94,6 +117,9 @@ class TimeStatusServiceLive(
     deviceRepo: DeviceRepo,
     trafficRepo: TrafficReportRepo,
     extRepo: TimeExtensionRepo,
+    // Defaulting to the noop lets the many call sites in TimeApiSpec / snapshot specs keep their
+    // 7-arg constructions — they exercise today, which always takes the live path anyway.
+    rollupRepo: TimeUsedRollupRepo = NoopTimeUsedRollupRepo,
 ) extends TimeStatusService {
 
   def todaysState(
@@ -104,6 +130,21 @@ class TimeStatusServiceLive(
     dayState(now, PolicyService.householdLocalDate(now, settings), settings, profileId)
 
   def dayState(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Option[ProfileDayState]] = {
+    val today = PolicyService.householdLocalDate(now, settings)
+    if (date.isBefore(today))
+      rollupRepo.getDayForProfile(profileId, date).flatMap {
+        case Some(used) => dayStateFromRolled(now, date, profileId, used)
+        case None       => dayStateLive(now, date, settings, profileId)
+      }
+    else dayStateLive(now, date, settings, profileId)
+  }
+
+  def dayStateLive(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
@@ -136,6 +177,16 @@ class TimeStatusServiceLive(
     }
 
   def dayStateAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, ProfileDayState]] = {
+    val today = PolicyService.householdLocalDate(now, settings)
+    if (date.isBefore(today)) dayStateAllFromRollup(now, date, settings)
+    else dayStateAllLive(now, date, settings)
+  }
+
+  def dayStateAllLive(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
@@ -173,13 +224,87 @@ class TimeStatusServiceLive(
         )
       }.toMap
     }
+
+  // Build a ProfileDayState for a past date from a precomputed `usedMinutes`,
+  // skipping the heavy presence load. Schedules / paused / extensions / daily
+  // limit / site limits are still loaded live so the block-precedence math
+  // matches the live folder. Per-site `usedMinutes` is reported as zero — the
+  // v1 rollup is profile-total only; per-site is a tracked follow-up.
+  private def dayStateFromRolled(
+      now: Instant,
+      date: LocalDate,
+      profileId: ProfileId,
+      usedMinutes: Int,
+  ): Task[Option[ProfileDayState]] =
+    profileRepo.findById(profileId).flatMap {
+      case None    => ZIO.succeed(None)
+      case Some(p) =>
+        for {
+          schedules <- scheduleRepo.listForProfile(profileId)
+          tl        <- timeLimitRepo.findForProfile(profileId)
+          stls      <- siteTimeLimitRepo.listForProfile(profileId)
+          extMins   <- extRepo.getProfileTotalExtension(profileId, date)
+        } yield Some(
+          TimeStatusService.assemble(
+            profile = p,
+            schedules = schedules,
+            dailyLimit = tl.map(_.dailyMinutes),
+            siteLimits = stls,
+            usedMinutes = usedMinutes,
+            extensionMinutes = extMins,
+            date = date,
+            now = now,
+          ),
+        )
+    }
+
+  // Batched variant. On a partial cache miss the missing profiles fall back
+  // to the live aggregation in one go — cheaper than recursing per-profile.
+  private def dayStateAllFromRollup(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, ProfileDayState]] =
+    for {
+      profiles <- profileRepo.listAll
+      rolled   <- rollupRepo.getDayMap(date)
+      hit  = profiles.filter(p => rolled.contains(p.id))
+      miss = profiles.filterNot(p => rolled.contains(p.id))
+      schedsP <- ZIO.foreach(hit)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      tlsP    <- ZIO.foreach(hit)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
+      stlsP   <- ZIO.foreach(hit)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      exts    <- extRepo.snapshotAllByProfile(date)
+      live    <-
+        if miss.isEmpty then ZIO.succeed(Map.empty[ProfileId, ProfileDayState])
+        else
+          dayStateAllLive(now, date, settings).map(_.filter { case (pid, _) =>
+            miss.exists(_.id == pid)
+          })
+    } yield {
+      val schedMap = schedsP.toMap
+      val tlMap    = tlsP.toMap
+      val stlMap   = stlsP.toMap
+      val cached   = hit.iterator.map { p =>
+        p.id -> TimeStatusService.assemble(
+          profile = p,
+          schedules = schedMap.getOrElse(p.id, Nil),
+          dailyLimit = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
+          siteLimits = stlMap.getOrElse(p.id, Nil),
+          usedMinutes = rolled(p.id),
+          extensionMinutes = exts.getOrElse(p.id, 0),
+          date = date,
+          now = now,
+        )
+      }.toMap
+      cached ++ live
+    }
 }
 
 object TimeStatusService {
 
   val layer: ZLayer[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo,
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo,
     Nothing,
     TimeStatusService,
   ] = ZLayer.fromFunction {
@@ -191,7 +316,8 @@ object TimeStatusService {
         dr: DeviceRepo,
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+        ru: TimeUsedRollupRepo,
+    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
   }
 
   /**
@@ -233,20 +359,6 @@ object TimeStatusService {
       if mins == 0 then acc else acc.updated(pat, mins)
     }
 
-    val (blocked, reason) =
-      if profile.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
-      else if schedules.exists(s => PolicyService.scheduleActiveAt(s, now)) then
-        (true, Some(MacBlockReason.Schedule: MacBlockReason))
-      else
-        dailyLimit match {
-          case Some(limit) if totalMinutesUsed >= limit + extensionMinutes =>
-            (true, Some(MacBlockReason.TimeLimit: MacBlockReason))
-          case _                                                           =>
-            (false, None)
-        }
-
-    val remaining = dailyLimit.map(l => (l + extensionMinutes - totalMinutesUsed).max(0))
-
     val perSite = siteLimits.map { sl =>
       SiteDayState(
         label = sl.label,
@@ -257,11 +369,70 @@ object TimeStatusService {
       )
     }
 
+    assemble(
+      profile = profile,
+      schedules = schedules,
+      dailyLimit = dailyLimit,
+      siteLimits = siteLimits,
+      usedMinutes = totalMinutesUsed,
+      extensionMinutes = extensionMinutes,
+      date = date,
+      now = now,
+      perSiteOverride = Some(perSite),
+    )
+  }
+
+  /**
+   * Shared assembly used by both [[fold]] (live presence aggregation) and the rollup read path
+   * (#1160), once `usedMinutes` is known. Computes `blocked` / `blockReason` / `remaining` so the
+   * cached-read path produces the same precedence Paused > Schedule > TimeLimit as the live path —
+   * the source-of-truth invariant is enforced here by construction.
+   *
+   * `perSiteOverride = None` means the caller did not load per-site presence; per-site usage is
+   * emitted as zero against the configured site limits (the v1 rollup is profile-total only).
+   */
+  def assemble(
+      profile: Profile,
+      schedules: List[DbSchedule],
+      dailyLimit: Option[Int],
+      siteLimits: List[SiteTimeLimit],
+      usedMinutes: Int,
+      extensionMinutes: Int,
+      date: LocalDate,
+      now: Instant,
+      perSiteOverride: Option[List[SiteDayState]] = None,
+  ): ProfileDayState = {
+    val (blocked, reason) =
+      if profile.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
+      else if schedules.exists(s => PolicyService.scheduleActiveAt(s, now)) then
+        (true, Some(MacBlockReason.Schedule: MacBlockReason))
+      else
+        dailyLimit match {
+          case Some(limit) if usedMinutes >= limit + extensionMinutes =>
+            (true, Some(MacBlockReason.TimeLimit: MacBlockReason))
+          case _                                                      =>
+            (false, None)
+        }
+
+    val remaining = dailyLimit.map(l => (l + extensionMinutes - usedMinutes).max(0))
+
+    val perSite = perSiteOverride.getOrElse(
+      siteLimits.map { sl =>
+        SiteDayState(
+          label = sl.label,
+          domainPattern = sl.domainPattern,
+          dailyLimitMinutes = sl.dailyMinutes,
+          usedMinutes = 0,
+          exemptFromDaily = sl.exemptFromDaily,
+        )
+      },
+    )
+
     ProfileDayState(
       profileId = profile.id,
       date = date,
       dailyLimitMinutes = dailyLimit,
-      usedMinutes = totalMinutesUsed,
+      usedMinutes = usedMinutes,
       extensionMinutes = extensionMinutes,
       remainingMinutes = remaining,
       blocked = blocked,

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -56,20 +56,15 @@ trait TimeStatusService {
   ): Task[Option[ProfileDayState]]
 
   /**
-   * Same as [[todaysState]] but for an explicit date. Used by the `?date=` query-param override on
-   * the seven `/api/time/status/...` endpoints so the UI can scroll back to a historical day; the
+   * Same as [[todaysState]] but for an explicit date. The `?date=` query-param override on the
+   * `/api/time/status/...` endpoints uses this so the UI can scroll back to a historical day; the
    * date is treated as the canonical bucket date (no tz reprojection — `time_usage` /
    * `traffic_reports` are already bucketed under household-local dates).
    *
-   * For past dates this reads `usedMinutes` from the `time_used_daily` rollup (#1160) when
-   * available, falling back to a live aggregation on miss. Today is always live so enforcement
-   * (which threads through [[dayStateAllLive]] on the snapshot path) and the UI never disagree on
-   * the current cap.
-   *
-   * `now` is still needed so the schedule/paused arm of the block evaluation has a wall-clock
-   * instant to test windows against. For historical dates the schedule arm will generally not be
-   * active (today's wall clock is not in yesterday's schedule window), but pinning `now` here keeps
-   * the function total.
+   * For today, this reads the `time_used_daily` rollup (#1160) and adds a live aggregation of the
+   * presence buckets the rollup hasn't yet absorbed (period_start >= rolled_through). On a cache
+   * miss — or for past dates — it falls through to the all-live path so the result is identical to
+   * what `dayStateLive` would have returned.
    */
   def dayState(
       now: Instant,
@@ -80,8 +75,8 @@ trait TimeStatusService {
 
   /**
    * Batched form for [[PolicyService.snapshot]] and the `/api/time/status/summary` route. Emits one
-   * `ProfileDayState` per profile for `date`. For past dates this is served from the
-   * `time_used_daily` rollup; today is computed live.
+   * `ProfileDayState` per profile for `date`. For today this is served from the rollup + a live
+   * tail; for past dates it's all-live.
    */
   def dayStateAll(
       now: Instant,
@@ -118,7 +113,7 @@ class TimeStatusServiceLive(
     trafficRepo: TrafficReportRepo,
     extRepo: TimeExtensionRepo,
     // Defaulting to the noop lets the many call sites in TimeApiSpec / snapshot specs keep their
-    // 7-arg constructions — they exercise today, which always takes the live path anyway.
+    // 7-arg constructions — they exercise the all-live path either way.
     rollupRepo: TimeUsedRollupRepo = NoopTimeUsedRollupRepo,
 ) extends TimeStatusService {
 
@@ -136,10 +131,10 @@ class TimeStatusServiceLive(
       profileId: ProfileId,
   ): Task[Option[ProfileDayState]] = {
     val today = PolicyService.householdLocalDate(now, settings)
-    if (date.isBefore(today))
+    if (date == today)
       rollupRepo.getDayForProfile(profileId, date).flatMap {
-        case Some(used) => dayStateFromRolled(now, date, profileId, used)
-        case None       => dayStateLive(now, date, settings, profileId)
+        case Some(rolled) => dayStateFromRollupAndTail(now, date, settings, profileId, rolled)
+        case None         => dayStateLive(now, date, settings, profileId)
       }
     else dayStateLive(now, date, settings, profileId)
   }
@@ -182,7 +177,7 @@ class TimeStatusServiceLive(
       settings: HouseholdSettings,
   ): Task[Map[ProfileId, ProfileDayState]] = {
     val today = PolicyService.householdLocalDate(now, settings)
-    if (date.isBefore(today)) dayStateAllFromRollup(now, date, settings)
+    if (date == today) dayStateAllFromRollup(now, date, settings)
     else dayStateAllLive(now, date, settings)
   }
 
@@ -225,16 +220,15 @@ class TimeStatusServiceLive(
       }.toMap
     }
 
-  // Build a ProfileDayState for a past date from a precomputed `usedMinutes`,
-  // skipping the heavy presence load. Schedules / paused / extensions / daily
-  // limit / site limits are still loaded live so the block-precedence math
-  // matches the live folder. Per-site `usedMinutes` is reported as zero — the
-  // v1 rollup is profile-total only; per-site is a tracked follow-up.
-  private def dayStateFromRolled(
+  // Today single-profile read: rolled seconds + live aggregation of buckets the rollup hasn't
+  // absorbed yet (period_start >= rolledThrough). Truncation to minutes happens once at the end so
+  // the result is byte-identical to a full live aggregation over the whole day.
+  private def dayStateFromRollupAndTail(
       now: Instant,
       date: LocalDate,
+      settings: HouseholdSettings,
       profileId: ProfileId,
-      usedMinutes: Int,
+      rolled: RolledDay,
   ): Task[Option[ProfileDayState]] =
     profileRepo.findById(profileId).flatMap {
       case None    => ZIO.succeed(None)
@@ -243,23 +237,31 @@ class TimeStatusServiceLive(
           schedules <- scheduleRepo.listForProfile(profileId)
           tl        <- timeLimitRepo.findForProfile(profileId)
           stls      <- siteTimeLimitRepo.listForProfile(profileId)
-          extMins   <- extRepo.getProfileTotalExtension(profileId, date)
-        } yield Some(
-          TimeStatusService.assemble(
-            profile = p,
-            schedules = schedules,
-            dailyLimit = tl.map(_.dailyMinutes),
-            siteLimits = stls,
-            usedMinutes = usedMinutes,
-            extensionMinutes = extMins,
-            date = date,
-            now = now,
-          ),
-        )
+          devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
+          tail <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, rolled.rolledThrough)
+          extMins <- extRepo.getProfileTotalExtension(profileId, date)
+        } yield {
+          val tailSeconds =
+            TimeStatusService.usedSecondsForProfile(p, devices, stls, tail, settings)
+          val totalUsed   = ((rolled.usedSeconds + tailSeconds) / 60L).toInt
+          Some(
+            TimeStatusService.assemble(
+              profile = p,
+              schedules = schedules,
+              dailyLimit = tl.map(_.dailyMinutes),
+              siteLimits = stls,
+              usedMinutes = totalUsed,
+              extensionMinutes = extMins,
+              date = date,
+              now = now,
+            ),
+          )
+        }
     }
 
-  // Batched variant. On a partial cache miss the missing profiles fall back
-  // to the live aggregation in one go — cheaper than recursing per-profile.
+  // Batched today read. On any cache miss (some profile lacks a rollup row) we fall through to the
+  // all-live path for the entire batch — cheaper than mixing two code paths and the next fiber tick
+  // refills the missing rows. After the fiber settles, every batch is rollup+tail.
   private def dayStateAllFromRollup(
       now: Instant,
       date: LocalDate,
@@ -268,36 +270,66 @@ class TimeStatusServiceLive(
     for {
       profiles <- profileRepo.listAll
       rolled   <- rollupRepo.getDayMap(date)
-      hit  = profiles.filter(p => rolled.contains(p.id))
-      miss = profiles.filterNot(p => rolled.contains(p.id))
-      schedsP <- ZIO.foreach(hit)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
-      tlsP    <- ZIO.foreach(hit)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
-      stlsP   <- ZIO.foreach(hit)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      result   <-
+        if profiles.exists(p => !rolled.contains(p.id)) then dayStateAllLive(now, date, settings)
+        else dayStateAllFromRollupHits(now, date, settings, profiles, rolled)
+    } yield result
+
+  private def dayStateAllFromRollupHits(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profiles: List[Profile],
+      rolled: Map[ProfileId, RolledDay],
+  ): Task[Map[ProfileId, ProfileDayState]] = {
+    // All rolled_through watermarks come from the same fiber tick in steady state, but a new
+    // profile + fresh tick can land just before the read — so use the earliest watermark and let
+    // per-profile filtering handle any per-row over-fetch.
+    val watermark = rolled.values.iterator.map(_.rolledThrough).min
+    for {
+      devices <- deviceRepo.listAll
+      schedsP <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      tlsP    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
+      stlsP   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
       exts    <- extRepo.snapshotAllByProfile(date)
-      live    <-
-        if miss.isEmpty then ZIO.succeed(Map.empty[ProfileId, ProfileDayState])
-        else
-          dayStateAllLive(now, date, settings).map(_.filter { case (pid, _) =>
-            miss.exists(_.id == pid)
-          })
     } yield {
       val schedMap = schedsP.toMap
       val tlMap    = tlsP.toMap
       val stlMap   = stlsP.toMap
-      val cached   = hit.iterator.map { p =>
+      val devsByP  =
+        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+      profiles.iterator.map { p =>
+        val devs        = devsByP.getOrElse(p.id, Nil)
+        val pRolled     = rolled(p.id)
+        // Per-profile watermark may exceed the batch min (e.g. a newer tick partially completed)
+        // — filter the over-fetched tail rows back to the row's own boundary.
+        val pTail       =
+          tail.filter(r =>
+            devs.exists(_.mac == r.mac) && !r.periodStart.isBefore(pRolled.rolledThrough),
+          )
+        val tailSeconds =
+          TimeStatusService.usedSecondsForProfile(
+            p,
+            devs,
+            stlMap.getOrElse(p.id, Nil),
+            pTail,
+            settings,
+          )
+        val totalUsed   = ((pRolled.usedSeconds + tailSeconds) / 60L).toInt
         p.id -> TimeStatusService.assemble(
           profile = p,
           schedules = schedMap.getOrElse(p.id, Nil),
           dailyLimit = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
           siteLimits = stlMap.getOrElse(p.id, Nil),
-          usedMinutes = rolled(p.id),
+          usedMinutes = totalUsed,
           extensionMinutes = exts.getOrElse(p.id, 0),
           date = date,
           now = now,
         )
       }.toMap
-      cached ++ live
     }
+  }
 }
 
 object TimeStatusService {
@@ -340,19 +372,10 @@ object TimeStatusService {
       now: Instant,
       settings: HouseholdSettings,
   ): ProfileDayState = {
-    val patterns   = siteLimits.map(_.domainPattern)
-    val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
-    val perPat     = Presence.patternMinutesByMac(presence, patterns)
-    val perMacTot  = Presence.totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
-
-    // #751: cap-enforcement honours the profile's overlap mode (Sum vs Dedup) — the same branch the
-    // routes used to apply independently.
-    val totalMinutesUsed = profile.crossDeviceOverlapMode match {
-      case CrossDeviceOverlapMode.Sum   =>
-        devices.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
-      case CrossDeviceOverlapMode.Dedup =>
-        Presence.dedupedTotalMinutes(presence, exemptPats, settings.heartbeatFilter)
-    }
+    val patterns         = siteLimits.map(_.domainPattern)
+    val perPat           = Presence.patternMinutesByMac(presence, patterns)
+    val totalSecondsUsed = usedSecondsForProfile(profile, devices, siteLimits, presence, settings)
+    val totalMinutesUsed = (totalSecondsUsed / 60L).toInt
 
     val byDomain: Map[String, Int] = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
       val mins = devices.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
@@ -383,8 +406,32 @@ object TimeStatusService {
   }
 
   /**
-   * Shared assembly used by both [[fold]] (live presence aggregation) and the rollup read path
-   * (#1160), once `usedMinutes` is known. Computes `blocked` / `blockReason` / `remaining` so the
+   * Pure: per-profile total active seconds from a presence batch, applying the heartbeat filter and
+   * the profile's `crossDeviceOverlapMode` (Sum vs Dedup). Shared by [[fold]] (live) and the
+   * rollup+tail read path so the cached and live computations stay structurally identical (#1160
+   * source-of-truth invariant). Returning seconds — not minutes — lets the decomposition rolled +
+   * tail stay exact across the watermark boundary.
+   */
+  def usedSecondsForProfile(
+      profile: Profile,
+      devices: List[Device],
+      siteLimits: List[SiteTimeLimit],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): Long = {
+    val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
+    profile.crossDeviceOverlapMode match {
+      case CrossDeviceOverlapMode.Sum   =>
+        val perMac = Presence.totalSecondsByMac(presence, exemptPats, settings.heartbeatFilter)
+        devices.iterator.map(d => perMac.getOrElse(d.mac, 0L)).sum
+      case CrossDeviceOverlapMode.Dedup =>
+        Presence.dedupedTotalSeconds(presence, exemptPats, settings.heartbeatFilter)
+    }
+  }
+
+  /**
+   * Shared assembly used by both [[fold]] (live presence aggregation) and the rollup+tail read
+   * path, once `usedMinutes` is known. Computes `blocked` / `blockReason` / `remaining` so the
    * cached-read path produces the same precedence Paused > Schedule > TimeLimit as the live path —
    * the source-of-truth invariant is enforced here by construction.
    *

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -1,80 +1,103 @@
 package wifihaven.api.usage
 
-import wifihaven.api.db.{HouseholdSettingsRepo, RollupRepo, TimeUsedRollupRepo}
+import wifihaven.api.db.{
+  DeviceRepo,
+  HouseholdSettingsRepo,
+  ProfileRepo,
+  RolledDay,
+  RollupRepo,
+  SiteTimeLimitRepo,
+  TimeUsedRollupRepo,
+  TrafficReportRepo,
+}
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.Clock
+import wifihaven.shared.types.ProfileId
 import zio.*
 
-import java.time.{Duration, Instant, LocalDate}
+import java.time.{Duration, Instant}
 
 /**
- * #1160: scheduled re-aggregation of `TimeStatusService.dayStateAll(...).usedMinutes` into
- * `time_used_daily`. Mirrors the byte-rollup fiber pattern in [[RollupJobs]] — fiber loop, per-tick
- * advisory lock, runs recorded in `rollup_runs` so the existing /api/admin/rollup-status surface
- * picks the new job up by name.
+ * #1160: scheduled refresh of `time_used_daily` for **today**. Each tick aggregates today's
+ * presence rows (up to `now`) and upserts one row per profile carrying `(used_seconds,
+ * rolled_through = now)`. The read path in `TimeStatusServiceLive` adds a live tail of buckets past
+ * the watermark, so callers see real-time totals built mostly from the cached row plus a small live
+ * slice.
  *
- * Scope (v1): caches `usedMinutes` for past dates only — today stays live (and so does enforcement,
- * since `PolicyService.snapshot` always evaluates today). The fiber re-rolls a trailing window so
- * yesterday lands in the cache shortly after the midnight rollover. Per-site / per-app rollups and
- * a today-tier are tracked separately.
+ * Past dates are intentionally not cached here — the existing live path (and the byte-rollup tables
+ * from #809 for usage graphs) cover them. The hot path is `/api/time/status/summary` rendering the
+ * per-profile screen-time figures (#1099); past-day reads are cold.
  *
- * Invalidation is wholesale via [[TimeUsedRollupRepo.deleteAll]] (called from the
- * `household_settings` UPDATE — covers `daily_reset_tz`, `daily_reset_time`, and any heartbeat-
- * filter knob). After invalidation the fiber refills on its next tick.
+ * Invalidation is wholesale via `TimeUsedRollupRepo.deleteAll` (called from
+ * `HouseholdSettingsRepoLive.update` — covers the heartbeat filter, daily reset time, and tz). The
+ * next tick refills.
+ *
+ * Multi-instance note: only one fiber should be writing each row at a time, but UPSERT keyed on
+ * `(profile_id, date)` with a monotonically-advancing `rolled_through` makes redundant writes
+ * idempotent semantically — two instances racing yield the same row either way. An advisory lock is
+ * unnecessary for v1 (one API instance in prod); add one alongside [[RollupLockKeys]] if/when this
+ * is run multi-instance.
  */
 object TimeUsedRollupJob {
 
-  /** Trailing window the fiber re-rolls every tick. Bounded by the raw retention horizon (#811). */
-  val LookbackDays: Int = 30
-
-  /** Refresh cadence — keeps the cache reasonably fresh for the UI's perceived-latency budget. */
-  val Interval: Duration = Duration.ofMinutes(5)
+  /**
+   * Refresh cadence. The tail aggregation handles freshness between ticks; this just bounds the
+   * tail's size so reads don't drift toward a full-day live aggregation as the day wears on.
+   */
+  val Interval: Duration = Duration.ofMinutes(3)
 
   /**
-   * Fiber loop entry point. Mirrors [[RollupJobs.hourlyLoop]]: tick body either succeeds (records a
-   * row), skips on advisory-lock contention (debug log), or fails (records error). Never dies.
+   * Fiber loop entry point. Errors are caught and recorded in `rollup_runs`; the fiber never dies.
    */
   def loop(
       rollup: TimeUsedRollupRepo,
       runs: RollupRepo,
-      svc: TimeStatusService,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
   ): UIO[Unit] =
-    runOnce(rollup, runs, svc, hs, clock)
+    runOnce(rollup, runs, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, clock)
       .repeat(Schedule.fixed(Interval))
       .unit
 
   /**
-   * Single tick body, exposed for the test that exercises one date end-to-end without going through
-   * the fiber loop. The contract is the same as the production tick: compute live, persist via
-   * upsertBatch, return the count of profiles rolled.
+   * Single tick body, exposed for the test that exercises the rollup end-to-end without going
+   * through the fiber loop. Computes today (per `now`) directly from the repos and persists the
+   * resulting (used_seconds, rolled_through = `now`) rows. Returns the count of profiles rolled.
    */
   def oneTickForTest(
       rollup: TimeUsedRollupRepo,
-      svc: TimeStatusService,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
-      date: LocalDate,
-  ): Task[Int] =
-    for {
-      settings <- hs.get
-      states   <- svc.dayStateAllLive(now, date, settings)
-      n        <- rollup.upsertBatch(date, states.view.mapValues(_.usedMinutes).toMap)
-    } yield n
+  ): Task[Int] = doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now)
 
   // ── internals ──────────────────────────────────────────────────────────────
 
   private def runOnce(
       rollup: TimeUsedRollupRepo,
       runs: RollupRepo,
-      svc: TimeStatusService,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
   ): UIO[Unit] =
     for {
       started  <- clock.instant
-      result   <- doTick(rollup, svc, hs, clock).either
+      result   <-
+        clock.instant
+          .flatMap(now =>
+            doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now),
+          )
+          .either
       finished <- clock.instant
       _        <- result match {
         case Right(n) =>
@@ -95,27 +118,44 @@ object TimeUsedRollupJob {
       }
     } yield ()
 
-  // Re-roll the trailing window of past dates (today is excluded — today reads
-  // live so enforcement and /summary agree, and writing today on every tick
-  // would just be noise the UI never reads). Caps at LookbackDays.
+  // The cached row covers presence buckets with `period_start < rolled_through`. Setting
+  // `rolled_through = now` makes the read path's tail-load filter (`period_start >= rolled_through`)
+  // pick up any bucket that lands after this tick — including buckets that finish during the tick
+  // itself but arrive at the DB after the snapshot read. The double-counting risk is bounded by
+  // bucket granularity (5 min); the next tick re-rolls with a fresh `now` and supersedes the row.
   private def doTick(
       rollup: TimeUsedRollupRepo,
-      svc: TimeStatusService,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
-      clock: Clock,
-  ): Task[Int] =
-    for {
-      now      <- clock.instant
-      settings <- hs.get
-      today = PolicyService.householdLocalDate(now, settings)
-      // Iterate yesterday → today − LookbackDays, oldest first so a partial
-      // failure leaves the most-stale days re-rolled.
-      dates = (1 to LookbackDays).map(d => today.minusDays(d.toLong)).toList.reverse
-      count <- ZIO.foldLeft(dates)(0) { (acc, d) =>
-        for {
-          states <- svc.dayStateAllLive(now, d, settings)
-          n      <- rollup.upsertBatch(d, states.view.mapValues(_.usedMinutes).toMap)
-        } yield acc + n
-      }
-    } yield count
+      now: Instant,
+  ): Task[Int] = for {
+    settings <- hs.get
+    today = PolicyService.householdLocalDate(now, settings)
+    profiles <- profileRepo.listAll
+    devices  <- deviceRepo.listAll
+    stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+    presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
+    perProfile: Map[ProfileId, RolledDay] = {
+      val stlMap  = stlsP.toMap
+      val devsByP =
+        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+      profiles.iterator.map { p =>
+        val devs = devsByP.getOrElse(p.id, Nil)
+        val mac  = devs.map(_.mac).toSet
+        val pres = presence.filter(r => mac.contains(r.mac))
+        val secs = TimeStatusService.usedSecondsForProfile(
+          p,
+          devs,
+          stlMap.getOrElse(p.id, Nil),
+          pres,
+          settings,
+        )
+        p.id -> RolledDay(secs, now)
+      }.toMap
+    }
+    n <- rollup.upsertBatch(today, perProfile)
+  } yield n
 }

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -1,0 +1,121 @@
+package wifihaven.api.usage
+
+import wifihaven.api.db.{HouseholdSettingsRepo, RollupRepo, TimeUsedRollupRepo}
+import wifihaven.api.policy.{PolicyService, TimeStatusService}
+import wifihaven.shared.Clock
+import zio.*
+
+import java.time.{Duration, Instant, LocalDate}
+
+/**
+ * #1160: scheduled re-aggregation of `TimeStatusService.dayStateAll(...).usedMinutes` into
+ * `time_used_daily`. Mirrors the byte-rollup fiber pattern in [[RollupJobs]] — fiber loop, per-tick
+ * advisory lock, runs recorded in `rollup_runs` so the existing /api/admin/rollup-status surface
+ * picks the new job up by name.
+ *
+ * Scope (v1): caches `usedMinutes` for past dates only — today stays live (and so does enforcement,
+ * since `PolicyService.snapshot` always evaluates today). The fiber re-rolls a trailing window so
+ * yesterday lands in the cache shortly after the midnight rollover. Per-site / per-app rollups and
+ * a today-tier are tracked separately.
+ *
+ * Invalidation is wholesale via [[TimeUsedRollupRepo.deleteAll]] (called from the
+ * `household_settings` UPDATE — covers `daily_reset_tz`, `daily_reset_time`, and any heartbeat-
+ * filter knob). After invalidation the fiber refills on its next tick.
+ */
+object TimeUsedRollupJob {
+
+  /** Trailing window the fiber re-rolls every tick. Bounded by the raw retention horizon (#811). */
+  val LookbackDays: Int = 30
+
+  /** Refresh cadence — keeps the cache reasonably fresh for the UI's perceived-latency budget. */
+  val Interval: Duration = Duration.ofMinutes(5)
+
+  /**
+   * Fiber loop entry point. Mirrors [[RollupJobs.hourlyLoop]]: tick body either succeeds (records a
+   * row), skips on advisory-lock contention (debug log), or fails (records error). Never dies.
+   */
+  def loop(
+      rollup: TimeUsedRollupRepo,
+      runs: RollupRepo,
+      svc: TimeStatusService,
+      hs: HouseholdSettingsRepo,
+      clock: Clock,
+  ): UIO[Unit] =
+    runOnce(rollup, runs, svc, hs, clock)
+      .repeat(Schedule.fixed(Interval))
+      .unit
+
+  /**
+   * Single tick body, exposed for the test that exercises one date end-to-end without going through
+   * the fiber loop. The contract is the same as the production tick: compute live, persist via
+   * upsertBatch, return the count of profiles rolled.
+   */
+  def oneTickForTest(
+      rollup: TimeUsedRollupRepo,
+      svc: TimeStatusService,
+      hs: HouseholdSettingsRepo,
+      now: Instant,
+      date: LocalDate,
+  ): Task[Int] =
+    for {
+      settings <- hs.get
+      states   <- svc.dayStateAllLive(now, date, settings)
+      n        <- rollup.upsertBatch(date, states.view.mapValues(_.usedMinutes).toMap)
+    } yield n
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  private def runOnce(
+      rollup: TimeUsedRollupRepo,
+      runs: RollupRepo,
+      svc: TimeStatusService,
+      hs: HouseholdSettingsRepo,
+      clock: Clock,
+  ): UIO[Unit] =
+    for {
+      started  <- clock.instant
+      result   <- doTick(rollup, svc, hs, clock).either
+      finished <- clock.instant
+      _        <- result match {
+        case Right(n) =>
+          ZIO.logInfo(s"rollup time_used_daily tick ok rows=$n") *>
+            runs.recordRun("time_used_daily", started, finished, "ok", None, n).ignore
+        case Left(e)  =>
+          ZIO.logErrorCause("rollup time_used_daily tick failed", Cause.fail(e)) *>
+            runs
+              .recordRun(
+                "time_used_daily",
+                started,
+                finished,
+                "error",
+                Some(e.getMessage.take(500)),
+                0,
+              )
+              .ignore
+      }
+    } yield ()
+
+  // Re-roll the trailing window of past dates (today is excluded — today reads
+  // live so enforcement and /summary agree, and writing today on every tick
+  // would just be noise the UI never reads). Caps at LookbackDays.
+  private def doTick(
+      rollup: TimeUsedRollupRepo,
+      svc: TimeStatusService,
+      hs: HouseholdSettingsRepo,
+      clock: Clock,
+  ): Task[Int] =
+    for {
+      now      <- clock.instant
+      settings <- hs.get
+      today = PolicyService.householdLocalDate(now, settings)
+      // Iterate yesterday → today − LookbackDays, oldest first so a partial
+      // failure leaves the most-stale days re-rolled.
+      dates = (1 to LookbackDays).map(d => today.minusDays(d.toLong)).toList.reverse
+      count <- ZIO.foldLeft(dates)(0) { (acc, d) =>
+        for {
+          states <- svc.dayStateAllLive(now, d, settings)
+          n      <- rollup.upsertBatch(d, states.view.mapValues(_.usedMinutes).toMap)
+        } yield acc + n
+      }
+    } yield count
+}

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -111,7 +111,7 @@ object TestDatabase {
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
       TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
-      AlertRepo & AppRepo & RollupRepo
+      AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -78,6 +78,12 @@ object DbFailureSpec extends ZIOSpecDefault {
         from: java.time.LocalDate,
         to: java.time.LocalDate,
     ) = throwing
+    def listPresenceRowsSince(
+        macs: List[MacAddress],
+        d: java.time.LocalDate,
+        s: java.time.Instant,
+    ) =
+      throwing
     def listRawInRange(
         macs: List[MacAddress],
         fromInstant: java.time.Instant,

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -10,12 +10,15 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.test.*
 
-import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
 
 /**
- * #1160: rollup is a cache of `TimeStatusService.dayStateAll`. Tests assert the source-of-truth
- * invariant (rollup == live) and the two non-trivial invalidation triggers (household-settings tz
- * change, heartbeat-filter change).
+ * #1160: rollup caches today's `used_seconds` per profile with a `rolled_through` watermark. The
+ * read path is `rollup + live tail`. These tests assert:
+ *   - source-of-truth invariant: rollup(today) + tail == live(today)
+ *   - cache miss falls back to all-live
+ *   - past dates ignore the rollup entirely
+ *   - heartbeat-filter and tz changes invalidate the cache
  */
 object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
 
@@ -45,16 +48,19 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-tur", Sha256Hex.unsafe("t" * 64)))
 
+  // Seed `minutes` consecutive 5-min buckets starting at `startOffsetMin` minutes after midnight
+  // UTC on `date`. Each bucket is fully active (300 active_seconds).
   private def seedTraffic(
       routerId: RouterId,
       mac: String,
       hostname: String,
       date: LocalDate,
       minutes: Int,
+      startOffsetMin: Int = 0,
   ): ZIO[TrafficReportRepo, Throwable, Unit] =
     ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
       val buckets = minutes / 5
-      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(startOffsetMin * 60L)
       val inserts = (0 until buckets).map { i =>
         val start = day0.plusSeconds(i * 300L)
         TrafficReportInsert(
@@ -81,7 +87,10 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     } yield upd
 
   def spec = suite("TimeUsedRollupSpec (#1160)")(
-    test("invariant: rollup(date) usedMinutes == TimeStatusService.dayState(date).usedMinutes") {
+    test("invariant: rollup(today) + live-tail == live(today) for a multi-device fixture") {
+      // Seed two devices on the kids profile. The fiber writes rolled_through somewhere in the
+      // middle of the day; the read combines the rolled prefix + the live tail and must equal what
+      // a full live aggregation over the whole day would have produced.
       for {
         _   <- cleanDb
         hsr <- ZIO.service[HouseholdSettingsRepo]
@@ -90,27 +99,94 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         dr  <- ZIO.service[DeviceRepo]
         tlr <- ZIO.service[TimeLimitRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
+        trr <- ZIO.service[TrafficReportRepo]
         s   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- tlr.upsert(kid, 120)
+        _   <- tlr.upsert(kid, 240)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:10", "kid-a", kid)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:11", "kid-b", kid)
         rid <- seedRouterRow
-        date = LocalDate.of(2025, 1, 6)
-        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:10", "youtube.com", date, 25)
-        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:11", "tiktok.com", date, 15)
-        // Compute live via a fresh service (before the rollup is written).
-        svc <- makeService
-        now = LocalDateTime.of(2025, 1, 7, 12, 0).toInstant(ZoneOffset.UTC)
-        live   <- svc.dayStateAllLive(now, date, s)
-        // Run the job once — it should populate the rollup.
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, svc, hsr, now, date)
-        rolled <- ru.getDayMap(date)
-      } yield assertTrue(
-        rolled.get(kid).contains(live(kid).usedMinutes),
-      ) && assertTrue(live(kid).usedMinutes > 0)
+        today = LocalDate.of(2025, 1, 6)
+        // 25 min on device A starting at 08:00, then 30 more min on device B starting at 10:00.
+        // (Non-overlapping macs/hours so Sum mode yields a clean total of 55 min.)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:10", "youtube.com", today, 25, 8 * 60)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:11", "tiktok.com", today, 30, 10 * 60)
+        // now = 12:00 today
+        now       = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        // Roll up everything up to 09:00 — captures only device A's 25 min; the read tail covers
+        // 09:00 onward (device B's 30 min).
+        watermark = LocalDateTime.of(2025, 1, 6, 9, 0).toInstant(ZoneOffset.UTC)
+        // Compute live value first (rollup is empty so this goes through dayStateAllLive).
+        svc      <- makeService
+        live     <- svc.dayStateAllLive(now, today, s)
+        // Manually plant a rolled row at the chosen watermark; the read path should compose it
+        // with the live tail and recover the live total exactly.
+        rolledA  <- {
+          // Construct the rolled `usedSeconds` for device A in [00:00, 09:00) by aggregating live.
+          // We do this by calling usedSecondsForProfile on the bucketed prefix presence.
+          val prefix = LocalDateTime.of(2025, 1, 6, 9, 0).toInstant(ZoneOffset.UTC)
+          for {
+            profile <- ZIO.serviceWithZIO[ProfileRepo](_.findById(kid)).someOrFailException
+            devices <- ZIO
+              .serviceWithZIO[DeviceRepo](_.listAll)
+              .map(_.filter(_.profileId.contains(kid)))
+            stls    <- ZIO.serviceWithZIO[SiteTimeLimitRepo](_.listForProfile(kid))
+            allPres <- trr.listPresenceRows(devices.map(_.mac), today)
+            prefixP = allPres.filter(_.periodStart.isBefore(prefix))
+            secs    = TimeStatusService.usedSecondsForProfile(profile, devices, stls, prefixP, s)
+          } yield secs
+        }
+        _        <- ru.upsertDay(kid, today, RolledDay(rolledA, watermark))
+        // Now read via the rollup+tail path.
+        composed <- svc.dayStateAll(now, today, s)
+      } yield assertTrue(composed(kid).usedMinutes == live(kid).usedMinutes) &&
+        assertTrue(live(kid).usedMinutes > 0)
     },
-    test("dayState reads rollup for past days, returning rolled used_minutes") {
+    test("fiber tick + immediate read reproduces the live total exactly") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        stl <- ZIO.service[SiteTimeLimitRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:20", "kid-a", kid)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:20", "youtube.com", today, 40, 9 * 60)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        svc    <- makeService
+        live   <- svc.dayStateAllLive(now, today, s)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        cached <- svc.dayStateAll(now, today, s)
+      } yield assertTrue(cached(kid).usedMinutes == live(kid).usedMinutes) &&
+        assertTrue(live(kid).usedMinutes == 40)
+    },
+    test("cache miss falls back to all-live") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:25", "kid-a", kid)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:25", "youtube.com", today, 15, 9 * 60)
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        st <- svc.dayState(now, today, s, kid)
+      } yield assertTrue(st.exists(_.usedMinutes == 15))
+    },
+    test("past dates ignore the rollup entirely") {
+      // Plant a misleading rollup row on a *past* date — the read path must NOT use it, so the
+      // returned usedMinutes reflects the (absent) live presence rows instead.
       for {
         _   <- cleanDb
         hsr <- ZIO.service[HouseholdSettingsRepo]
@@ -120,14 +196,14 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         ru  <- ZIO.service[TimeUsedRollupRepo]
         s   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:20", "kid", kid)
-        date = LocalDate.of(2025, 1, 6)
-        // Pre-populate the rollup directly with a sentinel value distinct from any raw aggregation.
-        _   <- ru.upsertDay(kid, date, 99)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:30", "kid-a", kid)
+        pastDate = LocalDate.of(2025, 1, 5)
+        bogus    = Instant.parse("2025-01-05T23:59:59Z")
+        _   <- ru.upsertDay(kid, pastDate, RolledDay(usedSeconds = 9_999L, rolledThrough = bogus))
         svc <- makeService
-        now = LocalDateTime.of(2025, 1, 7, 12, 0).toInstant(ZoneOffset.UTC) // tomorrow
-        st <- svc.dayState(now, date, s, kid)
-      } yield assertTrue(st.exists(_.usedMinutes == 99))
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC) // tomorrow
+        st <- svc.dayState(now, pastDate, s, kid)
+      } yield assertTrue(st.exists(_.usedMinutes == 0))
     },
     test("heartbeat-filter change deletes the rollup so the next refill reflects the new filter") {
       for {
@@ -137,18 +213,17 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         sr  <- ZIO.service[ScheduleRepo]
         dr  <- ZIO.service[DeviceRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
-        s   <- setTz(hsr, "UTC")
+        _   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:30", "kid", kid)
-        date = LocalDate.of(2025, 1, 6)
-        _    <- ru.upsertDay(kid, date, 50)
-        pre  <- ru.getDayMap(date)
-        // Mutating the filter via the repo must invalidate the rollup.
-        cur  <- hsr.get
-        _    <- hsr.update(
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:40", "kid", kid)
+        today = LocalDate.of(2025, 1, 6)
+        _   <- ru.upsertDay(kid, today, RolledDay(50L * 60L, Instant.parse("2025-01-06T09:00:00Z")))
+        pre <- ru.getDayMap(today)
+        cur <- hsr.get
+        _   <- hsr.update(
           cur.copy(heartbeatFilter = HeartbeatFilter(enabled = true, 1000, List("ntp.org"))),
         )
-        post <- ru.getDayMap(date)
+        post <- ru.getDayMap(today)
       } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
     },
     test("daily-reset-tz change invalidates the rollup") {
@@ -160,11 +235,11 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         ru  <- ZIO.service[TimeUsedRollupRepo]
         _   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
-        date = LocalDate.of(2025, 1, 6)
-        _    <- ru.upsertDay(kid, date, 42)
-        pre  <- ru.getDayMap(date)
-        _    <- setTz(hsr, "America/Denver")
-        post <- ru.getDayMap(date)
+        today = LocalDate.of(2025, 1, 6)
+        _   <- ru.upsertDay(kid, today, RolledDay(42L * 60L, Instant.parse("2025-01-06T09:00:00Z")))
+        pre <- ru.getDayMap(today)
+        _   <- setTz(hsr, "America/Denver")
+        post <- ru.getDayMap(today)
       } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -167,5 +167,5 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         post <- ru.getDayMap(date)
       } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
     },
-  )
+  ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -1,0 +1,171 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.usage.TimeUsedRollupJob
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
+
+/**
+ * #1160: rollup is a cache of `TimeStatusService.dayStateAll`. Tests assert the source-of-truth
+ * invariant (rollup == live) and the two non-trivial invalidation triggers (household-settings tz
+ * change, heartbeat-filter change).
+ */
+object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def makeService: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & HouseholdSettingsRepo,
+    Nothing,
+    TimeStatusService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ru   <- ZIO.service[TimeUsedRollupRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-tur", Sha256Hex.unsafe("t" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def setTz(hsr: HouseholdSettingsRepo, tz: String): Task[HouseholdSettings] =
+    for {
+      cur <- hsr.get
+      upd = cur.copy(dailyResetTz = java.time.ZoneId.of(tz))
+      _ <- hsr.update(upd)
+    } yield upd
+
+  def spec = suite("TimeUsedRollupSpec (#1160)")(
+    test("invariant: rollup(date) usedMinutes == TimeStatusService.dayState(date).usedMinutes") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 120)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:10", "kid-a", kid)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:11", "kid-b", kid)
+        rid <- seedRouterRow
+        date = LocalDate.of(2025, 1, 6)
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:10", "youtube.com", date, 25)
+        _   <- seedTraffic(rid, "aa:bb:cc:dd:ee:11", "tiktok.com", date, 15)
+        // Compute live via a fresh service (before the rollup is written).
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 7, 12, 0).toInstant(ZoneOffset.UTC)
+        live   <- svc.dayStateAllLive(now, date, s)
+        // Run the job once — it should populate the rollup.
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, svc, hsr, now, date)
+        rolled <- ru.getDayMap(date)
+      } yield assertTrue(
+        rolled.get(kid).contains(live(kid).usedMinutes),
+      ) && assertTrue(live(kid).usedMinutes > 0)
+    },
+    test("dayState reads rollup for past days, returning rolled used_minutes") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:20", "kid", kid)
+        date = LocalDate.of(2025, 1, 6)
+        // Pre-populate the rollup directly with a sentinel value distinct from any raw aggregation.
+        _   <- ru.upsertDay(kid, date, 99)
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 7, 12, 0).toInstant(ZoneOffset.UTC) // tomorrow
+        st <- svc.dayState(now, date, s, kid)
+      } yield assertTrue(st.exists(_.usedMinutes == 99))
+    },
+    test("heartbeat-filter change deletes the rollup so the next refill reflects the new filter") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:30", "kid", kid)
+        date = LocalDate.of(2025, 1, 6)
+        _    <- ru.upsertDay(kid, date, 50)
+        pre  <- ru.getDayMap(date)
+        // Mutating the filter via the repo must invalidate the rollup.
+        cur  <- hsr.get
+        _    <- hsr.update(
+          cur.copy(heartbeatFilter = HeartbeatFilter(enabled = true, 1000, List("ntp.org"))),
+        )
+        post <- ru.getDayMap(date)
+      } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
+    },
+    test("daily-reset-tz change invalidates the rollup") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        _   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        date = LocalDate.of(2025, 1, 6)
+        _    <- ru.upsertDay(kid, date, 42)
+        pre  <- ru.getDayMap(date)
+        _    <- setTz(hsr, "America/Denver")
+        post <- ru.getDayMap(date)
+      } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
+    },
+  )
+}


### PR DESCRIPTION
## Design

**Table shape.** `time_used_daily(profile_id, date, used_seconds, rolled_through, rolled_at)`, PK `(profile_id, date)`. Stores `used_seconds` — not minutes — so the rollup-prefix + live-tail decomposition is exact across the watermark boundary; truncation to minutes happens once at the end of the read. `rolled_through` is the upper bound (exclusive) of the presence buckets the row covers.

**Scope: today only.** Past dates are not cached here. The existing live path and the byte-rollup tables (V38) handle historical reads for usage graphs. The hot path this exists for is `/api/time/status/summary` rendering per-profile screen-time figures (#1099); past-day reads are cold.

**Read path.**
- For `date == today`: `getDayForProfile(today)` → if hit, load `listPresenceRowsSince(devices, today, rolled_through)` (the tail) and return `((rolled.used_seconds + usedSecondsForProfile(tail)) / 60).toInt`. If miss, fall through to the all-live path. Batched variant (`dayStateAll`) uses the same rule, falling through to all-live if any profile lacks a row.
- For past dates: always live (no rollup lookup).

**Decomposition correctness.** `Presence.totalSecondsByMac` and `Presence.dedupedTotalSeconds` aggregate per-bucket maxima. Buckets are 5-min granular and disjoint on either side of `period_start = rolled_through`, so:
- Sum mode: `sum_per_mac(rolled buckets) + sum_per_mac(tail buckets) == sum_per_mac(all)` ✓
- Dedup mode: each bucket counts once on its own side; the union is still each bucket counted once ✓
- Exempt-from-daily patterns and the heartbeat filter apply per-row inside each side identically ✓

The read uses the same pure helper (`TimeStatusService.usedSecondsForProfile`) that the rollup writer uses, so the cached and live results are structurally identical (#1104 source-of-truth invariant).

**Enforcement.** `PolicyService.snapshot` calls `dayStateAll(now, today, settings)`, which now reads the rollup + tail. Tail-load freshness is whatever the most recent `traffic_reports` insert is — same as the previous live path. The rollup never returns a stale total because the tail always covers everything past the watermark. Enforcement and the UI necessarily agree.

**Re-roll triggers.**
- `HouseholdSettingsRepoLive.update` runs `UPDATE household_settings ... ; DELETE FROM time_used_daily` in one transaction. Covers `daily_reset_tz`, `daily_reset_time`, and every heartbeat-filter field — all three gate the active-minute definition or the day boundary. After invalidation, today reads fall through to all-live until the next tick (≤3 min).
- Midnight rollover: the fiber computes today against the current `now`. After midnight `householdLocalDate(now, settings)` returns the new day; the previous day's row is left alone (read path ignores past dates). Cleanup happens via retention (out of scope here; small per-row footprint).
- Late `traffic_reports` for today: tail-load picks them up immediately; the fiber persists them on the next tick.

## Summary

- New `time_used_daily` table (migration V43); one row per profile per active date carrying `used_seconds` + `rolled_through`.
- New `TimeUsedRollupRepo` + `TimeUsedRollupJob` (fiber every 3 min); runs recorded in `rollup_runs` so `/api/admin/rollup-status` picks them up by name.
- New `listPresenceRowsSince(macs, date, since)` on `TrafficReportRepo` for tail-load.
- `TimeStatusService` gains `dayStateAllLive` / `dayStateLive`; `dayState` / `dayStateAll` dispatch to `rollup + tail` for today and live for past. New shared pure helper `usedSecondsForProfile` so the cache and live paths use identical math.
- Invalidation hooked into `HouseholdSettingsRepoLive.update` (atomic with the settings UPDATE).
- `PolicyService.apply` (used by snapshot specs) wires `NoopTimeUsedRollupRepo`.

## Scope deferred

- **Per-site `SiteDayState` cache**. The rollup carries profile-total seconds only; for cached reads cached reads emit `SiteDayState.usedMinutes = 0` for the synthesized per-app rows (the post-#764 SiteTimeLimit shape is generated from time-limited app assignments). /summary doesn't consume them. Tracked as #1167.
- **Per-app rollup (#1061)**. Separate concern with its own read endpoint; not in `ProfileDayState`.

## Test plan

- [x] Invariant: planted rolled prefix + read-time tail == full-live total for a multi-device fixture
- [x] Fiber tick → immediate read reproduces the live total exactly
- [x] Cache miss falls back to all-live (same value as before this PR)
- [x] Past dates ignore the rollup (a bogus row on a past date doesn't leak into the read)
- [x] heartbeat-filter change deletes the rollup
- [x] daily-reset-tz change deletes the rollup
- [x] `mill api.test` clean (all specs pass)
- [x] scalafmt clean

Closes #1160. Supersedes the perf half of #1099.