### PR TITLE
deploy: build the metrics overlay into install.sh (opt-in) (#1328)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -46,9 +46,26 @@ Default admin login: `admin / changeme` — change it immediately via
 
 ## Metrics (optional): Prometheus + Grafana
 
-The API exposes Prometheus metrics at `GET /metrics`. To collect and visualize
-them on the self-hosted host, layer the metrics overlay on top of the prod
-stack — it adds Prometheus and Grafana, both checked-in declaratively
+The API exposes Prometheus metrics at `GET /metrics`. The installer can wire up
+the metrics stack for you — opt in by setting `WIFIHAVEN_ENABLE_METRICS=1`
+(or answering `y` at the prompt):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/install.sh \
+  | WIFIHAVEN_ENABLE_METRICS=1 bash
+```
+
+With the flag set, the installer fetches the overlay (a repo tarball, so all
+dashboards come along), generates `WIFIHAVEN_GRAFANA_ADMIN_PASSWORD`, prompts
+for the Grafana bind/port, brings up Prometheus + Grafana alongside the API,
+and prints the Grafana URL + admin password at the end. The helper scripts
+(`start`/`stop`/`restart`/`status`/`update`) then manage the metrics services
+too, and `update.sh` refreshes the dashboards from main. Without the flag the
+install is unchanged — no metrics services, no Grafana vars in `.env`.
+
+To layer the overlay manually instead (on an existing install or for a one-off),
+add it on top of the prod stack — it adds Prometheus and Grafana, both
+checked-in declaratively
 (see [`docs/design/metrics-observability.md`](../docs/design/metrics-observability.md) §6.1):
 
 ```bash

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -29,13 +29,20 @@
 #                            now; port-aware allow/block tracked in #296.
 #                            Empty = no global allow list. (default: prompt)
 #   WIFIHAVEN_NEW_ADMIN_PW   new admin password          (default: prompt)
+#   WIFIHAVEN_ENABLE_METRICS opt in to the Prometheus + Grafana metrics stack
+#                            (#1207). Off by default; non-interactive installs
+#                            default off. Accepts y/yes/1/true to enable.
+#   WIFIHAVEN_GRAFANA_BIND   host interface Grafana binds (default: 127.0.0.1,
+#                            only used when metrics enabled)
+#   WIFIHAVEN_GRAFANA_PORT   host port for Grafana        (default: 3000,
+#                            only used when metrics enabled)
 #   WIFIHAVEN_NONINTERACTIVE if set, never prompt; fail if any value missing.
 
 set -euo pipefail
 
 case "${1:-}" in
   -h|--help)
-    sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
     exit 0
     ;;
 esac
@@ -44,6 +51,13 @@ REPO_RAW="${WIFIHAVEN_REPO_RAW:-https://raw.githubusercontent.com/wifihaven/wifi
 COMPOSE_URL="${REPO_RAW}/deploy/docker-compose.prod.yml"
 ENV_EXAMPLE_URL="${REPO_RAW}/deploy/.env.example"
 HELPER_SCRIPTS=(start stop restart logs status update)
+
+# Git ref the metrics-overlay tarball is fetched from. The metrics overlay
+# pulls a whole-repo tarball (the grafana/dashboards/ directory is not
+# enumerable via raw URLs and would rot if hardcoded), then extracts the
+# deploy/ subtree. Defaults to main; override for testing a branch.
+REPO_REF="${WIFIHAVEN_REPO_REF:-main}"
+REPO_TARBALL_URL="${WIFIHAVEN_REPO_TARBALL_URL:-https://github.com/wifihaven/wifihaven/archive/refs/heads/${REPO_REF}.tar.gz}"
 
 c_red()    { printf '\033[31m%s\033[0m\n' "$*"; }
 c_green()  { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -109,6 +123,40 @@ prompt_secret() {
 genpw()    { openssl rand -base64 24 | tr -d '\n=/+' | cut -c1-24; }
 gensecret(){ openssl rand -base64 48 | tr -d '\n'; }
 
+# fetch_metrics_overlay DEST_DIR
+#
+# Downloads the repo tarball and copies the metrics-overlay subtree
+# (docker-compose.metrics.yml + prometheus/ + grafana/) into DEST_DIR,
+# mirroring the deploy/ layout so the overlay's relative paths resolve. A
+# tarball is used rather than individually-named raw URLs because the
+# grafana/dashboards/ directory is not enumerable over raw.githubusercontent
+# and a hardcoded filename list would rot as dashboards are added (#1328).
+fetch_metrics_overlay() {
+  local dest="$1"
+  local tmp src
+  tmp="$(mktemp -d)"
+  if ! curl -fsSL "$REPO_TARBALL_URL" -o "${tmp}/repo.tar.gz"; then
+    rm -rf "$tmp"
+    die "Could not download repo tarball from ${REPO_TARBALL_URL} (needed for the metrics overlay)."
+  fi
+  if ! tar -xzf "${tmp}/repo.tar.gz" -C "$tmp"; then
+    rm -rf "$tmp"
+    die "Could not extract repo tarball (needed for the metrics overlay)."
+  fi
+  # The tarball's top-level dir is wifihaven-<ref>; find the deploy/ subtree
+  # by name rather than guessing it, so any ref resolves.
+  src="$(find "$tmp" -maxdepth 2 -type d -name deploy | head -1)"
+  if [ -z "$src" ] || [ ! -f "${src}/docker-compose.metrics.yml" ]; then
+    rm -rf "$tmp"
+    die "Repo tarball did not contain deploy/docker-compose.metrics.yml."
+  fi
+  cp "${src}/docker-compose.metrics.yml" "${dest}/"
+  rm -rf "${dest}/prometheus" "${dest}/grafana"
+  cp -R "${src}/prometheus" "${dest}/"
+  cp -R "${src}/grafana"    "${dest}/"
+  rm -rf "$tmp"
+}
+
 cat <<'BANNER'
 
           _  __ _ _
@@ -166,6 +214,25 @@ prompt WIFIHAVEN_UI_ALLOWED_HOSTS \
                                 "Admin UI hostname(s) (comma-sep, blank = none)" \
                                 ""
 
+# Opt-in metrics stack (#1207, #1328). Off by default; non-interactive
+# installs default off. When on we also fetch the overlay files, generate a
+# Grafana admin password, and layer docker-compose.metrics.yml at bring-up.
+prompt WIFIHAVEN_ENABLE_METRICS "Enable Prometheus + Grafana metrics stack? (y/N)" "N"
+METRICS_ENABLED=0
+if [[ "${WIFIHAVEN_ENABLE_METRICS}" =~ ^([Yy]([Ee][Ss])?|1|[Tt][Rr][Uu][Ee])$ ]]; then
+  METRICS_ENABLED=1
+fi
+
+# Compose files that make up this install. The metrics overlay is layered
+# only when opted in; the same array is persisted to compose.env for the
+# helper scripts and used for every compose invocation below.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+if [ "$METRICS_ENABLED" -eq 1 ]; then
+  COMPOSE_FILE_ARGS+=(-f docker-compose.metrics.yml)
+  prompt WIFIHAVEN_GRAFANA_BIND "Grafana bind address (127.0.0.1 keeps it host-local)" "127.0.0.1"
+  prompt WIFIHAVEN_GRAFANA_PORT "Grafana host port"                                     "3000"
+fi
+
 # ── 3. Install directory ──────────────────────────────────────────────────
 
 step "Preparing $WIFIHAVEN_INSTALL_DIR"
@@ -222,6 +289,20 @@ for s in "${HELPER_SCRIPTS[@]}"; do
   chmod +x "${s}.sh"
 done
 ok "docker-compose.prod.yml + .env.example + ${#HELPER_SCRIPTS[@]} helper scripts downloaded"
+
+if [ "$METRICS_ENABLED" -eq 1 ]; then
+  fetch_metrics_overlay "$PWD"
+  # compose.env records the layered compose files so the helper scripts pick
+  # up the metrics overlay too. Written only when metrics is enabled — a
+  # default install leaves no compose.env and the scripts fall back to the
+  # prod stack alone, byte-for-byte as before.
+  cat > compose.env <<EOF
+# Generated by deploy/install.sh — sourced by the helper scripts so they
+# manage the same compose files this install was brought up with.
+COMPOSE_FILE_ARGS=(${COMPOSE_FILE_ARGS[*]})
+EOF
+  ok "metrics overlay downloaded (docker-compose.metrics.yml + prometheus/ + grafana/)"
+fi
 
 # ── 5. Refuse to clobber an existing install ──────────────────────────────
 #
@@ -314,18 +395,37 @@ WIFIHAVEN_API_PORT=${WIFIHAVEN_API_HOST_PORT}
 # paused household member can still reach the admin UI to unpause themselves.
 WIFIHAVEN_UI_ALLOWED_HOSTS=${WIFIHAVEN_UI_ALLOWED_HOSTS}
 EOF
+
+if [ "$METRICS_ENABLED" -eq 1 ]; then
+  GRAFANA_ADMIN_PASSWORD="$(genpw)"
+  cat >> .env <<EOF
+
+# Metrics overlay (#1207) — read by docker-compose.metrics.yml.
+# Grafana admin login is 'admin' with this generated password.
+WIFIHAVEN_GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+WIFIHAVEN_GRAFANA_BIND=${WIFIHAVEN_GRAFANA_BIND}
+WIFIHAVEN_GRAFANA_PORT=${WIFIHAVEN_GRAFANA_PORT}
+# /metrics is internal-only on the compose network, so no scrape token is
+# needed for the self-hosted overlay. Set one to require a bearer token.
+WIFIHAVEN_METRICS_SCRAPE_TOKEN=
+EOF
+fi
 chmod 600 .env
-ok "Wrote .env (db password and JWT secret auto-generated, chmod 600)"
+if [ "$METRICS_ENABLED" -eq 1 ]; then
+  ok "Wrote .env (db password, JWT secret, Grafana admin password auto-generated, chmod 600)"
+else
+  ok "Wrote .env (db password and JWT secret auto-generated, chmod 600)"
+fi
 
 
 # ── 6. Pull + start ───────────────────────────────────────────────────────
 
 step "Pulling image"
-docker compose -f docker-compose.prod.yml --env-file .env pull
+docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env pull
 ok "Image pulled"
 
 step "Starting stack"
-docker compose -f docker-compose.prod.yml --env-file .env up -d
+docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env up -d
 ok "Containers started"
 
 # ── 7. Wait for health ────────────────────────────────────────────────────
@@ -370,14 +470,14 @@ wait_for_api() {
   echo
   echo "Recent api container logs:"
   echo "------------------------------------------------------------------"
-  docker compose -f docker-compose.prod.yml --env-file .env logs api --tail=100 || true
+  docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env logs api --tail=100 || true
   echo "------------------------------------------------------------------"
   echo "Container status:"
-  docker compose -f docker-compose.prod.yml --env-file .env ps || true
+  docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env ps || true
   echo
   echo "Common causes:"
   echo "  - DB credentials in .env don't match what postgres was created with"
-  echo "    (try: docker compose -f docker-compose.prod.yml --env-file .env down -v"
+  echo "    (try: docker compose ${COMPOSE_FILE_ARGS[*]} --env-file .env down -v"
   echo "     and re-run install.sh)"
   echo "  - WIFIHAVEN_JWT_SECRET missing or empty in .env"
   echo "  - Postgres still initializing (rare; retry install.sh once)"
@@ -584,3 +684,20 @@ Next steps:
   To turn it off: ${SUDO:+sudo }systemctl disable --now wifihaven-update.timer
      See docs/deploy.md §1.3.
 EOF
+
+if [ "$METRICS_ENABLED" -eq 1 ]; then
+  GRAFANA_URL="http://${WIFIHAVEN_GRAFANA_BIND}:${WIFIHAVEN_GRAFANA_PORT}"
+  echo
+  c_green "  Metrics stack (Prometheus + Grafana) is enabled."
+  cat <<EOF
+
+  Grafana     : ${GRAFANA_URL}
+  Login       : admin / ${GRAFANA_ADMIN_PASSWORD}
+                (also saved in ${WIFIHAVEN_INSTALL_DIR}/.env as
+                 WIFIHAVEN_GRAFANA_ADMIN_PASSWORD)
+
+  The Prometheus datasource and dashboards are auto-provisioned. The helper
+  scripts manage the metrics services too; update.sh refreshes the dashboards
+  from main. /metrics is internal-only and never published on a host port.
+EOF
+fi

--- a/deploy/install.test.sh
+++ b/deploy/install.test.sh
@@ -224,6 +224,66 @@ else
   fail "install.sh does not default to renamed install paths (#359)"
 fi
 
+# ── 12. #1328: metrics opt-in is off by default. The normalization regex
+#       only flips METRICS_ENABLED for y/yes/1/true; everything else (incl.
+#       the "N" default) stays off. Extract the snippet and exercise it.
+metrics_enabled_for() {
+  WIFIHAVEN_ENABLE_METRICS="$1" bash -c '
+    METRICS_ENABLED=0
+    if [[ "${WIFIHAVEN_ENABLE_METRICS}" =~ ^([Yy]([Ee][Ss])?|1|[Tt][Rr][Uu][Ee])$ ]]; then
+      METRICS_ENABLED=1
+    fi
+    echo "$METRICS_ENABLED"'
+}
+metrics_off_ok=1
+for v in "N" "n" "no" "" "0" "false" "anything"; do
+  [[ "$(metrics_enabled_for "$v")" == "0" ]] || metrics_off_ok=0
+done
+metrics_on_ok=1
+for v in "y" "Y" "yes" "YES" "1" "true" "TRUE"; do
+  [[ "$(metrics_enabled_for "$v")" == "1" ]] || metrics_on_ok=0
+done
+if [[ "${metrics_off_ok}" -eq 1 && "${metrics_on_ok}" -eq 1 ]]; then
+  pass "metrics opt-in: off for N/empty/0/false, on for y/yes/1/true (#1328)"
+else
+  fail "metrics opt-in normalization wrong (off_ok=${metrics_off_ok} on_ok=${metrics_on_ok})"
+fi
+
+# ── 13. #1328: install.sh layers the metrics overlay only when enabled and
+#       fetches it via a repo tarball (the dashboards dir isn't raw-enumerable).
+if grep -q 'COMPOSE_FILE_ARGS+=(-f docker-compose.metrics.yml)' "${SCRIPT}" \
+   && grep -q 'fetch_metrics_overlay' "${SCRIPT}" \
+   && grep -q 'archive/refs/heads' "${SCRIPT}"; then
+  pass "install.sh layers metrics overlay + fetches it via tarball (#1328)"
+else
+  fail "install.sh missing metrics overlay layering / tarball fetch (#1328)"
+fi
+
+# ── 14. #1328: helper scripts source compose.env and default to prod-only
+#       when it's absent (back-compat with pre-metrics installs).
+SCRIPTS_DIR="$(dirname "${SCRIPT}")/scripts"
+helpers_ok=1
+for s in start stop restart logs status update; do
+  f="${SCRIPTS_DIR}/${s}.sh"
+  grep -q 'COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)' "$f" || helpers_ok=0
+  grep -q '\[ -f compose.env \] && source compose.env' "$f"     || helpers_ok=0
+  grep -q 'docker compose "${COMPOSE_FILE_ARGS\[@\]}"' "$f"      || helpers_ok=0
+done
+if [[ "${helpers_ok}" -eq 1 ]]; then
+  pass "helper scripts source compose.env with prod-only fallback (#1328)"
+else
+  fail "helper scripts not wired to compose.env (#1328)"
+fi
+
+# ── 15. #1328: update.sh refreshes the metrics overlay + dashboards from main
+#       (via the tarball) when metrics is enabled.
+if grep -q 'archive/refs/heads' "${SCRIPTS_DIR}/update.sh" \
+   && grep -q 'metrics_enabled' "${SCRIPTS_DIR}/update.sh"; then
+  pass "update.sh refreshes metrics overlay + dashboards when enabled (#1328)"
+else
+  fail "update.sh does not refresh metrics overlay when enabled (#1328)"
+fi
+
 echo
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ ${FAIL} -eq 0 ]]

--- a/deploy/scripts/logs.sh
+++ b/deploy/scripts/logs.sh
@@ -5,7 +5,11 @@
 #   ./logs.sh api postgres
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
 if [ "$#" -eq 0 ]; then
   set -- api
 fi
-exec docker compose -f docker-compose.prod.yml --env-file .env logs -f "$@"
+exec docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env logs -f "$@"

--- a/deploy/scripts/restart.sh
+++ b/deploy/scripts/restart.sh
@@ -2,4 +2,8 @@
 # Restart the WifiHaven stack in place (without recreating containers).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
-exec docker compose -f docker-compose.prod.yml --env-file .env restart "$@"
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
+exec docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env restart "$@"

--- a/deploy/scripts/start.sh
+++ b/deploy/scripts/start.sh
@@ -2,4 +2,8 @@
 # Start the WifiHaven stack (idempotent — safe to re-run).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
-exec docker compose -f docker-compose.prod.yml --env-file .env up -d "$@"
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
+exec docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env up -d "$@"

--- a/deploy/scripts/status.sh
+++ b/deploy/scripts/status.sh
@@ -2,4 +2,8 @@
 # Show container status (containers, ports, health).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
-exec docker compose -f docker-compose.prod.yml --env-file .env ps "$@"
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
+exec docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env ps "$@"

--- a/deploy/scripts/stop.sh
+++ b/deploy/scripts/stop.sh
@@ -3,4 +3,8 @@
 # volume is preserved (use `docker volume rm` to wipe it explicitly).
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
-exec docker compose -f docker-compose.prod.yml --env-file .env down "$@"
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
+exec docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env down "$@"

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -9,11 +9,31 @@
 # Also refreshes docker-compose.prod.yml from the repo before pulling, so
 # new env vars / service additions in a release reach the container instead
 # of silently no-opping against a stale local compose file.
+#
+# When the metrics overlay is enabled (compose.env layers in
+# docker-compose.metrics.yml), this also refreshes the overlay file,
+# prometheus config, and the Grafana dashboards from main so dashboard
+# updates reach existing installs.
 set -euo pipefail
 cd "$(dirname "$(readlink -f "$0")")"
 
 REPO_RAW="${WIFIHAVEN_REPO_RAW:-https://raw.githubusercontent.com/wifihaven/wifihaven/main}"
 COMPOSE_URL="${REPO_RAW}/deploy/docker-compose.prod.yml"
+REPO_REF="${WIFIHAVEN_REPO_REF:-main}"
+REPO_TARBALL_URL="${WIFIHAVEN_REPO_TARBALL_URL:-https://github.com/wifihaven/wifihaven/archive/refs/heads/${REPO_REF}.tar.gz}"
+
+# compose.env (written by install.sh when the metrics overlay is enabled)
+# defines COMPOSE_FILE_ARGS. Absent = prod stack only, as before.
+COMPOSE_FILE_ARGS=(-f docker-compose.prod.yml)
+[ -f compose.env ] && source compose.env
+
+metrics_enabled() {
+  local f
+  for f in "${COMPOSE_FILE_ARGS[@]}"; do
+    [ "$f" = "docker-compose.metrics.yml" ] && return 0
+  done
+  return 1
+}
 
 # Refresh docker-compose.prod.yml from main. Preserve the old file as .bak
 # so a network blip doesn't wipe out a working install.
@@ -27,5 +47,29 @@ else
   rm -f docker-compose.prod.yml.new
 fi
 
-docker compose -f docker-compose.prod.yml --env-file .env pull
-docker compose -f docker-compose.prod.yml --env-file .env up -d
+# Refresh the metrics overlay + dashboards when enabled. The
+# grafana/dashboards/ directory isn't enumerable over raw URLs, so we pull a
+# repo tarball and extract the deploy/ subtree (same mechanism install.sh
+# uses). On any failure we keep the existing files rather than break a
+# working install.
+if metrics_enabled; then
+  tmp="$(mktemp -d)"
+  if curl -fsSL "$REPO_TARBALL_URL" -o "${tmp}/repo.tar.gz" \
+     && tar -xzf "${tmp}/repo.tar.gz" -C "$tmp"; then
+    src="$(find "$tmp" -maxdepth 2 -type d -name deploy | head -1)"
+    if [ -n "$src" ] && [ -f "${src}/docker-compose.metrics.yml" ]; then
+      cp "${src}/docker-compose.metrics.yml" ./
+      rm -rf ./prometheus ./grafana
+      cp -R "${src}/prometheus" ./
+      cp -R "${src}/grafana"    ./
+    else
+      echo "warn: repo tarball missing deploy/metrics overlay; keeping existing files" >&2
+    fi
+  else
+    echo "warn: failed to fetch $REPO_TARBALL_URL; keeping existing metrics overlay" >&2
+  fi
+  rm -rf "$tmp"
+fi
+
+docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env pull
+docker compose "${COMPOSE_FILE_ARGS[@]}" --env-file .env up -d

--- a/docs/install-api.md
+++ b/docs/install-api.md
@@ -88,9 +88,20 @@ curl -fsSL https://raw.githubusercontent.com/wifihaven/wifihaven/main/deploy/ins
 | `WIFIHAVEN_API_HOST_PORT` | host port to bind | `8080` |
 | `WIFIHAVEN_API_BIND` | host interface to bind on | `0.0.0.0` |
 | `WIFIHAVEN_NEW_ADMIN_PW` | new admin password (skips rotation prompt) | prompt |
+| `WIFIHAVEN_ENABLE_METRICS` | opt in to the Prometheus + Grafana metrics stack (#1207) — fetches the overlay, generates a Grafana admin password, and brings it up alongside the API | off |
+| `WIFIHAVEN_GRAFANA_BIND` | host interface Grafana binds (only when metrics enabled) | `127.0.0.1` |
+| `WIFIHAVEN_GRAFANA_PORT` | host port for Grafana (only when metrics enabled) | `3000` |
 | `WIFIHAVEN_NONINTERACTIVE` | if set, never prompt; fail if any required value is missing | unset |
 
 Run `bash install.sh --help` to print the same list.
+
+Metrics are **opt-in and off by default** — a non-interactive install without
+`WIFIHAVEN_ENABLE_METRICS` is byte-for-byte what it is today (no Prometheus,
+no Grafana, no Grafana vars in `.env`). With it set, the installer prints the
+Grafana URL and the generated `admin` password at the end and the helper
+scripts manage the metrics services too (`update.sh` refreshes dashboards from
+main). The manual `-f prod -f metrics` overlay path is in
+[`deploy/README.md`](../deploy/README.md#metrics-optional-prometheus--grafana).
 
 The rest of this document is the manual walkthrough — read it if you'd
 rather understand each step, or if the script doesn't fit your environment


### PR DESCRIPTION
## Summary

Makes the Prometheus + Grafana metrics overlay (shipped in #1207 / #1327) a
first-class **opt-in** of the self-hosted installer. Closes #1328.

- **Opt-in switch** — `WIFIHAVEN_ENABLE_METRICS` (default off; non-interactive
  default off), using the existing `prompt`/`noninteractive` machinery.
- **Tarball fetch** — when enabled, the installer downloads a repo tarball and
  extracts the `deploy/` subtree so `prometheus.yml`, all Grafana provisioning,
  and **all** `grafana/dashboards/*.json` land alongside `docker-compose.metrics.yml`
  (the overlay uses relative paths). This avoids hardcoding a dashboard filename
  list that would rot — the dashboards dir isn't enumerable over raw URLs.
- **.env generation** — auto-generates `WIFIHAVEN_GRAFANA_ADMIN_PASSWORD`
  (reuses `genpw()`), prompts for `WIFIHAVEN_GRAFANA_BIND`/`_PORT`
  (default `127.0.0.1:3000`), and leaves `WIFIHAVEN_METRICS_SCRAPE_TOKEN` empty
  (`/metrics` is internal-only on the compose network).
- **Bring-up layering** — `-f docker-compose.prod.yml -f docker-compose.metrics.yml`.
- **Helper scripts** — all six source a generated `compose.env` (written only
  when metrics is enabled) to manage the metrics services too; absent it they
  fall back to the prod stack alone (back-compat with pre-metrics installs).
  `update.sh` refreshes the overlay + dashboards from main via the same tarball.
- **Completion banner** — prints the Grafana URL, `admin` username, and the
  generated admin password when enabled.
- **Docs** — `deploy/README.md` + `docs/install-api.md`.

Default install (flag off) is byte-for-byte unchanged: no metrics services, no
`compose.env`, no Grafana vars in `.env`.

No backwards-compat shims (nothing relevant deployed yet); this is a bash/infra
change so no Scala/scalafmt is touched.

## How I validated

Run locally on macOS, Docker 29.4.3. The prod API image
`ghcr.io/wifihaven/wifihaven-api:latest` **was** pullable, so I brought up the
full stack both ways.

- `bash -n` on `install.sh` + all six helper scripts — clean.
- `deploy/install.test.sh` — **19 passed, 0 failed** (added 4 new cases for the
  opt-in normalization, tarball-fetch layering, helper-script `compose.env`
  wiring, and `update.sh` overlay refresh).
- **Opt-in install** to a scratch dir
  (`WIFIHAVEN_ENABLE_METRICS=1 … WIFIHAVEN_NONINTERACTIVE=1 bash install.sh`):
  api + postgres + prometheus + grafana all came up. Verified:
  - overlay subtree landed mirroring `deploy/` (prometheus.yml, provisioning,
    4 dashboards), `compose.env` written, Grafana vars in `.env`;
  - Grafana provisioned the **Prometheus datasource** (`http://prometheus:9090`)
    and **all 4 dashboards** (API health, API self-metrics, Rollup health,
    Router fleet);
  - Prometheus target `wifihaven-api` → `http://api:8080/metrics` is **`up`**;
  - completion banner printed the Grafana URL + generated admin password.
- **Default install** (flag off): only api + postgres came up; **no**
  `compose.env`, **no** `docker-compose.metrics.yml`, **no** Grafana vars in
  `.env`, no prometheus/grafana containers — confirmed byte-for-byte clean.
- **Helper-script fallback**: ran the new `status.sh` in the default dir (no
  `compose.env`) — correctly managed the prod stack only.
- Both scratch installs torn down with `down -v`; no leftover containers/volumes.

Not exercised locally: the `update.sh` overlay-refresh path against a live
install (covered structurally by the test + the install-path tarball fetch,
which uses the identical mechanism) and systemd timer install (no `systemctl`
on macOS — installer warns and skips, as expected).

Refs #1207, #1327, design §6.1.