### PR TITLE
Pin migration-check checkouts to PR head to fix three-dot false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,9 +261,18 @@ jobs:
     if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Same merge-ref-vs-base.sha staleness as migration-isolation below:
+      # the check diffs `base.sha...HEAD` (three-dot), so HEAD must be the
+      # true PR head, not the synthetic merge ref, or the merge-base resolves
+      # wrong and the diff over-reports. (Lower blast radius here — the diff
+      # is scoped to the migration dir and only blocks mutations, which never
+      # land on main — but the pattern is identical, so pin it for the same
+      # reason.) On push/merge_group github.sha is the real commit, so the
+      # fallback is correct.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Resolve base SHA
         id: base
@@ -314,9 +323,23 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # Check out the REAL PR head, not the default synthetic merge ref.
+      # The "Resolve base SHA" step below passes the CURRENT main tip
+      # (pull_request.base.sha) as BASE, and the script diffs `BASE...HEAD`
+      # (three-dot = merge-base). When HEAD is the merge ref it can be stale
+      # relative to base.sha (main advances after the merge ref was computed),
+      # which defeats the merge-base resolution and collapses the diff to
+      # two-dot semantics — picking up every file main changed since the PR
+      # branched. That false-positived a migration-only PR (#1267) for
+      # touching render.yaml, which #1268/#1208 had changed on main after the
+      # PR branched. Pinning HEAD to the true PR head makes the merge-base
+      # resolve to the real branch point. For merge_group the checked-out
+      # commit is the real queued commit (github.sha), so the fallback is
+      # already correct there.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # In the merge queue the migration-coupled-justified label is not on the
       # event, so a PR justified at PR time would otherwise fail here. Resolve


### PR DESCRIPTION
Fixes #1275.

## Problem

The **Migration Isolation Check** (`migration-isolation` job) false-positives on legitimately-isolated migration-only PRs. PR #1267 — whose only change vs its branch point is `api/resources/db/migration/V47__connection_events_rollups.sql` — failed claiming it also touches `render.yaml`, which it never modified.

## Root cause

The job runs `check-migration-isolation.sh`, which correctly diffs `"${BASE}...HEAD"` (**three-dot** = merge-base, per AGENTS.md "Branch-diff checks"). The "Resolve base SHA" step passes `github.event.pull_request.base.sha` (the **current** main tip) as BASE. But the job checks out the default `actions/checkout@v6` ref, which for `pull_request` events is the synthetic **merge ref** (`refs/pull/<n>/merge`), not the PR head. When main advances after the merge ref was last computed, the merge ref is stale relative to `base.sha`, the three-dot merge-base no longer resolves to the PR's true branch point, and the diff picks up everything main changed since the PR branched — here `render.yaml` and `deploy/alloy/*`, landed by #1268/#1208 after #1267 branched.

Verified on the #1267 branch locally:
- `git diff --name-only origin/main...<branch>` → only the `.sql` (clean).
- `git diff --name-only origin/main..<branch>` (two-dot) → also `render.yaml`, `deploy/alloy/Dockerfile`, `deploy/alloy/config.alloy` (the false positives CI reported).

The script's three-dot logic is right; CI just feeds it the wrong HEAD.

## Fix

Pin the checkout `ref` to the real PR head:

```yaml
- uses: actions/checkout@v6
  with:
    fetch-depth: 0
    ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

With HEAD = the true PR head, `base.sha...HEAD` resolves to the real branch point. On `push` / `merge_group`, `github.event.pull_request.head.sha` is empty and `github.sha` is the real queued/pushed commit, so the fallback is correct.

`migrations-immutable` shares the identical checkout-merge-ref + base.sha three-dot pattern, so it gets the same pin. Its blast radius is lower (its diff is scoped to the migration dir and only blocks mutations, which never legitimately land on main), but the latent defect is identical, so it's fixed for the same reason. No other jobs touched.

## No script/test change

`check-migration-isolation.sh` and `check-migrations.sh` are correct as-is. The bug is purely which commit CI checks out as HEAD. This is a GitHub-internal merge-ref staleness condition that is not faithfully reproducible at the script-unit level (`check-migration-isolation.test.sh` already verifies the script produces clean three-dot output when given the true base/head), so there is no new unit test — the fix is workflow-level and the regression is covered by this PR's reasoning plus the existing script tests.

## Unblocks

This unblocks PR #1267 (and any future migration-only PR that branched before main advanced). Once this merges, #1267's failing **Migration Isolation Check** should be re-run.

## This is a standalone CI fix

Off `origin/main`. Not part of and not stacked on the #1265 migration PRs (#1267 / #1271).