### PR TITLE
fix(openwrt): close bl_ category bypass via dns-tail CNAME populator (#1348)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -329,8 +329,9 @@ function M.new(opts)
   -- `name` unchanged when it is not a known alias (#1344). Exposed publicly so
   -- the wifihaven-dns-tail sidecar can reuse the SAME learned alias memory to
   -- recover the brand for a directly-queried CDN target before suffix-matching
-  -- it against the kernel ea_/eb_ sets (#1346). Internally `resolve_head` is
-  -- already used by ingest_line; this is a thin public passthrough.
+  -- it against the kernel ea_/eb_ sets (#1346) and the category bl_ sets
+  -- (#1348). Internally `resolve_head` is already used by ingest_line; this is
+  -- a thin public passthrough.
   function self.resolve_head(name)
     return resolve_head(name)
   end
@@ -349,6 +350,78 @@ function M.new(opts)
   end
 
   return self
+end
+
+-- ---------------------------------------------------------------------------
+-- #1348: category-blocklist (bl_) dns-tail populator support.
+--
+-- bl_<id> / bl6_<id> category drop-sets are declared per blocklist id and
+-- populated at DNS resolve time by dnsmasq's `nftset=/<member>/...#bl_<id>`
+-- directive — which fires only for queries whose name suffix-matches a member
+-- host. When a client re-queries a member's CNAME target DIRECTLY it lands on a
+-- CDN-anycast IP dnsmasq never added to bl_<id>, so the category drop misses
+-- and blocked content becomes reachable (a silent filter bypass). dns-tail
+-- closes that gap exactly as it does for eb_ (#515): on each `reply <name> is
+-- <ip>` it resolves <name> through the CNAME-alias map (resolve_head) and, if
+-- the recovered brand is a blocklist member, adds the IP to that member's bl_
+-- set. dns-tail knows which bl_ sets EXIST (from `nft list table`) but not
+-- their MEMBERSHIP, so render.lua writes a host → set index it consumes here.
+--
+-- parse_blocklist_member_index(text) → { [host] = { {v4=set4, v6=set6}, … } }
+-- Inverse of render.blocklist_member_index. Each line is
+-- "<host>\t<bl_set>\t<bl6_set>"; a host present in multiple blocklists yields
+-- multiple rows (one {v4,v6} pair each).
+function M.parse_blocklist_member_index(text)
+  local out = {}
+  if type(text) ~= "string" or text == "" then return out end
+  for line in text:gmatch("[^\n]+") do
+    local host, set4, set6 = line:match("^(%S+)\t(%S+)\t(%S+)$")
+    if host then
+      local rows = out[host]
+      if not rows then rows = {}; out[host] = rows end
+      rows[#rows + 1] = { v4 = set4, v6 = set6 }
+    end
+  end
+  return out
+end
+
+-- populate_bl(reply, member_index, resolve_head_fn, add_fn) → matched?
+--
+--   reply           — a parse_resolved_reply result { name, ip, family }.
+--   member_index    — a parse_blocklist_member_index output.
+--   resolve_head_fn — cache.resolve_head (attributes a directly-queried CDN
+--                     target back to the branded chain head). nil-safe: when
+--                     absent the answered name is used verbatim.
+--   add_fn          — injected `add_fn(set_name, ip)` (dns-tail passes the real
+--                     nft add-element; tests pass a collector).
+--
+-- Resolves reply.name → branded head, then walks the head's label suffixes
+-- against the member index (mirroring dnsmasq's `/member/` subdomain match: a
+-- member matches itself and every subdomain). For every matching member it
+-- calls add_fn with the family-appropriate bl_/bl6_ set name, so an IP only
+-- reachable via a directly-queried CNAME target still lands in the category
+-- drop-set. A host in multiple blocklists adds to each. Returns true iff at
+-- least one member matched (testability).
+function M.populate_bl(reply, member_index, resolve_head_fn, add_fn)
+  if type(reply) ~= "table" or not reply.name or not reply.ip then return false end
+  if type(member_index) ~= "table" or type(add_fn) ~= "function" then return false end
+  local key  = (reply.family == "v6") and "v6" or "v4"
+  local name = resolve_head_fn and resolve_head_fn(reply.name) or reply.name
+  local matched = false
+  while name and name ~= "" do
+    local rows = member_index[name]
+    if rows then
+      for _, r in ipairs(rows) do
+        local set = r[key]
+        if set then add_fn(set, reply.ip) end
+      end
+      matched = true
+    end
+    local dot = name:find("%.")
+    if not dot then break end
+    name = name:sub(dot + 1)
+  end
+  return matched
 end
 
 -- Parses the output of an instance's `dump_text()` and returns a plain

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -13,4 +13,9 @@ M.block_page_hosts    = "/var/run/wifihaven/blocked_hosts"
 -- ip → hostname cache (#259): wifihaven-dns-tail writes, wifihaven-agent reads.
 M.dns_cache = "/tmp/wifihaven-dns-cache.txt"
 
+-- blocklist member → bl_ set index (#1348): policy.apply writes after each
+-- snapshot apply (in lockstep with /tmp/dnsmasq.d/wifihaven.conf), the
+-- wifihaven-dns-tail bl_ populator reads it on its set-refresh cadence.
+M.bl_member_index = "/tmp/wifihaven-bl-members.txt"
+
 return M

--- a/openwrt/files/usr/lib/lua/wifihaven/policy.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/policy.lua
@@ -42,6 +42,7 @@
 local M = {}
 
 local render = require("wifihaven.render")
+local paths  = require("wifihaven.paths")
 
 -- log is injectable for tests; default uses the real logger wrapper.
 local function default_log()
@@ -260,6 +261,18 @@ function M.apply(snapshot, write_fn, reload_fn, log, opts)
     log.err("policy.apply: write nft file failed: %s", tostring(err2))
     report("write_failed", false)
     return false
+  end
+
+  -- #1348: blocklist member → bl_ set index for the dns-tail bl_ populator.
+  -- Written in lockstep with the dnsmasq.conf above (whose nftset= directives
+  -- declare the same membership) so a directly-queried CNAME target landing on
+  -- a fresh CDN-anycast IP still populates the category drop-set. A write
+  -- failure here is non-fatal: it only loses the directly-queried-target
+  -- coverage until the next apply, not core enforcement, so we log and proceed.
+  local bl_index = render.blocklist_member_index(snapshot)
+  local okbl, errbl = write_fn(paths.bl_member_index, bl_index)
+  if not okbl then
+    log.warn("policy.apply: write bl member index failed: %s", tostring(errbl))
   end
 
   if dnsmasq_changed then

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -364,6 +364,38 @@ function M.dnsmasq(snapshot)
 end
 
 -- ---------------------------------------------------------------------------
+-- render.blocklist_member_index(snapshot) → string  (#1348)
+-- ---------------------------------------------------------------------------
+-- A host → bl_ set mapping for the wifihaven-dns-tail bl_ populator.
+--
+-- bl_<id>/bl6_<id> sets are populated at DNS resolve time by the dnsmasq
+-- `nftset=/<member>/...#bl_<id>` directives emitted above, which only fire for
+-- queries that suffix-match a member host. A device that re-queries a member's
+-- CNAME target directly lands on a CDN-anycast IP dnsmasq never added, so the
+-- category drop misses (silent filter bypass). dns-tail closes the gap the same
+-- way it does for eb_ (#515): it resolves each answered name through the #1344
+-- CNAME-alias map and, when the recovered brand is a blocklist member, adds the
+-- IP to that member's bl_ set. dns-tail can see which bl_ sets EXIST but not
+-- their MEMBERSHIP, so this exports it.
+--
+-- Derived from the same `snapshot._blocklist_hosts` that drives the `nftset=`
+-- directives, so the set names line up exactly with what render.nft declares.
+-- One row per (member host, blocklist id): "<host>\t<bl_set>\t<bl6_set>".
+function M.blocklist_member_index(snapshot)
+  local bl_hosts = snapshot and snapshot._blocklist_hosts or {}
+  local bl_ids   = sorted_keys(snapshot and snapshot.blocklists or {})
+  local lines = {}
+  for _, id in ipairs(bl_ids) do
+    local set4 = bl_set_name(id)
+    local set6 = bl6_set_name(id)
+    for _, host in ipairs(bl_hosts[id] or {}) do
+      lines[#lines + 1] = string.format("%s\t%s\t%s", host, set4, set6)
+    end
+  end
+  return table.concat(lines, "\n") .. (#lines > 0 and "\n" or "")
+end
+
+-- ---------------------------------------------------------------------------
 -- render.nft(snapshot, opts) → string
 -- ---------------------------------------------------------------------------
 -- opts (optional table):

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -22,6 +22,7 @@ local debug_opt   = uci_get("debug", "0")
 local source_path = "/tmp/wifihaven-dnsmasq.log"
 local cache_path  = paths.dns_cache
 local tmp_path    = cache_path .. ".tmp"
+local bl_index_path = paths.bl_member_index  -- #1348
 local leases_path = "/tmp/dhcp.leases"
 local nft_table   = "inet wifihaven"
 -- How often to refresh the bio-set membership cache (which MACs have a
@@ -129,13 +130,28 @@ local function refresh_nft_sets()
   return s
 end
 
-local ip_to_mac     = refresh_ip_to_mac()
-local nft_sets      = refresh_nft_sets()
+-- #1348: category-blocklist (bl_) member → set index. policy.apply writes
+-- `<host>\t<bl_set>\t<bl6_set>` rows to paths.bl_member_index after each apply
+-- (in lockstep with the dnsmasq nftset= directives that declare the same
+-- membership). Reload it on the same cadence as refresh_nft_sets — it changes
+-- only on a policy apply, which is slow relative to log-line throughput.
+local function refresh_bl_member_index()
+  local f = io.open(bl_index_path, "r")
+  if not f then return {} end
+  local text = f:read("*a")
+  f:close()
+  return dns_log.parse_blocklist_member_index(text)
+end
+
+local ip_to_mac       = refresh_ip_to_mac()
+local nft_sets        = refresh_nft_sets()
+local bl_member_index = refresh_bl_member_index()
 local last_lease_refresh = os.time()
 local last_bio_refresh   = os.time()
 local bio_adds_total     = 0
 local eb_adds_total      = 0
 local ea_adds_total      = 0
+local bl_adds_total      = 0
 
 local function maybe_populate_bio(line, now)
   local r = dns_log.parse_resolved_reply(line)
@@ -195,6 +211,28 @@ local function maybe_populate_ea(line)
   })
 end
 
+-- #1348: per-blocklist (bl_) set populator. bl_<id>/bl6_<id> are populated at
+-- DNS resolve time by dnsmasq's nftset=/<member>/...#bl_<id> directive, which
+-- fires only for queries whose name suffix-matches a member host. A client that
+-- re-queries a member's CNAME target directly lands on a CDN-anycast IP dnsmasq
+-- never added, so the category drop misses (silent filter bypass). Mirror the
+-- #515 eb_ fix: resolve the answered name through the CNAME-alias map
+-- (cache.resolve_head) and, when the recovered brand is a blocklist member, add
+-- the IP to that member's bl_ set ourselves. The dns_log.populate_bl core takes
+-- an injected add_fn (unit-tested in dns_log_spec); we wire the shared
+-- dns_sets.nft_add_element. Inline (not batched) for the same first-SYN-race
+-- reason as #505/#515 — the drop rule fires on the first packet.
+local function maybe_populate_bl(line)
+  local r = dns_log.parse_resolved_reply(line)
+  if not r or not r.name then return end
+  dns_log.populate_bl(r, bl_member_index, cache.resolve_head, function(set, ip)
+    dns_sets.nft_add_element(nft_table, set, ip)
+    bl_adds_total = bl_adds_total + 1
+    log.debug("dns-tail: bl add %s { %s } name=%s head-via-alias",
+              set, ip, r.name)
+  end)
+end
+
 log.info("dns-tail: populator init — %d lease(s), %d bio set(s), %d eb set(s), %d ea mac(s)",
          (function() local n = 0; for _ in pairs(ip_to_mac) do n = n + 1 end; return n end)(),
          (function() local n = 0; for _ in pairs(nft_sets.bio) do n = n + 1 end; return n end)(),
@@ -239,6 +277,11 @@ while true do
   -- flow's first packet, a whole-MAC block drops an explicitly-allowed app.
   maybe_populate_ea(line)
 
+  -- #1348: same lockstep argument — close the category-blocklist bypass for
+  -- directly-queried CNAME targets by adding the resolved IP to the member's
+  -- bl_ set when the answered name attributes (via the alias map) to a member.
+  maybe_populate_bl(line)
+
   if since_flush >= flush_every or (now - last_tick) >= 30 then
     cache.tick(now)
     atomic_write(cache_path, cache.dump_text())
@@ -257,6 +300,7 @@ while true do
   end
   if (now - last_bio_refresh) >= bio_refresh_seconds then
     nft_sets = refresh_nft_sets()
+    bl_member_index = refresh_bl_member_index()  -- #1348
     last_bio_refresh = now
   end
 
@@ -264,9 +308,9 @@ while true do
   -- dropping the pipe, regex never matching) are diagnosable from logread
   -- alone without on-VM access (#480).
   if (now - last_stats_log) >= 60 then
-    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d",
+    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d bl_adds=%d",
              lines_ingested, lines_since_stat, now - last_stats_log,
-             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total)
+             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total, bl_adds_total)
     last_stats_log   = now
     lines_since_stat = 0
   end

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -649,9 +649,12 @@ describe("populate_bl (#1348)", function()
   it("uses the v6 set name for an AAAA answer", function()
     local clk = fake_clock()
     local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
-    c.ingest_line("11 192.168.1.50/101 query[AAAA] tiktok.com from 192.168.1.50")
+    -- The alias edge cdn.akamai.net → tiktok.com is learned from the branded
+    -- A-record chain (the cache's alias map is fed by v4 reply lines, since
+    -- conntrack flows are v4); it's then reused for the AAAA direct re-query.
+    c.ingest_line("11 192.168.1.50/101 query[A] tiktok.com from 192.168.1.50")
     c.ingest_line("11 192.168.1.50/101 reply tiktok.com is <CNAME>")
-    c.ingest_line("11 192.168.1.50/101 reply cdn.akamai.net is 2606:2800::1")
+    c.ingest_line("11 192.168.1.50/101 reply cdn.akamai.net is 1.2.3.4")
 
     local idx = dns_log.parse_blocklist_member_index(
       "tiktok.com\tbl_social\tbl6_social\n")

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -531,3 +531,180 @@ describe("dump_text + load_table", function()
     assert.same({}, dns_log.load_table("garbage\nnot a real entry\n", 3600, 0))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- 2c. resolve_head public accessor (#1346/#1348)
+--
+-- The CNAME-alias resolution (#1344) was previously an internal closure used
+-- only by ingest_line. The dns-tail eb_/bl_ populators need to attribute a
+-- directly-queried CDN target back to the branded chain head BEFORE matching
+-- against set membership, so the live cache exposes it as a method (sharing the
+-- learned alias edges — no second map).
+-- ---------------------------------------------------------------------------
+
+describe("resolve_head accessor (#1346/#1348)", function()
+  local function fake_clock()
+    local t = 1000000
+    return { now = function() return t end, advance = function(s) t = t + s end }
+  end
+
+  it("returns the branded chain head for a learned CDN alias", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("1 192.168.1.10/100 query[A] cdn.kastatic.org from 192.168.1.10")
+    c.ingest_line("1 192.168.1.10/100 reply cdn.kastatic.org is <CNAME>")
+    c.ingest_line("1 192.168.1.10/100 reply prod.khan.map.fastly.net is 199.232.65.42")
+
+    assert.equal("cdn.kastatic.org", c.resolve_head("prod.khan.map.fastly.net"))
+  end)
+
+  it("returns the name unchanged when it is not a known alias", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    assert.equal("example.com", c.resolve_head("example.com"))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 2d. Category-blocklist member index + bl_ populator (#1348)
+--
+-- bl_<id> / bl6_<id> category drop-sets are declared per blocklist id and
+-- populated at DNS resolve time by dnsmasq's `nftset=/<member>/...#bl_<id>`
+-- directive — which fires only for queries whose name suffix-matches a member
+-- host. When a client re-queries a member's CNAME target DIRECTLY it lands on a
+-- CDN-anycast IP dnsmasq never added to bl_<id>, so the category drop misses
+-- and blocked content becomes reachable (a silent filter bypass, #1348).
+--
+-- dns-tail closes that gap the same way it does for eb_ (#515/#1346): on each
+-- `reply <name> is <ip>` it resolves <name> through the #1344 CNAME-alias map
+-- and, if the recovered brand is a blocklist member, adds the IP to that
+-- member's bl_ set. dns-tail knows which bl_ sets EXIST but not their
+-- MEMBERSHIP — `parse_blocklist_member_index` supplies host → bl_set so the
+-- populator can match, and `populate_bl` performs the alias-resolve + walk.
+-- ---------------------------------------------------------------------------
+
+describe("parse_blocklist_member_index (#1348)", function()
+  it("parses host → {v4,v6} set rows, grouping multiple ids per host", function()
+    local text = table.concat({
+      "tiktok.com\tbl_social\tbl6_social",
+      "tiktok.com\tbl_china\tbl6_china",
+      "youtube.com\tbl_video\tbl6_video",
+    }, "\n") .. "\n"
+    local idx = dns_log.parse_blocklist_member_index(text)
+
+    assert.equal(2, #idx["tiktok.com"])
+    assert.equal("bl_social", idx["tiktok.com"][1].v4)
+    assert.equal("bl6_social", idx["tiktok.com"][1].v6)
+    assert.equal("bl_china",  idx["tiktok.com"][2].v4)
+    assert.equal("bl_video",  idx["youtube.com"][1].v4)
+  end)
+
+  it("returns an empty table for nil / empty / malformed input", function()
+    assert.same({}, dns_log.parse_blocklist_member_index(nil))
+    assert.same({}, dns_log.parse_blocklist_member_index(""))
+    assert.same({}, dns_log.parse_blocklist_member_index("garbage no tabs here\n"))
+  end)
+end)
+
+describe("populate_bl (#1348)", function()
+  local function fake_clock()
+    local t = 1000000
+    return { now = function() return t end, advance = function(s) t = t + s end }
+  end
+
+  -- Collector standing in for dns-tail's injected nft_add_element.
+  local function collector()
+    local adds = {}
+    return adds, function(set, ip) adds[#adds + 1] = { set = set, ip = ip } end
+  end
+
+  it("adds a directly-queried CNAME target's IP to the member's bl_ set", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+
+    -- 1) The branded member tiktok.com was resolved earlier; the agent-side
+    --    population added IP A (1.2.3.4) to bl_social via dnsmasq. The chain
+    --    head → CDN target alias edge is learned here.
+    c.ingest_line("10 192.168.1.50/100 query[A] tiktok.com from 192.168.1.50")
+    c.ingest_line("10 192.168.1.50/100 reply tiktok.com is <CNAME>")
+    c.ingest_line("10 192.168.1.50/100 reply e35058.api12.akamaiedge.net is 1.2.3.4")
+
+    local idx = dns_log.parse_blocklist_member_index(
+      "tiktok.com\tbl_social\tbl6_social\n")
+
+    -- 2) The device re-queries the CDN target DIRECTLY and lands on a DIFFERENT
+    --    Akamai anycast IP B (5.6.7.8) that bl_social never got — the bypass.
+    clk.advance(5)
+    local reply = { name = "e35058.api12.akamaiedge.net", ip = "5.6.7.8", family = "v4" }
+
+    local adds, add_fn = collector()
+    dns_log.populate_bl(reply, idx, c.resolve_head, add_fn)
+
+    -- B must be added to the correct bl_<id> via the alias map + member index.
+    assert.equal(1, #adds)
+    assert.equal("bl_social", adds[1].set)
+    assert.equal("5.6.7.8",   adds[1].ip)
+  end)
+
+  it("uses the v6 set name for an AAAA answer", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("11 192.168.1.50/101 query[AAAA] tiktok.com from 192.168.1.50")
+    c.ingest_line("11 192.168.1.50/101 reply tiktok.com is <CNAME>")
+    c.ingest_line("11 192.168.1.50/101 reply cdn.akamai.net is 2606:2800::1")
+
+    local idx = dns_log.parse_blocklist_member_index(
+      "tiktok.com\tbl_social\tbl6_social\n")
+    local reply = { name = "cdn.akamai.net", ip = "2606:2800::2", family = "v6" }
+
+    local adds, add_fn = collector()
+    dns_log.populate_bl(reply, idx, c.resolve_head, add_fn)
+
+    assert.equal(1, #adds)
+    assert.equal("bl6_social", adds[1].set)
+  end)
+
+  it("matches a member via dnsmasq subdomain semantics (suffix walk)", function()
+    local c = dns_log.new({ ttl_seconds = 3600 })
+    local idx = dns_log.parse_blocklist_member_index("tiktok.com\tbl_social\tbl6_social\n")
+    -- A subdomain the alias map never saw; resolve_head returns it unchanged,
+    -- but it still suffix-matches the member tiktok.com.
+    local reply = { name = "www.tiktok.com", ip = "9.9.9.9", family = "v4" }
+
+    local adds, add_fn = collector()
+    dns_log.populate_bl(reply, idx, c.resolve_head, add_fn)
+
+    assert.equal(1, #adds)
+    assert.equal("bl_social", adds[1].set)
+  end)
+
+  it("adds to every blocklist a member belongs to", function()
+    local c = dns_log.new({ ttl_seconds = 3600 })
+    local idx = dns_log.parse_blocklist_member_index(table.concat({
+      "tiktok.com\tbl_social\tbl6_social",
+      "tiktok.com\tbl_china\tbl6_china",
+    }, "\n") .. "\n")
+    local reply = { name = "tiktok.com", ip = "1.1.1.1", family = "v4" }
+
+    local adds, add_fn = collector()
+    dns_log.populate_bl(reply, idx, c.resolve_head, add_fn)
+
+    assert.equal(2, #adds)
+    local sets = { [adds[1].set] = true, [adds[2].set] = true }
+    assert.is_true(sets["bl_social"])
+    assert.is_true(sets["bl_china"])
+  end)
+
+  it("does nothing when the resolved head is not a blocklist member (safe)", function()
+    local c = dns_log.new({ ttl_seconds = 3600 })
+    local idx = dns_log.parse_blocklist_member_index("tiktok.com\tbl_social\tbl6_social\n")
+    -- No prior brand chain observed for this target → resolve_head returns it
+    -- unchanged, and it matches no member. Never adds spuriously.
+    local reply = { name = "unrelated.example.net", ip = "8.8.8.8", family = "v4" }
+
+    local adds, add_fn = collector()
+    dns_log.populate_bl(reply, idx, c.resolve_head, add_fn)
+
+    assert.equal(0, #adds)
+  end)
+end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1198,6 +1198,50 @@ end)
 -- packet is dropped iff *any* matches. A host in extraBlocked still drops
 -- even though its IP also lands in resolved_<mac>.
 
+-- ---------------------------------------------------------------------------
+-- render.blocklist_member_index (#1348)
+--
+-- bl_<id>/bl6_<id> sets are populated at DNS resolve time by dnsmasq's
+-- nftset=/<member>/...#bl_<id> directive, which misses a directly-queried CNAME
+-- target landing on a fresh CDN-anycast IP (silent filter bypass). dns-tail
+-- closes that gap, but it only knows which bl_ sets EXIST — not their
+-- MEMBERSHIP. This index exports host → bl_set so the dns-tail populator can
+-- match a member resolved through the #1344 CNAME-alias map. It is derived from
+-- the same snapshot._blocklist_hosts that drives the nftset= directives, so the
+-- set names line up exactly.
+-- ---------------------------------------------------------------------------
+
+describe("render.blocklist_member_index (#1348)", function()
+  it("emits <host>\\t<bl_set>\\t<bl6_set> for each member of each blocklist", function()
+    local s = {
+      blocklists = {
+        test_ads = { version = "v1", url = "/api/blocklists/test_ads" },
+      },
+      _blocklist_hosts = {
+        test_ads = { "adserver.example.com", "doubleclick.net" },
+      },
+    }
+    local idx = render.blocklist_member_index(s)
+    assert.truthy(idx:find("adserver.example.com\tbl_test_ads\tbl6_test_ads", 1, true))
+    assert.truthy(idx:find("doubleclick.net\tbl_test_ads\tbl6_test_ads", 1, true))
+  end)
+
+  it("sanitizes the id into the set name the same way render.nft declares it", function()
+    local s = {
+      blocklists       = { ["test.cat-1"] = { version = "v1", url = "/x" } },
+      _blocklist_hosts = { ["test.cat-1"] = { "badhost.com" } },
+    }
+    local idx = render.blocklist_member_index(s)
+    -- bl_sanitize replaces ., :, -, whitespace with _.
+    assert.truthy(idx:find("badhost.com\tbl_test_cat_1\tbl6_test_cat_1", 1, true))
+  end)
+
+  it("returns an empty string when there are no blocklist members", function()
+    assert.equal("", render.blocklist_member_index({ blocklists = {} }))
+    assert.equal("", render.blocklist_member_index({}))
+  end)
+end)
+
 describe("render blockIpOnly enforcement (#353)", function()
 
   local function snap_bio()


### PR DESCRIPTION
## Summary

Closes the category-blocklist (`bl_`) filter bypass in #1348: a client that
re-queries a blocklist member's CNAME target **directly** lands on a
CDN-anycast IP the router never added to `bl_<id>`, so the category drop
misses and blocked content becomes reachable. This is higher severity than the
`ea_`/`eb_` half (a silent *bypass*, not a false block).

## Design

`bl_<id>`/`bl6_<id>` are declared per blocklist id and populated at DNS resolve
time by render's `nftset=/<member>/4#…#bl_<id>,6#…#bl6_<id>` directive — which
fires only for queries whose *name* suffix-matches a member host. A direct
re-query of a member's CNAME target (verified on prod: Apple devices do this)
doesn't suffix-match the member, so the resolved anycast IP never lands in the
set.

The fix mirrors the `eb_` dns-tail populator (#515/#1346): on each client
`reply <name> is <ip>`, dns-tail resolves `<name>` back to its branded chain
head through the #1344 CNAME-alias map and, if the recovered brand is a
blocklist **member**, adds the IP to that member's `bl_` set itself.

The one new piece: dns-tail knew which `bl_` sets *exist* (from
`nft list table`) but not their **membership** (`eb_`'s set name *is* the host;
`bl_`'s is the *id*). So render exports a minimal host→set index, written by
`policy.apply` alongside the dnsmasq fragment it's derived from.

## Changes (router-side only)

- `dns_log.resolve_head` — promote the #1344 CNAME-alias resolver to a **public
  method** on the cache instance (shares the live learned alias edges; no
  second map).
- `dns_log.parse_blocklist_member_index` / `dns_log.populate_bl` — pure index
  parser and an alias-resolve + dnsmasq-subdomain-walk populator that takes an
  **injected** `add_fn` (so it's unit-testable; dns-tail wraps it with the real
  `nft add element`).
- `render.blocklist_member_index` — emit `<host>\t<bl_set>\t<bl6_set>` rows from
  the same `_blocklist_hosts` that drives the `nftset=` directives, so set names
  line up exactly.
- `policy.apply` — write the index to `paths.bl_member_index`
  (`/tmp/wifihaven-bl-members.txt`) in lockstep with `dnsmasq.conf`; non-fatal
  on write failure.
- `wifihaven-dns-tail` — load + refresh the index on the existing 30s
  set-refresh cadence and run `maybe_populate_bl` inline per reply (same
  first-SYN-race argument as #505/#515); `bl_adds` added to the heartbeat.

**No wire/snapshot changes** (the API ships `blocklistIds`; membership is
resolved on the router from the blocklist bodies it already fetches) and **no
pinned CDN hostnames/IPs** (#1337) — the populator only ever adds IPs observed
in live client answers, attributed by the rotating alias map.

## Test plan

TDD, red→green visible in history:

- `a1a847d` — failing busted tests first.
- `dff696c` — implementation.

New coverage in `openwrt/test/dns_log_spec.lua` and `render_spec.lua`:
- the core bypass: a member resolved agent-side to IP-set A, then a device
  directly querying the member's CNAME target landing on IP B — asserts B is
  added to the correct `bl_<id>` via the alias map + member index;
- v6 (AAAA → `bl6_`), dnsmasq subdomain semantics (suffix walk), a member in
  multiple blocklists, and the safe no-op when the head matches no member;
- `parse_blocklist_member_index` parsing + the `resolve_head` accessor;
- `render.blocklist_member_index` row/sanitization/empty-input output.

Local: `busted test/` → **426 successes / 2 failures / 33 errors / 1 pending**
(+12 vs base; the 2 failover failures and 33 `luci.jsonc`/`wifihaven.render`
"not found" errors are pre-existing/environmental on this host, unchanged from
base).

## Dependency / merge order

Based on **#1345** (`claude/fix-dns-attribution`, PR open) — this PR targets
that branch so the diff is isolated. The **#1346** branch isn't pushed yet;
its public `resolve_head` accessor is added here idempotently. **Reconcile the
single shared accessor when sequencing merges: #1345 → #1346 → #1348.**

Refs #1348, #1344, #1346, #515, #505, #1337.
