### PR TITLE
ops(ci): multi-instance KVM runner + 5-bridge pool to unlock VM parallelism (#1163)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -23,15 +23,16 @@ name: VM e2e (fake API — Gate 2)
 #   pool pick (lib.sh::wh_pick_lan_bridge, #891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
-#   and each VM pair (router + client) consumes one — so 4 concurrent pairs
-#   is the absolute max. We cap CI matrix fan-out at `max-parallel: 3`
+#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
+#   and each VM pair (router + client) consumes one — so 5 concurrent pairs
+#   is the absolute max. We cap CI matrix fan-out at `max-parallel: 4`
 #   (below) to leave one bridge free for ad-hoc manual runs,
 #   scripts/e2e-kvm-sanity, and the keep-staging-warm cron, so none of those
-#   ever queue behind CI. Bumping to 4 is a one-line change if pressure
-#   justifies giving up the headroom slot.
+#   ever queue behind CI. The matching global governor is the runner-instance
+#   count on api.lan (4, one per job-bridge); see docs/ops/kvm-runner.md
+#   for the runner-count = bridge-count - 1 invariant (#1163).
 #
-#   When all 4 bridges are taken, wh_pick_lan_bridge fails loud with
+#   When all 5 bridges are taken, wh_pick_lan_bridge fails loud with
 #   "LAN bridge pool exhausted" (exit 1) rather than queueing forever — see
 #   scripts/vm/test-lan-bridge-pick.sh. Broader capacity plan: #657.
 
@@ -67,15 +68,15 @@ jobs:
     # #685: matrix over ipk-23.05 and apk-25.12 router images. fail-fast=false
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).
-    # max-parallel: 3 (#895) — with #891's bridge/port/MAC parameterization
-    # the arms can share a host, bounded by the 4-bridge pool minus one
-    # headroom slot (see the concurrency note at the top of this file). Today
-    # the single self-hosted kvm runner still serializes the arms via runner
-    # availability; once a second runner is added they parallelize up to the
-    # cap automatically.
+    # max-parallel: 4 (#1163) — with #891's bridge/port/MAC parameterization
+    # the arms can share a host, bounded by the 5-bridge pool minus one
+    # headroom slot (see the concurrency note at the top of this file). The
+    # 4 self-hosted kvm runner instances on api.lan are the global governor
+    # for cross-workflow concurrency; within a single workflow this cap is
+    # the per-matrix ceiling.
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         include:
           - pkg_format: ipk
@@ -94,7 +95,7 @@ jobs:
       # Per-job scope for the qemu `-name wh-*-${WH_RUN_ID}` suffix and the
       # .run/<id>/ state dir (config.sh:91,145,40-44). Lets teardown's
       # pkill backstop match only this run's qemu, never a sibling's.
-      # Now that #895 lets matrix arms run in parallel (max-parallel: 3),
+      # Now that #895 lets matrix arms run in parallel (max-parallel: 4),
       # the id MUST be unique per arm — two concurrently-booting arms sharing
       # one .run/<id>/ would clobber each other's overlay/pid/monitor.sock —
       # so we append the pkg_format. github.run_id already makes it unique

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -26,12 +26,15 @@ name: VM e2e (Gate 3a — router-side staging smoke)
 #   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
-#   each VM pair consumes one → 4 concurrent pairs max. CI matrix fan-out is
-#   capped at `max-parallel: 3` (below), leaving one bridge for ad-hoc runs,
-#   scripts/e2e-kvm-sanity, and keep-staging-warm. When all 4 are taken,
-#   wh_pick_lan_bridge fails loud ("LAN bridge pool exhausted", exit 1)
-#   instead of queueing forever. Broader capacity plan: #657.
+#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
+#   each VM pair consumes one → 5 concurrent pairs max. CI matrix fan-out is
+#   capped at `max-parallel: 4` (below), leaving one bridge for ad-hoc runs,
+#   scripts/e2e-kvm-sanity, and keep-staging-warm. The matching global
+#   governor is the runner-instance count on api.lan (4, one per job-bridge);
+#   see docs/ops/kvm-runner.md for the runner-count = bridge-count - 1
+#   invariant (#1163). When all 5 are taken, wh_pick_lan_bridge fails loud
+#   ("LAN bridge pool exhausted", exit 1) instead of queueing forever.
+#   Broader capacity plan: #657.
 
 on:
   workflow_call:
@@ -63,11 +66,11 @@ jobs:
     timeout-minutes: 20
     # Matrix over ipk-23.05 and apk-25.12 (#532). fail-fast=false so a
     # regression in one flavor still reports the other arm's status.
-    # max-parallel: 3 (#895) — bounded by the 4-bridge pool minus one
+    # max-parallel: 4 (#1163) — bounded by the 5-bridge pool minus one
     # headroom slot (see the concurrency note at the top of this file).
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         include:
           - pkg_format: ipk
@@ -83,7 +86,7 @@ jobs:
       # safety margin is free.
       WH_PORT_BASE: ${{ matrix.port_base }}
       # Same WH_RUN_ID convention as Gate 2 (#895): per-arm pkg_format suffix
-      # so concurrently-booting matrix arms (max-parallel: 3) don't share a
+      # so concurrently-booting matrix arms (max-parallel: 4) don't share a
       # .run/<id>/ state dir; github.run_id keeps it unique across concurrent
       # workflow runs (gate3a / gate3b / fake each get a distinct run_id, and
       # the per-workflow WH_PORT_BASE ranges below never overlap either).

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -26,12 +26,15 @@ name: VM e2e (Gate 3b — API/UI-side staging smoke)
 #   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 4 bridges (wh-lan0..wh-lan3),
-#   each VM pair consumes one → 4 concurrent pairs max. CI matrix fan-out is
-#   capped at `max-parallel: 3` (below), leaving one bridge for ad-hoc runs,
-#   scripts/e2e-kvm-sanity, and keep-staging-warm. When all 4 are taken,
-#   wh_pick_lan_bridge fails loud ("LAN bridge pool exhausted", exit 1)
-#   instead of queueing forever. Broader capacity plan: #657.
+#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
+#   each VM pair consumes one → 5 concurrent pairs max. CI matrix fan-out is
+#   capped at `max-parallel: 4` (below), leaving one bridge for ad-hoc runs,
+#   scripts/e2e-kvm-sanity, and keep-staging-warm. The matching global
+#   governor is the runner-instance count on api.lan (4, one per job-bridge);
+#   see docs/ops/kvm-runner.md for the runner-count = bridge-count - 1
+#   invariant (#1163). When all 5 are taken, wh_pick_lan_bridge fails loud
+#   ("LAN bridge pool exhausted", exit 1) instead of queueing forever.
+#   Broader capacity plan: #657.
 
 on:
   workflow_call:
@@ -52,11 +55,11 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 20
-    # max-parallel: 3 (#895) — bounded by the 4-bridge pool minus one headroom
+    # max-parallel: 4 (#1163) — bounded by the 5-bridge pool minus one headroom
     # slot (see the concurrency note at the top of this file).
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         include:
           - pkg_format: ipk

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -62,47 +62,74 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
 | `scripts/vm/.cache/imagebuilder/`       | OpenWRT Image Builder working tree     |
 | `.e2e-vm-venv/`                         | pytest venv (created lazily)           |
 
-## Registering the runner with GitHub
+## Sizing: runner count vs. bridge pool — load-bearing invariant
 
-The runner installs under `~/actions-runner` in the runner user's home directory
-— no sudo needed for the install itself.
+> **Invariant (#1163): `runner-count = bridge-pool-size − 1`.** The trailing
+> bridge in the pool is reserved as a manual-headroom slot for ad-hoc runs
+> (`scripts/e2e-kvm-sanity`, operator debugging, the keep-staging-warm
+> cron). Because `wh_pick_lan_bridge`
+> ([`scripts/vm/lib.sh`](../../scripts/vm/lib.sh)) hands out the
+> **lowest-numbered free bridge first** and there are never more than
+> `N − 1` concurrent jobs (capped by runner-instance count), the
+> highest-numbered bridge stays free in steady state.
+>
+> **Touch both knobs together.** If you scale runners, scale bridges. If
+> you scale bridges, scale runners. The matching workflow knob is
+> `max-parallel` in the VM e2e workflows (which equals `runner-count`).
+>
+> Today's sizing on api.lan: **5 bridges (`wh-lan0..wh-lan4`), 4 runner
+> instances (`actions-runner-1..4`), `max-parallel: 4`.**
+
+The runner-instance count is the global host-concurrency governor: GitHub
+queues jobs naturally when no runner is free, so once all 4 runners are
+busy, sibling jobs wait. No workflow-level `concurrency:` group is needed
+across workflows — the runner pool *is* the queue.
+
+## Registering the runners with GitHub
+
+Each runner instance installs under `~/actions-runner-N` in the runner
+user's home directory (N = 1..4 today). The install itself needs no sudo;
+the per-instance systemd unit needs sudo once.
 
 1. Pick the runner user (non-root). It must be in the `kvm` and `docker`
    groups and have the NOPASSWD `ip` rule from `docs/vm-e2e-ubuntu.md`.
    The natural choice is whichever user you already bootstrapped the VM
    harness with.
 
-2. Get a one-time registration token (from any machine with `gh` auth — the
-   token's only valid ~1 hour, so do this right before step 4):
+2. As the runner user, download and unpack the latest runner release once
+   into a tarball — you'll unpack a fresh copy into each instance dir.
+   Check <https://github.com/actions/runner/releases> for the current
+   version.
    ```bash
-   gh api -X POST repos/wifihaven/wifihaven/actions/runners/registration-token --jq .token
-   ```
-
-3. As the runner user, download and unpack the latest runner release. Check
-   <https://github.com/actions/runner/releases> for the current version.
-   ```bash
-   mkdir -p ~/actions-runner && cd ~/actions-runner
    RUNNER_VER=2.321.0    # ← update to current
-   curl -fsSL -o runner.tar.gz \
+   curl -fsSL -o /tmp/runner.tar.gz \
      "https://github.com/actions/runner/releases/download/v${RUNNER_VER}/actions-runner-linux-x64-${RUNNER_VER}.tar.gz"
-   tar xzf runner.tar.gz && rm runner.tar.gz
    ```
 
-4. Configure with the labels the workflow expects (paste the token from #2):
+3. For each instance `N` in `1..4`, fetch a **fresh** one-time registration
+   token (each is valid ~1 hour and is single-use) and configure a separate
+   work directory. **All instances carry the same labels** — `kvm` is what
+   the workflows match on:
    ```bash
-   cd ~/actions-runner
-   ./config.sh \
-     --url https://github.com/wifihaven/wifihaven \
-     --token <REGISTRATION_TOKEN> \
-     --name wifihaven-kvm-1 \
-     --labels self-hosted,linux,kvm \
-     --work _work \
-     --unattended
+   for N in 1 2 3 4; do
+     mkdir -p ~/actions-runner-$N && cd ~/actions-runner-$N
+     tar xzf /tmp/runner.tar.gz
+     TOKEN=$(gh api -X POST \
+       repos/wifihaven/wifihaven/actions/runners/registration-token --jq .token)
+     ./config.sh \
+       --url https://github.com/wifihaven/wifihaven \
+       --token "$TOKEN" \
+       --name "wifihaven-kvm-$N" \
+       --labels self-hosted,linux,kvm \
+       --work _work \
+       --unattended
+   done
    ```
 
-5. Smoke-test interactively before installing as a service:
+4. Smoke-test one instance interactively before installing the systemd
+   units:
    ```bash
-   ./run.sh
+   cd ~/actions-runner-1 && ./run.sh
    ```
    In another shell, dispatch the sanity workflow and watch it land:
    ```bash
@@ -111,22 +138,71 @@ The runner installs under `~/actions-runner` in the runner user's home directory
    ```
    Ctrl-C `./run.sh` once the workflow finishes.
 
-6. Install as a systemd service so the runner survives reboots. A template
-   lives at [`scripts/ci/kvm-runner.service`](../../scripts/ci/kvm-runner.service).
-   This is the only step that needs sudo:
+5. Install the systemd **template** unit so each runner instance survives
+   reboots. Template lives at
+   [`scripts/ci/kvm-runner@.service`](../../scripts/ci/kvm-runner@.service);
+   `%i` expands to the instance index, so a single file enables N services
+   (`kvm-runner@1`, `kvm-runner@2`, …). This is the only step that needs
+   sudo:
    ```bash
-   sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
+   sudo cp 'scripts/ci/kvm-runner@.service' /etc/systemd/system/kvm-runner@.service
    sudo sed -i \
      -e "s|<RUNNER_USER>|$USER|g" \
-     -e "s|<RUNNER_HOME>|$HOME/actions-runner|g" \
-     /etc/systemd/system/kvm-runner.service
+     -e "s|<RUNNER_HOME_BASE>|$HOME/actions-runner|g" \
+     /etc/systemd/system/kvm-runner@.service
    sudo systemctl daemon-reload
-   sudo systemctl enable --now kvm-runner.service
-   journalctl -u kvm-runner -f
+   sudo systemctl enable --now kvm-runner@{1,2,3,4}.service
+   journalctl -u 'kvm-runner@*' -f
    ```
 
-6. Verify the runner appears under
+6. Verify all 4 runners appear under
    `Settings → Actions → Runners` with the `kvm` label and status `Idle`.
+
+## Bridge pool (`/etc/qemu/bridge.conf`)
+
+The 4 job-runners share a host-wide pool of LAN bridges. The pool is
+created by `scripts/vm/lan-bridge-pool-bootstrap.sh`, which also appends
+`allow wh-lanN` entries to `/etc/qemu/bridge.conf`.
+
+```bash
+# Default pool size 5 → wh-lan0..wh-lan4. Override with WH_LAN_BRIDGE_POOL_SIZE.
+sudo scripts/vm/lan-bridge-pool-bootstrap.sh
+```
+
+Resulting `/etc/qemu/bridge.conf` (on top of any pre-existing entries):
+
+```
+allow wh-lan0   # job slot 0
+allow wh-lan1   # job slot 1
+allow wh-lan2   # job slot 2
+allow wh-lan3   # job slot 3
+allow wh-lan4   # manual headroom (e2e-kvm-sanity, keep-staging-warm, debug)
+```
+
+The picker (`scripts/vm/lib.sh::wh_pick_lan_bridge`) treats the pool as a
+uniform set, picking the lowest-numbered free bridge under a host-wide
+flock. **There is no code-level "reserved" flag on `wh-lan4`** — the
+headroom guarantee comes from the runner-count = pool-size − 1 invariant.
+If you bump runner count to 5, `wh-lan4` becomes a job slot and you must
+add `wh-lan5` to preserve headroom.
+
+## Verifying parallelism
+
+After all four runners are online, confirm the matrix arms actually run
+concurrently with a `workflow_dispatch`:
+
+```bash
+gh workflow run e2e-vm-fake.yml -R wifihaven/wifihaven
+RUN_ID=$(gh run list -R wifihaven/wifihaven \
+  --workflow=e2e-vm-fake.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run view "$RUN_ID" -R wifihaven/wifihaven --json jobs \
+  --jq '.jobs[] | {name, startedAt, completedAt}'
+```
+
+Both matrix arms' `startedAt` timestamps should overlap (typically within
+a few seconds of each other) instead of one arm starting only after the
+other completes. If they're back-to-back, only one runner is online or
+`max-parallel` is below the matrix size.
 
 ## Runtime privileges
 
@@ -149,7 +225,7 @@ the VM e2e harness on this host as a regular user, you're done.
 > **Don't re-add `NoNewPrivileges=true` to the systemd unit.** It refuses
 > the setuid transition for the `sudo ip link …` call above and breaks VM
 > bring-up with `sudo: The "no new privileges" flag is set …`. The unit
-> file in `scripts/ci/kvm-runner.service` deliberately omits it; the
+> file in `scripts/ci/kvm-runner@.service` deliberately omits it; the
 > NOPASSWD sudoers rule on `/usr/sbin/ip` is already the security gate.
 
 ## Trust model

--- a/scripts/ci/kvm-runner@.service
+++ b/scripts/ci/kvm-runner@.service
@@ -1,20 +1,22 @@
-## systemd unit template for the WifiHaven KVM self-hosted GitHub Actions runner.
+## systemd template unit for the WifiHaven KVM self-hosted GitHub Actions
+## runners. Each instance maps to ~/actions-runner-%i in the runner user's
+## home directory, where %i is the instance index (1..N).
 ##
 ## Install via:
-##   sudo cp scripts/ci/kvm-runner.service /etc/systemd/system/kvm-runner.service
+##   sudo cp 'scripts/ci/kvm-runner@.service' /etc/systemd/system/kvm-runner@.service
 ##   sudo sed -i \
 ##     -e "s|<RUNNER_USER>|$USER|g" \
-##     -e "s|<RUNNER_HOME>|$HOME/actions-runner|g" \
-##     /etc/systemd/system/kvm-runner.service
+##     -e "s|<RUNNER_HOME_BASE>|$HOME/actions-runner|g" \
+##     /etc/systemd/system/kvm-runner@.service
 ##   sudo systemctl daemon-reload
-##   sudo systemctl enable --now kvm-runner.service
+##   sudo systemctl enable --now kvm-runner@{1,2,3,4}.service
 ##
-## See docs/ops/kvm-runner.md for full setup, including registration.
-## Defaults assume the runner lives at ~/actions-runner in the runner
-## user's home directory.
+## See docs/ops/kvm-runner.md for full setup, including per-instance
+## registration. The runner-count must match (bridge-pool-size - 1) so the
+## manual-headroom slot stays free — see the invariant called out in that doc.
 
 [Unit]
-Description=GitHub Actions runner (WifiHaven, KVM)
+Description=GitHub Actions runner (WifiHaven, KVM) — instance %i
 After=network-online.target docker.service
 Wants=network-online.target
 
@@ -25,10 +27,10 @@ Type=simple
 User=<RUNNER_USER>
 Group=<RUNNER_USER>
 
-# Directory created by ./config.sh (where run.sh + _work live).
-WorkingDirectory=<RUNNER_HOME>
+# Per-instance work tree created by ./config.sh in actions-runner-%i.
+WorkingDirectory=<RUNNER_HOME_BASE>-%i
 
-ExecStart=<RUNNER_HOME>/run.sh
+ExecStart=<RUNNER_HOME_BASE>-%i/run.sh
 
 # The runner manages its own graceful shutdown when it receives SIGTERM —
 # it finishes the current job before exiting. Allow time for an e2e run.

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -39,7 +39,7 @@ auto-picks a free bridge from the pool — no extra env vars needed for the
 bridge.
 
 ```
-# Creates wh-lan0..wh-lan3 (default pool size 4) and ensures bridge.conf
+# Creates wh-lan0..wh-lan4 (default pool size 5) and ensures bridge.conf
 # has an `allow` line for each. Idempotent.
 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
 ```

--- a/scripts/vm/lan-bridge-pool-bootstrap.sh
+++ b/scripts/vm/lan-bridge-pool-bootstrap.sh
@@ -3,14 +3,21 @@
 # runs (#891). Idempotent.
 #
 # Creates ${WH_LAN_BRIDGE_POOL_SIZE} bridges named wh-lan0 .. wh-lan${N-1}
-# (default N=4) via `sudo ip link add`, and verifies each is listed in
+# (default N=5) via `sudo ip link add`, and verifies each is listed in
 # /etc/qemu/bridge.conf so qemu-bridge-helper will attach taps.
+#
+# Sizing convention (#1163): N = (concurrent-runner-count) + 1. The trailing
+# bridge is the manual-headroom slot reserved for ad-hoc runs and the
+# keep-staging-warm cron — it stays free because runners only fan out to N-1
+# bridges, and the wh_pick_lan_bridge picker hands out lowest-numbered first.
+# Today: 4 runners, 5 bridges. See docs/ops/kvm-runner.md for the full
+# invariant.
 #
 # Also ensures /etc/qemu/bridge.conf has an `allow wh-lanK` line for each
 # pool bridge (sudo tee -a). Idempotent: existing lines are left alone.
 #
 # Usage:
-#   sudo scripts/vm/lan-bridge-pool-bootstrap.sh           # default size 4
+#   sudo scripts/vm/lan-bridge-pool-bootstrap.sh           # default size 5
 #   WH_LAN_BRIDGE_POOL_SIZE=8 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
 
 set -euo pipefail
@@ -26,7 +33,7 @@ require_cmd() {
 }
 require_cmd ip
 
-SIZE="${WH_LAN_BRIDGE_POOL_SIZE:-4}"
+SIZE="${WH_LAN_BRIDGE_POOL_SIZE:-5}"
 if ! [[ "${SIZE}" =~ ^[0-9]+$ ]] || (( SIZE < 1 )); then
   echo "lan-bridge-pool-bootstrap: WH_LAN_BRIDGE_POOL_SIZE must be a positive integer (got '${SIZE}')" >&2
   exit 2


### PR DESCRIPTION
## Summary

Closes #1163. Builds on #657, #894, #1018, #1137.

The YAML side of VM parallelism (bridge/port/MAC parameterization, per-run concurrency, `max-parallel`) is already wired. The remaining bottleneck is that api.lan has only **one** self-hosted runner instance registered, so GitHub serializes job dispatch regardless of `max-parallel`. This PR scales the repo-side knobs to support 4 concurrent runners + a 5-bridge pool, making the runner-instance count itself the global host-concurrency governor.

### Repo changes

- **`scripts/ci/kvm-runner@.service`** — convert from a single static unit (`kvm-runner.service`) to a **systemd template** using `%i`, so the same file installs as `kvm-runner@1` … `kvm-runner@4`. `WorkingDirectory` and `ExecStart` point at `~/actions-runner-%i`. The deliberate `NoNewPrivileges` omission (needed by `sudo ip link …`) is preserved with the same explanatory comment.
- **`scripts/vm/lan-bridge-pool-bootstrap.sh`** — default `WH_LAN_BRIDGE_POOL_SIZE` 4 → 5 (creates `wh-lan0..wh-lan4`).
- **`docs/ops/kvm-runner.md`** — rewrite the install procedure for N runner instances (per-instance registration tokens, per-instance work dirs), document the `/etc/qemu/bridge.conf` layout (4 job slots + 1 manual-headroom slot), and add a `workflow_dispatch` verification step that checks matrix `startedAt` overlap. Prominently calls out the load-bearing invariant **`runner-count = bridge-pool-size − 1`** so future capacity changes touch both knobs together.
- **`.github/workflows/e2e-vm-{fake,gate3a,gate3b}.yml`** — `max-parallel: 3 → 4` and refresh the header concurrency comment blocks to the new 5-bridge / 4-runner sizing. `concurrency:` per-run group names and the master pipelines' `concurrency:` are untouched (working as intended).

### Picker semantics — no code change needed

`scripts/vm/lib.sh::wh_pick_lan_bridge` picks the **lowest-numbered free** bridge under a host-wide flock. There is no explicit "reserved" flag on `wh-lan4`; the manual-headroom guarantee comes from the runner-count = pool-size − 1 invariant (4 runners can only ever take 4 of the 5 bridges, leaving the highest-numbered one free). The doc spells this out so a future bump to 5 runners forces a matching bump to 6 bridges.

## Operator follow-up on api.lan (REQUIRED for parallelism to actually take effect)

The YAML changes alone do **not** deliver parallelism — they only unblock it. Until the operator runs these steps, the new \`max-parallel: 4\` is capped by the single existing runner:

1. **Add `wh-lan4` to the bridge pool**:
   ```bash
   sudo scripts/vm/lan-bridge-pool-bootstrap.sh
   # idempotent; existing wh-lan0..3 + their bridge.conf entries are left alone,
   # wh-lan4 is created and 'allow wh-lan4' appended.
   ```
2. **Register 3 additional runner instances** (`actions-runner-2/3/4`) with fresh single-use registration tokens from `gh api -X POST repos/wifihaven/wifihaven/actions/runners/registration-token`. Same labels: `self-hosted, linux, kvm`. The loop in `docs/ops/kvm-runner.md` § "Registering the runners with GitHub" runs all 4 in one go.
3. **Install the systemd template + enable all 4 services**:
   ```bash
   sudo cp 'scripts/ci/kvm-runner@.service' /etc/systemd/system/kvm-runner@.service
   sudo sed -i -e "s|<RUNNER_USER>|$USER|g" -e "s|<RUNNER_HOME_BASE>|$HOME/actions-runner|g" /etc/systemd/system/kvm-runner@.service
   sudo systemctl daemon-reload
   sudo systemctl enable --now kvm-runner@{1,2,3,4}.service
   ```
   The existing single-instance `kvm-runner.service` (if installed) should be `systemctl disable --now`'d before enabling the templates so they don't fight over the old `~/actions-runner` dir.
4. **Verify parallelism** with the documented `workflow_dispatch` of `e2e-vm-fake.yml` and check that the two matrix arms' `startedAt` timestamps overlap.

## Test plan

- [ ] Operator runs the four follow-up steps on api.lan.
- [ ] `gh workflow run e2e-vm-fake.yml` dispatched; both matrix arms (ipk + apk) `startedAt` overlap within ~10s.
- [ ] First Master Router CD run after deploy: Gate 2 ipk + apk + Gate 3a ipk + apk all run concurrently (4 jobs), total KVM wall time ≈ longest single job (~21m) instead of ~50m back-to-back.
- [ ] No `wh_pick_lan_bridge` "pool exhausted" failures in concurrent runs.
- [ ] `scripts/e2e-kvm-sanity` and `keep-staging-warm` cron still pick a bridge (should land on `wh-lan4` while CI is busy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)