### PR TITLE
ci: enforce migration-only PRs as the back-compat gate (#1179)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 
 ## Migration checklist
 
-- [ ] If this PR adds a Flyway migration, it touches **only** the migration + tests + docs + CI config — no `api/src/**`, `shared/src/**`, router agents, or `web/src/**`. The existing feature-test suite is the back-compat gate; that only works when migrations land alone. Code that uses the new schema goes in a follow-up PR. See [AGENTS.md §migrations-back-compat](../blob/main/AGENTS.md#migrations-back-compat).
+- [ ] If this PR adds a Flyway migration, it touches **only** the migration file(s) and Markdown docs — no source, no tests, no CI config, no fixtures. Tests for the new schema shape go in the follow-up PR that adopts it. The existing feature-test suite is the back-compat gate, and it only works when nothing else in the PR can move. See [AGENTS.md §migrations-back-compat](../blob/main/AGENTS.md#migrations-back-compat).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this PR change and why? Keep it short — link issues for detail. -->
+
+## Test plan
+
+<!-- Bulleted checklist of how this was tested. -->
+
+## Migration checklist
+
+- [ ] If this PR adds a Flyway migration, it touches **only** the migration + tests + docs + CI config — no `api/src/**`, `shared/src/**`, router agents, or `web/src/**`. The existing feature-test suite is the back-compat gate; that only works when migrations land alone. Code that uses the new schema goes in a follow-up PR. See [AGENTS.md §migrations-back-compat](../blob/main/AGENTS.md#migrations-back-compat).

--- a/.github/scripts/check-migration-isolation.sh
+++ b/.github/scripts/check-migration-isolation.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
-# If a PR adds a new Flyway migration, it must not also change production
-# source code (Scala, Lua router agent, Python OPNsense agent, frontend
-# src/, contract producers). Migration-only PRs guarantee that the existing
-# feature-test suite runs the OLD code against the NEW schema via the
-# embedded Postgres in TestDatabase — that is the real backward-compatibility
-# gate: if image-(N-1)'s code can't drive image-N's schema, the tests fail.
+# If a PR adds a new Flyway migration, it must contain ONLY the migration
+# plus documentation / agent-direction updates (Markdown). No source code,
+# no test changes, no CI config, no anything else.
+#
+# Why so strict? The real backward-compatibility gate is the existing
+# api.test feature suite (TestDatabase + embedded Postgres) — every
+# Flyway migration on the classpath is applied before tests run, including
+# the new one in this PR, and the existing test fixtures exercise the
+# unchanged production code paths in api/src/**. If image-(N-1) cannot
+# drive image-N's schema, the tests fail.
+#
+# Allowing test changes alongside the migration silently bypasses that
+# gate: a test author can adapt the fixtures to the new shape and the
+# back-compat regression becomes invisible until production rolls back.
+# Same for CI config. Only docs (which can never alter execution) are
+# safe to ship in the same PR.
 #
 # Allowed alongside a new migration:
-#   - api/resources/db/migration/**  (additional migration files)
-#   - api/test/**, shared/test/**    (tests — these run the old code paths)
-#   - **/*.md, .github/**            (docs, CI config)
-#   - .claude/**                     (local agent state — never in CI)
+#   - api/resources/db/migration/**   (more migration files)
+#   - **/*.md                         (docs, AGENTS.md, CLAUDE.md, READMEs)
 #
-# Denied (anything else under known production source roots):
-#   - api/src/**, shared/src/**, openwrt/files/**, openwrt/*.lua (non-test),
-#     opnsense/agent.py and other non-test python, web/src/**,
-#     docker/fake-router.py and other contract producers.
+# Disallowed: anything else — source code, tests, CI workflows, scripts,
+# fixtures, contract goldens, build files, configs. Code that adopts the
+# new schema (including new tests for it) lands in a follow-up PR.
 #
 # Escape hatch: apply the `migration-coupled-justified` label on the PR
 # and the workflow skips this job. Use it sparingly, with a written
@@ -48,26 +55,13 @@ done < <(git diff --name-only "${BASE}...HEAD")
 
 is_allowed() {
   local f="$1"
+  # Migrations directory: more migrations are fine in the same PR.
   case "$f" in
-    api/resources/db/migration/*) return 0 ;;
-    api/test/*|shared/test/*|openwrt/test/*|opnsense/test/*) return 0 ;;
-    .github/*) return 0 ;;
-    .claude/*) return 0 ;;
-    *.md|*/*.md|*/*/*.md|*/*/*/*.md) return 0 ;;
+    api/resources/db/migration/*.sql) return 0 ;;
   esac
-  return 1
-}
-
-is_denied_prod() {
-  local f="$1"
+  # Markdown: docs + agent-direction (AGENTS.md, CLAUDE.md, READMEs).
   case "$f" in
-    api/src/*|shared/src/*) return 0 ;;
-    openwrt/files/*) return 0 ;;
-    openwrt/*.lua) return 0 ;;
-    opnsense/agent.py|opnsense/wifihaven_*.py) return 0 ;;
-    web/src/*) return 0 ;;
-    docker/fake-router.py) return 0 ;;
-    shared/contract/*) return 0 ;;
+    *.md) return 0 ;;
   esac
   return 1
 }
@@ -75,35 +69,37 @@ is_denied_prod() {
 bad=()
 for f in "${changed[@]}"; do
   [[ -z "$f" ]] && continue
-  if is_allowed "$f"; then continue; fi
-  if is_denied_prod "$f"; then bad+=("$f"); fi
+  is_allowed "$f" && continue
+  bad+=("$f")
 done
 
 if [[ ${#bad[@]} -gt 0 ]]; then
-  echo "BLOCKED: this PR adds a migration AND touches production source:" >&2
+  echo "BLOCKED: this PR adds a migration AND touches non-migration / non-docs files:" >&2
   printf '  %s\n' "${bad[@]}" >&2
   cat >&2 <<'MSG'
 
-Schema changes must land in their own PR. The reason: the existing
-feature-test suite in api/test/** runs against embedded Postgres
-loaded with all migrations (including the new one) but the
-production code paths are unchanged. That's the real backward-
-compatibility gate — if image-(N-1) cannot drive image-N's schema,
-the existing tests will fail.
+Migrations must land alone, alongside docs only. The existing
+api.test feature suite is the back-compat gate: it applies every
+migration on the classpath against embedded Postgres and runs the
+unchanged production code from api/src/** against the new schema.
+If image-(N-1)'s code cannot drive image-N's schema, those existing
+tests fail.
 
-When the migration and the code that uses it land together, the
-tests are updated in lock-step with the schema and the back-compat
-regression is invisible until production rolls back.
+That gate only works when nothing else changes in the PR. Test
+edits, CI tweaks, and code edits all silently break it — a fixture
+author can update the assertions to the new shape; a CI change can
+skip the suite; a code change shifts the test subject.
 
 Split this PR:
-  1) Migration-only PR (schema change). Existing tests gate it.
-  2) Follow-up PR that adapts the code to use the new schema.
+  1) Schema-only PR. Migration + docs only. Existing tests gate it.
+  2) Follow-up PR with the code that adopts the new schema. New
+     tests for the new shape go here, not in the schema PR.
 
 If the change genuinely must be atomic (rare — please justify in the
-PR body), apply the `migration-coupled-justified` label to skip this
-check. See AGENTS.md §migrations-back-compat.
+PR body), apply the `migration-coupled-justified` label on the PR to
+skip this check. See AGENTS.md §migrations-back-compat.
 MSG
   exit 1
 fi
 
-echo "Migration isolation OK: only test / docs / CI changes accompany the new migration."
+echo "Migration isolation OK: only migration + docs changes in this PR."

--- a/.github/scripts/check-migration-isolation.sh
+++ b/.github/scripts/check-migration-isolation.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# If a PR adds a new Flyway migration, it must not also change production
+# source code (Scala, Lua router agent, Python OPNsense agent, frontend
+# src/, contract producers). Migration-only PRs guarantee that the existing
+# feature-test suite runs the OLD code against the NEW schema via the
+# embedded Postgres in TestDatabase — that is the real backward-compatibility
+# gate: if image-(N-1)'s code can't drive image-N's schema, the tests fail.
+#
+# Allowed alongside a new migration:
+#   - api/resources/db/migration/**  (additional migration files)
+#   - api/test/**, shared/test/**    (tests — these run the old code paths)
+#   - **/*.md, .github/**            (docs, CI config)
+#   - .claude/**                     (local agent state — never in CI)
+#
+# Denied (anything else under known production source roots):
+#   - api/src/**, shared/src/**, openwrt/files/**, openwrt/*.lua (non-test),
+#     opnsense/agent.py and other non-test python, web/src/**,
+#     docker/fake-router.py and other contract producers.
+#
+# Escape hatch: apply the `migration-coupled-justified` label on the PR
+# and the workflow skips this job. Use it sparingly, with a written
+# justification in the PR body.
+#
+# See AGENTS.md §migrations-back-compat for the invariant this enforces.
+set -euo pipefail
+
+BASE="${1:?usage: check-migration-isolation.sh <base-ref>}"
+
+added_migrations="$(
+  git diff --name-status --diff-filter=A "${BASE}...HEAD" \
+    -- 'api/resources/db/migration/' \
+    | awk -F'\t' '$1=="A" && $2 ~ /\.sql$/ {print $2}'
+)"
+
+if [[ -z "${added_migrations}" ]]; then
+  echo "No new migrations added; isolation check skipped."
+  exit 0
+fi
+
+echo "New migration(s) in this PR:"
+printf '  %s\n' ${added_migrations}
+echo
+
+changed=()
+while IFS= read -r line; do
+  changed+=("${line}")
+done < <(git diff --name-only "${BASE}...HEAD")
+
+is_allowed() {
+  local f="$1"
+  case "$f" in
+    api/resources/db/migration/*) return 0 ;;
+    api/test/*|shared/test/*|openwrt/test/*|opnsense/test/*) return 0 ;;
+    .github/*) return 0 ;;
+    .claude/*) return 0 ;;
+    *.md|*/*.md|*/*/*.md|*/*/*/*.md) return 0 ;;
+  esac
+  return 1
+}
+
+is_denied_prod() {
+  local f="$1"
+  case "$f" in
+    api/src/*|shared/src/*) return 0 ;;
+    openwrt/files/*) return 0 ;;
+    openwrt/*.lua) return 0 ;;
+    opnsense/agent.py|opnsense/wifihaven_*.py) return 0 ;;
+    web/src/*) return 0 ;;
+    docker/fake-router.py) return 0 ;;
+    shared/contract/*) return 0 ;;
+  esac
+  return 1
+}
+
+bad=()
+for f in "${changed[@]}"; do
+  [[ -z "$f" ]] && continue
+  if is_allowed "$f"; then continue; fi
+  if is_denied_prod "$f"; then bad+=("$f"); fi
+done
+
+if [[ ${#bad[@]} -gt 0 ]]; then
+  echo "BLOCKED: this PR adds a migration AND touches production source:" >&2
+  printf '  %s\n' "${bad[@]}" >&2
+  cat >&2 <<'MSG'
+
+Schema changes must land in their own PR. The reason: the existing
+feature-test suite in api/test/** runs against embedded Postgres
+loaded with all migrations (including the new one) but the
+production code paths are unchanged. That's the real backward-
+compatibility gate — if image-(N-1) cannot drive image-N's schema,
+the existing tests will fail.
+
+When the migration and the code that uses it land together, the
+tests are updated in lock-step with the schema and the back-compat
+regression is invisible until production rolls back.
+
+Split this PR:
+  1) Migration-only PR (schema change). Existing tests gate it.
+  2) Follow-up PR that adapts the code to use the new schema.
+
+If the change genuinely must be atomic (rare — please justify in the
+PR body), apply the `migration-coupled-justified` label to skip this
+check. See AGENTS.md §migrations-back-compat.
+MSG
+  exit 1
+fi
+
+echo "Migration isolation OK: only test / docs / CI changes accompany the new migration."

--- a/.github/scripts/check-migration-isolation.test.sh
+++ b/.github/scripts/check-migration-isolation.test.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Tests for check-migration-isolation.sh.
+#
+# The rule under test: a PR that adds a Flyway migration may ONLY touch
+# migrations and Markdown files. Anything else (tests, CI config,
+# scripts, source code, fixtures) is rejected.
 set -euo pipefail
 
 SCRIPT="$(cd "$(dirname "$0")" && pwd)/check-migration-isolation.sh"
@@ -18,14 +22,17 @@ setup() {
   git config commit.gpgsign false
   mkdir -p api/resources/db/migration api/src/main api/test/src \
            shared/src shared/test openwrt/files openwrt/test \
-           opnsense web/src docker .github
+           opnsense web/src docker .github/workflows docs
   echo "-- v1" > api/resources/db/migration/V1__init.sql
-  echo "// prod" > api/src/main/Main.scala
-  echo "// shared" > shared/src/Models.scala
-  echo "-- lua" > openwrt/files/policy.lua
-  echo "# agent" > opnsense/agent.py
-  echo "# tsx" > web/src/App.tsx
-  echo "# docs" > README.md
+  echo "// prod"     > api/src/main/Main.scala
+  echo "// shared"   > shared/src/Models.scala
+  echo "// test"     > api/test/src/Spec.scala
+  echo "-- lua"      > openwrt/files/policy.lua
+  echo "# agent"     > opnsense/agent.py
+  echo "# tsx"       > web/src/App.tsx
+  echo "name: ci"    > .github/workflows/ci.yml
+  echo "# docs"      > README.md
+  echo "# agents"    > AGENTS.md
   git add . && git commit -q -m base
   BASE="$(git rev-parse HEAD)"
   git checkout -q -b feature
@@ -53,7 +60,9 @@ run_case() {
   fi
 }
 
-case_no_migration() {
+# ── PASS cases ─────────────────────────────────────────────────────────
+
+case_no_migration_with_prod_edit() {
   echo "// edit" >> api/src/main/Main.scala
   git add . && git commit -q -m edit
 }
@@ -63,24 +72,49 @@ case_migration_only() {
   git add . && git commit -q -m mig
 }
 
-case_migration_plus_tests() {
+case_migration_plus_two_migrations() {
   echo "-- v2" > api/resources/db/migration/V2__add.sql
-  echo "// test" > api/test/src/NewSpec.scala
-  echo "// shared test" > shared/test/Spec.scala
-  git add . && git commit -q -m migtest
+  echo "-- v3" > api/resources/db/migration/V3__more.sql
+  git add . && git commit -q -m migs
 }
 
-case_migration_plus_docs() {
+case_migration_plus_readme() {
   echo "-- v2" > api/resources/db/migration/V2__add.sql
   echo "docs change" >> README.md
-  mkdir -p docs
-  echo "# new" > docs/new.md
   git add . && git commit -q -m migdoc
 }
 
-case_migration_plus_workflow() {
+case_migration_plus_agents_md() {
   echo "-- v2" > api/resources/db/migration/V2__add.sql
-  mkdir -p .github/workflows
+  echo "extra direction" >> AGENTS.md
+  git add . && git commit -q -m migagents
+}
+
+case_migration_plus_nested_md() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "# new" > docs/new.md
+  git add . && git commit -q -m mignested
+}
+
+# ── FAIL cases ─────────────────────────────────────────────────────────
+
+case_migration_plus_test() {
+  # Critical: even a TEST change is rejected. Tests are the back-compat
+  # gate; if they can mutate alongside the schema, the gate is bypassed.
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// new spec" > api/test/src/NewSpec.scala
+  git add . && git commit -q -m migtest
+}
+
+case_migration_plus_shared_test() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// shared spec" > shared/test/Spec.scala
+  git add . && git commit -q -m migstest
+}
+
+case_migration_plus_workflow() {
+  # CI changes could disable or alter the gate; rejected too.
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
   echo "name: x" > .github/workflows/x.yml
   git add . && git commit -q -m migci
 }
@@ -115,11 +149,15 @@ case_migration_plus_web_src() {
   git add . && git commit -q -m bad5
 }
 
-run_case "no migration — prod edit allowed"        pass case_no_migration
+run_case "no migration — prod edit unaffected"     pass case_no_migration_with_prod_edit
 run_case "migration only"                          pass case_migration_only
-run_case "migration + tests"                       pass case_migration_plus_tests
-run_case "migration + docs"                        pass case_migration_plus_docs
-run_case "migration + workflows"                   pass case_migration_plus_workflow
+run_case "migration + another migration"           pass case_migration_plus_two_migrations
+run_case "migration + README"                      pass case_migration_plus_readme
+run_case "migration + AGENTS.md"                   pass case_migration_plus_agents_md
+run_case "migration + nested docs/*.md"            pass case_migration_plus_nested_md
+run_case "migration + api/test (REJECTED)"         fail case_migration_plus_test
+run_case "migration + shared/test (REJECTED)"      fail case_migration_plus_shared_test
+run_case "migration + workflow"                    fail case_migration_plus_workflow
 run_case "migration + Scala api/src"               fail case_migration_plus_scala_src
 run_case "migration + shared/src"                  fail case_migration_plus_shared_src
 run_case "migration + openwrt router agent"        fail case_migration_plus_router_agent

--- a/.github/scripts/check-migration-isolation.test.sh
+++ b/.github/scripts/check-migration-isolation.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Tests for check-migration-isolation.sh.
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check-migration-isolation.sh"
+[[ -x "${SCRIPT}" ]] || chmod +x "${SCRIPT}"
+
+tmp=""
+cleanup() { [[ -n "${tmp}" ]] && rm -rf "${tmp}"; return 0; }
+trap cleanup EXIT
+
+setup() {
+  tmp="$(mktemp -d)"
+  cd "${tmp}"
+  git init -q
+  git config user.email t@t.io
+  git config user.name tester
+  git config commit.gpgsign false
+  mkdir -p api/resources/db/migration api/src/main api/test/src \
+           shared/src shared/test openwrt/files openwrt/test \
+           opnsense web/src docker .github
+  echo "-- v1" > api/resources/db/migration/V1__init.sql
+  echo "// prod" > api/src/main/Main.scala
+  echo "// shared" > shared/src/Models.scala
+  echo "-- lua" > openwrt/files/policy.lua
+  echo "# agent" > opnsense/agent.py
+  echo "# tsx" > web/src/App.tsx
+  echo "# docs" > README.md
+  git add . && git commit -q -m base
+  BASE="$(git rev-parse HEAD)"
+  git checkout -q -b feature
+}
+
+run_case() {
+  local name="$1"; shift
+  local want="$1"; shift
+  setup
+  "$@"
+  set +e
+  "${SCRIPT}" "${BASE}" >/tmp/iso.out 2>/tmp/iso.err
+  local rc=$?
+  set -e
+  rm -rf "${tmp}"; tmp=""
+  if [[ "${want}" == "pass" && ${rc} -eq 0 ]]; then
+    echo "PASS: ${name}"
+  elif [[ "${want}" == "fail" && ${rc} -ne 0 ]]; then
+    echo "PASS: ${name} (rejected as expected)"
+  else
+    echo "FAIL: ${name} (rc=${rc}, wanted ${want})" >&2
+    echo "--- stdout ---" >&2; cat /tmp/iso.out >&2
+    echo "--- stderr ---" >&2; cat /tmp/iso.err >&2
+    exit 1
+  fi
+}
+
+case_no_migration() {
+  echo "// edit" >> api/src/main/Main.scala
+  git add . && git commit -q -m edit
+}
+
+case_migration_only() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  git add . && git commit -q -m mig
+}
+
+case_migration_plus_tests() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// test" > api/test/src/NewSpec.scala
+  echo "// shared test" > shared/test/Spec.scala
+  git add . && git commit -q -m migtest
+}
+
+case_migration_plus_docs() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "docs change" >> README.md
+  mkdir -p docs
+  echo "# new" > docs/new.md
+  git add . && git commit -q -m migdoc
+}
+
+case_migration_plus_workflow() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  mkdir -p .github/workflows
+  echo "name: x" > .github/workflows/x.yml
+  git add . && git commit -q -m migci
+}
+
+case_migration_plus_scala_src() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// touch" >> api/src/main/Main.scala
+  git add . && git commit -q -m bad1
+}
+
+case_migration_plus_shared_src() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// touch" >> shared/src/Models.scala
+  git add . && git commit -q -m bad2
+}
+
+case_migration_plus_router_agent() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "-- touch" >> openwrt/files/policy.lua
+  git add . && git commit -q -m bad3
+}
+
+case_migration_plus_opnsense_agent() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "# touch" >> opnsense/agent.py
+  git add . && git commit -q -m bad4
+}
+
+case_migration_plus_web_src() {
+  echo "-- v2" > api/resources/db/migration/V2__add.sql
+  echo "// touch" >> web/src/App.tsx
+  git add . && git commit -q -m bad5
+}
+
+run_case "no migration — prod edit allowed"        pass case_no_migration
+run_case "migration only"                          pass case_migration_only
+run_case "migration + tests"                       pass case_migration_plus_tests
+run_case "migration + docs"                        pass case_migration_plus_docs
+run_case "migration + workflows"                   pass case_migration_plus_workflow
+run_case "migration + Scala api/src"               fail case_migration_plus_scala_src
+run_case "migration + shared/src"                  fail case_migration_plus_shared_src
+run_case "migration + openwrt router agent"        fail case_migration_plus_router_agent
+run_case "migration + opnsense agent"              fail case_migration_plus_opnsense_agent
+run_case "migration + web/src"                     fail case_migration_plus_web_src
+
+echo "All migration-isolation tests passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,9 @@ jobs:
               - 'render.yaml'
             migrations:
               - '.github/workflows/ci.yml'
-              - 'api/migrations/**'
+              - '.github/scripts/check-migrations.sh'
+              - '.github/scripts/check-migration-isolation.sh'
+              - 'api/resources/db/migration/**'
             workflows:
               - '.github/workflows/**'
               - '.github/actionlint.yaml'
@@ -245,6 +247,33 @@ jobs:
           # TODO(#885): remove this env block after the #883 PR has merged.
           ALLOW_MIGRATION_MUTATIONS: ${{ github.event.pull_request.head.ref == 'fix-883-dup-v27' && '1' || '0' }}
         run: bash .github/scripts/check-migrations.sh "$BASE_SHA"
+
+  # ── Migrations: enforce migration-only PRs ──────────────────────────────
+  # The existing api.test feature suite is the real back-compat gate — it
+  # runs the existing production code against embedded Postgres loaded with
+  # every migration (including the new one in this PR). That only works
+  # when the migration ships alone; co-shipping schema + code bypasses the
+  # gate and reintroduces the #1176-class of bug. See
+  # AGENTS.md §migrations-back-compat. Skip with the
+  # `migration-coupled-justified` label on the PR.
+  migration-isolation:
+    name: Migration Isolation Check
+    needs: changes
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.base.ref == 'main'
+      && needs.changes.outputs.migrations == 'true'
+      && !contains(github.event.pull_request.labels.*.name, 'migration-coupled-justified')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Reject migration PRs that also change production source
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash .github/scripts/check-migration-isolation.sh "$BASE_SHA"
 
   # ── Shell test discovery ─────────────────────────────────────────────────
   # Auto-discovers and runs every *.test.sh in the repo. Add a new test by
@@ -501,6 +530,7 @@ jobs:
       - changes
       - scala
       - migrations-immutable
+      - migration-isolation
       - shell-tests
       - lua-tests
       - contract-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,20 +265,22 @@ jobs:
       && needs.changes.outputs.migrations == 'true'
       && !contains(github.event.pull_request.labels.*.name, 'migration-coupled-justified')
     runs-on: ubuntu-latest
+    # CodeQL actions/missing-workflow-permissions: the job only needs to
+    # read the repo to diff the branch — no token writes.
+    permissions:
+      contents: read
     steps:
-      # Check out the PR branch tip, NOT the GitHub-generated merge commit.
-      # The merge commit includes any unrelated migrations that landed on
-      # main while this PR was open, which the diff against base.sha then
-      # reports as "added" in this PR — false positives.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      # Diff against the merge-base with origin/main (three-dot semantics),
+      # not pull_request.base.sha. The base.sha can lag the actual main tip
+      # while a PR is open (we observed cdc5faae sticking around after V44
+      # landed on main), and unrelated migrations on main would otherwise
+      # show as "added" in this PR. Matches AGENTS.md "Branch-diff checks".
       - name: Reject migration PRs that also change production source
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: bash .github/scripts/check-migration-isolation.sh "$BASE_SHA"
+        run: bash .github/scripts/check-migration-isolation.sh origin/main
 
   # ── Shell test discovery ─────────────────────────────────────────────────
   # Auto-discovers and runs every *.test.sh in the repo. Add a new test by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,13 @@ jobs:
       && !contains(github.event.pull_request.labels.*.name, 'migration-coupled-justified')
     runs-on: ubuntu-latest
     steps:
+      # Check out the PR branch tip, NOT the GitHub-generated merge commit.
+      # The merge commit includes any unrelated migrations that landed on
+      # main while this PR was open, which the diff against base.sha then
+      # reports as "added" in this PR — false positives.
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Reject migration PRs that also change production source

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,52 @@ Migrations live in `api/resources/db/migration/` as `V{n}__{description}.sql`. T
 
 Tests run the same Flyway migrations from `classpath:db/migration` against the embedded Postgres in `TestDatabase`, so there is one source of truth — never maintain a parallel test schema. To change the schema, add a new `V{n}__...sql` migration; do not edit `V1__init.sql` (or any other already-applied migration).
 
+### Schema changes land in their own PR {#migrations-back-compat}
+
+**A PR that adds a Flyway migration must not also change production
+source code.** Migration-only PRs are how we prove a schema change is
+backward-compatible with the previously deployed image — the durable
+defense against the [#1176](https://github.com/wifihaven/wifihaven/issues/1176)
+class of bug (rollback blocked because applied schema is incompatible
+with the older image).
+
+The mechanism is the existing feature-test suite:
+
+- `api/test/**` runs the embedded Postgres via `TestDatabase`, which
+  applies **every** Flyway migration on the classpath, **including the
+  new one in this PR**, before any test runs.
+- The test fixtures exercise the **existing** production code paths in
+  `api/src/**` — i.e. image-(N-1)'s code.
+- If image-(N-1)'s queries, inserts, or wire shapes can't survive
+  DB-at-V<N>, those existing tests fail. That is the gate.
+
+When the migration and the code that adopts it ship in the same PR,
+the gate is silently bypassed: the code is updated in lock-step with
+the schema, so the tests pass, and the back-compat regression goes
+undetected until prod tries to roll back. CI enforces the split via
+`.github/scripts/check-migration-isolation.sh`.
+
+Allowed alongside a new migration: additional migration files; tests
+(`*/test/**`); docs (`**/*.md`); CI config (`.github/**`).
+
+Disallowed: `api/src/**`, `shared/src/**`, `openwrt/files/**`,
+`openwrt/*.lua` (non-test), `opnsense/agent.py` and other non-test
+python, `web/src/**`, `docker/fake-router.py`, `shared/contract/**`.
+
+The workflow is two PRs:
+
+1. **PR 1 — schema only.** Adds `V<N>__….sql` plus any tests probing
+   the new shape. Existing feature tests gate it. If they pass, the
+   migration is backward-compatible with image-(N-1) modulo any
+   coverage gap — so close coverage gaps when adding migrations.
+2. **PR 2 — code adopts the new schema.** Lands after PR 1 is merged
+   and deployed. This is where new repo methods, route handlers, and
+   wire shapes go.
+
+**Escape hatch:** for genuinely atomic changes (rare), apply the
+`migration-coupled-justified` label on the PR and explain in the body
+why splitting isn't possible. The check skips when the label is set.
+
 ## Branch-diff checks (CI + pre-push)
 
 CI checks and pre-push checks that compare a branch against `main` MUST diff against the **merge base** with `origin/main`, not `origin/main` directly. Use three-dot syntax (`origin/main...HEAD`) or an explicit `git merge-base origin/main HEAD`. Two-dot (`origin/main..HEAD`) over-reports when `main` has advanced since the branch diverged, producing spurious failures and noise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,45 +296,56 @@ Tests run the same Flyway migrations from `classpath:db/migration` against the e
 
 ### Schema changes land in their own PR {#migrations-back-compat}
 
-**A PR that adds a Flyway migration must not also change production
-source code.** Migration-only PRs are how we prove a schema change is
-backward-compatible with the previously deployed image — the durable
-defense against the [#1176](https://github.com/wifihaven/wifihaven/issues/1176)
-class of bug (rollback blocked because applied schema is incompatible
-with the older image).
+**A PR that adds a Flyway migration may contain only the migration and
+documentation (`*.md`) updates.** No source code. **No test changes.**
+No CI tweaks. No fixtures, no scripts, no build files. The follow-up
+PR — the one that adopts the new schema — carries all of that.
 
-The mechanism is the existing feature-test suite:
+This is the durable defense against the
+[#1176](https://github.com/wifihaven/wifihaven/issues/1176) class of
+bug (rollback blocked because the applied schema is incompatible with
+the previously deployed image). The gate is the existing feature-test
+suite:
 
-- `api/test/**` runs the embedded Postgres via `TestDatabase`, which
+- `api/test/**` runs embedded Postgres via `TestDatabase`, which
   applies **every** Flyway migration on the classpath, **including the
   new one in this PR**, before any test runs.
 - The test fixtures exercise the **existing** production code paths in
-  `api/src/**` — i.e. image-(N-1)'s code.
+  `api/src/**` — image-(N-1)'s code.
 - If image-(N-1)'s queries, inserts, or wire shapes can't survive
   DB-at-V<N>, those existing tests fail. That is the gate.
 
-When the migration and the code that adopts it ship in the same PR,
-the gate is silently bypassed: the code is updated in lock-step with
-the schema, so the tests pass, and the back-compat regression goes
-undetected until prod tries to roll back. CI enforces the split via
-`.github/scripts/check-migration-isolation.sh`.
+**The gate only works when nothing else in the PR can move.** Test
+edits silently bypass it: a fixture author can update the assertions
+to the new shape, and the back-compat regression goes undetected. CI
+changes can disable the suite entirely. Source changes shift the test
+subject. So all of those are forbidden in a migration PR — not just
+production source.
 
-Allowed alongside a new migration: additional migration files; tests
-(`*/test/**`); docs (`**/*.md`); CI config (`.github/**`).
+Docs are the one exception because they cannot alter execution.
 
-Disallowed: `api/src/**`, `shared/src/**`, `openwrt/files/**`,
-`openwrt/*.lua` (non-test), `opnsense/agent.py` and other non-test
-python, `web/src/**`, `docker/fake-router.py`, `shared/contract/**`.
+Allowed alongside a new migration:
+
+- `api/resources/db/migration/**.sql` — additional migration files
+- `**/*.md` — documentation, including `AGENTS.md`, `CLAUDE.md`,
+  READMEs, and anything under `docs/`
+
+Anything else is rejected by
+[`check-migration-isolation.sh`](.github/scripts/check-migration-isolation.sh).
+That includes `api/test/**` and `shared/test/**` — new tests probing
+the new schema shape belong in the follow-up PR, not here.
 
 The workflow is two PRs:
 
-1. **PR 1 — schema only.** Adds `V<N>__….sql` plus any tests probing
-   the new shape. Existing feature tests gate it. If they pass, the
-   migration is backward-compatible with image-(N-1) modulo any
-   coverage gap — so close coverage gaps when adding migrations.
+1. **PR 1 — schema only.** Just `V<N>__….sql` (plus any doc updates
+   that describe the new shape). The existing `api.test` suite is the
+   gate: if it passes, the migration is backward-compatible with
+   image-(N-1) — modulo coverage gaps, so close those *before* you
+   open the migration PR by adding tests in a prior PR that exercises
+   the lines the migration will touch.
 2. **PR 2 — code adopts the new schema.** Lands after PR 1 is merged
-   and deployed. This is where new repo methods, route handlers, and
-   wire shapes go.
+   and deployed. This is where new repo methods, route handlers, wire
+   shapes, and the tests that cover them go.
 
 **Escape hatch:** for genuinely atomic changes (rare), apply the
 `migration-coupled-justified` label on the PR and explain in the body


### PR DESCRIPTION
## Summary

A PR that adds a Flyway migration must not also change production source code. CI rejects it via `.github/scripts/check-migration-isolation.sh`. Schema changes land in their own PR, code that uses the new schema follows.

## Why this matters

The existing `api.test` feature suite already runs every Flyway migration on the classpath (via `TestDatabase` + embedded Postgres) against the production code in `api/src/**`. When the migration ships alone, the existing tests exercise image-(N-1)'s code against image-N's schema — that's the real backward-compatibility gate, and it's what would have caught [#1147](https://github.com/wifihaven/wifihaven/issues/1147) V40 before it shipped and produced the [#1176](https://github.com/wifihaven/wifihaven/issues/1176) rollback storm.

When the migration and the code that adopts it ship in the same PR, the tests get updated in lock-step with the schema, so the gate is silently bypassed.

Complements (and elevates above) [#1177](https://github.com/wifihaven/wifihaven/issues/1177)'s startup fail-fast guard, which becomes belt-and-suspenders rather than the primary defense.

## What's in the PR

- `.github/scripts/check-migration-isolation.sh` + `.test.sh` (auto-discovered by the existing `shell-tests` job, 10 fixture cases).
- New `Migration Isolation Check` workflow job; joined to the `CI` aggregate `needs:` list so the merge queue gates it.
- Escape hatch: PR label `migration-coupled-justified` skips the job.
- AGENTS.md §migrations-back-compat: the rule, the mechanism, allowed/disallowed paths, the two-PR workflow.
- PR template checkbox confirming isolation.
- Drive-by: fixes the stale `migrations` path filter in `ci.yml` (`api/migrations/**` → `api/resources/db/migration/**`); the immutability check had been triggering only via the force-all fallback.

## TDD progression

1. `test(ci): red` — fixtures committed before the script exists.
2. `feat(ci): green` — `check-migration-isolation.sh`.
3. `docs+ci:` — AGENTS.md + PR template + workflow wiring + path-filter fix.

## Test plan

- [x] 10 fixture cases — pass / fail / pass as expected
- [x] `actionlint .github/workflows/ci.yml` clean
- [x] On this PR's diff (no new migrations): isolation job is gated to skip
- [ ] CI run on this PR: `Shell Tests` runs the new `.test.sh` and passes
- [ ] Post-merge smoke: a throwaway PR adding `V<n>__bad.sql` + an `api/src/**` edit trips the new check; a migration-only PR passes

Closes #1179. Supersedes #1177 Part B as the primary defense (Part A still needed for the immediate CD unblock).