### PR TITLE
OpenWRT agent cumulative metrics + 60s push to /api/router/metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,11 @@ jobs:
               - 'openwrt/files/usr/lib/lua/wifihaven/render.nft'
               - 'openwrt/files/usr/lib/lua/wifihaven/conntrack.lua'
               - 'openwrt/files/usr/lib/lua/wifihaven/usage.lua'
+              # #1206: metrics.lua is the production builder for the
+              # router_metrics_batch.json fixture (build_metrics_batch in
+              # contract_gen.lua calls it), so a change here can drift the
+              # contract — run the bidirectional job when it moves.
+              - 'openwrt/files/usr/lib/lua/wifihaven/metrics.lua'
               - 'openwrt/test/shim/**'
               - 'api/**'
               - 'shared/**'

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -391,7 +391,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics batch ingest rate (#1205)",
-      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live router fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent. The per-agent router-fleet panels are deferred to #1279 (blocked on agent metrics #1206).",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live router fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent. Fleet-aggregate panels for the router-sourced agent metrics live on the 'Router fleet (agent metrics)' dashboard (#1206); per-(router_id) drill-down is deferred to #1279.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
       "id": 12,

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -1,0 +1,292 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WifiHaven router-fleet agent metrics (#1206): the cumulative counters/gauges/histograms each OpenWRT agent pushes to POST /api/router/metrics every 60s and the API folds into its exposition (RouterMetricsService, #1205). Panels target series actually emitted via that path — dnsmasq_restarts_total, policy_apply_total/_duration_seconds, snapshot_poll_total/_duration_seconds, agent_uptime_seconds, agent_version. The server attaches router_id; panels slice only by the bounded enum labels (reason/result/version) per the §4 cardinality firewall. See docs/design/metrics-observability.md §5.1.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "dnsmasq restarts by reason",
+      "description": "sum by (reason) (rate(dnsmasq_restarts_total[5m])) — the motivating metric for #1206. reason ∈ {boot, policy_change, manual}. A high policy_change rate means the agent is restarting dnsmasq on most applies (a DNS service blip each time); the #414 nft-only short-circuit should keep this near zero in steady state.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(dnsmasq_restarts_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Policy apply rate by result",
+      "description": "sum by (result) (rate(policy_apply_total[5m])) — result ∈ {ok, write_failed, nft_failed, smoke_warn}. A rising nft_failed/write_failed rate means agents are failing to install the rendered ruleset; smoke_warn flags dnsmasq serving a stale config after a restart.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(policy_apply_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Policy apply duration (p50 / p95)",
+      "description": "histogram_quantile over policy_apply_duration_seconds_bucket (boundaries 0.01→5s, PolicyApplyDurationBoundaries). How long an agent takes to render + write + nft-load a snapshot.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(policy_apply_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(policy_apply_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Snapshot poll rate by result",
+      "description": "sum by (result) (rate(snapshot_poll_total[5m])) — result ∈ {200, 304, error}. 304 dominates in steady state (ETag unchanged); a rising error rate means agents can't reach the API and will trip per-profile failover.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(snapshot_poll_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Snapshot poll duration (p50 / p95)",
+      "description": "histogram_quantile over snapshot_poll_duration_seconds_bucket (boundaries 0.01→5s, SnapshotPollDurationBoundaries). Round-trip time of GET /api/router/policy as seen from the agent.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(snapshot_poll_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(snapshot_poll_duration_seconds_bucket{env=\"$env\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Agent versions across the fleet",
+      "description": "count by (version) (agent_version{value=1}) — how many routers run each agent version (info-gauge idiom: agent_version is a constant 1 carrying the version label). Use during a rollout to watch routers move to the new build.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1, "stacking": { "mode": "normal", "group": "A" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "count by (version) (agent_version{env=\"$env\"})",
+          "legendFormat": "{{version}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Reporting agents & recent restarts",
+      "description": "count(agent_uptime_seconds) = routers that have pushed a metrics batch; min(agent_uptime_seconds) = the lowest uptime in the fleet — a sharp drop to near zero flags an agent (or router) restart.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "min uptime" },
+            "properties": [{ "id": "unit", "value": "s" }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "count(agent_uptime_seconds{env=\"$env\"})",
+          "legendFormat": "reporting agents",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "min(agent_uptime_seconds{env=\"$env\"})",
+          "legendFormat": "min uptime",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["wifihaven", "router", "fleet"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "prod", "value": "prod" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          { "selected": true, "text": "prod", "value": "prod" },
+          { "selected": false, "text": "staging", "value": "staging" }
+        ],
+        "query": "prod,staging",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WifiHaven — Router fleet (agent metrics)",
+  "uid": "wifihaven-router-fleet",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -59,7 +59,7 @@ provider "grafana" {
 
 locals {
   folder     = var.folder_uid != "" ? var.folder_uid : null
-  dashboards = ["api-health", "api-self-metrics", "rollup-health"]
+  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health"]
   dashfiles  = { for name in local.dashboards : name => "${path.module}/../../deploy/grafana/dashboards/${name}.json" }
 }
 

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -23,6 +23,13 @@ config wifihaven 'wifihaven'
 	# How often (seconds) to POST usage counters
 	option usage_report_interval '60'
 
+	# How often (seconds) to push the agent's cumulative observability metrics
+	# (counters/gauges/histograms) to /api/router/metrics. Runs on its own timer,
+	# independent of the policy poll. Counters are never reset on the agent — a
+	# missed push self-heals on the next success (the server re-bases off
+	# agentStartedAt). See docs/design/metrics-observability.md.
+	option metrics_report_interval '60'
+
 	# How often (seconds) to sample per-MAC activity for activeSeconds
 	# accounting. Must evenly divide usage_report_interval to avoid partial
 	# buckets at report boundaries (e.g. 10 with usage_report_interval=60

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -18,6 +18,12 @@
 --   instance.lookup(ip) → string | nil
 --   instance.tick(now)             -- evict expired entries (cheap; safe to call often)
 --   instance.size() → integer       -- testable
+--
+-- TODO(#1302): classify and count DNS query outcomes here
+-- (dns_queries_total{result} — resolved / nxdomain / servfail) and feed them
+-- into the agent's in-process metrics registry so they ship in the 60 s
+-- RouterMetricsBatch push (#1206). Deferred from #1206 to keep that PR focused
+-- on the apply/poll/restart telemetry.
 
 local M = {}
 

--- a/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
@@ -1,0 +1,214 @@
+-- metrics.lua — in-process metric registry + push builder for the agent (#1206).
+--
+-- Design: docs/design/metrics-observability.md §3.2 (wire shape), §3.3
+-- (cadence / retain-on-failure), §5.1 (metric catalogue).
+--
+-- The agent keeps cumulative running totals since process start and ships them
+-- to `POST /api/router/metrics` on a dedicated 60 s timer (see
+-- wifihaven-agent). Counters are NEVER reset on the agent — the server
+-- re-bases off `agentStartedAt` (the restart sentinel) and stores the delta,
+-- so a failed POST self-heals on the next success with no double-count and no
+-- data loss. That makes the agent side strictly simpler than the usage path's
+-- reset-on-ack model: build a batch, POST it, keep the registry as-is.
+--
+-- Metric NAMES and bounded LABEL keys here must match the API's allowlist
+-- (api/src/metrics/Metrics.scala `MetricGuard.Allowed`) exactly — anything
+-- off-allowlist is silently dropped server-side into metrics_rejected_total.
+-- `router_id` is attached by the server, so series here carry only their own
+-- bounded enum label (reason / result / status / version).
+--
+-- Public API:
+--   metrics.new({ router_id, agent_version, started_at, buckets? }) → reg
+--   metrics.inc_counter(reg, name, labels, by?)         -- by defaults to 1
+--   metrics.set_gauge(reg, name, labels, value)
+--   metrics.observe(reg, name, labels, value)           -- histogram observation
+--   metrics.build_batch(reg, sampled_at) → batch table  -- §3.2 shape
+--   metrics.post(api_url, token, reg, sampled_at, post_fn, log) → bool
+--
+-- build_batch is the single production builder; the contract fixture generator
+-- (openwrt/test/contract_gen.lua) calls it too so the golden fixture is
+-- generated from real production code, never a test-only mirror.
+
+local M = {}
+
+-- Histogram boundaries. MUST match the API server's
+-- PolicyApplyDurationBoundaries / SnapshotPollDurationBoundaries
+-- (api/src/metrics/Metrics.scala) so the server folds our cumulative bucket
+-- counts back into the matching registry buckets.
+M.DURATION_BUCKETS = { 0.01, 0.05, 0.1, 0.5, 1.0, 5.0 }
+
+local function default_log()
+  local ok, l = pcall(require, "wifihaven.log")
+  if ok then return l end
+  return {
+    info  = function() end,
+    err   = function() end,
+    warn  = function() end,
+    debug = function() end,
+  }
+end
+
+-- Stable per-series identity: name + sorted "k=v" label pairs. Used both to
+-- key the registry maps and to give build_batch a deterministic array order
+-- (so the contract fixture is byte-stable across regens).
+local function series_key(name, labels)
+  local parts = {}
+  for k, v in pairs(labels or {}) do
+    parts[#parts + 1] = tostring(k) .. "=" .. tostring(v)
+  end
+  table.sort(parts)
+  return name .. "{" .. table.concat(parts, ",") .. "}"
+end
+
+-- Copy labels so the caller can reuse its table without aliasing into the
+-- registry (and so build_batch can't be mutated by a later inc with the same
+-- table reference).
+local function copy_labels(labels)
+  local out = {}
+  for k, v in pairs(labels or {}) do out[k] = v end
+  return out
+end
+
+-- Format a bucket upper bound to a stable string the server's leValue()
+-- parses: integral bounds drop the ".0" (1.0 → "1"), fractional bounds keep
+-- their minimal decimal form (0.05 → "0.05").
+local function fmt_le(b)
+  return string.format("%.10g", b)
+end
+
+function M.new(opts)
+  opts = opts or {}
+  return {
+    router_id     = opts.router_id,
+    agent_version = opts.agent_version or "",
+    started_at    = opts.started_at,
+    buckets       = opts.buckets or M.DURATION_BUCKETS,
+    counters      = {}, -- key -> { name, labels, value }
+    gauges        = {}, -- key -> { name, labels, value }
+    histos        = {}, -- key -> { name, labels, counts = {bound -> n}, sum, count }
+  }
+end
+
+function M.inc_counter(reg, name, labels, by)
+  by = by or 1
+  local key = series_key(name, labels)
+  local c   = reg.counters[key]
+  if not c then
+    c = { name = name, labels = copy_labels(labels), value = 0 }
+    reg.counters[key] = c
+  end
+  c.value = c.value + by
+end
+
+function M.set_gauge(reg, name, labels, value)
+  local key = series_key(name, labels)
+  reg.gauges[key] = { name = name, labels = copy_labels(labels), value = value }
+end
+
+function M.observe(reg, name, labels, value)
+  local key = series_key(name, labels)
+  local h   = reg.histos[key]
+  if not h then
+    h = { name = name, labels = copy_labels(labels), counts = {}, sum = 0, count = 0 }
+    for _, b in ipairs(reg.buckets) do h.counts[b] = 0 end
+    reg.histos[key] = h
+  end
+  h.sum   = h.sum + value
+  h.count = h.count + 1
+  -- Cumulative buckets: an observation lands in every bucket whose upper
+  -- bound is ≥ the value. The +Inf overflow is derived from `count` at build.
+  for _, b in ipairs(reg.buckets) do
+    if value <= b then h.counts[b] = h.counts[b] + 1 end
+  end
+end
+
+-- Collect a name->series map into a list ordered by series_key, so the wire
+-- array order is deterministic (stable contract fixtures + readable diffs).
+local function ordered_list(map)
+  local keys = {}
+  for k in pairs(map) do keys[#keys + 1] = k end
+  table.sort(keys)
+  local out = {}
+  for _, k in ipairs(keys) do out[#out + 1] = map[k] end
+  return out
+end
+
+-- Build the §3.2 push body from the registry. Pure serializer of current
+-- registry state + the caller-supplied sampledAt — no clock reads, so the
+-- contract generator can drive it deterministically. Empty series lists are
+-- omitted entirely (rather than emitted as `{}`), since luci.jsonc encodes an
+-- empty Lua table as a JSON object and the API decoder expects arrays.
+function M.build_batch(reg, sampled_at)
+  local batch = {
+    routerId       = reg.router_id,
+    agentVersion   = reg.agent_version,
+    agentStartedAt = reg.started_at,
+    sampledAt      = sampled_at,
+  }
+
+  local counters = {}
+  for _, c in ipairs(ordered_list(reg.counters)) do
+    counters[#counters + 1] = { name = c.name, labels = c.labels, value = c.value }
+  end
+  if #counters > 0 then batch.counters = counters end
+
+  local gauges = {}
+  for _, g in ipairs(ordered_list(reg.gauges)) do
+    gauges[#gauges + 1] = { name = g.name, labels = g.labels, value = g.value }
+  end
+  if #gauges > 0 then batch.gauges = gauges end
+
+  local histograms = {}
+  for _, h in ipairs(ordered_list(reg.histos)) do
+    local buckets = {}
+    for _, b in ipairs(reg.buckets) do
+      buckets[#buckets + 1] = { le = fmt_le(b), count = h.counts[b] or 0 }
+    end
+    -- +Inf overflow == total observation count.
+    buckets[#buckets + 1] = { le = "+Inf", count = h.count }
+    histograms[#histograms + 1] = {
+      name    = h.name,
+      labels  = h.labels,
+      buckets = buckets,
+      sum     = h.sum,
+      count   = h.count,
+    }
+  end
+  if #histograms > 0 then batch.histograms = histograms end
+
+  return batch
+end
+
+-- POST the current batch. Best-effort: on failure we log and return false but
+-- DO NOT touch the registry — the cumulative counters are retained and the
+-- next successful push carries the full total (the server re-bases). No retry
+-- queue (unlike usage): a missed observability batch self-heals on its own.
+function M.post(api_url, token, reg, sampled_at, post_fn, log)
+  log = log or default_log()
+  local jsonc = require("luci.jsonc")
+  local batch = M.build_batch(reg, sampled_at)
+  local body  = jsonc.stringify(batch)
+  local url   = api_url .. "/api/router/metrics"
+  local hdrs  = {
+    ["Authorization"] = "Bearer " .. token,
+    ["Content-Type"]  = "application/json",
+  }
+
+  log.debug("metrics.post: POST url=%s counters=%d gauges=%d histograms=%d",
+            url,
+            batch.counters and #batch.counters or 0,
+            batch.gauges and #batch.gauges or 0,
+            batch.histograms and #batch.histograms or 0)
+  local status, resp_body, err = post_fn(url, body, hdrs)
+  if status and status >= 200 and status < 300 then
+    log.debug("metrics.post: success status=%d", status)
+    return true
+  end
+  local body_str = resp_body and tostring(resp_body) or ""
+  if #body_str > 200 then body_str = body_str:sub(1, 200) .. "...(truncated)" end
+  log.warn("metrics.post: POST failed (status=%s body=%q) err=%s — retaining cumulative counters",
+           tostring(status), body_str, tostring(err))
+  return false
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -210,9 +210,30 @@ local function first_extrablocked_host(dnsmasq_content)
       or dnsmasq_content:match("^nftset=/([^/\n]+)/[^\n]-#eb_")
 end
 
+-- True when a reload_fn / os.execute-style exit status indicates success.
+-- os.execute returns 0 on Lua 5.1 and `true` on 5.2+; the agent's run_cmd
+-- forwards either, and tests inject numeric exit codes directly.
+local function exec_ok(rc)
+  return rc == 0 or rc == true
+end
+
 function M.apply(snapshot, write_fn, reload_fn, log, opts)
   log = log or default_log()
   opts = opts or {}
+  -- #1206 metrics seam: an optional opts.on_apply(info) callback is invoked
+  -- exactly once per apply with { result, dnsmasq_restarted }. This lets the
+  -- agent increment policy_apply_total{result} and dnsmasq_restarts_total at
+  -- the real restart call site without policy.lua depending on the metrics
+  -- module. `result` is the apply outcome enum (write_failed / nft_failed /
+  -- smoke_warn / ok); `dnsmasq_restarted` is true only when we actually issued
+  -- a dnsmasq restart (false on the #414 nft-only short-circuit). The callback
+  -- is for observability only — it never alters the boolean return.
+  local on_apply = opts.on_apply
+  local function report(result, dnsmasq_restarted)
+    if on_apply then
+      pcall(on_apply, { result = result, dnsmasq_restarted = dnsmasq_restarted })
+    end
+  end
   local dnsmasq_content = render.dnsmasq(snapshot)
   local nft_content     = render.nft(snapshot, opts)
 
@@ -230,12 +251,14 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   local ok1, err1 = write_fn("/tmp/dnsmasq.d/wifihaven.conf", dnsmasq_content)
   if not ok1 then
     log.err("policy.apply: write dnsmasq conf failed: %s", tostring(err1))
+    report("write_failed", false)
     return false
   end
 
   local ok2, err2 = write_fn("/tmp/nftables.d/wifihaven.nft", nft_content)
   if not ok2 then
     log.err("policy.apply: write nft file failed: %s", tostring(err2))
+    report("write_failed", false)
     return false
   end
 
@@ -255,17 +278,20 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
   -- Single atomic `nft -f`. The rendered file's prelude removes both the
   -- boot default-deny skeleton (table inet wifihaven_boot — #308) and any
   -- prior runtime table in one transaction, then installs the new ruleset.
-  reload_fn("nft -f /tmp/nftables.d/wifihaven.nft")
+  local nft_rc = reload_fn("nft -f /tmp/nftables.d/wifihaven.nft")
+  local nft_ok = exec_ok(nft_rc)
 
   -- #328 / #351 smoke probe. Runs only when we actually restarted dnsmasq:
   -- the probe exists to catch "we restarted but dnsmasq is still serving
   -- a stale config", so it adds nothing when no restart happened.
+  local smoke_warn = false
   if dnsmasq_changed then
     local probe_domain = first_extrablocked_host(dnsmasq_content)
     if probe_domain then
       local check = opts.dns_check_fn or default_dns_check
       local result = check(probe_domain)
       if is_blocked_at_connection(result) then
+        smoke_warn = true
         log.warn(
           "policy.apply: smoke check failed; dnsmasq may be serving a stale " ..
           "config — got %q for %s (expected a real upstream IP)",
@@ -273,6 +299,20 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
       end
     end
   end
+
+  -- #1206: classify the apply outcome for policy_apply_total{result}. nft
+  -- load failure ranks above the smoke warning (it's the harder failure);
+  -- the boolean return is unchanged so failover/enforcement control flow is
+  -- untouched — this is observation only.
+  local result
+  if not nft_ok then
+    result = "nft_failed"
+  elseif smoke_warn then
+    result = "smoke_warn"
+  else
+    result = "ok"
+  end
+  report(result, dnsmasq_changed)
 
   return true
 end

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -15,6 +15,7 @@
 local uci        = require("uci")
 local policy     = require("wifihaven.policy")
 local blocklists = require("wifihaven.blocklists")
+local metrics    = require("wifihaven.metrics")
 local usage      = require("wifihaven.usage")
 local conntrack  = require("wifihaven.conntrack")
 local nflog      = require("wifihaven.nflog")
@@ -41,6 +42,11 @@ local max_batch     = tonumber(uci_get("event_batch_size",        "50"))
 local flush_int     = tonumber(uci_get("event_flush_interval",    "10"))
 local policy_int    = tonumber(uci_get("policy_poll_interval",    "5"))
 local usage_int     = tonumber(uci_get("usage_report_interval",   "60"))
+-- #1206: observability push runs on its OWN timer, decoupled from the ~5 s
+-- policy poll. Cumulative counters are shipped to /api/router/metrics every
+-- 60 s by default (matches usage_report_interval cadence but is a separate
+-- knob; the server re-bases off agentStartedAt so a missed push self-heals).
+local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
@@ -49,8 +55,53 @@ log.init({ debug = debug_opt })
 -- nil on a checkout / older install — header is then simply omitted.
 local agent_version = version.read()
 local policy_opts   = { agent_version = agent_version }
-log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds activity_sample_int=%ds agent_version=%s",
-         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, activity_sample_int, tostring(agent_version))
+log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds metrics_int=%ds activity_sample_int=%ds agent_version=%s",
+         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, metrics_int, activity_sample_int, tostring(agent_version))
+
+-- ── Metrics registry (#1206) ─────────────────────────────────────────────────
+-- In-process cumulative counters since process start. NEVER reset on the
+-- agent: the server re-bases off agentStartedAt (the restart sentinel, fixed
+-- for this process's life), so a failed push self-heals on the next success
+-- with no double-count. agentStartedAt is wall-clock RFC3339 UTC captured once
+-- here. The 60 s push timer lives in the on_tick loop below.
+local agent_started_at   = os.date("!%Y-%m-%dT%H:%M:%SZ")
+-- Monotonic anchor for the agent_uptime_seconds gauge: uptime = now - this.
+-- Monotonic (not wall-clock) so an NTP/DST jump can't make uptime go backward.
+local agent_started_mono = clock.monotonic_seconds()
+local mreg = metrics.new({
+  router_id     = router_id,
+  agent_version = agent_version or "",
+  started_at    = agent_started_at,
+})
+-- agent_version info gauge: constant value 1 carrying the version as a label,
+-- so an operator can slice the fleet by running version (Prometheus info-gauge
+-- idiom). Set once — the version doesn't change within a process lifetime.
+metrics.set_gauge(mreg, "agent_version", { version = agent_version or "" }, 1)
+
+-- Instrumentation helpers. Kept here (not in policy.lua) so the agent owns the
+-- reason/result enums and policy.lua stays metrics-agnostic — it only exposes
+-- the on_apply observation seam (#1206).
+--
+-- record_apply(reason) returns an on_apply callback for policy.apply: it
+-- increments policy_apply_total{result} on every apply and, when an actual
+-- dnsmasq restart happened (NOT the #414 nft-only short-circuit),
+-- dnsmasq_restarts_total{reason}. `reason` is decided by the caller from
+-- context: "boot" for startup applies, "policy_change" for the timer/failover
+-- re-applies.
+local function record_apply(reason)
+  return function(info)
+    metrics.inc_counter(mreg, "policy_apply_total", { result = info.result })
+    if info.dnsmasq_restarted then
+      metrics.inc_counter(mreg, "dnsmasq_restarts_total", { reason = reason })
+    end
+  end
+end
+
+-- record_poll(status) classifies a policy.fetch outcome into the bounded
+-- snapshot_poll_total{result} enum (200 / 304 / error) and increments it.
+local function record_poll(result)
+  metrics.inc_counter(mreg, "snapshot_poll_total", { result = result })
+end
 
 -- activity_sample_int should evenly divide usage_report_interval, or the last
 -- partial bucket at report flush time is shorter than the others. Warn and
@@ -251,6 +302,7 @@ local last_snapshot       = nil
 local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
+local last_metrics_run    = 0
 local last_activity_sample = 0
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
@@ -265,7 +317,12 @@ local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs 
 do
   local cached = policy.load_snapshot(read_file, log)
   if cached then
-    if policy.apply(cached, write_file, run_cmd, log) then
+    local t0 = clock.monotonic_seconds()
+    local applied = policy.apply(cached, write_file, run_cmd, log,
+                                 { on_apply = record_apply("boot") })
+    metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                    clock.monotonic_seconds() - t0)
+    if applied then
       render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
       persist_blocked_reasons()
       last_snapshot = cached
@@ -287,9 +344,18 @@ local last_usage_wall_ts = os.time()
 
 do
   log.debug("startup: initial policy fetch")
+  local pt0 = clock.monotonic_seconds()
   local snap, etag = policy.fetch(api_url, router_token, nil, http_get, log, policy_opts)
+  metrics.observe(mreg, "snapshot_poll_duration_seconds", {},
+                  clock.monotonic_seconds() - pt0)
   if snap then
-    if policy.apply(snap, write_file, run_cmd, log) then
+    record_poll("200")
+    local at0 = clock.monotonic_seconds()
+    local applied = policy.apply(snap, write_file, run_cmd, log,
+                                 { on_apply = record_apply("boot") })
+    metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                    clock.monotonic_seconds() - at0)
+    if applied then
       render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
       persist_blocked_reasons()
       current_etag = etag
@@ -299,6 +365,9 @@ do
       log.info("startup: applied initial policy etag=%s", tostring(etag))
     end
   else
+    -- nil snap with an etag is a 304 (unlikely on the first poll since we send
+    -- no If-None-Match, but classify defensively); nil etag is a fetch error.
+    record_poll(etag and "304" or "error")
     log.warn("startup: initial policy fetch returned no snapshot (will retry on timer)")
   end
   -- Scheduler timers use the monotonic clock so backward wall-clock jumps
@@ -306,6 +375,7 @@ do
   local mono = clock.monotonic_seconds()
   last_policy_run        = mono
   last_usage_run         = mono
+  last_metrics_run       = mono
   last_activity_sample   = mono
 end
 
@@ -437,10 +507,17 @@ conntrack.watch({
     -- Policy timer
     if (mono - last_policy_run) >= policy_int then
       last_policy_run = mono
+      local pt0 = clock.monotonic_seconds()
       local snap, etag = policy.fetch(api_url, router_token, current_etag, http_get, log, policy_opts)
+      metrics.observe(mreg, "snapshot_poll_duration_seconds", {},
+                      clock.monotonic_seconds() - pt0)
       local fetch_ok
       if snap then
+        record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
+        -- TODO(#1301): emit blocklist_fetch_failures_total{status} here from
+        -- bl_result.errors once the status enum is designed alongside the
+        -- broader blocklist-application work (#705).
         local bl_result = blocklists.fetch_and_cache(
           snap, http_get, nil, "/etc/wifihaven/blocklists")
         if #bl_result.errors > 0 then
@@ -454,7 +531,12 @@ conntrack.watch({
         -- Apply with no failover opts. If we were in failover, this
         -- apply already emits a clean ruleset (no failover chain), so we
         -- just need to clear the flag below.
-        if policy.apply(snap, write_file, run_cmd, log) then
+        local at0 = clock.monotonic_seconds()
+        local applied = policy.apply(snap, write_file, run_cmd, log,
+                                     { on_apply = record_apply("policy_change") })
+        metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                        clock.monotonic_seconds() - at0)
+        if applied then
           render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
           persist_blocked_reasons()
           current_etag = etag
@@ -465,12 +547,14 @@ conntrack.watch({
           fetch_ok = true
         end
       elseif etag then
+        record_poll("304")
         current_etag = etag  -- 304: just update etag
         policy.mark_poll_success(wall)  -- 304 still counts as a successful poll
         log.debug("policy timer: 304 not modified etag=%s poll_age=%s",
                   tostring(etag), policy.format_poll_age(policy.poll_age_seconds(wall)))
         fetch_ok = true
       else
+        record_poll("error")
         log.debug("policy timer: fetch failed poll_age=%s",
                   policy.format_poll_age(policy.poll_age_seconds(wall)))
         fetch_ok = false
@@ -492,7 +576,12 @@ conntrack.watch({
           -- with the computed opts. Skip if we have no cached snapshot at
           -- all (cold boot during outage): the #308 boot skeleton stays in
           -- effect and there's nothing useful we can render.
-          if policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts) then
+          fo_opts.on_apply = record_apply("policy_change")
+          local ft0 = clock.monotonic_seconds()
+          local fo_applied = policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts)
+          metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                          clock.monotonic_seconds() - ft0)
+          if fo_applied then
             if new_in_failover then
               log.info("failover render: poll failed, applying failover chain for closed-mode profiles (poll_age=%s)",
                        policy.format_poll_age(policy.poll_age_seconds(wall)))
@@ -570,6 +659,22 @@ conntrack.watch({
                    #usage_queue.buckets)
         end
       end
+    end
+
+    -- Metrics push timer (#1206). Independent of the ~5 s policy poll: ships
+    -- the cumulative registry to /api/router/metrics every metrics_int seconds
+    -- (default 60). Best-effort — on a failed POST the counters are RETAINED
+    -- (metrics.post never resets the registry), so the next success carries the
+    -- full total and the server re-bases off agentStartedAt. No retry queue.
+    if (mono - last_metrics_run) >= metrics_int then
+      last_metrics_run = mono
+      -- Refresh instantaneous gauges just before the snapshot. uptime is
+      -- derived from the monotonic clock so a wall-clock jump can't make it
+      -- go backward.
+      metrics.set_gauge(mreg, "agent_uptime_seconds", {},
+                        mono - agent_started_mono)
+      local sampled_at = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
+      metrics.post(api_url, router_token, mreg, sampled_at, http_post, log)
     end
 
     -- Drain any retry-queued buckets whose backoff has elapsed (monotonic now).

--- a/openwrt/luci/luasrc/model/cbi/wifihaven/settings.lua
+++ b/openwrt/luci/luasrc/model/cbi/wifihaven/settings.lua
@@ -42,6 +42,11 @@ local usage_int = s:option(Value, "usage_report_interval", translate("Usage repo
 usage_int.datatype = "uinteger"
 usage_int.placeholder = "60"
 
+local metrics_int = s:option(Value, "metrics_report_interval", translate("Metrics push interval (s)"),
+  translate("How often to push the agent's cumulative observability metrics to /api/router/metrics. Independent of the policy poll; counters self-heal on a missed push. Suggested 30–300."))
+metrics_int.datatype = "uinteger"
+metrics_int.placeholder = "60"
+
 local activity_sample_int = s:option(Value, "activity_sample_int", translate("Activity sample interval (s)"),
   translate("How often to sample per-MAC activity for activeSeconds accounting. Lower = more accurate, more CPU. Suggested 5–30. Must evenly divide usage_report_interval."))
 activity_sample_int.datatype = "uinteger"

--- a/openwrt/test/agent_spec.sh
+++ b/openwrt/test/agent_spec.sh
@@ -52,5 +52,43 @@ else
   check "selfheal_cron called at agent startup (#903)" "module required but selfheal_cron() never invoked"
 fi
 
+# #1206: the metrics module must be required, a registry created, and the
+# observability push wired in. Guard each half so a future refactor can't
+# silently drop the 60 s push (the dnsmasq_restarts_total telemetry that
+# motivated the feature would go dark with no test failure otherwise).
+if grep -q '^local metrics[[:space:]]*=[[:space:]]*require("wifihaven\.metrics")' "$SCRIPT"; then
+  check "metrics module required at agent startup (#1206)" ok
+else
+  check "metrics module required at agent startup (#1206)" "missing 'require(\"wifihaven.metrics\")' — no metrics push"
+fi
+
+if grep -q 'metrics\.new(' "$SCRIPT"; then
+  check "metrics registry created at agent startup (#1206)" ok
+else
+  check "metrics registry created at agent startup (#1206)" "module required but metrics.new() never called"
+fi
+
+if grep -q 'metrics\.post(' "$SCRIPT"; then
+  check "metrics push wired into the agent loop (#1206)" ok
+else
+  check "metrics push wired into the agent loop (#1206)" "registry built but metrics.post() never called — push won't happen"
+fi
+
+# The push MUST run on its own timer, decoupled from the ~5 s policy poll
+# (#1206 explicitly: a dedicated metrics_report_interval, not coupled to the
+# policy cadence). Assert the independent knob + a last_metrics_run scheduler
+# slot distinct from last_policy_run.
+if grep -q 'metrics_report_interval' "$SCRIPT"; then
+  check "metrics push reads its own metrics_report_interval knob (#1206)" ok
+else
+  check "metrics push reads its own metrics_report_interval knob (#1206)" "no metrics_report_interval — push is coupled to the policy poll"
+fi
+
+if grep -q 'last_metrics_run' "$SCRIPT"; then
+  check "metrics push has its own scheduler slot (#1206)" ok
+else
+  check "metrics push has its own scheduler slot (#1206)" "no last_metrics_run — timer not independent of the policy poll"
+fi
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/contract_gen.lua
+++ b/openwrt/test/contract_gen.lua
@@ -31,6 +31,7 @@
 local jsonc     = require("luci.jsonc")
 local conntrack = require("wifihaven.conntrack")
 local usage     = require("wifihaven.usage")
+local metrics   = require("wifihaven.metrics")
 
 -- ── Canonical pretty JSON encoder ─────────────────────────────────────────
 -- Stable enough that the CI drift guard's `git diff --exit-code` is
@@ -51,6 +52,13 @@ local function is_array(t)
 end
 
 local encode
+
+-- Sentinel for an *empty JSON object* (`{}`), distinct from an empty array
+-- (`[ ]`). is_array() can't tell an empty map from an empty list, and the
+-- default treats empty tables as arrays. The metrics builder uses this for
+-- empty `labels` maps so the fixture matches what production luci.jsonc
+-- emits (`{}`) and what the zio-json `Map[String,String]` decoder accepts.
+local EMPTY_OBJECT = setmetatable({}, {})
 
 local function encode_string(s)
   -- Defer to cjson via luci.jsonc.stringify for proper escaping.
@@ -77,6 +85,14 @@ encode = function(v, indent)
   local next_indent = indent .. "  "
   local t = type(v)
   if t ~= "table" then return encode_scalar(v) end
+
+  -- Explicit empty-object sentinel (distinct from empty array).
+  if v == EMPTY_OBJECT then return "{ }" end
+  -- Raw pre-formatted number token (see jnum) — emit verbatim. Lets the
+  -- metrics fixture render Double-typed fields in their decoder-canonical
+  -- form (whole numbers as `N.0`) so the ContractGoldenSpec round-trip,
+  -- which re-encodes through zio-json `Double`, matches byte-for-byte.
+  if v.__raw ~= nil then return v.__raw end
 
   local arr, n = is_array(v)
   if arr then
@@ -125,6 +141,22 @@ end
 
 local function canonical_pretty(v)
   return encode(v) .. "\n"
+end
+
+-- Render a number in the decoder-canonical form zio-json emits for a Scala
+-- `Double` field: whole numbers as `N.0` (e.g. 1 → "1.0", 880 → "880.0"),
+-- fractional numbers in their minimal %.14g form (0.82 → "0.82"). All numeric
+-- fields in RouterMetricsBatch are typed `Double`, so the metrics fixture must
+-- emit them this way for the ContractGoldenSpec round-trip (decode → re-encode
+-- through zio-json) to match byte-for-byte. Returns a __raw token (see encode).
+local function jnum(n)
+  local s
+  if n == math.floor(n) and math.abs(n) < 1e15 then
+    s = string.format("%.1f", n)
+  else
+    s = string.format("%.14g", n)
+  end
+  return { __raw = s }
 end
 
 -- ── Helpers to stamp ordering on production-built event tables ────────────
@@ -271,6 +303,83 @@ local function build_usage_report()
   return stamp(report, { "routerId", "periodStart", "periodEnd", "records" })
 end
 
+-- ── Build router_metrics_batch.json via metrics.build_batch ───────────────
+-- #1206. The agent's production metrics push body is assembled by
+-- metrics.build_batch (the SAME function the live 60 s push timer calls), so
+-- this fixture is generated from real production code. We populate a registry
+-- with one representative series per §5.1 emitted metric (cumulative counters,
+-- the two info/uptime gauges, both duration histograms), then stamp field
+-- ordering so the JSON key order is stable across regens. agentStartedAt is
+-- pinned (the API's restart sentinel) and routerId matches the other fixtures.
+
+local METRICS_BATCH_ORDER = {
+  "routerId", "agentVersion", "agentStartedAt", "sampledAt",
+  "counters", "gauges", "histograms",
+}
+local SERIES_ORDER = { "name", "labels", "value" }
+local HISTOGRAM_ORDER = { "name", "labels", "buckets", "sum", "count" }
+local BUCKET_ORDER = { "le", "count" }
+
+local function build_metrics_batch()
+  local reg = metrics.new({
+    router_id     = "11111111-2222-3333-4444-555555555555",
+    agent_version = "0.3.1",
+    started_at    = "2026-05-30T09:00:00Z",
+  })
+
+  -- Counters — cumulative running totals since agent start (§3.2).
+  metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "boot" }, 1)
+  metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "policy_change" }, 12)
+  metrics.inc_counter(reg, "policy_apply_total", { result = "ok" }, 880)
+  metrics.inc_counter(reg, "policy_apply_total", { result = "nft_failed" }, 3)
+  metrics.inc_counter(reg, "snapshot_poll_total", { result = "200" }, 140)
+  metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" }, 9300)
+  metrics.inc_counter(reg, "snapshot_poll_total", { result = "error" }, 6)
+
+  -- Gauges — instantaneous; agent_version is an info gauge (value 1).
+  metrics.set_gauge(reg, "agent_uptime_seconds", {}, 18060)
+  metrics.set_gauge(reg, "agent_version", { version = "0.3.1" }, 1)
+
+  -- Histograms — observe a few values so the cumulative buckets are non-trivial.
+  metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.02)
+  metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.2)
+  metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.6)
+  metrics.observe(reg, "snapshot_poll_duration_seconds", {}, 0.008)
+  metrics.observe(reg, "snapshot_poll_duration_seconds", {}, 0.02)
+  metrics.observe(reg, "snapshot_poll_duration_seconds", {}, 0.3)
+
+  local batch = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+
+  -- An empty `labels` map must serialize as a JSON object (`{}`), the way
+  -- production luci.jsonc emits it and the way the zio-json
+  -- `Map[String,String]` decoder accepts it — not as an empty array.
+  local function fix_labels(s)
+    if s.labels and next(s.labels) == nil then s.labels = EMPTY_OBJECT end
+  end
+
+  for _, c in ipairs(batch.counters or {}) do
+    fix_labels(c)
+    c.value = jnum(c.value)
+    stamp(c, SERIES_ORDER)
+  end
+  for _, g in ipairs(batch.gauges or {}) do
+    fix_labels(g)
+    g.value = jnum(g.value)
+    stamp(g, SERIES_ORDER)
+  end
+  for _, h in ipairs(batch.histograms or {}) do
+    fix_labels(h)
+    h.sum = jnum(h.sum)
+    h.count = jnum(h.count)
+    stamp(h, HISTOGRAM_ORDER)
+    for _, b in ipairs(h.buckets or {}) do
+      b.count = jnum(b.count)
+      stamp(b, BUCKET_ORDER)
+    end
+  end
+  return stamp(batch, METRICS_BATCH_ORDER)
+end
+
 -- ── register_router_request.json ─────────────────────────────────────────
 -- The register POST is built in openwrt/install.sh via shell `printf`, not
 -- lua, so there is no production lua function to call. We mirror the shell
@@ -309,6 +418,7 @@ function M.fixtures()
     return {
       ["router-to-api/router_events_request.json"]   = canonical_pretty(build_router_events_request()),
       ["router-to-api/usage_report.json"]            = canonical_pretty(build_usage_report()),
+      ["router-to-api/router_metrics_batch.json"]    = canonical_pretty(build_metrics_batch()),
       ["router-to-api/register_router_request.json"] = canonical_pretty(build_register_request()),
     }
   end)

--- a/openwrt/test/metrics_spec.lua
+++ b/openwrt/test/metrics_spec.lua
@@ -1,0 +1,292 @@
+-- metrics_spec.lua — unit tests for the in-process metrics registry (#1206).
+--
+-- Covers:
+--   * cumulative counter accumulation + batch shape (design §3.2)
+--   * gauge + histogram (cumulative buckets, sum, count, +Inf overflow)
+--   * dnsmasq_restarts_total fires exactly once on a real restart and NOT on
+--     a #414 short-circuited (nft-only) apply — via policy.apply's on_apply seam
+--   * policy_apply_total result enum (ok / write_failed / nft_failed / smoke_warn)
+--   * retain-on-failure: a failed POST never resets the registry; the next
+--     batch carries the full cumulative total (the server re-bases)
+--
+-- The agent's *production* metrics push body is assembled by metrics.build_batch
+-- — the SAME function the contract fixture generator calls — so this spec also
+-- pins the wire shape that ContractGoldenSpec round-trips against.
+
+local metrics = require("wifihaven.metrics")
+local policy  = require("wifihaven.policy")
+
+-- Find a series ({name, labels, value}) in a batch list by name + a single
+-- label match (labels are small bounded enums here).
+local function find_series(list, name, label_key, label_val)
+  for _, s in ipairs(list or {}) do
+    if s.name == name then
+      if not label_key then return s end
+      if s.labels and s.labels[label_key] == label_val then return s end
+    end
+  end
+  return nil
+end
+
+local function new_reg()
+  return metrics.new({
+    router_id     = "11111111-2222-3333-4444-555555555555",
+    agent_version = "0.3.1",
+    started_at    = "2026-05-30T09:00:00Z",
+  })
+end
+
+describe("metrics.new + build_batch", function()
+  it("carries identity + restart-sentinel fields", function()
+    local reg   = new_reg()
+    local batch = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+    assert.equal("11111111-2222-3333-4444-555555555555", batch.routerId)
+    assert.equal("0.3.1", batch.agentVersion)
+    assert.equal("2026-05-30T09:00:00Z", batch.agentStartedAt)
+    assert.equal("2026-05-30T14:01:00Z", batch.sampledAt)
+  end)
+
+  it("agentStartedAt stays constant across batches (restart sentinel)", function()
+    local reg = new_reg()
+    local b1  = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+    local b2  = metrics.build_batch(reg, "2026-05-30T14:02:00Z")
+    assert.equal(b1.agentStartedAt, b2.agentStartedAt)
+    assert.not_equal(b1.sampledAt, b2.sampledAt)
+  end)
+end)
+
+describe("metrics counters", function()
+  it("accumulate cumulatively and split by label", function()
+    local reg = new_reg()
+    metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "boot" })
+    metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "policy_change" })
+    metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "policy_change" })
+
+    local batch = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+    local boot  = find_series(batch.counters, "dnsmasq_restarts_total", "reason", "boot")
+    local pol   = find_series(batch.counters, "dnsmasq_restarts_total", "reason", "policy_change")
+    assert.equal(1, boot.value)
+    assert.equal(2, pol.value)
+  end)
+
+  it("keep climbing across successive batches (cumulative since start)", function()
+    local reg = new_reg()
+    metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" })
+    local b1 = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+    assert.equal(1, find_series(b1.counters, "snapshot_poll_total", "result", "304").value)
+    metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" })
+    local b2 = metrics.build_batch(reg, "2026-05-30T14:02:00Z")
+    assert.equal(2, find_series(b2.counters, "snapshot_poll_total", "result", "304").value)
+  end)
+
+  it("emit a deterministic counter ordering (stable fixtures)", function()
+    local reg = new_reg()
+    metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" })
+    metrics.inc_counter(reg, "dnsmasq_restarts_total", { reason = "boot" })
+    metrics.inc_counter(reg, "policy_apply_total", { result = "ok" })
+    local b1 = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
+    local order1 = {}
+    for i, c in ipairs(b1.counters) do
+      order1[i] = c.name .. (c.labels.reason or c.labels.result or "")
+    end
+    -- Rebuild from a fresh registry inserting in a different order.
+    local reg2 = new_reg()
+    metrics.inc_counter(reg2, "policy_apply_total", { result = "ok" })
+    metrics.inc_counter(reg2, "dnsmasq_restarts_total", { reason = "boot" })
+    metrics.inc_counter(reg2, "snapshot_poll_total", { result = "304" })
+    local b2 = metrics.build_batch(reg2, "2026-05-30T14:01:00Z")
+    local order2 = {}
+    for i, c in ipairs(b2.counters) do
+      order2[i] = c.name .. (c.labels.reason or c.labels.result or "")
+    end
+    assert.same(order1, order2)
+  end)
+end)
+
+describe("metrics gauges", function()
+  it("hold the last value set (instantaneous)", function()
+    local reg = new_reg()
+    metrics.set_gauge(reg, "agent_uptime_seconds", {}, 60)
+    metrics.set_gauge(reg, "agent_uptime_seconds", {}, 18060)
+    local g = find_series(metrics.build_batch(reg, "t").gauges, "agent_uptime_seconds")
+    assert.equal(18060, g.value)
+  end)
+
+  it("emit agent_version as an info gauge with a bounded version label", function()
+    local reg = new_reg()
+    metrics.set_gauge(reg, "agent_version", { version = "0.3.1" }, 1)
+    local g = find_series(metrics.build_batch(reg, "t").gauges, "agent_version", "version", "0.3.1")
+    assert.equal(1, g.value)
+  end)
+end)
+
+describe("metrics histograms", function()
+  it("accumulate cumulative buckets, +Inf overflow, sum and count", function()
+    local reg = new_reg()
+    metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.02)
+    metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.2)
+    metrics.observe(reg, "policy_apply_duration_seconds", {}, 7.0)
+
+    local h = find_series(metrics.build_batch(reg, "t").histograms, "policy_apply_duration_seconds")
+    assert.equal(3, h.count)
+    assert.is_true(math.abs(h.sum - 7.22) < 1e-9)
+
+    -- Buckets must be cumulative, ascending, with a trailing +Inf == count.
+    local by_le = {}
+    for _, b in ipairs(h.buckets) do by_le[b.le] = b.count end
+    assert.equal(0, by_le["0.01"])
+    assert.equal(1, by_le["0.05"])
+    assert.equal(1, by_le["0.1"])
+    assert.equal(2, by_le["0.5"])
+    assert.equal(2, by_le["1"])
+    assert.equal(2, by_le["5"])
+    assert.equal(3, by_le["+Inf"])
+    -- +Inf is the last bucket.
+    assert.equal("+Inf", h.buckets[#h.buckets].le)
+  end)
+
+  it("uses the same boundaries the API server folds against", function()
+    -- Server (api/src/metrics/Metrics.scala) folds on 0.01,0.05,0.1,0.5,1,5.
+    assert.same({ 0.01, 0.05, 0.1, 0.5, 1.0, 5.0 }, metrics.DURATION_BUCKETS)
+  end)
+end)
+
+describe("metrics.post — retain on failure (self-heal)", function()
+  it("never resets the registry on a failed POST; next batch is the full total", function()
+    local reg = new_reg()
+    metrics.inc_counter(reg, "policy_apply_total", { result = "ok" })
+    metrics.inc_counter(reg, "policy_apply_total", { result = "ok" })
+
+    -- POST fails (500). Counters must be retained.
+    local fail_post = function(_url, _body, _hdrs) return 500, "boom", nil end
+    local ok = metrics.post("http://api", "tok", reg, "t1", fail_post,
+      { warn = function() end, debug = function() end, err = function() end })
+    assert.is_false(ok)
+
+    -- More work accumulates on top of the retained total.
+    metrics.inc_counter(reg, "policy_apply_total", { result = "ok" })
+
+    -- Next POST succeeds; the body carries the FULL cumulative total (3),
+    -- not just the delta since the failed attempt.
+    local captured
+    local ok_post = function(_url, body, _hdrs)
+      captured = body
+      return 200, "", nil
+    end
+    local ok2 = metrics.post("http://api", "tok", reg, "t2", ok_post,
+      { warn = function() end, debug = function() end, err = function() end })
+    assert.is_true(ok2)
+    assert.truthy(captured:find('"value":3') or captured:find('"value": 3'))
+  end)
+
+  it("POSTs to /api/router/metrics with a bearer token", function()
+    local reg = new_reg()
+    metrics.set_gauge(reg, "agent_uptime_seconds", {}, 60)
+    local seen = {}
+    local post_fn = function(url, _body, hdrs)
+      seen.url = url; seen.auth = hdrs["Authorization"]; seen.ct = hdrs["Content-Type"]
+      return 200, "", nil
+    end
+    metrics.post("http://api.example", "rt_secret", reg, "t", post_fn,
+      { warn = function() end, debug = function() end, err = function() end })
+    assert.equal("http://api.example/api/router/metrics", seen.url)
+    assert.equal("Bearer rt_secret", seen.auth)
+    assert.equal("application/json", seen.ct)
+  end)
+end)
+
+-- ── policy.apply on_apply seam (dnsmasq_restarts_total + policy_apply_total) ──
+--
+-- The motivating metric: dnsmasq_restarts_total must increment at the actual
+-- restart call site, exactly once per real restart, and NOT on a #414
+-- nft-only short-circuited apply. policy.apply exposes this via an optional
+-- opts.on_apply callback so the agent (and these tests) observe the decision
+-- without policy.lua depending on the metrics module.
+
+local SNAP_JSON = [[{
+  "etag": "sha256:x",
+  "generatedAt": "2026-05-08T14:00:00Z",
+  "devices": {},
+  "profiles": {},
+  "blocklists": {}
+}]]
+
+local function decode_snap()
+  local jsonc = require("luci.jsonc")
+  return jsonc.parse(SNAP_JSON)
+end
+
+describe("policy.apply on_apply seam (#1206)", function()
+  it("reports dnsmasq_restarted=true when the conf changes (real restart)", function()
+    local info
+    -- read_fn returns nil → on-disk file absent → dnsmasq_changed=true.
+    policy.apply(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      nil,
+      { read_fn = function(_p) return nil end,
+        on_apply = function(i) info = i end })
+    assert.truthy(info)
+    assert.is_true(info.dnsmasq_restarted)
+    assert.equal("ok", info.result)
+  end)
+
+  it("reports dnsmasq_restarted=false on a #414 short-circuited (nft-only) apply", function()
+    -- Pre-seed read_fn with the exact rendered content so dnsmasq is unchanged.
+    local render = require("wifihaven.render")
+    local rendered = render.dnsmasq(decode_snap())
+    local info
+    local restart_issued = false
+    policy.apply(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(cmd)
+        if cmd:find("dnsmasq restart", 1, true) then restart_issued = true end
+        return 0
+      end,
+      nil,
+      { read_fn = function(_p) return rendered end,
+        on_apply = function(i) info = i end })
+    assert.truthy(info)
+    assert.is_false(info.dnsmasq_restarted)
+    assert.equal("ok", info.result)
+    assert.is_false(restart_issued)
+  end)
+
+  it("reports result=write_failed when a write fails", function()
+    local info
+    policy.apply(decode_snap(),
+      function(_p, _c) return nil, "io error" end,
+      function(_cmd) return 0 end,
+      nil,
+      { on_apply = function(i) info = i end })
+    assert.truthy(info)
+    assert.equal("write_failed", info.result)
+    assert.is_false(info.dnsmasq_restarted)
+  end)
+
+  it("reports result=nft_failed when the nft load exits non-zero", function()
+    local info
+    policy.apply(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(cmd)
+        if cmd:find("nft -f", 1, true) then return 1 end
+        return 0
+      end,
+      nil,
+      { read_fn = function(_p) return nil end,
+        on_apply = function(i) info = i end })
+    assert.truthy(info)
+    assert.equal("nft_failed", info.result)
+  end)
+
+  it("fires on_apply exactly once per apply", function()
+    local n = 0
+    policy.apply(decode_snap(),
+      function(_p, _c) return true, nil end,
+      function(_cmd) return 0 end,
+      nil,
+      { read_fn = function(_p) return nil end,
+        on_apply = function(_i) n = n + 1 end })
+    assert.equal(1, n)
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -21,6 +21,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/selfheal_spec.lua \
          test/version_spec.lua \
          test/update_spec.lua \
+         test/metrics_spec.lua \
          "$@"
 
 echo ""

--- a/shared/contract/README.md
+++ b/shared/contract/README.md
@@ -92,6 +92,13 @@ other.
   `usage.build_report` with a pinned `lookup_hostname` (FQDN for one
   record, miss for the other so it falls back to an IPv4-tagged HostId)
   and a pinned tracker (so `activeSeconds` is deterministic).
+* `router_metrics_batch.json` — `/api/router/metrics` POST (#1206). Built by
+  `metrics.build_batch` (the same function the agent's 60 s push timer calls)
+  from a registry populated with one representative series per §5.1 emitted
+  metric (cumulative counters, the uptime + version info gauges, both duration
+  histograms). Numeric fields render in their decoder-canonical `Double` form
+  (whole numbers as `N.0`) because every value in `RouterMetricsBatch` is typed
+  `Double`; `agentStartedAt` is pinned (the server's restart sentinel).
 * `register_router_request.json` — `/api/router/register` POST. Mirrors
   `openwrt/install.sh`'s printf format string (see exception above).
 

--- a/shared/contract/router-to-api/router_metrics_batch.json
+++ b/shared/contract/router-to-api/router_metrics_batch.json
@@ -1,0 +1,145 @@
+{
+  "routerId" : "11111111-2222-3333-4444-555555555555",
+  "agentVersion" : "0.3.1",
+  "agentStartedAt" : "2026-05-30T09:00:00Z",
+  "sampledAt" : "2026-05-30T14:01:00Z",
+  "counters" : [
+    {
+      "name" : "dnsmasq_restarts_total",
+      "labels" : {
+        "reason" : "boot"
+      },
+      "value" : 1.0
+    },
+    {
+      "name" : "dnsmasq_restarts_total",
+      "labels" : {
+        "reason" : "policy_change"
+      },
+      "value" : 12.0
+    },
+    {
+      "name" : "policy_apply_total",
+      "labels" : {
+        "result" : "nft_failed"
+      },
+      "value" : 3.0
+    },
+    {
+      "name" : "policy_apply_total",
+      "labels" : {
+        "result" : "ok"
+      },
+      "value" : 880.0
+    },
+    {
+      "name" : "snapshot_poll_total",
+      "labels" : {
+        "result" : "200"
+      },
+      "value" : 140.0
+    },
+    {
+      "name" : "snapshot_poll_total",
+      "labels" : {
+        "result" : "304"
+      },
+      "value" : 9300.0
+    },
+    {
+      "name" : "snapshot_poll_total",
+      "labels" : {
+        "result" : "error"
+      },
+      "value" : 6.0
+    }
+  ],
+  "gauges" : [
+    {
+      "name" : "agent_uptime_seconds",
+      "labels" : { },
+      "value" : 18060.0
+    },
+    {
+      "name" : "agent_version",
+      "labels" : {
+        "version" : "0.3.1"
+      },
+      "value" : 1.0
+    }
+  ],
+  "histograms" : [
+    {
+      "name" : "policy_apply_duration_seconds",
+      "labels" : { },
+      "buckets" : [
+        {
+          "le" : "0.01",
+          "count" : 0.0
+        },
+        {
+          "le" : "0.05",
+          "count" : 1.0
+        },
+        {
+          "le" : "0.1",
+          "count" : 1.0
+        },
+        {
+          "le" : "0.5",
+          "count" : 2.0
+        },
+        {
+          "le" : "1",
+          "count" : 3.0
+        },
+        {
+          "le" : "5",
+          "count" : 3.0
+        },
+        {
+          "le" : "+Inf",
+          "count" : 3.0
+        }
+      ],
+      "sum" : 0.82,
+      "count" : 3.0
+    },
+    {
+      "name" : "snapshot_poll_duration_seconds",
+      "labels" : { },
+      "buckets" : [
+        {
+          "le" : "0.01",
+          "count" : 1.0
+        },
+        {
+          "le" : "0.05",
+          "count" : 2.0
+        },
+        {
+          "le" : "0.1",
+          "count" : 2.0
+        },
+        {
+          "le" : "0.5",
+          "count" : 3.0
+        },
+        {
+          "le" : "1",
+          "count" : 3.0
+        },
+        {
+          "le" : "5",
+          "count" : 3.0
+        },
+        {
+          "le" : "+Inf",
+          "count" : 3.0
+        }
+      ],
+      "sum" : 0.328,
+      "count" : 3.0
+    }
+  ]
+}

--- a/shared/test/src/contract/ContractGoldenSpec.scala
+++ b/shared/test/src/contract/ContractGoldenSpec.scala
@@ -137,6 +137,9 @@ object ContractGoldenSpec extends ZIOSpecDefault {
       test("register_router_request.json decodes round-trip-clean") {
         assertRoundTrip[RegisterRouterRequest]("router-to-api/register_router_request.json")
       },
+      test("router_metrics_batch.json decodes round-trip-clean") {
+        assertRoundTrip[RouterMetricsBatch]("router-to-api/router_metrics_batch.json")
+      },
     ),
   )
 }


### PR DESCRIPTION
Closes #1206.

## What

Adds an in-process metric registry to the OpenWRT Lua agent and a dedicated
**60 s** push timer that POSTs a `RouterMetricsBatch` (design
§3.2) to `POST /api/router/metrics`. The server-side ingest already exists
(#1205, `RouterMetricsService` folds batches into the API's exposition); this
PR is the agent side that actually emits the series.

## Design notes

- **Independent 60 s timer.** The push runs on its own
  `metrics_report_interval` UCI knob (default 60, mirrors
  `usage_report_interval`) with its own `last_metrics_run` scheduler slot —
  **not** coupled to the ~5 s policy poll. New LuCI settings field + UCI
  default included; `agent_spec.sh` guards the decoupling.
- **Cumulative, retain-on-failure (§3.3).** Counters accumulate since process
  start and are **never reset on the agent**. `metrics.post` does not touch the
  registry on a failed POST, so the next success carries the full total and the
  server re-bases off `agentStartedAt` (the restart sentinel, fixed for the
  process lifetime). No double-count, no data loss, no retry queue — a missed
  observability batch self-heals. This is strictly simpler than the usage
  path's reset-on-ack model.

## Metrics (§5.1)

| series | type | labels |
|---|---|---|
| `dnsmasq_restarts_total` | counter | `reason` ∈ boot, policy_change |
| `policy_apply_total` | counter | `result` ∈ ok, write_failed, nft_failed, smoke_warn |
| `policy_apply_duration_seconds` | histogram | — |
| `snapshot_poll_total` | counter | `result` ∈ 200, 304, error |
| `snapshot_poll_duration_seconds` | histogram | — |
| `agent_uptime_seconds` | gauge | — |
| `agent_version` | info gauge (=1) | `version` |

`dnsmasq_restarts_total{reason}` — the metric that motivated #1206 — is
incremented at the **actual** dnsmasq restart call site, **not** on the #414
nft-only short-circuited apply. policy.apply stays metrics-agnostic: it exposes
a `opts.on_apply({result, dnsmasq_restarted})` observation seam (invoked once
per apply, wrapped in pcall, never alters the boolean return); the agent owns
the `reason`/`result` enums. Names and bounded label keys match the API
allowlist (`MetricGuard.Allowed`) exactly; `router_id` is attached server-side.

## Golden contract fixture (anti-drift)

POST-body assembly lives in the production builder `metrics.build_batch(...)`.
`contract_gen.lua` calls **that same function** to generate
`shared/contract/router-to-api/router_metrics_batch.json`, so the fixture comes
from real production code, never a test-only mirror. `ContractGoldenSpec`
decodes it through the production `RouterMetricsBatch` codec and asserts a clean
round-trip (decode → re-encode → structural equality), which catches any
dropped/defaulted/renamed field. All numeric fields render in their
decoder-canonical `Double` form (whole numbers as `N.0`) since every
`RouterMetricsBatch` value is typed `Double`.

## Dashboard

New checked-in `deploy/grafana/dashboards/router-fleet.json` ("Router fleet
(agent metrics)") with panels for every now-emitted series, registered in
`infra/grafana/main.tf`. Slices only by bounded enum labels (reason / result /
version). Passes `terraform fmt -check`, `terraform validate`, and
`json.tool`.

## Deferred (fresh issues, TODO markers in code)

- `blocklist_fetch_failures_total{status}` → **#1301** (coordinate with #705) —
  `TODO(#1301)` at the blocklist fetch site in `wifihaven-agent`.
- `dns_queries_total{result}` → **#1302** — `TODO(#1302)` in `dns_log.lua`.

## TDD

Red commit (`b2a9cf40`) lands the failing busted specs + the contract
round-trip assertion before any implementation; green commit (`a46da930`)
makes them pass.

## Validation

- busted: 460 passing (2 pre-existing `failover_spec` failures unrelated to this
  change — reproduced on a clean tree; 1 pre-existing `nft`-unavailable pending).
- `agent_spec.sh`, `install_spec.sh`, `init_spec.sh`, `boot_skeleton_spec.sh`,
  `update_spec.sh`: all green.
- `mill shared.test`: green (incl. `ContractGoldenSpec` round-trip).
- `scalafmt --check`: clean.
- `bash scripts/regen-contract-fixtures.sh` + `git diff --exit-code
  shared/contract/`: clean (fixture regenerates byte-identical).