### PR TITLE
Rename rollup metric label job -> rollup_job (#1291)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -183,9 +183,9 @@ object AppMetrics {
 
   /** Record a completed rollup run. `status` is "ok" or "error". */
   def recordRollup(job: String, status: String, durationSeconds: Double, rows: Int): UIO[Unit] =
-    rollupRuns.tagged("job", job).tagged("status", status).update(1L) *>
-      rollupDuration.tagged("job", job).update(math.max(0.0, durationSeconds)) *>
-      rollupRows.tagged("job", job).update(rows.toDouble)
+    rollupRuns.tagged("rollup_job", job).tagged("status", status).update(1L) *>
+      rollupDuration.tagged("rollup_job", job).update(math.max(0.0, durationSeconds)) *>
+      rollupRows.tagged("rollup_job", job).update(rows.toDouble)
 
   // ── DB connection pool (#1243, #1221) ───────────────────────────────────────
   // Set from the polling fiber in DbPoolMetrics. threads_awaiting was the

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -107,7 +107,10 @@ object MetricsExportSpec
       } yield assertTrue(body.contains("wifihaven_rollup_runs_total")) &&
         assertTrue(body.contains("wifihaven_rollup_duration_seconds")) &&
         assertTrue(body.contains("wifihaven_rollup_rows_upserted")) &&
-        assertTrue(body.contains("time_used_daily")))
+        assertTrue(body.contains("time_used_daily")) &&
+        // #1291: the fiber name is tagged under `rollup_job`, never the reserved
+        // `job` label (which Alloy clobbers with the scrape component name).
+        assertTrue(body.contains("rollup_job=\"time_used_daily\"")))
         .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Transactor[Task]](
           MetricsRuntime.prometheus(pollInterval),
           Clock.live,

--- a/deploy/grafana/dashboards/rollup-health.json
+++ b/deploy/grafana/dashboards/rollup-health.json
@@ -22,7 +22,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Rollup run rate by job / status",
-      "description": "sum by (job, status) (rate(wifihaven_rollup_runs_total[5m])). status is \"ok\" or \"error\".",
+      "description": "sum by (rollup_job, status) (rate(wifihaven_rollup_runs_total[5m])). status is \"ok\" or \"error\".",
       "type": "timeseries",
       "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
       "id": 1,
@@ -42,8 +42,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (job, status) (rate(wifihaven_rollup_runs_total{env=\"$env\"}[5m]))",
-          "legendFormat": "{{job}} / {{status}}",
+          "expr": "sum by (rollup_job, status) (rate(wifihaven_rollup_runs_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{rollup_job}} / {{status}}",
           "refId": "A"
         }
       ]
@@ -108,20 +108,20 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.50, sum by (le, job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
-          "legendFormat": "p50 {{job}}",
+          "expr": "histogram_quantile(0.50, sum by (le, rollup_job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p50 {{rollup_job}}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.95, sum by (le, job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
-          "legendFormat": "p95 {{job}}",
+          "expr": "histogram_quantile(0.95, sum by (le, rollup_job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p95 {{rollup_job}}",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "histogram_quantile(0.99, sum by (le, job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
-          "legendFormat": "p99 {{job}}",
+          "expr": "histogram_quantile(0.99, sum by (le, rollup_job) (rate(wifihaven_rollup_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p99 {{rollup_job}}",
           "refId": "C"
         }
       ]
@@ -150,7 +150,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "wifihaven_rollup_rows_upserted{env=\"$env\"}",
-          "legendFormat": "{{job}}",
+          "legendFormat": "{{rollup_job}}",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
Fixes #1291.

## Problem
The three rollup metric series tag the rollup fiber name (`hourly_bytes` / `daily_bytes` / `time_used_daily`) under `job`, which is a **reserved Prometheus scrape label**. When Grafana Alloy scrapes `/metrics` it overwrites the app's value with the scrape component name (`prometheus.scrape.api_prod` / `...api_staging`), so the per-fiber breakdown collapses to that one useless string in Grafana.

This is the root-cause follow-up to the dashboard stopgap in #1287 / PR #1288, which it supersedes.

## Changes
- **`api/src/metrics/Metrics.scala`** — `recordRollup` now tags all three series with `rollup_job` instead of `job`:
  ```
  - rollupRuns.tagged("job", job).tagged("status", status)...
  + rollupRuns.tagged("rollup_job", job).tagged("status", status)...
  ```
  (same for `rollupDuration` / `rollupRows`). Verified via `grep tagged("job"` across `api/src` + `shared/src` that only the rollup series used it. The DB `rollup_runs.job` column is untouched — this is purely the metric label.
- **`deploy/grafana/dashboards/rollup-health.json`** — repointed panels at the new label:
  - "Rollup run rate by job / status": `sum by (rollup_job, status) (...)`, legend `{{rollup_job}} / {{status}}`.
  - "Rows upserted (last run) by job": legend `{{rollup_job}}`.
  - Duration percentiles: `sum by (le, rollup_job)` with legends `p50/p95/p99 {{rollup_job}}`.
  - `env` and `datasource` template vars left exactly as fixed in #1288.
- **`api/test/src/feature/MetricsExportSpec.scala`** — the rollup-tick exposition test now asserts the emitted label is `rollup_job="time_used_daily"`. Committed red (asserting the new label before the rename) then green, per the repo TDD rule.

## Validation
- `mill api.compile` ✓
- `mill api.test wifihaven.api.feature.MetricsExportSpec` ✓ (rollup-tick test green)
- `scalafmt --check --non-interactive` ✓
- `python3 -c "import json; json.load(...)"` on the dashboard ✓
- No Flyway migration, so the migration-isolation rule doesn't apply.