### PR TITLE
fix(openwrt): attribute directly-queried CNAME targets to the branded host (#1344)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -723,6 +723,21 @@ so a flow to `142.250.x.x` shortly after `query[A] youtube.com` is logged as
 `youtube.com`, not `youtube-ui.l.google.com` (the last CNAME hop) and not
 the IP literal.
 
+Some clients (notably Apple devices) don't stop at one query: after resolving
+the branded host they **re-query the final CNAME target directly** as a
+separate lookup. On that second query the qname on the wire *is* the CDN
+target (e.g. `query[A] prod.khan.map.fastly.net`), so the query-id correlation
+— which is working correctly — still attributes the flow to the CDN target,
+which then fails to suffix-match the app's branded `extraAllowed` entry
+(`kastatic.org`) and is mislabelled / mis-classified as blocked. To recover the
+brand, `dns_log` remembers a bounded **CNAME-target → chain-head** map built
+from the chains it already parses (every non-head owner name in a chain maps to
+that chain's queried head). A later direct query for a known target is then
+attributed back to the branded ancestor the target was first observed under.
+This is best-effort: the very first direct-target query seen before any branded
+chain falls back to the target name (never worse than the IP-literal default),
+and stale alias edges expire on the same TTL as cache entries (#1344).
+
 The per-domain `--ipset=` mechanism is still used for the `site_limits`
 enforcement chains (nftables matches `ip daddr @profileN_<domain>`), but it
 is no longer load-bearing for hostname attribution in the query log — that

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -141,6 +141,9 @@ function M.new(opts)
   local ttl           = opts.ttl_seconds or 3600
   local max_entries   = opts.max_entries or 10000
   local max_pending   = opts.max_pending or 1024
+  -- CNAME-alias map bound. Distinct CDN target names observed across chains;
+  -- shares the entry-cache order of magnitude (#1344).
+  local max_aliases   = opts.max_aliases or 10000
   local now_fn        = opts.now_fn      or os.time
 
   -- ip → { hostname, ts, seq }
@@ -149,6 +152,14 @@ function M.new(opts)
   -- qid → { qname, ts, seq }
   local pending       = {}
   local pending_count = 0
+  -- CNAME target name → { head, ts, seq } (#1344).
+  -- Learned from observed CNAME chains: every non-head owner name in a chain
+  -- maps to that chain's head (the queried name). Lets us attribute a flow
+  -- back to the branded host even when the client re-queries the final CNAME
+  -- target directly (Apple devices do this), where the qname on the wire is
+  -- the CDN target itself.
+  local aliases       = {}
+  local alias_count   = 0
   -- monotonically increasing sequence number for LRU-by-insertion eviction
   local seq           = 0
 
@@ -203,6 +214,54 @@ function M.new(opts)
     pending[qid] = { qname = qname, ts = now, seq = next_seq() }
   end
 
+  local function evict_oldest_alias()
+    local oldest_name, oldest_seq
+    for name, a in pairs(aliases) do
+      if not oldest_seq or a.seq < oldest_seq then
+        oldest_name, oldest_seq = name, a.seq
+      end
+    end
+    if oldest_name then
+      aliases[oldest_name] = nil
+      alias_count = alias_count - 1
+    end
+  end
+
+  -- resolve_head(name) → the branded chain head `name` is a CNAME alias of, or
+  -- `name` itself when it is not a known alias. Bounded multi-hop with a cycle
+  -- guard so a re-queried intermediate hop (whose own alias was learned from a
+  -- longer chain) still resolves to the ultimate head (#1344). Expired alias
+  -- edges are ignored (and lazily dropped) so a stale CDN→brand mapping can't
+  -- pin an IP to the wrong brand forever.
+  local function resolve_head(name)
+    local now  = now_fn()
+    local seen = {}
+    for _ = 1, 8 do
+      local a = aliases[name]
+      if not a then break end
+      if (now - a.ts) > ttl then
+        aliases[name] = nil
+        alias_count = alias_count - 1
+        break
+      end
+      if seen[name] then break end
+      seen[name] = true
+      name = a.head
+    end
+    return name
+  end
+
+  local function remember_alias(target, head, now)
+    if target == head then return end
+    if aliases[target] == nil then
+      if alias_count >= max_aliases then
+        evict_oldest_alias()
+      end
+      alias_count = alias_count + 1
+    end
+    aliases[target] = { head = head, ts = now, seq = next_seq() }
+  end
+
   local self = {}
 
   function self.ingest_line(line)
@@ -215,9 +274,19 @@ function M.new(opts)
     local r = M.parse_reply_line(line)
     if not r then return end
     local p = pending[r.qid]
-    local original = p and p.qname or r.name
+    -- The chain head is the queried name (pending qname); fall back to the
+    -- reply owner when we never saw the query line. Resolve it through the
+    -- alias map so a re-queried CNAME target attributes back to the branded
+    -- host the target was first observed under (#1344).
+    local head = resolve_head(p and p.qname or r.name)
+    -- Record the CNAME-alias edge: this reply's owner name (r.name) is a name
+    -- reachable within `head`'s chain, so a later DIRECT query for r.name can
+    -- be attributed back to `head`. Skip the head's own line (target == head).
+    if r.name ~= head then
+      remember_alias(r.name, head, now)
+    end
     if r.ip then
-      store(r.ip, original, now)
+      store(r.ip, head, now)
     end
   end
 
@@ -244,6 +313,12 @@ function M.new(opts)
       if (now - p.ts) > ttl then
         pending[qid] = nil
         pending_count = pending_count - 1
+      end
+    end
+    for name, a in pairs(aliases) do
+      if (now - a.ts) > ttl then
+        aliases[name] = nil
+        alias_count = alias_count - 1
       end
     end
   end

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -3,6 +3,7 @@
 -- Requires: busted (luarocks install busted)
 
 local conntrack = require("conntrack")
+local dns_log   = require("dns_log")
 
 -- ---------------------------------------------------------------------------
 -- 1. ipset attribution: dest_ip → hostname
@@ -324,6 +325,60 @@ describe("handle_flow", function()
     assert.equal("connection_attempt", b.events[2]["type"])
     assert.equal(MAC,                  b.events[2].mac)
     assert.is_true(ctx.reported_macs[MAC])
+  end)
+
+  -- #1344: end-to-end — a real dns_log cache fed the real prod CNAME-chain log
+  -- shapes must let a directly-queried CDN target flow carve out of a whole-MAC
+  -- block via the app's branded extraAllowed entry. This wires the actual
+  -- attribution fix through handle_flow, not a stubbed lookup.
+  it("#1344: directly-queried CNAME-target flow carves out of a blocked MAC via the brand", function()
+    local cache = dns_log.new({ ttl_seconds = 3600 })
+    -- Branded chain observed (cdn.kastatic.org → … → prod.khan.map.fastly.net).
+    cache.ingest_line("38053 192.168.1.42/36172 query[A] cdn.kastatic.org from 192.168.1.42")
+    cache.ingest_line("38053 192.168.1.42/36172 reply cdn.kastatic.org is <CNAME>")
+    cache.ingest_line("38053 192.168.1.42/36172 reply fastly.kastatic.org is <CNAME>")
+    cache.ingest_line("38053 192.168.1.42/36172 reply prod.khan.map.fastly.net is 9.9.9.9")
+    -- Device then re-queries the CNAME target directly → lands on DST_IP.
+    cache.ingest_line("40000 192.168.1.42/61484 query[A] prod.khan.map.fastly.net from 192.168.1.42")
+    cache.ingest_line("40000 192.168.1.42/61484 reply prod.khan.map.fastly.net is " .. DST_IP)
+
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },          -- whole-MAC block (downtime schedule)
+      blocked_reason  = { [MAC] = "schedule" },
+      lookup_hostname = cache.lookup,              -- the REAL attribution path
+      ea_hosts_by_mac = { [MAC] = { ["kastatic.org"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal("connection_attempt", ev["type"])
+    -- Recovered brand cdn.kastatic.org suffix-matches kastatic.org → carve-out.
+    -- build_event normalises an allowed event's nil reason to "allow".
+    assert.equal(true,    ev.allowed)
+    assert.equal("allow", ev.reason)
+  end)
+
+  -- Contrast: without the observed branded chain the same direct-target flow
+  -- can only attribute to the CDN target, which does NOT suffix-match the brand,
+  -- so it is (mis-)classified as blocked — the pre-fix behaviour the operator hit.
+  it("#1344: direct CNAME-target flow with no observed brand chain stays blocked", function()
+    local cache = dns_log.new({ ttl_seconds = 3600 })
+    cache.ingest_line("40000 192.168.1.42/61484 query[A] prod.khan.map.fastly.net from 192.168.1.42")
+    cache.ingest_line("40000 192.168.1.42/61484 reply prod.khan.map.fastly.net is " .. DST_IP)
+
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      reported_macs   = { [MAC] = true },
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "schedule" },
+      lookup_hostname = cache.lookup,
+      ea_hosts_by_mac = { [MAC] = { ["kastatic.org"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
+    local ev = b.events[#b.events]
+    assert.equal(false,      ev.allowed)
+    assert.equal("schedule", ev.reason)
   end)
 
   it("does not re-emit first_seen_mac on subsequent flows from the same MAC", function()

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -265,6 +265,118 @@ describe("cache.ingest_line + lookup", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 2b. CNAME-alias attribution (#1344)
+--
+-- Some clients (notably Apple devices) resolve a branded host, then re-query
+-- the FINAL CNAME target *directly* as a separate query. On that direct query
+-- the qname on the wire IS the CDN target (e.g. `prod.khan.map.fastly.net`),
+-- so qid correlation — which works fine — still attributes the flow to the
+-- CDN target. That target does not suffix-match the app's `extraAllowed`
+-- entry (`kastatic.org` / `khanacademy.org`), so the flow is mislabelled and,
+-- during a whole-MAC block, mis-classified as blocked.
+--
+-- The branded chain WAS observed earlier (the client did resolve the branded
+-- host), so the cache can learn `<cdn target> → <branded chain head>` and
+-- attribute the later direct-target query back to the branded ancestor.
+--
+-- These cases use the real prod dnsmasq 2.91 `--log-queries=extra` line shapes
+-- captured on router.lan (issue #1344): a shared qid across the chain, the
+-- intervening `forwarded`/`nftset` lines (ignored by the parsers), and a
+-- separate direct query for the CNAME target.
+-- ---------------------------------------------------------------------------
+
+describe("CNAME-alias attribution (#1344)", function()
+  local function fake_clock()
+    local t = 1000000
+    return {
+      now  = function() return t end,
+      advance = function(secs) t = t + secs end,
+    }
+  end
+
+  it("attributes a directly-queried CNAME target back to the branded chain head", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    -- 1) Branded resolution observed first (real captured chain, qid 38053).
+    c.ingest_line("38053 127.0.0.1/36172 query[A] cdn.kastatic.org from 127.0.0.1")
+    c.ingest_line("38053 127.0.0.1/36172 forwarded cdn.kastatic.org to 2001:558:feed::1")
+    c.ingest_line("38053 127.0.0.1/36172 reply cdn.kastatic.org is <CNAME>")
+    c.ingest_line("38053 127.0.0.1/36172 reply fastly.kastatic.org is <CNAME>")
+    c.ingest_line("38053 127.0.0.1/36172 reply prod.khan.map.fastly.net is 199.232.65.42")
+
+    -- The branded chain itself attributes to the queried brand (works today).
+    assert.equal("cdn.kastatic.org", c.lookup("199.232.65.42"))
+
+    -- 2) The device later re-queries the CNAME target DIRECTLY, landing on a
+    --    different Fastly anycast IP (real: 151.101.65.42 to 192.168.10.159).
+    clk.advance(5)
+    c.ingest_line("40000 192.168.10.159/61484 query[A] prod.khan.map.fastly.net from 192.168.10.159")
+    c.ingest_line("40000 192.168.10.159/61484 reply prod.khan.map.fastly.net is 151.101.65.42")
+
+    -- The direct-target flow must be attributed to the branded ancestor, NOT
+    -- the CDN target — otherwise it can't suffix-match `kastatic.org`.
+    assert.equal("cdn.kastatic.org", c.lookup("151.101.65.42"))
+  end)
+
+  it("recovers the brand for www.khanacademy.org → prod.khan.map.fastly.net", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    c.ingest_line("20800 192.168.10.159/49808 query[A] www.khanacademy.org from 192.168.10.159")
+    c.ingest_line("20800 192.168.10.159/49808 reply www.khanacademy.org is <CNAME>")
+    c.ingest_line("20800 192.168.10.159/49808 reply prod.khan.map.fastly.net is 151.101.1.42")
+
+    clk.advance(3)
+    c.ingest_line("20817 192.168.10.159/61484 query[A] prod.khan.map.fastly.net from 192.168.10.159")
+    c.ingest_line("20817 192.168.10.159/61484 reply prod.khan.map.fastly.net is 151.101.129.42")
+
+    assert.equal("www.khanacademy.org", c.lookup("151.101.129.42"))
+  end)
+
+  it("resolves a directly-queried INTERMEDIATE CNAME hop back to the head too", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    -- Brand chains through an intermediate to a final target.
+    c.ingest_line("100 192.168.10.159/1000 query[A] cdn.kastatic.org from 192.168.10.159")
+    c.ingest_line("100 192.168.10.159/1000 reply cdn.kastatic.org is <CNAME>")
+    c.ingest_line("100 192.168.10.159/1000 reply fastly.kastatic.org is <CNAME>")
+    c.ingest_line("100 192.168.10.159/1000 reply prod.khan.map.fastly.net is 1.2.3.4")
+
+    -- Device re-queries the INTERMEDIATE hop directly.
+    clk.advance(2)
+    c.ingest_line("101 192.168.10.159/1001 query[A] fastly.kastatic.org from 192.168.10.159")
+    c.ingest_line("101 192.168.10.159/1001 reply fastly.kastatic.org is <CNAME>")
+    c.ingest_line("101 192.168.10.159/1001 reply prod.khan.map.fastly.net is 5.6.7.8")
+
+    assert.equal("cdn.kastatic.org", c.lookup("5.6.7.8"))
+  end)
+
+  it("falls back to the target name when the brand chain was never observed (safe degradation)", function()
+    -- No prior branded chain — the very first direct query for a CDN target
+    -- can only be attributed to the target itself. Never WORSE than today.
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    c.ingest_line("9 192.168.10.159/1 query[A] prod.khan.map.fastly.net from 192.168.10.159")
+    c.ingest_line("9 192.168.10.159/1 reply prod.khan.map.fastly.net is 199.232.65.42")
+
+    assert.equal("prod.khan.map.fastly.net", c.lookup("199.232.65.42"))
+  end)
+
+  it("does not rewrite a normal (non-CNAME) qname", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    c.ingest_line("1 192.168.1.42/54321 query[A] example.com from 192.168.1.42")
+    c.ingest_line("1 192.168.1.42/54321 reply example.com is 93.184.216.34")
+
+    assert.equal("example.com", c.lookup("93.184.216.34"))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 3. TTL + size eviction
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1344.

## Summary

The router's IP→hostname attribution (the `dns_log` cache) was recording the
**final CNAME-target name** (`prod.khan.map.fastly.net`, `a1744.dscw154.akamai.net`)
for some CDN-fronted flows instead of the branded host the user is actually on.
Because that attributed name (`hname`) drives both **logging** and conntrack.lua's
**ea_/eb_/bl_ flow classification**, the CDN target failed to suffix-match the app's
`extraAllowed` entry (`kastatic.org` / `khanacademy.org`) — so during a whole-MAC
downtime block, Khan Academy / Math Academy asset flows were mislabelled and
mis-classified as blocked. (Operator had to disable the downtime schedule to unblock.)

## Root cause — verified against real prod router logs

This was **not** a query-id correlation miss (the original hypothesis). Captured live
on `router.lan` (dnsmasq 2.91, `--log-queries=extra`):

```
38053 127.0.0.1/36172 query[A] cdn.kastatic.org from 127.0.0.1
38053 127.0.0.1/36172 reply cdn.kastatic.org is <CNAME>
38053 127.0.0.1/36172 reply fastly.kastatic.org is <CNAME>
38053 127.0.0.1/36172 reply prod.khan.map.fastly.net is 199.232.65.42
```

The qid (`38053`) **is** shared across the whole chain and the `query[A]` line **is**
present (in both the forwarded and cached paths), so qid correlation already attributes
`199.232.65.42 → cdn.kastatic.org` correctly for that query.

The real mechanism: the kid's Apple device (`192.168.10.159`) **re-queries the final
CNAME target directly** as a separate lookup. Over one session it issued:

```
18×  query[...] www.khanacademy.org          (branded name)
17×  query[...] prod.khan.map.fastly.net      (CNAME target, queried DIRECTLY)
```

On the *direct* target query the qname on the wire **is** `prod.khan.map.fastly.net`,
so the cache attributes the IP to the CDN target. The live cache
(`/tmp/wifihaven-dns-cache.txt`, 941 entries) is consequently full of raw CDN targets
(`a1815.dscr.akamai.net`, `e35058.api12.akamaiedge.net`, `d2763msf1wgvw2.cloudfront.net`,
`stripecdn.map.fastly.net`, …). But the device **did** earlier resolve the branded
`www.khanacademy.org`, and dnsmasq logged that chain — so the target→brand link was
observed and is recoverable.

## Fix (router-side only)

`dns_log` now remembers a bounded **CNAME-target → chain-head** map, built from the
chains it already parses (every non-head owner name in a chain maps to that chain's
queried head). A later direct query for a known target is attributed back to the
branded ancestor. Best-effort and TTL-bounded:

- a first direct-target query seen before any branded chain falls back to the target
  name (never worse than the IP-literal default);
- alias edges expire on the same TTL as cache entries;
- a bounded multi-hop resolver with a cycle guard handles re-queried intermediate hops.

Substitution happens at **store** time in the dns-tail sidecar, so the snapshot file the
agent reads already carries the branded name — no new wire/snapshot fields, and the API's
`extraAllowed` is already correct.

## Downstream effect

With correct attribution, `hname = cdn.kastatic.org` suffix-matches the `kastatic.org`
`extraAllowed` entry, so conntrack.lua's `#421` carve-out fires and the flow is
classified `allowed=true` instead of blocked. Proven end-to-end by a new conntrack test
that wires a **real** `dns_log` cache (fed the real prod log shapes) through
`handle_flow`, plus a contrast test showing the pre-fix mis-classification.

## Related follow-up (NOT in this PR)

The **kernel** `ea_<mac>_<host>` allow-set is populated only by dnsmasq's `nftset=/host/…`
directive, which fires only for names that suffix-match the configured domain — so a
*directly-queried* CNAME target's IPs may be absent from the kernel carve-out and the flow
can be **dropped** at enforcement time, independent of the attribution label. Restoring
enforcement-time connectivity for directly-queried CNAME targets needs a dns-tail
`ea_`-set populator keyed off the same CNAME-alias memory. Tracked in #1344 as a related
follow-up; this PR fixes the attribution lookup (logging + classification) the operator
identified as the primary defect.

## Test plan

TDD, red→green visible in history:

- `test(openwrt): failing tests for CNAME-target attribution` — 3 alias cases fail on
  current code; safe-degradation + non-rewrite cases pass.
- `fix(openwrt): attribute directly-queried CNAME targets …` — all green.

```
busted test/dns_log_spec.lua      → 36 successes / 0 failures
busted test/conntrack_spec.lua    → 94 successes / 0 failures (6 pre-existing
                                     luci.jsonc env errors in the JSON-encode path,
                                     unrelated to this change)
busted test/render_spec.lua       → 144 successes / 0 failures
```

No metric series added, so no dashboard change. Router-side only; no Scala touched.
