### PR TITLE
fix(openwrt): auto-update picks correct wifihaven asset + highest version (#1178)

### DIFF
--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -31,13 +31,21 @@ log() { logger -t wifihaven "update: $*"; }
 
 # Detect package manager. Prefer apk (24.10+) when both are present, since
 # routers mid-migration may still ship a vestigial opkg binary.
+#
+# PKG_NAME_RE is matched against the asset *basename*, not the full URL, and
+# is tight enough to reject luci-app-wifihaven and any future named variants
+# attached to the same release (#1178). The bare extension regex
+# (PKG_EXT) was too loose: GitHub publishes both luci-app and agent assets
+# under openwrt-latest, and "first match wins" silently picked the wrong one.
 if command -v apk >/dev/null 2>&1; then
   PM=apk
   PKG_EXT='\.apk$'
+  PKG_NAME_RE='^wifihaven_[^_]+_all\.apk$'
   TMP=/tmp/wifihaven-update.apk
 elif command -v opkg >/dev/null 2>&1; then
   PM=opkg
   PKG_EXT='\.ipk$'
+  PKG_NAME_RE='^wifihaven_[^_]+_[^_]+\.ipk$'
   TMP=/tmp/wifihaven-update.ipk
 else
   log "no package manager found (neither apk nor opkg); skipping"
@@ -50,23 +58,39 @@ if [ -z "$META" ]; then
   exit 0
 fi
 
-# Rolling-release freshness signal: the matched asset's sha256 digest. We walk
-# assets[*] in order, take the first whose URL matches our package extension,
-# and read its digest at the same index. (jsonfilter has no native way to
-# project paired fields, hence the index loop.)
-LATEST_URL=
-LATEST_STAMP=
+# Rolling-release freshness signal: the matched asset's sha256 digest. We
+# walk assets[*] collecting every entry whose *basename* matches the
+# agent-package regex (PKG_NAME_RE — see comment near package-manager
+# detection), then pick the highest version. GitHub asset order is not
+# deterministic across re-uploads, so "first match wins" would flap when CI
+# re-attaches the rolling assets (#1178).
+MATCHES=
 i=0
 while :; do
   URL=$(printf '%s' "$META" | jsonfilter -e "@.assets[$i].browser_download_url" 2>/dev/null)
   [ -z "$URL" ] && break
-  if printf '%s' "$URL" | grep -qE "$PKG_EXT"; then
-    LATEST_URL="$URL"
-    LATEST_STAMP=$(printf '%s' "$META" | jsonfilter -e "@.assets[$i].digest")
-    break
+  BASENAME=${URL##*/}
+  if printf '%s' "$BASENAME" | grep -qE "$PKG_NAME_RE"; then
+    DIGEST=$(printf '%s' "$META" | jsonfilter -e "@.assets[$i].digest")
+    # Version is the segment between 'wifihaven_' and the next underscore
+    # (e.g. '0.2.8-1' from wifihaven_0.2.8-1_all.apk).
+    VER=${BASENAME#wifihaven_}
+    VER=${VER%%_*}
+    MATCHES="${MATCHES}${VER} ${DIGEST} ${URL}
+"
   fi
   i=$((i + 1))
 done
+
+# sort -V (version sort) is supported by busybox sort on OpenWRT 23.05+ and
+# handles the rc-style suffixes our semver tags use (e.g. 0.2.8-1).
+LATEST_URL=
+LATEST_STAMP=
+BEST=$(printf '%s' "$MATCHES" | grep -v '^$' | sort -V -k1,1 | tail -n1)
+if [ -n "$BEST" ]; then
+  LATEST_STAMP=$(printf '%s\n' "$BEST" | awk '{print $2}')
+  LATEST_URL=$(printf '%s\n' "$BEST" | awk '{print $3}')
+fi
 if [ -z "$LATEST_STAMP" ] || [ -z "$LATEST_URL" ]; then
   log "could not resolve rolling release digest/asset; skipping"
   exit 0

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -322,5 +322,161 @@ grep -q 'restart failed' "$TESTDIR/logger.out" \
   || check "[restart fail] warning logged" "no warning in log"
 rm -rf "$TESTDIR"
 
+# ---- #1178: asset selection across multi-version, multi-package manifests ----
+# Before the fix, the asset regex was '\.apk$' / '\.ipk$' and the script took
+# the FIRST matching asset. With #499's coordinated semver tags and #1041's
+# luci-app-wifihaven package, `openwrt-latest` now publishes four matching
+# .apk assets per release: {luci-app-,}wifihaven_{old,new}_all.apk. The first
+# match was usually luci-app or an older wifihaven, and the script silently
+# either installed the wrong package or short-circuited on a stale digest.
+
+setup_multi_mocks() {
+  TESTDIR=$(mktemp -d -t wifihaven-update-multi.XXXXXX)
+  BINDIR="$TESTDIR/bin"
+  STATE="$TESTDIR/state"
+  mkdir -p "$BINDIR" "$STATE"
+  : > "$TESTDIR/downloads.log"
+
+  cat > "$BINDIR/logger" <<EOF
+#!/bin/sh
+shift 2
+printf '%s\n' "\$*" >> "$TESTDIR/logger.out"
+EOF
+
+  # curl records the URL it was asked to download so the test can assert
+  # which asset was picked. Meta fetches read MOCK_ASSETS_JSON; the smarter
+  # jsonfilter mock below indexes into MOCK_ASSETS instead, so meta body is
+  # only used to satisfy `[ -z "$META" ]`.
+  cat > "$BINDIR/curl" <<EOF
+#!/bin/sh
+out=""
+url=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) out="\$2"; shift 2;;
+    -*) shift;;
+    *) url="\$1"; shift;;
+  esac
+done
+if [ -n "\$out" ]; then
+  if [ "\${CURL_DOWNLOAD_FAIL:-0}" = "1" ]; then exit 22; fi
+  printf '%s\n' "\$url" >> "$TESTDIR/downloads.log"
+  printf 'fakepkg' > "\$out"
+else
+  printf '%s\n' "{\"assets\":[]}"
+fi
+EOF
+
+  # Smart jsonfilter mock: walks MOCK_ASSETS (newline-separated "url|digest")
+  # and answers any '@.assets[<i>].browser_download_url' / '...digest' query.
+  cat > "$BINDIR/jsonfilter" <<'EOF'
+#!/bin/sh
+expr=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -e) expr="$2"; shift 2;;
+    *) shift;;
+  esac
+done
+cat >/dev/null
+case "$expr" in
+  *.browser_download_url) field=url ;;
+  *.digest) field=digest ;;
+  *) exit 0 ;;
+esac
+idx=$(printf '%s' "$expr" | sed -n 's/.*\[\([0-9]*\)\].*/\1/p')
+line=$(printf '%s\n' "$MOCK_ASSETS" | sed -n "$((idx + 1))p")
+[ -z "$line" ] && exit 0
+url=${line%%|*}
+digest=${line##*|}
+case "$field" in
+  url) printf '%s\n' "$url" ;;
+  digest) printf '%s\n' "$digest" ;;
+esac
+EOF
+
+  INITD="$BINDIR/wifihaven-initd"
+  cat > "$INITD" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$TESTDIR/initd.calls"
+exit 0
+EOF
+
+  PATCHED="$TESTDIR/wifihaven-update"
+  sed -e "s|STATE_DIR=/var/lib/wifihaven|STATE_DIR=$STATE|" \
+      -e "s|/etc/init.d/wifihaven|$INITD|g" \
+      "$SCRIPT" > "$PATCHED"
+  chmod +x "$PATCHED" "$BINDIR"/*
+}
+
+picked_url() { tail -n1 "$TESTDIR/downloads.log" 2>/dev/null; }
+
+# Case G (#1178): multi-asset manifest with luci-app listed FIRST and the old
+# wifioven listed BEFORE the new one. Fix must (a) reject luci-app and
+# (b) pick the highest-version wifihaven, not the first matching asset.
+setup_multi_mocks
+mock_apk
+export MOCK_ASSETS="https://example.com/luci-app-wifihaven_0.1.0-1_all.apk|sha256:LUCI_OLD
+https://example.com/luci-app-wifihaven_0.2.8-1_all.apk|sha256:LUCI_NEW
+https://example.com/wifihaven_0.1.0-1_all.apk|sha256:WH_OLD
+https://example.com/wifihaven_0.2.8-1_all.apk|sha256:WH_NEW"
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+URL=$(picked_url)
+case "$URL" in
+  *luci-app*) check "[#1178 multi apk] does not pick luci-app asset" "picked $URL" ;;
+  *) check "[#1178 multi apk] does not pick luci-app asset" ok ;;
+esac
+case "$URL" in
+  *wifihaven_0.2.8-1_all.apk) check "[#1178 multi apk] picks highest-version wifihaven asset" ok ;;
+  *) check "[#1178 multi apk] picks highest-version wifihaven asset" "picked '$URL'" ;;
+esac
+[ "$(stamp_value)" = "sha256:WH_NEW" ] \
+  && check "[#1178 multi apk] stamp recorded matches the new asset" ok \
+  || check "[#1178 multi apk] stamp recorded matches the new asset" "stamp = '$(stamp_value)'"
+rm -rf "$TESTDIR"
+unset MOCK_ASSETS
+
+# Case H (#1178): manifest carries ONLY the old wifihaven version, and the
+# stamp already matches that digest. Script must short-circuit — no download,
+# no apk invocation. Guards against the regression where luci-app in the
+# manifest fooled the script into "upgrading" to an older asset.
+setup_multi_mocks
+mock_apk
+export MOCK_ASSETS="https://example.com/luci-app-wifihaven_0.1.0-1_all.apk|sha256:LUCI_OLD
+https://example.com/wifihaven_0.1.0-1_all.apk|sha256:WH_OLD"
+printf 'sha256:WH_OLD\n' > "$STATE/last_update_digest"
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+[ ! -s "$TESTDIR/downloads.log" ] \
+  && check "[#1178 old-only] no download when wifihaven stamp matches" ok \
+  || check "[#1178 old-only] no download when wifihaven stamp matches" "downloaded: $(picked_url)"
+[ ! -f "$TESTDIR/apk.calls" ] \
+  && check "[#1178 old-only] apk NOT invoked when wifihaven stamp matches" ok \
+  || check "[#1178 old-only] apk NOT invoked when wifihaven stamp matches" "apk.calls exists"
+rm -rf "$TESTDIR"
+unset MOCK_ASSETS
+
+# Case I (#1178): opkg path gets the same tightening. .ipk asset names carry
+# an architecture suffix (e.g. _aarch64_generic.ipk), so the ipk regex shape
+# differs from apk's.
+setup_multi_mocks
+rm -f "$BINDIR/apk"
+mock_opkg
+export MOCK_ASSETS="https://example.com/luci-app-wifihaven_0.1.0-1_aarch64_generic.ipk|sha256:LUCI_OLD_IPK
+https://example.com/luci-app-wifihaven_0.2.8-1_aarch64_generic.ipk|sha256:LUCI_NEW_IPK
+https://example.com/wifihaven_0.1.0-1_aarch64_generic.ipk|sha256:WH_OLD_IPK
+https://example.com/wifihaven_0.2.8-1_aarch64_generic.ipk|sha256:WH_NEW_IPK"
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+URL=$(picked_url)
+case "$URL" in
+  *luci-app*) check "[#1178 multi ipk] does not pick luci-app .ipk" "picked $URL" ;;
+  *) check "[#1178 multi ipk] does not pick luci-app .ipk" ok ;;
+esac
+case "$URL" in
+  *wifihaven_0.2.8-1_aarch64_generic.ipk) check "[#1178 multi ipk] picks highest-version wifihaven .ipk" ok ;;
+  *) check "[#1178 multi ipk] picks highest-version wifihaven .ipk" "picked '$URL'" ;;
+esac
+rm -rf "$TESTDIR"
+unset MOCK_ASSETS
+
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -168,7 +168,7 @@ if [ -n "$out" ]; then
   if [ "${CURL_DOWNLOAD_FAIL:-0}" = "1" ]; then exit 22; fi
   printf 'fakepkg' > "$out"
 else
-  printf '%s\n' '{"assets":[{"browser_download_url":"https://example.com/wifihaven.apk","digest":"sha256:NEW"},{"browser_download_url":"https://example.com/wifihaven.ipk","digest":"sha256:NEW"}]}'
+  printf '%s\n' '{"assets":[{"browser_download_url":"https://example.com/wifihaven_0.2.8-1_all.apk","digest":"sha256:NEW"},{"browser_download_url":"https://example.com/wifihaven_0.2.8-1_all.ipk","digest":"sha256:NEW"}]}'
 fi
 CURL_EOF
 
@@ -186,9 +186,9 @@ while [ $# -gt 0 ]; do
 done
 cat >/dev/null
 case "$expr" in
-  '@.assets[0].browser_download_url') echo "https://example.com/wifihaven.apk";;
+  '@.assets[0].browser_download_url') echo "https://example.com/wifihaven_0.2.8-1_all.apk";;
   '@.assets[0].digest') echo "sha256:NEW";;
-  '@.assets[1].browser_download_url') echo "https://example.com/wifihaven.ipk";;
+  '@.assets[1].browser_download_url') echo "https://example.com/wifihaven_0.2.8-1_all.ipk";;
   '@.assets[1].digest') echo "sha256:NEW";;
   *) ;;  # empty → caller treats as end-of-array
 esac
@@ -456,15 +456,15 @@ rm -rf "$TESTDIR"
 unset MOCK_ASSETS
 
 # Case I (#1178): opkg path gets the same tightening. .ipk asset names carry
-# an architecture suffix (e.g. _aarch64_generic.ipk), so the ipk regex shape
+# an architecture suffix (e.g. _all.ipk), so the ipk regex shape
 # differs from apk's.
 setup_multi_mocks
 rm -f "$BINDIR/apk"
 mock_opkg
-export MOCK_ASSETS="https://example.com/luci-app-wifihaven_0.1.0-1_aarch64_generic.ipk|sha256:LUCI_OLD_IPK
-https://example.com/luci-app-wifihaven_0.2.8-1_aarch64_generic.ipk|sha256:LUCI_NEW_IPK
-https://example.com/wifihaven_0.1.0-1_aarch64_generic.ipk|sha256:WH_OLD_IPK
-https://example.com/wifihaven_0.2.8-1_aarch64_generic.ipk|sha256:WH_NEW_IPK"
+export MOCK_ASSETS="https://example.com/luci-app-wifihaven_0.1.0-1_all.ipk|sha256:LUCI_OLD_IPK
+https://example.com/luci-app-wifihaven_0.2.8-1_all.ipk|sha256:LUCI_NEW_IPK
+https://example.com/wifihaven_0.1.0-1_all.ipk|sha256:WH_OLD_IPK
+https://example.com/wifihaven_0.2.8-1_all.ipk|sha256:WH_NEW_IPK"
 PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
 URL=$(picked_url)
 case "$URL" in
@@ -472,7 +472,7 @@ case "$URL" in
   *) check "[#1178 multi ipk] does not pick luci-app .ipk" ok ;;
 esac
 case "$URL" in
-  *wifihaven_0.2.8-1_aarch64_generic.ipk) check "[#1178 multi ipk] picks highest-version wifihaven .ipk" ok ;;
+  *wifihaven_0.2.8-1_all.ipk) check "[#1178 multi ipk] picks highest-version wifihaven .ipk" ok ;;
   *) check "[#1178 multi ipk] picks highest-version wifihaven .ipk" "picked '$URL'" ;;
 esac
 rm -rf "$TESTDIR"


### PR DESCRIPTION
## Summary
- Tighten asset regex to `^wifihaven_<ver>_all.apk$` / `_all.ipk$` matched against the basename — rejects `luci-app-wifihaven` and any future named variants attached to `openwrt-latest`.
- Walk *all* matching assets and pick the highest version via `sort -V`, instead of relying on GitHub's (non-deterministic) asset ordering. Without this, a stale older asset can win on re-publish and the digest short-circuit keeps the router pinned.
- Shell test pins the asset-pick logic across a representative multi-version manifest (luci-app + agent, old + new) plus an old-only no-op case, on both apk and opkg paths.

## TDD
- Commit 1 (red): three new cases in `openwrt/test/update_spec.sh` that fail on `main`.
- Commit 2 (green): regex + version-pick fix; brings the existing test fixture asset names in line with the tightened regex.

## Test plan
- [ ] New test fails on `main`, passes on this branch (`sh openwrt/test/update_spec.sh`)
- [ ] Full OpenWRT shell-test suite green
- [ ] After merge + `openwrt-latest` re-publish on next master-router CD, run `/usr/sbin/wifihaven-update` once on the prod router (192.168.10.1); confirm `apk version wifihaven` reports the current tag and `logread` carries the `update: rolling asset digest changed` + `update: installed rolling build` lines.

## Out of scope
Whether `luci-app-wifihaven` should also be in the auto-update path is a separate decision (it's the router footprint, but needs an explicit select-by-name step, not a side-effect of a loose regex). Worth a follow-up issue.

Closes #1178.