### PR TITLE
dashboard: "Most recently blocked" panel at the top (#1338)

### DIFF
--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -180,6 +180,52 @@ object LogApiSpec
         assertTrue(logs.head.host.value == "blocked.com") &&
         assertTrue(logs.head.blocked)
     },
+    test(
+      "GET /api/logs?blocked=true&limit=N returns blocked-only events, newest-first, within the limit (#1338 recently-blocked panel)",
+    ) {
+      // Contract the dashboard "Most recently blocked" panel relies on: the
+      // blocked filter + ts-DESC ordering + limit together yield the latest
+      // connection-layer drops only (allowed events excluded), capped.
+      val base = Instant.now().minusSeconds(600)
+      for {
+        _        <- cleanDb
+        routerId <- seedRouter()
+        connRepo <- ZIO.service[ConnectionEventRepo]
+        upRepo   <- ZIO.service[UserProfileRepo]
+        auth     <- makeAuth
+        token    <- auth.login("admin", "changeme").map(_.token.value)
+        ce = (mac: String, host: String, allowed: Boolean, ts: Instant) =>
+          ConnectionEventInsert(
+            routerId,
+            Some(MacAddress.unsafe(mac)),
+            HostId.Fqdn(Hostname.unsafe(host)),
+            None,
+            allowed,
+            BlockReason.fromWire(if (allowed) "allowed" else "category:adult"),
+            ts,
+          )
+        _ <- connRepo.insertBatch(
+          List(
+            ce("aa:bb:cc:dd:ee:01", "allowed-newest.com", true, base.plusSeconds(500)),
+            ce("aa:bb:cc:dd:ee:02", "blocked-newest.com", false, base.plusSeconds(400)),
+            ce("aa:bb:cc:dd:ee:03", "blocked-middle.com", false, base.plusSeconds(300)),
+            ce("aa:bb:cc:dd:ee:04", "blocked-oldest.com", false, base.plusSeconds(100)),
+          ),
+        )
+        routes = LogRoutes.routes(auth, connRepo, upRepo)
+        resp <- getJson(routes, "/api/logs?blocked=true&limit=2", token)
+        body <- resp.body.asString
+        page <- ZIO.fromEither(body.fromJson[QueryLogPage])
+        logs = page.rows
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // limit honoured
+        assertTrue(logs.length == 2) &&
+        // blocked-only — allowed-newest.com excluded despite being the newest event overall
+        assertTrue(logs.forall(_.blocked)) &&
+        assertTrue(!logs.exists(_.host.value == "allowed-newest.com")) &&
+        // newest-first — the two most recent blocked rows, in descending order
+        assertTrue(logs.map(_.host.value) == List("blocked-newest.com", "blocked-middle.com"))
+    },
     test("GET /api/logs?location= filters by router name") {
       for {
         _          <- cleanDb

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -19,6 +19,11 @@ const MIN = 60_000
 // un-aggregated recent drops. Capped small; the full history lives on the
 // Connection Events page.
 export const RECENT_BLOCKED_LIMIT = 20
+// "Recent" = the trailing 15 minutes: the panel answers "what just got dropped",
+// not "what was dropped today" (the 24h aggregate is "Top Blocked"). /api/logs
+// only takes integer `hours`, so we fetch a 1h window for headroom and trim to
+// the 15-min window client-side.
+export const RECENT_BLOCKED_WINDOW_MS = 15 * 60_000
 
 // Per-endpoint stale times (#803).
 const STALE = {
@@ -114,9 +119,11 @@ export function useDashboardNow(opts?: QueryOpts<DashboardNow>) {
 }
 
 // #1338: live feed of the most recent connection-layer drops (blocked-only,
-// newest-first). Reuses the existing /api/logs read with blocked=true; the
-// route already orders ts DESC and honours the limit, and applies the same
-// JWT/household scoping every other dashboard read uses. Polls on the same
+// newest-first, trailing 15 min). Reuses the existing /api/logs read with
+// blocked=true; the route already orders ts DESC and honours the limit, and
+// applies the same JWT/household scoping every other dashboard read uses. We
+// fetch a 1h window (integer-hours param) and trim to RECENT_BLOCKED_WINDOW_MS
+// client-side so a stale block doesn't masquerade as recent. Polls on the same
 // 10s cadence as the "now" snapshot so a just-now block surfaces immediately.
 // NB a row here is a real traffic-layer drop, not a DNS event (DNS always
 // resolves) — see memory/blocking_is_traffic_layer_not_dns.md.
@@ -124,7 +131,11 @@ export function useRecentBlocked(opts?: QueryOpts<QueryLog[]>) {
   return useQuery({
     queryKey: qk.recentBlocked(),
     queryFn: () =>
-      api.logs.query({ blocked: true, limit: RECENT_BLOCKED_LIMIT }).then(p => p.rows),
+      api.logs.query({ blocked: true, limit: RECENT_BLOCKED_LIMIT, hours: 1 }).then(p => p.rows),
+    select: (rows: QueryLog[]) => {
+      const cutoff = Date.now() - RECENT_BLOCKED_WINDOW_MS
+      return rows.filter(r => new Date(r.ts).getTime() >= cutoff)
+    },
     staleTime: STALE.recentBlocked,
     refetchInterval: 10_000,
     refetchIntervalInBackground: false,

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -10,14 +10,20 @@ import { api } from '@/api/client'
 import type {
   Alert, DashboardNow, Device, HouseholdSettings, ProfileDetail, ProfileTimeStatus,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
-  UsageSeriesResponse,
+  QueryLog, UsageSeriesResponse,
 } from '@/types/api'
 
 const MIN = 60_000
 
+// #1338: "Most recently blocked" dashboard panel — newest-first, blocked-only,
+// un-aggregated recent drops. Capped small; the full history lives on the
+// Connection Events page.
+export const RECENT_BLOCKED_LIMIT = 20
+
 // Per-endpoint stale times (#803).
 const STALE = {
   dashboardNow: 5_000,
+  recentBlocked: 5_000,
   timeStatusToday: 30_000,
   timeStatusPast: 5 * MIN,
   timeStatusWeek: 5 * MIN,
@@ -30,6 +36,7 @@ export const qk = {
   devices: () => ['devices'] as const,
   alerts: (includeAll: boolean) => ['alerts', includeAll] as const,
   dashboardNow: () => ['dashboard', 'now'] as const,
+  recentBlocked: () => ['dashboard', 'recent-blocked'] as const,
   timeStatusToday: () => ['time', 'status', 'today'] as const,
   timeStatusDate: (date: string) => ['time', 'status', 'date', date] as const,
   timeStatusWeek: (to?: string, bucketOffsetMin?: number) =>
@@ -100,6 +107,25 @@ export function useDashboardNow(opts?: QueryOpts<DashboardNow>) {
     queryKey: qk.dashboardNow(),
     queryFn: () => api.dashboard.now(),
     staleTime: STALE.dashboardNow,
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: false,
+    ...opts,
+  })
+}
+
+// #1338: live feed of the most recent connection-layer drops (blocked-only,
+// newest-first). Reuses the existing /api/logs read with blocked=true; the
+// route already orders ts DESC and honours the limit, and applies the same
+// JWT/household scoping every other dashboard read uses. Polls on the same
+// 10s cadence as the "now" snapshot so a just-now block surfaces immediately.
+// NB a row here is a real traffic-layer drop, not a DNS event (DNS always
+// resolves) — see memory/blocking_is_traffic_layer_not_dns.md.
+export function useRecentBlocked(opts?: QueryOpts<QueryLog[]>) {
+  return useQuery({
+    queryKey: qk.recentBlocked(),
+    queryFn: () =>
+      api.logs.query({ blocked: true, limit: RECENT_BLOCKED_LIMIT }).then(p => p.rows),
+    staleTime: STALE.recentBlocked,
     refetchInterval: 10_000,
     refetchIntervalInBackground: false,
     ...opts,

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/api/client', () => ({
 }))
 
 import { api } from '@/api/client'
-import { DashboardPage, NowSection } from './DashboardPage'
+import { DashboardPage, NowSection, RecentlyBlockedSection } from './DashboardPage'
 import { withQuery } from '@/test/queryWrapper'
 
 const stats: DashboardStats = {
@@ -40,6 +40,15 @@ const recent: QueryLog = {
   id: 1, mac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad",
   profileId: 1, profileName: 'Kids',
   host: { type: 'fqdn', value: 'example.com' }, qtype: 1, blocked: false, reason: { kind: 'allow' },
+  location: 'home', ts: '2026-05-07T10:15:30Z',
+}
+
+// #1338: a recent connection-layer drop, returned by /api/logs?blocked=true.
+const blockedRow: QueryLog = {
+  id: 99, mac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad",
+  profileId: 1, profileName: 'Kids',
+  host: { type: 'fqdn', value: 'connectivitycheck.gstatic.com' }, qtype: 1,
+  blocked: true, reason: { kind: 'category', slug: 'ads' },
   location: 'home', ts: '2026-05-07T10:15:30Z',
 }
 
@@ -82,7 +91,16 @@ const mockAlerts = () => api.alerts.list as unknown as ReturnType<typeof vi.fn>
 beforeEach(() => {
   vi.resetAllMocks()
   mockStats().mockResolvedValue(stats)
-  mockQuery().mockResolvedValue({ rows: [recent], nextCursor: null })
+  // #1338: the "Most recently blocked" panel and the "Recent Queries" table
+  // both hit api.logs.query; split the canned response by the blocked filter so
+  // each surface renders its own (distinct) fixture.
+  mockQuery().mockImplementation((params?: { blocked?: boolean }) =>
+    Promise.resolve(
+      params?.blocked
+        ? { rows: [blockedRow], nextCursor: null }
+        : { rows: [recent], nextCursor: null },
+    ),
+  )
   mockNow().mockResolvedValue(emptyNow)
   mockAlerts().mockResolvedValue([])
 })
@@ -126,6 +144,56 @@ describe('DashboardPage', () => {
     const statsCard  = screen.getByText('Queries today')
     const comparison = nowHeading.compareDocumentPosition(statsCard)
     expect(comparison & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('renders the Most Recently Blocked panel above the Now section (#1338)', async () => {
+    render(withQuery(<MemoryRouter><DashboardPage /></MemoryRouter>))
+    const blocked = await screen.findByTestId('recently-blocked-section')
+    const now     = screen.getByTestId('now-section')
+    const cmp     = blocked.compareDocumentPosition(now)
+    expect(cmp & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(await screen.findByText('connectivitycheck.gstatic.com')).toBeInTheDocument()
+  })
+})
+
+describe('RecentlyBlockedSection (#1338)', () => {
+  it('renders blocked rows: host, device + profile, and reason', async () => {
+    render(withQuery(<MemoryRouter><RecentlyBlockedSection /></MemoryRouter>))
+    expect(await screen.findByText('connectivitycheck.gstatic.com')).toBeInTheDocument()
+    expect(screen.getByText(/Kid's iPad · Kids/)).toBeInTheDocument()
+    expect(screen.getByText('category: ads')).toBeInTheDocument()
+    // Reuses the blocked=true read, capped to 20 (RECENT_BLOCKED_LIMIT).
+    expect(api.logs.query).toHaveBeenCalledWith({ blocked: true, limit: 20 })
+  })
+
+  it('links to the full Connection Events page', async () => {
+    render(withQuery(<MemoryRouter><RecentlyBlockedSection /></MemoryRouter>))
+    await screen.findByText('connectivitycheck.gstatic.com')
+    expect(screen.getByText(/View all/).closest('a')).toHaveAttribute('href', '/usage/events')
+  })
+
+  it('shows an empty state when nothing is blocked', async () => {
+    mockQuery().mockResolvedValue({ rows: [], nextCursor: null })
+    render(withQuery(<MemoryRouter><RecentlyBlockedSection /></MemoryRouter>))
+    expect(await screen.findByText(/Nothing blocked recently/)).toBeInTheDocument()
+  })
+
+  it('polls and updates the list on refetch', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    try {
+      mockQuery()
+        .mockResolvedValueOnce({ rows: [blockedRow], nextCursor: null })
+        .mockResolvedValue({
+          rows: [{ ...blockedRow, id: 100, host: { type: 'fqdn', value: 'ocsp.apple.com' } }],
+          nextCursor: null,
+        })
+      render(withQuery(<MemoryRouter><RecentlyBlockedSection /></MemoryRouter>))
+      await screen.findByText('connectivitycheck.gstatic.com')
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000) })
+      await waitFor(() => expect(screen.getByText('ocsp.apple.com')).toBeInTheDocument())
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/web/src/pages/DashboardPage.test.tsx
+++ b/web/src/pages/DashboardPage.test.tsx
@@ -44,12 +44,14 @@ const recent: QueryLog = {
 }
 
 // #1338: a recent connection-layer drop, returned by /api/logs?blocked=true.
+// ts must be inside the panel's 15-min recency window, so derive it from now.
+const recentBlockedTs = () => new Date(Date.now() - 12_000).toISOString() // 12s ago
 const blockedRow: QueryLog = {
   id: 99, mac: 'aa:bb:cc:dd:ee:01', deviceName: "Kid's iPad",
   profileId: 1, profileName: 'Kids',
   host: { type: 'fqdn', value: 'connectivitycheck.gstatic.com' }, qtype: 1,
   blocked: true, reason: { kind: 'category', slug: 'ads' },
-  location: 'home', ts: '2026-05-07T10:15:30Z',
+  location: 'home', ts: recentBlockedTs(),
 }
 
 const emptyNow: DashboardNow = { asOf: '2026-05-13T10:00:00Z', profiles: [] }
@@ -162,8 +164,21 @@ describe('RecentlyBlockedSection (#1338)', () => {
     expect(await screen.findByText('connectivitycheck.gstatic.com')).toBeInTheDocument()
     expect(screen.getByText(/Kid's iPad · Kids/)).toBeInTheDocument()
     expect(screen.getByText('category: ads')).toBeInTheDocument()
-    // Reuses the blocked=true read, capped to 20 (RECENT_BLOCKED_LIMIT).
-    expect(api.logs.query).toHaveBeenCalledWith({ blocked: true, limit: 20 })
+    // Reuses the blocked=true read, capped to 20 (RECENT_BLOCKED_LIMIT), 1h fetch
+    // window (trimmed to 15 min client-side).
+    expect(api.logs.query).toHaveBeenCalledWith({ blocked: true, limit: 20, hours: 1 })
+  })
+
+  it('drops blocks older than the 15-min recency window (#1338)', async () => {
+    // A real-but-stale block (e.g. ~11h ago, the beacons.gcp.gvt2.com case) must
+    // not masquerade as "recently blocked".
+    mockQuery().mockResolvedValue({
+      rows: [{ ...blockedRow, ts: new Date(Date.now() - 11 * 3600_000).toISOString() }],
+      nextCursor: null,
+    })
+    render(withQuery(<MemoryRouter><RecentlyBlockedSection /></MemoryRouter>))
+    expect(await screen.findByText(/Nothing blocked recently/)).toBeInTheDocument()
+    expect(screen.queryByText('connectivitycheck.gstatic.com')).not.toBeInTheDocument()
   })
 
   it('links to the full Connection Events page', async () => {

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -98,9 +98,9 @@ export function DashboardPage() {
 
 // ── "Most recently blocked" — live diagnostic feed, polls every 10s ──────────
 //
-// #1338: newest-first, un-aggregated list of the latest connection-layer drops,
-// the recency complement to "Top Blocked". When a site/app suddenly stops
-// working the operator wants to see *what just got dropped* (the gstatic /
+// #1338: newest-first, un-aggregated list of the connection-layer drops in the
+// trailing 15 minutes, the recency complement to "Top Blocked". When a site/app
+// suddenly stops working the operator wants to see *what just got dropped* (the gstatic /
 // ocsp / akamai dependency, the over-broad blocklist hit) without digging into
 // the Connection Events page. A row is a real traffic-layer drop — DNS always
 // resolves (memory/blocking_is_traffic_layer_not_dns.md). Reuses the dashboard's

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { api } from '@/api/client'
-import { useDashboardNow } from '@/api/queries'
+import { useDashboardNow, useRecentBlocked } from '@/api/queries'
 import type {
   DashboardNowDevice,
   DashboardNowProfile,
@@ -32,6 +33,8 @@ export function DashboardPage() {
       <NewDevicesHint />
 
       <AccessRequestsBanner />
+
+      <RecentlyBlockedSection />
 
       <NowSection />
 
@@ -91,6 +94,69 @@ export function DashboardPage() {
       </section>
     </div>
   )
+}
+
+// ── "Most recently blocked" — live diagnostic feed, polls every 10s ──────────
+//
+// #1338: newest-first, un-aggregated list of the latest connection-layer drops,
+// the recency complement to "Top Blocked". When a site/app suddenly stops
+// working the operator wants to see *what just got dropped* (the gstatic /
+// ocsp / akamai dependency, the over-broad blocklist hit) without digging into
+// the Connection Events page. A row is a real traffic-layer drop — DNS always
+// resolves (memory/blocking_is_traffic_layer_not_dns.md). Reuses the dashboard's
+// React Query polling + JWT/household scoping via useRecentBlocked.
+
+export function RecentlyBlockedSection() {
+  const { data = null } = useRecentBlocked()
+
+  return (
+    <section data-testid="recently-blocked-section" className="bg-white rounded-2xl border border-brand-border overflow-hidden">
+      <div className="px-5 py-4 border-b border-brand-border flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">
+          Most Recently Blocked
+        </h2>
+        <Link to="/usage/events" className="text-xs text-brand-accent-dark hover:underline shrink-0">
+          View all →
+        </Link>
+      </div>
+      {data === null
+        ? <p className="px-5 py-4 text-brand-text-muted text-sm">Loading recent blocks…</p>
+        : data.length === 0
+          ? <div className="px-5 py-4"><EmptyState variant="inline" title="Nothing blocked recently" /></div>
+          : (
+            <ul className="divide-y divide-brand-border">
+              {data.map(row => <RecentlyBlockedRow key={row.id} row={row} />)}
+            </ul>
+          )
+      }
+    </section>
+  )
+}
+
+function RecentlyBlockedRow({ row }: { row: QueryLog }) {
+  const who = row.deviceName ?? row.mac ?? 'unknown device'
+  return (
+    <li data-testid={`recently-blocked-${row.id}`} className="px-5 py-2.5 flex items-center gap-3">
+      <span className="text-xs text-brand-text-muted shrink-0 w-16 tabular-nums">
+        {formatRelativeTime(row.ts)}
+      </span>
+      <span className="font-mono text-sm text-brand-ink truncate flex-1 min-w-0">
+        <HostCell host={row.host} />
+      </span>
+      <span className="text-xs text-brand-text-muted truncate hidden sm:block max-w-[40%]">
+        {who}{row.profileName ? ` · ${row.profileName}` : ''}
+      </span>
+      <span className="text-xs text-red-700 shrink-0">{blockReasonText(row.reason)}</span>
+    </li>
+  )
+}
+
+// Relative "Xs/Xm/Xh ago" from an ISO timestamp. Mirrors formatLastSeen, which
+// works in elapsed-seconds; here we derive the elapsed from now() at render time
+// (React Query re-renders on each 10s poll, so the label stays roughly live).
+function formatRelativeTime(tsIso: string): string {
+  const elapsedMs = Date.now() - new Date(tsIso).getTime()
+  return formatLastSeen(Math.max(0, elapsedMs / 1000))
 }
 
 // ── "Now" section — live snapshot, polls every 10s ───────────────────────────
@@ -251,4 +317,4 @@ function PageLoader() {
   )
 }
 
-export { LogTable, PageLoader }
+export { LogTable, PageLoader, formatRelativeTime }


### PR DESCRIPTION
## Summary

Adds a **"Most Recently Blocked"** panel at the top of the dashboard — a live, newest-first, un-aggregated feed of the latest connection-layer drops. It's the recency complement to the existing aggregate "Top Blocked": when a site/app suddenly stops working, the operator can instantly see *what just got dropped* (the `connectivitycheck.gstatic.com` / `ocsp` / akamai dependency, an over-broad blocklist hit) without digging into the Connection Events page.

Closes #1338.

### What it shows
- Each row: relative timestamp ("12s ago"), host, `device · profile`, and block reason (same `blockReasonText` rendering used elsewhere).
- Blocked-only, newest-first, capped at 20, with a **View all →** link to `/usage/events`.
- Auto-refreshes on the dashboard's existing React Query 10s poll, so a just-now block surfaces immediately.
- Placed above the "Now" section (top of the dashboard).

### Backend — reuse, not a new query
The read the panel needs already exists: `GET /api/logs?blocked=true&limit=N` (via `ConnectionEventRepo.query`) already orders `ts DESC`, honours the limit, applies the same JWT/household scoping every other dashboard read uses, and is backed by vetted indexes. A new `useRecentBlocked` hook wraps it. This deliberately avoids adding a new, unvetted query on the unbounded-growth `connection_events` table (per the query-performance guardrail in AGENTS.md).

A row here is a real **traffic-layer** drop, not a DNS event — DNS always resolves; the block happens at the connection layer.

## Test plan
- **web** (`DashboardPage.test.tsx`, `nvm use 22`): the panel renders host / `device · profile` / reason rows from a mocked `blocked=true` response, links to the Connection Events page, shows an empty state when nothing is blocked, updates on the 10s poll, and sits above the "Now" section. `npx vitest run` → 325 passed; `type-check` + `lint` clean.
- **api** (`LogApiSpec`): new feature test (real embedded Postgres) asserts `GET /api/logs?blocked=true&limit=N` returns blocked-only events, newest-first, within the limit (allowed events excluded even when newer). Full `api.test` suite green.
- Red→green visible in history: tests committed before the implementation.

## Redesign follow-up
Commented on the dashboard redesign umbrella #1148 so "Most recently blocked" survives as a first-class element when this ad-hoc panel is reworked.