### PR TITLE
web: autosave Devices, Users & Household edit forms (#995)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,7 +8,7 @@ import type {
   RecentApexesResponse, RouterSummary, SetAppHostsRequest, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
-  UpdateAppRequest, UpdateHouseholdSettingsRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
+  UpdateAppRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesResponse, User,
 } from '@/types/api'
 
@@ -166,8 +166,6 @@ export const api = {
   // ── Household settings (#334) ──────────────────────────────────────────
   household: {
     get: () => req<HouseholdSettings>('GET', '/household/settings'),
-    update: (data: UpdateHouseholdSettingsRequest) =>
-      req<void>('PUT', '/household/settings', data),
     patch: (data: Record<string, unknown>) =>
       req<void>('PATCH', '/household/settings', data),
   },

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   DashboardNow, DashboardStats, Device,
   CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   ConnectionEventSeriesPage, QueryLogPage,
+  PatchUserRequest,
   RecentApexesResponse, RouterSummary, SetAppHostsRequest, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
@@ -127,6 +128,9 @@ export const api = {
     list: () => req<User[]>('GET', '/users'),
     create: (data: CreateUserRequest) =>
       req<{ id: number }>('POST', '/users', data),
+    // #997 / #1001: field-scoped partial update (username / role / profileIds).
+    patch: (id: number, data: PatchUserRequest) =>
+      req<void>('PATCH', `/users/${id}`, data),
     setProfiles: (id: number, profileIds: number[]) =>
       req<void>('PUT', `/users/${id}/profiles`, { profileIds } as SetUserProfilesRequest),
     delete: (id: number) => req<void>('DELETE', `/users/${id}`),

--- a/web/src/components/SaveStatusBadge.tsx
+++ b/web/src/components/SaveStatusBadge.tsx
@@ -1,0 +1,47 @@
+import type { SaveStatus } from '@/hooks/useDebouncedSave'
+
+// #995: shared autosave indicator. 'dirty' (debounce pending) and 'saving'
+// (in-flight) both communicate "not yet saved"; 'saved' is transient; 'error'
+// optionally renders an inline Retry. The dirty value lives in the form's own
+// state, so Retry just re-commits it.
+export function SaveStatusBadge({
+  status, error, testId, onRetry,
+}: {
+  status: SaveStatus
+  error: string | null
+  testId: string
+  onRetry?: () => void
+}) {
+  if (status === 'dirty') {
+    return <span data-testid={testId} data-status="dirty" className="text-xs text-brand-text-muted">Unsaved</span>
+  }
+  if (status === 'saving') {
+    return <span data-testid={testId} data-status="saving" className="text-xs text-brand-text-muted">Saving…</span>
+  }
+  if (status === 'saved') {
+    return <span data-testid={testId} data-status="saved" className="text-xs text-brand-accent">Saved just now</span>
+  }
+  if (status === 'error') {
+    return (
+      <span
+        data-testid={testId}
+        data-status="error"
+        className="inline-flex items-center gap-1.5 text-xs text-red-700"
+        title={error ?? ''}
+      >
+        Save failed
+        {onRetry && (
+          <button
+            type="button"
+            data-testid={`${testId}-retry`}
+            onClick={onRetry}
+            className="underline hover:no-underline font-medium"
+          >
+            Retry
+          </button>
+        )}
+      </span>
+    )
+  }
+  return <span data-testid={testId} data-status="idle" className="text-xs text-transparent select-none">·</span>
+}

--- a/web/src/hooks/useDebouncedSave.ts
+++ b/web/src/hooks/useDebouncedSave.ts
@@ -1,11 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
 
-export type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+// 'dirty' covers the debounce window (a change is pending but not yet sent);
+// 'saving' is the in-flight request. The UI groups both under an "Unsaved"
+// affordance (#995). 'saved' is transient and decays back to 'idle'.
+export type SaveStatus = 'idle' | 'dirty' | 'saving' | 'saved' | 'error'
 
 export interface UseDebouncedSave {
   status: SaveStatus
   error: string | null
   flush: () => Promise<void>
+  // #995: re-attempt the last value after a failed save without losing the
+  // dirty form value. The form keeps the value in its own state, so retrying
+  // just re-commits the current value.
+  retry: () => Promise<void>
 }
 
 // #973: debounce field changes into a single save. Tracks the LATEST baseline
@@ -47,7 +54,7 @@ export function useDebouncedSave<T>(
       // If newer changes came in while saving, leave them for the next tick.
       if (pendingRef.current != null && !eq(pendingRef.current, v)) {
         // pendingRef holds the latest value; let the effect re-schedule.
-        setStatus('idle')
+        setStatus('dirty')
       } else {
         setStatus('saved')
         if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
@@ -60,8 +67,14 @@ export function useDebouncedSave<T>(
   }
 
   useEffect(() => {
-    if (eq(value, baselineRef.current)) return
+    if (eq(value, baselineRef.current)) {
+      // Reverted back to the saved value before the debounce fired — drop the
+      // pending "Unsaved" state. The cleanup below already cleared the timer.
+      setStatus(s => (s === 'dirty' ? 'idle' : s))
+      return
+    }
     pendingRef.current = value
+    setStatus('dirty')
     if (timerRef.current) clearTimeout(timerRef.current)
     timerRef.current = setTimeout(() => {
       const v = pendingRef.current
@@ -90,5 +103,35 @@ export function useDebouncedSave<T>(
     }
   }
 
-  return { status, error, flush }
+  async function retry() {
+    if (status !== 'error') return
+    await commit(value)
+  }
+
+  return { status, error, flush, retry }
+}
+
+// #995: aggregate several field-level save states into one section-level
+// indicator (e.g. an Admin card with three independently-saving fields).
+// Precedence: any in-flight → 'saving'; else any pending → 'dirty'; else any
+// failed → 'error'; else any recently-saved → 'saved'; else 'idle'. `retry`
+// re-attempts every errored field; `error` surfaces the first failure.
+export function mergeSaveStatus(
+  parts: ReadonlyArray<{ status: SaveStatus; error: string | null; retry: () => Promise<void> }>,
+): { status: SaveStatus; error: string | null; retry: () => Promise<void> } {
+  const has = (s: SaveStatus) => parts.some(p => p.status === s)
+  const status: SaveStatus = has('saving')
+    ? 'saving'
+    : has('dirty')
+      ? 'dirty'
+      : has('error')
+        ? 'error'
+        : has('saved')
+          ? 'saved'
+          : 'idle'
+  const error = parts.find(p => p.status === 'error')?.error ?? null
+  const retry = async () => {
+    await Promise.all(parts.filter(p => p.status === 'error').map(p => p.retry()))
+  }
+  return { status, error, retry }
 }

--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('@/api/client', () => ({
@@ -26,9 +26,9 @@ const DEFAULT_UMM: UnmanagedMacPolicy = { policy: 'allow', blockPage: true }
 
 beforeEach(() => {
   vi.resetAllMocks()
-  // Server-of-record: simulates the live API. `update` mutates this and
-  // `get` reads from it, so tests exercise the real round-trip the UI does
-  // (PUT, then re-GET to refresh the summary — #571).
+  // Server-of-record: simulates the live API. `patch` deep-merges into this
+  // and `get` reads from it, so tests exercise the real round-trip the
+  // autosave UI does (PATCH a single field, then re-GET to reconcile).
   let stored: HouseholdSettings = {
     dailyResetTime: '00:00',
     dailyResetTz: 'America/Los_Angeles',
@@ -41,15 +41,6 @@ beforeEach(() => {
       heartbeatFilter: { ...stored.heartbeatFilter },
       unmanagedMacPolicy: { ...stored.unmanagedMacPolicy },
     }),
-  )
-  ;(api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-    async (next: HouseholdSettings) => {
-      stored = {
-        ...next,
-        heartbeatFilter: { ...next.heartbeatFilter },
-        unmanagedMacPolicy: { ...next.unmanagedMacPolicy },
-      }
-    },
   )
   ;(api.household.patch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
     async (patch: Partial<HouseholdSettings>) => {
@@ -66,348 +57,135 @@ beforeEach(() => {
   )
 })
 
-// Per-test override helper for the initial server state.
-function seedServer(s: Partial<HouseholdSettings>) {
-  (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-    dailyResetTime: '00:00',
-    dailyResetTz: 'America/Los_Angeles',
-    heartbeatFilter: { ...DEFAULT_HF },
-    unmanagedMacPolicy: { ...DEFAULT_UMM },
-    ...s,
-  })
-}
-
-describe('AdminPage — daily reset card', () => {
-  it('defaults to collapsed summary view with current values', async () => {
+describe('AdminPage — daily reset autosave (#1002)', () => {
+  it('renders live time + tz inputs, no Edit/Save/Cancel buttons', async () => {
     render(<AdminPage />)
-    const summary = await screen.findByTestId('household-summary')
-    expect(summary).toHaveTextContent(/Resets daily at 12:00 AM/i)
-    expect(summary).toHaveTextContent('America/Los_Angeles')
-    // Form inputs are hidden in viewing state
-    expect(screen.queryByTestId('household-reset-time')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('household-save')).not.toBeInTheDocument()
-  })
-
-  it('formats 13:30 as "1:30 PM" in the summary', async () => {
-    seedServer({ dailyResetTime: '13:30', dailyResetTz: 'America/New_York' })
-    render(<AdminPage />)
-    const summary = await screen.findByTestId('household-summary')
-    expect(summary).toHaveTextContent(/Resets daily at 1:30 PM/i)
-    expect(summary).toHaveTextContent('America/New_York')
-  })
-
-  it('clicking Edit opens the form pre-filled with current values', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
-
-    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
+    const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
     expect(time.value).toBe('00:00')
-    expect(screen.getByTestId('household-save')).toBeInTheDocument()
-    expect(screen.getByTestId('household-cancel')).toBeInTheDocument()
-    expect(screen.queryByTestId('household-summary')).not.toBeInTheDocument()
+    expect(screen.getByTestId('household-reset-tz-select')).toBeInTheDocument()
+    expect(screen.queryByTestId('household-edit')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('household-save')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('household-cancel')).not.toBeInTheDocument()
   })
 
-  it('saving calls api.household.update and collapses back to the summary with new values', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
+  it('editing the reset time fires a debounced PATCH {dailyResetTime}', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(<AdminPage />)
+      const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
 
-    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
-    await user.clear(time)
-    await user.type(time, '06:00')
+      await user.clear(time)
+      await user.type(time, '06:00')
+      expect(api.household.patch).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(700)
 
-    await user.click(screen.getByTestId('household-save'))
-
-    await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '06:00',
-        dailyResetTz: 'America/Los_Angeles',
-        heartbeatFilter: DEFAULT_HF,
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
-    )
-    const summary = await screen.findByTestId('household-summary')
-    expect(summary).toHaveTextContent(/Resets daily at 6:00 AM/i)
-    expect(screen.queryByTestId('household-reset-time')).not.toBeInTheDocument()
+      expect(api.household.patch).toHaveBeenCalledWith({ dailyResetTime: '06:00' })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it('cancel returns to the summary without persisting changes', async () => {
+  it('changing the timezone fires PATCH {dailyResetTz}', async () => {
     const user = userEvent.setup()
     render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
-
-    const time = screen.getByTestId('household-reset-time') as HTMLInputElement
-    await user.clear(time)
-    await user.type(time, '06:00')
-
-    await user.click(screen.getByTestId('household-cancel'))
-
-    expect(api.household.update).not.toHaveBeenCalled()
-    const summary = await screen.findByTestId('household-summary')
-    // Summary still shows original value
-    expect(summary).toHaveTextContent(/Resets daily at 12:00 AM/i)
-
-    // Re-opening edit shows original (not dirty) value
-    await user.click(screen.getByTestId('household-edit'))
-    expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('00:00')
-  })
-
-  it('(#571) changing the TZ in the dropdown persists it via update', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
+    await screen.findByTestId('household-reset-time')
 
     const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
     await user.selectOptions(tzSelect, 'America/New_York')
 
-    await user.click(screen.getByTestId('household-save'))
-
     await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '00:00',
-        dailyResetTz: 'America/New_York',
-        heartbeatFilter: DEFAULT_HF,
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
+      expect(api.household.patch).toHaveBeenCalledWith({ dailyResetTz: 'America/New_York' }),
     )
   })
 
-  it('(#571) filter that narrows to one option then click persists it', async () => {
-    // Repro of the on-device bug: operator picks "More…", types a filter
-    // that narrows to a single match, clicks it, hits Save. Pre-fix the
-    // controlled <select>'s value never updated because the lone <option>
-    // was already the browser's de-facto selection, so no `change` fired.
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
+  it('PATCH failure surfaces error + Retry; dirty value retained; Retry re-sends', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      (api.household.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('boom from server'),
+      )
+      render(<AdminPage />)
+      const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
 
-    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
-    await user.selectOptions(tzSelect, '__more__')
+      await user.clear(time)
+      await user.type(time, '06:00')
+      await vi.advanceTimersByTimeAsync(700)
 
-    const filterInput = screen.getByTestId('household-reset-tz-filter')
-    await user.type(filterInput, 'Denver')
+      const status = screen.getByTestId('household-save-status')
+      await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
+      expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('06:00')
 
-    const expanded = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
-    await user.selectOptions(expanded, 'America/Denver')
-
-    await user.click(screen.getByTestId('household-save'))
-
-    await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '00:00',
-        dailyResetTz: 'America/Denver',
-        heartbeatFilter: DEFAULT_HF,
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
-    )
-  })
-
-  it('(#571) picking a non-common TZ via "More…" expander persists it', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
-
-    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
-    await user.selectOptions(tzSelect, '__more__')
-
-    const expanded = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
-    await user.selectOptions(expanded, 'Europe/London')
-
-    await user.click(screen.getByTestId('household-save'))
-
-    await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '00:00',
-        dailyResetTz: 'Europe/London',
-        heartbeatFilter: DEFAULT_HF,
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
-    )
-  })
-
-  it('(#571) summary after save reflects what the server returns, not the local form', async () => {
-    // Simulate a server that silently drops dailyResetTz (the suspected
-    // shape of bug #571). The UI must surface the server-of-record value,
-    // not the user's typed-in value, so the operator sees the persistence
-    // failure rather than a false confirmation.
-    (api.household.update as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
-      async (next: { dailyResetTime: string }) => {
-        // Pretend server only persisted the time, ignoring the tz.
-        (api.household.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-          dailyResetTime: next.dailyResetTime,
-          dailyResetTz: 'America/Los_Angeles',
-          heartbeatFilter: { ...DEFAULT_HF },
-          unmanagedMacPolicy: { ...DEFAULT_UMM },
-        })
-      },
-    )
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
-
-    const tzSelect = screen.getByTestId('household-reset-tz-select') as HTMLSelectElement
-    await user.selectOptions(tzSelect, 'America/New_York')
-    await user.click(screen.getByTestId('household-save'))
-
-    const summary = await screen.findByTestId('household-summary')
-    // Surfaces the dropped value: America/Los_Angeles, NOT America/New_York.
-    expect(summary).toHaveTextContent('America/Los_Angeles')
-  })
-
-  it('keeps the form open and shows an error when the API rejects', async () => {
-    (api.household.update as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error('boom from server'),
-    )
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('household-summary')
-    await user.click(screen.getByTestId('household-edit'))
-    await user.click(screen.getByTestId('household-save'))
-
-    expect(await screen.findByText(/boom from server/i)).toBeInTheDocument()
-    // Still in editing state
-    expect(screen.getByTestId('household-reset-time')).toBeInTheDocument()
-    expect(screen.queryByTestId('household-summary')).not.toBeInTheDocument()
+      await user.click(screen.getByTestId('household-save-status-retry'))
+      await waitFor(() => expect(api.household.patch).toHaveBeenCalledTimes(2))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 
-describe('AdminPage — heartbeat filter card', () => {
-  it('summary shows "Disabled" when filter is off', async () => {
+describe('AdminPage — heartbeat filter autosave (#1002)', () => {
+  it('renders live enabled + bytes controls, no Save button', async () => {
     render(<AdminPage />)
-    const summary = await screen.findByTestId('heartbeat-filter-summary')
-    expect(summary).toHaveTextContent(/Disabled/i)
-  })
-
-  it('summary shows thresholds when filter is enabled', async () => {
-    seedServer({
-      heartbeatFilter: { enabled: true, bytesThreshold: 4096, heartbeatHostPatterns: [] },
-    })
-    render(<AdminPage />)
-    const summary = await screen.findByTestId('heartbeat-filter-summary')
-    expect(summary).toHaveTextContent(/Enabled/i)
-    expect(summary).toHaveTextContent('4096')
-  })
-
-  it('clicking Edit opens the form pre-filled with current values', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('heartbeat-filter-summary')
-    await user.click(screen.getByTestId('heartbeat-filter-edit'))
-
-    const enabled = screen.getByTestId('heartbeat-filter-enabled') as HTMLInputElement
+    const enabled = await screen.findByTestId('heartbeat-filter-enabled') as HTMLInputElement
     const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
     expect(enabled.checked).toBe(false)
     expect(bytes.value).toBe('2048')
+    expect(screen.queryByTestId('heartbeat-filter-save')).not.toBeInTheDocument()
   })
 
-  it('toggle + save sends the right body and the summary reflects the GET reconcile', async () => {
+  it('toggling enabled fires PATCH {heartbeatFilter:{enabled}}', async () => {
     const user = userEvent.setup()
     render(<AdminPage />)
-    await screen.findByTestId('heartbeat-filter-summary')
-    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+    await screen.findByTestId('heartbeat-filter-enabled')
 
     await user.click(screen.getByTestId('heartbeat-filter-enabled'))
-    await user.click(screen.getByTestId('heartbeat-filter-save'))
 
     await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '00:00',
-        dailyResetTz: 'America/Los_Angeles',
-        heartbeatFilter: { enabled: true, bytesThreshold: 2048, heartbeatHostPatterns: [] },
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
+      expect(api.household.patch).toHaveBeenCalledWith({ heartbeatFilter: { enabled: true } }),
     )
-    const summary = await screen.findByTestId('heartbeat-filter-summary')
-    expect(summary).toHaveTextContent(/Enabled/i)
-    expect(summary).toHaveTextContent('2048')
   })
 
-  it('threshold edits round-trip via update + re-GET', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('heartbeat-filter-summary')
-    await user.click(screen.getByTestId('heartbeat-filter-edit'))
+  it('editing the bytes threshold fires PATCH {heartbeatFilter:{bytesThreshold}}', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(<AdminPage />)
+      const bytes = await screen.findByTestId('heartbeat-filter-bytes') as HTMLInputElement
 
-    await user.click(screen.getByTestId('heartbeat-filter-enabled'))
-    const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
-    await user.clear(bytes)
-    await user.type(bytes, '8192')
+      await user.clear(bytes)
+      await user.type(bytes, '8192')
+      await vi.advanceTimersByTimeAsync(700)
 
-    await user.click(screen.getByTestId('heartbeat-filter-save'))
-
-    await waitFor(() =>
-      expect(api.household.update).toHaveBeenCalledWith({
-        dailyResetTime: '00:00',
-        dailyResetTz: 'America/Los_Angeles',
-        heartbeatFilter: { enabled: true, bytesThreshold: 8192, heartbeatHostPatterns: [] },
-        unmanagedMacPolicy: DEFAULT_UMM,
-      }),
-    )
-    const summary = await screen.findByTestId('heartbeat-filter-summary')
-    expect(summary).toHaveTextContent('8192')
+      expect(api.household.patch).toHaveBeenCalledWith({
+        heartbeatFilter: { bytesThreshold: 8192 },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
-
-  it('cancel discards local changes', async () => {
-    const user = userEvent.setup()
-    render(<AdminPage />)
-    await screen.findByTestId('heartbeat-filter-summary')
-    await user.click(screen.getByTestId('heartbeat-filter-edit'))
-
-    const bytes = screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement
-    await user.clear(bytes)
-    await user.type(bytes, '9999')
-    await user.click(screen.getByTestId('heartbeat-filter-cancel'))
-
-    expect(api.household.update).not.toHaveBeenCalled()
-    const summary = await screen.findByTestId('heartbeat-filter-summary')
-    expect(summary).toHaveTextContent(/Disabled/i)
-
-    // Re-opening edit shows server value, not the dirty form.
-    await user.click(screen.getByTestId('heartbeat-filter-edit'))
-    expect((screen.getByTestId('heartbeat-filter-bytes') as HTMLInputElement).value).toBe('2048')
-  })
-
 })
 
-// #961 — admin control surface for the unmanagedMacPolicy field.
-describe('AdminPage — unmanaged-MAC policy card', () => {
-  it('summary defaults to "Allow by default"', async () => {
-    render(<AdminPage />)
-    const summary = await screen.findByTestId('unmanaged-mac-policy-summary')
-    expect(summary).toHaveTextContent(/Allow by default/i)
-  })
-
-  it('summary shows "Block by default" when policy is block', async () => {
-    seedServer({ unmanagedMacPolicy: { policy: 'block', blockPage: true } })
-    render(<AdminPage />)
-    const summary = await screen.findByTestId('unmanaged-mac-policy-summary')
-    expect(summary).toHaveTextContent(/Block by default/i)
-    expect(summary).toHaveTextContent(/block page/i)
-  })
-
-  it('switching to block persists via PATCH and updates the summary', async () => {
+describe('AdminPage — unmanaged-MAC policy autosave (#1002)', () => {
+  it('selecting block fires PATCH {unmanagedMacPolicy:{policy}}', async () => {
     const user = userEvent.setup()
     render(<AdminPage />)
-    await screen.findByTestId('unmanaged-mac-policy-summary')
-    await user.click(screen.getByTestId('unmanaged-mac-policy-edit'))
+    await screen.findByTestId('unmanaged-mac-policy-block')
 
     await user.click(screen.getByTestId('unmanaged-mac-policy-block'))
-    await user.click(screen.getByTestId('unmanaged-mac-policy-save'))
 
     await waitFor(() =>
       expect(api.household.patch).toHaveBeenCalledWith({
-        unmanagedMacPolicy: { policy: 'block', blockPage: true },
+        unmanagedMacPolicy: { policy: 'block' },
       }),
     )
-    const summary = await screen.findByTestId('unmanaged-mac-policy-summary')
-    expect(summary).toHaveTextContent(/Block by default/i)
+  })
+
+  it('block-page checkbox is disabled while policy is allow', async () => {
+    render(<AdminPage />)
+    const card = await screen.findByTestId('unmanaged-mac-policy-card')
+    const blockPage = within(card).getByTestId('unmanaged-mac-policy-block-page') as HTMLInputElement
+    expect(blockPage.disabled).toBe(true)
   })
 })

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -1,17 +1,13 @@
 import { useEffect, useState } from 'react'
 import { api } from '@/api/client'
-import type { HeartbeatFilter, HouseholdSettings, UnmanagedMacPolicy } from '@/types/api'
+import type { HouseholdSettings, UnmanagedMacPolicy } from '@/types/api'
 import { TimezonePicker } from '@/components/TimezonePicker'
 import { PageLoader } from './DashboardPage'
+import { useDebouncedSave, mergeSaveStatus } from '@/hooks/useDebouncedSave'
+import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 
-function formatResetTime(hhmm: string): string {
-  const [hStr, mStr] = hhmm.split(':')
-  const h = Number(hStr)
-  const m = Number(mStr)
-  if (!Number.isFinite(h) || !Number.isFinite(m)) return hhmm
-  const period = h < 12 ? 'AM' : 'PM'
-  const display = h % 12 === 0 ? 12 : h % 12
-  return `${display}:${String(m).padStart(2, '0')} ${period}`
+function sameStrList(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((x, i) => x === b[i])
 }
 
 export function AdminPage() {
@@ -24,6 +20,13 @@ export function AdminPage() {
       .finally(() => setLoading(false))
   }, [])
 
+  // After any subsection autosave, re-read the server-of-record so a silently
+  // dropped field (#571) snaps back to its persisted value rather than showing
+  // a false confirmation.
+  async function reload() {
+    setHs(await api.household.get())
+  }
+
   if (loading) return <PageLoader />
 
   return (
@@ -33,9 +36,9 @@ export function AdminPage() {
         <p className="text-sm text-brand-text-muted mt-1">Settings that apply to the whole household.</p>
       </div>
 
-      {hs && <DailyResetCard value={hs} onSaved={setHs} />}
-      {hs && <HeartbeatFilterCard value={hs} onSaved={setHs} />}
-      {hs && <UnmanagedMacPolicyCard value={hs} onSaved={setHs} />}
+      {hs && <DailyResetCard value={hs} reload={reload} />}
+      {hs && <HeartbeatFilterCard value={hs} reload={reload} />}
+      {hs && <UnmanagedMacPolicyCard value={hs} reload={reload} />}
     </div>
   )
 }
@@ -45,44 +48,31 @@ export function AdminPage() {
 // enforcement of `block` is deferred behind Gate 2 (#654); for v1 this just
 // persists the policy + drives the in-SPA "Unmanaged Devices" copy.
 function UnmanagedMacPolicyCard({
-  value, onSaved,
+  value, reload,
 }: {
   value: HouseholdSettings
-  onSaved: (next: HouseholdSettings) => void
+  reload: () => Promise<void>
 }) {
-  const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState<UnmanagedMacPolicy>(value.unmanagedMacPolicy)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [policy, setPolicy] = useState<UnmanagedMacPolicy['policy']>(value.unmanagedMacPolicy.policy)
+  const [blockPage, setBlockPage] = useState(value.unmanagedMacPolicy.blockPage)
+  useEffect(() => { setPolicy(value.unmanagedMacPolicy.policy) }, [value.unmanagedMacPolicy.policy])
+  useEffect(() => { setBlockPage(value.unmanagedMacPolicy.blockPage) }, [value.unmanagedMacPolicy.blockPage])
 
-  function startEdit() {
-    setForm(value.unmanagedMacPolicy)
-    setError(null)
-    setEditing(true)
-  }
-
-  function cancel() {
-    setForm(value.unmanagedMacPolicy)
-    setError(null)
-    setEditing(false)
-  }
-
-  async function save() {
-    setSaving(true)
-    setError(null)
-    try {
-      await api.household.patch({ unmanagedMacPolicy: form })
-      const fresh = await api.household.get()
-      onSaved(fresh)
-      setEditing(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const ump = value.unmanagedMacPolicy
+  const policySave = useDebouncedSave(
+    policy,
+    async (next) => {
+      await api.household.patch({ unmanagedMacPolicy: { policy: next } })
+      await reload()
+    },
+  )
+  const blockPageSave = useDebouncedSave(
+    blockPage,
+    async (next) => {
+      await api.household.patch({ unmanagedMacPolicy: { blockPage: next } })
+      await reload()
+    },
+  )
+  const merged = mergeSaveStatus([policySave, blockPageSave])
 
   return (
     <div
@@ -91,165 +81,105 @@ function UnmanagedMacPolicyCard({
     >
       <div className="flex items-center justify-between gap-3">
         <h2 className="font-bold text-brand-ink">Unmanaged devices</h2>
-        {!editing && (
-          <button
-            type="button"
-            onClick={startEdit}
-            data-testid="unmanaged-mac-policy-edit"
-            className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
-          >
-            Edit
-          </button>
-        )}
+        <SaveStatusBadge
+          testId="unmanaged-mac-policy-save-status"
+          status={merged.status}
+          error={merged.error}
+          onRetry={merged.retry}
+        />
       </div>
 
-      {!editing ? (
-        <p data-testid="unmanaged-mac-policy-summary" className="text-sm text-brand-text">
-          {ump.policy === 'block' ? (
-            <>
-              <span className="font-medium text-brand-ink">Block by default</span>
-              {' — unmanaged MACs are denied egress'}
-              {ump.blockPage ? ' and land on the block page.' : '.'}
-            </>
-          ) : (
-            <>
-              <span className="font-medium text-brand-ink">Allow by default</span>
-              {' — unmanaged MACs flow freely; you still get an alert.'}
-            </>
-          )}
-        </p>
-      ) : (
-        <div className="space-y-3">
-          <p className="text-xs text-brand-text">
-            Applied to any MAC that connects to the network without being assigned to a profile.
-            When set to "block" the API marks the device manual-blocked in the next router
-            snapshot, so the existing per-MAC enforcement path applies — no router code change
-            needed.
-          </p>
-          {error && (
-            <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
-              {error}
-            </div>
-          )}
-          <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm text-brand-ink">
-              <input
-                type="radio"
-                name="unmanaged-mac-policy"
-                value="allow"
-                checked={form.policy === 'allow'}
-                onChange={() => setForm({ ...form, policy: 'allow' })}
-                data-testid="unmanaged-mac-policy-allow"
-              />
-              Allow unmanaged MACs (default; alert-only)
-            </label>
-            <label className="flex items-center gap-2 text-sm text-brand-ink">
-              <input
-                type="radio"
-                name="unmanaged-mac-policy"
-                value="block"
-                checked={form.policy === 'block'}
-                onChange={() => setForm({ ...form, policy: 'block' })}
-                data-testid="unmanaged-mac-policy-block"
-              />
-              Block unmanaged MACs
-            </label>
-          </div>
-          <label className="flex items-center gap-2 text-sm text-brand-ink">
-            <input
-              type="checkbox"
-              checked={form.blockPage}
-              disabled={form.policy !== 'block'}
-              onChange={e => setForm({ ...form, blockPage: e.target.checked })}
-              data-testid="unmanaged-mac-policy-block-page"
-              className="h-4 w-4"
-            />
-            Show block page (HTTP/80 DNATs to the "device not enrolled" page)
-          </label>
-          <div className="flex gap-3 pt-1">
-            <button
-              type="button"
-              onClick={cancel}
-              disabled={saving}
-              data-testid="unmanaged-mac-policy-cancel"
-              className="px-4 py-2 rounded-lg bg-brand-alt text-brand-text text-sm font-medium disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              disabled={saving}
-              data-testid="unmanaged-mac-policy-save"
-              className="px-4 py-2 rounded-lg bg-brand-accent text-white text-sm font-semibold disabled:opacity-50"
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </button>
-          </div>
-        </div>
-      )}
+      <p className="text-xs text-brand-text">
+        Applied to any MAC that connects to the network without being assigned to a profile.
+        When set to "block" the API marks the device manual-blocked in the next router
+        snapshot, so the existing per-MAC enforcement path applies — no router code change
+        needed.
+      </p>
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm text-brand-ink">
+          <input
+            type="radio"
+            name="unmanaged-mac-policy"
+            value="allow"
+            checked={policy === 'allow'}
+            onChange={() => setPolicy('allow')}
+            data-testid="unmanaged-mac-policy-allow"
+          />
+          Allow unmanaged MACs (default; alert-only)
+        </label>
+        <label className="flex items-center gap-2 text-sm text-brand-ink">
+          <input
+            type="radio"
+            name="unmanaged-mac-policy"
+            value="block"
+            checked={policy === 'block'}
+            onChange={() => setPolicy('block')}
+            data-testid="unmanaged-mac-policy-block"
+          />
+          Block unmanaged MACs
+        </label>
+      </div>
+      <label className="flex items-center gap-2 text-sm text-brand-ink">
+        <input
+          type="checkbox"
+          checked={blockPage}
+          disabled={policy !== 'block'}
+          onChange={e => setBlockPage(e.target.checked)}
+          data-testid="unmanaged-mac-policy-block-page"
+          className="h-4 w-4"
+        />
+        Show block page (HTTP/80 DNATs to the "device not enrolled" page)
+      </label>
     </div>
   )
 }
 
 function HeartbeatFilterCard({
-  value, onSaved,
+  value, reload,
 }: {
   value: HouseholdSettings
-  onSaved: (next: HouseholdSettings) => void
+  reload: () => Promise<void>
 }) {
-  const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState<HeartbeatFilter>(value.heartbeatFilter)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [enabled, setEnabled] = useState(value.heartbeatFilter.enabled)
+  const [bytes, setBytes] = useState(value.heartbeatFilter.bytesThreshold)
+  const [hosts, setHosts] = useState<string[]>(value.heartbeatFilter.heartbeatHostPatterns)
+  useEffect(() => { setEnabled(value.heartbeatFilter.enabled) }, [value.heartbeatFilter.enabled])
+  useEffect(() => { setBytes(value.heartbeatFilter.bytesThreshold) }, [value.heartbeatFilter.bytesThreshold])
+  useEffect(
+    () => { setHosts(value.heartbeatFilter.heartbeatHostPatterns) },
+    [value.heartbeatFilter.heartbeatHostPatterns],
+  )
 
-  function startEdit() {
-    setForm(value.heartbeatFilter)
-    setError(null)
-    setEditing(true)
-  }
+  const bytesValid = Number.isFinite(bytes) && bytes >= 0
 
-  function cancel() {
-    setForm(value.heartbeatFilter)
-    setError(null)
-    setEditing(false)
-  }
-
-  const validationError: string | null = (() => {
-    if (!Number.isFinite(form.bytesThreshold) || form.bytesThreshold < 0) {
-      return 'Bytes threshold must be ≥ 0.'
-    }
-    return null
-  })()
-
-  async function save() {
-    if (validationError) return
-    setSaving(true)
-    setError(null)
-    try {
-      await api.household.update({
-        dailyResetTime: value.dailyResetTime,
-        dailyResetTz: value.dailyResetTz,
+  const enabledSave = useDebouncedSave(
+    enabled,
+    async (next) => {
+      await api.household.patch({ heartbeatFilter: { enabled: next } })
+      await reload()
+    },
+  )
+  const bytesSave = useDebouncedSave(
+    bytes,
+    async (next) => {
+      if (!Number.isFinite(next) || next < 0) throw new Error('Bytes threshold must be ≥ 0.')
+      await api.household.patch({ heartbeatFilter: { bytesThreshold: Math.trunc(next) } })
+      await reload()
+    },
+  )
+  const hostsSave = useDebouncedSave(
+    hosts,
+    async (next) => {
+      await api.household.patch({
         heartbeatFilter: {
-          enabled: form.enabled,
-          bytesThreshold: Math.trunc(form.bytesThreshold),
-          heartbeatHostPatterns: form.heartbeatHostPatterns
-            .map(p => p.trim())
-            .filter(p => p.length > 0),
+          heartbeatHostPatterns: next.map(p => p.trim()).filter(p => p.length > 0),
         },
-        unmanagedMacPolicy: value.unmanagedMacPolicy,
       })
-      const fresh = await api.household.get()
-      onSaved(fresh)
-      setEditing(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const hf = value.heartbeatFilter
+      await reload()
+    },
+    { equals: sameStrList },
+  )
+  const merged = mergeSaveStatus([enabledSave, bytesSave, hostsSave])
 
   return (
     <div
@@ -258,178 +188,98 @@ function HeartbeatFilterCard({
     >
       <div className="flex items-center justify-between gap-3">
         <h2 className="font-bold text-brand-ink">Heartbeat filter</h2>
-        {!editing && (
-          <button
-            type="button"
-            onClick={startEdit}
-            data-testid="heartbeat-filter-edit"
-            className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
-          >
-            Edit
-          </button>
-        )}
+        <SaveStatusBadge
+          testId="heartbeat-filter-save-status"
+          status={merged.status}
+          error={merged.error}
+          onRetry={merged.retry}
+        />
       </div>
 
-      {!editing ? (
-        <div className="space-y-1">
-          <p data-testid="heartbeat-filter-summary" className="text-sm text-brand-text">
-            {hf.enabled ? (
-              <>
-                <span className="font-medium text-brand-ink">Enabled</span>
-                {' — bytes ≥ '}
-                <span className="font-mono text-brand-ink">{hf.bytesThreshold}</span>
-              </>
-            ) : (
-              <span className="font-medium text-brand-ink">Disabled</span>
-            )}
-          </p>
-          <p
-            data-testid="heartbeat-filter-hosts-summary"
-            className="text-xs text-brand-text-muted"
-          >
-            {hf.heartbeatHostPatterns.length} host pattern
-            {hf.heartbeatHostPatterns.length === 1 ? '' : 's'}
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          <p className="text-xs text-brand-text">
-            Excludes low-traffic background "heartbeat" rows from device/profile screen-time
-            totals. A row is classified as a heartbeat when its bytes/minute is below the
-            configured floor.
-          </p>
-          {error && (
-            <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
-              {error}
-            </div>
-          )}
-          {validationError && (
-            <div
-              data-testid="heartbeat-filter-validation"
-              className="bg-amber-500/10 border border-amber-500/30 text-amber-700 text-sm rounded-xl px-4 py-2"
-            >
-              {validationError}
-            </div>
-          )}
-          <label className="flex items-center gap-2 text-sm text-brand-ink">
-            <input
-              type="checkbox"
-              checked={form.enabled}
-              onChange={e => setForm({ ...form, enabled: e.target.checked })}
-              data-testid="heartbeat-filter-enabled"
-              className="h-4 w-4"
-            />
-            Filter enabled
-          </label>
-          <div className="flex flex-wrap gap-3 items-end">
-            <div>
-              <label className="block text-xs text-brand-text-muted mb-1">Bytes/min threshold</label>
-              <input
-                type="number"
-                min={0}
-                step={1}
-                value={form.bytesThreshold}
-                onChange={e => setForm({ ...form, bytesThreshold: Number(e.target.value) })}
-                data-testid="heartbeat-filter-bytes"
-                className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm w-32"
-              />
-            </div>
-          </div>
-          <div>
-            <label className="block text-xs text-brand-text-muted mb-1">
-              Host allowlist (one pattern per line — `*.foo.com` or `foo.com`)
-            </label>
-            <textarea
-              value={form.heartbeatHostPatterns.join('\n')}
-              onChange={e =>
-                setForm({
-                  ...form,
-                  heartbeatHostPatterns: e.target.value.split(/\r?\n/),
-                })
-              }
-              data-testid="heartbeat-filter-hosts"
-              rows={8}
-              spellCheck={false}
-              className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-xs font-mono w-full"
-            />
-            <p className="text-xs text-brand-text-muted mt-1">
-              Rows whose host matches any pattern are classified as heartbeats regardless of
-              bytes / active fraction.
-            </p>
-          </div>
-          <div className="flex gap-3 pt-1">
-            <button
-              type="button"
-              onClick={cancel}
-              disabled={saving}
-              data-testid="heartbeat-filter-cancel"
-              className="px-4 py-2 rounded-lg bg-brand-alt text-brand-text text-sm font-medium disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              disabled={saving || validationError !== null}
-              data-testid="heartbeat-filter-save"
-              className="px-4 py-2 rounded-lg bg-brand-accent text-white text-sm font-semibold disabled:opacity-50"
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </button>
-          </div>
+      <p className="text-xs text-brand-text">
+        Excludes low-traffic background "heartbeat" rows from device/profile screen-time
+        totals. A row is classified as a heartbeat when its bytes/minute is below the
+        configured floor.
+      </p>
+      {!bytesValid && (
+        <div
+          data-testid="heartbeat-filter-validation"
+          className="bg-amber-500/10 border border-amber-500/30 text-amber-700 text-sm rounded-xl px-4 py-2"
+        >
+          Bytes threshold must be ≥ 0.
         </div>
       )}
+      <label className="flex items-center gap-2 text-sm text-brand-ink">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={e => setEnabled(e.target.checked)}
+          data-testid="heartbeat-filter-enabled"
+          className="h-4 w-4"
+        />
+        Filter enabled
+      </label>
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-brand-text-muted mb-1">Bytes/min threshold</label>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={bytes}
+            onChange={e => setBytes(Number(e.target.value))}
+            data-testid="heartbeat-filter-bytes"
+            className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm w-32"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-xs text-brand-text-muted mb-1">
+          Host allowlist (one pattern per line — `*.foo.com` or `foo.com`)
+        </label>
+        <textarea
+          value={hosts.join('\n')}
+          onChange={e => setHosts(e.target.value.split(/\r?\n/))}
+          data-testid="heartbeat-filter-hosts"
+          rows={8}
+          spellCheck={false}
+          className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-xs font-mono w-full"
+        />
+        <p className="text-xs text-brand-text-muted mt-1">
+          Rows whose host matches any pattern are classified as heartbeats regardless of
+          bytes / active fraction.
+        </p>
+      </div>
     </div>
   )
 }
 
 function DailyResetCard({
-  value, onSaved,
+  value, reload,
 }: {
   value: HouseholdSettings
-  onSaved: (next: HouseholdSettings) => void
+  reload: () => Promise<void>
 }) {
-  const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState<HouseholdSettings>(value)
-  const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [time, setTime] = useState(value.dailyResetTime)
+  const [tz, setTz] = useState(value.dailyResetTz)
+  useEffect(() => { setTime(value.dailyResetTime) }, [value.dailyResetTime])
+  useEffect(() => { setTz(value.dailyResetTz) }, [value.dailyResetTz])
 
-  function startEdit() {
-    setForm(value)
-    setError(null)
-    setEditing(true)
-  }
-
-  function cancel() {
-    setForm(value)
-    setError(null)
-    setEditing(false)
-  }
-
-  async function save() {
-    setSaving(true)
-    setError(null)
-    try {
-      await api.household.update({
-        dailyResetTime: form.dailyResetTime,
-        dailyResetTz: form.dailyResetTz,
-        heartbeatFilter: value.heartbeatFilter,
-        unmanagedMacPolicy: value.unmanagedMacPolicy,
-      })
-      // Re-read from the server so the summary reflects what was actually
-      // persisted, not just the local form. Without this, a server that
-      // silently dropped a field (e.g. a route handler ignoring dailyResetTz)
-      // would still show the new value in the UI and confuse the operator
-      // (#571).
-      const fresh = await api.household.get()
-      onSaved(fresh)
-      setEditing(false)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save')
-    } finally {
-      setSaving(false)
-    }
-  }
+  const timeSave = useDebouncedSave(
+    time,
+    async (next) => {
+      await api.household.patch({ dailyResetTime: next })
+      await reload()
+    },
+  )
+  const tzSave = useDebouncedSave(
+    tz,
+    async (next) => {
+      await api.household.patch({ dailyResetTz: next })
+      await reload()
+    },
+  )
+  const merged = mergeSaveStatus([timeSave, tzSave])
 
   return (
     <div
@@ -438,78 +288,39 @@ function DailyResetCard({
     >
       <div className="flex items-center justify-between gap-3">
         <h2 className="font-bold text-brand-ink">Daily reset</h2>
-        {!editing && (
-          <button
-            type="button"
-            onClick={startEdit}
-            data-testid="household-edit"
-            className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
-          >
-            Edit
-          </button>
-        )}
+        <SaveStatusBadge
+          testId="household-save-status"
+          status={merged.status}
+          error={merged.error}
+          onRetry={merged.retry}
+        />
       </div>
 
-      {!editing ? (
-        <p data-testid="household-summary" className="text-sm text-brand-text">
-          Resets daily at{' '}
-          <span className="font-medium text-brand-ink">{formatResetTime(value.dailyResetTime)}</span>{' '}
-          (<span className="font-mono text-brand-text">{value.dailyResetTz}</span>)
-        </p>
-      ) : (
-        <div className="space-y-3">
-          <p className="text-xs text-brand-text">
-            The wall-clock time at which daily usage limits reset. Both the reset time and
-            timezone are stored together — the reset always fires at the configured local clock
-            time, even across DST.
-          </p>
-          {error && (
-            <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
-              {error}
-            </div>
-          )}
-          <div className="flex flex-wrap gap-3 items-end">
-            <div>
-              <label className="block text-xs text-brand-text-muted mb-1">Reset time</label>
-              <input
-                type="time"
-                value={form.dailyResetTime}
-                onChange={e => setForm({ ...form, dailyResetTime: e.target.value })}
-                data-testid="household-reset-time"
-                className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm"
-              />
-            </div>
-            <div className="flex-1 min-w-[14rem]">
-              <label className="block text-xs text-brand-text-muted mb-1">Timezone</label>
-              <TimezonePicker
-                value={form.dailyResetTz}
-                onChange={tz => setForm({ ...form, dailyResetTz: tz })}
-                testId="household-reset-tz"
-              />
-            </div>
-          </div>
-          <div className="flex gap-3 pt-1">
-            <button
-              type="button"
-              onClick={cancel}
-              disabled={saving}
-              data-testid="household-cancel"
-              className="px-4 py-2 rounded-lg bg-brand-alt text-brand-text text-sm font-medium disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={save}
-              disabled={saving}
-              data-testid="household-save"
-              className="px-4 py-2 rounded-lg bg-brand-accent text-white text-sm font-semibold disabled:opacity-50"
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </button>
-          </div>
+      <p className="text-xs text-brand-text">
+        The wall-clock time at which daily usage limits reset. Both the reset time and
+        timezone are stored together — the reset always fires at the configured local clock
+        time, even across DST.
+      </p>
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label className="block text-xs text-brand-text-muted mb-1">Reset time</label>
+          <input
+            type="time"
+            value={time}
+            onChange={e => setTime(e.target.value)}
+            data-testid="household-reset-time"
+            className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm"
+          />
         </div>
-      )}
+        <div className="flex-1 min-w-[14rem]">
+          <label className="block text-xs text-brand-text-muted mb-1">Timezone</label>
+          <TimezonePicker
+            value={tz}
+            onChange={setTz}
+            testId="household-reset-tz"
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -119,15 +119,97 @@ describe('DevicesPage — add', () => {
   })
 })
 
-describe('DevicesPage — edit', () => {
-  it('pre-fills modal with existing device values', async () => {
+describe('DevicesPage — inline autosave edit (#1000)', () => {
+  const mac = 'aa:bb:cc:dd:ee:01'
+
+  it('expands an inline editor pre-filled with the device values; no Save button', async () => {
     const user = userEvent.setup()
     renderPage()
-    const ipadRow = await screen.findByTestId('device-row-aa:bb:cc:dd:ee:01')
+    const ipadRow = await screen.findByTestId(`device-row-${mac}`)
     await user.click(within(ipadRow).getByRole('button', { name: /Edit/ }))
 
-    expect(screen.getByDisplayValue('aa:bb:cc:dd:ee:01')).toBeInTheDocument()
-    expect(screen.getByDisplayValue("Kid's iPad")).toBeInTheDocument()
+    const editor = await screen.findByTestId(`device-editor-${mac}`)
+    expect(within(editor).getByDisplayValue("Kid's iPad")).toBeInTheDocument()
+    expect(
+      (within(editor).getByTestId(`device-profile-select-${mac}`) as HTMLSelectElement).value,
+    ).toBe('1')
+    // Autosave: no explicit Save button on the edit affordance.
+    expect(within(editor).queryByRole('button', { name: /^Save$/ })).not.toBeInTheDocument()
+  })
+
+  it('renaming fires a single debounced PATCH {name} and shows "Saved just now"', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      renderPage()
+      const ipadRow = await screen.findByTestId(`device-row-${mac}`)
+      await user.click(within(ipadRow).getByRole('button', { name: /Edit/ }))
+      const editor = await screen.findByTestId(`device-editor-${mac}`)
+      const input = within(editor).getByTestId(`device-name-input-${mac}`)
+
+      await user.clear(input)
+      await user.type(input, 'Living Room iPad')
+      expect(api.devices.patch).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(api.devices.patch).toHaveBeenCalledTimes(1)
+      expect(api.devices.patch).toHaveBeenCalledWith(mac, { name: 'Living Room iPad' })
+      await waitFor(() =>
+        expect(within(editor).getByTestId(`device-save-status-${mac}`)).toHaveAttribute(
+          'data-status',
+          'saved',
+        ),
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reassigning the profile inline fires PATCH {profileId}', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      renderPage()
+      const ipadRow = await screen.findByTestId(`device-row-${mac}`)
+      await user.click(within(ipadRow).getByRole('button', { name: /Edit/ }))
+      const editor = await screen.findByTestId(`device-editor-${mac}`)
+
+      await user.selectOptions(within(editor).getByTestId(`device-profile-select-${mac}`), '2')
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(api.devices.patch).toHaveBeenCalledWith(mac, { profileId: 2 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('PATCH failure surfaces inline error + Retry; dirty value retained; Retry re-sends', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      (api.devices.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('boom'),
+      )
+      renderPage()
+      const ipadRow = await screen.findByTestId(`device-row-${mac}`)
+      await user.click(within(ipadRow).getByRole('button', { name: /Edit/ }))
+      const editor = await screen.findByTestId(`device-editor-${mac}`)
+      const input = within(editor).getByTestId(`device-name-input-${mac}`)
+
+      await user.clear(input)
+      await user.type(input, 'Den iPad')
+      await vi.advanceTimersByTimeAsync(700)
+
+      const status = within(editor).getByTestId(`device-save-status-${mac}`)
+      await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
+      expect(input).toHaveValue('Den iPad') // dirty value preserved
+
+      await user.click(within(editor).getByTestId(`device-save-status-${mac}-retry`))
+      await waitFor(() => expect(api.devices.patch).toHaveBeenCalledTimes(2))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/web/src/pages/DevicesPage.tsx
+++ b/web/src/pages/DevicesPage.tsx
@@ -6,7 +6,9 @@ import { useAlerts, useDevices, useHouseholdSettings, useProfiles, useInvalidato
 import { useAuth } from '@/hooks/useAuth'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
 import { useNotificationPermission } from '@/hooks/useNotifyOnNewAlerts'
+import { useDebouncedSave, mergeSaveStatus } from '@/hooks/useDebouncedSave'
 import { EmptyState } from '@/components/EmptyState'
+import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import type { Alert, Device, PatchDeviceRequest, ProfileDetail } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 
@@ -42,9 +44,12 @@ export function DevicesPage() {
   const profiles = profilesQuery.data ?? []
   const unmanagedPolicy = householdQuery.data?.unmanagedMacPolicy
   const loading  = devicesQuery.isPending || profilesQuery.isPending
+  // Modal is create-only now (#1000): "Add Device" and "Enroll" unmanaged.
+  // Editing a known device happens inline on its row, autosaved per field.
   const [editing,  setEditing]  = useState<Device | null>(null)
   useEscapeClose(() => setEditing(null), editing !== null)
   const [form,     setForm]     = useState({ mac: '', name: '', profileId: 0 })
+  const [editingMac, setEditingMac] = useState<string | null>(null)
   const highlightMac = useHighlightFromQuery(devices)
 
   const upsertMutation = useMutation({
@@ -100,27 +105,33 @@ export function DevicesPage() {
         {knownDevices.length === 0
           ? <EmptyState title="No devices yet." />
           : knownDevices.map(d => (
-              <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`flex items-center gap-4 px-5 py-4 border-b border-brand-border last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-brand-accent/60 ring-inset' : ''}`}>
-                <Link to={`/devices/${encodeURIComponent(d.mac)}/timeline`} className="flex-1 min-w-0 hover:text-brand-accent transition-colors" data-testid={`device-timeline-link-${d.mac}`}>
-                  <p className="font-medium text-brand-ink truncate">{d.name}</p>
-                  <p className="text-xs text-brand-text-muted font-mono">{d.mac}</p>
-                </Link>
-                <div className="hidden sm:block text-sm">
-                  <span className="bg-brand-accent/10 text-brand-accent border border-brand-accent/20 px-2 py-1 rounded-lg text-xs">
-                    {d.profileName ?? 'No profile'}
-                  </span>
-                </div>
-                {isAdmin && (
-                  <div className="flex gap-2 shrink-0">
-                    <button
-                      onClick={() => { setEditing(d); setForm({ mac: d.mac, name: d.name, profileId: d.profileId ?? profiles[0]?.profile.id ?? 0 }) }}
-                      className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
-                    >Edit</button>
-                    <button
-                      onClick={() => del(d.mac)}
-                      className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
-                    >Remove</button>
+              <div key={d.mac} data-testid={`device-row-${d.mac}`} className={`px-5 py-4 border-b border-brand-border last:border-0 transition-shadow ${highlightMac === d.mac ? 'ring-2 ring-brand-accent/60 ring-inset' : ''}`}>
+                <div className="flex items-center gap-4">
+                  <Link to={`/devices/${encodeURIComponent(d.mac)}/timeline`} className="flex-1 min-w-0 hover:text-brand-accent transition-colors" data-testid={`device-timeline-link-${d.mac}`}>
+                    <p className="font-medium text-brand-ink truncate">{d.name}</p>
+                    <p className="text-xs text-brand-text-muted font-mono">{d.mac}</p>
+                  </Link>
+                  <div className="hidden sm:block text-sm">
+                    <span className="bg-brand-accent/10 text-brand-accent border border-brand-accent/20 px-2 py-1 rounded-lg text-xs">
+                      {d.profileName ?? 'No profile'}
+                    </span>
                   </div>
+                  {isAdmin && (
+                    <div className="flex gap-2 shrink-0">
+                      <button
+                        onClick={() => setEditingMac(m => (m === d.mac ? null : d.mac))}
+                        aria-expanded={editingMac === d.mac}
+                        className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
+                      >{editingMac === d.mac ? 'Done' : 'Edit'}</button>
+                      <button
+                        onClick={() => del(d.mac)}
+                        className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
+                      >Remove</button>
+                    </div>
+                  )}
+                </div>
+                {isAdmin && editingMac === d.mac && (
+                  <DeviceRowEditor device={d} profiles={profiles} onClose={() => setEditingMac(null)} />
                 )}
               </div>
             ))
@@ -183,7 +194,7 @@ export function DevicesPage() {
       {editing && (
         <div className="fixed inset-0 bg-black/70 flex items-end sm:items-center justify-center z-50 p-4">
           <div className="bg-white rounded-2xl border border-brand-border-strong w-full max-w-sm p-6 space-y-4">
-            <h3 className="text-lg font-bold text-brand-ink">{form.mac ? 'Edit Device' : 'Add Device'}</h3>
+            <h3 className="text-lg font-bold text-brand-ink">{form.mac ? 'Enroll Device' : 'Add Device'}</h3>
             <Field label="MAC Address" value={form.mac} onChange={v => setForm(f => ({...f, mac: v}))} placeholder="aa:bb:cc:dd:ee:ff" mono />
             <Field label="Name" value={form.name} onChange={v => setForm(f => ({...f, name: v}))} placeholder="Kid's iPad" />
             <div>
@@ -200,6 +211,87 @@ export function DevicesPage() {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// #1000 — inline, per-field autosave editor for a known device. Name and
+// profile each debounce-PATCH /devices/:mac independently; the row's status
+// badge aggregates both fields and offers Retry on failure. No Save button.
+function DeviceRowEditor({
+  device, profiles, onClose,
+}: {
+  device: Device
+  profiles: ProfileDetail[]
+  onClose: () => void
+}) {
+  const invalidators = useInvalidators()
+  const [name, setName] = useState(device.name)
+  const [profileId, setProfileId] = useState<number | null>(device.profileId)
+  useEffect(() => { setName(device.name) }, [device.name])
+  useEffect(() => { setProfileId(device.profileId) }, [device.profileId])
+
+  const nameSave = useDebouncedSave(
+    name,
+    async (next: string) => {
+      const trimmed = next.trim()
+      if (!trimmed) throw new Error('Name is required')
+      await api.devices.patch(device.mac, { name: trimmed })
+      await invalidators.deviceMutated()
+    },
+    { key: device.mac },
+  )
+
+  const profileSave = useDebouncedSave(
+    profileId,
+    async (next: number | null) => {
+      await api.devices.patch(device.mac, { profileId: next })
+      await invalidators.deviceMutated()
+    },
+    { key: device.mac },
+  )
+
+  const merged = mergeSaveStatus([nameSave, profileSave])
+
+  return (
+    <div
+      data-testid={`device-editor-${device.mac}`}
+      className="mt-3 pt-3 border-t border-brand-border flex flex-wrap items-end gap-3"
+    >
+      <div className="flex-1 min-w-[12rem]">
+        <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          data-testid={`device-name-input-${device.mac}`}
+          className="w-full bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-2.5 text-brand-ink focus:outline-none focus:border-brand-accent"
+        />
+      </div>
+      <div className="min-w-[10rem]">
+        <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-1">Profile</label>
+        <select
+          value={profileId ?? ''}
+          onChange={e => setProfileId(e.target.value === '' ? null : Number(e.target.value))}
+          data-testid={`device-profile-select-${device.mac}`}
+          className="w-full bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-2.5 text-brand-ink"
+        >
+          {profiles.map(p => <option key={p.profile.id} value={p.profile.id}>{p.profile.name}</option>)}
+        </select>
+      </div>
+      <div className="flex items-center gap-3 pb-2.5">
+        <SaveStatusBadge
+          status={merged.status}
+          error={merged.error}
+          testId={`device-save-status-${device.mac}`}
+          onRetry={merged.retry}
+        />
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
+        >Done</button>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -5,6 +5,7 @@ import { api } from '@/api/client'
 import { useProfiles, useDevices, useInvalidators, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
+import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import type {
   AppDetail, AppMode, AppPolicyAssignment,
   CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
@@ -878,8 +879,8 @@ function ProfileShellRow({
 // Subsection is collapsed-by-default. Collapsed header carries the at-a-
 // glance summary: "Daily limit: X min" + one row per schedule. Expanded body
 // holds the editable inputs (daily cap, schedules editor, overlap radios).
-// SaveStatus + the SaveStatusBadge component are imported from the shared
-// useDebouncedSave hook (#973).
+// SaveStatus comes from the shared useDebouncedSave hook; SaveStatusBadge is
+// the shared component in components/SaveStatusBadge.tsx (#973, #995).
 
 interface TimeFormState {
   timeLimit: string
@@ -1708,26 +1709,6 @@ function Subsection({
     </div>
   )
 }
-
-function SaveStatusBadge({
-  status, error, testId,
-}: { status: SaveStatus; error: string | null; testId: string }) {
-  if (status === 'saving') {
-    return <span data-testid={testId} data-status="saving" className="text-xs text-brand-text-muted">Saving…</span>
-  }
-  if (status === 'saved') {
-    return <span data-testid={testId} data-status="saved" className="text-xs text-brand-accent">Saved</span>
-  }
-  if (status === 'error') {
-    return (
-      <span data-testid={testId} data-status="error" className="text-xs text-red-700" title={error ?? ''}>
-        Save failed
-      </span>
-    )
-  }
-  return <span data-testid={testId} data-status="idle" className="text-xs text-transparent select-none">·</span>
-}
-
 
 // #973 — inline devices editor. Each row toggle issues PATCH /devices/:mac
 // with {profileId} (assign) or {profileId: null} (detach). The status badge

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@/api/client', () => ({
     users: {
       list: vi.fn(),
       create: vi.fn(),
+      patch: vi.fn(),
       setProfiles: vi.fn(),
       delete: vi.fn(),
     },
@@ -38,6 +39,7 @@ beforeEach(() => {
   ;(api.users.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aliceUser, bobUser])
   ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([kidsProfile, adultsProfile])
   ;(api.users.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 99 })
+  ;(api.users.patch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.users.setProfiles as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.users.delete as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
 })
@@ -101,28 +103,104 @@ describe('UsersPage — create flow', () => {
   })
 })
 
-describe('UsersPage — edit profile links', () => {
-  it('opens edit modal pre-selecting current profileIds and calls setProfiles', async () => {
+describe('UsersPage — inline autosave edit (#1001)', () => {
+  it('expands an inline editor pre-filled with username, role, and profiles; no Save button', async () => {
     const user = userEvent.setup()
     render(<UsersPage />)
     await screen.findByText('bob')
 
-    // Find bob's row and click its "Edit profiles" button
     const bobRow = screen.getByTestId('user-row-11')
-    await user.click(within(bobRow).getByRole('button', { name: /edit profiles/i }))
+    await user.click(within(bobRow).getByRole('button', { name: /^edit$/i }))
 
-    // Modal title includes bob
-    await screen.findByText(/Edit profiles · bob/)
+    const editor = await screen.findByTestId('user-editor-11')
+    expect(within(editor).getByDisplayValue('bob')).toBeInTheDocument()
+    // bob is a child, with Kids assigned
+    expect(within(editor).getByRole('button', { name: 'child' })).toBeInTheDocument()
+    expect(within(editor).queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
+  })
 
-    // Toggle: deselect Kids (currently selected), select Adults
-    await user.click(screen.getByRole('button', { name: /✓\s*Kids/ }))
-    await user.click(screen.getByRole('button', { name: 'Adults' }))
+  it('renaming fires a debounced PATCH {username}', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(<UsersPage />)
+      await screen.findByText('bob')
+      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+      const editor = await screen.findByTestId('user-editor-11')
+      const input = within(editor).getByTestId('user-name-input-11')
 
-    await user.click(screen.getByRole('button', { name: /^save$/i }))
+      await user.clear(input)
+      await user.type(input, 'bobby')
+      expect(api.users.patch).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(700)
 
-    await waitFor(() => {
-      expect(api.users.setProfiles).toHaveBeenCalledWith(11, [2])
-    })
+      expect(api.users.patch).toHaveBeenCalledWith(11, { username: 'bobby' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('changing role fires PATCH {role}', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(<UsersPage />)
+      await screen.findByText('bob')
+      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+      const editor = await screen.findByTestId('user-editor-11')
+
+      await user.click(within(editor).getByRole('button', { name: 'adult' }))
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(api.users.patch).toHaveBeenCalledWith(11, { role: 'adult' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('toggling a profile fires PATCH {profileIds} with full-replace semantics', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      render(<UsersPage />)
+      await screen.findByText('bob')
+      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+      const editor = await screen.findByTestId('user-editor-11')
+
+      // bob currently has Kids (1); add Adults (2)
+      await user.click(within(editor).getByRole('button', { name: 'Adults' }))
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(api.users.patch).toHaveBeenCalledWith(11, { profileIds: [1, 2] })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('PATCH failure surfaces inline error + Retry; dirty value retained; Retry re-sends', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    try {
+      (api.users.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
+      render(<UsersPage />)
+      await screen.findByText('bob')
+      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+      const editor = await screen.findByTestId('user-editor-11')
+      const input = within(editor).getByTestId('user-name-input-11')
+
+      await user.clear(input)
+      await user.type(input, 'bobby')
+      await vi.advanceTimersByTimeAsync(700)
+
+      const status = within(editor).getByTestId('user-save-status-11')
+      await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
+      expect(input).toHaveValue('bobby')
+
+      await user.click(within(editor).getByTestId('user-save-status-11-retry'))
+      await waitFor(() => expect(api.users.patch).toHaveBeenCalledTimes(2))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -3,7 +3,17 @@ import { api } from '@/api/client'
 import type { CreateUserRequest, ProfileDetail, User, UserRole } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { useEscapeClose } from '@/hooks/useEscapeClose'
+import { useDebouncedSave, mergeSaveStatus } from '@/hooks/useDebouncedSave'
 import { EmptyState } from '@/components/EmptyState'
+import { SaveStatusBadge } from '@/components/SaveStatusBadge'
+
+// Set-equality for the profileIds replace-set — order from toggling is
+// irrelevant, so the autosave hook should treat [1,2] and [2,1] as equal.
+function sameIdSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false
+  const s = new Set(a)
+  return b.every(x => s.has(x))
+}
 
 const ROLES: UserRole[] = ['admin', 'adult', 'child']
 
@@ -25,8 +35,8 @@ export function UsersPage() {
   const [loadError, setLoadError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
   const [createForm, setCreateForm] = useState<CreateForm>(emptyCreateForm())
+  // Which user row is expanded for inline (autosaved) editing.
   const [editingId, setEditingId] = useState<number | null>(null)
-  const [editProfileIds, setEditProfileIds] = useState<number[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -58,12 +68,6 @@ export function UsersPage() {
     setError(null)
   }
 
-  function startEdit(u: User) {
-    setEditingId(u.id)
-    setEditProfileIds([...u.profileIds])
-    setError(null)
-  }
-
   async function saveCreate() {
     if (!createForm.username.trim()) { setError('Username is required'); return }
     if (!createForm.password) { setError('Password is required'); return }
@@ -81,21 +85,6 @@ export function UsersPage() {
       await reload()
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create user')
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  async function saveEdit() {
-    if (editingId == null) return
-    setSaving(true)
-    setError(null)
-    try {
-      await api.users.setProfiles(editingId, editProfileIds)
-      setEditingId(null)
-      await reload()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to update profiles')
     } finally {
       setSaving(false)
     }
@@ -140,39 +129,45 @@ export function UsersPage() {
           : users.length === 0
           ? <EmptyState title="No users yet." />
           : users.map(u => (
-              <div key={u.id} data-testid={`user-row-${u.id}`} className="flex items-center gap-4 px-5 py-4 border-b border-brand-border last:border-0">
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-brand-ink truncate">{u.username}</p>
-                  <p className="text-xs text-brand-text-muted">
-                    <span className={`inline-block px-2 py-0.5 rounded font-mono mr-2 ${
-                      u.role === 'admin'
-                        ? 'bg-brand-accent/10 text-brand-accent'
-                        : u.role === 'adult'
-                          ? 'bg-blue-500/10 text-blue-700'
-                          : 'bg-amber-500/10 text-amber-700'
-                    }`}>{u.role}</span>
-                  </p>
+              <div key={u.id} data-testid={`user-row-${u.id}`} className="px-5 py-4 border-b border-brand-border last:border-0">
+                <div className="flex items-center gap-4">
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-brand-ink truncate">{u.username}</p>
+                    <p className="text-xs text-brand-text-muted">
+                      <span className={`inline-block px-2 py-0.5 rounded font-mono mr-2 ${
+                        u.role === 'admin'
+                          ? 'bg-brand-accent/10 text-brand-accent'
+                          : u.role === 'adult'
+                            ? 'bg-blue-500/10 text-blue-700'
+                            : 'bg-amber-500/10 text-amber-700'
+                      }`}>{u.role}</span>
+                    </p>
+                  </div>
+                  <div className="hidden sm:flex flex-wrap gap-1 max-w-md justify-end">
+                    {u.profileIds.length === 0
+                      ? <span className="text-xs text-brand-text-muted">No profiles</span>
+                      : u.profileIds.map(pid => (
+                          <span key={pid} className="text-xs bg-brand-alt text-brand-text border border-brand-border-strong px-2 py-1 rounded-lg">
+                            {profileNameById.get(pid) ?? `#${pid}`}
+                          </span>
+                        ))
+                    }
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      onClick={() => setEditingId(id => (id === u.id ? null : u.id))}
+                      aria-expanded={editingId === u.id}
+                      className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
+                    >{editingId === u.id ? 'Done' : 'Edit'}</button>
+                    <button
+                      onClick={() => del(u)}
+                      className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
+                    >Delete</button>
+                  </div>
                 </div>
-                <div className="hidden sm:flex flex-wrap gap-1 max-w-md justify-end">
-                  {u.profileIds.length === 0
-                    ? <span className="text-xs text-brand-text-muted">No profiles</span>
-                    : u.profileIds.map(pid => (
-                        <span key={pid} className="text-xs bg-brand-alt text-brand-text border border-brand-border-strong px-2 py-1 rounded-lg">
-                          {profileNameById.get(pid) ?? `#${pid}`}
-                        </span>
-                      ))
-                  }
-                </div>
-                <div className="flex gap-2 shrink-0">
-                  <button
-                    onClick={() => startEdit(u)}
-                    className="text-xs text-brand-text hover:text-brand-ink bg-brand-alt px-3 py-1.5 rounded-lg transition-colors"
-                  >Edit profiles</button>
-                  <button
-                    onClick={() => del(u)}
-                    className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-1.5 rounded-lg transition-colors"
-                  >Delete</button>
-                </div>
+                {editingId === u.id && (
+                  <UserRowEditor user={u} profiles={profiles} reload={reload} />
+                )}
               </div>
             ))
         }
@@ -230,29 +225,97 @@ export function UsersPage() {
         </Modal>
       )}
 
-      {editingId !== null && (
-        <Modal
-          title={`Edit profiles · ${users.find(u => u.id === editingId)?.username ?? ''}`}
-          onClose={() => setEditingId(null)}
-        >
-          {error && (
-            <div className="bg-red-500/10 border border-red-500/30 text-red-700 text-sm rounded-xl px-4 py-2">
-              {error}
-            </div>
-          )}
-          <ProfilePicker
-            profiles={profiles}
-            selected={editProfileIds}
-            onChange={setEditProfileIds}
-          />
-          <ModalFooter
-            saving={saving}
-            onCancel={() => setEditingId(null)}
-            onSave={saveEdit}
-            saveLabel="Save"
-          />
-        </Modal>
-      )}
+    </div>
+  )
+}
+
+function UserRowEditor({
+  user, profiles, reload,
+}: {
+  user: User
+  profiles: ProfileDetail[]
+  reload: () => Promise<void>
+}) {
+  const [username, setUsername] = useState(user.username)
+  const [role, setRole] = useState<UserRole>(user.role)
+  const [profileIds, setProfileIds] = useState<number[]>(user.profileIds)
+  useEffect(() => { setUsername(user.username) }, [user.username])
+  useEffect(() => { setRole(user.role) }, [user.role])
+  useEffect(() => { setProfileIds(user.profileIds) }, [user.profileIds])
+
+  const nameSave = useDebouncedSave(
+    username,
+    async (next: string) => {
+      const trimmed = next.trim()
+      if (!trimmed) throw new Error('Username is required')
+      await api.users.patch(user.id, { username: trimmed })
+      await reload()
+    },
+    { key: user.id },
+  )
+
+  const roleSave = useDebouncedSave(
+    role,
+    async (next: UserRole) => {
+      await api.users.patch(user.id, { role: next })
+      await reload()
+    },
+    { key: user.id },
+  )
+
+  const profilesSave = useDebouncedSave(
+    profileIds,
+    async (next: number[]) => {
+      await api.users.patch(user.id, { profileIds: next })
+      await reload()
+    },
+    { key: user.id, equals: sameIdSet },
+  )
+
+  const merged = mergeSaveStatus([nameSave, roleSave, profilesSave])
+
+  return (
+    <div data-testid={`user-editor-${user.id}`} className="mt-4 pt-4 border-t border-brand-border space-y-4">
+      <div className="flex items-center justify-between">
+        <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider">Username</label>
+        <SaveStatusBadge
+          testId={`user-save-status-${user.id}`}
+          status={merged.status}
+          error={merged.error}
+          onRetry={merged.retry}
+        />
+      </div>
+      <input
+        type="text"
+        data-testid={`user-name-input-${user.id}`}
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+        className="w-full bg-brand-surface border border-brand-border-strong rounded-xl px-4 py-3 text-brand-ink focus:outline-none focus:border-brand-accent"
+      />
+      <div>
+        <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-2">Role</label>
+        <div className="flex gap-2">
+          {ROLES.map(r => {
+            const on = role === r
+            return (
+              <button key={r} type="button"
+                onClick={() => setRole(r)}
+                className={`text-sm px-4 py-2 rounded-lg border transition-colors ${
+                  on
+                    ? 'bg-brand-accent/20 text-brand-accent border-brand-accent/40'
+                    : 'bg-brand-alt text-brand-text border-brand-border-strong hover:border-brand-border-strong'
+                }`}>
+                {r}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+      <ProfilePicker
+        profiles={profiles}
+        selected={profileIds}
+        onChange={setProfileIds}
+      />
     </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -605,6 +605,15 @@ export interface CreateUserRequest {
   profileIds: number[]
 }
 
+// #997 — field-scoped partial update; the server applies only the keys
+// present. profileIds is replace-set ([] unassigns all). Password changes go
+// through the dedicated change-password endpoint, never here.
+export interface PatchUserRequest {
+  username?: string
+  role?: UserRole
+  profileIds?: number[]
+}
+
 export interface SetUserProfilesRequest {
   profileIds: number[]
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -54,13 +54,6 @@ export interface HouseholdSettings {
   unmanagedMacPolicy: UnmanagedMacPolicy
 }
 
-export interface UpdateHouseholdSettingsRequest {
-  dailyResetTime: string
-  dailyResetTz: string
-  heartbeatFilter: HeartbeatFilter
-  unmanagedMacPolicy: UnmanagedMacPolicy
-}
-
 export interface TimeLimit {
   id: number
   profileId: number


### PR DESCRIPTION
Rolls out the umbrella #995 autosave shape to the three remaining web edit forms whose API prereqs (#996/#997/#998) have merged. Edit forms are now always-live with debounced per-field PATCH and no Save buttons.

Closes #1000
Closes #1001
Closes #1002

## Shape (consistent across all three)
- Debounced per-field/section autosave; no Save/Cancel buttons on edit.
- `SaveStatusBadge` per subsection: "Unsaved" (debounce pending / in-flight) → "Saved just now" (transient) → idle.
- Errors surface inline with **Retry**; the dirty value is retained and Retry re-sends.
- Per-field PATCH under the hood — no PUT-on-keystroke.

## Shared hook consolidation
- Extracted `SaveStatusBadge` into `web/src/components/SaveStatusBadge.tsx` (was inline in `ProfilesPage`).
- Extended `useDebouncedSave` with a `dirty` state, `retry()`, and `mergeSaveStatus()` to aggregate several field saves into one section indicator. Profile (#973-#977) now consumes the shared badge; Apps (#1003) can adopt the same primitives.

## Per resource
- **Devices** (#1000): inline row editor — name + profile, `PATCH /api/devices/:mac`.
- **Users** (#1001): inline row editor — username + role + linked profiles, `PATCH /api/users/:id`. Added the missing `api.users.patch` client method + `PatchUserRequest` type.
- **Household** (#1002): Daily reset, Heartbeat filter, and Unmanaged-MAC policy cards converted from edit/save/cancel to always-live autosave via `PATCH /api/household/settings` (server deep-merges nested subfields). Removed the now-orphaned `api.household.update` PUT method + `UpdateHouseholdSettingsRequest` type.

## TDD
Red→green commits are visible per resource in the branch history (failing vitest committed before each implementation).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src` clean
- [x] `npx vitest run` — 303 passing (node 22)
- [ ] Manual smoke: edit a device/user/household field, confirm debounced PATCH + status badge transitions and inline Retry on a forced failure.