### PR TITLE
fix(vm): move qemu control sockets to short path to avoid sun_path limit

### DIFF
--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -191,9 +191,12 @@ router-down.sh               # graceful shutdown via monitor → SIGTERM → SIG
 lan-bridge-down.sh           # tear down the bridge (only when all VMs are stopped)
 ```
 
-`router-up.sh` writes its overlay, pidfile, monitor socket, and serial console
-log under `.run/router/`. Snapshots live inside the overlay (qcow2 internal
-snapshots) and can be inspected with `qemu-img snapshot -l`.
+`router-up.sh` writes its overlay, pidfile, and serial console log under
+`.run/router/`. The QEMU monitor socket lives **outside** `.run/`, under a short
+base dir (`${XDG_RUNTIME_DIR:-/tmp}/wh-vm/…`, exported as `WH_SOCK_DIR`), because
+the AF_UNIX `sun_path` limit caps socket paths at ~108 chars and the `.run/` tree
+sits under a deep CI runner home. Snapshots live inside the overlay (qcow2
+internal snapshots) and can be inspected with `qemu-img snapshot -l`.
 
 ### Image pinning + bumping
 
@@ -215,9 +218,11 @@ The OpenWRT version and SHA256 are pinned in [`config.sh`](config.sh)
   Stock OpenWRT root password is empty on first boot — set one immediately or
   wait for #150 (custom image bakes in a known test password + SSH key).
 - **LuCI HTTP**: `http://127.0.0.1:${WH_ROUTER_HTTP_PORT}` (default 8080).
-- **QEMU monitor** (savevm / loadvm / info network / system_powerdown):
+- **QEMU monitor** (savevm / loadvm / info network / system_powerdown). The
+  socket path is printed by `router-up.sh`; it lives under `WH_SOCK_DIR`
+  (`${XDG_RUNTIME_DIR:-/tmp}/wh-vm/…/router-monitor.sock`), not under `.run/`:
   ```bash
-  socat - UNIX-CONNECT:scripts/vm/.run/router/monitor.sock
+  socat - UNIX-CONNECT:"${XDG_RUNTIME_DIR:-/tmp}/wh-vm/router-monitor.sock"
   ```
 
 ### Snapshots

--- a/scripts/vm/client-down.sh
+++ b/scripts/vm/client-down.sh
@@ -24,7 +24,7 @@ done
 
 RUN_DIR="${WH_RUN_DIR}/${NAME}"
 PIDFILE="${RUN_DIR}/qemu.pid"
-QMP_SOCK="${RUN_DIR}/qemu.sock"
+QMP_SOCK="$(wh_client_qmp_sock "${NAME}")"
 
 if [[ ! -d "${RUN_DIR}" ]]; then
   echo "[client-down] '${NAME}' not running (no ${RUN_DIR})"
@@ -61,6 +61,8 @@ if [[ -n "${PID}" ]] && kill -0 "${PID}" 2>/dev/null; then
 fi
 
 rm -rf "${RUN_DIR}"
+rm -f "${QMP_SOCK}"
+rmdir "${WH_SOCK_DIR}" 2>/dev/null || true
 
 # Fallback: a previous run was killed hard (e.g., CI cancellation) and
 # left a qemu alive without an up-to-date pidfile. Kill by name so the

--- a/scripts/vm/client-up.sh
+++ b/scripts/vm/client-up.sh
@@ -13,9 +13,10 @@
 # State for a running client lives under ${WH_RUN_DIR}/<name>/:
 #   overlay.qcow2  — disk overlay (discarded by client-down.sh)
 #   qemu.pid       — qemu pid
-#   qemu.sock      — QMP monitor socket
 #   ssh.port       — host port for SSH
 #   mac            — the LAN-side MAC, for `client-exec.sh` debugging
+# The QMP control socket lives outside .run/, under WH_SOCK_DIR (a short base
+# path), because the AF_UNIX sun_path limit caps socket paths at ~108 chars.
 
 set -euo pipefail
 
@@ -90,7 +91,7 @@ if [[ -f "${RUN_DIR}/qemu.pid" ]] && kill -0 "$(cat "${RUN_DIR}/qemu.pid")" 2>/d
   exit 1
 fi
 rm -rf "${RUN_DIR}"
-mkdir -p "${RUN_DIR}"
+mkdir -p "${RUN_DIR}" "${WH_SOCK_DIR}"
 
 if [[ -z "${SSH_PORT}" ]]; then
   SSH_PORT="${WH_CLIENT_SSH_PORT_BASE}"
@@ -116,7 +117,10 @@ MGMT_NETDEV="user,id=mgmt,net=10.0.2.0/24,host=10.0.2.2,dhcpstart=10.0.2.15,rest
 MGMT_DEVICE="virtio-net-pci,netdev=mgmt"
 
 PIDFILE="${RUN_DIR}/qemu.pid"
-QMP_SOCK="${RUN_DIR}/qemu.sock"
+# QMP socket lives under WH_SOCK_DIR (short path) — see config.sh WH_SOCK_DIR
+# note for the AF_UNIX sun_path reason. Clear any stale socket from a prior run.
+QMP_SOCK="$(wh_client_qmp_sock "${NAME}")"
+rm -f "${QMP_SOCK}"
 
 # Background the qemu process. -daemonize gives us a stable pidfile.
 qemu-system-x86_64 \

--- a/scripts/vm/config.sh
+++ b/scripts/vm/config.sh
@@ -42,6 +42,28 @@ if [[ -n "${WH_RUN_ID}" ]]; then
 else
   WH_RUN_DIR="${WH_VM_DIR}/.run"
 fi
+# Short base dir for qemu UNIX *control sockets* (router monitor, client QMP).
+# These MUST NOT live under .run/: the AF_UNIX sun_path limit is ~108 chars,
+# and the .run/ tree sits under a deep CI runner home
+# (.../_work/wifihaven/wifihaven/scripts/vm/.run/<run-id>/router/monitor.sock).
+# The multi-instance self-hosted runner from #1163 lengthened that prefix
+# (actions-runner → actions-runner-4), pushing the monitor socket path past the
+# ceiling — qemu refused to create the socket and no VM gate could boot. Keeping
+# the sockets in /run (or /tmp) makes the path independent of the runner home.
+# Only the sockets relocate here; serial logs, overlays, pidfiles, and bridge
+# markers stay under .run/ so nothing else moves.
+if [[ -n "${WH_RUN_ID}" ]]; then
+  WH_SOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}/wh-vm/${WH_RUN_ID}"
+else
+  WH_SOCK_DIR="${XDG_RUNTIME_DIR:-/tmp}/wh-vm"
+fi
+
+# QMP control-socket path for a client slot. Lives under WH_SOCK_DIR (short
+# path) rather than ${WH_RUN_DIR}/<name>/ for the sun_path reason above.
+wh_client_qmp_sock() {
+  printf '%s/client-%s-qmp.sock' "${WH_SOCK_DIR}" "$1"
+}
+
 WH_KEYS_DIR="${WH_VM_DIR}/keys"
 WH_CLIENT_BASE_IMG="${WH_CACHE_DIR}/client-base.qcow2"
 WH_CLIENT_SSH_KEY="${WH_KEYS_DIR}/client_test_ed25519"
@@ -81,7 +103,9 @@ WH_ROUTER_BASE_IMG="${WH_CACHE_DIR}/${WH_OPENWRT_IMAGE%.gz}"
 WH_ROUTER_RUN_DIR="${WH_RUN_DIR}/router"
 WH_ROUTER_OVERLAY="${WH_ROUTER_RUN_DIR}/overlay.qcow2"
 WH_ROUTER_PIDFILE="${WH_ROUTER_RUN_DIR}/qemu.pid"
-WH_ROUTER_MONITOR_SOCK="${WH_ROUTER_RUN_DIR}/monitor.sock"
+# Monitor socket lives under WH_SOCK_DIR (short path), not WH_ROUTER_RUN_DIR —
+# see the WH_SOCK_DIR note above for the sun_path reason.
+WH_ROUTER_MONITOR_SOCK="${WH_SOCK_DIR}/router-monitor.sock"
 WH_ROUTER_SERIAL_LOG="${WH_ROUTER_RUN_DIR}/console.log"
 
 # QEMU `-name` for the router VM. Suffixed with WH_RUN_ID so `pgrep -f` in

--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -7,7 +7,7 @@ HERE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=config.sh
 source "${HERE_LIB}/config.sh"
 
-mkdir -p "${WH_CACHE_DIR}" "${WH_ROUTER_RUN_DIR}"
+mkdir -p "${WH_CACHE_DIR}" "${WH_ROUTER_RUN_DIR}" "${WH_SOCK_DIR}"
 
 log() { printf '[router-vm] %s\n' "$*" >&2; }
 die() { printf '[router-vm] error: %s\n' "$*" >&2; exit 1; }

--- a/scripts/vm/router-down.sh
+++ b/scripts/vm/router-down.sh
@@ -22,6 +22,7 @@ stale_qemu_sweep() {
 if ! router_is_running; then
   log "router VM not running"
   rm -f "${WH_ROUTER_PIDFILE}" "${WH_ROUTER_MONITOR_SOCK}"
+  rmdir "${WH_SOCK_DIR}" 2>/dev/null || true
   stale_qemu_sweep
   # Release the bridge-pool reservation (#907) even on the not-running path —
   # a failed router-up.sh leaves a reservation containing a now-dead PID, which
@@ -59,6 +60,7 @@ if kill -0 "${pid}" 2>/dev/null; then
 fi
 
 rm -f "${WH_ROUTER_PIDFILE}" "${WH_ROUTER_MONITOR_SOCK}"
+rmdir "${WH_SOCK_DIR}" 2>/dev/null || true
 stale_qemu_sweep
 # Release the bridge-pool reservation (#907). Safe no-op if we weren't using
 # a pool bridge — wh_clear_bridge_reservation just rm -f's the marker file.


### PR DESCRIPTION
## Summary

The qemu **monitor** (router) and **QMP** (client) UNIX *control sockets* lived under `scripts/vm/.run/<run-id>/…/*.sock`. The `AF_UNIX` `sun_path` limit (~108 chars) is exceeded once that `.run/` tree sits under the multi-instance self-hosted runner home introduced by [#1163](https://github.com/wifihaven/wifihaven/pull/1163) (`actions-runner` → `actions-runner-4`). qemu then refuses to create the socket and the VM never boots — breaking **all** VM gates (Gate 2, Gate 3a router publish; Gate 3b API/UI publish).

Failing run: https://github.com/wifihaven/wifihaven/actions/runs/26701392883 — both Gate 3b matrix arms (apk + ipk) die at `test_gate3_smoke` setup with:

```
qemu-system-x86_64: -monitor unix:/home/runner/actions-runner-4/_work/wifihaven/wifihaven/scripts/vm/.run/26701392883-1-apk/router/monitor.sock,server,nowait: UNIX socket path '…' is too long
```

This is **not** bridge-pool exhaustion (the pick succeeded, `wh-lan2`). It is a [#1163](https://github.com/wifihaven/wifihaven/pull/1163) regression: the longer runner-home prefix pushed the deeply-nested socket path past the ceiling.

## Fix

Relocate **only** the qemu control sockets to a short base dir `WH_SOCK_DIR` = `${XDG_RUNTIME_DIR:-/tmp}/wh-vm/<run-id>`, keyed per matrix arm via `WH_RUN_ID` (which already encodes run id + index + variant) so concurrent arms don't collide. Because the base is `/run` or `/tmp`, the runner-home prefix no longer factors into the length.

- `config.sh` — define `WH_SOCK_DIR` + `wh_client_qmp_sock()`; repoint `WH_ROUTER_MONITOR_SOCK` there.
- `lib.sh` / `client-up.sh` — `mkdir -p "${WH_SOCK_DIR}"`.
- `router-down.sh` / `client-down.sh` — remove the socket and `rmdir` the (now-empty) sock dir on teardown.
- Non-socket artifacts (serial logs, overlays, pidfiles, `lan-bridge` marker, `.bridge-pool.lock`) stay under `.run/` — nothing else moves. The `file:` serial *log* is a regular file, not a socket, so it's left in place.

## Evidence (path length, with the `actions-runner-4` prefix)

| | path | len |
|---|---|---|
| **before** | `…/actions-runner-4/_work/wifihaven/wifihaven/scripts/vm/.run/26701392883-1-apk/router/monitor.sock` | **109** ❌ |
| **after** (`/tmp` fallback) | `/tmp/wh-vm/26701392883-1-apk/router-monitor.sock` | **48** ✅ |
| **after** (`XDG_RUNTIME_DIR`) | `/run/user/1001/wh-vm/26701392883-1-apk/router-monitor.sock` | **58** ✅ |

## Test plan

- [ ] Gate 2 + Gate 3a (router publish) VM smoke boots qemu without the `sun_path` error
- [ ] Gate 3b apk + ipk arms boot the router VM and pass `test_gate3_smoke`
- [ ] Concurrent matrix arms get distinct sock dirs (keyed by `WH_RUN_ID`), no collision
- [ ] `router-down.sh` / `client-down.sh` clean up sockets + sock dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)