### PR TITLE
Ingest router-pushed metrics at POST /api/router/metrics (#1205)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -5,7 +5,13 @@ import doobie.implicits.*
 import wifihaven.api.auth.*
 import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
-import wifihaven.api.metrics.{DbPoolMetrics, HttpMetrics, MetricsRuntime, RouterPresenceMetrics}
+import wifihaven.api.metrics.{
+  DbPoolMetrics,
+  HttpMetrics,
+  MetricsRuntime,
+  RouterMetricsService,
+  RouterPresenceMetrics,
+}
 import wifihaven.api.notify.Notifier
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
@@ -271,7 +277,8 @@ object Main extends ZIOAppDefault {
       timeCache     <- ZIO.service[TimeStatusCache]
       xa            <- ZIO.service[Transactor[Task]]
       promPublisher <- ZIO.service[PrometheusPublisher]
-      routerAuth    = new RouterAuthLive(routerRepo)
+      routerAuth = new RouterAuthLive(routerRepo)
+      routerMetrics <- RouterMetricsService.make
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
     } yield {
       // #1177: split the route composition into typed chunks. A flat `++` chain across
@@ -355,6 +362,7 @@ object Main extends ZIOAppDefault {
             alertRepo,
             hsRepo,
           ) ++
+          RouterMetricsRoutes.routes(routerAuth, routerMetrics) ++
           AlertRoutes.routes(
             auth,
             alertRepo,

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -37,15 +37,32 @@ object MetricGuard {
     )
 
   /**
-   * §5.2 — metric name → its permitted label keys. The only (name, keys) pairs that may be emitted.
+   * §5.1/§5.2 — metric name → its permitted label keys. The only (name, keys) pairs that may be
+   * emitted. `router_id` (and `installation_id`, once that concept lands) are bounded fleet-size
+   * dimensions the server attaches to every router-pushed series (§4.2) — they are deliberately NOT
+   * in [[ForbiddenKeys]].
    */
   val Allowed: Map[String, Set[String]] = Map(
+    // §5.2 API self-metrics.
     "http_requests_total"                       -> Set("route", "method", "status"),
     "http_request_duration_seconds"             -> Set("route", "method"),
     "db_query_duration_seconds"                 -> Set("op"),
     "auth_failures_total"                       -> Set("reason"),
     "agent_connected_routers"                   -> Set.empty[String],
     "traffic_reports_filtered_zero_bytes_total" -> Set.empty[String],
+    // §5.1 router-sourced, pushed via POST /api/router/metrics (#1205). Every one carries the
+    // server-attached `router_id` + `installation_id` plus its own bounded enum label.
+    "dnsmasq_restarts_total"                    -> Set("reason", "router_id", "installation_id"),
+    "policy_apply_total"                        -> Set("result", "router_id", "installation_id"),
+    "policy_apply_duration_seconds"             -> Set("router_id", "installation_id"),
+    "snapshot_poll_total"                       -> Set("result", "router_id", "installation_id"),
+    "snapshot_poll_duration_seconds"            -> Set("router_id", "installation_id"),
+    "agent_uptime_seconds"                      -> Set("router_id", "installation_id"),
+    "agent_version"                             -> Set("version", "router_id", "installation_id"),
+    "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
+    "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
+    // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
+    "router_metrics_batches_total"              -> Set("status"),
   )
 
   private val rejected = Metric.counter("metrics_rejected_total")
@@ -165,6 +182,30 @@ object AppMetrics {
 
   def setConnectedRouters(count: Int): UIO[Unit] =
     MetricGuard.gauge("agent_connected_routers", Map.empty, count.toDouble)
+
+  // ── Router metrics ingest (#1205) ────────────────────────────────────────────
+  // One increment per POST /api/router/metrics. `status` ∈ {ok, malformed,
+  // router_mismatch}. The concrete server-side health signal for the push path.
+
+  def recordRouterMetricsBatch(status: String): UIO[Unit] =
+    MetricGuard.counter("router_metrics_batches_total", Map("status" -> status))
+
+  // §5.1 — server-side histogram boundaries for the router-pushed duration histograms. The agent
+  // (#1206) reports cumulative bucket counts on these same boundaries; RouterMetricsService folds
+  // the per-batch bucket-count deltas back into these registry histograms.
+  val PolicyApplyDurationBoundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(0.01, 0.05, 0.1, 0.5, 1.0, 5.0))
+
+  val SnapshotPollDurationBoundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(0.01, 0.05, 0.1, 0.5, 1.0, 5.0))
+
+  /**
+   * Boundaries keyed by router-pushed histogram name; the fold falls back to this when unmatched.
+   */
+  val RouterHistogramBoundaries: Map[String, MetricKeyType.Histogram.Boundaries] = Map(
+    "policy_apply_duration_seconds"  -> PolicyApplyDurationBoundaries,
+    "snapshot_poll_duration_seconds" -> SnapshotPollDurationBoundaries,
+  )
 
   // ── Rollup health (#1243) ──────────────────────────────────────────────────
   // Emitted from RollupRepoLive.recordRun — the single completion point both the

--- a/api/src/metrics/RouterMetricsService.scala
+++ b/api/src/metrics/RouterMetricsService.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.metrics
 
-import wifihaven.shared.RouterMetricsBatch
+import wifihaven.shared.{MetricHistogram, RouterMetricsBatch}
+import wifihaven.shared.types.RouterId
 import zio.*
 
 /**
@@ -21,9 +22,126 @@ trait RouterMetricsService {
 
 object RouterMetricsService {
   def make: UIO[RouterMetricsService] =
-    ZIO.succeed(new RouterMetricsServiceLive)
+    Ref
+      .make(Map.empty[RouterId, RouterMetricsServiceLive.RouterState])
+      .map(new RouterMetricsServiceLive(_))
 }
 
-final class RouterMetricsServiceLive extends RouterMetricsService {
-  def ingest(batch: RouterMetricsBatch): UIO[Unit] = ZIO.unit
+object RouterMetricsServiceLive {
+
+  /**
+   * Per-router re-basing state. `generation` is the agent's `agentStartedAt`; on change the agent
+   * restarted and all of its cumulative values reset to zero, so the baselines drop. `counters`
+   * maps a series key to its last reported cumulative value; `histograms` maps a series key to its
+   * last reported per-`le` cumulative bucket counts.
+   */
+  final case class RouterState(
+      generation: String,
+      counters: Map[String, Double],
+      histograms: Map[String, Map[String, Double]],
+  )
+
+  /** Stable identity for a series: name + its agent-sent labels (sorted). */
+  private[metrics] def seriesKey(name: String, labels: Map[String, String]): String =
+    name + labels.toList.sortBy(_._1).map((k, v) => s"$k=$v").mkString("{", ",", "}")
+
+  /** `"+Inf"` → +∞; otherwise parse the numeric upper bound. */
+  private def leValue(le: String): Double =
+    if le == "+Inf" || le == "Inf" then Double.PositiveInfinity
+    else le.toDoubleOption.getOrElse(Double.PositiveInfinity)
+}
+
+final class RouterMetricsServiceLive(
+    state: Ref[Map[RouterId, RouterMetricsServiceLive.RouterState]],
+) extends RouterMetricsService {
+  import RouterMetricsServiceLive.*
+
+  def ingest(batch: RouterMetricsBatch): UIO[Unit] =
+    state.modify(fold(batch, _)).flatten
+
+  /**
+   * Pure fold: compute the registry emissions (already cardinality-gated by [[MetricGuard]]) and
+   * the updated per-router state for `batch`. Returns the combined effect to run plus the new map;
+   * the caller runs the effect *after* the atomic state swap so a concurrent batch from another
+   * router can't interleave a stale baseline.
+   */
+  private def fold(
+      batch: RouterMetricsBatch,
+      all: Map[RouterId, RouterState],
+  ): (UIO[Unit], Map[RouterId, RouterState]) = {
+    val rid     = batch.routerId.value.toString
+    val prev    = all.get(batch.routerId)
+    // A restart (or a never-seen router) means there is no valid baseline → re-base from zero.
+    val sameGen = prev.exists(_.generation == batch.agentStartedAt)
+    val baseCtr = if sameGen then prev.get.counters else Map.empty[String, Double]
+    val baseHst = if sameGen then prev.get.histograms else Map.empty[String, Map[String, Double]]
+
+    val (newCtr, ctrEffects) =
+      batch.counters.foldLeft((baseCtr, Chunk.empty[UIO[Unit]])) { case ((acc, effs), c) =>
+        val key   = seriesKey(c.name, c.labels)
+        val last  = acc.getOrElse(key, 0.0)
+        val delta = c.value - last
+        // A negative delta within a generation shouldn't happen (cumulative), but if it does treat
+        // it like a reset and re-base to the current value rather than decrementing the counter.
+        val by    = if delta < 0 then c.value else delta
+        val emit  = MetricGuard.counter(c.name, c.labels + ("router_id" -> rid), math.round(by))
+        (acc.updated(key, c.value), effs :+ emit)
+      }
+
+    val gaugeEffects =
+      Chunk
+        .fromIterable(batch.gauges)
+        .map(g => MetricGuard.gauge(g.name, g.labels + ("router_id" -> rid), g.value))
+
+    val (newHst, hstEffects) =
+      batch.histograms.foldLeft((baseHst, Chunk.empty[UIO[Unit]])) { case ((acc, effs), h) =>
+        val key                   = seriesKey(h.name, h.labels)
+        val (emit, nowCumulative) = foldHistogram(h, acc.getOrElse(key, Map.empty), rid)
+        (acc.updated(key, nowCumulative), effs :+ emit)
+      }
+
+    val effect = ZIO.collectAllDiscard(ctrEffects ++ gaugeEffects ++ hstEffects)
+    (effect, all.updated(batch.routerId, RouterState(batch.agentStartedAt, newCtr, newHst)))
+  }
+
+  /**
+   * Fold one cumulative-bucket histogram into the registry by re-emitting, per bucket, the *new*
+   * observations since the last batch — `(count_le − count_prev_le)` deltas — at the bucket's upper
+   * bound so they land in the matching registry bucket. Returns the emission plus this batch's
+   * per-`le` cumulative counts to store as the next baseline. Note: `_sum` is reconstructed from
+   * the representative bucket values, so it approximates (not reproduces) the agent's reported
+   * `sum` — acceptable for best-effort fleet observability; exact per-observation sums are not a
+   * goal (§4).
+   */
+  private def foldHistogram(
+      h: MetricHistogram,
+      prevBuckets: Map[String, Double],
+      rid: String,
+  ): (UIO[Unit], Map[String, Double]) = {
+    val boundaries =
+      AppMetrics.RouterHistogramBoundaries.getOrElse(
+        h.name,
+        AppMetrics.PolicyApplyDurationBoundaries,
+      )
+    val sorted     = h.buckets.sortBy(b => leValue(b.le))
+    val maxFinite  = sorted.map(b => leValue(b.le)).filter(_.isFinite).maxOption.getOrElse(1.0)
+    val labels     = h.labels + ("router_id" -> rid)
+
+    // Walk buckets in ascending `le`, tracking the running cumulative-below for both this batch and
+    // the previous one, so each step yields the half-open bucket's new-observation delta.
+    val (_, _, effs) =
+      sorted.foldLeft((0.0, 0.0, Chunk.empty[UIO[Unit]])) { case ((nowLower, prevLower, effs), b) =>
+        val nowCum   = b.count
+        val prevCum  = prevBuckets.getOrElse(b.le, 0.0)
+        val deltaObs = math.max(0L, math.round((nowCum - nowLower) - (prevCum - prevLower)))
+        val repr     = if leValue(b.le).isInfinite then maxFinite + 1.0 else leValue(b.le)
+        val emit     =
+          MetricGuard
+            .histogram(h.name, labels, repr, boundaries)
+            .replicateZIODiscard(deltaObs.toInt)
+        (nowCum, prevCum, effs :+ emit)
+      }
+
+    (ZIO.collectAllDiscard(effs), sorted.map(b => b.le -> b.count).toMap)
+  }
 }

--- a/api/src/metrics/RouterMetricsService.scala
+++ b/api/src/metrics/RouterMetricsService.scala
@@ -1,0 +1,29 @@
+package wifihaven.api.metrics
+
+import wifihaven.shared.RouterMetricsBatch
+import zio.*
+
+/**
+ * #1205 / design §3 — carrier-agnostic ingest for router-pushed metrics. Takes a *parsed* batch
+ * (never a `Request`), so both the REST adapter (`POST /api/router/metrics`) today and the #1023
+ * websocket `{"op":"metrics"}` frame dispatcher tomorrow fold into the exact same handler.
+ *
+ * Counters on the wire are cumulative running totals; this service translates them into the ZIO
+ * metric registry idempotently by tracking the last value per (router, series) and emitting only
+ * the delta. When `agentStartedAt` changes the agent restarted and its counters reset to zero, so
+ * the baseline is dropped and the new cumulative re-bases from zero — the re-exposed counter keeps
+ * climbing monotonically with no negative delta. Every emission passes through [[MetricGuard]], so
+ * an unknown name or a forbidden label key is dropped and counted in `metrics_rejected_total`.
+ */
+trait RouterMetricsService {
+  def ingest(batch: RouterMetricsBatch): UIO[Unit]
+}
+
+object RouterMetricsService {
+  def make: UIO[RouterMetricsService] =
+    ZIO.succeed(new RouterMetricsServiceLive)
+}
+
+final class RouterMetricsServiceLive extends RouterMetricsService {
+  def ingest(batch: RouterMetricsBatch): UIO[Unit] = ZIO.unit
+}

--- a/api/src/routes/RouterMetricsRoutes.scala
+++ b/api/src/routes/RouterMetricsRoutes.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.routes
 
-import wifihaven.api.metrics.RouterMetricsService
+import wifihaven.api.metrics.{AppMetrics, RouterMetricsService}
 import wifihaven.shared.RouterMetricsBatch
 import zio.*
 import zio.http.*
@@ -27,10 +27,12 @@ object RouterMetricsRoutes {
             batch  <- ZIO
               .fromEither(body.fromJson[RouterMetricsBatch])
               .mapError(e => Response.badRequest(e))
-            _      <- ZIO
-              .fail(Response.text("router_id mismatch").status(Status.Forbidden))
+              .tapError(_ => AppMetrics.recordRouterMetricsBatch("malformed"))
+            _      <- (AppMetrics.recordRouterMetricsBatch("router_mismatch") *>
+              ZIO.fail(Response.text("router_id mismatch").status(Status.Forbidden)))
               .when(batch.routerId != router.id)
             _      <- svc.ingest(batch)
+            _      <- AppMetrics.recordRouterMetricsBatch("ok")
           } yield Response.ok
         },
     )

--- a/api/src/routes/RouterMetricsRoutes.scala
+++ b/api/src/routes/RouterMetricsRoutes.scala
@@ -1,0 +1,37 @@
+package wifihaven.api.routes
+
+import wifihaven.api.metrics.RouterMetricsService
+import wifihaven.shared.RouterMetricsBatch
+import zio.*
+import zio.http.*
+import zio.json.*
+
+/**
+ * #1205 / design §3 — `POST /api/router/metrics`: the router → API metrics push transport. A thin
+ * adapter over the carrier-agnostic [[RouterMetricsService]]; reuses [[RouterAuth]] (the existing
+ * per-router bearer token — no new credential) and cross-checks the body `routerId` against the
+ * token's router, mirroring `/api/router/usage` and `/api/router/events`.
+ *
+ * A malformed batch is a `400` (logged, not retried — a bad metrics batch is not worth a retry
+ * storm); a wrong/missing token is `401`; a body whose `routerId` doesn't match the token is `403`.
+ */
+object RouterMetricsRoutes {
+
+  def routes(auth: RouterAuth, svc: RouterMetricsService): Routes[Any, Response] =
+    Routes(
+      Method.POST / "api" / "router" / "metrics" ->
+        handler { (req: Request) =>
+          for {
+            router <- auth.authenticate(req)
+            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+            batch  <- ZIO
+              .fromEither(body.fromJson[RouterMetricsBatch])
+              .mapError(e => Response.badRequest(e))
+            _      <- ZIO
+              .fail(Response.text("router_id mismatch").status(Status.Forbidden))
+              .when(batch.routerId != router.id)
+            _      <- svc.ingest(batch)
+          } yield Response.ok
+        },
+    )
+}

--- a/api/test/src/feature/RouterMetricsIngestSpec.scala
+++ b/api/test/src/feature/RouterMetricsIngestSpec.scala
@@ -68,11 +68,16 @@ object RouterMetricsIngestSpec
 
   /**
    * The numeric value of the first non-comment line of `metric` that contains every `mustContain`.
+   * Exposition lines are `name{labels} <value> <timestampMs>`, so the value is the second-to-last
+   * whitespace token when a timestamp is present (this connector always emits one).
    */
   private def seriesValue(body: String, metric: String, mustContain: String*): Option[Double] =
     body.linesIterator
       .filter(l => !l.startsWith("#") && l.startsWith(metric) && mustContain.forall(l.contains))
-      .flatMap(_.trim.split("\\s+").lastOption)
+      .flatMap { l =>
+        val toks = l.trim.split("\\s+")
+        if toks.length >= 3 then toks.lift(toks.length - 2) else toks.lastOption
+      }
       .flatMap(_.toDoubleOption)
       .toList
       .headOption

--- a/api/test/src/feature/RouterMetricsIngestSpec.scala
+++ b/api/test/src/feature/RouterMetricsIngestSpec.scala
@@ -1,0 +1,252 @@
+package wifihaven.api.feature
+
+import wifihaven.api.MetricsConfig
+import wifihaven.api.db.*
+import wifihaven.api.metrics.RouterMetricsService
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+/**
+ * #1205 / design §3 — `POST /api/router/metrics` ingest. Drives the real route (RouterAuth +
+ * routerId cross-check) against embedded Postgres and folds router-pushed cumulative counters into
+ * the live Prometheus publisher that `GET /metrics` scrapes.
+ *
+ * Load-bearing assertions: counters are re-exposed under a bounded `router_id` label; cumulative
+ * semantics mean a replayed batch never double-counts; an agent restart (changed `agentStartedAt`)
+ * re-bases cleanly with no negative delta; and an unknown name / forbidden label is dropped and
+ * counted in `metrics_rejected_total`, never emitted.
+ */
+object RouterMetricsIngestSpec
+    extends ZIOSpec[
+      TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher,
+    ] {
+
+  override val bootstrap =
+    TestDatabase.layer ++
+      TestLayers.withClock(TestClock.schoolDayAfternoon) ++
+      wifihaven.api.metrics.MetricsRuntime.prometheus(100.millis)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  /** Enroll a fresh router, returning its id + the plaintext bearer token. */
+  private def newRouter(name: String): ZIO[RouterRepo, Throwable, (RouterId, String)] =
+    for {
+      repo <- ZIO.service[RouterRepo]
+      token = s"TOK_${name}_${java.util.UUID.randomUUID().toString.take(8)}"
+      id <- repo.create(name, Sha256Hex.unsafe("e" * 64))
+      _  <- repo.completeEnrollment(id, Sha256Hex.unsafe(RouterAuth.sha256Hex(token)))
+    } yield (id, token)
+
+  private def post(
+      routes: Routes[Any, Response],
+      token: String,
+      body: String,
+  ): ZIO[Any, Response, Response] = {
+    val req = Request
+      .post(URL.decode("/api/router/metrics").toOption.get, Body.fromString(body))
+      .addHeader(Header.ContentType(MediaType.application.json))
+      .addHeader(Header.Authorization.Bearer(token))
+    routes.runZIO(req)
+  }
+
+  private def scrape: ZIO[PrometheusPublisher, Response, String] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      rs = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
+      resp <- rs(Request.get("/metrics"))
+      body <- resp.body.asString.orElseFail(Response.internalServerError("scrape decode failed"))
+    } yield body
+
+  /**
+   * The numeric value of the first non-comment line of `metric` that contains every `mustContain`.
+   */
+  private def seriesValue(body: String, metric: String, mustContain: String*): Option[Double] =
+    body.linesIterator
+      .filter(l => !l.startsWith("#") && l.startsWith(metric) && mustContain.forall(l.contains))
+      .flatMap(_.trim.split("\\s+").lastOption)
+      .flatMap(_.toDoubleOption)
+      .toList
+      .headOption
+
+  private def batchJson(
+      routerId: RouterId,
+      agentStartedAt: String,
+      counters: List[MetricCounter] = Nil,
+      gauges: List[MetricGauge] = Nil,
+      histograms: List[MetricHistogram] = Nil,
+  ): String =
+    RouterMetricsBatch(
+      routerId = routerId,
+      agentVersion = "0.3.1",
+      agentStartedAt = agentStartedAt,
+      sampledAt = "2026-05-30T14:01:00Z",
+      counters = counters,
+      gauges = gauges,
+      histograms = histograms,
+    ).toJson
+
+  def spec = suite("router metrics ingest (#1205)")(
+    test("valid batch + correct token → 200; series appear under router_id") {
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-ok")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        body   = batchJson(
+          rid,
+          "2026-05-30T09:00:00Z",
+          counters = List(
+            MetricCounter("dnsmasq_restarts_total", Map("reason" -> "boot"), 1),
+            MetricCounter("policy_apply_total", Map("result" -> "ok"), 880),
+          ),
+          gauges = List(MetricGauge("agent_uptime_seconds", Map.empty, 18060)),
+          histograms = List(
+            MetricHistogram(
+              "policy_apply_duration_seconds",
+              Map.empty,
+              List(
+                MetricHistogramBucket("0.05", 3),
+                MetricHistogramBucket("0.1", 5),
+                MetricHistogramBucket("+Inf", 6),
+              ),
+              sum = 0.4,
+              count = 6,
+            ),
+          ),
+        )
+        resp <- post(routes, tok, body)
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield {
+        val ridStr = rid.value.toString
+        assertTrue(resp.status == Status.Ok) &&
+        assertTrue(
+          seriesValue(scraped, "dnsmasq_restarts_total", s"""router_id="$ridStr"""", "boot")
+            .contains(1.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "policy_apply_total", s"""router_id="$ridStr"""", "ok")
+            .contains(880.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "agent_uptime_seconds", s"""router_id="$ridStr"""")
+            .contains(18060.0),
+        ) &&
+        assertTrue(scraped.contains("policy_apply_duration_seconds"))
+      }
+    },
+    test("missing token → 401; routerId mismatch → 403") {
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-auth")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        noTokResp <- routes
+          .runZIO(
+            Request.post(
+              URL.decode("/api/router/metrics").toOption.get,
+              Body.fromString(batchJson(rid, "2026-05-30T09:00:00Z")),
+            ),
+          )
+        otherId = RouterId(java.util.UUID.randomUUID())
+        mismatch <- post(routes, tok, batchJson(otherId, "2026-05-30T09:00:00Z"))
+      } yield assertTrue(noTokResp.status == Status.Unauthorized) &&
+        assertTrue(mismatch.status == Status.Forbidden)
+    },
+    test("replayed batch does not double-count (cumulative semantics)") {
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-replay")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        body   = batchJson(
+          rid,
+          "2026-05-30T09:00:00Z",
+          counters = List(MetricCounter("snapshot_poll_total", Map("result" -> "304"), 9300)),
+        )
+        _ <- post(routes, tok, body)
+        _       <- post(routes, tok, body) // identical replay
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield assertTrue(
+        seriesValue(
+          scraped,
+          "snapshot_poll_total",
+          s"""router_id="${rid.value.toString}"""",
+          "304",
+        ).contains(9300.0),
+      )
+    },
+    test("agent restart (changed agentStartedAt) re-bases with no negative delta") {
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-restart")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        genA   = batchJson(
+          rid,
+          "2026-05-30T09:00:00Z",
+          counters = List(MetricCounter("snapshot_poll_total", Map("result" -> "200"), 100)),
+        )
+        genB   = batchJson(
+          rid,
+          "2026-05-30T12:00:00Z", // agent restarted → counters reset to 0, now at 5
+          counters = List(MetricCounter("snapshot_poll_total", Map("result" -> "200"), 5)),
+        )
+        _ <- post(routes, tok, genA)
+        _       <- post(routes, tok, genB)
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield
+      // 100 (gen A) + 5 (re-based gen B) = 105 — climbed, never went negative.
+      assertTrue(
+        seriesValue(
+          scraped,
+          "snapshot_poll_total",
+          s"""router_id="${rid.value.toString}"""",
+          "200",
+        ).contains(105.0),
+      )
+    },
+    test("unknown name / forbidden label is dropped and counted in metrics_rejected_total") {
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-reject")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        body   = batchJson(
+          rid,
+          "2026-05-30T09:00:00Z",
+          counters = List(
+            MetricCounter("totally_made_up_metric", Map.empty, 7),
+            MetricCounter("dnsmasq_restarts_total", Map("mac" -> "aa:bb:cc:dd:ee:ff"), 4),
+          ),
+        )
+        resp <- post(routes, tok, body)
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(!scraped.contains("totally_made_up_metric")) &&
+        assertTrue(!scraped.contains("""mac="aa:bb:cc:dd:ee:ff"""")) &&
+        assertTrue(scraped.contains("metrics_rejected_total")) &&
+        assertTrue(
+          seriesValue(scraped, "metrics_rejected_total", """reason="unknown_name"""")
+            .exists(_ >= 1.0),
+        )
+    },
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+}

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -387,6 +387,35 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Router metrics batch ingest rate (#1205)",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live router fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent. The per-agent router-fleet panels are deferred to #1279 (blocked on agent metrics #1206).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (status) (rate(router_metrics_batches_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1096,6 +1096,51 @@ case class UsageReport(
 ) derives JsonCodec
 
 /**
+ * #1205 / design §3.2 — the router → API metrics push batch. The OpenWRT agent posts one of these
+ * to `POST /api/router/metrics` every ~60 s. Counters are **cumulative running totals** since agent
+ * start; the server re-bases when `agentStartedAt` changes (agent restart) instead of recording a
+ * negative delta, so duplicate/retried batches never double-count (see RouterMetricsService).
+ *
+ * Deliberately a standalone JSON document with no HTTP-framing dependence: when #1023 (websocket
+ * transport) lands it rehomes verbatim as `{"op":"metrics","payload":<this body>}` and dispatches
+ * into the same carrier-agnostic RouterMetricsService.
+ *
+ * The agent sends only the *extra* labels per series (e.g. `reason`/`result`/`status`/`version`);
+ * the server attaches the bounded `router_id` (and `installation_id` once that concept lands)
+ * dimension itself.
+ */
+case class MetricCounter(name: String, labels: Map[String, String] = Map.empty, value: Double)
+    derives JsonCodec
+
+case class MetricGauge(name: String, labels: Map[String, String] = Map.empty, value: Double)
+    derives JsonCodec
+
+/**
+ * A single cumulative bucket: observations with value ≤ `le` (`"+Inf"` for the overflow bucket).
+ */
+case class MetricHistogramBucket(le: String, count: Double) derives JsonCodec
+
+case class MetricHistogram(
+    name: String,
+    labels: Map[String, String] = Map.empty,
+    buckets: List[MetricHistogramBucket],
+    sum: Double,
+    count: Double,
+) derives JsonCodec
+
+case class RouterMetricsBatch(
+    routerId: RouterId,
+    agentVersion: String,
+    // Counter-reset sentinel: a changed value between batches means the agent restarted and its
+    // cumulative counters reset to zero, so the server re-bases rather than seeing a negative delta.
+    agentStartedAt: String,
+    sampledAt: String,
+    counters: List[MetricCounter] = Nil,
+    gauges: List[MetricGauge] = Nil,
+    histograms: List[MetricHistogram] = Nil,
+) derives JsonCodec
+
+/**
  * Router event payload. `type` discriminates:
  *   - "connection_attempt": (mac, host, destIp, allowed, reason, ts)
  *   - "dhcp_lease": (mac, ip, hostname, ts) — `hostname` here is the DHCP-advertised name, which by


### PR DESCRIPTION
Implements #1205 / design §3 — the router → API metrics push transport.

## What
- `POST /api/router/metrics`: a thin REST adapter over a new
  carrier-agnostic `RouterMetricsService`. It reuses the existing
  per-router bearer token (`RouterAuth`, no new credential) and
  cross-checks the body `routerId` against the token's router
  (missing/bad token → 401, mismatch → 403, malformed batch → 400).
- The service takes a **parsed** `RouterMetricsBatch`, never a
  `Request`, so the #1023 websocket `{"op":"metrics"}` frame dispatcher
  can fold into the exact same handler later. The REST endpoint lands
  first.
- Wire schema (`shared/src/Models.scala`): `RouterMetricsBatch`
  (`routerId`, `agentVersion`, `agentStartedAt`, `sampledAt`,
  `counters` / `gauges` / `histograms`) + the per-series line types,
  per design §3.2.

## Cumulative-counter re-basing
Counters and histogram buckets on the wire are cumulative running
totals. The service keeps per-`(router, series)` state and emits only
the **delta** since the last batch, so a replayed/duplicate batch never
double-counts. `agentStartedAt` is the restart sentinel: when it
changes, the agent restarted and its cumulative values reset to zero, so
the stored baseline is dropped and the series re-bases from zero — the
re-exposed registry counter keeps climbing monotonically with **no
negative delta**. A within-generation negative delta (shouldn't happen)
is likewise treated as a reset. The fold is pure and runs inside a
single `Ref.modify`; emission happens after the atomic state swap so a
concurrent batch can't interleave a stale baseline.

## Cardinality
Every emission passes through `MetricGuard`: an unknown metric name or a
forbidden label key is dropped and counted in `metrics_rejected_total`,
never emitted. The 9 router-sourced names are added to the allowlist
with their bounded label sets. `router_id` is re-attached server-side
as a **bounded** label (one value per enrolled router) — it is permitted
in the allowlist and is **not** in `ForbiddenKeys`. No unbounded label
(mac, ip, hostname, …) is ever emitted.

## Dashboard
Adds a concrete server-side series `router_metrics_batches_total{status}`
(ok / malformed / router_mismatch) and one panel for it in the existing
`api-self-metrics.json`. The router-**fleet** panels (which need the
router-side series this endpoint will start receiving) are deferred to
#1279 / #1206, to be added alongside their instrumentation rather than
shipping no-data panels now.

## Tests
`api/test/src/feature/RouterMetricsIngestSpec.scala` (TDD, embedded
Postgres, real route + Prometheus publisher; red→green visible in commit
history): valid batch → 200 with series under `router_id`; missing token
→ 401, routerId mismatch → 403; replayed batch does not double-count;
agent restart re-bases cleanly (100 + 5 → 105, never negative); unknown
name / forbidden label dropped and counted in `metrics_rejected_total`.

`mill api.test` and `mill shared.test` both green. Not a migration PR —
re-basing state lives in the registry/memory, no schema change.