### PR TITLE
Render deploy webhooks → Grafana deploy-marker annotations (#1245)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       fake-api: ${{ steps.filter.outputs.fake-api || steps.force.outputs.all }}
       workflows: ${{ steps.filter.outputs.workflows || steps.force.outputs.all }}
       grafana-tf: ${{ steps.filter.outputs.grafana-tf || steps.force.outputs.all }}
+      deploy-webhook: ${{ steps.filter.outputs.deploy-webhook || steps.force.outputs.all }}
     steps:
       - name: Force full matrix for CD / manual triggers
         id: force
@@ -145,6 +146,11 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'infra/grafana/**'
               - 'deploy/grafana/dashboards/**'
+            # #1245: standalone Render→Grafana deploy-annotation receiver.
+            # stdlib-only, so its own pytest job rather than the opnsense one.
+            deploy-webhook:
+              - '.github/workflows/ci.yml'
+              - 'deploy/deploy-webhook/**'
             migrations:
               - '.github/workflows/ci.yml'
               - '.github/scripts/check-migrations.sh'
@@ -530,6 +536,27 @@ jobs:
         working-directory: opnsense
         run: python -m pytest test/ -v
 
+  # ── deploy-webhook: Render→Grafana annotation receiver tests (#1245) ────
+  deploy-webhook-tests:
+    name: Deploy Webhook Tests
+    needs: changes
+    if: needs.changes.outputs.deploy-webhook == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run deploy-webhook tests
+        working-directory: deploy/deploy-webhook
+        run: python -m pytest test/ -v
+
   # ── Gate-2 fake API shim: aiohttp service unit tests (#682) ─────────────
   fake-api-tests:
     name: Fake API Shim Tests
@@ -682,6 +709,7 @@ jobs:
       - lua-tests
       - contract-tests
       - python-tests
+      - deploy-webhook-tests
       - fake-api-tests
       - render-blueprint
       - grafana-terraform

--- a/deploy/deploy-webhook/Dockerfile
+++ b/deploy/deploy-webhook/Dockerfile
@@ -1,0 +1,14 @@
+# #1245: standalone Render → Grafana Cloud deploy-annotation receiver.
+#
+# stdlib-only Python — no requirements.txt, no pip. Built by Render from this
+# repo (render.yaml -> wifihaven-deploy-webhook, dockerfilePath here), mirroring
+# the Alloy thin-image pattern (deploy/alloy/Dockerfile).
+#
+# Pin the base tag for reproducibility; bump deliberately.
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY app.py /app/app.py
+
+# Render injects PORT; app.py honours it (default 10000). No build step.
+CMD ["python", "app.py"]

--- a/deploy/deploy-webhook/README.md
+++ b/deploy/deploy-webhook/README.md
@@ -1,0 +1,83 @@
+# deploy-webhook — Render deploy events → Grafana annotations (#1245)
+
+A standalone, stdlib-only Python service that receives Render deploy
+lifecycle webhooks and writes them as **Grafana Cloud annotations**, so each
+deploy shows up as a vertical marker across every dashboard. It exists so the
+"which deploy caused this?" question stops being hand-archaeology — the
+2026-05-31 DB-CPU regression was correlated to its deploy manually because
+Render's metrics stream ([#1244](https://github.com/wifihaven/wifihaven/issues/1244))
+carries metrics but **not** deploy events.
+
+## Why standalone (not a route on the API)
+
+The API server's concern is parental-control policy. A Grafana-Cloud client
+living there would be dead weight for the self-hosted install, which has no
+Grafana Cloud stack. So this is a thin Render service modeled on the Alloy
+collector ([`deploy/alloy`](../alloy)): checked-in code, baked into a small
+image, deployed declaratively via [`render.yaml`](../../render.yaml)
+(`wifihaven-deploy-webhook`).
+
+## What it does
+
+1. Verifies the webhook's **Standard-Webhooks** signature
+   (`webhook-id` / `webhook-timestamp` / `webhook-signature`) using
+   `WEBHOOK_SECRET`. Unsigned/forged requests get `401`.
+2. Classifies the event: `deploy_started` → *started*, `deploy_ended` →
+   *live* / *failed* / *canceled*. Canceled and non-deploy events are dropped.
+3. Resolves the deployed git sha. The thin webhook payload omits it, so the
+   sha is fetched from the Render API when `RENDER_API_TOKEN` is set; otherwise
+   the annotation falls back to the service name.
+4. POSTs a Grafana annotation: `text = "deploy <sha> <lifecycle>"`,
+   `tags = ["deploy", "render", <env>, <serviceName>, <lifecycle>]`,
+   `time` = the payload timestamp. `env` is derived from the service name
+   (`wifihaven-api-prod` → `prod`, `wifihaven-api-staging` → `staging`).
+
+It deliberately does **not** scaffold any notification/alerting transport —
+this is metrics annotation only.
+
+## Endpoints
+
+- `POST /webhook` — the Render webhook target.
+- `GET /healthz` — Render health check.
+
+## Configuration (all Render-managed secrets, `sync: false`)
+
+| Env var | Required | Purpose |
+| --- | --- | --- |
+| `WEBHOOK_SECRET` | yes | Standard-Webhooks signing secret (`whsec_…` or plain). |
+| `GRAFANA_URL` | yes | Grafana stack base URL, e.g. `https://<stack>.grafana.net`. |
+| `GRAFANA_TOKEN` | yes | Grafana API token with `annotations:write`. |
+| `RENDER_API_TOKEN` | no | Resolves the git sha via the Render API; omit to fall back to service name. |
+| `ENV_OVERRIDE` | no | Force the env tag instead of deriving it from the service name. |
+| `PORT` | no | Injected by Render; defaults to `10000`. |
+
+No secret is committed — `render.yaml` declares the keys with `sync: false`
+and the operator sets the values in the Render dashboard.
+
+## Operator wiring (one-time)
+
+1. Apply the blueprint so `wifihaven-deploy-webhook` exists and note its URL.
+2. Set `WEBHOOK_SECRET`, `GRAFANA_URL`, `GRAFANA_TOKEN` (and optionally
+   `RENDER_API_TOKEN`) in the service's environment.
+3. In Render → each API service → **Settings → Webhooks**, add a webhook
+   pointing at `https://<this-service>/webhook`. Copy the generated signing
+   secret into `WEBHOOK_SECRET` (it must match for signatures to verify).
+
+## Live verification is operator-gated
+
+End-to-end verification depends on a **live Grafana Cloud stack**
+([#1208](https://github.com/wifihaven/wifihaven/issues/1208) /
+[#1244](https://github.com/wifihaven/wifihaven/issues/1244)) and the
+dashboard wiring above, which are out of band of this PR. Once wired, trigger
+a deploy and confirm a `deploy …` annotation appears on the Grafana
+dashboards lined up against the DB-CPU / pool series — the reproducible form
+of the 2026-05-31 scenario.
+
+## Tests
+
+stdlib + pytest, no other deps:
+
+```sh
+cd deploy/deploy-webhook
+./test/run_tests.sh        # or: python3 -m pytest test/ -v
+```

--- a/deploy/deploy-webhook/app.py
+++ b/deploy/deploy-webhook/app.py
@@ -26,7 +26,6 @@ import hashlib
 import hmac
 import json
 import os
-import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -282,10 +281,12 @@ def main():
     try:
         server.serve_forever()
     except KeyboardInterrupt:
+        # Ctrl-C / SIGINT is a normal shutdown; the finally below closes the
+        # socket cleanly, so swallow it and exit 0.
         pass
     finally:
         server.server_close()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/deploy/deploy-webhook/app.py
+++ b/deploy/deploy-webhook/app.py
@@ -1,0 +1,291 @@
+"""Standalone Render → Grafana Cloud deploy-annotation receiver (#1245).
+
+Render emits a webhook on each deploy lifecycle transition; this thin service
+verifies the Standard-Webhooks signature, classifies the event, and POSTs a
+Grafana annotation so deploys render as vertical markers across every
+dashboard. It exists so "which deploy caused this?" stops being hand-archaeology
+(2026-05-31 incident).
+
+Deliberately a standalone Render service, NOT a route on the API: the API's job
+is parental-control policy, and a Grafana-Cloud client there would be dead
+weight for self-hosted installs. Modeled on the Alloy worker (render.yaml →
+wifihaven-alloy). stdlib only — no pip deps, mirroring the opnsense/ agent.
+
+Env (all Render-managed; see render.yaml → wifihaven-deploy-webhook):
+  WEBHOOK_SECRET     Render webhook signing secret (whsec_… or plain). Required.
+  GRAFANA_URL        Grafana stack base URL, e.g. https://<stack>.grafana.net
+  GRAFANA_TOKEN      Grafana API token with annotations:write
+  RENDER_API_TOKEN   optional — used to resolve the deployed git sha (the thin
+                     webhook payload omits it); falls back to serviceName.
+  ENV_OVERRIDE       optional — force the env tag instead of deriving it.
+  PORT               listen port (Render injects it; default 10000).
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# serviceName → env tag. One receiver handles both Render API services.
+_ENV_BY_SERVICE = {
+    "wifihaven-api-prod": "prod",
+    "wifihaven-api-staging": "staging",
+}
+
+
+def _log(**fields):
+    """Structured stdout line — Render captures stdout; no metrics surface on a
+    non-API sidecar (the 'new functionality ships with metrics' rule is
+    API-process scoped)."""
+    print(json.dumps(fields), flush=True)
+
+
+def parse_event(body_bytes):
+    """Decode the webhook JSON body. Returns the dict, or None on invalid JSON.
+    Tolerates unknown fields (forward-compat with Render payload additions)."""
+    try:
+        ev = json.loads(body_bytes)
+    except (ValueError, TypeError):
+        return None
+    return ev if isinstance(ev, dict) else None
+
+
+def classify(ev):
+    """Map a Render event to a deploy lifecycle:
+    started | live | failed | canceled | ignored.
+
+    Only 'started', 'live', and 'failed' become annotations; 'canceled' and
+    'ignored' (non-deploy events) are dropped by build_annotation."""
+    if not isinstance(ev, dict):
+        return "ignored"
+    etype = ev.get("type")
+    if etype == "deploy_started":
+        return "started"
+    if etype == "deploy_ended":
+        status = (ev.get("data") or {}).get("status")
+        if status == "succeeded":
+            return "live"
+        if status == "failed":
+            return "failed"
+        if status == "canceled":
+            return "canceled"
+    return "ignored"
+
+
+def _secret_key_bytes(secret):
+    """Standard-Webhooks signing key. A 'whsec_'-prefixed secret carries a
+    base64 key; a bare secret is used as raw UTF-8 bytes."""
+    if secret.startswith("whsec_"):
+        return base64.b64decode(secret[len("whsec_") :])
+    return secret.encode()
+
+
+def verify_signature(secret, webhook_id, timestamp, body_bytes, header):
+    """Constant-time Standard-Webhooks verification.
+
+    Signs '{id}.{timestamp}.{rawbody}' with HMAC-SHA256. `header` is the
+    space-separated `webhook-signature` value; each entry is `v1,<base64sig>`.
+    Returns True iff any entry matches. Empty secret or header never verify."""
+    if not secret or not header:
+        return False
+    try:
+        key = _secret_key_bytes(secret)
+    except (ValueError, base64.binascii.Error):
+        return False
+    signed = webhook_id.encode() + b"." + timestamp.encode() + b"." + body_bytes
+    expected = base64.b64encode(hmac.new(key, signed, hashlib.sha256).digest()).decode()
+    for entry in header.split():
+        version, _, sig = entry.partition(",")
+        if version == "v1" and hmac.compare_digest(sig, expected):
+            return True
+    return False
+
+
+def env_for(service_name, override=None):
+    """Env tag for a Render service. Override wins; known services map to
+    prod/staging; anything else is blank."""
+    if override:
+        return override
+    return _ENV_BY_SERVICE.get(service_name or "", "")
+
+
+def _timestamp_ms(ev, fallback_ms):
+    """Epoch-ms for the annotation: parse the ISO-8601 payload timestamp,
+    falling back to fallback_ms when it is absent or unparseable."""
+    raw = ev.get("timestamp") if isinstance(ev, dict) else None
+    if not raw:
+        return fallback_ms
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except ValueError:
+        return fallback_ms
+
+
+def build_annotation(ev, lifecycle, sha, env, fallback_ms):
+    """Build the Grafana annotation dict, or None for non-annotated lifecycles
+    (ignored, canceled).
+
+    text  = 'deploy <sha-or-serviceName> <lifecycle>'
+    tags  = ['deploy', 'render', <env?>, <serviceName?>, <lifecycle>]
+    time  = payload timestamp (ms) or fallback_ms"""
+    if lifecycle in ("ignored", "canceled"):
+        return None
+    data = (ev or {}).get("data") or {}
+    service_name = data.get("serviceName")
+    ident = sha or service_name or "unknown"
+    tags = ["deploy", "render"]
+    if env:
+        tags.append(env)
+    if service_name:
+        tags.append(service_name)
+    tags.append(lifecycle)
+    return {
+        "time": _timestamp_ms(ev, fallback_ms),
+        "text": f"deploy {ident} {lifecycle}",
+        "tags": tags,
+    }
+
+
+def fetch_sha(event_id, render_token):
+    """Best-effort: resolve the deployed git sha via the Render API. The thin
+    webhook payload omits it. Returns a short sha or None (no token, lookup
+    failure, or sha absent — caller falls back to serviceName)."""
+    if not event_id or not render_token:
+        return None
+    req = urllib.request.Request(
+        f"https://api.render.com/v1/events/{event_id}",
+        headers={"Authorization": f"Bearer {render_token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            payload = json.loads(resp.read())
+    except (urllib.error.URLError, ValueError, TimeoutError) as exc:
+        _log(level="warn", msg="render sha lookup failed", error=str(exc))
+        return None
+    # The event details nest a deploy with a commit; shapes vary, so probe
+    # defensively and treat any miss as "no sha".
+    details = payload.get("details") if isinstance(payload, dict) else None
+    deploy = (details or {}).get("deploy") if isinstance(details, dict) else None
+    commit = (deploy or {}).get("commit") if isinstance(deploy, dict) else None
+    sha = (commit or {}).get("id") if isinstance(commit, dict) else None
+    return sha[:7] if isinstance(sha, str) and sha else None
+
+
+def post_annotation(grafana_url, grafana_token, annotation):
+    """POST the annotation to Grafana. Returns True on 2xx."""
+    if not grafana_url or not grafana_token:
+        _log(level="warn", msg="grafana not configured; annotation dropped", annotation=annotation)
+        return False
+    body = json.dumps(annotation).encode()
+    req = urllib.request.Request(
+        grafana_url.rstrip("/") + "/api/annotations",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {grafana_token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as exc:
+        _log(level="error", msg="grafana annotation rejected", status=exc.code, body=exc.read().decode("utf-8", "replace"))
+        return False
+    except (urllib.error.URLError, TimeoutError) as exc:
+        _log(level="error", msg="grafana annotation post failed", error=str(exc))
+        return False
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, body=b""):
+        self.send_response(code)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def log_message(self, *args):  # noqa: D401 — silence default stderr access log
+        pass
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._send(200, b"ok")
+        else:
+            self._send(404)
+
+    def do_POST(self):
+        if self.path != "/webhook":
+            self._send(404)
+            return
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+
+        secret = os.environ.get("WEBHOOK_SECRET", "")
+        wid = self.headers.get("webhook-id", "")
+        ts = self.headers.get("webhook-timestamp", "")
+        sig = self.headers.get("webhook-signature", "")
+        if not verify_signature(secret, wid, ts, body, sig):
+            _log(level="warn", msg="signature verification failed", webhook_id=wid)
+            self._send(401)
+            return
+
+        ev = parse_event(body)
+        if ev is None:
+            self._send(400)
+            return
+
+        lifecycle = classify(ev)
+        if lifecycle in ("ignored", "canceled"):
+            _log(level="info", msg="event skipped", lifecycle=lifecycle, type=ev.get("type"))
+            self._send(204)
+            return
+
+        data = ev.get("data") or {}
+        env = env_for(data.get("serviceName"), os.environ.get("ENV_OVERRIDE"))
+        sha = fetch_sha(data.get("id"), os.environ.get("RENDER_API_TOKEN"))
+        fallback_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        annotation = build_annotation(ev, lifecycle, sha, env, fallback_ms)
+
+        ok = post_annotation(
+            os.environ.get("GRAFANA_URL", ""),
+            os.environ.get("GRAFANA_TOKEN", ""),
+            annotation,
+        )
+        _log(
+            level="info",
+            msg="annotation processed",
+            lifecycle=lifecycle,
+            env=env,
+            service=data.get("serviceName"),
+            sha=sha,
+            posted=ok,
+        )
+        self._send(202 if ok else 502)
+
+
+def main():
+    port = int(os.environ.get("PORT", "10000"))
+    if not os.environ.get("WEBHOOK_SECRET"):
+        _log(level="error", msg="WEBHOOK_SECRET unset; all webhooks will be rejected")
+    server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
+    _log(level="info", msg="deploy-webhook receiver listening", port=port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/deploy-webhook/test/run_tests.sh
+++ b/deploy/deploy-webhook/test/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Run the wifihaven deploy-webhook receiver unit tests.
+# Requires: pip install pytest
+set -e
+cd "$(dirname "$0")/.."
+python3 -m pytest test/ "$@"

--- a/deploy/deploy-webhook/test/test_webhook.py
+++ b/deploy/deploy-webhook/test/test_webhook.py
@@ -139,8 +139,8 @@ class TestBuildAnnotation:
         assert "prod" in ann["tags"]
         assert "wifihaven-api-prod" in ann["tags"]
         assert "live" in ann["tags"]
-        # timestamp parsed from the payload, not the fallback
-        assert ann["time"] == 1748655180000
+        # timestamp parsed from the payload (2026-05-31T01:33:00Z), not the fallback
+        assert ann["time"] == 1780191180000
 
     def test_falls_back_to_service_name_without_sha(self):
         ev = parse_event(FAILED_BODY)

--- a/deploy/deploy-webhook/test/test_webhook.py
+++ b/deploy/deploy-webhook/test/test_webhook.py
@@ -1,0 +1,159 @@
+"""Tests for deploy/deploy-webhook/app.py — the standalone Render→Grafana
+deploy-annotation receiver (#1245).
+
+Run with: pytest deploy/deploy-webhook/test/test_webhook.py
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app import (  # noqa: E402
+    build_annotation,
+    classify,
+    env_for,
+    parse_event,
+    verify_signature,
+)
+
+LIVE_BODY = json.dumps(
+    {
+        "type": "deploy_ended",
+        "timestamp": "2026-05-31T01:33:00Z",
+        "data": {
+            "id": "evt-abc",
+            "serviceId": "srv-prod",
+            "serviceName": "wifihaven-api-prod",
+            "status": "succeeded",
+        },
+    }
+).encode()
+
+FAILED_BODY = json.dumps(
+    {
+        "type": "deploy_ended",
+        "timestamp": "2026-05-31T01:40:00Z",
+        "data": {"serviceName": "wifihaven-api-staging", "status": "failed"},
+    }
+).encode()
+
+STARTED_BODY = json.dumps(
+    {"type": "deploy_started", "data": {"serviceName": "wifihaven-api-prod"}}
+).encode()
+
+
+def _sign(key_bytes, webhook_id, ts, body_bytes):
+    """Reproduce Standard-Webhooks signing so verify_signature can be checked."""
+    signed = webhook_id.encode() + b"." + ts.encode() + b"." + body_bytes
+    sig = hmac.new(key_bytes, signed, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(sig).decode()
+
+
+class TestParseAndClassify:
+    def test_parse_extracts_fields(self):
+        ev = parse_event(LIVE_BODY)
+        assert ev["type"] == "deploy_ended"
+        assert ev["timestamp"] == "2026-05-31T01:33:00Z"
+        assert ev["data"]["serviceName"] == "wifihaven-api-prod"
+        assert ev["data"]["status"] == "succeeded"
+
+    def test_parse_tolerates_unknown_fields(self):
+        body = json.dumps(
+            {"type": "deploy_ended", "futureField": 42, "data": {"status": "succeeded"}}
+        ).encode()
+        assert parse_event(body)["type"] == "deploy_ended"
+
+    def test_parse_invalid_json_returns_none(self):
+        assert parse_event(b"not json{{") is None
+
+    def test_classify_lifecycles(self):
+        assert classify(parse_event(LIVE_BODY)) == "live"
+        assert classify(parse_event(FAILED_BODY)) == "failed"
+        assert classify(parse_event(STARTED_BODY)) == "started"
+
+    def test_classify_canceled_and_unknown_are_skipped(self):
+        canceled = parse_event(
+            json.dumps({"type": "deploy_ended", "data": {"status": "canceled"}}).encode()
+        )
+        other = parse_event(json.dumps({"type": "server_restarted", "data": {}}).encode())
+        assert classify(canceled) == "canceled"
+        assert classify(other) == "ignored"
+
+
+class TestSignature:
+    SECRET = "topsecret-webhook-key"
+    WID = "evt-abc"
+    TS = "1717000000"
+
+    def test_valid_plain_secret_verifies(self):
+        header = _sign(self.SECRET.encode(), self.WID, self.TS, LIVE_BODY)
+        assert verify_signature(self.SECRET, self.WID, self.TS, LIVE_BODY, header)
+
+    def test_tampered_body_fails(self):
+        header = _sign(self.SECRET.encode(), self.WID, self.TS, LIVE_BODY)
+        assert not verify_signature(self.SECRET, self.WID, self.TS, LIVE_BODY + b"x", header)
+
+    def test_wrong_secret_fails(self):
+        header = _sign(self.SECRET.encode(), self.WID, self.TS, LIVE_BODY)
+        assert not verify_signature("wrong-secret", self.WID, self.TS, LIVE_BODY, header)
+
+    def test_whsec_prefixed_secret_is_base64_decoded(self):
+        raw_key = b"0123456789abcdef0123456789abcdef"
+        secret = "whsec_" + base64.b64encode(raw_key).decode()
+        header = _sign(raw_key, self.WID, self.TS, LIVE_BODY)
+        assert verify_signature(secret, self.WID, self.TS, LIVE_BODY, header)
+
+    def test_empty_secret_never_verifies(self):
+        assert not verify_signature("", self.WID, self.TS, LIVE_BODY, "v1,whatever")
+
+    def test_empty_header_never_verifies(self):
+        assert not verify_signature(self.SECRET, self.WID, self.TS, LIVE_BODY, "")
+
+
+class TestEnvFor:
+    def test_derives_env_from_service_name(self):
+        assert env_for("wifihaven-api-prod") == "prod"
+        assert env_for("wifihaven-api-staging") == "staging"
+
+    def test_override_wins(self):
+        assert env_for("wifihaven-api-prod", "custom") == "custom"
+
+    def test_unknown_service_is_blank(self):
+        assert env_for("some-other-service") == ""
+        assert env_for(None) == ""
+
+
+class TestBuildAnnotation:
+    def test_live_deploy_includes_sha_and_tags(self):
+        ev = parse_event(LIVE_BODY)
+        ann = build_annotation(ev, "live", "abc1234", "prod", 999)
+        assert ann is not None
+        assert "abc1234" in ann["text"]
+        assert "deploy" in ann["text"]
+        assert "deploy" in ann["tags"]
+        assert "prod" in ann["tags"]
+        assert "wifihaven-api-prod" in ann["tags"]
+        assert "live" in ann["tags"]
+        # timestamp parsed from the payload, not the fallback
+        assert ann["time"] == 1748655180000
+
+    def test_falls_back_to_service_name_without_sha(self):
+        ev = parse_event(FAILED_BODY)
+        ann = build_annotation(ev, "failed", None, "staging", 999)
+        assert "failed" in ann["tags"]
+        assert "wifihaven-api-staging" in ann["text"]
+
+    def test_uses_fallback_time_when_timestamp_missing(self):
+        ev = parse_event(STARTED_BODY)
+        ann = build_annotation(ev, "started", None, "prod", 12345)
+        assert ann["time"] == 12345
+
+    def test_skipped_lifecycles_produce_no_annotation(self):
+        ev = parse_event(LIVE_BODY)
+        assert build_annotation(ev, "ignored", None, "prod", 1) is None
+        assert build_annotation(ev, "canceled", None, "prod", 1) is None

--- a/render.yaml
+++ b/render.yaml
@@ -273,6 +273,56 @@ services:
       - key: GRAFANA_CLOUD_PROM_PASSWORD
         sync: false
 
+  # ── Deploy-event annotations: Render webhooks → Grafana Cloud ────────────────
+  # #1245: turns each Render deploy lifecycle webhook (started / live / failed)
+  # into a Grafana annotation so deploys show as vertical markers across every
+  # dashboard. This is the fix for the 2026-05-31 "which deploy pegged DB CPU?"
+  # archaeology — Render's metrics stream (#1244) carries metrics but not deploy
+  # events, so the marker has to come from the webhook.
+  #
+  # Standalone by design, NOT a route on the API: the API owns parental-control
+  # policy, and a Grafana-Cloud client there would be dead weight for the
+  # self-hosted install. stdlib-only Python baked into a thin image
+  # (deploy/deploy-webhook/Dockerfile), same pattern as wifihaven-alloy above.
+  #
+  # type:web — unlike Alloy this has an inbound role (Render POSTs the webhook),
+  # so it binds a port and exposes /healthz. One receiver serves both API
+  # services; it derives the env tag from the payload's serviceName. Not a
+  # dependency of either API service and they don't depend on it — an annotation
+  # outage never affects API availability or blocks a deploy.
+  #
+  # autoDeploy:no keeps promotion explicit, consistent with the other services.
+  #
+  # Wiring (operator, one-time, in the Render dashboard): create a webhook on
+  # each API service pointing at this service's /webhook URL; copy the generated
+  # signing secret into WEBHOOK_SECRET below. See deploy/deploy-webhook/README.md.
+  - type: web
+    runtime: docker
+    name: wifihaven-deploy-webhook
+    plan: starter
+    region: oregon
+    numInstances: 1
+    healthCheckPath: /healthz
+    autoDeploy: no
+    dockerfilePath: ./deploy/deploy-webhook/Dockerfile
+    dockerContext: ./deploy/deploy-webhook
+    envVars:
+      # Render webhook signing secret (Standard-Webhooks; whsec_… or plain).
+      # Render-managed — set in the dashboard from the webhook's signing secret.
+      - key: WEBHOOK_SECRET
+        sync: false
+      # Grafana Cloud stack base URL (https://<stack>.grafana.net) + an API
+      # token with annotations:write. Render-managed secrets.
+      - key: GRAFANA_URL
+        sync: false
+      - key: GRAFANA_TOKEN
+        sync: false
+      # Optional: the thin webhook payload omits the git sha, so the receiver
+      # resolves it via the Render API when this token is set; otherwise the
+      # annotation falls back to the service name. Render-managed secret.
+      - key: RENDER_API_TOKEN
+        sync: false
+
 databases:
   # ── Staging Postgres ───────────────────────────────────────────────────────
   # Free plan — staging data is expendable; recreation is a feature (#585).


### PR DESCRIPTION
## Summary

Closes #1245. Render deploy lifecycle webhooks (started / live / failed) now
become **Grafana Cloud annotations**, so each deploy renders as a vertical
marker across every dashboard. This is the fix for the 2026-05-31 incident
where "which deploy pegged DB CPU?" was reconstructed by hand — Render's
metrics stream (#1244) carries metrics but **not** deploy events.

A **standalone thin Render service** (`type: web`, `runtime: docker`), modeled
on the existing Alloy worker — deliberately **not** a route on the API:

- The API's concern is parental-control policy; a Grafana-Cloud client there
  would be dead weight for the self-hosted install, which has no Grafana stack.
- stdlib-only Python (no pip deps), baked into a thin image, deployed
  declaratively via `render.yaml` (`wifihaven-deploy-webhook`).

What it does, in one path webhook→annotation (no notification/alerting
scaffolding):

- Verifies the **Standard-Webhooks** HMAC-SHA256 signature (`whsec_`-aware);
  forged/unsigned requests get `401`.
- Classifies the event and derives the env tag from `serviceName` — one
  receiver serves both prod and staging.
- Resolves the deployed git sha via the Render API when `RENDER_API_TOKEN`
  is set (the thin payload omits it); otherwise falls back to the service name.
- POSTs `{time, text: "deploy <sha> <lifecycle>", tags: [...]}` to
  `/api/annotations`.

Secrets (`WEBHOOK_SECRET`, `GRAFANA_URL`, `GRAFANA_TOKEN`, `RENDER_API_TOKEN`)
are declared `sync: false` in `render.yaml` and set in the Render dashboard —
never committed.

TDD: red (`4c7a93cb`) → green (`eafffe7c`) is visible in the commit history.

## Files

- `deploy/deploy-webhook/app.py` — the receiver (stdlib only).
- `deploy/deploy-webhook/test/test_webhook.py` — 18 unit tests.
- `deploy/deploy-webhook/Dockerfile` — thin `python:3.13-slim` image.
- `deploy/deploy-webhook/README.md` — operator wiring + operator-gated live verification.
- `render.yaml` — `wifihaven-deploy-webhook` service block with `sync: false` secrets.
- `.github/workflows/ci.yml` — `deploy-webhook-tests` pytest gate + path filter.

## Live verification is operator-gated

End-to-end verification depends on a **live Grafana Cloud stack**
(#1208 / #1244) and the one-time webhook + secret wiring in the Render
dashboard, which are out of band of this PR. Once wired, a deploy produces a
`deploy …` annotation lined up against the DB-CPU / pool series — the
reproducible form of the 2026-05-31 scenario.

## Test plan

- [x] `cd deploy/deploy-webhook && python3 -m pytest test/` — 18 passing
- [x] `python3 -m py_compile deploy/deploy-webhook/app.py`
- [x] `ruby -ryaml -e "YAML.load_file('render.yaml')"` — valid blueprint
- [x] `actionlint .github/workflows/ci.yml` — clean
- [ ] Operator: wire the Render webhook + secrets, trigger a deploy, confirm the annotation appears on the Grafana dashboards (operator-gated)