### PR TITLE
Add Grafana Alloy collector for cloud app-metrics path (#1208)

### DIFF
--- a/deploy/alloy/Dockerfile
+++ b/deploy/alloy/Dockerfile
@@ -1,0 +1,19 @@
+# #1208: Grafana Alloy collector for the cloud app-metrics path.
+#
+# A runtime:image service can't mount a repo-local file into a prebuilt
+# image, and Alloy needs our config.alloy baked in — so we build a thin
+# image FROM the official Alloy release and COPY the config. Built by Render
+# from this repo (render.yaml -> wifihaven-alloy, dockerfilePath here).
+#
+# Pin the base tag explicitly for reproducibility; bump deliberately.
+FROM grafana/alloy:v1.5.1
+
+# Default Alloy config path is /etc/alloy/config.alloy.
+COPY config.alloy /etc/alloy/config.alloy
+
+# Run in agent mode. The HTTP server is bound to loopback only — Alloy has no
+# inbound role here (it scrapes + remote_writes), so it is not exposed.
+CMD ["run", \
+     "/etc/alloy/config.alloy", \
+     "--storage.path=/var/lib/alloy/data", \
+     "--server.http.listen-addr=127.0.0.1:12345"]

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -1,0 +1,71 @@
+// #1208: Grafana Alloy (Prometheus agent-mode) config for the cloud
+// app-metrics path. Alloy scrapes the API's INTERNAL Render address
+// (never the public api.wifihaven.net) and remote_writes the samples to
+// Grafana Cloud Prometheus. See docs/design/metrics-observability.md §6.2.
+//
+// This is the APP-metrics producer. Render's own INFRA metrics (managed
+// Postgres CPU / connections / disk, service CPU/mem) flow via a separate
+// Render-native OTel stream (#1244, design §6.3) into the same Grafana
+// Cloud stack — do not add them here.
+//
+// All secrets/endpoints come from the Render env (sync:false in
+// render.yaml). Nothing sensitive is committed.
+
+// ── Scrape: production API /metrics (internal address) ──────────────────────
+prometheus.scrape "api_prod" {
+  targets = [
+    {
+      __address__ = "wifihaven-api-prod:8080",
+      instance    = "wifihaven-api-prod",
+      env         = "prod",
+    },
+  ]
+  metrics_path    = "/metrics"
+  scheme          = "http"
+  scrape_interval = "30s"
+
+  // #1242: GET /metrics is gated behind a bearer scrape token. The token is
+  // pulled from the prod API service via render.yaml fromService.
+  authorization {
+    type        = "Bearer"
+    credentials = sys.env("WIFIHAVEN_METRICS_SCRAPE_TOKEN_PROD")
+  }
+
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Scrape: staging API /metrics (internal address) ─────────────────────────
+prometheus.scrape "api_staging" {
+  targets = [
+    {
+      __address__ = "wifihaven-api-staging:8080",
+      instance    = "wifihaven-api-staging",
+      env         = "staging",
+    },
+  ]
+  metrics_path    = "/metrics"
+  scheme          = "http"
+  scrape_interval = "30s"
+
+  authorization {
+    type        = "Bearer"
+    credentials = sys.env("WIFIHAVEN_METRICS_SCRAPE_TOKEN_STAGING")
+  }
+
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Remote write: Grafana Cloud Prometheus ──────────────────────────────────
+// URL + credentials are Render-managed secrets (sync:false). Grafana Cloud
+// uses HTTP basic auth: username = numeric instance/user id, password = a
+// Grafana Cloud API token with metrics-push scope.
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_CLOUD_PROM_URL")
+
+    basic_auth {
+      username = sys.env("GRAFANA_CLOUD_PROM_USER")
+      password = sys.env("GRAFANA_CLOUD_PROM_PASSWORD")
+    }
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -207,6 +207,63 @@ services:
       - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN
         generateValue: true
 
+  # ── Metrics collector: Grafana Alloy → Grafana Cloud ─────────────────────────
+  # #1208: the cloud APP-metrics path. Alloy (Prometheus agent-mode) scrapes
+  # each API's INTERNAL Render address — http://wifihaven-api-{prod,staging}:8080
+  # /metrics, never the public api.wifihaven.net — and remote_writes the samples
+  # to Grafana Cloud Prometheus. Config is checked in at deploy/alloy/config.alloy
+  # and baked into a thin image via deploy/alloy/Dockerfile (a runtime:image
+  # service can't mount a repo-local config). See docs/design/metrics-observability.md §6.2.
+  #
+  # NON-CRITICAL (design §6.2): a metrics outage must never affect API
+  # availability or block an API deploy. Nothing here is a dependency of either
+  # API service, and neither API depends on this — the two surfaces fail
+  # independently. This is the APP-metrics producer only; Render's own INFRA
+  # metrics (managed-Postgres CPU/conns/disk) stream separately via #1244.
+  #
+  # type:worker — Alloy has no inbound role (it pulls + pushes), so no port and
+  # no health check. Render workers have no free tier; `starter` is the floor.
+  # Must be region:oregon to share the private network with the API services
+  # (cross-region private networking isn't available).
+  #
+  # autoDeploy:no keeps promotion explicit (manual deploy / `render blueprint
+  # apply`), consistent with the API services. A config.alloy change applies on
+  # the next deploy of this service; it never rides the API CD pipeline.
+  - type: worker
+    runtime: docker
+    name: wifihaven-alloy
+    plan: starter
+    region: oregon
+    autoDeploy: no
+    dockerfilePath: ./deploy/alloy/Dockerfile
+    dockerContext: ./deploy/alloy
+    envVars:
+      # Scrape bearer tokens — pulled from each API service's generated
+      # WIFIHAVEN_METRICS_SCRAPE_TOKEN (#1242) so the values stay in sync
+      # without being committed or hand-copied. config.alloy reads these via
+      # sys.env(...).
+      - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN_PROD
+        fromService:
+          name: wifihaven-api-prod
+          type: web
+          envVarKey: WIFIHAVEN_METRICS_SCRAPE_TOKEN
+      - key: WIFIHAVEN_METRICS_SCRAPE_TOKEN_STAGING
+        fromService:
+          name: wifihaven-api-staging
+          type: web
+          envVarKey: WIFIHAVEN_METRICS_SCRAPE_TOKEN
+      # Grafana Cloud Prometheus remote_write target + credentials. Values are
+      # Render-managed secrets set in the dashboard (out of band) — same
+      # sync:false pattern as other secrets. URL is the Grafana Cloud
+      # remote_write endpoint; USER is the numeric instance id; PASSWORD is a
+      # Grafana Cloud API token with metrics-push scope.
+      - key: GRAFANA_CLOUD_PROM_URL
+        sync: false
+      - key: GRAFANA_CLOUD_PROM_USER
+        sync: false
+      - key: GRAFANA_CLOUD_PROM_PASSWORD
+        sync: false
+
 databases:
   # ── Staging Postgres ───────────────────────────────────────────────────────
   # Free plan — staging data is expendable; recreation is a feature (#585).


### PR DESCRIPTION
## Summary

Closes the cloud **app-metrics** path from #1208 (design `docs/design/metrics-observability.md` §6.2). The API ships `/metrics` (#1242/#1249: JVM/runtime + HikariCP + rollup metrics behind a bearer scrape token) but nothing scrapes it. This adds a **Grafana Alloy** (Prometheus agent-mode) collector on Render that scrapes each API's **internal** address and `remote_write`s to Grafana Cloud Prometheus.

- **`render.yaml`** — new `wifihaven-alloy` worker (`runtime: docker`, `plan: starter`, `region: oregon`, `autoDeploy: no`). Built from the in-repo Dockerfile because a `runtime: image` service can't mount our checked-in config.
- **`deploy/alloy/config.alloy`** — two `prometheus.scrape` jobs (prod + staging) + one `prometheus.remote_write` to Grafana Cloud. Minimal and reviewable.
- **`deploy/alloy/Dockerfile`** — thin image `FROM grafana/alloy:v1.5.1` that bakes `config.alloy` in.

### Scrape targets (internal only — never the public domain)
- `http://wifihaven-api-prod:8080/metrics`
- `http://wifihaven-api-staging:8080/metrics`

`Authorization: Bearer <token>` is sent on each scrape. The tokens are pulled from each API service's generated `WIFIHAVEN_METRICS_SCRAPE_TOKEN` (#1242) via `fromService`, so they stay in sync without being committed or hand-copied — no new token env var was needed on the API side; #1242 already wired it as `generateValue: true` on both API services.

### remote_write target
- `GRAFANA_CLOUD_PROM_URL` (Grafana Cloud Prometheus remote_write endpoint), with HTTP basic auth `GRAFANA_CLOUD_PROM_USER` (numeric instance id) / `GRAFANA_CLOUD_PROM_PASSWORD` (push-scoped API token).

### Secrets (declared `sync: false`, values set in the Render dashboard out of band)
- `GRAFANA_CLOUD_PROM_URL`
- `GRAFANA_CLOUD_PROM_USER`
- `GRAFANA_CLOUD_PROM_PASSWORD`

The two scrape-token vars (`WIFIHAVEN_METRICS_SCRAPE_TOKEN_{PROD,STAGING}`) are **not** dashboard secrets — they resolve automatically via `fromService`.

## Non-critical by design
The Alloy worker is independent of the API: no API job depends on it and it depends on no API job. A metrics outage cannot block an API deploy or affect API availability (design §6.2). It is also independent of #1244 (Render-native OTel stream for **infra** metrics) — two producers, one Grafana Cloud stack. This PR does not touch #1244's path.

## Acceptance for this PR
Reviewable `render.yaml` + `config.alloy` that pass the `render-blueprint` lint (validated locally with the same `ruby -ryaml YAML.load_file` the CI job runs). Live end-to-end verification (series visible in Grafana Cloud) happens **after** the operator sets the three Grafana Cloud secrets in the Render dashboard.

## Sequencing
CD is currently broken by #1259 (reusable-workflow permission escalation in the CD callers); a fix PR is queued. This PR can merge in parallel but **won't deploy until #1259 lands and CD is green** — do not expect a green CD deploy here until then.

Refs #1208.