### PR TITLE
test(e2e): promote G4 bl_ CNAME direct-requery slot to a real gating assertion (#1348)

### DIFF
--- a/scripts/e2e/fake-api/fake_api/app.py
+++ b/scripts/e2e/fake-api/fake_api/app.py
@@ -105,6 +105,31 @@ async def post_usage(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+async def get_blocklist(request: web.Request) -> web.Response:
+    """Serve a blocklist by id — mirrors the real GET /api/blocklists/<id>.
+
+    The agent's blocklists.lua fetches this URL, parses it as a
+    newline-delimited host list (lines starting with # are comments), and
+    caches the result on disk keyed by (id, version). The fake serves
+    whatever content was registered via POST /test/blocklist; if no content
+    has been registered for the id it returns 404 so the agent logs a fetch
+    error (matching the behaviour of an unknown blocklist id in production).
+    """
+    unauth = _require_bearer(request)
+    if unauth is not None:
+        return unauth
+    state: State = request.app[STATE_KEY]
+    bl_id = request.match_info["id"]
+    content = state.get_blocklist(bl_id)
+    if content is None:
+        return web.Response(status=404, text=f"blocklist {bl_id!r} not registered")
+    return web.Response(
+        status=200,
+        text=content,
+        content_type="text/plain",
+    )
+
+
 # --- Test-control endpoints --------------------------------------------------
 
 
@@ -205,6 +230,31 @@ async def test_get_policy_fetches(request: web.Request) -> web.Response:
     )
 
 
+async def test_post_blocklist(request: web.Request) -> web.Response:
+    """Register blocklist content for GET /api/blocklists/<id>.
+
+    Body: { "id": "<blocklist-id>", "hosts": ["host1", "host2", ...] }
+
+    The hosts are stored as a newline-delimited plain-text body, exactly the
+    format blocklists.lua expects. An empty `hosts` list is valid — it
+    registers an empty blocklist (useful for clearing a previous registration
+    without removing the id from the snapshot's `blocklists` dict).
+    """
+    body = await _read_json(request)
+    bl_id = body.get("id")
+    if not bl_id or not isinstance(bl_id, str):
+        raise web.HTTPBadRequest(reason="missing or invalid 'id' field")
+    hosts = body.get("hosts", [])
+    if not isinstance(hosts, list):
+        raise web.HTTPBadRequest(reason="'hosts' must be a list")
+    content = "\n".join(str(h) for h in hosts)
+    if content:
+        content += "\n"
+    state: State = request.app[STATE_KEY]
+    state.set_blocklist(bl_id, content)
+    return web.json_response({"ok": True, "id": bl_id, "host_count": len(hosts)})
+
+
 async def test_post_reset(request: web.Request) -> web.Response:
     state: State = request.app[STATE_KEY]
     state.reset()
@@ -232,7 +282,9 @@ def make_app(state: State | None = None) -> web.Application:
     app.router.add_get("/api/router/policy", get_policy)
     app.router.add_post("/api/router/events", post_events)
     app.router.add_post("/api/router/usage", post_usage)
+    app.router.add_get("/api/blocklists/{id}", get_blocklist)
     app.router.add_post("/test/snapshot", test_post_snapshot)
+    app.router.add_post("/test/blocklist", test_post_blocklist)
     app.router.add_get("/test/events", test_get_events)
     app.router.add_get("/test/usage", test_get_usage)
     app.router.add_get("/test/register", test_get_register)

--- a/scripts/e2e/fake-api/fake_api/state.py
+++ b/scripts/e2e/fake-api/fake_api/state.py
@@ -52,6 +52,11 @@ class State:
     usage: list[UsageRecord] = field(default_factory=list)
     policy_fetches: list[PolicyFetchRecord] = field(default_factory=list)
     clock_base: str | None = None
+    # blocklist content keyed by blocklist id: id → newline-delimited host list.
+    # Served at GET /api/blocklists/<id>. Populated by POST /test/blocklist.
+    # Persists across resets so tests don't have to re-register them after each
+    # router restore; a test that needs a clean slate can POST an empty body.
+    blocklists: dict[str, str] = field(default_factory=dict)
     _next_event_id: int = 1
     _next_usage_id: int = 1
     _next_policy_fetch_id: int = 1
@@ -112,6 +117,20 @@ class State:
         self.usage.append(UsageRecord(id=rec_id, body=body))
         return rec_id
 
+    def set_blocklist(self, id: str, content: str) -> None:
+        """Set the content for a blocklist (newline-delimited host list).
+
+        Content is intentionally preserved across `reset()` calls so test
+        scenarios don't have to re-register blocklist bodies after each
+        per-function router restore. A scenario that needs an empty slate can
+        call `set_blocklist(id, "")` explicitly.
+        """
+        self.blocklists[id] = content
+
+    def get_blocklist(self, id: str) -> str | None:
+        """Return the content for a blocklist id, or None if not registered."""
+        return self.blocklists.get(id)
+
     def reset(self) -> None:
         self.snapshot = copy.deepcopy(self.initial_snapshot)
         self.registers.clear()
@@ -122,3 +141,4 @@ class State:
         self._next_usage_id = 1
         self._next_policy_fetch_id = 1
         self.clock_base = None
+        # Note: blocklists are intentionally NOT cleared here — see set_blocklist.

--- a/scripts/e2e/lib/fake_client.py
+++ b/scripts/e2e/lib/fake_client.py
@@ -40,6 +40,27 @@ class FakeAPIClient:
         """Clear captured state and restore the initial snapshot."""
         self._post_json("/test/reset", {})
 
+    # ── /test/blocklist ────────────────────────────────────────────────────
+
+    def register_blocklist(self, id: str, hosts: list[str]) -> None:
+        """Register a blocklist so GET /api/blocklists/<id> returns its hosts.
+
+        The content persists across reset() calls so the scenario only needs
+        to call this once (e.g. in the test body before serve_snapshot). The
+        agent's blocklists.lua fetches this URL and caches the host list on
+        disk keyed by (id, version); the version in the snapshot controls
+        cache busting, not this call.
+
+        Pass an empty `hosts` list to register an empty blocklist (different
+        from omitting the id — an empty list returns HTTP 200 with no hosts
+        so the agent creates an empty bl_ set rather than logging a 404 error).
+        """
+        body = self._post_json("/test/blocklist", {"id": id, "hosts": hosts})
+        log.info(
+            "fake: registered blocklist id=%r with %d hosts",
+            id, body.get("host_count", 0),
+        )
+
     # ── /test/events ───────────────────────────────────────────────────────
 
     def events(

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -96,7 +96,6 @@ def bl_set_name(bl_id: str) -> str:
 
     Example: id="e2e-cname-bl" → "bl_e2e_cname_bl"
     """
-    import re
     sanitized = re.sub(r"[.\:\-\s]", "_", bl_id)
     return "bl_" + sanitized
 

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -87,11 +87,50 @@ def eb_set_name(host: str) -> str:
     return "eb_" + host.replace(".", "_").replace(":", "_")
 
 
+def bl_set_name(bl_id: str) -> str:
+    """render.lua::bl_sanitize(): `[.:-\\s]` → `_`.
+
+    Category-blocklist drop-sets are named `bl_<sanitized_id>` where
+    bl_sanitize replaces dots, colons, hyphens, and whitespace with
+    underscores. See render.lua `bl_sanitize()`.
+
+    Example: id="e2e-cname-bl" → "bl_e2e_cname_bl"
+    """
+    import re
+    sanitized = re.sub(r"[.\:\-\s]", "_", bl_id)
+    return "bl_" + sanitized
+
+
 def wait_eb_set_populated(host: str, *, timeout_s: float = 90) -> list[str]:
     name = eb_set_name(host)
     def probe():
         elems = router_nft_set(name)
         return elems if elems else None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {name} to gain at least one element",
+    )
+
+
+def wait_bl_set_populated(bl_id: str, *, timeout_s: float = 90) -> list[str]:
+    """Wait until the nft bl_ category-drop-set for a blocklist id has at
+    least one element.
+
+    This is the router-state side of the bl_ category-blocklist assertion — it
+    confirms dns-tail's bl_ populator (added by #1348/#1350) added a
+    directly-queried CNAME-target's IP to the category drop-set. The primary
+    assertion in G4 is still traffic-level (wait_block_page), but this check
+    surfaces the specific sub-component that failed when the traffic probe
+    catches a regression. Mirrors wait_eb_set_populated.
+
+    bl_set_name(id) → render.lua::bl_sanitize convention.
+    """
+    name = bl_set_name(bl_id)
+
+    def probe():
+        elems = router_nft_set(name)
+        return elems if elems else None
+
     return wait_until(
         probe, timeout_s=timeout_s, interval_s=3,
         description=f"nft set {name} to gain at least one element",

--- a/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
+++ b/scripts/e2e/scenarios_fake/test_cname_direct_requery.py
@@ -1,26 +1,30 @@
-"""Suite G — directly-queried CNAME targets: ea_/eb_ kernel set population (#1351).
+"""Suite G — directly-queried CNAME targets: ea_/eb_/bl_ kernel set population (#1351).
 
-Guards the dns-tail ea_/eb_ populator introduced in #1346/#1349 against
-whole-system regression. The Lua busted unit tests (openwrt/test/dns_tail_sets_spec.lua)
-cover the module in isolation; THIS suite proves the full pipeline on a real router VM:
+Guards the dns-tail ea_/eb_ populator introduced in #1346/#1349 and the bl_
+populator introduced in #1348/#1350 against whole-system regression. The Lua
+busted unit tests (openwrt/test/dns_tail_sets_spec.lua) cover the modules in
+isolation; THIS suite proves the full pipeline on a real router VM:
 
     client → dnsmasq (CNAME chain resolution + log-queries=extra)
            → dns-tail sidecar (CNAME alias memory + nft add element)
-           → nftables ea_/eb_ sets
+           → nftables ea_/eb_/bl_ sets
            → nftables forward rules (drop or carve-out)
 
-The failure mode captured by #1346/#1349:
+The failure mode captured by #1346/#1349 (ea_/eb_) and #1348/#1350 (bl_):
   (1) Client first resolves the branded host (e.g. `e2e-brand.wifihaven.net`).
       dnsmasq logs the full CNAME chain; dns-tail learns the alias map
       `e2e-edge.wifihaven.net → e2e-brand.wifihaven.net`.
   (2) Client then re-queries the leaf CNAME target DIRECTLY
       (`dig e2e-edge.wifihaven.net`). dnsmasq's `nftset=` callback only fires
       for names that suffix-match the configured domain — it does NOT fire for
-      the raw CDN leaf. Pre-#1349 dns-tail also missed this: `maybe_populate_eb`
-      keyed only on `r.name` (= CDN leaf), which never label-matched `eb_<brand>`.
-  (3) The directly-queried IP was therefore ABSENT from the kernel ea_/eb_ set,
-      so a whole-MAC block did not carve out the flow (ea_ miss → false block)
-      and an extraBlocked host was silently reachable (eb_ miss → filter bypass).
+      the raw CDN leaf.
+  (3) Pre-#1349 dns-tail also missed ea_/eb_ population for the direct re-query.
+      Pre-#1350 dns-tail also missed bl_ population for the direct re-query.
+  (4) The directly-queried IP was therefore ABSENT from the kernel ea_/eb_/bl_
+      sets, so a whole-MAC block did not carve out the flow (ea_ miss → false
+      block), extraBlocked hosts were silently reachable (eb_ miss → filter
+      bypass), and category-blocked content was reachable (bl_ miss → filter
+      bypass — the highest severity case, since it bypasses a broad blocklist).
 
 DNS chain (wifihaven.net zone — real Cloudflare records, managed by infra/cloudflare/main.tf):
 
@@ -32,7 +36,7 @@ Records are DNS-only (no Cloudflare proxy) so the chain resolves as authored.
 The leaf A points to 93.184.216.34 (IANA's example.com IP) — a real HTTP server
 that returns a response the harness can distinguish from the block page. The
 DNAT for port 80 intercepts before the real origin is reached in the blocked
-case, so the origin's actual content is irrelevant for the eb_ test.
+case, so the origin's actual content is irrelevant for the eb_/bl_ tests.
 
 TERRAFORM PREREQUISITE: `terraform apply` in infra/cloudflare/ must have been
 run (operator-applied, CLOUDFLARE_API_TOKEN required) before this suite can
@@ -47,8 +51,9 @@ Cases:
        its IPs in ea_ and HTTP to the leaf succeeds (carve-out fires).
   G3 — attribution: after direct re-query, connection_event reports the BRANDED
        host (e2e-brand.wifihaven.net), not the CDN/leaf target.
-  G4 — bl_ category blocklist slot (TODO(#1348): xfail until bl_ dns-tail
-       populator is implemented).
+  G4 — bl_ category blocklist: direct re-query of the leaf puts its IPs in the
+       bl_ category drop-set and HTTP/80 to the leaf hits the block page.
+       Guards the dns-tail bl_ populator from #1348/#1350.
 
 Assertions are TRAFFIC-LEVEL (connection-layer, as required by docs/architecture.md
 Truth-1 and CLAUDE.md): DNS always resolves; blocking is an nftables property.
@@ -59,10 +64,12 @@ from __future__ import annotations
 import pytest
 
 from ._observers import (
+    bl_set_name,
     dig_ipv4_answers,
     ea_set_name,
     eb_set_name,
     mac_in_blocked_set,
+    wait_bl_set_populated,
     wait_block_page,
     wait_ea_set_populated,
     wait_eb_set_populated,
@@ -356,35 +363,122 @@ def test_attribution_reports_branded_host_after_direct_requery(router, client, f
     )
 
 
-# ── G4 — bl_ (category blocklist) — xfail pending #1348 ─────────────────────
+# ── G4 — bl_ (category blocklist) — dns-tail populator from #1348/#1350 ──────
+
+# Blocklist id used for G4. Any ASCII-safe string is fine; we use a dedicated
+# id so the bl_ set name is predictable and the test doesn't cross-pollinate
+# other scenarios. The name intentionally contains hyphens to exercise
+# bl_sanitize (render.lua replaces `-` → `_`).
+_BL_ID = "e2e-cname-bl"
 
 
-@pytest.mark.xfail(
-    reason=(
-        "TODO(#1348): bl_ category-blocklist bypass via directly-queried CNAME "
-        "targets is not yet fixed. The bl_ populator (blocklists.lua) is driven "
-        "by agent-side resolution, not by client DNS answers, so the #1346/#1349 "
-        "dns-tail alias-map fix is not a drop-in here. This slot will flip from "
-        "xfail to a real assertion once #1348 ships a dns-tail bl_ populator."
-    ),
-    strict=False,
-)
-def test_bl_direct_requery_blocked_xfail(router, client, fake_api):
-    """G4 (xfail — #1348): category-blocklist (bl_) enforcement for
-    directly-queried CNAME targets.
+def test_bl_direct_requery_blocked(router, client, fake_api):
+    """G4: direct re-query of the CNAME leaf populates the bl_ category
+    drop-set and HTTP/80 to that IP hits the block page.
 
-    The bl_/bl6_ sets are populated by the agent's periodic blocklists.lua
-    resolution, not by client DNS answers. When a device re-queries a blocklist
-    member's CNAME target directly, the resolved IP may not be in the bl_ set
-    (CDN-anycast IP variance). Fixing this requires a dns-tail bl_ populator
-    that maps client-observed CNAME-target answers back to blocklist membership
-    via the #1344 alias map — tracked in #1348.
+    Regression guard for #1348/#1350 (dns-tail bl_ populator). The
+    pre-#1350 failure mode:
+      - blocklists.lua adds BRAND_HOST's agent-resolved IPs to bl_<id>
+        on the periodic 30 s cadence.
+      - A device re-queries LEAF_HOST directly. Dnsmasq's `nftset=/<member>/…`
+        callback does NOT fire (the wire qname is the CDN leaf, not the member).
+        Pre-#1350 dns-tail also skipped bl_ population for the direct re-query.
+      - The directly-queried IP is absent from bl_<id> → category block is
+        silently bypassed.
 
-    This slot exists so the scenario file is complete and will flip to a real
-    assertion when #1348 ships, without requiring a new PR at that time.
+    Post-#1350 dns-tail runs maybe_populate_bl on each `reply <name> is <ip>`:
+    it resolves LEAF_HOST through the CNAME alias map → BRAND_HOST, finds that
+    BRAND_HOST is a member of bl_<id>, and calls `nft add element bl_<id> {ip}`
+    inline — the same lockstep approach as eb_ (#515/#1346).
+
+    Harness design:
+      - A fake-api-served blocklist is registered at /api/blocklists/<id>
+        containing BRAND_HOST. The snapshot's `blocklists` dict points to
+        that URL. blocklists.lua fetches and caches it; render.lua emits both
+        the `nftset=/<member>/…` dnsmasq directive and the bl-member-index file
+        that dns-tail loads every 30 s.
+      - NO extraBlocked entry for LEAF_HOST. The point is that bl_ alone must
+        catch the directly-queried leaf IP via the dns-tail populator.
+      - Steps follow G1 (eb_ case): (1) resolve brand → alias map built,
+        (2) direct re-query of leaf → maybe_populate_bl fires, (3) HTTP/80
+        to the leaf must hit the block page (DNAT intercepted before real origin).
+
+    Primary assertion (traffic-level, per docs/architecture.md Truth-1):
+      HTTP/80 to LEAF_HOST returns the block-page body.
+    Secondary (diagnostic):
+      wait_bl_set_populated confirms bl_<id> has the leaf IP on the router.
     """
-    # When #1348 ships: set up a snapshot with a blocklist that includes
-    # BRAND_HOST (or a host whose CNAME chain is BRAND_HOST→...→LEAF_HOST),
-    # resolve the branded host (step 1), re-query the leaf directly (step 2),
-    # and assert HTTP to LEAF_HOST hits the block page. For now: xfail-by-pass.
-    pytest.xfail("bl_ direct-requery populator not yet implemented (#1348)")
+    # Register blocklist content in the fake before serving the snapshot.
+    # blocklists.lua fetches /api/blocklists/<id>; the fake serves it from its
+    # in-memory store. The version in the snapshot controls cache-busting on the
+    # agent (a new version string forces a fresh fetch even if the file is already
+    # on disk). We use a stable version string here — the agent will fetch once
+    # and cache; subsequent policy cycles see a 304 for the snapshot but the
+    # blocklist cache file is already present.
+    fake_api.register_blocklist(_BL_ID, [BRAND_HOST])
+
+    snap = (
+        SnapshotBuilder()
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-cname-bl",
+            blocklist_ids=[_BL_ID],
+        )
+        .add_device(mac=client.mac, name="e2e-cname-bl-dev", profile_id=KIDS_PID)
+        .add_blocklist(id=_BL_ID, version="2026.06.01")
+        .build(etag='"sha256:cname-bl-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Step 1: resolve the branded host so dns-tail builds the alias map
+    # (edge→brand). Without this first resolution the alias map is empty and
+    # maybe_populate_bl falls back to the raw replied name (LEAF_HOST), which
+    # is not a member of the blocklist.
+    chain_ips = _wait_for_chain_resolution(client)
+    assert chain_ips, (
+        f"dig {BRAND_HOST} returned no IPv4 answers — check that "
+        f"terraform apply has been run for infra/cloudflare/ (#1351)"
+    )
+
+    # Truth-1: DNS for the branded host returns real IPs, not NXDOMAIN.
+    assert any(chain_ips), (
+        f"expected real IPv4 from chain resolution, got {chain_ips!r}"
+    )
+
+    # Step 2: re-query the leaf CNAME target directly (simulates Apple device).
+    # dns-tail observes the `reply e2e-edge.wifihaven.net is 93.184.216.34`
+    # log line, resolves the name → BRAND_HOST via the alias map, finds it in
+    # the bl-member-index, and calls `nft add element bl_<id> {ip}`.
+    leaf_ips = _requery_leaf_directly(client)
+    assert leaf_ips, (
+        f"direct dig {LEAF_HOST} returned no IPv4 — leaf A record missing or "
+        f"not yet propagated (terraform apply required)"
+    )
+    assert LEAF_IP in leaf_ips, (
+        f"expected {LEAF_IP} in direct-requery answers for {LEAF_HOST}, "
+        f"got {leaf_ips!r}"
+    )
+
+    # Primary assertion: HTTP/80 to the leaf hits the block page. The bl_
+    # category drop + DNAT fires because the leaf IP is now in bl_<id>;
+    # the connection never reaches 93.184.216.34.
+    probe = wait_block_page(client, host=LEAF_HOST, timeout_s=120)
+    assert probe.http_code == 200, (
+        f"expected block page (HTTP 200) for {LEAF_HOST}, got {probe.http_code!r} — "
+        f"bl_ category drop may be missing the directly-queried leaf IP"
+    )
+
+    # Secondary (diagnostic): assert bl_<id> set membership. This narrows the
+    # failure to the dns-tail bl_ populator when the traffic probe catches a
+    # regression even though the set is empty.
+    bl_members = wait_bl_set_populated(_BL_ID, timeout_s=60)
+    assert bl_members, (
+        f"nft set {bl_set_name(_BL_ID)} is empty — dns-tail bl_ populator "
+        f"(#1348/#1350) did not add the directly-queried leaf IP to the "
+        f"category drop-set"
+    )
+    assert any(LEAF_IP in m for m in bl_members), (
+        f"leaf IP {LEAF_IP} not found in {bl_set_name(_BL_ID)} members: "
+        f"{bl_members!r} — direct-requery IP was not attributed to blocklist member"
+    )


### PR DESCRIPTION
## Summary

- The G4 `xfail` placeholder in Suite G (`test_cname_direct_requery.py`) was waiting on #1348. #1348 shipped via #1350 (dns-tail bl_ populator). This PR promotes G4 to a real traffic-level assertion that gates the router image.
- Adds `GET /api/blocklists/{id}` and `POST /test/blocklist` to the fake API so the router agent's `blocklists.lua` can fetch a fake-served host list during the VM e2e.
- Adds `bl_set_name()` and `wait_bl_set_populated()` to `_observers.py` mirroring the existing `wait_eb_set_populated()`.
- No production source changes; no migrations.

## The gap

#1353 added Suite G covering eb_, ea_, and attribution. G4 was left as a `TODO(#1348): xfail` because the dns-tail bl_ populator wasn't shipped yet. Now that #1350 has merged, the slot can become a real test. Pre-#1350, a client that re-queried a blocklist member's CNAME target directly landed on a CDN-anycast IP the router never added to `bl_<id>` — category block silently bypassed. #1350 closes that via `maybe_populate_bl` (same lockstep approach as `maybe_populate_eb`).

## Fake-API blocklist endpoint

The router agent's `blocklists.lua` fetches the URL from `snapshot.blocklists[id].url`, parses a newline-delimited host list, and caches it on disk keyed by `(id, version)`. The fake now serves `GET /api/blocklists/{id}` (returning `text/plain` host lists) and exposes `POST /test/blocklist` to register content. Blocklist content intentionally survives `reset()` — `blocklists.lua` caches by `(id, version)` on disk, so re-serving the same host list between per-function resets is fine.

## G4 test design — traffic-level (not nft-state) assertion

Per `docs/architecture.md` Truth-1 and CLAUDE.md:

1. Register a fake-api blocklist containing `BRAND_HOST` at `/api/blocklists/e2e-cname-bl`.
2. Snapshot: profile with `blocklistIds=["e2e-cname-bl"]`. **No** `extraBlocked` entry for `LEAF_HOST` — bl_ alone must enforce.
3. Step 1: client resolves `e2e-brand.wifihaven.net` → dns-tail builds alias map `e2e-edge → e2e-brand`.
4. Step 2: client re-queries `e2e-edge.wifihaven.net` directly → dns-tail's `maybe_populate_bl` fires, adds `93.184.216.34` to `bl_e2e_cname_bl`.
5. **Primary assertion**: HTTP/80 to `e2e-edge.wifihaven.net` returns the block-page body (DNAT fires; real origin is never reached).
6. **Secondary (diagnostic)**: `wait_bl_set_populated` confirms `bl_e2e_cname_bl` has the leaf IP — narrows regressions to the dns-tail bl_ populator.

DNS chain uses the same `wifihaven.net` Cloudflare records from #1353 (no new Terraform records required).

## CI / gate wiring

Unchanged from #1353:
- `cname_direct_requery` marker already registered in `pytest.ini` under `--strict-markers`.
- `e2e-vm-fake.yml` collects all `scenarios_fake/**/*.py` automatically.
- `master-router.yml` path filter already includes `scripts/e2e/scenarios_fake/**`.

The `xfail` decorator is gone — G4 now participates in the same gate as G1–G3.

## Test plan

**Ran locally (sandbox):**
```
# scripts/e2e/
pytest scenarios_fake/test_cname_direct_requery.py --collect-only
  → 4 tests collected, 0 errors (no xfail markers — G4 is a real test now)

pytest scenarios_fake/ --collect-only
  → 35 tests collected (31 prior + 4 new), 0 errors

pytest -m cname_direct_requery --collect-only
  → 4/35 tests collected, --strict-markers: OK

python3 -c "from fake_api.state import State; s = State.fresh(); s.set_blocklist('t','x\n'); s.reset(); assert s.get_blocklist('t') == 'x\n'"
  → passes (blocklist survives reset)
```

**Only runs in the VM gate (KVM runner + Cloudflare DNS records):**

G4's real assertions require:
1. The Cloudflare DNS records already applied (`terraform apply` — operator-applied, same prereq as G1–G3 from #1353).
2. A KVM runner with the OpenWRT router VM image (`e2e-vm-fake.yml`, self-hosted `api.lan` runner).
3. An Alpine client VM.
4. The dns-tail bl_ populator from #1350 present in the router image under test.

The full KVM VM e2e cannot run in the sandbox. The Gate 2 workflow runs on push to main via `master-router.yml`.

References #1348, #1350, #1351. Closes the bl_ follow-up tracked in #1351.