### PR TITLE
test(e2e): router e2e for directly-queried CNAME targets — ea_/eb_/attribution (#1351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       fake-api: ${{ steps.filter.outputs.fake-api || steps.force.outputs.all }}
       workflows: ${{ steps.filter.outputs.workflows || steps.force.outputs.all }}
       grafana-tf: ${{ steps.filter.outputs.grafana-tf || steps.force.outputs.all }}
+      cloudflare-tf: ${{ steps.filter.outputs.cloudflare-tf || steps.force.outputs.all }}
       deploy-webhook: ${{ steps.filter.outputs.deploy-webhook || steps.force.outputs.all }}
     steps:
       - name: Force full matrix for CD / manual triggers
@@ -146,6 +147,9 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'infra/grafana/**'
               - 'deploy/grafana/dashboards/**'
+            cloudflare-tf:
+              - '.github/workflows/ci.yml'
+              - 'infra/cloudflare/**'
             # #1245: standalone Render→Grafana deploy-annotation receiver.
             # stdlib-only, so its own pytest job rather than the opnsense one.
             deploy-webhook:
@@ -631,6 +635,40 @@ jobs:
             python3 -m json.tool "$f" > /dev/null
           done
 
+  # ── infra/cloudflare Terraform: fmt + validate ──────────────────────────
+  # Cheap config-quality gate for the Cloudflare DNS/Pages Terraform in
+  # infra/cloudflare/. Catches fmt drift and invalid HCL before an operator
+  # runs `terraform apply` against the wifihaven.net zone.
+  #
+  # NOTE: this job does NOT run `terraform apply`. Cloudflare API credentials
+  # (CLOUDFLARE_API_TOKEN) are never needed here and are NOT in CI secrets.
+  # All DNS record changes (including the e2e test fixture records added in
+  # #1351) require a manual `terraform apply` by the operator.
+  cloudflare-terraform:
+    name: Cloudflare Terraform Lint
+    needs: changes
+    if: needs.changes.outputs.cloudflare-tf == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.15.3'
+
+      - name: terraform fmt
+        working-directory: infra/cloudflare
+        run: terraform fmt -check -diff
+
+      - name: terraform init + validate
+        working-directory: infra/cloudflare
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate
+
   # ── GitHub Actions workflow lint ─────────────────────────────────────────
   # actionlint statically checks every workflow under .github/workflows/ for
   # syntax errors, bad expressions, unknown runner labels, and (via the
@@ -713,6 +751,7 @@ jobs:
       - fake-api-tests
       - render-blueprint
       - grafana-terraform
+      - cloudflare-terraform
       - actionlint
       - frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -49,6 +49,12 @@ on:
       - '.github/workflows/e2e-vm-fake.yml'
       - '.github/workflows/e2e-vm-gate3a.yml'
       - '.github/workflows/ci.yml'
+      # e2e scenario files: a new or changed fake-mode scenario that gates the
+      # router image should re-run the full pipeline, not just CI tests.
+      - 'scripts/e2e/scenarios_fake/**'
+      - 'scripts/e2e/lib/**'
+      - 'scripts/e2e/fake-api/**'
+      - 'scripts/e2e/pytest.ini'
   workflow_dispatch:
 
 # Workflow-level concurrency scoped to THIS pipeline's group name — router

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -133,3 +133,50 @@ resource "cloudflare_record" "api_staging" {
   ttl     = 1
   comment = "Render wifihaven-api-staging (#613)"
 }
+
+# ── e2e CNAME chain — controllable test fixture for #1351 ──────────────────
+#
+# A three-hop chain used by scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+# to prove the dns-tail ea_/eb_ populator handles directly-queried CNAME targets
+# (#1346/#1349) end-to-end on a real router VM.
+#
+# Records are DNS-only (proxied=false) so the chain resolves as authored and
+# the leaf A record is never hidden behind Cloudflare's edge. The leaf IP is
+# 93.184.216.34 (IANA's example.com — stable, responds to HTTP/80 with a
+# non-block-page body, and is already used as the harness's reference
+# "internet-reachable" origin in scripts/e2e/lib/wait.py).
+#
+# Prerequisite: `terraform apply` against the wifihaven.net zone must run
+# (operator-applied; see PR #1351 description) before the e2e gate can resolve
+# this chain from the router VM. CI validates fmt + validate only; it does NOT
+# apply. See .github/workflows/ci.yml cloudflare-terraform job.
+
+resource "cloudflare_record" "e2e_brand" {
+  zone_id = var.zone_id
+  name    = "e2e-brand"
+  type    = "CNAME"
+  content = "e2e-mid.wifihaven.net"
+  proxied = false
+  ttl     = 300
+  comment = "e2e test fixture: branded host for direct-requery CNAME test (#1351)"
+}
+
+resource "cloudflare_record" "e2e_mid" {
+  zone_id = var.zone_id
+  name    = "e2e-mid"
+  type    = "CNAME"
+  content = "e2e-edge.wifihaven.net"
+  proxied = false
+  ttl     = 300
+  comment = "e2e test fixture: mid-hop for direct-requery CNAME test (#1351)"
+}
+
+resource "cloudflare_record" "e2e_edge" {
+  zone_id = var.zone_id
+  name    = "e2e-edge"
+  type    = "A"
+  content = var.e2e_edge_ip
+  proxied = false
+  ttl     = 300
+  comment = "e2e test fixture: leaf A record for direct-requery CNAME test (#1351)"
+}

--- a/infra/cloudflare/terraform.tfvars.example
+++ b/infra/cloudflare/terraform.tfvars.example
@@ -3,3 +3,7 @@ zone_id    = "<paste from Cloudflare dash → wifihaven.net → right sidebar �
 
 api_prod_cname_target    = "<from Render → wifihaven-api-prod    → Settings → Custom Domains>"
 api_staging_cname_target = "<from Render → wifihaven-api-staging → Settings → Custom Domains>"
+
+# e2e test fixture leaf IP — default is 93.184.216.34 (IANA example.com).
+# Override only if you need a different origin for direct-requery CNAME tests (#1351).
+# e2e_edge_ip = "93.184.216.34"

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -17,3 +17,9 @@ variable "api_staging_cname_target" {
   type        = string
   description = "CNAME target for api-staging.wifihaven.net — Render → wifihaven-api-staging → Settings → Custom Domains shows the exact value."
 }
+
+variable "e2e_edge_ip" {
+  type        = string
+  description = "Leaf A record IP for e2e-edge.wifihaven.net — used by the direct-requery CNAME e2e fixture (#1351). Must be an IP that responds to HTTP/80 with a non-block-page body so the harness can distinguish 'reached real origin' from 'got DNAT block page'. Default: 93.184.216.34 (IANA example.com — stable, used by the harness as its reference internet-reachable origin)."
+  default     = "93.184.216.34"
+}

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -17,6 +17,7 @@ markers =
     unknown_device: suite F (#432) — unknown-device autocreation
     install_health: post-install router health asserts (#922 — cron, etc.)
     nflog: #1122 — forward-drop visibility via nflog (per-MAC drop comment + agent emission)
+    cname_direct_requery: suite G (#1351) — ea_/eb_ population for directly-queried CNAME targets
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -108,3 +108,73 @@ def wait_event_for_mac(fake_api, mac: str, *, allowed: bool, reason: str,
         probe, timeout_s=timeout_s, interval_s=2,
         description=f"fake event allowed={allowed} reason={reason!r} for {mac}",
     )
+
+
+def _san(s: str) -> str:
+    """render.lua::sanitize(): `[.:]` → `_`."""
+    return s.replace(".", "_").replace(":", "_")
+
+
+def ea_set_name(mac: str, host: str) -> str:
+    """Return the nft set name for an ea_ allow-set.
+
+    render.lua names these `ea_<sanmac>_<sanhost>` where sanmac and sanhost
+    are the sanitized (dots/colons→underscores) forms. The mac is the full
+    colon-separated form as seen in the snapshot.
+
+    Example: mac=aa:bb:cc:11:22:33, host=khanacademy.org
+             → ea_aa_bb_cc_11_22_33_khanacademy_org
+    """
+    return "ea_" + _san(mac) + "_" + _san(host)
+
+
+def wait_ea_set_populated(mac: str, host: str, *, timeout_s: float = 90) -> list[str]:
+    """Wait until the nft ea_ allow-set for (mac, host) has at least one element.
+
+    This is the router-state side of the ea_ assertion — it confirms the
+    dns-tail sidecar populated the kernel carve-out for a directly-queried
+    CNAME target. The primary assertion is still traffic-level (wait_http_succeeds
+    / wait_block_page), but the set membership check surfaces the specific
+    sub-component that failed when the traffic probe catches a regression.
+    """
+    name = ea_set_name(mac, host)
+
+    def probe():
+        elems = router_nft_set(name)
+        return elems if elems else None
+
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {name} to gain at least one element",
+    )
+
+
+def wait_event_with_host_attribution(
+    fake_api,
+    mac: str,
+    *,
+    branded_host: str,
+    timeout_s: float = 120,
+) -> dict:
+    """Wait until the fake has a connection_event whose host.value contains
+    the branded hostname (not the raw CDN/leaf target).
+
+    Used to assert #1344/#1345 attribution: after a direct re-query of a
+    CNAME target, the event posted to /api/router/events must record the
+    branded ancestor, not the CDN hostname.
+    """
+    def probe():
+        for ev in fake_api.events_for_mac(mac):
+            host_field = ev.get("host") or {}
+            hval = host_field.get("value") or ""
+            if branded_host.lower() in hval.lower():
+                return ev
+        return None
+
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=(
+            f"connection_event for {mac} with host attribution containing "
+            f"{branded_host!r}"
+        ),
+    )

--- a/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+++ b/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
@@ -1,0 +1,390 @@
+"""Suite G — directly-queried CNAME targets: ea_/eb_ kernel set population (#1351).
+
+Guards the dns-tail ea_/eb_ populator introduced in #1346/#1349 against
+whole-system regression. The Lua busted unit tests (openwrt/test/dns_tail_sets_spec.lua)
+cover the module in isolation; THIS suite proves the full pipeline on a real router VM:
+
+    client → dnsmasq (CNAME chain resolution + log-queries=extra)
+           → dns-tail sidecar (CNAME alias memory + nft add element)
+           → nftables ea_/eb_ sets
+           → nftables forward rules (drop or carve-out)
+
+The failure mode captured by #1346/#1349:
+  (1) Client first resolves the branded host (e.g. `e2e-brand.wifihaven.net`).
+      dnsmasq logs the full CNAME chain; dns-tail learns the alias map
+      `e2e-edge.wifihaven.net → e2e-brand.wifihaven.net`.
+  (2) Client then re-queries the leaf CNAME target DIRECTLY
+      (`dig e2e-edge.wifihaven.net`). dnsmasq's `nftset=` callback only fires
+      for names that suffix-match the configured domain — it does NOT fire for
+      the raw CDN leaf. Pre-#1349 dns-tail also missed this: `maybe_populate_eb`
+      keyed only on `r.name` (= CDN leaf), which never label-matched `eb_<brand>`.
+  (3) The directly-queried IP was therefore ABSENT from the kernel ea_/eb_ set,
+      so a whole-MAC block did not carve out the flow (ea_ miss → false block)
+      and an extraBlocked host was silently reachable (eb_ miss → filter bypass).
+
+DNS chain (wifihaven.net zone — real Cloudflare records, managed by infra/cloudflare/main.tf):
+
+    e2e-brand.wifihaven.net  CNAME → e2e-mid.wifihaven.net
+    e2e-mid.wifihaven.net    CNAME → e2e-edge.wifihaven.net
+    e2e-edge.wifihaven.net   A     → 93.184.216.34   (IANA example.com)
+
+Records are DNS-only (no Cloudflare proxy) so the chain resolves as authored.
+The leaf A points to 93.184.216.34 (IANA's example.com IP) — a real HTTP server
+that returns a response the harness can distinguish from the block page. The
+DNAT for port 80 intercepts before the real origin is reached in the blocked
+case, so the origin's actual content is irrelevant for the eb_ test.
+
+TERRAFORM PREREQUISITE: `terraform apply` in infra/cloudflare/ must have been
+run (operator-applied, CLOUDFLARE_API_TOKEN required) before this suite can
+pass — CI validates fmt+validate only; it does not apply. Without the real DNS
+records the `dig e2e-brand.wifihaven.net` step will NXDOMAIN and the scenario
+will fail at the resolution step, not the enforcement step. See PR #1351.
+
+Cases:
+  G1 — eb_ (extraBlocked): direct re-query of the leaf puts its IPs in eb_
+       and HTTP/80 to the leaf hits the block page.
+  G2 — ea_ (extraAllowed under blocked=True): direct re-query of the leaf puts
+       its IPs in ea_ and HTTP to the leaf succeeds (carve-out fires).
+  G3 — attribution: after direct re-query, connection_event reports the BRANDED
+       host (e2e-brand.wifihaven.net), not the CDN/leaf target.
+  G4 — bl_ category blocklist slot (TODO(#1348): xfail until bl_ dns-tail
+       populator is implemented).
+
+Assertions are TRAFFIC-LEVEL (connection-layer, as required by docs/architecture.md
+Truth-1 and CLAUDE.md): DNS always resolves; blocking is an nftables property.
+nft set membership is checked as a DIAGNOSTIC secondary assertion, not the primary.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    dig_ipv4_answers,
+    ea_set_name,
+    eb_set_name,
+    mac_in_blocked_set,
+    wait_block_page,
+    wait_ea_set_populated,
+    wait_eb_set_populated,
+    wait_event_with_host_attribution,
+    wait_http_succeeds,
+)
+from .snapshot_builder import SnapshotBuilder
+from lib.traffic import dns_query
+from lib.vm import router_nft_set
+from lib.wait import wait_until
+
+pytestmark = pytest.mark.cname_direct_requery
+
+# ── Fixture hostnames (Cloudflare wifihaven.net zone) ──────────────────────
+#
+# These are the e2e controllable records added to infra/cloudflare/main.tf.
+# They must exist in the real wifihaven.net zone (terraform apply) before this
+# suite can run. The three-hop chain is:
+#   BRAND_HOST → CNAME → MID_HOST → CNAME → LEAF_HOST → A → LEAF_IP
+
+BRAND_HOST = "e2e-brand.wifihaven.net"  # branded/queried host in extraBlocked/extraAllowed
+MID_HOST = "e2e-mid.wifihaven.net"  # intermediate CNAME hop
+LEAF_HOST = "e2e-edge.wifihaven.net"  # final CNAME target; Apple devices re-query this directly
+LEAF_IP = "93.184.216.34"  # leaf A record — IANA example.com (stable, responds to HTTP)
+
+KIDS_PID = 700
+ADULTS_PID = 701
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _resolve_chain(client) -> list[str]:
+    """Resolve the branded host from the client; return IPv4 answers.
+
+    This step exercises step (1) of the attack surface: dnsmasq observes the
+    full CNAME chain for BRAND_HOST and dns-tail builds the alias map
+    leaf→brand. Without this first resolution the alias map is empty and the
+    direct-requery step proves nothing new.
+    """
+    res = dns_query(client, BRAND_HOST, timeout_s=10)
+    lines = [l.strip() for l in (res.stdout or "").splitlines() if l.strip()]
+    import re
+    ipv4 = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
+    return [l for l in lines if ipv4.match(l)]
+
+
+def _requery_leaf_directly(client) -> list[str]:
+    """Re-query the leaf CNAME target directly, simulating Apple device behavior.
+
+    This is step (2): the client issues `dig e2e-edge.wifihaven.net` as a fresh,
+    standalone query. The qname on the wire is the CDN leaf, NOT the branded host.
+    dnsmasq's nftset= callback does not fire for the leaf name. dns-tail's
+    maybe_populate_ea/eb must recover the branded ancestor from the alias map and
+    add the IP to the correct ea_/eb_ set inline (#1346/#1349).
+    """
+    return dig_ipv4_answers(client, LEAF_HOST)
+
+
+def _wait_for_chain_resolution(client, *, timeout_s: float = 120) -> list[str]:
+    """Poll until BRAND_HOST resolves to at least one IPv4 answer.
+
+    If the Terraform records haven't propagated yet (TTL or just-applied)
+    this guard surfaces the root cause (NXDOMAIN / empty answer) rather than
+    letting the test hang at the next step.
+    """
+    return wait_until(
+        lambda: _resolve_chain(client) or None,
+        timeout_s=timeout_s,
+        interval_s=5,
+        description=(
+            f"dig {BRAND_HOST} to return at least one IPv4 answer "
+            f"(requires terraform apply for infra/cloudflare)"
+        ),
+    )
+
+
+# ── G1 — eb_: directly-queried leaf IP lands in eb_ → HTTP hits block page ──
+
+
+def test_eb_direct_requery_blocked(router, client, fake_api):
+    """G1: direct re-query of the CNAME leaf populates eb_ and triggers the
+    block page for HTTP/80 connections to that IP.
+
+    Pre-#1349 regression: the directly-queried leaf IP was absent from
+    `eb_<brand>` so the extraBlocked rule was silently bypassed — an
+    extraBlocked host was reachable simply by re-querying its CNAME target
+    directly. This is the higher-severity half (#1346 severity note).
+
+    Primary assertion (traffic-level): HTTP/80 to LEAF_HOST returns the block
+    page body (DNAT fires → real origin is never reached).
+    Secondary (diagnostic): the leaf IP appears in `eb_<brand>` set on the router.
+    DNS still returns real IPv4 (Truth-1 guard — never NXDOMAIN).
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-cname-eb",
+            extra_blocked=[BRAND_HOST],
+        )
+        .add_device(mac=client.mac, name="e2e-cname-eb-dev", profile_id=KIDS_PID)
+        .build(etag='"sha256:cname-eb-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Step 1: resolve the branded host so dns-tail builds the alias map.
+    chain_ips = _wait_for_chain_resolution(client)
+    assert chain_ips, (
+        f"dig {BRAND_HOST} returned no IPv4 answers — check that "
+        f"terraform apply has been run for infra/cloudflare/ (#1351)"
+    )
+
+    # Truth-1: DNS for the branded host returns real IPs, not NXDOMAIN.
+    assert LEAF_IP in chain_ips or any(ip for ip in chain_ips), (
+        f"expected real IPv4 from chain resolution, got {chain_ips!r}"
+    )
+
+    # Step 2: re-query the leaf CNAME target directly (simulates Apple device).
+    leaf_ips = _requery_leaf_directly(client)
+    assert leaf_ips, (
+        f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "
+        f"not yet propagated (terraform apply required)"
+    )
+    assert LEAF_IP in leaf_ips, (
+        f"expected {LEAF_IP} in direct-requery answers for {LEAF_HOST}, got {leaf_ips!r}"
+    )
+
+    # Primary assertion: HTTP/80 to the leaf's branded hostname hits the block page.
+    # The DNAT rule fires because the leaf IP should now be in eb_<brand>; the
+    # connection never reaches 93.184.216.34.
+    probe = wait_block_page(client, host=LEAF_HOST, timeout_s=120)
+    assert probe.http_code == 200, (
+        f"expected block page (HTTP 200) for {LEAF_HOST}, got {probe.http_code!r}"
+    )
+
+    # Secondary (diagnostic): assert eb_<brand> set membership.
+    # This narrows the failure to the dns-tail populator when the traffic
+    # probe catches a regression even though the set is empty.
+    eb_members = wait_eb_set_populated(BRAND_HOST, timeout_s=60)
+    assert eb_members, (
+        f"nft set {eb_set_name(BRAND_HOST)} is empty — dns-tail eb_ populator "
+        f"did not add the directly-queried leaf IP to the brand's drop set"
+    )
+    assert any(LEAF_IP in m for m in eb_members), (
+        f"leaf IP {LEAF_IP} not found in {eb_set_name(BRAND_HOST)} members: "
+        f"{eb_members!r} — direct-requery IP was not attributed to brand"
+    )
+
+
+# ── G2 — ea_: directly-queried leaf IP lands in ea_ → flow is allowed ────────
+
+
+def test_ea_direct_requery_allowed_under_blocked_mac(router, client, fake_api):
+    """G2: under a whole-MAC block (blocked=True), an extraAllowed CNAME-fronted
+    host's directly-queried leaf IP lands in ea_ and the connection is carved out.
+
+    Pre-#1349 regression: the directly-queried leaf IP was absent from
+    `ea_<mac>_<brand>` so the carve-out did not fire and the app was falsely
+    blocked during a downtime schedule — the original prod incident with Khan
+    Academy / Math Academy (#1344).
+
+    Primary assertion (traffic-level): HTTP to LEAF_HOST succeeds (real response
+    body, NOT the block page) even though blocked=True for the MAC. If ea_ is
+    not populated for the directly-queried IP, the forward-drop rule fires and
+    curl sees HTTPCODE:000 / connection reset — distinguishable from the block
+    page by `wait_http_succeeds` which rejects block-page-looking bodies.
+    Secondary (diagnostic): the leaf IP appears in `ea_<mac>_<brand>` on the router.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-cname-ea",
+            blocked=True,
+            block_reason="Schedule",
+            extra_allowed=[BRAND_HOST],
+        )
+        .add_device(mac=client.mac, name="e2e-cname-ea-dev", profile_id=KIDS_PID)
+        .build(etag='"sha256:cname-ea-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Confirm the MAC is in blocked_macs (whole-MAC block active).
+    from ._observers import wait_mac_in_blocked_set
+    wait_mac_in_blocked_set(client.mac, present=True, timeout_s=90)
+
+    # Step 1: resolve the branded host so dns-tail builds the alias map.
+    chain_ips = _wait_for_chain_resolution(client)
+    assert chain_ips, (
+        f"dig {BRAND_HOST} returned no IPv4 — check terraform apply (#1351)"
+    )
+
+    # Step 2: re-query the leaf directly.
+    leaf_ips = _requery_leaf_directly(client)
+    assert leaf_ips, (
+        f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
+    )
+    assert LEAF_IP in leaf_ips, (
+        f"expected {LEAF_IP} in direct-requery answers for {LEAF_HOST}, "
+        f"got {leaf_ips!r}"
+    )
+
+    # Primary assertion: HTTP to LEAF_HOST succeeds despite blocked=True.
+    # The ea_ carve-out for the directly-queried IP must be present in the
+    # kernel set for the forward-drop to spare this flow.
+    probe = wait_http_succeeds(client, host=LEAF_HOST, timeout_s=120)
+    assert probe.http_code is not None and 200 <= probe.http_code < 400, (
+        f"expected allowed HTTP response (200-399) for {LEAF_HOST} under "
+        f"blocked=True, got {probe.http_code!r} — ea_ carve-out may be missing"
+    )
+
+    # Secondary (diagnostic): assert ea_<mac>_<brand> set membership.
+    ea_members = wait_ea_set_populated(client.mac, BRAND_HOST, timeout_s=60)
+    assert ea_members, (
+        f"nft set {ea_set_name(client.mac, BRAND_HOST)} is empty — dns-tail "
+        f"ea_ populator did not add the directly-queried leaf IP to the "
+        f"brand's allow-set for this MAC"
+    )
+    assert any(LEAF_IP in m for m in ea_members), (
+        f"leaf IP {LEAF_IP} not found in "
+        f"{ea_set_name(client.mac, BRAND_HOST)} members: {ea_members!r}"
+    )
+
+
+# ── G3 — attribution: connection_event reports BRAND_HOST, not LEAF_HOST ─────
+
+
+def test_attribution_reports_branded_host_after_direct_requery(router, client, fake_api):
+    """G3: after the client re-queries the leaf CNAME target directly, the
+    connection_event posted to /api/router/events attributes the flow to the
+    BRANDED host (e2e-brand.wifihaven.net), not the raw CDN/leaf target
+    (e2e-edge.wifihaven.net).
+
+    This proves #1344/#1345 end-to-end: dns_log's CNAME alias map correctly
+    recovers the branded chain-head at attribution time so that logs and
+    per-host usage are readable and conntrack.lua's ea_/eb_ classification
+    suffix-matches the app's allowlist entry.
+
+    Primary assertion: a connection_event for client.mac whose host.value
+    contains BRAND_HOST appears in the fake after the direct re-query and an
+    HTTP request to LEAF_HOST.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-cname-attr")
+        .add_device(mac=client.mac, name="e2e-cname-attr-dev", profile_id=KIDS_PID)
+        .build(etag='"sha256:cname-attr-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Step 1: resolve the branded host (builds alias map in dns-tail/dns_log).
+    chain_ips = _wait_for_chain_resolution(client)
+    assert chain_ips, (
+        f"dig {BRAND_HOST} returned no IPv4 — check terraform apply (#1351)"
+    )
+
+    # Step 2: direct re-query of the leaf target.
+    leaf_ips = _requery_leaf_directly(client)
+    assert leaf_ips, (
+        f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing"
+    )
+
+    # Step 3: make an HTTP request to LEAF_HOST so conntrack.lua emits a
+    # connection_event with the attributed hostname. In the allowed profile
+    # the connection goes through to the real origin.
+    wait_http_succeeds(client, host=LEAF_HOST, timeout_s=60)
+
+    # Primary assertion: the event posted to /api/router/events carries the
+    # branded host, not the CDN leaf target.
+    ev = wait_event_with_host_attribution(
+        fake_api,
+        client.mac,
+        branded_host=BRAND_HOST,
+        timeout_s=120,
+    )
+    assert ev is not None, (
+        f"no connection_event for {client.mac} with host attribution "
+        f"containing {BRAND_HOST!r} — dns_log alias map not recovering "
+        f"branded host after direct re-query of {LEAF_HOST}"
+    )
+
+    # Sanity: the event must NOT attribute to the raw CDN leaf name.
+    host_val = (ev.get("host") or {}).get("value") or ""
+    assert LEAF_HOST not in host_val, (
+        f"connection_event attributed to CDN leaf {LEAF_HOST!r} instead of "
+        f"branded host {BRAND_HOST!r} — #1344 attribution regression"
+    )
+
+
+# ── G4 — bl_ (category blocklist) — xfail pending #1348 ─────────────────────
+
+
+@pytest.mark.xfail(
+    reason=(
+        "TODO(#1348): bl_ category-blocklist bypass via directly-queried CNAME "
+        "targets is not yet fixed. The bl_ populator (blocklists.lua) is driven "
+        "by agent-side resolution, not by client DNS answers, so the #1346/#1349 "
+        "dns-tail alias-map fix is not a drop-in here. This slot will flip from "
+        "xfail to a real assertion once #1348 ships a dns-tail bl_ populator."
+    ),
+    strict=False,
+)
+def test_bl_direct_requery_blocked_xfail(router, client, fake_api):
+    """G4 (xfail — #1348): category-blocklist (bl_) enforcement for
+    directly-queried CNAME targets.
+
+    The bl_/bl6_ sets are populated by the agent's periodic blocklists.lua
+    resolution, not by client DNS answers. When a device re-queries a blocklist
+    member's CNAME target directly, the resolved IP may not be in the bl_ set
+    (CDN-anycast IP variance). Fixing this requires a dns-tail bl_ populator
+    that maps client-observed CNAME-target answers back to blocklist membership
+    via the #1344 alias map — tracked in #1348.
+
+    This slot exists so the scenario file is complete and will flip to a real
+    assertion when #1348 ships, without requiring a new PR at that time.
+    """
+    # When #1348 ships: set up a snapshot with a blocklist that includes
+    # BRAND_HOST (or a host whose CNAME chain is BRAND_HOST→...→LEAF_HOST),
+    # resolve the branded host (step 1), re-query the leaf directly (step 2),
+    # and assert HTTP to LEAF_HOST hits the block page. For now: xfail-by-pass.
+    pytest.xfail("bl_ direct-requery populator not yet implemented (#1348)")


### PR DESCRIPTION
Closes #1351.

## Summary

- Adds **Suite G** (`scripts/e2e/scenarios_fake/test_cname_direct_requery.py`) — a real router-VM e2e test that proves the `dns-tail → ea_/eb_ kernel set → nftables forward-drop` pipeline for directly-queried CNAME targets end-to-end.
- Adds controllable DNS chain to `infra/cloudflare/main.tf` (`e2e-brand` → `e2e-mid` → `e2e-edge` → `93.184.216.34`).
- Adds `ea_` observer helpers to `_observers.py`, a `cname_direct_requery` pytest marker, a `cloudflare-terraform` CI lint job, and extends `master-router.yml`'s path filter to include `scripts/e2e/scenarios_fake/**`.

## The gap

#1346/#1349 (ea_/eb_ dns-tail populator) and #1344/#1345 (attribution) are covered only by busted Lua unit tests that feed canned log lines into isolated modules. The real failure mode is whole-system: dnsmasq → dns-tail sidecar → nft add element → nftables forward rules. The busted tests can pass while the deployed sidecar wiring, the `nft -a list table` parse, or the procd service is broken (cf. #1334, where the category path was a silent prod no-op despite green unit tests). This PR closes that gap.

## Real DNS chain — controllable, not pinned to CDN edge IPs

Per the operator requirement, the CNAME chain uses real **wifihaven.net Cloudflare DNS records** managed declaratively in `infra/cloudflare/main.tf`:

```
e2e-brand.wifihaven.net  CNAME → e2e-mid.wifihaven.net     (branded host)
e2e-mid.wifihaven.net    CNAME → e2e-edge.wifihaven.net     (mid-hop)
e2e-edge.wifihaven.net   A     → 93.184.216.34              (leaf, IANA example.com)
```

All records are DNS-only (`proxied = false`, TTL 300) so the chain resolves as authored. The leaf A points to `93.184.216.34` (IANA's stable example.com IP), which responds to HTTP/80 with a non-block-page body. This lets the harness distinguish "reached real origin" (allowed) from "got DNAT block page" (blocked) at the connection layer.

**`terraform apply` prerequisite:** CI validates `fmt + validate` only (new `cloudflare-terraform` job). It does NOT apply. An operator must run `terraform apply` in `infra/cloudflare/` with `CLOUDFLARE_API_TOKEN` before the Gate 2 VM e2e can pass G1–G3. Without the records live, `dig e2e-brand.wifihaven.net` NXDOMAINs and the test fails at the resolution guard step (not silently skipped). The cloudflare Terraform in this repo is applied manually today — there is no CI-driven apply for the Cloudflare zone.

## Traffic-level (not router-state) assertion design

Per docs/architecture.md Truth-1 and CLAUDE.md: DNS always resolves; blocking is a connection-layer property. All four cases assert at the **connection layer** from the client VM:

- **G1 (eb_)**: branded host in `extraBlocked`. Client resolves chain (step 1: dnsmasq sees CNAME chain, dns-tail builds alias map), then re-queries leaf directly (step 2). **Primary assertion**: `wait_block_page` — HTTP/80 to `e2e-edge.wifihaven.net` returns the block page body (DNAT intercepted before real origin). **Secondary (diagnostic)**: `wait_eb_set_populated` confirms `eb_e2e-brand_wifihaven_net` has the leaf IP.

- **G2 (ea_)**: `blocked=True/Schedule`, branded host in `extraAllowed`. Same resolve-then-direct-requery. **Primary assertion**: `wait_http_succeeds` — HTTP to the leaf returns a real (non-block-page) response even though the MAC is whole-blocked. **Secondary**: `wait_ea_set_populated` confirms `ea_<sanmac>_e2e-brand_wifihaven_net` has the leaf IP.

- **G3 (attribution)**: Profile allows all. After direct re-query + HTTP to leaf, **primary assertion**: a `connection_event` for `client.mac` in the fake whose `host.value` contains `e2e-brand.wifihaven.net` (not `e2e-edge.wifihaven.net`). Proves #1344/#1345 end-to-end.

- **G4 (bl_/xfail)**: Slot marked `@pytest.mark.xfail` with `TODO(#1348)`. Calls `pytest.xfail(...)` at test body. Flips to a real assertion when #1348 ships the dns-tail bl_ populator; no follow-up PR required at that time.

## Per-case coverage

| Case | Scenario | Primary assertion | Secondary (diagnostic) |
|------|----------|------------------|----------------------|
| G1 | eb_ direct-requery bypass (#1346 higher-severity) | `wait_block_page` — HTTP hits block page | `wait_eb_set_populated` — leaf IP in `eb_<brand>` |
| G2 | ea_ direct-requery false-block (#1346 ea_ half) | `wait_http_succeeds` — real response despite blocked=True | `wait_ea_set_populated` — leaf IP in `ea_<mac>_<brand>` |
| G3 | #1344/#1345 attribution | `connection_event.host.value` contains branded host | — |
| G4 | #1348 bl_ bypass | xfail/TODO slot | — |

## CI / gate wiring

- **Marker**: `cname_direct_requery` added to `pytest.ini` under `--strict-markers`. The existing `scenarios_fake/` pytest run in `e2e-vm-fake.yml` (Gate 2) collects all `scenarios_fake/**` files automatically — no workflow change needed for collection.
- **master-router.yml**: path filter extended with `scripts/e2e/scenarios_fake/**`, `scripts/e2e/lib/**`, `scripts/e2e/fake-api/**`, `scripts/e2e/pytest.ini` so changes to test scenarios trigger the router CD pipeline (Gate 2 + Gate 3a + publish-openwrt), not just CI tests.
- **cloudflare-terraform CI job**: new job in `ci.yml` mirroring `grafana-terraform` — runs `terraform fmt -check` + `terraform init -backend=false && terraform validate` on `infra/cloudflare/**` changes. Wired into the `ci` all-clear job. Does NOT apply.

## Local validation

```
# infra/cloudflare/
terraform fmt -check -diff          → exit 0 (no drift)
terraform init -backend=false -input=false && terraform validate
                                    → Success! The configuration is valid.

# scripts/e2e/
pytest scenarios_fake/test_cname_direct_requery.py --collect-only
                                    → 4 tests collected, 0 errors

pytest scenarios_fake/ --collect-only
                                    → 35 tests collected (31 prior + 4 new), 0 errors

pytest -m cname_direct_requery --collect-only
                                    → 4 tests collected (strict-markers: OK)
```

## What only runs in the VM gate

**G1, G2, G3 real assertions** require:
1. The Cloudflare DNS records applied (`terraform apply` — manual, operator-applied).
2. A KVM runner with the OpenWRT router VM image (self-hosted `api.lan` runner, `e2e-vm-fake.yml`).
3. An Alpine client VM booted on the LAN bridge.

The full VM e2e cannot run in the sandbox. The Gate 2 workflow (`e2e-vm-fake.yml`) runs on push to main via `master-router.yml`, consuming the exact `.img` artifact built by `build-release-artifacts` before testing. This PR's path-filter addition to `master-router.yml` ensures future scenario changes also trigger the pipeline.

**G4 (xfail)** will always pass in the VM gate (it calls `pytest.xfail` unconditionally) until #1348 ships.

## Notes

- No production source changes; migration-isolation rule does not apply.
- No Scala touched; `scalafmt` N/A.
- `ea_set_name` and `wait_ea_set_populated` added to `_observers.py` — these are reusable by any future suite that needs to assert ea_ carve-out membership.
- The `_san` helper in `_observers.py` mirrors `render.lua`'s `sanitize()` function exactly (dots/colons → underscores), consistent with the existing `eb_set_name`.