### PR TITLE
fix(luci): pull in luci-compat for Lua/CBI runtime (#1278)

### DIFF
--- a/openwrt/luci/Makefile
+++ b/openwrt/luci/Makefile
@@ -8,7 +8,7 @@ PKG_MAINTAINER:=WifiHaven <noreply@example.com>
 PKG_LICENSE:=MIT
 
 LUCI_TITLE:=LuCI support for WifiHaven
-LUCI_DEPENDS:=+luci-base +wifihaven
+LUCI_DEPENDS:=+luci-base +luci-compat +wifihaven
 LUCI_PKGARCH:=all
 
 include $(INCLUDE_DIR)/package.mk

--- a/openwrt/luci/build-apk.sh
+++ b/openwrt/luci/build-apk.sh
@@ -77,7 +77,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/wifihaven/wifihaven" \
     --info "maintainer:WifiHaven <noreply@example.com>" \
-    --info "depends:luci-base wifihaven" \
+    --info "depends:luci-base luci-compat wifihaven" \
     --files "$WORK/data" \
     --output "$OUT_APK"
 

--- a/openwrt/luci/build-ipk.sh
+++ b/openwrt/luci/build-ipk.sh
@@ -19,7 +19,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: luci-app-wifihaven
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: luci-base, wifihaven
+Depends: luci-base, luci-compat, wifihaven
 Architecture: all
 Maintainer: WifiHaven <noreply@example.com>
 Description: LuCI web UI for the WifiHaven router agent. Exposes cadence

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -176,6 +176,27 @@ grep -q "uhttpd-mod-lua" "$ROOT/build-apk.sh" \
   || check "build-apk.sh depends pulls in uhttpd-mod-lua" \
            "missing uhttpd-mod-lua dep in build-apk.sh"
 
+# #1278: luci-app-wifihaven is a classic Lua/CBI LuCI app. On modern OpenWRT
+# (23.05+, apk-based 24.10) luci-base is the ucode/JS framework; the server-
+# side Lua dispatcher/CBI runtime ships separately in luci-compat. Without it
+# the page renders "No Lua runtime installed." All three dep declarations for
+# the luci app (Makefile + both build scripts, since Image Builder reads the
+# built package metadata, not the Makefile) must pull in luci-compat.
+grep -q "luci-compat" "$ROOT/luci/Makefile" \
+  && check "luci/Makefile LUCI_DEPENDS pulls in luci-compat" ok \
+  || check "luci/Makefile LUCI_DEPENDS pulls in luci-compat" \
+           "missing luci-compat dep in luci/Makefile"
+
+grep -q "luci-compat" "$ROOT/luci/build-ipk.sh" \
+  && check "luci/build-ipk.sh Depends pulls in luci-compat" ok \
+  || check "luci/build-ipk.sh Depends pulls in luci-compat" \
+           "missing luci-compat dep in luci/build-ipk.sh"
+
+grep -q "luci-compat" "$ROOT/luci/build-apk.sh" \
+  && check "luci/build-apk.sh depends pulls in luci-compat" ok \
+  || check "luci/build-apk.sh depends pulls in luci-compat" \
+           "missing luci-compat dep in luci/build-apk.sh"
+
 # #704: ensure_dnsmasq_full apk branch must use `apk info -e`, not
 # `apk list -I`.  On apk-tools v3 (OpenWRT 24.10+) `apk list -I` exits 0
 # with empty stdout when the package is absent, so the old check always


### PR DESCRIPTION
## Summary

Fixes #1278. `luci-app-wifihaven` is a classic **Lua/CBI** LuCI app
(`controller/wifihaven.lua`, `model/cbi/wifihaven/settings.lua`,
`view/wifihaven/status.htm`). On modern OpenWRT (23.05+, apk-based 24.10),
`luci-base` ships only the **ucode/JS** framework — the server-side **Lua
dispatcher/CBI runtime** for legacy apps lives in a separate package,
`luci-compat` (which pulls `luci-lua-runtime`). The package declared only
`+luci-base +wifihaven`, so on any router without `luci-compat` the page
rendered **"No Lua runtime installed."** Confirmed live on `router.lan`;
interim fix there was a manual `apk add luci-compat`.

## Fix — three dep declarations, all updated

The released artifacts come from the build scripts, not just the SDK
Makefile (the OpenWRT Image Builder reads the built package metadata), so
all three must agree:

- `openwrt/luci/Makefile:11` — `LUCI_DEPENDS:=+luci-base +luci-compat +wifihaven`
- `openwrt/luci/build-apk.sh:80` — `--info "depends:luci-base luci-compat wifihaven"`
- `openwrt/luci/build-ipk.sh:22` — `Depends: luci-base, luci-compat, wifihaven`

## Tests

Added three canaries in `openwrt/test/install_spec.sh` (mirroring the
existing #528 `uhttpd-mod-lua` checks) asserting `luci-compat` appears in
each of the three declarations. Full suite: **39 passed, 0 failed.**

Built the ipk locally to confirm the rendered control metadata:

```
Depends: luci-base, luci-compat, wifihaven
```

## install.sh degrades gracefully — no change needed

The luci-app install step at `openwrt/install.sh:204-221` already wraps both
the apk and opkg installs in `|| info "luci-app-wifihaven install failed
(luci-base not present?) — continuing without web UI"`. Adding the
`luci-compat` dep does not change that: if `luci-compat` is absent from the
feed, the install command fails and the existing `||` handler skips with an
informative message rather than aborting the whole install. Verified by
inspection; no edit required.

## Rollout

CD is healthy (router artifacts ship via `master-router.yml`). The fix takes
effect for routers on the next published router release + auto-update; no
manual `apk add luci-compat` needed thereafter.