### PR TITLE
Prometheus /metrics with JVM, DB-pool, and rollup metrics

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -12,6 +12,7 @@ case class AppConfig(
     jwt: JwtConfig,
     cors: CorsConfig,
     policy: PolicyConfig = PolicyConfig(),
+    metrics: MetricsConfig = MetricsConfig(),
 ) {
   // WIFIHAVEN_DEBUG env var: when set to a non-empty, non-"0"/"false"/"no"
   // value, mounts the read-only /api/debug/* endpoints (loopback only).
@@ -47,6 +48,19 @@ case class JwtConfig(
     secret: String,
     expiryHours: Int,
 )
+
+// #1242: Prometheus /metrics exposition. `enabled` mounts the GET /metrics
+// route; when off, non-/metrics behaviour is unchanged and the route 404s.
+// `scrapeToken`, when non-empty, is required as `Authorization: Bearer <token>`
+// — the API is internet-facing on Render, so prod/staging set it. Empty (the
+// self-hosted default) leaves /metrics open on the loopback-bound deployment.
+case class MetricsConfig(
+    enabled: Boolean = true,
+    scrapeToken: String = "",
+) {
+  val scrapeTokenOpt: Option[String] =
+    Option(scrapeToken).map(_.trim).filter(_.nonEmpty)
+}
 
 // #612: cross-origin browser access for the split SPA.
 // `allowedOrigins` is a comma-separated list of full origins (scheme+host+

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -5,6 +5,7 @@ import doobie.implicits.*
 import wifihaven.api.auth.*
 import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
+import wifihaven.api.metrics.{DbPoolMetrics, MetricsRuntime}
 import wifihaven.api.notify.Notifier
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
@@ -17,11 +18,15 @@ import zio.http.*
 import zio.interop.catz.*
 import zio.logging.*
 import zio.logging.backend.SLF4J
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.metrics.jvm.DefaultJvmMetrics
 
 object Main extends ZIOAppDefault {
 
+  // #1242: enable ZIO runtime metrics (fibers, GC, etc.) so they flow into the
+  // Prometheus registry exposed at /metrics, alongside SLF4J logging.
   override val bootstrap =
-    Runtime.removeDefaultLoggers >>> SLF4J.slf4j
+    (Runtime.removeDefaultLoggers >>> SLF4J.slf4j) ++ Runtime.enableRuntimeMetrics
 
   def run =
     (for {
@@ -105,6 +110,11 @@ object Main extends ZIOAppDefault {
         )
         .forkDaemon
       _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
+      // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
+      // for the process and never blocks startup.
+      dbPool          <- ZIO.service[Database.DbPool]
+      _               <- DbPoolMetrics.loop(dbPool.dataSource, dbPool.maxSize).forkDaemon
+      _               <- ZIO.logInfo("db-pool metrics fiber forked")
       _               <- ZIO
         .logWarning(
           "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
@@ -156,41 +166,45 @@ object Main extends ZIOAppDefault {
       TimeStatusCache.live() >+>
       BlocklistCache.live >+>
       BlocklistFetcher.live >+>
-      Notifier.live
+      Notifier.live >+>
+      // #1242: Prometheus publisher + snapshot listener, and JVM metrics collectors.
+      MetricsRuntime.prometheus() >+>
+      DefaultJvmMetrics.live
 
   private def allRoutes(
       templates: Map[wifihaven.shared.types.AppTemplateId, AppTemplate],
       bundledBlocklists: Map[wifihaven.shared.types.BlocklistId, BundledBlocklist],
   ) =
     for {
-      auth        <- ZIO.service[AuthService]
-      userRepo    <- ZIO.service[UserRepo]
-      upRepo      <- ZIO.service[UserProfileRepo]
-      profileRepo <- ZIO.service[ProfileRepo]
-      schedRepo   <- ZIO.service[ScheduleRepo]
-      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
-      tlRepo      <- ZIO.service[TimeLimitRepo]
-      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-      deviceRepo  <- ZIO.service[DeviceRepo]
-      blRepo      <- ZIO.service[BlocklistRepo]
-      blCache     <- ZIO.service[BlocklistCache]
-      blFetcher2  <- ZIO.service[BlocklistFetcher]
-      usageRepo   <- ZIO.service[TimeUsageRepo]
-      extRepo     <- ZIO.service[TimeExtensionRepo]
-      routerRepo  <- ZIO.service[RouterRepo]
-      trafficRepo <- ZIO.service[TrafficReportRepo]
-      rollupRepo2 <- ZIO.service[RollupRepo]
-      connRepo    <- ZIO.service[ConnectionEventRepo]
-      blockEvRepo <- ZIO.service[BlockEventRepo]
-      alertRepo   <- ZIO.service[AlertRepo]
-      appRepo     <- ZIO.service[AppRepo]
-      notifier    <- ZIO.service[Notifier]
-      policy      <- ZIO.service[PolicyService]
-      timeStatus  <- ZIO.service[wifihaven.api.policy.TimeStatusService]
-      cfg         <- ZIO.service[AppConfig]
-      clock       <- ZIO.service[Clock]
-      timeCache   <- ZIO.service[TimeStatusCache]
-      xa          <- ZIO.service[Transactor[Task]]
+      auth          <- ZIO.service[AuthService]
+      userRepo      <- ZIO.service[UserRepo]
+      upRepo        <- ZIO.service[UserProfileRepo]
+      profileRepo   <- ZIO.service[ProfileRepo]
+      schedRepo     <- ZIO.service[ScheduleRepo]
+      hsRepo        <- ZIO.service[HouseholdSettingsRepo]
+      tlRepo        <- ZIO.service[TimeLimitRepo]
+      stlRepo       <- ZIO.service[SiteTimeLimitRepo]
+      deviceRepo    <- ZIO.service[DeviceRepo]
+      blRepo        <- ZIO.service[BlocklistRepo]
+      blCache       <- ZIO.service[BlocklistCache]
+      blFetcher2    <- ZIO.service[BlocklistFetcher]
+      usageRepo     <- ZIO.service[TimeUsageRepo]
+      extRepo       <- ZIO.service[TimeExtensionRepo]
+      routerRepo    <- ZIO.service[RouterRepo]
+      trafficRepo   <- ZIO.service[TrafficReportRepo]
+      rollupRepo2   <- ZIO.service[RollupRepo]
+      connRepo      <- ZIO.service[ConnectionEventRepo]
+      blockEvRepo   <- ZIO.service[BlockEventRepo]
+      alertRepo     <- ZIO.service[AlertRepo]
+      appRepo       <- ZIO.service[AppRepo]
+      notifier      <- ZIO.service[Notifier]
+      policy        <- ZIO.service[PolicyService]
+      timeStatus    <- ZIO.service[wifihaven.api.policy.TimeStatusService]
+      cfg           <- ZIO.service[AppConfig]
+      clock         <- ZIO.service[Clock]
+      timeCache     <- ZIO.service[TimeStatusCache]
+      xa            <- ZIO.service[Transactor[Task]]
+      promPublisher <- ZIO.service[PrometheusPublisher]
       routerAuth    = new RouterAuthLive(routerRepo)
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield {
@@ -202,6 +216,7 @@ object Main extends ZIOAppDefault {
       // a short, well-typed concatenation.
       val systemRoutes: Routes[Any, Response] =
         HealthRoutes.routes(dbHealthCheck) ++
+          MetricsRoutes.routes(cfg.metrics, promPublisher) ++
           VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
           AuthRoutes.routes(auth, userRepo, upRepo) ++
           ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -13,6 +13,12 @@ import scala.concurrent.ExecutionContext
 
 object Database {
 
+  /**
+   * #1243: handle on the live HikariCP pool so the metrics fiber can read `getHikariPoolMXBean`.
+   * Surfaced as a service alongside the `Transactor[Task]` (they share the same datasource).
+   */
+  final case class DbPool(dataSource: HikariDataSource, maxSize: Int)
+
   private def makeDataSource(cfg: DbConfig): HikariDataSource = {
     val ds = new HikariDataSource()
     ds.setJdbcUrl(s"jdbc:postgresql://${cfg.host}:${cfg.port}/${cfg.database}")
@@ -58,13 +64,16 @@ object Database {
   private def acquireDataSource(cfg: DbConfig): ZIO[Scope, Throwable, HikariDataSource] =
     ZIO.acquireRelease(ZIO.attempt(makeDataSource(cfg)))(ds => ZIO.succeed(ds.close()))
 
-  val transactorLayer: ZLayer[DbConfig, Throwable, Transactor[Task]] =
-    ZLayer.scoped {
+  // Outputs both the `Transactor[Task]` and a `DbPool` handle over the same Hikari datasource, so
+  // the #1243 pool-metrics fiber can poll the live MXBean without a second datasource.
+  val transactorLayer: ZLayer[DbConfig, Throwable, Transactor[Task] & DbPool] =
+    ZLayer.scopedEnvironment {
       for {
         cfg       <- ZIO.service[DbConfig]
         connectEC <- makeConnectEC(cfg.poolSize)
         ds        <- acquireDataSource(cfg)
-      } yield Transactor.fromDataSource[Task](ds, connectEC)
+        xa = Transactor.fromDataSource[Task](ds, connectEC)
+      } yield ZEnvironment[Transactor[Task]](xa).add[DbPool](DbPool(ds, cfg.poolSize))
     }
 
   def runMigrations(cfg: DbConfig): Task[Unit] =

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -379,6 +379,16 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
           VALUES ($job, $startedAt, $finishedAt, $status, $error, $rowsUpserted)""".update.run
       .transact(xa)
       .unit
+      // #1243: publish the time-series alongside the existing rollup_runs row. The /api/admin/
+      // rollup-status point-in-time view is unchanged; this just exports to Prometheus.
+      .zipLeft(
+        wifihaven.api.metrics.AppMetrics.recordRollup(
+          job = job,
+          status = status,
+          durationSeconds = (finishedAt.toEpochMilli - startedAt.toEpochMilli) / 1000.0,
+          rows = rowsUpserted,
+        ),
+      )
 
   def recentRuns(limit: Int): Task[List[RollupRun]] =
     sql"""SELECT id, job, started_at, finished_at, status, error, rows_upserted

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -1,0 +1,118 @@
+package wifihaven.api.metrics
+
+import com.zaxxer.hikari.HikariDataSource
+import zio.*
+import zio.metrics.*
+import zio.metrics.connectors
+import zio.metrics.connectors.MetricsConfig as ConnectorsConfig
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+
+/**
+ * #1242 / #1243: all WifiHaven application metrics, published through the Prometheus registry
+ * exposed at `GET /metrics`. Every series is a plain `zio.metrics.Metric`, so the connector's
+ * periodic snapshot picks them up alongside the JVM/runtime metrics.
+ */
+object AppMetrics {
+
+  // ── Rollup health (#1243) ──────────────────────────────────────────────────
+  // Emitted from RollupRepoLive.recordRun — the single completion point both the
+  // hourly/daily byte-rollup fibers and the time_used_daily fiber funnel through.
+
+  private val rollupRuns = Metric.counter("wifihaven_rollup_runs_total")
+
+  // Sub-second to multi-minute coverage: a prod rollup over a growth table can
+  // run for minutes (#1197), so the boundaries span 0.05s → ~200s.
+  private val rollupDuration = Metric.histogram(
+    "wifihaven_rollup_duration_seconds",
+    MetricKeyType.Histogram.Boundaries.exponential(0.05, 2.0, 13),
+  )
+
+  private val rollupRows = Metric.gauge("wifihaven_rollup_rows_upserted")
+
+  /** Record a completed rollup run. `status` is "ok" or "error". */
+  def recordRollup(job: String, status: String, durationSeconds: Double, rows: Int): UIO[Unit] =
+    rollupRuns.tagged("job", job).tagged("status", status).update(1L) *>
+      rollupDuration.tagged("job", job).update(math.max(0.0, durationSeconds)) *>
+      rollupRows.tagged("job", job).update(rows.toDouble)
+
+  // ── DB connection pool (#1243, #1221) ───────────────────────────────────────
+  // Set from the polling fiber in DbPoolMetrics. threads_awaiting was the
+  // leading indicator of the 2026-05-31 pool-exhaustion crash loop.
+
+  private val dbActive  = Metric.gauge("wifihaven_db_pool_active_connections")
+  private val dbIdle    = Metric.gauge("wifihaven_db_pool_idle_connections")
+  private val dbTotal   = Metric.gauge("wifihaven_db_pool_total_connections")
+  private val dbWaiting = Metric.gauge("wifihaven_db_pool_threads_awaiting_connection")
+  private val dbMax     = Metric.gauge("wifihaven_db_pool_max_size")
+
+  def setDbPool(stats: DbPoolStats): UIO[Unit] =
+    dbActive.update(stats.active.toDouble) *>
+      dbIdle.update(stats.idle.toDouble) *>
+      dbTotal.update(stats.total.toDouble) *>
+      dbWaiting.update(stats.threadsAwaiting.toDouble) *>
+      dbMax.update(stats.maxSize.toDouble)
+}
+
+/** Point-in-time HikariCP pool snapshot. */
+final case class DbPoolStats(
+    active: Int,
+    idle: Int,
+    total: Int,
+    threadsAwaiting: Int,
+    maxSize: Int,
+)
+
+/** #1243: poll the HikariCP MXBean and publish the pool gauges. */
+object DbPoolMetrics {
+
+  /** Default cadence; chosen short enough to catch a saturation spike before the 30s timeout. */
+  val DefaultInterval: Duration = 10.seconds
+
+  /**
+   * Read the live pool stats. The MXBean is null until the pool is initialised (first connection),
+   * so we fall back to zeros for the dynamic counters while still reporting the configured max.
+   */
+  def read(ds: HikariDataSource, maxSize: Int): UIO[DbPoolStats] =
+    ZIO.succeed {
+      Option(ds.getHikariPoolMXBean) match {
+        case Some(mx) =>
+          DbPoolStats(
+            active = mx.getActiveConnections,
+            idle = mx.getIdleConnections,
+            total = mx.getTotalConnections,
+            threadsAwaiting = mx.getThreadsAwaitingConnection,
+            maxSize = maxSize,
+          )
+        case None     =>
+          DbPoolStats(0, 0, 0, 0, maxSize)
+      }
+    }
+
+  def pollOnce(ds: HikariDataSource, maxSize: Int): UIO[Unit] =
+    read(ds, maxSize).flatMap(AppMetrics.setDbPool)
+
+  /** Fiber loop: poll every `interval`. Never fails; intended to be forked as a daemon. */
+  def loop(ds: HikariDataSource, maxSize: Int, interval: Duration = DefaultInterval): UIO[Unit] =
+    pollOnce(ds, maxSize).repeat(Schedule.fixed(interval)).unit
+}
+
+/** #1242: Prometheus connector wiring — publisher + the periodic snapshot listener. */
+object MetricsRuntime {
+
+  /** Snapshot cadence for the Prometheus listener; Prometheus scrapes typically every 15–30s. */
+  val DefaultInterval: Duration = 5.seconds
+
+  /**
+   * Provides the [[PrometheusPublisher]] (whose `get` renders the exposition text) plus the
+   * background listener fiber that snapshots the metric registry every `interval`. The `Unit`
+   * output of `prometheusLayer` and the `ConnectorsConfig` are folded in via `>+>`; the wider
+   * intersection is a subtype of the declared `PrometheusPublisher` output.
+   */
+  def prometheus(
+      interval: Duration = DefaultInterval,
+  ): ZLayer[Any, Nothing, PrometheusPublisher] = {
+    val cfgAndPublisher =
+      ZLayer.succeed(ConnectorsConfig(interval)) ++ connectors.prometheus.publisherLayer
+    cfgAndPublisher >+> connectors.prometheus.prometheusLayer
+  }
+}

--- a/api/src/routes/MetricsRoutes.scala
+++ b/api/src/routes/MetricsRoutes.scala
@@ -1,0 +1,54 @@
+package wifihaven.api.routes
+
+import wifihaven.api.MetricsConfig
+import zio.*
+import zio.http.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+
+/**
+ * #1242: Prometheus exposition endpoint. `GET /metrics` renders the registry snapshot held by the
+ * connector's [[PrometheusPublisher]] as `text/plain; version=0.0.4`.
+ *
+ * Auth is config-gated: when `cfg.scrapeToken` is set, the request must carry `Authorization:
+ * Bearer <token>` (the API is internet-facing on Render). When unset, the endpoint is open — the
+ * self-hosted default, where the API isn't publicly exposed. When `cfg.enabled` is false the route
+ * isn't mounted at all.
+ */
+object MetricsRoutes {
+
+  // Prometheus text exposition format version 0.0.4.
+  private val ContentType = "text/plain; version=0.0.4; charset=utf-8"
+
+  def routes(cfg: MetricsConfig, publisher: PrometheusPublisher): Routes[Any, Response] =
+    if !cfg.enabled then Routes.empty
+    else
+      Routes(
+        Method.GET / "metrics" ->
+          handler { (req: Request) =>
+            if authorized(req, cfg) then
+              publisher.get.map(text =>
+                Response(status = Status.Ok, body = Body.fromCharSequence(text))
+                  .removeHeader("content-type")
+                  .addHeader("content-type", ContentType),
+              )
+            else
+              ZIO.succeed(
+                Response
+                  .text("missing or invalid metrics scrape token")
+                  .status(Status.Unauthorized),
+              )
+          },
+      )
+
+  private def authorized(req: Request, cfg: MetricsConfig): Boolean =
+    cfg.scrapeTokenOpt match {
+      case None           => true
+      case Some(expected) => bearer(req).contains(expected)
+    }
+
+  private def bearer(req: Request): Option[String] =
+    req
+      .header(Header.Authorization)
+      .map(_.renderedValue)
+      .collect { case v if v.startsWith("Bearer ") => v.drop("Bearer ".length) }
+}

--- a/api/test/src/feature/MetricsApiSpec.scala
+++ b/api/test/src/feature/MetricsApiSpec.scala
@@ -1,0 +1,75 @@
+package wifihaven.api.feature
+
+import wifihaven.api.MetricsConfig
+import wifihaven.api.metrics.MetricsRuntime
+import wifihaven.api.routes.MetricsRoutes
+import zio.*
+import zio.http.*
+import zio.metrics.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.metrics.jvm.DefaultJvmMetrics
+import zio.test.*
+
+// #1242: the Prometheus /metrics exposition endpoint. Drives the real route
+// against a live publisher + JVM metrics, so the assertions exercise the same
+// registry → publisher → text-exposition path production uses.
+object MetricsApiSpec extends ZIOSpecDefault {
+
+  // Short poll interval so the publisher's background snapshot is fresh well
+  // within the per-test sleep below; live clock required for the fiber to tick.
+  private val pollInterval = 100.millis
+
+  private def scrape(
+      cfg: MetricsConfig,
+      auth: Option[String],
+  ): ZIO[PrometheusPublisher, Response, Response] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      routes = MetricsRoutes.routes(cfg, pub)
+      base   = Request.get("/metrics")
+      req    = auth.fold(base)(t => base.addHeader(Header.Authorization.Bearer(t)))
+      resp <- routes(req)
+    } yield resp
+
+  def spec = suite("Metrics /metrics exposition (#1242)")(
+    test(
+      "GET /metrics returns 200 text/plain with HELP/TYPE, a runtime metric, and a custom metric",
+    ) {
+      val probe = Metric.counter("wifihaven_test_probe_total")
+      (for {
+        _    <- probe.update(1L)
+        _    <- ZIO.sleep(800.millis)
+        resp <- scrape(MetricsConfig(enabled = true), None).merge
+        body <- resp.body.asString
+        ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(ct.startsWith("text/plain")) &&
+        assertTrue(body.contains("# HELP")) &&
+        assertTrue(body.contains("# TYPE")) &&
+        assertTrue(body.contains("jvm")) &&
+        assertTrue(body.contains("wifihaven_test_probe_total")))
+        .provide(DefaultJvmMetrics.live, MetricsRuntime.prometheus(pollInterval))
+    } @@ TestAspect.withLiveClock,
+    test("with a scrape token configured, no/invalid bearer is 401 and the right bearer is 200") {
+      val cfg = MetricsConfig(enabled = true, scrapeToken = "s3cret-token")
+      (for {
+        _       <- ZIO.sleep(300.millis)
+        noAuth  <- scrape(cfg, None).merge
+        badAuth <- scrape(cfg, Some("wrong")).merge
+        okAuth  <- scrape(cfg, Some("s3cret-token")).merge
+      } yield assertTrue(noAuth.status == Status.Unauthorized) &&
+        assertTrue(badAuth.status == Status.Unauthorized) &&
+        assertTrue(okAuth.status == Status.Ok))
+        .provide(MetricsRuntime.prometheus(pollInterval))
+    } @@ TestAspect.withLiveClock,
+    test("metrics.enabled = false serves no /metrics route") {
+      val cfg = MetricsConfig(enabled = false)
+      (for {
+        pub <- ZIO.service[PrometheusPublisher]
+        routes = MetricsRoutes.routes(cfg, pub)
+        resp <- routes(Request.get("/metrics")).merge
+      } yield assertTrue(resp.status == Status.NotFound))
+        .provide(MetricsRuntime.prometheus(pollInterval))
+    } @@ TestAspect.withLiveClock,
+  )
+}

--- a/api/test/src/feature/MetricsApiSpec.scala
+++ b/api/test/src/feature/MetricsApiSpec.scala
@@ -36,19 +36,26 @@ object MetricsApiSpec extends ZIOSpecDefault {
       "GET /metrics returns 200 text/plain with HELP/TYPE, a runtime metric, and a custom metric",
     ) {
       val probe = Metric.counter("wifihaven_test_probe_total")
-      (for {
-        _    <- probe.update(1L)
-        _    <- ZIO.sleep(800.millis)
-        resp <- scrape(MetricsConfig(enabled = true), None).merge
-        body <- resp.body.asString
-        ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
-      } yield assertTrue(resp.status == Status.Ok) &&
-        assertTrue(ct.startsWith("text/plain")) &&
-        assertTrue(body.contains("# HELP")) &&
-        assertTrue(body.contains("# TYPE")) &&
-        assertTrue(body.contains("jvm")) &&
-        assertTrue(body.contains("wifihaven_test_probe_total")))
-        .provide(DefaultJvmMetrics.live, MetricsRuntime.prometheus(pollInterval))
+      ZIO
+        .scoped {
+          for {
+            // Build DefaultJvmMetrics.live explicitly so its collectors run and the
+            // jvm_* series register. Its output is Unit, which ZIO would prune if
+            // it were just listed in `.provide`.
+            _    <- DefaultJvmMetrics.live.build
+            _    <- probe.update(1L)
+            _    <- ZIO.sleep(800.millis)
+            resp <- scrape(MetricsConfig(enabled = true), None).merge
+            body <- resp.body.asString
+            ct = resp.header(Header.ContentType).map(_.renderedValue).getOrElse("")
+          } yield assertTrue(resp.status == Status.Ok) &&
+            assertTrue(ct.startsWith("text/plain")) &&
+            assertTrue(body.contains("# HELP")) &&
+            assertTrue(body.contains("# TYPE")) &&
+            assertTrue(body.contains("jvm")) &&
+            assertTrue(body.contains("wifihaven_test_probe_total"))
+        }
+        .provide(MetricsRuntime.prometheus(pollInterval))
     } @@ TestAspect.withLiveClock,
     test("with a scrape token configured, no/invalid bearer is 401 and the right bearer is 200") {
       val cfg = MetricsConfig(enabled = true, scrapeToken = "s3cret-token")

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -9,7 +9,6 @@ import wifihaven.api.usage.TimeUsedRollupJob
 import wifihaven.shared.Clock
 import wifihaven.testinfra.*
 import zio.*
-import zio.http.*
 import zio.metrics.connectors.prometheus.PrometheusPublisher
 import zio.test.*
 
@@ -30,10 +29,10 @@ object MetricsExportSpec
   // A Hikari pool wired to the per-spec embedded DB, so getHikariPoolMXBean is real.
   private def hikari(
       maxSize: Int,
-  ): ZIO[EmbeddedPostgres & TestDb & Scope, Throwable, HikariDataSource] =
+  ): ZIO[EmbeddedPostgres & TestDatabase.TestDb & Scope, Throwable, HikariDataSource] =
     for {
       pg <- ZIO.service[EmbeddedPostgres]
-      db <- ZIO.service[TestDb]
+      db <- ZIO.service[TestDatabase.TestDb]
       ds <- ZIO.acquireRelease(ZIO.attempt {
         val h = new HikariDataSource()
         h.setJdbcUrl(pg.getJdbcUrl("postgres", db.name))
@@ -66,13 +65,15 @@ object MetricsExportSpec
         assertTrue(body.contains("wifihaven_db_pool_total_connections")) &&
         assertTrue(body.contains("wifihaven_db_pool_threads_awaiting_connection")) &&
         assertTrue(body.contains("wifihaven_db_pool_max_size")) &&
-        // max_size gauge was set to 7
+        // max_size gauge was set to 7 (sample line: `name 7.0 <timestamp>`)
         assertTrue(
           body.linesIterator.exists(l =>
-            l.startsWith("wifihaven_db_pool_max_size") && l.trim.endsWith("7.0"),
+            l.startsWith("wifihaven_db_pool_max_size ") && l.split(" ").lift(1).contains("7.0"),
           ),
         ))
-        .provide(MetricsRuntime.prometheus(pollInterval))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]](
+          MetricsRuntime.prometheus(pollInterval),
+        )
     } @@ TestAspect.withLiveClock,
     test("driving a rollup tick emits the rollup counter/histogram/gauge series") {
       (for {
@@ -107,7 +108,10 @@ object MetricsExportSpec
         assertTrue(body.contains("wifihaven_rollup_duration_seconds")) &&
         assertTrue(body.contains("wifihaven_rollup_rows_upserted")) &&
         assertTrue(body.contains("time_used_daily")))
-        .provide(MetricsRuntime.prometheus(pollInterval), Clock.live)
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]](
+          MetricsRuntime.prometheus(pollInterval),
+          Clock.live,
+        )
     } @@ TestAspect.withLiveClock,
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -1,0 +1,113 @@
+package wifihaven.api.feature
+
+import com.zaxxer.hikari.HikariDataSource
+import doobie.Transactor
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.db.*
+import wifihaven.api.metrics.{DbPoolMetrics, MetricsRuntime}
+import wifihaven.api.usage.TimeUsedRollupJob
+import wifihaven.shared.Clock
+import wifihaven.testinfra.*
+import zio.*
+import zio.http.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+// #1243: DB-pool gauges + rollup counters/histograms published through the
+// Prometheus registry. Runs against embedded Postgres (no repo mocks).
+object MetricsExportSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val pollInterval = 100.millis
+
+  private def exposition: ZIO[PrometheusPublisher, Nothing, String] =
+    ZIO.serviceWithZIO[PrometheusPublisher](_.get)
+
+  // A Hikari pool wired to the per-spec embedded DB, so getHikariPoolMXBean is real.
+  private def hikari(
+      maxSize: Int,
+  ): ZIO[EmbeddedPostgres & TestDb & Scope, Throwable, HikariDataSource] =
+    for {
+      pg <- ZIO.service[EmbeddedPostgres]
+      db <- ZIO.service[TestDb]
+      ds <- ZIO.acquireRelease(ZIO.attempt {
+        val h = new HikariDataSource()
+        h.setJdbcUrl(pg.getJdbcUrl("postgres", db.name))
+        h.setUsername("postgres")
+        h.setMaximumPoolSize(maxSize)
+        h
+      })(h => ZIO.succeed(h.close()))
+      // Force at least one connection through the pool so the MXBean reports live numbers.
+      _  <- ZIO.attempt {
+        val c = ds.getConnection
+        try c.createStatement().execute("SELECT 1")
+        finally c.close()
+      }
+    } yield ds
+
+  def spec = suite("Metrics export (#1243)")(
+    test("db-pool gauges are present with sane values after a poll") {
+      (for {
+        _    <- cleanDb
+        _    <- ZIO.scoped {
+          for {
+            ds <- hikari(maxSize = 7)
+            _  <- DbPoolMetrics.pollOnce(ds, maxSize = 7)
+          } yield ()
+        }
+        _    <- ZIO.sleep(400.millis)
+        body <- exposition
+      } yield assertTrue(body.contains("wifihaven_db_pool_active_connections")) &&
+        assertTrue(body.contains("wifihaven_db_pool_idle_connections")) &&
+        assertTrue(body.contains("wifihaven_db_pool_total_connections")) &&
+        assertTrue(body.contains("wifihaven_db_pool_threads_awaiting_connection")) &&
+        assertTrue(body.contains("wifihaven_db_pool_max_size")) &&
+        // max_size gauge was set to 7
+        assertTrue(
+          body.linesIterator.exists(l =>
+            l.startsWith("wifihaven_db_pool_max_size") && l.trim.endsWith("7.0"),
+          ),
+        ))
+        .provide(MetricsRuntime.prometheus(pollInterval))
+    } @@ TestAspect.withLiveClock,
+    test("driving a rollup tick emits the rollup counter/histogram/gauge series") {
+      (for {
+        _              <- cleanDb
+        timeRollupRepo <- ZIO.service[TimeUsedRollupRepo]
+        rollupRepo     <- ZIO.service[RollupRepo]
+        profileRepo    <- ZIO.service[ProfileRepo]
+        deviceRepo     <- ZIO.service[DeviceRepo]
+        stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+        trafficRepo    <- ZIO.service[TrafficReportRepo]
+        hsRepo         <- ZIO.service[HouseholdSettingsRepo]
+        clock          <- ZIO.service[Clock]
+        // The loop runs one tick immediately (repeat runs the body before scheduling),
+        // which records a run via RollupRepo.recordRun — the metric-emission site.
+        fiber          <- TimeUsedRollupJob
+          .loop(
+            timeRollupRepo,
+            rollupRepo,
+            profileRepo,
+            deviceRepo,
+            stlRepo,
+            trafficRepo,
+            hsRepo,
+            clock,
+          )
+          .fork
+        _              <- ZIO.sleep(600.millis)
+        _              <- fiber.interrupt
+        _              <- ZIO.sleep(300.millis)
+        body           <- exposition
+      } yield assertTrue(body.contains("wifihaven_rollup_runs_total")) &&
+        assertTrue(body.contains("wifihaven_rollup_duration_seconds")) &&
+        assertTrue(body.contains("wifihaven_rollup_rows_upserted")) &&
+        assertTrue(body.contains("time_used_daily")))
+        .provide(MetricsRuntime.prometheus(pollInterval), Clock.live)
+    } @@ TestAspect.withLiveClock,
+  ) @@ TestAspect.sequential
+}

--- a/build.mill
+++ b/build.mill
@@ -38,6 +38,7 @@ val zioHttpVersion     = "3.0.1"
 val zioJsonVersion     = "0.7.3"
 val zioConfigVersion   = "4.0.2"
 val zioLoggingVersion  = "2.3.1"
+val zioMetricsVersion  = "2.3.1"
 val doobieVersion      = "1.0.0-RC5"
 val flywayVersion      = "10.17.3"
 val jwtVersion         = "10.0.1"
@@ -109,6 +110,7 @@ object api extends CommonModule {
     mvn"dev.zio::zio-config-magnolia:$zioConfigVersion",
     mvn"dev.zio::zio-logging:$zioLoggingVersion",
     mvn"dev.zio::zio-logging-slf4j:$zioLoggingVersion",
+    mvn"dev.zio::zio-metrics-connectors-prometheus:$zioMetricsVersion",
     mvn"org.tpolecat::doobie-core:$doobieVersion",
     mvn"org.tpolecat::doobie-postgres:$doobieVersion",
     mvn"org.tpolecat::doobie-hikari:$doobieVersion",

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -45,4 +45,14 @@ wifihaven {
     # Precursor to the DB-backed global profile in #937.
     uiAllowedHosts = ""
   }
+
+  metrics {
+    # #1242: Prometheus exposition at GET /metrics (JVM + runtime + app
+    # gauges/counters). enabled=false leaves the route unmounted.
+    enabled = true
+    # When set, GET /metrics requires `Authorization: Bearer <token>`.
+    # Leave empty for self-hosted installs where the API isn't publicly
+    # exposed; set a token on internet-facing (Render) deployments.
+    scrapeToken = ""
+  }
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 : "${WIFIHAVEN_DEBUG:=}"
 : "${WIFIHAVEN_ALLOWED_ORIGINS:=}"
 : "${WIFIHAVEN_UI_ALLOWED_HOSTS:=}"
+: "${WIFIHAVEN_METRICS_ENABLED:=true}"
+: "${WIFIHAVEN_METRICS_SCRAPE_TOKEN:=}"
 
 export WIFIHAVEN_LOG_LEVEL WIFIHAVEN_DEBUG
 
@@ -52,6 +54,10 @@ wifihaven {
   }
   policy {
     uiAllowedHosts = "${WIFIHAVEN_UI_ALLOWED_HOSTS}"
+  }
+  metrics {
+    enabled     = ${WIFIHAVEN_METRICS_ENABLED}
+    scrapeToken = "${WIFIHAVEN_METRICS_SCRAPE_TOKEN}"
   }
 }
 EOF

--- a/render.yaml
+++ b/render.yaml
@@ -99,6 +99,10 @@ services:
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
         generateValue: true
+      # #1242: GET /metrics is internet-facing on Render, so gate it behind a
+      # bearer token. Generated ONCE on first apply; share with the scraper.
+      - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN
+        generateValue: true
 
   # ── Production API ─────────────────────────────────────────────────────────
   - type: web
@@ -192,6 +196,10 @@ services:
         value: "false"
       # Generated ONCE on first apply. Never rotate — see header.
       - key: WIFIHAVEN_JWT_SECRET
+        generateValue: true
+      # #1242: GET /metrics is internet-facing on Render, so gate it behind a
+      # bearer token. Generated ONCE on first apply; share with the scraper.
+      - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN
         generateValue: true
 
 databases:


### PR DESCRIPTION
## Summary

Adds a config-gated Prometheus exposition endpoint and the application
metrics that feed it. Replaces the bespoke JSON admin-endpoint approach
(#1241, closed) — everything here is standard Prometheus exposition.

### #1242 — `/metrics` foundation
- `GET /metrics` renders the registry snapshot as
  `text/plain; version=0.0.4` via the `zio-metrics-connectors`
  Prometheus publisher (added `dev.zio::zio-metrics-connectors-prometheus`).
- JVM metrics (`DefaultJvmMetrics.live`) + ZIO runtime metrics
  (`Runtime.enableRuntimeMetrics`) are wired into the app layers.
- Auth is config-gated via new `metrics { enabled, scrapeToken }`:
  - `enabled = false` → route not mounted.
  - `scrapeToken` set → requires `Authorization: Bearer <token>` (401 otherwise).
  - unset → open (self-hosted default, API not publicly exposed).
- Config plumbed through `docker/entrypoint.sh`,
  `config/application.conf.example`, and `render.yaml`
  (`WIFIHAVEN_METRICS_SCRAPE_TOKEN` via `generateValue: true` on both
  staging and prod, never hardcoded).

### #1243 — DB-pool + rollup metrics
- A ~10s daemon fiber polls the live HikariCP `getHikariPoolMXBean` into
  `wifihaven_db_pool_{active,idle,total,threads_awaiting}_connections` and
  `_max_size` gauges. The connect-EC / `acquireRelease` wiring from #1221
  is unchanged; the pool is surfaced as a `DbPool` service over the same
  datasource.
- `RollupRepoLive.recordRun` (the single funnel both rollup loops use)
  emits `wifihaven_rollup_runs_total{job,status}`,
  `wifihaven_rollup_duration_seconds{job}`, and
  `wifihaven_rollup_rows_upserted{job}` alongside the existing
  `rollup_runs` DB writes and `/api/admin/rollup-status` (both unchanged).

Relates to #1240 (observability) and #471.

## Test plan
- [x] `MetricsApiSpec` (zio-http-testkit): 200 + `text/plain` + `# HELP`/`# TYPE`
      + jvm series + custom probe; 401 on missing/wrong bearer and 200 on the
      right token when a scrape token is configured; 404 when `enabled = false`.
- [x] `MetricsExportSpec` (embedded Postgres): `wifihaven_db_pool_*` gauges
      present with `max_size = 7` after a poll; a rollup tick emits the
      counter/histogram/gauge series for `time_used_daily`.
- [x] `mill api.test` — full suite green.

Closes #1242
Closes #1243