### PR TITLE
fix(vm): reap orphaned VMs + reconcile bridge pool with cross-pipeline concurrency

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -23,18 +23,20 @@ name: VM e2e (fake API — Gate 2)
 #   pool pick (lib.sh::wh_pick_lan_bridge, #891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
-#   and each VM pair (router + client) consumes one — so 5 concurrent pairs
-#   is the absolute max. We cap CI matrix fan-out at `max-parallel: 4`
-#   (below) to leave one bridge free for ad-hoc manual runs,
-#   scripts/e2e-kvm-sanity, and the keep-staging-warm cron, so none of those
-#   ever queue behind CI. The matching global governor is the runner-instance
-#   count on api.lan (4, one per job-bridge); see docs/ops/kvm-runner.md
-#   for the runner-count = bridge-count - 1 invariant (#1163).
+#   group: api.lan's /etc/qemu/bridge.conf has 7 bridges (wh-lan0..wh-lan6),
+#   and each VM pair (router + client) consumes one. The pool is sized so
+#   usable bridges (6) cover the worst case across BOTH CD pipelines — Master
+#   Router CD's Gate 2 + Gate 3a and Master API/UI CD's Gate 3b can run
+#   concurrently, 2 arms each = 6 — leaving wh-lan6 as manual headroom for
+#   ad-hoc runs, scripts/e2e-kvm-sanity, and the keep-staging-warm cron
+#   (#657/#1163). The runner-instance count on api.lan (4) is a *lower*
+#   secondary governor; see docs/ops/kvm-runner.md for the
+#   pool-size - 1 >= worst-case-arms invariant.
 #
-#   When all 5 bridges are taken, wh_pick_lan_bridge fails loud with
-#   "LAN bridge pool exhausted" (exit 1) rather than queueing forever — see
-#   scripts/vm/test-lan-bridge-pick.sh. Broader capacity plan: #657.
+#   When all bridges are taken, wh_pick_lan_bridge first reaps any orphan
+#   leaked by a crashed/forgotten run, then fails loud with "LAN bridge pool
+#   exhausted" (exit 1) rather than queueing forever — see
+#   scripts/vm/test-lan-bridge-pick.sh.
 
 on:
   workflow_call:
@@ -69,11 +71,11 @@ jobs:
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).
     # max-parallel: 4 (#1163) — with #891's bridge/port/MAC parameterization
-    # the arms can share a host, bounded by the 5-bridge pool minus one
-    # headroom slot (see the concurrency note at the top of this file). The
-    # 4 self-hosted kvm runner instances on api.lan are the global governor
-    # for cross-workflow concurrency; within a single workflow this cap is
-    # the per-matrix ceiling.
+    # the arms can share a host. The 7-bridge pool (6 usable + 1 headroom)
+    # covers the worst-case 6 concurrent arms across both pipelines; see the
+    # concurrency note at the top of this file. The 4 self-hosted kvm runner
+    # instances on api.lan are the lower global governor for cross-workflow
+    # concurrency; within a single workflow this cap is the per-matrix ceiling.
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -26,15 +26,16 @@ name: VM e2e (Gate 3a — router-side staging smoke)
 #   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
-#   each VM pair consumes one → 5 concurrent pairs max. CI matrix fan-out is
-#   capped at `max-parallel: 4` (below), leaving one bridge for ad-hoc runs,
-#   scripts/e2e-kvm-sanity, and keep-staging-warm. The matching global
-#   governor is the runner-instance count on api.lan (4, one per job-bridge);
-#   see docs/ops/kvm-runner.md for the runner-count = bridge-count - 1
-#   invariant (#1163). When all 5 are taken, wh_pick_lan_bridge fails loud
-#   ("LAN bridge pool exhausted", exit 1) instead of queueing forever.
-#   Broader capacity plan: #657.
+#   group: api.lan's /etc/qemu/bridge.conf has 7 bridges (wh-lan0..wh-lan6),
+#   each VM pair consumes one. The pool is sized so usable bridges (6) cover
+#   the worst case across BOTH CD pipelines — Master Router CD's Gate 2 +
+#   Gate 3a and Master API/UI CD's Gate 3b can run concurrently, 2 arms each
+#   = 6 — with wh-lan6 left as manual headroom (#657/#1163). The runner-
+#   instance count on api.lan (4) is a *lower* secondary governor; see
+#   docs/ops/kvm-runner.md for the pool-size - 1 >= worst-case-arms
+#   invariant. When all bridges are taken, wh_pick_lan_bridge first reaps any
+#   orphan leaked by a crashed run, then fails loud ("LAN bridge pool
+#   exhausted", exit 1) instead of queueing forever.
 
 on:
   workflow_call:
@@ -66,8 +67,9 @@ jobs:
     timeout-minutes: 20
     # Matrix over ipk-23.05 and apk-25.12 (#532). fail-fast=false so a
     # regression in one flavor still reports the other arm's status.
-    # max-parallel: 4 (#1163) — bounded by the 5-bridge pool minus one
-    # headroom slot (see the concurrency note at the top of this file).
+    # max-parallel: 4 (#1163) — the 7-bridge pool (6 usable + 1 headroom)
+    # covers the worst-case 6 concurrent arms across both pipelines (see the
+    # concurrency note at the top of this file).
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -26,15 +26,16 @@ name: VM e2e (Gate 3b — API/UI-side staging smoke)
 #   WH_RUN_ID / WH_PORT_BASE (below) + the wh-lan* bridge pool pick (#891).
 #
 #   The hard ceiling on concurrent VM pairs is the bridge pool, NOT this
-#   group: api.lan's /etc/qemu/bridge.conf has 5 bridges (wh-lan0..wh-lan4),
-#   each VM pair consumes one → 5 concurrent pairs max. CI matrix fan-out is
-#   capped at `max-parallel: 4` (below), leaving one bridge for ad-hoc runs,
-#   scripts/e2e-kvm-sanity, and keep-staging-warm. The matching global
-#   governor is the runner-instance count on api.lan (4, one per job-bridge);
-#   see docs/ops/kvm-runner.md for the runner-count = bridge-count - 1
-#   invariant (#1163). When all 5 are taken, wh_pick_lan_bridge fails loud
-#   ("LAN bridge pool exhausted", exit 1) instead of queueing forever.
-#   Broader capacity plan: #657.
+#   group: api.lan's /etc/qemu/bridge.conf has 7 bridges (wh-lan0..wh-lan6),
+#   each VM pair consumes one. The pool is sized so usable bridges (6) cover
+#   the worst case across BOTH CD pipelines — Master Router CD's Gate 2 +
+#   Gate 3a and Master API/UI CD's Gate 3b can run concurrently, 2 arms each
+#   = 6 — with wh-lan6 left as manual headroom (#657/#1163). The runner-
+#   instance count on api.lan (4) is a *lower* secondary governor; see
+#   docs/ops/kvm-runner.md for the pool-size - 1 >= worst-case-arms
+#   invariant. When all bridges are taken, wh_pick_lan_bridge first reaps any
+#   orphan leaked by a crashed run, then fails loud ("LAN bridge pool
+#   exhausted", exit 1) instead of queueing forever.
 
 on:
   workflow_call:
@@ -55,8 +56,9 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, kvm]
     timeout-minutes: 20
-    # max-parallel: 4 (#1163) — bounded by the 5-bridge pool minus one headroom
-    # slot (see the concurrency note at the top of this file).
+    # max-parallel: 4 (#1163) — the 7-bridge pool (6 usable + 1 headroom)
+    # covers the worst-case 6 concurrent arms across both pipelines (see the
+    # concurrency note at the top of this file).
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/docs/ops/kvm-runner.md
+++ b/docs/ops/kvm-runner.md
@@ -62,28 +62,73 @@ Cache locations (kept across runs, safe to delete to force a rebuild):
 | `scripts/vm/.cache/imagebuilder/`       | OpenWRT Image Builder working tree     |
 | `.e2e-vm-venv/`                         | pytest venv (created lazily)           |
 
-## Sizing: runner count vs. bridge pool — load-bearing invariant
+## Sizing: bridge pool vs. concurrent demand — load-bearing invariant
 
-> **Invariant (#1163): `runner-count = bridge-pool-size − 1`.** The trailing
-> bridge in the pool is reserved as a manual-headroom slot for ad-hoc runs
-> (`scripts/e2e-kvm-sanity`, operator debugging, the keep-staging-warm
-> cron). Because `wh_pick_lan_bridge`
+> **Invariant (#657 / #1163): `bridge-pool-size − 1 ≥ worst-case concurrent
+> VM matrix arms across ALL pipelines`.** The "−1" is the manual-headroom
+> slot reserved for ad-hoc runs (`scripts/e2e-kvm-sanity`, operator
+> debugging, the keep-staging-warm cron). Because `wh_pick_lan_bridge`
 > ([`scripts/vm/lib.sh`](../../scripts/vm/lib.sh)) hands out the
-> **lowest-numbered free bridge first** and there are never more than
-> `N − 1` concurrent jobs (capped by runner-instance count), the
-> highest-numbered bridge stays free in steady state.
+> **lowest-numbered free bridge first**, the highest-numbered bridge is the
+> last to be taken and stays free as long as the invariant holds.
 >
-> **Touch both knobs together.** If you scale runners, scale bridges. If
-> you scale bridges, scale runners. The matching workflow knob is
-> `max-parallel` in the VM e2e workflows (which equals `runner-count`).
+> **Count the arms, not the runners.** The two CD pipelines can run their VM
+> gates concurrently: **Master Router CD** fans out Gate 2
+> (`e2e-vm-fake.yml`, 2 arms: ipk+apk) and Gate 3a (`e2e-vm-gate3a.yml`,
+> 2 arms); **Master API/UI CD** fans out Gate 3b (`e2e-vm-gate3b.yml`,
+> 2 arms). Worst case = **3 workflows × 2 arms = 6 concurrent VM pairs**,
+> regardless of runner count. So usable bridges must be ≥ 6 → **pool size
+> ≥ 7**.
 >
-> Today's sizing on api.lan: **5 bridges (`wh-lan0..wh-lan4`), 4 runner
-> instances (`actions-runner-1..4`), `max-parallel: 4`.**
+> Today's sizing on api.lan: **7 bridges (`wh-lan0..wh-lan6`; `wh-lan6` =
+> headroom), 4 runner instances (`actions-runner-1..4`), `max-parallel: 4`.**
+
+> **Why we sized to arms, not runners.** The previous invariant tied the pool
+> to the runner count (`runner-count = pool-size − 1`). That made the
+> no-exhaustion guarantee depend on *two* host-side numbers staying in sync —
+> bridge count and runner count — and a drift between them (the pool was left
+> at 4 when it should have been 5) was a contributing cause of run
+> [26716313048](https://github.com/wifihaven/wifihaven/actions/runs/26716313048)
+> exhausting the pool. Sizing to worst-case arms makes the bridge guarantee
+> self-contained: `usable ≥ 6` holds no matter how many runners are online or
+> how `max-parallel` is set. The runner count remains a *secondary, lower*
+> governor (see below) — it can only ever reduce concurrency below the pool
+> ceiling, never exceed it.
 
 The runner-instance count is the global host-concurrency governor: GitHub
-queues jobs naturally when no runner is free, so once all 4 runners are
-busy, sibling jobs wait. No workflow-level `concurrency:` group is needed
-across workflows — the runner pool *is* the queue.
+queues jobs naturally when no runner is free, so with 4 runners at most 4 VM
+pairs run at once even though the pool could host 6. That is fine — the extra
+bridges are headroom against future runner scaling and against the bridge/runner
+drift above. No workflow-level `concurrency:` group is used across the VM gate
+workflows: a shared `concurrency` group is a *mutex* (GitHub allows one running
++ one pending per group and **cancels** any older pending run), which would
+cancel a required gate on the second pipeline — unacceptable for a release gate.
+The pool-size-≥-worst-case-arms invariant is what guarantees no exhaustion
+instead.
+
+### Orphan reaping keeps the pool from silently shrinking
+
+Even a correctly-sized pool degrades if a run ends without its teardown: a
+manual session the operator forgot, the keep-staging-warm cron, or a CI job
+whose host crashed before the `if: always()` teardown step. Each leaks a tap
+and/or a reservation marker, which the picker counts as "in use" forever. To
+stop a single leak from permanently removing a bridge, `wh_pick_lan_bridge`
+runs `wh_reap_orphan_bridges` (`scripts/vm/lib.sh`) under the pool flock before
+every pick. It is precise by construction — it only reclaims a bridge whose
+owner is provably gone:
+
+- **dead-pid reservation markers** are removed;
+- **taps with no owning qemu** (qemu was hard-killed, tap lingered) are deleted;
+- **wh-* qemus older than `WH_VM_MAX_LIFETIME`** (default 45 min, comfortably
+  above the 20–30 min job timeouts) on a **non-headroom** bridge are killed as
+  definitive orphans — their run is long gone.
+
+It never touches a within-lifetime qemu (a live local or concurrent-sibling
+run is always well under the ceiling) and never age-reaps the **headroom**
+(highest-numbered) bridge. **Long-lived manual/debug VMs must therefore use the
+headroom bridge** (e.g. `WH_LAN_BRIDGE=wh-lan6 scripts/vm/router-up.sh`); a
+manual VM parked on a job slot for more than `WH_VM_MAX_LIFETIME` will be reaped
+as a presumed leak.
 
 ## Registering the runners with GitHub
 
@@ -160,12 +205,12 @@ the per-instance systemd unit needs sudo once.
 
 ## Bridge pool (`/etc/qemu/bridge.conf`)
 
-The 4 job-runners share a host-wide pool of LAN bridges. The pool is
+The job-runners share a host-wide pool of LAN bridges. The pool is
 created by `scripts/vm/lan-bridge-pool-bootstrap.sh`, which also appends
 `allow wh-lanN` entries to `/etc/qemu/bridge.conf`.
 
 ```bash
-# Default pool size 5 → wh-lan0..wh-lan4. Override with WH_LAN_BRIDGE_POOL_SIZE.
+# Default pool size 7 → wh-lan0..wh-lan6. Override with WH_LAN_BRIDGE_POOL_SIZE.
 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
 ```
 
@@ -176,15 +221,20 @@ allow wh-lan0   # job slot 0
 allow wh-lan1   # job slot 1
 allow wh-lan2   # job slot 2
 allow wh-lan3   # job slot 3
-allow wh-lan4   # manual headroom (e2e-kvm-sanity, keep-staging-warm, debug)
+allow wh-lan4   # job slot 4
+allow wh-lan5   # job slot 5  (worst-case 6th concurrent VM arm)
+allow wh-lan6   # manual headroom (e2e-kvm-sanity, keep-staging-warm, debug)
 ```
 
 The picker (`scripts/vm/lib.sh::wh_pick_lan_bridge`) treats the pool as a
 uniform set, picking the lowest-numbered free bridge under a host-wide
-flock. **There is no code-level "reserved" flag on `wh-lan4`** — the
-headroom guarantee comes from the runner-count = pool-size − 1 invariant.
-If you bump runner count to 5, `wh-lan4` becomes a job slot and you must
-add `wh-lan5` to preserve headroom.
+flock. **There is no code-level "reserved" flag on `wh-lan6`** — the
+headroom guarantee comes from the pool-size − 1 ≥ worst-case-arms invariant
+above, plus the lowest-first pick order. The orphan reaper *does* treat the
+highest-numbered bridge specially: it is exempt from age-based reaping so a
+long manual debug VM parked there survives. If you add a fourth VM gate
+workflow or widen a matrix, recompute worst-case arms and grow the pool to
+`arms + 1` so the highest bridge stays free.
 
 ## Verifying parallelism
 

--- a/scripts/vm/README.md
+++ b/scripts/vm/README.md
@@ -39,7 +39,7 @@ auto-picks a free bridge from the pool — no extra env vars needed for the
 bridge.
 
 ```
-# Creates wh-lan0..wh-lan4 (default pool size 5) and ensures bridge.conf
+# Creates wh-lan0..wh-lan6 (default pool size 7) and ensures bridge.conf
 # has an `allow` line for each. Idempotent.
 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
 ```

--- a/scripts/vm/lan-bridge-pool-bootstrap.sh
+++ b/scripts/vm/lan-bridge-pool-bootstrap.sh
@@ -3,21 +3,34 @@
 # runs (#891). Idempotent.
 #
 # Creates ${WH_LAN_BRIDGE_POOL_SIZE} bridges named wh-lan0 .. wh-lan${N-1}
-# (default N=5) via `sudo ip link add`, and verifies each is listed in
+# (default N=7) via `sudo ip link add`, and verifies each is listed in
 # /etc/qemu/bridge.conf so qemu-bridge-helper will attach taps.
 #
-# Sizing convention (#1163): N = (concurrent-runner-count) + 1. The trailing
-# bridge is the manual-headroom slot reserved for ad-hoc runs and the
-# keep-staging-warm cron — it stays free because runners only fan out to N-1
-# bridges, and the wh_pick_lan_bridge picker hands out lowest-numbered first.
-# Today: 4 runners, 5 bridges. See docs/ops/kvm-runner.md for the full
-# invariant.
+# Sizing convention (#1163 / #657): N = (worst-case concurrent VM matrix arms
+# across ALL pipelines) + 1. The +1 is the manual-headroom slot reserved for
+# ad-hoc runs and the keep-staging-warm cron — it stays free because the
+# wh_pick_lan_bridge picker hands out the lowest-numbered free bridge first, so
+# the highest-numbered bridge is the last to be taken.
+#
+# Why worst-case arms, not runner-count: the old invariant tied N to the runner
+# count (N = runners + 1). But the two CD pipelines can run their VM gates
+# concurrently — Master Router CD fans out Gate 2 (e2e-vm-fake, 2 arms) + Gate
+# 3a (2 arms), and Master API/UI CD fans out Gate 3b (2 arms) — for up to 6
+# concurrent VM pairs, independent of how many runners are online. Sizing the
+# pool to the runner count made bridge availability depend on a second host-side
+# number staying in sync, which silently drifted and contributed to run
+# 26716313048 exhausting the pool. Sizing to worst-case arms decouples the
+# guarantee from runner count: usable bridges (N-1) >= 6 always holds.
+#
+# Today: 3 VM gate workflows x 2 matrix arms = 6 worst-case arms, so N = 7
+# (wh-lan0..wh-lan6; wh-lan6 = headroom). See docs/ops/kvm-runner.md for the
+# full invariant.
 #
 # Also ensures /etc/qemu/bridge.conf has an `allow wh-lanK` line for each
 # pool bridge (sudo tee -a). Idempotent: existing lines are left alone.
 #
 # Usage:
-#   sudo scripts/vm/lan-bridge-pool-bootstrap.sh           # default size 5
+#   sudo scripts/vm/lan-bridge-pool-bootstrap.sh           # default size 7
 #   WH_LAN_BRIDGE_POOL_SIZE=8 sudo scripts/vm/lan-bridge-pool-bootstrap.sh
 
 set -euo pipefail
@@ -33,7 +46,7 @@ require_cmd() {
 }
 require_cmd ip
 
-SIZE="${WH_LAN_BRIDGE_POOL_SIZE:-5}"
+SIZE="${WH_LAN_BRIDGE_POOL_SIZE:-7}"
 if ! [[ "${SIZE}" =~ ^[0-9]+$ ]] || (( SIZE < 1 )); then
   echo "lan-bridge-pool-bootstrap: WH_LAN_BRIDGE_POOL_SIZE must be a positive integer (got '${SIZE}')" >&2
   exit 2

--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -150,6 +150,106 @@ wh_bridge_reserved() {
   return 1
 }
 
+# --- Orphan reaping (#657 / #1163) -------------------------------------------
+# A bridge is removed from the pool when it has either an attached tap OR a live
+# reservation. A run that ends without its teardown running — a manual session
+# the operator forgot, the keep-staging-warm cron, or a CI job whose host
+# crashed before the `if: always()` teardown step — leaks one or both and
+# permanently shrinks the pool. (This is exactly how run 26716313048 hit "LAN
+# bridge pool exhausted": three VMs from a manual debug session four days
+# earlier were still squatting wh-lan0/wh-lan1.) The reaper below reclaims such
+# leaks before each pick, precisely enough to never disturb a concurrent
+# legitimate run.
+
+# Wall-clock lifetime (whole seconds) of a pid, empty if not running.
+wh_proc_age_secs() {
+  local pid="$1"
+  [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
+  ps -o etimes= -p "${pid}" 2>/dev/null | tr -d '[:space:]'
+}
+
+# Longest wall-clock lifetime a *CI* VM can legitimately reach. The VM gates
+# carry timeout-minutes 20–30, so any wh-* qemu older than this on a non-
+# headroom bridge is unambiguously a leaked orphan (its run is long gone). The
+# 45-minute default sits well above the longest job timeout AND above any live
+# concurrent run, so age-reaping can never catch a VM that a real run still
+# owns. Override for unusual hosts.
+WH_VM_MAX_LIFETIME="${WH_VM_MAX_LIFETIME:-2700}"
+
+# pids of wh-* qemu VMs whose LAN netdev is attached to bridge $1. The trailing
+# `([^0-9]|$)` anchors the bridge name so `wh-lan1` does not also match
+# `wh-lan10` (substring) — ERE has no lookahead, and the netdev token is always
+# followed by a space (the next `-device`) or end-of-arg.
+wh_qemu_pids_on_bridge() {
+  local br="$1"
+  pgrep -f "qemu-system-x86_64.*-name wh-.*br=${br}([^0-9]|\$)" 2>/dev/null || true
+}
+
+# pids of ANY qemu attached to bridge $1 (not just our wh-* VMs). Used to decide
+# whether a lingering tap is truly ownerless before deleting it.
+wh_any_qemu_pids_on_bridge() {
+  local br="$1"
+  pgrep -f "qemu-system-x86_64.*br=${br}([^0-9]|\$)" 2>/dev/null || true
+}
+
+# Delete taps on bridge $1 that no qemu owns (qemu exited but its tap lingered,
+# e.g. a hard SIGKILL). No-op while any qemu is still attached — those taps are
+# legitimately in use. Best-effort on privilege: tap teardown needs CAP_NET_ADMIN,
+# granted to the runner via the NOPASSWD `ip` sudoers rule.
+wh_delete_orphan_taps() {
+  local br="$1"
+  local brif="${WH_SYS_CLASS_NET}/${br}/brif"
+  [[ -d "${brif}" ]] || return 0
+  # If any qemu (wh-* or otherwise) still holds the bridge, leave its taps alone.
+  [[ -n "$(wh_any_qemu_pids_on_bridge "${br}")" ]] && return 0
+  local tap
+  while IFS= read -r tap; do
+    [[ -n "${tap}" ]] || continue
+    log "deleting orphan tap ${tap} on ${br} (no owning qemu)"
+    ip link delete "${tap}" 2>/dev/null \
+      || sudo -n ip link delete "${tap}" 2>/dev/null \
+      || log "could not delete tap ${tap} (needs privilege) — leaving for operator"
+  done < <(ls "${brif}" 2>/dev/null)
+}
+
+# Reclaim leaked bridges across the pool given as positional args. Precise by
+# construction — only ever touches a bridge whose owner is provably gone:
+#   1. stale (dead-pid) reservation markers           → removed
+#   2. wh-* qemus older than WH_VM_MAX_LIFETIME on a   → killed (definitive
+#      NON-headroom bridge                                orphan; its run is gone)
+#   3. taps with no owning qemu                         → deleted
+# It NEVER kills a within-lifetime qemu (a live legitimate run, local or a
+# concurrent sibling, is always well under the ceiling) and NEVER age-reaps the
+# headroom bridge (the highest-numbered pool member), so a long-running manual
+# debug VM parked there survives. Long-lived manual VMs therefore belong on the
+# headroom slot — see docs/ops/kvm-runner.md.
+wh_reap_orphan_bridges() {
+  local headroom
+  headroom="$(printf '%s\n' "$@" | sort -V | tail -n1)"
+  local br pid age
+  for br in "$@"; do
+    # (1) Drop a dead-pid reservation as a side effect.
+    wh_bridge_reserved "${br}" >/dev/null 2>&1 || true
+    # (2) Age-reap orphan qemus on non-headroom bridges.
+    if [[ "${br}" != "${headroom}" ]]; then
+      while IFS= read -r pid; do
+        [[ -n "${pid}" ]] || continue
+        age="$(wh_proc_age_secs "${pid}")"
+        [[ "${age}" =~ ^[0-9]+$ ]] || continue
+        if (( age >= WH_VM_MAX_LIFETIME )); then
+          log "reaping orphan qemu pid=${pid} on ${br} (age ${age}s ≥ ${WH_VM_MAX_LIFETIME}s ceiling — no live run owns it)"
+          kill "${pid}" 2>/dev/null || true
+          for _ in 1 2 3 4 5; do kill -0 "${pid}" 2>/dev/null || break; sleep 0.2; done
+          kill -9 "${pid}" 2>/dev/null || true
+          wh_clear_bridge_reservation "${br}"
+        fi
+      done < <(wh_qemu_pids_on_bridge "${br}")
+    fi
+    # (3) Delete taps left behind by a now-dead qemu.
+    wh_delete_orphan_taps "${br}"
+  done
+}
+
 # Pick a LAN bridge from the wh-lan* pool when one wasn't set explicitly (#891).
 #
 # Contract:
@@ -213,6 +313,11 @@ wh_pick_lan_bridge() {
   if ! flock -w 60 9; then
     die "could not acquire bridge-pool lock (${lock_file}) within 60s"
   fi
+  # Reclaim bridges leaked by crashed / out-of-namespace / forgotten runs before
+  # scanning, so a leaked tap or stale marker can't permanently shrink the pool
+  # (#657). Held under the same flock as the scan+reserve below, so two
+  # concurrent pickers can't race on the same orphan.
+  wh_reap_orphan_bridges "${pool[@]}"
   local chosen=""
   local br
   while IFS= read -r br; do

--- a/scripts/vm/router-up.sh
+++ b/scripts/vm/router-up.sh
@@ -25,6 +25,17 @@ fi
 # WH_LAN_BRIDGE=wh-lan0 (today's default). Holds a flock until this shell exits.
 wh_pick_lan_bridge
 
+# If we picked a pool bridge but qemu never comes up (image download fails,
+# overlay create errors, qemu refuses to boot), release the reservation we just
+# wrote so the slot isn't stranded until the next pick's reaper notices the
+# dead-pid marker. Cleared once qemu is confirmed running (see end of script).
+_router_booted=0
+_release_reservation_on_fail() {
+  [[ "${_router_booted}" == "1" ]] && return 0
+  [[ -n "${WH_LAN_BRIDGE_PICKED:-}" ]] && wh_clear_bridge_reservation "${WH_LAN_BRIDGE}"
+}
+trap _release_reservation_on_fail EXIT
+
 "${HERE}/lan-bridge-up.sh"
 
 ensure_openwrt_image
@@ -80,6 +91,10 @@ if [[ -n "${WH_LAN_BRIDGE_PICKED:-}" ]]; then
     wh_write_bridge_reservation "${WH_LAN_BRIDGE}" "${_qpid}"
   fi
 fi
+
+# qemu is up and the reservation now carries its pid — the EXIT trap must no
+# longer release the slot.
+_router_booted=1
 
 log "router VM started (pid $(cat "${WH_ROUTER_PIDFILE}" 2>/dev/null || echo '?'))"
 log ""

--- a/scripts/vm/test-lan-bridge-pick.sh
+++ b/scripts/vm/test-lan-bridge-pick.sh
@@ -112,6 +112,22 @@ out="$(run_pick)"
 assert "non-zero rc" "RC=1" "${out}"
 assert "pool-exhausted message" "LAN bridge pool exhausted" "${out}"
 cleanup_tmp
+
+echo "test-lan-bridge-pick: case 3 — orphan reaper reclaims dead-pid markers"
+setup_tmp
+# Every bridge carries a reservation whose owning pid is dead (a crashed/
+# forgotten run that never ran teardown). wh_reap_orphan_bridges must reclaim
+# them so the pool isn't falsely reported exhausted. PID 2^31-1 is reserved by
+# Linux and never assigned, so kill -0 always fails → treated as dead.
+dead_pid=2147483647
+for i in 0 1 2 3; do
+  printf 'pid=%s\nrun_id=stale\n' "${dead_pid}" \
+    > "${WH_BRIDGE_RESERVATION_DIR}/wh-lan${i}.reservation"
+done
+out="$(run_pick)"
+assert "rc=0 after reclaim" "RC=0" "${out}"
+assert "picked reclaimed wh-lan0" "WH_LAN_BRIDGE=wh-lan0" "${out}"
+cleanup_tmp
 set -e
 
 echo


### PR DESCRIPTION
## Context

Gate 3b run [26716313048](https://github.com/wifihaven/wifihaven/actions/runs/26716313048) failed with:

```
[router-vm] error: LAN bridge pool exhausted — every wh-lan* is in use
(attached tap or live reservation): wh-lan0 wh-lan1 wh-lan2 wh-lan3
```

Two distinct, real root causes — addressed independently below. Refs #657
(capacity watch) and #1163 (multi-instance runner / pool sizing).

## Root cause 1 — teardown leak / namespacing gap

Per-run teardown is `pkill -f "qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}"`
— it only reaps VMs whose name carries *this* run's `WH_RUN_ID`. Anything
started outside that namespace (a manual debug session, the keep-staging-warm
cron, or a crashed run with a different/empty `WH_RUN_ID`) is invisible to
teardown and squats its bridge forever. The bridge picker treats "attached
tap OR live reservation" as in-use, so one leaked tap permanently removes a
bridge from the pool. In this incident, three VMs from a manual debug session
four days earlier were still running on wh-lan0/wh-lan1 (one a bare
`wh-client1` on the old un-namespaced `.run/client1` path).

**Fix (Part A):**
- New `wh_reap_orphan_bridges` in [`scripts/vm/lib.sh`](scripts/vm/lib.sh),
  run **under the pool flock before every pick** so two pickers can't race on
  the same orphan. It is precise by construction — only reclaims a bridge
  whose owner is provably gone:
  - dead-pid reservation markers → removed;
  - taps with no owning qemu (hard SIGKILL left a lingering tap) → deleted
    (best-effort via the NOPASSWD `ip` rule);
  - wh-* qemus older than `WH_VM_MAX_LIFETIME` (default **45 min**, well above
    the 20–30 min gate `timeout-minutes`) on a **non-headroom** bridge →
    killed as definitive orphans (their run is long gone).
  - It **never** touches a within-lifetime qemu (a live local or concurrent-
    sibling run is always far under the ceiling) and **never** age-reaps the
    **headroom** (highest-numbered) bridge — so a long manual debug VM parked
    there survives. This is the explicit guard against killing other live runs
    or the manual-headroom slot.
- Early-failure `trap` in [`scripts/vm/router-up.sh`](scripts/vm/router-up.sh)
  releases the just-written reservation if qemu never boots, cleared once qemu
  is confirmed up. (CI teardown already runs `if: always()` — confirmed,
  unchanged.)

## Root cause 2 — pool undersized vs. cross-pipeline concurrency

The pool was sized to the runner count (old invariant `N = runners + 1`), and
the live host had only 4 bridges. But the **two CD pipelines run their VM
gates concurrently**: Master Router CD fans out Gate 2 (`e2e-vm-fake`, 2 arms)
+ Gate 3a (2 arms), and Master API/UI CD fans out Gate 3b (2 arms) — up to
**6 concurrent VM pairs**, independent of runner count. Sizing the pool to the
runner count made the no-exhaustion guarantee depend on *two* host-side numbers
staying in sync, and that drift (pool left at 4) contributed to the exhaustion.

**Design decision (Part B): grow the pool; re-anchor the invariant to arms,
not runners.**

I considered all three candidates:
- **Shared GitHub Actions `concurrency` group across the three VM workflows** —
  rejected. A `concurrency` group is a *mutex* (one running + one pending per
  group; GitHub **cancels** any older pending run). A constant shared group
  would cancel a required gate on the second pipeline — unacceptable for a
  release gate.
- **Lower `max-parallel`** — rejected. It bounds arms *within* one workflow,
  not *across* the two pipelines, so it can't cap the cross-pipeline total.
- **Grow the bridge pool to cover worst-case cross-pipeline demand** — chosen.
  Robust (the guarantee no longer depends on runner count or `max-parallel`
  staying in sync), and cheapest to operate (bridges are virtual netdevs; no
  CI latency, no serialization, no risk of cancelling gates).

New invariant (docs/ops/kvm-runner.md): **`pool-size − 1 ≥ worst-case
concurrent VM matrix arms across all pipelines`**. Today: 3 VM gate workflows
× 2 arms = 6 → usable ≥ 6 → **pool size 7** (wh-lan0..wh-lan6; wh-lan6 =
headroom). The runner-instance count (4) remains a *lower secondary* governor
— it can only reduce concurrency below the pool ceiling, never exceed it.

Changes: bump `lan-bridge-pool-bootstrap.sh` default 5 → 7; update
`docs/ops/kvm-runner.md`, `scripts/vm/README.md`, and the capacity comments in
all three VM workflows.

## Required operator action (host-side)

The bridges are provisioned on api.lan, not by CI. Run on the KVM host:

```bash
sudo WH_LAN_BRIDGE_POOL_SIZE=7 scripts/vm/lan-bridge-pool-bootstrap.sh
```

This is idempotent — it creates wh-lan4/5/6, appends their `allow` lines to
`/etc/qemu/bridge.conf`, and leaves wh-lan0..3 alone. (Provisioning only
wh-lan4 — the previously-planned single-bridge bump — would **not** close the
gap: 6 worst-case arms > 4 usable. N must be 7.)

## Tests / checks

- New case 3 in [`scripts/vm/test-lan-bridge-pick.sh`](scripts/vm/test-lan-bridge-pick.sh):
  dead-pid reservation markers on every bridge are reclaimed by the reaper and
  the pick succeeds (no false "exhausted"). Existing cases 1 & 2 unchanged.
  (The suite self-skips on hosts without `flock(1)`, i.e. dev macOS; it runs on
  the Linux KVM runner.)
- Reaper dead/live marker handling unit-verified locally: dead-pid markers
  reclaimed, a live-pid marker survives.
- `shellcheck -x` on every touched shell file: no new findings (only the pre-
  existing info-level SC1091/SC2012 and the pre-existing SC2034 in the test).
- `bash -n` syntax-clean on all touched scripts.

## Test plan

- [ ] Operator runs the bootstrap command above; confirm 7 bridges + 7 `allow`
      lines in `/etc/qemu/bridge.conf`.
- [ ] Re-run Gate 3b (and a concurrent Master Router CD) to confirm no
      exhaustion.
- [ ] Confirm `scripts/vm/test-lan-bridge-pick.sh` passes on the KVM runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)