### PR TITLE
test(web): harden debounced autosave tests against fake-timer race (#1235)

### DIFF
--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('@/api/client', () => ({
@@ -70,13 +70,15 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
 
   it('editing the reset time fires a debounced PATCH {dailyResetTime}', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     try {
       render(<AdminPage />)
       const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
 
-      await user.clear(time)
-      await user.type(time, '06:00')
+      // Set the value atomically: typing a `<input type="time">` char-by-char
+      // under fake timers lets the 700ms debounce fire on a transient partial
+      // value (e.g. '00:59') before the full '06:00' lands. fireEvent.change
+      // gives the debounce a single, final value to latch.
+      fireEvent.change(time, { target: { value: '06:00' } })
       expect(api.household.patch).not.toHaveBeenCalled()
       await vi.advanceTimersByTimeAsync(700)
 
@@ -109,8 +111,7 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
       render(<AdminPage />)
       const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
 
-      await user.clear(time)
-      await user.type(time, '06:00')
+      fireEvent.change(time, { target: { value: '06:00' } })
       await vi.advanceTimersByTimeAsync(700)
 
       const status = screen.getByTestId('household-save-status')
@@ -149,13 +150,11 @@ describe('AdminPage — heartbeat filter autosave (#1002)', () => {
 
   it('editing the bytes threshold fires PATCH {heartbeatFilter:{bytesThreshold}}', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     try {
       render(<AdminPage />)
       const bytes = await screen.findByTestId('heartbeat-filter-bytes') as HTMLInputElement
 
-      await user.clear(bytes)
-      await user.type(bytes, '8192')
+      fireEvent.change(bytes, { target: { value: '8192' } })
       await vi.advanceTimersByTimeAsync(700)
 
       expect(api.household.patch).toHaveBeenCalledWith({

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { AppDetail, ProfileDetail } from '@/types/api'
 import { withQuery } from '@/test/queryWrapper'
@@ -188,8 +188,9 @@ describe('AppsPage — inline edit autosave (#1003)', () => {
       render(withQuery(<AppsPage />))
       await expandYouTube(user)
       const nameInput = screen.getByTestId('app-name-input-10') as HTMLInputElement
-      await user.clear(nameInput)
-      await user.type(nameInput, 'YT')
+      // Set atomically: char-by-char typing under fake timers lets the 700ms
+      // debounce fire on a transient partial value, producing extra PATCHes.
+      fireEvent.change(nameInput, { target: { value: 'YT' } })
 
       // Pre-debounce: dirty, no save yet.
       expect(patchMock()).not.toHaveBeenCalled()
@@ -219,8 +220,7 @@ describe('AppsPage — inline edit autosave (#1003)', () => {
       await expandYouTube(user)
       await user.click(screen.getByTestId('icon-picker-tab-url'))
       const urlInput = screen.getByTestId('icon-picker-url-input') as HTMLInputElement
-      await user.clear(urlInput)
-      await user.type(urlInput, 'https://example.com/icon.png')
+      fireEvent.change(urlInput, { target: { value: 'https://example.com/icon.png' } })
 
       await vi.advanceTimersByTimeAsync(700)
 
@@ -276,8 +276,7 @@ describe('AppsPage — inline edit autosave (#1003)', () => {
       render(withQuery(<AppsPage />))
       await expandYouTube(user)
       const nameInput = screen.getByTestId('app-name-input-10') as HTMLInputElement
-      await user.clear(nameInput)
-      await user.type(nameInput, 'YT')
+      fireEvent.change(nameInput, { target: { value: 'YT' } })
 
       await vi.advanceTimersByTimeAsync(700)
 

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import type { Device, ProfileDetail } from '@/types/api'
@@ -147,8 +147,9 @@ describe('DevicesPage — inline autosave edit (#1000)', () => {
       const editor = await screen.findByTestId(`device-editor-${mac}`)
       const input = within(editor).getByTestId(`device-name-input-${mac}`)
 
-      await user.clear(input)
-      await user.type(input, 'Living Room iPad')
+      // Set atomically: typing char-by-char under fake timers lets the 700ms
+      // debounce fire on a transient partial value, producing extra PATCHes.
+      fireEvent.change(input, { target: { value: 'Living Room iPad' } })
       expect(api.devices.patch).not.toHaveBeenCalled()
 
       await vi.advanceTimersByTimeAsync(700)
@@ -197,8 +198,7 @@ describe('DevicesPage — inline autosave edit (#1000)', () => {
       const editor = await screen.findByTestId(`device-editor-${mac}`)
       const input = within(editor).getByTestId(`device-name-input-${mac}`)
 
-      await user.clear(input)
-      await user.type(input, 'Den iPad')
+      fireEvent.change(input, { target: { value: 'Den iPad' } })
       await vi.advanceTimersByTimeAsync(700)
 
       const status = within(editor).getByTestId(`device-save-status-${mac}`)

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import type { Device, ProfileDetail, ProfileTimeSummary, User } from '@/types/api'
@@ -501,8 +501,9 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
       await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
 
       const input = within(kidsCard).getByTestId('profile-time-limit-1')
-      await user.clear(input)
-      await user.type(input, '90')
+      // Set atomically: char-by-char typing under fake timers lets the 700ms
+      // debounce fire on a transient partial value, producing extra PUTs.
+      fireEvent.change(input, { target: { value: '90' } })
 
       // Pre-debounce: no save yet.
       expect(api.profiles.update).not.toHaveBeenCalled()

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ProfileDetail, User } from '@/types/api'
 
@@ -129,8 +129,9 @@ describe('UsersPage — inline autosave edit (#1001)', () => {
       const editor = await screen.findByTestId('user-editor-11')
       const input = within(editor).getByTestId('user-name-input-11')
 
-      await user.clear(input)
-      await user.type(input, 'bobby')
+      // Set atomically: char-by-char typing under fake timers lets the 700ms
+      // debounce fire on a transient partial value, producing extra PATCHes.
+      fireEvent.change(input, { target: { value: 'bobby' } })
       expect(api.users.patch).not.toHaveBeenCalled()
       await vi.advanceTimersByTimeAsync(700)
 
@@ -188,8 +189,7 @@ describe('UsersPage — inline autosave edit (#1001)', () => {
       const editor = await screen.findByTestId('user-editor-11')
       const input = within(editor).getByTestId('user-name-input-11')
 
-      await user.clear(input)
-      await user.type(input, 'bobby')
+      fireEvent.change(input, { target: { value: 'bobby' } })
       await vi.advanceTimersByTimeAsync(700)
 
       const status = within(editor).getByTestId('user-save-status-11')


### PR DESCRIPTION
## Summary

Fixes the flaky FE test `AdminPage > editing the reset time fires a debounced PATCH {dailyResetTime}` (#1235) and pre-emptively hardens the sibling autosave tests introduced in #1214.

The tests type a multi-character value char-by-char via `user.type(input, …)` into a **controlled** input while `vi.useFakeTimers({ shouldAdvanceTime: true })` advances real time and a 700ms `useDebouncedSave` debounce runs. The debounce can elapse mid-typing and fire on a transient partial value — CI captured `dailyResetTime: '00:59'` instead of `'06:00'`. The same race can double-fire the `toHaveBeenCalledTimes(1)` assertions in the Devices/Users/Apps/Profiles autosave tests.

The component (`AdminPage.tsx` et al.) is **not** buggy — a real user types fast enough that the debounce never fires between keystrokes. This is a test-determinism fix only: replace `user.clear` + `user.type` with a single `fireEvent.change`, so the debounce has exactly one final value to latch.

## Changes
- `AdminPage.test.tsx` — reset-time, bytes-threshold, and PATCH-failure-retry tests
- `DevicesPage.test.tsx` — rename + retry autosave tests
- `AppsPage.test.tsx` — rename, icon-url, and retry autosave tests
- `UsersPage.test.tsx` — rename + retry autosave tests
- `ProfilesPage.test.tsx` — daily-cap autosave test

Tests that only click/select a single value, or that run under real timers (e.g. the #973 inline-name tests, blur-saved minutes inputs), were left untouched — they aren't subject to this race.

## Test plan
- [x] `vitest run src/pages/AdminPage.test.tsx` — 5 consecutive green runs
- [x] Devices/Apps/Profiles/Users suites — 3 consecutive green runs
- [x] Full `vitest run` — 317 passed (29 files)
- [x] `npm run lint` clean
- [x] `npm run type-check` clean

Unblocks the #1231 merge queue.

Closes #1235