### PR TITLE
web: inline autosave for Apps edit (replace modal + Save button)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,10 +4,10 @@ import type {
   DashboardNow, DashboardStats, Device,
   CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   ConnectionEventSeriesPage, QueryLogPage,
-  RecentApexesResponse, RouterSummary, SetAppHostsRequest, SetUserProfilesRequest, TimeExtension,
+  PatchAppRequest, RecentApexesResponse, RouterSummary, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
-  UpdateAppRequest, UpdateHouseholdSettingsRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
+  UpdateHouseholdSettingsRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
 } from '@/types/api'
 
@@ -359,11 +359,9 @@ export const api = {
     list: () => req<AppDetail[]>('GET', '/apps'),
     get: (id: number) => req<AppDetail>('GET', `/apps/${id}`),
     create: (data: CreateAppRequest) => req<AppDetail>('POST', '/apps', data),
-    update: (id: number, data: UpdateAppRequest) =>
-      req<void>('PUT', `/apps/${id}`, data),
+    patch: (id: number, data: PatchAppRequest) =>
+      req<void>('PATCH', `/apps/${id}`, data),
     delete: (id: number) => req<void>('DELETE', `/apps/${id}`),
-    setHosts: (id: number, hosts: string[]) =>
-      req<void>('PUT', `/apps/${id}/hosts`, { hosts } as SetAppHostsRequest),
     // #766: recently-visited apexes for a device — drives the picker in the
     // apps create/edit flow. Colons in the MAC are sent raw: zio-http doesn't
     // auto-decode percent-encoded colons in path segments, so

--- a/web/src/hooks/useDebouncedSave.ts
+++ b/web/src/hooks/useDebouncedSave.ts
@@ -5,7 +5,13 @@ export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
 export interface UseDebouncedSave {
   status: SaveStatus
   error: string | null
+  // True when the live value differs from the last-saved baseline and no save
+  // has completed for it yet — i.e. a change is queued or in flight. Drives the
+  // "Unsaved" indicator (#1003).
+  dirty: boolean
   flush: () => Promise<void>
+  // Re-run the save that last failed (#1003). No-op unless status is 'error'.
+  retry: () => Promise<void>
 }
 
 // #973: debounce field changes into a single save. Tracks the LATEST baseline
@@ -24,6 +30,7 @@ export function useDebouncedSave<T>(
   const baselineRef = useRef<T>(value)
   const lastKeyRef  = useRef(key)
   const pendingRef  = useRef<T | null>(null)
+  const failedRef   = useRef<T | null>(null)
   const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const eq = equals ?? Object.is
@@ -44,6 +51,7 @@ export function useDebouncedSave<T>(
     try {
       await save(v)
       baselineRef.current = v
+      failedRef.current = null
       // If newer changes came in while saving, leave them for the next tick.
       if (pendingRef.current != null && !eq(pendingRef.current, v)) {
         // pendingRef holds the latest value; let the effect re-schedule.
@@ -54,6 +62,7 @@ export function useDebouncedSave<T>(
         savedTimerRef.current = setTimeout(() => setStatus('idle'), 1500)
       }
     } catch (e) {
+      failedRef.current = v
       setStatus('error')
       setError(e instanceof Error ? e.message : 'Save failed')
     }
@@ -90,5 +99,12 @@ export function useDebouncedSave<T>(
     }
   }
 
-  return { status, error, flush }
+  async function retry() {
+    const v = failedRef.current
+    if (v !== null) await commit(v as T)
+  }
+
+  const dirty = !eq(value, baselineRef.current)
+
+  return { status, error, dirty, flush, retry }
 }

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -9,9 +9,8 @@ vi.mock('@/api/client', () => ({
     apps: {
       list: vi.fn(),
       create: vi.fn(),
-      update: vi.fn(),
+      patch: vi.fn(),
       delete: vi.fn(),
-      setHosts: vi.fn(),
       recentApexes: vi.fn(),
     },
     profiles: {
@@ -31,15 +30,12 @@ function makeProfile(id: number, name: string): ProfileDetail {
     profile: {
       id, name,
       blockedCategories: [],
-      
-      
       paused: false,
       failureMode: 'last-known-good',
       crossDeviceOverlapMode: 'sum',
     },
     schedules: [],
     timeLimit: null,
-    
   }
 }
 
@@ -54,6 +50,7 @@ function makeApp(over: Partial<AppDetail['app']> & { id: number; name: string; s
       slug: over.slug,
       templateId: over.templateId ?? null,
       icon: over.icon ?? null,
+      iconType: over.iconType,
       createdAt: '2026-05-01T00:00:00Z',
     },
     hosts: [],
@@ -62,7 +59,7 @@ function makeApp(over: Partial<AppDetail['app']> & { id: number; name: string; s
 }
 
 const youtube: AppDetail = {
-  ...makeApp({ id: 10, name: 'YouTube', slug: 'youtube', icon: '📺' }),
+  ...makeApp({ id: 10, name: 'YouTube', slug: 'youtube', icon: '📺', iconType: 'emoji' }),
   hosts: ['youtube.com', 'googlevideo.com'],
   assignments: [
     { id: 100, appId: 10, profileId: 1, mode: 'time_limited', dailyMinutes: 60, exemptFromDaily: true },
@@ -73,6 +70,10 @@ const reddit: AppDetail = {
   ...makeApp({ id: 11, name: 'Reddit', slug: 'reddit' }),
   hosts: ['reddit.com'],
   assignments: [],
+}
+
+function patchMock() {
+  return api.apps.patch as unknown as ReturnType<typeof vi.fn>
 }
 
 beforeEach(() => {
@@ -94,6 +95,7 @@ beforeEach(() => {
         subdomains: ['m.youtube.com', 'www.youtube.com'] },
     ],
   })
+  patchMock().mockResolvedValue(undefined)
 })
 
 describe('AppsPage — list', () => {
@@ -101,11 +103,9 @@ describe('AppsPage — list', () => {
     render(withQuery(<AppsPage />))
     await screen.findByText('YouTube')
     expect(screen.getByText('Reddit')).toBeInTheDocument()
-    // YouTube row: 2 hosts, 1 profile
     const ytRow = screen.getByRole('button', { name: /youtube/i })
     expect(within(ytRow).getByText(/2 hosts/i)).toBeInTheDocument()
     expect(within(ytRow).getByText(/1 profile/i)).toBeInTheDocument()
-    // Reddit row: 1 host, no profiles
     const rdRow = screen.getByRole('button', { name: /reddit/i })
     expect(within(rdRow).getByText(/1 host/i)).toBeInTheDocument()
     expect(within(rdRow).getByText(/no profiles/i)).toBeInTheDocument()
@@ -118,8 +118,8 @@ describe('AppsPage — list', () => {
   })
 })
 
-describe('AppsPage — create flow', () => {
-  it('round-trips name + hosts through POST /apps and reloads the list', async () => {
+describe('AppsPage — create flow (stays explicit, no autosave)', () => {
+  it('round-trips name + hosts through POST /apps and reloads the list; never PATCHes', async () => {
     (api.apps.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       ...makeApp({ id: 12, name: 'Discord', slug: 'discord' }),
       hosts: ['discord.com'],
@@ -133,7 +133,6 @@ describe('AppsPage — create flow', () => {
       screen.getByPlaceholderText(/youtube\.com/i),
       'discord.com, *.discordapp.net',
     )
-    // After create, the list will include the new app
     ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
       youtube, reddit,
       { ...makeApp({ id: 12, name: 'Discord', slug: 'discord' }), hosts: ['discord.com'] },
@@ -147,45 +146,10 @@ describe('AppsPage — create flow', () => {
       })
     })
     await screen.findByText('Discord')
+    // The create flow must never autosave.
+    expect(patchMock()).not.toHaveBeenCalled()
   })
-})
 
-describe('AppsPage — edit flow', () => {
-  it('renders existing hosts as chips and round-trips edits via PUT /apps + PUT /apps/:id/hosts', async () => {
-    const user = userEvent.setup()
-    render(withQuery(<AppsPage />))
-    await user.click(await screen.findByRole('button', { name: /youtube/i }))
-    // Existing host chips
-    expect(screen.getByText('youtube.com')).toBeInTheDocument()
-    expect(screen.getByText('googlevideo.com')).toBeInTheDocument()
-    // Remove a host
-    await user.click(screen.getByRole('button', { name: /remove googlevideo\.com/i }))
-    expect(screen.queryByText('googlevideo.com')).not.toBeInTheDocument()
-    // Add a new host via the Add button
-    await user.type(
-      screen.getByPlaceholderText(/^example\.com$/i),
-      '*.ytimg.com',
-    )
-    await user.click(screen.getByRole('button', { name: 'Add' }))
-    expect(screen.getByText('*.ytimg.com')).toBeInTheDocument()
-    // Rename
-    const nameInput = screen.getByDisplayValue('YouTube') as HTMLInputElement
-    await user.clear(nameInput)
-    await user.type(nameInput, 'YT')
-    await user.click(screen.getByRole('button', { name: /^save$/i }))
-    await waitFor(() => {
-      expect(api.apps.update).toHaveBeenCalledWith(10, {
-        name: 'YT',
-        icon: '📺',
-        iconType: 'emoji',
-        templateId: null,
-      })
-      expect(api.apps.setHosts).toHaveBeenCalledWith(10, ['youtube.com', '*.ytimg.com'])
-    })
-  })
-})
-
-describe('AppsPage — icon picker (#1004)', () => {
   it('emoji tab: typed value is sent with iconType=emoji on create', async () => {
     (api.apps.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       ...makeApp({ id: 20, name: 'Discord', slug: 'discord' }),
@@ -205,84 +169,164 @@ describe('AppsPage — icon picker (#1004)', () => {
         hosts: [],
       })
     })
-  })
-
-  it('URL tab: pasted URL is sent with iconType=url on edit', async () => {
-    const user = userEvent.setup()
-    render(withQuery(<AppsPage />))
-    await user.click(await screen.findByRole('button', { name: /youtube/i }))
-    await user.click(screen.getByTestId('icon-picker-tab-url'))
-    const urlInput = screen.getByTestId('icon-picker-url-input') as HTMLInputElement
-    await user.clear(urlInput)
-    await user.type(urlInput, 'https://example.com/icon.png')
-    await user.click(screen.getByRole('button', { name: /^save$/i }))
-    await waitFor(() => {
-      expect(api.apps.update).toHaveBeenCalledWith(10, {
-        name: 'YouTube',
-        icon: 'https://example.com/icon.png',
-        iconType: 'url',
-        templateId: null,
-      })
-    })
-  })
-
-  it('Favicon tab: picking a host saves DuckDuckGo URL with iconType=url', async () => {
-    const user = userEvent.setup()
-    render(withQuery(<AppsPage />))
-    await user.click(await screen.findByRole('button', { name: /youtube/i }))
-    await user.click(screen.getByTestId('icon-picker-tab-favicon'))
-    await user.click(screen.getByTestId('icon-picker-favicon-youtube.com'))
-    await user.click(screen.getByRole('button', { name: /^save$/i }))
-    await waitFor(() => {
-      expect(api.apps.update).toHaveBeenCalledWith(10, {
-        name: 'YouTube',
-        icon: 'https://icons.duckduckgo.com/ip3/youtube.com.ico',
-        iconType: 'url',
-        templateId: null,
-      })
-    })
-  })
-
-  it('Switching tabs preserves the name field', async () => {
-    const user = userEvent.setup()
-    render(withQuery(<AppsPage />))
-    await screen.findByText('YouTube')
-    await user.click(screen.getByRole('button', { name: /new app/i }))
-    await user.type(screen.getByPlaceholderText('YouTube'), 'Discord')
-    await user.click(screen.getByTestId('icon-picker-tab-url'))
-    await user.click(screen.getByTestId('icon-picker-tab-emoji'))
-    expect((screen.getByPlaceholderText('YouTube') as HTMLInputElement).value).toBe('Discord')
+    expect(patchMock()).not.toHaveBeenCalled()
   })
 })
 
-describe('AppsPage — recent-activity picker (#766)', () => {
-  it('opens picker from the create flow, multi-selects apexes, and appends them to the hosts input', async () => {
-    (api.apps.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ...makeApp({ id: 13, name: 'YT', slug: 'yt' }),
-      hosts: ['youtube.com', 'googlevideo.com'],
-    })
-    const user = userEvent.setup()
-    render(withQuery(<AppsPage />))
-    await screen.findByText('YouTube')
-    await user.click(screen.getByRole('button', { name: /new app/i }))
-    await user.type(screen.getByPlaceholderText('YouTube'), 'YT')
-    await user.click(screen.getByRole('button', { name: /pick from recent activity/i }))
-    await screen.findByText(/top apexes a device hit/i)
-    await waitFor(() => expect(api.apps.recentApexes).toHaveBeenCalled())
-    await user.click(await screen.findByLabelText('Select youtube.com'))
-    await user.click(screen.getByLabelText('Select googlevideo.com'))
-    await user.click(screen.getByTestId('picker-add-button'))
-    const textarea = screen.getByPlaceholderText(/youtube\.com/i) as HTMLTextAreaElement
-    await waitFor(() => {
-      expect(textarea.value).toMatch(/youtube\.com/)
-      expect(textarea.value).toMatch(/googlevideo\.com/)
-    })
+describe('AppsPage — inline edit autosave (#1003)', () => {
+  async function expandYouTube(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(await screen.findByRole('button', { name: /youtube/i }))
+    // Inline editor surfaces, no Save button.
+    await screen.findByTestId('app-name-input-10')
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+  }
+
+  it('renaming autosaves via PATCH after debounce — no Save button; Unsaved then Saved just now', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(withQuery(<AppsPage />))
+      await expandYouTube(user)
+      const nameInput = screen.getByTestId('app-name-input-10') as HTMLInputElement
+      await user.clear(nameInput)
+      await user.type(nameInput, 'YT')
+
+      // Pre-debounce: dirty, no save yet.
+      expect(patchMock()).not.toHaveBeenCalled()
+      expect(screen.getByTestId('app-name-status-10')).toHaveAttribute('data-status', 'dirty')
+      expect(screen.getByTestId('app-name-status-10')).toHaveTextContent(/unsaved/i)
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(patchMock()).toHaveBeenCalledTimes(1)
+      expect(patchMock()).toHaveBeenLastCalledWith(10, { name: 'YT' })
+
+      await waitFor(() => {
+        const status = screen.getByTestId('app-name-status-10')
+        expect(status).toHaveAttribute('data-status', 'saved')
+        expect(status).toHaveTextContent(/saved just now/i)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('opens picker from the edit flow and appends apexes to existing chips', async () => {
+  it('changing the icon autosaves via PATCH with icon + iconType', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(withQuery(<AppsPage />))
+      await expandYouTube(user)
+      await user.click(screen.getByTestId('icon-picker-tab-url'))
+      const urlInput = screen.getByTestId('icon-picker-url-input') as HTMLInputElement
+      await user.clear(urlInput)
+      await user.type(urlInput, 'https://example.com/icon.png')
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(patchMock()).toHaveBeenLastCalledWith(10, {
+        icon: 'https://example.com/icon.png',
+        iconType: 'url',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('adding a host autosaves the full host list via PATCH (full-replace)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(withQuery(<AppsPage />))
+      await expandYouTube(user)
+      await user.type(screen.getByPlaceholderText(/^example\.com$/i), '*.ytimg.com')
+      await user.click(screen.getByRole('button', { name: 'Add' }))
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(patchMock()).toHaveBeenLastCalledWith(10, {
+        hosts: ['youtube.com', 'googlevideo.com', '*.ytimg.com'],
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('removing a host autosaves the reduced host list via PATCH', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(withQuery(<AppsPage />))
+      await expandYouTube(user)
+      await user.click(screen.getByRole('button', { name: /remove googlevideo\.com/i }))
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(patchMock()).toHaveBeenLastCalledWith(10, { hosts: ['youtube.com'] })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('save failure shows inline error + Retry; dirty value stays; Retry re-sends', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      patchMock().mockRejectedValueOnce(new Error('boom'))
+      render(withQuery(<AppsPage />))
+      await expandYouTube(user)
+      const nameInput = screen.getByTestId('app-name-input-10') as HTMLInputElement
+      await user.clear(nameInput)
+      await user.type(nameInput, 'YT')
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-name-status-10')).toHaveAttribute('data-status', 'error')
+      })
+      // Dirty value stays in the form.
+      expect((screen.getByTestId('app-name-input-10') as HTMLInputElement).value).toBe('YT')
+
+      // Retry re-sends the same PATCH and succeeds.
+      patchMock().mockResolvedValueOnce(undefined)
+      await user.click(screen.getByRole('button', { name: /retry/i }))
+      await waitFor(() => {
+        expect(patchMock()).toHaveBeenLastCalledWith(10, { name: 'YT' })
+        expect(screen.getByTestId('app-name-status-10')).toHaveAttribute('data-status', 'saved')
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('AppsPage — icon picker on inline edit (#1004)', () => {
+  it('Favicon tab: picking a host autosaves DuckDuckGo URL with iconType=url', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(withQuery(<AppsPage />))
+      await user.click(await screen.findByRole('button', { name: /youtube/i }))
+      await screen.findByTestId('app-name-input-10')
+      await user.click(screen.getByTestId('icon-picker-tab-favicon'))
+      await user.click(screen.getByTestId('icon-picker-favicon-youtube.com'))
+      await vi.advanceTimersByTimeAsync(700)
+      expect(patchMock()).toHaveBeenLastCalledWith(10, {
+        icon: 'https://icons.duckduckgo.com/ip3/youtube.com.ico',
+        iconType: 'url',
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('AppsPage — recent-activity picker on inline edit (#766)', () => {
+  it('opens picker from the inline editor and appends apexes to existing chips', async () => {
     const user = userEvent.setup()
     render(withQuery(<AppsPage />))
     await user.click(await screen.findByRole('button', { name: /reddit/i }))
+    await screen.findByTestId('app-name-input-11')
     await user.click(screen.getByRole('button', { name: /pick from recent activity/i }))
     await waitFor(() => expect(api.apps.recentApexes).toHaveBeenCalled())
     await user.click(await screen.findByLabelText('Select googlevideo.com'))
@@ -293,11 +337,12 @@ describe('AppsPage — recent-activity picker (#766)', () => {
   })
 })
 
-describe('AppsPage — delete flow', () => {
+describe('AppsPage — delete flow (inline)', () => {
   it('warns when the app has profile assignments and names them', async () => {
     const user = userEvent.setup()
     render(withQuery(<AppsPage />))
     await user.click(await screen.findByRole('button', { name: /youtube/i }))
+    await screen.findByTestId('app-name-input-10')
     await user.click(screen.getByRole('button', { name: /delete app/i }))
     expect(screen.getByText(/assigned to/i)).toBeInTheDocument()
     expect(screen.getAllByText(/Kids/).length).toBeGreaterThan(0)
@@ -311,6 +356,7 @@ describe('AppsPage — delete flow', () => {
     const user = userEvent.setup()
     render(withQuery(<AppsPage />))
     await user.click(await screen.findByRole('button', { name: /reddit/i }))
+    await screen.findByTestId('app-name-input-11')
     await user.click(screen.getByRole('button', { name: /delete app/i }))
     expect(screen.queryByText(/assigned to/i)).not.toBeInTheDocument()
     expect(screen.getByText(/cannot be undone/i)).toBeInTheDocument()
@@ -328,17 +374,15 @@ describe('AppsPage — host input copy (#1006)', () => {
     await user.click(await screen.findByRole('button', { name: /new app/i }))
     const textarea = screen.getByPlaceholderText(/youtube\.com/i) as HTMLTextAreaElement
     expect(textarea.placeholder).not.toContain('*.')
-    // Open edit modal too — checks the single-host input placeholder.
     await user.click(screen.getByRole('button', { name: /^cancel$/i }))
     await user.click(await screen.findByRole('button', { name: /youtube/i }))
     const hostInput = screen.getByPlaceholderText(/^example\.com$/i) as HTMLInputElement
     expect(hostInput.placeholder).not.toContain('*.')
-    // No visible UI string should mention *.example.com.
     expect(screen.queryByText(/\*\.example\.com/i)).not.toBeInTheDocument()
   })
 })
 
-describe('AppsPage — Escape closes modals (#1008)', () => {
+describe('AppsPage — Escape closes create modal (#1008)', () => {
   it('closes the create modal on Escape', async () => {
     const user = userEvent.setup()
     render(withQuery(<AppsPage />))
@@ -359,7 +403,6 @@ describe('AppsPage — Escape closes modals (#1008)', () => {
     await user.click(screen.getByRole('button', { name: /pick from recent activity/i }))
     await screen.findByText(/top apexes a device hit/i)
     await user.keyboard('{Escape}')
-    // Picker closes but the underlying create modal stays open.
     await waitFor(() => {
       expect(screen.queryByText(/top apexes a device hit/i)).not.toBeInTheDocument()
     })

--- a/web/src/pages/AppsPage.tsx
+++ b/web/src/pages/AppsPage.tsx
@@ -8,6 +8,7 @@ import { IconPicker, type IconValue } from '@/components/IconPicker'
 import { AppIcon } from '@/components/AppIcon'
 import { EmptyState } from '@/components/EmptyState'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
+import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
 
 interface EditFormState {
   name: string
@@ -20,15 +21,6 @@ function blankCreateForm(): EditFormState {
   return { name: '', icon: '', iconType: 'emoji', hosts: [] }
 }
 
-function detailToForm(d: AppDetail): EditFormState {
-  return {
-    name: d.app.name,
-    icon: d.app.icon ?? '',
-    iconType: d.app.iconType ?? 'emoji',
-    hosts: [...d.hosts],
-  }
-}
-
 function splitHosts(raw: string): string[] {
   return raw
     .split(/[\s,]+/)
@@ -36,11 +28,15 @@ function splitHosts(raw: string): string[] {
     .filter(Boolean)
 }
 
+function sameHosts(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((h, i) => h === b[i])
+}
+
 export function AppsPage() {
   const [apps, setApps] = useState<AppDetail[]>([])
   const [loading, setLoading] = useState(true)
   const [creating, setCreating] = useState(false)
-  const [editing, setEditing] = useState<AppDetail | null>(null)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
   const { data: profiles = [] } = useProfiles()
 
@@ -60,6 +56,17 @@ export function AppsPage() {
       .catch(e => setError(e instanceof Error ? e.message : 'Failed to load apps'))
       .finally(() => setLoading(false))
   }, [])
+
+  // #1003 — inline autosave persists each field as it changes. Rather than a
+  // full reload after every keystroke-debounce, merge the saved field into the
+  // open row so the editor's own resync effects see the value it just wrote
+  // (no clobber) and the collapsed summary counts stay accurate.
+  function applyLocal(id: number, fn: (d: AppDetail) => AppDetail) {
+    setApps(prev =>
+      [...prev.map(a => (a.app.id === id ? fn(a) : a))]
+        .sort((a, b) => a.app.name.localeCompare(b.app.name)),
+    )
+  }
 
   if (loading) return <PageLoader />
 
@@ -91,30 +98,42 @@ export function AppsPage() {
           ? <EmptyState title="No apps yet." hint="Create one to start grouping hosts." />
           : apps.map(a => {
               const assignProfiles = new Set(a.assignments.map(x => x.profileId))
+              const expanded = expandedId === a.app.id
               return (
-                <button
-                  key={a.app.id}
-                  onClick={() => { setEditing(a); setError(null) }}
-                  className="w-full text-left border-b border-brand-border last:border-0 hover:bg-brand-alt/40 transition-colors"
-                >
-                  <div className="flex items-center gap-4 px-5 py-4">
-                    <span className="w-8 text-center inline-flex items-center justify-center">
-                      <AppIcon icon={a.app.icon} iconType={a.app.iconType} size="lg" />
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <p className="font-medium text-brand-ink truncate">{a.app.name}</p>
-                      <p className="text-xs text-brand-text-muted mt-0.5 font-mono">{a.app.slug}</p>
+                <div key={a.app.id} className="border-b border-brand-border last:border-0">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(expanded ? null : a.app.id)}
+                    aria-expanded={expanded}
+                    className="w-full text-left hover:bg-brand-alt/40 transition-colors"
+                  >
+                    <div className="flex items-center gap-4 px-5 py-4">
+                      <span className="w-8 text-center inline-flex items-center justify-center">
+                        <AppIcon icon={a.app.icon} iconType={a.app.iconType} size="lg" />
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-brand-ink truncate">{a.app.name}</p>
+                        <p className="text-xs text-brand-text-muted mt-0.5 font-mono">{a.app.slug}</p>
+                      </div>
+                      <div className="text-right text-xs text-brand-text shrink-0">
+                        <p>{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</p>
+                        <p className="text-brand-text-muted mt-0.5">
+                          {assignProfiles.size === 0
+                            ? 'no profiles'
+                            : `${assignProfiles.size} profile${assignProfiles.size === 1 ? '' : 's'}`}
+                        </p>
+                      </div>
                     </div>
-                    <div className="text-right text-xs text-brand-text shrink-0">
-                      <p>{a.hosts.length} host{a.hosts.length === 1 ? '' : 's'}</p>
-                      <p className="text-brand-text-muted mt-0.5">
-                        {assignProfiles.size === 0
-                          ? 'no profiles'
-                          : `${assignProfiles.size} profile${assignProfiles.size === 1 ? '' : 's'}`}
-                      </p>
-                    </div>
-                  </div>
-                </button>
+                  </button>
+                  {expanded && (
+                    <InlineAppEditor
+                      detail={a}
+                      profileNameById={profileNameById}
+                      onPatched={applyLocal}
+                      onDeleted={async () => { setExpandedId(null); await reload() }}
+                    />
+                  )}
+                </div>
               )
             })
         }
@@ -124,16 +143,6 @@ export function AppsPage() {
         <CreateAppModal
           onClose={() => setCreating(false)}
           onSaved={async () => { setCreating(false); await reload() }}
-        />
-      )}
-
-      {editing && (
-        <EditAppModal
-          detail={editing}
-          profileNameById={profileNameById}
-          onClose={() => setEditing(null)}
-          onSaved={async () => { setEditing(null); await reload() }}
-          onDeleted={async () => { setEditing(null); await reload() }}
         />
       )}
     </div>
@@ -255,232 +264,307 @@ function CreateAppModal({ onClose, onSaved }: {
   )
 }
 
-function EditAppModal({ detail, profileNameById, onClose, onSaved, onDeleted }: {
+// #1003 — inline editor for an expanded app row. Name and icon autosave on a
+// debounce; the hosts list autosaves on each add/remove (debounced, full
+// replace). Each field carries its own save-status badge + Retry. There is no
+// Save button — the create flow stays explicit, edit does not.
+function InlineAppEditor({ detail, profileNameById, onPatched, onDeleted }: {
   detail: AppDetail
   profileNameById: Map<number, string>
-  onClose: () => void
-  onSaved: () => void | Promise<void>
+  onPatched: (id: number, fn: (d: AppDetail) => AppDetail) => void
   onDeleted: () => void | Promise<void>
 }) {
-  const [form, setForm] = useState<EditFormState>(() => detailToForm(detail))
+  const id = detail.app.id
+  const [name, setName] = useState(detail.app.name)
+  const [icon, setIcon] = useState(detail.app.icon ?? '')
+  const [iconType, setIconType] = useState<IconType>(detail.app.iconType ?? 'emoji')
+  const [hosts, setHosts] = useState<string[]>([...detail.hosts])
   const [newHost, setNewHost] = useState('')
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  // Resync from the parent after a save merges the value back in (no-op when
+  // the field equals what we just wrote, so live edits aren't clobbered).
+  useEffect(() => { setName(detail.app.name) }, [detail.app.name])
+  useEffect(() => {
+    setIcon(detail.app.icon ?? '')
+    setIconType(detail.app.iconType ?? 'emoji')
+  }, [detail.app.icon, detail.app.iconType])
+  useEffect(() => { setHosts([...detail.hosts]) }, [detail.hosts])
+
+  const nameSave = useDebouncedSave(
+    name,
+    async (next: string) => {
+      const trimmed = next.trim()
+      if (!trimmed) throw new Error('Name is required')
+      await api.apps.patch(id, { name: trimmed })
+      onPatched(id, a => ({ ...a, app: { ...a.app, name: trimmed } }))
+    },
+    { delayMs: 600, key: id },
+  )
+
+  const iconValue = useMemo(() => ({ icon, iconType }), [icon, iconType])
+  const iconSave = useDebouncedSave(
+    iconValue,
+    async (v: IconValue) => {
+      const iconStr = v.icon.trim()
+      if (iconStr) {
+        await api.apps.patch(id, { icon: iconStr, iconType: v.iconType })
+        onPatched(id, a => ({ ...a, app: { ...a.app, icon: iconStr, iconType: v.iconType } }))
+      } else {
+        await api.apps.patch(id, { icon: null })
+        onPatched(id, a => ({ ...a, app: { ...a.app, icon: null } }))
+      }
+    },
+    { delayMs: 600, key: id, equals: (a, b) => a.icon === b.icon && a.iconType === b.iconType },
+  )
+
+  const hostsSave = useDebouncedSave(
+    hosts,
+    async (next: string[]) => {
+      await api.apps.patch(id, { hosts: next })
+      onPatched(id, a => ({ ...a, hosts: [...next] }))
+    },
+    { delayMs: 600, key: id, equals: sameHosts },
+  )
+
+  function addHosts() {
+    const additions = splitHosts(newHost)
+    if (additions.length === 0) return
+    setHosts(hs => [...new Set([...hs, ...additions])])
+    setNewHost('')
+  }
+
+  function removeHost(h: string) {
+    setHosts(hs => hs.filter(x => x !== h))
+  }
 
   function addFromPicker(picked: string[]) {
     if (picked.length === 0) return
-    setForm(f => ({ ...f, hosts: [...new Set([...f.hosts, ...picked])] }))
+    setHosts(hs => [...new Set([...hs, ...picked])])
     setPickerOpen(false)
   }
 
   const assignedProfiles = useMemo(() => {
     const ids = new Set(detail.assignments.map(a => a.profileId))
-    return [...ids].map(id => profileNameById.get(id) ?? `profile ${id}`)
+    return [...ids].map(pid => profileNameById.get(pid) ?? `profile ${pid}`)
   }, [detail.assignments, profileNameById])
 
-  function addHosts() {
-    const additions = splitHosts(newHost)
-    if (additions.length === 0) return
-    setForm(f => ({
-      ...f,
-      hosts: [...new Set([...f.hosts, ...additions])],
-    }))
-    setNewHost('')
-  }
-
-  function removeHost(h: string) {
-    setForm(f => ({ ...f, hosts: f.hosts.filter(x => x !== h) }))
-  }
-
-  async function submit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!form.name.trim()) { setError('Name is required'); return }
-    setSaving(true)
-    setError(null)
-    try {
-      const iconStr = form.icon.trim()
-      await api.apps.update(detail.app.id, {
-        name: form.name.trim(),
-        icon: iconStr || null,
-        iconType: iconStr ? form.iconType : undefined,
-        templateId: detail.app.templateId,
-      })
-      await api.apps.setHosts(detail.app.id, form.hosts)
-      await onSaved()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save app')
-    } finally {
-      setSaving(false)
-    }
-  }
-
   async function performDelete() {
-    setSaving(true)
-    setError(null)
+    setDeleting(true)
+    setDeleteError(null)
     try {
-      await api.apps.delete(detail.app.id)
+      await api.apps.delete(id)
       await onDeleted()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to delete app')
-      setSaving(false)
+      setDeleteError(e instanceof Error ? e.message : 'Failed to delete app')
+      setDeleting(false)
     }
   }
 
   // #768 — template host list lives on the starter-library track; until that
   // ships we can only detect "has a template" via templateId. The button is
   // visible-but-disabled with a tooltip explaining what it'll do once #768
-  // lands. Once #768 publishes a template-fetch endpoint, this should compare
-  // current hosts to the template's host list and only enable on divergence.
+  // lands.
   const hasTemplate = detail.app.templateId !== null
 
   return (
-    <Modal title={`Edit ${detail.app.name}`} onClose={onClose}>
-      <form onSubmit={submit} className="space-y-5">
-        {error && (
-          <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
-            {error}
-          </div>
-        )}
-        <Field label="Name" required>
+    <div className="px-5 pb-5 pt-1 space-y-5 bg-brand-surface/30 border-t border-brand-border">
+      <div>
+        <label
+          htmlFor={`app-name-input-${id}`}
+          className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-2"
+        >
+          Name
+        </label>
+        <div className="flex items-center gap-3">
           <input
-            type="text" value={form.name} required
-            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
-            className="w-full bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-3 text-brand-ink focus:outline-none focus:border-brand-accent"
+            id={`app-name-input-${id}`}
+            data-testid={`app-name-input-${id}`}
+            aria-label="App name"
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            className="flex-1 bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-3 text-brand-ink focus:outline-none focus:border-brand-accent"
           />
-        </Field>
-        <Field label="Icon (optional)">
-          <IconPicker
-            value={{ icon: form.icon, iconType: form.iconType }}
-            onChange={(v: IconValue) => setForm(f => ({ ...f, icon: v.icon, iconType: v.iconType }))}
-            hosts={form.hosts}
-          />
-        </Field>
-        <Field label="Hosts">
-          <div className="flex flex-wrap gap-2 mb-3 min-h-[2rem]" data-testid="hosts-chips">
-            {form.hosts.length === 0 && (
-              <span className="text-xs text-brand-text-muted italic">No hosts yet.</span>
-            )}
-            {form.hosts.map(h => (
-              <span key={h} className="inline-flex items-center gap-1 bg-brand-alt text-brand-accent text-xs font-mono px-2.5 py-1 rounded-lg">
-                {h}
-                <button
-                  type="button"
-                  onClick={() => removeHost(h)}
-                  aria-label={`Remove ${h}`}
-                  className="text-brand-text-muted hover:text-red-700 transition-colors leading-none"
-                >×</button>
-              </span>
-            ))}
-          </div>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newHost}
-              onChange={e => setNewHost(e.target.value)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  addHosts()
-                }
-              }}
-              placeholder="example.com"
-              title="Wildcards are unnecessary — example.com automatically covers every subdomain."
-              className="flex-1 bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-2 text-brand-ink font-mono text-sm focus:outline-none focus:border-brand-accent"
-            />
-            <button
-              type="button"
-              onClick={addHosts}
-              className="px-4 py-2 rounded-xl bg-brand-alt text-brand-ink hover:bg-brand-alt text-sm font-medium"
-            >Add</button>
-          </div>
-          <button
-            type="button"
-            onClick={() => setPickerOpen(true)}
-            className="mt-2 text-xs font-medium text-brand-accent hover:text-brand-accent bg-brand-accent/10 px-3 py-1.5 rounded-lg"
-          >Pick from recent activity</button>
-        </Field>
+          <SaveStatusBadge save={nameSave} testId={`app-name-status-${id}`} />
+        </div>
+      </div>
 
-        {hasTemplate && (
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-semibold text-brand-text-muted uppercase tracking-wider">
+            Icon
+          </span>
+          <SaveStatusBadge save={iconSave} testId={`app-icon-status-${id}`} />
+        </div>
+        <IconPicker
+          value={{ icon, iconType }}
+          onChange={(v: IconValue) => { setIcon(v.icon); setIconType(v.iconType) }}
+          hosts={hosts}
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-semibold text-brand-text-muted uppercase tracking-wider">
+            Hosts
+          </span>
+          <SaveStatusBadge save={hostsSave} testId={`app-hosts-status-${id}`} />
+        </div>
+        <div className="flex flex-wrap gap-2 mb-3 min-h-[2rem]" data-testid="hosts-chips">
+          {hosts.length === 0 && (
+            <span className="text-xs text-brand-text-muted italic">No hosts yet.</span>
+          )}
+          {hosts.map(h => (
+            <span key={h} className="inline-flex items-center gap-1 bg-brand-alt text-brand-accent text-xs font-mono px-2.5 py-1 rounded-lg">
+              {h}
+              <button
+                type="button"
+                onClick={() => removeHost(h)}
+                aria-label={`Remove ${h}`}
+                className="text-brand-text-muted hover:text-red-700 transition-colors leading-none"
+              >×</button>
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newHost}
+            onChange={e => setNewHost(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                addHosts()
+              }
+            }}
+            placeholder="example.com"
+            title="Wildcards are unnecessary — example.com automatically covers every subdomain."
+            className="flex-1 bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-2 text-brand-ink font-mono text-sm focus:outline-none focus:border-brand-accent"
+          />
           <button
             type="button"
-            disabled
-            title="Reset to template will be enabled once the starter library (#768) ships."
-            className="w-full py-2 rounded-xl bg-brand-alt/60 text-brand-text-muted text-sm font-medium cursor-not-allowed"
-          >
-            Reset to template (requires #768)
-          </button>
+            onClick={addHosts}
+            className="px-4 py-2 rounded-xl bg-brand-alt text-brand-ink hover:bg-brand-alt text-sm font-medium"
+          >Add</button>
+        </div>
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="mt-2 text-xs font-medium text-brand-accent hover:text-brand-accent bg-brand-accent/10 px-3 py-1.5 rounded-lg"
+        >Pick from recent activity</button>
+      </div>
+
+      {hasTemplate && (
+        <button
+          type="button"
+          disabled
+          title="Reset to template will be enabled once the starter library (#768) ships."
+          className="w-full py-2 rounded-xl bg-brand-alt/60 text-brand-text-muted text-sm font-medium cursor-not-allowed"
+        >
+          Reset to template (requires #768)
+        </button>
+      )}
+
+      <div className="border-t border-brand-border pt-4 space-y-3">
+        {deleteError && (
+          <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
+            {deleteError}
+          </div>
         )}
-
-        <div className="border-t border-brand-border pt-4 space-y-3">
-          <p className="text-xs text-brand-text-muted">
-            Used by {assignedProfiles.length === 0
-              ? <span className="text-brand-text">no profiles</span>
-              : <span className="text-brand-text">{assignedProfiles.join(', ')}</span>}.
-          </p>
-          {!confirmingDelete
-            ? (
-                <button
-                  type="button"
-                  onClick={() => setConfirmingDelete(true)}
-                  className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
-                >Delete app…</button>
-              )
-            : (
-                <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-3 space-y-3">
-                  {assignedProfiles.length > 0
-                    ? (
-                        <p className="text-sm text-red-800">
-                          This app is currently assigned to{' '}
-                          <strong>{assignedProfiles.length} profile{assignedProfiles.length === 1 ? '' : 's'}</strong>
-                          {' '}({assignedProfiles.join(', ')}).
-                          Deleting it will remove those assignments. Continue?
-                        </p>
-                      )
-                    : (
-                        <p className="text-sm text-red-800">
-                          Delete <strong>{detail.app.name}</strong>? This cannot be undone.
-                        </p>
-                      )}
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => setConfirmingDelete(false)}
-                      disabled={saving}
-                      className="flex-1 py-2 rounded-lg bg-brand-alt text-brand-text text-sm font-medium disabled:opacity-50"
-                    >Cancel</button>
-                    <button
-                      type="button"
-                      onClick={performDelete}
-                      disabled={saving}
-                      className="flex-1 py-2 rounded-lg bg-red-500 text-brand-ink text-sm font-semibold disabled:opacity-50"
-                    >{saving ? 'Deleting…' : 'Delete'}</button>
-                  </div>
+        <p className="text-xs text-brand-text-muted">
+          Used by {assignedProfiles.length === 0
+            ? <span className="text-brand-text">no profiles</span>
+            : <span className="text-brand-text">{assignedProfiles.join(', ')}</span>}.
+        </p>
+        {!confirmingDelete
+          ? (
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(true)}
+                className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
+              >Delete app…</button>
+            )
+          : (
+              <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-3 space-y-3">
+                {assignedProfiles.length > 0
+                  ? (
+                      <p className="text-sm text-red-800">
+                        This app is currently assigned to{' '}
+                        <strong>{assignedProfiles.length} profile{assignedProfiles.length === 1 ? '' : 's'}</strong>
+                        {' '}({assignedProfiles.join(', ')}).
+                        Deleting it will remove those assignments. Continue?
+                      </p>
+                    )
+                  : (
+                      <p className="text-sm text-red-800">
+                        Delete <strong>{detail.app.name}</strong>? This cannot be undone.
+                      </p>
+                    )}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingDelete(false)}
+                    disabled={deleting}
+                    className="flex-1 py-2 rounded-lg bg-brand-alt text-brand-text text-sm font-medium disabled:opacity-50"
+                  >Cancel</button>
+                  <button
+                    type="button"
+                    onClick={performDelete}
+                    disabled={deleting}
+                    className="flex-1 py-2 rounded-lg bg-red-500 text-brand-ink text-sm font-semibold disabled:opacity-50"
+                  >{deleting ? 'Deleting…' : 'Delete'}</button>
                 </div>
-              )}
-        </div>
+              </div>
+            )}
+      </div>
 
-        <div className="flex gap-3 pt-2">
-          <button type="button" onClick={onClose} disabled={saving}
-            className="flex-1 py-3 rounded-xl bg-brand-alt text-brand-text font-medium disabled:opacity-50">
-            Close
-          </button>
-          <button type="submit" disabled={saving}
-            className="flex-1 py-3 rounded-xl bg-brand-accent text-white font-semibold disabled:opacity-50">
-            {saving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
-      </form>
       {pickerOpen && (
         <RecentApexPicker
-          existingHosts={form.hosts}
+          existingHosts={hosts}
           onClose={() => setPickerOpen(false)}
           onAdd={addFromPicker}
         />
       )}
-    </Modal>
+    </div>
   )
+}
+
+// #1003 — per-field save status. "Unsaved" while a change is queued/in flight,
+// "Saved just now" transiently after a successful write, "Save failed" + Retry
+// on error. Mirrors the profile-subsection autosave indicators (#973).
+function SaveStatusBadge({ save, testId }: {
+  save: { status: SaveStatus; dirty: boolean; error: string | null; retry: () => Promise<void> }
+  testId: string
+}) {
+  const { status, dirty, error, retry } = save
+  if (status === 'error') {
+    return (
+      <span className="inline-flex items-center gap-2">
+        <span data-testid={testId} data-status="error" title={error ?? ''} className="text-xs text-red-700">
+          Save failed
+        </span>
+        <button
+          type="button"
+          onClick={() => { void retry() }}
+          className="text-xs font-medium text-red-700 bg-red-500/10 px-2.5 py-1 rounded-lg hover:bg-red-500/20"
+        >Retry</button>
+      </span>
+    )
+  }
+  if (status === 'saving') {
+    return <span data-testid={testId} data-status="saving" className="text-xs text-brand-text-muted">Saving…</span>
+  }
+  if (status === 'saved') {
+    return <span data-testid={testId} data-status="saved" className="text-xs text-brand-accent">Saved just now</span>
+  }
+  if (dirty) {
+    return <span data-testid={testId} data-status="dirty" className="text-xs text-brand-text-muted">Unsaved</span>
+  }
+  return <span data-testid={testId} data-status="idle" className="text-xs text-transparent select-none">·</span>
 }
 
 function Field({ label, required, children }: {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -717,15 +717,15 @@ export interface CreateAppRequest {
   hosts: string[]
 }
 
-export interface UpdateAppRequest {
-  name: string
+// #999/#1003 — field-scoped partial update for PATCH /apps/:id. Omitted keys
+// are untouched; `null` clears a nullable field; `hosts` is a full replace
+// (matches PUT /apps/:id/hosts). `slug` is immutable post-create.
+export interface PatchAppRequest {
+  name?: string
   icon?: string | null
   iconType?: IconType
   templateId?: number | null
-}
-
-export interface SetAppHostsRequest {
-  hosts: string[]
+  hosts?: string[]
 }
 
 // #766 — recently-visited apex picker payload. One row per PSL-collapsed


### PR DESCRIPTION
Closes #1003.

## Summary
- Replaces the Apps edit modal + explicit Save with an **inline expanded-row editor**. Clicking an app row expands it in place; there is no Save button on edit.
- **Per-field autosave via `PATCH /api/apps/:id`** (the endpoint + symmetric App shapes from #999/#1016):
  - **Name** and **icon** autosave on a ~600ms debounce.
  - **Hosts** autosave on each add/remove with full-replace semantics (matching the old `PUT /apps/:id/hosts`).
- Each field shows an **Unsaved → Saving… → Saved just now** indicator; on failure it shows an inline **Save failed + Retry**, and the dirty value stays in the form so Retry re-sends it.
- The **create flow stays explicit** (modal + Create App button) and never autosaves.
- `useDebouncedSave` gains an additive `dirty` flag (drives the Unsaved indicator) and `retry()` (re-runs the last failed save) — reused, not forked, so the profile subsections (#973–#977) are unaffected.
- The web client swaps `apps.update` (PUT) + `apps.setHosts` (PUT) for a single `apps.patch` (PATCH); the now-unused `UpdateAppRequest` / `SetAppHostsRequest` shapes are removed.

## Test plan
- [x] `vitest run` (node 22) — full web suite green (307 tests).
- [x] New `AppsPage.test.tsx` specs (red→green visible in history):
  - [x] Renaming autosaves a debounced PATCH; shows Unsaved then Saved just now; no Save button.
  - [x] Changing icon (URL / favicon tabs) autosaves `{icon, iconType}`.
  - [x] Adding / removing a host autosaves the full host list.
  - [x] Save failure surfaces error + Retry; dirty value persists; Retry re-sends and succeeds.
  - [x] Create flow round-trips via POST and never PATCHes.
- [x] `npm run type-check` and `npm run lint` clean.