### PR TITLE
Honor the requested usage bucket at any range (#1262)

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -537,67 +537,51 @@ object UsageRoutes {
   // 1m/apex/app are rejected with typed errors per #846.
   // ── #813 source-tier routing ──────────────────────────────────────────────
   //
-  // Pick which table backs the aggregated path based on window width.
-  // Document boundaries:
-  //   ≤ 24h           → traffic_reports (5-min raw rows)
-  //   > 24h and ≤ 14d → traffic_hourly
-  //   > 14d           → traffic_daily
-  //
-  // An explicit `bucket=` overrides the window-width pick by demanding at
-  // least that granularity, but only when feasible: asking for `bucket=10m`
-  // on a 30-day window auto-promotes to 1h and sets the response header
-  // `X-Bucket-Promoted-From: 10m` so the SPA can surface a notice (#814 will
-  // own the UX). We auto-promote rather than 400 because the SPA currently
-  // sends bucket strictly from a static dropdown — silent promotion is more
-  // forgiving than a hard reject during the rollout.
+  // #1262: bucket and range are independent client choices. The requested
+  // bucket is ALWAYS honored at its width — the range never coarsens it. The
+  // range only influences which physical table backs the read, and only ever
+  // toward a *finer* source (raw), never a coarser one. Concretely the source
+  // is the finer of:
+  //   - the bucket's correctness cap: the coarsest table that can still render
+  //     the requested width (raw/1m/10m → raw, 1h/12h → hourly, 1d/1w → daily).
+  //     Reading anything coarser would lose resolution — that was the old
+  //     promotion bug. Shared with the connection-events endpoint via
+  //     wifihaven.shared.BucketPolicy so the two can't drift.
+  //   - the window's cost preference: a wide window justifies a coarser rollup
+  //     so the read touches ~50 rows per host instead of millions.
+  // Examples: bucket=10m over 30d → raw (fine, paginated); bucket=1h over a 2h
+  // window → raw (fresh); bucket=1d over 90d → daily rollup (cheap).
   private enum SourceTier {
     case Raw, Hourly, Daily
   }
 
-  // Finest bucket each tier can serve. Anything finer must be promoted.
-  private def minBucketFor(t: SourceTier): UsageTraffic.Bucket = t match {
-    case SourceTier.Raw    => UsageTraffic.Bucket.Raw // 5m
-    case SourceTier.Hourly => UsageTraffic.Bucket.OneHour
-    case SourceTier.Daily  => UsageTraffic.Bucket.OneDay
+  private def coarseness(t: SourceTier): Int = t match {
+    case SourceTier.Raw    => 0
+    case SourceTier.Hourly => 1
+    case SourceTier.Daily  => 2
   }
 
-  // Ordered fine-to-coarse so "promote to next coarser" is just an index step.
-  private val bucketRank: List[UsageTraffic.Bucket] = List(
-    UsageTraffic.Bucket.Raw,
-    UsageTraffic.Bucket.OneMin,
-    UsageTraffic.Bucket.TenMin,
-    UsageTraffic.Bucket.OneHour,
-    UsageTraffic.Bucket.TwelveHour,
-    UsageTraffic.Bucket.OneDay,
-    UsageTraffic.Bucket.OneWeek,
-  )
+  // Coarsest table that can render `b` without losing resolution (the cap).
+  private def bucketTier(b: UsageTraffic.Bucket): SourceTier =
+    BucketPolicy.grainForBucket(b.code) match {
+      case BucketGrain.Raw    => SourceTier.Raw
+      case BucketGrain.Hourly => SourceTier.Hourly
+      case BucketGrain.Daily  => SourceTier.Daily
+    }
 
-  private case class TierPick(
-      tier: SourceTier,
-      effectiveBucket: UsageTraffic.Bucket,
-      promotedFrom: Option[UsageTraffic.Bucket],
-  )
+  // Coarseness the window justifies on cost grounds — only the *cost* input to
+  // `pickTier`; it never coarsens the bucket itself.
+  private def windowTier(window: java.time.Duration): SourceTier = {
+    val hours = window.toHours
+    if (hours <= 24) SourceTier.Raw
+    else if (hours <= 14 * 24) SourceTier.Hourly
+    else SourceTier.Daily
+  }
 
-  private def pickTier(
-      requested: UsageTraffic.Bucket,
-      window: java.time.Duration,
-  ): TierPick = {
-    val hours            = window.toHours
-    val tier: SourceTier =
-      if (hours <= 24) SourceTier.Raw
-      else if (hours <= 14 * 24) SourceTier.Hourly
-      else SourceTier.Daily
-    // Tier is window-driven. The request's `bucket=` controls the *displayed*
-    // bucket, not the data source. If the request asks for finer fidelity
-    // than the chosen tier can provide (e.g. bucket=10m on a 30-day window),
-    // we promote it to the tier's finest bucket and signal via the
-    // X-Bucket-Promoted-From response header — silent promotion is gentler
-    // than a 400 while #814 is still rolling out the SPA gating.
-    val minBucket        = minBucketFor(tier)
-    val requestedRank    = bucketRank.indexOf(requested)
-    val minRank          = bucketRank.indexOf(minBucket)
-    if (requestedRank >= minRank) TierPick(tier, requested, None)
-    else TierPick(tier, minBucket, Some(requested))
+  private def pickTier(b: UsageTraffic.Bucket, window: java.time.Duration): SourceTier = {
+    val cap  = bucketTier(b)
+    val pref = windowTier(window)
+    if (coarseness(pref) <= coarseness(cap)) pref else cap
   }
 
   // Convert rollup rows back into the shape buildAggregate consumes. The
@@ -683,10 +667,11 @@ object UsageRoutes {
         .fail(Response.badRequest("from must be < to"))
         .when(!fromI.isBefore(toI))
       // #862/#809: the prior 31-day window cap is gone. The aggregated path
-      // now routes wide windows to traffic_hourly / traffic_daily (see
-      // `pickTier` below) so a 90-day query reads ~50 daily rows per host
-      // instead of millions of 5-min rows. The raw path still pushes keyset
-      // paging into SQL so its wide-window cost stays bounded by the page cap.
+      // routes coarse buckets to traffic_hourly / traffic_daily (see
+      // `tierForBucket` below) so a 90-day, 1d query reads ~50 daily rows per
+      // host instead of millions of 5-min rows. A fine bucket reads raw at any
+      // range, with keyset paging keeping its wide-window cost bounded by the
+      // page cap.
       // #865: mac and profileId are comma-separated multi-value lists. A
       // single value still works ("mac=aa:bb:cc:dd:ee:01"). Empty/absent =
       // no filter on that column.
@@ -802,33 +787,30 @@ object UsageRoutes {
                     ),
                   )
                 }
-          } yield (
-            TrafficUsageResponse(
-              bucket = bucket.code,
-              groupBy = Nil,
-              from = fromI.toString,
-              to = toI.toString,
-              tz = zone.getId,
-              rawRows = built,
-              aggregateRows = Nil,
-              rawRowLimit = Some(rawLimit),
-              rawRowsTruncated = false,
-              nextCursor = nextCur,
-            ),
-            Option.empty[UsageTraffic.Bucket],
+          } yield TrafficUsageResponse(
+            bucket = bucket.code,
+            groupBy = Nil,
+            from = fromI.toString,
+            to = toI.toString,
+            tz = zone.getId,
+            rawRows = built,
+            aggregateRows = Nil,
+            rawRowLimit = Some(rawLimit),
+            rawRowsTruncated = false,
+            nextCursor = nextCur,
           )
         case _                       =>
-          // Aggregated path: pick the smallest table that can serve the
-          // requested window (#813). Fall back to in-app bucketing on the
-          // chosen rows — the rollup tables store hourly / daily sums so the
-          // 90-day case touches ~50 rows per host, not millions.
-          val pick = pickTier(bucket, Duration.between(fromI, toI))
+          // Aggregated path: source table = finer of (bucket cap, window cost
+          // preference) (#1262). The requested bucket is always honored; the
+          // range can only steer the read toward finer/fresher data, never
+          // coarsen the bucket.
+          val tier = pickTier(bucket, Duration.between(fromI, toI))
           for {
             rows      <-
               if (macs.isEmpty && (macsRaw.nonEmpty || profileIds.nonEmpty))
                 ZIO.succeed(List.empty[wifihaven.api.usage.TrafficUsageDbRow])
               else
-                pick.tier match {
+                tier match {
                   case SourceTier.Raw    =>
                     trafficRepo
                       .listRawInRange(macs, fromI, toI)
@@ -856,7 +838,7 @@ object UsageRoutes {
             allAgg = UsageTraffic
               .buildAggregate(
                 rows,
-                pick.effectiveBucket,
+                bucket,
                 zone,
                 effectiveGroupBy,
                 devByMac,
@@ -884,23 +866,16 @@ object UsageRoutes {
                     wifihaven.api.db.Cursor.AggCursor(r.windowStart, keyOf(r)),
                   )
                 }
-          } yield (
-            TrafficUsageResponse(
-              bucket = pick.effectiveBucket.code,
-              groupBy = effectiveGroupBy.toList.map(_.code).sorted,
-              from = fromI.toString,
-              to = toI.toString,
-              tz = zone.getId,
-              rawRows = Nil,
-              aggregateRows = page,
-              nextCursor = nextCur,
-            ),
-            pick.promotedFrom,
+          } yield TrafficUsageResponse(
+            bucket = bucket.code,
+            groupBy = effectiveGroupBy.toList.map(_.code).sorted,
+            from = fromI.toString,
+            to = toI.toString,
+            tz = zone.getId,
+            rawRows = Nil,
+            aggregateRows = page,
+            nextCursor = nextCur,
           )
       }
-    } yield {
-      val (body, promotedFrom) = resp
-      val base                 = Response.json(body.toJson)
-      promotedFrom.fold(base)(b => base.addHeader("X-Bucket-Promoted-From", b.code))
-    }
+    } yield Response.json(resp.toJson)
 }

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -17,17 +17,20 @@ import zio.test.*
 
 import java.time.ZoneOffset
 
-// #813: window-driven source-tier routing. The aggregated path of
-// /api/usage/traffic picks the smallest table that can serve the requested
-// window:
-//   ≤ 24h           → traffic_reports (5-min raw)
-//   > 24h and ≤ 14d → traffic_hourly
-//   > 14d           → traffic_daily
+// #813/#1262: BUCKET-driven source-tier routing. The aggregated path of
+// /api/usage/traffic picks the table from the requested bucket, never from the
+// window — bucket and range are independent client choices:
+//   raw / 1m / 10m → traffic_reports (5-min raw)
+//   1h / 12h       → traffic_hourly
+//   1d / 1w        → traffic_daily
+//
+// #1262: a wide window must NOT coarsen the caller's bucket. A fine bucket over
+// a 30-day window is served from raw (bounded by keyset pagination), at the
+// requested width, with no `X-Bucket-Promoted-From` promotion.
 //
 // These tests pre-populate the rollup tables (via the same `rerollHourly` /
 // `rerollDaily` repo calls the scheduled fibers use) and then verify the
-// endpoint reads from the right tier by checking response shape and the
-// `X-Bucket-Promoted-From` header on too-fine-for-tier requests.
+// endpoint reads from the tier the bucket selects.
 object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
   override val bootstrap =
@@ -103,8 +106,8 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       .mapError(e => new RuntimeException(e.toString))
       .map(_.token.value)
 
-  def spec = suite("/api/usage/traffic source-tier routing (#813)")(
-    test("7-day window reads traffic_hourly (rollup seeded → results > 0)") {
+  def spec = suite("/api/usage/traffic bucket-driven source-tier routing (#813/#1262)")(
+    test("bucket=1h reads traffic_hourly (rollup seeded → results > 0)") {
       val today = TestClock.schoolDayAfternoon.toLocalDate
       val from  = today.minusDays(7).atStartOfDay(ZoneOffset.UTC).toInstant
       val to    = today.atStartOfDay(ZoneOffset.UTC).toInstant
@@ -124,7 +127,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         rb     <- buildRoutes
         (routes, auth) = rb
         token <- loginAdmin(auth)
-        // 7-day window, bucket=1h → tier=Hourly.
+        // bucket=1h → tier=Hourly (independent of the 7-day window).
         url = URL
           .decode(
             s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=1h&groupBy=domain",
@@ -141,7 +144,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         resp.headers.get("X-Bucket-Promoted-From").isEmpty,
       )
     },
-    test("30-day window reads traffic_daily") {
+    test("bucket=1d reads traffic_daily") {
       val today = TestClock.schoolDayAfternoon.toLocalDate
       val from  = today.minusDays(30).atStartOfDay(ZoneOffset.UTC).toInstant
       val to    = today.atStartOfDay(ZoneOffset.UTC).toInstant
@@ -175,7 +178,13 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         out.aggregateRows.nonEmpty,
       )
     },
-    test("30-day window with bucket=10m auto-promotes and sets X-Bucket-Promoted-From") {
+    // #1262 regression: bucket and range are independent. A 10m bucket over a
+    // 30-day window must stay 10m and be served from raw — NOT promoted to the
+    // daily tier's 1d the way the old window-driven routing did. Seeds an hour
+    // of raw rows inside the window so the served grain is observable: 10-min
+    // buckets ⇒ several sub-hour rows. If the bucket were coarsened to 1d this
+    // collapses to a single daily row read from the (empty) daily rollup.
+    test("bucket=10m over a 30-day window stays 10m and reads raw (no promotion)") {
       val today = TestClock.schoolDayAfternoon.toLocalDate
       val from  = today.minusDays(30).atStartOfDay(ZoneOffset.UTC).toInstant
       val to    = today.atStartOfDay(ZoneOffset.UTC).toInstant
@@ -186,13 +195,16 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         deviceRepo  <- ZIO.service[DeviceRepo]
         kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
         _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-        _           <- seedRouter
-        rb          <- buildRoutes
+        routerId    <- seedRouter
+        // 1h of 5-min raw rows on day -5, inside the 30-day window.
+        seedStart = today.minusDays(5).atStartOfDay(ZoneOffset.UTC).toInstant
+        _  <- seedRaw(routerId, seedStart, 12)
+        rb <- buildRoutes
         (routes, auth) = rb
         token <- loginAdmin(auth)
         url = URL
           .decode(
-            s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=10m",
+            s"/api/usage/traffic?mac=$testMac&from=$from&to=$to&bucket=10m&groupBy=domain",
           )
           .toOption
           .get
@@ -201,9 +213,13 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
       } yield assertTrue(
         resp.status == Status.Ok,
-        // Bucket promoted from 10m to 1d (the daily tier's finest bucket).
-        out.bucket == "1d",
-        resp.headers.get("X-Bucket-Promoted-From").exists(_.contains("10m")),
+        // Requested width is honored, never coarsened by the range.
+        out.bucket == "10m",
+        // 1h of data at 10m grain ⇒ multiple sub-hour windows (came from raw,
+        // not a single daily-rollup row).
+        out.aggregateRows.size >= 2,
+        // No silent promotion.
+        resp.headers.get("X-Bucket-Promoted-From").isEmpty,
       )
     },
   ) @@ TestAspect.sequential

--- a/shared/src/BucketPolicy.scala
+++ b/shared/src/BucketPolicy.scala
@@ -1,0 +1,33 @@
+package wifihaven.shared
+
+// #1262: on the usage-series endpoints, bucket width and time range are
+// INDEPENDENT client choices — the range must never coarsen the bucket. The
+// only range-independent decision is which storage grain can render a given
+// bucket width without losing resolution:
+//
+//   - sub-hour buckets (raw / 1m / 10m) need the raw 5-min rows
+//   - 1h / 12h buckets can be summed from the hourly rollup
+//   - 1d / 1w buckets can be summed from the daily rollup
+//
+// Both /api/usage/traffic and (once #1265 lands its connection-events rollups)
+// /api/connection-events/series classify their requested bucket through here,
+// so the two can't disagree about which tier serves a width. This is the
+// single shared mapping that keeps them from drifting — and it is keyed on the
+// bucket, not the window.
+enum BucketGrain {
+  case Raw, Hourly, Daily
+}
+
+object BucketPolicy {
+
+  /**
+   * Coarsest storage grain that can render `bucketCode` without losing resolution. Keyed on the
+   * requested bucket width alone — the time range is irrelevant. Unknown/finer codes fall back to
+   * Raw (the only grain that can serve arbitrary fine widths).
+   */
+  def grainForBucket(bucketCode: String): BucketGrain = bucketCode match {
+    case "1h" | "12h" => BucketGrain.Hourly
+    case "1d" | "1w"  => BucketGrain.Daily
+    case _            => BucketGrain.Raw
+  }
+}

--- a/shared/test/src/BucketPolicySpec.scala
+++ b/shared/test/src/BucketPolicySpec.scala
@@ -1,0 +1,29 @@
+package wifihaven.shared
+
+import zio.test.*
+
+// #1262: the shared bucket->storage-grain classification both usage-series
+// endpoints route through. Keyed on the requested bucket alone — the time
+// range is never an input — so the two endpoints can't disagree about which
+// tier serves a width.
+object BucketPolicySpec extends ZIOSpecDefault {
+
+  private def grain(code: String, expected: BucketGrain) =
+    test(s"$code -> $expected") {
+      assertTrue(BucketPolicy.grainForBucket(code) == expected)
+    }
+
+  def spec = suite("BucketPolicy.grainForBucket")(
+    grain("raw", BucketGrain.Raw),
+    grain("1m", BucketGrain.Raw),
+    grain("10m", BucketGrain.Raw),
+    grain("1h", BucketGrain.Hourly),
+    grain("12h", BucketGrain.Hourly),
+    grain("1d", BucketGrain.Daily),
+    grain("1w", BucketGrain.Daily),
+    // Unknown/finer codes fall back to Raw — the only grain that can serve an
+    // arbitrary fine width.
+    grain("5m", BucketGrain.Raw),
+    grain("", BucketGrain.Raw),
+  )
+}


### PR DESCRIPTION
Fixes #1262.

## The bug

`/api/usage/traffic`'s aggregated path chose its rollup tier from the **time
window** (`≤24h → raw`, `≤14d → hourly`, else `daily`) and then **promoted
(coarsened) the caller's bucket** to that tier's finest width, signalling via an
`X-Bucket-Promoted-From` header. So `bucket=10m` over a 30-day window silently
came back as `1d`. The bucket and the range are meant to be **independent client
choices** — the range must never coarsen the bucket.

The connection-events series endpoint (`/api/connection-events/series`) doesn't
have this problem: it bins raw rows with `date_bin` at exactly the requested
width, for any range. That's the behavior traffic should have too. The thing
"that should be shared but isn't" is the classification of *which storage grain
can faithfully render a given bucket width* — traffic had it tangled up with
window-based tier routing; connection-events had no rollups so it never needed
it.

## The fix

1. **The requested bucket is always honored** at its width. No promotion, no
   `X-Bucket-Promoted-From` header.
2. **The source table is the *finer* of two inputs**, so the range can only
   ever steer the read toward finer/fresher data, never coarsen the bucket:
   - **bucket correctness cap** — the coarsest table that can still render the
     requested width without losing resolution. This is the new shared
     `wifihaven.shared.BucketPolicy.grainForBucket`: `raw/1m/10m → raw`,
     `1h/12h → hourly`, `1d/1w → daily`.
   - **window cost preference** — a wide window justifies a coarser rollup so
     the read touches ~50 rows per host instead of millions.

   Examples: `bucket=10m` over 30d → **raw** (fine, keyset-paginated, per the
   chosen behavior for the expensive corner); `bucket=1h` over a 2h window →
   **raw** (fresh, no rollup lag); `bucket=1d` over 90d → **daily rollup**
   (cheap).

`grainForBucket` is the single bucket→grain mapping. Connection-events already
honors any bucket for any range, and will route through this same
classification once its rollups land (#1265), so the two endpoints can't drift.

## Shared mapping location

- `shared/src/BucketPolicy.scala` — `BucketGrain` + `grainForBucket` (keyed on
  the bucket alone; the range is never an input).
- `api/src/routes/UsageRoutes.scala` — `pickTier` = finer of `bucketTier`
  (uses `grainForBucket`) and `windowTier` (cost).

## Red → green (visible in history)

- `fa81a974` — failing regression test: `bucket=10m` over a 30-day window must
  stay `10m`, be served from raw (several sub-hour rows), and carry no
  promotion header. Fails against the old window-driven routing.
- `468cda2c` — implementation; the test passes, and the old
  "auto-promotes / sets X-Bucket-Promoted-From" assertion is replaced.

## Tests

- `shared/test/src/BucketPolicySpec.scala` — pins every bucket→grain case.
- `UsageRoutingSpec` — `bucket=1h` → hourly rollup, `bucket=1d` → daily rollup,
  and the `bucket=10m`-over-30d regression.
- Full `mill api.test` + `mill shared.test` green; `scalafmt` clean.

## Note

CD is currently down (#1259), so the usual post-merge deploy automation may not
fire on this PR — flagging so the merge isn't assumed to have deployed.