### PR TITLE
ci(cloudflare): automate terraform apply on main via remote state

### DIFF
--- a/.github/workflows/master-cloudflare.yml
+++ b/.github/workflows/master-cloudflare.yml
@@ -1,0 +1,100 @@
+name: Master Cloudflare CD
+
+# Cloudflare DNS/Pages deployment pipeline — reconciles the wifihaven.net zone
+# and the Cloudflare Pages projects to the in-repo infra/cloudflare Terraform.
+#
+# Split out as its own pipeline (mirrors master-grafana.yml, #1283): the
+# Cloudflare apply has nothing to do with the API/SPA release cadence, so it
+# only fires when infra/cloudflare/** or this workflow changes, and never
+# blocks — or is blocked by — an API/SPA release.
+#
+# Flow (one job):
+#   deploy-cloudflare — terraform apply of infra/cloudflare against the live
+#     wifihaven.net zone + Cloudflare Pages. State + locking live on HCP
+#     Terraform (the `cloud {}` block in main.tf); the apply itself runs here on
+#     the runner (HCP workspace in *local* execution mode), exactly like the
+#     Grafana pipeline.
+#
+# Why this needs remote state (#1357): infra/cloudflare used a LOCAL, gitignored
+# state file. A CI checkout has no such file, so a naive apply would see an
+# empty state and try to recreate all ~10 already-existing resources and fail.
+# The HCP remote backend gives CI the canonical state + a lock.
+#
+# The apply is idempotent: with the migrated state, a re-run with no repo edits
+# reports "No changes". PR review + the ci.yml cloudflare-terraform lint job
+# (fmt + validate) are the pre-merge gate; this pipeline is the post-merge
+# apply. The one-time state migration + secret/token-scope setup are
+# operator-gated — see infra/cloudflare/README.md.
+#
+# Secrets/scope: the Cloudflare token here needs BOTH `Account / Cloudflare
+# Pages / Edit` (Pages projects/domains) AND `Zone / DNS / Edit` scoped to
+# wifihaven.net (the CNAME/TXT records). The existing CLOUDFLARE_API_TOKEN was
+# created for the Pages wrangler deploys and may only carry the Pages scope, so
+# the operator must either widen it or set a separate CLOUDFLARE_DNS_API_TOKEN
+# (preferred here when present). See the README.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/cloudflare/**'
+      - '.github/workflows/master-cloudflare.yml'
+  workflow_dispatch:
+
+# Scoped to this pipeline's own group. Unlike master-grafana.yml we do NOT
+# cancel in-progress runs: killing `terraform apply` mid-run could orphan the
+# HCP state lock and block the next apply. Queueing lets the in-flight apply
+# finish, then the next push reconciles to the latest repo state.
+concurrency:
+  group: master-cloudflare-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-cloudflare:
+    name: Deploy Cloudflare (Terraform apply)
+    # Gate to main: the path filter lets feature-branch pushes create a run,
+    # but on a non-main ref no job is eligible and GitHub records a spurious
+    # 0-job failure. Skipping (not failing) keeps that neutral. (mirrors
+    # master-grafana.yml's guard, #1136)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Cloudflare + HCP secrets are configured
+        id: gate
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_DNS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$TF_API_TOKEN" ] && [ -n "$CLOUDFLARE_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::TF_API_TOKEN and/or a Cloudflare token not set — skipping Cloudflare apply. See infra/cloudflare/README.md for the one-time backend setup."
+          fi
+
+      - name: Set up Terraform
+        if: steps.gate.outputs.configured == 'true'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.15.3'
+
+      - name: Terraform init + apply
+        if: steps.gate.outputs.configured == 'true'
+        working-directory: infra/cloudflare
+        env:
+          # HCP Terraform: remote state + locking (workspace in local exec mode).
+          TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
+          TF_CLOUD_ORGANIZATION: wifihaven
+          TF_WORKSPACE: cloudflare
+          # Cloudflare provider auth — needs Pages/Edit + Zone:DNS/Edit on
+          # wifihaven.net. Prefer a dedicated DNS-scoped token; fall back to the
+          # Pages deploy token only if it has been widened to cover DNS.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_DNS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          terraform init -input=false
+          terraform apply -auto-approve -input=false

--- a/infra/cloudflare/.gitignore
+++ b/infra/cloudflare/.gitignore
@@ -1,6 +1,7 @@
-# State files: contain provider-specific data and may include sensitive
-# values (per resource). Local state only for now — TODO(#613-followup)
-# to move to a remote backend.
+# State files: now stored remotely on HCP Terraform (the `cloud {}` block in
+# main.tf). Any *.tfstate left locally is a stale/transient artifact (e.g. the
+# pre-migration local backend) and must never be committed — it can hold
+# per-resource sensitive values (#1357, formerly #613-followup).
 *.tfstate
 *.tfstate.*
 

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -5,50 +5,168 @@ Declarative config for everything Cloudflare-side (#613):
 - Pages projects `wifihaven` (prod) and `wifihaven-staging` (Direct Upload).
 - Pages custom domains: `wifihaven.net`, `www.wifihaven.net`, `staging.wifihaven.net`.
 - DNS-only CNAMEs: `api.wifihaven.net`, `api-staging.wifihaven.net` → Render.
+- SPF TXT record + the `e2e-brand` / `e2e-mid` / `e2e-edge` test-fixture
+  CNAME chain (#1351).
 
-**Not managed here**: the zone itself (added once via the dash; NS flip at
-the registrar is a one-shot manual step), and the GitHub repo secrets
-(`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`).
+**Not managed here**: the zone itself (added once via the dash; NS flip at the
+registrar is a one-shot manual step), and the GitHub repo secrets.
+
+## State backend — remote (HCP Terraform)
+
+State lives on **HCP Terraform** (Terraform Cloud, free tier) via the `cloud {}`
+block in `main.tf`, not a local file. This is what makes the CI apply pipeline
+viable: native state locking serializes applies, and a fresh CI checkout reads
+the canonical state instead of an empty local one — so it never tries to
+recreate the ~10 already-live resources (#1357 — closes the old `#613-followup`
+local-state TODO).
+
+- **Org / workspace**: from the `TF_CLOUD_ORGANIZATION` and `TF_WORKSPACE` env
+  vars (the workflow sets them to `wifihaven` / `cloudflare`; local operators
+  export the same). The `cloud {}` block is intentionally empty so it stays
+  account- and creds-agnostic.
+- **Auth**: the `TF_TOKEN_app_terraform_io` env var (an HCP user/team API
+  token). In CI it is the `TF_API_TOKEN` repo secret.
+- **Execution mode**: the workspace runs in **Local** mode — HCP only stores
+  state + provides locking; `terraform apply` runs on the GitHub runner (like
+  the infra/grafana pipeline), so the Cloudflare token stays a GitHub secret
+  and never moves into HCP.
+
+## Applies are CI-driven
+
+A merge to `main` that touches `infra/cloudflare/**` triggers
+[`.github/workflows/master-cloudflare.yml`](../../.github/workflows/master-cloudflare.yml),
+which runs `terraform init && terraform apply -auto-approve` against the live
+zone. **You no longer run `terraform apply` by hand** for routine changes —
+edit the HCL, open a PR, and the apply happens on merge.
+
+- The PR-time gate is the `cloudflare-terraform` job in `ci.yml` (fmt +
+  `validate -backend=false`). It needs no creds and does not apply.
+- The pipeline no-ops (skips with a notice) until `TF_API_TOKEN` and a
+  DNS-scoped Cloudflare token are set — see below.
 
 ## Prerequisites
 
-1. The zone `wifihaven.net` is active on Cloudflare (NS flipped, status
-   shows "Active" in the dash).
-2. The four Render services from `render.yaml` exist and have CNAME targets
-   shown in their **Settings → Custom Domains** tabs.
-3. Cloudflare API token with these scopes:
+1. Zone `wifihaven.net` active on Cloudflare (NS flipped, "Active" in the dash).
+2. Render services exist with CNAME targets in **Settings → Custom Domains**.
+3. Cloudflare API token scopes:
    - `Account / Cloudflare Pages / Edit`
    - `Zone / DNS / Edit` (scoped to the wifihaven.net zone)
 4. Terraform ≥ 1.6 installed (`brew install terraform`).
 
-## First apply
+## Required secrets / token scope
+
+The CI apply needs two repo secrets:
+
+| Secret | Purpose | Notes |
+|--------|---------|-------|
+| `TF_API_TOKEN` | HCP Terraform state-backend auth | User/team token from app.terraform.io → Account settings → Tokens. |
+| `CLOUDFLARE_DNS_API_TOKEN` (preferred) or `CLOUDFLARE_API_TOKEN` | Cloudflare provider auth | Needs **both** `Account / Cloudflare Pages / Edit` **and** `Zone / DNS / Edit` on wifihaven.net. |
+
+> ⚠️ **Token-scope caveat.** The existing `CLOUDFLARE_API_TOKEN` secret was
+> created for the Pages `wrangler` deploys (`master-api-ui.yml`) and may carry
+> only `Account / Cloudflare Pages / Edit`. The DNS records here additionally
+> need `Zone / DNS / Edit`. **Verify the token's scopes** in the Cloudflare dash
+> before the first apply. Either widen the existing token, or mint a new token
+> with both scopes and store it as `CLOUDFLARE_DNS_API_TOKEN` (the workflow
+> prefers it and falls back to `CLOUDFLARE_API_TOKEN`).
 
 ```sh
-cd infra/cloudflare
-
-cp terraform.tfvars.example terraform.tfvars
-$EDITOR terraform.tfvars   # fill in the four values
-
-export CLOUDFLARE_API_TOKEN=<paste the token>
-
-terraform init
-terraform plan
-terraform apply
+gh secret set TF_API_TOKEN --repo wifihaven/wifihaven
+gh secret set CLOUDFLARE_DNS_API_TOKEN --repo wifihaven/wifihaven
 ```
 
-Apply should create 7 resources (2 Pages projects + 3 Pages domains +
-2 CNAMEs). Pages cert provisioning takes a minute or two — check status
-in the Cloudflare dash → Workers & Pages → project → Custom domains.
+## One-time backend setup + state migration (operator-gated)
+
+Do this **once**, locally, with your existing local state present. It moves the
+already-live resources into HCP so CI does not try to recreate them. **Run this
+before merging anything that would trigger the pipeline.**
+
+1. **Create the HCP org + workspace.** On https://app.terraform.io create an org
+   named `wifihaven` (or adjust `TF_CLOUD_ORGANIZATION` in the workflow + below)
+   and a workspace named `cloudflare`. Set the workspace **Execution Mode =
+   Local** (workspace → Settings → General).
+
+2. **Authenticate + point at the workspace:**
+
+   ```sh
+   cd infra/cloudflare
+   export TF_TOKEN_app_terraform_io=<HCP user/team token>   # or run: terraform login
+   export TF_CLOUD_ORGANIZATION=wifihaven
+   export TF_WORKSPACE=cloudflare
+   export CLOUDFLARE_API_TOKEN=<token with Pages + Zone:DNS Edit>
+   ```
+
+3. **Migrate the existing local state into HCP:**
+
+   ```sh
+   terraform init -migrate-state
+   # Terraform detects the backend change (local → cloud) and offers to copy the
+   # existing terraform.tfstate into the new HCP workspace. Answer "yes".
+   ```
+
+4. **Verify nothing will be recreated.** A clean plan must report **No
+   changes** — that proves all live resources are tracked:
+
+   ```sh
+   terraform plan
+   # Expect: "No changes. Your infrastructure matches the configuration."
+   ```
+
+   `terraform state list` should show exactly these 14 resources:
+
+   ```
+   cloudflare_pages_project.prod
+   cloudflare_pages_project.staging
+   cloudflare_pages_domain.apex
+   cloudflare_pages_domain.www
+   cloudflare_pages_domain.staging
+   cloudflare_record.spf
+   cloudflare_record.spa_apex
+   cloudflare_record.spa_www
+   cloudflare_record.spa_staging
+   cloudflare_record.api_prod
+   cloudflare_record.api_staging
+   cloudflare_record.e2e_brand
+   cloudflare_record.e2e_mid
+   cloudflare_record.e2e_edge
+   ```
+
+   **If the local state was lost** (plan wants to *create* resources that
+   already exist), do NOT apply — `terraform import` each one, then re-run
+   `terraform plan` until it is clean:
+
+   ```sh
+   terraform import cloudflare_pages_project.prod    wifihaven/wifihaven
+   terraform import cloudflare_pages_project.staging wifihaven/wifihaven-staging
+   terraform import cloudflare_pages_domain.apex     wifihaven/wifihaven/wifihaven.net
+   terraform import cloudflare_pages_domain.www      wifihaven/wifihaven/www.wifihaven.net
+   terraform import cloudflare_pages_domain.staging  wifihaven/wifihaven-staging/staging.wifihaven.net
+   terraform import cloudflare_record.spf           <zone_id>/<record_id>
+   terraform import cloudflare_record.spa_apex      <zone_id>/<record_id>
+   terraform import cloudflare_record.spa_www       <zone_id>/<record_id>
+   terraform import cloudflare_record.spa_staging   <zone_id>/<record_id>
+   terraform import cloudflare_record.api_prod      <zone_id>/<record_id>
+   terraform import cloudflare_record.api_staging   <zone_id>/<record_id>
+   terraform import cloudflare_record.e2e_brand     <zone_id>/<record_id>
+   terraform import cloudflare_record.e2e_mid       <zone_id>/<record_id>
+   terraform import cloudflare_record.e2e_edge      <zone_id>/<record_id>
+   ```
+
+   (DNS record IDs: Cloudflare dash → DNS → each record, or the API
+   `GET /zones/<zone_id>/dns_records`. Pages import IDs use `<account>/<project>`
+   and `<account>/<project>/<domain>`. `zone_id` is in `terraform.tfvars`.)
+
+5. **Set the CI secrets** (`TF_API_TOKEN`, `CLOUDFLARE_DNS_API_TOKEN`) as above.
+   From here, merges to `main` apply automatically.
 
 ## Subsequent changes
 
-Edit `main.tf` → `terraform plan` → `terraform apply`. State file is
-local (`terraform.tfstate`); back it up out-of-repo (1Password, encrypted
-drive) and migrate to a remote backend before sharing infra ops.
-TODO(#613-followup).
+Edit `main.tf` → open a PR (the `cloudflare-terraform` lint job runs) → merge.
+`master-cloudflare.yml` applies on merge. To preview locally, with the env vars
+from step 2 exported: `terraform plan`.
 
 ## Drift
 
-`terraform plan` with no local edits should report "No changes". If it
-proposes deletions you didn't intend (e.g. somebody added a custom domain
-via the dash), reconcile by adding the resource here, not by applying.
+`terraform plan` with no local edits should report "No changes". If it proposes
+deletions you didn't intend (e.g. somebody added a record via the dash),
+reconcile by adding the resource here, not by applying around it.

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -11,14 +11,32 @@
 #   - The Cloudflare API token (operator creates in the dash; secret stored
 #     in GitHub repo + 1Password).
 #
-# State: local backend. The state file holds resource IDs but no secrets
+# State: remote backend on HCP Terraform (the `cloud {}` block below), free
+# tier, with native state locking. The state holds resource IDs but no secrets
 # (the API token comes from CLOUDFLARE_API_TOKEN env, not a tfvars file).
-# Commit terraform.tfstate to a private store or move to a remote backend
-# before sharing infra ops with another operator. TODO(#613-followup):
-# move to a remote backend.
+# Applies are CI-driven on merge to main via
+# .github/workflows/master-cloudflare.yml; see README.md for the one-time
+# backend setup + local-state migration runbook (#1357, formerly the
+# #613-followup remote-state TODO).
 
 terraform {
   required_version = ">= 1.6"
+
+  # Remote state on HCP Terraform (Terraform Cloud), free tier. Native state
+  # locking means CI applies can't race or clobber the operator's state, and a
+  # fresh CI checkout reads the canonical state instead of seeing an empty
+  # local one and trying to recreate the ~10 live resources (#1357; closes the
+  # old #613-followup local-state marker).
+  #
+  # Org + workspace come from TF_CLOUD_ORGANIZATION / TF_WORKSPACE env vars
+  # (set in .github/workflows/master-cloudflare.yml and documented in
+  # README.md), so this block stays account- and creds-agnostic. Auth is the
+  # TF_TOKEN_app_terraform_io env var. The workspace runs in *local* execution
+  # mode: HCP only stores state + provides locking, while `terraform apply`
+  # runs on the GitHub runner (mirrors the infra/grafana pipeline) with the
+  # Cloudflare token from GitHub secrets.
+  cloud {}
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
@@ -146,10 +164,10 @@ resource "cloudflare_record" "api_staging" {
 # non-block-page body, and is already used as the harness's reference
 # "internet-reachable" origin in scripts/e2e/lib/wait.py).
 #
-# Prerequisite: `terraform apply` against the wifihaven.net zone must run
-# (operator-applied; see PR #1351 description) before the e2e gate can resolve
-# this chain from the router VM. CI validates fmt + validate only; it does NOT
-# apply. See .github/workflows/ci.yml cloudflare-terraform job.
+# These records are applied by the CI pipeline (master-cloudflare.yml) on merge
+# to main — no manual `terraform apply` is needed going forward (#1357). The
+# ci.yml cloudflare-terraform job still validates fmt + validate on every PR
+# but does NOT apply.
 
 resource "cloudflare_record" "e2e_brand" {
   zone_id = var.zone_id


### PR DESCRIPTION
Closes #1357. Context: #1351 (e2e CNAME fixtures), #613 / #613-followup (Cloudflare TF + the deferred remote-state TODO).

## The problem

`infra/cloudflare` is the source of truth for the Pages projects, the API CNAMEs, the SPF record, and the #1351 e2e CNAME fixtures — but it had **no automated apply**. Every change needed a manual operator-run `terraform apply`, which is easy to miss and is exactly why the #1351 records needed a manual apply before the router-VM e2e gate could resolve them.

The hard blocker isn't the workflow — it's **state**. The backend was **local** with a **gitignored** `*.tfstate`. A CI runner is a fresh checkout with no state file, so a naive `terraform apply` would see an empty state, try to **create all ~14 already-live resources**, and fail on "already exists" (or fight the operator's local state). So remote state is a hard prerequisite, and this PR folds in the deferred `TODO(#613-followup)` remote-state work.

## Remote-backend decision (the crux)

**Chosen: HCP Terraform (Terraform Cloud) free tier, via a `cloud {}` block, in _Local_ execution mode.**

| Option | Locking | Extra infra to provision | Verdict |
|--------|---------|--------------------------|---------|
| **HCP Terraform (chosen)** | ✅ native | None — just an operator-created org + workspace | **Least infra, native locking, one new secret.** |
| Cloudflare R2 (S3-compatible) | ⚠️ no native lock table — needs TF ≥1.10 `use_lockfile` (conditional-write `.tflock`) or a separate lock store | An R2 bucket + access keys + `skip_*`/endpoint config | In-vendor, but more moving parts and the locking story is newer/less battle-tested. |
| Postgres / HTTP backend | ✅ (pg advisory locks) | A DB or a state server; couples infra state to app DB or adds a service | Most infra; rejected. |

Within HCP there's a second choice — **Local vs Remote execution mode**. I picked **Local**: HCP only stores state + provides the lock, and `terraform apply` runs **on the GitHub runner**, exactly mirroring the `infra/grafana` pipeline. This keeps the Cloudflare token in **GitHub secrets** (passed as env to the runner) instead of splitting secrets into HCP workspace variables, which Remote execution would require. One new backend secret (`TF_API_TOKEN`), nothing else moves.

The `cloud {}` block is intentionally **empty** — org/workspace come from `TF_CLOUD_ORGANIZATION` / `TF_WORKSPACE` env (set as literals `wifihaven` / `cloudflare` in the workflow) and auth from `TF_TOKEN_app_terraform_io`. That keeps the HCL account- and creds-agnostic **and** keeps the existing PR-time lint working: I verified `terraform init -backend=false && terraform validate` still passes with the `cloud {}` block, so `ci.yml`'s `cloudflare-terraform` gate is untouched.

## What's in this PR

1. **`main.tf`** — `cloud {}` remote backend block; replaces the `TODO(#613-followup)` local-state marker with a reference to #1357; updates the e2e-chain comment (CI applies now, no manual step).
2. **`.github/workflows/master-cloudflare.yml`** — new `terraform init && terraform apply -auto-approve -input=false`, gated to **`main` pushes touching `infra/cloudflare/**`** (and the workflow file), mirroring `master-grafana.yml`'s trigger / `if: github.ref == 'refs/heads/main'` guard / permissions / concurrency. Two deliberate deviations from the Grafana template, both commented:
   - **`cancel-in-progress: false`** (Grafana uses `true`). Killing `terraform apply` mid-run could orphan the HCP state lock; queueing lets the in-flight apply finish and the next push reconciles.
   - Gate skips cleanly (with a `::notice::`) until `TF_API_TOKEN` + a Cloudflare token are present — so it no-ops, not fails, until the operator finishes setup.
3. **`.gitignore`** — `*.tfstate` comment updated (remote now primary; any local state is a stale artifact).
4. **`README.md`** — remote-backend docs, required secrets/scope table, and the operator-gated migration runbook (below).

**The PR-time gate stays unchanged:** `ci.yml`'s `cloudflare-terraform` job (fmt + `validate -backend=false`) remains the pre-merge gate; this new pipeline is the **post-merge** apply.

## Token scope — operator must verify ⚠️

The existing `CLOUDFLARE_API_TOKEN` secret was created for the Pages `wrangler` deploys (`master-api-ui.yml`) and **may carry only `Account / Cloudflare Pages / Edit`**. The DNS records here additionally need **`Zone / DNS / Edit`** scoped to `wifihaven.net`. **Do not assume it's wide enough.** Either widen that token, or mint a DNS-scoped token and store it as **`CLOUDFLARE_DNS_API_TOKEN`** — the workflow prefers it and falls back to `CLOUDFLARE_API_TOKEN`.

## Operator runbook — one-time backend setup + state migration (NOT run in this PR)

This touches **prod DNS state**, so the migration and first apply are deliberately operator-gated. Run once, locally, with the existing local state present:

1. **Create HCP org + workspace.** app.terraform.io → org `wifihaven` (or edit `TF_CLOUD_ORGANIZATION`) → workspace `cloudflare`. Set **Execution Mode = Local**.
2. **Auth + target:**
   ```sh
   cd infra/cloudflare
   export TF_TOKEN_app_terraform_io=<HCP token>   # or: terraform login
   export TF_CLOUD_ORGANIZATION=wifihaven
   export TF_WORKSPACE=cloudflare
   export CLOUDFLARE_API_TOKEN=<token with Pages + Zone:DNS Edit>
   ```
3. **Migrate local → HCP:** `terraform init -migrate-state` → answer `yes` to copy `terraform.tfstate` into the workspace.
4. **Verify no recreation** — `terraform plan` must report **"No changes."** `terraform state list` must show exactly these 14 resources:
   `pages_project.{prod,staging}`, `pages_domain.{apex,www,staging}`, `record.{spf,spa_apex,spa_www,spa_staging,api_prod,api_staging,e2e_brand,e2e_mid,e2e_edge}`.
   If the local state was lost (plan wants to **create** existing resources), `terraform import` each instead of applying — full import command list is in `infra/cloudflare/README.md`.
5. **Set CI secrets:** `gh secret set TF_API_TOKEN` and `gh secret set CLOUDFLARE_DNS_API_TOKEN`. From here, merges to `main` apply automatically.

## What ran locally vs. what's operator-gated

- ✅ Ran here: `terraform fmt -check -diff` (clean), `terraform init -backend=false && terraform validate` (valid), `actionlint master-cloudflare.yml` (clean).
- ⛔ **Not** run here, by design — I have no creds and must not touch live state: `terraform apply`, `terraform init -migrate-state`, and the first CI apply. **The apply pipeline is not proven end-to-end** until the operator migrates state and confirms the token scopes per the runbook above.

## Acceptance (#1357)

- [x] Remote backend with locking; HCL keeps `validate -backend=false` working.
- [x] Merge to `main` touching `infra/cloudflare/**` applies automatically (post-setup).
- [x] #1351 e2e records apply via the pipeline going forward — no manual step.
- [x] Migration + token-scope runbook documented (PR + README).
- [ ] Operator-gated: HCP setup, state migration, secret/scope confirmation, first apply.