### PR TITLE
fix(openwrt): populate category blocklist ipsets — fixes prod no-op (#1334)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,16 +108,20 @@ enforce — it is not a mirror of the server's policy model.
 See [`docs/architecture.md`](docs/architecture.md) for the full snapshot
 shape, wire JSON examples, and the enforcement model.
 
-> **Implementation deviations as of May 2026.** Some code does not yet match
-> the model above; these are tracked follow-ups, not the canonical design:
-> `extraBlocked` is currently enforced via dnsmasq NXDOMAIN
-> (`address=/host/#`) and is global rather than per-MAC; category blocklists
-> are not yet applied on the router at all; `blockIpOnly` does not exist
-> yet; the snapshot still carries per-profile `schedules`, `dailyMinutes`,
-> `timeUsedToday`, `siteLimits`, `failureMode`, and `blockedCategories`
-> that should collapse into `blocked` / `extraBlocked` / `blocklistIds`
-> server-side. Treat the model above as the target. If you are working
-> in this area, link the relevant follow-up issue.
+> **Implementation status as of June 2026.** The model above is what the
+> code does. `extraBlocked` enforces via per-`(MAC, host)` nftables drops on
+> the resolved IPs (`eb_`/`eb6_` sets), not a DNS sinkhole. Category
+> blocklists enforce via per-`(MAC, blocklistId)` nftables drops on the
+> `bl_`/`bl6_` sets, which the agent populates by fetching each blocklist URL
+> and resolving its members at DNS time (`blocklists.lua` →
+> `render.lua`). `blockIpOnly` is implemented (per-MAC `resolved_` sets). The
+> snapshot ships the collapsed per-MAC `BlockRules` shape only — `blocked`,
+> `blockReason`, `extraBlocked`, `extraAllowed`, `blocklistIds`,
+> `blockIpOnly` — plus per-profile `failureMode`; schedules, daily minutes,
+> time-used, and site limits are all evaluated server-side and never reach
+> the wire. (The category-enforcement path was a silent no-op on prod until
+> [#1334](https://github.com/wifihaven/wifihaven/issues/1334) fixed the
+> agent's blocklist-fetch call.)
 
 ## What this project is
 

--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -5,7 +5,7 @@
 -- Writes are atomic: body goes to <path>.tmp then renamed to <path>.
 --
 -- Public API:
---   M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir)
+--   M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url)
 --     → { hosts_by_id = {[id]={hosts}}, errors = {...} }
 --   M.load_cached(snapshot, fs, cache_dir)
 --     → { [id] = {hosts} }
@@ -35,10 +35,17 @@ local function cache_path(cache_dir, id, version)
 end
 
 -- Fetch and cache all blocklists in the snapshot.
--- http_get_fn(url, etag) -> body_or_nil, http_status, new_etag
+-- http_get_fn(url, headers) -> http_status, body, resp_headers
+--   This is the same signature wifihaven-agent's http_get and policy.fetch
+--   use — status FIRST. (#1334: an earlier body-first assumption here meant
+--   the status check always tripped, so every category fetch "failed" and the
+--   bl_ ipset stayed empty, turning category enforcement into a silent no-op.)
+-- base_url: optional api base (e.g. "http://router:8080"). The snapshot ships
+--   relative blocklist urls ("/api/blocklists/<id>"); when base_url is given
+--   and the url is root-relative, they're joined so curl gets an absolute URL.
 -- fs: optional table with {read, write, rename, remove, list}; defaults to real I/O.
 -- Returns: { hosts_by_id = {[id]={hosts}}, errors = {...} }
-function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir)
+function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url)
   cache_dir = cache_dir or DEFAULT_CACHE_DIR
   local result = { hosts_by_id = {}, errors = {} }
 
@@ -81,13 +88,19 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir)
     local url     = bl.url
     local path    = cache_path(cache_dir, id, version)
 
+    -- Resolve a root-relative url ("/api/blocklists/<id>") against the
+    -- configured api base (#1334). Absolute urls (scheme://…) pass through.
+    if base_url and type(url) == "string" and url:sub(1, 1) == "/" then
+      url = base_url .. url
+    end
+
     -- Check if (id, version) is already cached.
     local existing = read_fn(path)
     if existing then
       result.hosts_by_id[id] = parse_body(existing)
     else
-      -- Fetch from API.
-      local body, status, _etag = http_get_fn(url, nil)
+      -- Fetch from API. Signature matches the agent's http_get: status first.
+      local status, body = http_get_fn(url, nil)
       if type(status) ~= "number" or status ~= 200 then
         result.errors[#result.errors + 1] =
           string.format("blocklists: fetch failed for %s (status=%s)", tostring(id), tostring(status))

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -519,7 +519,7 @@ conntrack.watch({
         -- bl_result.errors once the status enum is designed alongside the
         -- broader blocklist-application work (#705).
         local bl_result = blocklists.fetch_and_cache(
-          snap, http_get, nil, "/etc/wifihaven/blocklists")
+          snap, http_get, nil, "/etc/wifihaven/blocklists", api_url)
         if #bl_result.errors > 0 then
           for _, e in ipairs(bl_result.errors) do
             log.warn("blocklist fetch: %s", tostring(e))

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -85,6 +85,39 @@ describe("blocklists.fetch_and_cache", function()
     assert.equal(0, #result.errors)
   end)
 
+  -- #1334 regression: in production the agent passes its own `http_get`
+  -- (wifihaven-agent), whose signature is `http_get(url, headers) -> status,
+  -- body, resp_headers` — status FIRST. The snapshot also ships a *relative*
+  -- blocklist url (`/api/blocklists/<id>`), which must be resolved against the
+  -- router's configured api_url before it reaches curl. Both were previously
+  -- mismatched here (mock returned body-first; url was absolute), so the bug —
+  -- every category fetch silently failing and the bl_ ipset staying empty —
+  -- was invisible to the suite while category enforcement was a no-op on prod.
+  it("uses the agent's real http_get signature (status, body) and resolves relative urls via base_url", function()
+    local fs   = make_fs()
+    local seen_url
+    -- Mirrors wifihaven-agent's http_get: returns (status, body, headers).
+    local function prod_http_get(url, _headers)
+      seen_url = url
+      return 200, "doubleclick.net\ngoogleadservices.com\n", {}
+    end
+
+    local s = snap({ ads = { version = "v1", url = "/api/blocklists/ads" } })
+    local result = blocklists.fetch_and_cache(
+      s, prod_http_get, fs, "/etc/wifihaven/blocklists", "http://api.example:8080")
+
+    -- Relative url was joined to the configured api base.
+    assert.equal("http://api.example:8080/api/blocklists/ads", seen_url)
+    assert.equal(0, #result.errors)
+    local hosts = result.hosts_by_id["ads"]
+    assert.not_nil(hosts, "ads hosts must be cached (otherwise bl_ ipset stays empty)")
+    local found = {}
+    for _, h in ipairs(hosts) do found[h] = true end
+    assert.truthy(found["doubleclick.net"])
+    assert.truthy(found["googleadservices.com"])
+    assert.not_nil(fs._files["/etc/wifihaven/blocklists/ads-v1.txt"])
+  end)
+
   it("does NOT re-fetch when (id, version) file already exists in cache", function()
     local fs      = make_fs()
     local fetches = 0

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -58,12 +58,12 @@ describe("blocklists.fetch_and_cache", function()
   it("fetches body and writes to <cache_dir>/<id>-<version>.txt atomically", function()
     local fs       = make_fs()
     local fetches  = 0
-    local function http_get(url, _etag)
+    local function http_get(url, _headers)
       fetches = fetches + 1
       if url:find("test_ads", 1, true) then
-        return "doubleclick.net\ngoogleadservices.com\n", 200, '"v1"'
+        return 200, "doubleclick.net\ngoogleadservices.com\n", {}
       end
-      return nil, 404, nil
+      return 404, nil, {}
     end
 
     local s = snap({ test_ads = { version = "abc123", url = "http://api/api/blocklists/test_ads" } })
@@ -121,7 +121,7 @@ describe("blocklists.fetch_and_cache", function()
   it("does NOT re-fetch when (id, version) file already exists in cache", function()
     local fs      = make_fs()
     local fetches = 0
-    local function http_get(_url, _etag) fetches = fetches + 1; return "host.example\n", 200, '"v1"' end
+    local function http_get(_url, _headers) fetches = fetches + 1; return 200, "host.example\n", {} end
 
     -- Pre-seed the cache file.
     local cache_dir = "/etc/wifihaven/blocklists"
@@ -136,7 +136,7 @@ describe("blocklists.fetch_and_cache", function()
   it("re-fetches when version changes (old file still in cache_dir)", function()
     local fs      = make_fs()
     local fetches = 0
-    local function http_get(_url, _etag) fetches = fetches + 1; return "newhost.example\n", 200, '"v2"' end
+    local function http_get(_url, _headers) fetches = fetches + 1; return 200, "newhost.example\n", {} end
 
     local cache_dir = "/etc/wifihaven/blocklists"
     -- Old version file in cache.
@@ -156,8 +156,8 @@ describe("blocklists.fetch_and_cache", function()
 
   it("HTTP non-200 response: returns error, does not write cache file", function()
     local fs = make_fs()
-    local function http_get(_url, _etag)
-      return "server error", 500, nil
+    local function http_get(_url, _headers)
+      return 500, "server error", {}
     end
 
     local s = snap({ test_ads = { version = "abc123", url = "http://api/api/blocklists/test_ads" } })
@@ -169,8 +169,8 @@ describe("blocklists.fetch_and_cache", function()
 
   it("skips comment lines and blank lines in the body", function()
     local fs = make_fs()
-    local function http_get(_url, _etag)
-      return "# version: abc123\nads.example.com\n\ndoubleclick.net\n", 200, '"v1"'
+    local function http_get(_url, _headers)
+      return 200, "# version: abc123\nads.example.com\n\ndoubleclick.net\n", {}
     end
 
     local s = snap({ test_ads = { version = "v1", url = "http://api/api/blocklists/test_ads" } })


### PR DESCRIPTION
## Summary

Category-blocklist enforcement (e.g. the `ads` list on the `Sameer` profile) was a **silent no-op on prod**: ad hosts on the configured list stayed reachable from the device even though the snapshot, `render.lua` (nft drop rules + dnsmasq `nftset=` populators), and the `bl_`/`bl6_` set declarations were all correct. Closes the gap left open since #352.

## Prod root-cause finding

Diagnosed against `api.wifihaven.net`:

- **Snapshot is correct.** Profile 2 (`Sameer`) carries `blockedCategories: ["malware","ads","ads-extended"]`; `PolicyService.computeBlockRules` maps that to `BlockRules.blocklistIds`, and the snapshot ships `blocklists["ads"]` with a version + url. The operator's computers are on profile 2.
- **The break is in the agent's blocklist fetch.** `blocklists.fetch_and_cache` had two defects, *both* of which independently leave the `bl_` ipset empty:
  1. **Wrong `http_get` return order.** The agent's real `http_get` (and `policy.fetch`) return `(status, body, headers)` — status first. `fetch_and_cache` read `(body, status, etag)`, so the `status ~= 200` check ran against the body string and *every* fetch was recorded as an error → nothing cached.
  2. **Relative URL never joined.** The snapshot ships `url = "/api/blocklists/<id>"` (root-relative). `fetch_and_cache` passed it straight to `curl`, which cannot resolve a host-less URL.

With the ipset empty, the rendered per-`(MAC, blocklistId)` drop rules matched no destinations → hosts reachable. DNS resolution was never the issue (blocking is connection-layer by design).

**Why the test suite missed it:** every `blocklists_spec` mock returned values body-first with absolute URLs — i.e. it tested a contract the production agent never uses.

## Fix

- `fetch_and_cache` now uses the agent's `(status, body, headers)` signature and resolves root-relative URLs against a new `base_url` arg.
- `wifihaven-agent` passes its configured `api_url` as that base.
- Existing spec mocks updated to mirror the production contract; new regression added.
- Reconciled the stale `AGENTS.md` implementation-status note (category blocklists, per-MAC `extraBlocked`, and `blockIpOnly` are all implemented).

## Operational note

This is a real agent code bug, so a router must roll its agent build forward to a package containing this fix before category enforcement works. Worth confirming the prod router isn't also stuck on an older version (cf. the #1178 self-update deadlock).

## Test plan

- [x] `busted test/blocklists_spec.lua` — new regression fails before the fix (red), passes after (green); 11/11 pass.
- [x] Red→green visible in commit history.
- [ ] Router-side acceptance (operator): after the agent rolls forward, `nft list set inet wifihaven bl_ads` is populated, a member ad host is dropped at the connection layer for a profile-2 device, and a control host stays reachable.

Refs #1334. (render/failover specs require a local `nft` binary and aren't runnable in this sandbox; they're unmodified by this PR.)