### PR TITLE
ci(secrets): rename STAGING_ADMIN_PASS → WH_STAGING_ADMIN_PASS (#1102)

### DIFF
--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Run Gate 3a smoke against staging
         env:
-          WH_ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          WH_ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}
           WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
         run: scripts/e2e-vm.sh --mode=gate3
 

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Run Gate 3b smoke against freshly-deployed staging
         env:
-          WH_ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          WH_ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}
           WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
         run: scripts/e2e-vm.sh --mode=gate3
 

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -420,7 +420,7 @@ jobs:
       - name: Admin API smoke against staging
         env:
           E2E_BASE_URL: ${{ env.STAGING_API_URL }}
-          ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}
           RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}
         run: scripts/e2e-tests.sh
       - name: Router API smoke against staging
@@ -429,7 +429,7 @@ jobs:
           # Post-#613 the SPA is on Cloudflare Pages, not the API host —
           # so the `/blocked` SPA-route check has to hit the SPA host.
           E2E_SPA_URL: https://staging.wifihaven.net
-          ADMIN_PASS: ${{ secrets.STAGING_ADMIN_PASS }}
+          ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}
           RUN_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}
         run: scripts/e2e-router.sh
 

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -19,7 +19,7 @@ BASE="${E2E_BASE_URL:-http://127.0.0.1:8080}"
 SPA_BASE="${E2E_SPA_URL:-$BASE}"
 # See scripts/e2e-tests.sh — fake-router rotates the seeded admin password on
 # first boot, so by the time this script runs the DB has the rotated value.
-# Against deployed staging (Gate 1 / #653) overridden from STAGING_ADMIN_PASS.
+# Against deployed staging (Gate 1 / #653) overridden from WH_STAGING_ADMIN_PASS.
 ADMIN_PASS="${ADMIN_PASS:-fake-router-bootstrap-pw-do-not-use-elsewhere}"
 # Unique suffix avoids collisions with residue from a previous (or concurrent)
 # run against a persistent backend (staging). On the disposable compose stack

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -16,7 +16,7 @@ BASE="${E2E_BASE_URL:-http://127.0.0.1:8080}"
 # first run to this value. e2e scripts execute *after* `compose up --wait`,
 # so the DB is always in the post-rotation state by the time we log in.
 # Against the deployed staging API (Gate 1 / #653) this is overridden from
-# the workflow's STAGING_ADMIN_PASS secret.
+# the workflow's WH_STAGING_ADMIN_PASS secret.
 ADMIN_PASS="${ADMIN_PASS:-fake-router-bootstrap-pw-do-not-use-elsewhere}"
 # Unique suffix so we don't collide with residue from a previous run against
 # a persistent backend (staging). Against the disposable compose stack this


### PR DESCRIPTION
## Summary

- Renames every `secrets.STAGING_ADMIN_PASS` reference to `secrets.WH_STAGING_ADMIN_PASS` to follow the project's `WH_` prefix convention for GitHub Actions secrets.
- The env-var names that secrets are mapped **into** (`ADMIN_PASS`, `WH_ADMIN_PASS`) are unchanged — only the right-hand `secrets.*` references are flipped.

## Files and lines changed

| File | Line(s) | Change |
|------|---------|--------|
| `.github/workflows/master-api-ui.yml` | 423, 432 | `secrets.STAGING_ADMIN_PASS` → `secrets.WH_STAGING_ADMIN_PASS` (Gate 1 `api-smoke-staging` job, two steps) |
| `.github/workflows/e2e-vm-gate3a.yml` | 166 | same rename (Gate 3a) |
| `.github/workflows/e2e-vm-gate3b.yml` | 162 | same rename (Gate 3b) |
| `scripts/e2e-tests.sh` | 19 | comment-only update |
| `scripts/e2e-router.sh` | 22 | comment-only update |

## `WH_STAGING_ADMIN_PASS` secret status

`gh secret list` shows only `STAGING_ADMIN_PASS` exists (created 2026-05-19). **`WH_STAGING_ADMIN_PASS` does NOT exist yet.**

## ⚠️ Required operator action before merge

**Operator must add the repo secret `WH_STAGING_ADMIN_PASS` with the same value as `STAGING_ADMIN_PASS` before merging this PR, otherwise Gate 1 (`api-smoke-staging`) and Gate 3a/3b will fail authentication against the staging API.**

Steps:
1. Copy the value of `STAGING_ADMIN_PASS` from the repo secrets page (Settings → Secrets → Actions).
2. Add a new secret named `WH_STAGING_ADMIN_PASS` with the same value via `gh secret set WH_STAGING_ADMIN_PASS --repo wifihaven/wifihaven` or the GitHub UI.
3. Merge this PR.
4. After one green CI cycle confirms everything works, delete the old `STAGING_ADMIN_PASS` secret.

## actionlint

Ran `actionlint` on all three changed workflow files — no errors or warnings.

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)