### PR TITLE
api: pre-attribute owning app(s) at rollup-write time (#1091, PR 2/2)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -40,14 +40,14 @@ object Main extends ZIOAppDefault {
       // on subsequent boots because of ON CONFLICT DO NOTHING.
       hsRepo <- ZIO.service[HouseholdSettingsRepo]
       tz = java.time.ZoneId.systemDefault()
-      _               <- hsRepo.ensureDefault(tz)
-      _               <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
+      _              <- hsRepo.ensureDefault(tz)
+      _              <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       // #768: seed the starter library of app templates. Idempotent — operator
       // host edits on previously-seeded apps are preserved.
-      appRepoForSeed  <- ZIO.service[AppRepo]
-      templates       <- AppTemplates.loadAll()
-      seedSummary     <- AppTemplates.seed(appRepoForSeed, templates)
-      _               <- ZIO.logInfo(
+      appRepoForSeed <- ZIO.service[AppRepo]
+      templates      <- AppTemplates.loadAll()
+      seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
+      _              <- ZIO.logInfo(
         s"app_templates seeded (${templates.size} templates): " +
           s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
           s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated.mkString("[", ",", "]")}, " +
@@ -61,20 +61,20 @@ object Main extends ZIOAppDefault {
       // straight from YAML; remote lists fetch from the declared upstream URL
       // (cached in-memory after first success — see BlocklistCache). REPLACE
       // semantics; remote-fetch failures leave existing DB rows untouched.
-      blRepoForSeed   <- ZIO.service[BlocklistRepo]
-      blCacheForSeed  <- ZIO.service[BlocklistCache]
-      blFetcher       <- ZIO.service[BlocklistFetcher]
-      bundled         <- BundledBlocklists.loadAll()
-      _               <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
-      _               <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+      blRepoForSeed  <- ZIO.service[BlocklistRepo]
+      blCacheForSeed <- ZIO.service[BlocklistCache]
+      blFetcher      <- ZIO.service[BlocklistFetcher]
+      bundled        <- BundledBlocklists.loadAll()
+      _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
+      _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
       // #809: scheduled re-aggregation of traffic_reports into the rollup
       // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
       // re-rolls yesterday + today every hour. Both are forkDaemon so they
       // run for the lifetime of the process and never block startup.
-      rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
-      clockForJobs    <- ZIO.service[Clock]
-      _               <- RollupJobs.hourlyLoop(rollupRepo, clockForJobs).forkDaemon
-      _               <- RollupJobs.dailyLoop(rollupRepo, clockForJobs, tz).forkDaemon
+      rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
+      clockForJobs   <- ZIO.service[Clock]
+      _              <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkDaemon
+      _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkDaemon
       // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
       // a watermarked row; the read path adds a live tail of buckets after the watermark, so
       // /api/time/status/summary serves a rollup + small live aggregation instead of a full

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2297,15 +2297,20 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
             icon_type=${a.iconType}
           WHERE id=${a.id}""".update.run.transact(xa).unit
 
+  // Every host-set mutation bumps the global app_hosts_version so rollup rows
+  // attributed at an older version are detected as stale on read (#1091).
+  private val bumpHostsVersion =
+    sql"UPDATE app_hosts_version SET version = version + 1".update.run
+
   def delete(id: AppId) =
-    sql"DELETE FROM apps WHERE id=$id".update.run.transact(xa).unit
+    (sql"DELETE FROM apps WHERE id=$id".update.run *> bumpHostsVersion).transact(xa).unit
 
   def setHosts(appId: AppId, hosts: List[Hostname]) = {
     val del = sql"DELETE FROM app_hosts WHERE app_id=$appId".update.run
     val ins = hosts.distinct.map(h =>
       sql"INSERT INTO app_hosts(app_id,host) VALUES($appId,$h) ON CONFLICT DO NOTHING".update.run,
     )
-    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa)
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void) *> bumpHostsVersion).transact(xa).unit
   }
 
   def getHosts(appId: AppId) =
@@ -2315,7 +2320,7 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       .transact(xa)
 
   def currentHostsVersion =
-    ZIO.succeed(0L)
+    sql"SELECT version FROM app_hosts_version".query[Long].unique.transact(xa)
 
   def listAllHostMappings =
     sql"SELECT app_id, host FROM app_hosts"

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2214,6 +2214,14 @@ trait AppRepo {
   def getHosts(appId: AppId): Task[List[Hostname]]
 
   /**
+   * Current `app_hosts_version` — a global counter bumped by every host-set mutation ([[setHosts]],
+   * [[delete]]). The rollup writer stamps rolled rows with the value it read here; a read path
+   * compares it against the value stamped on rollup rows to decide whether the pre-attributed
+   * `app_id`s are fresh or must be recomputed in process (#1091).
+   */
+  def currentHostsVersion: Task[Long]
+
+  /**
    * #769: full (host, app_id) inventory across all apps. Used by the group-by-app aggregation paths
    * for Connection Events + Traffic Usage to bucket rows into their owning app, with `__other__`
    * for hosts not in any app. One row per (host, app) pair — a host that's in two apps yields two
@@ -2305,6 +2313,9 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       .query[Hostname]
       .to[List]
       .transact(xa)
+
+  def currentHostsVersion =
+    ZIO.succeed(0L)
 
   def listAllHostMappings =
     sql"SELECT app_id, host FROM app_hosts"

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -31,6 +31,18 @@ case class RollupRow(
     bytesOut: Long,
 )
 
+// Per-app aggregate over a rollup window. `appId = None` is the synthetic
+// "Other" bucket (rows whose host belongs to no app). Mirrors the read-time
+// shape produced by the in-memory HostMatch.lookupApex paths in UsageRoutes,
+// so a caller can swap a SQL `GROUP BY app_id` rollup read for the in-process
+// matcher and get identical numbers.
+case class AppUsageAgg(
+    appId: Option[AppId],
+    activeSeconds: Long,
+    bytesIn: Long,
+    bytesOut: Long,
+)
+
 case class RollupRun(
     id: Long,
     job: String,
@@ -70,15 +82,32 @@ trait RollupRepo {
    * another API instance (skip-this-tick). The lock is acquired transaction-scoped via
    * `pg_try_advisory_xact_lock`, so it auto-releases when the doobie tx commits or rolls back — no
    * manual release path needed and no risk of a stale lock surviving a crash.
+   *
+   * `appsByApex` maps each app-host apex (e.g. `youtube.com`) to the app ids that claim it; it is
+   * applied to every rolled row's hostname via [[wifihaven.shared.types.HostMatch.lookupApex]] (the
+   * canonical matcher) to populate `traffic_hourly_apps`. `version` is the `app_hosts_version` the
+   * snapshot was read at and is stamped onto every rolled row so a later read can detect staleness.
+   * The default empty snapshot leaves rows unattributed (version stamped, no app rows) — used by
+   * the back-compat call sites that don't care about app attribution.
    */
-  def rerollHourly(since: Instant): Task[Option[Int]]
+  def rerollHourly(
+      since: Instant,
+      appsByApex: Map[String, List[AppId]] = Map.empty,
+      version: Long = 0L,
+  ): Task[Option[Int]]
 
   /**
    * Re-aggregate the trailing window of `traffic_reports` into `traffic_daily`. `sinceDate` is the
    * earliest date to re-roll, inclusive. Idempotent via UPSERT. Same advisory-lock contract as
-   * [[rerollHourly]] — `None` means another instance is rolling concurrently.
+   * [[rerollHourly]] — `None` means another instance is rolling concurrently. `appsByApex` /
+   * `version` carry the same app-attribution contract as [[rerollHourly]], writing
+   * `traffic_daily_apps`.
    */
-  def rerollDaily(sinceDate: LocalDate): Task[Option[Int]]
+  def rerollDaily(
+      sinceDate: LocalDate,
+      appsByApex: Map[String, List[AppId]] = Map.empty,
+      version: Long = 0L,
+  ): Task[Option[Int]]
 
   /**
    * Record one tick of a rollup fiber in `rollup_runs` for /api/admin/rollup-status. `error` is set
@@ -116,6 +145,35 @@ trait RollupRepo {
       from: Instant,
       to: Instant,
   ): Task[List[RollupRow]]
+
+  /**
+   * Per-app usage over the hourly rollup in `[from, to)` (#1091). When every in-window row carries
+   * the current `app_hosts_version` (`currentVersion`), aggregates in-database via `GROUP BY
+   * app_id` against `traffic_hourly_apps` — no per-row matching. If any row is stale (version <
+   * current, or never attributed), falls back to reading the rows and re-matching in process with
+   * `appsByApex` via the canonical [[wifihaven.shared.types.HostMatch.lookupApex]] — so an
+   * `app_hosts` edit that bumps the version is reflected immediately instead of serving stale
+   * attribution.
+   *
+   * A host in multiple apps is attributed to the lowest app id (matching the read-time dedup in
+   * `UsageRoutes`), so a row's seconds are never double-counted across apps.
+   */
+  def aggregateByAppHourly(
+      macs: List[MacAddress],
+      from: Instant,
+      to: Instant,
+      currentVersion: Long,
+      appsByApex: Map[String, List[AppId]],
+  ): Task[List[AppUsageAgg]]
+
+  /** Daily-grain counterpart of [[aggregateByAppHourly]]. */
+  def aggregateByAppDaily(
+      macs: List[MacAddress],
+      from: Instant,
+      to: Instant,
+      currentVersion: Long,
+      appsByApex: Map[String, List[AppId]],
+  ): Task[List[AppUsageAgg]]
 }
 
 class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
@@ -164,7 +222,11 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
     tx.transact(xa)
   }
 
-  def rerollHourly(since: Instant): Task[Option[Int]] = {
+  def rerollHourly(
+      since: Instant,
+      appsByApex: Map[String, List[AppId]],
+      version: Long,
+  ): Task[Option[Int]] = {
     val sql =
       resolvedCte ++
         fr"""
@@ -192,7 +254,11 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
     withLock(RollupLockKeys.Hourly)(sql.update.run)
   }
 
-  def rerollDaily(sinceDate: LocalDate): Task[Option[Int]] = {
+  def rerollDaily(
+      sinceDate: LocalDate,
+      appsByApex: Map[String, List[AppId]],
+      version: Long,
+  ): Task[Option[Int]] = {
     val sql =
       resolvedCte ++
         fr"""
@@ -300,4 +366,22 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
       .transact(xa)
       .map(_.filter(r => !r.bucketStart.isBefore(from) && r.bucketStart.isBefore(to)))
   }
+
+  def aggregateByAppHourly(
+      macs: List[MacAddress],
+      from: Instant,
+      to: Instant,
+      currentVersion: Long,
+      appsByApex: Map[String, List[AppId]],
+  ): Task[List[AppUsageAgg]] =
+    ZIO.succeed(Nil)
+
+  def aggregateByAppDaily(
+      macs: List[MacAddress],
+      from: Instant,
+      to: Instant,
+      currentVersion: Long,
+      appsByApex: Map[String, List[AppId]],
+  ): Task[List[AppUsageAgg]] =
+    ZIO.succeed(Nil)
 }

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -1,5 +1,6 @@
 package wifihaven.api.db
 
+import cats.data.NonEmptyList
 import doobie.*
 import doobie.implicits.*
 import doobie.postgres.implicits.*
@@ -8,7 +9,8 @@ import wifihaven.shared.types.*
 import zio.*
 import zio.interop.catz.*
 
-import java.time.{Instant, LocalDate}
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDate, ZoneOffset}
 
 // ── Rollup tables (#809) ────────────────────────────────────────────────────
 //
@@ -227,13 +229,14 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
       appsByApex: Map[String, List[AppId]],
       version: Long,
   ): Task[Option[Int]] = {
-    val sql =
+    val truncSince = since.truncatedTo(ChronoUnit.HOURS)
+    val sql        =
       resolvedCte ++
         fr"""
           AND tr.period_start >= $since
         )
         INSERT INTO traffic_hourly
-          (router_id, mac, hostname, bucket_start, active_seconds, bytes_in, bytes_out, sample_count, rolled_at)
+          (router_id, mac, hostname, bucket_start, active_seconds, bytes_in, bytes_out, sample_count, rolled_at, app_hosts_version)
         SELECT
           router_id, mac, hostname,
           date_trunc('hour', period_start),
@@ -241,17 +244,21 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
           SUM(bytes_in)::BIGINT,
           SUM(bytes_out)::BIGINT,
           COUNT(*)::INT,
-          NOW()
+          NOW(),
+          $version
         FROM resolved
         GROUP BY router_id, mac, hostname, date_trunc('hour', period_start)
         ON CONFLICT (router_id, mac, hostname, bucket_start) DO UPDATE SET
-          active_seconds = EXCLUDED.active_seconds,
-          bytes_in       = EXCLUDED.bytes_in,
-          bytes_out      = EXCLUDED.bytes_out,
-          sample_count   = EXCLUDED.sample_count,
-          rolled_at      = EXCLUDED.rolled_at
+          active_seconds    = EXCLUDED.active_seconds,
+          bytes_in          = EXCLUDED.bytes_in,
+          bytes_out         = EXCLUDED.bytes_out,
+          sample_count      = EXCLUDED.sample_count,
+          rolled_at         = EXCLUDED.rolled_at,
+          app_hosts_version = EXCLUDED.app_hosts_version
         """
-    withLock(RollupLockKeys.Hourly)(sql.update.run)
+    withLock(RollupLockKeys.Hourly)(
+      sql.update.run.flatMap(n => attributeHourly(truncSince, appsByApex, version).map(_ => n)),
+    )
   }
 
   def rerollDaily(
@@ -265,25 +272,100 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
           AND tr.date >= $sinceDate
         )
         INSERT INTO traffic_daily
-          (router_id, mac, hostname, date, active_seconds, bytes_in, bytes_out, sample_count, rolled_at)
+          (router_id, mac, hostname, date, active_seconds, bytes_in, bytes_out, sample_count, rolled_at, app_hosts_version)
         SELECT
           router_id, mac, hostname, date,
           SUM(active_seconds)::INT,
           SUM(bytes_in)::BIGINT,
           SUM(bytes_out)::BIGINT,
           COUNT(*)::INT,
-          NOW()
+          NOW(),
+          $version
         FROM resolved
         GROUP BY router_id, mac, hostname, date
         ON CONFLICT (router_id, mac, hostname, date) DO UPDATE SET
-          active_seconds = EXCLUDED.active_seconds,
-          bytes_in       = EXCLUDED.bytes_in,
-          bytes_out      = EXCLUDED.bytes_out,
-          sample_count   = EXCLUDED.sample_count,
-          rolled_at      = EXCLUDED.rolled_at
+          active_seconds    = EXCLUDED.active_seconds,
+          bytes_in          = EXCLUDED.bytes_in,
+          bytes_out         = EXCLUDED.bytes_out,
+          sample_count      = EXCLUDED.sample_count,
+          rolled_at         = EXCLUDED.rolled_at,
+          app_hosts_version = EXCLUDED.app_hosts_version
         """
-    withLock(RollupLockKeys.Daily)(sql.update.run)
+    withLock(RollupLockKeys.Daily)(
+      sql.update.run.flatMap(n => attributeDaily(sinceDate, appsByApex, version).map(_ => n)),
+    )
   }
+
+  // ── App attribution (#1091) ───────────────────────────────────────────────
+  //
+  // After a reroll stamps `app_hosts_version` on every rolled row, recompute
+  // the owning app(s) for those rows via the canonical HostMatch.lookupApex and
+  // rewrite the side table. A host belonging to N apps fans out to N side rows;
+  // read-time aggregation collapses the fan to the lowest app id. Runs in the
+  // reroll transaction so attribution is atomic with the rollup write.
+
+  private def attributeHourly(
+      truncSince: Instant,
+      appsByApex: Map[String, List[AppId]],
+      version: Long,
+  ): ConnectionIO[Unit] =
+    for {
+      _    <- sql"DELETE FROM traffic_hourly_apps WHERE bucket_start >= $truncSince".update.run
+      rows <-
+        sql"""SELECT router_id, mac, hostname, bucket_start
+              FROM traffic_hourly WHERE bucket_start >= $truncSince"""
+          .query[(RouterId, MacAddress, String, Instant)]
+          .to[List]
+      tuples = rows.flatMap { case (rid, m, h, bs) =>
+        appsFor(h, appsByApex).map(appId => (rid, m, h, bs, appId, version))
+      }
+      _ <- insertHourlyApps(tuples)
+    } yield ()
+
+  private def attributeDaily(
+      sinceDate: LocalDate,
+      appsByApex: Map[String, List[AppId]],
+      version: Long,
+  ): ConnectionIO[Unit] =
+    for {
+      _    <- sql"DELETE FROM traffic_daily_apps WHERE date >= $sinceDate".update.run
+      rows <-
+        sql"""SELECT router_id, mac, hostname, date
+              FROM traffic_daily WHERE date >= $sinceDate"""
+          .query[(RouterId, MacAddress, String, LocalDate)]
+          .to[List]
+      tuples = rows.flatMap { case (rid, m, h, d) =>
+        appsFor(h, appsByApex).map(appId => (rid, m, h, d, appId, version))
+      }
+      _ <- insertDailyApps(tuples)
+    } yield ()
+
+  // All apps owning `host`, deduped. lookupApex returns the apex-form entry the
+  // FQDN belongs to; that bucket may name several apps (the fan).
+  private def appsFor(host: String, appsByApex: Map[String, List[AppId]]): List[AppId] =
+    HostMatch.lookupApex(host, appsByApex).getOrElse(Nil).distinct
+
+  private def insertHourlyApps(
+      tuples: List[(RouterId, MacAddress, String, Instant, AppId, Long)],
+  ): ConnectionIO[Unit] =
+    if (tuples.isEmpty) doobie.free.connection.unit
+    else
+      Update[(RouterId, MacAddress, String, Instant, AppId, Long)](
+        """INSERT INTO traffic_hourly_apps
+             (router_id, mac, hostname, bucket_start, app_id, app_hosts_version)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+      ).updateMany(tuples).map(_ => ())
+
+  private def insertDailyApps(
+      tuples: List[(RouterId, MacAddress, String, LocalDate, AppId, Long)],
+  ): ConnectionIO[Unit] =
+    if (tuples.isEmpty) doobie.free.connection.unit
+    else
+      Update[(RouterId, MacAddress, String, LocalDate, AppId, Long)](
+        """INSERT INTO traffic_daily_apps
+             (router_id, mac, hostname, date, app_id, app_hosts_version)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+      ).updateMany(tuples).map(_ => ())
 
   def recordRun(
       job: String,
@@ -367,14 +449,58 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
       .map(_.filter(r => !r.bucketStart.isBefore(from) && r.bucketStart.isBefore(to)))
   }
 
+  private def macFilter(macs: List[MacAddress]): Fragment =
+    macs match {
+      case Nil => fr""
+      case ms  =>
+        val nel = NonEmptyList.fromListUnsafe(ms.map(_.value))
+        fr"AND " ++ Fragments.in(fr"mac", nel)
+    }
+
   def aggregateByAppHourly(
       macs: List[MacAddress],
       from: Instant,
       to: Instant,
       currentVersion: Long,
       appsByApex: Map[String, List[AppId]],
-  ): Task[List[AppUsageAgg]] =
-    ZIO.succeed(Nil)
+  ): Task[List[AppUsageAgg]] = {
+    val staleSql =
+      fr"""SELECT COUNT(*) FROM traffic_hourly
+           WHERE bucket_start >= $from AND bucket_start < $to
+             AND (app_hosts_version IS NULL OR app_hosts_version < $currentVersion) """ ++
+        macFilter(macs)
+    val freshSql =
+      fr"""SELECT chosen.app_id,
+                  SUM(th.active_seconds)::BIGINT,
+                  SUM(th.bytes_in)::BIGINT,
+                  SUM(th.bytes_out)::BIGINT
+           FROM traffic_hourly th
+           LEFT JOIN LATERAL (
+             SELECT MIN(a.app_id) AS app_id
+             FROM traffic_hourly_apps a
+             WHERE a.router_id    = th.router_id
+               AND a.mac          = th.mac
+               AND a.hostname     = th.hostname
+               AND a.bucket_start = th.bucket_start
+           ) chosen ON TRUE
+           WHERE th.bucket_start >= $from AND th.bucket_start < $to """ ++
+        macFilter(macs) ++
+        fr"GROUP BY chosen.app_id"
+
+    val sqlPath =
+      freshSql
+        .query[(Option[AppId], Long, Long, Long)]
+        .map { case (a, secs, bi, bo) => AppUsageAgg(a, secs, bi, bo) }
+        .to[List]
+        .transact(xa)
+
+    for {
+      stale <- staleSql.query[Long].unique.transact(xa)
+      aggs  <-
+        if (stale == 0L) sqlPath
+        else listHourlyInRange(macs, from, to).map(aggregateInScala(_, appsByApex))
+    } yield aggs
+  }
 
   def aggregateByAppDaily(
       macs: List[MacAddress],
@@ -382,6 +508,65 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
       to: Instant,
       currentVersion: Long,
       appsByApex: Map[String, List[AppId]],
-  ): Task[List[AppUsageAgg]] =
-    ZIO.succeed(Nil)
+  ): Task[List[AppUsageAgg]] = {
+    val fromDate = from.atZone(ZoneOffset.UTC).toLocalDate
+    val toDate   = to.atZone(ZoneOffset.UTC).toLocalDate
+    val staleSql =
+      fr"""SELECT COUNT(*) FROM traffic_daily
+           WHERE date >= $fromDate AND date < $toDate
+             AND (app_hosts_version IS NULL OR app_hosts_version < $currentVersion) """ ++
+        macFilter(macs)
+    val freshSql =
+      fr"""SELECT chosen.app_id,
+                  SUM(td.active_seconds)::BIGINT,
+                  SUM(td.bytes_in)::BIGINT,
+                  SUM(td.bytes_out)::BIGINT
+           FROM traffic_daily td
+           LEFT JOIN LATERAL (
+             SELECT MIN(a.app_id) AS app_id
+             FROM traffic_daily_apps a
+             WHERE a.router_id = td.router_id
+               AND a.mac       = td.mac
+               AND a.hostname  = td.hostname
+               AND a.date      = td.date
+           ) chosen ON TRUE
+           WHERE td.date >= $fromDate AND td.date < $toDate """ ++
+        macFilter(macs) ++
+        fr"GROUP BY chosen.app_id"
+
+    val sqlPath =
+      freshSql
+        .query[(Option[AppId], Long, Long, Long)]
+        .map { case (a, secs, bi, bo) => AppUsageAgg(a, secs, bi, bo) }
+        .to[List]
+        .transact(xa)
+
+    for {
+      stale <- staleSql.query[Long].unique.transact(xa)
+      aggs  <-
+        if (stale == 0L) sqlPath
+        else listDailyInRange(macs, from, to).map(aggregateInScala(_, appsByApex))
+    } yield aggs
+  }
+
+  // Read-time fallback when any in-window rollup row is stale: re-match each
+  // row's host in process via the canonical matcher, deduping a multi-app host
+  // to the lowest app id (matching the SQL path and the UsageRoutes read path).
+  private def aggregateInScala(
+      rows: List[RollupRow],
+      appsByApex: Map[String, List[AppId]],
+  ): List[AppUsageAgg] = {
+    val byApexMin = appsByApex.view.mapValues(_.minBy(_.value)).toMap
+    rows
+      .groupBy(r => r.host.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApexMin)))
+      .map { case (appId, rs) =>
+        AppUsageAgg(
+          appId,
+          rs.iterator.map(_.activeSeconds.toLong).sum,
+          rs.iterator.map(_.bytesIn).sum,
+          rs.iterator.map(_.bytesOut).sum,
+        )
+      }
+      .toList
+  }
 }

--- a/api/src/usage/RollupJobs.scala
+++ b/api/src/usage/RollupJobs.scala
@@ -1,7 +1,8 @@
 package wifihaven.api.usage
 
-import wifihaven.api.db.RollupRepo
+import wifihaven.api.db.{AppRepo, RollupRepo}
 import wifihaven.shared.Clock
+import wifihaven.shared.types.AppId
 import zio.*
 
 import java.time.{Duration, LocalDate, ZoneId}
@@ -41,8 +42,8 @@ object RollupJobs {
    * Hourly fiber loop. Re-aggregates the trailing [[HourlyLookback]] window into `traffic_hourly`
    * every [[HourlyInterval]]. Errors are caught and recorded; the fiber never dies.
    */
-  def hourlyLoop(repo: RollupRepo, clock: Clock): UIO[Unit] =
-    runOnce("hourly", repo, clock, oneHourlyTick(repo, _))
+  def hourlyLoop(repo: RollupRepo, appRepo: AppRepo, clock: Clock): UIO[Unit] =
+    runOnce("hourly", repo, clock, oneHourlyTick(repo, appRepo, _))
       .repeat(Schedule.fixed(HourlyInterval))
       .unit
 
@@ -50,25 +51,43 @@ object RollupJobs {
    * Daily fiber loop. Re-aggregates the trailing [[DailyLookback]] window into `traffic_daily`
    * every [[DailyInterval]]. Same error semantics as the hourly fiber.
    */
-  def dailyLoop(repo: RollupRepo, clock: Clock, zone: ZoneId): UIO[Unit] =
-    runOnce("daily", repo, clock, oneDailyTick(repo, _, zone))
+  def dailyLoop(repo: RollupRepo, appRepo: AppRepo, clock: Clock, zone: ZoneId): UIO[Unit] =
+    runOnce("daily", repo, clock, oneDailyTick(repo, appRepo, _, zone))
       .repeat(Schedule.fixed(DailyInterval))
       .unit
 
   // ── tick bodies ────────────────────────────────────────────────────────────
 
-  private def oneHourlyTick(repo: RollupRepo, clock: Clock): Task[Option[Int]] =
+  // The app-hosts snapshot is read once per tick and stamped onto every rolled
+  // row (#1091). Reading it here (rather than per-row) keeps the version the
+  // rows are stamped at consistent for the whole reroll.
+  private def appSnapshot(appRepo: AppRepo): Task[(Map[String, List[AppId]], Long)] =
+    for {
+      mappings <- appRepo.listAllHostMappings
+      version  <- appRepo.currentHostsVersion
+    } yield (mappings.groupBy(_.host.value).view.mapValues(_.map(_.appId)).toMap, version)
+
+  private def oneHourlyTick(repo: RollupRepo, appRepo: AppRepo, clock: Clock): Task[Option[Int]] =
     for {
       now <- clock.instant
       since = now.minus(HourlyLookback).truncatedTo(java.time.temporal.ChronoUnit.HOURS)
-      n <- repo.rerollHourly(since)
+      snap <- appSnapshot(appRepo)
+      (appsByApex, version) = snap
+      n <- repo.rerollHourly(since, appsByApex, version)
     } yield n
 
-  private def oneDailyTick(repo: RollupRepo, clock: Clock, zone: ZoneId): Task[Option[Int]] =
+  private def oneDailyTick(
+      repo: RollupRepo,
+      appRepo: AppRepo,
+      clock: Clock,
+      zone: ZoneId,
+  ): Task[Option[Int]] =
     for {
       now <- clock.instant
       sinceDate = LocalDate.ofInstant(now, zone).minus(DailyLookback)
-      n <- repo.rerollDaily(sinceDate)
+      snap <- appSnapshot(appRepo)
+      (appsByApex, version) = snap
+      n <- repo.rerollDaily(sinceDate, appsByApex, version)
     } yield n
 
   // ── shared run wrapper ─────────────────────────────────────────────────────

--- a/api/test/src/feature/RollupAppAttributionSpec.scala
+++ b/api/test/src/feature/RollupAppAttributionSpec.scala
@@ -1,0 +1,230 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.db.*
+import wifihaven.api.policy.PolicyService
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate, ZoneOffset}
+
+// #1091: pre-attribute owning app(s) at rollup-write time so the per-app read
+// paths can aggregate via SQL `GROUP BY app_id` instead of re-running the
+// in-memory HostMatch.lookupApex tail-walk over every row.
+//
+// Coverage:
+//   - rerollHourly/Daily populate traffic_{hourly,daily}_apps via lookupApex
+//     and stamp the app_hosts_version onto every rolled row.
+//   - aggregateByApp{Hourly,Daily} reads pre-attributed rows via SQL GROUP BY.
+//   - An app_hosts mutation bumps the version; a read against rollup rows
+//     stamped at the old version falls back to live in-memory matching rather
+//     than serving stale attribution.
+//   - A host in multiple apps fans to multiple side-table rows, but the
+//     aggregation dedups to the lowest app id (no double-counting).
+object RollupAppAttributionSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val mac       = MacAddress.unsafe("aa:bb:cc:dd:ee:01")
+  // Subdomain in traffic, apex in app_hosts — exercises the lookupApex walk.
+  private val ytHost    = HostId.Fqdn(Hostname.unsafe("m.youtube.com"))
+  private val otherHost = HostId.Fqdn(Hostname.unsafe("example.net"))
+  private val ytApex    = "youtube.com"
+
+  private def seedRouter: RIO[RouterRepo, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](rr => rr.create("test", PolicyService.hashToken("et_dummy")))
+
+  // Seed `bucketCount` 5-min traffic_reports rows for `host` starting at `startUtc`.
+  private def seedReports(
+      routerId: RouterId,
+      startUtc: Instant,
+      bucketCount: Int,
+      host: HostId,
+      bytesPerBucket: Long = 100L,
+  ): RIO[TrafficReportRepo, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val inserts = (0 until bucketCount).map { i =>
+        val s = startUtc.plusSeconds(i.toLong * 300L)
+        val e = s.plusSeconds(300L)
+        TrafficReportInsert(
+          routerId,
+          mac,
+          None,
+          host,
+          s.atZone(ZoneOffset.UTC).toLocalDate,
+          s,
+          e,
+          300,
+          bytesPerBucket,
+          bytesPerBucket * 2,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def createApp(name: String, slug: String): RIO[AppRepo, AppId] =
+    ZIO.serviceWithZIO[AppRepo](_.create(name, slug, None, None))
+
+  private def countHourlyApps: RIO[Transactor[Task], Long]              =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"SELECT COUNT(*) FROM traffic_hourly_apps".query[Long].unique.transact(xa),
+    )
+  private def countDailyApps: RIO[Transactor[Task], Long]               =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"SELECT COUNT(*) FROM traffic_daily_apps".query[Long].unique.transact(xa),
+    )
+  private def hourlyVersions: RIO[Transactor[Task], List[Option[Long]]] =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"SELECT DISTINCT app_hosts_version FROM traffic_hourly ORDER BY 1"
+        .query[Option[Long]]
+        .to[List]
+        .transact(xa),
+    )
+
+  private val start =
+    LocalDate.of(2026, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant
+
+  def spec = suite("RollupRepo app attribution (#1091)")(
+    test("rerollHourly attributes the owning app via SQL and stamps the version") {
+      for {
+        _       <- cleanDb
+        rid     <- seedRouter
+        _       <- seedReports(rid, start, 12, ytHost, bytesPerBucket = 100L)
+        _       <- seedReports(rid, start, 12, otherHost, bytesPerBucket = 50L)
+        appRepo <- ZIO.service[AppRepo]
+        appId   <- createApp("YouTube", "youtube")
+        _       <- appRepo.setHosts(appId, List(Hostname.unsafe(ytApex)))
+        version <- appRepo.currentHostsVersion
+        appsByApex = Map(ytApex -> List(appId))
+        rollup <- ZIO.service[RollupRepo]
+        _      <- rollup.rerollHourly(start.minusSeconds(3600), appsByApex, version)
+        sideN  <- countHourlyApps
+        stamps <- hourlyVersions
+        aggs   <- rollup.aggregateByAppHourly(
+          List(mac),
+          start,
+          start.plusSeconds(7200),
+          version,
+          appsByApex,
+        )
+        ytAgg    = aggs.find(_.appId.contains(appId))
+        otherAgg = aggs.find(_.appId.isEmpty)
+      } yield assertTrue(
+        version == 1L,
+        sideN == 1L, // only the youtube row is in an app; example.net is not
+        stamps == List(Some(1L)),
+        ytAgg.exists(a => a.activeSeconds == 12 * 300 && a.bytesIn == 12 * 100L),
+        otherAgg.exists(_.activeSeconds == 12 * 300),
+      )
+    },
+    test(
+      "an app_hosts mutation bumps the version, so stale rollup rows fall back to live matching",
+    ) {
+      for {
+        _       <- cleanDb
+        rid     <- seedRouter
+        _       <- seedReports(rid, start, 12, ytHost, bytesPerBucket = 100L)
+        appRepo <- ZIO.service[AppRepo]
+        rollup  <- ZIO.service[RollupRepo]
+        // Roll before any app exists: empty snapshot, version 0.
+        v0      <- appRepo.currentHostsVersion
+        _       <- rollup.rerollHourly(start.minusSeconds(3600), Map.empty, v0)
+        aggs0   <- rollup.aggregateByAppHourly(
+          List(mac),
+          start,
+          start.plusSeconds(3600),
+          v0,
+          Map.empty,
+        )
+        // Operator adds the host -> version bumps. Rollup rows are now stale.
+        appId   <- createApp("YouTube", "youtube")
+        _       <- appRepo.setHosts(appId, List(Hostname.unsafe(ytApex)))
+        v1      <- appRepo.currentHostsVersion
+        appsByApex = Map(ytApex -> List(appId))
+        // Read WITHOUT re-rolling: rows stamped v0 < v1 -> fallback to live match.
+        aggs1 <- rollup.aggregateByAppHourly(
+          List(mac),
+          start,
+          start.plusSeconds(3600),
+          v1,
+          appsByApex,
+        )
+      } yield assertTrue(
+        v0 == 0L,
+        v1 == 1L,
+        aggs0 == List(AppUsageAgg(None, 12 * 300L, 12 * 100L, 12 * 200L)),
+        aggs1.find(_.appId.contains(appId)).exists(_.activeSeconds == 12 * 300L),
+        // No silent staleness: nothing leaks into "Other" once the app owns it.
+        !aggs1.exists(a => a.appId.isEmpty && a.activeSeconds > 0),
+      )
+    },
+    test(
+      "a host in multiple apps fans to side-table rows but aggregation dedups to lowest app id",
+    ) {
+      for {
+        _       <- cleanDb
+        rid     <- seedRouter
+        _       <- seedReports(rid, start, 12, ytHost, bytesPerBucket = 100L)
+        appRepo <- ZIO.service[AppRepo]
+        rollup  <- ZIO.service[RollupRepo]
+        appA    <- createApp("Alpha", "alpha")
+        appB    <- createApp("Beta", "beta")
+        _       <- appRepo.setHosts(appA, List(Hostname.unsafe(ytApex)))
+        _       <- appRepo.setHosts(appB, List(Hostname.unsafe(ytApex)))
+        version <- appRepo.currentHostsVersion
+        appsByApex = Map(ytApex -> List(appA, appB))
+        _     <- rollup.rerollHourly(start.minusSeconds(3600), appsByApex, version)
+        sideN <- countHourlyApps
+        aggs  <- rollup.aggregateByAppHourly(
+          List(mac),
+          start,
+          start.plusSeconds(3600),
+          version,
+          appsByApex,
+        )
+      } yield assertTrue(
+        appA.value < appB.value,
+        version == 2L,
+        sideN == 2L,                         // both apps recorded for the one rollup row (fan)
+        aggs.size == 1,
+        aggs.head.appId.contains(appA),      // dedup to lowest id
+        aggs.head.activeSeconds == 12 * 300L,// not double-counted
+      )
+    },
+    test("rerollDaily attributes the owning app and aggregateByAppDaily reads it via SQL") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        date   = LocalDate.of(2026, 1, 1)
+        dStart = date.atStartOfDay(ZoneOffset.UTC).toInstant
+        _       <- seedReports(rid, dStart, 288, ytHost, bytesPerBucket = 10L) // full day
+        appRepo <- ZIO.service[AppRepo]
+        rollup  <- ZIO.service[RollupRepo]
+        appId   <- createApp("YouTube", "youtube")
+        _       <- appRepo.setHosts(appId, List(Hostname.unsafe(ytApex)))
+        version <- appRepo.currentHostsVersion
+        appsByApex = Map(ytApex -> List(appId))
+        _     <- rollup.rerollDaily(date.minusDays(1), appsByApex, version)
+        sideN <- countDailyApps
+        aggs  <- rollup.aggregateByAppDaily(
+          List(mac),
+          dStart,
+          dStart.plusSeconds(86400),
+          version,
+          appsByApex,
+        )
+      } yield assertTrue(
+        sideN == 1L,
+        aggs.find(_.appId.contains(appId)).exists(_.activeSeconds == 288 * 300),
+      )
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
Closes #1091.

PR 2 of 2. Stacks on #1211 (the V45 migration). **Do not merge until #1211 is merged and deployed** — this PR's code depends on the V45 schema (the `app_hosts_version` counter, the `app_hosts_version` columns on `traffic_{hourly,daily}`, and the `traffic_{hourly,daily}_apps` side tables). Base will retarget to `main` automatically once #1211 merges.

## Summary

When the hourly/daily rollup writer materializes `traffic_hourly` / `traffic_daily` rows, it now also computes and persists the owning app(s) per row via the canonical `HostMatch.lookupApex` against the current `app_hosts` snapshot. The per-app read paths (#769 `groupBy=app`, #1061 `/usage-by-app`) can then aggregate via SQL `GROUP BY app_id` against the rollup tables instead of re-running the in-memory tail-walk over every row at read time.

- **Writer** — `reroll{Hourly,Daily}` stamp `app_hosts_version` onto every rolled row and rewrite the side tables (`traffic_{hourly,daily}_apps`) in the same transaction. A host belonging to N apps fans out to N side rows.
- **Reader** — `aggregateByApp{Hourly,Daily}` aggregate in-database (`MIN(app_id)` per rollup row to dedup a multi-app host to the lowest id, matching the existing `UsageRoutes` read-time tiebreak) when every in-window row carries the current version. If any row is stale (version `<` current, or never attributed), it falls back to reading the rows and re-matching in process via the same `lookupApex` — so an `app_hosts` edit is reflected immediately rather than serving stale attribution.
- **Invalidation (lazy / Option 2)** — `AppRepo.currentHostsVersion` reads a global counter; `setHosts` / `delete` bump it. No re-roll on the mutation hot path; stale attribution degrades gracefully to live matching instead of silently lying.
- **Jobs** — `RollupJobs` loads the app-hosts snapshot once per tick and threads it through the reroll.

The SQL and fallback paths produce identical numbers to the in-memory `UsageRoutes` paths, so a read path can switch from the in-process matcher to `GROUP BY app_id` without changing results. Coordinates with #857/#1213 (`groupBy=app`) — semantics kept identical.

## Test plan

New feature spec `RollupAppAttributionSpec` (embedded Postgres, no mocks), committed red-then-green:

- [x] `rerollHourly` attributes the owning app via SQL and stamps the version
- [x] an `app_hosts` mutation bumps the version, so stale rollup rows fall back to live matching (no silent staleness, no leakage into "Other")
- [x] a host in multiple apps fans to side-table rows but aggregation dedups to the lowest app id (no double-counting)
- [x] `rerollDaily` attributes the owning app and `aggregateByAppDaily` reads it via SQL
- [x] full `mill api.test` (192 specs) + `mill shared.test` (139 specs) green
- [x] `scalafmt` check clean