### PR TITLE
ci: cut v<X.Y.Z> tag only in Router CD; drop duplicate API/UI tag job (#1293)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -516,49 +516,7 @@ jobs:
           echo "Promoting $src → $dst"
           docker buildx imagetools create -t "$dst" "$src"
 
-  # 6b. Cut the v<X.Y.Z> annotated git tag (#499). Idempotent: skipped if
-  # the tag already exists (e.g. an earlier OpenWRT-only release on the same
-  # SHA already cut it). The OpenWRT publish path (publish-openwrt-release.yml)
-  # also creates this tag on the v<X.Y.Z> release; whichever pipeline finishes
-  # first wins, the other no-ops.
-  cut-release-tag:
-    name: Cut v<X.Y.Z> release tag (#499)
-    if: github.ref == 'refs/heads/main'
-    needs: [approve-production, retag-latest]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          # Need a token with push perms; GITHUB_TOKEN at `contents: write`
-          # is enough for ref creation.
-          persist-credentials: true
-
-      - name: Derive version
-        id: ver
-        run: |
-          set -eu
-          version=$(./scripts/ci/derive-version.sh)
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Push annotated tag (idempotent)
-        env:
-          VERSION: ${{ steps.ver.outputs.version }}
-        run: |
-          set -eu
-          tag="v${VERSION}"
-          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
-            echo "Tag ${tag} already exists on origin — skipping."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${tag}" -m "WifiHaven ${tag}"
-          git push origin "${tag}"
-
-  # 6c. Trigger the Render prod deploy hook + wait for healthy. Prod tracks
+  # 6b. Trigger the Render prod deploy hook + wait for healthy. Prod tracks
   # the `:latest` tag, so this must run after retag-latest has moved the
   # pointer — or Render will deploy whatever was on `:latest` before. We
   # depend on retag-latest to enforce ordering.

--- a/.github/workflows/publish-openwrt-release.yml
+++ b/.github/workflows/publish-openwrt-release.yml
@@ -101,10 +101,13 @@ jobs:
             release/wifihaven-router-openwrt-*-apk.tar.gz
             release/wifihaven-router-images.sha256
 
-      # #499: cut the annotated git tag before the versioned release upload so
-      # the tag carries a real tagger + message (softprops would otherwise
-      # create a lightweight tag). Idempotent: the API/UI pipeline's
-      # cut-release-tag job may have already pushed it; skip cleanly if so.
+      # #499/#1293: Router CD is the sole author of the v<X.Y.Z> tag — it owns
+      # the coordinated release whose shippable artifacts are published here,
+      # so the tag never exists before the release it names. We cut the
+      # annotated tag before the versioned release upload so it carries a real
+      # tagger + message (softprops would otherwise create a lightweight tag).
+      # The existence check is kept as a safety net against retries; under
+      # normal operation no other pipeline pushes this tag.
       - name: Cut annotated v<X.Y.Z> tag (#499)
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

Both CD pipelines cut the `v<X.Y.Z>` release tag in an idempotent race today. The tag names a coordinated release whose shippable artifacts (OpenWRT `.ipk`/`.apk`, luci packages, VM image) are produced and published by Router CD, so it should be owned solely by that pipeline — never created before the release it names.

- **`.github/workflows/master-api-ui.yml`** — removed the `cut-release-tag` job ("Cut v<X.Y.Z> release tag (#499)") and its comment block. API/UI CD now ends at prod deploy + `:latest` promotion + SPA deploy. Verified no other job `needs:` it — `deploy-prod-render` depends on `approve-production`/`retag-latest`.
- **`.github/workflows/publish-openwrt-release.yml`** — Router CD remains the sole tag author. Reworded the stale rationale comment that cited the API/UI pipeline / "whichever pipeline finishes first wins". Kept the idempotent `git ls-remote --tags` existence guard as a safety net against retries.
- Version derivation (`scripts/ci/derive-version.sh`, the `Derive version` steps) is untouched — this only removes the duplicate tag **write** from API/UI.

## Behavior change (intended, accepted per #1293)

A commit that triggers **only** API/UI CD — touching api/ui paths but not `openwrt/**`/router paths, so Router CD doesn't run — will **no longer get a `v<X.Y.Z>` git tag** for that prod deploy. The tag now tracks router/openwrt releases only. This is the explicit directive in the issue, not a silent gap.

## Validation

- `actionlint` passes on both changed workflows.

Refs #499, #1134, #1224.

Closes #1293