### PR TITLE
docs: backwards-compat policy now in effect (prod is deployed)

### DIFF
--- a/.claude/memory/project_wire_versioning_deferred.md
+++ b/.claude/memory/project_wire_versioning_deferred.md
@@ -1,13 +1,14 @@
 ---
 name: Wire schema versioning deferred to pre-v1.0
-description: Issue #376 (snapshotVersion + capability negotiation) is intentionally deferred; API and agent ship in tandem until then
+description: Issue #376 (snapshotVersion + capability negotiation) is intentionally deferred; until it lands, wire changes must be additive/backwards-compatible (no breaking changes)
 type: project
 ---
 Wire-contract schema-evolution policy (issue [#376](https://github.com/wifihaven/wifihaven/issues/376) — snapshotVersion, serverCapabilities/agentCapabilities negotiation, capability registry) is **deferred until we approach v1.0 release**. Decided 2026-05-14.
 
-**Why:** Pre-v1.0, API and OpenWRT agent are deployed in tandem from the same repo by a single operator (sameer); the cost of a tandem-deploy constraint is lower than the cost of building and maintaining a capability-negotiation framework now. Auto-update mismatch windows are tolerable for the current install base of one.
+**Why:** Building and maintaining a full capability-negotiation framework now costs more than it buys at the current install base. As of the prod deploy the API and the OpenWRT agent deploy **independently** (no tandem deploy), so the wire is a public contract — but for an install base of ~one the cheap discipline of additive-only, ignore-unknown-on-input changes is enough to keep an older deployed agent and a newer API compatible without a versioning handshake.
 
 **How to apply:**
 - Do NOT proactively add `snapshotVersion`, `serverCapabilities`, `agentCapabilities`, capability headers, or registry tables to the wire contract.
-- In-flight shape-change issues (e.g. #385 `failure-mode-three`, #386 `failover-threshold-in-snapshot`, #374 `unmanaged-mac-policy`, #383 `https-block-page`, #391 `hostid-tagged-union`, #392 `ipv6-ipsets`) ship as plain breaking shape changes coordinated by tandem deploy — they do NOT need to name a capability or gate emission.
+- Wire shape changes must follow the backwards-compatibility policy in `AGENTS.md` ("Backwards compatibility"): **additive fields only, ignore unknown on input, deprecation windows for removals.** Breaking/non-additive wire changes are off the table until #376 lands — they are no longer free, because there is no tandem deploy to coordinate both sides at once.
+- The historical shape-change issues (e.g. #385 `failure-mode-three`, #386 `failover-threshold-in-snapshot`, #374 `unmanaged-mac-policy`, #383 `https-block-page`, #391 `hostid-tagged-union`, #392 `ipv6-ipsets`) that predate the deploy could land as plain breaking changes; anything still in flight must now be made additive instead.
 - If a future task asks for the capability framework, surface this memory and confirm v1.0 timing before starting. The draft design (rules + registry) is in the #376 thread / chat history if it needs to be revived.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,17 +278,41 @@ Rules:
 
 ## Backwards compatibility
 
-Nothing has been deployed yet. **Do not add backwards-compatibility shims,
-deprecation paths, or "ignore unknown fields" tolerance for the sake of
-older clients.** Breaking changes to API request/response shapes, UCI keys,
-DB schema (pre-migration), and CLI flags are fine — just change the code
-on all sides in the same PR.
+**WifiHaven is deployed to prod, so this policy is now IN EFFECT.** The
+API and the agents deploy **independently** — there is no longer a tandem
+deploy that lets you change both sides of the wire at once. A snapshot the
+API emits today may be parsed by an older already-deployed agent, and an
+event an older agent posts must still be accepted by a newer API. So the
+router↔API request/response shapes (and the policy snapshot in particular)
+are a **public contract**.
 
-This policy flips once we've done our first real deploy, which is gated on
-picking a permanent project name ([#38](https://github.com/wifihaven/wifihaven/issues/38)).
-After that ships, API request/response shapes become a public contract and
-we keep them backwards compatible (additive fields, ignore-unknown on input,
-deprecation windows for removals).
+Rules for any change to a wire-visible shape (API request/response bodies,
+the policy snapshot, the usage/event ingest payloads):
+
+- **Additive only.** New fields are fine; renaming, removing, retyping, or
+  changing the meaning of an existing field is not.
+- **Ignore unknown fields on input.** Both sides must tolerate fields they
+  don't recognize, so a newer peer can add fields without breaking an older
+  one.
+- **Deprecation windows for removals.** To drop a field, stop relying on it,
+  ship that, wait for the fleet to roll forward, then remove it in a later
+  change — never in the same step.
+- **The API may still change freely** as long as it stays backwards
+  compatible with already-deployed agents under the rules above.
+
+Non-additive / breaking wire changes are gated on **wire versioning and
+capability negotiation** ([#376](https://github.com/wifihaven/wifihaven/issues/376)):
+that mechanism is what will eventually let the two sides agree on a shape
+before using it. Until #376 lands, treat breaking wire changes as off the
+table.
+
+Surfaces that are **not** part of the cross-process wire contract — UCI keys
+written and read by the same agent build, CLI flags, and DB schema (guarded
+separately by Flyway migrations) — can still change without a deprecation
+window, but coordinate them within their own component.
+
+(The flip was driven by the actual prod deploy, not by the permanent-name
+decision [#38](https://github.com/wifihaven/wifihaven/issues/38).)
 
 ## Docker inside Claude Code agents (worktrees)
 

--- a/docs/design/blocklists.md
+++ b/docs/design/blocklists.md
@@ -170,8 +170,11 @@ profile).
   category-list serialization, snapshot builder with apps + blocklists
   composed.
 - **Contract (Gate 1)**: `shared/contract/api-to-router/policy_snapshot.json`
-  golden — blocklists field shape stays stable; any change requires
-  tandem-deploy planning.
+  golden — blocklists field shape stays stable. Now that prod is deployed
+  the snapshot is a public contract: changes must be additive and
+  ignore-unknown-tolerant (see "Backwards compatibility" in `AGENTS.md`);
+  non-additive changes are gated on wire versioning
+  ([#376](https://github.com/wifihaven/wifihaven/issues/376)).
 - **Router (Gate 2 / #654)**: blocklist fetch via `If-None-Match`, periodic
   refresh timer, empty-status logging (sub-G items #705/#709), HTTPS DNAT
   (#383), unmanaged-MAC fallthrough (#374), block-page redirect emits

--- a/docs/design/ios-mobile-app.md
+++ b/docs/design/ios-mobile-app.md
@@ -147,9 +147,16 @@ client (`web/src/api/client.ts`) and its DTOs into a small `web-shared/`
 package (or use Capacitor's bundle which is the SPA itself, so the share is
 free).
 
-Monorepo wins: single-PR atomic API+mobile changes (no compat shims), one CI
-config, one issue tracker. Separate-repo costs (independent CI, cross-repo
-PRs, version skew) are not justified at household scale.
+Monorepo wins: single-PR atomic API+mobile *source* changes, one CI config,
+one issue tracker. Separate-repo costs (independent CI, cross-repo PRs,
+version skew) are not justified at household scale.
+
+Note: the monorepo makes the *source* change atomic, but it does **not**
+make the *deploy* atomic. Now that prod is live the API↔client wire is a
+public contract (see "Backwards compatibility" in `AGENTS.md`), and a mobile
+binary already on a user's device can't be force-updated in lockstep with the
+API — so API changes the mobile app depends on must still be additive and
+backwards compatible, exactly as for the router↔API wire.
 
 ---
 


### PR DESCRIPTION
## Summary

WifiHaven is now deployed to prod, which makes several docs stale: they still
claim "nothing has been deployed yet." This PR reconciles them with the
deployed reality.

- **`AGENTS.md` (→ `CLAUDE.md` symlink) "Backwards compatibility":** rewritten
  to state the policy is **in effect**. The API and agents deploy
  independently, so the router↔API request/response shapes (the policy
  snapshot in particular) are a public contract: additive fields only,
  ignore-unknown on input, deprecation windows for removals. The API may
  still change freely as long as it stays backwards compatible with
  already-deployed agents. Non-additive wire changes are gated on wire
  versioning / capability negotiation (#376). The flip is decoupled from the
  permanent-name decision (#38) — it was driven by the actual prod deploy.
- **`docs/design/blocklists.md`:** the snapshot golden's "any change requires
  tandem-deploy planning" now points at the additive backwards-compat policy
  and #376.
- **`docs/design/ios-mobile-app.md`:** the monorepo "no compat shims" claim is
  clarified — the monorepo makes the *source* change atomic, not the *deploy*;
  API changes a shipped mobile binary depends on must still be additive.
- **`.claude/memory/project_wire_versioning_deferred.md`:** #376 stays
  deferred, but the rationale is updated from "tandem deploy / pre-v1.0" to
  independent deploys held compatible by additive-only discipline.

`docs/architecture.md` already reflects the deploy (its schema is marked "in
production"), so no change was needed there.

Docs-only change — only `*.md` files touched.

## Test plan

- [ ] No source, test, CI, or config files changed (verified: all four touched
      files are `*.md`).

Closes #1324