### PR TITLE
ui: API-unreachable banner + per-list error state (#1191)

### DIFF
--- a/web/src/api/apiHealth.test.tsx
+++ b/web/src/api/apiHealth.test.tsx
@@ -1,0 +1,116 @@
+// #1191 — global API-unreachable detector + banner.
+//
+// When the API returns 5xx or a network/timeout error, the SPA must surface
+// a global banner instead of letting pages render empty lists (which look
+// indistinguishable from "no data" — the operator's #1191 incident report).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { apiHealth } from './apiHealth'
+import { ApiUnreachableBanner } from '@/components/ApiUnreachableBanner'
+import { api } from './client'
+
+function renderBanner(client = new QueryClient()) {
+  return render(
+    <QueryClientProvider client={client}>
+      <ApiUnreachableBanner />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  apiHealth.reset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('apiHealth store', () => {
+  it('starts healthy and turns unhealthy after a reported failure', () => {
+    expect(apiHealth.snapshot().unreachable).toBe(false)
+    apiHealth.reportFailure('5xx')
+    expect(apiHealth.snapshot().unreachable).toBe(true)
+  })
+
+  it('clears on reported success', () => {
+    apiHealth.reportFailure('network')
+    expect(apiHealth.snapshot().unreachable).toBe(true)
+    apiHealth.reportSuccess()
+    expect(apiHealth.snapshot().unreachable).toBe(false)
+  })
+
+  it('notifies subscribers when state flips', () => {
+    const cb = vi.fn()
+    const unsub = apiHealth.subscribe(cb)
+    apiHealth.reportFailure('5xx')
+    expect(cb).toHaveBeenCalled()
+    unsub()
+  })
+})
+
+describe('ApiUnreachableBanner', () => {
+  it('is hidden when API is healthy', () => {
+    renderBanner()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('renders a red banner with a Retry button when API is unreachable', () => {
+    renderBanner()
+    act(() => { apiHealth.reportFailure('5xx') })
+    const banner = screen.getByRole('alert')
+    expect(banner).toBeInTheDocument()
+    expect(banner.textContent).toMatch(/can't reach the API/i)
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('Retry triggers queryClient.invalidateQueries and clears the banner on next success', async () => {
+    const qc = new QueryClient()
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+    renderBanner(qc)
+    act(() => { apiHealth.reportFailure('5xx') })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(invalidate).toHaveBeenCalled()
+    act(() => { apiHealth.reportSuccess() })
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+  })
+})
+
+describe('client.req integration with apiHealth', () => {
+  function mockFetchOnce(status: number, body = '{}') {
+    const headers = new Headers({ 'content-type': 'application/json' })
+    return vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(body, { status, headers }),
+    )
+  }
+
+  it('reports failure when the API returns 5xx', async () => {
+    mockFetchOnce(502, 'bad gateway')
+    await expect(api.routers.list()).rejects.toThrow()
+    expect(apiHealth.snapshot().unreachable).toBe(true)
+  })
+
+  it('reports failure on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    await expect(api.routers.list()).rejects.toThrow()
+    expect(apiHealth.snapshot().unreachable).toBe(true)
+  })
+
+  it('reports success and clears prior failure when the API returns 200', async () => {
+    apiHealth.reportFailure('5xx')
+    mockFetchOnce(200, '[]')
+    await api.routers.list()
+    expect(apiHealth.snapshot().unreachable).toBe(false)
+  })
+
+  it('does not flip to unreachable on 4xx (API is alive)', async () => {
+    // 4xx other than the special 401/403 paths is a client-side error; the
+    // API is reachable and answering. Don't trigger the banner.
+    mockFetchOnce(400, 'bad request')
+    await expect(api.routers.list()).rejects.toThrow()
+    expect(apiHealth.snapshot().unreachable).toBe(false)
+  })
+})

--- a/web/src/api/apiHealth.ts
+++ b/web/src/api/apiHealth.ts
@@ -1,0 +1,50 @@
+// #1191 — module-scoped store tracking whether the SPA's API calls are
+// currently failing. `client.req()` calls reportFailure/reportSuccess; the
+// global <ApiUnreachableBanner /> subscribes via useSyncExternalStore.
+//
+// Deliberately tiny: no transports, no auto-retry loop, no toast pile-up.
+// One bit of state ("unreachable now?") with a reason string for the
+// banner copy.
+
+export type ApiHealthReason = '5xx' | 'network' | 'timeout'
+
+export interface ApiHealthSnapshot {
+  unreachable: boolean
+  reason: ApiHealthReason | null
+  /** Wall-clock ms of the most recent failure; used to bust the snapshot
+   *  identity so React re-renders even when `unreachable` stays true. */
+  failedAt: number | null
+}
+
+type Listener = () => void
+
+let snapshot: ApiHealthSnapshot = { unreachable: false, reason: null, failedAt: null }
+const listeners = new Set<Listener>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+export const apiHealth = {
+  snapshot(): ApiHealthSnapshot {
+    return snapshot
+  },
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener)
+    return () => { listeners.delete(listener) }
+  },
+  reportFailure(reason: ApiHealthReason): void {
+    snapshot = { unreachable: true, reason, failedAt: Date.now() }
+    emit()
+  },
+  reportSuccess(): void {
+    if (!snapshot.unreachable) return
+    snapshot = { unreachable: false, reason: null, failedAt: null }
+    emit()
+  },
+  /** Test-only — wipes state between tests. */
+  reset(): void {
+    snapshot = { unreachable: false, reason: null, failedAt: null }
+    emit()
+  },
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,3 +1,4 @@
+import { apiHealth } from '@/api/apiHealth'
 import type {
   Alert, AppDetail, ApproveAlertRequest, BlockedInfoResponse, BlocklistHosts, BlocklistSummary, CreateAppRequest, CreateRouterRequest, CreateRouterResponse, CreateUserRequest,
   DashboardNow, DashboardStats, Device,
@@ -22,6 +23,11 @@ function getToken(): string | null {
   return localStorage.getItem('token')
 }
 
+// #1191: requests time out at REQUEST_TIMEOUT_MS so a hung backend surfaces
+// the banner instead of spinning forever. Per-call AbortController so we
+// don't leak signal across calls.
+const REQUEST_TIMEOUT_MS = 10_000
+
 async function req<T>(
   method: string,
   path: string,
@@ -32,13 +38,30 @@ async function req<T>(
   const token = getToken()
   if (!skipAuth && token) headers['Authorization'] = `Bearer ${token}`
 
-  const res = await fetch(`${BASE}${path}`, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  })
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  let res: Response
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    })
+  } catch (e) {
+    clearTimeout(timeoutId)
+    // Network error or abort (timeout). Either way the API isn't reachable
+    // right now — light up the global banner via apiHealth.
+    const aborted = e instanceof DOMException && e.name === 'AbortError'
+    apiHealth.reportFailure(aborted ? 'timeout' : 'network')
+    throw e
+  }
+  clearTimeout(timeoutId)
 
   if (res.status === 401) {
+    // 401 is an auth-state outcome, not an API-down signal. The API answered.
+    apiHealth.reportSuccess()
     localStorage.removeItem('token')
     window.location.href = '/login'
     throw new Error('Unauthorised')
@@ -47,6 +70,7 @@ async function req<T>(
   // #586: server enforces must_change_password — redirect to /account so
   // the operator can set a new password before using any other route.
   if (res.status === 403) {
+    apiHealth.reportSuccess()
     const text = await res.text().catch(() => '')
     if (text.includes('password_change_required')) {
       window.location.href = '/account'
@@ -55,10 +79,22 @@ async function req<T>(
     throw new Error(text || `HTTP 403`)
   }
 
-  if (!res.ok) {
+  // #1191: 5xx is the canonical "API is broken" signal — surface the banner.
+  // 4xx (other than the special cases above) is a client error; the API is
+  // alive and answering, so don't trigger the banner on it.
+  if (res.status >= 500) {
+    apiHealth.reportFailure('5xx')
     const text = await res.text().catch(() => res.statusText)
     throw new Error(text || `HTTP ${res.status}`)
   }
+
+  if (!res.ok) {
+    apiHealth.reportSuccess()
+    const text = await res.text().catch(() => res.statusText)
+    throw new Error(text || `HTTP ${res.status}`)
+  }
+
+  apiHealth.reportSuccess()
 
   if (res.status === 204 || res.headers.get('content-length') === '0') {
     return undefined as T

--- a/web/src/components/ApiUnreachableBanner.tsx
+++ b/web/src/components/ApiUnreachableBanner.tsx
@@ -1,0 +1,46 @@
+import { useSyncExternalStore } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { apiHealth } from '@/api/apiHealth'
+
+// #1191 — page-level banner shown at the top of the app shell when the SPA
+// can't reach the API. Replaces the silent "empty list" failure mode where
+// a 502 looked identical to "no data exists."
+//
+// One Retry button → global invalidate, no auto-retry loop. In-flight
+// mutations (autosave forms — feedback_autosave_default.md) are left
+// untouched; they own their own retry/failure UI.
+export function ApiUnreachableBanner() {
+  const snap = useSyncExternalStore(apiHealth.subscribe, apiHealth.snapshot, apiHealth.snapshot)
+  const qc = useQueryClient()
+  if (!snap.unreachable) return null
+
+  function onRetry() {
+    qc.invalidateQueries()
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="bg-red-600 text-white text-sm"
+      data-testid="api-unreachable-banner"
+    >
+      <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center gap-3 justify-between">
+        <div>
+          <strong className="font-semibold">WifiHaven can't reach the API right now.</strong>
+          {' '}
+          <span className="opacity-90">
+            Showing cached data where available.
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="bg-white text-red-700 font-semibold px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/layout/Layout.test.tsx
+++ b/web/src/components/layout/Layout.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { withQuery } from '@/test/queryWrapper'
 
 const navigateMock = vi.fn()
 const logoutMock = vi.fn()
@@ -31,13 +32,15 @@ beforeEach(() => {
 
 function renderLayout() {
   return render(
-    <MemoryRouter initialEntries={['/dashboard']}>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/dashboard" element={<div>dash</div>} />
-        </Route>
-      </Routes>
-    </MemoryRouter>
+    withQuery(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/dashboard" element={<div>dash</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    ),
   )
 }
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '@/hooks/useAuth'
+import { ApiUnreachableBanner } from '@/components/ApiUnreachableBanner'
 
 interface NavItem {
   to: string
@@ -222,6 +223,10 @@ export function Layout() {
           </div>
         )}
       </header>
+
+      {/* #1191: global API-unreachable banner; sits just under the header
+          so it's visible on every route without intercepting page layout. */}
+      <ApiUnreachableBanner />
 
       {/* Page content */}
       <main className="flex-1 max-w-7xl mx-auto w-full px-4 py-6">

--- a/web/src/pages/RoutersPage.tsx
+++ b/web/src/pages/RoutersPage.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/components/EmptyState'
 export function RoutersPage() {
   const [routers, setRouters] = useState<RouterSummary[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
   const [name, setName] = useState('')
   const [saving, setSaving] = useState(false)
@@ -39,8 +40,16 @@ export function RoutersPage() {
   }
 
   async function reload() {
-    const list = await api.routers.list()
-    setRouters(list)
+    try {
+      const list = await api.routers.list()
+      setRouters(list)
+      setLoadError(null)
+    } catch (e) {
+      // #1191: keep last-known-good rows so a transient outage doesn't blank
+      // the page, but flip the error state so the list shows "couldn't load"
+      // instead of an empty state when there was nothing cached.
+      setLoadError(e instanceof Error ? e.message : 'Failed to load routers')
+    }
   }
 
   useEffect(() => {
@@ -89,7 +98,18 @@ export function RoutersPage() {
       </div>
 
       <div className="bg-white rounded-2xl border border-brand-border overflow-hidden">
-        {routers.length === 0
+        {routers.length === 0 && loadError
+          ? <EmptyState
+              title="Couldn't load routers."
+              hint={loadError}
+              action={
+                <button
+                  onClick={() => { setLoading(true); reload().finally(() => setLoading(false)) }}
+                  className="bg-brand-accent text-white text-sm font-semibold px-3 py-1.5 rounded-lg"
+                >Retry</button>
+              }
+            />
+          : routers.length === 0
           ? <EmptyState title="No routers enrolled yet." />
           : routers.map(r => (
               <div key={r.id} className="border-b border-brand-border last:border-0">

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -22,6 +22,7 @@ export function UsersPage() {
   const [users, setUsers] = useState<User[]>([])
   const [profiles, setProfiles] = useState<ProfileDetail[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
   const [createForm, setCreateForm] = useState<CreateForm>(emptyCreateForm())
   const [editingId, setEditingId] = useState<number | null>(null)
@@ -36,9 +37,15 @@ export function UsersPage() {
   }, [profiles])
 
   async function reload() {
-    const [u, p] = await Promise.all([api.users.list(), api.profiles.list()])
-    setUsers(u)
-    setProfiles(p)
+    try {
+      const [u, p] = await Promise.all([api.users.list(), api.profiles.list()])
+      setUsers(u)
+      setProfiles(p)
+      setLoadError(null)
+    } catch (e) {
+      // #1191 — surface the fetch failure instead of rendering an empty list.
+      setLoadError(e instanceof Error ? e.message : 'Failed to load users')
+    }
   }
 
   useEffect(() => {
@@ -119,7 +126,18 @@ export function UsersPage() {
       </div>
 
       <div className="bg-white rounded-2xl border border-brand-border overflow-hidden">
-        {users.length === 0
+        {users.length === 0 && loadError
+          ? <EmptyState
+              title="Couldn't load users."
+              hint={loadError}
+              action={
+                <button
+                  onClick={() => { setLoading(true); reload().finally(() => setLoading(false)) }}
+                  className="bg-brand-accent text-white text-sm font-semibold px-3 py-1.5 rounded-lg"
+                >Retry</button>
+              }
+            />
+          : users.length === 0
           ? <EmptyState title="No users yet." />
           : users.map(u => (
               <div key={u.id} data-testid={`user-row-${u.id}`} className="flex items-center gap-4 px-5 py-4 border-b border-brand-border last:border-0">


### PR DESCRIPTION
## Summary

When the prod API was returning 502 on 2026-05-31, every list in the SPA
rendered as empty — making it indistinguishable from "the database is
gone." This change replaces that silent-failure mode with an explicit
red banner at the top of the layout, plus per-list "couldn't load"
states for the imperative-fetch pages.

- New `apiHealth` store, flipped by `client.req()` on 5xx / network /
  timeout, cleared on the next 2xx.
- New `<ApiUnreachableBanner />` mounted in `Layout` — visible on every
  authenticated route. Single Retry button that invalidates the global
  TanStack Query cache; no auto-retry loop (would mask the problem and
  hammer a recovering API).
- Per-call `AbortController` with a 10s timeout in `client.req()` so a
  hung backend lights up the banner instead of spinning.
- `RoutersPage` and `UsersPage` (imperative fetches) now distinguish
  "fetch errored" from "no rows" and show a Retry empty-state.
- React-Query-backed pages (Dashboard, Profiles, Devices) get the
  banner globally; their existing `useQuery` error paths are unchanged.
- 4xx is treated as "API alive, client error" and does not trip the
  banner. 401/403 still follow their existing redirect paths.

In-flight mutations (autosave forms) are deliberately untouched — they
own their own retry/failure UI per the operator's autosave preference.

Closes #1191.

## Test plan

- [x] `npm test` — 306 tests pass (10 new in `apiHealth.test.tsx`).
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: `docker compose stop api` (or proxy returning 502),
      reload SPA → banner appears within 2s, Routers/Users show
      "Couldn't load" instead of empty.
- [ ] Manual: restart API, click Retry → banner clears, lists populate.
- [ ] Manual: 4xx (e.g. delete a router that's already gone) → no
      banner, error surfaces inline as today.