### PR TITLE
Grafana: env picker + datasource pin on api-self-metrics

### DIFF
--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -42,7 +42,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (status) (rate(http_requests_total[5m]))",
+          "expr": "sum by (status) (rate(http_requests_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }
@@ -71,19 +71,19 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket{env=\"$env\"}[5m])))",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{env=\"$env\"}[5m])))",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket{env=\"$env\"}[5m])))",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -120,13 +120,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "expr": "sum(rate(http_requests_total{status=~\"5..\", env=\"$env\"}[5m])) / sum(rate(http_requests_total{env=\"$env\"}[5m]))",
           "legendFormat": "5xx",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(http_requests_total{status=~\"4..\"}[5m])) / sum(rate(http_requests_total[5m]))",
+          "expr": "sum(rate(http_requests_total{status=~\"4..\", env=\"$env\"}[5m])) / sum(rate(http_requests_total{env=\"$env\"}[5m]))",
           "legendFormat": "4xx",
           "refId": "B"
         }
@@ -155,7 +155,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\"}[5m])))",
           "legendFormat": "{{route}}",
           "refId": "A"
         }
@@ -184,7 +184,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "topk(10, sum by (route, method) (rate(http_requests_total[5m])))",
+          "expr": "topk(10, sum by (route, method) (rate(http_requests_total{env=\"$env\"}[5m])))",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -213,7 +213,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (op) (rate(db_query_duration_seconds_count[5m]))",
+          "expr": "sum by (op) (rate(db_query_duration_seconds_count{env=\"$env\"}[5m]))",
           "legendFormat": "{{op}}",
           "refId": "A"
         }
@@ -242,7 +242,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(db_query_duration_seconds_bucket[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(db_query_duration_seconds_bucket{env=\"$env\"}[5m])))",
           "legendFormat": "{{op}}",
           "refId": "A"
         }
@@ -271,7 +271,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (reason) (rate(auth_failures_total[5m]))",
+          "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -310,7 +310,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "agent_connected_routers",
+          "expr": "agent_connected_routers{env=\"$env\"}",
           "legendFormat": "connected",
           "refId": "A"
         }
@@ -346,7 +346,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "rate(traffic_reports_filtered_zero_bytes_total[5m])",
+          "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
           "legendFormat": "filtered rows/s",
           "refId": "A"
         }
@@ -382,7 +382,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (reason) (rate(metrics_rejected_total[5m]))",
+          "expr": "sum by (reason) (rate(metrics_rejected_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
         }
@@ -395,7 +395,22 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": { "selected": true, "text": "prod", "value": "prod" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          { "selected": true, "text": "prod", "value": "prod" },
+          { "selected": false, "text": "staging", "value": "staging" }
+        ],
+        "query": "prod,staging",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",


### PR DESCRIPTION
Applies the same two fixes from #1287 / #1288 to the newly added `api-self-metrics` dashboard (added after that PR branched).

## File changed
- `deploy/grafana/dashboards/api-self-metrics.json`

## 1. staging/prod env picker
New `env` template variable, placed first (renders top-left):

```json
{
  "current": { "selected": true, "text": "prod", "value": "prod" },
  "label": "Environment",
  "name": "env",
  "options": [
    { "selected": true, "text": "prod", "value": "prod" },
    { "selected": false, "text": "staging", "value": "staging" }
  ],
  "query": "prod,staging",
  "type": "custom"
}
```

Custom variable (not `label_values`) — matches the approach settled on in #1288, where the query var surfaced Alloy's clobbered `job` label. `env="$env"` injected into all **14** panel selectors, handling bare metrics, existing matchers (`status=~"5.."` → `{status=~"5..", env="$env"}`), and selectors nested in `rate(...)` / `histogram_quantile(...)` / `topk(...)` / `sum by (...)`.

## 2. Datasource pin
The `datasource` variable's `current` is pinned to the Grafana Cloud hosted-metrics Prometheus so it never prompts and never resolves to the wrong default:

```json
"current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" }
```

## Provisioning
`infra/grafana/main.tf` loads this dashboard via `config_json = file(...)` already (the file existed on main); `master-grafana.yml` applies it on push. No Terraform change needed.

## Validation
- JSON parses; all 14 panel exprs verified to contain `env=`.
- `terraform validate` clean in `infra/grafana/`.

Companion to #1288 (api-health + rollup-health). Related root-cause follow-up: #1291.