### PR TITLE
fix(web): refresh profile-wide time bar on app-policy edits

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1208,3 +1208,60 @@ describe('ProfilesPage — per-app usage bar in Apps section (#1061)', () => {
     expect(screen.queryByTestId('app-row-50-usage')).not.toBeInTheDocument()
   })
 })
+
+// #1086 — an app-policy edit (toggle exemptFromDaily, switch mode, remove the
+// assignment) feeds the server-side daily-cap math (`buildProfileTimeStatus`),
+// so the profile-wide used/cap text + bar must refetch. The summary is served
+// by `api.time.summaryAll` via the ['time','status','summary','today'] query;
+// invalidating the ['time','status'] subtree refetches it. Before the fix the
+// AppRow only refetched the apps list, so summaryAll was called exactly once
+// (the initial mount) and the headline bar went stale until the 30s window.
+describe('ProfilesPage — app-policy edits refresh the profile-wide time bar (#1086)', () => {
+  const khanTimeLimited = {
+    app: { id: 60, name: 'Khan', slug: 'khan', templateId: null, icon: '📚', createdAt: '2026-01-01' },
+    hosts: ['khanacademy.org'],
+    assignments: [
+      { id: 3, appId: 60, profileId: 1, mode: 'time_limited' as const, dailyMinutes: 60, exemptFromDaily: true },
+    ],
+  }
+
+  async function openApps(user: ReturnType<typeof userEvent.setup>) {
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(screen.getByTestId('profile-apps-toggle-1'))
+  }
+
+  it('toggling "Counts toward daily limit" invalidates the time-status summary', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([khanTimeLimited])
+    const user = userEvent.setup()
+    await openApps(user)
+    const cb = await screen.findByTestId('app-row-60-counts-toward-daily')
+    expect(api.time.summaryAll).toHaveBeenCalledTimes(1)
+    await user.click(cb)
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(60, 1, { mode: 'time_limited', dailyMinutes: 60, exemptFromDaily: false }),
+    )
+    await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
+  })
+
+  it('switching an app between modes invalidates the time-status summary', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([khanTimeLimited])
+    const user = userEvent.setup()
+    await openApps(user)
+    await user.click(await screen.findByTestId('app-row-60-block'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(60, 1, { mode: 'blocked', dailyMinutes: null }),
+    )
+    await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
+  })
+
+  it('removing an app assignment invalidates the time-status summary', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([khanTimeLimited])
+    const user = userEvent.setup()
+    await openApps(user)
+    await user.click(await screen.findByTestId('app-row-60-clear'))
+    await waitFor(() => expect(api.apps.deletePolicy).toHaveBeenCalledWith(60, 1))
+    await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
+  })
+})

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1465,6 +1465,27 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
   // bar simply doesn't render until the value arrives.
   usedMins?: number
 }) {
+  // #1086 — app-policy edits (mode switch, exemptFromDaily toggle, removal)
+  // feed the server-side daily-cap math, so a successful write must invalidate
+  // the ['time','status'] subtree to refetch the profile-wide used/cap bar.
+  // `onChanged` (reloadApps) only refreshes the component-state apps list, not
+  // the react-query time-status caches — so we wrap the writes in mutations
+  // that run `profileMutated()` on success, mirroring `grantMutation`.
+  const invalidators = useInvalidators()
+  const setPolicyMutation = useMutation({
+    mutationFn: (vars: { mode: AppMode; dailyMinutes: number | null; exemptFromDaily?: boolean }) =>
+      api.apps.setPolicy(app.app.id, profileId, {
+        mode: vars.mode,
+        dailyMinutes: vars.dailyMinutes,
+        ...(vars.exemptFromDaily !== undefined ? { exemptFromDaily: vars.exemptFromDaily } : {}),
+      }),
+    onSuccess: () => invalidators.profileMutated(),
+  })
+  const deletePolicyMutation = useMutation({
+    mutationFn: () => api.apps.deletePolicy(app.app.id, profileId),
+    onSuccess: () => invalidators.profileMutated(),
+  })
+
   const current = findAssignment(app, profileId)
   const [minutesDraft, setMinutesDraft] = useState<string>(() =>
     current?.mode === 'time_limited' && current.dailyMinutes != null
@@ -1487,11 +1508,7 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
     setBusy(true)
     setLocalError(null)
     try {
-      await api.apps.setPolicy(app.app.id, profileId, {
-        mode,
-        dailyMinutes,
-        ...(exemptFromDaily !== undefined ? { exemptFromDaily } : {}),
-      })
+      await setPolicyMutation.mutateAsync({ mode, dailyMinutes, exemptFromDaily })
       await onChanged()
     } catch (e) {
       setLocalError(e instanceof Error ? e.message : 'Failed to update')
@@ -1504,7 +1521,7 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
     setBusy(true)
     setLocalError(null)
     try {
-      await api.apps.deletePolicy(app.app.id, profileId)
+      await deletePolicyMutation.mutateAsync()
       setMinutesDraft('')
       await onChanged()
     } catch (e) {


### PR DESCRIPTION
## Summary

Closes #1086.

On `/profiles`, editing an app's policy inside an expanded card did not
refresh the profile-wide used/cap text + bar at the top of the card. The
`AppRow` write path (`apply` / `clear`) called `api.apps.setPolicy` /
`deletePolicy` then `await onChanged()`, where `onChanged` (`reloadApps`)
only refetches the component-state apps list — it never invalidated the
`['time','status']` react-query subtree. But `exemptFromDaily` and the app
mode feed the server-side daily-cap math (`buildProfileTimeStatus`), so the
headline bar stayed stale until the `useTimeStatusSummary` 30s stale window
expired or the operator navigated away and back.

Fix (option 2 from the issue): wrap `setPolicy` / `deletePolicy` in TanStack
`useMutation`s whose `onSuccess` runs `invalidators.profileMutated()` (which
already touches `['time','status']`), mirroring how `grantMutation` already
invalidates the subtree after a +Time grant. `onChanged()` is still called to
refresh the apps list.

This covers all four paths through the same `apply`/`clear` callback:

- Toggling **"Counts toward daily limit"** (flips `exemptFromDaily`)
- Switching an app between **Block / Allow / Time-limited**
- **Removing** an app's profile-specific config

Web-only change — no API changes.

## Test plan

- [x] New failing-then-passing vitest cases in `ProfilesPage.test.tsx`
      asserting toggling `exemptFromDaily`, switching mode, and removing an
      app assignment each invalidate the time-status summary (a second
      `api.time.summaryAll` fetch). Red commit precedes the fix commit.
- [x] `npm test` (web) — 309 passed
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean