### PR TITLE
Add (mac,dest_ip,ts) partial index to fix rollup attribution CPU peg (#1254)

### DIFF
--- a/api/resources/db/migration/V46__add_connection_events_attr_index.sql
+++ b/api/resources/db/migration/V46__add_connection_events_attr_index.sql
@@ -1,0 +1,45 @@
+-- V46__add_connection_events_attr_index.sql
+-- #1254: the byte-rollup hostname-attribution lateral (the #809 reroll in
+-- RollupRepoLive.resolvedCte, mirrored by TrafficReportRepoLive) pegged prod DB
+-- CPU at 100% continuously. The lateral, run once per traffic_reports row, is:
+--
+--   SELECT resolved_host_value FROM connection_events
+--   WHERE mac = tr.mac AND dest_ip = tr.host_value
+--     AND resolved_host_value IS NOT NULL
+--     AND ts >= tr.date AND ts < tr.date + INTERVAL '1 day'
+--   ORDER BY ts DESC LIMIT 1
+--
+-- connection_events already carries idx_conn_events_mac_dest_resolved
+-- (mac, dest_ip) WHERE resolved_host_value IS NOT NULL (V22, re-established in
+-- V42), but it has no `ts` column. With (mac, dest_ip) alone the planner would
+-- have to read every all-time row for that pair, then filter the day-range and
+-- sort for the LIMIT 1 — so it never picks it. Instead, prod EXPLAIN (2026-05-31)
+-- showed the lateral using (mac, ts) on most weekly partitions and, on the
+-- largest one (connection_events_2026_22, ~15k rows), falling back to the
+-- ts-only idx_conn_events_ts: Index Cond on the ts range, Filter on mac/dest_ip.
+-- That scans a full day of events per traffic_reports row; ~70k tr rows × a
+-- day's worth of events ≈ 1e8 touches, queries ran 9+ minutes, rerolls piled up
+-- and CPU never idled.
+--
+-- A composite (mac, dest_ip, ts) lets the planner serve the whole lateral from
+-- one index seek: (mac, dest_ip) equality + the ts range + the ORDER BY ts DESC
+-- LIMIT 1, no heap filter, no sort. Strictly the cheapest plan, so it wins over
+-- both the (mac, ts) and ts-only fallbacks. The reroll drops from minutes to
+-- sub-millisecond per row. The partial predicate matches the lateral's
+-- `resolved_host_value IS NOT NULL` and keeps the index to the small fraction of
+-- rows that carry a resolution. This index is a strict superset of
+-- idx_conn_events_mac_dest_resolved (same leading columns + predicate); the
+-- older index could be dropped as a follow-up, left in place here to keep this
+-- change to the one index the incident needs.
+--
+-- Partitioning: connection_events is weekly RANGE-partitioned (V42). Creating
+-- the index on the parent propagates it to every existing and future partition,
+-- which is what we want. A partitioned-parent CREATE INDEX cannot be
+-- CONCURRENTLY, but the partitions are tiny (single-digit MB) so the build is
+-- sub-second on the Flyway startup path. Column types match the lateral's
+-- predicates (mac, dest_ip TEXT; ts TIMESTAMPTZ), so the composite btree is used
+-- directly.
+
+CREATE INDEX IF NOT EXISTS idx_conn_events_attr
+  ON connection_events (mac, dest_ip, ts)
+  WHERE resolved_host_value IS NOT NULL;


### PR DESCRIPTION
## Summary

Fixes #1254. Adds Flyway migration **V46** creating a partial composite index on `connection_events`:

```sql
CREATE INDEX IF NOT EXISTS idx_conn_events_attr
  ON connection_events (mac, dest_ip, ts)
  WHERE resolved_host_value IS NOT NULL;
```

The #809 byte-rollup hostname-attribution lateral (`RollupRepoLive.resolvedCte`, mirrored by `TrafficReportRepoLive`) pegged prod DB CPU at 100% continuously. Per `traffic_reports` row it runs:

```sql
SELECT resolved_host_value FROM connection_events
WHERE mac = tr.mac AND dest_ip = tr.host_value
  AND resolved_host_value IS NOT NULL
  AND ts >= tr.date AND ts < tr.date + INTERVAL '1 day'
ORDER BY ts DESC LIMIT 1
```

## Diagnosis correction

The issue states "nothing on `(mac, dest_ip)`". That's **not** the case — live prod inspection (2026-05-31) shows `idx_conn_events_mac_dest_resolved (mac, dest_ip) WHERE resolved_host_value IS NOT NULL` (V22, re-established in V42) **exists and is valid**. The real problem is that index lacks **`ts`**, so the planner never uses it for this lateral (it would have to read all-time rows for the pair, then filter the day-range and sort for the `LIMIT 1`).

Live prod `EXPLAIN` of the lateral instead showed:

- partitions `2026_23..26` + `pre_partition`: `*_mac_ts_idx` — `Index Cond: mac + ts range`, `Filter: resolved_host_value IS NOT NULL AND dest_ip = ...`
- **largest partition `connection_events_2026_22` (~15k rows): falls back to the ts-only `idx_conn_events_ts`** — `Index Cond: ts range`, `Filter: mac AND dest_ip`.

So on the busiest partition the lateral scans a **full day** of events per `traffic_reports` row. ~70k tr rows × a day's events ≈ ~1e8 touches → queries ran 9+ minutes, rerolls overlapped (hourly + daily, distinct advisory-lock keys), CPU never idled.

## Why `(mac, dest_ip, ts)` fixes it

The composite serves the whole lateral from one index seek: `(mac, dest_ip)` equality + the `ts` range + `ORDER BY ts DESC LIMIT 1` — no heap filter, no sort. Strictly the cheapest plan, so the planner adopts it over both the `(mac, ts)` and ts-only fallbacks. Per-row cost drops from "scan a day's events" to a single index entry → **minutes → sub-millisecond**, CPU off the peg.

The partial predicate matches the lateral's `resolved_host_value IS NOT NULL`, keeping the index to the small fraction of rows carrying a resolution. Created on the **partitioned parent** so it propagates to all existing + future weekly partitions; can't be `CONCURRENTLY` on a partitioned parent, but partitions are single-digit MB so the build is sub-second on the Flyway startup path.

## Notes

- This new index is a strict superset of `idx_conn_events_mac_dest_resolved` (same leading columns + predicate). The older index is now redundant and could be dropped as a follow-up; left in place here to keep this change to the one index the incident needs.
- Scope kept to the index only — the optional overlap/single-flight/incremental-reroll rework from the issue is deferred; fast queries finishing before the next tick removes the pile-up.
- No tier/`render.yaml` change here (that's #1251). No DDL applied to prod — migration only.

## Migration-only PR

Per `CLAUDE.md` §migrations-back-compat and `check-migration-isolation.sh`, a PR adding a migration may contain only the migration + docs — no test changes. The existing `api.test` suite is the back-compat / correctness gate: it applies V46 against embedded Postgres and runs the rollup/attribution specs unchanged. An index cannot change query results, only speed, so green tests confirm correctness is preserved.

## Test plan

- [x] `mill api.test` green (192/192 groups, 0 failures) — V46 applies cleanly on the embedded-PG Flyway path
- [x] Migration isolation check passes (migration-only)
- [ ] Post-deploy: confirm prod rollup query plan switches to `idx_conn_events_attr` and DB CPU drops off the peg