### PR TITLE
Move Grafana dashboard deploy to its own master-grafana.yml pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,9 +564,9 @@ jobs:
   # ── infra/grafana Terraform: fmt + validate ─────────────────────────────
   # Mirrors render-blueprint: a cheap config-quality gate for the Grafana
   # Cloud dashboard deploy layer (#1270). Catches fmt drift and invalid HCL
-  # before the master-api-ui.yml deploy-grafana-{staging,prod} jobs run
-  # `terraform apply`. Also json-parses every committed dashboard so a
-  # malformed export can't reach Grafana.
+  # before the master-grafana.yml deploy-grafana job runs `terraform apply`.
+  # Also json-parses every committed dashboard so a malformed export can't
+  # reach Grafana.
   grafana-terraform:
     name: Grafana Terraform Lint
     needs: changes

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -28,9 +28,10 @@ name: Master API/UI CD
 #                                       • deploy-prod-render — curl prod deploy hook + health poll
 #                                       • deploy-spa-prod    — build + wrangler push to
 #                                                              wifihaven Pages project (#613)
-#                                       • deploy-grafana       — terraform apply of the in-repo
-#                                                              dashboards to the single Grafana
-#                                                              Cloud stack (non-critical)
+#
+# Grafana dashboard deploy lives on its own pipeline (master-grafana.yml),
+# fired only by dashboard/Terraform changes under deploy/grafana/** and
+# infra/grafana/** — see the `paths:` exclusions below.
 #
 # OpenWRT release lives on master-router.yml. shared/** wire-schema changes
 # fire BOTH pipelines until #597 (capability negotiation) lands — the
@@ -55,6 +56,12 @@ on:
       - '.github/workflows/master-api-ui.yml'
       - '.github/workflows/e2e-vm-gate3b.yml'
       - '.github/workflows/ci.yml'
+      # Grafana dashboards/Terraform deploy on their own pipeline
+      # (master-grafana.yml). Excluded here so a dashboard-only change does
+      # not trigger a full API/SPA redeploy. A push that also touches api/web/
+      # etc. still matches those positive patterns and runs this pipeline.
+      - '!deploy/grafana/**'
+      - '!infra/grafana/**'
   workflow_dispatch:
 
 # Workflow-level concurrency scoped to THIS pipeline's group name — api/ui
@@ -622,54 +629,3 @@ jobs:
           workingDirectory: web
           # See staging step for why --commit-message is forced ASCII.
           command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"
-
-  # 6e. Deploy Grafana dashboards to Grafana Cloud. Applies the in-repo
-  # dashboards (deploy/grafana/dashboards/*.json) to the single Grafana Cloud
-  # stack via the infra/grafana Terraform, gated on approve-production so the
-  # dashboards only ship once the production deploy is approved (mirrors
-  # deploy-spa-prod). One stack serves every environment: the dashboards select
-  # their data via the templated ${datasource} variable at view time, so there
-  # is no per-environment dashboard copy. The apply is idempotent — each
-  # grafana_dashboard is upserted by its stable uid (overwrite = true) — so a
-  # re-apply just reconciles the stack to the repo. Non-critical (design §6.2):
-  # continue-on-error keeps a dashboard hiccup from failing the release. A no-op
-  # until GRAFANA_URL / GRAFANA_AUTH are set out-of-band.
-  deploy-grafana:
-    name: Deploy Grafana dashboards (deploy-production)
-    if: github.ref == 'refs/heads/main'
-    needs: [approve-production]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check Grafana secrets are configured
-        id: gate
-        env:
-          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
-          GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH }}
-        run: |
-          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GRAFANA_URL / GRAFANA_AUTH not set — skipping dashboard deploy."
-          fi
-
-      - name: Set up Terraform
-        if: steps.gate.outputs.configured == 'true'
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.15.3'
-
-      - name: Terraform init + apply
-        if: steps.gate.outputs.configured == 'true'
-        working-directory: infra/grafana
-        env:
-          TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
-          TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
-        run: |
-          terraform init -input=false
-          terraform apply -auto-approve -input=false

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -13,9 +13,6 @@ name: Master API/UI CD
 #     → deploy-staging               (curl staging deploy hook; wait for /api/health)
 #       ‖ deploy-spa-staging         (build + wrangler push to Cloudflare Pages — parallel
 #                                     with deploy-staging, gated on the same test chain)
-#       ‖ deploy-grafana-staging     (terraform apply of deploy/grafana/dashboards/* to the
-#                                     STAGING Grafana Cloud stack — parallel, same test gate,
-#                                     non-critical/continue-on-error)
 #     → smoke-staging                (lightweight curl checks against api-staging.wifihaven.net
 #                                     AND staging.wifihaven.net SPA)
 #     → api-smoke-staging            (Gate 1 — admin + router API contract smoke against staging)
@@ -31,8 +28,8 @@ name: Master API/UI CD
 #                                       • deploy-prod-render — curl prod deploy hook + health poll
 #                                       • deploy-spa-prod    — build + wrangler push to
 #                                                              wifihaven Pages project (#613)
-#                                       • deploy-grafana-prod — terraform apply of the in-repo
-#                                                              dashboards to the PROD Grafana
+#                                       • deploy-grafana       — terraform apply of the in-repo
+#                                                              dashboards to the single Grafana
 #                                                              Cloud stack (non-critical)
 #
 # OpenWRT release lives on master-router.yml. shared/** wire-schema changes
@@ -334,58 +331,6 @@ jobs:
           # (e.g. `§`) with code 8000111 despite advertising UTF-8.
           command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"
 
-  # ── 4c. Deploy Grafana dashboards to Grafana Cloud (staging) ──────────────
-  # Provisions the in-repo dashboards (deploy/grafana/dashboards/*.json) into
-  # the STAGING Grafana Cloud stack via the infra/grafana Terraform. Runs in
-  # parallel with deploy-staging / deploy-spa-staging on the same test gate;
-  # the prod stack is deployed later, after the production-approval gate
-  # (deploy-grafana-prod), so staging dashboards ship with staging and prod
-  # dashboards ship with prod — the same staging-then-prod split the SPA uses.
-  #
-  # Non-critical (design §6.2): a dashboard-deploy failure is alert-worthy but
-  # must never block the API/SPA release, so continue-on-error is set. Until
-  # the GRAFANA_URL_STAGING / GRAFANA_AUTH_STAGING secrets are set out-of-band
-  # the apply is gated off and the job is a no-op.
-  deploy-grafana-staging:
-    name: Deploy Grafana dashboards (staging)
-    if: github.ref == 'refs/heads/main'
-    needs: [ci-tests, bootstrap-smoke, e2e, prod-stack-smoke]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check staging Grafana secrets are configured
-        id: gate
-        env:
-          GRAFANA_URL: ${{ secrets.GRAFANA_URL_STAGING }}
-          GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH_STAGING }}
-        run: |
-          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GRAFANA_URL_STAGING / GRAFANA_AUTH_STAGING not set — skipping staging dashboard deploy."
-          fi
-
-      - name: Set up Terraform
-        if: steps.gate.outputs.configured == 'true'
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: '1.15.3'
-
-      - name: Terraform init + apply (staging stack)
-        if: steps.gate.outputs.configured == 'true'
-        working-directory: infra/grafana
-        env:
-          TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL_STAGING }}
-          TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH_STAGING }}
-        run: |
-          terraform init -input=false
-          terraform apply -auto-approve -input=false
-
   # ── 5. Smoke-test staging ─────────────────────────────────────────────────
   # Fast (<2 min) end-user-facing checks against the deployed staging URL.
   # NOT a replica of scripts/e2e-tests.sh — that runs pre-deploy against the
@@ -678,15 +623,19 @@ jobs:
           # See staging step for why --commit-message is forced ASCII.
           command: pages deploy --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }}"
 
-  # 6e. Deploy Grafana dashboards to Grafana Cloud (prod). The prod analogue
-  # of deploy-grafana-staging — applies the same in-repo dashboards to the
-  # PROD Grafana Cloud stack, gated on approve-production so prod dashboards
-  # only ship once the production deploy is approved (mirrors deploy-spa-prod).
-  # Non-critical (design §6.2): continue-on-error keeps a dashboard hiccup
-  # from failing the production release. A no-op until GRAFANA_URL_PROD /
-  # GRAFANA_AUTH_PROD are set out-of-band.
-  deploy-grafana-prod:
-    name: Deploy Grafana dashboards (prod) (deploy-production)
+  # 6e. Deploy Grafana dashboards to Grafana Cloud. Applies the in-repo
+  # dashboards (deploy/grafana/dashboards/*.json) to the single Grafana Cloud
+  # stack via the infra/grafana Terraform, gated on approve-production so the
+  # dashboards only ship once the production deploy is approved (mirrors
+  # deploy-spa-prod). One stack serves every environment: the dashboards select
+  # their data via the templated ${datasource} variable at view time, so there
+  # is no per-environment dashboard copy. The apply is idempotent — each
+  # grafana_dashboard is upserted by its stable uid (overwrite = true) — so a
+  # re-apply just reconciles the stack to the repo. Non-critical (design §6.2):
+  # continue-on-error keeps a dashboard hiccup from failing the release. A no-op
+  # until GRAFANA_URL / GRAFANA_AUTH are set out-of-band.
+  deploy-grafana:
+    name: Deploy Grafana dashboards (deploy-production)
     if: github.ref == 'refs/heads/main'
     needs: [approve-production]
     runs-on: ubuntu-latest
@@ -696,17 +645,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check prod Grafana secrets are configured
+      - name: Check Grafana secrets are configured
         id: gate
         env:
-          GRAFANA_URL: ${{ secrets.GRAFANA_URL_PROD }}
-          GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH_PROD }}
+          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+          GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH }}
         run: |
           if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GRAFANA_URL_PROD / GRAFANA_AUTH_PROD not set — skipping prod dashboard deploy."
+            echo "::notice::GRAFANA_URL / GRAFANA_AUTH not set — skipping dashboard deploy."
           fi
 
       - name: Set up Terraform
@@ -715,12 +664,12 @@ jobs:
         with:
           terraform_version: '1.15.3'
 
-      - name: Terraform init + apply (prod stack)
+      - name: Terraform init + apply
         if: steps.gate.outputs.configured == 'true'
         working-directory: infra/grafana
         env:
-          TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL_PROD }}
-          TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH_PROD }}
+          TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
+          TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
         run: |
           terraform init -input=false
           terraform apply -auto-approve -input=false

--- a/.github/workflows/master-grafana.yml
+++ b/.github/workflows/master-grafana.yml
@@ -1,0 +1,87 @@
+name: Master Grafana CD
+
+# Grafana dashboard deployment pipeline — reconciles the single Grafana Cloud
+# stack (wifihaven.grafana.net) to the in-repo dashboards.
+#
+# Split out of master-api-ui.yml (#1283): the dashboard deploy has nothing to
+# do with the API/SPA release cadence, and folding it into that pipeline meant
+# it re-ran on every api/web/config push (and was gated behind the production
+# approval). As its own pipeline with a tight path scope it only fires when a
+# dashboard JSON or its Terraform actually changes, and never blocks — or is
+# blocked by — an API/SPA release.
+#
+# Flow (one job):
+#   deploy-grafana — terraform apply of the in-repo dashboards
+#     (deploy/grafana/dashboards/*.json) to the single Grafana Cloud stack via
+#     the infra/grafana Terraform.
+#
+# One stack serves every environment: the dashboards select their data via the
+# templated ${datasource} variable at view time, so there is no per-environment
+# copy and no staging/prod split. The apply is idempotent — each
+# grafana_dashboard is upserted by its stable uid (overwrite = true) — so a
+# re-run just reconciles the stack to the repo.
+#
+# No production-approval gate: a dashboard change is low-risk and independent
+# of the API/SPA release, so it ships straight from a push to main (the change
+# already went through PR review + the ci.yml grafana-terraform lint job).
+#
+# Path scope: see on.push.paths below. Docs and unrelated infra fire nothing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/grafana/**'
+      - 'infra/grafana/**'
+      - '.github/workflows/master-grafana.yml'
+  workflow_dispatch:
+
+# Scoped to this pipeline's own group — a newer dashboard push pre-empts an
+# in-flight apply (the next run reconciles to the latest repo state anyway).
+concurrency:
+  group: master-grafana-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-grafana:
+    name: Deploy Grafana dashboards
+    # Gate to main: the path filter lets feature-branch pushes create a run,
+    # but on a non-main ref no job is eligible and GitHub records a spurious
+    # 0-job failure. Skipping (not failing) keeps that neutral. (mirrors the
+    # master-router.yml `if` guard, #1136)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Grafana secrets are configured
+        id: gate
+        env:
+          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+          GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH }}
+        run: |
+          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GRAFANA_URL / GRAFANA_AUTH not set — skipping dashboard deploy."
+          fi
+
+      - name: Set up Terraform
+        if: steps.gate.outputs.configured == 'true'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.15.3'
+
+      - name: Terraform init + apply
+        if: steps.gate.outputs.configured == 'true'
+        working-directory: infra/grafana
+        env:
+          TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
+          TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve -input=false

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -34,24 +34,25 @@ Manages:
 ## In the CD pipeline
 
 This config is applied to **one Grafana Cloud stack that serves every
-environment**. It is wired into the Master API/UI CD pipeline
-([`master-api-ui.yml`](../../.github/workflows/master-api-ui.yml)) as a
-single job:
-
-- `deploy-grafana` — applies the dashboards after the `approve-production`
-  manual gate, alongside `deploy-prod-render` / `deploy-spa-prod`.
+environment**. It has its own deployment pipeline,
+[`master-grafana.yml`](../../.github/workflows/master-grafana.yml) (the
+`deploy-grafana` job), with a tight `paths:` scope — it fires **only** when a
+dashboard JSON or its Terraform changes (`deploy/grafana/**`,
+`infra/grafana/**`). It is deliberately *not* part of the API/SPA pipeline:
+a dashboard change is independent of the API release cadence, so it neither
+re-runs on every API/web push nor sits behind the `approve-production` gate.
+A push to `main` that touches those paths applies straight through (the
+change already passed PR review + the `grafana-terraform` lint job).
 
 There is no staging/prod split because the dashboards are
 environment-agnostic: each selects its data via the templated
 `${datasource}` variable at view time, so the same JSON renders against
 whichever Prometheus the viewer points it at. The target stack is selected
-purely by the `grafana_url` / `grafana_auth` variables. The job is
-**non-critical** (`continue-on-error`, design §6.2): a dashboard-deploy
-failure is alert-worthy but never blocks the API/SPA release.
+purely by the `grafana_url` / `grafana_auth` variables.
 
 ### Stateless by design
 
-The CD jobs run on ephemeral runners with no persisted Terraform state, so
+The CD job runs on an ephemeral runner with no persisted Terraform state, so
 every apply starts empty. That is safe because each `grafana_dashboard` is
 upserted by its stable `uid` (`overwrite = true`) — applying against an
 empty state updates the existing dashboard rather than erroring on a
@@ -80,11 +81,12 @@ and the GitHub Actions secrets.
 
 ## CI / auto-deploy (the normal path)
 
-Deploys run from the Master API/UI CD pipeline on push to `main` (see
-[In the CD pipeline](#in-the-cd-pipeline) above). The `master-api-ui.yml`
-`paths:` filter already includes `infra/**` and `deploy/**`, so a dashboard
-or Terraform change triggers the pipeline. Authentication comes from two
-GitHub Actions secrets set out-of-band (never committed):
+Deploys run from the `master-grafana.yml` pipeline on push to `main` (see
+[In the CD pipeline](#in-the-cd-pipeline) above). Its `paths:` filter is
+scoped to `deploy/grafana/**` and `infra/grafana/**`, so a dashboard or
+Terraform change triggers the pipeline — and nothing else does.
+Authentication comes from two GitHub Actions secrets set out-of-band (never
+committed):
 
 ```sh
 gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://wifihaven.grafana.net'

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -31,25 +31,23 @@ Manages:
   - api-health HTTP request-rate/latency panels → folded back in with
     [#1204](https://github.com/wifihaven/wifihaven/issues/1204) (tracked in [#1281](https://github.com/wifihaven/wifihaven/issues/1281))
 
-## Per-environment, in the CD pipeline
+## In the CD pipeline
 
-This config is applied **once per Grafana Cloud stack**. It is wired into
-the Master API/UI CD pipeline
-([`master-api-ui.yml`](../../.github/workflows/master-api-ui.yml)),
-mirroring the SPA's staging-then-prod split:
+This config is applied to **one Grafana Cloud stack that serves every
+environment**. It is wired into the Master API/UI CD pipeline
+([`master-api-ui.yml`](../../.github/workflows/master-api-ui.yml)) as a
+single job:
 
-- `deploy-grafana-staging` — applies to the **staging** stack in parallel
-  with `deploy-staging` / `deploy-spa-staging`, on the same test gate.
-- `deploy-grafana-prod` — applies to the **prod** stack after the
-  `approve-production` manual gate, alongside `deploy-prod-render` /
-  `deploy-spa-prod`.
+- `deploy-grafana` — applies the dashboards after the `approve-production`
+  manual gate, alongside `deploy-prod-render` / `deploy-spa-prod`.
 
-So staging dashboards ship with the staging deploy and prod dashboards ship
-with the prod deploy. The target stack is selected purely by the
-`grafana_url` / `grafana_auth` variables, fed from per-environment secrets.
-Both jobs are **non-critical** (`continue-on-error`, design §6.2): a
-dashboard-deploy failure is alert-worthy but never blocks the API/SPA
-release.
+There is no staging/prod split because the dashboards are
+environment-agnostic: each selects its data via the templated
+`${datasource}` variable at view time, so the same JSON renders against
+whichever Prometheus the viewer points it at. The target stack is selected
+purely by the `grafana_url` / `grafana_auth` variables. The job is
+**non-critical** (`continue-on-error`, design §6.2): a dashboard-deploy
+failure is alert-worthy but never blocks the API/SPA release.
 
 ### Stateless by design
 
@@ -65,39 +63,36 @@ unset the dashboards land in the stack's General folder. A consequence of
 statelessness: a dashboard removed from the repo is not auto-deleted from
 the stack — delete it by hand.
 
-**Not managed here**: the Grafana Cloud stacks themselves (created once per
-environment in the dashboard), the Prometheus datasource (dashboards use a
+**Not managed here**: the Grafana Cloud stack itself (created once in the
+dashboard), the Prometheus datasource (dashboards use a
 templated `${datasource}` variable resolved at view time, so the same JSON
 loads in both Grafana Cloud and a self-hosted provisioned Grafana, #1207),
 and the GitHub Actions secrets.
 
 ## Prerequisites
 
-1. A Grafana Cloud stack exists per environment (free tier is fine; see
-   design §6.2) — one for staging, one for prod.
-2. A **Grafana service-account token** per stack with dashboard write scope:
-   Grafana Cloud → Administration → Service accounts → add token.
+1. A Grafana Cloud stack exists (free tier is fine; see design §6.2) — one
+   stack serves every environment.
+2. A **Grafana service-account token** for the stack with dashboard write
+   scope: Grafana Cloud → Administration → Service accounts → add token.
 3. Terraform ≥ 1.6 installed (`brew install terraform`).
 
 ## CI / auto-deploy (the normal path)
 
 Deploys run from the Master API/UI CD pipeline on push to `main` (see
-[Per-environment, in the CD pipeline](#per-environment-in-the-cd-pipeline)
-above). The `master-api-ui.yml` `paths:` filter already includes
-`infra/**` and `deploy/**`, so a dashboard or Terraform change triggers the
-pipeline. Authentication comes from four GitHub Actions secrets set
-out-of-band (never committed):
+[In the CD pipeline](#in-the-cd-pipeline) above). The `master-api-ui.yml`
+`paths:` filter already includes `infra/**` and `deploy/**`, so a dashboard
+or Terraform change triggers the pipeline. Authentication comes from two
+GitHub Actions secrets set out-of-band (never committed):
 
 ```sh
-gh secret set GRAFANA_URL_STAGING  -R wifihaven/wifihaven --body 'https://<staging-stack>.grafana.net'
-gh secret set GRAFANA_AUTH_STAGING -R wifihaven/wifihaven --body '<staging service-account token>'
-gh secret set GRAFANA_URL_PROD     -R wifihaven/wifihaven --body 'https://<prod-stack>.grafana.net'
-gh secret set GRAFANA_AUTH_PROD    -R wifihaven/wifihaven --body '<prod service-account token>'
+gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://<stack>.grafana.net'
+gh secret set GRAFANA_AUTH -R wifihaven/wifihaven --body '<service-account token>'
 ```
 
-Until a given environment's pair is set, that environment's deploy job is a
-no-op gate. The PR acceptance bar is `terraform fmt`/`validate`-clean config
-plus `actionlint`-clean workflows, not a live deploy.
+Until both are set, the deploy job is a no-op gate. The PR acceptance bar is
+`terraform fmt`/`validate`-clean config plus `actionlint`-clean workflows,
+not a live deploy.
 
 `terraform fmt -check` + `terraform validate` for this directory also run in
 CI as the `grafana-terraform` lint job (mirrors the `render-blueprint`

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -72,7 +72,8 @@ and the GitHub Actions secrets.
 ## Prerequisites
 
 1. A Grafana Cloud stack exists (free tier is fine; see design §6.2) — one
-   stack serves every environment.
+   stack serves every environment. Ours is
+   [`wifihaven.grafana.net`](https://wifihaven.grafana.net).
 2. A **Grafana service-account token** for the stack with dashboard write
    scope: Grafana Cloud → Administration → Service accounts → add token.
 3. Terraform ≥ 1.6 installed (`brew install terraform`).
@@ -86,7 +87,7 @@ or Terraform change triggers the pipeline. Authentication comes from two
 GitHub Actions secrets set out-of-band (never committed):
 
 ```sh
-gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://<stack>.grafana.net'
+gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://wifihaven.grafana.net'
 gh secret set GRAFANA_AUTH -R wifihaven/wifihaven --body '<service-account token>'
 ```
 
@@ -103,7 +104,7 @@ precedent).
 ```sh
 cd infra/grafana
 
-export TF_VAR_grafana_url=https://<stack>.grafana.net
+export TF_VAR_grafana_url=https://wifihaven.grafana.net
 export TF_VAR_grafana_auth=<service-account token>
 # optional: export TF_VAR_folder_uid=<pre-created folder uid>
 

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -6,12 +6,13 @@
 #     the committed JSON stays canonical (no copy, no drift).
 #
 # Single stack: this config is applied to one Grafana Cloud stack that serves
-# every environment. In CD (master-api-ui.yml) the `deploy-grafana` job runs
-# it once, after the production-approval gate, authenticated by the
-# `grafana_url` / `grafana_auth` variables (fed from the GRAFANA_URL /
-# GRAFANA_AUTH secrets). Dashboards are environment-agnostic — they select
-# their data via the templated `${datasource}` variable at view time — so a
-# per-environment dashboard copy is unnecessary.
+# every environment. Its own CD pipeline (master-grafana.yml, the
+# `deploy-grafana` job) runs it on push to main whenever a dashboard or this
+# Terraform changes, authenticated by the `grafana_url` / `grafana_auth`
+# variables (fed from the GRAFANA_URL / GRAFANA_AUTH secrets). Dashboards are
+# environment-agnostic — they select their data via the templated
+# `${datasource}` variable at view time — so a per-environment dashboard copy
+# is unnecessary.
 #
 # Stateless by design. The CD jobs run on ephemeral runners with no
 # persisted state, so every apply starts from an empty state. That is safe

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -5,11 +5,13 @@
 #     deploy/grafana/dashboards/, sourced directly from the in-repo file so
 #     the committed JSON stays canonical (no copy, no drift).
 #
-# Per-environment: this same config is applied once per Grafana Cloud stack.
-# In CD (master-api-ui.yml) it runs twice — against the staging stack on the
-# staging deploy, and against the prod stack after the production-approval
-# gate — authenticated by per-environment service-account tokens. The
-# `grafana_url` / `grafana_auth` variables select the target stack.
+# Single stack: this config is applied to one Grafana Cloud stack that serves
+# every environment. In CD (master-api-ui.yml) the `deploy-grafana` job runs
+# it once, after the production-approval gate, authenticated by the
+# `grafana_url` / `grafana_auth` variables (fed from the GRAFANA_URL /
+# GRAFANA_AUTH secrets). Dashboards are environment-agnostic — they select
+# their data via the templated `${datasource}` variable at view time — so a
+# per-environment dashboard copy is unnecessary.
 #
 # Stateless by design. The CD jobs run on ephemeral runners with no
 # persisted state, so every apply starts from an empty state. That is safe
@@ -23,15 +25,14 @@
 # the dashboards land in the stack's General folder.
 #
 # Does NOT manage:
-#   - The Grafana Cloud stack / instance itself (created once per environment
-#     via the Grafana Cloud dashboard).
+#   - The Grafana Cloud stack / instance itself (created once via the Grafana
+#     Cloud dashboard).
 #   - The datasource: dashboards reference a templated `${datasource}`
 #     variable resolved at view time, so the same JSON loads against the
 #     Grafana Cloud Prometheus datasource (cloud path) and a self-hosted
 #     provisioned Prometheus (#1207) without edits.
-#   - The service-account token (operator creates it per stack in Grafana
-#     Cloud; value supplied via `grafana_auth` / the GRAFANA_AUTH_* secret,
-#     never committed).
+#   - The service-account token (operator creates it in Grafana Cloud; value
+#     supplied via `grafana_auth` / the GRAFANA_AUTH secret, never committed).
 
 terraform {
   required_version = ">= 1.6"

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -2,7 +2,7 @@
 # (gitignored) and fill in, OR export as TF_VAR_*. Both values are secrets —
 # never commit real values.
 #
-# In CD these are NOT read from a tfvars file: master-api-ui.yml feeds them
+# In CD these are NOT read from a tfvars file: master-grafana.yml feeds them
 # from the GRAFANA_URL / GRAFANA_AUTH GitHub Actions secrets (one Grafana
 # Cloud stack serves every environment).
 

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -3,8 +3,8 @@
 # never commit real values.
 #
 # In CD these are NOT read from a tfvars file: master-api-ui.yml feeds them
-# per environment from the GRAFANA_URL_STAGING / GRAFANA_AUTH_STAGING and
-# GRAFANA_URL_PROD / GRAFANA_AUTH_PROD GitHub Actions secrets.
+# from the GRAFANA_URL / GRAFANA_AUTH GitHub Actions secrets (one Grafana
+# Cloud stack serves every environment).
 
 grafana_url  = "https://<your-stack>.grafana.net"
 grafana_auth = "<Grafana service-account token — Administration → Service accounts>"

--- a/infra/grafana/variables.tf
+++ b/infra/grafana/variables.tf
@@ -7,7 +7,7 @@ variable "grafana_url" {
 variable "grafana_auth" {
   type        = string
   sensitive   = true
-  description = "Grafana service-account token (per stack) with dashboard write scope. Create in Grafana Cloud → Administration → Service accounts. In CD this is GRAFANA_AUTH_STAGING / GRAFANA_AUTH_PROD; never committed."
+  description = "Grafana service-account token with dashboard write scope. Create in Grafana Cloud → Administration → Service accounts. In CD this is the GRAFANA_AUTH secret; never committed."
 }
 
 variable "folder_uid" {


### PR DESCRIPTION
## Summary

There is a single Grafana Cloud stack (`wifihaven.grafana.net`), not one per
environment, and the in-repo dashboards are environment-agnostic — each
selects its data via the templated `${datasource}` variable at view time. So
the staging/prod deploy split introduced in #1270 was redundant.

Rather than just collapse the two jobs in `master-api-ui.yml`, this gives the
dashboard deploy its **own pipeline**, decoupled from the API/SPA release:

- **New `master-grafana.yml`** — single `deploy-grafana` job, path-scoped to
  `deploy/grafana/**` and `infra/grafana/**`, so it fires *only* when a
  dashboard JSON or its Terraform changes. No `approve-production` gate (a
  dashboard change is independent and low-risk; it already passed PR review +
  the `grafana-terraform` lint job). Gated on `GRAFANA_URL` / `GRAFANA_AUTH`
  secrets; a no-op until they're set.
- **`master-api-ui.yml`** — removed the old `deploy-grafana-staging` /
  `deploy-grafana-prod` jobs and excluded `deploy/grafana/**` /
  `infra/grafana/**` from its `paths:`, so a dashboard-only change no longer
  triggers a full API/SPA redeploy.
- Synced `infra/grafana` docs (README, `main.tf` header, `tfvars.example`,
  `variables.tf`) and the `ci.yml` lint comment to the new pipeline; recorded
  the `wifihaven.grafana.net` stack URL in the README.

Follow-up to #1270 (which merged in #1272). No dashboard JSON or Terraform
resource changes — workflows + docs only.

## Test plan

- [x] `actionlint` clean on all workflows (incl. new `master-grafana.yml`)
- [x] `terraform fmt -check` + `terraform validate` clean in `infra/grafana`
- [x] `GRAFANA_URL` / `GRAFANA_AUTH` repo secrets set
- [ ] After merge: edit a dashboard, confirm `master-grafana.yml` runs and
      `master-api-ui.yml` does **not**