### PR TITLE
ci: merge_group path-filters against merge-base; migration checks run in queue + CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,13 @@ env:
 
 jobs:
   # ── Path filter: decide which downstream jobs need to run on this PR ─────
-  # On workflow_call (from the Master CD workflows) and workflow_dispatch we force every
-  # output to 'true' so the post-merge CD gate and manual runs still execute
-  # the full matrix. On pull_request we let dorny/paths-filter compute deltas
-  # against the PR base. Any change to ci.yml itself also forces everything.
+  # On push (the Master CD workflows reach ci.yml as `push`) and
+  # workflow_dispatch we force every output to 'true' so the post-merge CD
+  # gate and manual runs still execute the full matrix. On pull_request AND
+  # merge_group (the merge queue) we let dorny/paths-filter compute deltas —
+  # against the PR base for PRs, against the merge-base for the queue (#1238)
+  # — so the queue runs only the suites whose paths changed. Any change to
+  # ci.yml itself also forces everything (it's in every filter).
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
@@ -44,22 +47,27 @@ jobs:
       fake-api: ${{ steps.filter.outputs.fake-api || steps.force.outputs.all }}
       workflows: ${{ steps.filter.outputs.workflows || steps.force.outputs.all }}
     steps:
-      - name: Force full matrix for non-PR triggers
+      - name: Force full matrix for CD / manual triggers
         id: force
+        # Only push (CD via the Master workflows) and workflow_dispatch force
+        # the whole matrix. merge_group path-filters like a PR (#1238).
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "all=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "all=false" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ github.event_name }}" in
+            push|workflow_dispatch) echo "all=true"  >> "$GITHUB_OUTPUT" ;;
+            *)                      echo "all=false" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - uses: actions/checkout@v6
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
 
       - uses: dorny/paths-filter@v3
         id: filter
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         with:
+          # On merge_group, diff against the merge-base so the queue runs only
+          # what the queued PR touched. On pull_request, an empty base lets
+          # paths-filter auto-detect the PR base as before.
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             scala:
               # Narrowed: Scala job only compiles + tests Scala. Docker
@@ -247,19 +255,33 @@ jobs:
   migrations-immutable:
     name: Migrations Immutability Check
     needs: changes
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && needs.changes.outputs.migrations == 'true'
+    # Path-gated like every other job (#1236). Runs on pull_request,
+    # merge_group (queue), and push (CD) — each resolves its own base SHA
+    # below. merge_group/CD always target main, so no base.ref clause.
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
+      - name: Resolve base SHA
+        id: base
+        # pull_request → PR base; merge_group → merge-base; push → before-SHA.
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request) echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT" ;;
+            merge_group)  echo "sha=${{ github.event.merge_group.base_sha }}"  >> "$GITHUB_OUTPUT" ;;
+            push)         echo "sha=${{ github.event.before }}"                >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Reject changes to existing migration files
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
           # Emergency escape hatch for #883 (duplicate V27 rename). The
           # mutation check is bypassed only on this specific PR branch;
-          # the duplicate-version check still runs.
+          # the duplicate-version check still runs. On non-PR events
+          # head.ref is empty, so this resolves to '0'.
           # TODO(#885): remove this env block after the #883 PR has merged.
           ALLOW_MIGRATION_MUTATIONS: ${{ github.event.pull_request.head.ref == 'fix-883-dup-v27' && '1' || '0' }}
         run: bash .github/scripts/check-migrations.sh "$BASE_SHA"
@@ -275,28 +297,56 @@ jobs:
   migration-isolation:
     name: Migration Isolation Check
     needs: changes
+    # Runs on pull_request + merge_group only (NOT push — redundant
+    # post-merge). Path-gated like the rest (#1236). The label escape hatch
+    # is handled two ways: inline `!contains(...)` for PRs (labels are in the
+    # event), and a resolve-step for the queue (merge_group has no labels —
+    # we look them up from the queued PR head SHA).
     if: |
-      github.event_name == 'pull_request'
-      && github.event.pull_request.base.ref == 'main'
-      && needs.changes.outputs.migrations == 'true'
+      needs.changes.outputs.migrations == 'true'
+      && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
       && !contains(github.event.pull_request.labels.*.name, 'migration-coupled-justified')
     runs-on: ubuntu-latest
-    # CodeQL actions/missing-workflow-permissions: the job only needs to
-    # read the repo to diff the branch — no token writes.
+    # CodeQL actions/missing-workflow-permissions: contents:read to diff the
+    # branch; pull-requests:read so `gh pr list` can resolve the queued PR's
+    # labels in merge_group (no token writes).
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      # Diff against the merge-base with origin/main (three-dot semantics),
-      # not pull_request.base.sha. The base.sha can lag the actual main tip
-      # while a PR is open (we observed cdc5faae sticking around after V44
-      # landed on main), and unrelated migrations on main would otherwise
-      # show as "added" in this PR. Matches AGENTS.md "Branch-diff checks".
+      # In the merge queue the migration-coupled-justified label is not on the
+      # event, so a PR justified at PR time would otherwise fail here. Resolve
+      # the originating PR from the queue head SHA and skip if it's labeled.
+      - name: Check coupled-justified label (merge_group)
+        id: label
+        if: github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          labels=$(gh pr list --search "${{ github.event.merge_group.head_sha }}" --state all --json labels -q '.[0].labels[].name' 2>/dev/null || true)
+          if echo "$labels" | grep -qx 'migration-coupled-justified'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Diff against the per-event base (three-dot semantics): PR base.sha for
+      # pull_request, merge-base for merge_group. The script already uses
+      # `<base>...HEAD`, so this resolves the same merge-base intent as the old
+      # hardcoded origin/main. Matches AGENTS.md "Branch-diff checks".
+      - name: Resolve base SHA
+        id: base
+        run: |
+          case "${{ github.event_name }}" in
+            pull_request) echo "sha=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT" ;;
+            merge_group)  echo "sha=${{ github.event.merge_group.base_sha }}"  >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Reject migration PRs that also change production source
-        run: bash .github/scripts/check-migration-isolation.sh origin/main
+        if: steps.label.outputs.skip != 'true'
+        run: bash .github/scripts/check-migration-isolation.sh "${{ steps.base.outputs.sha }}"
 
   # ── Shell test discovery ─────────────────────────────────────────────────
   # Auto-discovers and runs every *.test.sh in the repo. Add a new test by


### PR DESCRIPTION
Closes #1238
Closes #1236

These two issues are coupled and ship together. All changes are in `.github/workflows/ci.yml`; the diff scripts already accept any base ref via three-dot diff, so they're untouched.

## #1238 — `changes` job

- **Force gate** now a `case "${{ github.event_name }}"` switch: `all=true` only for `push` and `workflow_dispatch`; `all=false` otherwise (so `merge_group` no longer forces the full matrix).
- `actions/checkout@v6` and `dorny/paths-filter@v3` now run on `merge_group` as well as `pull_request`.
- `paths-filter` gets `base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}` — diff against the merge-base in the queue; empty base keeps PR auto-detect.

## #1236 — migration jobs

- **`migrations-immutable`**: gate replaced with `needs.changes.outputs.migrations == 'true'` (dropped the `pull_request`/`base.ref == 'main'` clause). New "Resolve base SHA" step switches on event: `pull_request → base.sha`, `merge_group → merge_group.base_sha`, `push → github.event.before`; passed to `check-migrations.sh "$BASE_SHA"`. The `ALLOW_MIGRATION_MUTATIONS` env block is preserved (head.ref empty on non-PR → `'0'`).
- **`migration-isolation`**: gated on `needs.changes.outputs.migrations == 'true'` AND (`pull_request` OR `merge_group`) — not `push`. Per-event base (PR `base.sha` / merge_group `base_sha`). Label hatch preserved in both contexts: existing inline `!contains(github.event.pull_request.labels.*.name, …)` for PRs; for `merge_group`, a `gh pr list --search <head_sha>` step resolves the queued PR's labels and sets `skip=true`, guarding the script step with `if: steps.label.outputs.skip != 'true'`. Added `GH_TOKEN: ${{ github.token }}` and `pull-requests: read` to the job permissions.

## Acceptance walkthrough

**#1238**
- *web-only PR in the queue runs only Frontend* — merge_group now path-filters against `merge_group.base_sha`; a `web/**`-only delta sets `frontend=true` and leaves scala/lua/python/migrations false, so only Frontend runs. ✅
- *migration-adding PR runs the migration jobs in the queue* — that delta sets `migrations=true`; both migration jobs are gated on that output and now allow `merge_group`. ✅
- *CD (`push` to main) still forces the full matrix* — `push` hits the `case` → `all=true`; every output is `'true'`. ✅
- *actionlint clean* — verified with actionlint v1.7.12 (the pinned `ACTIONLINT_VERSION`), shellcheck present, no findings. ✅

**#1236**
- *PR that adds a migration runs both migration jobs in the merge queue* — `migrations=true` in the queue (via #1238's filter) and both jobs permit `merge_group`. ✅
- *merge-queue run with no migration change skips both* — filter leaves `migrations=false`, so both jobs (and all other unrelated suites) skip. ✅
- *PR labeled `migration-coupled-justified` skips isolation in BOTH contexts* — `pull_request`: inline `!contains(...)` short-circuits the job. `merge_group`: the `gh pr list` label step sets `skip=true` and the script step's `if:` skips it. ✅
- *CD (`push`) executes the immutability check against `github.event.before`* — `migrations-immutable` runs on push (forced `migrations=true`); the base resolver emits `github.event.before` for the `push` case. ✅
- *actionlint clean* — same as above. ✅