### PR TITLE
db: V44 add reason_text dual-write + background backfill (back-compat reshape of V40) (#1176)

### DIFF
--- a/api/resources/db/migration/V44__reason_text_dual_write.sql
+++ b/api/resources/db/migration/V44__reason_text_dual_write.sql
@@ -1,0 +1,24 @@
+-- #1176 / #1179: back-compat reshape of V40 (TEXT → JSONB conversion).
+--
+-- V40 changed connection_events.reason and block_events.reason from TEXT to
+-- JSONB in a single step. An image binding `reason` as TEXT cannot then read
+-- or write the column, so a Render auto-rollback after V40 applied left prod
+-- on `aa070c0` returning 503 BatchUpdateException on every connection_attempt
+-- ingest. See #1176.
+--
+-- V44 introduces a parallel TEXT column `reason_text` that mirrors the
+-- pre-V40 wire-format string (e.g. "category:porn", "blocked", "schedule").
+-- Code in this PR dual-writes it from BlockReason.asWire(); a background
+-- backfill populates it for rows inserted between V40 and V44. Reads still
+-- come from the JSONB column — no SPA-visible change here.
+--
+-- This migration is schema-only: ADD COLUMN nullable, no inline UPDATE, no
+-- type change. Conforms to #1179's back-compat invariant: an image that
+-- predates V44 ignores the new column entirely; an image that knows about
+-- reason_text degrades gracefully on NULL until the backfill completes.
+
+ALTER TABLE connection_events
+  ADD COLUMN reason_text TEXT;
+
+ALTER TABLE block_events
+  ADD COLUMN reason_text TEXT;

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -67,12 +67,6 @@ object Main extends ZIOAppDefault {
       bundled         <- BundledBlocklists.loadAll()
       _               <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
       _               <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
-      // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
-      // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
-      // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
-      // no NULLs remain.
-      xaForBackfill   <- ZIO.service[Transactor[Task]]
-      _               <- ReasonTextBackfill.run(xaForBackfill).forkDaemon
       // #809: scheduled re-aggregation of traffic_reports into the rollup
       // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
       // re-rolls yesterday + today every hour. Both are forkDaemon so they
@@ -117,6 +111,11 @@ object Main extends ZIOAppDefault {
       // the tick rather than racing on the same DELETE.
       xaForJobs       <- ZIO.service[Transactor[Task]]
       _               <- RetentionSweepJob.start(xaForJobs)
+      // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
+      // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
+      // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
+      // no NULLs remain.
+      _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
       templatesById = templates.map(t => t.slug -> t).toMap
       bundledById   = bundled.map(b => b.id -> b).toMap
       routes <- allRoutes(templatesById, bundledById)

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -67,6 +67,12 @@ object Main extends ZIOAppDefault {
       bundled         <- BundledBlocklists.loadAll()
       _               <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
       _               <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+      // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
+      // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
+      // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
+      // no NULLs remain.
+      xaForBackfill   <- ZIO.service[Transactor[Task]]
+      _               <- ReasonTextBackfill.run(xaForBackfill).forkDaemon
       // #809: scheduled re-aggregation of traffic_reports into the rollup
       // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
       // re-rolls yesterday + today every hour. Both are forkDaemon so they

--- a/api/src/ReasonTextBackfill.scala
+++ b/api/src/ReasonTextBackfill.scala
@@ -1,0 +1,103 @@
+package wifihaven.api
+
+import doobie.*
+import doobie.implicits.*
+import zio.*
+import zio.interop.catz.*
+
+/**
+ * #1176 / #1179: one-shot backfill that populates `reason_text` (pre-V40 wire format) on rows
+ * inserted between V40 (TEXT → JSONB conversion) and V44 (the dual-write).
+ *
+ * Idempotent: `WHERE reason_text IS NULL`. Capped throughput — runs in id-range batches with a
+ * short sleep between batches so a slow Render PG doesn't see a burst on cold start. The kind →
+ * wire conversion is done in SQL with a CASE on `reason->>'kind'` that mirrors exactly what
+ * [[wifihaven.shared.BlockReason.asWire]] produces; the dual-write spec and the backfill spec pin
+ * both sides to the same canonical strings.
+ *
+ * Reads still come from `reason` (JSONB) so a partial backfill never affects the SPA — V45 (out of
+ * scope here) will cut reads to `reason_text` and drop the JSONB column once this has settled.
+ */
+object ReasonTextBackfill {
+
+  // Tuned for Render's small managed PG. Each batch updates up to BatchSize rows in a single
+  // UPDATE; SleepBetween throttles so we never monopolize the connection pool on cold start.
+  private val BatchSize: Int     = 5000
+  private val SleepBetween       = Duration.fromMillis(100)
+  // Hard cap so a runaway backfill (e.g. a stuck row) can't loop forever and block startup logs.
+  // Even at 5k/batch this covers 50M rows — well above prod's foreseeable size.
+  private val MaxBatchesPerTable = 10_000
+
+  /**
+   * SQL fragment that converts a `reason` JSONB into its pre-V40 wire-format TEXT. Must agree with
+   * `BlockReason.asWire` for every kind. `unknown` rows emit their `raw` field verbatim so a second
+   * `fromWire` reparse yields the same `Unknown(raw)`.
+   */
+  private val asWireSql: Fragment =
+    fr"""CASE reason->>'kind'
+           WHEN 'allow'         THEN 'allow'
+           WHEN 'blocked'       THEN 'blocked'
+           WHEN 'extraAllowed'  THEN 'extra_allowed'
+           WHEN 'extraBlocked'  THEN 'extra_blocked'
+           WHEN 'noProfile'     THEN 'no_profile'
+           WHEN 'paused'        THEN 'paused'
+           WHEN 'schedule'      THEN 'schedule'
+           WHEN 'timeLimit'     THEN 'time_limit'
+           WHEN 'manual'        THEN 'manual'
+           WHEN 'unmanaged'     THEN 'unmanaged_mac'
+           WHEN 'category'      THEN 'category:'        || (reason->>'slug')
+           WHEN 'siteTimeLimit' THEN 'site_time_limit:' || (reason->>'label')
+           WHEN 'appBlocked'    THEN 'app:'             || (reason->>'appId')
+           WHEN 'unknown'       THEN reason->>'raw'
+         END"""
+
+  /** Backfill both event tables. Safe to invoke at every startup. */
+  def run(xa: Transactor[Task]): Task[Unit] =
+    for {
+      _  <- ZIO.logInfo("reason_text backfill: starting")
+      n1 <- backfillTable(xa, "connection_events")
+      n2 <- backfillTable(xa, "block_events")
+      _  <- ZIO.logInfo(
+        s"reason_text backfill: complete (connection_events=$n1, block_events=$n2 rows updated)",
+      )
+    } yield ()
+
+  private def backfillTable(xa: Transactor[Task], table: String): Task[Long] = {
+    // Repeatedly UPDATE up to BatchSize NULL rows until none remain. `id` is unique across both
+    // tables (sequence-backed, retained as a surrogate even after V42 dropped the PK from the
+    // partitioned connection_events) so an id-based chunk avoids long lock holds and replays
+    // cleanly if the API restarts mid-backfill.
+    val tbl                   = Fragment.const(table)
+    val updateOnce: Task[Int] =
+      (fr"""UPDATE """ ++ tbl ++ fr"""
+            SET reason_text = """ ++ asWireSql ++ fr"""
+            WHERE id IN (
+              SELECT id FROM """ ++ tbl ++ fr"""
+              WHERE reason_text IS NULL
+              ORDER BY id
+              LIMIT $BatchSize
+            )""").update.run.transact(xa)
+
+    def loop(batch: Int, total: Long): Task[Long] =
+      if batch >= MaxBatchesPerTable then
+        ZIO
+          .logWarning(
+            s"reason_text backfill: hit MaxBatchesPerTable=$MaxBatchesPerTable on $table at $total rows; giving up — re-run on next startup",
+          )
+          .as(total)
+      else
+        updateOnce.flatMap { updated =>
+          if updated == 0 then ZIO.succeed(total)
+          else {
+            val newTotal = total + updated.toLong
+            ZIO.logDebug(
+              s"reason_text backfill: $table batch=$batch updated=$updated total=$newTotal",
+            ) *>
+              ZIO.sleep(SleepBetween) *>
+              loop(batch + 1, newTotal)
+          }
+        }
+
+    loop(0, 0L)
+  }
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1606,10 +1606,15 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
 class BlockEventRepoLive(xa: Transactor[Task]) extends BlockEventRepo {
   private type R = (BlockEventId, Option[MacAddress], HostId, BlockReason, String)
   private def toB(r: R)                           = BlockEvent(r._1, r._2, r._3, r._4, r._5)
+  // #1176/#1179: dual-write `reason_text` (pre-V40 TEXT wire format) alongside
+  // `reason` (post-V40 JSONB). Reads still come from `reason`; the parallel
+  // column exists so a Render auto-rollback that lands on a post-V44 image
+  // binding the column as TEXT can still serve.
   def insertBatch(events: List[BlockEventInsert]) =
-    Update[BlockEventInsert](
-      "INSERT INTO block_events(mac,host_type,host_value,reason) VALUES(?,?,?,?)",
-    ).updateMany(events).transact(xa)
+    Update[(BlockEventInsert, String)](
+      "INSERT INTO block_events(mac,host_type,host_value,reason,reason_text) " +
+        "VALUES(?,?,?,?,?)",
+    ).updateMany(events.map(e => (e, BlockReason.asWire(e.reason)))).transact(xa)
   def recent(limit: Int)                          =
     sql"SELECT id,mac,host_type,host_value,reason,ts::TEXT FROM block_events ORDER BY ts DESC LIMIT $limit"
       .query[R]
@@ -1645,14 +1650,16 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
   // replays; updateMany returns count of rows actually inserted.
   // #720: resolved_host_value carries an API-side FQDN attribution for
   // ipv4/ipv6-typed events; ingest sets it from sibling fqdn events.
+  // #1176/#1179: dual-write `reason_text` (pre-V40 TEXT wire format) alongside
+  // `reason` (post-V40 JSONB). See BlockEventRepoLive for the why.
   def insertBatch(events: List[ConnectionEventInsert]) =
-    Update[ConnectionEventInsert](
-      "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value) " +
-        "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?) " +
+    Update[(ConnectionEventInsert, String)](
+      "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value,reason_text) " +
+        "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?,?) " +
         // #806: unique key widened to (event_id, ts) for ts-range partitioning;
         // a replay carries the same router-supplied ts so dedup is unchanged.
         "ON CONFLICT (event_id, ts) DO NOTHING",
-    ).updateMany(events).transact(xa)
+    ).updateMany(events.map(e => (e, BlockReason.asWire(e.reason)))).transact(xa)
 
   // #720: read paths coalesce a populated resolved_host_value into the host
   // tuple so callers see ('fqdn', resolved) instead of ('ipv4', literal-ip).

--- a/api/test/src/feature/ReasonTextBackfillSpec.scala
+++ b/api/test/src/feature/ReasonTextBackfillSpec.scala
@@ -1,0 +1,142 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import wifihaven.api.ReasonTextBackfill
+import wifihaven.api.db.*
+import wifihaven.api.routes.RouterAuth
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+import zio.test.Assertion.*
+
+/**
+ * #1176 / #1179 — startup backfill populates `reason_text` for rows inserted between V40 (TEXT →
+ * JSONB) and V44 (the dual-write).
+ *
+ * Test seeds rows that match the "V40-applied, V44-not-yet" state: `reason` populated (JSONB),
+ * `reason_text` NULL. Backfill must transform each kind back to its canonical pre-V40 wire string —
+ * and the SQL must mirror exactly what `BlockReason.asWire` produces.
+ */
+object ReasonTextBackfillSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap
+      : ZLayer[Any, Throwable, TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] =
+    TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def seedRouter(rRepo: RouterRepo): Task[RouterId] = {
+    val token = "ROUTER_TOKEN_PLAIN"
+    val hash  = Sha256Hex.unsafe(RouterAuth.sha256Hex(token))
+    for {
+      id <- rRepo.create("rt", Sha256Hex.unsafe("a" * 64))
+      _  <- rRepo.completeEnrollment(id, hash)
+    } yield id
+  }
+
+  private val mac = MacAddress.unsafe("aa:bb:cc:11:22:33")
+
+  /**
+   * Each BlockReason variant: its JSONB shape (as `reason` stores it post-V40) and the expected
+   * pre-V40 wire string the backfill should produce in `reason_text`.
+   */
+  private val cases: List[(String, String)] = List(
+    """{"kind":"allow"}"""                             -> "allow",
+    """{"kind":"blocked"}"""                           -> "blocked",
+    """{"kind":"extraAllowed"}"""                      -> "extra_allowed",
+    """{"kind":"extraBlocked"}"""                      -> "extra_blocked",
+    """{"kind":"noProfile"}"""                         -> "no_profile",
+    """{"kind":"paused"}"""                            -> "paused",
+    """{"kind":"schedule"}"""                          -> "schedule",
+    """{"kind":"timeLimit"}"""                         -> "time_limit",
+    """{"kind":"manual"}"""                            -> "manual",
+    """{"kind":"unmanaged"}"""                         -> "unmanaged_mac",
+    """{"kind":"category","slug":"social-media"}"""    -> "category:social-media",
+    """{"kind":"siteTimeLimit","label":"youtube"}"""   -> "site_time_limit:youtube",
+    """{"kind":"appBlocked","appId":"netflix"}"""      -> "app:netflix",
+    """{"kind":"unknown","raw":"some-legacy-value"}""" -> "some-legacy-value",
+  )
+
+  override def spec = suite("ReasonTextBackfill")(
+    test("backfills connection_events.reason_text from reason JSONB") {
+      for {
+        _     <- cleanDb
+        rRepo <- ZIO.service[RouterRepo]
+        xa    <- ZIO.service[Transactor[Task]]
+        rid   <- seedRouter(rRepo)
+        // Bypass dual-write: raw SQL insert populates `reason` (JSONB) but leaves
+        // `reason_text` NULL — the exact V40-applied-V44-not-yet state.
+        _     <- ZIO.foreachDiscard(cases.zipWithIndex) { case ((reasonJson, _), idx) =>
+          val ts = java.time.Instant.parse("2026-05-30T12:00:00Z").plusSeconds(idx.toLong)
+          sql"""INSERT INTO connection_events(
+                   router_id, mac, host_type, host_value,
+                   dest_ip, allowed, reason, ts, event_id, resolved_host_value, reason_text
+                 ) VALUES(
+                   $rid, $mac, 'fqdn', 'example.com',
+                   NULL, false, ${reasonJson}::jsonb, $ts, gen_random_uuid(), NULL, NULL
+                 )""".update.run.transact(xa)
+        }
+        _     <- ReasonTextBackfill.run(xa)
+        rows  <- sql"""SELECT reason_text
+                      FROM connection_events
+                      ORDER BY ts ASC"""
+          .query[Option[String]]
+          .to[List]
+          .transact(xa)
+      } yield {
+        val expected = cases.map(_._2)
+        val got      = rows.map(_.getOrElse("<null>"))
+        assert(got)(equalTo(expected))
+      }
+    },
+    test("backfills block_events.reason_text from reason JSONB") {
+      for {
+        _     <- cleanDb
+        rRepo <- ZIO.service[RouterRepo]
+        _     <- seedRouter(rRepo)
+        xa    <- ZIO.service[Transactor[Task]]
+        _     <- ZIO.foreachDiscard(cases) { case (reasonJson, _) =>
+          sql"""INSERT INTO block_events(mac, host_type, host_value, reason, reason_text)
+                 VALUES($mac, 'fqdn', 'example.com', ${reasonJson}::jsonb, NULL)""".update.run
+            .transact(xa)
+        }
+        _     <- ReasonTextBackfill.run(xa)
+        rows  <- sql"""SELECT reason_text
+                      FROM block_events
+                      ORDER BY id ASC"""
+          .query[Option[String]]
+          .to[List]
+          .transact(xa)
+      } yield {
+        val expected = cases.map(_._2)
+        val got      = rows.map(_.getOrElse("<null>"))
+        assert(got)(equalTo(expected))
+      }
+    },
+    test("backfill is idempotent (no rows with NULL reason_text after run)") {
+      for {
+        _     <- cleanDb
+        rRepo <- ZIO.service[RouterRepo]
+        _     <- seedRouter(rRepo)
+        xa    <- ZIO.service[Transactor[Task]]
+        _     <- sql"""INSERT INTO block_events(mac, host_type, host_value, reason, reason_text)
+                    VALUES($mac, 'fqdn', 'example.com', '{"kind":"allow"}'::jsonb, NULL)""".update.run
+          .transact(xa)
+        _     <- ReasonTextBackfill.run(xa)
+        _     <- ReasonTextBackfill.run(xa)
+        nNull <- sql"""SELECT COUNT(*)::INT FROM block_events WHERE reason_text IS NULL"""
+          .query[Int]
+          .unique
+          .transact(xa)
+      } yield assert(nNull)(equalTo(0))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ReasonTextBackfillSpec.scala
+++ b/api/test/src/feature/ReasonTextBackfillSpec.scala
@@ -2,8 +2,10 @@ package wifihaven.api.feature
 
 import doobie.*
 import doobie.implicits.*
+import doobie.postgres.implicits.*
 import wifihaven.api.ReasonTextBackfill
 import wifihaven.api.db.*
+import wifihaven.api.db.TypeMeta.given
 import wifihaven.api.routes.RouterAuth
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -138,5 +140,5 @@ object ReasonTextBackfillSpec
           .transact(xa)
       } yield assert(nNull)(equalTo(0))
     },
-  ) @@ TestAspect.sequential
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 }

--- a/api/test/src/feature/ReasonTextDualWriteSpec.scala
+++ b/api/test/src/feature/ReasonTextDualWriteSpec.scala
@@ -1,0 +1,132 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.RouterAuth
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+import zio.test.Assertion.*
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * #1176 / #1179 — dual-write `reason_text` (TEXT, pre-V40 wire shape) alongside `reason` (JSONB,
+ * post-V40 shape) on both event tables.
+ *
+ * Once V45 cuts reads to `reason_text`, a Render auto-rollback that lands on a *post-V44* image
+ * still finds the column populated. Combined with #1179's back-compat policy this prevents the
+ * #1176-class outage from recurring.
+ *
+ * Reads remain off `reason` (JSONB) — no SPA-visible change here.
+ */
+object ReasonTextDualWriteSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap
+      : ZLayer[Any, Throwable, TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] =
+    TestDatabase.layer
+
+  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
+    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
+  )
+
+  private def seedRouter(rRepo: RouterRepo): Task[RouterId] = {
+    val token = "ROUTER_TOKEN_PLAIN"
+    val hash  = Sha256Hex.unsafe(RouterAuth.sha256Hex(token))
+    for {
+      id <- rRepo.create("rt", Sha256Hex.unsafe("a" * 64))
+      _  <- rRepo.completeEnrollment(id, hash)
+    } yield id
+  }
+
+  private val mac  = MacAddress.unsafe("aa:bb:cc:11:22:33")
+  private val host = HostId.fqdn(Hostname.unsafe("example.com"))
+
+  /**
+   * Each `BlockReason` paired with its canonical pre-V40 wire-format string — the exact characters
+   * a router agent prior to #1147 would have written to `connection_events.reason` (TEXT). The
+   * post-V44 dual-write produces this same TEXT alongside the JSONB column.
+   */
+  private val cases: List[(BlockReason, String)] = List(
+    BlockReason.Allow                                        -> "allow",
+    BlockReason.Blocked                                      -> "blocked",
+    BlockReason.ExtraAllowed                                 -> "extra_allowed",
+    BlockReason.ExtraBlocked                                 -> "extra_blocked",
+    BlockReason.NoProfile                                    -> "no_profile",
+    MacBlockReason.Paused                                    -> "paused",
+    MacBlockReason.Schedule                                  -> "schedule",
+    MacBlockReason.TimeLimit                                 -> "time_limit",
+    MacBlockReason.Manual                                    -> "manual",
+    MacBlockReason.Unmanaged                                 -> "unmanaged_mac",
+    BlockReason.Category(BlocklistId.unsafe("social-media")) -> "category:social-media",
+    BlockReason.SiteTimeLimit("youtube")                     -> "site_time_limit:youtube",
+    BlockReason.AppBlocked("netflix")                        -> "app:netflix",
+    BlockReason.Unknown("weird")                             -> "weird",
+  )
+
+  override def spec = suite("ReasonTextDualWrite")(
+    test("ConnectionEventRepo.insertBatch populates both reason (JSONB) and reason_text (TEXT)") {
+      for {
+        _     <- cleanDb
+        rRepo <- ZIO.service[RouterRepo]
+        cRepo <- ZIO.service[ConnectionEventRepo]
+        xa    <- ZIO.service[Transactor[Task]]
+        rid   <- seedRouter(rRepo)
+        inserts = cases.zipWithIndex.map { case ((r, _), idx) =>
+          ConnectionEventInsert(
+            routerId = rid,
+            mac = Some(mac),
+            host = host,
+            destIp = None,
+            allowed = false,
+            reason = r,
+            ts = Instant.parse("2026-05-30T12:00:00Z").plusSeconds(idx.toLong),
+            eventId = Some(UUID.randomUUID()),
+            resolvedHost = None,
+          )
+        }
+        _    <- cRepo.insertBatch(inserts)
+        rows <- sql"""SELECT reason::TEXT, reason_text
+                      FROM connection_events
+                      ORDER BY ts ASC"""
+          .query[(String, Option[String])]
+          .to[List]
+          .transact(xa)
+      } yield {
+        val expected = cases.map(_._2)
+        val got      = rows.map(_._2.getOrElse("<null>"))
+        assert(got)(equalTo(expected))
+      }
+    },
+    test("BlockEventRepo.insertBatch populates both reason (JSONB) and reason_text (TEXT)") {
+      for {
+        _     <- cleanDb
+        rRepo <- ZIO.service[RouterRepo]
+        _     <- seedRouter(rRepo)
+        bRepo <- ZIO.service[BlockEventRepo]
+        xa    <- ZIO.service[Transactor[Task]]
+        inserts = cases.map { case (r, _) =>
+          BlockEventInsert(mac = Some(mac), host = host, reason = r)
+        }
+        _    <- bRepo.insertBatch(inserts)
+        rows <- sql"""SELECT reason_text
+                      FROM block_events
+                      ORDER BY id ASC"""
+          .query[Option[String]]
+          .to[List]
+          .transact(xa)
+      } yield {
+        val expected = cases.map(_._2)
+        val got      = rows.map(_.getOrElse("<null>"))
+        assert(got)(equalTo(expected))
+      }
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1308,6 +1308,36 @@ object BlockReason {
     case other                                                 => Unknown(other)
   }
 
+  /**
+   * Inverse of [[fromWire]]. Returns the canonical pre-V40 TEXT-format wire string for a
+   * `BlockReason` — what a router agent prior to #1147 would have written to
+   * `connection_events.reason` (TEXT) or `block_events.reason` (TEXT).
+   *
+   * Used as the source of truth for the back-compat dual-write introduced in V44 (#1176 / #1179):
+   * every write to either table populates `reason_text` from `asWire(reason)` so a rollback to an
+   * image that binds the column as TEXT can still read meaningful values.
+   *
+   * Each non-`Unknown` case round-trips through `fromWire(asWire(r)) == r`. The `Unknown(raw)` case
+   * emits `raw` verbatim — anything `fromWire` couldn't categorize is preserved unmodified, so a
+   * second `fromWire` reparse still produces the same `Unknown(raw)`.
+   */
+  def asWire(r: BlockReason): String = r match {
+    case Allow                    => "allow"
+    case Blocked                  => "blocked"
+    case ExtraAllowed             => "extra_allowed"
+    case ExtraBlocked             => "extra_blocked"
+    case NoProfile                => "no_profile"
+    case MacBlockReason.Paused    => "paused"
+    case MacBlockReason.Schedule  => "schedule"
+    case MacBlockReason.TimeLimit => "time_limit"
+    case MacBlockReason.Manual    => "manual"
+    case MacBlockReason.Unmanaged => "unmanaged_mac"
+    case Category(slug)           => s"category:${slug.value}"
+    case SiteTimeLimit(label)     => s"site_time_limit:$label"
+    case AppBlocked(appId)        => s"app:$appId"
+    case Unknown(raw)             => raw
+  }
+
   // Kind-tagged JSON. Encoder/Decoder are written by hand to keep the wire
   // format stable independent of source-order rearrangement, and to give a
   // single source of truth for the strings the SPA pattern-matches on.


### PR DESCRIPTION
## Design

- **V44** adds nullable `reason_text TEXT` to `connection_events` and `block_events`. Schema-only, fast — no inline backfill, no type change.
- Repos dual-write `reason` (JSONB, the V40 shape) AND `reason_text` (wire string via `BlockReason.asWire`).
- `ReasonTextBackfill` runs as a forked daemon on startup and populates `reason_text` from existing `reason` JSONB in id-chunked batches. Idempotent; safe to re-run; throttled with a per-batch sleep so a slow Render PG doesn't see a burst on cold start.
- Reads unchanged — still off `reason` (JSONB). No SPA-visible change.

Numbering note: the task brief named this "V41". The actual next migration slot in `api/resources/db/migration/` is V44 (V41–V43 are already in main: traffic partitioning, connection_events partitioning, time_used_daily).

## Why

With this in main, a future Render auto-rollback that drops back to a *post-V44* image still finds `reason_text` populated, so a TEXT-binding read path on a later cut-over stays valid. Combined with #1179's policy (no inline backfills, no in-place type changes), the next shape change of `reason` is rollback-safe by construction.

This PR does NOT retroactively rescue `aa070c0` — that image binds `reason` as TEXT against what is now a JSONB column. Recovering prod still requires operator-approved forward-roll once this lands.

V45 (out of scope here) will cut reads to `reason_text` and later drop the legacy JSONB column once this has settled.

## TDD progression (visible in commit history)

1. **red** — V44 + failing dual-write spec (reason_text NULL because repos don't write it yet)
2. **green** — `BlockReason.asWire` + dual-write SQL
3. **red** — backfill spec referencing not-yet-existent `ReasonTextBackfill` object (won't compile)
4. **green** — `ReasonTextBackfill` + Main wiring

## Test plan

- [x] Feature test: `insertBatch` writes both `reason` (JSONB) and `reason_text` (wire string) for every BlockReason kind
- [x] Backfill job test: NULL `reason_text` becomes populated with the matching wire string for each `BlockReason` kind
- [x] Idempotency test: two consecutive backfill runs leave no NULLs
- [x] `mill api.test` clean (14/14 suites, 0 failures)
- [x] `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources` clean
- [ ] Future V45 PR — out of scope — cuts reads + drops the legacy column after this has settled

Refs #1176. Conforms to #1179's back-compat invariant.