### PR TITLE
ci: grant pull-requests:read to ci.yml caller jobs so CD can start (#1259)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -85,6 +85,15 @@ jobs:
     # turns that spurious red run neutral. `workflow_dispatch` on main still
     # satisfies this; dispatch on a non-main ref is intentionally skipped. (#1136)
     if: github.ref == 'refs/heads/main'
+    # ci.yml's migration-isolation job declares `pull-requests: read` (for the
+    # merge_group `gh pr list` label lookup). GitHub validates a called
+    # workflow's job permissions against the caller's grant at LOAD time,
+    # before `if:` gating — so without this scope the call exceeds the
+    # workflow-level `contents: read` cap and the whole CD run startup_failures
+    # even though that job is skipped on push. (#1259)
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
 
   # ── 2. E2E + smoke tests (unconditional) ──────────────────────────────────

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -77,8 +77,15 @@ jobs:
     # turns that spurious red run neutral. `workflow_dispatch` on main still
     # satisfies this; dispatch on a non-main ref is intentionally skipped. (#1136)
     if: github.ref == 'refs/heads/main'
+    # ci.yml's migration-isolation job declares `pull-requests: read` (for the
+    # merge_group `gh pr list` label lookup). GitHub validates a called
+    # workflow's job permissions against the caller's grant at LOAD time,
+    # before `if:` gating — so without this scope the call exceeds the cap and
+    # the whole CD run startup_failures even though that job is skipped on
+    # push. (#1259)
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
 
   # #1224: build EVERY shippable release artifact exactly once, pre-gate,


### PR DESCRIPTION
## Summary

Unblock CD. Both Master CD pipelines (`master-api-ui.yml`, `master-router.yml`) have failed to **start** (`startup_failure`, 0 jobs scheduled) on every push to `main` since fdccd34 (#1239). Prod and router deploys are fully blocked. Fixes #1259.

## Root cause

#1239 added a job-level `permissions: { contents: read, pull-requests: read }` block to the `migration-isolation` job in `.github/workflows/ci.yml`. That file is a reusable workflow invoked via `uses: ./.github/workflows/ci.yml` from both CD callers, which cap `GITHUB_TOKEN` at the workflow level with `permissions: contents: read`.

GitHub validates that a called workflow's job permissions never exceed the caller's grant — and it does this at **load time, before `if:` gating is evaluated**. So even though `migration-isolation` is skipped on `push` (it only runs on `pull_request`/`merge_group`), its *declared* `pull-requests: read` exceeds the caller's `contents: read` cap and aborts the entire CD run with `startup_failure`.

Standalone CI (pull_request/merge_group) is unaffected because it runs with the default broad token, which already includes `pull-requests`.

## Fix

Grant `pull-requests: read` to **only** the job that invokes `ci.yml` in each caller, so the called job's request no longer exceeds the caller's grant. The workflow-level `permissions:` blocks are left untouched (still `contents: read`), keeping the broader token scope unchanged.

- `master-api-ui.yml` → `ci-tests` job: added a job-level `permissions` block (`contents: read` + `pull-requests: read`).
- `master-router.yml` → `ci-tests` job: added `pull-requests: read` to the existing job-level `permissions` block.

`ci.yml` itself is **not** touched — the `pull-requests: read` request there is legitimate (the merge_group `gh pr list` label lookup needs it).

## Validation

- `actionlint` clean on all three workflows. Note actionlint does **not** model the permission-escalation rule, so a clean run is necessary but not sufficient — the real proof is the next `main` push producing a CD run that actually schedules jobs instead of a 0-job `startup_failure`.

## Note

**Must merge before any other prod deploy can land** — CD has been down since the #1239 merge; nothing ships through it until this lands.