### PR TITLE
API self-metrics: http/db/auth/zero-byte series + cardinality firewall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,6 +490,43 @@ Before the PR merges:
 > Out of scope here: automated query-plan regression testing in CI — a
 > heavier, separate idea. This rule is just the agent-workflow guardrail.
 
+## A new metric ships with its dashboard {#metrics-need-a-dashboard}
+
+**A PR that adds or changes an emitted metric series must also add or update
+a Grafana panel that consumes it, in the same PR.** A metric nobody can see
+is dead weight: it costs cardinality and registry space but never reaches an
+operator's eyes until an incident, which is exactly when you don't want to be
+authoring PromQL from scratch.
+
+"Emitted metric series" means any new `Metric.counter` / `histogram` / `gauge`
+(or `AppMetrics`/`MetricGuard` helper) whose name reaches the `/metrics`
+exposition. Adding a label to an existing series counts too if it changes what
+an operator would want to slice by.
+
+In the same PR:
+
+1. **Add the panel where it belongs.** Dashboards are checked-in JSON under
+   [`deploy/grafana/dashboards/`](deploy/grafana/dashboards/), deployed by
+   [`master-grafana.yml`](.github/workflows/master-grafana.yml) via the
+   [`infra/grafana`](infra/grafana/) Terraform. Extend an existing dashboard
+   when the metric fits its theme (process health vs. application
+   self-metrics vs. rollup health); add a new `*.json` and register it in
+   `infra/grafana/main.tf`'s `dashboards` list when it's a new concern.
+2. **Target the series you actually emit — never a design-doc catalog.** Grep
+   `api/src` for the exact metric name and labels and write the PromQL against
+   that. Histograms render as `<name>_bucket{le=…}` / `_sum` / `_count` (use
+   `histogram_quantile`); the zio-prometheus connector does **not** append
+   `_total` to counters, so the name in code is the name in the query. Do not
+   ship no-data panels for metrics that aren't emitted yet — defer those to
+   the follow-up PR that instruments them.
+3. **Keep labels low-cardinality in the query, too.** Slice only by bounded
+   label keys (templated `route`, `op`, `reason`, `status`); never by a
+   per-mac / per-domain / per-device / per-ip value. If the firewall would
+   reject the label, the panel shouldn't group by it.
+4. **The CI gate is `grafana-terraform`** ([`ci.yml`](.github/workflows/ci.yml)):
+   `terraform fmt -check`, `terraform validate`, and `python3 -m json.tool`
+   on every dashboard. Run all three locally before pushing.
+
 ## Branch-diff checks (CI + pre-push)
 
 CI checks and pre-push checks that compare a branch against `main` MUST diff against the **merge base** with `origin/main`, not `origin/main` directly. Use three-dot syntax (`origin/main...HEAD`) or an explicit `git merge-base origin/main HEAD`. Two-dot (`origin/main..HEAD`) over-reports when `main` has advanced since the branch diverged, producing spurious failures and noise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,6 +490,42 @@ Before the PR merges:
 > Out of scope here: automated query-plan regression testing in CI — a
 > heavier, separate idea. This rule is just the agent-workflow guardrail.
 
+## New functionality ships with metrics {#instrument-new-functionality}
+
+**When you add a meaningful new code path — a route, a background job, a
+periodic poller, an external call, an ingest/enforcement step — instrument it
+with a metric in the same PR.** The architectural model puts all decision and
+aggregation logic server-side in the API (the router is a dumb applier), so the
+API process is the one place an operator can see what the system is doing. A
+feature that emits no metric is invisible until it breaks.
+
+What "meaningful" means — instrument it when at least one is true:
+
+- It can **fail or be rejected** in a way an operator would want to rate-alert
+  on (auth/validation failures, dropped/filtered records, ret-exhausted calls).
+  Emit a `*_total{reason}` counter with a **bounded** reason enum.
+- It does **work whose latency or volume matters** (a DB query on a
+  growth table, a rollup, an external fetch, a request handler). Emit a
+  `*_duration_seconds` histogram and/or a throughput counter.
+- It reflects **fleet/system state** an operator would check first during an
+  incident (connected routers, queue depth, last-success timestamp). Emit a
+  gauge.
+
+Rules of thumb:
+
+- **Route the emission through `AppMetrics` / `MetricGuard`** (see
+  `api/src/metrics/Metrics.scala`), not a bare `Metric.*` at the call site, so
+  the §4 cardinality firewall and the name/label allowlist apply. Add the new
+  `(name -> allowed keys)` entry to `MetricGuard.Allowed`.
+- **Labels are a small, known enum** — `route` (templated), `op`, `reason`,
+  `status`, `job`. **Never** a per-mac / per-domain / per-device / per-ip /
+  per-user value; those are forbidden keys and will be rejected.
+- **Don't over-instrument.** A pure helper, a trivial getter, or a path already
+  covered by the HTTP/DB middleware doesn't need its own series. One good
+  counter or histogram beats five redundant ones, and every series costs
+  cardinality.
+- A new metric then **ships with its dashboard panel** — see the next rule.
+
 ## A new metric ships with its dashboard {#metrics-need-a-dashboard}
 
 **A PR that adds or changes an emitted metric series must also add or update

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -5,7 +5,7 @@ import doobie.implicits.*
 import wifihaven.api.auth.*
 import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
-import wifihaven.api.metrics.{DbPoolMetrics, MetricsRuntime}
+import wifihaven.api.metrics.{DbPoolMetrics, HttpMetrics, MetricsRuntime, RouterPresenceMetrics}
 import wifihaven.api.notify.Notifier
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
@@ -155,12 +155,12 @@ object Main extends ZIOAppDefault {
         // a time budget, or a separate small pool for the rollup work. The pool-size
         // bump (this PR) and the dedicated connect EC are the first-order fix; this
         // is the durability follow-up tracked in #1221.
-        timeRollupRepo  <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
-        profileRepoForJ <- ZIO.service[wifihaven.api.db.ProfileRepo]
-        deviceRepoForJ  <- ZIO.service[wifihaven.api.db.DeviceRepo]
-        stlRepoForJ     <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
-        trafficRepoForJ <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
-        _               <- TimeUsedRollupJob
+        timeRollupRepo   <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+        profileRepoForJ  <- ZIO.service[wifihaven.api.db.ProfileRepo]
+        deviceRepoForJ   <- ZIO.service[wifihaven.api.db.DeviceRepo]
+        stlRepoForJ      <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+        trafficRepoForJ  <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
+        _                <- TimeUsedRollupJob
           .loop(
             timeRollupRepo,
             rollupRepo,
@@ -172,33 +172,38 @@ object Main extends ZIOAppDefault {
             clockForJobs,
           )
           .forkScoped
-        _               <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
+        _                <- ZIO.logInfo("rollup fibers forked (hourly + daily + time_used_daily)")
         // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
         // for the process and never blocks startup.
-        dbPool          <- ZIO.service[Database.DbPool]
-        _               <- DbPoolMetrics.loop(dbPool.dataSource, dbPool.maxSize).forkDaemon
-        _               <- ZIO.logInfo("db-pool metrics fiber forked")
-        _               <- ZIO
+        dbPool           <- ZIO.service[Database.DbPool]
+        _                <- DbPoolMetrics.loop(dbPool.dataSource, dbPool.maxSize).forkDaemon
+        _                <- ZIO.logInfo("db-pool metrics fiber forked")
+        // #1204: publish agent_connected_routers — routers seen within the window.
+        // forkDaemon: a read-only periodic SELECT, never blocks startup.
+        routerRepoMetric <- ZIO.service[RouterRepo]
+        _                <- RouterPresenceMetrics.loop(routerRepoMetric).forkDaemon
+        _                <- ZIO.logInfo("router-presence metrics fiber forked")
+        _                <- ZIO
           .logWarning(
             "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
               "Disable in production.",
           )
           .when(cfg.seedTestBlocklists)
-        _               <- BundledBlocklists
+        _                <- BundledBlocklists
           .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
           .when(cfg.seedTestBlocklists)
         // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
         // Multi-instance-safe via Postgres advisory lock — losing instances skip
         // the tick rather than racing on the same DELETE.
-        xaForJobs       <- ZIO.service[Transactor[Task]]
-        _               <- RetentionSweepJob.start(xaForJobs)
+        xaForJobs        <- ZIO.service[Transactor[Task]]
+        _                <- RetentionSweepJob.start(xaForJobs)
         // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
         // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
         // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
         // no NULLs remain.
-        _               <- ReasonTextBackfill.run(xaForJobs).forkDaemon
+        _                <- ReasonTextBackfill.run(xaForJobs).forkDaemon
         // Keep the process alive on the already-bound server fiber; exits if it dies.
-        _               <- serverFiber.join
+        _                <- serverFiber.join
       } yield ())
       .provide(serverEnv)
 
@@ -271,9 +276,15 @@ object Main extends ZIOAppDefault {
       // Prometheus registry (no DB) and must stay scrapeable during a slow
       // startup — exactly the scenario this gate exists for. Everything else is
       // gated below.
-      val ungatedRoutes: Routes[Any, Response] =
-        HealthRoutes.routes(ready, dbHealthCheck) ++
-          MetricsRoutes.routes(cfg.metrics, promPublisher)
+      //
+      // #1204: /metrics is deliberately left OUT of HttpMetrics.instrument below —
+      // the scrape endpoint should not count itself, and counting it would just
+      // add a self-referential series that climbs with Prometheus' poll rate.
+      val healthRoutes: Routes[Any, Response] =
+        HealthRoutes.routes(ready, dbHealthCheck)
+
+      val metricsRoutes: Routes[Any, Response] =
+        MetricsRoutes.routes(cfg.metrics, promPublisher)
 
       val systemRoutes: Routes[Any, Response] =
         VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
@@ -359,11 +370,15 @@ object Main extends ZIOAppDefault {
         if (cfg.http.serveSpa) StaticRoutes.routes(cfg.http.staticDir) else Routes.empty
 
       // #1248: gate all real routes behind readiness (503 until migrations +
-      // seeds complete), then mount the ungated observability routes alongside.
-      ungatedRoutes ++
-        Readiness.gate(
-          systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
-          ready,
-        )
+      // seeds complete). #1204: wrap health + the gated real routes in the HTTP
+      // metrics middleware (templated route labels), then mount the uninstrumented
+      // /metrics scrape endpoint alongside.
+      HttpMetrics.instrument(
+        healthRoutes ++
+          Readiness.gate(
+            systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+            ready,
+          ),
+      ) ++ metricsRoutes
     }
 }

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -3,6 +3,7 @@ package wifihaven.api.auth
 import at.favre.lib.crypto.bcrypt.BCrypt
 import wifihaven.api.JwtConfig
 import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import pdi.jwt.*
@@ -58,7 +59,7 @@ class AuthServiceLive(
   private val secret                 = jwtConfig.secret
 
   def login(username: String, password: String): IO[AuthError, LoginResponse] =
-    for {
+    (for {
       user  <- userRepo
         .findByUsername(username)
         .mapError(e => AuthError.Unexpected(e.getMessage))
@@ -77,7 +78,17 @@ class AuthServiceLive(
       token <- ZIO
         .attempt(JwtZIOJson.encode(claim, secret, algo))
         .mapError(e => AuthError.Unexpected(e.getMessage))
-    } yield LoginResponse(JwtToken.unsafe(token), user.role, user.username, user.mustChangePassword)
+    } yield LoginResponse(
+      JwtToken.unsafe(token),
+      user.role,
+      user.username,
+      user.mustChangePassword,
+    ))
+      .tapError {
+        // #1204: a bad password or unknown user both collapse to InvalidCredentials.
+        case AuthError.InvalidCredentials => AppMetrics.recordAuthFailure("bad_password")
+        case _                            => ZIO.unit
+      }
 
   // We delegate expiration/not-before checks to our injected Clock (see below).
   private val jwtOpts = JwtOptions(expiration = false, notBefore = false)
@@ -105,18 +116,33 @@ class AuthServiceLive(
           ZIO.fail(AuthError.TokenExpired).when(claims.exp < now).as(claims)
         }
       }
+      .tapError {
+        // #1204: only the expired case is a bounded, security-relevant reason. A
+        // malformed/forged token (InvalidToken) is not in the §5.2 reason enum.
+        case AuthError.TokenExpired => AppMetrics.recordAuthFailure("expired_token")
+        case _                      => ZIO.unit
+      }
+
+  // #1204: a role check that fails Forbidden is the forbidden_role signal. verify's
+  // own failures (expired_token) are already counted above, so they don't surface as
+  // Forbidden here — no double counting.
+  private def tapForbiddenRole(z: IO[AuthError, JwtClaims]): IO[AuthError, JwtClaims] =
+    z.tapError {
+      case AuthError.Forbidden => AppMetrics.recordAuthFailure("forbidden_role")
+      case _                   => ZIO.unit
+    }
 
   def requireAdmin(token: String): IO[AuthError, JwtClaims] =
-    verify(token).flatMap { claims =>
+    tapForbiddenRole(verify(token).flatMap { claims =>
       if claims.role == "admin" then ZIO.succeed(claims)
       else ZIO.fail(AuthError.Forbidden)
-    }
+    })
 
   def requireWriter(token: String): IO[AuthError, JwtClaims] =
-    verify(token).flatMap { claims =>
+    tapForbiddenRole(verify(token).flatMap { claims =>
       if claims.role == "admin" || claims.role == "adult" then ZIO.succeed(claims)
       else ZIO.fail(AuthError.Forbidden)
-    }
+    })
 
   def requirePasswordChanged(token: String): IO[AuthError, JwtClaims] =
     verify(token).flatMap { claims =>

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -8,6 +8,7 @@ import wifihaven.shared.*
 import wifihaven.shared.types.*
 import wifihaven.shared.Schedule
 import wifihaven.api.db.TypeMeta.given
+import wifihaven.api.metrics.DbMetrics
 import zio.*
 import zio.interop.catz.*
 import java.time.{Instant, LocalDate, LocalTime, ZoneId}
@@ -366,6 +367,12 @@ trait RouterRepo {
   def completeEnrollment(id: RouterId, tokenHash: Sha256Hex): Task[Unit]
   def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]): Task[Unit]
 
+  /**
+   * #1204: routers whose last_seen_at is at or after `cutoff`. Drives the agent_connected_routers
+   * gauge.
+   */
+  def countSeenSince(cutoff: Instant): Task[Int]
+
   def delete(id: RouterId): Task[Unit]
 }
 
@@ -520,11 +527,13 @@ trait ConnectionEventRepo {
 
 class UserRepoLive(xa: Transactor[Task]) extends UserRepo {
   def findByUsername(u: String)             =
-    sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE username=$u"
-      .query[(UserId, String, String, UserRole, Instant, Boolean)]
-      .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
-      .option
-      .transact(xa)
+    DbMetrics.timed("user.findByUsername")(
+      sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE username=$u"
+        .query[(UserId, String, String, UserRole, Instant, Boolean)]
+        .map { case (id, un, ph, role, ca, mcp) => DbUser(id, un, ph, role, ca, mcp) }
+        .option
+        .transact(xa),
+    )
   def findById(id: UserId)                  =
     sql"SELECT id,username,password_hash,role,created_at,must_change_password FROM users WHERE id=$id"
       .query[(UserId, String, String, UserRole, Instant, Boolean)]
@@ -625,11 +634,13 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     CrossDeviceOverlapMode.parse(r._7).getOrElse(CrossDeviceOverlapMode.Sum),
   )
   def listAll                                       =
-    sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
-      .query[R]
-      .map(toP)
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("profile.listAll")(
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
+        .query[R]
+        .map(toP)
+        .to[List]
+        .transact(xa),
+    )
   def findById(id: ProfileId)                       =
     sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
       .query[R]
@@ -781,21 +792,23 @@ class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
 
 class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
   def listAll                                                                          =
-    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id ORDER BY d.name"
-      .query[
-        (
-            DeviceId,
-            MacAddress,
-            String,
-            Option[ProfileId],
-            Option[String],
-            Option[IpAddress],
-            Option[String],
-        ),
-      ]
-      .map(r => Device(r._1, r._2, r._3, r._4, r._5, r._6, r._7))
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("device.listAll")(
+      sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id ORDER BY d.name"
+        .query[
+          (
+              DeviceId,
+              MacAddress,
+              String,
+              Option[ProfileId],
+              Option[String],
+              Option[IpAddress],
+              Option[String],
+          ),
+        ]
+        .map(r => Device(r._1, r._2, r._3, r._4, r._5, r._6, r._7))
+        .to[List]
+        .transact(xa),
+    )
   def findByMac(mac: MacAddress)                                                       =
     sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id WHERE d.mac=$mac"
       .query[
@@ -1300,11 +1313,13 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
       .option
       .transact(xa)
   def findByTokenHash(h: Sha256Hex)                                         =
-    (fr"SELECT " ++ cols ++ fr" FROM routers WHERE token_hash=$h")
-      .query[R]
-      .map(toR)
-      .option
-      .transact(xa)
+    DbMetrics.timed("router.findByTokenHash")(
+      (fr"SELECT " ++ cols ++ fr" FROM routers WHERE token_hash=$h")
+        .query[R]
+        .map(toR)
+        .option
+        .transact(xa),
+    )
   def create(name: String, enrollmentTokenHash: Sha256Hex)                  =
     sql"INSERT INTO routers(name,enrollment_token_hash) VALUES($name,$enrollmentTokenHash) RETURNING id"
       .query[RouterId]
@@ -1322,6 +1337,13 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
           WHERE id=$id""".update.run
       .transact(xa)
       .unit
+  def countSeenSince(cutoff: Instant)                                       =
+    DbMetrics.timed("router.countSeenSince")(
+      sql"SELECT count(*) FROM routers WHERE last_seen_at >= $cutoff"
+        .query[Int]
+        .unique
+        .transact(xa),
+    )
   def delete(id: RouterId)                                                  =
     sql"DELETE FROM routers WHERE id=$id".update.run.transact(xa).unit
 }
@@ -1344,9 +1366,11 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
   private def toT(r: R)                               =
     TrafficReport(r._1, r._2, r._3, r._4, r._5, r._6, r._7, r._8, r._9, r._10, r._11)
   def insertBatch(reports: List[TrafficReportInsert]) =
-    Update[TrafficReportInsert](
-      "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
-    ).updateMany(reports).transact(xa)
+    DbMetrics.timed("traffic.insertBatch")(
+      Update[TrafficReportInsert](
+        "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
+      ).updateMany(reports).transact(xa),
+    )
   // TODO(#730): remove this read-side join once usage records carry dest_ip.
   // Promotes ipv4/ipv6-typed traffic_reports rows to their resolved fqdn at
   // SELECT time via the same LATERAL join used in TimeUsageRepoLive.

--- a/api/src/metrics/HttpMetrics.scala
+++ b/api/src/metrics/HttpMetrics.scala
@@ -1,0 +1,55 @@
+package wifihaven.api.metrics
+
+import zio.*
+import zio.http.*
+
+/**
+ * #1204: HTTP request metrics (`http_requests_total{route,method,status}` and
+ * `http_request_duration_seconds{route,method}`).
+ *
+ * The hard requirement (§4) is that `route` is the *templated* path — `/api/devices/:mac`, never
+ * the concrete id — because a per-id label would be unbounded and would leak device identity into
+ * the metric registry. We get this for free by transforming each route individually and reading its
+ * own `routePattern.pathCodec`: the only string that can ever become a label is the route template
+ * the handler was registered under. A concrete path segment is physically unreachable here, so no
+ * id can leak even by mistake.
+ *
+ * This mirrors zio-http's built-in `Middleware.metrics`, but emits the `route` label (the built-in
+ * uses `path`, which §4.3 forbids) and routes every emission through [[AppMetrics.recordHttp]] /
+ * the cardinality firewall. Timing wraps the handler's full exit (success *and* failure), so
+ * 4xx/5xx responses produced on the error channel are still counted.
+ *
+ * Trade-off: a request that matches no route never reaches a transformed handler, so it is not
+ * counted. That is the safe direction — an unmatched request carries a raw, attacker-controlled
+ * path that must never become a label. Per-route templating keeps the label space bounded to the
+ * ~40 registered templates.
+ */
+object HttpMetrics {
+
+  private def renderTemplate(rp: RoutePattern[?]): String =
+    rp.pathCodec.render(":", "")
+
+  def instrument(routes: Routes[Any, Response]): Routes[Any, Response] =
+    Routes.fromIterable(routes.routes.map(instrumentOne))
+
+  private def instrumentOne(route: Route[Any, Response]): Route[Any, Response] = {
+    val routeLabel = renderTemplate(route.routePattern)
+    val method     = route.routePattern.method.render
+    route.transform[Any] { handler =>
+      Handler.fromFunctionZIO[Request] { req =>
+        Clock.nanoTime.flatMap { start =>
+          handler(req).either
+            .flatMap { result =>
+              val response = result.merge
+              Clock.nanoTime.flatMap { end =>
+                AppMetrics
+                  .recordHttp(routeLabel, method, response.status.code, (end - start) / 1e9d)
+                  .as(result)
+              }
+            }
+            .flatMap(ZIO.fromEither(_))
+        }
+      }
+    }
+  }
+}

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.metrics
 
 import com.zaxxer.hikari.HikariDataSource
+import wifihaven.api.db.RouterRepo
 import zio.*
 import zio.metrics.*
 import zio.metrics.connectors
@@ -8,11 +9,162 @@ import zio.metrics.connectors.MetricsConfig as ConnectorsConfig
 import zio.metrics.connectors.prometheus.PrometheusPublisher
 
 /**
+ * #1204 §4.1: server-side cardinality firewall. Every self-metric emission goes through here, so a
+ * metric can only be written under an allowlisted name with an allowlisted (and never-forbidden)
+ * set of label keys. Anything else is dropped and counted in `metrics_rejected_total{reason}`
+ * rather than polluting the registry with an unbounded series. For the current call sites the
+ * names/keys are all static, so the reject path is a defensive backstop — but it's the same gate
+ * the future `/api/router/metrics` ingest (router-pushed series) will reuse.
+ */
+object MetricGuard {
+
+  /**
+   * §4.3 — keys whose value-space grows with users/devices/domains/flows. Never allowed anywhere.
+   */
+  val ForbiddenKeys: Set[String] =
+    Set(
+      "mac",
+      "device_id",
+      "domain",
+      "host",
+      "hostname",
+      "ip",
+      "dst_ip",
+      "user_id",
+      "profile_id",
+      "path",
+      "query",
+    )
+
+  /**
+   * §5.2 — metric name → its permitted label keys. The only (name, keys) pairs that may be emitted.
+   */
+  val Allowed: Map[String, Set[String]] = Map(
+    "http_requests_total"                       -> Set("route", "method", "status"),
+    "http_request_duration_seconds"             -> Set("route", "method"),
+    "db_query_duration_seconds"                 -> Set("op"),
+    "auth_failures_total"                       -> Set("reason"),
+    "agent_connected_routers"                   -> Set.empty[String],
+    "traffic_reports_filtered_zero_bytes_total" -> Set.empty[String],
+  )
+
+  private val rejected = Metric.counter("metrics_rejected_total")
+
+  private def reject(reason: String): UIO[Unit] =
+    rejected.tagged("reason", reason).update(1L)
+
+  /** None ⇒ rejected (already counted); Some(labels) ⇒ cleared to emit. */
+  private def check(name: String, labels: Map[String, String]): UIO[Option[Map[String, String]]] =
+    Allowed.get(name) match {
+      case None          => reject("unknown_name").as(None)
+      case Some(allowed) =>
+        val keys = labels.keySet
+        if keys.exists(ForbiddenKeys.contains) || !keys.subsetOf(allowed) then
+          reject("forbidden_label").as(None)
+        else ZIO.some(labels)
+    }
+
+  def counter(name: String, labels: Map[String, String], by: Long = 1L): UIO[Unit] =
+    check(name, labels).flatMap {
+      case None     => ZIO.unit
+      case Some(ls) =>
+        ls.foldLeft(Metric.counter(name))((m, kv) => m.tagged(kv._1, kv._2)).update(by)
+    }
+
+  def histogram(
+      name: String,
+      labels: Map[String, String],
+      value: Double,
+      boundaries: MetricKeyType.Histogram.Boundaries,
+  ): UIO[Unit] =
+    check(name, labels).flatMap {
+      case None     => ZIO.unit
+      case Some(ls) =>
+        ls.foldLeft(Metric.histogram(name, boundaries))((m, kv) => m.tagged(kv._1, kv._2))
+          .update(value)
+    }
+
+  def gauge(name: String, labels: Map[String, String], value: Double): UIO[Unit] =
+    check(name, labels).flatMap {
+      case None     => ZIO.unit
+      case Some(ls) =>
+        ls.foldLeft(Metric.gauge(name))((m, kv) => m.tagged(kv._1, kv._2)).update(value)
+    }
+}
+
+/**
  * #1242 / #1243: all WifiHaven application metrics, published through the Prometheus registry
  * exposed at `GET /metrics`. Every series is a plain `zio.metrics.Metric`, so the connector's
  * periodic snapshot picks them up alongside the JVM/runtime metrics.
  */
 object AppMetrics {
+
+  // ── HTTP server (#1204) ─────────────────────────────────────────────────────
+  // Emitted from HttpMetrics.instrument, which wraps every real route. `route` is
+  // the *templated* path (e.g. /api/devices/:mac), never a concrete id — see §4.
+
+  /** §5.2 latency SLO buckets: 5ms → 5s. */
+  val HttpDurationBoundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(
+      Chunk(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+    )
+
+  def recordHttp(route: String, method: String, status: Int, durationSeconds: Double): UIO[Unit] =
+    MetricGuard.counter(
+      "http_requests_total",
+      Map("route" -> route, "method" -> method, "status" -> status.toString),
+    ) *>
+      MetricGuard.histogram(
+        "http_request_duration_seconds",
+        Map("route" -> route, "method" -> method),
+        math.max(0.0, durationSeconds),
+        HttpDurationBoundaries,
+      )
+
+  // ── DB query timing (#1204) ──────────────────────────────────────────────────
+  // Emitted from DbMetrics.timed around the Doobie transact of hot repo methods.
+  // `op` is a hand-named constant per method, never the SQL text.
+
+  /** Sub-millisecond → multi-second DB latency. */
+  val DbDurationBoundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(
+      Chunk(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+    )
+
+  def recordDbQuery(op: String, durationSeconds: Double): UIO[Unit] =
+    MetricGuard.histogram(
+      "db_query_duration_seconds",
+      Map("op" -> op),
+      math.max(0.0, durationSeconds),
+      DbDurationBoundaries,
+    )
+
+  // ── Auth failures (#1204) ────────────────────────────────────────────────────
+  // `reason` ∈ {bad_password, expired_token, bad_router_token, forbidden_role}.
+
+  def recordAuthFailure(reason: String): UIO[Unit] =
+    MetricGuard.counter("auth_failures_total", Map("reason" -> reason))
+
+  // ── #864: traffic_reports rows dropped as zero-bytes-zero-seconds ────────────
+  // Replaces the per-request warn-log + TODO marker. A rising rate means the
+  // #858 agent regression (emitting empty rows) has returned.
+
+  def recordZeroByteFiltered(rows: Int): UIO[Unit] =
+    ZIO
+      .when(rows > 0)(
+        MetricGuard.counter(
+          "traffic_reports_filtered_zero_bytes_total",
+          Map.empty,
+          rows.toLong,
+        ),
+      )
+      .unit
+
+  // ── Fleet liveness (#1204) ───────────────────────────────────────────────────
+  // Set by RouterPresenceMetrics: routers seen (last_seen_at) within the window.
+
+  def setConnectedRouters(count: Int): UIO[Unit] =
+    MetricGuard.gauge("agent_connected_routers", Map.empty, count.toDouble)
 
   // ── Rollup health (#1243) ──────────────────────────────────────────────────
   // Emitted from RollupRepoLive.recordRun — the single completion point both the
@@ -94,6 +246,52 @@ object DbPoolMetrics {
   /** Fiber loop: poll every `interval`. Never fails; intended to be forked as a daemon. */
   def loop(ds: HikariDataSource, maxSize: Int, interval: Duration = DefaultInterval): UIO[Unit] =
     pollOnce(ds, maxSize).repeat(Schedule.fixed(interval)).unit
+}
+
+/**
+ * #1204: time the Doobie transact of a repo method into `db_query_duration_seconds{op}`. `op` is a
+ * hand-named constant supplied at the call site — never derived from the SQL — so the label space
+ * stays a small, known enum. Records on every exit (success or failure) so a slow failing query is
+ * still visible.
+ */
+object DbMetrics {
+  def timed[A](op: String)(query: Task[A]): Task[A] =
+    Clock.nanoTime.flatMap { start =>
+      query.onExit { _ =>
+        Clock.nanoTime.flatMap(end => AppMetrics.recordDbQuery(op, (end - start) / 1e9d))
+      }
+    }
+}
+
+/**
+ * #1204: publish `agent_connected_routers` — the single "is the fleet alive?" gauge. Counts routers
+ * whose `last_seen_at` is within `window` (touched on every policy poll + usage/event push). Pure
+ * read path: a periodic `SELECT count(*)`, no migration needed.
+ */
+object RouterPresenceMetrics {
+
+  /** A router that hasn't been seen within this window is treated as disconnected. */
+  val DefaultWindow: Duration = 10.minutes
+
+  /** Poll cadence; well below the window so the gauge tracks fleet state promptly. */
+  val DefaultInterval: Duration = 30.seconds
+
+  def pollOnce(repo: RouterRepo, window: Duration): UIO[Unit] =
+    (for {
+      now   <- Clock.instant
+      count <- repo.countSeenSince(now.minus(window))
+      _     <- AppMetrics.setConnectedRouters(count)
+    } yield ()).catchAll(e =>
+      ZIO.logWarning(s"agent_connected_routers poll failed: ${e.getMessage}"),
+    )
+
+  /** Fiber loop; never fails. Intended to be forked as a daemon. */
+  def loop(
+      repo: RouterRepo,
+      window: Duration = DefaultWindow,
+      interval: Duration = DefaultInterval,
+  ): UIO[Unit] =
+    pollOnce(repo, window).repeat(Schedule.fixed(interval)).unit
 }
 
 /** #1242: Prometheus connector wiring — publisher + the periodic snapshot listener. */

--- a/api/src/routes/RouterAuth.scala
+++ b/api/src/routes/RouterAuth.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.routes
 
 import wifihaven.api.db.RouterRepo
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.shared.Router
 import wifihaven.shared.types.*
 import zio.*
@@ -50,4 +51,12 @@ class RouterAuthLive(repo: RouterRepo) extends RouterAuth {
             ZIO.fromOption(_).orElseFail(Response.unauthorized("Invalid router token")),
           )
       }
+      // #1204: count only the 401s (missing / unrecognized token), not a 500 from a
+      // transient DB error that ErrorMapper also turns into a Response.
+      .tapError(resp =>
+        AppMetrics
+          .recordAuthFailure("bad_router_token")
+          .when(resp.status == Status.Unauthorized)
+          .unit,
+      )
 }

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.routes
 
 import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.policy.PolicyService
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -118,8 +119,14 @@ object RouterIngestRoutes {
   ): IO[Response, Unit] = {
     // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
     // reset_time), matching the read-side date used by PolicyService.snapshot.
-    val date    = PolicyService.householdLocalDate(periodStart, settings)
-    val inserts = records.map(r =>
+    val date         = PolicyService.householdLocalDate(periodStart, settings)
+    // #864: a healthy agent never reports a row with no bytes and no active
+    // seconds. The read side already filters these (listRawInRange), so they're
+    // dead weight; count them here at ingest so a silent return of the #858 agent
+    // regression shows up as a rising rate rather than a per-request warn-log.
+    val zeroByteRows =
+      records.count(r => r.activeSeconds == 0L && r.bytesIn == 0L && r.bytesOut == 0L)
+    val inserts      = records.map(r =>
       TrafficReportInsert(
         routerId,
         r.mac,
@@ -134,6 +141,7 @@ object RouterIngestRoutes {
       ),
     )
     for {
+      _        <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
       // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
       // Only those rows should drive time_usage / device updates; replays return 0.
       newCount <- trafficRepo.insertBatch(inserts).mapError(ErrorMapper.dbErrorToResponse)

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -717,8 +717,10 @@ object UsageRoutes {
             )
       }
       // #858: zero-bytes-zero-seconds rows are filtered at SQL level in
-      // listRawInRange so the application never sees them. TODO(#864) wire
-      // a metric for "rows filtered" once observability lands.
+      // listRawInRange so the application never sees them. #864: they're counted
+      // at ingest into traffic_reports_filtered_zero_bytes_total (see
+      // RouterIngestRoutes.handleUsage), so a return of the #858 regression is
+      // now a metric rather than a per-request log.
       profiles   <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
       profNames = profiles.iterator.map(p => p.id -> p.name).toMap
       devByMac  = allDevices.iterator.map(d => d.mac -> d).toMap

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -61,6 +61,7 @@ object DbFailureSpec extends ZIOSpecDefault {
     def findById(id: RouterId)                                                = throwing
     def findByEnrollmentTokenHash(h: Sha256Hex)                               = throwing
     def findByTokenHash(h: Sha256Hex)                                         = throwing
+    def countSeenSince(cutoff: java.time.Instant)                             = throwing
     def create(n: String, h: Sha256Hex)                                       = throwing
     def completeEnrollment(id: RouterId, h: Sha256Hex)                        = throwing
     def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]) = throwing

--- a/api/test/src/feature/MetricsSelfMetricsSpec.scala
+++ b/api/test/src/feature/MetricsSelfMetricsSpec.scala
@@ -55,7 +55,9 @@ object MetricsSelfMetricsSpec
       pub <- ZIO.service[PrometheusPublisher]
       routes = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
       resp <- routes(Request.get("/metrics"))
-      body <- resp.body.asString.orElseFail(Response.internalServerError())
+      body <- resp.body.asString.orElseFail(
+        Response.internalServerError("scrape body decode failed"),
+      )
     } yield body
 
   /**
@@ -140,7 +142,7 @@ object MetricsSelfMetricsSpec
 
         // Let the publisher snapshot the registry (poll is 100ms; live clock keeps the fiber ticking).
         _    <- ZIO.sleep(700.millis)
-        body <- scrape.merge
+        body <- scrape.catchAll(resp => resp.body.asString.orDie)
 
         httpLines = seriesLines(body, "http_requests_total")
       } yield

--- a/api/test/src/feature/MetricsSelfMetricsSpec.scala
+++ b/api/test/src/feature/MetricsSelfMetricsSpec.scala
@@ -1,0 +1,165 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.MetricsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.metrics.{HttpMetrics, MetricsRuntime}
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+import java.time.Instant
+
+/**
+ * #1204: API self-metrics (http_requests_total / http_request_duration_seconds /
+ * db_query_duration_seconds / auth_failures_total / traffic_reports_filtered_zero_bytes_total).
+ * Drives the real routes (wrapped in the production [[HttpMetrics.instrument]] middleware) and the
+ * real auth + ingest paths against embedded Postgres, then scrapes the live Prometheus publisher
+ * used by `GET /metrics`.
+ *
+ * The load-bearing assertion is the templated `route` label: a DELETE of a concrete MAC must
+ * surface as `route="/api/devices/:mac"`, never the concrete id, and no
+ * `mac`/`device_id`/`ip`/`domain` label key may appear on the http series — that is the §4
+ * cardinality firewall.
+ */
+object MetricsSelfMetricsSpec
+    extends ZIOSpec[
+      TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher,
+    ] {
+
+  override val bootstrap =
+    TestDatabase.layer ++
+      TestLayers.withClock(TestClock.schoolDayAfternoon) ++
+      MetricsRuntime.prometheus(100.millis)
+
+  private val adminJwt = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, adminJwt, clock)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def scrape: ZIO[PrometheusPublisher, Response, String] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      routes = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
+      resp <- routes(Request.get("/metrics"))
+      body <- resp.body.asString.orElseFail(Response.internalServerError())
+    } yield body
+
+  /**
+   * Lines of the exposition whose series name matches `metric` (ignores HELP/TYPE comment lines).
+   */
+  private def seriesLines(body: String, metric: String): List[String] =
+    body.linesIterator.filter(l => !l.startsWith("#") && l.startsWith(metric)).toList
+
+  def spec = suite("API self-metrics (#1204)")(
+    test(
+      "exercising routes + auth + ingest emits http/db/auth/zero-byte series with a templated route label and no high-cardinality labels",
+    ) {
+      val concreteMac = "aa:bb:cc:dd:ee:ff"
+      for {
+        _           <- cleanDb
+        profileRepo <- ZIO.service[ProfileRepo]
+        deviceRepo  <- ZIO.service[DeviceRepo]
+        upRepo      <- ZIO.service[UserProfileRepo]
+        routerRepo  <- ZIO.service[RouterRepo]
+        auth        <- makeAuth
+        token       <- auth.login("admin", "changeme").map(_.token.value)
+        profiles    <- profileRepo.listAll
+        kidsId = profiles.find(_.name == "Kids").get.id
+        _ <- deviceRepo.upsert(MacAddress.unsafe(concreteMac), "iPad", Some(kidsId), "192.168.1.50")
+
+        // Real router-ingest routes so a zero-byte usage record is dropped + counted (#864).
+        ingestAuth = new RouterAuthLive(routerRepo)
+        tu       <- ZIO.service[TimeUsageRepo]
+        connR    <- ZIO.service[ConnectionEventRepo]
+        alertR   <- ZIO.service[AlertRepo]
+        hsR      <- ZIO.service[HouseholdSettingsRepo]
+        trafficR <- ZIO.service[TrafficReportRepo]
+        routerToken = "ROUTER_TOKEN_PLAIN"
+        routerId <- routerRepo.create("r1", Sha256Hex.unsafe("m" * 64))
+        _        <- routerRepo.completeEnrollment(
+          routerId,
+          Sha256Hex.unsafe(RouterAuth.sha256Hex(routerToken)),
+        )
+
+        // The whole real route surface, wrapped in the production HTTP metrics middleware.
+        routes = HttpMetrics.instrument(
+          DeviceRoutes.routes(auth, deviceRepo, upRepo) ++
+            RouterIngestRoutes
+              .routes(ingestAuth, routerRepo, trafficR, tu, deviceRepo, connR, alertR, hsR),
+        )
+
+        // GET /api/devices → device.listAll (db metric) + http metric.
+        getReq = Request
+          .get(URL.decode("/api/devices").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        _ <- routes.runZIO(getReq)
+
+        // DELETE /api/devices/<concrete mac> → http metric with templated route label.
+        delReq = Request
+          .delete(URL.decode(s"/api/devices/$concreteMac").toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        _ <- routes.runZIO(delReq)
+
+        // A bad-password login → auth_failures_total{reason="bad_password"}.
+        _ <- auth.login("admin", "totally-wrong").either
+
+        // A zero-byte usage record → traffic_reports_filtered_zero_bytes_total.
+        zeroRec   = UsageRecord(
+          MacAddress.unsafe(concreteMac),
+          Some(IpAddress.unsafe("192.168.1.50")),
+          HostId.Fqdn(Hostname.unsafe("example.com")),
+          0L,
+          0L,
+          0L,
+        )
+        usageBody = UsageReport(
+          routerId,
+          Instant.parse("2026-05-07T14:00:00Z").toString,
+          Instant.parse("2026-05-07T14:05:00Z").toString,
+          List(zeroRec),
+        ).toJson
+        usageReq  = Request
+          .post(URL.decode("/api/router/usage").toOption.get, Body.fromString(usageBody))
+          .addHeader(Header.ContentType(MediaType.application.json))
+          .addHeader(Header.Authorization.Bearer(routerToken))
+        _ <- routes.runZIO(usageReq)
+
+        // Let the publisher snapshot the registry (poll is 100ms; live clock keeps the fiber ticking).
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.merge
+
+        httpLines = seriesLines(body, "http_requests_total")
+      } yield
+      // All five new series are present.
+      assertTrue(body.contains("http_requests_total")) &&
+        assertTrue(body.contains("http_request_duration_seconds")) &&
+        assertTrue(body.contains("db_query_duration_seconds")) &&
+        assertTrue(body.contains("auth_failures_total")) &&
+        assertTrue(body.contains("""reason="bad_password"""")) &&
+        assertTrue(body.contains("traffic_reports_filtered_zero_bytes_total")) &&
+        // The DELETE surfaces under the templated route, never the concrete id.
+        assertTrue(httpLines.exists(_.contains("""route="/api/devices/:mac""""))) &&
+        assertTrue(!httpLines.exists(_.contains(concreteMac))) &&
+        // No forbidden high-cardinality label key on the http series.
+        assertTrue(!httpLines.exists(_.contains("mac="))) &&
+        assertTrue(!httpLines.exists(_.contains("device_id="))) &&
+        assertTrue(!httpLines.exists(_.contains("ip="))) &&
+        assertTrue(!httpLines.exists(_.contains("domain="))) &&
+        assertTrue(!httpLines.exists(_.contains("path=")))
+    } @@ TestAspect.withLiveClock,
+  ) @@ TestAspect.sequential
+}

--- a/deploy/grafana/dashboards/api-health.json
+++ b/deploy/grafana/dashboards/api-health.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven API process health: JVM heap/GC/threads, process CPU/memory, and the HikariCP connection pool (the 2026-05-31 crash-loop leading indicator). Series from zio.metrics.jvm.DefaultJvmMetrics and the wifihaven_db_pool_* gauges (#1242/#1243). HTTP request-rate/latency panels are deferred until the zio-http metrics middleware lands (#1204). See docs/design/metrics-observability.md §5.",
+  "description": "WifiHaven API process health: JVM heap/GC/threads, process CPU/memory, and the HikariCP connection pool (the 2026-05-31 crash-loop leading indicator). Series from zio.metrics.jvm.DefaultJvmMetrics and the wifihaven_db_pool_* gauges (#1242/#1243). HTTP request-rate/latency and the other application self-metrics live on the 'WifiHaven — API self-metrics' dashboard (#1204). See docs/design/metrics-observability.md §5.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -1,0 +1,420 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WifiHaven API application self-metrics (#1204): HTTP request rate/latency by templated route, DB query latency by op, auth failures by reason, fleet liveness (agent_connected_routers), the #864 zero-byte traffic filter, and the §4 cardinality-firewall reject counter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src; the `route` label is always the templated path (/api/devices/:mac), never a concrete id. See docs/design/metrics-observability.md §5.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "HTTP request rate by status",
+      "description": "sum by (status) (rate(http_requests_total[5m])) — requests/sec across all routes, split by HTTP status. From HttpMetrics.instrument.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1, "stacking": { "mode": "normal", "group": "A" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "HTTP request latency (p50 / p95 / p99)",
+      "description": "histogram_quantile over http_request_duration_seconds_bucket across all routes. Buckets span 5ms → 5s (HttpDurationBoundaries).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "HTTP error ratio (4xx / 5xx)",
+      "description": "Fraction of requests returning 4xx and 5xx. A 5xx spike is the API-fault signal; 4xx tracks auth/validation rejections.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "legendFormat": "5xx",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(http_requests_total{status=~\"4..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "legendFormat": "4xx",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "HTTP p95 latency by route",
+      "description": "histogram_quantile(0.95, ...) of http_request_duration_seconds_bucket per templated route. `route` is the path template (e.g. /api/devices/:mac), so cardinality is bounded by the route table.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Top routes by request rate",
+      "description": "topk(10, sum by (route, method) (rate(http_requests_total[5m]))) — busiest templated routes.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "topk(10, sum by (route, method) (rate(http_requests_total[5m])))",
+          "legendFormat": "{{method}} {{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "DB query rate by op",
+      "description": "sum by (op) (rate(db_query_duration_seconds_count[5m])) — queries/sec per instrumented repo method. `op` is a hand-named constant (e.g. device.listAll), never SQL text.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (op) (rate(db_query_duration_seconds_count[5m]))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "DB query p95 latency by op",
+      "description": "histogram_quantile(0.95, ...) of db_query_duration_seconds_bucket per op — the leading indicator of a missing-index regression (the 2026-05-31 #809 incident) per the query-EXPLAIN rule.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(db_query_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Auth failures by reason",
+      "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(auth_failures_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Connected routers",
+      "description": "agent_connected_routers — routers whose last_seen_at is within the 10-minute window (RouterPresenceMetrics). The single 'is the fleet alive?' gauge.",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 32 },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "agent_connected_routers",
+          "legendFormat": "connected",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Zero-byte traffic rows filtered (#864)",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 32 },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(traffic_reports_filtered_zero_bytes_total[5m])",
+          "legendFormat": "filtered rows/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Metrics rejected (cardinality firewall)",
+      "description": "sum by (reason) (rate(metrics_rejected_total[5m])) — emissions blocked by the §4.1 MetricGuard allowlist. reason ∈ {unknown_name, forbidden_label}. Should be flat zero in steady state; a non-zero rate flags a code path attempting an unallowlisted/high-cardinality series.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.001 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(metrics_rejected_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["wifihaven", "api"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WifiHaven — API self-metrics",
+  "uid": "wifihaven-api-self-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -59,7 +59,7 @@ provider "grafana" {
 
 locals {
   folder     = var.folder_uid != "" ? var.folder_uid : null
-  dashboards = ["api-health", "rollup-health"]
+  dashboards = ["api-health", "api-self-metrics", "rollup-health"]
   dashfiles  = { for name in local.dashboards : name => "${path.module}/../../deploy/grafana/dashboards/${name}.json" }
 }
 


### PR DESCRIPTION
## Summary

Implements the remaining scope of #1204 (the `/metrics` endpoint + Prometheus
registry/publisher + JVM metrics already landed in #1242/#1243). Adds the API's
own application-level series and the §4 cardinality firewall. Also **closes #864**
by counting filtered zero-byte usage rows.

### New series

- `http_requests_total{route,method,status}` — counter
- `http_request_duration_seconds{route,method}` — histogram
- `db_query_duration_seconds{op}` — histogram (hand-named bounded `op` enum per repo method)
- `auth_failures_total{reason}` — counter (`bad_password`, `expired_token`, `bad_router_token`, `forbidden_role`)
- `agent_connected_routers` — gauge (routers seen within a 10-minute window via a read-path poller over `routers.last_seen_at`; no migration)
- `traffic_reports_filtered_zero_bytes_total` — counter (closes #864; incremented per zero-byte/zero-second usage row at ingest)
- `metrics_rejected_total{reason}` — firewall rejection counter

### Templated route label (enforced)

`route` is always the **templated** path — a `DELETE /api/devices/aa:bb:cc:dd:ee:ff`
surfaces as `route="/api/devices/:mac"`, never the concrete id. This is structural,
not sanitization: `HttpMetrics.instrument` wraps each registered `Route` with a
per-route transform that reads `route.routePattern.pathCodec.render(":","")`, so the
only string that can become a label is the route template itself — a concrete id is
physically unreachable. Trade-off: a request matching no registered template is never
counted (there's no route to attach the transform to), which is acceptable — it cannot
leak cardinality.

### Cardinality

`MetricGuard` is a server-side allowlist of metric name → permitted label keys plus a
forbidden-key set. Every self-metric helper routes through it; unknown names or
forbidden keys (`mac`, `device_id`, `ip`, `domain`, `path`, …) are dropped and counted
into `metrics_rejected_total{reason}`. **No per-mac / per-domain / per-device / per-ip
label is ever emitted.** The feature test asserts the http series carry none of those keys.

## Test plan

- [x] `mill api.test` green (includes new `MetricsSelfMetricsSpec` driving real routes through `HttpMetrics.instrument` + auth + ingest against embedded Postgres, scraping the live Prometheus publisher)
- [x] `mill shared.test` green
- [x] `scalafmt --check` clean
- [x] Red→green visible in history: failing spec committed before the implementation

Refs #1204. Closes #864.

## Dashboards

Adds `deploy/grafana/dashboards/api-self-metrics.json` ("WifiHaven — API
self-metrics"), registered in `infra/grafana/main.tf` and deployed by
`master-grafana.yml`. Every panel targets a series this PR actually emits
(per the "dashboards must match emitted metrics" rule — no design-doc
no-data panels):

- HTTP request rate by status + error ratio (4xx/5xx)
- HTTP latency p50/p95/p99 (overall) and p95 by templated `route`
- Top routes by request rate
- DB query rate + p95 latency by `op`
- Auth failures by `reason`
- `agent_connected_routers` fleet-liveness stat
- Zero-byte traffic rows filtered (#864)
- `metrics_rejected_total` by reason — self-monitors the §4 cardinality firewall

Also drops the now-stale "HTTP panels deferred until #1204" note from
`api-health.json`. Validated locally: `terraform fmt -check`, `terraform
validate`, and `python3 -m json.tool` on both dashboards all pass (the
ci.yml `grafana-terraform` gate).
