### PR TITLE
fix(api): unbreak main — split allRoutes ++ chain to ground type inference (#1177)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -180,80 +180,97 @@ object Main extends ZIOAppDefault {
       xa          <- ZIO.service[Transactor[Task]]
       routerAuth    = new RouterAuthLive(routerRepo)
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
-    } yield HealthRoutes.routes(dbHealthCheck) ++
-      VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
-      AuthRoutes.routes(auth, userRepo, upRepo) ++
-      ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
-      HouseholdSettingsRoutes.routes(auth, hsRepo) ++
-      DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
-      TimeRoutes.routes(
-        auth,
-        deviceRepo,
-        tlRepo,
-        stlRepo,
-        trafficRepo,
-        extRepo,
-        profileRepo,
-        upRepo,
-        hsRepo,
-        timeStatus,
-        clock,
-        timeCache,
-      ) ++
-      LogRoutes.routes(auth, connRepo, upRepo) ++
-      UsageRoutes.routes(
-        auth,
-        deviceRepo,
-        trafficRepo,
-        upRepo,
-        profileRepo,
-        appRepo,
-        rollupRepo2,
-        clock,
-      ) ++
-      DashboardNowRoutes.routes(
-        auth,
-        trafficRepo,
-        connRepo,
-        deviceRepo,
-        profileRepo,
-        upRepo,
-        clock,
-      ) ++
-      BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists) ++
-      RouterRoutes.routes(routerRepo, policy, routerAuth, blockEvRepo) ++
-      AdminRouterRoutes.routes(auth, routerRepo) ++
-      RollupAdminRoutes.routes(auth, rollupRepo2) ++
-      RouterIngestRoutes.routes(
-        routerAuth,
-        routerRepo,
-        trafficRepo,
-        usageRepo,
-        deviceRepo,
-        connRepo,
-        alertRepo,
-        hsRepo,
-      ) ++
-      AlertRoutes.routes(
-        auth,
-        alertRepo,
-        deviceRepo,
-        profileRepo,
-        extRepo,
-        appRepo,
-        hsRepo,
-        notifier,
-        clock,
-      ) ++
-      AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates) ++
-      DebugRoutes.routes(
-        cfg.debugEnabled,
-        deviceRepo,
-        connRepo,
-        usageRepo,
-        trafficRepo,
-        clock,
-        timeCache,
-      ) ++
-      (if (cfg.http.serveSpa) StaticRoutes.routes(cfg.http.staticDir) else Routes.empty)
+    } yield {
+      // #1177: split the route composition into typed chunks. A flat `++` chain across
+      // 18+ Routes was hitting Scala 3's type-inference recursion limit on CI (Linux
+      // JDK 21 default stack), failing with "Recursion limit exceeded" at the first
+      // `++` even though local macOS builds happened to fit. Explicit `Routes[Any, Response]`
+      // ascriptions on the chunks ground the inference per chunk so the final fold is
+      // a short, well-typed concatenation.
+      val systemRoutes: Routes[Any, Response] =
+        HealthRoutes.routes(dbHealthCheck) ++
+          VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
+          AuthRoutes.routes(auth, userRepo, upRepo) ++
+          ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
+          HouseholdSettingsRoutes.routes(auth, hsRepo) ++
+          DeviceRoutes.routes(auth, deviceRepo, upRepo)
+
+      val statsRoutes: Routes[Any, Response] =
+        TimeRoutes.routes(
+          auth,
+          deviceRepo,
+          tlRepo,
+          stlRepo,
+          trafficRepo,
+          extRepo,
+          profileRepo,
+          upRepo,
+          hsRepo,
+          timeStatus,
+          clock,
+          timeCache,
+        ) ++
+          LogRoutes.routes(auth, connRepo, upRepo) ++
+          UsageRoutes.routes(
+            auth,
+            deviceRepo,
+            trafficRepo,
+            upRepo,
+            profileRepo,
+            appRepo,
+            rollupRepo2,
+            clock,
+          ) ++
+          DashboardNowRoutes.routes(
+            auth,
+            trafficRepo,
+            connRepo,
+            deviceRepo,
+            profileRepo,
+            upRepo,
+            clock,
+          ) ++
+          BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists)
+
+      val routerAndAdminRoutes: Routes[Any, Response] =
+        RouterRoutes.routes(routerRepo, policy, routerAuth, blockEvRepo) ++
+          AdminRouterRoutes.routes(auth, routerRepo) ++
+          RollupAdminRoutes.routes(auth, rollupRepo2) ++
+          RouterIngestRoutes.routes(
+            routerAuth,
+            routerRepo,
+            trafficRepo,
+            usageRepo,
+            deviceRepo,
+            connRepo,
+            alertRepo,
+            hsRepo,
+          ) ++
+          AlertRoutes.routes(
+            auth,
+            alertRepo,
+            deviceRepo,
+            profileRepo,
+            extRepo,
+            appRepo,
+            hsRepo,
+            notifier,
+            clock,
+          ) ++
+          AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates) ++
+          DebugRoutes.routes(
+            cfg.debugEnabled,
+            deviceRepo,
+            connRepo,
+            usageRepo,
+            trafficRepo,
+            clock,
+            timeCache,
+          )
+
+      val spaRoutes: Routes[Any, Response] =
+        if (cfg.http.serveSpa) StaticRoutes.routes(cfg.http.staticDir) else Routes.empty
+
+      systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes
+    }
 }


### PR DESCRIPTION
## Unbreak main

`mill __.compile` on `main` fails with 242 errors rooted at `Main.scala:185` — a Scala 3 "Recursion limit exceeded" / "illegal cyclic reference" at the first `++` in `allRoutes`, with cascading "Not found: type Request/IO/Response" noise in `Routes.scala`.

Root cause: PR #1165 (#1160 time-used rollup) added 6 more `ZIO.service` lookups to `Main.run`'s for-comprehension. The chained `++` across 18 `Routes` calls in `allRoutes` was already near the type-inference recursion limit on dotty; the additional state in the surrounding for-comp pushed cold-cache compiles over the edge. Local macOS builds happened to fit; cold ubuntu CI (JDK 21) didn't.

Fix: split `allRoutes`'s flat `++` chain into four explicitly typed `Routes[Any, Response]` chunks (system / stats / router-and-admin / spa). Each `++` fold is now short and well-grounded, so type inference doesn't recurse through the full chain.

- No revert of #1160 — its design lands as intended.
- The build itself is the test for this fix; no separate red commit (CI before this PR is already red).

## How #1165 got through the merge queue

`merge_queue` already runs with `grouping_strategy: ALLGREEN`, which waits for the `merge_group`-triggered `CI / CI` to pass before merging. The problem was that the `merge_group` CI run **did** pass, because Mill's Zinc cache was restored from a prior successful run and the type-inference recursion didn't re-trigger on incremental compile. Master CD (cold cache, post-merge) hit it. Tracked separately as #1186.

## Test plan
- [x] `mill __.compile` green locally
- [x] `mill __.test` green locally
- [x] `scalafmt --check --non-interactive` clean
- [ ] CI on this PR returns green on the same `CI / Scala Build & Test` job that failed on `main`

Closes #1177.