### PR TITLE
db(migration): V45 rollup app-attribution tables (#1091, PR 1/2)

### DIFF
--- a/api/resources/db/migration/V45__rollup_app_attribution.sql
+++ b/api/resources/db/migration/V45__rollup_app_attribution.sql
@@ -1,0 +1,68 @@
+-- V45: pre-attribute app ownership at rollup-write time (#1091).
+--
+-- Lets the per-app read paths (#769 groupBy=app, #1061 usage-by-app)
+-- aggregate via SQL `GROUP BY app_id` against the rollup tables instead of
+-- re-running the in-memory HostMatch.lookupApex tail-walk over every row at
+-- read time. The rollup writer computes the owning app(s) once, at
+-- rollup-write time, and persists them here.
+--
+-- Invalidation is Option 2 (lazy): every app_hosts mutation bumps a global
+-- counter; each rollup row records the counter value it was attributed at.
+-- On read, if any in-window rollup row carries a version older than the
+-- current counter (or NULL = never attributed), the read path falls back to
+-- live in-memory matching for that window. No re-roll on the app_hosts
+-- mutation hot path; stale rollup attribution degrades gracefully instead of
+-- silently lying.
+--
+-- Prod-data-volume note (AGENTS.md §migrations-prod-data-volume):
+-- traffic_hourly / traffic_daily are unbounded-growth tables, but the two
+-- ALTERs below add NULLable columns with NO default, which Postgres records
+-- as a catalog-only change — no table rewrite, no full scan. Safe at prod
+-- scale (unlike a NOT NULL / DEFAULT add, which would rewrite). The side
+-- tables and the counter table are brand-new and empty.
+
+-- Monotonic counter, bumped on every app_hosts mutation. Single row enforced
+-- by the boolean PK + CHECK; readers do `SELECT version FROM
+-- app_hosts_version`, writers do `UPDATE ... SET version = version + 1`.
+CREATE TABLE app_hosts_version (
+  singleton BOOLEAN PRIMARY KEY DEFAULT TRUE,
+  version   BIGINT  NOT NULL DEFAULT 0,
+  CONSTRAINT app_hosts_version_singleton CHECK (singleton)
+);
+INSERT INTO app_hosts_version (singleton, version) VALUES (TRUE, 0);
+
+-- The app_hosts version each rollup row was attributed at. NULL = never
+-- attributed (rolled before V45, or before the writer ran the attribution
+-- step). A value < the current counter = stale → read-time fallback.
+ALTER TABLE traffic_hourly ADD COLUMN app_hosts_version BIGINT;
+ALTER TABLE traffic_daily  ADD COLUMN app_hosts_version BIGINT;
+
+-- Per-rollup-row → owning app(s). A host that belongs to N apps fans out to N
+-- rows here, so app_id is part of the PK. The composite FK back to the parent
+-- rollup row cascades deletes (router teardown, re-roll churn); the FK to apps
+-- cascades app removal. Indexed on app_id for the `GROUP BY app_id` read path.
+CREATE TABLE traffic_hourly_apps (
+  router_id         UUID        NOT NULL,
+  mac               TEXT        NOT NULL,
+  hostname          TEXT        NOT NULL,
+  bucket_start      TIMESTAMPTZ NOT NULL,
+  app_id            BIGINT      NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  app_hosts_version BIGINT      NOT NULL,
+  PRIMARY KEY (router_id, mac, hostname, bucket_start, app_id),
+  FOREIGN KEY (router_id, mac, hostname, bucket_start)
+    REFERENCES traffic_hourly (router_id, mac, hostname, bucket_start) ON DELETE CASCADE
+);
+CREATE INDEX idx_traffic_hourly_apps_app ON traffic_hourly_apps (app_id);
+
+CREATE TABLE traffic_daily_apps (
+  router_id         UUID        NOT NULL,
+  mac               TEXT        NOT NULL,
+  hostname          TEXT        NOT NULL,
+  date              DATE        NOT NULL,
+  app_id            BIGINT      NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  app_hosts_version BIGINT      NOT NULL,
+  PRIMARY KEY (router_id, mac, hostname, date, app_id),
+  FOREIGN KEY (router_id, mac, hostname, date)
+    REFERENCES traffic_daily (router_id, mac, hostname, date) ON DELETE CASCADE
+);
+CREATE INDEX idx_traffic_daily_apps_app ON traffic_daily_apps (app_id);


### PR DESCRIPTION
## Summary

Schema-only PR for #1091 (pre-attribute `app_id` at rollup-write time). This is **PR 1 of 2** — per AGENTS.md §migrations-back-compat, a migration lands alone (migration + docs only) and the existing `api.test` suite is the back-compat gate. The writer + read-path adoption land in the follow-up code PR.

Adds `V45__rollup_app_attribution.sql`:

- **`app_hosts_version`** — single-row monotonic counter, bumped on every `app_hosts` mutation. Backs Option 2 (lazy invalidation): each rollup row records the version it was attributed at; on read, a row older than the current counter falls back to live in-memory matching.
- **`traffic_hourly` / `traffic_daily`** gain a NULLable `app_hosts_version` column. The ALTERs are catalog-only (NULLable, no default) — **no table rewrite**, safe at prod growth-table scale per §migrations-prod-data-volume.
- **`traffic_hourly_apps` / `traffic_daily_apps`** — per-rollup-row → owning app(s). A host in N apps fans to N rows (app_id is part of the PK). Composite FK to the parent rollup row cascades; FK to `apps` cascades app removal; indexed on `app_id` for the `GROUP BY app_id` read path.

## Test plan

- [x] `mill api.test` — all 192 existing feature tests pass with V45 applied (embedded Postgres applies every classpath migration before the suite runs). This is the back-compat gate: image-(N-1) code drives the V45 schema unchanged.
- [ ] Follow-up PR (code adoption, "Closes #1091") merges after this one is deployed.