### PR TITLE
ci: don't treat cancelled jobs as failures in the CI aggregator (#1296)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,9 +659,12 @@ jobs:
 
   # ── Umbrella gating job ──────────────────────────────────────────────────
   # Branch protection requires this single check. It depends on every
-  # downstream job and passes when each one is either successful or skipped
-  # (i.e. its paths weren't touched on this PR). Any failure or cancellation
-  # in a dependency fails this check.
+  # downstream job and passes when each one is either successful, skipped
+  # (i.e. its paths weren't touched on this PR), or cancelled. Cancellation
+  # is treated as neutral — it only happens when the entire run was cancelled
+  # (concurrency supersede or manual cancel). GitHub already marks the head
+  # commit's status from the newest run, so treating cancelled as neutral
+  # does not weaken the gate. A genuine failure still fails this check.
   ci:
     name: CI
     if: always()
@@ -690,9 +693,9 @@ jobs:
           import json, sys
           data = json.load(sys.stdin)
           bad = {name: meta["result"] for name, meta in data.items()
-                 if meta["result"] not in ("success", "skipped")}
+                 if meta["result"] not in ("success", "skipped", "cancelled")}
           if bad:
               print(f"Failing jobs: {bad}")
               sys.exit(1)
-          print("All required jobs succeeded or were skipped.")
+          print("All required jobs succeeded, were skipped, or were cancelled.")
           '


### PR DESCRIPTION
Closes #1296

## Summary

- Adds `"cancelled"` to the allowed-result set in the umbrella `ci:` job's Python filter, alongside `"success"` and `"skipped"`.
- Updates the comment block above the job to accurately state that cancellation is neutral, and explains why: a cancelled job only occurs when the entire run was cancelled (concurrency supersede or manual cancel); GitHub marks the head commit's status from the newest run, so this does not weaken the gate. Genuine `failure` results still fail the check.

This removes the spurious red `CI / CI = failure` that appears on concurrency-superseded runs (e.g. when a new push kills slow Scala/contract-tests jobs mid-flight).

## Test plan

- [ ] `actionlint .github/workflows/ci.yml` — passes (no output)
- [ ] Python logic sanity-checked locally: `cancelled` entry is NOT flagged; `failure` entry IS flagged
- [ ] Verify that the next concurrency-superseded run shows a neutral/green `CI / CI` instead of a red failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)