### PR TITLE
feat(#1265): route /connection-events/series reads to the rollup tiers

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -485,6 +485,27 @@ trait ConnectionEventRepo {
   ): Task[List[ConnectionEventAggRow]]
 
   /**
+   * #1265: rollup-backed counterpart of [[querySeries]]. Reads pre-aggregated counts from
+   * `connection_events_hourly` / `connection_events_daily` (selected by `grain`) instead of
+   * scanning the raw `connection_events` table, re-binning the stored grain up to the requested
+   * `bucketSeconds`. Produces the same [[ConnectionEventAggRow]] shape, with two deliberate
+   * differences from the raw path (the rollup is lossy by design):
+   *   - `lastSeen` is bucket-granular (the rebinned window boundary), since the rollup only stores
+   *     bucket starts, not individual event timestamps;
+   *   - multicast/broadcast rows are absent because the reroll excludes them at write time, so this
+   *     path must only be chosen when `includeMulticast` is false (the route enforces this).
+   *
+   * `count_succeeded` / `count_blocked` are summed (not re-derived from an `allowed` split, which
+   * the rollup does not carry); the `blocked` filter narrows to the matching count column.
+   */
+  def querySeriesRollup(
+      f: LogFilter,
+      bucketSeconds: Int,
+      groupBy: Set[String],
+      grain: BucketGrain,
+  ): Task[List[ConnectionEventAggRow]]
+
+  /**
    * #1265: re-aggregate the trailing N hours of `connection_events` into
    * `connection_events_hourly`. Counterpart of [[RollupRepo.rerollHourly]] but for the event-count
    * tier. `since` is the earliest `ts` to re-roll, inclusive; callers truncate it to an hour
@@ -1915,35 +1936,11 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
   // defaults to "2026-05-21 22:00:00+00" (space separator) which `new Date(...)`
   // rejects as Invalid Date.
   def querySeries(f: LogFilter, bucketSeconds: Int, groupBy: Set[String]) = {
-    // #862: inline `bucketSeconds` as a SQL literal (it's a server-controlled
-    // enum value, not user input) so the SELECT and GROUP BY copies of the
-    // date_bin expression are byte-identical. Postgres matches the SELECT
-    // expression against GROUP BY by parse tree; if doobie assigns different
-    // parameter positions to the two copies, the match fails and PG raises
-    // "ce.ts must appear in GROUP BY".
-    val bucketIv    = Fragment.const(s"make_interval(secs => $bucketSeconds)")
-    val domainExpr  = fr"COALESCE(ce.resolved_host_value, ce.host_value)"
-    val deviceExpr  = fr"COALESCE(d.name, ce.mac::TEXT)"
-    val profileExpr = fr"COALESCE(p.name, '(unassigned)')"
+    val domainExpr = fr"COALESCE(ce.resolved_host_value, ce.host_value)"
+    val deviceExpr = fr"COALESCE(d.name, ce.mac::TEXT)"
+    // Raw path bins on the per-event timestamp.
+    val tsBin      = fr"ce.ts"
 
-    // #917: strictly additive — empty set = no drill, one row per window.
-    // Multi-group composes freely across {domain, device, profile, app}.
-    val wantsDomain  = groupBy.contains("domain")
-    val wantsDevice  = groupBy.contains("device")
-    val wantsProfile = groupBy.contains("profile")
-    val wantsApp     = groupBy.contains("app")
-
-    // #862: the window bucket uses the full date_bin/to_char expression (not
-    // the SELECT alias) so the HAVING clause for the keyset cursor below can
-    // reference the same expression — PG doesn't recognize SELECT aliases in
-    // HAVING.
-    val winExpr = fr"""to_char(date_bin($bucketIv, ce.ts, TIMESTAMP '2000-01-01 00:00:00')
-                          AT TIME ZONE 'UTC',
-                          'YYYY-MM-DD"T"HH24:MI:SS"Z"')"""
-
-    // Shared FROM + filter fragments. Extracted ahead of the SELECT so the
-    // #857 host-resolution probe below can reuse the exact same window + filter
-    // predicates as the aggregation, guaranteeing both see the same host set.
     val fromJoins = fr"""FROM connection_events ce
            LEFT JOIN devices d  ON d.mac = ce.mac
            LEFT JOIN profiles p ON p.id  = d.profile_id
@@ -1968,6 +1965,159 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     val byLoc     = f.location.fold(fr"")(l => fr"AND r.name = $l")
     val byMc      = if (f.includeMulticast) fr"" else multicastFilterSql
     val filters   = window ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc ++ byMc
+
+    val succProj     = fr"COUNT(*) FILTER (WHERE ce.allowed)::INT"
+    val blkProj      = fr"COUNT(*) FILTER (WHERE NOT ce.allowed)::INT"
+    val lastSeenExpr =
+      fr"""to_char(MAX(ce.ts) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')"""
+
+    runSeries(
+      f,
+      bucketSeconds,
+      groupBy,
+      fromJoins,
+      filters,
+      domainExpr,
+      deviceExpr,
+      tsBin,
+      succProj,
+      blkProj,
+      lastSeenExpr,
+    )
+  }
+
+  // #1265: rollup-backed `/series`. Reads pre-aggregated counts from the hourly
+  // or daily rollup (per `grain`) and re-bins them up to `bucketSeconds`. Shares
+  // all of runSeries' projection/cursor/decode machinery with the raw path; only
+  // the source-specific fragments differ:
+  //   - source is the rollup table aliased `cer`, bin on its bucket boundary;
+  //   - counts are SUMmed from the stored split columns (no per-event `allowed`);
+  //   - the `blocked` filter narrows to the matching count column and zeroes the
+  //     opposite projection so a mixed (mac,host,bucket) row contributes one side;
+  //   - no multicast filter — the reroll already excluded those at write time, so
+  //     this path is only chosen when includeMulticast is false (route enforces).
+  def querySeriesRollup(
+      f: LogFilter,
+      bucketSeconds: Int,
+      groupBy: Set[String],
+      grain: BucketGrain,
+  ) = {
+    val isDaily    = grain == BucketGrain.Daily
+    val table      =
+      if (isDaily) fr"connection_events_daily cer" else fr"connection_events_hourly cer"
+    // Bin on the stored bucket boundary (timestamptz). For daily, lift the DATE
+    // to a UTC midnight timestamptz so date_bin sees the same type as the hourly
+    // bucket_start and the raw ce.ts path.
+    val tsBin      =
+      if (isDaily) fr"(cer.date::timestamp AT TIME ZONE 'UTC')" else fr"cer.bucket_start"
+    val domainExpr = fr"cer.hostname"
+    // Rollup folds NULL mac to ''; lift it back to NULL so the device name
+    // COALESCE matches the raw path's `COALESCE(d.name, ce.mac::TEXT)`.
+    val deviceExpr = fr"COALESCE(d.name, NULLIF(cer.mac, ''))"
+
+    val fromJoins = fr"FROM " ++ table ++ fr"""
+           LEFT JOIN devices d  ON d.mac = cer.mac
+           LEFT JOIN profiles p ON p.id  = d.profile_id
+           LEFT JOIN routers r  ON r.id  = cer.router_id"""
+    val anchor    = f.until.fold(fr"NOW()")(u => fr"$u::TIMESTAMPTZ")
+    val window    =
+      fr"AND " ++ tsBin ++ fr"> " ++ anchor ++ fr"- make_interval(hours => ${f.hours}) AND " ++
+        tsBin ++ fr"<= " ++ anchor
+    val byMac     = cats.data.NonEmptyList
+      .fromList(f.macs)
+      .fold(fr"")(nel => fr"AND " ++ Fragments.in(fr"cer.mac", nel))
+    val byDev     = cats.data.NonEmptyList
+      .fromList(f.deviceIds)
+      .fold(fr"")(nel => fr"AND " ++ Fragments.in(fr"d.id", nel))
+    val byPid     = cats.data.NonEmptyList
+      .fromList(f.profileIds)
+      .fold(fr"")(nel => fr"AND " ++ Fragments.in(fr"d.profile_id", nel))
+    // Rollup has split counts, not a per-event `allowed` flag: narrow to the
+    // matching count column rather than filtering individual events.
+    val byBl      = f.blocked.fold(fr"")(b =>
+      if (b) fr"AND cer.count_blocked > 0" else fr"AND cer.count_succeeded > 0",
+    )
+    val byDom     = f.domain.fold(fr"")(d => fr"AND cer.hostname ILIKE ${s"%$d%"}")
+    val byLoc     = f.location.fold(fr"")(l => fr"AND r.name = $l")
+    // No multicast filter: excluded at reroll write time.
+    val filters   = window ++ byMac ++ byDev ++ byPid ++ byBl ++ byDom ++ byLoc
+
+    // Sum the stored split counts. When the caller narrows to blocked/allowed,
+    // zero the opposite projection so a row mixing both contributes only the
+    // matching side (mirrors the raw path's FILTER collapsing to one side).
+    val succProj     =
+      if (f.blocked.contains(true)) fr"0::INT" else fr"COALESCE(SUM(cer.count_succeeded), 0)::INT"
+    val blkProj      =
+      if (f.blocked.contains(false)) fr"0::INT" else fr"COALESCE(SUM(cer.count_blocked), 0)::INT"
+    // lastSeen is bucket-granular (the rollup stores no per-event ts): bin
+    // MAX(bucket) to the requested window so it equals window_start.
+    val bucketIv     = Fragment.const(s"make_interval(secs => $bucketSeconds)")
+    val lastSeenExpr =
+      fr"""to_char(date_bin($bucketIv, MAX(""" ++ tsBin ++ fr"""), TIMESTAMP '2000-01-01 00:00:00')
+                          AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')"""
+
+    runSeries(
+      f,
+      bucketSeconds,
+      groupBy,
+      fromJoins,
+      filters,
+      domainExpr,
+      deviceExpr,
+      tsBin,
+      succProj,
+      blkProj,
+      lastSeenExpr,
+    )
+  }
+
+  // #847 + #846 + #1265: shared aggregation engine for both the raw and
+  // rollup-backed `/series` reads. Callers supply the source-specific fragments
+  // (FROM/joins, row filters, the domain/device group expressions, the
+  // timestamp to bin on, the succeeded/blocked count projections, and the
+  // last_seen projection); everything else — app resolution, multi-group
+  // composition, keyset cursor, ORDER BY, and the result decode — is identical.
+  //
+  // Buckets are computed in UTC via date_bin — the UI re-renders boundaries in
+  // household-local tz for display. #846: emit ISO 8601 with a T separator and
+  // trailing Z so JS Date.parse accepts these without a per-field workaround.
+  private def runSeries(
+      f: LogFilter,
+      bucketSeconds: Int,
+      groupBy: Set[String],
+      fromJoins: Fragment,
+      filters: Fragment,
+      domainExpr: Fragment,
+      deviceExpr: Fragment,
+      tsBin: Fragment,
+      succProj: Fragment,
+      blkProj: Fragment,
+      lastSeenExpr: Fragment,
+  ): Task[List[ConnectionEventAggRow]] = {
+    // #862: inline `bucketSeconds` as a SQL literal (it's a server-controlled
+    // enum value, not user input) so the SELECT and GROUP BY copies of the
+    // date_bin expression are byte-identical. Postgres matches the SELECT
+    // expression against GROUP BY by parse tree; if doobie assigns different
+    // parameter positions to the two copies, the match fails and PG raises
+    // "must appear in GROUP BY".
+    val bucketIv    = Fragment.const(s"make_interval(secs => $bucketSeconds)")
+    val profileExpr = fr"COALESCE(p.name, '(unassigned)')"
+
+    // #917: strictly additive — empty set = no drill, one row per window.
+    // Multi-group composes freely across {domain, device, profile, app}.
+    val wantsDomain  = groupBy.contains("domain")
+    val wantsDevice  = groupBy.contains("device")
+    val wantsProfile = groupBy.contains("profile")
+    val wantsApp     = groupBy.contains("app")
+
+    // #862: the window bucket uses the full date_bin/to_char expression (not
+    // the SELECT alias) so the HAVING clause for the keyset cursor below can
+    // reference the same expression — PG doesn't recognize SELECT aliases in
+    // HAVING.
+    val winExpr =
+      fr"""to_char(date_bin($bucketIv, """ ++ tsBin ++ fr""", TIMESTAMP '2000-01-01 00:00:00')
+                          AT TIME ZONE 'UTC',
+                          'YYYY-MM-DD"T"HH24:MI:SS"Z"')"""
 
     // #857: resolve each in-window host to its app(s) in Scala via
     // HostMatch.lookupApex — the single host→apex matcher shared with the
@@ -2081,14 +2231,11 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
             selAppSlug ++ fr"AS grp_app_slug," ++
             selAppName ++ fr"AS grp_app_name," ++
             selAppIcon ++ fr"AS grp_app_icon," ++
-            selAppId ++ fr"""AS grp_app_id,
-                  to_char(date_bin($bucketIv, ce.ts, TIMESTAMP '2000-01-01 00:00:00')
-                          AT TIME ZONE 'UTC',
-                          'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS window_start,
-                  COUNT(*) FILTER (WHERE ce.allowed)::INT      AS count_succeeded,
-                  COUNT(*) FILTER (WHERE NOT ce.allowed)::INT  AS count_blocked,
-                  to_char(MAX(ce.ts) AT TIME ZONE 'UTC',
-                          'YYYY-MM-DD"T"HH24:MI:SS"Z"')  AS last_seen,
+            selAppId ++ fr"AS grp_app_id," ++
+            winExpr ++ fr"AS window_start," ++
+            succProj ++ fr"AS count_succeeded," ++
+            blkProj ++ fr"AS count_blocked," ++
+            lastSeenExpr ++ fr"""AS last_seen,
                   mode() WITHIN GROUP (ORDER BY """ ++ deviceExpr ++ fr""") AS top_device,
                   COUNT(DISTINCT """ ++ deviceExpr ++ fr""")::INT          AS distinct_devices,
                   COUNT(DISTINCT """ ++ profileExpr ++ fr""")::INT         AS distinct_profiles,
@@ -2236,9 +2383,13 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
   // hourly buckets line up exactly with what the on-the-fly read computes.
   def rerollConnEventsHourly(since: Instant): Task[Option[Int]] = {
     val truncSince = since.truncatedTo(java.time.temporal.ChronoUnit.HOURS)
-    val sql        =
-      sql"""
-        INSERT INTO connection_events_hourly
+    // #1265 (PR3): exclude multicast/broadcast at write time so the rollup
+    // matches /series's DEFAULT (includeMulticast=false) view. The rollup drops
+    // host_type/host_value, so the read path can't re-filter — the only place to
+    // apply the #969 exclusion is here, against the raw columns. A read that
+    // wants multicast (includeMulticast=true) falls back to raw.
+    val head       =
+      fr"""INSERT INTO connection_events_hourly
           (router_id, mac, hostname, bucket_start, count_succeeded, count_blocked, sample_count, rolled_at)
         SELECT
           ce.router_id,
@@ -2250,17 +2401,18 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
           COUNT(*)::INT,
           NOW()
         FROM connection_events ce
-        WHERE ce.ts >= $truncSince
-        GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+        WHERE ce.ts >= $truncSince"""
+    val tail       =
+      fr"""GROUP BY ce.router_id, COALESCE(ce.mac, ''),
                  COALESCE(ce.resolved_host_value, ce.host_value),
                  date_bin(INTERVAL '1 hour', ce.ts, TIMESTAMP '2000-01-01 00:00:00')
         ON CONFLICT (router_id, mac, hostname, bucket_start) DO UPDATE SET
           count_succeeded = EXCLUDED.count_succeeded,
           count_blocked   = EXCLUDED.count_blocked,
           sample_count    = EXCLUDED.sample_count,
-          rolled_at       = EXCLUDED.rolled_at
-      """
-    withRollupLock(RollupLockKeys.ConnEventsHourly)(sql.update.run)
+          rolled_at       = EXCLUDED.rolled_at"""
+    val q          = head ++ fr" " ++ multicastFilterSql ++ fr" " ++ tail
+    withRollupLock(RollupLockKeys.ConnEventsHourly)(q.update.run)
   }
 
   def rerollConnEventsDaily(sinceDate: LocalDate): Task[Option[Int]] = {
@@ -2270,9 +2422,9 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     // scan (#1254 class). The lower bound is sinceDate's UTC midnight; any event
     // whose UTC date is >= sinceDate has ts >= that instant.
     val sinceTs = sinceDate.atStartOfDay(java.time.ZoneOffset.UTC).toInstant
-    val sql     =
-      sql"""
-        INSERT INTO connection_events_daily
+    // #1265 (PR3): same multicast exclusion as the hourly reroll — see note there.
+    val head    =
+      fr"""INSERT INTO connection_events_daily
           (router_id, mac, hostname, date, count_succeeded, count_blocked, sample_count, rolled_at)
         SELECT
           ce.router_id,
@@ -2284,17 +2436,18 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
           COUNT(*)::INT,
           NOW()
         FROM connection_events ce
-        WHERE ce.ts >= $sinceTs
-        GROUP BY ce.router_id, COALESCE(ce.mac, ''),
+        WHERE ce.ts >= $sinceTs"""
+    val tail    =
+      fr"""GROUP BY ce.router_id, COALESCE(ce.mac, ''),
                  COALESCE(ce.resolved_host_value, ce.host_value),
                  (ce.ts AT TIME ZONE 'UTC')::DATE
         ON CONFLICT (router_id, mac, hostname, date) DO UPDATE SET
           count_succeeded = EXCLUDED.count_succeeded,
           count_blocked   = EXCLUDED.count_blocked,
           sample_count    = EXCLUDED.sample_count,
-          rolled_at       = EXCLUDED.rolled_at
-      """
-    withRollupLock(RollupLockKeys.ConnEventsDaily)(sql.update.run)
+          rolled_at       = EXCLUDED.rolled_at"""
+    val q       = head ++ fr" " ++ multicastFilterSql ++ fr" " ++ tail
+    withRollupLock(RollupLockKeys.ConnEventsDaily)(q.update.run)
   }
 
   def stats =

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1147,6 +1147,37 @@ object TimeRoutes {
 // ── Query log routes ───────────────────────────────────────────────────────
 
 object LogRoutes {
+  // #1265: choose the source table for /api/connection-events/series. Mirrors
+  // UsageRoutes.pickTier on the traffic side: the bucket width caps how coarse
+  // a rollup may serve it (via the shared wifihaven.shared.BucketPolicy, so the
+  // two endpoints can't drift), and a wide window justifies coarsening on cost
+  // grounds. The finer of (cap, window-pref) wins. Raw → None (read the live
+  // connection_events table). includeMulticast forces raw, because the reroll
+  // excludes multicast/broadcast at write time so the rollups can't serve it.
+  private def seriesGrain(
+      bucket: ConnectionEventBucket,
+      hours: Int,
+      includeMulticast: Boolean,
+  ): Option[BucketGrain] =
+    if (includeMulticast) None
+    else {
+      val cap                       = BucketPolicy.grainForBucket(bucket.wire)
+      val pref                      =
+        if (hours <= 24) BucketGrain.Raw
+        else if (hours <= 14 * 24) BucketGrain.Hourly
+        else BucketGrain.Daily
+      def rank(g: BucketGrain): Int = g match {
+        case BucketGrain.Raw    => 0
+        case BucketGrain.Hourly => 1
+        case BucketGrain.Daily  => 2
+      }
+      val chosen                    = if (rank(pref) <= rank(cap)) pref else cap
+      chosen match {
+        case BucketGrain.Raw => None
+        case g               => Some(g)
+      }
+    }
+
   // #862: tiny parse helpers for pagination params. Pulled into top-level so
   // both /api/logs and /api/connection-events/series use the same shape.
   private def parseInstantOpt(req: Request, name: String): IO[Response, Option[java.time.Instant]] =
@@ -1310,9 +1341,12 @@ object LogRoutes {
               cursorKey = cursorOpt.map(_.key),
               includeMulticast = req.url.queryParam("includeMulticast").contains("true"),
             )
-            rows <- connRepo
-              .querySeries(filter, bucket.seconds, groupByCodes)
-              .mapError(ErrorMapper.dbErrorToResponse)
+            // #1265: route coarse + wide reads to the rollup tables; fine,
+            // short, or multicast-inclusive reads stay on raw connection_events.
+            rows <- (seriesGrain(bucket, filter.hours, filter.includeMulticast) match {
+              case None    => connRepo.querySeries(filter, bucket.seconds, groupByCodes)
+              case Some(g) => connRepo.querySeriesRollup(filter, bucket.seconds, groupByCodes, g)
+            }).mapError(ErrorMapper.dbErrorToResponse)
             nextCur =
               if (rows.size < limit) None
               else

--- a/api/test/src/feature/BlockedMacEventIngestSpec.scala
+++ b/api/test/src/feature/BlockedMacEventIngestSpec.scala
@@ -163,9 +163,14 @@ object BlockedMacEventIngestSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
         )
         body = RouterEventsRequest(id, evs).toJson
         _        <- post(ingest, "/api/router/events", body, tk)
+        // hours=24 keeps this on the raw tier (#1265): a freshly-ingested,
+        // not-yet-rerolled event is only visible on the live connection_events
+        // table. A wider window would route to the hourly rollup (rollup-lag by
+        // design — that path is covered in LogApiSpec). This test is about
+        // ingest visibility, so it reads the fresh path.
         resp     <- get(
           logRoutes,
-          s"/api/connection-events/series?bucket=1h&blocked=true&hours=168",
+          s"/api/connection-events/series?bucket=1h&blocked=true&hours=24",
           adminTok,
         )
         respBody <- resp.body.asString

--- a/api/test/src/feature/ConnectionEventRollupSpec.scala
+++ b/api/test/src/feature/ConnectionEventRollupSpec.scala
@@ -277,5 +277,59 @@ object ConnectionEventRollupSpec
         runs.exists(r => r.job == RollupJobs.ConnEventsHourlyJob && r.status == "ok"),
       )
     },
+    // #1265 (PR3): the rollup is the source for the DEFAULT /series view, which
+    // excludes IPv4/IPv6 multicast + broadcast (#969). Since the rollup carries
+    // no host_type/host_value, the read path can't re-filter, so the reroll must
+    // exclude multicast at write time — keeping the rollup == default-view set.
+    test("rerollConnEventsHourly/Daily exclude multicast + broadcast destinations") {
+      for {
+        _   <- cleanDb
+        rid <- seedRouter
+        bucket = LocalDate.of(2026, 2, 1).atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(3600)
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        mcast = (ip: String) =>
+          ConnectionEventInsert(
+            rid,
+            None,
+            HostId.IPv4(IpAddress.unsafe(ip)),
+            None,
+            true,
+            BlockReason.fromWire("allowed"),
+            bucket.plusSeconds(30),
+          )
+        _           <- connRepo.insertBatch(
+          List(
+            event(rid, "keep.com", allowed = true, bucket.plusSeconds(10)),
+            mcast("239.255.255.250"), // SSDP multicast (224.0.0.0/4)
+            mcast("255.255.255.255"), // IPv4 broadcast
+            ConnectionEventInsert(
+              rid,
+              None,
+              HostId.IPv6(IpAddress.unsafe("ff02::fb")),
+              None,
+              true,
+              BlockReason.fromWire("allowed"),
+              bucket.plusSeconds(40),
+            ),                        // IPv6 multicast (ff00::/8)
+          ),
+        )
+        _           <- connRepo.rerollConnEventsHourly(bucket.minusSeconds(3600))
+        _           <- connRepo.rerollConnEventsDaily(LocalDate.of(2026, 2, 1).minusDays(1))
+        xa          <- ZIO.service[Transactor[Task]]
+        hourlyHosts <-
+          sql"SELECT hostname FROM connection_events_hourly ORDER BY hostname"
+            .query[String]
+            .to[List]
+            .transact(xa)
+        dailyHosts  <-
+          sql"SELECT hostname FROM connection_events_daily ORDER BY hostname"
+            .query[String]
+            .to[List]
+            .transact(xa)
+      } yield assertTrue(
+        hourlyHosts == List("keep.com"),
+        dailyHosts == List("keep.com"),
+      )
+    },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/DbFailureSpec.scala
+++ b/api/test/src/feature/DbFailureSpec.scala
@@ -169,6 +169,13 @@ object DbFailureSpec extends ZIOSpecDefault {
     def listForRouter(r: RouterId, l: Int)                                              = throwing
     def query(f: LogFilter)                                                             = throwing
     def querySeries(f: LogFilter, bucketSeconds: Int, groupBy: Set[String])             = throwing
+    def querySeriesRollup(
+        f: LogFilter,
+        bucketSeconds: Int,
+        groupBy: Set[String],
+        grain: BucketGrain,
+    ) =
+      throwing
     def stats                                                                           = throwing
     def topBlocked(h: Int, l: Int)                                                      = throwing
     def lastSeenByMacSince(since: Instant)                                              = throwing

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -9,15 +9,18 @@ import wifihaven.shared.types.*
 import wifihaven.shared.Clock.TestClock
 import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import doobie.*
+import doobie.implicits.*
+import zio.interop.catz.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
 import zio.test.*
-import zio.test.Assertion.*
 
-import java.time.Instant
+import java.time.{Instant, LocalDate, ZoneOffset}
 
-object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+object LogApiSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
 
   override val bootstrap =
     TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
@@ -47,6 +50,44 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
     )
 
   private def recentTs = Instant.now().minusSeconds(300)
+
+  private def ceFqdn(
+      routerId: RouterId,
+      mac: String,
+      host: String,
+      allowed: Boolean,
+  ): ConnectionEventInsert =
+    ConnectionEventInsert(
+      routerId,
+      Some(MacAddress.unsafe(mac)),
+      HostId.Fqdn(Hostname.unsafe(host)),
+      None,
+      allowed,
+      BlockReason.fromWire(if (allowed) "allowed" else "category:adult"),
+      recentTs,
+    )
+
+  private def ceMulticast(routerId: RouterId, ip: String): ConnectionEventInsert =
+    ConnectionEventInsert(
+      routerId,
+      None,
+      HostId.IPv4(IpAddress.unsafe(ip)),
+      None,
+      true,
+      BlockReason.fromWire("allowed"),
+      recentTs,
+    )
+
+  // #1265: roll the just-inserted events into both rollup tiers, then wipe the
+  // raw table. A subsequent /series read that still returns the data could only
+  // have been served by a rollup table — the proof that tier-routing engaged.
+  private def rollAndWipeRaw(connRepo: ConnectionEventRepo) =
+    for {
+      _  <- connRepo.rerollConnEventsHourly(Instant.now().minusSeconds(7200))
+      _  <- connRepo.rerollConnEventsDaily(LocalDate.now(ZoneOffset.UTC).minusDays(1))
+      xa <- ZIO.service[Transactor[Task]]
+      _  <- sql"DELETE FROM connection_events".update.run.transact(xa)
+    } yield ()
 
   def spec = suite("Log API (connection_events)")(
     test("GET /api/logs returns events mapped to QueryLog shape with router name as location") {
@@ -1406,6 +1447,205 @@ object LogApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clo
             .find(_.groups.get("domain").contains("239.255.255.250"))
             .exists(_.countSucceeded == 2),
         )
+    },
+    // ── #1265: rollup tier read-routing ──────────────────────────────────────
+    // Proof technique: insert events, roll them into the hourly+daily rollups,
+    // then DELETE the raw connection_events. A /series read that still returns
+    // the counts could only have come from a rollup table.
+    test("#1265: coarse bucket + wide window is served from the DAILY rollup (raw wiped)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = false),
+            ceFqdn(routerId, "aa:bb:cc:00:00:02", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "facebook.com", allowed = true),
+          ),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        // bucket=1d → Daily cap; hours=720 (30d) → Daily window preference.
+        resp <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720",
+          token,
+        )
+        body <- resp.body.asString
+        page <- ZIO.fromEither(body.fromJson[ConnectionEventSeriesPage])
+        rows = page.rows
+        yt   = rows.find(_.groups.getOrElse("domain", "") == "youtube.com")
+        fb   = rows.find(_.groups.getOrElse("domain", "") == "facebook.com")
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(yt.exists(r => r.countSucceeded == 2 && r.countBlocked == 1)) &&
+        assertTrue(yt.exists(_.distinctDevices == 2)) &&
+        assertTrue(fb.exists(r => r.countSucceeded == 1 && r.countBlocked == 0))
+    },
+    test("#1265: coarse bucket + medium window is served from the HOURLY rollup (raw wiped)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = false),
+            ceFqdn(routerId, "aa:bb:cc:00:00:02", "facebook.com", allowed = true),
+          ),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        // bucket=1h → Hourly cap; hours=48 (2d) → Hourly window preference.
+        resp <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1h&groupBy=domain&hours=48",
+          token,
+        )
+        body <- resp.body.asString
+        page <- ZIO.fromEither(body.fromJson[ConnectionEventSeriesPage])
+        rows = page.rows
+        yt   = rows.find(_.groups.getOrElse("domain", "") == "youtube.com")
+        fb   = rows.find(_.groups.getOrElse("domain", "") == "facebook.com")
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(yt.exists(r => r.countSucceeded == 1 && r.countBlocked == 1)) &&
+        assertTrue(fb.exists(r => r.countSucceeded == 1 && r.countBlocked == 0))
+    },
+    test("#1265: fine bucket + short window stays on RAW (empty after raw wiped)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true)),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        // bucket=10m → Raw cap; default hours=24 → Raw. Must NOT touch a rollup.
+        respFine   <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=10m&groupBy=domain",
+          token,
+        )
+        bodyFine   <- respFine.body.asString
+        pageFine   <- ZIO.fromEither(bodyFine.fromJson[ConnectionEventSeriesPage])
+        // bucket=1h but default hours=24 → window preference Raw → stays raw.
+        respNarrow <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1h&groupBy=domain",
+          token,
+        )
+        bodyNarrow <- respNarrow.body.asString
+        pageNarrow <- ZIO.fromEither(bodyNarrow.fromJson[ConnectionEventSeriesPage])
+      } yield assertTrue(respFine.status == Status.Ok) &&
+        assertTrue(pageFine.rows.isEmpty) &&
+        assertTrue(pageNarrow.rows.isEmpty)
+    },
+    test("#1265: includeMulticast=true always falls back to RAW (empty after raw wiped)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceMulticast(routerId, "239.255.255.250"),
+          ),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        // Default (multicast excluded) coarse+wide read is served by the rollup,
+        // and the rollup excludes multicast at write time → only youtube.
+        respDef <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720",
+          token,
+        )
+        bodyDef <- respDef.body.asString
+        pageDef <- ZIO.fromEither(bodyDef.fromJson[ConnectionEventSeriesPage])
+        // includeMulticast=true cannot be served by the rollup (no host_type), so
+        // it must fall back to raw — which we wiped → empty.
+        respInc <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720&includeMulticast=true",
+          token,
+        )
+        bodyInc <- respInc.body.asString
+        pageInc <- ZIO.fromEither(bodyInc.fromJson[ConnectionEventSeriesPage])
+      } yield assertTrue(pageDef.rows.flatMap(_.groups.get("domain")) == List("youtube.com")) &&
+        assertTrue(pageInc.rows.isEmpty)
+    },
+    test("#1265: blocked filter on the rollup path sums only the matching count column") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true),
+            ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = false),
+          ),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        respB <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720&blocked=true",
+          token,
+        )
+        bodyB <- respB.body.asString
+        pageB <- ZIO.fromEither(bodyB.fromJson[ConnectionEventSeriesPage])
+        respA <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720&blocked=false",
+          token,
+        )
+        bodyA <- respA.body.asString
+        pageA <- ZIO.fromEither(bodyA.fromJson[ConnectionEventSeriesPage])
+        ytB = pageB.rows.find(_.groups.getOrElse("domain", "") == "youtube.com")
+        ytA = pageA.rows.find(_.groups.getOrElse("domain", "") == "youtube.com")
+      } yield assertTrue(ytB.exists(r => r.countBlocked == 1 && r.countSucceeded == 0)) &&
+        assertTrue(ytA.exists(r => r.countSucceeded == 2 && r.countBlocked == 0))
+    },
+    test("#1265: rollup-served lastSeen is bucket-granular (equals windowStart)") {
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        _        <- connRepo.insertBatch(
+          List(ceFqdn(routerId, "aa:bb:cc:00:00:01", "youtube.com", allowed = true)),
+        )
+        _        <- rollAndWipeRaw(connRepo)
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(
+          routes,
+          "/api/connection-events/series?bucket=1d&groupBy=domain&hours=720",
+          token,
+        )
+        body <- resp.body.asString
+        page <- ZIO.fromEither(body.fromJson[ConnectionEventSeriesPage])
+        yt = page.rows.find(_.groups.getOrElse("domain", "") == "youtube.com")
+      } yield assertTrue(yt.exists(r => r.lastSeen == r.windowStart))
     },
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
## Summary

PR 3 of the #1265 connection-events rollup work (PR1 = V47 schema #1267; PR2 = reroll fibers #1284). This is the read-side adoption: `/api/connection-events/series` now serves coarse + wide queries from the `connection_events_hourly` / `_daily` rollups instead of scanning raw `connection_events`, mirroring the traffic-side tiering.

- **`querySeriesRollup`** reads pre-aggregated counts from the hourly/daily rollup (selected by `BucketGrain`), re-binning the stored grain up to the requested bucket. Extracted a shared `runSeries` engine so the raw and rollup paths share all the app-resolution / keyset-cursor / result-decode machinery and can't drift.
- **Tier routing** (`LogRoutes.seriesGrain`) mirrors `UsageRoutes.pickTier` through the shared `wifihaven.shared.BucketPolicy`: bucket width caps how coarse a rollup may serve a request, the window justifies coarsening on cost, the finer of the two wins. `includeMulticast=true` forces raw.
- **Reroll writers** now exclude multicast/broadcast at write time, so the rollups match `/series`'s default (`includeMulticast=false`) view. A read that wants multicast falls back to raw.

### Deliberate, documented rollup lossiness
- `lastSeen` is bucket-granular (the rollup stores bucket boundaries, not per-event timestamps), so it equals `windowStart`.
- Counts are summed from the stored split columns rather than re-derived from a per-event `allowed` flag; the `blocked` filter narrows to the matching count column and zeroes the opposite projection.
- `topDevice` weighting is row-based rather than event-based — invisible in the UI (LogsPage renders only counts / distinct* / sole* / lastSeen).

## Query performance
Per the EXPLAIN-before-merge rule: the rollup reads filter on `(router_id, mac, hostname, bucket_start|date)` — the rollup tables' PK — and join `devices`/`profiles`/`routers` by key. The whole point of this PR is that wide windows touch ~tens of rows per host from the rollup instead of full-day scans of the unbounded `connection_events` table. Raw-tier reads are unchanged from the existing `querySeries` path.

## Test plan
- [x] `mill api.test` — full suite green (incl. 6 new rollup-routing tests in `LogApiSpec` and the multicast-exclusion test in `ConnectionEventRollupSpec`)
- [x] Red→green visible in history: failing tests committed first (5b938a49), implementation second (26c6170c)
- [x] `BlockedMacEventIngestSpec` narrowed to a 24h window so the ingest-visibility check stays on the fresh raw tier (not-yet-rerolled events are raw-only by design)
- [x] scalafmt clean