### PR TITLE
fix(openwrt): populate kernel ea_/eb_ sets for directly-queried CNAME targets (#1346)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -325,6 +325,16 @@ function M.new(opts)
 
   function self.size() return entry_count end
 
+  -- resolve_head(name) → the branded chain head `name` is a CNAME alias of, or
+  -- `name` unchanged when it is not a known alias (#1344). Exposed publicly so
+  -- the wifihaven-dns-tail sidecar can reuse the SAME learned alias memory to
+  -- recover the brand for a directly-queried CDN target before suffix-matching
+  -- it against the kernel ea_/eb_ sets (#1346). Internally `resolve_head` is
+  -- already used by ingest_line; this is a thin public passthrough.
+  function self.resolve_head(name)
+    return resolve_head(name)
+  end
+
   -- Serialise the live cache to a single newline-delimited string.
   -- Format: "<ip>\t<hostname>\t<ts>\n" per non-expired entry.
   function self.dump_text()

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_tail_sets.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_tail_sets.lua
@@ -1,0 +1,190 @@
+-- dns_tail_sets.lua — pure nft-set populator logic for the wifihaven-dns-tail
+-- sidecar.
+--
+-- The sidecar tails dnsmasq's `--log-queries=extra` output and, for each
+-- resolved reply, populates a handful of nftables sets out of band (dnsmasq's
+-- own `nftset=` callback is unreliable / unscoped in the deployed 2.91 build —
+-- #496/#505/#515). Three set families are driven here:
+--
+--   * resolved_<mac>        — blockIpOnly allow-by-resolution (#505)
+--   * eb_<sanhost>          — extraBlocked drop set (#515)
+--   * ea_<sanmac>_<sanhost> — extraAllowed carve-out (#421); NEW dns-tail
+--                             populator added in #1346 (was dnsmasq-only).
+--
+-- #1346 — the directly-queried CNAME-target gap. Some clients (Apple devices)
+-- resolve a branded host, then re-query the FINAL CNAME target *directly* as a
+-- separate lookup. On that direct query the answered name is the CDN target
+-- (e.g. `prod.khan.map.fastly.net`), which does NOT suffix-match the declared
+-- ea_/eb_<brand> set — so dnsmasq's nftset callback AND the pre-#1346 eb_
+-- populator both miss it, leaving the resolved IP out of the kernel set (an
+-- allowed app is falsely blocked / an extraBlocked host silently bypassed).
+-- We recover the branded chain head from the dns_log alias map learned in
+-- #1344/#1345 (`resolve_head`) and walk THAT name's labels too.
+--
+-- This logic lives in its own module (rather than inline in the sidecar) so it
+-- is unit-testable with an injected exec function — the same get_fn/write_fn/
+-- exec_fn injection pattern used in policy.lua / conntrack.lua. The sidecar
+-- wires the real `os.execute`, the live dns_log cache's `resolve_head`, the
+-- DHCP-derived ip→MAC map, and the declared-set membership tables.
+
+local M = {}
+
+-- Replace dots and colons with underscores. Mirrors render.sanitize so the
+-- (MAC|host) → set-name mapping is byte-identical to what render.lua emits —
+-- keep them in concert if either changes.
+function M.sanitize(s)
+  return (s:gsub("[%.%:]", "_"))
+end
+
+-- The answer IP comes from dnsmasq's log line (already validated as v4/v6 by
+-- dns_log.parse_resolved_reply), but pass it through a strict allow-list
+-- anyway so the value handed to `nft add element` can never carry shell
+-- metacharacters.
+function M.safe_addr(ip)
+  if type(ip) ~= "string" then return nil end
+  if ip:find("[^%x%.:]") then return nil end
+  return ip
+end
+
+-- Build the `nft add element` command for one (set, ip), or nil if the ip
+-- fails the allow-list. Output is discarded: ENOENT is expected if the set was
+-- removed between our refresh and this call (admin policy change), and
+-- "element exists" is a legitimate duplicate. Neither is actionable.
+function M.add_element_cmd(nft_table, set_name, ip)
+  local safe = M.safe_addr(ip)
+  if not safe then return nil end
+  return string.format(
+    "nft add element %s %s { %s } >/dev/null 2>&1",
+    nft_table, set_name, safe)
+end
+
+-- Run the add via exec_fn (defaults to os.execute). Returns true if a command
+-- was issued. exec_fn is injectable for tests (capture instead of execute).
+function M.nft_add_element(nft_table, set_name, ip, exec_fn)
+  local cmd = M.add_element_cmd(nft_table, set_name, ip)
+  if not cmd then return false end
+  local exec = exec_fn or os.execute
+  exec(cmd)
+  return true
+end
+
+-- Sanitized-MAC sub-pattern: six hex pairs joined by `_`. The ea_ set name
+-- embeds BOTH mac and host (`ea_<sanmac>_<sanhost>`, e.g.
+-- `ea_04_72_ef_d6_e4_5a_kastatic_org`); the fixed-width MAC prefix is what
+-- lets us split it back into (sanmac, sanhost) unambiguously even though both
+-- halves contain underscores.
+local SANMAC = "%x%x_%x%x_%x%x_%x%x_%x%x_%x%x"
+
+-- Classify one `nft -a list table` line, mutating the membership tables in
+-- `s` (s = { bio={}, eb4={}, eb6={}, ea4={}, ea6={} }):
+--   bio[sanmac]            = true      resolved_<sanmac>      (#505)
+--   eb4[sanhost]           = true      eb_<sanhost>           (#515)
+--   eb6[sanhost]           = true      eb6_<sanhost>          (#515)
+--   ea4[sanmac][sanhost]   = true      ea_<sanmac>_<sanhost>  (#421/#1346)
+--   ea6[sanmac][sanhost]   = true      ea6_<sanmac>_<sanhost>
+-- The literal `resolved_`/`eb_`/`eb6_`/`ea_`/`ea6_` prefixes are mutually
+-- exclusive (none is a prefix of another after the trailing `_`), so the
+-- independent matches below cannot cross-fire.
+function M.classify_set_line(line, s)
+  local sanmac = line:match("set%s+resolved_([%w_]+)%s*{")
+  if sanmac then s.bio[sanmac] = true end
+  local eb4 = line:match("set%s+eb_([%w_]+)%s*{")
+  if eb4 then s.eb4[eb4] = true end
+  local eb6 = line:match("set%s+eb6_([%w_]+)%s*{")
+  if eb6 then s.eb6[eb6] = true end
+  local ea4m, ea4h = line:match("set%s+ea_(" .. SANMAC .. ")_([%w_]+)%s*{")
+  if ea4m then
+    s.ea4[ea4m] = s.ea4[ea4m] or {}
+    s.ea4[ea4m][ea4h] = true
+  end
+  local ea6m, ea6h = line:match("set%s+ea6_(" .. SANMAC .. ")_([%w_]+)%s*{")
+  if ea6m then
+    s.ea6[ea6m] = s.ea6[ea6m] or {}
+    s.ea6[ea6m][ea6h] = true
+  end
+end
+
+-- Walk the candidate sanitized-host suffixes for an answered name and invoke
+-- fn(sanhost) for each, stopping the CURRENT name's walk when fn returns true
+-- (first-hit-wins, mirroring dnsmasq's `nftset=/example.com/...` semantics
+-- where example.com matches itself and every subdomain).
+--
+-- Two candidate names are walked: the answered `name` itself, then — when
+-- distinct — the branded chain head recovered from the #1344 alias map. That
+-- second walk is the #1346 fix: a directly-queried CDN target only matches a
+-- declared <brand> set through its recovered head.
+function M.each_candidate_host(name, resolve_head, fn)
+  local head  = (resolve_head and resolve_head(name)) or name
+  local names = (head ~= name) and { name, head } or { name }
+  for _, nm in ipairs(names) do
+    local n = nm
+    while n and n ~= "" do
+      if fn(M.sanitize(n)) then break end
+      local dot = n:find("%.")
+      if not dot then break end
+      n = n:sub(dot + 1)
+    end
+  end
+end
+
+-- maybe_populate_eb(r, deps) — extraBlocked populator (#515 + #1346).
+-- r    : a dns_log.parse_resolved_reply result { name, ip, family }.
+-- deps : { eb4, eb6, nft_table, exec_fn?, resolve_head?, log? }
+-- Returns the number of `nft add element` commands issued (0+). A host whose
+-- answered name OR recovered branded head suffix-matches a declared
+-- eb_/eb6_<sanhost> set gets its resolved IP added to that set.
+function M.maybe_populate_eb(r, deps)
+  if not r or not r.name then return 0 end
+  local set    = (r.family == "v6") and deps.eb6 or deps.eb4
+  local prefix = (r.family == "v6") and "eb6_" or "eb_"
+  local adds, seen = 0, {}
+  M.each_candidate_host(r.name, deps.resolve_head, function(sanhost)
+    if set[sanhost] then
+      if not seen[sanhost] then
+        seen[sanhost] = true
+        M.nft_add_element(deps.nft_table, prefix .. sanhost, r.ip, deps.exec_fn)
+        adds = adds + 1
+        if deps.log then deps.log(prefix .. sanhost, r) end
+      end
+      return true  -- first match for this candidate name wins
+    end
+    return false
+  end)
+  return adds
+end
+
+-- maybe_populate_ea(r, deps) — extraAllowed carve-out populator (#1346, NEW).
+-- Mirrors maybe_populate_eb but the sets are per-(mac, host): map the reply's
+-- client_ip → MAC, then for each ea_<sanmac>_<sanhost> set belonging to that
+-- MAC whose host suffix-matches the answered name OR its recovered branded
+-- head, add the resolved IP.
+-- r    : a dns_log.parse_resolved_reply result { client_ip, name, ip, family }.
+-- deps : { ea4, ea6, ip_to_mac, nft_table, exec_fn?, resolve_head?, log? }
+-- Returns the number of `nft add element` commands issued (0+).
+function M.maybe_populate_ea(r, deps)
+  if not r or not r.name then return 0 end
+  local mac = deps.ip_to_mac and deps.ip_to_mac[r.client_ip]
+  if not mac then return 0 end
+  local sanmac = M.sanitize(mac)
+  local by_mac = (r.family == "v6") and deps.ea6 or deps.ea4
+  local hosts  = by_mac and by_mac[sanmac]
+  if not hosts then return 0 end
+  local prefix = (r.family == "v6") and "ea6_" or "ea_"
+  local adds, seen = 0, {}
+  M.each_candidate_host(r.name, deps.resolve_head, function(sanhost)
+    if hosts[sanhost] then
+      if not seen[sanhost] then
+        seen[sanhost] = true
+        M.nft_add_element(deps.nft_table,
+          prefix .. sanmac .. "_" .. sanhost, r.ip, deps.exec_fn)
+        adds = adds + 1
+        if deps.log then deps.log(prefix .. sanmac .. "_" .. sanhost, r, mac) end
+      end
+      return true
+    end
+    return false
+  end)
+  return adds
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -8,6 +8,7 @@
 
 local uci       = require("uci")
 local dns_log   = require("wifihaven.dns_log")
+local dns_sets  = require("wifihaven.dns_tail_sets")
 local conntrack = require("wifihaven.conntrack")
 local log       = require("wifihaven.log")
 local paths     = require("wifihaven.paths")
@@ -91,12 +92,11 @@ end
 -- policy ingestion path.
 -- ---------------------------------------------------------------------------
 
--- Replace dots and colons with underscores (mirrors render.sanitize so the
--- MAC → set-name mapping is consistent — name them in concert if you change
--- the rule in render.lua).
-local function sanitize_mac(mac)
-  return (mac:gsub("[%.%:]", "_"))
-end
+-- sanitize / safe_addr / nft_add_element / set classification + the eb_/ea_
+-- populators live in wifihaven.dns_tail_sets so the suffix-walk + #1344 alias
+-- recovery is unit-testable with an injected exec function. Alias the helpers
+-- we still call directly here.
+local sanitize = dns_sets.sanitize
 
 local function refresh_ip_to_mac()
   local leases = conntrack.parse_dhcp_leases(leases_path)
@@ -109,115 +109,97 @@ local function refresh_ip_to_mac()
   return out
 end
 
--- Returns three sets keyed by sanitized name:
---   bio  — { [sanmac]   = true } MACs with a resolved_<sanmac> set (#505).
---   eb4  — { [sanhost]  = true } hosts with an eb_<sanhost>  set (#515).
---   eb6  — { [sanhost]  = true } hosts with an eb6_<sanhost> set (#515).
--- All three live in the same `inet wifihaven` table and refresh on the same
--- cadence, so a single `nft list table` popen pays for all of them.
+-- Discover the declared sets in the live nft table. Returns the membership
+-- tables dns_tail_sets expects:
+--   bio  — { [sanmac]          = true } MACs with a resolved_<sanmac> set (#505).
+--   eb4  — { [sanhost]         = true } hosts with an eb_<sanhost>  set (#515).
+--   eb6  — { [sanhost]         = true } hosts with an eb6_<sanhost> set (#515).
+--   ea4  — { [sanmac]={[sanhost]=true} } per-(MAC,host) ea_ allow sets (#1346).
+--   ea6  — { [sanmac]={[sanhost]=true} } the v6 sibling.
+-- All live in the same `inet wifihaven` table and refresh on the same cadence,
+-- so a single `nft list table` popen pays for all of them.
 local function refresh_nft_sets()
-  local bio, eb4, eb6 = {}, {}, {}
+  local s = { bio = {}, eb4 = {}, eb6 = {}, ea4 = {}, ea6 = {} }
   local h = io.popen("nft -a list table " .. nft_table .. " 2>/dev/null", "r")
-  if not h then return bio, eb4, eb6 end
+  if not h then return s end
   for line in h:lines() do
-    local sanmac = line:match("set%s+resolved_([%w_]+)%s*{")
-    if sanmac then bio[sanmac] = true end
-    local sanhost4 = line:match("set%s+eb_([%w_]+)%s*{")
-    if sanhost4 then eb4[sanhost4] = true end
-    local sanhost6 = line:match("set%s+eb6_([%w_]+)%s*{")
-    if sanhost6 then eb6[sanhost6] = true end
+    dns_sets.classify_set_line(line, s)
   end
   h:close()
-  return bio, eb4, eb6
-end
-
--- Shell-quoting: the answer IP comes from dnsmasq's log line (we already
--- ran is_ipv4 / is_ipv6 on it), so it can only be hex/digits/dots/colons —
--- but pass it through a strict allow-list anyway to be paranoid about any
--- future call site reusing this helper.
-local function safe_addr(ip)
-  if type(ip) ~= "string" then return nil end
-  if ip:find("[^%x%.:]") then return nil end
-  return ip
-end
-
-local function nft_add_element(set_name, ip)
-  local safe = safe_addr(ip)
-  if not safe then return end
-  -- Discard nft's output; we expect ENOENT if the set was removed between
-  -- our cache refresh and the nft call (admin disabled blockIpOnly), and
-  -- "element exists" if the same IP was added moments ago (legitimate
-  -- duplicate). Neither is actionable here.
-  os.execute(string.format(
-    "nft add element %s %s { %s } >/dev/null 2>&1",
-    nft_table, set_name, safe))
+  return s
 end
 
 local ip_to_mac     = refresh_ip_to_mac()
-local bio_sanmacs, eb_sanhosts, eb6_sanhosts = refresh_nft_sets()
+local nft_sets      = refresh_nft_sets()
 local last_lease_refresh = os.time()
 local last_bio_refresh   = os.time()
 local bio_adds_total     = 0
 local eb_adds_total      = 0
+local ea_adds_total      = 0
 
 local function maybe_populate_bio(line, now)
   local r = dns_log.parse_resolved_reply(line)
   if not r then return end
   local mac = ip_to_mac[r.client_ip]
   if not mac then return end
-  local sanmac = sanitize_mac(mac)
-  if not bio_sanmacs[sanmac] then return end
+  local sanmac = sanitize(mac)
+  if not nft_sets.bio[sanmac] then return end
   local set_name = (r.family == "v6" and "resolved6_" or "resolved_") .. sanmac
-  nft_add_element(set_name, r.ip)
+  dns_sets.nft_add_element(nft_table, set_name, r.ip)
   bio_adds_total = bio_adds_total + 1
   log.debug("dns-tail: bio add %s { %s } client=%s mac=%s",
             set_name, r.ip, r.client_ip, mac)
 end
 
--- #515: per-host extraBlocked set populator.
+-- #515 + #1346: per-host extraBlocked populator.
 --
 -- render.lua emits an `nftset=/host/4#...#eb_<sanhost>,6#...#eb6_<sanhost>`
 -- for every effective extraBlocked host, but in the deployed dnsmasq build
--- those sets stay empty under e2e (test_extra_blocked × 2 timed out waiting
--- for eb_example_com to gain its first element). Mirror the #505 fix shape:
--- tail the same query log we already read for hostname attribution, and run
--- `nft add element` ourselves when we see a `reply <host> is <ip>` that
--- matches a declared eb_<sanhost> / eb6_<sanhost> set.
---
--- Subdomain semantics: dnsmasq's `nftset=/example.com/...` matches
--- example.com AND every subdomain. Mirror that by walking labels — for
--- `www.example.com` we test `www_example_com`, then `example_com`, then
--- `com`. First hit wins; the v4 and v6 set memberships are checked
--- independently so a host with only AAAA records still populates eb6_.
-local function sanitize_host(h)
-  return (h:gsub("[%.%:]", "_"))
-end
-
+-- those sets stay empty under e2e (#515). We mirror the #505 fix: run
+-- `nft add element` ourselves when a `reply <host> is <ip>` matches a declared
+-- eb_<sanhost> / eb6_<sanhost> set. #1346 also recovers the branded chain head
+-- from the dns_log alias map (cache.resolve_head), so a DIRECTLY-queried CDN
+-- target whose branded ancestor suffix-matches a declared eb_ set still
+-- populates that set instead of silently bypassing the block.
 local function maybe_populate_eb(line)
   local r = dns_log.parse_resolved_reply(line)
-  if not r or not r.name then return end
-  local sets   = (r.family == "v6") and eb6_sanhosts or eb_sanhosts
-  local prefix = (r.family == "v6") and "eb6_"       or "eb_"
-  local n = r.name
-  while n and n ~= "" do
-    local sanhost = sanitize_host(n)
-    if sets[sanhost] then
-      nft_add_element(prefix .. sanhost, r.ip)
-      eb_adds_total = eb_adds_total + 1
-      log.debug("dns-tail: eb add %s%s { %s } name=%s",
-                prefix, sanhost, r.ip, r.name)
-      return
-    end
-    local dot = n:find("%.")
-    if not dot then return end
-    n = n:sub(dot + 1)
-  end
+  if not r then return end
+  eb_adds_total = eb_adds_total + dns_sets.maybe_populate_eb(r, {
+    eb4 = nft_sets.eb4, eb6 = nft_sets.eb6,
+    nft_table    = nft_table,
+    resolve_head = cache.resolve_head,
+    log = function(set_name)
+      log.debug("dns-tail: eb add %s { %s } name=%s", set_name, r.ip, r.name)
+    end,
+  })
 end
 
-log.info("dns-tail: populator init — %d lease(s), %d bio set(s), %d eb set(s)",
+-- #1346: per-(MAC, host) extraAllowed carve-out populator. There was NO
+-- dns-tail populator for ea_ before this — the kernel allow set was filled
+-- only by dnsmasq's `nftset=/host/...#ea_<mac>_<host>` directive, which misses
+-- the directly-queried CDN target (the target doesn't suffix-match the brand).
+-- Mirror the eb_ path but key the declared sets by MAC: map client_ip → MAC,
+-- recover the branded head, and add the IP to that MAC's matching ea_ set.
+local function maybe_populate_ea(line)
+  local r = dns_log.parse_resolved_reply(line)
+  if not r then return end
+  ea_adds_total = ea_adds_total + dns_sets.maybe_populate_ea(r, {
+    ea4 = nft_sets.ea4, ea6 = nft_sets.ea6,
+    ip_to_mac    = ip_to_mac,
+    nft_table    = nft_table,
+    resolve_head = cache.resolve_head,
+    log = function(set_name, _r, mac)
+      log.debug("dns-tail: ea add %s { %s } client=%s mac=%s name=%s",
+                set_name, r.ip, r.client_ip, mac, r.name)
+    end,
+  })
+end
+
+log.info("dns-tail: populator init — %d lease(s), %d bio set(s), %d eb set(s), %d ea mac(s)",
          (function() local n = 0; for _ in pairs(ip_to_mac) do n = n + 1 end; return n end)(),
-         (function() local n = 0; for _ in pairs(bio_sanmacs) do n = n + 1 end; return n end)(),
-         (function() local n = 0; for _ in pairs(eb_sanhosts) do n = n + 1 end; return n end)())
+         (function() local n = 0; for _ in pairs(nft_sets.bio) do n = n + 1 end; return n end)(),
+         (function() local n = 0; for _ in pairs(nft_sets.eb4) do n = n + 1 end; return n end)(),
+         (function() local n = 0; for _ in pairs(nft_sets.ea4) do n = n + 1 end; return n end)())
 
 local since_flush      = 0
 local last_tick        = os.time()
@@ -252,6 +234,11 @@ while true do
   -- through.
   maybe_populate_eb(line)
 
+  -- #1346: per-(MAC, host) extraAllowed carve-out, same first-SYN-race
+  -- argument — if the resolved IP isn't in the ea_<mac>_<host> set before the
+  -- flow's first packet, a whole-MAC block drops an explicitly-allowed app.
+  maybe_populate_ea(line)
+
   if since_flush >= flush_every or (now - last_tick) >= 30 then
     cache.tick(now)
     atomic_write(cache_path, cache.dump_text())
@@ -269,7 +256,7 @@ while true do
     last_lease_refresh = now
   end
   if (now - last_bio_refresh) >= bio_refresh_seconds then
-    bio_sanmacs, eb_sanhosts, eb6_sanhosts = refresh_nft_sets()
+    nft_sets = refresh_nft_sets()
     last_bio_refresh = now
   end
 
@@ -277,9 +264,9 @@ while true do
   -- dropping the pipe, regex never matching) are diagnosable from logread
   -- alone without on-VM access (#480).
   if (now - last_stats_log) >= 60 then
-    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d",
+    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d",
              lines_ingested, lines_since_stat, now - last_stats_log,
-             cache.size(), bio_adds_total, eb_adds_total)
+             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total)
     last_stats_log   = now
     lines_since_stat = 0
   end

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -374,6 +374,33 @@ describe("CNAME-alias attribution (#1344)", function()
 
     assert.equal("example.com", c.lookup("93.184.216.34"))
   end)
+
+  -- #1346: the kernel ea_/eb_ set populators in wifihaven-dns-tail need to
+  -- recover the branded chain head for a directly-queried CDN target so they
+  -- can suffix-match it against a declared ea_/eb_ set. #1345 learns the
+  -- target → head map but kept resolve_head local; expose it publicly so the
+  -- sidecar can reuse the same memory.
+  describe("self.resolve_head (public alias resolution, #1346)", function()
+    it("returns the branded head for a learned CNAME target", function()
+      local clk = fake_clock()
+      local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+      c.ingest_line("38053 127.0.0.1/36172 query[A] cdn.kastatic.org from 127.0.0.1")
+      c.ingest_line("38053 127.0.0.1/36172 reply cdn.kastatic.org is <CNAME>")
+      c.ingest_line("38053 127.0.0.1/36172 reply fastly.kastatic.org is <CNAME>")
+      c.ingest_line("38053 127.0.0.1/36172 reply prod.khan.map.fastly.net is 199.232.65.42")
+
+      assert.is_function(c.resolve_head)
+      assert.equal("cdn.kastatic.org", c.resolve_head("prod.khan.map.fastly.net"))
+      assert.equal("cdn.kastatic.org", c.resolve_head("fastly.kastatic.org"))
+    end)
+
+    it("returns the name unchanged when it is not a known alias", function()
+      local clk = fake_clock()
+      local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+      assert.equal("unknown.example", c.resolve_head("unknown.example"))
+    end)
+  end)
 end)
 
 -- ---------------------------------------------------------------------------

--- a/openwrt/test/dns_tail_sets_spec.lua
+++ b/openwrt/test/dns_tail_sets_spec.lua
@@ -1,0 +1,239 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/dns_tail_sets.lua
+--
+-- dns_tail_sets holds the pure nft-set populator logic the wifihaven-dns-tail
+-- sidecar runs out of band against the dnsmasq query log:
+--   * resolved_<mac>  (#505, blockIpOnly)
+--   * eb_<sanhost>    (#515, extraBlocked)
+--   * ea_<sanmac>_<sanhost> (#1346, extraAllowed carve-out)
+--
+-- It was extracted from the sidecar script so the suffix-walk + #1344 alias
+-- recovery is unit-testable with an injected exec function (mirrors the
+-- get_fn/write_fn/exec_fn injection pattern in policy.lua / conntrack.lua).
+--
+-- The headline #1346 behaviour: when a client re-queries the FINAL CNAME
+-- target directly (Apple devices do this), the answered name is the CDN
+-- target and never suffix-matches the declared ea_/eb_<brand> set. dnsmasq's
+-- own nftset= callback misses it for the same reason. We recover the branded
+-- chain head from the dns_log alias map (resolve_head) and walk THAT too.
+--
+-- Run with: busted openwrt/test/dns_tail_sets_spec.lua
+
+local sets    = require("dns_tail_sets")
+local dns_log = require("dns_log")
+
+-- Capture nft commands instead of executing them.
+local function recorder()
+  local cmds = {}
+  return cmds, function(cmd) cmds[#cmds + 1] = cmd end
+end
+
+-- Did any recorded command add `ip` to a set whose name matches `set_pat`?
+local function added(cmds, set_pat, ip)
+  for _, c in ipairs(cmds) do
+    if c:find(set_pat, 1, true) and c:find("{ " .. ip .. " }", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+-- ---------------------------------------------------------------------------
+-- helpers
+-- ---------------------------------------------------------------------------
+
+describe("sanitize / safe_addr", function()
+  it("replaces dots and colons with underscores", function()
+    assert.equal("kastatic_org", sets.sanitize("kastatic.org"))
+    assert.equal("04_72_ef_d6_e4_5a", sets.sanitize("04:72:ef:d6:e4:5a"))
+  end)
+
+  it("safe_addr passes v4/v6 literals and rejects shell metacharacters", function()
+    assert.equal("1.2.3.4", sets.safe_addr("1.2.3.4"))
+    assert.equal("2606:2800::1", sets.safe_addr("2606:2800::1"))
+    assert.is_nil(sets.safe_addr("1.2.3.4; rm -rf /"))
+    assert.is_nil(sets.safe_addr(nil))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- set discovery (parse `nft -a list table` output)
+-- ---------------------------------------------------------------------------
+
+describe("classify_set_line", function()
+  local function blank()
+    return { bio = {}, eb4 = {}, eb6 = {}, ea4 = {}, ea6 = {} }
+  end
+
+  it("indexes resolved_/eb_/eb6_ sets by sanitized host (existing #505/#515)", function()
+    local s = blank()
+    sets.classify_set_line("\t\tset resolved_aa_bb_cc_dd_ee_ff {", s)
+    sets.classify_set_line("\t\tset eb_example_com {", s)
+    sets.classify_set_line("\t\tset eb6_example_com {", s)
+    assert.is_true(s.bio["aa_bb_cc_dd_ee_ff"])
+    assert.is_true(s.eb4["example_com"])
+    assert.is_true(s.eb6["example_com"])
+  end)
+
+  it("indexes ea_/ea6_ sets by sanmac → {sanhost} splitting the fixed MAC prefix", function()
+    local s = blank()
+    -- real prod example: ea_04_72_ef_d6_e4_5a_kastatic_org
+    sets.classify_set_line("\t\tset ea_04_72_ef_d6_e4_5a_kastatic_org {", s)
+    sets.classify_set_line("\t\tset ea6_04_72_ef_d6_e4_5a_kastatic_org {", s)
+    assert.is_true(s.ea4["04_72_ef_d6_e4_5a"]["kastatic_org"])
+    assert.is_true(s.ea6["04_72_ef_d6_e4_5a"]["kastatic_org"])
+  end)
+
+  it("keeps a multi-label host intact after the MAC prefix", function()
+    local s = blank()
+    sets.classify_set_line("\t\tset ea_04_72_ef_d6_e4_5a_www_khanacademy_org {", s)
+    assert.is_true(s.ea4["04_72_ef_d6_e4_5a"]["www_khanacademy_org"])
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- eb_ / eb6_ populator (#515 + #1346 alias recovery)
+-- ---------------------------------------------------------------------------
+
+describe("maybe_populate_eb", function()
+  it("adds the answered name's IP to a declared eb_ set (existing #515 path)", function()
+    local cmds, exec = recorder()
+    local r = { name = "ads.example.com", ip = "1.2.3.4", family = "v4" }
+    local n = sets.maybe_populate_eb(r, {
+      eb4 = { example_com = true }, eb6 = {},
+      nft_table = "inet wifihaven", exec_fn = exec,
+    })
+    assert.equal(1, n)
+    assert.is_true(added(cmds, "eb_example_com", "1.2.3.4"))
+  end)
+
+  it("recovers the branded head for a DIRECTLY-queried CDN target (#1346)", function()
+    -- Drive a real dns_log cache: branded chain first, then a direct re-query
+    -- of the CNAME target on a different anycast IP.
+    local t = 1000000
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = function() return t end })
+    c.ingest_line("1 192.168.1.9/5 query[A] tiktok.com from 192.168.1.9")
+    c.ingest_line("1 192.168.1.9/5 reply tiktok.com is <CNAME>")
+    c.ingest_line("1 192.168.1.9/5 reply e35058.api12.akamaiedge.net is 23.45.67.89")
+
+    -- Now the direct re-query: the answered name is the CDN target, which does
+    -- NOT label-match eb_tiktok_com — only the recovered head does.
+    local cmds, exec = recorder()
+    local r = { name = "e35058.api12.akamaiedge.net", ip = "23.0.0.1", family = "v4" }
+    local n = sets.maybe_populate_eb(r, {
+      eb4 = { tiktok_com = true }, eb6 = {},
+      nft_table = "inet wifihaven", exec_fn = exec,
+      resolve_head = c.resolve_head,
+    })
+    assert.equal(1, n)
+    assert.is_true(added(cmds, "eb_tiktok_com", "23.0.0.1"))
+  end)
+
+  it("populates eb6_ for AAAA answers", function()
+    local cmds, exec = recorder()
+    local r = { name = "example.com", ip = "2606:2800::1", family = "v6" }
+    sets.maybe_populate_eb(r, {
+      eb4 = {}, eb6 = { example_com = true },
+      nft_table = "inet wifihaven", exec_fn = exec,
+    })
+    assert.is_true(added(cmds, "eb6_example_com", "2606:2800::1"))
+  end)
+
+  it("adds nothing when neither the name nor its head matches a declared set", function()
+    local cmds, exec = recorder()
+    local r = { name = "unrelated.example", ip = "9.9.9.9", family = "v4" }
+    local n = sets.maybe_populate_eb(r, {
+      eb4 = { tiktok_com = true }, eb6 = {},
+      nft_table = "inet wifihaven", exec_fn = exec,
+      resolve_head = function(x) return x end,
+    })
+    assert.equal(0, n)
+    assert.equal(0, #cmds)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- ea_ / ea6_ populator (#1346 — new; mirrors eb_ but keyed by (mac, host))
+-- ---------------------------------------------------------------------------
+
+describe("maybe_populate_ea", function()
+  local function deps(extra)
+    local d = {
+      ea4 = {}, ea6 = {},
+      ip_to_mac = { ["192.168.10.159"] = "04:72:ef:d6:e4:5a" },
+      nft_table = "inet wifihaven",
+    }
+    for k, v in pairs(extra or {}) do d[k] = v end
+    return d
+  end
+
+  it("adds the resolved IP to ea_<sanmac>_<sanhost> for the answering MAC", function()
+    local cmds, exec = recorder()
+    local r = { client_ip = "192.168.10.159", name = "static.kastatic.org",
+                ip = "151.101.1.42", family = "v4" }
+    local n = sets.maybe_populate_ea(r, deps({
+      ea4 = { ["04_72_ef_d6_e4_5a"] = { kastatic_org = true } },
+      exec_fn = exec,
+    }))
+    assert.equal(1, n)
+    assert.is_true(added(cmds, "ea_04_72_ef_d6_e4_5a_kastatic_org", "151.101.1.42"))
+  end)
+
+  it("recovers the brand for a DIRECTLY-queried CDN target (#1346 headline case)", function()
+    -- Kid device resolves the branded host, then re-queries the Fastly target
+    -- directly on a fresh anycast IP — the exact prod scenario from #1344.
+    local t = 1000000
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = function() return t end })
+    c.ingest_line("38053 192.168.10.159/36172 query[A] cdn.kastatic.org from 192.168.10.159")
+    c.ingest_line("38053 192.168.10.159/36172 reply cdn.kastatic.org is <CNAME>")
+    c.ingest_line("38053 192.168.10.159/36172 reply fastly.kastatic.org is <CNAME>")
+    c.ingest_line("38053 192.168.10.159/36172 reply prod.khan.map.fastly.net is 199.232.65.42")
+
+    local cmds, exec = recorder()
+    -- Direct re-query: answered name is the CDN target on a NEW IP.
+    local r = { client_ip = "192.168.10.159", name = "prod.khan.map.fastly.net",
+                ip = "151.101.65.42", family = "v4" }
+    local n = sets.maybe_populate_ea(r, deps({
+      ea4 = { ["04_72_ef_d6_e4_5a"] = { kastatic_org = true } },
+      exec_fn = exec, resolve_head = c.resolve_head,
+    }))
+    assert.equal(1, n)
+    assert.is_true(added(cmds, "ea_04_72_ef_d6_e4_5a_kastatic_org", "151.101.65.42"))
+  end)
+
+  it("populates ea6_ for AAAA answers", function()
+    local cmds, exec = recorder()
+    local r = { client_ip = "192.168.10.159", name = "static.kastatic.org",
+                ip = "2606:2800::5", family = "v6" }
+    sets.maybe_populate_ea(r, deps({
+      ea6 = { ["04_72_ef_d6_e4_5a"] = { kastatic_org = true } },
+      exec_fn = exec,
+    }))
+    assert.is_true(added(cmds, "ea6_04_72_ef_d6_e4_5a_kastatic_org", "2606:2800::5"))
+  end)
+
+  it("does nothing when the client IP maps to no MAC", function()
+    local cmds, exec = recorder()
+    local r = { client_ip = "10.0.0.99", name = "static.kastatic.org",
+                ip = "1.2.3.4", family = "v4" }
+    local n = sets.maybe_populate_ea(r, deps({
+      ea4 = { ["04_72_ef_d6_e4_5a"] = { kastatic_org = true } },
+      exec_fn = exec,
+    }))
+    assert.equal(0, n)
+    assert.equal(0, #cmds)
+  end)
+
+  it("does not add to another MAC's ea_ set", function()
+    -- The answering MAC has no ea_ set declared; a DIFFERENT MAC does. The
+    -- per-(mac,host) scoping must not leak the carve-out across devices.
+    local cmds, exec = recorder()
+    local r = { client_ip = "192.168.10.159", name = "static.kastatic.org",
+                ip = "1.2.3.4", family = "v4" }
+    local n = sets.maybe_populate_ea(r, deps({
+      ea4 = { ["aa_bb_cc_dd_ee_ff"] = { kastatic_org = true } },
+      exec_fn = exec,
+    }))
+    assert.equal(0, n)
+    assert.equal(0, #cmds)
+  end)
+end)


### PR DESCRIPTION
Closes #1346. Enforcement-side follow-up to #1344 / #1345.

## The gap

Some clients (verified on prod `router.lan`: Apple devices) re-query the final
CNAME target **directly** as a separate lookup after resolving the branded host
— e.g. `query[A] prod.khan.map.fastly.net` issued 17× after `www.khanacademy.org`.

On that direct query the answered name is the CDN target, which does **not**
suffix-match the declared `ea_<mac>_<host>` / `eb_<host>` set:

- dnsmasq's `nftset=/<host>/…` callback only fires for names that suffix-match
  the configured domain, so it never adds the directly-queried target's IPs to
  the kernel `ea_`/`eb_` set.
- dns-tail's existing `eb_` populator (#515) keys on the answered name's own
  labels, so it misses too. There was **no** dns-tail `ea_` populator at all.

Result: the directly-queried target's IPs are absent from the kernel sets —
an `extraAllowed` app is **falsely blocked** during a whole-MAC block (`ea_`),
and an `extraBlocked` host is **silently bypassed** (`eb_`, the higher-severity
half).

## The fix (router-side only — no wire/snapshot changes)

#1344/#1345 already learn a CDN-target → branded-chain-head map in `dns_log`.
This PR reuses that memory at the kernel-set populator:

1. **Expose `resolve_head` publicly** on the `dns_log` cache instance (it was
   local-only after #1345).
2. **Extract the dns-tail set populators** into a new
   `wifihaven.dns_tail_sets` module so the suffix-walk + alias recovery is
   unit-testable with an injected exec function (mirrors the
   `get_fn`/`write_fn`/`exec_fn` injection pattern in `policy.lua` /
   `conntrack.lua`). `nft_add_element` now takes the exec function; set
   discovery handles the `ea_<sanmac>_<sanhost>` shape by splitting the
   fixed-width sanitized-MAC prefix.
3. **`maybe_populate_eb`** now also resolves the answered name through
   `cache.resolve_head` and walks the recovered head's labels against the
   declared `eb_`/`eb6_` sets, in addition to the existing `r.name` walk.
4. **`maybe_populate_ea`** (new): map `client_ip → MAC`, recover the branded
   head, and `nft add element` the resolved IP into that MAC's matching
   `ea_<sanmac>_<sanhost>` / `ea6_…` set — inline, in lockstep with the cache
   flush (same first-SYN-race rationale as #505/#515).
5. **Counters**: add `ea_adds_total`; the new `eb_` head path folds into the
   existing `eb_adds_total`. These are agent in-process counters surfaced in
   the dns-tail heartbeat logline, **not** the API `/metrics` exposition, so no
   Grafana panel is required (per the metrics rules — nothing new reaches the
   API exposition here).

## Test plan (TDD — red→green visible in history)

- `cbf2e649` commits the failing specs first; `d5bfcb7b` makes them pass.
- New `openwrt/test/dns_tail_sets_spec.lua` drives a **real** `dns_log` cache
  through a branded CNAME chain, then a **direct** re-query of the final CDN
  target on a fresh anycast IP, and asserts the populators recover the branded
  head and add the directly-queried target's IP to the correct
  `ea_<mac>_<host>` / `eb_<host>` set. Covers v4/v6, per-MAC scoping (no
  cross-device leak), unmapped client IP, and the safe-degradation /
  no-match paths.
- New `dns_log_spec` cases cover the public `resolve_head`.
- `busted test/`: **430 successes / 2 failures / 33 errors / 1 pending** — the
  2 failures (`failover_spec`) and 33 errors are pre-existing **environmental**
  gaps (`luci.jsonc` / `wifihaven.render` not installable locally), unchanged
  from the base commit (414 successes before; +16 new). `dns_log_spec`,
  `dns_tail_sets_spec`, and `render_spec` are all green. No Scala touched.

## Notes

- Builds on #1344 / #1345 (now merged to `main`); this branch is based on
  `main`.
- Does **not** implement the `bl_` category-blocklist path — that's tracked
  separately in #1348.
