### PR TITLE
docs: reinforce that blocking is connection-layer, not DNS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,19 @@ hostname attribution (forward-lookup ipset population so nftables can match
 on `(mac, dst ip ∈ resolved-hosts-for-this-mac)`), but it is not the
 enforcer.
 
+> **ANTI-PATTERN — never reason "resolved ⇒ reachable / not blocked."**
+> A successful DNS lookup proves nothing about whether traffic is allowed:
+> DNS *always* resolves, and the resolved IP is exactly what nftables drops.
+> Reachability is a connection-layer property, not a DNS one. So:
+> - Do NOT conclude "the app's domain resolved fine, so it wasn't blocked."
+> - Do NOT describe a fix as "allow the domain's DNS." An allow entry works
+>   by carving the host's *resolved IPs* out of the forward-drop — the
+>   per-`(mac, host)` `ea_` ipset that dnsmasq's nftset callback populates at
+>   resolve time — it does not touch DNS at all.
+>
+> This slip recurs (e.g. [#1307](https://github.com/wifihaven/wifihaven/issues/1307));
+> see [#1313](https://github.com/wifihaven/wifihaven/issues/1313).
+
 **2. The router agent is a dumb applier.** The API server ships a policy
 snapshot in which every decision is already pre-computed. After a one-time
 resolution step, the enforcement pipeline sees a `Map[MacAddress, BlockRules]`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,16 @@ asked for. dnsmasq does not return a fake answer for any blocked host — the
 host resolves normally, the device opens a TCP connection, and nftables
 either drops the SYN (blocked) or DNATs HTTP/80 to the local block page.
 
+> **Corollary — "a hostname resolved" tells you nothing about reachability.**
+> The resolved IP is precisely what nftables drops, so never infer "DNS
+> resolved ⇒ not blocked," and never describe a fix as "allow the domain's
+> DNS." An allowlist entry carves the host's *resolved IPs* out of the
+> forward-drop via the per-`(mac, host)` `ea_` ipset that dnsmasq's nftset
+> callback populates at resolve time (§0.2 `extraAllowed`) — it does not
+> change any DNS answer. This connection-layer-vs-DNS confusion recurs in
+> agent work (e.g. [#1307](https://github.com/wifihaven/wifihaven/issues/1307));
+> see [#1313](https://github.com/wifihaven/wifihaven/issues/1313).
+
 We rejected DNS-based blocking (sinkhole / RPZ / NXDOMAIN) because:
 
 - DoH / DoT bypasses any DNS-layer block trivially.


### PR DESCRIPTION
## Why

Agents keep slipping into a DNS-level mental model of WifiHaven's blocking —
e.g. "the app's domain resolved fine, so it wasn't blocked." That contradicts
the canonical architecture and recurred in the [#1307](https://github.com/wifihaven/wifihaven/issues/1307)
work. The truth is already in the docs but wasn't sticky enough.

## What changed (docs only)

- **`AGENTS.md`** (`CLAUDE.md` symlink) — added a short, quotable **ANTI-PATTERN**
  callout right under truth #1 in the "Architectural model" section: never reason
  "resolved ⇒ reachable / not blocked," and never describe a fix as "allow the
  domain's DNS." An allow entry carves the host's resolved IPs out of the
  forward-drop via the per-`(mac, host)` `ea_` ipset, not via DNS.
- **`docs/architecture.md`** — added a matching corollary in §0.1 (enforcement
  model): the resolved IP is exactly what nftables drops; allow = nftables
  carve-out via the `ea_` ipset populated by dnsmasq at resolve time.

Both cross-link [#1307](https://github.com/wifihaven/wifihaven/issues/1307) (where the
slip happened) and [#1313](https://github.com/wifihaven/wifihaven/issues/1313).

Only `*.md` files change — no source, tests, or config.

Closes #1313