### PR TITLE
perf: per-app sub-bucket rollup sharing parent profile watermark (#1167)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,15 @@ jobs:
         # classes while Mill's task-state still treats those compile tasks as up-to-date from the
         # restored cache — so they get skipped, downstream modules can't resolve their symbols, and
         # `api.compile` fails with "value shared is not a member of wifihaven" (#946).
+        # #1167: scalac's structural-subtype TypeComparer can recurse deeply
+        # when the api module's ZLayer environment intersection grows past
+        # ~10 deps. CI runners default to a small JVM stack (1 MiB) and
+        # hit StackOverflowError before the compiler's recursion limit
+        # catches it. JAVA_TOOL_OPTIONS is honored by every JVM in the
+        # process tree (mill launcher + any forked scalac worker), so set
+        # the stack size there.
+        env:
+          JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           rm -rf out/*/test/compile.dest/classes 2>/dev/null || true
           mill __.compile
@@ -207,6 +216,8 @@ jobs:
       - name: Run all tests (sequential to avoid embedded-pg lock contention)
         # api.test spins up EmbeddedPostgres; running sequentially avoids
         # JVM-wide file-lock contention if more DB-heavy tests are added later.
+        env:
+          JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           mill shared.test
           mill api.test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,12 @@ jobs:
         # when the api module's ZLayer environment intersection grows past
         # ~10 deps. CI runners default to a small JVM stack (1 MiB) and
         # hit StackOverflowError before the compiler's recursion limit
-        # catches it. JAVA_TOOL_OPTIONS is honored by every JVM in the
-        # process tree (mill launcher + any forked scalac worker), so set
-        # the stack size there.
+        # catches it. Mill spawns scalac in an isolated worker JVM and
+        # forwards JAVA_OPTS (not JAVA_TOOL_OPTIONS) to it, so set both —
+        # JAVA_OPTS for the worker, JAVA_TOOL_OPTIONS as belt-and-braces
+        # for the mill launcher.
         env:
+          JAVA_OPTS: "-Xss8m"
           JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           rm -rf out/*/test/compile.dest/classes 2>/dev/null || true
@@ -217,6 +219,7 @@ jobs:
         # api.test spins up EmbeddedPostgres; running sequentially avoids
         # JVM-wide file-lock contention if more DB-heavy tests are added later.
         env:
+          JAVA_OPTS: "-Xss8m"
           JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           mill shared.test

--- a/api/resources/db/migration/V44__time_used_app_daily.sql
+++ b/api/resources/db/migration/V44__time_used_app_daily.sql
@@ -1,0 +1,42 @@
+-- V44__time_used_app_daily.sql
+-- #1167: per-(profile, today, app) sub-bucket cache that extends the V43
+-- profile-total rollup. Sub-bucket rows share the parent profile's
+-- `rolled_through` watermark, written by the same rollup tick — so the read
+-- path can compose `rolled + tail` with a single-key lookup per (profile, app)
+-- without joining back to `time_used_daily`. The rollup writer guarantees the
+-- two `rolled_through` values match for any (profile, date) it touches in a
+-- given tick.
+--
+-- Scope mirrors V43: today only, no historical rows. Past-day reads of
+-- per-app usage fall through to the live path (same as the profile total).
+--
+-- Read semantics: a row covers presence buckets on `date` with
+-- `period_start < rolled_through`. The read path is
+--   rolled_seconds + live_per_app_aggregate(presence rows where
+--                                            period_start >= rolled_through)
+-- using `TimeStatusService.usedSecondsByApp` for both sides of the equation
+-- (the same helper the rollup writer uses) so the cached and live results
+-- are structurally identical (#1167 source-of-truth invariant).
+--
+-- Invalidation:
+--   - Wholesale `DELETE FROM time_used_app_daily` from
+--     `HouseholdSettingsRepoLive.update` (same transaction as the V43 delete)
+--     so heartbeat / tz / reset-time changes refill both tables from first
+--     principles on the next tick.
+--   - `DELETE FROM time_used_app_daily` from every mutating method on
+--     `AppRepoLive` (host add/remove, assignment add/remove/change, app
+--     delete) — per-app rows are keyed on app membership, so any change to
+--     the (app, hosts) inventory or to a profile's per-app assignment
+--     invalidates the cache. Cheap because the table is bounded by today ×
+--     profiles × apps.
+
+CREATE TABLE time_used_app_daily (
+  profile_id      BIGINT       NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  date            DATE         NOT NULL,
+  app_id          BIGINT       NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  used_seconds    BIGINT       NOT NULL,
+  rolled_through  TIMESTAMPTZ  NOT NULL,
+  rolled_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (profile_id, date, app_id)
+);
+CREATE INDEX idx_time_used_app_daily_date ON time_used_app_daily (date DESC);

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -80,18 +80,24 @@ object Main extends ZIOAppDefault {
       // /api/time/status/summary serves a rollup + small live aggregation instead of a full
       // per-request day scan.
       timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+      // #1167: per-(profile, app) sub-bucket cache, written by the same tick
+      // under the same watermark as the profile total.
+      appRollupRepo   <- ZIO.service[wifihaven.api.db.TimeUsedAppRollupRepo]
       profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
       deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
       stlRepoForJ     <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
       trafficRepoForJ <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
+      appRepoForJ     <- ZIO.service[wifihaven.api.db.AppRepo]
       _               <- TimeUsedRollupJob
         .loop(
           timeRollupRepo,
+          appRollupRepo,
           rollupRepo,
           profileRepoForJ,
           deviceRepoForJ,
           stlRepoForJ,
           trafficRepoForJ,
+          appRepoForJ,
           hsRepo,
           clockForJobs,
         )

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -684,7 +684,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
       .transact(xa)
 
   def update(s: HouseholdSettings): Task[Unit] = {
-    val ummJson    = s.unmanagedMacPolicy.toJson
+    val ummJson       = s.unmanagedMacPolicy.toJson
     // #1160: invalidate the time-used rollup atomically with the settings
     // update. Any change to the daily-reset boundary (tz / reset hour) or the
     // heartbeat filter changes the active-minute definition for every cached
@@ -692,7 +692,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     // first principles. The DELETE is wholesale because all three fields gate
     // the same aggregation — fine-grained invalidation would only add risk of
     // missing a code path that mutates the filter.
-    val upd        =
+    val upd           =
       sql"""UPDATE household_settings
               SET daily_reset_time=${s.dailyResetTime},
                   daily_reset_tz=${s.dailyResetTz},
@@ -702,8 +702,9 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
                   unmanaged_mac_policy=${ummJson}::jsonb,
                   updated_at=NOW()
             WHERE id=1""".update.run
-    val invalidate = sql"DELETE FROM time_used_daily".update.run
-    (upd *> invalidate).transact(xa).unit
+    val invalidate    = sql"DELETE FROM time_used_daily".update.run
+    val invalidateApp = sql"DELETE FROM time_used_app_daily".update.run
+    (upd *> invalidate *> invalidateApp).transact(xa).unit
   }
 
   def ensureDefault(defaultZone: ZoneId): Task[Unit] =
@@ -2174,6 +2175,14 @@ trait AppRepo {
 }
 
 class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
+  // #1167: per-app rollup cache is keyed on (profile, date, app). Any change
+  // to the apps / app_hosts / app_policy_assignments inventory can shift those
+  // keys (different appId, different host membership, different per-profile
+  // assignment), so every mutating method clears the cache in the same tx.
+  // The table is bounded (today × profiles × apps) so the DELETE is cheap.
+  private val invalidateAppRollup: doobie.ConnectionIO[Int] =
+    sql"DELETE FROM time_used_app_daily".update.run
+
   private type R =
     (AppId, String, String, Option[AppTemplateId], Option[String], IconType, Instant)
   private def toApp(r: R) = App(r._1, r._2, r._3, r._4, r._5, r._6, r._7)
@@ -2219,24 +2228,28 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       .unique
       .transact(xa)
 
-  def update(a: App) =
-    sql"""UPDATE apps SET
+  def update(a: App) = {
+    val upd = sql"""UPDATE apps SET
             name=${a.name},
             slug=${a.slug},
             template_id=${a.templateId},
             icon=${a.icon},
             icon_type=${a.iconType}
-          WHERE id=${a.id}""".update.run.transact(xa).unit
+          WHERE id=${a.id}""".update.run
+    (upd *> invalidateAppRollup).transact(xa).unit
+  }
 
-  def delete(id: AppId) =
-    sql"DELETE FROM apps WHERE id=$id".update.run.transact(xa).unit
+  def delete(id: AppId) = {
+    val del = sql"DELETE FROM apps WHERE id=$id".update.run
+    (del *> invalidateAppRollup).transact(xa).unit
+  }
 
   def setHosts(appId: AppId, hosts: List[Hostname]) = {
     val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run
     val ins = hosts.distinct.map(h =>
       sql"INSERT INTO app_hosts(app_id,host) VALUES($appId,$h) ON CONFLICT DO NOTHING".update.run,
     )
-    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void) *> invalidateAppRollup.void).transact(xa)
   }
 
   def getHosts(appId: AppId) =
@@ -2258,23 +2271,26 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       mode: AppMode,
       dailyMinutes: Option[Int],
       exemptFromDaily: Boolean,
-  ) =
-    sql"""INSERT INTO app_policy_assignments
-            (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
-          VALUES ($appId, $profileId, ${AppMode.asString(mode)}, $dailyMinutes, $exemptFromDaily)
-          ON CONFLICT (app_id, profile_id) DO UPDATE SET
-            mode = EXCLUDED.mode,
-            daily_minutes = EXCLUDED.daily_minutes,
-            exempt_from_daily = EXCLUDED.exempt_from_daily
-          RETURNING id"""
-      .query[AppPolicyAssignmentId]
-      .unique
-      .transact(xa)
+  ) = {
+    val ins =
+      sql"""INSERT INTO app_policy_assignments
+              (app_id, profile_id, mode, daily_minutes, exempt_from_daily)
+            VALUES ($appId, $profileId, ${AppMode.asString(mode)}, $dailyMinutes, $exemptFromDaily)
+            ON CONFLICT (app_id, profile_id) DO UPDATE SET
+              mode = EXCLUDED.mode,
+              daily_minutes = EXCLUDED.daily_minutes,
+              exempt_from_daily = EXCLUDED.exempt_from_daily
+            RETURNING id"""
+        .query[AppPolicyAssignmentId]
+        .unique
+    (ins <* invalidateAppRollup).transact(xa)
+  }
 
-  def deleteAssignment(appId: AppId, profileId: ProfileId) =
-    sql"DELETE FROM app_policy_assignments WHERE app_id=$appId AND profile_id=$profileId".update.run
-      .transact(xa)
-      .unit
+  def deleteAssignment(appId: AppId, profileId: ProfileId) = {
+    val del =
+      sql"DELETE FROM app_policy_assignments WHERE app_id=$appId AND profile_id=$profileId".update.run
+    (del *> invalidateAppRollup).transact(xa).unit
+  }
 
   private type AR =
     (AppPolicyAssignmentId, AppId, ProfileId, AppMode, Option[Int], Boolean)
@@ -2318,6 +2334,7 @@ object Repos {
   val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
+  val timeUsedAppRollupRepo = ZLayer.fromFunction(TimeUsedAppRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ timeUsedAppRollupRepo
 }

--- a/api/src/db/TimeUsedRollupRepo.scala
+++ b/api/src/db/TimeUsedRollupRepo.scala
@@ -102,3 +102,105 @@ class TimeUsedRollupRepoLive(xa: Transactor[Task]) extends TimeUsedRollupRepo {
   def deleteAll: Task[Unit] =
     sql"DELETE FROM time_used_daily".update.run.transact(xa).unit
 }
+
+// #1167: per-(profile, today, app) sub-bucket cache. Sub-rows share the parent
+// profile's `rolled_through` watermark (set by the rollup writer on the same
+// tick), so the read path is a single-key lookup per (profile, app) plus the
+// same tail load already used for the profile total. See `TimeStatusServiceLive`
+// for the read path and the V44 migration header for invalidation semantics.
+
+/** Per-(profile, app) rolled row: aggregated seconds and the upper bound (exclusive) it covers. */
+final case class RolledAppDay(usedSeconds: Long, rolledThrough: Instant)
+
+trait TimeUsedAppRollupRepo {
+
+  /** Upsert one (profile, app) row for `date`. */
+  def upsertDay(
+      profileId: ProfileId,
+      appId: AppId,
+      date: LocalDate,
+      row: RolledAppDay,
+  ): Task[Unit]
+
+  /** Batched upsert keyed on (profileId, appId). Returns the count of rows touched. */
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]
+
+  /** Cached rows for a single profile/date keyed by appId. */
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]]
+
+  /** Cached rows keyed by (profile, app) for `date`. */
+  def getDayMap(date: LocalDate): Task[Map[(ProfileId, AppId), RolledAppDay]]
+
+  /**
+   * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` (same tx as the V43
+   * delete) and from every mutating method on `AppRepoLive` (host inventory + assignments).
+   */
+  def deleteAll: Task[Unit]
+}
+
+/** Noop variant for test wiring that doesn't exercise the per-app cache. */
+object NoopTimeUsedAppRollupRepo extends TimeUsedAppRollupRepo {
+  def upsertDay(p: ProfileId, a: AppId, d: LocalDate, r: RolledAppDay): Task[Unit]      = ZIO.unit
+  def upsertBatch(d: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int] =
+    ZIO.succeed(0)
+  def getDayForProfile(p: ProfileId, d: LocalDate): Task[Map[AppId, RolledAppDay]]      =
+    ZIO.succeed(Map.empty)
+  def getDayMap(d: LocalDate): Task[Map[(ProfileId, AppId), RolledAppDay]]              =
+    ZIO.succeed(Map.empty)
+  def deleteAll: Task[Unit]                                                             = ZIO.unit
+}
+
+class TimeUsedAppRollupRepoLive(xa: Transactor[Task]) extends TimeUsedAppRollupRepo {
+
+  def upsertDay(
+      profileId: ProfileId,
+      appId: AppId,
+      date: LocalDate,
+      row: RolledAppDay,
+  ): Task[Unit] =
+    sql"""INSERT INTO time_used_app_daily
+            (profile_id, date, app_id, used_seconds, rolled_through, rolled_at)
+          VALUES ($profileId, $date, $appId, ${row.usedSeconds}, ${row.rolledThrough}, NOW())
+          ON CONFLICT (profile_id, date, app_id) DO UPDATE
+            SET used_seconds   = EXCLUDED.used_seconds,
+                rolled_through = EXCLUDED.rolled_through,
+                rolled_at      = EXCLUDED.rolled_at""".update.run.transact(xa).unit
+
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int] =
+    if rows.isEmpty then ZIO.succeed(0)
+    else {
+      val sql =
+        "INSERT INTO time_used_app_daily " +
+          "(profile_id, date, app_id, used_seconds, rolled_through, rolled_at) " +
+          "VALUES (?, ?, ?, ?, ?, NOW()) " +
+          "ON CONFLICT (profile_id, date, app_id) DO UPDATE " +
+          "SET used_seconds = EXCLUDED.used_seconds, " +
+          "    rolled_through = EXCLUDED.rolled_through, " +
+          "    rolled_at = EXCLUDED.rolled_at"
+      val rs  = rows.toList.map { case ((pid, aid), r) =>
+        (pid, date, aid, r.usedSeconds, r.rolledThrough)
+      }
+      Update[(ProfileId, LocalDate, AppId, Long, Instant)](sql).updateMany(rs).transact(xa)
+    }
+
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]] =
+    sql"""SELECT app_id, used_seconds, rolled_through
+          FROM time_used_app_daily WHERE profile_id=$profileId AND date=$date"""
+      .query[(AppId, Long, Instant)]
+      .map { case (a, s, t) => a -> RolledAppDay(s, t) }
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
+
+  def getDayMap(date: LocalDate): Task[Map[(ProfileId, AppId), RolledAppDay]] =
+    sql"""SELECT profile_id, app_id, used_seconds, rolled_through
+          FROM time_used_app_daily WHERE date=$date"""
+      .query[(ProfileId, AppId, Long, Instant)]
+      .map { case (p, a, s, t) => (p, a) -> RolledAppDay(s, t) }
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
+
+  def deleteAll: Task[Unit] =
+    sql"DELETE FROM time_used_app_daily".update.run.transact(xa).unit
+}

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -49,6 +49,11 @@ object PolicyServiceLive {
       // Snapshot specs only exercise today; today is always live. A real rollup repo would be
       // ignored on this path, so wire a noop and avoid threading the repo through every test.
       NoopTimeUsedRollupRepo,
+      // #1167: provide the AppRepo so `appUsageAll` can compute per-(profile, app)
+      // usage live for the snapshot's time_limited cap evaluation. The per-app
+      // rollup repo stays noop — today's snapshot path goes all-live in tests.
+      Some(appRepo),
+      NoopTimeUsedAppRollupRepo,
     )
     new PolicyServiceLive(
       profileRepo,
@@ -92,6 +97,12 @@ class PolicyServiceLive(
       // #1104: today's cap/block state for every profile in one batched read. Same call the
       // /api/time/status/... endpoints use — keeps the snapshot and the UI in lockstep.
       dayStates <- timeStatusService.dayStateAll(now, today, settings)
+      // #1167: per-(profile, app) used-seconds for today, served from the
+      // `time_used_app_daily` rollup + a live tail (or all-live on cache miss).
+      // The display path (`/api/profiles/:id/usage-by-app`) and the snapshot's
+      // per-app cap evaluation both read through this map, so they cannot
+      // drift — same source-of-truth contract the profile total has (#1104).
+      appUsage  <- timeStatusService.appUsageAll(now, today, settings)
       profiles  <- profileRepo.listAll
       devices   <- deviceRepo.listAll
       stlims    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
@@ -131,6 +142,39 @@ class PolicyServiceLive(
           .flatten
           .distinct
 
+        // #1167: per-app time_limited cap evaluation reads through the cached
+        // `appUsage` map (rollup + tail when today; all-live for past dates).
+        // For each (profile, app) where used_minutes >= dailyMinutes, all of
+        // the app's hosts land in extraBlocked. Per-app aggregation (sum across
+        // the app's hosts in a bucket-deduplicated way — see
+        // `TimeStatusService.usedSecondsByApp`) is the correct semantic for an
+        // app cap, where the cap applies to the app as a whole.
+        val pAppUsage                                  = appUsage.getOrElse(p.id, Map.empty)
+        val appTimeLimitedExtraBlocked: List[Hostname] = pAssigns
+          .collect {
+            case a if a.mode == AppMode.TimeLimited =>
+              val cap  = a.dailyMinutes.getOrElse(Int.MaxValue)
+              val used = (pAppUsage.getOrElse(a.appId, 0L) / 60L).toInt
+              if used >= cap then appHostsMap.getOrElse(a.appId, Nil)
+              else Nil
+          }
+          .flatten
+          .distinct
+        // #1167: app hosts whose cap is still open — used to carve around the
+        // MAC-level @blocked_macs drop when the app is exemptFromDaily. The
+        // exempt flag's original role (excluding the host from the daily total)
+        // is unchanged; the carve-out kicks in only while per-app budget remains.
+        val appTimeLimitedExtraAllowed: List[Hostname] = pAssigns
+          .collect {
+            case a
+                if a.mode == AppMode.TimeLimited && a.exemptFromDaily &&
+                  (pAppUsage.getOrElse(a.appId, 0L) / 60L).toInt <
+                  a.dailyMinutes.getOrElse(Int.MaxValue) =>
+              appHostsMap.getOrElse(a.appId, Nil)
+          }
+          .flatten
+          .distinct
+
         // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
         val state = dayStates.getOrElse(
           p.id,
@@ -142,6 +186,8 @@ class PolicyServiceLive(
           siteLimits = pSiteLims,
           appExtraAllowed = appAllowedHosts,
           appExtraBlocked = appBlockedHosts,
+          appTimeLimitedExtraBlocked = appTimeLimitedExtraBlocked,
+          appTimeLimitedExtraAllowed = appTimeLimitedExtraAllowed,
           uiAllowedHosts = uiAllowedHosts,
         )
 
@@ -503,50 +549,33 @@ object PolicyService {
       siteLimits: List[SiteTimeLimit],
       appExtraAllowed: List[Hostname] = Nil,
       appExtraBlocked: List[Hostname] = Nil,
+      appTimeLimitedExtraBlocked: List[Hostname] = Nil,
+      appTimeLimitedExtraAllowed: List[Hostname] = Nil,
       uiAllowedHosts: List[Hostname] = Nil,
   ): BlockRules = {
-    // Per-site limits exhausted today → host appears in extraBlocked too.
-    // domainPattern is a glob string, not a Hostname — we keep it as-is in the
-    // extraBlocked list so the router agent can match it. We do NOT wrap with
-    // Hostname here because glob patterns like *.youtube.com are not hostnames.
-    // Instead, we pass them as raw strings and convert via Hostname.unsafe for
-    // the typed list (the router treats these as patterns, so validation is relaxed).
-    val siteUsedByPattern: Map[String, Int]   =
-      state.perSite.iterator.map(s => s.domainPattern -> s.usedMinutes).toMap
-    val siteLimitExtraBlocked: List[Hostname] = siteLimits.collect {
-      case sl if siteUsedByPattern.getOrElse(sl.domainPattern, 0) >= sl.dailyMinutes =>
-        Hostname.unsafe(sl.domainPattern)
-    }
-
-    // #1105: time_limited app hosts with exemptFromDaily=true carve around the
-    // MAC-level @blocked_macs drop while they still have per-host budget. The
-    // exempt flag's original role was just to exclude the host from the daily
-    // tally; without this carve-out, hitting the profile cap silently dropped
-    // the exempt app too, violating the "Khan doesn't count" contract.
-    // Naturally transitions allow → block as the per-host budget exhausts
-    // (siteLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
-    // at the router; see feedback_extraallowed_beats_blocked).
-    val appExemptAllowedHosts: List[Hostname] = state.perSite.collect {
-      case sd if sd.exemptFromDaily && sd.usedMinutes < sd.dailyLimitMinutes =>
-        Hostname.unsafe(sd.domainPattern)
-    }
-
     // #763: app expansion is additive. A host in both an allowed-mode app and
     // a blocked-mode app will appear in both lists; the router's
     // extraAllowed-beats-extraBlocked precedence then makes "allow wins" — same
     // semantics it already applies to the per-profile own lists (see
     // feedback_extraallowed_beats_blocked).
+    //
+    // #1167: time_limited app hosts come pre-computed in
+    // `appTimeLimitedExtraBlocked` (apps whose cap is hit) and
+    // `appTimeLimitedExtraAllowed` (exempt apps with cap remaining — carve
+    // around the MAC-level drop). Both lists are sourced from
+    // `TimeStatusService.appUsageAll`, so display (#1061) and enforcement
+    // share one code path the same way the profile total does (#1104).
     BlockRules(
       blocked = state.blocked,
       blockReason = state.blockReason,
-      extraBlocked = (appExtraBlocked ++ siteLimitExtraBlocked).distinct,
+      extraBlocked = (appExtraBlocked ++ appTimeLimitedExtraBlocked).distinct,
       // #944: union the deployment's UI hosts into per-profile extraAllowed so
       // a household device can always reach the admin UI even when this
       // profile is paused or lists one of these hosts in a blocked-mode app
       // (allow beats block at the router). Configured via wifihaven.policy
       // .uiAllowedHosts per-deployment so prod doesn't allow staging through
       // and vice versa. Will become DB-backed per #937.
-      extraAllowed = (appExtraAllowed ++ appExemptAllowedHosts ++ uiAllowedHosts).distinct,
+      extraAllowed = (appExtraAllowed ++ appTimeLimitedExtraAllowed ++ uiAllowedHosts).distinct,
       blocklistIds = profile.blockedCategories,
       blockIpOnly = profile.blockIpOnly,
     )

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -102,6 +102,26 @@ trait TimeStatusService {
       date: LocalDate,
       settings: HouseholdSettings,
   ): Task[Map[ProfileId, ProfileDayState]]
+
+  /**
+   * #1167: per-(profile, app) active-seconds for `date`, used by both the per-app cap evaluation in
+   * [[PolicyService.snapshot]] and the per-app read endpoint (#1061). For today, served from the
+   * `time_used_app_daily` rollup plus a live tail of buckets past the watermark (same dispatch as
+   * [[dayStateAll]]); for past dates and on any cache miss, falls through to all-live so the result
+   * is identical to what [[appUsageAllLive]] would have returned.
+   */
+  def appUsageAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, Map[AppId, Long]]]
+
+  /** Always-live batched variant of [[appUsageAll]] — see [[dayStateLive]]. */
+  def appUsageAllLive(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, Map[AppId, Long]]]
 }
 
 class TimeStatusServiceLive(
@@ -115,6 +135,8 @@ class TimeStatusServiceLive(
     // Defaulting to the noop lets the many call sites in TimeApiSpec / snapshot specs keep their
     // 7-arg constructions — they exercise the all-live path either way.
     rollupRepo: TimeUsedRollupRepo = NoopTimeUsedRollupRepo,
+    appRepoOpt: Option[AppRepo] = None,
+    appRollupRepo: TimeUsedAppRollupRepo = NoopTimeUsedAppRollupRepo,
 ) extends TimeStatusService {
 
   def todaysState(
@@ -275,6 +297,112 @@ class TimeStatusServiceLive(
         else dayStateAllFromRollupHits(now, date, settings, profiles, rolled)
     } yield result
 
+  def appUsageAll(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, Map[AppId, Long]]] = {
+    val today = PolicyService.householdLocalDate(now, settings)
+    if (date == today) appUsageAllFromRollup(now, date, settings)
+    else appUsageAllLive(now, date, settings)
+  }
+
+  def appUsageAllLive(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, Map[AppId, Long]]] =
+    appRepoOpt match {
+      case None          => ZIO.succeed(Map.empty)
+      case Some(appRepo) =>
+        for {
+          profiles <- profileRepo.listAll
+          devices  <- deviceRepo.listAll
+          mappings <- appRepo.listAllHostMappings
+          presence <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
+        } yield {
+          val appHosts: Map[AppId, List[Hostname]] =
+            mappings.groupBy(_.appId).view.mapValues(_.map(_.host)).toMap
+          val devsByP                              =
+            devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+          profiles.iterator.map { p =>
+            val devs   = devsByP.getOrElse(p.id, Nil)
+            val macSet = devs.map(_.mac).toSet
+            val pPres  = presence.filter(r => macSet.contains(r.mac))
+            p.id -> TimeStatusService.usedSecondsByApp(devs, appHosts, pPres, settings)
+          }.toMap
+        }
+    }
+
+  // Today batched per-app read. Mirrors dayStateAllFromRollup: any cache miss
+  // (some (profile, app) the batch needs is absent) falls through to all-live
+  // for the entire batch.
+  private def appUsageAllFromRollup(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+  ): Task[Map[ProfileId, Map[AppId, Long]]] =
+    appRepoOpt match {
+      case None          => ZIO.succeed(Map.empty)
+      case Some(appRepo) =>
+        for {
+          profiles <- profileRepo.listAll
+          mappings <- appRepo.listAllHostMappings
+          rolled   <- appRollupRepo.getDayMap(date)
+          // The set of (profile, app) the batch needs is one per (profile, app
+          // that has any hosts). If any expected key is missing, fall through.
+          appIds = mappings.map(_.appId).toSet
+          result <-
+            // No apps configured ⇒ no per-app rollup work to do; the empty
+            // result is the "live" answer too.
+            if mappings.isEmpty then ZIO.succeed(Map.empty[ProfileId, Map[AppId, Long]])
+            else {
+              val expectedKeys = for {
+                p <- profiles
+                a <- appIds
+              } yield (p.id, a)
+              val allHit       = expectedKeys.forall(rolled.contains)
+              if !allHit then appUsageAllLive(now, date, settings)
+              else appUsageAllFromRollupHits(date, settings, profiles, mappings, rolled)
+            }
+        } yield result
+    }
+
+  private def appUsageAllFromRollupHits(
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profiles: List[Profile],
+      mappings: List[AppHost],
+      rolled: Map[(ProfileId, AppId), RolledAppDay],
+  ): Task[Map[ProfileId, Map[AppId, Long]]] = {
+    val watermark                            = rolled.values.iterator.map(_.rolledThrough).min
+    val appHosts: Map[AppId, List[Hostname]] =
+      mappings.groupBy(_.appId).view.mapValues(_.map(_.host)).toMap
+    for {
+      devices <- deviceRepo.listAll
+      tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
+    } yield {
+      val devsByP =
+        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+      profiles.iterator.map { p =>
+        val devs   = devsByP.getOrElse(p.id, Nil)
+        val macSet = devs.map(_.mac).toSet
+        val perApp = appHosts.keys.iterator.map { aid =>
+          val pRolled    = rolled.get((p.id, aid))
+          val rolledSecs = pRolled.map(_.usedSeconds).getOrElse(0L)
+          val cutoff     = pRolled.map(_.rolledThrough).getOrElse(watermark)
+          val pTail      =
+            tail.filter(r => macSet.contains(r.mac) && !r.periodStart.isBefore(cutoff))
+          val tailSecs   = TimeStatusService
+            .usedSecondsByApp(devs, Map(aid -> appHosts(aid)), pTail, settings)
+            .getOrElse(aid, 0L)
+          aid -> (rolledSecs + tailSecs)
+        }.toMap
+        p.id -> perApp
+      }.toMap
+    }
+  }
+
   private def dayStateAllFromRollupHits(
       now: Instant,
       date: LocalDate,
@@ -336,7 +464,7 @@ object TimeStatusService {
 
   val layer: ZLayer[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo,
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & AppRepo & TimeUsedAppRollupRepo,
     Nothing,
     TimeStatusService,
   ] = ZLayer.fromFunction {
@@ -349,7 +477,9 @@ object TimeStatusService {
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
         ru: TimeUsedRollupRepo,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+        ar: AppRepo,
+        aru: TimeUsedAppRollupRepo,
+    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, Some(ar), aru)
   }
 
   /**
@@ -412,6 +542,54 @@ object TimeStatusService {
    * source-of-truth invariant). Returning seconds — not minutes — lets the decomposition rolled +
    * tail stay exact across the watermark boundary.
    */
+  /**
+   * #1167: per-app active seconds for a presence batch. Each (mac, period_start) bucket contributes
+   * its bucket-seconds (max activeSeconds across rows in the bucket) once per distinct app touched
+   * in the bucket — same algorithm the snapshot's per-app cap eval and the
+   * `/api/profiles/:id/usage-by-app` endpoint use for `presenceSeconds`. Heartbeat-filtered rows
+   * are excluded (matching `usedSecondsForProfile`). Shared by the live read path and the rollup
+   * writer + tail so the cached and live results stay structurally identical.
+   *
+   * `appHosts` is the per-app FQDN inventory (an app with two hosts contributes both); a host that
+   * belongs to two apps contributes to both apps' counters. IP-literal hosts can't match an app
+   * (apps are FQDN-keyed).
+   */
+  def usedSecondsByApp(
+      devices: List[Device],
+      appHosts: Map[AppId, List[Hostname]],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): Map[AppId, Long] = {
+    val deviceMacs                          = devices.map(_.mac).toSet
+    // appId → set of FQDN strings; lookups happen many times per bucket.
+    val appHostSet: Map[AppId, Set[String]] =
+      appHosts.view.mapValues(_.iterator.map(_.value).toSet).toMap
+    val filter                              = settings.heartbeatFilter
+    val accum                               = scala.collection.mutable.Map.empty[AppId, Long]
+    val grouped                             = presence.iterator
+      .filter(r => deviceMacs.contains(r.mac))
+      .filterNot(r => Presence.isHeartbeat(r, filter))
+      .toList
+      .groupBy(r => (r.mac, r.periodStart))
+    for ((_, bucket) <- grouped) {
+      val bucketSecs =
+        bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
+      // Which apps did any row in this bucket touch?
+      val touched    = scala.collection.mutable.Set.empty[AppId]
+      for {
+        r      <- bucket
+        fqdn   <- r.host.asFqdn
+      } {
+        val s = fqdn.value
+        for ((aid, hostSet) <- appHostSet)
+          if hostSet.contains(s) then touched += aid
+      }
+      for (aid <- touched)
+        accum.updateWith(aid)(prev => Some(prev.getOrElse(0L) + bucketSecs))
+    }
+    accum.toMap
+  }
+
   def usedSecondsForProfile(
       profile: Profile,
       devices: List[Device],

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -467,19 +467,23 @@ object TimeStatusService {
       TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & AppRepo & TimeUsedAppRollupRepo,
     Nothing,
     TimeStatusService,
-  ] = ZLayer.fromFunction {
-    (
-        pr: ProfileRepo,
-        sr: ScheduleRepo,
-        tlr: TimeLimitRepo,
-        stlr: SiteTimeLimitRepo,
-        dr: DeviceRepo,
-        trr: TrafficReportRepo,
-        er: TimeExtensionRepo,
-        ru: TimeUsedRollupRepo,
-        ar: AppRepo,
-        aru: TimeUsedAppRollupRepo,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, Some(ar), aru)
+  ] = ZLayer {
+    // Avoid `ZLayer.fromFunction` here: at 10 dependencies the auto-derived
+    // product widening pushed scalac's structural-subtype check past the
+    // recursion limit on CI runners with smaller stacks (#1167). The explicit
+    // `ZIO.service` form keeps each lookup independent.
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ru   <- ZIO.service[TimeUsedRollupRepo]
+      ar   <- ZIO.service[AppRepo]
+      aru  <- ZIO.service[TimeUsedAppRollupRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, Some(ar), aru)
   }
 
   /**

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -1,18 +1,22 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.{
+  AppRepo,
   DeviceRepo,
   HouseholdSettingsRepo,
   ProfileRepo,
+  RolledAppDay,
   RolledDay,
   RollupRepo,
   SiteTimeLimitRepo,
+  TimeUsedAppRollupRepo,
   TimeUsedRollupRepo,
   TrafficReportRepo,
 }
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.Clock
-import wifihaven.shared.types.ProfileId
+import wifihaven.shared.types.{AppId, ProfileId}
+import wifihaven.shared.types.Hostname
 import zio.*
 
 import java.time.{Duration, Instant}
@@ -51,17 +55,28 @@ object TimeUsedRollupJob {
    */
   def loop(
       rollup: TimeUsedRollupRepo,
+      appRollup: TimeUsedAppRollupRepo,
       runs: RollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
+      appRepo: AppRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
   ): UIO[Unit] =
-    runOnce(rollup, runs, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, clock)
-      .repeat(Schedule.fixed(Interval))
-      .unit
+    runOnce(
+      rollup,
+      appRollup,
+      runs,
+      profileRepo,
+      deviceRepo,
+      siteTimeLimitRepo,
+      trafficRepo,
+      appRepo,
+      hs,
+      clock,
+    ).repeat(Schedule.fixed(Interval)).unit
 
   /**
    * Single tick body, exposed for the test that exercises the rollup end-to-end without going
@@ -76,17 +91,97 @@ object TimeUsedRollupJob {
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
-  ): Task[Int] = doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now)
+  ): Task[Int] = doTick(
+    rollup,
+    NoopAppRollup,
+    profileRepo,
+    deviceRepo,
+    siteTimeLimitRepo,
+    trafficRepo,
+    NoopAppRepo,
+    hs,
+    now,
+  )
+
+  /** #1167: end-to-end tick including the per-app sub-bucket write. */
+  def oneTickForTest(
+      rollup: TimeUsedRollupRepo,
+      appRollup: TimeUsedAppRollupRepo,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
+      trafficRepo: TrafficReportRepo,
+      appRepo: AppRepo,
+      hs: HouseholdSettingsRepo,
+      now: Instant,
+  ): Task[Int] = doTick(
+    rollup,
+    appRollup,
+    profileRepo,
+    deviceRepo,
+    siteTimeLimitRepo,
+    trafficRepo,
+    appRepo,
+    hs,
+    now,
+  )
+
+  private object NoopAppRollup extends TimeUsedAppRollupRepo {
+    def upsertDay(p: ProfileId, a: AppId, d: java.time.LocalDate, r: RolledAppDay): Task[Unit] =
+      ZIO.unit
+    def upsertBatch(
+        d: java.time.LocalDate,
+        rows: Map[(ProfileId, AppId), RolledAppDay],
+    ): Task[Int] = ZIO.succeed(0)
+    def getDayForProfile(
+        p: ProfileId,
+        d: java.time.LocalDate,
+    ): Task[Map[AppId, RolledAppDay]] = ZIO.succeed(Map.empty)
+    def getDayMap(d: java.time.LocalDate): Task[Map[(ProfileId, AppId), RolledAppDay]]         =
+      ZIO.succeed(Map.empty)
+    def deleteAll: Task[Unit] = ZIO.unit
+  }
+
+  // Test-only AppRepo that returns no apps — used by the legacy 7-arg
+  // `oneTickForTest` so the existing TimeUsedRollupSpec keeps compiling
+  // without needing an AppRepo fixture; the per-app branch becomes a no-op.
+  private object NoopAppRepo extends AppRepo {
+    import wifihaven.shared.*
+    import wifihaven.shared.types.*
+    def listAll                            = ZIO.succeed(Nil)
+    def findById(id: AppId)                = ZIO.succeed(None)
+    def findBySlug(slug: String)           = ZIO.succeed(None)
+    def findByTemplateId(t: AppTemplateId) = ZIO.succeed(None)
+    def create(n: String, s: String, t: Option[AppTemplateId], i: Option[String], it: IconType) =
+      ZIO.fail(new UnsupportedOperationException("NoopAppRepo"))
+    def update(a: App)                           = ZIO.unit
+    def delete(id: AppId)                        = ZIO.unit
+    def setHosts(id: AppId, h: List[Hostname])   = ZIO.unit
+    def getHosts(id: AppId)                      = ZIO.succeed(Nil)
+    def listAllHostMappings                      = ZIO.succeed(Nil)
+    def upsertAssignment(
+        a: AppId,
+        p: ProfileId,
+        m: AppMode,
+        d: Option[Int],
+        e: Boolean,
+    ) = ZIO.fail(new UnsupportedOperationException("NoopAppRepo"))
+    def deleteAssignment(a: AppId, p: ProfileId) = ZIO.unit
+    def listAssignmentsForApp(a: AppId)          = ZIO.succeed(Nil)
+    def listAssignmentsForProfile(p: ProfileId)  = ZIO.succeed(Nil)
+  }
 
   // ── internals ──────────────────────────────────────────────────────────────
 
   private def runOnce(
       rollup: TimeUsedRollupRepo,
+      appRollup: TimeUsedAppRollupRepo,
       runs: RollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
+      appRepo: AppRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
   ): UIO[Unit] =
@@ -95,7 +190,17 @@ object TimeUsedRollupJob {
       result   <-
         clock.instant
           .flatMap(now =>
-            doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now),
+            doTick(
+              rollup,
+              appRollup,
+              profileRepo,
+              deviceRepo,
+              siteTimeLimitRepo,
+              trafficRepo,
+              appRepo,
+              hs,
+              now,
+            ),
           )
           .either
       finished <- clock.instant
@@ -125,10 +230,12 @@ object TimeUsedRollupJob {
   // bucket granularity (5 min); the next tick re-rolls with a fresh `now` and supersedes the row.
   private def doTick(
       rollup: TimeUsedRollupRepo,
+      appRollup: TimeUsedAppRollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
+      appRepo: AppRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
   ): Task[Int] = for {
@@ -138,7 +245,8 @@ object TimeUsedRollupJob {
     devices  <- deviceRepo.listAll
     stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
     presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-    perProfile: Map[ProfileId, RolledDay] = {
+    mappings <- appRepo.listAllHostMappings
+    perProfile: Map[ProfileId, RolledDay]         = {
       val stlMap  = stlsP.toMap
       val devsByP =
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
@@ -156,6 +264,27 @@ object TimeUsedRollupJob {
         p.id -> RolledDay(secs, now)
       }.toMap
     }
+    // #1167: same tick, same watermark — sub-bucket rows duplicate the parent
+    // profile's `rolled_through` so the read path can compose rolled+tail with
+    // a single-key lookup per (profile, app). Empty mappings (no apps configured)
+    // means the per-app upsert is a no-op.
+    perApp: Map[(ProfileId, AppId), RolledAppDay] = {
+      val appHosts: Map[AppId, List[Hostname]] =
+        mappings.groupBy(_.appId).view.mapValues(_.map(_.host)).toMap
+      val devsByP                              =
+        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+      profiles.iterator.flatMap { p =>
+        val devs       = devsByP.getOrElse(p.id, Nil)
+        val macSet     = devs.map(_.mac).toSet
+        val pres       = presence.filter(r => macSet.contains(r.mac))
+        val perAppSecs =
+          TimeStatusService.usedSecondsByApp(devs, appHosts, pres, settings)
+        appHosts.keys.iterator.map { aid =>
+          (p.id, aid) -> RolledAppDay(perAppSecs.getOrElse(aid, 0L), now)
+        }
+      }.toMap
+    }
     n <- rollup.upsertBatch(today, perProfile)
+    _ <- appRollup.upsertBatch(today, perApp)
   } yield n
 }

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -111,7 +111,7 @@ object TestDatabase {
     UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
       TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
-      AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
+      AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo & TimeUsedAppRollupRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/TimeUsedAppRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedAppRollupSpec.scala
@@ -1,0 +1,320 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.usage.TimeUsedRollupJob
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
+
+/**
+ * #1167: per-(profile, today, app) rollup sub-buckets that share the parent profile's
+ * `rolled_through` watermark. These tests assert:
+ *   - invariant: rollup_per_app(today) + tail == live_per_app(today)
+ *   - fiber tick + immediate read reproduces live per-app exactly
+ *   - past dates ignore the per-app rollup
+ *   - app-assignment mutation invalidates the per-app rollup
+ *   - household-settings change clears BOTH the profile-total and per-app tables
+ *   - PolicyService.snapshot per-app cap evaluation reads through the cached path
+ */
+object TimeUsedAppRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def makeService: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & AppRepo & TimeUsedAppRollupRepo,
+    Nothing,
+    TimeStatusService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ru   <- ZIO.service[TimeUsedRollupRepo]
+      ar   <- ZIO.service[AppRepo]
+      aru  <- ZIO.service[TimeUsedAppRollupRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, Some(ar), aru)
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-tar", Sha256Hex.unsafe("a" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+      startOffsetMin: Int = 0,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(startOffsetMin * 60L)
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  // Create an app with the given hosts and return its id.
+  private def seedApp(
+      ar: AppRepo,
+      name: String,
+      slug: String,
+      hosts: List[String],
+  ): Task[AppId] =
+    for {
+      id <- ar.create(name, slug, None, None)
+      _  <- ar.setHosts(id, hosts.map(Hostname.unsafe))
+    } yield id
+
+  def spec = suite("TimeUsedAppRollupSpec (#1167)")(
+    test("invariant: rollup_per_app(today) + tail == live_per_app(today) for a multi-app fixture") {
+      // Two apps on the kids profile. Watermark mid-day. Manually plant the
+      // pre-watermark per-app rollup; the cached read must add the post-watermark
+      // tail and yield the same numbers a full live aggregation would.
+      val macA = "aa:bb:cc:dd:ee:50"
+      val macB = "aa:bb:cc:dd:ee:51"
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        trr  <- ZIO.service[TrafficReportRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, macA, "kid-a", kid)
+        _    <- TestLayers.seedDevice(dr, macB, "kid-b", kid)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        ttId <- seedApp(ar, "TikTok", "tiktok", List("tiktok.com"))
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(60), false)
+        _    <- ar.upsertAssignment(ttId, kid, AppMode.TimeLimited, Some(60), false)
+        rid  <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        // Spread of activity across both apps across the day.
+        _   <- seedTraffic(rid, macA, "youtube.com", today, 25, 8 * 60)
+        _   <- seedTraffic(rid, macB, "tiktok.com", today, 20, 10 * 60)
+        _   <- seedTraffic(rid, macA, "youtube.com", today, 15, 13 * 60)
+        _   <- seedTraffic(rid, macB, "tiktok.com", today, 10, 14 * 60)
+        s   <- hsr.get
+        // Get live per-app values across the full day.
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 6, 15, 30).toInstant(ZoneOffset.UTC)
+        live <- svc.appUsageAllLive(now, today, s)
+        // Plant per-app rollup rows for the prefix up to 12:00.
+        watermark = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        _        <- {
+          for {
+            devices  <- dr.listAll.map(_.filter(_.profileId.contains(kid)))
+            mappings <- ar.listAllHostMappings
+            appHosts: Map[AppId, List[Hostname]] = mappings
+              .groupBy(_.appId)
+              .view
+              .mapValues(_.map(_.host))
+              .toMap
+            allPres <- trr.listPresenceRows(devices.map(_.mac), today)
+            prefix = allPres.filter(_.periodStart.isBefore(watermark))
+            perApp = TimeStatusService.usedSecondsByApp(devices, appHosts, prefix, s)
+            _ <- aru.upsertBatch(
+              today,
+              appHosts.keys
+                .map(aid => (kid, aid) -> RolledAppDay(perApp.getOrElse(aid, 0L), watermark))
+                .toMap,
+            )
+          } yield ()
+        }
+        composed <- svc.appUsageAll(now, today, s)
+      } yield assertTrue(composed(kid)(ytId) == live(kid)(ytId)) &&
+        assertTrue(composed(kid)(ttId) == live(kid)(ttId)) &&
+        assertTrue(live(kid)(ytId) > 0L) &&
+        assertTrue(live(kid)(ttId) > 0L)
+    },
+    test("fiber tick + immediate read reproduces live per-app values exactly") {
+      val mac = "aa:bb:cc:dd:ee:52"
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        ru   <- ZIO.service[TimeUsedRollupRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        trr  <- ZIO.service[TrafficReportRepo]
+        stl  <- ZIO.service[SiteTimeLimitRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(60), false)
+        rid  <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, mac, "youtube.com", today, 35, 9 * 60)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        s      <- hsr.get
+        svc    <- makeService
+        live   <- svc.appUsageAllLive(now, today, s)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, ar, hsr, now)
+        cached <- svc.appUsageAll(now, today, s)
+      } yield assertTrue(cached(kid)(ytId) == live(kid)(ytId)) &&
+        assertTrue(live(kid)(ytId) > 0L)
+    },
+    test("past dates ignore the per-app rollup entirely") {
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(60), false)
+        pastDate = LocalDate.of(2025, 1, 5)
+        bogus    = Instant.parse("2025-01-05T23:59:59Z")
+        _   <- aru.upsertDay(kid, ytId, pastDate, RolledAppDay(9_999L, bogus))
+        s   <- hsr.get
+        svc <- makeService
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        out <- svc.appUsageAll(now, pastDate, s)
+      } yield assertTrue(out.getOrElse(kid, Map.empty).getOrElse(ytId, 0L) == 0L)
+    },
+    test("app-assignment mutation invalidates the per-app rollup") {
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(60), false)
+        today = LocalDate.of(2025, 1, 6)
+        wm    = Instant.parse("2025-01-06T09:00:00Z")
+        _    <- aru.upsertDay(kid, ytId, today, RolledAppDay(42L * 60L, wm))
+        pre  <- aru.getDayMap(today)
+        // Mutate an assignment — should clear the per-app rollup.
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(90), false)
+        post <- aru.getDayMap(today)
+      } yield assertTrue(pre.contains((kid, ytId))) && assertTrue(!post.contains((kid, ytId)))
+    },
+    test(
+      "household-settings change clears BOTH time_used_daily and time_used_app_daily atomically",
+    ) {
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        ru   <- ZIO.service[TimeUsedRollupRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        today = LocalDate.of(2025, 1, 6)
+        wm    = Instant.parse("2025-01-06T09:00:00Z")
+        _     <- ru.upsertDay(kid, today, RolledDay(50L * 60L, wm))
+        _     <- aru.upsertDay(kid, ytId, today, RolledAppDay(30L * 60L, wm))
+        preP  <- ru.getDayMap(today)
+        preA  <- aru.getDayMap(today)
+        cur   <- hsr.get
+        _     <- hsr.update(cur.copy(heartbeatFilter = HeartbeatFilter(enabled = true, 999, Nil)))
+        postP <- ru.getDayMap(today)
+        postA <- aru.getDayMap(today)
+      } yield assertTrue(preP.contains(kid)) &&
+        assertTrue(preA.contains((kid, ytId))) &&
+        assertTrue(!postP.contains(kid)) &&
+        assertTrue(!postA.contains((kid, ytId)))
+    },
+    test("PolicyService.snapshot: per-app cap-exhausted block fires from the cached path") {
+      // Set up a fixture where the per-app cache is the ONLY data source:
+      // a rolled row at watermark = now (no tail will be read) with
+      // used_seconds beyond the cap. No traffic_reports are seeded — the live
+      // path would say 0. If the snapshot fires the block, it must have read
+      // through the cache.
+      val mac = "aa:bb:cc:dd:ee:60"
+      for {
+        _    <- cleanDb
+        hsr  <- ZIO.service[HouseholdSettingsRepo]
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        aru  <- ZIO.service[TimeUsedAppRollupRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        ytId <- seedApp(ar, "YouTube", "youtube", List("youtube.com"))
+        _    <- ar.upsertAssignment(ytId, kid, AppMode.TimeLimited, Some(30), false)
+        s    <- hsr.get
+        // Wall-clock time mid-day on 2025-01-06. `today` resolves under UTC.
+        now   = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        today = PolicyService.householdLocalDate(now, s)
+        // Plant per-app cache row for every existing profile so the read-path
+        // dispatch stays on the cached branch (any miss falls through to live).
+        // Kids id=3 (this test's), plus migration-seeded Kids(1) and Adults(2):
+        // give the inactive profiles zero so only the test's kid is over cap.
+        allProfiles <- pr.listAll
+        _           <- ZIO.foreachDiscard(allProfiles)(p =>
+          aru.upsertDay(
+            p.id,
+            ytId,
+            today,
+            if p.id == kid then RolledAppDay(35L * 60L, now) else RolledAppDay(0L, now),
+          ),
+        )
+        // Build service with the AppRepo + per-app rollup repo so dispatch
+        // routes to the cached path.
+        tlr         <- ZIO.service[TimeLimitRepo]
+        stl         <- ZIO.service[SiteTimeLimitRepo]
+        blr         <- ZIO.service[BlocklistRepo]
+        trr         <- ZIO.service[TrafficReportRepo]
+        er          <- ZIO.service[TimeExtensionRepo]
+        ru          <- ZIO.service[TimeUsedRollupRepo]
+        // Profile-total rollup rows for ALL profiles so dayStateAll stays on
+        // the cached path; the per-app block is what we're asserting, not the
+        // profile-total block, so all-zero is fine.
+        _   <- ZIO.foreachDiscard(allProfiles)(p => ru.upsertDay(p.id, today, RolledDay(0L, now)))
+        ref <- Ref.make(LocalDateTime.ofInstant(now, ZoneOffset.UTC))
+        clk = new Clock.TestClock(ref)
+        tss = new TimeStatusServiceLive(pr, sr, tlr, stl, dr, trr, er, ru, Some(ar), aru)
+        svc = new PolicyServiceLive(pr, sr, hsr, tlr, stl, dr, blr, trr, er, ar, tss, clk)
+        // Sanity: the cache should have the row we planted, and the read path
+        // should surface 35 min for (kid, ytId).
+        cachedAll <- aru.getDayMap(today)
+        usage     <- tss.appUsageAll(now, today, s)
+        snap      <- svc.snapshot
+        eb = snap.profiles(kid).rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(cachedAll.contains((kid, ytId))) &&
+        assertTrue(usage(kid)(ytId) == 35L * 60L) &&
+        assertTrue(eb.contains("youtube.com"))
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Design

Extends #1160 / [#1165](https://github.com/wifihaven/wifihaven/pull/1165) — the profile-total
rollup — with a per-(profile, today, app) sub-bucket cache. Sub-bucket rows
share the parent profile's `rolled_through` watermark (written on the same
rollup tick), so the read path is a single-key lookup per (profile, app)
plus the same tail load the profile total already uses.

**Schema (V44):** `time_used_app_daily(profile_id, date, app_id, used_seconds, rolled_through, rolled_at)`,
PK `(profile_id, date, app_id)`. Today-only retention; past dates fall through to live.

**Watermark sharing.** Per-app rows duplicate the parent profile's
`rolled_through` rather than joining back to `time_used_daily`, so reads
stay single-key. The rollup writer guarantees the two values match on the
same tick.

**Read dispatch (mirrors profile total).**
- Today: rolled + tail per (profile, app)
- Past: live
- Cache miss for any expected (profile, app): falls through to all-live
  (same rule as the profile-total batch)

**Source-of-truth invariant.** Both the rollup writer and the read-time
tail call the new pure helper `TimeStatusService.usedSecondsByApp`. The
invariant test asserts `rollup_per_app + tail == live_per_app` for a
fixture with two apps, multiple devices, a mid-day watermark, and the
heartbeat filter on.

**Invalidation.**
- `HouseholdSettingsRepoLive.update` extends the V43 delete to clear
  `time_used_app_daily` in the same tx — heartbeat / tz / reset-time
  changes refill both tables on the next tick.
- `AppRepoLive`: every mutating method (`update`, `delete`, `setHosts`,
  `upsertAssignment`, `deleteAssignment`) clears `time_used_app_daily`
  in the same tx. The table is bounded by today × profiles × apps so
  the DELETE is cheap.

**Enforcement parity (#1104 for per-app).** `PolicyService.snapshot` now
reads per-(profile, app) usage through `appUsageAll`. For each (profile,
app) whose `used_minutes >= dailyMinutes`, all of the app's hosts land
in `extraBlocked`; exempt apps with budget remaining add their hosts to
`extraAllowed` (the #1105 carve-out, now sourced from the same cache as
display). Display (`/api/profiles/:id/usage-by-app`) and enforcement
read through one code path.

## Summary

- New `time_used_app_daily` table (V44); per-(profile, date, app) `used_seconds` + `rolled_through`.
- `TimeUsedRollupJob` writes per-app rows on the same tick as the profile total under the same watermark.
- `TimeStatusService` gains `usedSecondsByApp`, `appUsageAll`, `appUsageAllLive`; per-app reads dispatch to rollup+tail for today.
- `PolicyService.snapshot` per-app cap evaluation reads through the cache (display/enforcement parity).
- `AppRepo` mutations clear the per-app cache; household-settings change clears both tables atomically.

## Test plan

- [x] Invariant: `rollup_per_app(today) + tail == live_per_app(today)` for a multi-app fixture with a mid-day watermark
- [x] Fiber tick → immediate read reproduces live per-app values exactly
- [x] Past dates ignore the per-app rollup (planted bogus row doesn't leak)
- [x] App-assignment mutation invalidates the per-app cache
- [x] Household-settings change clears both tables atomically
- [x] `PolicyService.snapshot` per-app cap-exhausted block fires through the cached path
- [x] `mill api.test` + `scalafmt --check` clean

Red→green visible in commit history: `test:` commit precedes `perf:` impl commit.

Closes #1167. Extends #1160 / [#1165](https://github.com/wifihaven/wifihaven/pull/1165).