### PR TITLE
api: connection_events reroll fibers + retention sweep (#1265, code PR 2/2)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -145,6 +145,15 @@ object Main extends ZIOAppDefault {
         clockForJobs <- ZIO.service[Clock]
         _            <- RollupJobs.hourlyLoop(rollupRepo, appRepoForSeed, clockForJobs).forkScoped
         _ <- RollupJobs.dailyLoop(rollupRepo, appRepoForSeed, clockForJobs, tz).forkScoped
+        // #1265: connection-event rollup tier — same cadence/lookback as the
+        // traffic rollups, re-rolling the trailing windows into
+        // connection_events_hourly / _daily. forkScoped so they're interrupted
+        // before the Hikari pool closes on shutdown.
+        connRepoForJobs <- ZIO.service[ConnectionEventRepo]
+        _ <- RollupJobs.connEventsHourlyLoop(connRepoForJobs, rollupRepo, clockForJobs).forkScoped
+        _ <- RollupJobs
+          .connEventsDailyLoop(connRepoForJobs, rollupRepo, clockForJobs, tz)
+          .forkScoped
         // #1160: per-(profile, today) `used_seconds` cache. Tick aggregates today's presence into
         // a watermarked row; the read path adds a live tail of buckets after the watermark, so
         // /api/time/status/summary serves a rollup + small live aggregation instead of a full
@@ -172,7 +181,9 @@ object Main extends ZIOAppDefault {
             clockForJobs,
           )
           .forkScoped
-        _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
+        _               <- ZIO.logInfo(
+          "rollup fibers forked (hourly + daily + time_used_daily + conn_events_hourly + conn_events_daily)",
+        )
         // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
         // for the process and never blocks startup.
         dbPool          <- ZIO.service[Database.DbPool]

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -483,6 +483,33 @@ trait ConnectionEventRepo {
       bucketSeconds: Int,
       groupBy: Set[String],
   ): Task[List[ConnectionEventAggRow]]
+
+  /**
+   * #1265: re-aggregate the trailing N hours of `connection_events` into
+   * `connection_events_hourly`. Counterpart of [[RollupRepo.rerollHourly]] but for the event-count
+   * tier. `since` is the earliest `ts` to re-roll, inclusive; callers truncate it to an hour
+   * boundary so every bucket in the window is recomputed in full. Idempotent via UPSERT keyed
+   * `(router_id, mac, hostname, bucket_start)` — re-rolling an already-rolled bucket replaces it
+   * with the freshly summed counts.
+   *
+   * Returns `Some(n)` rows touched on success, `None` when another instance held the advisory lock
+   * (skip-this-tick). The lock is transaction-scoped (`pg_try_advisory_xact_lock`) and
+   * auto-releases on commit/rollback. The source scan is bounded by `idx_conn_events_ts` plus
+   * weekly partition pruning, so a tick never scans the full unbounded table (#1254 class).
+   *
+   * Hostname is post-resolved (`COALESCE(resolved_host_value, host_value)`) so the read path stays
+   * join-free for the host dimension; device/profile/app attribution stays a read-time join off
+   * `mac`. NULL macs fold into a `''` bucket so window totals stay faithful to raw.
+   */
+  def rerollConnEventsHourly(since: Instant): Task[Option[Int]]
+
+  /**
+   * #1265: daily-grain counterpart of [[rerollConnEventsHourly]] writing `connection_events_daily`.
+   * `sinceDate` is the earliest UTC date to re-roll, inclusive. Same advisory-lock + idempotency
+   * contract.
+   */
+  def rerollConnEventsDaily(sinceDate: LocalDate): Task[Option[Int]]
+
   def stats: Task[DashboardStats]
   def topBlocked(hours: Int, limit: Int): Task[List[DomainCount]]
 
@@ -2180,6 +2207,94 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
           .to[List]
       }
       .transact(xa)
+  }
+
+  // ── Connection-event rollups (#1265) ───────────────────────────────────────
+  //
+  // The event-count analogue of RollupRepo's traffic rollups. Unlike traffic,
+  // there is NO app side table and NO resolve LATERAL: connection_events already
+  // carries resolved_host_value, and app/device/profile attribution is a
+  // read-time join. So the reroll is a single GROUP BY with split allowed/blocked
+  // FILTER counts, matching exactly what querySeries projects.
+  //
+  // The trailing-window source scan is bounded by idx_conn_events_ts (and weekly
+  // partition pruning), so a tick never seq-scans the unbounded base table.
+
+  // Run the upsert inside a tx guarded by a transaction-scoped advisory lock; if
+  // another instance holds it, commit immediately with None. The lock
+  // auto-releases on commit/rollback — no manual unlock to leak. Mirrors
+  // RollupRepoLive.withLock.
+  private def withRollupLock(key: Long)(upsert: doobie.ConnectionIO[Int]): Task[Option[Int]] = {
+    val tx = for {
+      got <- sql"SELECT pg_try_advisory_xact_lock($key)".query[Boolean].unique
+      n   <- if (got) upsert.map(Option(_)) else doobie.free.connection.pure(Option.empty[Int])
+    } yield n
+    tx.transact(xa)
+  }
+
+  // date_bin anchor matches querySeries' '2000-01-01 00:00:00' origin so rolled
+  // hourly buckets line up exactly with what the on-the-fly read computes.
+  def rerollConnEventsHourly(since: Instant): Task[Option[Int]] = {
+    val truncSince = since.truncatedTo(java.time.temporal.ChronoUnit.HOURS)
+    val sql        =
+      sql"""
+        INSERT INTO connection_events_hourly
+          (router_id, mac, hostname, bucket_start, count_succeeded, count_blocked, sample_count, rolled_at)
+        SELECT
+          ce.router_id,
+          COALESCE(ce.mac, ''),
+          COALESCE(ce.resolved_host_value, ce.host_value),
+          date_bin(INTERVAL '1 hour', ce.ts, TIMESTAMP '2000-01-01 00:00:00'),
+          COUNT(*) FILTER (WHERE ce.allowed)::INT,
+          COUNT(*) FILTER (WHERE NOT ce.allowed)::INT,
+          COUNT(*)::INT,
+          NOW()
+        FROM connection_events ce
+        WHERE ce.ts >= $truncSince
+        GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+                 COALESCE(ce.resolved_host_value, ce.host_value),
+                 date_bin(INTERVAL '1 hour', ce.ts, TIMESTAMP '2000-01-01 00:00:00')
+        ON CONFLICT (router_id, mac, hostname, bucket_start) DO UPDATE SET
+          count_succeeded = EXCLUDED.count_succeeded,
+          count_blocked   = EXCLUDED.count_blocked,
+          sample_count    = EXCLUDED.sample_count,
+          rolled_at       = EXCLUDED.rolled_at
+      """
+    withRollupLock(RollupLockKeys.ConnEventsHourly)(sql.update.run)
+  }
+
+  def rerollConnEventsDaily(sinceDate: LocalDate): Task[Option[Int]] = {
+    // Filter on raw `ts` (not a function of ts) so the source scan stays on
+    // idx_conn_events_ts + partition pruning — wrapping ts in
+    // `(ts AT TIME ZONE 'UTC')::DATE` in the predicate would force a full-table
+    // scan (#1254 class). The lower bound is sinceDate's UTC midnight; any event
+    // whose UTC date is >= sinceDate has ts >= that instant.
+    val sinceTs = sinceDate.atStartOfDay(java.time.ZoneOffset.UTC).toInstant
+    val sql     =
+      sql"""
+        INSERT INTO connection_events_daily
+          (router_id, mac, hostname, date, count_succeeded, count_blocked, sample_count, rolled_at)
+        SELECT
+          ce.router_id,
+          COALESCE(ce.mac, ''),
+          COALESCE(ce.resolved_host_value, ce.host_value),
+          (ce.ts AT TIME ZONE 'UTC')::DATE,
+          COUNT(*) FILTER (WHERE ce.allowed)::INT,
+          COUNT(*) FILTER (WHERE NOT ce.allowed)::INT,
+          COUNT(*)::INT,
+          NOW()
+        FROM connection_events ce
+        WHERE ce.ts >= $sinceTs
+        GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+                 COALESCE(ce.resolved_host_value, ce.host_value),
+                 (ce.ts AT TIME ZONE 'UTC')::DATE
+        ON CONFLICT (router_id, mac, hostname, date) DO UPDATE SET
+          count_succeeded = EXCLUDED.count_succeeded,
+          count_blocked   = EXCLUDED.count_blocked,
+          sample_count    = EXCLUDED.sample_count,
+          rolled_at       = EXCLUDED.rolled_at
+      """
+    withRollupLock(RollupLockKeys.ConnEventsDaily)(sql.update.run)
   }
 
   def stats =

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -70,8 +70,12 @@ case class RollupRun(
 // column in the rollups, written at reroll time with the current household
 // filter settings.
 object RollupLockKeys {
-  val Hourly: Long = 0x1108L << 32 | 0x0001L
-  val Daily: Long  = 0x1108L << 32 | 0x0002L
+  val Hourly: Long           = 0x1108L << 32 | 0x0001L
+  val Daily: Long            = 0x1108L << 32 | 0x0002L
+  // #1265: connection-event rollup tier. Distinct keys so a CE reroll never
+  // cross-serializes with a traffic reroll (they touch disjoint tables).
+  val ConnEventsHourly: Long = 0x1108L << 32 | 0x0003L
+  val ConnEventsDaily: Long  = 0x1108L << 32 | 0x0004L
 }
 
 trait RollupRepo {

--- a/api/src/usage/RetentionSweepJob.scala
+++ b/api/src/usage/RetentionSweepJob.scala
@@ -16,6 +16,9 @@ import java.time.{Duration as JDuration, ZoneOffset, ZonedDateTime}
  *   - `connection_events` — drop rows older than 30 days
  *   - `traffic_hourly` — drop rows older than 90 days (gated on #809 table presence)
  *   - `traffic_daily` — drop rows older than 180 days (gated on #809 table presence; `date` col)
+ *   - `connection_events_hourly` — drop rows older than 90 days (#1265; gated on V47 table
+ *     presence)
+ *   - `connection_events_daily` — drop rows older than 180 days (#1265; gated; `date` col)
  *
  * Multi-instance-safe via a session-scoped Postgres advisory lock. Losing the race makes the tick a
  * no-op. The lock auto-releases if the connection drops, so a crashing instance can't wedge it.
@@ -33,10 +36,14 @@ object RetentionSweepJob {
 
   // Retention horizons (days). Hardcoded for v1; operator-tunable config
   // (`usage.rawRetentionDays` etc.) is a follow-up.
-  val RawRetentionDays: Int    = 30
-  val EventsRetentionDays: Int = 30
-  val HourlyRetentionDays: Int = 90
-  val DailyRetentionDays: Int  = 180
+  val RawRetentionDays: Int              = 30
+  val EventsRetentionDays: Int           = 30
+  val HourlyRetentionDays: Int           = 90
+  val DailyRetentionDays: Int            = 180
+  // #1265: connection-event rollups share the traffic-rollup horizons (raw 30d
+  // already covered by EventsRetentionDays; hourly 3mo / daily 6mo here).
+  val ConnEventsHourlyRetentionDays: Int = 90
+  val ConnEventsDailyRetentionDays: Int  = 180
 
   // Daily run hour (UTC). Design doc prefers router-local, but the API is
   // multi-household so picking *a* local zone is ill-defined. v1 = UTC; revisit
@@ -75,15 +82,22 @@ object RetentionSweepJob {
 
   private def sweepAllTables: ConnectionIO[List[SweepResult]] =
     for {
-      raw    <- deleteOlderThan("traffic_reports", "period_start", RawRetentionDays)
-      events <- deleteOlderThan("connection_events", "ts", EventsRetentionDays)
-      hourly <- ifTableExists("traffic_hourly") {
+      raw      <- deleteOlderThan("traffic_reports", "period_start", RawRetentionDays)
+      events   <- deleteOlderThan("connection_events", "ts", EventsRetentionDays)
+      hourly   <- ifTableExists("traffic_hourly") {
         deleteOlderThan("traffic_hourly", "bucket_start", HourlyRetentionDays)
       }
-      daily  <- ifTableExists("traffic_daily") {
+      daily    <- ifTableExists("traffic_daily") {
         // V38's traffic_daily uses `date` (DATE), not `bucket_start` — see
         // docs/design/usage-retention.md §3.
         deleteOlderThan("traffic_daily", "date", DailyRetentionDays)
+      }
+      ceHourly <- ifTableExists("connection_events_hourly") {
+        deleteOlderThan("connection_events_hourly", "bucket_start", ConnEventsHourlyRetentionDays)
+      }
+      ceDaily  <- ifTableExists("connection_events_daily") {
+        // V47's connection_events_daily uses `date` (DATE), not `bucket_start`.
+        deleteOlderThan("connection_events_daily", "date", ConnEventsDailyRetentionDays)
       }
     } yield {
       val base = List(
@@ -92,7 +106,9 @@ object RetentionSweepJob {
       )
       val h    = hourly.map(SweepResult("traffic_hourly", _)).toList
       val d    = daily.map(SweepResult("traffic_daily", _)).toList
-      base ++ h ++ d
+      val ceH  = ceHourly.map(SweepResult("connection_events_hourly", _)).toList
+      val ceD  = ceDaily.map(SweepResult("connection_events_daily", _)).toList
+      base ++ h ++ d ++ ceH ++ ceD
     }
 
   private def ifTableExists[A](table: String)(body: => ConnectionIO[A]): ConnectionIO[Option[A]] =

--- a/api/src/usage/RollupJobs.scala
+++ b/api/src/usage/RollupJobs.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.usage
 
-import wifihaven.api.db.{AppRepo, RollupRepo}
+import wifihaven.api.db.{AppRepo, ConnectionEventRepo, RollupRepo}
 import wifihaven.shared.Clock
 import wifihaven.shared.types.AppId
 import zio.*
@@ -66,6 +66,50 @@ object RollupJobs {
     runOnce("daily", repo, clock, oneDailyTick(repo, appRepo, _, zone))
       .repeat(Schedule.fixed(DailyInterval))
       .unit
+
+  // #1265: connection-event rollup loops. Same cadence/lookback as the traffic
+  // rollups — they re-roll the same trailing windows, just into the
+  // connection_events_* tables via ConnectionEventRepo. recordRun observability
+  // reuses the shared RollupRepo + rollup_runs table under the job names below.
+  val ConnEventsHourlyJob: String = "connection_events_hourly"
+  val ConnEventsDailyJob: String  = "connection_events_daily"
+
+  def connEventsHourlyLoop(
+      connRepo: ConnectionEventRepo,
+      rollupRepo: RollupRepo,
+      clock: Clock,
+  ): UIO[Unit] =
+    runOnce(ConnEventsHourlyJob, rollupRepo, clock, oneConnHourlyTick(connRepo, _))
+      .repeat(Schedule.fixed(HourlyInterval))
+      .unit
+
+  def connEventsDailyLoop(
+      connRepo: ConnectionEventRepo,
+      rollupRepo: RollupRepo,
+      clock: Clock,
+      zone: ZoneId,
+  ): UIO[Unit] =
+    runOnce(ConnEventsDailyJob, rollupRepo, clock, oneConnDailyTick(connRepo, _, zone))
+      .repeat(Schedule.fixed(DailyInterval))
+      .unit
+
+  private def oneConnHourlyTick(connRepo: ConnectionEventRepo, clock: Clock): Task[Option[Int]] =
+    for {
+      now <- clock.instant
+      since = now.minus(HourlyLookback).truncatedTo(java.time.temporal.ChronoUnit.HOURS)
+      n <- connRepo.rerollConnEventsHourly(since)
+    } yield n
+
+  private def oneConnDailyTick(
+      connRepo: ConnectionEventRepo,
+      clock: Clock,
+      zone: ZoneId,
+  ): Task[Option[Int]] =
+    for {
+      now <- clock.instant
+      sinceDate = LocalDate.ofInstant(now, zone).minus(DailyLookback)
+      n <- connRepo.rerollConnEventsDaily(sinceDate)
+    } yield n
 
   // ── tick bodies ────────────────────────────────────────────────────────────
 

--- a/api/test/src/feature/ConnectionEventRollupSpec.scala
+++ b/api/test/src/feature/ConnectionEventRollupSpec.scala
@@ -1,0 +1,281 @@
+package wifihaven.api.feature
+
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.implicits.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.db.*
+import wifihaven.api.policy.PolicyService
+import wifihaven.api.usage.RollupJobs
+import wifihaven.shared.*
+import wifihaven.shared.Clock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import zio.*
+import zio.interop.catz.*
+import zio.test.*
+
+import java.time.{Instant, LocalDate, ZoneOffset}
+
+// #1265: connection-event rollup tier — V47 tables + reroll behavior, mirroring
+// RollupRepoSpec for the traffic tier.
+//
+// Coverage:
+//   - V47 creates connection_events_hourly / _daily with the expected PKs +
+//     bucket indexes.
+//   - rerollConnEventsHourly / Daily aggregate connection_events into split
+//     count_succeeded / count_blocked correctly.
+//   - Re-running either is a no-op (UPSERT idempotency); late events update
+//     counts in place.
+//   - NULL-mac events fold into the '' bucket (no rows dropped).
+//   - Advisory lock gates concurrent reroll (multi-instance skip).
+//   - RollupJobs.runOnce records a connection_events_* row in rollup_runs.
+object ConnectionEventRollupSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def seedRouter: RIO[RouterRepo, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("ce-rollup-test", PolicyService.hashToken("et_dummy")))
+
+  private val mac = MacAddress.unsafe("aa:bb:cc:dd:ee:01")
+
+  // Insert one connection_event at `ts` for the given host/allowed.
+  private def event(
+      routerId: RouterId,
+      hostname: String,
+      allowed: Boolean,
+      ts: Instant,
+      macOpt: Option[MacAddress] = Some(mac),
+  ): ConnectionEventInsert =
+    ConnectionEventInsert(
+      routerId,
+      macOpt,
+      HostId.Fqdn(Hostname.unsafe(hostname)),
+      None,
+      allowed,
+      BlockReason.fromWire(if (allowed) "allowed" else "category:adult"),
+      ts,
+    )
+
+  private def hourlyCount: RIO[Transactor[Task], Long] =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"SELECT COUNT(*) FROM connection_events_hourly".query[Long].unique.transact(xa),
+    )
+  private def dailyCount: RIO[Transactor[Task], Long]  =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"SELECT COUNT(*) FROM connection_events_daily".query[Long].unique.transact(xa),
+    )
+
+  // Read a single hourly bucket's counts back.
+  private def hourlyCounts(
+      bucketStart: Instant,
+  ): RIO[Transactor[Task], Option[(Int, Int, Int)]] =
+    ZIO.serviceWithZIO[Transactor[Task]](xa =>
+      sql"""SELECT count_succeeded, count_blocked, sample_count
+            FROM connection_events_hourly WHERE bucket_start = $bucketStart"""
+        .query[(Int, Int, Int)]
+        .option
+        .transact(xa),
+    )
+
+  def spec = suite("ConnectionEventRollup + V47 migration")(
+    test("V47 creates connection_events_hourly + _daily with PKs and bucket indexes") {
+      for {
+        _          <- cleanDb
+        xa         <- ZIO.service[Transactor[Task]]
+        tableNames <-
+          sql"""SELECT table_name FROM information_schema.tables
+                WHERE table_schema='public'
+                  AND table_name IN ('connection_events_hourly','connection_events_daily')
+                ORDER BY table_name"""
+            .query[String]
+            .to[List]
+            .transact(xa)
+        hourlyIdx  <-
+          sql"""SELECT indexname FROM pg_indexes
+                WHERE tablename='connection_events_hourly'
+                  AND indexname IN ('idx_ce_hourly_bucket_start','idx_ce_hourly_mac_bucket')"""
+            .query[String]
+            .to[List]
+            .transact(xa)
+        dailyIdx   <-
+          sql"""SELECT indexname FROM pg_indexes
+                WHERE tablename='connection_events_daily'
+                  AND indexname IN ('idx_ce_daily_date','idx_ce_daily_mac_date')"""
+            .query[String]
+            .to[List]
+            .transact(xa)
+        hourlyPk   <-
+          sql"""SELECT pg_get_constraintdef(c.oid)
+                FROM pg_constraint c
+                WHERE c.conrelid='connection_events_hourly'::regclass AND c.contype='p'"""
+            .query[String]
+            .unique
+            .transact(xa)
+      } yield assertTrue(
+        tableNames == List("connection_events_daily", "connection_events_hourly"),
+        hourlyIdx.size == 2,
+        dailyIdx.size == 2,
+        hourlyPk.contains("router_id") && hourlyPk.contains("mac") &&
+          hourlyPk.contains("hostname") && hourlyPk.contains("bucket_start"),
+      )
+    },
+    test("rerollConnEventsHourly aggregates events into one bucket with split allowed/blocked") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        // bucket = 2026-01-01 05:00 UTC; 3 allowed + 2 blocked
+        bucket = LocalDate
+          .of(2026, 1, 1)
+          .atStartOfDay(ZoneOffset.UTC)
+          .toInstant
+          .plusSeconds(5 * 3600)
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        _        <- connRepo.insertBatch(
+          List(
+            event(rid, "example.com", allowed = true, bucket.plusSeconds(60)),
+            event(rid, "example.com", allowed = true, bucket.plusSeconds(120)),
+            event(rid, "example.com", allowed = true, bucket.plusSeconds(180)),
+            event(rid, "example.com", allowed = false, bucket.plusSeconds(240)),
+            event(rid, "example.com", allowed = false, bucket.plusSeconds(300)),
+          ),
+        )
+        rolled   <- connRepo.rerollConnEventsHourly(bucket.minusSeconds(3600)).map(_.getOrElse(0))
+        counts   <- hourlyCounts(bucket)
+      } yield assertTrue(
+        rolled > 0,
+        counts.contains((3, 2, 5)),
+      )
+    },
+    test("rerollConnEventsHourly is idempotent and updates counts when late events land") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        bucket = LocalDate.of(2026, 1, 2).atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(3600)
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        _        <- connRepo.insertBatch(
+          List(
+            event(rid, "a.com", allowed = true, bucket.plusSeconds(10)),
+            event(rid, "a.com", allowed = false, bucket.plusSeconds(20)),
+          ),
+        )
+        since = bucket.minusSeconds(3600)
+        _     <- connRepo.rerollConnEventsHourly(since)
+        first <- hourlyCounts(bucket)
+        n1    <- hourlyCount
+        // Re-roll with no new data: counts unchanged, no extra rows.
+        _     <- connRepo.rerollConnEventsHourly(since)
+        n2    <- hourlyCount
+        // A late event in the same bucket bumps the recomputed count in place.
+        _ <- connRepo.insertBatch(List(event(rid, "a.com", allowed = true, bucket.plusSeconds(30))))
+        _ <- connRepo.rerollConnEventsHourly(since)
+        after <- hourlyCounts(bucket)
+        n3    <- hourlyCount
+      } yield assertTrue(
+        first.contains((1, 1, 2)),
+        n1 == 1L,
+        n2 == 1L,
+        after.contains((2, 1, 3)),
+        n3 == 1L,
+      )
+    },
+    test("rerollConnEventsDaily aggregates a day's events into one daily row") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        date  = LocalDate.of(2026, 1, 3)
+        start = date.atStartOfDay(ZoneOffset.UTC).toInstant
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        _        <- connRepo.insertBatch(
+          List(
+            event(rid, "d.com", allowed = true, start.plusSeconds(3600)),
+            event(rid, "d.com", allowed = true, start.plusSeconds(7200)),
+            event(rid, "d.com", allowed = false, start.plusSeconds(10800)),
+          ),
+        )
+        _        <- connRepo.rerollConnEventsDaily(date.minusDays(1))
+        xa       <- ZIO.service[Transactor[Task]]
+        row      <- sql"""SELECT count_succeeded, count_blocked, sample_count
+                      FROM connection_events_daily WHERE date = $date"""
+          .query[(Int, Int, Int)]
+          .option
+          .transact(xa)
+        cnt      <- dailyCount
+      } yield assertTrue(row.contains((2, 1, 3)), cnt == 1L)
+    },
+    test("NULL-mac events fold into the '' bucket rather than being dropped") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        bucket = LocalDate
+          .of(2026, 1, 4)
+          .atStartOfDay(ZoneOffset.UTC)
+          .toInstant
+          .plusSeconds(2 * 3600)
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        _        <- connRepo.insertBatch(
+          List(
+            event(rid, "n.com", allowed = true, bucket.plusSeconds(5), macOpt = None),
+            event(rid, "n.com", allowed = false, bucket.plusSeconds(6), macOpt = None),
+          ),
+        )
+        _        <- connRepo.rerollConnEventsHourly(bucket.minusSeconds(3600))
+        xa       <- ZIO.service[Transactor[Task]]
+        row      <- sql"""SELECT mac, count_succeeded, count_blocked
+                     FROM connection_events_hourly WHERE bucket_start = $bucket"""
+          .query[(String, Int, Int)]
+          .option
+          .transact(xa)
+      } yield assertTrue(row.contains(("", 1, 1)))
+    },
+    test("rerollConnEventsHourly skips when another session holds the advisory lock (#818)") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        bucket = LocalDate.of(2026, 3, 1).atStartOfDay(ZoneOffset.UTC).toInstant
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        _ <- connRepo.insertBatch(List(event(rid, "x.com", allowed = true, bucket.plusSeconds(60))))
+        db      <- ZIO.service[TestDatabase.TestDb]
+        skipped <- ZIO.scoped {
+          for {
+            conn <- ZIO.acquireRelease(ZIO.attempt(db.ds.getConnection))(c =>
+              ZIO.attempt(c.close()).ignore,
+            )
+            _    <- ZIO.attempt {
+              val rs = conn
+                .createStatement()
+                .executeQuery(s"SELECT pg_advisory_lock(${RollupLockKeys.ConnEventsHourly})")
+              rs.close()
+            }
+            res  <- connRepo.rerollConnEventsHourly(bucket.minusSeconds(3600))
+          } yield res
+        }
+      } yield assertTrue(skipped.isEmpty)
+    },
+    test("RollupJobs.runOnce records a connection_events_hourly run in rollup_runs") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        bucket = LocalDate.of(2026, 1, 6).atStartOfDay(ZoneOffset.UTC).toInstant
+        connRepo   <- ZIO.service[ConnectionEventRepo]
+        rollupRepo <- ZIO.service[RollupRepo]
+        _ <- connRepo.insertBatch(List(event(rid, "r.com", allowed = true, bucket.plusSeconds(60))))
+        clock <- Clock.TestClock
+          .makeWithControl(java.time.LocalDateTime.of(2026, 1, 6, 12, 0))
+          .map(_._1)
+        _     <- RollupJobs.runOnce(
+          RollupJobs.ConnEventsHourlyJob,
+          rollupRepo,
+          clock,
+          _ => connRepo.rerollConnEventsHourly(bucket.minusSeconds(3600)),
+        )
+        runs  <- rollupRepo.recentRuns(10)
+      } yield assertTrue(
+        runs.exists(r => r.job == RollupJobs.ConnEventsHourlyJob && r.status == "ok"),
+      )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -11,7 +11,7 @@ import zio.json.*
 import zio.test.*
 
 import java.sql.SQLException
-import java.time.Instant
+import java.time.{Instant, LocalDate}
 import java.util.UUID
 
 /**
@@ -175,6 +175,8 @@ object DbFailureSpec extends ZIOSpecDefault {
     def findRecentFqdnFor(r: RouterId, ip: IpAddress, since: Instant)                   = throwing
     def backfillResolvedFor(r: RouterId, ip: IpAddress, fqdn: Hostname, since: Instant) =
       throwing
+    def rerollConnEventsHourly(since: Instant)                                          = throwing
+    def rerollConnEventsDaily(sinceDate: LocalDate)                                     = throwing
   }
 
   private def jsonField(body: String, key: String): Option[String] =

--- a/api/test/src/feature/RetentionSweepJobSpec.scala
+++ b/api/test/src/feature/RetentionSweepJobSpec.scala
@@ -146,6 +146,40 @@ object RetentionSweepJobSpec
         assertTrue(res.exists(_.exists(r => r.table == "traffic_hourly" && r.rowsDeleted == 1))) &&
         assertTrue(res.exists(_.exists(r => r.table == "traffic_daily" && r.rowsDeleted == 1)))
     },
+    test("deletes connection_events_hourly older than 90d and _daily older than 180d") {
+      for {
+        _    <- cleanDb
+        xa   <- ZIO.service[Transactor[Task]]
+        rid  <- seedRouter
+        // hourly: 100d old expires, 89d old kept
+        _    <- sql"""INSERT INTO connection_events_hourly
+                       (router_id, mac, hostname, bucket_start,
+                        count_succeeded, count_blocked, sample_count)
+                     VALUES
+                       ($rid, 'dd:dd:dd:dd:dd:01', 'example.com',
+                        NOW() - INTERVAL '100 days', 1, 0, 1),
+                       ($rid, 'dd:dd:dd:dd:dd:02', 'example.com',
+                        NOW() - INTERVAL '89 days', 1, 0, 1)""".update.run.transact(xa)
+        // daily: 200d old expires, 179d old kept (uses `date` column)
+        _    <- sql"""INSERT INTO connection_events_daily
+                       (router_id, mac, hostname, date,
+                        count_succeeded, count_blocked, sample_count)
+                     VALUES
+                       ($rid, 'ee:ee:ee:ee:ee:01', 'example.com',
+                        (NOW() - INTERVAL '200 days')::date, 1, 0, 1),
+                       ($rid, 'ee:ee:ee:ee:ee:02', 'example.com',
+                        (NOW() - INTERVAL '179 days')::date, 1, 0, 1)""".update.run.transact(xa)
+        res  <- RetentionSweepJob.sweepOnce(xa)
+        hRow <- sql"SELECT count(*) FROM connection_events_hourly".query[Int].unique.transact(xa)
+        dRow <- sql"SELECT count(*) FROM connection_events_daily".query[Int].unique.transact(xa)
+      } yield assertTrue(hRow == 1) && assertTrue(dRow == 1) &&
+        assertTrue(
+          res.exists(_.exists(r => r.table == "connection_events_hourly" && r.rowsDeleted == 1)),
+        ) &&
+        assertTrue(
+          res.exists(_.exists(r => r.table == "connection_events_daily" && r.rowsDeleted == 1)),
+        )
+    },
     test("acquires + releases advisory lock cleanly across consecutive ticks") {
       // If the previous tick failed to release the lock, the next tick would
       // come back as `None` (skipped). Verify two ticks in a row both run.


### PR DESCRIPTION
## Summary

Code half of #1265 (connection-events rollup tier), stacked on the
schema-only migration in **#1267**. Adopts the V47
`connection_events_hourly` / `_daily` tables: re-aggregation fibers,
the repo UPSERTs, `rollup_runs` observability wiring, and the retention
sweep extension. **Read-path routing in `querySeries` is deferred** to a
follow-up PR — it needs the #1262 shared range→bucket-width mapping,
which is not yet on `main`, and the issue is emphatic about not
introducing a third divergent threshold.

> Depends on #1267 — review/merge that first. This PR is based on
> `claude/fix-1265-ce-rollups`; once #1267 merges, retarget this PR's
> base to `main`.

## What's here

- **`ConnectionEventRepo.rerollConnEventsHourly/Daily`** — UPSERT-keyed
  `INSERT … SELECT` over `connection_events`:
  - NULL-mac events fold into a `''` bucket via `COALESCE(ce.mac, '')`
    so no counts are dropped (mac is a PK column, NOT NULL in the rollup).
  - allowed/blocked split into `count_succeeded` / `count_blocked`
    (`COUNT(*) FILTER (WHERE ce.allowed)` etc.).
  - hostname is the post-resolved host
    `COALESCE(resolved_host_value, host_value)`.
  - Concurrent rerolls gated behind `pg_try_advisory_xact_lock`
    (`RollupLockKeys.ConnEventsHourly/Daily`) — multi-instance skip (#818).
- **`RollupJobs.connEvents{Hourly,Daily}Loop`** — same cadence/lookback
  as the traffic rollups, reusing the shared `runOnce` + `rollup_runs`
  observability under job names `connection_events_hourly` /
  `connection_events_daily`. `Main` forks both fibers.
- **`RetentionSweepJob`** — extends the #811 sweep with
  `connection_events_hourly` (90d) and `connection_events_daily` (180d),
  gated on `to_regclass(...)` table presence.

## Index validation (#query-explain-before-merge)

Validated against a full V1→V47 apply on Docker Postgres 16:

- **Reroll source scan** filters on raw `ce.ts >= $since` (NOT a
  function of `ts`), so it uses the existing `idx_conn_events_ts`
  (`ts DESC`) / `idx_conn_events_mac_ts` (`mac, ts DESC`) and weekly
  partition pruning — a bounded range scan per tick, never a
  full-table scan. This deliberately avoids the #1254 / V38-class
  defeat where wrapping `ts` in `(ts AT TIME ZONE 'UTC')::DATE`
  forced a seq scan. **No new source-table index needed.**
- **Rollup read-path indexes** (added in #1267, mirroring V38):
  `idx_ce_hourly_bucket_start` (`bucket_start DESC`),
  `idx_ce_hourly_mac_bucket` (`mac, bucket_start DESC`),
  `idx_ce_daily_date` (`date DESC`), `idx_ce_daily_mac_date`
  (`mac, date DESC`). The schema decision (split count columns,
  `allowed` not in the PK) is documented in V47's header.

## Test plan

- [x] `ConnectionEventRollupSpec` — V47 table/PK/index existence,
      hourly & daily reroll with split counts, UPSERT idempotency +
      late-event recompute, NULL-mac `''` bucket folding, advisory-lock
      multi-instance skip, `rollup_runs` row via `RollupJobs.runOnce`.
- [x] `RetentionSweepJobSpec` — `connection_events_hourly` (90d) and
      `connection_events_daily` (180d) horizons.
- [x] `DbFailureSpec` / `RollupShutdownSpec` / `RollupCadenceSpec` still
      green after the trait + wiring changes.
- [x] TDD red→green visible in commit history (failing specs committed
      before the implementation).
- [x] `scalafmt` clean.