### PR TITLE
fix(ci): release build derives apk-valid clean version on manual dispatch

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -23,11 +23,17 @@ name: Build router release artifacts
 # four MUST match; this job is the single point where that version is chosen.
 #
 # Triggers:
-#   - workflow_call — invoked by master-router.yml ahead of the gates.
-#     Exposes `version` so the caller can pass it to the publish job.
+#   - workflow_call — invoked by master-router.yml ahead of the gates. The
+#     caller passes publish_release: true to force the clean release version
+#     (see the Derive version step), and consumes the `version` output.
 #   - workflow_dispatch — manual debug build (produces -dev.<sha> artifacts).
 on:
   workflow_call:
+    inputs:
+      publish_release:
+        description: "True when invoked from Master Router CD's release pipeline. Forces the clean release version regardless of the inherited triggering event. Leave false/unset for debug builds."
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The release version derived once for all artifacts (e.g. 0.2.7, or 0.2.7-dev.<sha> on workflow_dispatch)."
@@ -57,17 +63,41 @@ jobs:
           # fetch full history so the single derivation is correct.
           fetch-depth: 0
 
+      # Surface inputs.publish_release as a step output so the Derive version
+      # step can branch on it from plain shell. The input is read in an `if:`
+      # condition — the only `inputs.*` form actionlint accepts here, since
+      # this workflow also declares a no-input `workflow_dispatch` trigger,
+      # which collapses the `inputs` object type to `{}` for `run:`/`env:`
+      # interpolations. When publish_release is false/unset this step is
+      # skipped and steps.publish.outputs.release is empty.
+      - name: Determine publish mode
+        id: publish
+        if: inputs.publish_release == true
+        run: echo "release=true" >> "$GITHUB_OUTPUT"
+
       - name: Derive version
         id: ver
         # #499/#1134: single source of truth is the repo-root VERSION file
         # (MAJOR.MINOR) plus the commit count since that file last changed
         # (PATCH). This is the ONLY place the release version is computed —
         # everything downstream (packages, VM images, release tag) consumes
-        # this output verbatim. workflow_dispatch runs append -dev.<sha> so
-        # ad-hoc builds can't collide with a real tagged release.
+        # this output verbatim.
+        #
+        # Branch on the publish flag, NOT github.event_name: a reusable
+        # workflow called via `workflow_call` inherits the CALLER's triggering
+        # event, so when master-router.yml is itself dispatched manually this
+        # workflow still sees event_name == 'workflow_dispatch' even though
+        # it's the real release path. The -dev.<sha> suffix is invalid apk
+        # (APKv3) version syntax — apk-tools only accepts a -r<N> release
+        # suffix and rejects the package — so a release build must always
+        # derive the clean release version. Ad-hoc workflow_dispatch debug
+        # builds (publish_release unset) still get -dev.<sha> so they can't
+        # collide with a real tagged release.
         run: |
           set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ steps.publish.outputs.release }}" = "true" ]; then
+            version=$(./scripts/ci/derive-version.sh)
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             short=$(echo "${GITHUB_SHA}" | cut -c1-7)
             version=$(./scripts/ci/derive-version.sh --dev "$short")
           else

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -93,6 +93,12 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/build-release-artifacts.yml
+    # publish_release forces the clean release version. The reusable workflow
+    # otherwise falls back to github.event_name, which it inherits from THIS
+    # caller — so a manual workflow_dispatch of Master Router CD would
+    # otherwise produce an apk-invalid -dev.<sha> version and fail the build.
+    with:
+      publish_release: true
 
   # Gate 2 (#654/#686): router enforcement in qemu OpenWRT + Alpine client
   # against an in-process fake API serving snapshot fixtures. Runs on the


### PR DESCRIPTION
## Summary

Master Router CD run [26715985681](https://github.com/wifihaven/wifihaven/actions/runs/26715985681/job/78745398312) failed at the openwrt **Build .apk** step with:

```
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: package version is invalid
```

The derived version was `0.2.41-dev.3ed0545`. apk-tools (APKv3) only accepts a `-r<N>` release suffix, not `-dev.<sha>` — the `.ipk` built fine because opkg is lenient.

## Root cause

A reusable workflow invoked via `workflow_call` **inherits the caller's triggering event**. `master-router.yml` calls the release build, and when Master Router CD is itself triggered via `workflow_dispatch` the called workflow still observes `github.event_name == 'workflow_dispatch'` and takes the `--dev` branch on the *real release path*. On a normal push-to-main trigger `event_name` is `push`, which is why this only surfaced on a manual dispatch.

> **Re-targeted after #1226.** #1224/#1226 (the build-once / test / publish restructure) merged to `main` while this PR was open and moved the version derivation out of `openwrt-build.yml` (now PR-validation only) into the new `build-release-artifacts.yml`. The `github.event_name` discriminator — and the bug — moved with it, so this PR is rebased onto the new `main` and fixes it at its new home.

## Fix

- `build-release-artifacts.yml`: add a `publish_release` `workflow_call` input (default `false`) and branch the **Derive version** step on it, so a release build **always** derives the clean release version. Ad-hoc `workflow_dispatch` debug builds (`publish_release` unset) still get `-dev.<sha>`.
- `master-router.yml`: pass `publish_release: true` when calling the release build.

The input is surfaced via a small `if:`-gated step output rather than interpolated as `${{ inputs.publish_release }}` inside the `run:` script: actionlint rejects `inputs.*` run-interpolation in a workflow that also declares a no-input `workflow_dispatch` trigger (the `inputs` object type collapses to `{}`), and only tolerates `inputs.*` in `if:` conditions.

## Test plan

- [x] `actionlint -color` passes locally
- [ ] CI green on this PR
- [ ] After merge, operator re-runs **Master Router CD** to publish `0.2.41` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)