### PR TITLE
test(web): settle initial load before fake timers in AdminPage autosave tests (#1354)

### DIFF
--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -69,11 +69,17 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
   })
 
   it('editing the reset time fires a debounced PATCH {dailyResetTime}', async () => {
+    // Let the initial async `api.household.get()` load fully settle under real
+    // timers BEFORE switching to fake timers. Enabling fake timers up front
+    // makes `findByTestId`'s internal waitFor resolve while a load-driven React
+    // update is still pending, and the next `fireEvent.change` is clobbered by
+    // that unflushed resync — so the controlled input never reaches '06:00' and
+    // the debounce never fires (#1354). Fake timers are only needed for the
+    // deterministic debounce window, so we scope them to it.
+    render(<AdminPage />)
+    const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
-      render(<AdminPage />)
-      const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
-
       // Set the value atomically: typing a `<input type="time">` char-by-char
       // under fake timers lets the 700ms debounce fire on a transient partial
       // value (e.g. '00:59') before the full '06:00' lands. fireEvent.change
@@ -102,15 +108,16 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
   })
 
   it('PATCH failure surfaces error + Retry; dirty value retained; Retry re-sends', async () => {
+    (api.household.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('boom from server'),
+    )
+    // Settle the initial load under real timers before enabling fake timers —
+    // see the reset-time test for why (#1354).
+    render(<AdminPage />)
+    const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
     vi.useFakeTimers({ shouldAdvanceTime: true })
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     try {
-      (api.household.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error('boom from server'),
-      )
-      render(<AdminPage />)
-      const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
-
       fireEvent.change(time, { target: { value: '06:00' } })
       await vi.advanceTimersByTimeAsync(700)
 
@@ -149,11 +156,12 @@ describe('AdminPage — heartbeat filter autosave (#1002)', () => {
   })
 
   it('editing the bytes threshold fires PATCH {heartbeatFilter:{bytesThreshold}}', async () => {
+    // Settle the initial load under real timers before enabling fake timers —
+    // see the reset-time test for why (#1354).
+    render(<AdminPage />)
+    const bytes = await screen.findByTestId('heartbeat-filter-bytes') as HTMLInputElement
     vi.useFakeTimers({ shouldAdvanceTime: true })
     try {
-      render(<AdminPage />)
-      const bytes = await screen.findByTestId('heartbeat-filter-bytes') as HTMLInputElement
-
       fireEvent.change(bytes, { target: { value: '8192' } })
       await vi.advanceTimersByTimeAsync(700)
 


### PR DESCRIPTION
## Symptom

`AdminPage.test.tsx` > **"editing the reset time fires a debounced PATCH {dailyResetTime}"** (and its two siblings, the bytes-threshold and PATCH-failure-retry tests) fail **deterministically** in isolation and on CI under vitest v4.1.7:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ { dailyResetTime: '06:00' } ]
Number of calls: 0
```

This was invisible on `main` because the `Frontend Build & Lint` CI job is path-gated to `web/**` + `package*.json` + `.github/workflows/ci.yml`, so it's skipped on normal non-`web/` PRs. It only surfaced on #1353 (an e2e/CI-only PR) because that PR edits `ci.yml`, which is in the `frontend` filter — so `main` shows green while the test is actually broken.

## Determination: (a) test-side fake-timer race, NOT a product bug

Evidence gathered before fixing:

- The test **fails in isolation** (`-t "debounced PATCH"`, 3/3) but **passes in the full file** (9/9). The only difference: in the full file a *prior* real-timer test renders `AdminPage` first.
- All three fake-timer tests (reset-time, bytes-threshold, PATCH-failure) fail the same way in isolation — i.e. the failure tracks the harness pattern, not any one field's product logic.
- Instrumenting the failing test showed that immediately after `await findByTestId(...)`, `fireEvent.change(time, { value: '06:00' })` left the controlled input's value at the **old** `'00:00'` — the change was dropped, so the debounce never had a changed value to latch and no PATCH fired.
- Inserting a single settle-flush (`await act(async () => { await vi.advanceTimersByTimeAsync(0) })`) between `findByTestId` and the change makes the input reach `'06:00'` and fires exactly 1 PATCH.

**Root cause:** the tests enabled `vi.useFakeTimers({ shouldAdvanceTime: true })` *before* rendering and awaiting the component's initial async `api.household.get()` load. Under vitest 4, that makes `findByTestId`'s internal `waitFor` resolve while a load-driven React state update is still pending; the immediately-following `fireEvent.change` is then clobbered by the unflushed resync effect (`useEffect(() => setTime(value.dailyResetTime), [...])` in `DailyResetCard`). In the full-file run a prior real-timer test had already settled the component, masking the race.

The product autosave in `AdminPage.tsx` / `useDebouncedSave` is **correct** — once the component is settled, a programmatic `fireEvent.change` on the `<input type="time">` fires a debounced PATCH exactly as designed (confirmed: full-file run is green, and the flush experiment fires 1 PATCH). So this is a test-determinism fix, in the same spirit as #1237, not a component change.

## Fix

Test-only, `web/` only. For the three affected tests: render and `await findByTestId(...)` under **real** timers so the initial load fully settles, then enable fake timers scoped to the deterministic debounce window. Assertions are **unchanged** — each test still requires a debounced PATCH to fire with the exact payload (`{ dailyResetTime: '06:00' }`, `{ heartbeatFilter: { bytesThreshold: 8192 } }`, and the retry re-send). No assertion was deleted, skipped, or loosened. No API/wire/migration changes.

## Commands run (node 22, vite 8)

```
# before: each fails in isolation, 0 PATCH calls
npx vitest run src/pages/AdminPage.test.tsx -t "debounced PATCH"        # FAIL (0 calls)

# after:
npx vitest run src/pages/AdminPage.test.tsx -t "debounced PATCH"        # 1 passed
npx vitest run src/pages/AdminPage.test.tsx -t "bytes threshold fires"  # 1 passed
npx vitest run src/pages/AdminPage.test.tsx -t "PATCH failure surfaces" # 1 passed

# full frontend gate (matches ci.yml frontend job exactly):
npm run type-check   # clean
npm run lint         # clean
npm test             # 326 passed (29 files)
npm run build        # built ✓
```

## Unblocks

This unblocks the frontend gate on #1353, which only goes red because it edits `ci.yml` and thereby triggers the otherwise-skipped `Frontend Build & Lint` job against this latent failure.

Closes #1354