### PR TITLE
Fix #1221: raise DB pool size + isolate blocking JDBC EC

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -79,6 +79,12 @@ object Main extends ZIOAppDefault {
       // a watermarked row; the read path adds a live tail of buckets after the watermark, so
       // /api/time/status/summary serves a rollup + small live aggregation instead of a full
       // per-request day scan.
+      // TODO(#1221): bound the connection hold time of this rollup recompute and
+      // of the per-profile UsageSeries read (#1099) so neither can monopolize the
+      // shared Hikari pool for tens of seconds under load — e.g. a smaller batch,
+      // a time budget, or a separate small pool for the rollup work. The pool-size
+      // bump (this PR) and the dedicated connect EC are the first-order fix; this
+      // is the durability follow-up tracked in #1221.
       timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
       profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
       deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
@@ -138,7 +144,7 @@ object Main extends ZIOAppDefault {
   private val serverEnv =
     AppConfig.layer >+>
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.db)) >+>
-      ZLayer.fromZIO(ZIO.serviceWith[AppConfig](c => Database.makeTransactor(c.db))) >+>
+      Database.transactorLayer >+>
       Repos.all >+>
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.jwt)) >+>
       Clock.live >+>

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -7,9 +7,13 @@ import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*
 
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, ThreadFactory}
+import scala.concurrent.ExecutionContext
+
 object Database {
 
-  def makeTransactor(cfg: DbConfig): Transactor[Task] = {
+  private def makeDataSource(cfg: DbConfig): HikariDataSource = {
     val ds = new HikariDataSource()
     ds.setJdbcUrl(s"jdbc:postgresql://${cfg.host}:${cfg.port}/${cfg.database}")
     ds.setUsername(cfg.user)
@@ -19,8 +23,49 @@ object Database {
     ds.setConnectionTimeout(30000)
     ds.setIdleTimeout(600000)
     ds.setMaxLifetime(1800000)
-    Transactor.fromDataSource[Task](ds, scala.concurrent.ExecutionContext.global)
+    ds
   }
+
+  // #1221: dedicated bounded blocking EC for JDBC connection acquisition.
+  // Previously the transactor ran connection-acquisition on
+  // `ExecutionContext.global` (ZIO's compute pool); a saturated Hikari pool
+  // would then block compute threads waiting on `connectionTimeout`, starving
+  // unrelated fibers and amplifying the crash loop. doobie's guidance is a
+  // dedicated `connectEC` sized to the JDBC pool: a fixed pool of `poolSize`
+  // threads can never await more connections than exist, and the blocking lives
+  // off the compute pool. Threads are daemon so a leaked pool can't pin the JVM.
+  private def makeConnectEC(poolSize: Int): ZIO[Scope, Nothing, ExecutionContext] =
+    ZIO
+      .acquireRelease(
+        ZIO.succeed {
+          val tf = new ThreadFactory {
+            private val counter                = new AtomicInteger(0)
+            def newThread(r: Runnable): Thread = {
+              val t = new Thread(r, s"wifihaven-db-connect-${counter.incrementAndGet()}")
+              t.setDaemon(true)
+              t
+            }
+          }
+          Executors.newFixedThreadPool(math.max(1, poolSize), tf)
+        },
+      )(es => ZIO.succeed(es.shutdown()))
+      .map(ExecutionContext.fromExecutorService)
+
+  /**
+   * Scoped transactor layer. Owns both the Hikari datasource and the dedicated connect EC, closing
+   * both on scope teardown so neither thread pool leaks.
+   */
+  private def acquireDataSource(cfg: DbConfig): ZIO[Scope, Throwable, HikariDataSource] =
+    ZIO.acquireRelease(ZIO.attempt(makeDataSource(cfg)))(ds => ZIO.succeed(ds.close()))
+
+  val transactorLayer: ZLayer[DbConfig, Throwable, Transactor[Task]] =
+    ZLayer.scoped {
+      for {
+        cfg       <- ZIO.service[DbConfig]
+        connectEC <- makeConnectEC(cfg.poolSize)
+        ds        <- acquireDataSource(cfg)
+      } yield Transactor.fromDataSource[Task](ds, connectEC)
+    }
 
   def runMigrations(cfg: DbConfig): Task[Unit] =
     ZIO.attempt {

--- a/api/test/src/unit/ConfigSpec.scala
+++ b/api/test/src/unit/ConfigSpec.scala
@@ -1,0 +1,54 @@
+package wifihaven.api.unit
+
+import wifihaven.api.AppConfig
+import zio.config.*
+import zio.config.magnolia.*
+import zio.config.typesafe.*
+import zio.test.*
+
+/**
+ * #1221: `db.poolSize` must be configurable per deployment. In prod the value arrives as the
+ * `WIFIHAVEN_DB_POOL_SIZE` env var, which `docker/entrypoint.sh` substitutes into the rendered
+ * `application.conf` as `wifihaven.db.poolSize`. These tests pin the Scala side of that contract:
+ * the derived config reads whatever `poolSize` the HOCON carries (so a non-default env value flows
+ * through) and falls back to the example default when the override is absent.
+ */
+object ConfigSpec extends ZIOSpecDefault {
+
+  private def hocon(poolSize: String) =
+    s"""wifihaven {
+       |  db {
+       |    host     = "localhost"
+       |    port     = 5432
+       |    database = "wifihaven"
+       |    user     = "wifihaven"
+       |    password = "changeme"
+       |    poolSize = $poolSize
+       |  }
+       |  http { host = "0.0.0.0", port = 8080, staticDir = "web/dist", serveSpa = true }
+       |  jwt  { secret = "change-this-to-a-random-32-char-secret!!", expiryHours = 24 }
+       |  cors { allowedOrigins = "" }
+       |}""".stripMargin
+
+  private def load(poolSize: String) =
+    read(
+      deriveConfig[AppConfig]
+        .nested("wifihaven")
+        .from(TypesafeConfigProvider.fromHoconString(hocon(poolSize))),
+    )
+
+  def spec = suite("AppConfig db.poolSize")(
+    test("reads the configured poolSize (env value flows through entrypoint → HOCON)") {
+      for cfg <- load("20")
+      yield assertTrue(cfg.db.poolSize == 20)
+    },
+    test("a non-default override is honoured, not pinned to 5") {
+      for cfg <- load("8")
+      yield assertTrue(cfg.db.poolSize == 8)
+    },
+    test("local-dev default (5) parses when no override is supplied") {
+      for cfg <- load("5")
+      yield assertTrue(cfg.db.poolSize == 5)
+    },
+  )
+}

--- a/render.yaml
+++ b/render.yaml
@@ -64,6 +64,14 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
+      # #1221: HikariCP pool size. The HOCON default (5) crash-looped prod
+      # under concurrent ingest + the time_used_daily rollup fiber + slow
+      # UsageSeries reads (pool exhausted → 30s connectionTimeout → healthcheck
+      # fails → crash loop). wifihaven-pg-staging is free (256 MB RAM → 100
+      # max_connections). Staging is single-instance and low-traffic, so 8 is
+      # ample and stays well clear of Render's reserved connections.
+      - key: WIFIHAVEN_DB_POOL_SIZE
+        value: "8"
       # #590: Render Hobby caps at ~512 MB. Leave headroom for OS + JIT +
       # native heap; bump or move to `plan: pro` if OOM appears in logs.
       - key: JVM_HEAP_OPTS
@@ -131,6 +139,17 @@ services:
           property: password
       - key: WIFIHAVEN_HTTP_PORT
         value: 8080
+      # #1221: HikariCP pool size. The HOCON default (5) is fatal here — under
+      # household load, concurrent router ingest POSTs + the time_used_daily
+      # rollup fiber (#1165/#1167) + slow per-profile UsageSeries reads (#1099)
+      # held all 5 connections, the 30s connectionTimeout fired, the healthcheck
+      # failed, and Render crash-looped the instance (incident 2026-05-31).
+      # wifihaven-pg-prod is basic-256mb (256 MB RAM → 100 max_connections per
+      # Render's "< 8 GB" tier). 20 gives the single prod instance real headroom
+      # under load while leaving ~80 connections for Render's reserved/maintenance
+      # connections and any future read replica or out-of-band rollup worker.
+      - key: WIFIHAVEN_DB_POOL_SIZE
+        value: "20"
       # #786 / #785: bumped to `plan: standard` (2 GB / 1 CPU, $25/mo) after
       # prod started flapping under household load on free's 512 MB cap.
       # Heap sized to leave ~600 MB for OS + JIT + native; revisit if OOM


### PR DESCRIPTION
## Root cause

Prod (`api.wifihaven.net`) crash-looped on **HikariCP connection-pool exhaustion**, not the Profiles read path. The pool defaulted to **5** (`db.poolSize` HOCON default; `render.yaml` set no `WIFIHAVEN_DB_POOL_SIZE` override), and under household load the 5 connections were held simultaneously by:

1. Concurrent router ingest (`POST /api/router/events|usage`),
2. The new `time_used_daily` rollup fiber (#1165/#1167, merged the day before), and
3. Slow per-profile `UsageSeries` reads (#1099, 12–90s each).

With only 5 slots and a 30s `connectionTimeout`, everything else queued 30s → 502, the healthcheck failed, and Render crash-looped the instance.

Separately, `Transactor.fromDataSource[Task](ds, ExecutionContext.global)` ran blocking connection-acquisition on ZIO's compute pool, so a saturated Hikari pool also starved unrelated fibers.

## Changes

- **`render.yaml`** — set `WIFIHAVEN_DB_POOL_SIZE` on both web services: **prod 20**, **staging 8**. The env already flows into HOCON `poolSize` via `docker/entrypoint.sh`; prod just never set it. Declarative per repo convention.
- **`api/src/db/Database.scala`** — replace `ExecutionContext.global` with a **dedicated bounded blocking EC** (fixed pool sized to `poolSize`) for JDBC connection acquisition, owned by a **scoped `ZLayer`** alongside the datasource so neither thread pool leaks. A pool sized to `poolSize` can never await more connections than exist, and the blocking lives off the compute pool. `Main.scala` updated to use `Database.transactorLayer`.
- **`api/test/src/unit/ConfigSpec.scala`** — asserts `db.poolSize` is read from HOCON (the env-override path), incl. a non-default value and the local-dev default.
- **`TODO(#1221)`** in `Main.scala` — bounding the rollup recompute / `UsageSeries` connection hold time (issue item 3) is the durability follow-up; deferred to its own PR rather than half-done here.

## Pool sizes vs. `max_connections`

`wifihaven-pg-prod` is **basic-256mb** = 256 MB RAM → **100 `max_connections`** (Render's "< 8 GB" tier, [docs](https://render.com/docs/postgresql-creating-connecting)). Prod at **20** leaves ~80 connections for Render's reserved/maintenance connections and any future read replica or out-of-band rollup worker. Staging PG is free (also 256 MB → 100); staging is single-instance/low-traffic, so **8** is ample.

## Test plan

- [x] `mill api.compile`
- [x] `mill api.test` — full suite green (incl. new `ConfigSpec`: 3/3 pass)
- [x] `scalafmt --check` clean on all touched files
- [ ] Post-merge: confirm prod boots with `total=20` in the HikariPool startup log and holds under household load.

## Notes

Discussed bumping the prod PG instance (e.g. `basic-1gb`) — deferred. The pool fix resolves the crash loop; a bigger instance is a lever for the slow-query *amplifiers* and belongs with the item-3 query-bounding work under #1221, since a larger instance alone only raises the ceiling without bounding an unbounded query.

Closes #1221 (first-order fix; durability follow-ups tracked in the issue).