### PR TITLE
Fix #1228: lower prod DB pool to fit basic_256mb tier

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -144,12 +144,25 @@ services:
       # rollup fiber (#1165/#1167) + slow per-profile UsageSeries reads (#1099)
       # held all 5 connections, the 30s connectionTimeout fired, the healthcheck
       # failed, and Render crash-looped the instance (incident 2026-05-31).
-      # wifihaven-pg-prod is basic-256mb (256 MB RAM → 100 max_connections per
-      # Render's "< 8 GB" tier). 20 gives the single prod instance real headroom
-      # under load while leaving ~80 connections for Render's reserved/maintenance
-      # connections and any future read replica or out-of-band rollup worker.
+      #
+      # #1228: 20 was the over-correction. wifihaven-pg-prod is basic-256mb. The
+      # Postgres hard cap is max_connections=103 (verified live 2026-05-31, no
+      # per-role/per-db connlimit), so 20 is nowhere near the connection ceiling
+      # — the binding constraint is the 256 MB of DB RAM, where every backend
+      # costs several MB. A single instance at 20 runs fine, but Render rolling
+      # deploys briefly run TWO instances (old + new), so peak connections =
+      # 2×poolSize + the rollup/seed fibers. At 20 that overlap (~40+ backends)
+      # pressured the 256 MB instance enough that the NEW instance's startup
+      # queries stalled — it logged "starting on 0.0.0.0:8080" but never bound
+      # the port, and Render failed the deploy at the 15-min port-scan timeout
+      # (deploys dep-d8e4p5… update_failed, prod went undeployable). 8 (matching
+      # staging) caps 2-instance overlap at 2×8=16 plus a few rollup backends —
+      # comfortably within the memory budget — while staying well clear of the
+      # pool-exhaustion crash-loop that killed 5. If the rollup workload later
+      # needs real headroom, upsize the prod Postgres tier and raise this
+      # together rather than racing the pool up against 256 MB of RAM.
       - key: WIFIHAVEN_DB_POOL_SIZE
-        value: "20"
+        value: "8"
       # #786 / #785: bumped to `plan: standard` (2 GB / 1 CPU, $25/mo) after
       # prod started flapping under household load on free's 512 MB cap.
       # Heap sized to leave ~600 MB for OS + JIT + native; revisit if OOM


### PR DESCRIPTION
Closes #1228.

## Problem
PR #1223 set prod `WIFIHAVEN_DB_POOL_SIZE=20` (was crash-looping at the HOCON default of 5). A single prod instance at 20 serves fine, but Render rolling deploys briefly run **two** instances (old + new). The old instance keeps its ~20 backends while the new one opens its own pool, so peak connections during a deploy are `2 × poolSize` plus the rollup/seed fibers. That overlap is what broke prod deploys on 2026-05-31.

## Verified max_connections (don't guess)
The issue assumed `basic_256mb` caps at ~22–25 connections. That's **not** the limiting factor — I queried the live prod DB (`dpg-d856k9h9rddc73a3npng`):

```
SHOW max_connections;                  -> 103
superuser_reserved_connections         -> 3
per-role / per-db connlimit            -> none (-1)
```

So the Postgres hard cap is **103**, and 2×20=40 is nowhere near it. The real binding constraint on a 256 MB instance is **per-backend memory** (each Postgres backend costs several MB; ~40 backends pressures a 256 MB box). The failed-deploy logs confirm the mechanism — the new instance logged startup but never bound its port while a rollup tick still succeeded (DB reachable but pressured):

```
14:58:38  WifiHaven API starting on 0.0.0.0:8080
14:59–15:03  ==> No open ports detected, continuing to scan...
15:03:43  ==> Port scan timeout reached, no open ports detected
15:04:01  RollupJobs - rollup hourly tick ok rows=2404
15:13:31  ==> Timed Out
```

Deploy `dep-d8e4p5f7f7vs73cqhi80` = `update_failed`; prod was effectively undeployable.

## Fix
- Lower prod `WIFIHAVEN_DB_POOL_SIZE` **20 → 8** (matching staging). `2 × 8 = 16` backends during a deploy overlap, plus a few rollup fibers, sits comfortably within the 256 MB DB memory budget while staying clear of the pool-exhaustion crash-loop that killed pool=5.
- Rewrote the misleading prod comment (it claimed ~80 spare connections / "leave headroom for a read replica") with the verified `max_connections=103`, the real memory constraint, and the 2-instance rolling-deploy reasoning.

The bounded connect-EC and env-configurable `db.poolSize` plumbing from #1223 are correct and untouched — only the prod value (and its comment) changed.

## Optional / operator decision (not done here)
If the rollup workload ever needs genuine connection headroom, the right move is to **upsize the prod Postgres tier and raise the pool together**, rather than racing the pool against 256 MB of RAM. Left as an operator call — this PR only lowers the pool to fit the current tier.

## Rollout note
The **first** deploy of this change still overlaps old(20) + new(8) ≈ 28 backends, so it may be tight (same 256 MB pressure that caused the original hang, just less of it). Once this is live, every subsequent deploy overlaps 8 + 8 = 16 and is safe. If the first deploy stalls, a one-off manual restart of the single instance (no overlap) lands it.

## Tests
Config-only change; no Scala touched. `ConfigSpec` already pins the `db.poolSize` plumbing contract with generic fixtures (5/8/20) independent of the render.yaml value, so it stays green.