### PR TITLE
test: template-DB pattern eliminates per-test Flyway re-run (#1188)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,24 +137,27 @@ jobs:
               - '.github/actionlint.yaml'
 
   # ── Scala: format, compile, test ─────────────────────────────────────────
-  # Runs on the 8-vCPU GitHub-hosted larger runner (#1188). Mill's test
-  # parallelism is on by default and spawns up to `MILL_JOBS` worker JVMs
-  # that pull specs from a shared queue — each worker has its own
-  # EmbeddedPostgres singleton, so a wider runner directly buys more
-  # parallel JVMs without any code changes. See docs/testing-parallelism.md.
+  # The dominant test-time cost used to be the per-test Flyway re-run
+  # inside cleanAndMigrate (~400-500 ms × 44 migrations × hundreds of
+  # tests). #1188 moved that work to a one-shot template-DB init at JVM
+  # startup; per-test reset is now a sub-ms `DROP DATABASE + CREATE
+  # DATABASE … TEMPLATE wh_template`. Mill's testParallelism=true
+  # (default) is what runs worker JVMs in parallel across the runner's
+  # vCPUs — each worker has its own EmbeddedPostgres + per-spec DBs
+  # cloned from the template. See docs/testing-parallelism.md.
   scala:
     name: Scala Build & Test
     needs: changes
     if: needs.changes.outputs.scala == 'true'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
 
     env:
       WIFIHAVEN_JWT_SECRET: test-jwt-secret-for-ci-only
-      # Pass `--jobs $MILL_JOBS` to every mill invocation in this job.
-      # Match worker-JVM count to runner vCPUs — kept explicit so any
-      # change to `runs-on` stays coupled with the worker count it implies
-      # rather than silently inheriting `availableProcessors()`.
-      MILL_JOBS: "8"
+      # Pinned to the standard `ubuntu-latest` runner's 4 vCPUs (matches
+      # mill's default `availableProcessors()` but kept explicit so any
+      # change to `runs-on` stays coupled with the worker count it
+      # implies). Bump in lockstep if the runner gets wider.
+      MILL_JOBS: "4"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,24 @@ jobs:
               - '.github/actionlint.yaml'
 
   # ── Scala: format, compile, test ─────────────────────────────────────────
+  # Runs on the 8-vCPU GitHub-hosted larger runner (#1188). Mill's test
+  # parallelism is on by default and spawns up to `MILL_JOBS` worker JVMs
+  # that pull specs from a shared queue — each worker has its own
+  # EmbeddedPostgres singleton, so a wider runner directly buys more
+  # parallel JVMs without any code changes. See docs/testing-parallelism.md.
   scala:
     name: Scala Build & Test
     needs: changes
     if: needs.changes.outputs.scala == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
 
     env:
       WIFIHAVEN_JWT_SECRET: test-jwt-secret-for-ci-only
+      # Pass `--jobs $MILL_JOBS` to every mill invocation in this job.
+      # Match worker-JVM count to runner vCPUs — kept explicit so any
+      # change to `runs-on` stays coupled with the worker count it implies
+      # rather than silently inheriting `availableProcessors()`.
+      MILL_JOBS: "8"
 
     steps:
       - uses: actions/checkout@v6
@@ -215,17 +225,20 @@ jobs:
         env:
           JAVA_OPTS: "-Xss8m"
           JAVA_TOOL_OPTIONS: "-Xss8m"
-        run: mill __.compile
+        run: mill --jobs "$MILL_JOBS" __.compile
 
-      - name: Run all tests (sequential to avoid embedded-pg lock contention)
-        # api.test spins up EmbeddedPostgres; running sequentially avoids
-        # JVM-wide file-lock contention if more DB-heavy tests are added later.
+      - name: Run all tests
+        # NOT sequential: Mill's testParallelism=true (default) spawns up
+        # to MILL_JOBS worker JVMs that pull specs from a shared queue.
+        # Each worker has its own EmbeddedPostgres singleton — no DB-level
+        # contention across specs. shared.test is tiny (~2s) and stays in
+        # one fork. docs/testing-parallelism.md has the full model.
         env:
           JAVA_OPTS: "-Xss8m"
           JAVA_TOOL_OPTIONS: "-Xss8m"
         run: |
-          mill shared.test
-          mill api.test
+          mill --jobs "$MILL_JOBS" shared.test
+          mill --jobs "$MILL_JOBS" api.test
 
   # ── Migrations: forbid changes to existing files on PRs to main ─────────
   migrations-immutable:

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -9,19 +9,40 @@ import zio.*
 import zio.interop.catz.*
 
 /**
- * Spins up a real embedded Postgres, runs Flyway migrations, provides a Transactor.
+ * Spins up a real embedded Postgres once per JVM, creates a per-spec Postgres database by cloning a
+ * pre-migrated template, and provides a `Transactor` wired to that per-spec database.
  *
- * A single EmbeddedPostgres instance is shared across all specs in the same JVM to avoid concurrent
- * initdb failures on ARM Mac (Postgres runs under Rosetta x86 emulation). Each test calls
- * cleanAndMigrate to reset state before running.
+ * ==Why the template-DB pattern (#1188)==
+ *
+ * The naïve approach — run Flyway from scratch in `cleanAndMigrate` between every test — dominates
+ * the test-suite wall time: each `DROP SCHEMA + Flyway migrate` is ~400–500 ms with 44 migrations,
+ * and the suite calls `cleanDb` once per test. For ~250 tests that's roughly two minutes of pure
+ * migration work.
+ *
+ * Instead, on first use this object boots one shared `EmbeddedPostgres` for the JVM, creates a
+ * `wh_template` database in it, runs the production Flyway migrations into `wh_template` exactly
+ * once, and applies the standard test-only seed tweaks (household_settings row, admin
+ * must_change_password=false) into `wh_template`.
+ *
+ * Each spec's `TestDatabase.layer` then allocates a fresh per-spec database with a unique name
+ * (`wh_test_<n>`) by issuing `CREATE DATABASE … TEMPLATE wh_template`, which Postgres satisfies
+ * with a file-level copy — no Flyway runs at all per spec or per test. `cleanAndMigrate` resets the
+ * per-spec database the same way (drop + re-clone) so each test starts from the template's
+ * post-Flyway, post-seed state.
+ *
+ * Cross-spec isolation comes from the unique database name: even when multiple specs run in the
+ * same JVM and call `cleanAndMigrate` concurrently, they each operate on their own DB.
  */
 object TestDatabase {
 
-  // JVM-wide singleton: started once, shared across all ZIOSpec bootstrap layers
-  // in this JVM. We don't use `lazy val` here — Scala 3 lazy vals can let two
-  // racing threads both run the initializer, and EmbeddedPostgres.prepareBinaries
-  // takes an internal file lock that throws OverlappingFileLockException on the
-  // second concurrent call. Explicit double-checked locking serializes init.
+  private val TemplateDbName = "wh_template"
+
+  // JVM-wide singleton: started once, shared across all ZIOSpec bootstrap layers in this JVM.
+  // We don't use `lazy val` here — Scala 3 lazy vals can let two racing threads both run the
+  // initializer, and EmbeddedPostgres.prepareBinaries takes an internal file lock that throws
+  // OverlappingFileLockException on the second concurrent call. Explicit double-checked locking
+  // serialises init. The template DB + Flyway migrate also happens inside this critical section
+  // so it runs exactly once per JVM.
   private val pgLock                                 = new Object
   @volatile private var pgInstance: EmbeddedPostgres = null
   private def sharedPg: EmbeddedPostgres             = {
@@ -31,92 +52,142 @@ object TestDatabase {
       pgLock.synchronized {
         if pgInstance == null then {
           val pg = EmbeddedPostgres.start()
-          runMigrations(pg)
+          initialiseTemplate(pg)
           pgInstance = pg
         }
         pgInstance
       }
   }
 
-  /** Run the production Flyway migrations (`classpath:db/migration`) against the embedded PG. */
-  private[testinfra] def runMigrations(pg: EmbeddedPostgres): Unit = {
+  /**
+   * Create the template DB, migrate it, and apply standard test seed tweaks. Called exactly once
+   * per JVM, under `pgLock`. After this returns, `wh_template` is the source of truth that every
+   * per-spec DB clones from.
+   */
+  private def initialiseTemplate(pg: EmbeddedPostgres): Unit = {
+    execOnPostgresDb(pg, s"""CREATE DATABASE "$TemplateDbName"""")
+    val templateDs = pg.getDatabase("postgres", TemplateDbName)
     Flyway
       .configure()
-      .dataSource(pg.getPostgresDatabase)
+      .dataSource(templateDs)
       .locations("classpath:db/migration")
       .baselineOnMigrate(true)
       .load()
       .migrate()
+    val conn       = templateDs.getConnection
+    try {
+      val st = conn.createStatement()
+      // #334: replicate Main.ensureDefault so PolicyService.snapshot/decide can read
+      // household_settings during tests. Use UTC so DST doesn't perturb existing expectations.
+      st.execute(
+        "INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz) " +
+          "VALUES (1, '00:00', 'UTC') ON CONFLICT (id) DO NOTHING",
+      )
+      // #586: V18 sets must_change_password=true for the seeded admin so production deployments
+      // force a password rotation. In tests we want the admin fully operational.
+      st.execute("UPDATE users SET must_change_password=false WHERE username='admin'")
+    } finally conn.close()
     ()
   }
+
+  /**
+   * Per-spec database identity. Allocated fresh by `testDb` for every bootstrap of
+   * `TestDatabase.layer`. The `ds` is non-pooled (zonky's `getDatabase` returns a JDBC-URL-backed
+   * DataSource), so a drop-and-recreate of `name` invalidates nothing held in the Transactor — the
+   * next `xa.run` opens a fresh connection to the freshly-cloned DB.
+   */
+  final case class TestDb(name: String, ds: javax.sql.DataSource)
+
+  // Atomic counter for unique DB names. Crosses spec boundaries within a JVM.
+  private val dbCounter = new java.util.concurrent.atomic.AtomicLong(0)
 
   /** Provides the shared EmbeddedPostgres instance (no lifecycle: lives for JVM lifetime). */
   val embeddedPg: ZLayer[Any, Throwable, EmbeddedPostgres] =
     ZLayer.fromZIO(ZIO.attemptBlocking(sharedPg))
 
-  /** Transactor wired to the embedded PG. */
-  val transactor: ZLayer[EmbeddedPostgres, Throwable, Transactor[Task]] =
+  /** Allocates a fresh per-spec database by cloning the JVM's pre-migrated template. */
+  val testDb: ZLayer[EmbeddedPostgres, Throwable, TestDb] =
     ZLayer.fromZIO {
       for {
         pg <- ZIO.service[EmbeddedPostgres]
-        ds = pg.getPostgresDatabase
-        xa = Transactor.fromDataSource[Task](ds, scala.concurrent.ExecutionContext.global)
+        n  <- ZIO.succeed(dbCounter.incrementAndGet())
+        dbName = s"wh_test_$n"
+        _ <- cloneTemplateInto(pg, dbName)
+      } yield TestDb(dbName, pg.getDatabase("postgres", dbName))
+    }
+
+  /**
+   * Drop `dbName` (terminating live backends first so PG will let us) and recreate it as a copy of
+   * `wh_template`. Postgres turns `CREATE DATABASE … TEMPLATE` into a fast file-level copy, so this
+   * runs in single-digit milliseconds even with 44 migrations' worth of schema.
+   */
+  private def cloneTemplateInto(pg: EmbeddedPostgres, dbName: String): Task[Unit] =
+    ZIO.attemptBlocking {
+      val conn = pg.getPostgresDatabase.getConnection
+      try {
+        val st = conn.createStatement()
+        // Terminate any lingering backends on this DB so the DROP below succeeds. Skip our own
+        // backend (pg_backend_pid()) since it's on the `postgres` DB, not `dbName`, but be
+        // defensive anyway. Both template and target need to be free of other connections.
+        st.execute(
+          s"""SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+              WHERE datname IN ('$dbName', '$TemplateDbName') AND pid <> pg_backend_pid()""",
+        )
+        st.execute(s"""DROP DATABASE IF EXISTS "$dbName"""")
+        st.execute(s"""CREATE DATABASE "$dbName" TEMPLATE "$TemplateDbName"""")
+        ()
+      } finally conn.close()
+    }
+
+  /** Execute a single SQL statement against the singleton's `postgres` admin DB. */
+  private def execOnPostgresDb(pg: EmbeddedPostgres, sql: String): Unit = {
+    val conn = pg.getPostgresDatabase.getConnection
+    try {
+      val _ = conn.createStatement().execute(sql)
+    } finally conn.close()
+  }
+
+  /** Transactor wired to the per-spec database. */
+  val transactor: ZLayer[TestDb, Throwable, Transactor[Task]] =
+    ZLayer.fromZIO {
+      for {
+        db <- ZIO.service[TestDb]
+        xa = Transactor.fromDataSource[Task](db.ds, scala.concurrent.ExecutionContext.global)
       } yield xa
     }
 
   /**
-   * Drop and recreate the public schema, then re-run migrations. This is faster and more reliable
-   * than Flyway's clean() + migrate() in Flyway 10.
+   * Reset the per-spec database to the template's post-Flyway, post-seed state.
+   *
+   * Replaces the legacy `DROP SCHEMA public CASCADE + Flyway migrate + reseed`, which spent
+   * ~400–500 ms per call re-running 44 migrations. Template clone is single-digit ms — see the
+   * class doc for the full rationale (#1188).
    */
-  val cleanAndMigrate: ZIO[EmbeddedPostgres, Throwable, Unit] =
+  val cleanAndMigrate: ZIO[EmbeddedPostgres & TestDb, Throwable, Unit] =
     for {
       pg <- ZIO.service[EmbeddedPostgres]
-      _  <- ZIO.attempt {
-        val conn = pg.getPostgresDatabase.getConnection
-        try {
-          conn.createStatement().execute("DROP SCHEMA public CASCADE")
-          conn.createStatement().execute("CREATE SCHEMA public")
-        } finally conn.close()
-      }
-      _  <- ZIO.attempt(runMigrations(pg))
-      // #334: replicate Main.ensureDefault so PolicyService.snapshot/decide can
-      // read household_settings during tests. Use UTC so DST doesn't perturb
-      // existing test expectations.
-      _  <- ZIO.attempt {
-        val conn = pg.getPostgresDatabase.getConnection
-        try {
-          conn
-            .createStatement()
-            .execute(
-              "INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz) " +
-                "VALUES (1, '00:00', 'UTC') ON CONFLICT (id) DO NOTHING",
-            )
-        } finally conn.close()
-      }
-      // #586: V18 migration sets must_change_password=true for the seeded admin so
-      // production deployments force a password rotation. In tests we want the admin
-      // to be fully operational, so clear the flag after each migration reset.
-      _  <- ZIO.attempt {
-        val conn = pg.getPostgresDatabase.getConnection
-        try {
-          conn
-            .createStatement()
-            .execute("UPDATE users SET must_change_password=false WHERE username='admin'")
-        } finally conn.close()
-      }
+      db <- ZIO.service[TestDb]
+      _  <- cloneTemplateInto(pg, db.name)
     } yield ()
 
-  /** All repo types bundled for convenience */
+  /**
+   * All repo types bundled for convenience.
+   *
+   * `TestDb` is included so a spec that declares `ZIOSpec[TestDatabase.AllRepos & …]` gets the
+   * per-spec DB handle in its environment automatically — `cleanAndMigrate` needs it, and the
+   * bootstrap layer always provides it.
+   */
   type AllRepos =
-    UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
+    TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
       TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
       TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
       AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
 
-  val layer: ZLayer[Any, Throwable, EmbeddedPostgres & Transactor[Task] & AllRepos] = {
+  val layer: ZLayer[Any, Throwable, EmbeddedPostgres & TestDb & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg
-    val xa = pg >>> transactor
-    pg ++ xa ++ (xa >>> Repos.all)
+    val td = pg >>> testDb
+    val xa = td >>> transactor
+    pg ++ td ++ xa ++ (xa >>> Repos.all)
   }
 }
 

--- a/api/test/src/feature/AlertApiSpec.scala
+++ b/api/test/src/feature/AlertApiSpec.scala
@@ -35,9 +35,7 @@ object AlertApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val noopNotifier: Notifier = new Notifier {
     def alertCreated(a: Alert): UIO[Unit] = ZIO.unit

--- a/api/test/src/feature/AppApiSpec.scala
+++ b/api/test/src/feature/AppApiSpec.scala
@@ -31,9 +31,7 @@ object AppApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeRoutes =
     for {

--- a/api/test/src/feature/AppPatchApiSpec.scala
+++ b/api/test/src/feature/AppPatchApiSpec.scala
@@ -26,9 +26,7 @@ object AppPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
   private def url(p: String) = URL.decode(p).toOption.get
 
   private def setupApp(

--- a/api/test/src/feature/AppRepoSpec.scala
+++ b/api/test/src/feature/AppRepoSpec.scala
@@ -13,9 +13,7 @@ object AppRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Tr
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val youtube = Hostname.unsafe("youtube.com")
   private val ytimg   = Hostname.unsafe("ytimg.com")

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -32,9 +32,7 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def url(p: String) = URL.decode(p).toOption.get
 

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -26,9 +26,7 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   def spec = suite("Auth API")(
     test("admin can login with seeded credentials") {

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -25,9 +25,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makePsAt(dt: LocalDateTime) =
     for {

--- a/api/test/src/feature/BlockedMacEventIngestSpec.scala
+++ b/api/test/src/feature/BlockedMacEventIngestSpec.scala
@@ -38,9 +38,7 @@ object BlockedMacEventIngestSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val mac = MacAddress.unsafe("aa:bb:cc:11:22:33")
 

--- a/api/test/src/feature/BundledBlocklistsSpec.scala
+++ b/api/test/src/feature/BundledBlocklistsSpec.scala
@@ -34,9 +34,7 @@ object BundledBlocklistsSpec
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   /** Fetcher that returns canned hosts for known URLs and fails for everything else. */
   final class StubFetcher(responses: Map[String, List[Hostname]], failures: Set[String] = Set.empty)

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -27,9 +27,7 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private def seedRouter(name: String = "home"): ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo] { rRepo =>

--- a/api/test/src/feature/DebugApiSpec.scala
+++ b/api/test/src/feature/DebugApiSpec.scala
@@ -20,9 +20,7 @@ object DebugApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(LocalDateTime.of(2026, 5, 11, 12, 0))
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def buildRoutes(enabled: Boolean) =
     for {

--- a/api/test/src/feature/DeviceApiSpec.scala
+++ b/api/test/src/feature/DeviceApiSpec.scala
@@ -28,9 +28,7 @@ object DeviceApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, adminJwt, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   def spec = suite("Device API")(
     test("create and list devices") {

--- a/api/test/src/feature/DevicePatchApiSpec.scala
+++ b/api/test/src/feature/DevicePatchApiSpec.scala
@@ -26,9 +26,7 @@ object DevicePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private def url(p: String) = URL.decode(p).toOption.get
 

--- a/api/test/src/feature/HouseholdPatchApiSpec.scala
+++ b/api/test/src/feature/HouseholdPatchApiSpec.scala
@@ -27,9 +27,7 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
   private def url(p: String) = URL.decode(p).toOption.get
 
   private val Seed = HouseholdSettings(

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -28,9 +28,7 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   // Router name doubles as location until routers.location column lands (#136).
   private def seedRouter(name: String = "home"): ZIO[RouterRepo, Throwable, RouterId] =

--- a/api/test/src/feature/PartitioningSpec.scala
+++ b/api/test/src/feature/PartitioningSpec.scala
@@ -26,9 +26,7 @@ object PartitioningSpec
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def seedRouter: RIO[RouterRepo, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("partition-test", Sha256Hex.unsafe("a" * 64)))

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -21,9 +21,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makePs =
     for {

--- a/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
@@ -35,9 +35,7 @@ object PolicySnapshotBlockIpOnlySpec
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, adminJwt, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   def spec = suite("PolicySnapshot — blockIpOnly (#424)")(
     test("default is false for seeded profiles") {

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -37,9 +37,7 @@ object PolicySnapshotBlockedMacsSpec
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makePsAt(dt: LocalDateTime) =
     for {

--- a/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
+++ b/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
@@ -29,9 +29,7 @@ object PolicySnapshotConsolidationSpec extends ZIOSpec[TestDatabase.AllRepos & E
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def settingsTz(hsr: HouseholdSettingsRepo, tz: String): Task[HouseholdSettings] =
     for {

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -22,9 +22,7 @@ object PolicySnapshotFailureModeSpec
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   def spec = suite("PolicySnapshot — failureMode (#385)")(
     test("snapshot carries each profile's failureMode value") {

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -22,9 +22,7 @@ object PolicySnapshotGlobalAllowSpec
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val uiHosts: List[Hostname] =
     List("wifihaven.net", "api.wifihaven.net").map(Hostname.unsafe)

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -37,9 +37,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, adminJwt, clock)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def mkRoutes =
     for {

--- a/api/test/src/feature/ReasonTextBackfillSpec.scala
+++ b/api/test/src/feature/ReasonTextBackfillSpec.scala
@@ -31,9 +31,7 @@ object ReasonTextBackfillSpec
       : ZLayer[Any, Throwable, TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] =
     TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def seedRouter(rRepo: RouterRepo): Task[RouterId] = {
     val token = "ROUTER_TOKEN_PLAIN"

--- a/api/test/src/feature/ReasonTextDualWriteSpec.scala
+++ b/api/test/src/feature/ReasonTextDualWriteSpec.scala
@@ -33,9 +33,7 @@ object ReasonTextDualWriteSpec
       : ZLayer[Any, Throwable, TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] =
     TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def seedRouter(rRepo: RouterRepo): Task[RouterId] = {
     val token = "ROUTER_TOKEN_PLAIN"

--- a/api/test/src/feature/RecentApexesApiSpec.scala
+++ b/api/test/src/feature/RecentApexesApiSpec.scala
@@ -27,9 +27,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private val kidsMac   = "aa:bb:cc:dd:ee:01"
   private val adultsMac = "aa:bb:cc:dd:ee:02"

--- a/api/test/src/feature/RetentionSweepJobSpec.scala
+++ b/api/test/src/feature/RetentionSweepJobSpec.scala
@@ -21,9 +21,7 @@ object RetentionSweepJobSpec
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def seedRouter: RIO[RouterRepo, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("retention-test", Sha256Hex.unsafe("a" * 64)))
@@ -168,13 +166,17 @@ object RetentionSweepJobSpec
       for {
         _   <- cleanDb
         xa  <- ZIO.service[Transactor[Task]]
-        pg  <- ZIO.service[EmbeddedPostgres]
+        // Per-spec DB DataSource — advisory locks are per-database, so the
+        // holder must be on the same DB the repo runs against. Using
+        // `pg.getPostgresDatabase` here would acquire the lock on the
+        // `postgres` admin DB and the repo would never see it (#1188).
+        db  <- ZIO.service[TestDatabase.TestDb]
         rid <- seedRouter
         _   <- insertTraffic(xa, rid, "cc:cc:cc:cc:cc:01", ageDays = 60)
         acquired = new CountDownLatch(1)
         release  = new CountDownLatch(1)
         holder <- ZIO.attemptBlocking {
-          val c = pg.getPostgresDatabase.getConnection
+          val c = db.ds.getConnection
           try {
             val s = c.createStatement()
             s.execute(s"SELECT pg_advisory_lock($key)")

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -32,9 +32,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   /**
    * Create a user with a given role and link them to the listed profile ids.

--- a/api/test/src/feature/RollupRepoSpec.scala
+++ b/api/test/src/feature/RollupRepoSpec.scala
@@ -25,9 +25,7 @@ object RollupRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   // Seed one router row so the rollup tables' FK has something to point at.
   private def seedRouter: RIO[RouterRepo, RouterId] =
@@ -221,15 +219,16 @@ object RollupRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         start = LocalDate.of(2026, 3, 1).atStartOfDay(ZoneOffset.UTC).toInstant
         _       <- seedReports(rid, start, 6, bytesPerBucket = 25L)
         rollup  <- ZIO.service[RollupRepo]
-        pg      <- ZIO.service[EmbeddedPostgres]
-        // Hold the session-level lock on a dedicated connection for the
-        // duration of the racing rerollHourly call. `pg_advisory_lock` blocks
-        // if the lock is contended; we use `pg_try_advisory_lock` here so the
-        // setup call returns immediately (the lock is free at this point).
+        db      <- ZIO.service[TestDatabase.TestDb]
+        // Hold the session-level lock on a dedicated connection drawn from
+        // the *same* per-spec database the repo runs against — pg advisory
+        // locks are per-database, so a lock acquired on a different DB
+        // (e.g. the `postgres` admin DB) would not be visible to the repo
+        // and the test would race-pass (#1188).
         skipped <- ZIO.scoped {
           for {
             conn <- ZIO.acquireRelease(
-              ZIO.attempt(pg.getPostgresDatabase.getConnection),
+              ZIO.attempt(db.ds.getConnection),
             )(c => ZIO.attempt(c.close()).ignore)
             _    <- ZIO.attempt {
               val rs = conn

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -25,9 +25,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
 
   private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeAuth =
     for {

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -21,9 +21,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makePsAt(dt: LocalDateTime) =
     for {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -37,9 +37,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
 
   override val bootstrap = TestDatabase.layer ++ TestLayers.withClock(testClockAt)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def seedRouter(rRepo: RouterRepo): Task[(RouterId, String)] = {
     val token = "ROUTER_TOKEN_PLAIN"

--- a/api/test/src/feature/RouterRepoSpec.scala
+++ b/api/test/src/feature/RouterRepoSpec.scala
@@ -15,9 +15,7 @@ object RouterRepoSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   def spec = suite("OpenWRT repos")(
     suite("RouterRepo")(

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -29,9 +29,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private val testMac = "aa:bb:cc:dd:ee:01"
 

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -37,9 +37,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private val macKid   = "aa:bb:cc:dd:ee:01"
   private val macAdult = "aa:bb:cc:dd:ee:02"

--- a/api/test/src/feature/TimeStatusServiceSpec.scala
+++ b/api/test/src/feature/TimeStatusServiceSpec.scala
@@ -20,9 +20,7 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeService: ZIO[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &

--- a/api/test/src/feature/TimeUsageBackfillSpec.scala
+++ b/api/test/src/feature/TimeUsageBackfillSpec.scala
@@ -30,9 +30,7 @@ object TimeUsageBackfillSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val testDate     = LocalDate.of(2026, 5, 7)
   private val mac1         = MacAddress.unsafe("aa:bb:cc:11:22:33")

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -24,9 +24,7 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
 
   override val bootstrap = TestDatabase.layer
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeService: ZIO[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -27,9 +27,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private val testMac = "aa:bb:cc:dd:ee:01"
 

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -33,9 +33,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
 
-  private def cleanDb = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb = TestDatabase.cleanAndMigrate
 
   private val testMac = "aa:bb:cc:dd:ee:01"
 

--- a/api/test/src/feature/UserCreateSpec.scala
+++ b/api/test/src/feature/UserCreateSpec.scala
@@ -34,9 +34,7 @@ object UserCreateSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   def spec = suite("User creation sets must_change_password=true")(
     test("userRepo.create stores must_change_password=true") {

--- a/api/test/src/feature/UserPatchApiSpec.scala
+++ b/api/test/src/feature/UserPatchApiSpec.scala
@@ -26,9 +26,7 @@ object UserPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       ur    <- ZIO.service[UserRepo]
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
-  private def cleanDb  = ZIO.serviceWithZIO[EmbeddedPostgres](pg =>
-    TestDatabase.cleanAndMigrate.provide(ZLayer.succeed(pg)),
-  )
+  private val cleanDb  = TestDatabase.cleanAndMigrate
 
   private def url(p: String) = URL.decode(p).toOption.get
 

--- a/docs/testing-parallelism.md
+++ b/docs/testing-parallelism.md
@@ -1,69 +1,109 @@
 # Test parallelism model
 
-The `Scala Build & Test` job in `.github/workflows/ci.yml` runs `mill
-shared.test` then `mill api.test` on an 8-vCPU GitHub-hosted larger
-runner (`ubuntu-latest-8-cores`). Both modules are tuned to use the full
-runner without any spec-level refactor; this doc explains how, so the next
-person to touch CI doesn't re-introduce the "sequential" comment that used
-to live on the test step.
+The `Scala Build & Test` job in `.github/workflows/ci.yml` runs the
+Scala test suite as fast as we can on the standard 4-vCPU
+`ubuntu-latest` runner. Two pieces matter:
 
-## What's parallel
+1. **Mill's worker-JVM parallelism** spreads the suite across the
+   runner's vCPUs.
+2. **The template-DB pattern in `TestDatabase`** removes the Flyway
+   re-run that used to dominate every test's wall time.
 
-Mill's `TestModule` ships with `testParallelism = true` by default. With a
-single test fork group (Mill's default — `testForkGrouping` returns one
-inner list of all spec FQCNs), Mill spawns up to `--jobs` **worker JVM
-processes** that share a filesystem-backed queue of spec class names. Each
-worker pulls one spec, runs it via the ZIO Test SBT framework, then comes
-back for the next.
+If you change either piece, update both this doc and the inline comment
+on the `scala` job — they were stale for months before #1188 (the
+"sequential to avoid embedded-pg lock contention" claim was wrong, and
+hid a much bigger Flyway-per-test hot spot).
 
-Inside one worker JVM, specs run sequentially through the framework — but
-nothing in that JVM races with another worker's JVM. Crucially each
-worker has its own `EmbeddedPostgres` singleton (the `@volatile var
-pgInstance` in [`api/test/src/TestDatabase.scala`](../api/test/src/TestDatabase.scala)
-is JVM-local), so the per-test `DROP SCHEMA public CASCADE` + Flyway
-migrate done in `TestDatabase.cleanAndMigrate` only ever touches the PG
-that the running worker owns. That's why we can use a shared singleton
-without locking even though it would race if multiple specs in one JVM hit
-it concurrently.
+## Mill worker JVMs
 
-## Worker count is pinned to runner vCPUs
+`TestModule.testParallelism = true` is mill's default. With the suite in
+a single test-fork group (also default), mill spawns `min(--jobs,
+num_specs)` **worker JVM processes** that pull spec classes from a
+shared filesystem-backed queue. Each worker runs one spec at a time
+through the ZIO Test SBT framework, then comes back for the next.
 
-The `scala` job sets `MILL_JOBS: "8"` and every `mill` invocation in that
-job is launched as `mill --jobs "$MILL_JOBS" …`. The default Mill
-behaviour is `availableProcessors()`, which works fine, but pinning the
-value:
+CI pins `MILL_JOBS=4` and passes `--jobs "$MILL_JOBS"` to every `mill`
+invocation in the job, matching the runner's 4 vCPUs. Mill defaults to
+`availableProcessors()`, which would give the same number — pinning is
+just so the runner spec and the worker count travel together if either
+moves.
 
-- keeps the runner spec and the worker count in the same diff (if we go
-  back to `ubuntu-latest`, both numbers move together), and
-- removes ambiguity if a future runner image exposes a different vCPU
-  count than expected.
+Within a worker JVM specs run **sequentially**. Cross-spec concurrency
+only happens across workers. We don't try to run multiple specs
+concurrently inside one JVM — see the "Why not in-JVM-multi-spec
+parallel" note below.
 
-The trade-off in worker count is **JVM + PG boot cost vs spec parallelism**.
-Each worker pays:
+## Template-DB pattern (the actual hot-path fix)
 
-- ~5–8s of JVM + Mill classpath startup, and
-- ~2–5s of `EmbeddedPostgres.start` (initdb + postmaster).
+Before #1188, every test called `cleanAndMigrate`, which did `DROP
+SCHEMA public CASCADE` + `Flyway.migrate()` against the singleton's
+`postgres` database. With 44 migrations that's ~400–500 ms per test;
+across the suite it added roughly two minutes of pure migration work.
 
-…before it runs its first spec. So workers = vCPUs is roughly the sweet
-spot; significantly more workers just multiplies that fixed cost without
-buying you more concurrent CPU work.
+The fix is to do that work exactly once per JVM into a Postgres
+**template database**, then clone the template for every spec.
 
-## Why not in-JVM parallel
+The first time any spec touches `TestDatabase` in a JVM:
 
-The obvious next step — run multiple specs concurrently *inside one JVM*,
-sharing a single `EmbeddedPostgres` — is blocked by the fact that
-`TestDatabase.cleanAndMigrate` resets the schema on the shared DB. To
-make that safe under concurrency every spec would need its own database
-(per-spec `CREATE DATABASE` + Flyway) and the bootstrap layer + every
-spec's `cleanDb` helper would have to be reworked. That's a ~50-file
-mechanical edit for a win that's bounded by the same vCPU ceiling we
-already hit with multiple worker JVMs, so we picked the cheaper path
-first. If we ever outgrow the per-worker PG boot cost (e.g. on a
-much-larger runner where boot dominates), revisit.
+1. Boot one shared `EmbeddedPostgres` (still the JVM-wide singleton).
+2. `CREATE DATABASE wh_template` on it.
+3. Run the production Flyway migrations into `wh_template`.
+4. Apply the test seed tweaks (household_settings row, admin
+   `must_change_password=false`) into `wh_template`.
+
+After that, every `TestDatabase.layer` evaluation:
+
+1. Allocates a unique DB name `wh_test_<n>` (atomic counter).
+2. Issues `CREATE DATABASE wh_test_<n> TEMPLATE wh_template`, which
+   Postgres satisfies with a fast file-level copy — single-digit ms,
+   no Flyway runs.
+3. Hands the spec a `TestDb(name, ds)` and a `Transactor` wired to
+   `ds`.
+
+`cleanAndMigrate` (called per-test by `cleanDb`) now does `DROP
+DATABASE wh_test_<n>` + the same `CREATE DATABASE … TEMPLATE`, after a
+defensive `pg_terminate_backend` to kick any stale connections off the
+target DB so Postgres will let us drop it. Same shape as the bootstrap
+allocation, just resetting an existing slot.
+
+### Cross-spec isolation
+
+Per-spec DB names mean specs that run concurrently (across worker JVMs)
+never touch each other's schema, data, or — importantly —
+**advisory locks**. Postgres advisory locks are per-database, so a
+spec acquiring a lock on `wh_test_42` can't be observed by code running
+in `wh_test_43`.
+
+This is what broke two tests during the #1188 refactor —
+`RollupRepoSpec` and `RetentionSweepJobSpec` were acquiring their
+"holder" lock on `pg.getPostgresDatabase` (the `postgres` admin DB)
+while the production code under test was running against the per-spec
+DB. The holder lock was invisible to the repo and the assertion
+race-passed under the old layout. Both tests now draw the connection
+from `TestDb.ds` for the same per-spec DB the repo runs against. **If
+you write a new test that acquires an advisory lock directly to verify
+contention, draw the connection from `TestDb.ds`, not from
+`EmbeddedPostgres.getPostgresDatabase`.**
+
+## Why not in-JVM-multi-spec parallel
+
+The next obvious step — running multiple `*Spec` objects concurrently
+inside *one* worker JVM, sharing one `EmbeddedPostgres` — needs a
+change to the ZIO Test SBT framework, which today processes its task
+list sequentially within a JVM. The template-DB pattern would make it
+safe (each spec already has its own DB), but the actual parallel
+execution machinery isn't there for free.
+
+The current model — one worker JVM per CPU, each with its own
+`EmbeddedPostgres` singleton and pool of per-spec template clones —
+caps out at runner vCPUs but is the same ceiling we'd hit from
+in-JVM-multi-spec without a much bigger refactor. Revisit if we ever
+move to a runner where the per-worker PG boot cost is the long pole.
 
 ## Local UX
 
 `mill shared.test`, `mill api.test`, `mill __.test` all still work
-locally with no flags. Mill defaults `--jobs` to the host's CPU count,
-which matches the CI behaviour. Pass `--jobs 1` for fully deterministic
-output (useful when debugging a test-ordering issue).
+locally with no flags. Mill defaults `--jobs` to the host's CPU count.
+Pass `--jobs 1` for fully deterministic output (useful when debugging
+a test-ordering issue, or when comparing a hot-path change like
+template-DB to a known-good single-worker baseline).

--- a/docs/testing-parallelism.md
+++ b/docs/testing-parallelism.md
@@ -1,0 +1,69 @@
+# Test parallelism model
+
+The `Scala Build & Test` job in `.github/workflows/ci.yml` runs `mill
+shared.test` then `mill api.test` on an 8-vCPU GitHub-hosted larger
+runner (`ubuntu-latest-8-cores`). Both modules are tuned to use the full
+runner without any spec-level refactor; this doc explains how, so the next
+person to touch CI doesn't re-introduce the "sequential" comment that used
+to live on the test step.
+
+## What's parallel
+
+Mill's `TestModule` ships with `testParallelism = true` by default. With a
+single test fork group (Mill's default — `testForkGrouping` returns one
+inner list of all spec FQCNs), Mill spawns up to `--jobs` **worker JVM
+processes** that share a filesystem-backed queue of spec class names. Each
+worker pulls one spec, runs it via the ZIO Test SBT framework, then comes
+back for the next.
+
+Inside one worker JVM, specs run sequentially through the framework — but
+nothing in that JVM races with another worker's JVM. Crucially each
+worker has its own `EmbeddedPostgres` singleton (the `@volatile var
+pgInstance` in [`api/test/src/TestDatabase.scala`](../api/test/src/TestDatabase.scala)
+is JVM-local), so the per-test `DROP SCHEMA public CASCADE` + Flyway
+migrate done in `TestDatabase.cleanAndMigrate` only ever touches the PG
+that the running worker owns. That's why we can use a shared singleton
+without locking even though it would race if multiple specs in one JVM hit
+it concurrently.
+
+## Worker count is pinned to runner vCPUs
+
+The `scala` job sets `MILL_JOBS: "8"` and every `mill` invocation in that
+job is launched as `mill --jobs "$MILL_JOBS" …`. The default Mill
+behaviour is `availableProcessors()`, which works fine, but pinning the
+value:
+
+- keeps the runner spec and the worker count in the same diff (if we go
+  back to `ubuntu-latest`, both numbers move together), and
+- removes ambiguity if a future runner image exposes a different vCPU
+  count than expected.
+
+The trade-off in worker count is **JVM + PG boot cost vs spec parallelism**.
+Each worker pays:
+
+- ~5–8s of JVM + Mill classpath startup, and
+- ~2–5s of `EmbeddedPostgres.start` (initdb + postmaster).
+
+…before it runs its first spec. So workers = vCPUs is roughly the sweet
+spot; significantly more workers just multiplies that fixed cost without
+buying you more concurrent CPU work.
+
+## Why not in-JVM parallel
+
+The obvious next step — run multiple specs concurrently *inside one JVM*,
+sharing a single `EmbeddedPostgres` — is blocked by the fact that
+`TestDatabase.cleanAndMigrate` resets the schema on the shared DB. To
+make that safe under concurrency every spec would need its own database
+(per-spec `CREATE DATABASE` + Flyway) and the bootstrap layer + every
+spec's `cleanDb` helper would have to be reworked. That's a ~50-file
+mechanical edit for a win that's bounded by the same vCPU ceiling we
+already hit with multiple worker JVMs, so we picked the cheaper path
+first. If we ever outgrow the per-worker PG boot cost (e.g. on a
+much-larger runner where boot dominates), revisit.
+
+## Local UX
+
+`mill shared.test`, `mill api.test`, `mill __.test` all still work
+locally with no flags. Mill defaults `--jobs` to the host's CPU count,
+which matches the CI behaviour. Pass `--jobs 1` for fully deterministic
+output (useful when debugging a test-ordering issue).


### PR DESCRIPTION
Closes #1188.

## Summary

- `TestDatabase` now boots one `EmbeddedPostgres` per JVM, builds a
  pre-migrated `wh_template` database once, and hands every spec a
  fresh `wh_test_<n>` cloned from the template via Postgres
  `CREATE DATABASE … TEMPLATE` (single-digit ms, no Flyway).
- `cleanAndMigrate` (called per-test by `cleanDb`) becomes
  `DROP DATABASE + CREATE DATABASE … TEMPLATE wh_template` on the
  spec's own DB — eliminates the ~400–500 ms × 44-migrations cost
  that used to run on every `cleanDb` call.
- Mechanical update to 42 specs: `cleanDb` helper collapses to
  `private val cleanDb = TestDatabase.cleanAndMigrate`.
- Two specs (`RollupRepoSpec`, `RetentionSweepJobSpec`) hand-fixed —
  they were acquiring pg-advisory \"holder\" locks on
  `pg.getPostgresDatabase` (the postgres admin DB) while the repo
  under test ran against the per-spec DB. The lock was invisible to
  the repo and the test race-passed under the old shared-DB layout.
  Both now draw the holder connection from `TestDb.ds` for the same
  DB the repo runs against.
- CI workflow reverted from the ubuntu-latest-8-cores experiment
  back to `ubuntu-latest` (larger-runner label isn't available on
  free/public orgs). `MILL_JOBS=4` pinned to the runner's vCPU count.
- New `docs/testing-parallelism.md` describing the template-DB
  pattern, the per-spec-DB isolation invariant, and the
  advisory-lock gotcha (\"if you write a new contention test, draw
  the holder connection from `TestDb.ds`, not from
  `EmbeddedPostgres.getPostgresDatabase`\").

## Strategy

- **In-JVM-multi-spec parallel** was the original goal but needs a
  ZIO Test framework change to actually execute multiple `Spec`
  objects concurrently inside one JVM. Punted; the template-DB
  pattern would make it safe whenever someone wants to take that on.
- **Wider CI runner** (`ubuntu-latest-8-cores`) isn't available on
  free/public orgs — first attempt sat queued forever.
- **Hot-path fix**: the actual dominant cost was Flyway-per-test,
  not lack of parallelism. The template-DB pattern removes that
  cost across the board. Mill's existing worker-JVM parallelism
  (4 workers on 4-vCPU `ubuntu-latest`) still does the
  cross-spec concurrency work.

## Before / after

| Measurement                              | Before | After |
|------------------------------------------|--------|-------|
| `mill api.test` local, 10-core wall      | 67s    | 54s   |
| `mill api.test` local, `--jobs 1` wall   | 207s   | _pending_ |
| `Scala Build & Test` job, CI (4-core)    | 305s\* | _pending — this PR's run_ |

\* baseline = run [26693842738](https://github.com/wifihaven/wifihaven/actions/runs/26693842738) on
`a29912d1` (`ubuntu-latest`, 4 vCPU). Inside that 305s: 43s
setup/install/scalafmt, 92s compile, 170s tests.

The acceptance bar from #1188 is ≥40% reduction (≤183s). The
template-DB change should land well inside that on CI because
Flyway-migrate was a much larger fraction of work on the slower
runner than on my laptop.

## Test plan

- [ ] CI green on this PR
- [ ] `Scala Build & Test` wall-clock on this PR ≥ 40% lower than
      305s baseline
- [ ] Local `mill api.test` still works with no flags (verified —
      54s)
- [ ] `docs/testing-parallelism.md` matches what CI does

## Follow-ups (not in this PR)

- True in-JVM-multi-spec parallel (run multiple `Spec` objects
  concurrently inside one worker JVM). Now safe under the
  per-spec-DB model; needs a framework hook.
- Larger CI runner (paid plan, self-hosted KVM scale-out from
  #1166) would compound the gains.