### PR TITLE
Ride out transient DB outages at startup instead of crashing main (#1255)

### DIFF
--- a/api/src/Config.scala
+++ b/api/src/Config.scala
@@ -35,7 +35,36 @@ case class DbConfig(
     user: String,
     password: String,
     poolSize: Int,
+    // #1255: tolerance for transient DB unavailability (planned resize, failover,
+    // brief network hiccup). Optional — absent block uses the defaults below.
+    resilience: DbResilienceConfig = DbResilienceConfig(),
 )
+
+// #1255: how the API rides out a *transient* DB outage instead of crashing
+// `main`. The startup DB-heavy init (Flyway migrations, ensureDefault, seeds)
+// retries with bounded exponential backoff + jitter on connection-class
+// failures only; genuine errors (a bad migration, a constraint violation) still
+// fail fast. The Hikari pool is configured so its creation never hard-fails on a
+// DB that is briefly down at boot.
+case class DbResilienceConfig(
+    // base delay for the exponential backoff between startup-init retries
+    startupRetryBaseMillis: Long = 1000,
+    // per-attempt backoff is capped at this so a late retry doesn't sleep for ages
+    startupRetryMaxBackoffSeconds: Long = 30,
+    // total wall-clock budget for retrying; after this the init fails loudly
+    startupRetryMaxElapsedSeconds: Long = 300,
+    // Hikari initializationFailTimeout. Negative => create the pool even if the DB
+    // is down at boot (connections are established lazily on first use), so pool
+    // creation can never take the process down during a DB blip.
+    initializationFailTimeoutMillis: Long = -1,
+    // Hikari connectionTimeout — how long getConnection waits before throwing a
+    // SQLTransientConnectionException (which the startup retry treats as transient).
+    connectionTimeoutMillis: Long = 30000,
+) {
+  def startupRetryBase: zio.Duration       = zio.Duration.fromMillis(startupRetryBaseMillis)
+  def startupRetryMaxBackoff: zio.Duration = zio.Duration.fromSeconds(startupRetryMaxBackoffSeconds)
+  def startupRetryMaxElapsed: zio.Duration = zio.Duration.fromSeconds(startupRetryMaxElapsedSeconds)
+}
 
 case class HttpConfig(
     host: String,

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -82,42 +82,58 @@ object Main extends ZIOAppDefault {
           .provide(ZLayer.succeed(serverConfig) >>> Server.live)
           .forkScoped
         _      <- ZIO.logInfo("HTTP port bound; running DB-heavy startup behind readiness gate")
-        _      <- Database.runMigrations(cfg.db)
-        _      <- ZIO.logInfo("Database migrations complete")
-        // #334: ensure household_settings has its single row, defaulting the
-        // daily-reset tz to the API server's local zone on first install. No-op
-        // on subsequent boots because of ON CONFLICT DO NOTHING.
+        // Service handles are pure layer reads (no DB I/O); resolve them up front
+        // so the retried DB-init block below is purely the idempotent DB work.
         hsRepo <- ZIO.service[HouseholdSettingsRepo]
-        tz = java.time.ZoneId.systemDefault()
-        _ <- hsRepo.ensureDefault(tz)
-        _ <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
-        // #768: seed the starter library of app templates. Idempotent — operator
-        // host edits on previously-seeded apps are preserved.
         appRepoForSeed <- ZIO.service[AppRepo]
-        seedSummary    <- AppTemplates.seed(appRepoForSeed, templates)
-        _              <- ZIO.logInfo(
-          s"app_templates seeded (${templates.size} templates): " +
-            s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
-            s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated.mkString("[", ",", "]")}, " +
-            s"augmented=${seedSummary.augmented.size} " +
-            seedSummary.augmented
-              .map(a => s"${a.slug}+[${a.addedHosts.mkString(",")}]")
-              .mkString("[", ",", "]") + ", " +
-            s"preserved=${seedSummary.preserved.size}",
-        )
-        // #958: seed the bundled category blocklists. Inline lists pull hosts
-        // straight from YAML; remote lists fetch from the declared upstream URL
-        // (cached in-memory after first success — see BlocklistCache). REPLACE
-        // semantics; remote-fetch failures leave existing DB rows untouched.
         blRepoForSeed  <- ZIO.service[BlocklistRepo]
         blCacheForSeed <- ZIO.service[BlocklistCache]
         blFetcher      <- ZIO.service[BlocklistFetcher]
-        _              <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
-        _              <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+        tz = java.time.ZoneId.systemDefault()
+        // #1255: a transient DB outage (a few seconds during a resize/failover/
+        // restart) used to throw a Hikari/PSQL connection error straight to
+        // `main`, exiting the JVM and crash-looping until the DB returned. Wrap
+        // the DB-heavy init so connection-class failures retry with bounded
+        // exponential backoff + jitter while readiness stays false (/api/health
+        // 503). Genuine errors (a bad migration, a constraint violation) still
+        // fail fast and loud — see Database.isTransientConnectionError. The block
+        // is idempotent (Flyway tracks applied migrations; ensureDefault is
+        // ON CONFLICT DO NOTHING; the seeds are REPLACE / idempotent), so a retry
+        // safely re-runs it from the start.
+        _            <- Database.withStartupRetry(cfg.db.resilience, "startup DB init") {
+          for {
+            _ <- Database.runMigrations(cfg.db)
+            _ <- ZIO.logInfo("Database migrations complete")
+            // #334: ensure household_settings has its single row, defaulting the
+            // daily-reset tz to the API server's local zone on first install.
+            _ <- hsRepo.ensureDefault(tz)
+            _ <- ZIO.logInfo(s"household_settings ensured (install-default tz=${tz.getId})")
+            // #768: seed the starter library of app templates. Idempotent —
+            // operator host edits on previously-seeded apps are preserved.
+            seedSummary <- AppTemplates.seed(appRepoForSeed, templates)
+            _           <- ZIO.logInfo(
+              s"app_templates seeded (${templates.size} templates): " +
+                s"created=${seedSummary.created.size} ${seedSummary.created.mkString("[", ",", "]")}, " +
+                s"repopulated=${seedSummary.repopulated.size} ${seedSummary.repopulated
+                    .mkString("[", ",", "]")}, " +
+                s"augmented=${seedSummary.augmented.size} " +
+                seedSummary.augmented
+                  .map(a => s"${a.slug}+[${a.addedHosts.mkString(",")}]")
+                  .mkString("[", ",", "]") + ", " +
+                s"preserved=${seedSummary.preserved.size}",
+            )
+            // #958: seed the bundled category blocklists. Inline lists pull hosts
+            // straight from YAML; remote lists fetch from the declared upstream
+            // URL (cached in-memory after first success — see BlocklistCache).
+            // REPLACE semantics; remote-fetch failures leave existing rows alone.
+            _           <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
+            _           <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+          } yield ()
+        }
         // #1248: migrations + ensureDefault + seeds are done — flip readiness so
         // /api/health returns 200 and the gated routes start serving real traffic.
-        _              <- readyRef.set(true)
-        _              <- ZIO.logInfo("readiness flipped → /api/health healthy, API routes ungated")
+        _            <- readyRef.set(true)
+        _            <- ZIO.logInfo("readiness flipped → /api/health healthy, API routes ungated")
         // #809: scheduled re-aggregation of traffic_reports into the rollup
         // tables. #1230: cadence matches the tier each table is read at — hourly
         // tick re-rolls the trailing 2h every hour, daily tick re-rolls the
@@ -125,9 +141,9 @@ object Main extends ZIOAppDefault {
         // traffic_reports, not these tables). #1247: forkScoped (not forkDaemon)
         // into the run scope so they are interrupted before the Hikari pool
         // closes on shutdown; the fork never blocks startup either way.
-        rollupRepo     <- ZIO.service[wifihaven.api.db.RollupRepo]
-        clockForJobs   <- ZIO.service[Clock]
-        _              <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
+        rollupRepo   <- ZIO.service[wifihaven.api.db.RollupRepo]
+        clockForJobs <- ZIO.service[Clock]
+        _            <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
         _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkScoped
         // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
         // a watermarked row; the read path adds a live tail of buckets after the watermark, so

--- a/api/src/db/Database.scala
+++ b/api/src/db/Database.scala
@@ -2,13 +2,16 @@ package wifihaven.api.db
 
 import com.zaxxer.hikari.HikariDataSource
 import doobie.Transactor
-import wifihaven.api.DbConfig
+import wifihaven.api.{DbConfig, DbResilienceConfig}
 import org.flywaydb.core.Flyway
 import zio.*
 import zio.interop.catz.*
 
+import java.net.{ConnectException, SocketException}
+import java.sql.{SQLException, SQLTransientConnectionException}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory}
+import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 
 object Database {
@@ -26,7 +29,15 @@ object Database {
     ds.setPassword(cfg.password)
     ds.setMaximumPoolSize(cfg.poolSize)
     ds.setMinimumIdle(2)
-    ds.setConnectionTimeout(30000)
+    ds.setConnectionTimeout(cfg.resilience.connectionTimeoutMillis)
+    // #1255: with a negative initializationFailTimeout Hikari creates the pool
+    // without probing the DB at construction time and establishes connections
+    // lazily on first use. So a DB that is briefly down at boot can never fail
+    // pool creation (which would propagate to `main` and exit the JVM) — the
+    // first query instead throws a transient error that the startup retry rides
+    // out. Once the DB returns, Hikari's housekeeping re-establishes connections
+    // automatically; a refused/closed connection is never treated as fatal.
+    ds.setInitializationFailTimeout(cfg.resilience.initializationFailTimeoutMillis)
     ds.setIdleTimeout(600000)
     ds.setMaxLifetime(1800000)
     ds
@@ -91,4 +102,71 @@ object Database {
         .migrate()
       ()
     }
+
+  /**
+   * #1255: is `t` (or anything in its cause chain) a *transient* DB-connectivity failure that
+   * warrants a retry — as opposed to a genuine error (bad migration, constraint violation, syntax
+   * error) that must fail fast and loud?
+   *
+   * Transient = the kind of thing a few-second DB restart/failover produces:
+   *   - `SQLTransientConnectionException` — Hikari "Connection is not available, request timed out"
+   *     when the pool can't hand out a live connection.
+   *   - `java.net.ConnectException` — "Connection refused" while the DB is down.
+   *   - `java.net.SocketException` — connection reset / socket closed mid-flight.
+   *   - any `SQLException` whose SQLState is in the connection class `08*` (PostgreSQL: 08001
+   *     unable to connect, 08006 connection failure, …).
+   *
+   * The cause chain matters because Flyway wraps the PSQLException in a FlywayException, which in
+   * turn wraps the underlying ConnectException; the outer type alone tells us nothing.
+   */
+  def isTransientConnectionError(t: Throwable): Boolean = {
+    @tailrec
+    def loop(e: Throwable, seen: List[Throwable]): Boolean =
+      if (e == null || seen.exists(_ eq e)) false
+      else {
+        val hit = e match {
+          case _: SQLTransientConnectionException => true
+          case _: ConnectException                => true
+          case _: SocketException                 => true
+          case sql: SQLException                  =>
+            Option(sql.getSQLState).exists(_.startsWith("08"))
+          case _                                  => false
+        }
+        if (hit) true else loop(e.getCause, e :: seen)
+      }
+    loop(t, Nil)
+  }
+
+  /**
+   * #1255: run a DB-heavy startup effect, retrying *only* on transient connection-class failures
+   * (see [[isTransientConnectionError]]) with bounded exponential backoff + jitter. A genuine error
+   * fails fast on the first attempt; a transient error that outlasts the elapsed budget also fails
+   * (the original error is re-raised) rather than retrying forever. The wrapped effect must be
+   * idempotent — it is re-run from the start on each retry.
+   */
+  def withStartupRetry[R, A](r: DbResilienceConfig, label: String)(
+      io: ZIO[R, Throwable, A],
+  ): ZIO[R, Throwable, A] = {
+    // delay = min(exponential growth, maxBackoff), then jittered; the union keeps
+    // recurring forever (both sides are infinite) — the actual stop conditions are
+    // the intersected schedules below.
+    val backoff  =
+      (Schedule.exponential(r.startupRetryBase) || Schedule.spaced(
+        r.startupRetryMaxBackoff,
+      )).jittered
+    val schedule =
+      backoff &&
+        Schedule.recurWhile[Throwable](isTransientConnectionError) &&
+        Schedule.upTo(r.startupRetryMaxElapsed)
+    io.tapError {
+      case t if isTransientConnectionError(t) =>
+        ZIO.logWarning(
+          s"$label: transient DB connectivity error, retrying with backoff " +
+            s"(base=${r.startupRetryBaseMillis}ms, cap=${r.startupRetryMaxBackoffSeconds}s, " +
+            s"budget=${r.startupRetryMaxElapsedSeconds}s): " +
+            s"${t.getClass.getName}: ${t.getMessage}",
+        )
+      case _                                  => ZIO.unit
+    }.retry(schedule)
+  }
 }

--- a/api/test/src/feature/DbStartupResilienceSpec.scala
+++ b/api/test/src/feature/DbStartupResilienceSpec.scala
@@ -1,0 +1,119 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import wifihaven.api.DbResilienceConfig
+import wifihaven.api.db.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+
+import java.net.ConnectException
+import java.sql.{SQLException, SQLTransientConnectionException}
+
+/**
+ * #1255: a transient DB outage (a few-second restart during a resize/failover) must not take the
+ * API process down. The DB-heavy startup init has to retry connection-class failures with bounded
+ * backoff and come up once the DB returns, while a *genuine* error (bad migration, bad SQL,
+ * constraint violation) still fails fast instead of retrying forever.
+ *
+ * These tests drive the real `Database.withStartupRetry` helper against the embedded Postgres: real
+ * PSQLExceptions on the failure paths, a real `SELECT 1` once the simulated outage clears.
+ */
+object DbStartupResilienceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  // Tight budget so the suite stays fast; the production defaults are minutes.
+  private val fastConfig = DbResilienceConfig(
+    startupRetryBaseMillis = 5,
+    startupRetryMaxBackoffSeconds = 1,
+    startupRetryMaxElapsedSeconds = 10,
+  )
+
+  // PSQLException carries SQLState; emulate the connection class (08*) and a
+  // non-connection (genuine) class without reaching for the driver internals.
+  private def sqlState(state: String): SQLException =
+    new SQLException(s"simulated SQLState=$state", state)
+
+  def spec = suite("DbStartupResilienceSpec")(
+    test("transient connection failures retry, then startup completes once the DB is reachable") {
+      for {
+        xa       <- ZIO.service[Transactor[Task]]
+        attempts <- Ref.make(0)
+        // Fails the first 3 attempts with a Hikari-style transient error, then
+        // actually runs a real query against the embedded DB ("DB came back").
+        init = attempts.updateAndGet(_ + 1).flatMap { n =>
+          if (n <= 3)
+            ZIO.fail(
+              new SQLTransientConnectionException("HikariPool-1 - Connection is not available"),
+            )
+          else
+            sql"SELECT 1".query[Int].unique.transact(xa)
+        }
+        result <- Database.withStartupRetry(fastConfig, "test init")(init)
+        count  <- attempts.get
+      } yield assertTrue(result == 1, count == 4)
+    } @@ TestAspect.withLiveClock,
+    test("a genuine (non-connection) SQL error fails fast without retrying") {
+      for {
+        attempts <- Ref.make(0)
+        // 42P01 = undefined_table: a real bug, must NOT be retried.
+        init = attempts.update(_ + 1) *> ZIO.fail(sqlState("42P01"))
+        exit  <- Database.withStartupRetry(fastConfig, "test init")(init).exit
+        count <- attempts.get
+      } yield assertTrue(exit.isFailure, count == 1)
+    } @@ TestAspect.withLiveClock,
+    test("a real undefined-table query error fails fast (not treated as transient)") {
+      for {
+        xa       <- ZIO.service[Transactor[Task]]
+        attempts <- Ref.make(0)
+        init = attempts.update(_ + 1) *>
+          sql"SELECT 1 FROM table_that_does_not_exist".query[Int].unique.transact(xa)
+        exit  <- Database.withStartupRetry(fastConfig, "test init")(init).exit
+        count <- attempts.get
+      } yield assertTrue(exit.isFailure, count == 1)
+    } @@ TestAspect.withLiveClock,
+    test("a persistent transient failure eventually fails once the elapsed budget is spent") {
+      for {
+        attempts <- Ref.make(0)
+        cfg  = fastConfig.copy(startupRetryMaxElapsedSeconds = 1)
+        init = attempts.update(_ + 1) *>
+          ZIO.fail(new ConnectException("Connection refused"))
+        exit  <- Database.withStartupRetry(cfg, "test init")(init).exit
+        count <- attempts.get
+      } yield assertTrue(exit.isFailure, count > 1)
+    } @@ TestAspect.withLiveClock,
+    suite("isTransientConnectionError classification")(
+      test("Hikari SQLTransientConnectionException is transient") {
+        assertTrue(
+          Database.isTransientConnectionError(
+            new SQLTransientConnectionException("Connection is not available"),
+          ),
+        )
+      },
+      test("ConnectException (connection refused) is transient") {
+        assertTrue(Database.isTransientConnectionError(new ConnectException("Connection refused")))
+      },
+      test("SQLState 08006 (connection failure) is transient") {
+        assertTrue(Database.isTransientConnectionError(sqlState("08006")))
+      },
+      test("a nested ConnectException under a wrapper is transient") {
+        val wrapped =
+          new RuntimeException("Flyway failed", new ConnectException("Connection refused"))
+        assertTrue(Database.isTransientConnectionError(wrapped))
+      },
+      test("constraint violation (23505) is NOT transient") {
+        assertTrue(!Database.isTransientConnectionError(sqlState("23505")))
+      },
+      test("undefined table (42P01) is NOT transient") {
+        assertTrue(!Database.isTransientConnectionError(sqlState("42P01")))
+      },
+      test("a plain RuntimeException is NOT transient") {
+        assertTrue(!Database.isTransientConnectionError(new RuntimeException("boom")))
+      },
+    ),
+  )
+}

--- a/api/test/src/feature/DbStartupResilienceSpec.scala
+++ b/api/test/src/feature/DbStartupResilienceSpec.scala
@@ -22,7 +22,8 @@ import java.sql.{SQLException, SQLTransientConnectionException}
  * These tests drive the real `Database.withStartupRetry` helper against the embedded Postgres: real
  * PSQLExceptions on the failure paths, a real `SELECT 1` once the simulated outage clears.
  */
-object DbStartupResilienceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+object DbStartupResilienceSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
 
   override val bootstrap = TestDatabase.layer
 

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -6,6 +6,23 @@ wifihaven {
     user     = "wifihaven"
     password = "changeme"
     poolSize = 5
+
+    # #1255: tolerate a transient DB outage (a few-second restart during a plan
+    # resize / failover / network blip) instead of crashing the process. The
+    # DB-heavy startup init (migrations + seeds) retries connection-class errors
+    # with bounded exponential backoff + jitter while /api/health stays 503;
+    # genuine errors (a bad migration, a constraint violation) still fail fast.
+    # The whole block is optional — omit it to use the defaults shown here.
+    # resilience {
+    #   startupRetryBaseMillis        = 1000   # base backoff between retries
+    #   startupRetryMaxBackoffSeconds = 30     # cap on a single backoff delay
+    #   startupRetryMaxElapsedSeconds = 300    # total retry budget before failing loudly
+    #   # Hikari initializationFailTimeout. Negative => create the pool even if the
+    #   # DB is down at boot (connections established lazily), so pool creation can
+    #   # never take the process down during a DB blip.
+    #   initializationFailTimeoutMillis = -1
+    #   connectionTimeoutMillis         = 30000
+    # }
   }
 
   http {


### PR DESCRIPTION
Closes #1255.

## Problem

A *transient* Postgres outage — a few seconds during a planned restart (plan resize, failover, brief network hiccup) — used to **kill the API process**. A Hikari `Connection is not available` / `Connection refused` propagated all the way to `main`, the JVM exited, and Render had to restart the instance, crash-looping until the DB fully returned.

### Live evidence (2026-05-31 prod, during the #1251 `basic-256mb` → `basic-1gb` resize)

```
21:51  PSQLException: Connection to dpg-...-a:5432 refused
21:51  java.net.ConnectException: Connection refused
21:51  SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out
21:53  Exception in thread "main"          <-- process exits
```

A planned DB restart should be a non-event.

## Fix

1. **`Database.withStartupRetry`** wraps the DB-heavy startup init in `Main.scala` (Flyway migrations, `hsRepo.ensureDefault`, `AppTemplates.seed`, `BundledBlocklists.seed`) and retries on transient connection failures with **bounded exponential backoff + jitter**, capped by a total elapsed budget. The block is idempotent, so re-running it from the start on each retry is safe.

2. **Transient-vs-fatal gating** is strict (`Database.isTransientConnectionError`). It retries only:
   - `SQLTransientConnectionException` (Hikari pool timeout),
   - `java.net.ConnectException` / `SocketException` (refused / reset),
   - `SQLException` with SQLState in the connection class `08*`,

   walking the **cause chain** (Flyway wraps `PSQLException` wraps `ConnectException`, so the outer type alone is uninformative). **Genuine errors — a bad migration, a constraint violation (`23505`), an undefined table (`42P01`), a plain `RuntimeException` — are NOT retried.** They fail fast and loud so real bugs aren't masked behind minutes of futile retrying.

3. **Hikari config** — `initializationFailTimeout` set negative so pool creation never hard-fails on a DB that's briefly down at boot (connections are established lazily and recovered automatically once the DB returns); `connectionTimeout` is now configurable too.

4. All thresholds go through **zio-config/HOCON** via the optional `db.resilience` block (`DbResilienceConfig`), defaulting to base=1s, per-attempt cap=30s, total budget=5m. Documented in `config/application.conf.example`.

Readiness stays `false` (`/api/health` 503) for the duration of the retry and flips `true` only after init succeeds, so a 5–30s DB restart is at most a brief readiness blip, never a process exit. The rollup/backfill fibers already catch per-tick errors and record to `rollup_runs`, so a connection-refused mid-tick is non-fatal there (confirmed; not changed).

## Relationship to #1248

Builds **on top of** the merged #1248 (#1252), which bound the HTTP port before DB-heavy init and added the readiness gate. This change reuses that `readyRef` gate: #1248 = bind port before DB init; this = make that init resilient to transient DB loss. No conflict — branched off latest `main` (which includes #1252).

Out of scope (kept separate, per the issue): #1247 shutdown race, #1254 index, #1251 tier.

## Tests (TDD, red → green in history)

`api/test/src/feature/DbStartupResilienceSpec.scala`, driving the real helper against embedded Postgres:

- a flaky init that fails 3× with a Hikari/connection error then runs a real `SELECT 1` **retries and completes** (4 attempts);
- a genuine error (undefined-table query, injected `42P01`/`23505`) **fails fast** (1 attempt, no retry);
- a persistent transient failure **eventually fails** once the elapsed budget is spent;
- `isTransientConnectionError` classification incl. nested causes.

The failing test is committed before the implementation. `mill api.test` passes (192 specs).

## Test plan

- [x] `mill api.test`
- [x] `scalafmt --check --non-interactive`
- [ ] Observe a planned DB restart on staging causes only a readiness blip, no process exit