### PR TITLE
fix(openwrt-update): drop openwrt-latest fallback; treat 404 as hard skip (#1170)

### DIFF
--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -9,10 +9,10 @@
 # semver release published by .github/workflows/openwrt-build.yml (#499 /
 # #1134).
 #
-# Bootstrap fallback: if /releases/latest returns 404 (no versioned release
-# yet on a fresh repo) we fall back to the rolling openwrt-latest tag with
-# a WARNING log. Remove the fallback once the versioned path is universal —
-# tracked in TODO below.
+# Versioned releases are now universal (the router CD pipeline publishes a
+# v<X.Y.Z> tag on every release), so a 404 from /releases/latest is a hard
+# skip: log an error and exit cleanly. We no longer fall back to the rolling
+# openwrt-latest tag (#1170; refs #244 / #499 / #1134).
 #
 # Supports both opkg (OpenWRT <= 23.05) and apk-tools (OpenWRT 24.10+).
 # /etc/config/wifihaven is declared as a conffile, so router_token survives
@@ -21,7 +21,6 @@
 set -u
 
 API_URL="https://api.github.com/repos/wifihaven/wifihaven/releases/latest"
-FALLBACK_API_URL="https://api.github.com/repos/wifihaven/wifihaven/releases/tags/openwrt-latest"
 INSTALLED_VERSION_FILE=/usr/lib/wifihaven/VERSION
 STATE_DIR=/var/lib/wifihaven
 # Stores the version string of the package last installed (e.g. "0.2.8").
@@ -54,16 +53,17 @@ else
   exit 0
 fi
 
-# Fetch /releases/latest, falling back to the rolling openwrt-latest tag on
-# 404 to keep a fresh repo (no v<X.Y.Z> tag yet) self-healing.
+# Fetch /releases/latest. Versioned releases are universal (#1170), so a 404
+# means no published semver release — a hard skip, not a fallback.
 HTTP_CODE=$(curl -s -o /tmp/wifihaven-update.meta -w '%{http_code}' "$API_URL" 2>/dev/null || echo "000")
 case "$HTTP_CODE" in
   200)
     META=$(cat /tmp/wifihaven-update.meta)
     ;;
   404)
-    log "warn: $API_URL returned 404; falling back to openwrt-latest (TODO(#1170): remove once versioned path is universal)"
-    META=$(curl -sf "$FALLBACK_API_URL") || META=
+    log "error: $API_URL returned 404 (no versioned release published); skipping"
+    rm -f /tmp/wifihaven-update.meta
+    exit 0
     ;;
   *)
     log "could not fetch $API_URL (http $HTTP_CODE); skipping"
@@ -80,8 +80,7 @@ fi
 # Extract tag_name and the highest-version matching asset URL. A versioned
 # release normally carries a single wifihaven_<X.Y.Z>-<rel>_all.<ext> asset,
 # but we still walk the full list, reject luci-app (#1178), and `sort -V`
-# in case multiple revisions are ever attached. The fallback openwrt-latest
-# release uses the same asset layout, so this works for both paths.
+# in case multiple revisions are ever attached.
 TAG=$(printf '%s' "$META" | jsonfilter -e '@.tag_name')
 LATEST_VERSION=$(printf '%s' "$TAG" | sed 's/^v//')
 MATCHES=

--- a/openwrt/test/update_spec.sh
+++ b/openwrt/test/update_spec.sh
@@ -44,10 +44,10 @@ grep -q 'releases/latest' "$SCRIPT" \
   && check "fetches /releases/latest" ok \
   || check "fetches /releases/latest" "wrong API endpoint"
 
-# 4a. Keeps the openwrt-latest URL only as a 404 fallback.
+# 4a. #1170: no openwrt-latest fallback endpoint — a 404 is a hard skip.
 grep -q 'releases/tags/openwrt-latest' "$SCRIPT" \
-  && check "keeps openwrt-latest as fallback" ok \
-  || check "keeps openwrt-latest as fallback" "missing fallback endpoint"
+  && check "[#1170] no openwrt-latest fallback endpoint remains" "still references fallback endpoint" \
+  || check "[#1170] no openwrt-latest fallback endpoint remains" ok
 
 # 4b. Persists the last-installed version under /var/lib/wifihaven.
 grep -q 'last_update_version' "$SCRIPT" \
@@ -144,10 +144,11 @@ shift 2
 printf '%s\n' "\$*" >> "$TESTDIR/logger.out"
 EOF
 
-  # Mock curl. Three call shapes:
+  # Mock curl. Two call shapes the script uses:
   #   1) Meta fetch with -o + -w (HTTP code capture): /releases/latest path.
   #   2) Asset download with -o (no -w): record URL into downloads.log.
-  #   3) Bare GET (no -o, no -w): fallback openwrt-latest fetch.
+  # (The bare-GET branch below is vestigial — the openwrt-latest fallback
+  # was removed in #1170 — but harmless if ever hit.)
   cat > "$BINDIR/curl" <<'CURL_EOF'
 #!/bin/sh
 out=""
@@ -353,18 +354,22 @@ grep -q 'restart failed' "$TESTDIR/logger.out" \
   || check "[restart fail] warning logged" "no warning in log"
 rm -rf "$TESTDIR"
 
-# Case G: /releases/latest 404 → falls back to openwrt-latest, logs WARNING.
+# Case G (#1170): /releases/latest 404 → hard skip. Logs an error, does NOT
+# fall back to openwrt-latest, and never installs/restarts.
 setup_mocks
 mock_apk
 printf '0.2.7\n' > "$VERS_DIR/VERSION"
 MOCK_HTTP_CODE=404 PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
-grep -q 'returned 404; falling back to openwrt-latest' "$TESTDIR/logger.out" \
-  && check "[404 fallback] WARNING logged about fallback" ok \
-  || check "[404 fallback] WARNING logged about fallback" "no fallback warning"
+grep -q 'returned 404 (no versioned release published); skipping' "$TESTDIR/logger.out" \
+  && check "[#1170 404 skip] error logged about missing versioned release" ok \
+  || check "[#1170 404 skip] error logged about missing versioned release" "no 404-skip error"
 N=$(count_restart_calls)
-[ "$N" = "1" ] \
-  && check "[404 fallback] still installs via fallback tag" ok \
-  || check "[404 fallback] still installs via fallback tag" "expected 1, got $N"
+[ "$N" = "0" ] \
+  && check "[#1170 404 skip] does NOT install/restart" ok \
+  || check "[#1170 404 skip] does NOT install/restart" "expected 0, got $N"
+[ ! -f "$TESTDIR/apk.calls" ] \
+  && check "[#1170 404 skip] apk NOT invoked" ok \
+  || check "[#1170 404 skip] apk NOT invoked" "apk.calls exists"
 rm -rf "$TESTDIR"
 unset MOCK_HTTP_CODE
 


### PR DESCRIPTION
## Summary

The auto-updater `openwrt/files/usr/sbin/wifihaven-update` fetched
`/releases/latest` and, on HTTP 404, fell back to the rolling
`openwrt-latest` tag — a bootstrap escape hatch for a fresh repo with no
`v<X.Y.Z>` tag yet.

Versioned releases are now universal (the router CD pipeline publishes a
`v<X.Y.Z>` tag on every release), so the fallback is dead weight. This PR
removes it: a 404 from `/releases/latest` now logs a clear error via
`logger -t wifihaven` and exits cleanly without attempting the rolling tag.

- Removed `FALLBACK_API_URL` and the 404 fallback branch in the
  `HTTP_CODE` case statement.
- Updated header/inline comments to reflect the hard-skip behavior.
- The #1178 tightened asset-pick regex is untouched.

## Tests

- Updated `openwrt/test/update_spec.sh`:
  - Case G now asserts the 404 path logs an error, does **not** install or
    restart, and does **not** invoke the package manager.
  - Static check 4a now asserts the fallback endpoint is gone.
- Full shell suite: **38 passed, 0 failed**.
- `shellcheck` on changed scripts: no new error-severity findings
  (pre-existing SC2034/SC2015 warnings unchanged).

Refs #244, #499, #1134.

Closes #1170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)