### PR TITLE
db: connection_events hourly/daily rollup tables (#1265, schema PR 1/2)

### DIFF
--- a/api/resources/db/migration/V47__connection_events_rollups.sql
+++ b/api/resources/db/migration/V47__connection_events_rollups.sql
@@ -1,0 +1,160 @@
+-- V47__connection_events_rollups.sql
+-- #1265 (sub-issue of #844; deferred in #847): pre-aggregated rollup tier for
+-- the Connection Events page, mirroring the traffic rollup track (V38 / #809).
+--
+-- Today ConnectionEventRepo.querySeries runs `date_bin(...)` + GROUP BY against
+-- the raw, unbounded-growth `connection_events` table on every request. Wide
+-- windows (the 90-day Connection Events view) scan millions of rows. The fix is
+-- the same two-tier rollup that traffic uses: an hourly and a daily table that
+-- the read path routes to once the requested window is wider than a few hours
+-- (the #1262 shared range→bucket-width mapping; routing lands in the follow-up
+-- code PR, NOT here — this is the schema-only migration per AGENTS.md
+-- #migrations-back-compat).
+--
+-- ── Schema decision: SPLIT count columns, `allowed` NOT in the PK ───────────
+-- The issue offered two shapes: (a) `allowed` in the PK so a row is per
+-- (…, bucket_start, allowed), or (b) split `count_succeeded` / `count_blocked`
+-- columns so a row is per (…, bucket_start). We pick (b) — split columns.
+-- Rationale: querySeries already projects exactly these two values via
+--   COUNT(*) FILTER (WHERE ce.allowed)     AS count_succeeded
+--   COUNT(*) FILTER (WHERE NOT ce.allowed) AS count_blocked
+-- so the rollup read path can SUM(count_succeeded) / SUM(count_blocked) per
+-- bucket with no GROUP-BY collapse over an `allowed` dimension, and the
+-- allowed/blocked split survives a re-roll without doubling the row count. It
+-- also keeps the PK identical in arity to V38's traffic rollups, so the read
+-- routing, retention, and rollup_runs wiring stay structurally the same.
+--
+-- ── Stored dimensions ───────────────────────────────────────────────────────
+-- Per #1265 §3 the rollup stores only (router_id, mac, hostname, bucket). The
+-- Connection Events page's device / profile / app attribution all derive from a
+-- READ-TIME join off `mac` (devices→profiles) or a read-time apex match off the
+-- hostname (apps), exactly as querySeries does today and exactly as the traffic
+-- rollups do — so those columns are NOT stored here. `hostname` is the
+-- post-resolved host: COALESCE(resolved_host_value, host_value), resolved once
+-- at roll-write time so the read path stays join-free for the host dimension.
+-- Location filtering is `routers.name`, reached by joining `routers` on the
+-- stored `router_id`.
+--
+-- ── Idempotency ─────────────────────────────────────────────────────────────
+-- Strictly UPSERT-keyed, same contract as V38. The follow-up code PR's hourly
+-- fiber re-rolls the trailing N hours every tick; the daily fiber re-rolls the
+-- previous + current day. Re-rolling an already-rolled bucket replaces the row
+-- with an identical value when the source hasn't moved.
+--
+-- ── Lock behavior ───────────────────────────────────────────────────────────
+-- Plain CREATE INDEX; the tables are empty at migration time so the indexes
+-- build instantly. No long lock, no critical-path scan here (see the backfill
+-- note at the bottom — the historical backfill is deliberately NOT run on the
+-- Flyway startup path).
+
+-- ── connection_events_hourly ────────────────────────────────────────────────
+-- `mac` is NOT NULL here even though connection_events.mac is nullable: it is a
+-- PK column, and un-attributed (NULL-mac) events are folded into a '' bucket by
+-- the reroll's COALESCE(ce.mac, '') so no counts are dropped and the empty-
+-- groupBy window totals stay faithful to raw.
+CREATE TABLE connection_events_hourly (
+  router_id       UUID         NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  mac             TEXT         NOT NULL,
+  hostname        TEXT         NOT NULL,
+  bucket_start    TIMESTAMPTZ  NOT NULL,
+  count_succeeded INT          NOT NULL DEFAULT 0,
+  count_blocked   INT          NOT NULL DEFAULT 0,
+  sample_count    INT          NOT NULL DEFAULT 0,
+  rolled_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (router_id, mac, hostname, bucket_start)
+);
+-- Read-path indexes — analogues of V38's on traffic_hourly. The Connection
+-- Events series filters/group-bys probe: bucket_start (window), mac (device &
+-- profile joins both hang off ce.mac), allowed (now SPLIT into columns, so no
+-- index needed), domain (ILIKE '%x%' — leading-wildcard, btree can't help, same
+-- as raw today), location (routers.name via router_id, which leads the PK).
+-- So the two V38-analogue indexes plus the PK cover the real probe set.
+CREATE INDEX idx_ce_hourly_bucket_start ON connection_events_hourly (bucket_start DESC);
+CREATE INDEX idx_ce_hourly_mac_bucket   ON connection_events_hourly (mac, bucket_start DESC);
+
+-- ── connection_events_daily ─────────────────────────────────────────────────
+CREATE TABLE connection_events_daily (
+  router_id       UUID         NOT NULL REFERENCES routers(id) ON DELETE CASCADE,
+  mac             TEXT         NOT NULL,
+  hostname        TEXT         NOT NULL,
+  date            DATE         NOT NULL,
+  count_succeeded INT          NOT NULL DEFAULT 0,
+  count_blocked   INT          NOT NULL DEFAULT 0,
+  sample_count    INT          NOT NULL DEFAULT 0,
+  rolled_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (router_id, mac, hostname, date)
+);
+CREATE INDEX idx_ce_daily_date     ON connection_events_daily (date DESC);
+CREATE INDEX idx_ce_daily_mac_date ON connection_events_daily (mac, date DESC);
+
+-- ── rollup_runs observability ───────────────────────────────────────────────
+-- Reuse the existing V38 rollup_runs table (no schema change). The follow-up
+-- code PR's fibers append rows under the job names
+--   connection_events_hourly / connection_events_daily
+-- and the one-shot operator backfill below uses
+--   backfill_connection_events_hourly / backfill_connection_events_daily.
+-- /api/admin/rollup-status already reads the last N runs regardless of job name.
+
+-- ── Historical backfill — OPERATOR-APPLIED, OUT-OF-BAND. DO NOT UNCOMMENT. ───
+-- AGENTS.md #migrations-prod-data-volume: `connection_events` is an
+-- unbounded-growth event table. A full-history aggregation scans every row.
+-- Against the empty embedded Postgres in tests this is milliseconds; against
+-- prod it is MINUTES, and Flyway runs on the API startup critical path, so an
+-- inline backfill here risks blowing Render's 15-minute port-scan deploy
+-- timeout — the exact failure mode of #1197 (the V41/V42 partition migrations
+-- whose "this is seconds" comment was measured on dev/staging and was false at
+-- prod scale). So unlike V38, the backfill is NOT inlined and NOT run on
+-- startup.
+--
+-- Going-forward population is handled entirely by the reroll fibers (follow-up
+-- PR). For historical rows, the operator runs the block below out-of-band
+-- (deploy quiesced / off the startup path), AFTER sizing it against the live
+-- `connection_events` row count. The source scan is a bounded range scan per
+-- bucket-grain via the existing idx_conn_events_ts (ts DESC) / idx_conn_events_
+-- mac_ts (mac, ts DESC) — confirm with EXPLAIN (ANALYZE) against prod-like
+-- volume before running (#1261).
+--
+-- INSERT INTO connection_events_hourly
+--   (router_id, mac, hostname, bucket_start,
+--    count_succeeded, count_blocked, sample_count, rolled_at)
+-- SELECT
+--   ce.router_id,
+--   COALESCE(ce.mac, '')                                   AS mac,
+--   COALESCE(ce.resolved_host_value, ce.host_value)        AS hostname,
+--   date_bin(INTERVAL '1 hour', ce.ts, TIMESTAMP '2000-01-01 00:00:00') AS bucket_start,
+--   COUNT(*) FILTER (WHERE ce.allowed)::INT                 AS count_succeeded,
+--   COUNT(*) FILTER (WHERE NOT ce.allowed)::INT             AS count_blocked,
+--   COUNT(*)::INT                                           AS sample_count,
+--   NOW()
+-- FROM connection_events ce
+-- -- size before running: add `WHERE ce.ts >= '<start>'` to bound the scan
+-- GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+--          COALESCE(ce.resolved_host_value, ce.host_value),
+--          date_bin(INTERVAL '1 hour', ce.ts, TIMESTAMP '2000-01-01 00:00:00')
+-- ON CONFLICT (router_id, mac, hostname, bucket_start) DO UPDATE SET
+--   count_succeeded = EXCLUDED.count_succeeded,
+--   count_blocked   = EXCLUDED.count_blocked,
+--   sample_count    = EXCLUDED.sample_count,
+--   rolled_at       = EXCLUDED.rolled_at;
+--
+-- INSERT INTO connection_events_daily
+--   (router_id, mac, hostname, date,
+--    count_succeeded, count_blocked, sample_count, rolled_at)
+-- SELECT
+--   ce.router_id,
+--   COALESCE(ce.mac, '')                                   AS mac,
+--   COALESCE(ce.resolved_host_value, ce.host_value)        AS hostname,
+--   (ce.ts AT TIME ZONE 'UTC')::DATE                        AS date,
+--   COUNT(*) FILTER (WHERE ce.allowed)::INT                 AS count_succeeded,
+--   COUNT(*) FILTER (WHERE NOT ce.allowed)::INT             AS count_blocked,
+--   COUNT(*)::INT                                           AS sample_count,
+--   NOW()
+-- FROM connection_events ce
+-- GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+--          COALESCE(ce.resolved_host_value, ce.host_value),
+--          (ce.ts AT TIME ZONE 'UTC')::DATE
+-- ON CONFLICT (router_id, mac, hostname, date) DO UPDATE SET
+--   count_succeeded = EXCLUDED.count_succeeded,
+--   count_blocked   = EXCLUDED.count_blocked,
+--   sample_count    = EXCLUDED.sample_count,
+--   rolled_at       = EXCLUDED.rolled_at;

--- a/api/resources/db/migration/V47__connection_events_rollups.sql
+++ b/api/resources/db/migration/V47__connection_events_rollups.sql
@@ -96,15 +96,19 @@ CREATE INDEX idx_ce_daily_mac_date ON connection_events_daily (mac, date DESC);
 -- /api/admin/rollup-status already reads the last N runs regardless of job name.
 
 -- ── Historical backfill — OPERATOR-APPLIED, OUT-OF-BAND. DO NOT UNCOMMENT. ───
--- AGENTS.md #migrations-prod-data-volume: `connection_events` is an
--- unbounded-growth event table. A full-history aggregation scans every row.
--- Against the empty embedded Postgres in tests this is milliseconds; against
--- prod it is MINUTES, and Flyway runs on the API startup critical path, so an
--- inline backfill here risks blowing Render's 15-minute port-scan deploy
--- timeout — the exact failure mode of #1197 (the V41/V42 partition migrations
--- whose "this is seconds" comment was measured on dev/staging and was false at
--- prod scale). So unlike V38, the backfill is NOT inlined and NOT run on
--- startup.
+-- `connection_events` is weekly RANGE-partitioned (V42 / #806) and capped to
+-- ~30 days by the #811 retention sweep (RetentionSweepJob.EventsRetentionDays),
+-- so a backfill scans at most ~30 days of rows — NOT all history. (AGENTS.md
+-- #migrations-prod-data-volume lists it as "unbounded-growth", but that
+-- describes the ingest rate; retention bounds the stored size a scan touches,
+-- and that's the dimension that drives backfill cost.) Even so, ~30 days at
+-- prod connection rates is a single large GROUP-BY pass that can run MINUTES,
+-- and Flyway executes migrations on the API startup critical path — so an
+-- inline backfill here would risk Render's 15-minute port-scan deploy timeout
+-- (the failure mode of #1197, where the V41/V42 partition migrations' "this is
+-- seconds" comment held on dev/staging but not at prod scale). So unlike V38,
+-- the backfill is NOT inlined and NOT run on startup; it stays operator-applied
+-- and off-path defensively.
 --
 -- Going-forward population is handled entirely by the reroll fibers (follow-up
 -- PR). For historical rows, the operator runs the block below out-of-band
@@ -112,7 +116,8 @@ CREATE INDEX idx_ce_daily_mac_date ON connection_events_daily (mac, date DESC);
 -- `connection_events` row count. The source scan is a bounded range scan per
 -- bucket-grain via the existing idx_conn_events_ts (ts DESC) / idx_conn_events_
 -- mac_ts (mac, ts DESC) — confirm with EXPLAIN (ANALYZE) against prod-like
--- volume before running (#1261).
+-- volume before running (#1261). Note the daily rollup can only be seeded ~30
+-- days deep from raw; its 180-day horizon fills forward via the fibers.
 --
 -- INSERT INTO connection_events_hourly
 --   (router_id, mac, hostname, bucket_start,


### PR DESCRIPTION
## Summary

Schema-only migration (PR 1 of 2) for the connection-events rollup tier from #1265 — the tier deferred in #847 and never filed, while the traffic side got the full #809/#813/#814 track. Mirrors the V38 traffic rollups.

Per **AGENTS.md #migrations-back-compat**, a migration PR may contain only `.sql` + `.md`. This PR is one `.sql` file. The code that adopts the schema — reroll fibers, `querySeries` window-width routing via the shared #1262 `BucketPolicy`, and the retention-sweep extension — lands in **PR 2**, stacked on this branch.

## Schema decision: split count columns (not `allowed` in the PK)

`connection_events_hourly` (`bucket_start`) and `connection_events_daily` (`date`), both keyed `(router_id, mac, hostname, bucket)` with **split `count_succeeded` / `count_blocked`** columns rather than `allowed` in the key. `ConnectionEventRepo.querySeries` already projects exactly these two values via `COUNT(*) FILTER (WHERE ce.allowed)` / `FILTER (WHERE NOT ce.allowed)`, so the rollup read path can `SUM` both per bucket with no GROUP-BY collapse over an `allowed` dimension, and the split survives a re-roll without doubling rows. Carries `sample_count`, `rolled_at`. `mac` is `NOT NULL` (PK column); un-attributed NULL-mac events fold into a `''` bucket via `COALESCE(ce.mac,'')` so window totals stay faithful to raw.

Device / profile / app attribution stays a read-time join off `mac` (and an apex match off the hostname), exactly as `querySeries` and the traffic rollups do — so those columns are not stored.

`rollup_runs` (V38) is reused unchanged; the follow-up fibers append under `connection_events_hourly` / `connection_events_daily`.

## Indexes — verified, not repeating the #1254 / V38 misses

EXPLAIN (ANALYZE, BUFFERS) against ~500k seeded `connection_events` (40 days, 50 macs, 200 hosts) + populated rollups:

- **Read-path** (mirrors V38): `(bucket_start DESC)`, `(mac, bucket_start DESC)`, `(date DESC)`, `(mac, date DESC)`. Confirmed `idx_ce_daily_mac_date` backs the mac+date filtered read (Bitmap Index Scan, Index Cond on both cols) and `idx_ce_hourly_bucket_start` backs the narrow-window read. The 90-day full read seq-scans the small rollup table — expected, that's the rollup payoff. The real `querySeries` probe set is `mac` (device+profile joins both hang off `ce.mac`), `bucket_start`/`date` (window), and `router_id` (location via `routers.name`, leads the PK); `allowed` is now split columns and `domain` is a leading-wildcard `ILIKE` no btree can serve — so these indexes cover it.
- **Reroll source scan** over the unbounded `connection_events` is the #1254 class. A trailing-2h reroll partition-prunes to just the current-week partition and uses a Bitmap Index Scan on `ts` (`connection_events_<wk>_ts_idx`, the existing `idx_conn_events_ts`) — **never a full-table scan**. `(mac, ts)` (`idx_conn_events_mac_ts`) is also already present. No new index needed on the source table.

## Prod-data-volume caveat (AGENTS.md #migrations-prod-data-volume)

The full-history backfill scans all of `connection_events` (unbounded growth) → **minutes at prod scale, not the ms it takes on empty embedded Postgres** (cf. #1197, which blew Render's 15-min port-scan deploy timeout). So unlike V38 it is **not inlined and not run on the Flyway startup critical path** — it ships as a commented operator-applied block to run out-of-band after sizing against the live row count. Going-forward population is entirely the reroll fibers' job (PR 2).

## Test plan

- [x] All migrations V1→V47 apply cleanly in order against Postgres 16.
- [x] Reroll source scan is index-backed + partition-pruned (Bitmap Index Scan on `ts`, current-week partition only).
- [x] Routed reads index-backed (`idx_ce_daily_mac_date`, `idx_ce_hourly_bucket_start`).
- [x] PR contains only the migration `.sql` — passes `check-migration-isolation.sh`.
- [ ] CI `api.test` (the back-compat gate): image-(N-1) code drives DB-at-V47.

Refs #1265. Umbrella #844; deferred in #847; traffic precedent #809/#813/#814; retention #811; index/prod-volume lessons #1254/#1197/#1261; surfaced by #1262.