### PR TITLE
infra-allow: add Apple connectivity host (#1337)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -475,13 +475,19 @@ object PolicyService {
     "ocsp.pki.goog",                 // Google Trust Services OCSP
     "ocsp.digicert.com",             // DigiCert OCSP (common CA for app backends)
     "clientservices.googleapis.com", // Google client-services bootstrap
-    // #1337: transitive CDN deps the operator saw dropped under a whole-MAC block,
-    // breaking otherwise-allowed apps. Added as exact hosts, NOT a *.akamai.net
-    // wildcard: dnsmasq nftset=/akamai.net/ would match suffixes (the mechanism is
-    // clean), but a blanket Akamai allow punches through the block for services
-    // served entirely from Akamai edge hostnames with no separate origin we block —
-    // ad/tracking CDNs in particular ride Akamai. Keep it to vetted exact hosts (#1337).
-    "a1744.dscw154.akamai.net",      // Akamai edge shard (Apple/app asset delivery)
+    // #1337: Apple's network-connectivity-test CDN — a device-level infra probe,
+    // owned by Apple and stable. Added as an exact host.
+    //
+    // We deliberately did NOT add CDN edge hostnames for specific apps (the
+    // operator originally hit `a1744.dscw154.akamai.net` for Math Academy and
+    // `prod.khan.map.fastly.net` for Khan): those are CDN *mapping* artifacts that
+    // rotate (Khan's `cdn.kastatic.org` is on Fastly now, not Akamai), so pinning
+    // one rots silently. Per-app CDN assets are covered the stable way — by the
+    // app's own branded domains in extraAllowed (e.g. `mathacademy.com`,
+    // `kastatic.org`), whose resolved IPs (including via CNAME to a CDN) belong in
+    // the per-(MAC, host) ea_ set. That carve-out only works once the ea_ set is
+    // actually populated from resolved IPs, which is a separate router-side gap
+    // tracked in its own issue — not something more infra-allow entries can fix.
     "netcts.cdn-apple.com",          // Apple network connectivity-test CDN
   ).map(Hostname.unsafe)
 

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -475,6 +475,14 @@ object PolicyService {
     "ocsp.pki.goog",                 // Google Trust Services OCSP
     "ocsp.digicert.com",             // DigiCert OCSP (common CA for app backends)
     "clientservices.googleapis.com", // Google client-services bootstrap
+    // #1337: transitive CDN deps the operator saw dropped under a whole-MAC block,
+    // breaking otherwise-allowed apps. Added as exact hosts, NOT a *.akamai.net
+    // wildcard: dnsmasq nftset=/akamai.net/ would match suffixes (the mechanism is
+    // clean), but a blanket Akamai allow punches through the block for services
+    // served entirely from Akamai edge hostnames with no separate origin we block —
+    // ad/tracking CDNs in particular ride Akamai. Keep it to vetted exact hosts (#1337).
+    "a1744.dscw154.akamai.net",      // Akamai edge shard (Apple/app asset delivery)
+    "netcts.cdn-apple.com",          // Apple network connectivity-test CDN
   ).map(Hostname.unsafe)
 
   /** Content-derived version: first 16 hex chars of SHA-256 over sorted domain list. */

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -134,6 +134,21 @@ object PolicySnapshotGlobalAllowSpec
         assertTrue(expected.subsetOf(rules.extraAllowed.map(_.value).toSet))
       }
     },
+    test("every profile's extraAllowed includes the #1337 akamai/apple CDN infra hosts") {
+      // #1337: two transitive-dep CDN hosts the operator hit being dropped under a
+      // whole-MAC block. They live in the curated infraAllowHosts constant, so they
+      // must surface in every profile's extraAllowed (copied per-profile, allow beats
+      // the @blocked_macs drop via #421 ea_ enforcement).
+      val newHosts = Set("a1744.dscw154.akamai.net", "netcts.cdn-apple.com")
+      for {
+        _    <- cleanDb
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield assertTrue(
+        snap.profiles.nonEmpty,
+        snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
+      )
+    },
     test(
       "global host in extraBlocked still appears in extraAllowed (allow-beats-block at router)",
     ) {

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -134,12 +134,14 @@ object PolicySnapshotGlobalAllowSpec
         assertTrue(expected.subsetOf(rules.extraAllowed.map(_.value).toSet))
       }
     },
-    test("every profile's extraAllowed includes the #1337 akamai/apple CDN infra hosts") {
-      // #1337: two transitive-dep CDN hosts the operator hit being dropped under a
-      // whole-MAC block. They live in the curated infraAllowHosts constant, so they
-      // must surface in every profile's extraAllowed (copied per-profile, allow beats
-      // the @blocked_macs drop via #421 ea_ enforcement).
-      val newHosts = Set("a1744.dscw154.akamai.net", "netcts.cdn-apple.com")
+    test("every profile's extraAllowed includes the #1337 Apple connectivity-test host") {
+      // #1337: Apple's network-connectivity-test CDN is a device-level infra dep that
+      // was dropped under a whole-MAC block. It lives in the curated infraAllowHosts
+      // constant, so it must surface in every profile's extraAllowed (copied
+      // per-profile, allow beats the @blocked_macs drop via #421 ea_ enforcement).
+      // App-specific CDN edge hostnames were deliberately NOT added (they rotate);
+      // app assets are covered via the app's branded domains instead.
+      val newHosts = Set("netcts.cdn-apple.com")
       for {
         _    <- cleanDb
         svc  <- makePs


### PR DESCRIPTION
Refs #1337.

## Summary

Adds **one** host to the curated `PolicyService.infraAllowHosts` constant
([api/src/policy/PolicyService.scala](api/src/policy/PolicyService.scala)):

- `netcts.cdn-apple.com` — Apple's network-connectivity-test CDN, a
  device-level infra probe. Apple-owned and stable.

These are copied into every profile's `extraAllowed`, so they survive a
whole-MAC block via the #421 `ea_` enforcement path. Additive to a curated
constant — no wire-shape change, no new snapshot field (#1311). The cleaner
DB-backed version remains #1315.

## What changed since the first revision (the akamai host was dropped)

The issue also asked about adding `a1744.dscw154.akamai.net` (and, as a design
question, allowing all of Akamai). I added it initially, then **dropped it**
after live debugging the operator's actual incident. Two findings:

1. **CDN edge hostnames rotate — pinning one rots.** `dig cdn.kastatic.org`
   shows Khan is on **Fastly** now (`prod.khan.map.fastly.net`), not Akamai. The
   `aNNNN.dscwNNN.akamai.net` / `prod.khan.map.fastly.net` shards are CDN mapping
   artifacts, not stable identifiers. (The Akamai-wildcard idea is separately a
   no-go: a blanket allow punches through the block for services served entirely
   from Akamai edge hosts with no separate blocked origin — ad/tracking CDNs ride
   Akamai.)

2. **The drop was not a missing-host problem.** During a downtime-schedule
   (whole-MAC) block, `mathacademy.com` was correctly **allowed** and attributed
   in connection events — but the apps' CDN-fronted **asset** flows (which resolve
   via CNAME to akamai/fastly) were dropped. Root cause: the per-(MAC, host) `ea_`
   nftset that the `extraAllowed` carve-out matches on is **declared but not
   populated** on the router. Live prod evidence (read-only `nft list`):

   ```
   ea_  : declared=338  with_elements=9
   ea6_ : declared=338  with_elements=5
   eb_  : declared=5    with_elements=2   # eb_ has an out-of-band populator
   ```

   `ea_` is the only DNS-populated set type with no out-of-band populator in
   `wifihaven-dns-tail` (unlike `resolved_`/#505, `eb_`/#515, `bl_`/#1334, which
   all needed one because dnsmasq's `nftset=/host/…` path is unreliable in the
   deployed build). So the entire `extraAllowed` carve-out — infra-allow, per-app
   allows, admin allows — silently fails under a block. **More infra-allow entries
   cannot fix this**; it's a separate router-side bug, filed as its own issue with
   a fix sketch (out-of-band `maybe_populate_ea` keyed off the qid-correlated
   original queried name, so `cdn.mathacademy.com` suffix-matches the
   `ea_…_mathacademy_com` set rather than the CNAME-target name).

Per-app CDN assets are therefore covered the stable way — by each app's branded
domains (`mathacademy.com`, `kastatic.org`, already in the app templates) in
`extraAllowed` — once `ea_` population is fixed.

## Test plan

TDD, red→green→trim visible in history:
1. red — `PolicySnapshotGlobalAllowSpec` asserts the new host(s) in every
   profile's `extraAllowed`.
2. green — add to `infraAllowHosts`.
3. trim — drop the stale akamai host; test now asserts only
   `netcts.cdn-apple.com`.

```
mill api.test.testOnly wifihaven.api.feature.PolicySnapshotGlobalAllowSpec
→ 5 tests passed.
```

`scalafmt --check` passes. No `render.lua` change (no wildcard landed).