### PR TITLE
fix(api): no-store on today time-status reads (#1299)

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -458,11 +458,11 @@ object DeviceRoutes {
 // ── Time routes ────────────────────────────────────────────────────────────
 
 object TimeRoutes {
-  // #802: cache-control freshness windows mirror the in-process TimeStatusCache TTLs
-  // (today=30s, past=1h). SPAs and intermediaries can use these to skip refetches when
-  // the local copy is fresh; mutating endpoints don't depend on these for correctness.
-  private val TodayMaxAgeSeconds: Long = 30L
-  private val PastMaxAgeSeconds: Long  = 3600L
+  // #802/#1299: today-mode reads are authenticated and mutation-sensitive (a +Time grant
+  // must show up immediately), so they're served no-store — the browser HTTP cache must
+  // never answer a post-mutation refetch with a stale extensionMins. Past data is logically
+  // immutable and safe to cache for an hour.
+  private val PastMaxAgeSeconds: Long = 3600L
 
   // #802: emit a hit-rate summary every N requests. Cheap heuristic — no scheduler.
   private val StatsLogEveryNRequests = 100
@@ -815,13 +815,13 @@ object TimeRoutes {
         },
     )
 
-  // #802: Cache-Control header derived from whether the response covers today.
-  // Today: short max-age so the SPA picks up bucket churn within the cache window.
+  // #802/#1299: Cache-Control header derived from whether the response covers today.
+  // Today: no-store — authenticated and mutation-sensitive, so the SPA's post-mutation
+  //        refetch must never be answered from the browser HTTP cache (stale extensionMins).
   // Past:  long max-age — past data is logically immutable.
-  // `private` because mutating endpoints (POST /api/time/extend) don't need it and we
-  // want to avoid intermediary caching for the JWT-authenticated traffic.
+  // `private` because mutating endpoints (POST /api/time/extend) don't need it.
   private def cacheControlFor(isTodayMode: Boolean): Header.CacheControl =
-    if isTodayMode then Header.CacheControl.MaxAge(TodayMaxAgeSeconds.toInt)
+    if isTodayMode then Header.CacheControl.NoStore
     else Header.CacheControl.MaxAge(PastMaxAgeSeconds.toInt)
 
   // #802: emit a one-line stats log every N (hits+misses), no scheduler needed. Sampled

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -287,7 +287,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         finalStats.hits == statsAfterGrant.hits + 1L,
       )
     },
-    test("Cache-Control: max-age=30 for today, max-age=3600 for past") {
+    test("Cache-Control: no-store for today, max-age=3600 for past") {
       for {
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
@@ -306,7 +306,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         todayResp <- get(routes, s"/api/time/status?profileId=${kidsId.value}&date=$today", token)
         pastResp  <- get(routes, s"/api/time/status?profileId=${kidsId.value}&date=$past", token)
       } yield assertTrue(
-        todayResp.headers.get("Cache-Control").exists(_.contains("max-age=30")),
+        todayResp.headers.get("Cache-Control").exists(_.contains("no-store")),
         pastResp.headers.get("Cache-Control").exists(_.contains("max-age=3600")),
       )
     },


### PR DESCRIPTION
## Root cause

On the Profiles page, granting a time extension (**+Time**) succeeded on
the backend but the used/cap bar and `(+Xm)` cap text didn't refresh
until a hard reload. The today-mode time-status read endpoints were
served with `Cache-Control: max-age=30`, so the browser HTTP cache
answered the SPA's post-mutation refetch with a **stale `extensionMins`**
for up to 30s. Confirmed in prod: the `GET /api/time/status/summary`
response body itself carried the old extension value within the 30s
window; a hard reload (which bypasses the HTTP cache) showed the fresh
value.

## Fix

`cacheControlFor` in `api/src/routes/Routes.scala` now returns
`Header.CacheControl.NoStore` for today-mode reads — they're
authenticated and mutation-sensitive, so the browser HTTP cache must
never answer a refetch from cache. Past-mode reads keep
`max-age=3600` since past data is logically immutable. The now-unused
`TodayMaxAgeSeconds` val is removed and the `#802` comments reworded.

This one function feeds all four read routes (today/past):
`GET /api/time/status/summary`, `/summary/week`, `/api/time/status`,
and `/api/time/status/.../week`.

## Tests (red → green)

- Red: updated the `TimeStatusCacheSpec` header assertion to expect
  `no-store` on today — failed against the old `max-age=30`.
- Green: the route change flips today-mode to `no-store` while past
  stays `max-age=3600`.

`mill api.test` passes (all suites green); `scalafmt --check` clean.

## Companion

Client-side defense-in-depth (`cache: 'no-store'` in the SPA fetch
wrapper) shipped in #1300. This PR is the server-side root-cause fix.

Closes #1299