### PR TITLE
Fix #1232: include hidden .cache files when uploading VM images

### DIFF
--- a/.github/workflows/build-release-artifacts.yml
+++ b/.github/workflows/build-release-artifacts.yml
@@ -274,6 +274,10 @@ jobs:
         with:
           name: vm-image-ipk
           path: scripts/vm/.cache/openwrt-wifihaven-ipk-*.img
+          # The .img lives under scripts/vm/.cache/, a dotted dir; upload-artifact
+          # v4+ defaults include-hidden-files: false and drops files under hidden
+          # path components, so without this the glob matches but the file is excluded.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 
@@ -282,6 +286,9 @@ jobs:
         with:
           name: vm-image-apk
           path: scripts/vm/.cache/openwrt-wifihaven-apk-*.img
+          # See note on the ipk upload above: .cache/ is hidden, so files under it
+          # are excluded by default unless include-hidden-files is set.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
## Summary

The `Build router release artifacts` workflow fails on `main` at **Upload VM image artifact (ipk)** (and apk would follow):

```
No files were found with the provided path: scripts/vm/.cache/openwrt-wifihaven-ipk-*.img. No artifacts will be uploaded.
```

The VM image is written to `scripts/vm/.cache/openwrt-wifihaven-<fmt>-<ver>.img` — under `.cache/`, a dotted (hidden) directory. Since v4, `actions/upload-artifact` defaults `include-hidden-files: false` and **excludes any file under a hidden/dotted path component**. The glob matches the file, but the action then drops it as hidden, and `if-no-files-found: error` fails the job. The earlier packaging step's `[ -f "$ipk_img" ]` on the same path passes, proving the `.img` is on disk — only the hidden-file-aware upload drops it.

This is a clean regression from the #1224/#1226 CD refactor (`6383359f`), surfaced on the **first run of the refactored pipeline**.

## Fix

Add `include-hidden-files: true` to both VM image upload steps in `.github/workflows/build-release-artifacts.yml`:
- `Upload VM image artifact (ipk)`
- `Upload VM image artifact (apk)`

The `Upload release assets artifact` step (`path: release/**`) is unaffected — `release/` and `release/versioned/` are not hidden.

`actionlint` passes on the modified workflow.

## Verification

The real proof is a **green run of the release workflow on this PR**: both VM-image artifacts (`vm-image-ipk`, `vm-image-apk`) upload successfully, and the downstream Gate 2 / Gate 3a jobs that consume the raw `.img` uploads can fetch them.

Closes #1232