### PR TITLE
Bump wifihaven-api-staging from free to starter plan (#1268)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,7 +30,14 @@ services:
   - type: web
     runtime: image
     name: wifihaven-api-staging
-    plan: free
+    # #1268: was `free` (512 MB / 0.1 CPU, spins down). The free tier's slow
+    # deploy cutover + 0.1-CPU starvation made the new instance miss CD's
+    # 15-min "serve the new sha" window even though the JVM itself started
+    # clean (no OOM in the deploy logs — see #1268). `starter` keeps the same
+    # 512 MB (proven sufficient with the heap below) but removes spin-down and
+    # gives 0.5 CPU. Bump to `standard` (2 GB / 1 CPU, like prod) only if OOM
+    # actually appears in the logs.
+    plan: starter
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health
@@ -72,8 +79,10 @@ services:
       # ample and stays well clear of Render's reserved connections.
       - key: WIFIHAVEN_DB_POOL_SIZE
         value: "8"
-      # #590: Render Hobby caps at ~512 MB. Leave headroom for OS + JIT +
-      # native heap; bump or move to `plan: pro` if OOM appears in logs.
+      # #590 / #1268: `starter` is 512 MB (same as the old free tier). Leave
+      # headroom for OS + JIT + native heap; this -Xmx384m envelope started
+      # clean with no OOM on free, so it carries over unchanged. Raise the heap
+      # (and move to `plan: standard`, 2 GB) only if OOM appears in logs.
       - key: JVM_HEAP_OPTS
         value: "-Xms256m -Xmx384m"
       # Staging runs DEBUG so issues are visible in the Render log stream.


### PR DESCRIPTION
Closes #1268.

## Problem

The Master API/UI CD `deploy-staging` job times out — staging keeps serving the previous sha and the new instance never goes live within CD's 15-min window. Example failing run: https://github.com/wifihaven/wifihaven/actions/runs/26726941820/job/78764175726 (`Timed out waiting for staging to serve sha=8989995`).

## Root cause — verified against the Render deploy logs (NOT OOM)

I pulled the failing deploy's logs (`dep-d8ebtmq8qa3s73bb0qh0`, deploy window 23:06–23:21 UTC) for `wifihaven-api-staging`. The JVM started **cleanly** on the existing `-Xms256m -Xmx384m` heap:

- `23:06:45` HTTP port bound
- `23:06:57` DB migrations complete
- `23:09:00` readiness flipped → `/api/health` healthy, routes ungated
- `23:09:36` Render: *"Your service is live 🎉"*

There is **no `OutOfMemoryError`, no heap exhaustion, no GC death-spiral, and no kill/restart loop** anywhere in the window. The app served health checks (`responseTimeMS=2-3`) continuously. The CD timeout came from the **`free` tier's slow, single-instance deploy cutover** (the polled sha stayed on the old instance until `23:21:10`) compounded by **0.1 CPU** and spin-down — i.e. a spin-down/CPU problem, **not memory pressure**.

## Fix

Raise `wifihaven-api-staging` `plan: free` → **`plan: starter`** in `render.yaml`.

- `starter` = **512 MB / 0.5 CPU**, no spin-down. Same RAM as the old free tier, which the logs prove was sufficient for the JVM at `-Xmx384m`, so the heap config carries over unchanged.
- This directly removes the two things that broke CD: spin-down and the 0.1-CPU starvation (now 5× the CPU).
- Comments in `render.yaml` updated (plan block + the JVM-heap note that previously said "bump to `plan: pro` if OOM") so they reflect the new tier and point at `standard` as the next step if OOM ever does appear.

### Why `starter` and not `standard`
The issue's decision rule says use `standard` (2 GB / 1 CPU) only if the logs show OOM/heap pressure, and `starter` if it's "clearly NO memory pressure and purely spin-down/CPU." The logs match the latter exactly. `starter` keeps the proven-sufficient memory envelope and is the minimal right-sized fix.

## Cost (per-service, please confirm at review)

| Tier | Resources | Monthly |
|------|-----------|---------|
| `free` (current) | 512 MB / 0.1 CPU, spins down | **$0** |
| **`starter` (this PR)** | 512 MB / 0.5 CPU | **≈ $7/mo** |
| `standard` (prod parity) | 2 GB / 1 CPU | ≈ $25/mo |

If you'd rather staging mirror prod's RAM envelope (2 GB) for prod-parity reasons despite the no-OOM evidence, switch this one line to `plan: standard` at review (+$18/mo) — I'd then also bump the heap. My recommendation, backed by the logs, is `starter`.

## Validation

- `render.yaml` parses cleanly (`ruby -ryaml -e "YAML.load_file('render.yaml')"`) — the same check the `render-blueprint` CI job runs. Both API service plans confirmed: staging=`starter`, prod=`standard`.
- Declarative infra-only change; no Scala, so no mill/scalafmt needed.

## Expected outcome

CD is healthy again (the #1259 `startup_failure` is fixed), so once this merges the next `main` deploy will actually run — and staging should come up on the new sha well inside the CD wait window, with no "still serving old sha" timeout.