### PR TITLE
web: render favicon app icons as images across all surfaces

### DIFF
--- a/web/src/components/AppIcon.test.tsx
+++ b/web/src/components/AppIcon.test.tsx
@@ -1,0 +1,60 @@
+// Tests for AppIcon — the single source of truth for rendering an app's icon.
+// #1081: favicon-URL icons were rendering as the raw URL *string* (text) instead
+// of an <img> across multiple surfaces (the add-app picker on the profile card,
+// the Connection Events table, and the Traffic Usage table). Those table rows
+// carry only `appIcon` from the backend — no `appIconType` — so AppIcon must
+// infer the type from the string when it is not supplied, while still honouring
+// the #1004 https-only safety rule.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AppIcon } from './AppIcon'
+
+const FAVICON = 'https://icons.duckduckgo.com/ip3/youtube.com.ico'
+
+describe('AppIcon', () => {
+  it('renders an explicit url icon as an <img> with the favicon src', () => {
+    const { container } = render(<AppIcon icon={FAVICON} iconType="url" />)
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img!.getAttribute('src')).toBe(FAVICON)
+  })
+
+  it('#1081: infers a favicon image when iconType is omitted (Events / Traffic rows)', () => {
+    const { container } = render(<AppIcon icon={FAVICON} />)
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img!.getAttribute('src')).toBe(FAVICON)
+    // It must NOT have fallen through to printing the raw URL string as text.
+    expect(container.textContent).not.toContain(FAVICON)
+  })
+
+  it('renders an emoji icon as text, not an image', () => {
+    const { container } = render(<AppIcon icon="📺" iconType="emoji" />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.getByText('📺')).toBeInTheDocument()
+  })
+
+  it('renders the fallback glyph when no icon is set', () => {
+    const { container } = render(<AppIcon icon={null} />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.getByText('◳')).toBeInTheDocument()
+  })
+
+  it('respects an explicit emoji type even when the string looks like a URL', () => {
+    const { container } = render(<AppIcon icon={FAVICON} iconType="emoji" />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain(FAVICON)
+  })
+
+  it('#1004: a non-https url falls back to the placeholder, never an <img>', () => {
+    const { container } = render(<AppIcon icon="http://evil.example/x.png" iconType="url" />)
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.getByText('◳')).toBeInTheDocument()
+  })
+
+  it('#1004: a javascript: scheme string is never rendered as an <img>, even when inferred', () => {
+    const { container } = render(<AppIcon icon="javascript:alert(1)" />)
+    expect(container.querySelector('img')).toBeNull()
+  })
+})

--- a/web/src/components/AppIcon.tsx
+++ b/web/src/components/AppIcon.tsx
@@ -24,6 +24,20 @@ const SIZE_TEXT: Record<NonNullable<Props['size']>, string> = {
 // malicious icon string can never reach the DOM as an attacker-controlled
 // `src`. Base64 PNGs are wrapped here so callers never construct the data:
 // URI from raw input.
+// #1081 — some surfaces (the Connection Events and Traffic Usage tables) carry
+// only the icon string with no `iconType`, because the aggregated wire rows
+// don't include it. When the type is absent we infer it: an https URL is a
+// favicon/image, anything else is treated as an emoji/text glyph. An explicit
+// `iconType` always wins, so callers can force text even for URL-shaped strings.
+function resolveIconType(icon: string, iconType?: IconType): IconType {
+  if (iconType) return iconType
+  try {
+    return new URL(icon).protocol === 'https:' ? 'url' : 'emoji'
+  } catch {
+    return 'emoji'
+  }
+}
+
 function safeImageSrc(icon: string, iconType: IconType): string | null {
   if (iconType === 'url') {
     try {
@@ -41,9 +55,10 @@ function safeImageSrc(icon: string, iconType: IconType): string | null {
   return null
 }
 
-export function AppIcon({ icon, iconType = 'emoji', size = 'md', className }: Props) {
+export function AppIcon({ icon, iconType, size = 'md', className }: Props) {
   const px = SIZE_PX[size]
-  const src = icon && iconType !== 'emoji' ? safeImageSrc(icon, iconType) : null
+  const effectiveType = icon ? resolveIconType(icon, iconType) : 'emoji'
+  const src = icon && effectiveType !== 'emoji' ? safeImageSrc(icon, effectiveType) : null
   if (src) {
     return (
       <img
@@ -59,7 +74,7 @@ export function AppIcon({ icon, iconType = 'emoji', size = 'md', className }: Pr
   }
   return (
     <span aria-hidden className={`${SIZE_TEXT[size]} ${className ?? ''}`}>
-      {iconType === 'emoji' ? (icon || '◳') : '◳'}
+      {effectiveType === 'emoji' ? (icon || '◳') : '◳'}
     </span>
   )
 }

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
 import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog, TrafficUsageBucket } from '@/types/api'
 import { blockReasonText } from '@/types/blockReason'
+import { AppIcon } from '@/components/AppIcon'
 import { HostCell } from '@/components/HostCell'
 import { GroupableHeader } from '@/components/usage/GroupableHeader'
 import { HeaderFilter } from '@/components/usage/HeaderFilter'
@@ -367,9 +368,7 @@ function AppCell({
   if (active) {
     return (
       <span className="inline-flex items-center gap-1.5">
-        {appIcon && (
-          <span aria-hidden="true" className="text-base leading-none">{appIcon}</span>
-        )}
+        {appIcon && <AppIcon icon={appIcon} size="sm" />}
         <span>{appName ?? 'Other'}</span>
       </span>
     )

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1441,7 +1441,7 @@ function AppsSection({ profileId, isNew, apps, onChanged, testIdPrefix = 'apps-s
                       onClick={() => addApp(a)}
                       className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg bg-white hover:bg-brand-alt border border-brand-border-strong text-left"
                     >
-                      <span className="text-base w-5 text-center" aria-hidden>{a.app.icon || '◳'}</span>
+                      <AppIcon icon={a.app.icon} iconType={a.app.iconType} size="sm" className="w-5 text-center" />
                       <span className="text-sm text-brand-ink flex-1 truncate">{a.app.name}</span>
                       <span className="text-xs text-brand-text-muted">{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</span>
                     </button>

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -10,6 +10,7 @@ import type {
   TrafficUsageRawRow,
   TrafficUsageResponse,
 } from '@/types/api'
+import { AppIcon } from '@/components/AppIcon'
 import { HostCell } from '@/components/HostCell'
 import { BucketSelector } from '@/components/usage/BucketSelector'
 import { GroupableHeader } from '@/components/usage/GroupableHeader'
@@ -536,9 +537,7 @@ function AppCell({
   if (active) {
     return (
       <span className="inline-flex items-center gap-1.5">
-        {appIcon && (
-          <span aria-hidden="true" className="text-base leading-none">{appIcon}</span>
-        )}
+        {appIcon && <AppIcon icon={appIcon} size="sm" />}
         <span>{appName ?? 'Other'}</span>
       </span>
     )


### PR DESCRIPTION
Closes #1081

## Summary

- App icons that are favicon URLs were rendering as the raw URL **string** (text) instead of an `<img>` in several places: the add-app picker on the expanded profile card, the Connection Events table, and the Traffic Usage table.
- Consolidated all rendering through the existing `AppIcon` component (the one already used by the apps list / starter library and the icon picker).
- `AppIcon` now **infers** the icon type when none is supplied: an https URL → `<img>`, anything else → emoji/text glyph. This is needed because the Connection Events and Traffic Usage aggregated wire rows carry only `appIcon` and no `appIconType`. An explicit `iconType` always wins, so callers can still force text.
- The #1004 https-only safety rule is preserved: non-https or junk strings fall back to the placeholder glyph and never reach the DOM as an `<img>` `src`.

Web-only change (React/TypeScript/Vite) — no API/Scala changes.

## Test plan

- [x] New `web/src/components/AppIcon.test.tsx` (committed red first, then green) covers: explicit `url` → img; **inferred** favicon (no `iconType`) → img; emoji → text; no icon → fallback glyph; explicit `emoji` over a URL-shaped string → text; non-https and `javascript:` strings → never an img.
- [x] `npm run test` — 313 tests pass (node 22).
- [x] `npm run type-check` clean.
- [x] `npm run lint` clean.
- [ ] Manual: favicon-icon app shows the image in the add-app picker, Connection Events table, and Traffic Usage table; emoji icons still render as emoji; no-icon apps still show the fallback glyph.