### PR TITLE
feat(openwrt): updateChannel support in wifihaven-update (#772 phase a)

### DIFF
--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -8,6 +8,11 @@ config wifihaven 'wifihaven'
 	# Router UUID returned during enrollment
 	option router_id ''
 
+	# Auto-update channel (#772): 'stable' (default) tracks the highest
+	# non-prerelease v<X.Y.Z> release; 'canary' tracks the openwrt-canary
+	# pre-release, which receives builds during the pre-promotion soak window.
+	option update_channel 'stable'
+
 	# LAN subnet prefix used to identify outbound (egress) flows
 	option lan_prefix '192.168.1.'
 

--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -54,14 +54,42 @@ else
   exit 0
 fi
 
-# Fetch /releases/latest, falling back to the rolling openwrt-latest tag on
-# 404 to keep a fresh repo (no v<X.Y.Z> tag yet) self-healing.
+# Update channel (#772). Default "stable" reproduces the historical
+# behaviour: poll /releases/latest (the highest non-prerelease v<X.Y.Z>).
+# "canary" polls the dedicated openwrt-canary pre-release, which the release
+# pipeline publishes on approval *before* the stable semver tag is cut,
+# giving a soak window for a small cohort. The UCI key is snake_case to
+# match the other wifihaven options; the conceptual/wire name is
+# updateChannel. Unknown/unset values fall back to stable.
+CHANNEL=$(uci -q get wifihaven.wifihaven.update_channel 2>/dev/null || echo stable)
+case "$CHANNEL" in
+  canary) CHANNEL=canary ;;
+  *)      CHANNEL=stable ;;
+esac
+
+# Pick the release endpoint for this channel. stable keeps the baked-in
+# /releases/latest API_URL and 404-falls-back to the rolling openwrt-latest
+# tag so a fresh repo with no v<X.Y.Z> release stays self-healing
+# (TODO(#1170): drop the fallback once the versioned path is universal).
+# canary targets the openwrt-canary pre-release tag; a 404 there means no
+# canary build has been published yet, so we hold on the current version
+# rather than silently dropping back to stable.
+CANARY_TAG=openwrt-canary
+if [ "$CHANNEL" = canary ]; then
+  API_URL="https://api.github.com/repos/wifihaven/wifihaven/releases/tags/$CANARY_TAG"
+fi
+
 HTTP_CODE=$(curl -s -o /tmp/wifihaven-update.meta -w '%{http_code}' "$API_URL" 2>/dev/null || echo "000")
 case "$HTTP_CODE" in
   200)
     META=$(cat /tmp/wifihaven-update.meta)
     ;;
   404)
+    if [ "$CHANNEL" = canary ]; then
+      log "canary channel: $CANARY_TAG not published yet (http 404); staying on current version"
+      rm -f /tmp/wifihaven-update.meta
+      exit 0
+    fi
     log "warn: $API_URL returned 404; falling back to openwrt-latest (TODO(#1170): remove once versioned path is universal)"
     META=$(curl -sf "$FALLBACK_API_URL") || META=
     ;;
@@ -107,6 +135,17 @@ LATEST_URL=
 BEST=$(printf '%s' "$MATCHES" | grep -v '^$' | sort -V -k1,1 | tail -n1)
 if [ -n "$BEST" ]; then
   LATEST_URL=$(printf '%s\n' "$BEST" | awk '{print $2}')
+fi
+
+# On canary, tag_name is the rolling "openwrt-canary" string, not a
+# v<X.Y.Z> — so LATEST_VERSION derived from the tag above is not comparable
+# to the baked VERSION file and would force a reinstall on every cron tick.
+# Derive the comparable version from the selected asset instead
+# (e.g. "0.3.6-1" -> "0.3.6"); consecutive canary builds carry distinct
+# patch numbers (derive-version.sh), so this still detects real changes.
+if [ "$CHANNEL" = canary ] && [ -n "$BEST" ]; then
+  BEST_VER=$(printf '%s\n' "$BEST" | awk '{print $1}')
+  LATEST_VERSION=${BEST_VER%-*}
 fi
 if [ -z "$LATEST_URL" ] || [ -z "$LATEST_VERSION" ]; then
   log "could not resolve asset url / version from release metadata; skipping"

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -49,6 +49,21 @@ grep -q 'releases/tags/openwrt-latest' "$SCRIPT" \
   && check "keeps openwrt-latest as fallback" ok \
   || check "keeps openwrt-latest as fallback" "missing fallback endpoint"
 
+# 4a-i (#772). Reads the update channel from UCI, defaulting to stable.
+grep -q 'uci -q get wifihaven.wifihaven.update_channel' "$SCRIPT" \
+  && check "[#772] reads update_channel from UCI" ok \
+  || check "[#772] reads update_channel from UCI" "no uci update_channel read"
+
+# 4a-ii (#772). Canary channel polls the dedicated openwrt-canary pre-release.
+grep -q 'releases/tags/\$CANARY_TAG\|releases/tags/openwrt-canary' "$SCRIPT" \
+  && check "[#772] canary channel targets openwrt-canary tag" ok \
+  || check "[#772] canary channel targets openwrt-canary tag" "no canary tag endpoint"
+
+# 4a-iii (#772). Unknown/unset channel collapses to stable.
+grep -q 'echo stable' "$SCRIPT" \
+  && check "[#772] update_channel defaults to stable" ok \
+  || check "[#772] update_channel defaults to stable" "no stable default"
+
 # 4b. Persists the last-installed version under /var/lib/wifihaven.
 grep -q 'last_update_version' "$SCRIPT" \
   && check "persists last-installed version under /var/lib/wifihaven" ok \
@@ -225,6 +240,17 @@ EOF
 #!/bin/sh
 printf '%s\n' "\$*" >> "$TESTDIR/initd.calls"
 exit \${MOCK_INITD_EXIT:-0}
+EOF
+
+  # uci mock (#772). Only answers the update_channel query the script makes;
+  # returns $MOCK_CHANNEL (default empty → script's `|| echo stable` applies).
+  # Other queries exit nonzero, matching `uci -q get` on a missing key.
+  cat > "$BINDIR/uci" <<EOF
+#!/bin/sh
+case "\$*" in
+  *update_channel*) [ -n "\${MOCK_CHANNEL:-}" ] && printf '%s\n' "\$MOCK_CHANNEL" || exit 1 ;;
+  *) exit 1 ;;
+esac
 EOF
 
   PATCHED="$TESTDIR/wifihaven-update"
@@ -412,6 +438,70 @@ case "$URL" in
 esac
 rm -rf "$TESTDIR"
 unset MOCK_ASSETS
+
+# ── Channel selection (#772) ──────────────────────────────────────────────
+
+# Case J (#772): canary channel installs from the openwrt-canary pre-release.
+# The canary tag_name is non-semver ("openwrt-canary"), so the comparable
+# version is derived from the selected asset (0.3.0). Installed 0.2.7 → install.
+setup_mocks
+mock_apk
+printf '0.2.7\n' > "$VERS_DIR/VERSION"
+MOCK_CHANNEL=canary MOCK_TAG=openwrt-canary \
+  MOCK_ASSETS='https://example.com/wifihaven_0.3.0-1_all.apk
+https://example.com/wifihaven_0.3.0-1_all.ipk' \
+  PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+URL=$(picked_url)
+case "$URL" in
+  */tags/openwrt-canary*|*wifihaven_0.3.0-1_all.apk) check "[#772 canary] installs canary asset" ok ;;
+  *) check "[#772 canary] installs canary asset" "picked '$URL'" ;;
+esac
+[ "$(stamp_value)" = "0.3.0" ] \
+  && check "[#772 canary] stamp = asset-derived version (not tag_name)" ok \
+  || check "[#772 canary] stamp = asset-derived version (not tag_name)" "stamp = '$(stamp_value)'"
+rm -rf "$TESTDIR"
+
+# Case K (#772): canary no-op — installed == canary asset version → skip,
+# no reinstall on every cron tick despite the rolling non-semver tag_name.
+setup_mocks
+mock_apk
+printf '0.3.0\n' > "$VERS_DIR/VERSION"
+MOCK_CHANNEL=canary MOCK_TAG=openwrt-canary \
+  MOCK_ASSETS='https://example.com/wifihaven_0.3.0-1_all.apk' \
+  PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+N=$(count_restart_calls)
+[ "$N" = "0" ] \
+  && check "[#772 canary no-op] restart NOT called when version matches" ok \
+  || check "[#772 canary no-op] restart NOT called when version matches" "expected 0, got $N"
+rm -rf "$TESTDIR"
+
+# Case L (#772): canary tag 404 → hold on current version, NO fallback to
+# stable / openwrt-latest, no reinstall.
+setup_mocks
+mock_apk
+printf '0.2.7\n' > "$VERS_DIR/VERSION"
+MOCK_CHANNEL=canary MOCK_HTTP_CODE=404 \
+  PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+grep -q 'canary channel: openwrt-canary not published yet' "$TESTDIR/logger.out" \
+  && check "[#772 canary 404] logs not-published-yet and holds" ok \
+  || check "[#772 canary 404] logs not-published-yet and holds" "no canary-404 log"
+N=$(count_restart_calls)
+[ "$N" = "0" ] \
+  && check "[#772 canary 404] does NOT fall back / reinstall" ok \
+  || check "[#772 canary 404] does NOT fall back / reinstall" "expected 0, got $N"
+rm -rf "$TESTDIR"
+unset MOCK_CHANNEL MOCK_TAG MOCK_HTTP_CODE
+
+# Case M (#772): default (no UCI key) behaves as stable — unchanged path,
+# still hits /releases/latest and installs the semver asset.
+setup_mocks
+mock_apk
+printf '0.2.7\n' > "$VERS_DIR/VERSION"
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+[ "$(stamp_value)" = "0.2.8" ] \
+  && check "[#772 default] absent UCI key → stable path (v0.2.8)" ok \
+  || check "[#772 default] absent UCI key → stable path (v0.2.8)" "stamp = '$(stamp_value)'"
+rm -rf "$TESTDIR"
 
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Phase (a) of #772 (canary channel). Adds per-router channel selection to the
OpenWRT auto-updater — **consumer side only**, fully backward-compatible.

- New `update_channel` UCI option in `/etc/config/wifihaven`, default `stable`.
- `wifihaven-update` reads it via `uci -q get wifihaven.wifihaven.update_channel`:
  - **stable** (default): unchanged — `/releases/latest` (highest non-prerelease
    `v<X.Y.Z>`) with the existing `openwrt-latest` 404 fallback.
  - **canary**: polls the `openwrt-canary` pre-release tag. Because that tag's
    `tag_name` is the non-semver rolling string, the comparable version is
    derived from the **selected asset** (`0.3.0-1` → `0.3.0`) instead of the
    tag, so it detects real changes without reinstalling on every cron tick.
    A 404 on the canary tag **holds** on the current version (no silent drop
    back to stable / openwrt-latest).

Default `stable` means **zero behavior change for every existing router** until
an operator opts a router into canary.

### Not in this PR (later #772 phases — see the design comment on #772)
- **(b)** Producer side: publishing to `openwrt-canary` + splitting the
  canary-publish from the stable `v<X.Y.Z>` promotion to create a soak gap.
  Until (b) lands, a canary router 404s and holds — safe no-op.
- **(c)** LuCI settings channel dropdown.

## Test plan
- [x] `sh openwrt/test/update_spec.sh` — 46/46 pass, incl. 5 new canary cases
      (install, no-op, 404-hold, asset-derived version, default-stable) + 3
      static checks.
- [ ] After phase (b) ships, flip the test router (192.168.10.42) to
      `update_channel 'canary'` and confirm it pulls canary ahead of stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)