### PR TITLE
fix(api): decouple port-bind from Postgres warm-up so slow PG doesn't fail Render port-scan (#1197)

### DIFF
--- a/api/src/Bootstrap.scala
+++ b/api/src/Bootstrap.scala
@@ -1,0 +1,26 @@
+package wifihaven.api
+
+import zio.*
+
+/**
+ * Decouples the HTTP port-bind from the DB warm-up chain so that a slow Postgres at startup does
+ * not cause Render's port-scan to time out (#1197).
+ *
+ * `warmup` runs in a forked daemon: migrations, seeds, and background-job kick-off. It is allowed
+ * to fail without taking the server down — the next request to a DB-touching route surfaces the
+ * underlying error in the normal way, and operator-side restart/observability picks it up.
+ *
+ * `serve` runs on the main fiber so the process exits naturally if `Server.serve` returns.
+ */
+object Bootstrap {
+  def boot[R](
+      warmup: ZIO[R, Throwable, Unit],
+      serve: ZIO[R, Throwable, Unit],
+  ): ZIO[R, Throwable, Unit] =
+    for {
+      _ <- warmup
+        .catchAllCause(c => ZIO.logErrorCause("startup warm-up failed; server stays up", c))
+        .forkDaemon
+      _ <- serve
+    } yield ()
+}

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -25,27 +25,77 @@ object Main extends ZIOAppDefault {
 
   def run =
     (for {
-      cfg    <- ZIO.service[AppConfig]
-      _      <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
-      _      <- ZIO
+      cfg       <- ZIO.service[AppConfig]
+      _         <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
+      _         <- ZIO
         .logWarning(
           "WIFIHAVEN_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +
             "Disable in production.",
         )
         .when(cfg.debugEnabled)
-      _      <- Database.runMigrations(cfg.db)
-      _      <- ZIO.logInfo("Database migrations complete")
+      // YAML loads are file-system only (no DB) and feed route construction, so they
+      // run on the port-bind critical path. The DB-touching warm-up below forks.
+      templates <- AppTemplates.loadAll()
+      bundled   <- BundledBlocklists.loadAll()
+      templatesById = templates.map(t => t.slug -> t).toMap
+      bundledById   = bundled.map(b => b.id -> b).toMap
+      routes <- allRoutes(templatesById, bundledById)
+      withCors = Cors.wrap(routes, cfg.cors)
+      _ <- ZIO
+        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
+        .when(cfg.cors.origins.nonEmpty)
+      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
+      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
+      // Bump to 4 MiB — well above any realistic single-bucket payload and below
+      // Render's edge 413 threshold.
+      serverConfig = Server.Config.default
+        .port(cfg.http.port)
+        .disableRequestStreaming(4 * 1024 * 1024)
+      tz           = java.time.ZoneId.systemDefault()
+      warmup       = warmupChain(cfg, tz, templates, bundled)
+      serve        = Server
+        .serve(withCors)
+        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
+      // #1197: bind :8080 immediately and run all DB warm-up in a forked daemon.
+      // Previously the entire warm-up chain (Flyway + seeds + remote blocklist
+      // fetches) ran on the critical path, so a cold Render Postgres at deploy
+      // time exceeded the 15-min port-scan window and the deploy failed.
+      _ <- Bootstrap.boot(warmup, serve)
+    } yield ()).provide(serverEnv)
+
+  /**
+   * The full DB warm-up chain. Runs in a forked daemon (see Bootstrap.boot). Order matters:
+   * migrations must precede any seed; rollup/retention jobs are themselves forkDaemon and never
+   * block the warm-up either.
+   *
+   * If any step fails, Bootstrap logs the cause and lets the server keep running. Subsequent
+   * restarts retry. Operator alerting on errored deploys catches genuine breakage.
+   */
+  private def warmupChain(
+      cfg: AppConfig,
+      tz: java.time.ZoneId,
+      templates: List[AppTemplate],
+      bundled: List[BundledBlocklist],
+  ): ZIO[
+    HouseholdSettingsRepo & AppRepo & BlocklistRepo & BlocklistCache & BlocklistFetcher &
+      wifihaven.api.db.RollupRepo & Clock & wifihaven.api.db.TimeUsedRollupRepo &
+      wifihaven.api.db.ProfileRepo & wifihaven.api.db.DeviceRepo &
+      wifihaven.api.db.SiteTimeLimitRepo & wifihaven.api.db.TrafficReportRepo & Transactor[Task],
+    Throwable,
+    Unit,
+  ] =
+    for {
+      _               <- Database.runMigrations(cfg.db)
+      _               <- ZIO.logInfo("Database migrations complete")
       // #334: ensure household_settings has its single row, defaulting the
       // daily-reset tz to the API server's local zone on first install. No-op
       // on subsequent boots because of ON CONFLICT DO NOTHING.
-      hsRepo <- ZIO.service[HouseholdSettingsRepo]
-      tz = java.time.ZoneId.systemDefault()
+      hsRepo          <- ZIO.service[HouseholdSettingsRepo]
       _               <- hsRepo.ensureDefault(tz)
       _               <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       // #768: seed the starter library of app templates. Idempotent — operator
       // host edits on previously-seeded apps are preserved.
       appRepoForSeed  <- ZIO.service[AppRepo]
-      templates       <- AppTemplates.loadAll()
       seedSummary     <- AppTemplates.seed(appRepoForSeed, templates)
       _               <- ZIO.logInfo(
         s"app_templates seeded (${templates.size} templates): " +
@@ -57,28 +107,19 @@ object Main extends ZIOAppDefault {
             .mkString("[", ",", "]") + ", " +
           s"preserved=${seedSummary.preserved.size}",
       )
-      // #958: seed the bundled category blocklists. Inline lists pull hosts
-      // straight from YAML; remote lists fetch from the declared upstream URL
-      // (cached in-memory after first success — see BlocklistCache). REPLACE
-      // semantics; remote-fetch failures leave existing DB rows untouched.
+      // #958: seed the bundled category blocklists.
       blRepoForSeed   <- ZIO.service[BlocklistRepo]
       blCacheForSeed  <- ZIO.service[BlocklistCache]
       blFetcher       <- ZIO.service[BlocklistFetcher]
-      bundled         <- BundledBlocklists.loadAll()
       _               <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
       _               <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
-      // #809: scheduled re-aggregation of traffic_reports into the rollup
-      // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
-      // re-rolls yesterday + today every hour. Both are forkDaemon so they
-      // run for the lifetime of the process and never block startup.
+      // #809: rollup fibers — fork inside the warm-up daemon; they live for the
+      // lifetime of the process.
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       clockForJobs    <- ZIO.service[Clock]
       _               <- RollupJobs.hourlyLoop(rollupRepo, clockForJobs).forkDaemon
       _               <- RollupJobs.dailyLoop(rollupRepo, clockForJobs, tz).forkDaemon
-      // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
-      // a watermarked row; the read path adds a live tail of buckets after the watermark, so
-      // /api/time/status/summary serves a rollup + small live aggregation instead of a full
-      // per-request day scan.
+      // #1160: per-(profile, today) used_seconds cache.
       timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
       profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
       deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
@@ -106,34 +147,12 @@ object Main extends ZIOAppDefault {
       _               <- BundledBlocklists
         .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
         .when(cfg.seedTestBlocklists)
-      // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
-      // Multi-instance-safe via Postgres advisory lock — losing instances skip
-      // the tick rather than racing on the same DELETE.
+      // #811: daily retention sweep.
       xaForJobs       <- ZIO.service[Transactor[Task]]
       _               <- RetentionSweepJob.start(xaForJobs)
-      // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
-      // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
-      // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
-      // no NULLs remain.
+      // #1176/#1179: backfill reason_text on rows inserted between V40 and V44.
       _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
-      templatesById = templates.map(t => t.slug -> t).toMap
-      bundledById   = bundled.map(b => b.id -> b).toMap
-      routes <- allRoutes(templatesById, bundledById)
-      withCors = Cors.wrap(routes, cfg.cors)
-      _ <- ZIO
-        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
-        .when(cfg.cors.origins.nonEmpty)
-      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
-      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
-      // Bump to 4 MiB — well above any realistic single-bucket payload and below
-      // Render's edge 413 threshold.
-      serverConfig = Server.Config.default
-        .port(cfg.http.port)
-        .disableRequestStreaming(4 * 1024 * 1024)
-      _ <- Server
-        .serve(withCors)
-        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
-    } yield ()).provide(serverEnv)
+    } yield ()
 
   private val serverEnv =
     AppConfig.layer >+>

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -19,6 +19,12 @@ object Database {
     ds.setConnectionTimeout(30000)
     ds.setIdleTimeout(600000)
     ds.setMaxLifetime(1800000)
+    // #1197: do not block JVM startup on a successful first connection. If
+    // Postgres is cold at boot, Hikari's default initializationFailTimeout=1
+    // would attempt-and-fail-fast which is fine, but the route handler path
+    // is what eventually retries. Setting -1 explicitly documents that
+    // pool init is best-effort and never gates port-bind.
+    ds.setInitializationFailTimeout(-1)
     Transactor.fromDataSource[Task](ds, scala.concurrent.ExecutionContext.global)
   }
 

--- a/api/test/src/feature/BootstrapSpec.scala
+++ b/api/test/src/feature/BootstrapSpec.scala
@@ -1,0 +1,48 @@
+package wifihaven.api.feature
+
+import wifihaven.api.Bootstrap
+import zio.*
+import zio.test.*
+
+object BootstrapSpec extends ZIOSpecDefault {
+
+  def spec = suite("Bootstrap.boot")(
+    test("starts the HTTP server before the warm-up chain completes") {
+      for {
+        warmupStarted <- Promise.make[Nothing, Unit]
+        warmupBlocker <- Promise.make[Nothing, Unit]
+        serverStarted <- Promise.make[Nothing, Unit]
+        warmup = warmupStarted.succeed(()) *> warmupBlocker.await
+        serve  = serverStarted.succeed(()) *> ZIO.never
+        fiber <- Bootstrap.boot(warmup, serve).fork
+        // Server must signal "started" without the warm-up ever finishing.
+        // If boot is serial (warmup before serve), this await will hang
+        // because warmupBlocker is never completed.
+        ok    <- serverStarted.await.timeout(5.seconds)
+        _     <- fiber.interrupt
+      } yield assertTrue(ok.isDefined)
+    },
+    test("warm-up still runs alongside serve (not silently dropped)") {
+      for {
+        warmupStarted <- Promise.make[Nothing, Unit]
+        serveStarted  <- Promise.make[Nothing, Unit]
+        warmup = warmupStarted.succeed(()).unit
+        serve  = serveStarted.succeed(()) *> ZIO.never
+        fiber <- Bootstrap.boot(warmup, serve).fork
+        ok    <- warmupStarted.await.timeout(5.seconds)
+        _     <- serveStarted.await.timeout(5.seconds)
+        _     <- fiber.interrupt
+      } yield assertTrue(ok.isDefined)
+    },
+    test("warm-up failure does not crash the server fiber") {
+      for {
+        serveStarted <- Promise.make[Nothing, Unit]
+        warmup = ZIO.fail(new RuntimeException("simulated cold-PG warm-up failure"))
+        serve  = serveStarted.succeed(()) *> ZIO.never
+        fiber <- Bootstrap.boot(warmup, serve).fork
+        ok    <- serveStarted.await.timeout(5.seconds)
+        _     <- fiber.interrupt
+      } yield assertTrue(ok.isDefined)
+    },
+  )
+}


### PR DESCRIPTION
Closes #1197.

## Root cause

Prod deploy `dep-d8do3b6rnols739i6bp0` (image `4661ea`, 2026-05-31T00:32:44Z) timed out at Render's 15-min port-scan window. The container never bound :8080. The JVM logged exactly one line and then went silent:

```
00:32:54.201Z INFO Main - WifiHaven API starting on 0.0.0.0:8080
   ... <silence for 15 minutes> ...
00:47:46.334Z ==> Timed Out
```

The very next step in `Main.run` was `Database.runMigrations(cfg.db)`. Flyway never even emitted its `Schema "public" has a version …` WARN, so its own JDBC connection hung against a cold Render Postgres.

The rollback deploy hit the same code path but happened to come up at **+1m 43s** because PG was already warm. Within that 1m 43s, the slowest single step was **bundled blocklist seeding at +96s**. Every step in the warm-up chain was on the port-bind critical path.

## Fix

`Main.run` now:

1. Loads YAML templates / bundled blocklists (file-system only, no DB).
2. Constructs routes (Doobie `Transactor` + Hikari pool are lazy — no I/O).
3. Calls `Bootstrap.boot(warmup, serve)`, which:
   - Forks the **entire** DB warm-up chain (`Database.runMigrations`, `household_settings ensureDefault`, `AppTemplates.seed`, `BundledBlocklists.seed`, `RollupJobs.{hourly,daily}Loop`, `TimeUsedRollupJob.loop`, `RetentionSweepJob.start`, `ReasonTextBackfill.run`) as a daemon, catching all causes (logged, doesn't crash the process).
   - Runs `Server.serve` on the main fiber, binding :8080 immediately.

Also sets `HikariDataSource.setInitializationFailTimeout(-1)` explicitly: even the daemon's first DB call won't block waiting for an unreachable PG.

## What it preserves

- Flyway still runs at every startup (just off the critical path).
- The #1177 route-composition typing fix in `allRoutes` is untouched.
- Warm-up step ordering inside the daemon is unchanged.
- No `render.yaml` changes — fully declarative still.
- No new client / transport / framework.

## TDD

1. [test(api): red — Bootstrap.boot must bind server before warm-up](https://github.com/wifihaven/wifihaven/commit/34253983) — pins the API: serve runs before warmup completes; warmup still runs; warmup failure doesn't crash serve. Fails to compile against current main (no `Bootstrap`).
2. [fix(api): green — bind port before DB warm-up](https://github.com/wifihaven/wifihaven/commit/c23110c9) — adds `Bootstrap`, refactors `Main.run`, sets Hikari init timeout.

## Validation

- `mill api.compile` — green.
- `mill api.test` — all 52 features + the new `BootstrapSpec` pass (the 3 new tests verify serve-before-warmup, warmup-still-runs, and warmup-failure-doesn't-crash-serve).
- `scalafmt --check` — clean.
- Manual prod-shape validation not done here (can't test on prod safely). Suggested chain for the operator before forward-rolling:
  1. **Local**: bring up the API against a slow Postgres (e.g. inject a 60s delay in `TestDatabase` or `pg_ctl start` + iptables delay). Confirm port binds within seconds; `/api/health` returns 200 immediately; DB-touching endpoints block/queue or return 5xx until pool warms.
  2. **Staging** (`srv-d8549fgjo89c73buvkf0`, `wifihaven-api-staging`) — deploy via existing CD. Watch Render logs for `WifiHaven API starting` immediately followed by Render's port-scan succeeding (under 30s), then the warm-up log lines arriving asynchronously.
  3. **Prod** — only after staging shape is confirmed.

Do **not** auto-merge; operator queues manually.

## Out of scope

- Deploy-safety guardrails / pre-promotion checks — that's #1194.
- Hikari pool-size tuning — separate issue noted in the diagnosis comment (01:01Z pool-exhaustion errors on the *running* container, unrelated to the port-scan failure).