### PR TITLE
deploy: self-hosted Prometheus + Grafana compose overlay (#1207)

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -37,6 +37,29 @@ WIFIHAVEN_API_PORT=8080
 # WIFIHAVEN_UI_ALLOWED_HOSTS=wifihaven.example,api.wifihaven.example
 # Dev example:  WIFIHAVEN_UI_ALLOWED_HOSTS=api.lan
 
+# ─── Metrics overlay (off by default) ────────────────────────────────────────
+#
+# These knobs are READ by deploy/docker-compose.metrics.yml. They have no
+# effect on the production stack on their own — add the overlay to enable
+# Prometheus + Grafana (#1207):
+#
+#   docker compose -f deploy/docker-compose.prod.yml \
+#     -f deploy/docker-compose.metrics.yml --env-file deploy/.env up -d
+#
+# Grafana admin password. REQUIRED when the metrics overlay is active.
+# WIFIHAVEN_GRAFANA_ADMIN_PASSWORD=replace-with-strong-password
+#
+# Where Grafana is published on the host. Default 127.0.0.1:3000 — keep it
+# LAN-local; do not expose Grafana on 0.0.0.0 without a reverse proxy.
+# WIFIHAVEN_GRAFANA_BIND=127.0.0.1
+# WIFIHAVEN_GRAFANA_PORT=3000
+#
+# Bearer token required on GET /metrics. /metrics is never published on a host
+# port (Prometheus scrapes it in-network), so this is optional for the
+# self-hosted overlay. Set a token to require auth anyway; Prometheus uses the
+# same value. Empty leaves /metrics open on the internal network.
+# WIFIHAVEN_METRICS_SCRAPE_TOKEN=replace-with-random-token
+
 # ─── Debugging (off by default) ──────────────────────────────────────────────
 #
 # These knobs are READ by deploy/docker-compose.debug.yml. They have no

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -9,6 +9,10 @@ reach this api over the network (see [`docs/architecture.md`](../docs/architectu
 | File                              | Purpose |
 | --------------------------------- | ------- |
 | `docker-compose.prod.yml`         | Single-stack compose: postgres + api. |
+| `docker-compose.metrics.yml`      | Opt-in overlay: Prometheus + Grafana for self-hosted metrics (#1207). |
+| `prometheus/prometheus.yml`       | Prometheus scrape config used by the metrics overlay. |
+| `grafana/provisioning/`           | Grafana datasource + dashboard provisioning for the overlay. |
+| `grafana/dashboards/`             | Versioned dashboard JSON loaded by the overlay (and Grafana Cloud). |
 | `.env.example`                    | Template for secrets/config. Copy to `.env`. |
 | `wifihaven-api.service`           | Legacy systemd unit for host-based deploys. Kept for reference; new installs should use Compose. |
 
@@ -39,6 +43,42 @@ compose network and is unreachable from the host or LAN.
 
 Default admin login: `admin / changeme` — change it immediately via
 `POST /api/auth/change-password`.
+
+## Metrics (optional): Prometheus + Grafana
+
+The API exposes Prometheus metrics at `GET /metrics`. To collect and visualize
+them on the self-hosted host, layer the metrics overlay on top of the prod
+stack — it adds Prometheus and Grafana, both checked-in declaratively
+(see [`docs/design/metrics-observability.md`](../docs/design/metrics-observability.md) §6.1):
+
+```bash
+# In deploy/.env, set at least WIFIHAVEN_GRAFANA_ADMIN_PASSWORD (required by
+# the overlay). Optionally set WIFIHAVEN_METRICS_SCRAPE_TOKEN to require a
+# bearer token on /metrics.
+
+docker compose \
+  -f deploy/docker-compose.prod.yml \
+  -f deploy/docker-compose.metrics.yml \
+  --env-file deploy/.env up -d
+```
+
+- **`/metrics` is never published on a host port.** Prometheus scrapes the API
+  in-network as `api:8080`; nothing on the host or LAN can reach `/metrics`
+  directly.
+- **Grafana** is published on `127.0.0.1:3000` by default (override with
+  `WIFIHAVEN_GRAFANA_BIND` / `WIFIHAVEN_GRAFANA_PORT`). Log in as `admin` with
+  `WIFIHAVEN_GRAFANA_ADMIN_PASSWORD`. The Prometheus datasource and the
+  dashboards under `grafana/dashboards/` are provisioned automatically.
+- **Opt-in.** Omit `-f deploy/docker-compose.metrics.yml` and the API runs
+  exactly as before with no metrics stack. Prometheus retains 90 days locally
+  on the `promdata` volume (§7.2).
+
+Common operations use the same `-f prod -f metrics` invocation, e.g.:
+
+```bash
+docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.metrics.yml \
+  --env-file deploy/.env logs -f prometheus grafana
+```
 
 ## Design notes
 

--- a/deploy/docker-compose.metrics.yml
+++ b/deploy/docker-compose.metrics.yml
@@ -1,0 +1,78 @@
+# Metrics overlay: self-hosted Prometheus + Grafana. (#1207)
+#
+# Opt-in. Layer it on top of the prod stack — without it, the API runs
+# exactly as before and no metrics stack exists:
+#
+#   docker compose \
+#     -f deploy/docker-compose.prod.yml \
+#     -f deploy/docker-compose.metrics.yml \
+#     --env-file deploy/.env up -d
+#
+# Prometheus scrapes the API's /metrics over the internal compose network
+# (api:8080); /metrics is never published on a host port. Grafana is published
+# on a LAN-local host port for the operator. Both Prometheus config and Grafana
+# datasource/dashboard provisioning are checked into the repo — declarative, no
+# dashboard clicking. See docs/design/metrics-observability.md §6.1 / §7.2 / §8.
+
+services:
+  # Forward the scrape token into the API so GET /metrics enforces it when set.
+  # Empty (the default) leaves /metrics open on the internal network — fine,
+  # since it is never exposed beyond the compose network.
+  api:
+    environment:
+      WIFIHAVEN_METRICS_SCRAPE_TOKEN: ${WIFIHAVEN_METRICS_SCRAPE_TOKEN:-}
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      # Prometheus has no env-var expansion in its config file, so the bearer
+      # token is materialized to a file (on the writable data volume) at
+      # startup and referenced via credentials_file in prometheus.yml.
+      WIFIHAVEN_METRICS_SCRAPE_TOKEN: ${WIFIHAVEN_METRICS_SCRAPE_TOKEN:-}
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - promdata:/prometheus
+    # No published host port — Prometheus is reachable only in-network
+    # (Grafana proxies to it as http://prometheus:9090).
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        printf '%s' "$${WIFIHAVEN_METRICS_SCRAPE_TOKEN}" > /prometheus/scrape_token
+        exec /bin/prometheus \
+          --config.file=/etc/prometheus/prometheus.yml \
+          --storage.tsdb.path=/prometheus \
+          --storage.tsdb.retention.time=90d \
+          --web.enable-lifecycle
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${WIFIHAVEN_GRAFANA_ADMIN_PASSWORD:?WIFIHAVEN_GRAFANA_ADMIN_PASSWORD required for the metrics overlay}
+      # Operator-local dashboard tool; no public sign-up, no anonymous access.
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafanadata:/var/lib/grafana
+    ports:
+      # LAN-local by default — bind to loopback or a LAN address, not 0.0.0.0.
+      - "${WIFIHAVEN_GRAFANA_BIND:-127.0.0.1}:${WIFIHAVEN_GRAFANA_PORT:-3000}:3000"
+
+volumes:
+  promdata:
+  grafanadata:

--- a/deploy/grafana/provisioning/dashboards/wifihaven.yml
+++ b/deploy/grafana/provisioning/dashboards/wifihaven.yml
@@ -1,0 +1,17 @@
+# Grafana dashboard provisioning for the self-hosted metrics overlay.
+# Auto-loads the versioned JSON in deploy/grafana/dashboards/ (api-health,
+# api-self-metrics, router-fleet, rollup-health). The repo copy is canonical
+# (design §8); edits made in the UI are not persisted back here.
+
+apiVersion: 1
+
+providers:
+  - name: wifihaven
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,17 @@
+# Grafana datasource provisioning for the self-hosted metrics overlay.
+# Points Grafana at the in-network Prometheus service. Set as the default
+# datasource so the dashboards' ${datasource} template variable (type:
+# datasource, query: prometheus) resolves to it automatically.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: wifihaven-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,35 @@
+# Self-hosted Prometheus scrape config for the metrics overlay
+# (deploy/docker-compose.metrics.yml). See docs/design/metrics-observability.md
+# §6.1 / §7.2.
+#
+# Only target: the API's /metrics, reached over the internal compose network as
+# `api:8080`. /metrics is NEVER published on a host port — Prometheus is the
+# only thing that scrapes it, in-network.
+#
+# Auth: GET /metrics is gated by a bearer token when WIFIHAVEN_METRICS_SCRAPE_TOKEN
+# is set on the api service (api/src/routes/MetricsRoutes.scala). The overlay's
+# prometheus entrypoint writes that same token to /prometheus/scrape_token before
+# launch (Prometheus has no env-var expansion in its config), and we reference it
+# via credentials_file. When the token is empty the endpoint is open and the
+# empty credentials are simply ignored.
+
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: wifihaven-api
+    metrics_path: /metrics
+    scheme: http
+    authorization:
+      type: Bearer
+      credentials_file: /prometheus/scrape_token
+    static_configs:
+      - targets: ["api:8080"]
+        # The shared dashboards under deploy/grafana/dashboards/ filter every
+        # query by {env="$env"}, where the $env template variable defaults to
+        # "prod". Labeling the self-hosted target env="prod" lets those
+        # dashboards render unchanged — there is only one environment here.
+        labels:
+          env: "prod"
+          instance: "wifihaven-api"


### PR DESCRIPTION
Closes #1207.

Adds an opt-in docker-compose overlay layering Prometheus + Grafana onto the
self-hosted prod stack (`docs/design/metrics-observability.md` §6.1 / §7.2 / §8).

## What's added
- **`deploy/docker-compose.metrics.yml`** — overlay (layered via `-f prod -f metrics`):
  - `prometheus` (`prom/prometheus:v2.54.1`): scrapes `api:8080/metrics` over the
    internal compose network, **no published host port for `/metrics`**, persistent
    `promdata` volume, `--storage.tsdb.retention.time=90d`, 15s scrape interval.
  - `grafana` (`grafana/grafana:11.2.0`): Prometheus pre-provisioned as default
    datasource, dashboards auto-loaded from `deploy/grafana/dashboards/`, admin
    password from `.env`, published on a **LAN-local** host port (`127.0.0.1:3000`
    default).
  - Forwards `WIFIHAVEN_METRICS_SCRAPE_TOKEN` into the `api` service so the token is
    enforced when set.
- **`deploy/prometheus/prometheus.yml`** — bearer-auth scrape via `credentials_file`.
- **`deploy/grafana/provisioning/`** — datasource + dashboard provisioning YAML.
- **`deploy/.env.example` + `deploy/README.md`** — new env knobs and the launch command.

## Design notes / decisions
- **Token wiring matches the API.** The API reads `WIFIHAVEN_METRICS_SCRAPE_TOKEN`
  (`docker/entrypoint.sh` → `metrics.scrapeToken`, `api/src/routes/MetricsRoutes.scala`).
  The overlay reuses that exact name on both `api` and `prometheus`. Plain Prometheus
  has no env-var expansion in its config, so the entrypoint writes the token to
  `/prometheus/scrape_token` at startup and the config references it via
  `credentials_file`. Empty token = `/metrics` open on the internal network (fine —
  it's never exposed beyond the compose network).
- **Dashboards render unchanged.** The shared dashboards filter every query by
  `{env="$env"}` (default `prod`), so the self-hosted scrape target is labeled
  `env=prod` — no dashboard edits needed.
- **Opt-in / no behavior change.** Without the overlay, the prod stack is identical.

## How I validated
- `docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.metrics.yml config` — **merged config parses**, shared `default` network, `api` correctly gets the token env merged, `/metrics` has no host port mapping.
- `promtool check config` on `deploy/prometheus/prometheus.yml` (with the runtime token file present) — **SUCCESS**.
- **Grafana standalone smoke** (`grafana/grafana:11.2.0` with the provisioning + dashboards mounted): `/api/health` ok; `/api/datasources` shows the Prometheus datasource provisioned as default with uid `wifihaven-prometheus`; `/api/search` lists all four dashboards (api-health, api-self-metrics, rollup-health, router-fleet). Container torn down after.
- **Not brought up end-to-end locally.** The full prod stack needs the Scala API image (long build), so I did not run the API+Prometheus live scrape path. The Prometheus→API scrape leg (target up, live data) is unverified locally; it is covered by the issue's acceptance bring-up on a real host. Everything else above was verified.