### PR TITLE
Bind HTTP port before DB-heavy startup so a slow DB can't fail the port scan (#1248)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -25,27 +25,60 @@ object Main extends ZIOAppDefault {
 
   def run =
     (for {
-      cfg    <- ZIO.service[AppConfig]
-      _      <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
-      _      <- ZIO
+      cfg       <- ZIO.service[AppConfig]
+      _         <- ZIO.logInfo(s"WifiHaven API starting on ${cfg.http.host}:${cfg.http.port}")
+      _         <- ZIO
         .logWarning(
           "WIFIHAVEN_DEBUG=1 set — /api/debug/* endpoints are MOUNTED (loopback only). " +
             "Disable in production.",
         )
         .when(cfg.debugEnabled)
-      _      <- Database.runMigrations(cfg.db)
-      _      <- ZIO.logInfo("Database migrations complete")
+      // #1248: readiness signal. False until migrations + ensureDefault + seeds
+      // complete. /api/health reports 503 status=starting and the real routes
+      // are gated to 503 while false, so we can bind the port immediately
+      // (below) without ever serving a request against an unmigrated schema.
+      readyRef  <- Ref.make(false)
+      // Static definitions load from bundled resource files, not the DB, so we
+      // read them up front and build the routes before binding — no DB work
+      // happens before the port is open.
+      templates <- AppTemplates.loadAll()
+      bundled   <- BundledBlocklists.loadAll()
+      templatesById = templates.map(t => t.slug -> t).toMap
+      bundledById   = bundled.map(b => b.id -> b).toMap
+      routes <- allRoutes(templatesById, bundledById, readyRef.get)
+      withCors = Cors.wrap(routes, cfg.cors)
+      _ <- ZIO
+        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
+        .when(cfg.cors.origins.nonEmpty)
+      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
+      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
+      // Bump to 4 MiB — well above any realistic single-bucket payload and below
+      // Render's edge 413 threshold.
+      serverConfig = Server.Config.default
+        .port(cfg.http.port)
+        .disableRequestStreaming(4 * 1024 * 1024)
+      // #1248: bind the port FIRST. Render's port scan (the ~15-min-timeout gate)
+      // only needs something listening, so it passes in milliseconds even when the
+      // DB is pegged. The DB-heavy init below then runs while the health check
+      // (a separate, longer gate) polls /api/health and waits for readiness — a
+      // slow DB delays promotion, never the port bind.
+      serverFiber <- Server
+        .serve(withCors)
+        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
+        .fork
+      _           <- ZIO.logInfo("HTTP port bound; running DB-heavy startup behind readiness gate")
+      _           <- Database.runMigrations(cfg.db)
+      _           <- ZIO.logInfo("Database migrations complete")
       // #334: ensure household_settings has its single row, defaulting the
       // daily-reset tz to the API server's local zone on first install. No-op
       // on subsequent boots because of ON CONFLICT DO NOTHING.
-      hsRepo <- ZIO.service[HouseholdSettingsRepo]
+      hsRepo      <- ZIO.service[HouseholdSettingsRepo]
       tz = java.time.ZoneId.systemDefault()
       _              <- hsRepo.ensureDefault(tz)
       _              <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
       // #768: seed the starter library of app templates. Idempotent — operator
       // host edits on previously-seeded apps are preserved.
       appRepoForSeed <- ZIO.service[AppRepo]
-      templates      <- AppTemplates.loadAll()
       seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
       _              <- ZIO.logInfo(
         s"app_templates seeded (${templates.size} templates): " +
@@ -64,9 +97,12 @@ object Main extends ZIOAppDefault {
       blRepoForSeed  <- ZIO.service[BlocklistRepo]
       blCacheForSeed <- ZIO.service[BlocklistCache]
       blFetcher      <- ZIO.service[BlocklistFetcher]
-      bundled        <- BundledBlocklists.loadAll()
       _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
       _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+      // #1248: migrations + ensureDefault + seeds are done — flip readiness so
+      // /api/health returns 200 and the gated routes start serving real traffic.
+      _              <- readyRef.set(true)
+      _              <- ZIO.logInfo("readiness flipped → /api/health healthy, API routes ungated")
       // #809: scheduled re-aggregation of traffic_reports into the rollup
       // tables. #1230: cadence matches the tier each table is read at — hourly
       // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
@@ -124,23 +160,8 @@ object Main extends ZIOAppDefault {
       // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
       // no NULLs remain.
       _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
-      templatesById = templates.map(t => t.slug -> t).toMap
-      bundledById   = bundled.map(b => b.id -> b).toMap
-      routes <- allRoutes(templatesById, bundledById)
-      withCors = Cors.wrap(routes, cfg.cors)
-      _ <- ZIO
-        .logInfo(s"CORS enabled for origins: ${cfg.cors.origins.mkString(", ")}")
-        .when(cfg.cors.origins.nonEmpty)
-      // #1017: zio-http 3.0.1's RequestStreaming.Disabled default cap is 100 KiB;
-      // /api/router/usage bodies routinely exceed that as mac_ip_tracking fills.
-      // Bump to 4 MiB — well above any realistic single-bucket payload and below
-      // Render's edge 413 threshold.
-      serverConfig = Server.Config.default
-        .port(cfg.http.port)
-        .disableRequestStreaming(4 * 1024 * 1024)
-      _ <- Server
-        .serve(withCors)
-        .provide(ZLayer.succeed(serverConfig) >>> Server.live)
+      // Keep the process alive on the already-bound server fiber; exits if it dies.
+      _               <- serverFiber.join
     } yield ()).provide(serverEnv)
 
   private val serverEnv =
@@ -161,6 +182,7 @@ object Main extends ZIOAppDefault {
   private def allRoutes(
       templates: Map[wifihaven.shared.types.AppTemplateId, AppTemplate],
       bundledBlocklists: Map[wifihaven.shared.types.BlocklistId, BundledBlocklist],
+      ready: UIO[Boolean],
   ) =
     for {
       auth        <- ZIO.service[AuthService]
@@ -200,9 +222,15 @@ object Main extends ZIOAppDefault {
       // `++` even though local macOS builds happened to fit. Explicit `Routes[Any, Response]`
       // ascriptions on the chunks ground the inference per chunk so the final fold is
       // a short, well-typed concatenation.
+      // #1248: /api/health is NOT readiness-gated — it carries its own
+      // not-ready logic (503 status=starting until migrations + seeds finish)
+      // so Render's health check can observe startup progress while the port is
+      // already bound. Everything else is gated below.
+      val healthRoutes: Routes[Any, Response] =
+        HealthRoutes.routes(ready, dbHealthCheck)
+
       val systemRoutes: Routes[Any, Response] =
-        HealthRoutes.routes(dbHealthCheck) ++
-          VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
+        VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
           AuthRoutes.routes(auth, userRepo, upRepo) ++
           ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo) ++
@@ -284,6 +312,12 @@ object Main extends ZIOAppDefault {
       val spaRoutes: Routes[Any, Response] =
         if (cfg.http.serveSpa) StaticRoutes.routes(cfg.http.staticDir) else Routes.empty
 
-      systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes
+      // #1248: gate all real routes behind readiness (503 until migrations +
+      // seeds complete), then mount the ungated health probe alongside.
+      healthRoutes ++
+        Readiness.gate(
+          systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+          ready,
+        )
     }
 }

--- a/api/src/Readiness.scala
+++ b/api/src/Readiness.scala
@@ -1,0 +1,34 @@
+package wifihaven.api
+
+import zio.*
+import zio.http.*
+
+/**
+ * #1248: the HTTP port is bound before DB-heavy startup (migrations + ensureDefault + seeds) runs,
+ * so Render's port scan passes in milliseconds and a slow/pegged DB can no longer fail a deploy on
+ * the port-scan timeout. The cost of binding early is that a real request can arrive before the
+ * schema is migrated — `gate` is what makes that safe.
+ *
+ * `gate` wraps the non-health routes so that, while `ready` is false, every request short-circuits
+ * to 503 `status=starting` *before* the handler runs (so it never queries an unmigrated DB). The
+ * readiness check is re-read per request, so the gate begins passing traffic through the instant
+ * startup flips it true. `/api/health` is deliberately NOT gated — it carries its own readiness
+ * logic so Render's health check can observe the not-ready state and wait for promotion.
+ */
+object Readiness {
+
+  private val notReady: Response =
+    Response
+      .json("""{"status":"starting"}""")
+      .status(Status.ServiceUnavailable)
+
+  def gate(routes: Routes[Any, Response], ready: UIO[Boolean]): Routes[Any, Response] =
+    routes.transform[Any] { h =>
+      Handler.fromFunctionZIO[Request] { req =>
+        ready.flatMap {
+          case true  => h(req)
+          case false => ZIO.succeed(notReady)
+        }
+      }
+    }
+}

--- a/api/src/routes/HealthRoutes.scala
+++ b/api/src/routes/HealthRoutes.scala
@@ -4,26 +4,39 @@ import zio.*
 import zio.http.*
 
 /**
- * Unauthenticated health probe for Docker/uptime monitors/reverse proxies.
+ * Unauthenticated health probe for Docker/uptime monitors/reverse proxies and Render's
+ * `healthCheckPath`.
  *
- * `checkDb` performs a cheap round-trip to Postgres (e.g. `SELECT 1`). Only the failure's class
- * name is exposed in the response body so SQL details don't leak.
+ * `ready` reflects whether DB-heavy startup (migrations + ensureDefault + seeds) has finished.
+ * #1248: the port is bound *before* that work runs so Render's port scan passes immediately; until
+ * `ready` flips true this probe returns 503 `status=starting` and does NOT touch the DB (the schema
+ * may be mid-migration). Once ready, `checkDb` performs a cheap round-trip to Postgres (e.g.
+ * `SELECT 1`). Only the failure's class name is exposed so SQL details don't leak.
  *
  * HEAD mirrors GET's status code with an empty body, per HTTP convention, so HEAD-based uptime
  * probes work.
  */
 object HealthRoutes {
-  def routes(checkDb: Task[Unit]): Routes[Any, Response] = {
+  def routes(ready: UIO[Boolean], checkDb: Task[Unit]): Routes[Any, Response] = {
     val getResponse: UIO[Response] =
-      checkDb.fold(
-        err => {
-          val cls = err.getClass.getSimpleName
-          Response
-            .json(s"""{"status":"error","db":"$cls"}""")
-            .status(Status.ServiceUnavailable)
-        },
-        _ => Response.json("""{"status":"ok","db":"ok"}"""),
-      )
+      ready.flatMap {
+        case false =>
+          ZIO.succeed(
+            Response
+              .json("""{"status":"starting"}""")
+              .status(Status.ServiceUnavailable),
+          )
+        case true  =>
+          checkDb.fold(
+            err => {
+              val cls = err.getClass.getSimpleName
+              Response
+                .json(s"""{"status":"error","db":"$cls"}""")
+                .status(Status.ServiceUnavailable)
+            },
+            _ => Response.json("""{"status":"ok","db":"ok"}"""),
+          )
+      }
 
     Routes(
       Method.GET / "api" / "health"  ->

--- a/api/test/src/feature/HealthApiSpec.scala
+++ b/api/test/src/feature/HealthApiSpec.scala
@@ -15,9 +15,12 @@ object HealthApiSpec extends ZIOSpecDefault {
   private def head(routes: Routes[Any, Response]): UIO[Response] =
     routes(Request.get("/api/health").copy(method = Method.HEAD)).merge
 
+  private val ready    = ZIO.succeed(true)
+  private val notReady = ZIO.succeed(false)
+
   def spec = suite("Health API")(
-    test("GET /api/health returns 200 with status=ok,db=ok when DB check succeeds") {
-      val routes = HealthRoutes.routes(ZIO.unit)
+    test("GET /api/health returns 200 with status=ok,db=ok when ready and DB check succeeds") {
+      val routes = HealthRoutes.routes(ready, ZIO.unit)
       for {
         resp <- get(routes)
         body <- resp.body.asString
@@ -26,8 +29,27 @@ object HealthApiSpec extends ZIOSpecDefault {
         assertTrue(json.asObject.flatMap(_.get("status")).flatMap(_.asString).contains("ok")) &&
         assertTrue(json.asObject.flatMap(_.get("db")).flatMap(_.asString).contains("ok"))
     },
-    test("GET /api/health returns 503 with status=error when DB check fails") {
+    test("GET /api/health returns 503 with status=starting while not ready (DB never touched)") {
+      // #1248: until migrations + seeds finish, readiness is false. The health
+      // probe must report not-ready even though the port is already bound, and
+      // it must NOT run the DB check (the DB may be unmigrated/pegged).
+      for {
+        dbTouched <- Ref.make(false)
+        checkDb = dbTouched.set(true)
+        routes  = HealthRoutes.routes(notReady, checkDb)
+        resp    <- get(routes)
+        body    <- resp.body.asString
+        json    <- ZIO.fromEither(body.fromJson[Json])
+        touched <- dbTouched.get
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(
+          json.asObject.flatMap(_.get("status")).flatMap(_.asString).contains("starting"),
+        ) &&
+        assertTrue(!touched)
+    },
+    test("GET /api/health returns 503 with status=error when ready but DB check fails") {
       val routes = HealthRoutes.routes(
+        ready,
         ZIO.fail(new java.sql.SQLException("connection refused")),
       )
       for {
@@ -40,16 +62,25 @@ object HealthApiSpec extends ZIOSpecDefault {
           json.asObject.flatMap(_.get("db")).flatMap(_.asString).contains("SQLException"),
         )
     },
-    test("HEAD /api/health returns 200 with empty body when DB check succeeds") {
-      val routes = HealthRoutes.routes(ZIO.unit)
+    test("HEAD /api/health returns 200 with empty body when ready and DB check succeeds") {
+      val routes = HealthRoutes.routes(ready, ZIO.unit)
       for {
         resp <- head(routes)
         body <- resp.body.asString
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(body.isEmpty)
     },
-    test("HEAD /api/health returns 503 with empty body when DB check fails") {
+    test("HEAD /api/health returns 503 with empty body when not ready") {
+      val routes = HealthRoutes.routes(notReady, ZIO.unit)
+      for {
+        resp <- head(routes)
+        body <- resp.body.asString
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(body.isEmpty)
+    },
+    test("HEAD /api/health returns 503 with empty body when ready but DB check fails") {
       val routes = HealthRoutes.routes(
+        ready,
         ZIO.fail(new java.sql.SQLException("connection refused")),
       )
       for {
@@ -60,7 +91,7 @@ object HealthApiSpec extends ZIOSpecDefault {
     },
     test("error response does not leak SQL details") {
       val secret = "ERROR: relation \"secret_table\" does not exist at line 42"
-      val routes = HealthRoutes.routes(ZIO.fail(new java.sql.SQLException(secret)))
+      val routes = HealthRoutes.routes(ready, ZIO.fail(new java.sql.SQLException(secret)))
       for {
         resp <- get(routes)
         body <- resp.body.asString

--- a/api/test/src/feature/ReadinessGateSpec.scala
+++ b/api/test/src/feature/ReadinessGateSpec.scala
@@ -1,0 +1,60 @@
+package wifihaven.api.feature
+
+import wifihaven.api.Readiness
+import zio.*
+import zio.http.*
+import zio.json.ast.Json
+import zio.test.*
+
+object ReadinessGateSpec extends ZIOSpecDefault {
+
+  // A trivial downstream route that records whether it actually ran, so we can
+  // assert the gate short-circuits *before* the handler touches anything.
+  private def probeRoutes(ran: Ref[Boolean]): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "anything" ->
+        handler { (_: Request) => ran.set(true).as(Response.json("""{"ok":true}""")) },
+    )
+
+  def spec = suite("Readiness gate")(
+    test("returns 503 starting and never invokes the handler while not ready") {
+      // #1248: the port binds before migrations finish, so a real request can
+      // arrive while readiness is still false. The gate must reject it with 503
+      // rather than let it hit an unmigrated DB.
+      for {
+        ran <- Ref.make(false)
+        gated = Readiness.gate(probeRoutes(ran), ZIO.succeed(false))
+        resp   <- gated(Request.get("/api/anything")).merge
+        body   <- resp.body.asString
+        json   <- ZIO.fromEither(body.fromJson[Json])
+        didRun <- ran.get
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(
+          json.asObject.flatMap(_.get("status")).flatMap(_.asString).contains("starting"),
+        ) &&
+        assertTrue(!didRun)
+    },
+    test("passes the request through once ready") {
+      for {
+        ran <- Ref.make(false)
+        gated = Readiness.gate(probeRoutes(ran), ZIO.succeed(true))
+        resp   <- gated(Request.get("/api/anything")).merge
+        body   <- resp.body.asString
+        didRun <- ran.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(body.contains("\"ok\":true")) &&
+        assertTrue(didRun)
+    },
+    test("re-reads readiness on every request (false then true)") {
+      for {
+        readyRef <- Ref.make(false)
+        ran      <- Ref.make(false)
+        gated = Readiness.gate(probeRoutes(ran), readyRef.get)
+        before <- gated(Request.get("/api/anything")).merge
+        _      <- readyRef.set(true)
+        after  <- gated(Request.get("/api/anything")).merge
+      } yield assertTrue(before.status == Status.ServiceUnavailable) &&
+        assertTrue(after.status == Status.Ok)
+    },
+  )
+}

--- a/api/test/src/feature/StaticRoutesSpec.scala
+++ b/api/test/src/feature/StaticRoutesSpec.scala
@@ -111,7 +111,7 @@ object StaticRoutesSpec extends ZIOSpecDefault {
         for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           serveSpa = false
-          rs       = HealthRoutes.routes(ZIO.unit) ++
+          rs       = HealthRoutes.routes(ZIO.succeed(true), ZIO.unit) ++
             (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
           root   <- get(rs, "/")
           health <- get(rs, "/api/health")
@@ -124,7 +124,7 @@ object StaticRoutesSpec extends ZIOSpecDefault {
         for {
           _ <- write(dir, "index.html", "<html>spa</html>")
           serveSpa = true
-          rs       = HealthRoutes.routes(ZIO.unit) ++
+          rs       = HealthRoutes.routes(ZIO.succeed(true), ZIO.unit) ++
             (if (serveSpa) StaticRoutes.routes(dir.getAbsolutePath) else Routes.empty)
           root   <- get(rs, "/")
           body   <- root.body.asString


### PR DESCRIPTION
## Summary

Fixes #1248. Render's deploy flow has **two distinct gates**:

1. **Port scan** — only needs *something* listening on the port; this is the **~15-minute timeout** we keep hitting.
2. **Health check** (`healthCheckPath: /api/health`) — gates promotion, on its own separate/longer window.

Previously `Server.serve` bound the port only **after** all DB-heavy startup (Flyway migrations, `ensureDefault`, `AppTemplates`/`BundledBlocklists` seeds, rollup forks, reason-text backfill). When the prod DB (`basic_256mb`) is CPU-pegged those init queries stall, delaying the port bind past the port-scan timeout — Render then marks the deploy `update_failed` even though the app is otherwise healthy. The 2026-05-31 deploy logged `starting on 0.0.0.0:8080` at 21:15:26 and didn't bind until 21:25:16, squeaking in just under the timeout.

This change **binds the port first**, then runs DB-heavy init behind a readiness gate exposed through the health check, exploiting the gate split: the port scan passes in milliseconds, and a slow DB now delays only *promotion* (via the longer health-check window), never the *port bind*.

## What changed

- **Readiness signal** — a `Ref[Boolean]` initialized `false`, flipped `true` only after migrations + `ensureDefault` + seeds complete.
- **Port binds immediately** — `Server.serve` is forked at startup before any DB work; the process then runs migrations/seeds and finally `serverFiber.join`s to stay alive.
- **`/api/health` is readiness-aware** (`api/src/routes/HealthRoutes.scala`): returns `503 {"status":"starting"}` — **without touching the DB** — until ready, then resumes the existing `SELECT 1` check (`200` ok / `503` error). It is deliberately **not** gated, so Render's health check can observe the not-ready state and wait.
- **Readiness gate** (`api/src/Readiness.scala`): wraps all non-health routes and short-circuits to `503 {"status":"starting"}` *before* the handler runs while not ready, so no real request can hit an unmigrated/unseeded DB even though the port is open. Readiness is re-read per request, so routes begin serving the instant startup flips it.
- Rollup / backfill fibers fork after the readiness flip, as before.

### Hard constraints, addressed

- **Migrations complete before real traffic is served.** The gate returns 503 for every non-health route until migrations + seeds finish, so the early port bind never exposes an unmigrated schema.
- **`/api/health` stays semantically meaningful**: 503 during startup, 200 only once migrations + seeds are done.
- **Render tolerates health-check 503s during initial deploy.** Render does not kill a booting instance for failing health checks *before its first healthy response* on a deploy — it polls until healthy (within the health-check window) and only then promotes. So returning 503 while migrations run is exactly the intended "not yet" signal and will not prematurely kill the instance. `render.yaml` prod + staging already set `healthCheckPath: /api/health` (unchanged here). **Caveat:** the health-check window is longer than the port scan but still finite — a migration that runs *longer than that window* would fail promotion. That's a separate concern (see #1197 / prod data-volume migration guidance) and out of scope here; this change only decouples the *port bind* from DB init.
- No backwards-compat shims (API + agent tandem-deploy).

Out of scope (untouched): `render.yaml` pool sizes / DB tier, the rollup incremental-reroll idea, #1221/#1228.

## Test plan

TDD — failing tests committed first, then the implementation (red→green visible in history).

- [x] `api/test/src/feature/HealthApiSpec.scala` — `/api/health` returns 503 `status=starting` while not ready **and never invokes the DB check**; 200 ok once ready + DB ok; 503 error when ready but DB fails; HEAD mirrors status with empty body; no SQL detail leak.
- [x] `api/test/src/feature/ReadinessGateSpec.scala` — gate returns 503 `starting` and **never invokes the downstream handler** while not ready; passes through once ready; re-reads readiness per request (false→true).
- [x] `api/test/src/feature/StaticRoutesSpec.scala` — updated to the new `HealthRoutes.routes(ready, checkDb)` signature.
- [x] Full `mill api.test` — 192 specs green.
- [x] `scalafmt --check` clean on all touched files.