### PR TITLE
ux(web): move Pause + Delete into collapsed profile row (#1063)

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -313,15 +313,19 @@ describe('ProfilesPage — +Time mutation (#972 / #946)', () => {
   })
 })
 
-describe('ProfilesPage — pause / delete', () => {
-  // #406: pause is now an explicit PUT with the full profile + paused=!current.
-  // The previous POST /pause endpoint was a server-side toggle (race-prone).
-  it('clicking Pause calls api.profiles.update with paused=true and reloads', async () => {
+describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
+  // #1063 — Pause/Resume + Delete were moved from the expanded body into the
+  // collapsed summary row (alongside the +Time button). The card no longer
+  // needs to be expanded to reach either action.
+  // #406: pause is still an explicit PUT with the full profile + paused=!current.
+  it('Pause button is rendered in the collapsed row and fires update without expanding', async () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
-    await expand(1, user)
-    await user.click(within(kidsCard).getByRole('button', { name: /Pause/ }))
+    // collapsed body is hidden — no schedule subsection visible
+    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    const pauseBtn = within(kidsCard).getByTestId('profile-row-pause-1')
+    await user.click(pauseBtn)
     await waitFor(() =>
       expect(api.profiles.update).toHaveBeenCalledWith(
         1,
@@ -331,12 +335,12 @@ describe('ProfilesPage — pause / delete', () => {
     await waitFor(() => expect(api.profiles.list).toHaveBeenCalledTimes(2))
   })
 
-  it('clicking Resume calls api.profiles.update with paused=false', async () => {
+  it('Resume button is rendered in the collapsed row for a paused profile', async () => {
     const user = userEvent.setup()
     renderPage()
     const adultsCard = await screen.findByTestId('profile-card-2')
-    await expand(2, user)
-    await user.click(within(adultsCard).getByRole('button', { name: /Resume/ }))
+    expect(within(adultsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    await user.click(within(adultsCard).getByTestId('profile-row-pause-2'))
     await waitFor(() =>
       expect(api.profiles.update).toHaveBeenCalledWith(
         2,
@@ -345,13 +349,13 @@ describe('ProfilesPage — pause / delete', () => {
     )
   })
 
-  it('confirms then calls api.profiles.delete', async () => {
+  it('Delete button is rendered in the collapsed row and confirms before deleting', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
-    await expand(1, user)
-    await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
+    expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
+    await user.click(within(kidsCard).getByTestId('profile-row-delete-1'))
     expect(confirmSpy).toHaveBeenCalled()
     await waitFor(() => expect(api.profiles.delete).toHaveBeenCalledWith(1))
     confirmSpy.mockRestore()
@@ -362,10 +366,24 @@ describe('ProfilesPage — pause / delete', () => {
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
-    await expand(1, user)
-    await user.click(within(kidsCard).getByRole('button', { name: /^Delete$/ }))
+    await user.click(within(kidsCard).getByTestId('profile-row-delete-1'))
     expect(api.profiles.delete).not.toHaveBeenCalled()
     confirmSpy.mockRestore()
+  })
+
+  it('expanded body no longer renders the Pause/Delete affordances', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    // collapsed-row controls are the only Pause/Delete: exactly one of each,
+    // and both carry the row test ids.
+    const pauseButtons = within(kidsCard).getAllByRole('button', { name: /Pause|Resume/ })
+    expect(pauseButtons).toHaveLength(1)
+    expect(pauseButtons[0]).toBe(within(kidsCard).getByTestId('profile-row-pause-1'))
+    const deleteButtons = within(kidsCard).getAllByRole('button', { name: /^Delete$/ })
+    expect(deleteButtons).toHaveLength(1)
+    expect(deleteButtons[0]).toBe(within(kidsCard).getByTestId('profile-row-delete-1'))
   })
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -551,9 +551,9 @@ export function ProfilesPage() {
 }
 
 // #972 — collapsed accordion row for the merged Profiles page. Header carries
-// the summary (name, used/cap + bar, pause chip, +Time). Expanded body holds
-// the inline subsections (#973-#977) that replaced the old per-profile modal,
-// plus the read-only devices listing and the Delete control.
+// the summary (name, used/cap + bar, pause chip, +Time, Pause/Delete — #1063).
+// Expanded body holds the inline subsections (#973-#977) that replaced the
+// old per-profile modal, plus the read-only devices listing.
 function ProfileShellRow({
   pd, summary, devices, allDevices, users, apps, allUsers, isAdmin, expanded, highlight, defaultTz,
   onToggle, onDelete, onTogglePause, onGrantTime,
@@ -710,6 +710,39 @@ function ProfileShellRow({
               + Time
             </button>
           )}
+
+          {/* #1063 — Pause/Resume + Delete were promoted from the expanded
+              card body into the collapsed summary row. Both are high-frequency
+              one-shot actions; making the operator expand the card first was
+              busywork. Icon-only Pause (chip already says Paused/Active);
+              Delete is muted + far right so it's hard to mis-click. */}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={onTogglePause}
+              data-testid={`profile-row-pause-${pd.profile.id}`}
+              aria-label={pd.profile.paused ? 'Resume profile' : 'Pause profile'}
+              title={pd.profile.paused ? 'Resume profile' : 'Pause profile'}
+              className={`text-xs px-2 py-1.5 rounded-lg border transition-colors ${
+                pd.profile.paused
+                  ? 'bg-brand-accent/10 text-brand-accent border-brand-accent/20 hover:bg-brand-accent-dark/20'
+                  : 'bg-amber-500/10 text-amber-700 border-amber-500/20 hover:bg-amber-500/20'
+              }`}
+            >
+              {pd.profile.paused ? '▶' : '⏸'}
+            </button>
+          )}
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={onDelete}
+              data-testid={`profile-row-delete-${pd.profile.id}`}
+              title="Delete profile"
+              className="text-xs text-brand-text-muted hover:text-red-700 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 px-2 py-1.5 rounded-lg transition-colors"
+            >
+              Delete
+            </button>
+          )}
         </div>
       </div>
 
@@ -731,23 +764,6 @@ function ProfileShellRow({
           {isAdmin && (
             <DevicesSubsection pd={pd} assigned={devices} allDevices={allDevices} />
           )}
-          {isAdmin && (
-            <div className="flex flex-wrap gap-2">
-              <button onClick={onTogglePause}
-                className={`text-xs px-3 py-1.5 rounded-lg border transition-colors ${
-                  pd.profile.paused
-                    ? 'bg-brand-accent/10 text-brand-accent border-brand-accent/20 hover:bg-brand-accent-dark/20'
-                    : 'bg-amber-500/10 text-amber-700 border-amber-500/20 hover:bg-amber-500/20'
-                }`}>
-                {pd.profile.paused ? '▶ Resume' : '⏸ Pause'}
-              </button>
-              <button onClick={onDelete}
-                className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors">
-                Delete
-              </button>
-            </div>
-          )}
-
           {pd.profile.blockedCategories.length > 0 && (
             <div>
               <p className="text-xs text-brand-text-muted uppercase tracking-wider mb-2">Blocked categories</p>


### PR DESCRIPTION
## Summary
- Pause/Resume icon-only button + Delete moved into the collapsed summary row beside `+ Time`
- Expanded card body no longer renders the Pause/Delete affordances
- Admin-only; read-only users see neither button

## Test plan
- [x] vitest: Pause/Resume visible in collapsed row, fires the right mutation
- [x] vitest: Delete visible in collapsed row, gated by confirm
- [x] vitest: expanded body no longer contains either button
- [x] `nvm use 22 && npm test` green (294 passed)

Closes #1063.