### PR TITLE
Fix #1230: lower rollup cadences to match read tiers

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -68,9 +68,11 @@ object Main extends ZIOAppDefault {
       _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
       _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
       // #809: scheduled re-aggregation of traffic_reports into the rollup
-      // tables. Hourly tick re-rolls the trailing 2h every 5 min; daily tick
-      // re-rolls yesterday + today every hour. Both are forkDaemon so they
-      // run for the lifetime of the process and never block startup.
+      // tables. #1230: cadence matches the tier each table is read at — hourly
+      // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
+      // trailing 2 days once a day (reads of recent windows hit raw
+      // traffic_reports, not these tables). Both are forkDaemon so they run for
+      // the lifetime of the process and never block startup.
       rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
       clockForJobs   <- ZIO.service[Clock]
       _              <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkDaemon

--- a/api/src/usage/RollupJobs.scala
+++ b/api/src/usage/RollupJobs.scala
@@ -24,19 +24,30 @@ import java.time.{Duration, LocalDate, ZoneId}
 // runs so an operator can tell at a glance whether the rollups are alive.
 object RollupJobs {
 
-  // How many hours back the hourly fiber re-rolls every tick. Two hours is
-  // enough cushion for the closed-hour boundary plus any router clock skew
-  // (#9) without re-aggregating a meaningful slice of history each pass.
+  // How many hours back the hourly fiber re-rolls every tick. Two hours covers
+  // the closed-hour boundary plus router clock skew (#9), and — now that the
+  // fiber ticks hourly (#1230) — gives one tick of self-heal slack: a missed
+  // tick's hour is still inside the next tick's 2h window. Must stay
+  // >= HourlyInterval or a missed tick drops a bucket (see RollupCadenceSpec).
   val HourlyLookback: Duration = Duration.ofHours(2)
 
-  // The daily fiber re-rolls today + yesterday every tick — yesterday because
-  // late-arriving router posts can extend the previous day's traffic_reports
-  // rows past midnight, and today because the rollup should be no more than
-  // an hour stale.
-  val DailyLookback: java.time.Period = java.time.Period.ofDays(1)
+  // The daily fiber re-rolls the trailing two days every tick: yesterday +
+  // today (late-arriving router posts extend the previous day past midnight),
+  // plus one extra day of slack so a missed daily tick (#1230 widened the
+  // cadence to 24h) still self-heals on the next one. Must stay >= 2 days
+  // while DailyInterval is 24h (see RollupCadenceSpec).
+  val DailyLookback: java.time.Period = java.time.Period.ofDays(2)
 
-  val HourlyInterval: Duration = Duration.ofMinutes(5)
-  val DailyInterval: Duration  = Duration.ofMinutes(60)
+  // #1230: re-roll cadences match the tier each table is read at, not the
+  // bucket name. `pickTier` (UsageRoutes) reads ≤24h windows from raw
+  // traffic_reports, 24h–14d from traffic_hourly, >14d from traffic_daily — so
+  // a rolled bucket isn't read until it crosses its threshold. Rolling far more
+  // often just burns DB work on the 256 MB prod instance (#1228). Hourly cadence
+  // gives every hour ~24 re-rolls of slack before it's first read; daily cadence
+  // gives every day ~14 days. The trailing-window lookbacks above keep a single
+  // missed tick self-healing.
+  val HourlyInterval: Duration = Duration.ofHours(1)
+  val DailyInterval: Duration  = Duration.ofHours(24)
 
   /**
    * Hourly fiber loop. Re-aggregates the trailing [[HourlyLookback]] window into `traffic_hourly`

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -41,10 +41,13 @@ import java.time.{Duration, Instant}
 object TimeUsedRollupJob {
 
   /**
-   * Refresh cadence. The tail aggregation handles freshness between ticks; this just bounds the
-   * tail's size so reads don't drift toward a full-day live aggregation as the day wears on.
+   * Refresh cadence. The read path's tail aggregation (`TimeStatusServiceLive`, buckets with
+   * `period_start >= rolled_through`) makes the screen-time figure exact regardless of cadence, so
+   * this interval only bounds the tail's size — it is not a freshness knob. #1230 widened it from
+   * 3m to 15m to cut DB churn on the 256 MB prod instance (#1228): at 5-min bucket granularity the
+   * tail tops out at ~3 rows per profile, a negligible per-read cost for ~5× fewer recompute ticks.
    */
-  val Interval: Duration = Duration.ofMinutes(3)
+  val Interval: Duration = Duration.ofMinutes(15)
 
   /**
    * Fiber loop entry point. Errors are caught and recorded in `rollup_runs`; the fiber never dies.

--- a/api/test/src/unit/RollupCadenceSpec.scala
+++ b/api/test/src/unit/RollupCadenceSpec.scala
@@ -1,0 +1,39 @@
+package wifihaven.api.unit
+
+import wifihaven.api.usage.{RollupJobs, TimeUsedRollupJob}
+import zio.test.*
+
+import java.time.Duration
+
+/**
+ * #1230: the rollup fibers re-aggregate on cadences far tighter than the reads they back require,
+ * dominating DB load on the 256 MB prod Postgres. `pickTier` reads ≤24h windows from raw
+ * `traffic_reports`, 24h–14d from `traffic_hourly`, >14d from `traffic_daily`, so a rolled bucket
+ * is not read until it crosses its tier threshold — the only freshness requirement is "rolled at
+ * least once before that". These tests pin the lowered cadences and, crucially, the self-heal
+ * invariant that guards them: each fiber's lookback window must be at least its tick interval, so a
+ * single missed tick is re-covered by the next one. Widening a cadence without widening the
+ * lookback to match would silently drop buckets on a missed tick.
+ */
+object RollupCadenceSpec extends ZIOSpecDefault {
+
+  def spec = suite("rollup cadences (#1230)")(
+    test("hourly fiber ticks hourly, not every 5 minutes") {
+      assertTrue(RollupJobs.HourlyInterval == Duration.ofHours(1))
+    },
+    test("daily fiber ticks daily, not hourly") {
+      assertTrue(RollupJobs.DailyInterval == Duration.ofHours(24))
+    },
+    test("time_used fiber ticks every 15 minutes, not every 3") {
+      assertTrue(TimeUsedRollupJob.Interval == Duration.ofMinutes(15))
+    },
+    test("hourly lookback covers a missed tick (lookback >= interval)") {
+      assertTrue(RollupJobs.HourlyLookback.compareTo(RollupJobs.HourlyInterval) >= 0)
+    },
+    test("daily lookback covers a missed tick (lookback spans >= one interval)") {
+      // DailyLookback is a Period of whole days; the daily interval is 24h, so the lookback must
+      // span at least 2 days for a missed daily tick to self-heal on the next one.
+      assertTrue(RollupJobs.DailyLookback.getDays >= 2)
+    },
+  )
+}


### PR DESCRIPTION
Closes #1230.

## Problem
Three scheduled rollup fibers re-aggregated on cadences far tighter than the reads they back require, dominating DB load on the 256 MB prod Postgres (related: #1228 pool pressure; the `TODO(#1221)` in `Main.scala` flags this rollup recompute as a pool hog):

| Fiber | Table | Was | Per hour |
|---|---|---|---|
| `RollupJobs.hourlyLoop` | `traffic_hourly` | every **5 min** | 12× |
| `RollupJobs.dailyLoop` | `traffic_daily` | every **60 min** | 24×/day |
| `TimeUsedRollupJob.loop` | `time_used_daily` | every **3 min** | 20× |

~33 re-roll cycles/hour, each several queries (the time_used tick is N+1 over profiles; the hourly/daily ticks each re-read `listAllHostMappings` + re-aggregate a trailing window).

## Root cause
Reads of recent windows never touch the rollup tables. `pickTier` (`api/src/routes/UsageRoutes.scala`) routes by window width:

- ≤ 24h → raw `traffic_reports`
- 24h–14d → `traffic_hourly`
- \> 14d → `traffic_daily`

So `traffic_hourly` isn't read until a bucket is ≥24h old, and `traffic_daily` not until ≥14d old. Re-rolling the trailing 2h every 5 min produced buckets no read would consult for 24 hours. The only freshness requirement is "rolled at least once before crossing the read threshold."

`time_used_daily` is the one fiber backing a hot read (`/api/time/status/summary`), but that read adds a **live tail** from `rolled_through` (`TimeStatusService`), so its screen-time figure is exact regardless of cadence — the tick only bounds tail size.

## Change
| Constant | From | To |
|---|---|---|
| `RollupJobs.HourlyInterval` | 5 min | **1 hour** |
| `RollupJobs.DailyInterval` | 60 min | **24 hours** |
| `RollupJobs.DailyLookback` | 1 day | **2 days** |
| `TimeUsedRollupJob.Interval` | 3 min | **15 min** |

`DailyLookback` widened to 2 days so a missed daily tick still self-heals now that the cadence is 24h (the trailing-window re-roll is what recovers a missed tick; the lookback must span ≥ one interval). `HourlyLookback` stays 2h, which already covers the new 1h interval.

Cuts ~33 re-roll cycles/hour to ~5 (~85% fewer scheduled DB ops) with no correctness impact.

## Freshness impact (none that's user-visible)
- Usage graphs for the current day/24h read raw `traffic_reports` — unchanged.
- `traffic_hourly` / `traffic_daily` are only read for windows already ≥24h / ≥14d old, by which time the new cadence has rolled them many times over.
- Screen-time summary stays exact via the live tail; at 15-min cadence the tail tops out at ~3 five-minute buckets per profile per read.

## Tests
TDD, red→green visible in history:
- `test(#1230): pin lowered rollup cadences + lookback self-heal invariant (red)`
- `fix(#1230): lower rollup cadences to match read tiers (green)`

New `api/test/src/unit/RollupCadenceSpec.scala` pins the three intervals **and** the self-heal invariant (each fiber's lookback ≥ its interval) — the latter is the real guard, so a future cadence widening can't silently drop buckets on a missed tick. Existing `RollupRepoSpec`, `RollupAppAttributionSpec`, `TimeUsedRollupSpec`, `UsageRoutingSpec` stay green.