### PR TITLE
ci: build router release artifacts once, test those, publish without rebuild (#1224)

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -1,0 +1,297 @@
+name: Build router release artifacts
+
+# Single build job for the router release pipeline (#1224).
+#
+# Builds EVERY shippable artifact exactly once, versioned with the final
+# release version derived here (and nowhere else):
+#
+#   - wifihaven router      .ipk / .apk
+#   - luci-app-wifihaven    .ipk / .apk
+#   - qemu VM images        ipk/OpenWRT 23.05 + apk/OpenWRT 25.12 (raw .img
+#                           for the gates + .tar.gz release tarballs)
+#
+# These exact artifacts are then:
+#   - consumed by Gate 2 / Gate 3a (the raw .img uploads), so the bits we
+#     test are the bits we ship; and
+#   - downloaded verbatim by publish-openwrt-release.yml after approval — no
+#     rebuild, no re-derivation (publish can no longer fail on a compile).
+#
+# Coordinated-version invariant (#499 / #1134): the version is derived ONCE
+# in the `Derive version` step and threaded verbatim into the baked agent
+# VERSION file (#771), every package version, the VM images, and — via the
+# `version` workflow output — the release name and the v<X.Y.Z> tag. All
+# four MUST match; this job is the single point where that version is chosen.
+#
+# Triggers:
+#   - workflow_call — invoked by master-router.yml ahead of the gates.
+#     Exposes `version` so the caller can pass it to the publish job.
+#   - workflow_dispatch — manual debug build (produces -dev.<sha> artifacts).
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: "The release version derived once for all artifacts (e.g. 0.2.7, or 0.2.7-dev.<sha> on workflow_dispatch)."
+        value: ${{ jobs.build.outputs.version }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build:
+    name: Build all release artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # #499: derive-version.sh counts commits since VERSION last changed;
+          # a shallow clone returns 0 and produces a bogus patch number. Always
+          # fetch full history so the single derivation is correct.
+          fetch-depth: 0
+
+      - name: Derive version
+        id: ver
+        # #499/#1134: single source of truth is the repo-root VERSION file
+        # (MAJOR.MINOR) plus the commit count since that file last changed
+        # (PATCH). This is the ONLY place the release version is computed —
+        # everything downstream (packages, VM images, release tag) consumes
+        # this output verbatim. workflow_dispatch runs append -dev.<sha> so
+        # ad-hoc builds can't collide with a real tagged release.
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            short=$(echo "${GITHUB_SHA}" | cut -c1-7)
+            version=$(./scripts/ci/derive-version.sh --dev "$short")
+          else
+            version=$(./scripts/ci/derive-version.sh)
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "release=1"        >> "$GITHUB_OUTPUT"
+          echo "Derived version: $version"
+
+      - name: Build .ipk
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+          PKG_RELEASE: ${{ steps.ver.outputs.release }}
+        run: |
+          chmod +x openwrt/build-ipk.sh
+          openwrt/build-ipk.sh
+
+      - name: Verify .ipk contents
+        run: |
+          ipk=$(ls openwrt/wifihaven_*.ipk)
+          echo "Package: $ipk"
+          ls -lh "$ipk"
+          echo "--- ar contents ---"
+          ar t "$ipk"
+          echo "--- control ---"
+          ar p "$ipk" control.tar.gz | tar tz
+          echo "--- data ---"
+          ar p "$ipk" data.tar.gz | tar tz
+
+      # #499: coordinated-version assertion. The version baked into the .ipk's
+      # control file must match the version derived from the repo-root VERSION
+      # file. Fails when VERSION is missing or the .ipk Version line doesn't
+      # start with $(cat VERSION). Guards the static Makefile 0.1.0 sentinel.
+      - name: Assert .ipk version matches VERSION file (#499)
+        run: |
+          set -eu
+          if [ ! -f VERSION ]; then
+            echo "ERROR: repo-root VERSION file is missing (#499)" >&2
+            exit 1
+          fi
+          base=$(tr -d ' \n' < VERSION)
+          ipk=$(ls openwrt/wifihaven_*.ipk)
+          baked=$(ar p "$ipk" control.tar.gz | tar xzO ./control | awk '/^Version:/{print $2}')
+          echo "VERSION base: $base"
+          echo "ipk Version:  $baked"
+          case "$baked" in
+            "$base".*) : ;;
+            *) echo "ERROR: ipk Version '$baked' does not start with VERSION base '$base.'" >&2; exit 1 ;;
+          esac
+          case "$baked" in
+            0.1.0-*) echo "ERROR: ipk Version is the static Makefile sentinel 0.1.0 (#499)" >&2; exit 1 ;;
+          esac
+
+      - name: Build luci-app-wifihaven .ipk
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+          PKG_RELEASE: ${{ steps.ver.outputs.release }}
+        run: |
+          chmod +x openwrt/luci/build-ipk.sh
+          openwrt/luci/build-ipk.sh
+
+      - name: Verify luci-app-wifihaven .ipk contents
+        run: |
+          ipk=$(ls openwrt/luci/luci-app-wifihaven_*.ipk)
+          echo "Package: $ipk"
+          ls -lh "$ipk"
+          ar p "$ipk" data.tar.gz | tar tz
+
+      - name: Install apk-tools build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            meson ninja-build pkg-config libssl-dev libzstd-dev wget
+
+      - name: Build .apk
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+          PKG_RELEASE: ${{ steps.ver.outputs.release }}
+        run: |
+          chmod +x openwrt/build-apk.sh
+          openwrt/build-apk.sh
+
+      - name: Build luci-app-wifihaven .apk
+        env:
+          PKG_VERSION: ${{ steps.ver.outputs.version }}
+          PKG_RELEASE: ${{ steps.ver.outputs.release }}
+        run: |
+          chmod +x openwrt/luci/build-apk.sh
+          openwrt/luci/build-apk.sh
+
+      - name: Verify luci-app-wifihaven .apk contents
+        run: |
+          apk_file=$(ls openwrt/luci/luci-app-wifihaven_*.apk)
+          apk_bin="$HOME/.cache/wifihaven-apk-tools/build/src/apk"
+          echo "Package: $apk_file"
+          ls -lh "$apk_file"
+          "$apk_bin" adbdump "$apk_file"
+
+      - name: Verify .apk contents
+        run: |
+          apk_file=$(ls openwrt/wifihaven_*.apk)
+          echo "Package: $apk_file"
+          ls -lh "$apk_file"
+          apk_bin="$HOME/.cache/wifihaven-apk-tools/build/src/apk"
+          echo "--- file type ---"
+          file "$apk_file"
+          echo "--- apk adbdump (metadata + payload listing) ---"
+          "$apk_bin" adbdump "$apk_file"
+
+      # Qemu VM images (#893). Build BOTH flavors from the packages compiled
+      # above (IPK_SOURCE/APK_SOURCE=path) so the image carries the exact
+      # versioned package — no recompile, no version drift. The raw .img is
+      # what Gate 2 / Gate 3a boot.
+      - name: Build qemu VM image (ipk / OpenWRT 23.05)
+        env:
+          PKG_FORMAT: ipk
+          IPK_SOURCE: path
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          ipks=("$PWD"/openwrt/wifihaven_*.ipk)
+          IPK_PATH="${ipks[0]}"
+          export IPK_PATH
+          chmod +x scripts/vm/build-router-image.sh
+          scripts/vm/build-router-image.sh
+
+      - name: Build qemu VM image (apk / OpenWRT 25.12)
+        env:
+          PKG_FORMAT: apk
+          APK_SOURCE: path
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          apks=("$PWD"/openwrt/wifihaven_*.apk)
+          APK_PATH="${apks[0]}"
+          export APK_PATH
+          scripts/vm/build-router-image.sh
+
+      # Package each VM image as a release tarball. Contents: the bootable
+      # ext4-combined .img only — router-up.sh (lib.sh:ensure_openwrt_image)
+      # consumes a single raw .img and creates its own qcow2 overlay. Asset
+      # filenames are version-derived from versions.sh; the .sha256 lets
+      # downstream verify the fetch.
+      - name: Package qemu VM images as release tarballs
+        run: |
+          set -euo pipefail
+          ipk_short="$(PKG_FORMAT=ipk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
+          apk_short="$(PKG_FORMAT=apk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
+          ipk_img="scripts/vm/.cache/openwrt-wifihaven-ipk-${ipk_short}.img"
+          apk_img="scripts/vm/.cache/openwrt-wifihaven-apk-${apk_short}.img"
+          [ -f "$ipk_img" ] || { echo "missing $ipk_img" >&2; exit 1; }
+          [ -f "$apk_img" ] || { echo "missing $apk_img" >&2; exit 1; }
+          mkdir -p release
+          ipk_tar="release/wifihaven-router-openwrt-${ipk_short}-ipk.tar.gz"
+          apk_tar="release/wifihaven-router-openwrt-${apk_short}-apk.tar.gz"
+          tar -czf "$ipk_tar" -C "$(dirname "$ipk_img")" "$(basename "$ipk_img")"
+          tar -czf "$apk_tar" -C "$(dirname "$apk_img")" "$(basename "$apk_img")"
+          ( cd release && sha256sum \
+              "$(basename "$ipk_tar")" \
+              "$(basename "$apk_tar")" \
+              > wifihaven-router-images.sha256 )
+          echo "--- release tarballs ---"
+          ls -lh release/
+
+      # #499: stage wifihaven-version-stamped copies of the VM-image tarballs
+      # alongside the stable-name originals. The rolling openwrt-latest release
+      # keeps the stable filenames (Gate 3b's glob + agent auto-update resolve
+      # them); the v<X.Y.Z> release receives the version-stamped copies so a
+      # specific past release is reachable by URL.
+      - name: Stage versioned VM-image tarball copies (#499)
+        run: |
+          set -euo pipefail
+          ver="${{ steps.ver.outputs.version }}"
+          mkdir -p release/versioned
+          for src in release/wifihaven-router-openwrt-*-ipk.tar.gz release/wifihaven-router-openwrt-*-apk.tar.gz; do
+            [ -f "$src" ] || continue
+            base=$(basename "$src")
+            stamped="release/versioned/${base/wifihaven-router-openwrt-/wifihaven-router-openwrt-${ver}-}"
+            cp "$src" "$stamped"
+          done
+          ( cd release/versioned && sha256sum wifihaven-router-openwrt-*-ipk.tar.gz wifihaven-router-openwrt-*-apk.tar.gz \
+              > wifihaven-router-images.sha256 )
+          ls -lh release/versioned/
+
+      # Collect the four packages into release/ so publish-openwrt-release.yml
+      # can attach everything from a single downloaded artifact tree, decoupled
+      # from the openwrt/ build layout.
+      - name: Assemble release/ package set
+        run: |
+          set -euo pipefail
+          cp openwrt/wifihaven_*.ipk release/
+          cp openwrt/wifihaven_*.apk release/
+          cp openwrt/luci/luci-app-wifihaven_*.ipk release/
+          cp openwrt/luci/luci-app-wifihaven_*.apk release/
+          echo "--- release/ contents ---"
+          ls -lh release/ release/versioned/
+
+      # Raw .img uploads consumed by the gates. Named per flavor (no version /
+      # sha in the name) — artifacts are already scoped to this workflow run,
+      # so a bare name is unambiguous and lets the gates download by an exact,
+      # deterministic name instead of a loose glob.
+      - name: Upload VM image artifact (ipk)
+        uses: actions/upload-artifact@v6
+        with:
+          name: vm-image-ipk
+          path: scripts/vm/.cache/openwrt-wifihaven-ipk-*.img
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload VM image artifact (apk)
+        uses: actions/upload-artifact@v6
+        with:
+          name: vm-image-apk
+          path: scripts/vm/.cache/openwrt-wifihaven-apk-*.img
+          if-no-files-found: error
+          retention-days: 7
+
+      # Everything publish-openwrt-release.yml attaches to the GitHub Release:
+      # the four packages plus the stable-name and version-stamped VM tarballs
+      # (and their sha256 sidecars), preserving the release/ tree layout.
+      - name: Upload release assets artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-assets
+          path: release/**
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -40,7 +40,7 @@ on:
   workflow_call:
     inputs:
       consume_vm_image_artifact:
-        description: "Download the VM image from a sibling build-vm-image job artifact instead of building locally. Master Router CD sets this true so the .img is built once per run."
+        description: "Download the VM image from the sibling build-release-artifacts job instead of building locally. Master Router CD sets this true so the gates boot the exact .img that ships (#1224)."
         type: boolean
         default: false
   workflow_dispatch:
@@ -150,21 +150,17 @@ jobs:
           echo "path=$IMG" >> "$GITHUB_OUTPUT"
           echo "Resolved image: $IMG"
 
-      # Download the per-flavor image from the sibling build-vm-image job
-      # when Master Router CD invokes us with consume_vm_image_artifact=true.
-      # The artifact pattern matches openwrt-wifihaven-<flavor>-<version>-<sha>
-      # (cf. router-image-build.yml's upload). Today build-vm-image only
-      # builds .ipk; the .apk arm's download is a no-op and the next step
-      # falls through to a local build. Follow-up: extend build-vm-image
-      # to matrix-build both flavors.
-      - name: Download VM image artifact (from build-vm-image)
+      # #1224: download the exact per-flavor .img built once pre-gate by
+      # build-release-artifacts (artifact `vm-image-<flavor>`, scoped to this
+      # run). NO continue-on-error and NO local-build fallback when consuming:
+      # the whole point is to boot the artifact that ships, so a missing
+      # artifact must fail loud rather than silently rebuild a different image.
+      - name: Download VM image artifact (from build-release-artifacts)
         if: inputs.consume_vm_image_artifact
-        continue-on-error: true
         uses: actions/download-artifact@v6
         with:
-          pattern: openwrt-wifihaven-${{ matrix.pkg_format }}-*-${{ github.sha }}
+          name: vm-image-${{ matrix.pkg_format }}
           path: scripts/vm/.cache
-          merge-multiple: true
 
       - name: Build router image (if not cached / not downloaded)
         run: |

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -40,7 +40,7 @@ on:
   workflow_call:
     inputs:
       consume_vm_image_artifact:
-        description: "Download the VM image from a sibling build-vm-image job artifact instead of building locally. Master Router CD sets this true so the .img is built once per run."
+        description: "Download the VM image from the sibling build-release-artifacts job instead of building locally. Master Router CD sets this true so the gates boot the exact .img that ships (#1224)."
         type: boolean
         default: false
   workflow_dispatch:
@@ -131,18 +131,17 @@ jobs:
           echo "path=$IMG" >> "$GITHUB_OUTPUT"
           echo "Resolved image: $IMG"
 
-      # Reuse the sibling build-vm-image artifact when invoked from
-      # master-router.yml (consume_vm_image_artifact=true). Today
-      # build-vm-image only matrix-builds .ipk; the .apk arm's download is
-      # a no-op and the next step falls through to a local build.
-      - name: Download VM image artifact (from build-vm-image)
+      # #1224: download the exact per-flavor .img built once pre-gate by
+      # build-release-artifacts (artifact `vm-image-<flavor>`, scoped to this
+      # run). NO continue-on-error and NO local-build fallback when consuming:
+      # Gate 3a must enroll the artifact that ships, so a missing artifact
+      # fails loud rather than silently rebuilding a different image.
+      - name: Download VM image artifact (from build-release-artifacts)
         if: inputs.consume_vm_image_artifact
-        continue-on-error: true
         uses: actions/download-artifact@v6
         with:
-          pattern: openwrt-wifihaven-${{ matrix.pkg_format }}-*-${{ github.sha }}
+          name: vm-image-${{ matrix.pkg_format }}
           path: scripts/vm/.cache
-          merge-multiple: true
 
       - name: Build router image (if not cached / not downloaded)
         run: |

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -499,9 +499,9 @@ jobs:
 
   # 6b. Cut the v<X.Y.Z> annotated git tag (#499). Idempotent: skipped if
   # the tag already exists (e.g. an earlier OpenWRT-only release on the same
-  # SHA already cut it). The OpenWRT publish path in openwrt-build.yml also
-  # creates this tag via softprops/action-gh-release on the v<X.Y.Z> release;
-  # whichever pipeline finishes first wins, the other no-ops.
+  # SHA already cut it). The OpenWRT publish path (publish-openwrt-release.yml)
+  # also creates this tag on the v<X.Y.Z> release; whichever pipeline finishes
+  # first wins, the other no-ops.
   cut-release-tag:
     name: Cut v<X.Y.Z> release tag (#499)
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -10,12 +10,18 @@ name: Master Router CD
 # fires on changes to its own path scope, so api/ui churn cannot stall
 # router releases.
 #
-# Flow:
+# Flow (#1224 — build once, test those exact bits, publish without rebuild):
 #   ci-tests                    (full matrix; ci.yml self-filters by path)
-#     → gate-2-router-fake-api  (qemu OpenWRT + Alpine + fake API on KVM)
-#     ‖ gate-3a-router-staging  (qemu OpenWRT + Alpine + real staging API)
-#       → approve-production    (manual gate, `production` environment)
-#         → publish-openwrt     (rolling openwrt-latest GitHub Release)
+#     → build-release-artifacts (ONE job: .ipk/.apk + luci .ipk/.apk + both
+#       │                        qemu VM images, versioned with the final
+#       │                        release version derived ONCE; uploaded as
+#       │                        workflow artifacts)
+#       → gate-2-router-fake-api  (boots the uploaded VM image + fake API)
+#       ‖ gate-3a-router-staging  (boots the uploaded VM image + staging API)
+#         → approve-production    (manual gate, `production` environment)
+#           → publish-openwrt     (DOWNLOADS the tested artifacts → rolling
+#                                  openwrt-latest + versioned v<X.Y.Z>; no
+#                                  rebuild, no version re-derivation)
 #
 # Gates 2 and 3a both share the e2e-vm self-hosted-runner concurrency
 # group (#657 capacity follow-up), so in practice they serialize on the
@@ -38,7 +44,8 @@ on:
       # reach the Lua router agent, so we don't fire CD on those.
       - 'shared/contract/**'
       - '.github/workflows/master-router.yml'
-      - '.github/workflows/openwrt-build.yml'
+      - '.github/workflows/build-release-artifacts.yml'
+      - '.github/workflows/publish-openwrt-release.yml'
       - '.github/workflows/e2e-vm-fake.yml'
       - '.github/workflows/e2e-vm-gate3a.yml'
       - '.github/workflows/ci.yml'
@@ -74,18 +81,18 @@ jobs:
       contents: read
     uses: ./.github/workflows/ci.yml
 
-  # Build the OpenWRT VM image early so downstream tests can consume it.
-  # Reuses router-image-build.yml (which also runs standalone on PRs).
-  # The upload is a workflow artifact only — internal CI use; the .img is
-  # never attached to the user-facing openwrt-latest release (only the
-  # .ipk/.apk packages from publish-openwrt are).
-  build-vm-image:
-    name: Build OpenWRT VM image
+  # #1224: build EVERY shippable release artifact exactly once, pre-gate,
+  # versioned with the final release version derived a single time. The gates
+  # boot the uploaded VM images and publish-openwrt downloads these same bytes
+  # — so tested bits == published bits, and the coordinated-version invariant
+  # (#499/#1134) is anchored here. Exposes `version` for the publish job.
+  build-release-artifacts:
+    name: Build release artifacts
     if: github.ref == 'refs/heads/main'
     needs: [ci-tests]
     permissions:
       contents: read
-    uses: ./.github/workflows/router-image-build.yml
+    uses: ./.github/workflows/build-release-artifacts.yml
 
   # Gate 2 (#654/#686): router enforcement in qemu OpenWRT + Alpine client
   # against an in-process fake API serving snapshot fixtures. Runs on the
@@ -94,7 +101,7 @@ jobs:
   gate-2-router-fake-api:
     name: Gate 2 — router fake-API e2e
     if: github.ref == 'refs/heads/main'
-    needs: [ci-tests, build-vm-image]
+    needs: [ci-tests, build-release-artifacts]
     permissions:
       contents: read
     uses: ./.github/workflows/e2e-vm-fake.yml
@@ -111,7 +118,7 @@ jobs:
   gate-3a-router-staging:
     name: Gate 3a — router staging smoke
     if: github.ref == 'refs/heads/main'
-    needs: [ci-tests, build-vm-image]
+    needs: [ci-tests, build-release-artifacts]
     permissions:
       contents: read
     uses: ./.github/workflows/e2e-vm-gate3a.yml
@@ -137,17 +144,22 @@ jobs:
       - name: Approved
         run: echo "Router release approved — publishing openwrt-latest."
 
-  # Rolling openwrt-latest release. Reusable openwrt-build.yml with
-  # publish_release: true; see that file for the gating logic. Intentionally
-  # has NO concurrency group: once approval lands, this job must run to
-  # completion regardless of any later main push.
+  # #1224: download-and-release ONLY. publish-openwrt-release.yml pulls the
+  # release-assets artifact built pre-gate by build-release-artifacts and
+  # attaches those exact, already-tested bytes — no recompile, no version
+  # re-derivation. The version is threaded verbatim from the build job's
+  # output, preserving the coordinated-version invariant (#499/#1134).
+  # `needs` build-release-artifacts (transitively satisfied via the gates,
+  # but listed explicitly so its `version` output is in scope here).
+  # Intentionally has NO concurrency group: once approval lands, this job
+  # must run to completion regardless of any later main push.
   publish-openwrt:
     name: Publish OpenWRT release
     if: github.ref == 'refs/heads/main'
-    needs: [approve-production]
+    needs: [build-release-artifacts, approve-production]
     permissions:
       contents: write
-    uses: ./.github/workflows/openwrt-build.yml
+    uses: ./.github/workflows/publish-openwrt-release.yml
     with:
-      publish_release: true
+      version: ${{ needs.build-release-artifacts.outputs.version }}
     secrets: inherit

--- a/.github/workflows/openwrt-build.yml
+++ b/.github/workflows/openwrt-build.yml
@@ -1,20 +1,19 @@
 name: OpenWRT Package Build
 
-# Release flow (post-#498): the rolling "openwrt-latest" GitHub Release is
-# published exclusively from Master Router CD's publish-openwrt path, behind the
-# manual-approval gate. There is no standalone `push.tags: ["v*"]` trigger —
-# tag pushes would otherwise fire this workflow ungated and race with the
-# coordinated release from master-router.yml (see #498).
+# PR / push validation ONLY (#1224). This workflow compiles the router and
+# luci-app packages on every openwrt/** change to catch build breakage early,
+# uploads them as throwaway workflow artifacts, and stops there.
 #
-# Triggers retained:
-#   - push to main (paths: openwrt/**)  — build-only confidence run, no upload
+# It does NOT publish and is NOT part of Master Router CD. The release path
+# builds every shippable artifact exactly once in build-release-artifacts.yml
+# (pre-gate) and publishes them unchanged in publish-openwrt-release.yml
+# (post-approval). There is no `workflow_call` / `publish_release` path here
+# anymore — that was the duplicate, publish-time rebuild #1224 removed.
+#
+# Triggers:
+#   - push to main (paths: openwrt/**)  — build-only confidence run
 #   - pull_request (paths: openwrt/**)  — PR validation
 #   - workflow_dispatch                 — one-off debug builds
-#   - workflow_call                     — invoked by master-router.yml deploy-production
-#                                         with publish_release: true
-#
-# The build itself still runs for PR / main-push validation; only the public
-# artifact promotion (GitHub Release upload) is gated by `publish_release`.
 on:
   push:
     branches: ["main"]
@@ -22,12 +21,6 @@ on:
   pull_request:
     paths: ["openwrt/**"]
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      publish_release:
-        description: "If true, attach packages to the rolling openwrt-latest GitHub Release. Set only from Master Router CD's publish-openwrt path."
-        type: boolean
-        default: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -37,7 +30,7 @@ jobs:
     name: Build .ipk and .apk
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v6
@@ -197,186 +190,3 @@ jobs:
           name: wifihaven-apk-${{ steps.ver.outputs.version }}-${{ steps.ver.outputs.release }}
           path: openwrt/wifihaven_*.apk
           if-no-files-found: error
-
-      # Qemu VM image build (#893) — produces the bootable router images that
-      # downstream Gate 3b (#655) fetches by stable URL to test API/UI changes
-      # against the last-published router. Gated on publish_release so PR /
-      # main-push validation runs don't pay the ~2× IB cost; this is only the
-      # release pipeline's concern. Reuses the .ipk/.apk built above via
-      # IPK_PATH/APK_PATH so we don't recompile the wifihaven package.
-      - name: Build qemu VM image (ipk / OpenWRT 23.05)
-        if: inputs.publish_release == true
-        env:
-          PKG_FORMAT: ipk
-          IPK_SOURCE: path
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          ipks=("$PWD"/openwrt/wifihaven_*.ipk)
-          IPK_PATH="${ipks[0]}"
-          export IPK_PATH
-          chmod +x scripts/vm/build-router-image.sh
-          scripts/vm/build-router-image.sh
-
-      - name: Build qemu VM image (apk / OpenWRT 25.12)
-        if: inputs.publish_release == true
-        env:
-          PKG_FORMAT: apk
-          APK_SOURCE: path
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          apks=("$PWD"/openwrt/wifihaven_*.apk)
-          APK_PATH="${apks[0]}"
-          export APK_PATH
-          scripts/vm/build-router-image.sh
-
-      # Package each VM image as a release tarball. Contents: the bootable
-      # ext4-combined .img only — scripts/vm/router-up.sh (lib.sh:ensure_openwrt_image)
-      # consumes a single raw .img and creates its own qcow2 overlay, so no
-      # kernel/initrd sidecars are needed. Asset filenames are version-derived
-      # from versions.sh so a future OPENWRT_VERSION_{IPK,APK} bump renames the
-      # asset cleanly; the .sha256 file lets downstream verify the fetch.
-      - name: Package qemu VM images as release tarballs
-        if: inputs.publish_release == true
-        run: |
-          set -euo pipefail
-          # Resolve the major.minor for each flavor (matches build-router-image.sh's
-          # OUTPUT_IMG path).
-          ipk_short="$(PKG_FORMAT=ipk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
-          apk_short="$(PKG_FORMAT=apk bash -c '. scripts/vm/versions.sh; echo "$OPENWRT_VERSION_SHORT"')"
-          ipk_img="scripts/vm/.cache/openwrt-wifihaven-ipk-${ipk_short}.img"
-          apk_img="scripts/vm/.cache/openwrt-wifihaven-apk-${apk_short}.img"
-          [ -f "$ipk_img" ] || { echo "missing $ipk_img" >&2; exit 1; }
-          [ -f "$apk_img" ] || { echo "missing $apk_img" >&2; exit 1; }
-          mkdir -p release
-          ipk_tar="release/wifihaven-router-openwrt-${ipk_short}-ipk.tar.gz"
-          apk_tar="release/wifihaven-router-openwrt-${apk_short}-apk.tar.gz"
-          tar -czf "$ipk_tar" -C "$(dirname "$ipk_img")" "$(basename "$ipk_img")"
-          tar -czf "$apk_tar" -C "$(dirname "$apk_img")" "$(basename "$apk_img")"
-          ( cd release && sha256sum \
-              "$(basename "$ipk_tar")" \
-              "$(basename "$apk_tar")" \
-              > wifihaven-router-images.sha256 )
-          echo "--- release assets ---"
-          ls -lh release/
-
-      # #499: stage versioned copies of the VM-image tarballs alongside the
-      # stable-name originals. The openwrt-latest rolling release keeps the
-      # stable filenames so Gate 3b's glob (`wifihaven-router-openwrt-*-
-      # <fmt>.tar.gz`) and any agent auto-update path continue to resolve.
-      # The new v<X.Y.Z> release receives the wifihaven-version-stamped
-      # copies so a specific past release is reachable by URL.
-      - name: Stage versioned VM-image tarball copies (#499)
-        if: inputs.publish_release == true
-        run: |
-          set -euo pipefail
-          ver="${{ steps.ver.outputs.version }}"
-          mkdir -p release/versioned
-          for src in release/wifihaven-router-openwrt-*-ipk.tar.gz release/wifihaven-router-openwrt-*-apk.tar.gz; do
-            [ -f "$src" ] || continue
-            # original: wifihaven-router-openwrt-<short>-<fmt>.tar.gz
-            # stamped:  wifihaven-router-openwrt-<ver>-<short>-<fmt>.tar.gz
-            base=$(basename "$src")
-            stamped="release/versioned/${base/wifihaven-router-openwrt-/wifihaven-router-openwrt-${ver}-}"
-            cp "$src" "$stamped"
-          done
-          ( cd release/versioned && sha256sum wifihaven-router-openwrt-*-ipk.tar.gz wifihaven-router-openwrt-*-apk.tar.gz \
-              > wifihaven-router-images.sha256 )
-          ls -lh release/versioned/
-
-      # Wipe any assets currently attached to openwrt-latest before the
-      # publish step re-uploads the fresh build. softprops/action-gh-release
-      # overwrites assets with the same name but never DELETES unrelated
-      # ones, so older PKG_VERSION artifacts (e.g. wifihaven_0.1.0-1_*)
-      # pile up on the rolling release forever and confuse the auto-
-      # updater's fallback path (#244).
-      - name: Clear stale openwrt-latest assets
-        if: inputs.publish_release == true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -eu
-          if gh release view openwrt-latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release view openwrt-latest --repo "$GITHUB_REPOSITORY" \
-              --json assets --jq '.assets[].name' \
-            | while IFS= read -r name; do
-                [ -z "$name" ] && continue
-                echo "deleting stale asset: $name"
-                gh release delete-asset openwrt-latest "$name" \
-                  --repo "$GITHUB_REPOSITORY" --yes
-              done
-          else
-            echo "openwrt-latest release does not exist yet; nothing to clean"
-          fi
-
-      # Rolling pre-release. Pointer that consumers (Gate 3b, agent auto-
-      # update) keep targeting by stable URL. The versioned release below
-      # is the new canonical artifact; openwrt-latest is intentionally kept
-      # in lockstep so the migration is non-breaking — see #499 PR body.
-      - name: Publish rolling openwrt-latest release (gated by caller)
-        if: inputs.publish_release == true
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: openwrt-latest
-          name: "openwrt-latest (rolling)"
-          body: |
-            Rolling build of the OpenWRT agent from the latest `main`
-            (currently v${{ steps.ver.outputs.version }}).
-            Replaced on every publish from `main` touching `openwrt/**`.
-            For pinned consumers, prefer the v<X.Y.Z> release tag (#499).
-            For #228 live debugging — see #243 / #244.
-          prerelease: true
-          files: |
-            openwrt/wifihaven_*.ipk
-            openwrt/wifihaven_*.apk
-            openwrt/luci/luci-app-wifihaven_*.ipk
-            openwrt/luci/luci-app-wifihaven_*.apk
-            release/wifihaven-router-openwrt-*-ipk.tar.gz
-            release/wifihaven-router-openwrt-*-apk.tar.gz
-            release/wifihaven-router-images.sha256
-
-      # #499: cut the annotated git tag before the release upload so the
-      # tag carries a real tagger + message. softprops/action-gh-release
-      # would otherwise create a lightweight tag. Idempotent: the API/UI
-      # pipeline's cut-release-tag job may have already pushed it; skip
-      # cleanly in that case.
-      - name: Cut annotated v<X.Y.Z> tag (#499)
-        if: inputs.publish_release == true
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          set -eu
-          tag="v${VERSION}"
-          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
-            echo "Tag ${tag} already exists on origin — skipping."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${tag}" -m "WifiHaven ${tag}"
-          git push origin "${tag}"
-
-      # #499: versioned canonical release. The annotated tag was pushed
-      # in the previous step; this just attaches release assets to it.
-      - name: Publish versioned v<X.Y.Z> release (#499)
-        if: inputs.publish_release == true
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.ver.outputs.version }}
-          name: "v${{ steps.ver.outputs.version }}"
-          body: |
-            WifiHaven v${{ steps.ver.outputs.version }}.
-
-            OpenWRT packages and bootable VM images for this release.
-
-            See `openwrt-latest` for the rolling pointer kept in lockstep.
-          prerelease: false
-          files: |
-            openwrt/wifihaven_*.ipk
-            openwrt/wifihaven_*.apk
-            openwrt/luci/luci-app-wifihaven_*.ipk
-            openwrt/luci/luci-app-wifihaven_*.apk
-            release/versioned/wifihaven-router-openwrt-*-ipk.tar.gz
-            release/versioned/wifihaven-router-openwrt-*-apk.tar.gz
-            release/versioned/wifihaven-router-images.sha256

--- a/.github/workflows/publish-openwrt-release.yml
+++ b/.github/workflows/publish-openwrt-release.yml
@@ -1,0 +1,144 @@
+name: Publish OpenWRT release
+
+# Download-and-release ONLY (#1224). This workflow performs zero compilation
+# and zero version derivation. It downloads the already-built, already-tested
+# `release-assets` artifact produced by build-release-artifacts.yml earlier in
+# the same Master Router CD run and attaches those exact bytes to the GitHub
+# Release. A publish can therefore no longer fail on a rebuild after the gates
+# passed and a human approved (the #1224 failure mode).
+#
+# The release version is NOT recomputed here — it is passed in verbatim via
+# the `version` input, threaded from build-release-artifacts.yml's `version`
+# output, preserving the coordinated-version invariant (#499 / #1134).
+#
+# Triggers:
+#   - workflow_call — invoked by master-router.yml's publish-openwrt job,
+#     behind the approve-production manual gate.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The release version derived once in build-release-artifacts.yml. Used verbatim for the release name, body, and the v<X.Y.Z> tag. NOT re-derived here."
+        type: string
+        required: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  publish:
+    name: Attach tested artifacts to release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      # Needed only to cut the annotated git tag (history + push creds).
+      # No build inputs are read from the tree — the artifacts are downloaded.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # The exact artifacts the gates tested, built once pre-gate. Restores
+      # the release/ tree (packages + stable-name and versioned VM tarballs
+      # + sha256 sidecars) as laid out by build-release-artifacts.yml.
+      - name: Download tested release assets
+        uses: actions/download-artifact@v6
+        with:
+          name: release-assets
+          path: release
+
+      - name: List downloaded assets
+        run: |
+          echo "--- release/ ---"
+          ls -lh release/
+          echo "--- release/versioned/ ---"
+          ls -lh release/versioned/
+
+      # Wipe any assets currently attached to openwrt-latest before re-upload.
+      # softprops/action-gh-release overwrites same-named assets but never
+      # DELETES unrelated ones, so older-version artifacts pile up on the
+      # rolling release forever and confuse the auto-updater fallback (#244).
+      - name: Clear stale openwrt-latest assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if gh release view openwrt-latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release view openwrt-latest --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq '.assets[].name' \
+            | while IFS= read -r name; do
+                [ -z "$name" ] && continue
+                echo "deleting stale asset: $name"
+                gh release delete-asset openwrt-latest "$name" \
+                  --repo "$GITHUB_REPOSITORY" --yes
+              done
+          else
+            echo "openwrt-latest release does not exist yet; nothing to clean"
+          fi
+
+      # Rolling pre-release. Stable-name pointer that consumers (Gate 3b, agent
+      # auto-update) keep targeting by URL. Kept in lockstep with the versioned
+      # release below (#499).
+      - name: Publish rolling openwrt-latest release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: openwrt-latest
+          name: "openwrt-latest (rolling)"
+          body: |
+            Rolling build of the OpenWRT agent from the latest `main`
+            (currently v${{ inputs.version }}).
+            Replaced on every publish from `main` touching `openwrt/**`.
+            For pinned consumers, prefer the v<X.Y.Z> release tag (#499).
+            For #228 live debugging — see #243 / #244.
+          prerelease: true
+          files: |
+            release/wifihaven_*.ipk
+            release/wifihaven_*.apk
+            release/luci-app-wifihaven_*.ipk
+            release/luci-app-wifihaven_*.apk
+            release/wifihaven-router-openwrt-*-ipk.tar.gz
+            release/wifihaven-router-openwrt-*-apk.tar.gz
+            release/wifihaven-router-images.sha256
+
+      # #499: cut the annotated git tag before the versioned release upload so
+      # the tag carries a real tagger + message (softprops would otherwise
+      # create a lightweight tag). Idempotent: the API/UI pipeline's
+      # cut-release-tag job may have already pushed it; skip cleanly if so.
+      - name: Cut annotated v<X.Y.Z> tag (#499)
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          tag="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
+            echo "Tag ${tag} already exists on origin — skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "WifiHaven ${tag}"
+          git push origin "${tag}"
+
+      # #499: versioned canonical release. The annotated tag was pushed in the
+      # previous step; this attaches the version-stamped assets to it.
+      - name: Publish versioned v<X.Y.Z> release (#499)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: "v${{ inputs.version }}"
+          body: |
+            WifiHaven v${{ inputs.version }}.
+
+            OpenWRT packages and bootable VM images for this release.
+
+            See `openwrt-latest` for the rolling pointer kept in lockstep.
+          prerelease: false
+          files: |
+            release/wifihaven_*.ipk
+            release/wifihaven_*.apk
+            release/luci-app-wifihaven_*.ipk
+            release/luci-app-wifihaven_*.apk
+            release/versioned/wifihaven-router-openwrt-*-ipk.tar.gz
+            release/versioned/wifihaven-router-openwrt-*-apk.tar.gz
+            release/versioned/wifihaven-router-images.sha256

--- a/.github/workflows/router-image-build.yml
+++ b/.github/workflows/router-image-build.yml
@@ -1,17 +1,18 @@
 name: Build OpenWRT VM image
 
-# Two roles:
-#   - PR validation on changes to openwrt/** or scripts/vm/**
-#   - Reusable callee from master-router.yml's build-vm-image job, gated
-#     on approve-production so the artifact only ships for prod-approved
-#     commits
+# PR validation ONLY: smoke-builds the ipk/23.05 router VM image on changes to
+# openwrt/** or scripts/vm/** so image-build breakage surfaces before merge.
+#
+# It is NOT part of Master Router CD. Since #1224 the release pipeline builds
+# both VM-image flavors (versioned, once) in build-release-artifacts.yml and
+# the gates boot those exact artifacts — this workflow no longer feeds the
+# gates, so it carries no `workflow_call` trigger.
 on:
   pull_request:
     paths:
       - "openwrt/**"
       - "scripts/vm/**"
       - ".github/workflows/router-image-build.yml"
-  workflow_call:
   workflow_dispatch:
 
 env:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -139,7 +139,24 @@ Output: `openwrt/wifihaven_<version>-<release>_all.ipk`
 
 ### 2.2 Build and publish: `.ipk` → GitHub Releases
 
-Workflow: `.github/workflows/openwrt-build.yml`.
+Release pipeline (#1224 — build once, test those bits, publish without
+rebuild): driven by `.github/workflows/master-router.yml`:
+
+1. `build-release-artifacts.yml` (pre-gate) — builds **all** shippable
+   artifacts exactly once (router `.ipk`/`.apk`, luci-app `.ipk`/`.apk`,
+   both qemu VM-image tarballs), versioned with the release version derived
+   a single time, and uploads them as workflow artifacts.
+2. Gate 2 / Gate 3a boot the **uploaded** VM image — so the bits tested are
+   the bits that ship.
+3. `approve-production` — manual approval gate.
+4. `publish-openwrt-release.yml` — **downloads** the already-built,
+   already-tested artifacts and attaches them to the rolling
+   `openwrt-latest` and versioned `v<X.Y.Z>` releases. No recompilation and
+   no version re-derivation, so a publish can't fail on a rebuild.
+
+`.github/workflows/openwrt-build.yml` still runs on `openwrt/**` PRs and
+pushes for **build-only validation** (it uploads throwaway artifacts and
+never publishes).
 
 **Release strategy: tagged releases only (Option B from #130).**
 Routers auto-update only when a `vX.Y.Z` tag is pushed. We do *not* publish


### PR DESCRIPTION
## Summary

Closes #1224.

Master Router CD built release artifacts **twice** and shipped bits it never tested:

- The pre-gate `build-vm-image` (`router-image-build.yml`) built a VM image with `IPK_SOURCE=local` — i.e. the **static `0.1.0` Makefile sentinel**, not a real release version. Gate 2/Gate 3a tested *that*.
- After `approve-production`, `publish-openwrt` (`openwrt-build.yml`, `publish_release: true`) **rebuilt** the `.ipk`/`.apk` and both qemu VM images from scratch and published those. So the published bits were never gated, and a publish-time recompile could fail after the gates + a human approval — which is exactly what happened (an invalid apk version killed publish at the finish line).

This restructures the pipeline to **build once, test those exact bits, then publish them unchanged.**

## Job graph

**Before**
```
ci-tests
  └─ build-vm-image (router-image-build.yml)        # ipk-only VM image @ 0.1.0 sentinel
       ├─ gate-2-router-fake-api (e2e-vm-fake.yml)   # tests that image
       └─ gate-3a-router-staging (e2e-vm-gate3a.yml) # tests that image
            └─ approve-production
                 └─ publish-openwrt (openwrt-build.yml, publish_release:true)
                      # REBUILDS .ipk/.apk + both VM images, derives version, publishes
```

**After**
```
ci-tests
  └─ build-release-artifacts (build-release-artifacts.yml)   # ONE job:
       │   router .ipk/.apk, luci .ipk/.apk, both qemu VM images
       │   (ipk/23.05 + apk/25.12), versioned with the release version
       │   derived ONCE; uploaded as workflow artifacts
       ├─ gate-2-router-fake-api   # boots the uploaded vm-image-<flavor>
       └─ gate-3a-router-staging   # boots the uploaded vm-image-<flavor>
            └─ approve-production   # unchanged manual gate
                 └─ publish-openwrt (publish-openwrt-release.yml)
                      # DOWNLOADS release-assets, attaches to rolling +
                      # versioned releases, cuts the tag. No rebuild,
                      # no version re-derivation.
```

## What changed

- **New `build-release-artifacts.yml`** (reusable): builds every shippable artifact exactly once from the versioned packages (VM images use `IPK_SOURCE=path`/`APK_SOURCE=path` so they carry the exact compiled package — no recompile). Uploads:
  - `vm-image-ipk` / `vm-image-apk` — the raw `.img` the gates boot.
  - `release-assets` — the `release/` tree (4 packages + stable-name and version-stamped VM tarballs + sha256 sidecars) the publish job attaches.
  - Exposes the derived `version` as a **workflow output**.
- **New `publish-openwrt-release.yml`** (reusable): download-and-release **only**. Takes `version` as an input (threaded verbatim from the build job's output), downloads `release-assets`, clears stale `openwrt-latest` assets, publishes the rolling + versioned releases, and cuts the annotated `v<X.Y.Z>` tag. Zero compilation, zero re-derivation.
- **Gates** (`e2e-vm-fake.yml`, `e2e-vm-gate3a.yml`): consume `vm-image-<flavor>` by **deterministic artifact name**. Dropped the old loose `pattern:` + `continue-on-error` (which silently fell back to a local rebuild of a *different* image); a missing artifact now fails loud.
- **`openwrt-build.yml`**: trimmed to PR/push **build-only validation** (uploads throwaway artifacts, never publishes). Removed the `workflow_call`/`publish_release` path and all VM-image + release steps — that was the duplicate, publish-time rebuild.
- **`router-image-build.yml`**: dropped its now-dead `workflow_call` (PR validation only; no longer feeds the gates). Header corrected.
- **Docs/comments**: `docs/deploy.md` §2.2 now describes the build-once flow; fixed a stale cross-pipeline tag comment in `master-api-ui.yml`.

## Artifact threading

Workflow artifacts (not cache), all scoped to the single CD run and keyed on deterministic names. The reusable build/gate/publish workflows all execute under the caller's run, so download-by-name resolves across them. Naming is per-flavor (`vm-image-ipk`/`vm-image-apk`) and per-purpose (`release-assets`) — no version/sha in the name needed since the run scopes them. The single derived version is passed to publish via a `workflow_call` output → input, not re-read from git.

## Coordinated-version invariant (#499 / #1134)

The version is derived in exactly one place — the `Derive version` step of `build-release-artifacts.yml` — and used verbatim for: the baked agent `VERSION` file (#771, via `PKG_VERSION` into `build-ipk.sh`/`build-apk.sh`), every package version, both VM images (built from those packages), and the `v<X.Y.Z>` release tag (passed as the publish input). The existing `.ipk` ↔ `VERSION`-file assertion is retained. **Master API/UI CD Gate 3b is unaffected** — it consumes the *last-published* `openwrt-latest` router image (a different lineage); publish still attaches the same stable-name tarballs there.

## Relationship to the hotfix

Subsumes the in-flight local `fix/openwrt-publish-release-version` hotfix (which patched the publish job's version derivation to key off `inputs.publish_release`). That branch was never pushed/PR'd; this restructure removes version derivation from publish entirely, so it's moot.

## Test plan

- [ ] Actionlint CI job green (ran `actionlint` locally on all workflows — clean).
- [ ] Master Router CD green end-to-end on a real release: one VM-image build, gates boot the uploaded artifact, publish attaches without recompiling.
- [ ] Verify rolling `openwrt-latest` and versioned `v<X.Y.Z>` releases carry the same versioned packages + VM tarballs as before.
- [ ] Confirm `workflow_dispatch` of `build-release-artifacts.yml` still produces `-dev.<sha>` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)