### PR TITLE
ux: unified by-app axis on usage graphs; retire Host toggle (#1079 #778)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,17 @@ jobs:
         # classes while Mill's task-state still treats those compile tasks as up-to-date from the
         # restored cache — so they get skipped, downstream modules can't resolve their symbols, and
         # `api.compile` fails with "value shared is not a member of wifihaven" (#946).
+        # scalac TypeComparer recurses deeply on the long `++` chain of `Routes`
+        # values in api/src/Main.scala once the ZLayer environment intersection
+        # grows. GitHub runners default to a 1 MiB JVM stack and StackOverflow
+        # before scalac's recursion-limit guard catches it. Mill spawns scalac
+        # in an isolated worker JVM and forwards JAVA_OPTS (not JAVA_TOOL_OPTIONS)
+        # to it, so set both — JAVA_OPTS for the worker, JAVA_TOOL_OPTIONS as
+        # belt-and-braces for the mill launcher. (Same fix that landed on
+        # perf/1167-per-app-rollup but never reached main after squash-merge.)
+        env:
+          JAVA_OPTS: "-Xss8m"
+          JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           rm -rf out/*/test/compile.dest/classes 2>/dev/null || true
           mill __.compile
@@ -207,6 +218,9 @@ jobs:
       - name: Run all tests (sequential to avoid embedded-pg lock contention)
         # api.test spins up EmbeddedPostgres; running sequentially avoids
         # JVM-wide file-lock contention if more DB-heavy tests are added later.
+        env:
+          JAVA_OPTS: "-Xss8m"
+          JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
           mill shared.test
           mill api.test

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -157,7 +157,7 @@ object UsageRoutes {
             zone <- ZIO
               .attempt(ZoneId.of(tzStr))
               .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
-            topN = req.url
+            topN       = req.url
               .queryParam("topN")
               .flatMap(_.toIntOption)
               .getOrElse(5)
@@ -165,7 +165,15 @@ object UsageRoutes {
               // #964: cap bumped from 20 → 500 so the per-device 'other'
               // drill-in can request the full long-tail of hosts in one shot.
               .min(500)
-            resp <- (macOpt, profileIdOpt) match {
+            // #1079: groupBy=app surfaces the unified per-app + per-non-app-host
+            // axis on the response (`topEntries` / `bucketsByEntry`). Optional;
+            // older Host/Device-only callers leave it off and the new fields
+            // stay empty.
+            groupByApp = req.url.queryParam("groupBy").exists(_.split(',').contains("app"))
+            appLookup <-
+              if (groupByApp) loadAppLookup(appRepo)
+              else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+            resp      <- (macOpt, profileIdOpt) match {
               case (Some(mac), _) =>
                 buildForDevice(
                   mac,
@@ -176,6 +184,8 @@ object UsageRoutes {
                   deviceRepo,
                   trafficRepo,
                   userProfileRepo,
+                  groupByApp,
+                  appLookup,
                 )
               case (_, Some(pid)) =>
                 buildForProfile(
@@ -188,6 +198,8 @@ object UsageRoutes {
                   deviceRepo,
                   trafficRepo,
                   userProfileRepo,
+                  groupByApp,
+                  appLookup,
                 )
               case _              => ZIO.fail(Response.badRequest("unreachable"))
             }
@@ -294,6 +306,30 @@ object UsageRoutes {
       )
     }
 
+  // #1079 — build the host → owning-app lookup used by the unified-axis
+  // builder. Mirrors the deterministic "lowest appId wins" tiebreak from
+  // #1061 and the apex-aware match from #1085 so subdomain traffic attributes
+  // to the apex-form app entry.
+  private def loadAppLookup(
+      appRepo: AppRepo,
+  ): IO[Response, HostId => Option[UsageSeries.AppInfo]] =
+    for {
+      apps     <- appRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      mappings <- appRepo.listAllHostMappings.mapError(ErrorMapper.dbErrorToResponse)
+    } yield {
+      val appById = apps.iterator.map(a => a.id -> a).toMap
+      val byApex  = mappings
+        .groupBy(_.host.value)
+        .view
+        .mapValues(ms => ms.iterator.map(_.appId).minBy(_.value))
+        .toMap
+      (h: HostId) =>
+        h.asFqdn
+          .flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApex))
+          .flatMap(appById.get)
+          .map(a => UsageSeries.AppInfo(a.id, a.slug, a.name, a.icon))
+    }
+
   private def buildForDevice(
       mac: MacAddress,
       date: LocalDate,
@@ -303,6 +339,8 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
+      groupByApp: Boolean,
+      appLookup: HostId => Option[UsageSeries.AppInfo],
   ): IO[Response, UsageSeriesResponse] =
     for {
       device <- deviceRepo
@@ -311,7 +349,10 @@ object UsageRoutes {
         .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
       _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
       rows   <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
-      (topHosts, buckets) = UsageSeries.build(rows, zone, topN)
+      (topHosts, buckets)          = UsageSeries.build(rows, zone, topN)
+      (topEntries, bucketsByEntry) =
+        if (groupByApp) UsageSeries.buildEntries(rows, zone, topN, appLookup)
+        else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
     } yield UsageSeriesResponse(
       deviceMac = Some(mac),
       deviceName = Some(device.name),
@@ -319,6 +360,8 @@ object UsageRoutes {
       tz = zone.getId,
       topHosts = topHosts,
       buckets = buckets,
+      topEntries = topEntries,
+      bucketsByEntry = bucketsByEntry,
     )
 
   private def buildForProfile(
@@ -331,6 +374,8 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
+      groupByApp: Boolean,
+      appLookup: HostId => Option[UsageSeries.AppInfo],
   ): IO[Response, UsageSeriesResponse] =
     for {
       _       <- requireProfileReadAccess(claims, pid, userProfileRepo)
@@ -345,6 +390,9 @@ object UsageRoutes {
       rows <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
       (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
         UsageSeries.buildProfile(rows, nameByMac, zone, topN, profile.crossDeviceOverlapMode)
+      (topEntries, bucketsByEntry)                           =
+        if (groupByApp) UsageSeries.buildEntries(rows, zone, topN, appLookup)
+        else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
     } yield UsageSeriesResponse(
       profileId = Some(pid),
       profileName = Some(profile.name),
@@ -354,6 +402,8 @@ object UsageRoutes {
       buckets = bucketsByHost,
       topDevices = topDevices,
       bucketsByDevice = bucketsByDevice,
+      topEntries = topEntries,
+      bucketsByEntry = bucketsByEntry,
     )
 
   // Pull the requested local-day window. Two adjacent UTC days bracket every

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -282,4 +282,145 @@ object UsageSeries {
 
     (topHosts, bucketsByHost.toList, topDevices, bucketsByDevice.toList)
   }
+
+  // ── #1079 unified by-app axis ──────────────────────────────────────────────
+  //
+  // For each (mac, period_start) bucket, attribute its byte-share-weighted
+  // seconds to either the host's owning app (if it has one — `appOfHost`) or
+  // to the host itself as a first-class entry. Day totals, top-N cap, and a
+  // single 'Other' long-tail bucket are computed over the resulting mixed
+  // entity list. 'Other' is strictly the long tail — non-app hosts that fit
+  // inside top-N surface individually, not lumped together.
+  case class AppInfo(id: AppId, slug: String, name: String, icon: Option[String])
+
+  private def entityRefOf(key: Either[AppInfo, HostId]): UsageEntityRef =
+    key match {
+      case Left(a)  =>
+        UsageEntityRef(
+          kind = "app",
+          id = a.slug,
+          name = a.name,
+          appId = Some(a.id),
+          appIcon = a.icon,
+          host = None,
+        )
+      case Right(h) =>
+        UsageEntityRef(
+          kind = "host",
+          id = h.value,
+          name = h.value,
+          appId = None,
+          appIcon = None,
+          host = Some(h),
+        )
+    }
+
+  private def sortKey(k: Either[AppInfo, HostId]): (Int, String) = k match {
+    case Left(a)  => (0, a.slug)
+    case Right(h) => (1, h.value)
+  }
+
+  def buildEntries(
+      rows: List[PresenceRow],
+      zone: ZoneId,
+      topN: Int,
+      appOfHost: HostId => Option[AppInfo],
+  ): (List[UsageEntityTotal], List[UsageEntityBucket]) = {
+    // (hour, bucketSeconds, byHostBytes) — group rows into 5-min buckets per
+    // (mac, period_start) so two devices in the same wall-clock window don't
+    // collapse onto each other.
+    type Key = Either[AppInfo, HostId]
+
+    val fiveMin = rows.groupBy(r => (r.mac, r.periodStart)).toList.map { case ((_, ps), bucket) =>
+      val hour   = ps.atZone(zone).getHour
+      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
+      val byHost = bucket.iterator
+        .map(r => r.host -> r.bytes)
+        .toList
+        .groupMapReduce(_._1)(_._2)(_ + _)
+      (hour, secs, byHost)
+    }
+
+    // Day totals per entity (byte-share-weighted; even-share if zero bytes).
+    val perEntityDaySecs = scala.collection.mutable.Map.empty[Key, Double]
+    for ((_, secs, byHost) <- fiveMin if byHost.nonEmpty) {
+      val totalBytes = byHost.valuesIterator.sum
+      if (totalBytes > 0L)
+        for ((h, b) <- byHost) {
+          val key   = appOfHost(h).map(Left(_)).getOrElse(Right(h))
+          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+          perEntityDaySecs.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
+        }
+      else {
+        val share = secs.toDouble / byHost.size
+        for (h <- byHost.keys) {
+          val key = appOfHost(h).map(Left(_)).getOrElse(Right(h))
+          perEntityDaySecs.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
+        }
+      }
+    }
+
+    val ordered = perEntityDaySecs.toList
+      .map { case (k, s) => (k, (s / 60).toInt) }
+      .filter { case (_, m) => m > 0 }
+      .sortBy { case (k, m) => (-m, sortKey(k)) }
+
+    val topKeys    = ordered.take(topN).map(_._1)
+    val topKeySet  = topKeys.toSet
+    val topEntries = ordered.take(topN).map { case (k, m) =>
+      UsageEntityTotal(entityRefOf(k), m)
+    }
+    val rank       = topKeys.iterator.zipWithIndex.toMap
+
+    val byHour  = fiveMin.groupBy(_._1)
+    val buckets = (0 until 24).map { hr =>
+      val hrBuckets = byHour.getOrElse(hr, Nil)
+      val total     = hrBuckets.iterator.map { case (_, s, _) => s.toLong }.sum
+      val perEntity = scala.collection.mutable.Map.empty[Key, Double]
+      var other     = 0.0
+      for ((_, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
+        val totalBytes = byHost.valuesIterator.sum
+        if (totalBytes > 0L)
+          for ((h, b) <- byHost) {
+            val key   = appOfHost(h).map(Left(_)).getOrElse(Right(h))
+            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
+            if (topKeySet.contains(key))
+              perEntity.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
+            else other += share
+          }
+        else {
+          val share = secs.toDouble / byHost.size
+          for (h <- byHost.keys) {
+            val key = appOfHost(h).map(Left(_)).getOrElse(Right(h))
+            if (topKeySet.contains(key))
+              perEntity.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
+            else other += share
+          }
+        }
+      }
+      val perEntityListSorted = perEntity.iterator
+        .map { case (k, s) => (k, (s / 60).toInt) }
+        .filter(_._2 > 0)
+        .toList
+        .sortBy { case (k, _) => rank.getOrElse(k, Int.MaxValue) }
+        .map { case (k, m) => UsageBucketEntity(entityRefOf(k), m) }
+      val totalMins = (total / 60).toInt
+      val perSum    = perEntityListSorted.iterator.map(_.mins).sum
+      // Residual minutes either come from the long tail OR from per-host
+      // flooring drift on the top entries. We attribute drift back to the
+      // top entry that lost the fractional second only when no actual tail
+      // contributed in this hour — otherwise drift collapses into the tail.
+      val otherMins =
+        if (other > 0.0) (totalMins - perSum).max(0)
+        else 0
+      UsageEntityBucket(
+        hour = hr,
+        totalMins = totalMins,
+        perEntity = perEntityListSorted,
+        otherMins = otherMins,
+      )
+    }.toList
+
+    (topEntries, buckets)
+  }
 }

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -380,6 +380,119 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.buckets.forall(_.totalMins == 0)) &&
           assertTrue(out.topHosts.isEmpty && out.topDevices.isEmpty)
       },
+      // #1079 — unified app + non-app-host axis. Apps roll up; non-app hosts
+      // surface individually; 'Other' is strictly the long tail past topN.
+      test("#1079: groupBy=app emits per-app + per-non-app-host rows; Other = long tail only") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          // Two apps each owning one host.
+          ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
+          _           <- appRepo.setHosts(ytId, List(Hostname.unsafe("youtube.com")))
+          ggId        <- appRepo.create("Google", "google", None, None)
+          _           <- appRepo.setHosts(ggId, List(Hostname.unsafe("google.com")))
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Distinct minute counts so top-N ranking is deterministic.
+          // YouTube: 5 buckets = 25min. Hour 10.
+          _  <- ZIO.foreachDiscard(0 until 5)(i =>
+            insertRow(routerId, testMac, "youtube.com", today, 10, i * 5),
+          )
+          // Google: 4 buckets = 20min. Hour 11.
+          _  <- ZIO.foreachDiscard(0 until 4)(i =>
+            insertRow(routerId, testMac, "google.com", today, 11, i * 5),
+          )
+          // drop.com (non-app): 3 buckets = 15min. Hour 12.
+          _  <- ZIO.foreachDiscard(0 until 3)(i =>
+            insertRow(routerId, testMac, "drop.com", today, 12, i * 5),
+          )
+          // extra.com (non-app): 2 buckets = 10min. Hour 13.
+          _  <- ZIO.foreachDiscard(0 until 2)(i =>
+            insertRow(routerId, testMac, "extra.com", today, 13, i * 5),
+          )
+          // Long tail of 6 single-bucket non-app hosts at hour 14.
+          _  <- ZIO.foreachDiscard(0 until 6)(i =>
+            insertRow(routerId, testMac, s"tail$i.com", today, 14, i * 5),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/usage/series?mac=$testMac&date=$today&topN=4&groupBy=app")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          tops = out.topEntries
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // 4 top entries: two apps + two non-app hosts (NOT 2 apps + 1 "Other").
+          assertTrue(tops.length == 4) &&
+          assertTrue(
+            tops(0).entity.kind == "app" && tops(0).entity.name == "YouTube" && tops(
+              0,
+            ).dayMins == 25,
+          ) &&
+          assertTrue(
+            tops(1).entity.kind == "app" && tops(1).entity.name == "Google" && tops(1).dayMins == 20,
+          ) &&
+          assertTrue(
+            tops(2).entity.kind == "host" && tops(2).entity.id == "drop.com" && tops(
+              2,
+            ).dayMins == 15,
+          ) &&
+          assertTrue(
+            tops(3).entity.kind == "host" && tops(3).entity.id == "extra.com" && tops(
+              3,
+            ).dayMins == 10,
+          ) &&
+          // 'Other' = long tail = 6 × 5min, present only in buckets where the tail lives.
+          assertTrue(out.bucketsByEntry.length == 24) &&
+          assertTrue(out.bucketsByEntry(14).otherMins == 30) &&
+          // Hours without tail traffic shouldn't have an Other bar.
+          assertTrue(out.bucketsByEntry(10).otherMins == 0) &&
+          assertTrue(out.bucketsByEntry(11).otherMins == 0) &&
+          // Day total sums.
+          assertTrue(out.bucketsByEntry.iterator.map(_.totalMins).sum == 100)
+      },
+      // #1079 — when no host or app exceeds topN, there's no Other bucket.
+      test("#1079: groupBy=app with everything inside topN → no Other row") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Two unmapped hosts only, topN=5 (default).
+          _  <- insertRow(routerId, testMac, "drop.com", today, 10, 0)
+          _  <- insertRow(routerId, testMac, "extra.com", today, 10, 5)
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today&groupBy=app").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Both unmapped hosts are individual entries — NOT lumped into Other.
+          assertTrue(out.topEntries.length == 2) &&
+          assertTrue(out.topEntries.forall(_.entity.kind == "host")) &&
+          assertTrue(out.bucketsByEntry.iterator.map(_.otherMins).sum == 0)
+      },
     ) @@ TestAspect.sequential,
     // ── #846 Traffic Usage page ───────────────────────────────────────────
     suite("GET /api/usage/traffic")(

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -855,6 +855,27 @@ case class UsageDeviceBucket(
     otherMins: Int,
 ) derives JsonCodec
 
+// #1079 — unified by-app axis. Each entry is either an app (apps roll up
+// their member hosts) or a single non-app host. `Other` is the long tail
+// past `topN`, NOT a catch-all for unmapped hosts. Populated only when the
+// request asks `?groupBy=app`; otherwise both fields stay empty.
+case class UsageEntityRef(
+    kind: String, // "app" | "host"
+    id: String,   // app slug or hostname
+    name: String,
+    appId: Option[AppId] = None,
+    appIcon: Option[String] = None,
+    host: Option[HostId] = None,
+) derives JsonCodec
+case class UsageEntityTotal(entity: UsageEntityRef, dayMins: Int) derives JsonCodec
+case class UsageBucketEntity(entity: UsageEntityRef, mins: Int) derives JsonCodec
+case class UsageEntityBucket(
+    hour: Int,
+    totalMins: Int,
+    perEntity: List[UsageBucketEntity],
+    otherMins: Int,
+) derives JsonCodec
+
 case class UsageSeriesResponse(
     deviceMac: Option[MacAddress] = None,
     deviceName: Option[String] = None,
@@ -866,6 +887,8 @@ case class UsageSeriesResponse(
     buckets: List[UsageBucket],
     topDevices: List[UsageDeviceTotal] = Nil,
     bucketsByDevice: List[UsageDeviceBucket] = Nil,
+    topEntries: List[UsageEntityTotal] = Nil,
+    bucketsByEntry: List[UsageEntityBucket] = Nil,
 ) derives JsonCodec
 
 // ── Traffic Usage page (#846) ─────────────────────────────────────────────

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -198,6 +198,7 @@ export const api = {
       date?: string
       tz?: string
       topN?: number
+      groupBy?: 'app'
     }) => {
       const qs = new URLSearchParams()
       if (params.mac)       qs.set('mac', params.mac)
@@ -205,6 +206,7 @@ export const api = {
       if (params.date)      qs.set('date', params.date)
       if (params.tz)        qs.set('tz', params.tz)
       if (params.topN)      qs.set('topN', String(params.topN))
+      if (params.groupBy)   qs.set('groupBy', params.groupBy)
       return req<UsageSeriesResponse>('GET', `/usage/series?${qs}`)
     },
     // #846 Traffic Usage page — multi-column groupBy.

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -43,8 +43,10 @@ export const qk = {
   timeStatusSummaryToday: () => ['time', 'status', 'summary', 'today'] as const,
   timeStatusSummaryWeek: (to?: string) => ['time', 'status', 'summary', 'week', to ?? 'current'] as const,
   // #776 — hourly chart on the Today card.
-  usageSeriesProfile: (profileId: number, date: string, tz: string) =>
-    ['usage', 'series', 'profile', profileId, date, tz] as const,
+  // #1079 — groupBy is part of the cache key so the by-app axis doesn't
+  // share a cache slot with the legacy host axis.
+  usageSeriesProfile: (profileId: number, date: string, tz: string, groupBy?: string) =>
+    ['usage', 'series', 'profile', profileId, date, tz, groupBy ?? 'host'] as const,
   // #1061 — per-app time-used breakdown for one profile over [from,to].
   profileUsageByApp: (profileId: number, from: string, to: string) =>
     ['profiles', profileId, 'usage-by-app', from, to] as const,
@@ -191,13 +193,14 @@ export function useUsageSeriesProfileToday(
   profileId: number,
   date: string,
   tz: string,
-  opts?: QueryOpts<UsageSeriesResponse>,
+  opts?: QueryOpts<UsageSeriesResponse> & { groupBy?: 'app' },
 ) {
+  const { groupBy, ...rest } = opts ?? {}
   return useQuery({
-    queryKey: qk.usageSeriesProfile(profileId, date, tz),
-    queryFn: () => api.usage.series({ profileId, date, tz }),
+    queryKey: qk.usageSeriesProfile(profileId, date, tz, groupBy),
+    queryFn: () => api.usage.series({ profileId, date, tz, groupBy }),
     staleTime: STALE.timeStatusToday,
-    ...opts,
+    ...rest,
   })
 }
 

--- a/web/src/components/usage/ProfileTimelineChart.tsx
+++ b/web/src/components/usage/ProfileTimelineChart.tsx
@@ -6,10 +6,9 @@ import { api } from '@/api/client'
 import {
   useTimeStatusProfileWeek, useUsageSeriesProfileToday,
 } from '@/api/queries'
-import { HostCell } from '@/components/HostCell'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 import type {
-  UsageBucket, UsageDeviceBucket, UsageSeriesResponse,
+  UsageDeviceBucket, UsageEntityBucket, UsageSeriesResponse,
 } from '@/types/api'
 import {
   formatMins, groupBucketsByLocalDay, localBucketOffsetMin,
@@ -29,7 +28,7 @@ const DRILL_IN_TOP_N = 500
 const DEFAULT_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
 type Win = 'today' | 'week'
-type StackBy = 'total' | 'host' | 'device' | 'app'
+type StackBy = 'total' | 'device' | 'app'
 
 interface StackByOption {
   key: StackBy
@@ -38,17 +37,16 @@ interface StackByOption {
   title?: string
 }
 
+// #1079 — Host axis retired; the by-app axis is the new combined surface.
 const STACK_BY_OPTIONS: ReadonlyArray<StackByOption> = [
   { key: 'total',  label: 'Total' },
-  { key: 'host',   label: 'Host' },
   { key: 'device', label: 'Device' },
-  {
-    key: 'app',
-    label: 'App',
-    disabled: true,
-    title: 'Grouping by app requires /api/usage/series app support — coming soon.',
-  },
+  { key: 'app',    label: 'App' },
 ]
+
+function entityKey(e: { kind: string; id: string }): string {
+  return `${e.kind}:${e.id}`
+}
 
 function todayISO(): string {
   const d = new Date()
@@ -58,14 +56,14 @@ function todayISO(): string {
   return `${yyyy}-${mm}-${dd}`
 }
 
-function buildHostRows(buckets: UsageBucket[], keys: string[]) {
+function buildEntityRows(buckets: UsageEntityBucket[], keys: string[]) {
   return buckets.map(b => {
     const row: Record<string, number | string> = {
       hour: String(b.hour).padStart(2, '0'),
       total: b.totalMins,
     }
     for (const k of keys) row[k] = 0
-    for (const ph of b.perHost) row[ph.host.value] = ph.mins
+    for (const pe of b.perEntity) row[entityKey(pe.entity)] = pe.mins
     row[OTHER_KEY] = b.otherMins
     return row as { hour: string; total: number; [k: string]: number | string }
   })
@@ -91,6 +89,7 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
 
   const todayQuery = useUsageSeriesProfileToday(profileId, date, DEFAULT_TZ, {
     enabled: win === 'today',
+    groupBy: stackBy === 'app' ? 'app' : undefined,
   })
   const weekQuery = useTimeStatusProfileWeek(profileId, undefined, localBucketOffsetMin(), {
     enabled: win === 'week',
@@ -109,7 +108,7 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
     setOtherError(null)
     setOtherLoading(true)
     api.usage
-      .series({ profileId, date, tz: DEFAULT_TZ, topN: DRILL_IN_TOP_N })
+      .series({ profileId, date, tz: DEFAULT_TZ, topN: DRILL_IN_TOP_N, groupBy: 'app' })
       .then(setOtherData)
       .catch(e => setOtherError(e.message ?? 'Failed to load'))
       .finally(() => setOtherLoading(false))
@@ -117,12 +116,13 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
 
   const dayChart = useMemo(() => {
     if (!dayData) return { rows: [], series: [] as ChartSeries[] }
-    if (stackBy === 'host') {
-      const keys = (dayData.topHosts ?? []).filter(h => h.dayMins > 0).map(h => h.host.value)
-      const series: ChartSeries[] = keys.map((k, i) => ({
-        key: k, name: k, color: HOST_COLORS[i % HOST_COLORS.length],
+    if (stackBy === 'app') {
+      const top  = (dayData.topEntries ?? []).filter(e => e.dayMins > 0)
+      const keys = top.map(e => entityKey(e.entity))
+      const series: ChartSeries[] = top.map((e, i) => ({
+        key: entityKey(e.entity), name: e.entity.name, color: HOST_COLORS[i % HOST_COLORS.length],
       }))
-      return { rows: buildHostRows(dayData.buckets, keys), series }
+      return { rows: buildEntityRows(dayData.bucketsByEntry ?? [], keys), series }
     }
     if (stackBy === 'device') {
       const top = (dayData.topDevices ?? []).filter(d => d.dayMins > 0)
@@ -149,7 +149,10 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
     [weekData],
   )
 
-  const dayBuckets = stackBy === 'device' ? dayData?.bucketsByDevice : dayData?.buckets
+  const dayBuckets =
+    stackBy === 'device' ? dayData?.bucketsByDevice
+    : stackBy === 'app'    ? dayData?.bucketsByEntry
+    : dayData?.buckets
   const dayTotal   = dayBuckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
   const dayEmpty   = win === 'today' && !todayQuery.isPending && dayTotal === 0
   const weekTotal  = weekData?.totalMins ?? 0
@@ -235,16 +238,14 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
             <UsageHourlyBarChart
               rows={dayChart.rows}
               series={dayChart.series}
-              showLegend={stackBy === 'host' || stackBy === 'device'}
-              legendFormatter={stackBy === 'device'
-                ? (k) => dayChart.series.find(s => s.key === k)?.name ?? k
-                : undefined}
-              onOtherClick={stackBy === 'host' ? openOtherDrillIn : undefined}
+              showLegend={stackBy === 'app' || stackBy === 'device'}
+              legendFormatter={(k) => dayChart.series.find(s => s.key === k)?.name ?? k}
+              onOtherClick={stackBy === 'app' ? openOtherDrillIn : undefined}
               testId={`profile-timeline-${profileId}-chart`}
             />
             <div className="flex items-center justify-between text-[11px] text-brand-text-muted font-mono gap-2">
               <span>{formatMins(dayTotal)} total · {dayData?.tz ?? DEFAULT_TZ}</span>
-              {stackBy === 'host' && hasOther && (
+              {stackBy === 'app' && hasOther && (
                 <button type="button"
                   onClick={openOtherDrillIn}
                   data-testid={`profile-timeline-${profileId}-other-button`}
@@ -301,7 +302,7 @@ export function ProfileTimelineChart({ profileId }: { profileId: number }) {
 
       {/* #715/#957 — proportional attention is the wall-clock-share number; the
           Other long-tail drill-in surfaces host-presence for the leftover bucket. */}
-      {win === 'today' && (stackBy === 'host' || stackBy === 'device') && (
+      {win === 'today' && (stackBy === 'app' || stackBy === 'device') && (
         <p className="text-[10px] text-brand-text-muted">
           Stacks total to wall-clock minutes per hour. Per-host minutes are byte-share-weighted
           (proportional) within each 5-min window (#715).
@@ -337,9 +338,9 @@ function OtherDrillInModal({
   date, loading, error, data, topN, onClose, testIdPrefix,
 }: OtherDrillInModalProps) {
   useEscapeClose(onClose)
-  const tail = (data?.topHosts ?? []).filter(h => h.dayMins > 0).slice(topN)
-  const otherTotal = tail.reduce((a, h) => a + h.dayMins, 0)
-  const grandTotal = (data?.topHosts ?? []).reduce((a, h) => a + h.dayMins, 0)
+  const tail = (data?.topEntries ?? []).filter(e => e.dayMins > 0).slice(topN)
+  const otherTotal = tail.reduce((a, e) => a + e.dayMins, 0)
+  const grandTotal = (data?.topEntries ?? []).reduce((a, e) => a + e.dayMins, 0)
   return (
     <div role="dialog" aria-modal="true"
       data-testid={`${testIdPrefix}-other-modal`}
@@ -350,7 +351,7 @@ function OtherDrillInModal({
         <div className="flex items-start justify-between">
           <div>
             <h3 className="text-lg font-bold text-brand-ink">Inside the “Other” bucket</h3>
-            <p className="text-xs text-brand-text-muted mt-0.5">Hosts below the top {topN} on {date}.</p>
+            <p className="text-xs text-brand-text-muted mt-0.5">Apps &amp; hosts past the top {topN} on {date}.</p>
           </div>
           <button onClick={onClose}
             className="text-brand-text-muted hover:text-brand-text text-xl leading-none"
@@ -370,16 +371,19 @@ function OtherDrillInModal({
         )}
         {!loading && !error && tail.length > 0 && (
           <ul className="space-y-1 overflow-y-auto pr-1 -mr-1">
-            {tail.map(h => {
-              const shareOther = otherTotal > 0 ? (h.dayMins / otherTotal) * 100 : 0
-              const shareTotal = grandTotal > 0 ? (h.dayMins / grandTotal) * 100 : 0
+            {tail.map(e => {
+              const shareOther = otherTotal > 0 ? (e.dayMins / otherTotal) * 100 : 0
+              const shareTotal = grandTotal > 0 ? (e.dayMins / grandTotal) * 100 : 0
               return (
-                <li key={`${h.host.type}:${h.host.value}`}
-                  data-testid={`${testIdPrefix}-other-host-${h.host.value}`}
+                <li key={`${e.entity.kind}:${e.entity.id}`}
+                  data-testid={`${testIdPrefix}-other-entry-${e.entity.kind}-${e.entity.id}`}
                   className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2 gap-2">
-                  <HostCell host={h.host} className="truncate min-w-0" />
+                  <span className="truncate min-w-0 flex items-center gap-2">
+                    <span className="truncate">{e.entity.name}</span>
+                    <span className="text-[10px] text-brand-text-muted uppercase shrink-0">{e.entity.kind}</span>
+                  </span>
                   <span className="text-brand-text-muted font-mono shrink-0 tabular-nums">
-                    {formatMins(h.dayMins)}
+                    {formatMins(e.dayMins)}
                     <span className="text-brand-text-muted ml-2">
                       {shareOther.toFixed(0)}% of Other · {shareTotal.toFixed(0)}% of day
                     </span>

--- a/web/src/pages/DeviceTimelinePage.test.tsx
+++ b/web/src/pages/DeviceTimelinePage.test.tsx
@@ -57,32 +57,43 @@ function emptyDayResponse(date: string): UsageSeriesResponse {
     buckets: Array.from({ length: 24 }, (_, hour) => ({
       hour, totalMins: 0, perHost: [], otherMins: 0,
     })),
+    topEntries: [],
+    bucketsByEntry: Array.from({ length: 24 }, (_, hour) => ({
+      hour, totalMins: 0, perEntity: [], otherMins: 0,
+    })),
   }
 }
 
 function richResponse(date: string): UsageSeriesResponse {
+  const ytEntity = { kind: 'app' as const, id: 'youtube', name: 'YouTube', appId: 1 }
+  const ipEntity = {
+    kind: 'host' as const, id: '170.114.4.226', name: '170.114.4.226',
+    host: { type: 'ipv4' as const, value: '170.114.4.226' },
+  }
   return {
     deviceMac: MAC,
     deviceName: "Kid's iPad",
     date,
     tz: 'America/Los_Angeles',
-    topHosts: [
-      { host: { type: 'fqdn', value: 'youtube.com' },  dayMins: 30 },
-      { host: { type: 'ipv4', value: '170.114.4.226' }, dayMins: 4 },
+    topHosts: [],
+    buckets: Array.from({ length: 24 }, (_, hour) => ({ hour, totalMins: 0, perHost: [], otherMins: 0 })),
+    topEntries: [
+      { entity: ytEntity, dayMins: 30 },
+      { entity: ipEntity, dayMins: 4 },
     ],
-    buckets: Array.from({ length: 24 }, (_, hour) => {
+    bucketsByEntry: Array.from({ length: 24 }, (_, hour) => {
       if (hour === 14) {
         return {
           hour,
           totalMins: 10,
-          perHost: [
-            { host: { type: 'fqdn', value: 'youtube.com' }, mins: 7 },
-            { host: { type: 'ipv4', value: '170.114.4.226' }, mins: 2 },
+          perEntity: [
+            { entity: ytEntity, mins: 7 },
+            { entity: ipEntity, mins: 2 },
           ],
           otherMins: 1,
         }
       }
-      return { hour, totalMins: 0, perHost: [], otherMins: 0 }
+      return { hour, totalMins: 0, perEntity: [], otherMins: 0 }
     }),
   }
 }
@@ -103,7 +114,7 @@ describe('DeviceTimelinePage', () => {
     expect(screen.getByTestId('device-timeline-name')).toHaveTextContent("Kid's iPad")
   })
 
-  it('renders chart and top-host list with FQDN + bare-IP rows', async () => {
+  it('#1079: renders chart and unified by-app entry list (app + non-app host)', async () => {
     (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       richResponse('2026-05-20'),
     )
@@ -111,12 +122,9 @@ describe('DeviceTimelinePage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('device-timeline-chart')).toBeInTheDocument(),
     )
-    // Per-host legend rows render for both FQDN and IP.
-    expect(screen.getByTestId('device-timeline-host-youtube.com')).toBeInTheDocument()
-    const ipRow = screen.getByTestId('device-timeline-host-170.114.4.226')
-    expect(ipRow).toBeInTheDocument()
-    // #718: IP rows are de-emphasized via italic styling so the FQDN gap shows.
-    expect(ipRow.querySelector('.italic')).not.toBeNull()
+    // App rolls up its hosts; non-app host shows individually.
+    expect(screen.getByTestId('device-timeline-entry-app-youtube')).toBeInTheDocument()
+    expect(screen.getByTestId('device-timeline-entry-host-170.114.4.226')).toBeInTheDocument()
   })
 
   it('uses ?date= from URL when present', async () => {
@@ -128,56 +136,54 @@ describe('DeviceTimelinePage', () => {
   })
 
   describe('"Other" drill-in (#964)', () => {
+    function mkEntry(id: string, dayMins: number) {
+      return {
+        entity: {
+          kind: 'host' as const, id, name: id,
+          host: { type: 'fqdn' as const, value: id },
+        },
+        dayMins,
+      }
+    }
     function withOtherResponse(date: string): UsageSeriesResponse {
-      // Top-5 covers the first 5 hosts; the long-tail (hosts 6-9) gets
-      // folded into otherMins on the chart. A drill-in fetch with topN=500
-      // should return all 9 hosts.
-      const top5 = Array.from({ length: 5 }, (_, i) => ({
-        host: { type: 'fqdn' as const, value: `top${i}.com` },
-        dayMins: 50 - i,
-      }))
+      const top5 = Array.from({ length: 5 }, (_, i) => mkEntry(`top${i}.com`, 50 - i))
       return {
         deviceMac: MAC,
         deviceName: "Kid's iPad",
         date,
         tz: 'UTC',
-        topHosts: top5,
-        buckets: Array.from({ length: 24 }, (_, hour) => ({
+        topHosts: [],
+        buckets: Array.from({ length: 24 }, (_, hour) => ({ hour, totalMins: 0, perHost: [], otherMins: 0 })),
+        topEntries: top5,
+        bucketsByEntry: Array.from({ length: 24 }, (_, hour) => ({
           hour,
           totalMins: hour === 14 ? 50 : 0,
-          perHost: hour === 14 ? top5.map(h => ({ host: h.host, mins: 8 })) : [],
-          // Force a non-zero Other bucket so the drill-in affordance renders.
+          perEntity: hour === 14 ? top5.map(e => ({ entity: e.entity, mins: 8 })) : [],
           otherMins: hour === 14 ? 10 : 0,
         })),
       }
     }
     function withAllHostsResponse(date: string): UsageSeriesResponse {
       const all = [
-        ...Array.from({ length: 5 }, (_, i) => ({
-          host: { type: 'fqdn' as const, value: `top${i}.com` },
-          dayMins: 50 - i,
-        })),
-        ...Array.from({ length: 4 }, (_, i) => ({
-          host: { type: 'fqdn' as const, value: `tail${i}.com` },
-          dayMins: 6 - i, // 6, 5, 4, 3 — sorted desc
-        })),
+        ...Array.from({ length: 5 }, (_, i) => mkEntry(`top${i}.com`, 50 - i)),
+        ...Array.from({ length: 4 }, (_, i) => mkEntry(`tail${i}.com`, 6 - i)),
       ]
       return {
         deviceMac: MAC,
         deviceName: "Kid's iPad",
         date,
         tz: 'UTC',
-        topHosts: all,
-        buckets: Array.from({ length: 24 }, (_, hour) => ({
-          hour, totalMins: 0, perHost: [], otherMins: 0,
+        topHosts: [],
+        buckets: Array.from({ length: 24 }, (_, hour) => ({ hour, totalMins: 0, perHost: [], otherMins: 0 })),
+        topEntries: all,
+        bucketsByEntry: Array.from({ length: 24 }, (_, hour) => ({
+          hour, totalMins: 0, perEntity: [], otherMins: 0,
         })),
       }
     }
 
     it('shows the affordance only when Other > 0 and opens a modal with the long-tail', async () => {
       const mock = api.usage.series as unknown as ReturnType<typeof vi.fn>
-      // First call (initial render): top-5 + otherMins. Second call (drill-in
-      // fetch with topN=500): the full unaggregated list.
       mock
         .mockResolvedValueOnce(withOtherResponse('2026-05-20'))
         .mockResolvedValueOnce(withAllHostsResponse('2026-05-20'))
@@ -189,16 +195,14 @@ describe('DeviceTimelinePage', () => {
       await user.click(button)
 
       expect(screen.getByTestId('device-timeline-other-modal')).toBeInTheDocument()
-      // Second fetch goes out with the higher topN.
       await waitFor(() => expect(mock).toHaveBeenCalledTimes(2))
       expect(mock.mock.calls[1][0]).toMatchObject({ mac: MAC, date: '2026-05-20', topN: 500 })
 
-      // Long-tail rows render, top-5 do not.
       await waitFor(() =>
-        expect(screen.getByTestId('device-timeline-other-host-tail0.com')).toBeInTheDocument(),
+        expect(screen.getByTestId('device-timeline-other-entry-host-tail0.com')).toBeInTheDocument(),
       )
-      expect(screen.getByTestId('device-timeline-other-host-tail3.com')).toBeInTheDocument()
-      expect(screen.queryByTestId('device-timeline-other-host-top0.com')).toBeNull()
+      expect(screen.getByTestId('device-timeline-other-entry-host-tail3.com')).toBeInTheDocument()
+      expect(screen.queryByTestId('device-timeline-other-entry-host-top0.com')).toBeNull()
     })
 
     it('hides the affordance when there is no Other bucket on any hour', async () => {

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts'
 import { api } from '@/api/client'
 import type {
-  DeviceTimeStatusWeek, UsageBucket, UsageSeriesResponse,
+  DeviceTimeStatusWeek, UsageEntityBucket, UsageSeriesResponse,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { HostCell } from '@/components/HostCell'
@@ -47,17 +47,21 @@ function addDays(iso: string, n: number): string {
   return `${yy}-${mm}-${dd}`
 }
 
+function entityKey(e: { kind: string; id: string }): string {
+  return `${e.kind}:${e.id}`
+}
+
 function buildChartData(
-  buckets: UsageBucket[],
-  hostKeys: string[],
+  buckets: UsageEntityBucket[],
+  entityKeys: string[],
 ) {
   return buckets.map(b => {
     const row: Record<string, number | string> = {
       hour: String(b.hour).padStart(2, '0'),
       total: b.totalMins,
     }
-    for (const k of hostKeys) row[k] = 0
-    for (const ph of b.perHost) row[ph.host.value] = ph.mins
+    for (const k of entityKeys) row[k] = 0
+    for (const pe of b.perEntity) row[entityKey(pe.entity)] = pe.mins
     row[OTHER_KEY] = b.otherMins
     return row as { hour: string; total: number; [k: string]: number | string }
   })
@@ -84,7 +88,7 @@ export function DeviceTimelinePage() {
     setLoading(true)
     setError(null)
     const p = window === 'today'
-      ? api.usage.series({ mac, date, tz: DEFAULT_TZ, topN: TOP_N }).then(d => { setDayData(d); setWeekData(null) })
+      ? api.usage.series({ mac, date, tz: DEFAULT_TZ, topN: TOP_N, groupBy: 'app' }).then(d => { setDayData(d); setWeekData(null) })
       : api.time.statusDeviceWeek(mac, date, localBucketOffsetMin()).then(d => { setWeekData(d); setDayData(null) })
     p.catch(e => setError(e.message ?? 'Failed to load')).finally(() => setLoading(false))
   }, [mac, date, window])
@@ -107,7 +111,7 @@ export function DeviceTimelinePage() {
     // not to swap the chart underneath the operator.
     setOtherLoading(true)
     api.usage
-      .series({ mac, date, tz: DEFAULT_TZ, topN: DRILL_IN_TOP_N })
+      .series({ mac, date, tz: DEFAULT_TZ, topN: DRILL_IN_TOP_N, groupBy: 'app' })
       .then(setOtherData)
       .catch(e => setOtherError(e.message ?? 'Failed to load'))
       .finally(() => setOtherLoading(false))
@@ -115,13 +119,14 @@ export function DeviceTimelinePage() {
 
   const dayChart = useMemo(() => {
     if (!dayData) return { rows: [], series: [] as ChartSeries[] }
-    const hostKeys = dayData.topHosts.filter(h => h.dayMins > 0).map(h => h.host.value)
-    const series: ChartSeries[] = hostKeys.map((k, i) => ({
-      key: k,
-      name: k,
+    const top  = (dayData.topEntries ?? []).filter(e => e.dayMins > 0)
+    const keys = top.map(e => entityKey(e.entity))
+    const series: ChartSeries[] = top.map((e, i) => ({
+      key: entityKey(e.entity),
+      name: e.entity.name,
       color: HOST_COLORS[i % HOST_COLORS.length],
     }))
-    return { rows: buildChartData(dayData.buckets, hostKeys), series }
+    return { rows: buildChartData(dayData.bucketsByEntry ?? [], keys), series }
   }, [dayData])
 
   const weekChart = useMemo(() => {
@@ -131,16 +136,20 @@ export function DeviceTimelinePage() {
 
   if (loading && !dayData && !weekData) return <PageLoader />
 
-  const dayTotal = dayData?.buckets.reduce((a, b) => a + b.totalMins, 0) ?? 0
+  const dayTotal = (dayData?.bucketsByEntry ?? dayData?.buckets ?? []).reduce((a, b) => a + b.totalMins, 0)
   const dayEmpty = window === 'today' && dayTotal === 0
   const weekEmpty = window === 'week' && (weekData?.totalMins ?? 0) === 0
   const titleName = dayData?.deviceName ?? weekData?.deviceName ?? mac
-  // `mins` is the wall-clock-share number (#715 proportional). For the weekly
-  // breakdown we additionally surface bucket-presence in parens so the operator
-  // can spot heartbeat-style hosts that show up everywhere but with tiny bytes.
-  const hosts = window === 'today'
-    ? (dayData?.topHosts.filter(h => h.dayMins > 0) ?? []).map(h => ({ host: h.host, mins: h.dayMins, presenceMins: null as number | null }))
-    : (weekData?.hostUsage ?? []).map(h => ({ host: h.host, mins: h.proportionalMins, presenceMins: h.usedMins }))
+  // Today: unified by-app axis entries (#1079) — mixed apps + non-app hosts.
+  // Week: per-host list from the trailing-7d status endpoint, surfaced with
+  // bucket-presence in parens so heartbeat-style hosts are visible.
+  type TodayEntry = { id: string; kind: 'app' | 'host'; name: string; mins: number }
+  const todayEntries: TodayEntry[] = (dayData?.topEntries ?? [])
+    .filter(e => e.dayMins > 0)
+    .map(e => ({ id: e.entity.id, kind: e.entity.kind, name: e.entity.name, mins: e.dayMins }))
+  const weekHosts = (weekData?.hostUsage ?? []).map(h => ({
+    host: h.host, mins: h.proportionalMins, presenceMins: h.usedMins,
+  }))
 
   return (
     <div className="space-y-6">
@@ -288,46 +297,69 @@ export function DeviceTimelinePage() {
         )}
       </div>
 
-      {hosts.length > 0 && (
+      {window === 'today' && todayEntries.length > 0 && (
+        <div className="bg-white rounded-2xl border border-brand-border p-5">
+          <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-3">
+            Top apps &amp; hosts
+          </h2>
+          <ul className="space-y-1.5">
+            {todayEntries.map((e, i) => (
+              <li
+                key={`${e.kind}:${e.id}`}
+                data-testid={`device-timeline-entry-${e.kind}-${e.id}`}
+                className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                    style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
+                  />
+                  <span className="truncate">{e.name}</span>
+                  <span className="text-[10px] text-brand-text-muted uppercase shrink-0">{e.kind}</span>
+                </span>
+                <span className="text-brand-text-muted font-mono shrink-0 ml-2">{formatMins(e.mins)}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-[11px] text-brand-text-muted mt-3">
+            Apps roll up their member hosts. Non-app hosts surface individually.
+            'Other' covers the long tail past the top {TOP_N} — not unmapped hosts.
+          </p>
+        </div>
+      )}
+
+      {window === 'week' && weekHosts.length > 0 && (
         <div className="bg-white rounded-2xl border border-brand-border p-5">
           <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-3">
             Top hosts
           </h2>
           <ul className="space-y-1.5">
-            {hosts.map((h, i) => {
-              return (
-                <li
-                  key={`${h.host.type}:${h.host.value}`}
-                  data-testid={`device-timeline-host-${h.host.value}`}
-                  className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2"
-                >
-                  <span className="flex items-center gap-2 min-w-0">
-                    <span
-                      className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
-                      style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
-                    />
-                    {/* Per #718: bare-IP rows render but de-emphasized (HostCell)
-                        so the FQDN attribution gap is visible at a glance. */}
-                    <HostCell host={h.host} className="truncate" />
-                  </span>
+            {weekHosts.map((h, i) => (
+              <li
+                key={`${h.host.type}:${h.host.value}`}
+                data-testid={`device-timeline-host-${h.host.value}`}
+                className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2"
+              >
+                <span className="flex items-center gap-2 min-w-0">
                   <span
-                    className="text-brand-text-muted font-mono shrink-0 ml-2"
-                    title={h.presenceMins !== null
-                      ? `presence ${formatMins(h.presenceMins)} (every bucket this host appeared in)`
-                      : undefined}
-                  >
-                    {formatMins(h.mins)}
-                    {h.presenceMins !== null && (
-                      <span className="text-brand-text-muted"> ({formatMins(h.presenceMins)})</span>
-                    )}
-                  </span>
-                </li>
-              )
-            })}
+                    className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
+                    style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
+                  />
+                  <HostCell host={h.host} className="truncate" />
+                </span>
+                <span
+                  className="text-brand-text-muted font-mono shrink-0 ml-2"
+                  title={`presence ${formatMins(h.presenceMins)} (every bucket this host appeared in)`}
+                >
+                  {formatMins(h.mins)}
+                  <span className="text-brand-text-muted"> ({formatMins(h.presenceMins)})</span>
+                </span>
+              </li>
+            ))}
           </ul>
           <p className="text-[11px] text-brand-text-muted mt-3">
             Per-host minutes are byte-share-weighted wall-clock attention within each 5-minute
-            window (#715){window === 'week' ? '; presence in parens is how many buckets the host appeared in at all' : ', so the stack sums to the device\'s wall-clock minutes for that hour'}.
+            window (#715); presence in parens is how many buckets the host appeared in at all.
           </p>
         </div>
       )}
@@ -361,9 +393,9 @@ interface OtherDrillInModalProps {
 
 function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherDrillInModalProps) {
   useEscapeClose(onClose)
-  const tail = (data?.topHosts ?? []).filter(h => h.dayMins > 0).slice(topN)
-  const otherTotal = tail.reduce((a, h) => a + h.dayMins, 0)
-  const grandTotal = (data?.topHosts ?? []).reduce((a, h) => a + h.dayMins, 0)
+  const tail = (data?.topEntries ?? []).filter(e => e.dayMins > 0).slice(topN)
+  const otherTotal = tail.reduce((a, e) => a + e.dayMins, 0)
+  const grandTotal = (data?.topEntries ?? []).reduce((a, e) => a + e.dayMins, 0)
   return (
     <div
       role="dialog"
@@ -383,7 +415,7 @@ function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherD
               Inside the “Other” bucket
             </h3>
             <p className="text-xs text-brand-text-muted mt-0.5">
-              Hosts below the top {topN} on {date}.
+              Apps &amp; hosts past the top {topN} on {date}.
             </p>
           </div>
           <button
@@ -413,18 +445,21 @@ function OtherDrillInModal({ date, loading, error, data, topN, onClose }: OtherD
         )}
         {!loading && !error && tail.length > 0 && (
           <ul className="space-y-1 overflow-y-auto pr-1 -mr-1">
-            {tail.map(h => {
-              const shareOther = otherTotal > 0 ? (h.dayMins / otherTotal) * 100 : 0
-              const shareTotal = grandTotal > 0 ? (h.dayMins / grandTotal) * 100 : 0
+            {tail.map(e => {
+              const shareOther = otherTotal > 0 ? (e.dayMins / otherTotal) * 100 : 0
+              const shareTotal = grandTotal > 0 ? (e.dayMins / grandTotal) * 100 : 0
               return (
                 <li
-                  key={`${h.host.type}:${h.host.value}`}
-                  data-testid={`device-timeline-other-host-${h.host.value}`}
+                  key={`${e.entity.kind}:${e.entity.id}`}
+                  data-testid={`device-timeline-other-entry-${e.entity.kind}-${e.entity.id}`}
                   className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2 gap-2"
                 >
-                  <HostCell host={h.host} className="truncate min-w-0" />
+                  <span className="truncate min-w-0 flex items-center gap-2">
+                    <span className="truncate">{e.entity.name}</span>
+                    <span className="text-[10px] text-brand-text-muted uppercase shrink-0">{e.entity.kind}</span>
+                  </span>
                   <span className="text-brand-text-muted font-mono shrink-0 tabular-nums">
-                    {formatMins(h.dayMins)}
+                    {formatMins(e.dayMins)}
                     <span className="text-brand-text-muted ml-2">
                       {shareOther.toFixed(0)}% of Other · {shareTotal.toFixed(0)}% of day
                     </span>

--- a/web/src/pages/ProfileTimelinePage.test.tsx
+++ b/web/src/pages/ProfileTimelinePage.test.tsx
@@ -132,7 +132,7 @@ describe('ProfileTimelinePage', () => {
     expect(screen.queryByTestId('profile-timeline-host-youtube.com')).toBeNull()
   })
 
-  it('toggles between Total, Host, and Device; updates the visible breakdown', async () => {
+  it('toggles between Total and Device; updates the visible breakdown', async () => {
     (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       richResponse('2026-05-20'),
     )
@@ -140,31 +140,12 @@ describe('ProfileTimelinePage', () => {
     await waitFor(() =>
       expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
     )
-
-    fireEvent.click(screen.getByTestId('profile-timeline-stack-host'))
-    await waitFor(() =>
-      expect(screen.getByTestId('profile-timeline-host-youtube.com')).toBeInTheDocument(),
-    )
-    expect(screen.queryByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeNull()
+    expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('profile-timeline-stack-device'))
     await waitFor(() =>
       expect(screen.getByTestId('profile-timeline-device-aa:bb:cc:dd:ee:01')).toBeInTheDocument(),
     )
-    expect(screen.queryByTestId('profile-timeline-host-youtube.com')).toBeNull()
-  })
-
-  it('disables the App toggle with a tooltip until #769 lands', async () => {
-    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
-      richResponse('2026-05-20'),
-    )
-    renderPage([`/profiles/${PID}/timeline?date=2026-05-20`])
-    await waitFor(() =>
-      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
-    )
-    const appBtn = screen.getByTestId('profile-timeline-stack-app')
-    expect(appBtn).toBeDisabled()
-    expect(appBtn).toHaveAttribute('title')
   })
 
   // #1079 — unified by-app axis. Host toggle gone; App renders the mixed

--- a/web/src/pages/ProfileTimelinePage.test.tsx
+++ b/web/src/pages/ProfileTimelinePage.test.tsx
@@ -167,6 +167,74 @@ describe('ProfileTimelinePage', () => {
     expect(appBtn).toHaveAttribute('title')
   })
 
+  // #1079 — unified by-app axis. Host toggle gone; App renders the mixed
+  // app + non-app-host series; 'Other' only when long tail exceeds top-N.
+  it('#1079: stack-by toggle is Total/Device/App; Host is removed', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/profiles/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-stack-total')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('profile-timeline-stack-host')).toBeNull()
+    expect(screen.getByTestId('profile-timeline-stack-device')).toBeInTheDocument()
+    expect(screen.getByTestId('profile-timeline-stack-app')).toBeInTheDocument()
+  })
+
+  it('#1079: App view renders app + non-app-host entries from topEntries', async () => {
+    const resp: UsageSeriesResponse = {
+      ...richResponse('2026-05-20'),
+      topEntries: [
+        { entity: { kind: 'app',  id: 'youtube',  name: 'YouTube', appId: 1 }, dayMins: 25 },
+        { entity: { kind: 'host', id: 'drop.com', name: 'drop.com', host: { type: 'fqdn', value: 'drop.com' } }, dayMins: 10 },
+      ],
+      bucketsByEntry: Array.from({ length: 24 }, (_, h) => ({
+        hour: h,
+        totalMins: h === 14 ? 35 : 0,
+        perEntity: h === 14 ? [
+          { entity: { kind: 'app',  id: 'youtube',  name: 'YouTube', appId: 1 }, mins: 25 },
+          { entity: { kind: 'host', id: 'drop.com', name: 'drop.com', host: { type: 'fqdn', value: 'drop.com' } }, mins: 10 },
+        ] : [],
+        otherMins: 0,
+      })),
+    }
+    ;(api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(resp)
+    renderPage([`/profiles/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-stack-app')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByTestId('profile-timeline-stack-app'))
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-entry-app-youtube')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('profile-timeline-entry-host-drop.com')).toBeInTheDocument()
+  })
+
+  it('#1079: App view shows Other only when long tail exceeds top-N', async () => {
+    const resp: UsageSeriesResponse = {
+      ...richResponse('2026-05-20'),
+      topEntries: [
+        { entity: { kind: 'host', id: 'drop.com', name: 'drop.com', host: { type: 'fqdn', value: 'drop.com' } }, dayMins: 5 },
+      ],
+      bucketsByEntry: Array.from({ length: 24 }, (_, h) => ({
+        hour: h,
+        totalMins: h === 14 ? 5 : 0,
+        perEntity: h === 14
+          ? [{ entity: { kind: 'host', id: 'drop.com', name: 'drop.com', host: { type: 'fqdn', value: 'drop.com' } }, mins: 5 }]
+          : [],
+        otherMins: 0,
+      })),
+    }
+    ;(api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(resp)
+    renderPage([`/profiles/${PID}/timeline?date=2026-05-20&stackBy=app`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-entry-host-drop.com')).toBeInTheDocument(),
+    )
+    // No long tail in this fixture → no Other entry in the legend.
+    expect(screen.queryByTestId('profile-timeline-entry-other')).toBeNull()
+  })
+
   it('reads stackBy=device from URL', async () => {
     (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
       richResponse('2026-05-20'),

--- a/web/src/pages/ProfileTimelinePage.tsx
+++ b/web/src/pages/ProfileTimelinePage.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import { HostCell } from '@/components/HostCell'
 import type {
-  UsageBucket, UsageDeviceBucket, UsageSeriesResponse,
+  UsageDeviceBucket, UsageEntityBucket, UsageSeriesResponse,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import {
@@ -13,43 +12,38 @@ import {
 // #722 — per-profile daily timeline. Hourly stacked-bar chart of minutes-of-use
 // across all of a profile's devices, with a stack-by toggle that switches which
 // dimension drives the stacks. Colors are derived from a stable index of the
-// top-N entries so the same host (or device) keeps its color across re-renders.
+// top-N entries so the same entity keeps its color across re-renders.
 //
-// #964 — group-by options expanded to {total, host, device, app}. Default is
-// `total` (no drill-down, single bar per hour = profile total) to match the
-// strictly-additive aggregation model from #917. `app` is gated until the apps
-// chain (#769) extends /api/usage/series; rendered as disabled with a tooltip.
+// #1079 — group-by options collapsed to {total, device, app}. The standalone
+// 'host' axis was retired in favor of a unified by-app axis: apps roll up
+// their member hosts, non-app hosts surface individually, and 'Other' is
+// strictly the long tail past top-N (not a catch-all for unmapped hosts).
 
 const TOP_N = 5
 const DEFAULT_TZ =
   Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 
-type StackBy = 'total' | 'host' | 'device' | 'app'
+type StackBy = 'total' | 'device' | 'app'
 
 const STACK_BY_OPTIONS: ReadonlyArray<{
   key: StackBy
   label: string
-  disabled?: boolean
-  title?: string
 }> = [
   { key: 'total',  label: 'Total' },
-  { key: 'host',   label: 'Host' },
   { key: 'device', label: 'Device' },
-  {
-    key: 'app',
-    label: 'App',
-    disabled: true,
-    title: 'Grouping by app requires the apps chain (#769) — coming soon.',
-  },
+  { key: 'app',    label: 'App' },
 ]
 
 function parseStackBy(s: string | null): StackBy {
   switch (s) {
-    case 'host':   return 'host'
     case 'device': return 'device'
-    // 'app' isn't selectable yet — fall through to total.
+    case 'app':    return 'app'
     default:       return 'total'
   }
+}
+
+function entityKey(e: { kind: string; id: string }): string {
+  return `${e.kind}:${e.id}`
 }
 
 function todayISO(): string {
@@ -70,14 +64,14 @@ function addDays(iso: string, n: number): string {
   return `${yy}-${mm}-${dd}`
 }
 
-function buildHostRows(buckets: UsageBucket[], keys: string[]) {
+function buildEntityRows(buckets: UsageEntityBucket[], keys: string[]) {
   return buckets.map(b => {
     const row: Record<string, number | string> = {
       hour: String(b.hour).padStart(2, '0'),
       total: b.totalMins,
     }
     for (const k of keys) row[k] = 0
-    for (const ph of b.perHost) row[ph.host.value] = ph.mins
+    for (const pe of b.perEntity) row[entityKey(pe.entity)] = pe.mins
     row[OTHER_KEY] = b.otherMins
     return row as { hour: string; total: number; [k: string]: number | string }
   })
@@ -117,11 +111,14 @@ export function ProfileTimelinePage() {
     }
     setLoading(true)
     setError(null)
-    api.usage.series({ profileId: pid, date, tz: DEFAULT_TZ, topN: TOP_N })
+    api.usage.series({
+      profileId: pid, date, tz: DEFAULT_TZ, topN: TOP_N,
+      groupBy: stackBy === 'app' ? 'app' : undefined,
+    })
       .then(setData)
       .catch(e => setError(e.message ?? 'Failed to load'))
       .finally(() => setLoading(false))
-  }, [profileId, date])
+  }, [profileId, date, stackBy])
 
   function pushParam(key: string, val: string) {
     const sp = new URLSearchParams(params)
@@ -133,14 +130,16 @@ export function ProfileTimelinePage() {
 
   const chart = useMemo(() => {
     if (!data) return { rows: [], series: [] as ChartSeries[] }
-    if (stackBy === 'host') {
-      // Top-host indices drive colors; same host across renders keeps the
-      // same slot because the server returns topHosts sorted deterministically.
-      const keys = (data.topHosts ?? []).filter(h => h.dayMins > 0).map(h => h.host.value)
-      const series: ChartSeries[] = keys.map((k, i) => ({
-        key: k, name: k, color: HOST_COLORS[i % HOST_COLORS.length],
+    if (stackBy === 'app') {
+      // #1079 unified axis: apps + non-app hosts are first-class siblings.
+      const top  = (data.topEntries ?? []).filter(e => e.dayMins > 0)
+      const keys = top.map(e => entityKey(e.entity))
+      const series: ChartSeries[] = top.map((e, i) => ({
+        key: entityKey(e.entity),
+        name: e.entity.name,
+        color: HOST_COLORS[i % HOST_COLORS.length],
       }))
-      return { rows: buildHostRows(data.buckets, keys), series }
+      return { rows: buildEntityRows(data.bucketsByEntry ?? [], keys), series }
     } else if (stackBy === 'device') {
       const top = (data.topDevices ?? []).filter(d => d.dayMins > 0)
       const keys = top.map(d => d.deviceMac)
@@ -168,7 +167,10 @@ export function ProfileTimelinePage() {
 
   if (loading && !data) return <PageLoader />
 
-  const buckets = stackBy === 'device' ? data?.bucketsByDevice : data?.buckets
+  const buckets =
+    stackBy === 'device' ? data?.bucketsByDevice
+    : stackBy === 'app'    ? data?.bucketsByEntry
+    : data?.buckets
   const dayTotal = buckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
   const isEmpty  = dayTotal === 0
 
@@ -222,17 +224,12 @@ export function ProfileTimelinePage() {
                   key={opt.key}
                   role="tab"
                   aria-selected={stackBy === opt.key}
-                  aria-disabled={opt.disabled || undefined}
-                  disabled={opt.disabled}
-                  title={opt.title}
                   data-testid={`profile-timeline-stack-${opt.key}`}
-                  onClick={() => { if (!opt.disabled) setStackAndPush(opt.key) }}
+                  onClick={() => setStackAndPush(opt.key)}
                   className={`px-3 py-1.5 rounded-md font-medium transition-colors ${
                     stackBy === opt.key
                       ? 'bg-brand-accent text-white'
-                      : opt.disabled
-                        ? 'text-brand-text-muted cursor-not-allowed'
-                        : 'text-brand-text hover:text-brand-ink'
+                      : 'text-brand-text hover:text-brand-ink'
                   }`}
                 >
                   {opt.label}
@@ -278,31 +275,42 @@ export function ProfileTimelinePage() {
         </p>
       </div>
 
-      {data && stackBy === 'host' && (data.topHosts ?? []).length > 0 && (
+      {data && stackBy === 'app' && (data.topEntries ?? []).length > 0 && (
         <div className="bg-white rounded-2xl border border-brand-border p-5">
           <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-3">
-            Top hosts
+            Top apps &amp; hosts
           </h2>
           <ul className="space-y-1.5">
-            {data.topHosts.filter(h => h.dayMins > 0).map((h, i) => {
+            {data.topEntries!.filter(e => e.dayMins > 0).map((e, i) => {
+              const id = `${e.entity.kind}-${e.entity.id}`
               return (
                 <li
-                  key={`${h.host.type}:${h.host.value}`}
-                  data-testid={`profile-timeline-host-${h.host.value}`}
+                  key={entityKey(e.entity)}
+                  data-testid={`profile-timeline-entry-${id}`}
                   className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2"
+                  title={e.entity.kind === 'app'
+                    ? `App: rolls up its member hosts`
+                    : `Host: not attached to any app`}
                 >
                   <span className="flex items-center gap-2 min-w-0">
                     <span
                       className="inline-block w-2.5 h-2.5 rounded-sm shrink-0"
                       style={{ background: HOST_COLORS[i % HOST_COLORS.length] }}
                     />
-                    <HostCell host={h.host} className="truncate" />
+                    <span className="truncate">{e.entity.name}</span>
+                    <span className="text-[10px] text-brand-text-muted uppercase shrink-0">
+                      {e.entity.kind}
+                    </span>
                   </span>
-                  <span className="text-brand-text-muted font-mono shrink-0 ml-2">{h.dayMins}m</span>
+                  <span className="text-brand-text-muted font-mono shrink-0 ml-2">{e.dayMins}m</span>
                 </li>
               )
             })}
           </ul>
+          <p className="text-[10px] text-brand-text-muted mt-2">
+            'Other' covers hosts past the top {TOP_N}, not unmapped hosts —
+            those still appear individually above.
+          </p>
         </div>
       )}
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -407,6 +407,35 @@ export interface UsageDeviceBucket {
   otherMins: number
 }
 
+// #1079 — unified by-app axis. Apps roll up their member hosts; non-app hosts
+// surface individually as first-class entries; 'Other' is strictly the long
+// tail past top-N (never a catch-all for unmapped hosts).
+export interface UsageEntityRef {
+  kind: 'app' | 'host'
+  id: string
+  name: string
+  appId?: number
+  appIcon?: string
+  host?: HostId
+}
+
+export interface UsageEntityTotal {
+  entity: UsageEntityRef
+  dayMins: number
+}
+
+export interface UsageBucketEntity {
+  entity: UsageEntityRef
+  mins: number
+}
+
+export interface UsageEntityBucket {
+  hour: number
+  totalMins: number
+  perEntity: UsageBucketEntity[]
+  otherMins: number
+}
+
 export interface UsageSeriesResponse {
   // device-mode fields (mac=)
   deviceMac?: string
@@ -420,6 +449,9 @@ export interface UsageSeriesResponse {
   buckets: UsageBucket[]
   topDevices?: UsageDeviceTotal[]
   bucketsByDevice?: UsageDeviceBucket[]
+  // #1079 — populated when the request asked groupBy=app.
+  topEntries?: UsageEntityTotal[]
+  bucketsByEntry?: UsageEntityBucket[]
 }
 
 // #846 — Traffic Usage page. Wire-distinct from UsageSeriesResponse: that one


### PR DESCRIPTION
## Summary
- /api/usage/series groupBy=app now emits per-app rows + individual non-app host rows, capped at top-N (default 5); 'Other' = long tail only
- Chart toggle becomes \`Total / Device / App\` across /profiles expansion, /devices/:mac/timeline, /time/:profileId/timeline (Host removed)
- App view renders the unified series; 'Other' tooltip describes long tail, not all unmapped hosts

## Test plan
- [ ] API feature test: mixed app + non-app + long-tail series matches expected rows
- [ ] vitest: Host toggle gone; App view renders unified series + Other tail only when > top-N
- [ ] mill api.test + scalafmtCheckAll clean; vitest clean

Closes #1079, closes #778.