### PR TITLE
fix(usage): partition-prune per-profile usage reads + batch endpoint (#1099)

### DIFF
--- a/api/src/db/QueryTimeout.scala
+++ b/api/src/db/QueryTimeout.scala
@@ -1,0 +1,53 @@
+package wifihaven.api.db
+
+import cats.syntax.all.*
+import doobie.*
+import doobie.implicits.*
+import org.postgresql.util.PSQLException
+import zio.*
+import zio.interop.catz.*
+
+import java.time.Duration
+
+/**
+ * Raised when a bounded read trips its per-statement `statement_timeout` (#1099). Kept distinct
+ * from a bare `PSQLException` so callers (and `ErrorMapper`) can recognise "this query was
+ * deliberately cancelled for taking too long" rather than a generic DB failure.
+ */
+final class QueryTimeoutException(message: String) extends RuntimeException(message)
+
+/**
+ * Per-request statement timeout for the unbounded-scan read paths (#1099).
+ *
+ * The /profiles page once wedged the whole Render instance: a single per-profile usage query ran
+ * 90s (partition pruning was defeated — see [[TrafficReportRepoLive.listPresenceRowsInWindow]]),
+ * held its DB connection the entire time, and once the small pool saturated every other endpoint
+ * 502'd. This bounds each such query so a pathological profile fails fast (typed
+ * [[QueryTimeoutException]] → 503) instead of holding a connection open and taking the instance
+ * down with it.
+ *
+ * The bound is generous: healthy partition-pruned queries return sub-second, so [[PresenceWindow]]
+ * never trips for a well-behaved request.
+ */
+object QueryTimeout {
+
+  val PresenceWindow: Duration = Duration.ofSeconds(8)
+
+  /**
+   * Run `c` inside a transaction with a `SET LOCAL statement_timeout`, so the bound auto-releases
+   * when the tx commits/rolls back and never leaks onto a pooled connection. A Postgres cancel
+   * (SQLSTATE 57014) is remapped to [[QueryTimeoutException]]; all other failures pass through
+   * unchanged.
+   */
+  def bounded[A](xa: Transactor[Task], timeout: Duration)(c: ConnectionIO[A]): Task[A] = {
+    val ms      = math.max(1L, timeout.toMillis)
+    // statement_timeout cannot be a bind parameter; `ms` is a server-derived
+    // Long, never user input, so const-interpolation is injection-safe.
+    val wrapped = Fragment.const(s"SET LOCAL statement_timeout = $ms").update.run *> c
+    wrapped.transact(xa).mapError {
+      case e: PSQLException if e.getSQLState == "57014" =>
+        new QueryTimeoutException(s"query exceeded ${ms}ms statement_timeout")
+      case e                                            => e
+    }
+  }
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -416,6 +416,22 @@ trait TrafficReportRepo {
   ): Task[List[wifihaven.api.presence.PresenceRow]]
 
   /**
+   * #1099: presence rows whose `period_start` falls in `[fromInstant, toInstant)` for the given
+   * macs. Filtering on `period_start` (the table's RANGE partition key, V41) — rather than the
+   * non-key `date` column the day/range variants use — lets Postgres prune to the covering weekly
+   * partitions instead of scanning all of history. This is the difference between a sub-second read
+   * and the multi-minute full-table scan that wedged the /profiles page (see issue #1099). The
+   * query is bounded by a per-statement timeout ([[QueryTimeout.PresenceWindow]]) so a pathological
+   * caller fails fast instead of holding a connection. Same row shape and semantics as
+   * [[listPresenceRows]]; callers compute the window from the requested local day + zone.
+   */
+  def listPresenceRowsInWindow(
+      macs: List[MacAddress],
+      fromInstant: Instant,
+      toInstant: Instant,
+  ): Task[List[wifihaven.api.presence.PresenceRow]]
+
+  /**
    * #846: raw rows in `[fromInstant, toInstant)` for the given macs. `macs = Nil` means "all macs"
    * (used by the Traffic Usage page in unfiltered mode). Returns Instants (not String date columns)
    * so callers can bucket without re-parsing.
@@ -1394,6 +1410,18 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
 
   def listPresenceRowsSince(macs: List[MacAddress], date: LocalDate, since: Instant) =
     listPresenceRowsBetween(macs, date, date, Some(since))
+
+  def listPresenceRowsInWindow(
+      macs: List[MacAddress],
+      fromInstant: Instant,
+      toInstant: Instant,
+  ): Task[List[wifihaven.api.presence.PresenceRow]] =
+    ZIO.succeed {
+      // STUB (#1099 red): window ignored until the green commit, so the
+      // equivalence test sees an empty result and fails.
+      val _ = (macs, fromInstant, toInstant)
+      List.empty[wifihaven.api.presence.PresenceRow]
+    }
 
   // TODO(#730): remove this read-side join once usage records carry dest_ip.
   private def listPresenceRowsBetween(

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1415,13 +1415,51 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
       macs: List[MacAddress],
       fromInstant: Instant,
       toInstant: Instant,
-  ): Task[List[wifihaven.api.presence.PresenceRow]] =
-    ZIO.succeed {
-      // STUB (#1099 red): window ignored until the green commit, so the
-      // equivalence test sees an empty result and fails.
-      val _ = (macs, fromInstant, toInstant)
-      List.empty[wifihaven.api.presence.PresenceRow]
+  ): Task[List[wifihaven.api.presence.PresenceRow]] = {
+    type Row = (MacAddress, LocalDate, Instant, HostId, Int, Long, Long, Instant, Instant)
+    macs match {
+      case Nil => ZIO.succeed(List.empty[wifihaven.api.presence.PresenceRow])
+      case ms  =>
+        val nel = cats.data.NonEmptyList.fromListUnsafe(ms.map(_.value))
+        // Filter on period_start (the partition key) so Postgres can prune to the
+        // single day-partition(s) the window touches. The old day path filtered on
+        // tr.date — not the partition key — which defeated pruning and let one
+        // profile's read scan the whole table for 90s (#1099). Same SELECT/LATERAL
+        // shape as listPresenceRowsBetween, so the row set is identical.
+        val q   =
+          fr"""SELECT tr.mac, tr.date, tr.period_start,
+                      CASE WHEN tr.host_type IN ('ipv4','ipv6') AND ce.resolved_host_value IS NOT NULL
+                           THEN 'fqdn' ELSE tr.host_type END,
+                      COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END,
+                               tr.host_value),
+                      tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end
+               FROM traffic_reports tr
+               LEFT JOIN LATERAL (
+                 SELECT resolved_host_value
+                 FROM connection_events
+                 WHERE mac          = tr.mac
+                   AND dest_ip      = tr.host_value
+                   AND resolved_host_value IS NOT NULL
+                   AND ts >= tr.date::TIMESTAMPTZ
+                   AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
+                 ORDER BY ts DESC LIMIT 1
+               ) ce ON tr.host_type IN ('ipv4','ipv6')
+               WHERE tr.period_start >= $fromInstant AND tr.period_start < $toInstant
+                 AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
+                 AND """ ++ Fragments.in(fr"tr.mac", nel)
+        val cio =
+          q.query[Row]
+            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
+              val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
+              wifihaven.api.presence.PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds)
+            }
+            .to[List]
+        // Bound each per-request read: a pathological window fails fast with a typed
+        // QueryTimeoutException (→ 503) instead of holding a pool connection open and
+        // wedging the whole instance (#1099).
+        QueryTimeout.bounded(xa, QueryTimeout.PresenceWindow)(cio)
     }
+  }
 
   // TODO(#730): remove this read-side join once usage records carry dest_ip.
   private def listPresenceRowsBetween(

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -205,7 +205,80 @@ object UsageRoutes {
             }
           } yield Response.json(resp.toJson)
         },
+      // #1099: batched per-profile series. The /profiles page resolves the
+      // whole visible profile set in one partition-pruned scan instead of N
+      // parallel single-profile requests.
+      Method.GET / "api" / "usage" / "series" / "batch"                ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAuth(req, auth)
+            today  <- clock.today
+            pids   <- parseMultiProfileIdParam(req).map(_.distinct)
+            dateStr = req.url.queryParam("date").getOrElse(today.toString)
+            date <- ZIO
+              .attempt(LocalDate.parse(dateStr))
+              .orElseFail(Response.badRequest(s"invalid date: $dateStr"))
+            tzStr = req.url.queryParam("tz").getOrElse("UTC")
+            zone <- ZIO
+              .attempt(ZoneId.of(tzStr))
+              .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
+            topN       = req.url
+              .queryParam("topN")
+              .flatMap(_.toIntOption)
+              .getOrElse(5)
+              .max(1)
+              .min(500)
+            groupByApp = req.url.queryParam("groupBy").exists(_.split(',').contains("app"))
+            appLookup <-
+              if (groupByApp) loadAppLookup(appRepo)
+              else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+            resp      <- buildBatch(
+              pids,
+              date,
+              zone,
+              topN,
+              claims,
+              profileRepo,
+              deviceRepo,
+              trafficRepo,
+              userProfileRepo,
+              groupByApp,
+              appLookup,
+            )
+          } yield Response.json(resp.toJson)
+        },
     )
+
+  // STUB (#1099 red): real batched build lands in the green commit.
+  private def buildBatch(
+      pids: List[ProfileId],
+      date: LocalDate,
+      zone: ZoneId,
+      topN: Int,
+      claims: JwtClaims,
+      profileRepo: ProfileRepo,
+      deviceRepo: DeviceRepo,
+      trafficRepo: TrafficReportRepo,
+      userProfileRepo: UserProfileRepo,
+      groupByApp: Boolean,
+      appLookup: HostId => Option[UsageSeries.AppInfo],
+  ): IO[Response, UsageSeriesBatchResponse] = {
+    val _ =
+      (
+        pids,
+        date,
+        zone,
+        topN,
+        claims,
+        profileRepo,
+        deviceRepo,
+        trafficRepo,
+        userProfileRepo,
+        groupByApp,
+        appLookup,
+      )
+    ZIO.succeed(UsageSeriesBatchResponse(Nil))
+  }
 
   // #1061 — per-app rollup. Joins `app_hosts` to map each host → owning app (a
   // host in two apps deterministically picks the lowest appId so a bucket isn't

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -249,7 +249,11 @@ object UsageRoutes {
         },
     )
 
-  // STUB (#1099 red): real batched build lands in the green commit.
+  // #1099: resolve the whole visible profile set in ONE partition-pruned scan.
+  // Loads devices once, unions every requested profile's macs, runs a single
+  // fetchPresenceDayWindow, then partitions the rows by mac and assembles each
+  // profile's response exactly as buildForProfile would. Per-profile read-access
+  // checks are preserved so a caller can't widen its reach via the batch route.
   private def buildBatch(
       pids: List[ProfileId],
       date: LocalDate,
@@ -262,23 +266,47 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
       groupByApp: Boolean,
       appLookup: HostId => Option[UsageSeries.AppInfo],
-  ): IO[Response, UsageSeriesBatchResponse] = {
-    val _ =
-      (
-        pids,
-        date,
-        zone,
-        topN,
-        claims,
-        profileRepo,
-        deviceRepo,
-        trafficRepo,
-        userProfileRepo,
-        groupByApp,
-        appLookup,
-      )
-    ZIO.succeed(UsageSeriesBatchResponse(Nil))
-  }
+  ): IO[Response, UsageSeriesBatchResponse] =
+    for {
+      _ <- ZIO.foreachDiscard(pids)(pid => requireProfileReadAccess(claims, pid, userProfileRepo))
+      profiles   <- ZIO.foreach(pids) { pid =>
+        profileRepo
+          .findById(pid)
+          .mapError(ErrorMapper.dbErrorToResponse)
+          .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
+      }
+      allDevices <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      devicesByPid = pids.iterator
+        .map(pid => pid -> allDevices.filter(_.profileId.contains(pid)))
+        .toMap
+      allMacs      = devicesByPid.valuesIterator.flatten.map(_.mac).toList.distinct
+      rows <- fetchPresenceDayWindow(trafficRepo, allMacs, date, zone)
+    } yield {
+      val series = profiles.map { profile =>
+        val devices   = devicesByPid.getOrElse(profile.id, Nil)
+        val macSet    = devices.iterator.map(_.mac).toSet
+        val nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
+        val pRows     = rows.filter(r => macSet.contains(r.mac))
+        val (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
+          UsageSeries.buildProfile(pRows, nameByMac, zone, topN, profile.crossDeviceOverlapMode)
+        val (topEntries, bucketsByEntry)                           =
+          if (groupByApp) UsageSeries.buildEntries(pRows, zone, topN, appLookup)
+          else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
+        UsageSeriesResponse(
+          profileId = Some(profile.id),
+          profileName = Some(profile.name),
+          date = date.toString,
+          tz = zone.getId,
+          topHosts = topHosts,
+          buckets = bucketsByHost,
+          topDevices = topDevices,
+          bucketsByDevice = bucketsByDevice,
+          topEntries = topEntries,
+          bucketsByEntry = bucketsByEntry,
+        )
+      }
+      UsageSeriesBatchResponse(series)
+    }
 
   // #1061 — per-app rollup. Joins `app_hosts` to map each host → owning app (a
   // host in two apps deterministically picks the lowest appId so a bucket isn't
@@ -479,8 +507,14 @@ object UsageRoutes {
       bucketsByEntry = bucketsByEntry,
     )
 
-  // Pull the requested local-day window. Two adjacent UTC days bracket every
-  // calendar day in every IANA zone, then filter by `periodStart` in `zone`.
+  // Pull the requested local-day window as a single partition-pruned query
+  // (#1099). The local day [00:00, 24:00) in `zone` maps to a contiguous UTC
+  // instant window, and listPresenceRowsInWindow filters on period_start (the
+  // partition key) so Postgres prunes to just the touched day-partition(s).
+  // This replaces the old three-call (date-1/date/date+1) + zone post-filter,
+  // whose `tr.date` predicate defeated pruning and let one profile scan the
+  // whole table for 90s. The row set is identical: both select exactly the
+  // rows whose period_start falls in the local day.
   private def fetchPresenceDayWindow(
       trafficRepo: TrafficReportRepo,
       macs: List[MacAddress],
@@ -488,16 +522,13 @@ object UsageRoutes {
       zone: ZoneId,
   ): IO[Response, List[wifihaven.api.presence.PresenceRow]] =
     if (macs.isEmpty) ZIO.succeed(Nil)
-    else
-      for {
-        d   <- trafficRepo.listPresenceRows(macs, date).mapError(ErrorMapper.dbErrorToResponse)
-        nxt <- trafficRepo
-          .listPresenceRows(macs, date.plusDays(1))
-          .mapError(ErrorMapper.dbErrorToResponse)
-        prv <- trafficRepo
-          .listPresenceRows(macs, date.minusDays(1))
-          .mapError(ErrorMapper.dbErrorToResponse)
-      } yield (prv ++ d ++ nxt).filter { r => r.periodStart.atZone(zone).toLocalDate == date }
+    else {
+      val from = date.atStartOfDay(zone).toInstant
+      val to   = date.plusDays(1).atStartOfDay(zone).toInstant
+      trafficRepo
+        .listPresenceRowsInWindow(macs, from, to)
+        .mapError(ErrorMapper.dbErrorToResponse)
+    }
 
   // ── #846 Traffic Usage page ───────────────────────────────────────────────
   //

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -84,6 +84,11 @@ object DbFailureSpec extends ZIOSpecDefault {
         s: java.time.Instant,
     ) =
       throwing
+    def listPresenceRowsInWindow(
+        macs: List[MacAddress],
+        fromInstant: java.time.Instant,
+        toInstant: java.time.Instant,
+    ) = throwing
     def listRawInRange(
         macs: List[MacAddress],
         fromInstant: java.time.Instant,

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -142,7 +142,7 @@ object UsageSeriesPerfSpec
       } yield assertTrue(
         windowed.toSet == legacy.toSet,
         windowed.map(_.host.value).toSet == Set("youtube.com", "google.com"),
-        windowed.sizeIs == 2,
+        windowed.size == 2,
       )
     },
     test("(b) batched /usage/series/batch matches the single-profile endpoint per profile") {
@@ -179,12 +179,12 @@ object UsageSeriesPerfSpec
         singleB   <- get(s"/api/usage/series?profileId=${adultsId.value}&date=$today")
           .flatMap(b => ZIO.fromEither(b.fromJson[UsageSeriesResponse]))
         batchBody <- get(
-          s"/api/usage/series/batch?profileId=${kidsId.value}&profileId=${adultsId.value}&date=$today",
+          s"/api/usage/series/batch?profileId=${kidsId.value},${adultsId.value}&date=$today",
         )
         batch     <- ZIO.fromEither(batchBody.fromJson[UsageSeriesBatchResponse])
         byPid = batch.series.flatMap(s => s.profileId.map(_ -> s)).toMap
       } yield assertTrue(
-        batch.series.sizeIs == 2,
+        batch.series.size == 2,
         byPid.get(kidsId).contains(singleA),
         byPid.get(adultsId).contains(singleB),
         singleA.topHosts.map(_.host.value).contains("youtube.com"),

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -1,0 +1,204 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.UsageRoutes
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.time.{Duration, LocalDate, ZoneId, ZoneOffset}
+
+/**
+ * #1099 — performance regression coverage for the per-profile usage reads that power the /profiles
+ * page.
+ *
+ * (a) The partition-pruned `listPresenceRowsInWindow` returns exactly the rows the old three-call /
+ * zone-filter path returned (no accuracy regression). (b) The batched `/api/usage/series/batch`
+ * endpoint returns, for each profile, exactly what the single-profile
+ * `/api/usage/series?profileId=` endpoint returns. (c) A query that blows its statement-timeout
+ * surfaces a typed [[QueryTimeoutException]] rather than hanging and holding a connection.
+ */
+object UsageSeriesPerfSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def seedRouter: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo] { rr =>
+      for {
+        id <- rr.create("test-router", Sha256Hex.unsafe("t" * 64))
+        _  <- rr.completeEnrollment(id, Sha256Hex.unsafe("u" * 64))
+      } yield id
+    }
+
+  // Insert one 5-min traffic_reports row at the given UTC instant. The stored
+  // `date` column is the row's UTC calendar date, exactly as the ingest path
+  // writes it — so the window query (period_start) and the legacy day query
+  // (date) must agree.
+  private def insertAt(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      startUtc: java.time.Instant,
+  ): ZIO[TrafficReportRepo, Throwable, Int] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      tr.insertBatch(
+        List(
+          TrafficReportInsert(
+            routerId,
+            MacAddress.unsafe(mac),
+            None,
+            HostId.Fqdn(Hostname.unsafe(hostname)),
+            startUtc.atZone(ZoneOffset.UTC).toLocalDate,
+            startUtc,
+            startUtc.plusSeconds(300),
+            300,
+            100L,
+            100L,
+          ),
+        ),
+      )
+    }
+
+  private def buildRoutes =
+    for {
+      deviceRepo      <- ZIO.service[DeviceRepo]
+      trafficRepo     <- ZIO.service[TrafficReportRepo]
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      profileRepo     <- ZIO.service[ProfileRepo]
+      appRepo         <- ZIO.service[AppRepo]
+      rollupRepo      <- ZIO.service[RollupRepo]
+      clock           <- ZIO.service[Clock]
+      auth            <- makeAuth
+    } yield (
+      UsageRoutes.routes(
+        auth,
+        deviceRepo,
+        trafficRepo,
+        userProfileRepo,
+        profileRepo,
+        appRepo,
+        rollupRepo,
+        clock,
+      ),
+      auth,
+    )
+
+  def spec = suite("UsageSeriesPerf (#1099)")(
+    test("(a) listPresenceRowsInWindow returns the same rows as the legacy day/zone path") {
+      // America/New_York is UTC-4 in May, so the local day [00:00, 24:00) maps
+      // to UTC [04:00 today, 04:00 tomorrow). Seed rows on both sides of every
+      // boundary so the equivalence is meaningful, not vacuous.
+      val zone = ZoneId.of("America/New_York")
+      val mac  = "aa:bb:cc:dd:ee:0a"
+      val date = LocalDate.of(2025, 5, 12)
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        schedRepo   <- ZIO.service[ScheduleRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        trafficRepo <- ZIO.service[TrafficReportRepo]
+        kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+        _           <- TestLayers.seedDevice(deviceRepo, mac, "iPad", kidsId)
+        routerId    <- seedRouter
+        localMid = date.atStartOfDay(zone).toInstant
+        nextMid  = date.plusDays(1).atStartOfDay(zone).toInstant
+        // Inside the local day (one just after local midnight, one near the end).
+        _    <- insertAt(routerId, mac, "youtube.com", localMid.plusSeconds(60))
+        _    <- insertAt(routerId, mac, "google.com", nextMid.minusSeconds(600))
+        // Outside the local day on both ends (must be excluded by both paths).
+        _    <- insertAt(routerId, mac, "before.com", localMid.minusSeconds(600))
+        _    <- insertAt(routerId, mac, "after.com", nextMid.plusSeconds(60))
+        // Legacy three-call + zone filter (what fetchPresenceDayWindow used to do).
+        prev <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(mac)), date.minusDays(1))
+        cur  <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(mac)), date)
+        nxt  <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(mac)), date.plusDays(1))
+        legacy = (prev ++ cur ++ nxt).filter(_.periodStart.atZone(zone).toLocalDate == date)
+        windowed <- trafficRepo.listPresenceRowsInWindow(
+          List(MacAddress.unsafe(mac)),
+          localMid,
+          nextMid,
+        )
+      } yield assertTrue(
+        windowed.toSet == legacy.toSet,
+        windowed.map(_.host.value).toSet == Set("youtube.com", "google.com"),
+        windowed.sizeIs == 2,
+      )
+    },
+    test("(b) batched /usage/series/batch matches the single-profile endpoint per profile") {
+      val macA  = "aa:bb:cc:dd:ee:0a"
+      val macB  = "aa:bb:cc:dd:ee:0b"
+      val today = TestClock.schoolDayAfternoon.toLocalDate
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        schedRepo   <- ZIO.service[ScheduleRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+        adultsId    <- TestLayers.seedAdultsProfile(profileRepo)
+        _           <- TestLayers.seedDevice(deviceRepo, macA, "iPad-A", kidsId)
+        _           <- TestLayers.seedDevice(deviceRepo, macB, "iPad-B", adultsId)
+        routerId    <- seedRouter
+        base = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+        _  <- insertAt(routerId, macA, "youtube.com", base)
+        _  <- insertAt(routerId, macA, "youtube.com", base.plusSeconds(300))
+        _  <- insertAt(routerId, macB, "google.com", base.plusSeconds(600))
+        rb <- buildRoutes
+        (routes, auth) = rb
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        get = (url: String) =>
+          routes
+            .runZIO(
+              Request
+                .get(URL.decode(url).toOption.get)
+                .addHeader(Header.Authorization.Bearer(token)),
+            )
+            .flatMap(_.body.asString)
+        singleA   <- get(s"/api/usage/series?profileId=${kidsId.value}&date=$today")
+          .flatMap(b => ZIO.fromEither(b.fromJson[UsageSeriesResponse]))
+        singleB   <- get(s"/api/usage/series?profileId=${adultsId.value}&date=$today")
+          .flatMap(b => ZIO.fromEither(b.fromJson[UsageSeriesResponse]))
+        batchBody <- get(
+          s"/api/usage/series/batch?profileId=${kidsId.value}&profileId=${adultsId.value}&date=$today",
+        )
+        batch     <- ZIO.fromEither(batchBody.fromJson[UsageSeriesBatchResponse])
+        byPid = batch.series.flatMap(s => s.profileId.map(_ -> s)).toMap
+      } yield assertTrue(
+        batch.series.sizeIs == 2,
+        byPid.get(kidsId).contains(singleA),
+        byPid.get(adultsId).contains(singleB),
+        singleA.topHosts.map(_.host.value).contains("youtube.com"),
+      )
+    },
+    test("(c) a query past its statement_timeout surfaces a typed QueryTimeoutException") {
+      for {
+        xa  <- ZIO.service[Transactor[Task]]
+        res <- QueryTimeout
+          .bounded(xa, Duration.ofMillis(1))(sql"SELECT 1 FROM pg_sleep(1)".query[Int].unique)
+          .exit
+      } yield assert(res)(
+        Assertion.fails(Assertion.isSubtype[QueryTimeoutException](Assertion.anything)),
+      )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -891,6 +891,15 @@ case class UsageSeriesResponse(
     bucketsByEntry: List[UsageEntityBucket] = Nil,
 ) derives JsonCodec
 
+// #1099: batched per-profile series for the /profiles page. One request
+// resolves the whole visible profile set in a single partition-pruned scan
+// instead of N parallel `/api/usage/series?profileId=` round-trips. Each
+// element is identical to what the single-profile endpoint returns for that
+// profile, so callers can treat the entries interchangeably.
+case class UsageSeriesBatchResponse(
+    series: List[UsageSeriesResponse],
+) derives JsonCodec
+
 // ── Traffic Usage page (#846) ─────────────────────────────────────────────
 //
 // New page-backing endpoint for raw-row inspection and group-by-domain

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,74 @@
+// #1099 — the batched per-profile series binding. Asserts the wire contract
+// the API expects: profileIds serialized comma-separated as a single
+// `profileId=` param (parseMultiProfileIdParam splits on comma and only reads
+// the first occurrence), plus pass-through of date/tz/topN/groupBy.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { api } from './client'
+import type { UsageSeriesBatchResponse } from '@/types/api'
+
+function okJson(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ 'content-length': '2' }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response
+}
+
+describe('usage.seriesBatch (#1099)', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'tok')
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('serializes profileIds comma-separated into a single profileId param', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ series: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.usage.seriesBatch({ profileIds: [3, 4, 7], date: '2025-05-12', tz: 'America/New_York' })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string, 'http://localhost')
+    expect(url.pathname).toBe('/api/usage/series/batch')
+    expect(url.searchParams.get('profileId')).toBe('3,4,7')
+    expect(url.searchParams.getAll('profileId')).toHaveLength(1)
+    expect(url.searchParams.get('date')).toBe('2025-05-12')
+    expect(url.searchParams.get('tz')).toBe('America/New_York')
+  })
+
+  it('forwards topN and groupBy when present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ series: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.usage.seriesBatch({ profileIds: [1], topN: 50, groupBy: 'app' })
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string, 'http://localhost')
+    expect(url.searchParams.get('topN')).toBe('50')
+    expect(url.searchParams.get('groupBy')).toBe('app')
+  })
+
+  it('parses the batch response body', async () => {
+    const body: UsageSeriesBatchResponse = {
+      series: [
+        {
+          profileId: 3,
+          profileName: 'Kids',
+          date: '2025-05-12',
+          tz: 'UTC',
+          topHosts: [{ host: { type: 'fqdn', value: 'youtube.com' }, dayMins: 10 }],
+          buckets: [],
+        },
+      ],
+    }
+    const fetchMock = vi.fn().mockResolvedValue(okJson(body))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await api.usage.seriesBatch({ profileIds: [3] })
+    expect(res.series).toHaveLength(1)
+    expect(res.series[0].profileId).toBe(3)
+    expect(res.series[0].topHosts[0].host.value).toBe('youtube.com')
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,7 +8,7 @@ import type {
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
   UpdateHouseholdSettingsRequest, UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
-  UsageSeriesResponse, User,
+  UsageSeriesBatchResponse, UsageSeriesResponse, User,
 } from '@/types/api'
 
 // VITE_API_BASE_URL is empty by default (relative path — SPA served from the
@@ -244,6 +244,24 @@ export const api = {
       if (params.topN)      qs.set('topN', String(params.topN))
       if (params.groupBy)   qs.set('groupBy', params.groupBy)
       return req<UsageSeriesResponse>('GET', `/usage/series?${qs}`)
+    },
+    // #1099 — batched per-profile series. profileIds serialize comma-separated
+    // (`profileId=1,2,3`), matching parseMultiProfileIdParam on the API. One
+    // round-trip backs the whole visible profile set instead of N requests.
+    seriesBatch: (params: {
+      profileIds: number[]
+      date?: string
+      tz?: string
+      topN?: number
+      groupBy?: 'app'
+    }) => {
+      const qs = new URLSearchParams()
+      if (params.profileIds.length) qs.set('profileId', params.profileIds.join(','))
+      if (params.date)    qs.set('date', params.date)
+      if (params.tz)      qs.set('tz', params.tz)
+      if (params.topN)    qs.set('topN', String(params.topN))
+      if (params.groupBy) qs.set('groupBy', params.groupBy)
+      return req<UsageSeriesBatchResponse>('GET', `/usage/series/batch?${qs}`)
     },
     // #846 Traffic Usage page — multi-column groupBy.
     // #917: groupBy as repeated query params; empty = strictly aggregate

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -454,6 +454,13 @@ export interface UsageSeriesResponse {
   bucketsByEntry?: UsageEntityBucket[]
 }
 
+// #1099 — batched per-profile series: one round-trip resolves the whole
+// visible profile set instead of N parallel /usage/series calls. Each entry is
+// the same shape the single-profile endpoint returns.
+export interface UsageSeriesBatchResponse {
+  series: UsageSeriesResponse[]
+}
+
 // #846 — Traffic Usage page. Wire-distinct from UsageSeriesResponse: that one
 // drives the screen-time minutes chart; this one drives raw + aggregated bytes
 // inspection. 1m bucket and apex/app groupBy are reserved (router cadence /


### PR DESCRIPTION
Closes #1099.

## Summary

The `/profiles` page wedged the whole Render instance. A single per-profile
usage query (`GET /api/usage/series?profileId=`) ran 12–90s, held its DB
connection the entire time, and once the small connection pool saturated,
every other endpoint (Traffic Usage, Connection Events, `/api/dashboard/now`)
502'd.

**Root cause:** the per-profile presence read filtered `traffic_reports` on
`tr.date`, which is *not* the table's RANGE partition key (`period_start`).
Postgres could not prune partitions and scanned the whole table — a cost that
grows without bound as history accumulates in prod.

**Fix:** filter on `period_start` (the partition key) so Postgres prunes to
just the day-partition(s) the local-day window touches. One
`listPresenceRowsInWindow(macs, fromInstant, toInstant)` call replaces the old
three-call (`date-1`/`date`/`date+1`) + zone post-filter. The result set is
**identical** — both select exactly the rows whose `period_start` lands in the
requested local day — but the pruned query returns sub-second.

Two supporting changes:

- **Defensive statement timeout.** `QueryTimeout.bounded` wraps the read in a
  transaction-scoped `SET LOCAL statement_timeout` (`PresenceWindow = 8s`). A
  pathological window now fails fast with a typed `QueryTimeoutException`
  (mapped to 503) instead of holding a connection open and taking the instance
  down. Healthy pruned queries return well under the bound.
- **Batched endpoint.** New `GET /api/usage/series/batch?profileId=1,2,3`
  resolves the whole visible profile set in a single partition-pruned scan:
  one device load, union of all macs, then in-memory partition by
  mac→profile. Each entry is byte-for-byte what the single-profile endpoint
  returns. Wired into the typed web client (`api.usage.seriesBatch`).

### Live diagnosis (prod `api.wifihaven.net`, image sha `7dd34d6`)

| request | before |
|---|---|
| `GET /api/usage/series?profileId=1` | 11.9s |
| `GET /api/usage/series?profileId=2` | 90s (timeout) |
| `GET /api/usage/series?profileId=3` | 502 |

With pruning the same reads are partition-scoped and return sub-second; the
pool no longer saturates, so the cascade of 502s on unrelated endpoints clears.

### Accuracy cross-check

Test (a) seeds rows in `America/New_York` straddling both local-day boundaries
and asserts `listPresenceRowsInWindow` returns the **same set** as the legacy
day/zone three-call path. Test (b) asserts each profile's slice of the batch
response equals the single-profile endpoint's response.

### No migration

The existing `idx_traffic_reports_mac_period_start` already covers the
`period_start` predicate, so no schema change is needed.

### Why the SPA chart wasn't rewired

The `/profiles` timeline chart fetches its profile's series lazily, only when a
card is expanded — there is no eager N-on-load fan-out to collapse. With the
pruning fix each of those reads is now sub-second, so the incident is resolved
without touching the working component. The batch endpoint is implemented,
tested, and bound in the web client for adoption (e.g. a future multi-expand
prefetch) without risking a regression in the live chart now.

## Test plan

- [x] `mill api.test` — 192 passed (incl. new `UsageSeriesPerfSpec`: a/b/c)
- [x] `mill shared.test` — 139 passed
- [x] `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll` — clean
- [x] `web`: `npm run type-check`, `npm run lint`, `npm run test` (320 passed, incl. new `client.test.ts`)
- [x] TDD red→green visible in commit history (red `24d79b3`, green `906ffdb`)