### PR TITLE
fix(web): opt API reads out of the browser HTTP cache (#1299)

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -72,3 +72,39 @@ describe('usage.seriesBatch (#1099)', () => {
     expect(res.series[0].topHosts[0].host.value).toBe('youtube.com')
   })
 })
+
+// #1299 — the Profiles "+Time" grant didn't refresh the used/cap bar until a
+// force-reload. Root cause: today-mode time-status GETs are served with
+// `Cache-Control: max-age=30`, and `req()` did not opt out of the browser HTTP
+// cache, so React Query's post-mutation refetch was answered from cache with a
+// stale `extensionMins`. Every API call must send `cache: 'no-store'` so the
+// browser cache can never shadow a fresh read; React Query stays the only cache.
+describe('req opts every call out of the browser HTTP cache (#1299)', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'tok')
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('GET reads pass cache: no-store to fetch (the time-status summary path)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.time.summaryAll()
+
+    const opts = fetchMock.mock.calls[0][1] as RequestInit
+    expect(opts.cache).toBe('no-store')
+  })
+
+  it('mutations also pass cache: no-store (the +Time grant path)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ id: 1, grantedMinutes: 30 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.time.grantExtension({ profileId: 1, extraMinutes: 30, note: null })
+
+    const opts = fetchMock.mock.calls[0][1] as RequestInit
+    expect(opts.cache).toBe('no-store')
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -49,6 +49,13 @@ async function req<T>(
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: controller.signal,
+      // #1299: never let the browser HTTP cache answer an API read. Today-mode
+      // time-status GETs are served with Cache-Control: max-age=30, so without
+      // this a React Query refetch fired right after a mutation (e.g. the +Time
+      // grant invalidating ['time','status']) could be served the stale cached
+      // body — the used/cap bar then wouldn't update until a force-reload.
+      // React Query remains the single source of client-side caching.
+      cache: 'no-store',
     })
   } catch (e) {
     clearTimeout(timeoutId)

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -313,6 +313,54 @@ describe('ProfilesPage — +Time mutation (#972 / #946)', () => {
   })
 })
 
+// #1299 — granting +Time must refresh the collapsed summary's used/cap text +
+// bar (and the #975 "(+Xm)" extension surfacing) WITHOUT a reload. The summary
+// is served by `api.time.summaryAll` via the ['time','status','summary','today']
+// query; the grant mutation's onSuccess invalidates the ['time','status']
+// subtree (the #946 pattern, shared by the #1086 app-policy edits below), which
+// matches that key as a prefix and forces a refetch. This test is the
+// regression guard for that invalidation: drop the `invalidators.timeStatus()`
+// call in ProfilesPage's grantMutation.onSuccess and it goes red (summaryAll is
+// called once, the "(+30m)" suffix never appears).
+describe('ProfilesPage — +Time grant refreshes the summary used/cap (#1299)', () => {
+  it('grant refetches the time-status summary and surfaces the new extension without a reload', async () => {
+    const summaryFn = api.time.summaryAll as unknown as ReturnType<typeof vi.fn>
+    // Mount sees no extension; the post-grant refetch sees +30m on Kids.
+    summaryFn.mockResolvedValueOnce([kidsSummary, adultsSummary])
+    summaryFn.mockResolvedValue([
+      { ...kidsSummary, extensionMins: 30, remainingMins: 105 },
+      adultsSummary,
+    ])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+
+    // Pre-grant: base cap only, no "(+…)" suffix.
+    const time = within(kidsCard).getByTestId('profile-summary-time-1')
+    expect(time).toHaveTextContent('45m')
+    expect(time).toHaveTextContent('2:00')
+    expect(time).not.toHaveTextContent('(+')
+    expect(summaryFn).toHaveBeenCalledTimes(1)
+
+    await user.click(within(kidsCard).getByTestId('profile-row-grant-1'))
+    await user.click(screen.getByRole('button', { name: /^Grant 30m$/ }))
+
+    await waitFor(() =>
+      expect(api.time.grantExtension).toHaveBeenCalledWith({
+        profileId: 1, extraMinutes: 30, note: null,
+      }),
+    )
+    // The summary query is invalidated → refetched (no reload).
+    await waitFor(() => expect(summaryFn).toHaveBeenCalledTimes(2))
+    // 120 base + 30 extension = 150 = "2:30", with the #975 "(+30m)" call-out.
+    await waitFor(() => {
+      const t = within(kidsCard).getByTestId('profile-summary-time-1')
+      expect(t).toHaveTextContent('2:30')
+      expect(t).toHaveTextContent('(+30m)')
+    })
+  })
+})
+
 describe('ProfilesPage — pause / delete in collapsed row (#1063)', () => {
   // #1063 — Pause/Resume + Delete were moved from the expanded body into the
   // collapsed summary row (alongside the +Time button). The card no longer


### PR DESCRIPTION
## Summary

The Profiles **+Time** grant updated the backend but the used/cap bar didn't refresh until a force-reload (#1299). The original diagnosis (a missing React Query invalidation) was wrong — that invalidation has been correct since #972. **The real cause is the browser HTTP cache.**

### Root cause

Today-mode time-status reads — `GET /api/time/status/summary` and its siblings — are served with `Cache-Control: max-age=30` (`api/.../Routes.scala`, `TodayMaxAgeSeconds`). The SPA's `req()` in `web/src/api/client.ts` issued plain `fetch`es with no `cache` option, so the browser's HTTP cache was in play. Within the 30s window, the refetch that the `['time','status']` invalidation triggers right after `POST /time/extend` was answered **from the browser cache** with a stale `extensionMins` — the bar kept the old cap until a hard reload (`cache: reload`) bypassed the cache.

Confirmed live in prod via DevTools: at failure, the `time/status/summary` **Response body itself** carried the old `extensionMins`. This is intermittent precisely because it only bites inside the 30s `max-age` window.

### Fix (this PR — client, defense-in-depth)

Pass `cache: 'no-store'` on every API `fetch` so the browser cache can never shadow a fresh read. React Query stays the single source of client-side caching (its `staleTime` still dedups routine polling). One-line change in `client.ts`, plus tests.

The **root-cause server fix** — correcting the `Cache-Control` header so the API doesn't advertise mutation-sensitive authed reads as cacheable — ships separately and **closes #1299**. This PR is the belt-and-suspenders client half.

### TDD / what changed

- `web/src/api/client.test.ts` — new `#1299` block asserts `req()` sends `cache: 'no-store'` on both a GET (summary) and a mutation (grant). Committed **red first** (`opts.cache` was `undefined`), then green after the fix.
- `web/src/api/client.ts` — add `cache: 'no-store'` to the `req()` fetch options.
- (Also retains the earlier `ProfilesPage` test guarding that the grant invalidates/refetches the summary.)

## Test plan

- [x] `nvm use 22 && npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 320 passed (29 files)
- [x] New `client.test.ts` cases go red without the `cache: 'no-store'` change, green with it

Refs #1299 (closed by the server-side `Cache-Control` fix).
