### PR TITLE
fix(api): interrupt rollup fibers before Hikari pool close on shutdown

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -24,124 +24,134 @@ object Main extends ZIOAppDefault {
     Runtime.removeDefaultLoggers >>> SLF4J.slf4j
 
   def run =
-    (for {
-      cfg    <- ZIO.service[AppConfig]
-      _      <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
-      _      <- ZIO
-        .logWarning(
-          "WIFIHAVEN_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +
-            "Disable in production.",
+    // #1247: the whole startup/serve body runs inside an explicit `ZIO.scoped`
+    // so the rollup fibers can be `forkScoped` into it. That scope is *inner* to
+    // the layer scope opened by `.provide(serverEnv)`, so on SIGTERM it closes
+    // first — interrupting (and awaiting) the rollup fibers before the
+    // transactor layer's finalizer closes the Hikari pool. Without this the
+    // fibers race the pool close and each in-flight tick throws "pool has been
+    // closed", logging spurious ERRORs and recording bogus error rows.
+    ZIO
+      .scoped(for {
+        cfg    <- ZIO.service[AppConfig]
+        _      <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
+        _      <- ZIO
+          .logWarning(
+            "WIFIHAVEN_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +
+              "Disable in production.",
+          )
+          .when(cfg.debugEnabled)
+        _      <- Database.runMigrations(cfg.db)
+        _      <- ZIO.logInfo("Database migrations complete")
+        // #334: ensure household_settings has its single row, defaulting the
+        // daily-reset tz to the API server's local zone on first install. No-op
+        // on subsequent boots because of ON CONFLICT DO NOTHING.
+        hsRepo <- ZIO.service[HouseholdSettingsRepo]
+        tz = java.time.ZoneId.systemDefault()
+        _ <- hsRepo.ensureDefault(tz)
+        _ <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
+        // #768: seed the starter library of app templates. Idempotent — operator
+        // host edits on previously-seeded apps are preserved.
+        appRepoForSeed <- ZIO.service[AppRepo]
+        templates      <- AppTemplates.loadAll()
+        seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
+        _              <- ZIO.logInfo(
+          s"app_templates seeded (${templates.size} templates): " +
+            s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
+            s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated.mkString("[", ",", "]")}, " +
+            s"augmented=${seedSummary.augmented.size} " +
+            seedSummary.augmented
+              .map(a => s"${a.slug}+[${a.addedHosts.mkString(",")}]")
+              .mkString("[", ",", "]") + ", " +
+            s"preserved=${seedSummary.preserved.size}",
         )
-        .when(cfg.debugEnabled)
-      _      <- Database.runMigrations(cfg.db)
-      _      <- ZIO.logInfo("Database migrations complete")
-      // #334: ensure household_settings has its single row, defaulting the
-      // daily-reset tz to the API server's local zone on first install. No-op
-      // on subsequent boots because of ON CONFLICT DO NOTHING.
-      hsRepo <- ZIO.service[HouseholdSettingsRepo]
-      tz = java.time.ZoneId.systemDefault()
-      _              <- hsRepo.ensureDefault(tz)
-      _              <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
-      // #768: seed the starter library of app templates. Idempotent — operator
-      // host edits on previously-seeded apps are preserved.
-      appRepoForSeed <- ZIO.service[AppRepo]
-      templates      <- AppTemplates.loadAll()
-      seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
-      _              <- ZIO.logInfo(
-        s"app_templates seeded (${templates.size} templates): " +
-          s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
-          s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated.mkString("[", ",", "]")}, " +
-          s"augmented=${seedSummary.augmented.size} " +
-          seedSummary.augmented
-            .map(a => s"${a.slug}+[${a.addedHosts.mkString(",")}]")
-            .mkString("[", ",", "]") + ", " +
-          s"preserved=${seedSummary.preserved.size}",
-      )
-      // #958: seed the bundled category blocklists. Inline lists pull hosts
-      // straight from YAML; remote lists fetch from the declared upstream URL
-      // (cached in-memory after first success — see BlocklistCache). REPLACE
-      // semantics; remote-fetch failures leave existing DB rows untouched.
-      blRepoForSeed  <- ZIO.service[BlocklistRepo]
-      blCacheForSeed <- ZIO.service[BlocklistCache]
-      blFetcher      <- ZIO.service[BlocklistFetcher]
-      bundled        <- BundledBlocklists.loadAll()
-      _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
-      _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
-      // #809: scheduled re-aggregation of traffic_reports into the rollup
-      // tables. #1230: cadence matches the tier each table is read at — hourly
-      // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
-      // trailing 2 days once a day (reads of recent windows hit raw
-      // traffic_reports, not these tables). Both are forkDaemon so they run for
-      // the lifetime of the process and never block startup.
-      rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
-      clockForJobs   <- ZIO.service[Clock]
-      _              <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkDaemon
-      _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkDaemon
-      // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
-      // a watermarked row; the read path adds a live tail of buckets after the watermark, so
-      // /api/time/status/summary serves a rollup + small live aggregation instead of a full
-      // per-request day scan.
-      // TODO(#1221): bound the connection hold time of this rollup recompute and
-      // of the per-profile UsageSeries read (#1099) so neither can monopolize the
-      // shared Hikari pool for tens of seconds under load — e.g. a smaller batch,
-      // a time budget, or a separate small pool for the rollup work. The pool-size
-      // bump (this PR) and the dedicated connect EC are the first-order fix; this
-      // is the durability follow-up tracked in #1221.
-      timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
-      profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
-      deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
-      stlRepoForJ     <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
-      trafficRepoForJ <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
-      _               <- TimeUsedRollupJob
-        .loop(
-          timeRollupRepo,
-          rollupRepo,
-          profileRepoForJ,
-          deviceRepoForJ,
-          stlRepoForJ,
-          trafficRepoForJ,
-          hsRepo,
-          clockForJobs,
-        )
-        .forkDaemon
-      _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
-      _               <- ZIO
-        .logWarning(
-          "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
-            "Disable in production.",
-        )
-        .when(cfg.seedTestBlocklists)
-      _               <- BundledBlocklists
-        .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
-        .when(cfg.seedTestBlocklists)
-      // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
-      // Multi-instance-safe via Postgres advisory lock — losing instances skip
-      // the tick rather than racing on the same DELETE.
-      xaForJobs       <- ZIO.service[Transactor[Task]]
-      _               <- RetentionSweepJob.start(xaForJobs)
-      // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
-      // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
-      // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
-      // no NULLs remain.
-      _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
-      templatesById = templates.map(t => t.slug -> t).toMap
-      bundledById   = bundled.map(b => b.id -> b).toMap
-      routes <- allRoutes(templatesById, bundledById)
-      withCors = Cors.wrap(routes, cfg.cors)
-      _ <- ZIO
-        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
-        .when(cfg.cors.origins.nonEmpty)
-      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
-      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
-      // Bump to 4 MiB — well above any realistic single-bucket payload and below
-      // Render's edge 413 threshold.
-      serverConfig = Server.Config.default
-        .port(cfg.http.port)
-        .disableRequestStreaming(4 * 1024 * 1024)
-      _ <- Server
-        .serve(withCors)
-        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
-    } yield ()).provide(serverEnv)
+        // #958: seed the bundled category blocklists. Inline lists pull hosts
+        // straight from YAML; remote lists fetch from the declared upstream URL
+        // (cached in-memory after first success — see BlocklistCache). REPLACE
+        // semantics; remote-fetch failures leave existing DB rows untouched.
+        blRepoForSeed  <- ZIO.service[BlocklistRepo]
+        blCacheForSeed <- ZIO.service[BlocklistCache]
+        blFetcher      <- ZIO.service[BlocklistFetcher]
+        bundled        <- BundledBlocklists.loadAll()
+        _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
+        _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+        // #809: scheduled re-aggregation of traffic_reports into the rollup
+        // tables. #1230: cadence matches the tier each table is read at — hourly
+        // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
+        // trailing 2 days once a day (reads of recent windows hit raw
+        // traffic_reports, not these tables). #1247: forkScoped (not forkDaemon)
+        // into the run scope so they are interrupted before the Hikari pool
+        // closes on shutdown; the fork never blocks startup either way.
+        rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
+        clockForJobs   <- ZIO.service[Clock]
+        _              <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
+        _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkScoped
+        // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
+        // a watermarked row; the read path adds a live tail of buckets after the watermark, so
+        // /api/time/status/summary serves a rollup + small live aggregation instead of a full
+        // per-request day scan.
+        // TODO(#1221): bound the connection hold time of this rollup recompute and
+        // of the per-profile UsageSeries read (#1099) so neither can monopolize the
+        // shared Hikari pool for tens of seconds under load — e.g. a smaller batch,
+        // a time budget, or a separate small pool for the rollup work. The pool-size
+        // bump (this PR) and the dedicated connect EC are the first-order fix; this
+        // is the durability follow-up tracked in #1221.
+        timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+        profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
+        deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
+        stlRepoForJ     <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+        trafficRepoForJ <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
+        _               <- TimeUsedRollupJob
+          .loop(
+            timeRollupRepo,
+            rollupRepo,
+            profileRepoForJ,
+            deviceRepoForJ,
+            stlRepoForJ,
+            trafficRepoForJ,
+            hsRepo,
+            clockForJobs,
+          )
+          .forkScoped
+        _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
+        _               <- ZIO
+          .logWarning(
+            "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
+              "Disable in production.",
+          )
+          .when(cfg.seedTestBlocklists)
+        _               <- BundledBlocklists
+          .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
+          .when(cfg.seedTestBlocklists)
+        // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
+        // Multi-instance-safe via Postgres advisory lock — losing instances skip
+        // the tick rather than racing on the same DELETE.
+        xaForJobs       <- ZIO.service[Transactor[Task]]
+        _               <- RetentionSweepJob.start(xaForJobs)
+        // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
+        // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
+        // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
+        // no NULLs remain.
+        _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
+        templatesById = templates.map(t => t.slug -> t).toMap
+        bundledById   = bundled.map(b => b.id -> b).toMap
+        routes <- allRoutes(templatesById, bundledById)
+        withCors = Cors.wrap(routes, cfg.cors)
+        _ <- ZIO
+          .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
+          .when(cfg.cors.origins.nonEmpty)
+        // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
+        // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
+        // Bump to 4 MiB — well above any realistic single-bucket payload and below
+        // Render's edge 413 threshold.
+        serverConfig = Server.Config.default
+          .port(cfg.http.port)
+          .disableRequestStreaming(4 * 1024 * 1024)
+        _ <- Server
+          .serve(withCors)
+          .provide(ZLayer.succeed(serverConfig) >>> Server.live)
+      } yield ())
+      .provide(serverEnv)
 
   private val serverEnv =
     AppConfig.layer >+>

--- a/api/src/usage/RollupJobs.scala
+++ b/api/src/usage/RollupJobs.scala
@@ -118,15 +118,19 @@ object RollupJobs {
       result   <- body(clock).either
       finished <- clock.instant
       _        <- result match {
-        case Right(Some(n)) =>
+        case Right(Some(n))                            =>
           ZIO.logInfo(s"rollup $job tick ok rows=$n") *>
             repo.recordRun(job, started, finished, "ok", None, n).ignore
-        case Right(None)    =>
+        case Right(None)                               =>
           // Another instance held the advisory lock — expected under
           // multi-instance deploys, log at debug and don't write a
           // rollup_runs row (would noise up the admin view).
           ZIO.logDebug(s"rollup $job tick skipped (advisory lock held)")
-        case Left(e)        =>
+        case Left(e) if RollupShutdown.isPoolClosed(e) =>
+          // #1247: pool closed out from under a mid-flight tick during shutdown.
+          // Benign — don't log ERROR or record a bogus error run.
+          ZIO.logDebug(s"rollup $job tick aborted (pool closed during shutdown)")
+        case Left(e)                                   =>
           ZIO.logErrorCause(s"rollup $job tick failed", Cause.fail(e)) *>
             repo
               .recordRun(job, started, finished, "error", Some(e.getMessage.take(500)), 0)

--- a/api/src/usage/RollupJobs.scala
+++ b/api/src/usage/RollupJobs.scala
@@ -103,7 +103,11 @@ object RollupJobs {
 
   // ── shared run wrapper ─────────────────────────────────────────────────────
 
-  private def runOnce(
+  // `private[api]` so the shutdown-handling spec can drive a single tick with an
+  // injected body (a failing/never-completing effect) without going through the
+  // forever-looping fiber. The production `body` is always one of the tick
+  // functions above.
+  private[api] def runOnce(
       job: String,
       repo: RollupRepo,
       clock: Clock,

--- a/api/src/usage/RollupShutdown.scala
+++ b/api/src/usage/RollupShutdown.scala
@@ -1,0 +1,37 @@
+package wifihaven.api.usage
+
+import java.sql.SQLException
+
+/**
+ * #1247: shutdown-ordering helper shared by the rollup `runOnce` wrappers.
+ *
+ * On container teardown the scoped `HikariDataSource` finalizer closes the pool. The structural fix
+ * (forking the rollup fibers into a scope that depends on the transactor layer, so they are
+ * interrupted before the pool closes) handles the common case, but a tick already
+ * mid-`getConnection` can still surface "HikariDataSource (HikariPool-N) has been closed" before
+ * its interruption lands. That failure is a benign shutdown artifact, not a rollup failure:
+ * recording it in `rollup_runs` would fire a false rollup-health alert (#1240, #1243) on every
+ * deploy.
+ *
+ * We match *only* the pool-closed signal — a Hikari pool is never closed except on teardown — so a
+ * genuine SQL error during a normal tick still logs ERROR and records an error run. Interruption
+ * itself needs no handling here: it bypasses the `.either` in the wrappers, so an interrupted tick
+ * never reaches the error branch at all.
+ */
+object RollupShutdown {
+
+  /**
+   * True if `t` (or any cause in its chain) is a SQLException reporting a closed datasource/pool.
+   */
+  def isPoolClosed(t: Throwable): Boolean = {
+    @annotation.tailrec
+    def loop(cause: Throwable, seen: List[Throwable]): Boolean =
+      if (cause == null || seen.exists(_ eq cause)) false
+      else {
+        val msg = Option(cause.getMessage).getOrElse("")
+        val hit = cause.isInstanceOf[SQLException] && msg.contains("has been closed")
+        hit || loop(cause.getCause, cause :: seen)
+      }
+    loop(t, Nil)
+  }
+}

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -62,7 +62,11 @@ object TimeUsedRollupJob {
       hs: HouseholdSettingsRepo,
       clock: Clock,
   ): UIO[Unit] =
-    runOnce(rollup, runs, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, clock)
+    runOnce(
+      runs,
+      clock,
+      now => doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now),
+    )
       .repeat(Schedule.fixed(Interval))
       .unit
 
@@ -83,24 +87,18 @@ object TimeUsedRollupJob {
 
   // ── internals ──────────────────────────────────────────────────────────────
 
-  private def runOnce(
-      rollup: TimeUsedRollupRepo,
+  // `private[api]` with an injected tick `body` so the shutdown-handling spec can
+  // drive a single tick that fails (or never completes) without standing up the
+  // full repo graph or the forever-looping fiber. Production wiring in `loop`
+  // passes `doTick`.
+  private[api] def runOnce(
       runs: RollupRepo,
-      profileRepo: ProfileRepo,
-      deviceRepo: DeviceRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
-      trafficRepo: TrafficReportRepo,
-      hs: HouseholdSettingsRepo,
       clock: Clock,
+      body: Instant => Task[Int],
   ): UIO[Unit] =
     for {
       started  <- clock.instant
-      result   <-
-        clock.instant
-          .flatMap(now =>
-            doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now),
-          )
-          .either
+      result   <- clock.instant.flatMap(body).either
       finished <- clock.instant
       _        <- result match {
         case Right(n) =>

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -101,10 +101,14 @@ object TimeUsedRollupJob {
       result   <- clock.instant.flatMap(body).either
       finished <- clock.instant
       _        <- result match {
-        case Right(n) =>
+        case Right(n)                                  =>
           ZIO.logInfo(s"rollup time_used_daily tick ok rows=$n") *>
             runs.recordRun("time_used_daily", started, finished, "ok", None, n).ignore
-        case Left(e)  =>
+        case Left(e) if RollupShutdown.isPoolClosed(e) =>
+          // #1247: pool closed out from under a mid-flight tick during shutdown.
+          // Benign — don't log ERROR or record a bogus error run.
+          ZIO.logDebug("rollup time_used_daily tick aborted (pool closed during shutdown)")
+        case Left(e)                                   =>
           ZIO.logErrorCause("rollup time_used_daily tick failed", Cause.fail(e)) *>
             runs
               .recordRun(

--- a/api/test/src/feature/RollupShutdownSpec.scala
+++ b/api/test/src/feature/RollupShutdownSpec.scala
@@ -1,0 +1,124 @@
+package wifihaven.api.feature
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.db.*
+import wifihaven.api.usage.{RollupJobs, TimeUsedRollupJob}
+import wifihaven.shared.Clock
+import wifihaven.testinfra.*
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.sql.SQLException
+import java.time.LocalDateTime
+
+/**
+ * #1247: on shutdown the scoped Hikari pool finalizer can close the pool while a rollup tick is mid
+ * `getConnection`, so the tick throws "HikariDataSource (HikariPool-N) has been closed". Without
+ * special handling each such tick logs an ERROR stack trace and records an `error` row in
+ * `rollup_runs` — false rollup-failure signal on every deploy, which would pollute the
+ * Prometheus/Grafana export (#1243) and alert (#1240).
+ *
+ * The rollup `runOnce` wrappers must treat a pool-closed failure (and a mid-tick interruption) as a
+ * benign shutdown artifact: no ERROR log, no `error` run. A *real* SQL error during a normal tick
+ * must still log ERROR and record an `error` run, so the guard can't hide genuine failures.
+ */
+object RollupShutdownSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ Clock.TestClock.make(LocalDateTime.of(2026, 5, 31, 21, 10, 0))
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  // The exact shape Hikari throws once the datasource is closed.
+  private def poolClosed =
+    new SQLException("HikariDataSource (HikariPool-1) has been closed.")
+
+  // A genuine query error that is NOT a shutdown artifact — must still surface.
+  private def realSqlError =
+    new SQLException("ERROR: relation \"traffic_reports\" does not exist")
+
+  private def errorRuns(rollup: RollupRepo) =
+    rollup.recentRuns(20).map(_.filter(_.status == "error"))
+
+  private def loggedError(logs: Chunk[ZTestLogger.LogEntry]) =
+    logs.exists(_.logLevel == LogLevel.Error)
+
+  def spec = suite("RollupShutdownSpec")(
+    test("RollupJobs.runOnce: pool-closed failure writes no error row and logs no ERROR") {
+      (for {
+        _      <- cleanDb
+        rollup <- ZIO.service[RollupRepo]
+        clock  <- ZIO.service[Clock]
+        _      <- RollupJobs.runOnce("hourly", rollup, clock, _ => ZIO.fail(poolClosed))
+        runs   <- errorRuns(rollup)
+        logs   <- ZTestLogger.logOutput
+      } yield assertTrue(runs.isEmpty, !loggedError(logs)))
+        .provideSome[RollupRepo & Clock & EmbeddedPostgres & TestDatabase.TestDb](
+          ZTestLogger.default,
+        )
+    },
+    test("RollupJobs.runOnce: interrupted tick writes no error row and logs no ERROR") {
+      (for {
+        _      <- cleanDb
+        rollup <- ZIO.service[RollupRepo]
+        clock  <- ZIO.service[Clock]
+        gate   <- Promise.make[Nothing, Unit]
+        fiber  <- RollupJobs
+          .runOnce("hourly", rollup, clock, _ => gate.succeed(()) *> ZIO.never)
+          .fork
+        _      <- gate.await
+        _      <- fiber.interrupt
+        runs   <- errorRuns(rollup)
+        logs   <- ZTestLogger.logOutput
+      } yield assertTrue(runs.isEmpty, !loggedError(logs)))
+        .provideSome[RollupRepo & Clock & EmbeddedPostgres & TestDatabase.TestDb](
+          ZTestLogger.default,
+        )
+    },
+    test("RollupJobs.runOnce: real SQL failure logs ERROR and records an error run") {
+      (for {
+        _      <- cleanDb
+        rollup <- ZIO.service[RollupRepo]
+        clock  <- ZIO.service[Clock]
+        _      <- RollupJobs.runOnce("hourly", rollup, clock, _ => ZIO.fail(realSqlError))
+        runs   <- errorRuns(rollup)
+        logs   <- ZTestLogger.logOutput
+      } yield assertTrue(
+        runs.exists(r => r.job == "hourly"),
+        loggedError(logs),
+      ))
+        .provideSome[RollupRepo & Clock & EmbeddedPostgres & TestDatabase.TestDb](
+          ZTestLogger.default,
+        )
+    },
+    test("TimeUsedRollupJob.runOnce: pool-closed failure writes no error row and logs no ERROR") {
+      (for {
+        _      <- cleanDb
+        rollup <- ZIO.service[RollupRepo]
+        clock  <- ZIO.service[Clock]
+        _      <- TimeUsedRollupJob.runOnce(rollup, clock, _ => ZIO.fail(poolClosed))
+        runs   <- errorRuns(rollup)
+        logs   <- ZTestLogger.logOutput
+      } yield assertTrue(runs.isEmpty, !loggedError(logs)))
+        .provideSome[RollupRepo & Clock & EmbeddedPostgres & TestDatabase.TestDb](
+          ZTestLogger.default,
+        )
+    },
+    test("TimeUsedRollupJob.runOnce: real SQL failure logs ERROR and records an error run") {
+      (for {
+        _      <- cleanDb
+        rollup <- ZIO.service[RollupRepo]
+        clock  <- ZIO.service[Clock]
+        _      <- TimeUsedRollupJob.runOnce(rollup, clock, _ => ZIO.fail(realSqlError))
+        runs   <- errorRuns(rollup)
+        logs   <- ZTestLogger.logOutput
+      } yield assertTrue(
+        runs.exists(r => r.job == "time_used_daily"),
+        loggedError(logs),
+      ))
+        .provideSome[RollupRepo & Clock & EmbeddedPostgres & TestDatabase.TestDb](
+          ZTestLogger.default,
+        )
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary

On every prod deploy/restart the three rollup fibers (`RollupJobs` hourly + daily byte rollups and `TimeUsedRollupJob`'s `time_used_daily` rollup) raced the scoped `HikariDataSource` finalizer. The pool closed while a tick was mid-`getConnection`, so each in-flight tick threw `HikariDataSource (HikariPool-1) has been closed`, logged an ERROR stack trace, and recorded a bogus `error` row in `rollup_runs`. That false rollup-health signal would trip the upcoming Prometheus export (#1243) and alerting (#1240) on every deploy, and contributed to the `Exception in thread "main"` on shutdown.

### Structural fix (primary)
- The startup/serve body now runs inside an explicit `ZIO.scoped`, and the three rollup loops are `forkScoped` into that scope instead of `forkDaemon`.
- The run scope is *inner* to the layer scope opened by `.provide(serverEnv)`, so on SIGTERM it closes first — interrupting and awaiting the rollup fibers **before** the transactor layer's finalizer closes the Hikari pool.

### Belt-and-suspenders
- A tick that still surfaces a pool-closed `SQLException` during shutdown is treated as benign in both `runOnce` wrappers: logged at DEBUG, no `error` run recorded.
- Detection (`RollupShutdown.isPoolClosed`) is deliberately narrow — it matches only a `SQLException` whose message contains `has been closed` (a pool is never closed except on teardown). A genuine SQL error during a normal tick still logs ERROR and records an `error` run.
- Interruption needs no special handling: it bypasses the `.either` in the wrappers and never reaches the error branch, so an interrupted tick records nothing.

No cadence or query-logic changes — this is purely shutdown/interruption handling.

## Test plan
- [x] New `RollupShutdownSpec` (embedded Postgres, real `RollupRepo`, injected `Clock`, `ZTestLogger` for log assertions), committed red first then green:
  - pool-closed tick failure → no `error` row, no ERROR log (both jobs)
  - interrupted mid-tick → no `error` row, no ERROR log
  - genuine SQL failure → ERROR logged **and** `error` run recorded (both jobs)
- [x] `mill api.test` — full suite green (0 failures)
- [x] `scalafmt --check` clean across the repo

Related: #1240 (rollup-health alerting), #1243 (rollup metrics export).

Closes #1247.