### PR TITLE
docs: policy snapshot is a minimal functional shape, not a policy model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,36 @@ the router as one of the fields above. **Do not add decision logic — schedule
 evaluation, time accounting, category lookup, role-based defaults — to the
 router agent.**
 
+### The snapshot is a minimal functional shape, not a policy model
+
+The fields above are the *whole* wire vocabulary, and that is deliberate. The
+snapshot carries only the **functional** data the router must act on to
+enforce — it is not a mirror of the server's policy model.
+
+- **Express new policy via existing functional fields — never add a field for
+  the concept itself.** If a new policy idea can be carried by a field that
+  already exists, it MUST be. An "always-allow this host" rule is functionally
+  just another `extraAllowed` entry; a "block this app" rule is just
+  `extraBlocked` / `blocklistIds`. Adding a new top-level channel (e.g. an
+  `infraAllow` set) to name the *concept* pushes a policy tier onto the router
+  and is wrong. (This was the original misstep in
+  [#1307](https://github.com/wifihaven/wifihaven/issues/1307) — the global
+  infra allowlist now ships by copying its hosts into every profile's
+  `extraAllowed`, not via a new field.)
+- **No policy *reasons* on the wire except where functionally required.**
+  `blockReason` is the one intentional exception, and it exists only to pick
+  block-page copy — it is never read for enforcement. Do not add "why"
+  metadata for allow/deny decisions; the server resolves policy into functional
+  data and the router applies it blind.
+- **Redundancy and wire-shape are separate concerns.** Copying a shared set
+  (like the infra allowlist) into every profile's `extraAllowed` is the correct
+  wire shape even though it duplicates data. The duplication is a separate
+  optimization, tracked by the global-policy-layer work in
+  [#1308](https://github.com/wifihaven/wifihaven/issues/1308) — and reducing it
+  must NOT come at the cost of teaching the router about policy tiers. See
+  [#1311](https://github.com/wifihaven/wifihaven/issues/1311) for the full
+  rationale.
+
 See [`docs/architecture.md`](docs/architecture.md) for the full snapshot
 shape, wire JSON examples, and the enforcement model.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,65 @@ for usage attribution (§7.2). It is **never** the enforcement plane.
 >   top level — the DB column is per-profile and we keep it that way until
 >   there's a reason to consolidate.
 
+### 0.3 The snapshot is a minimal functional shape, not a policy model
+
+`BlockRules` is the complete wire vocabulary for enforcement, and keeping it
+that small is a deliberate design constraint, not an accident waiting to be
+"fixed" by adding fields. The snapshot carries only the **functional** data the
+router must act on; it is not a serialization of the server's richer policy
+model. When you reach for a new field, stop and check whether an existing
+functional field already expresses the behaviour.
+
+**1. The snapshot is the minimal functional shape needed to enforce.** Every
+field exists because the router has to act on it: drop all traffic
+(`blocked`), drop a host (`extraBlocked`), allow a host (`extraAllowed`), drop a
+category (`blocklistIds`), drop literal-IP traffic (`blockIpOnly`). If a new
+policy concept can be expressed through one of these, it **MUST** be — adding a
+new field for the concept itself is forbidden.
+
+The motivating example: while shipping the global infra allowlist
+([#1307](https://github.com/wifihaven/wifihaven/issues/1307)) — a curated set of
+infrastructure hosts that must stay reachable so allowed-mode apps keep working
+even when a whole MAC is blocked — an initial attempt added a top-level
+`PolicySnapshot.infraAllow` set (and even carried the *reason* each host was
+allowed) straight to the router. That was wrong: an always-allowed host is
+functionally indistinguishable from any other `extraAllowed` entry, and the
+router has no need for a separate "infra" channel or for *why* the host is
+allowed. The correct fix resolves the infra hosts server-side and copies them
+into every profile's `extraAllowed`, relying on the enforcement that already
+exists for that field. The router learns nothing new.
+
+**2. No policy *reasons* on the wire except where functionally required.**
+`blockReason: Option[MacBlockReason]` is the single intentional exception, and
+it exists only to choose block-page copy — it is **never** read for
+enforcement (see §0.2 and the type split that keeps router-only reasons out of
+the snapshot). Do not add analogous "why" metadata for allow/deny decisions. The
+server collapses the reasoning into functional data; the router applies that
+data blind. A field whose only consumer is human-readable explanation does not
+belong in the enforcement snapshot.
+
+**3. Policy lives server-side, in `PolicyService`.** All composition — global
+defaults, profile rules, per-device overrides, schedules, time limits, category
+membership, app modes, and the infra allowlist — collapses server-side into the
+per-MAC `BlockRules` described above. A new policy concept lands in
+`PolicyService` and presents to the router as one of the existing functional
+fields. The router never sees the tiers, the precedence order, or the inputs
+that produced the result.
+
+**4. Redundancy and wire-shape are separate concerns.** Copying a shared set
+(like the infra allowlist) into every profile's `extraAllowed` duplicates data
+across the snapshot, and that is an acceptable wire shape. The duplication is a
+distinct optimization, tracked by the global-policy-layer work in
+[#1308](https://github.com/wifihaven/wifihaven/issues/1308) (carry the global
+set once, with an override model), and it must be solved **without** teaching the
+router about policy tiers. Reducing bytes on the wire is never a reason to push
+a policy concept onto the dumb applier.
+
+This guardrail is recorded in
+[#1311](https://github.com/wifihaven/wifihaven/issues/1311); the same principle
+is summarized in the top-level [`AGENTS.md`](../AGENTS.md) architectural-model
+section.
+
 ## 1. Why this exists
 
 The original architecture ran a DNS server and a pcap-based traffic monitor on


### PR DESCRIPTION
## Summary

Documents an architectural guardrail so a future change doesn't re-introduce
policy-shaped fields into the enforcement snapshot.

The principle, in two places agents read (top-level `AGENTS.md` architectural
model + `docs/architecture.md` §0.3):

- **The snapshot is the minimal functional shape needed to enforce.** Every
  field exists because the router must act on it. A new policy concept
  expressible via an existing functional field (e.g. always-allow →
  `extraAllowed`) MUST use it — never add a new field for the concept.
- **No policy *reasons* on the wire except where functionally required.**
  `blockReason` is the one intentional exception (block-page copy only, never
  enforcement).
- **Policy lives server-side in `PolicyService`**, which collapses all
  composition into per-MAC `BlockRules`.
- **Redundancy and wire-shape are separate concerns.** Copying a shared set
  into every profile's `extraAllowed` is the correct shape; the redundancy is a
  separate optimization (#1308) and must not come at the cost of teaching the
  router about policy tiers.

Motivated by the initial misstep in the #1307 infra-allowlist work (a top-level
`infraAllow` field), now fixed by copying hosts into `extraAllowed`.

## Cross-refs

- #1307 — ships the infra allowlist by copying into `extraAllowed`
- #1308 — removes the redundancy via the global policy layer
- Closes #1311

## Scope

Docs only — `AGENTS.md` (symlinked as `CLAUDE.md`) and `docs/architecture.md`.
No source, tests, or config.