### PR TITLE
fix(openwrt): mkdir -p blocklists cache dir before write (#1363)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -43,7 +43,11 @@ end
 -- base_url: optional api base (e.g. "http://router:8080"). The snapshot ships
 --   relative blocklist urls ("/api/blocklists/<id>"); when base_url is given
 --   and the url is root-relative, they're joined so curl gets an absolute URL.
--- fs: optional table with {read, write, rename, remove, list}; defaults to real I/O.
+-- fs: optional table with {read, write, rename, remove, list, mkdir};
+--   defaults to real I/O. `mkdir(path)` must behave like `mkdir -p` — it is
+--   called once for cache_dir before any write, so a fresh image where
+--   /etc/wifihaven/blocklists/ doesn't exist yet doesn't ENOENT on the
+--   tmp-file open (#1363).
 -- Returns: { hosts_by_id = {[id]={hosts}}, errors = {...} }
 function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url)
   cache_dir = cache_dir or DEFAULT_CACHE_DIR
@@ -55,11 +59,12 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url)
   end
 
   -- Default filesystem ops (real I/O) when fs not injected.
-  local read_fn, write_fn, rename_fn
+  local read_fn, write_fn, rename_fn, mkdir_fn
   if fs then
     read_fn  = fs.read
     write_fn = fs.write
     rename_fn = fs.rename
+    mkdir_fn = fs.mkdir
   else
     read_fn  = function(path)
       local f, err = io.open(path, "r")
@@ -79,6 +84,23 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url)
       local ok, err = os.rename(from, to)
       if not ok then return nil, err end
       return true, nil
+    end
+    mkdir_fn = function(path)
+      -- mkdir -p; quoting the path so spaces / shell metachars don't break.
+      local ok = os.execute(string.format("mkdir -p %q", path))
+      if ok == true or ok == 0 then return true, nil end
+      return nil, "mkdir -p failed for " .. tostring(path)
+    end
+  end
+
+  -- Ensure the cache dir exists before the first atomic-tmp write (#1363).
+  -- On a fresh image /etc/wifihaven/blocklists/ doesn't exist yet, which
+  -- previously caused every fetch to ENOENT and the bl_ ipset to stay empty.
+  if mkdir_fn then
+    local mok, merr = mkdir_fn(cache_dir)
+    if not mok then
+      result.errors[#result.errors + 1] =
+        string.format("blocklists: mkdir failed for %s: %s", tostring(cache_dir), tostring(merr))
     end
   end
 

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -185,6 +185,65 @@ describe("blocklists.fetch_and_cache", function()
     assert.equal(2, #hosts)
   end)
 
+  -- #1363 regression: on a fresh image the cache_dir
+  -- (/etc/wifihaven/blocklists) does not exist yet, so the atomic-tmp open
+  -- fails with ENOENT and every category fetch records a "write failed: No
+  -- such file or directory" error. The bl_ ipset stays empty and category
+  -- enforcement is a silent no-op. fetch_and_cache must mkdir -p the cache
+  -- dir up front (via the injected fs.mkdir hook, defaulting to a real
+  -- mkdir on prod) before the first write.
+  it("creates the cache dir before writing when it does not exist (#1363)", function()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    -- fs whose write_fn errors with ENOENT until mkdir is called for the
+    -- parent dir. Mirrors the real busted_temp / POSIX behaviour.
+    local files = {}
+    local dirs  = {}
+    local mkdir_calls = {}
+    local fs = {
+      _files = files,
+      _dirs  = dirs,
+      mkdir = function(path)
+        mkdir_calls[#mkdir_calls + 1] = path
+        dirs[path] = true
+        return true, nil
+      end,
+      write = function(path, content)
+        local parent = path:match("^(.*)/[^/]+$")
+        if parent and not dirs[parent] then
+          return nil, path .. ": No such file or directory"
+        end
+        files[path] = content
+        return true, nil
+      end,
+      read = function(path) return files[path] end,
+      rename = function(from, to)
+        if files[from] then
+          files[to] = files[from]
+          files[from] = nil
+          return true, nil
+        end
+        return nil, "no such file: " .. tostring(from)
+      end,
+    }
+
+    local function http_get(_url, _headers)
+      return 200, "ads.example.com\n", {}
+    end
+
+    local s = snap({ test_ads = { version = "v1", url = "http://api/api/blocklists/test_ads" } })
+    local result = blocklists.fetch_and_cache(s, http_get, fs, cache_dir)
+
+    assert.truthy(#mkdir_calls > 0, "fetch_and_cache must mkdir the cache dir")
+    assert.equal(cache_dir, mkdir_calls[1])
+    -- No "No such file or directory" errors after the mkdir.
+    for _, e in ipairs(result.errors) do
+      assert.is_nil(e:match("No such file or directory"),
+        "unexpected ENOENT error after mkdir: " .. e)
+    end
+    assert.not_nil(files[cache_dir .. "/test_ads-v1.txt"],
+      "cache file must exist after fetch_and_cache succeeds")
+  end)
+
   it("returns error when http_get_fn is nil", function()
     local fs = make_fs()
     local s  = snap({ test_ads = { version = "abc123", url = "http://api/api/blocklists/test_ads" } })


### PR DESCRIPTION
## Summary
- Fixes #1363. `blocklists.fetch_and_cache` now `mkdir -p`s the cache dir before the first atomic-tmp write, so a fresh image where `/etc/wifihaven/blocklists/` doesn't exist yet doesn't ENOENT on every fetch.
- Threaded a new `mkdir_fn` through the injected `fs` table (parallel to `read_fn` / `write_fn` / `rename_fn`), defaulting to real `mkdir -p` on prod.

## Why
Surfaced during PR #1361 validation on the e2e VM image:

```
user.warn wifihaven: blocklist fetch: blocklists: write failed for e2e-cname-bl:
  /etc/wifihaven/blocklists/e2e-cname-bl-2026.06.01.txt.tmp: No such file or directory
```

This path was masked before #1360 because the fetch was 401'ing and never reached the write; the auth fix in #1360 unblocked the fetch and exposed the missing `mkdir`. Net effect on any image where the dir isn't pre-created: the `bl_` ipset stays empty and category enforcement silently no-ops — same shape as #1334.

## Test plan
- [x] TDD red commit first (`bf4f12b`): added a `blocklists_spec.lua` case whose injected `fs.write` returns `ENOENT` until `fs.mkdir` is called for the parent dir. Asserts `mkdir` was invoked, no `No such file or directory` error survives, and the final cache file exists.
- [x] Fix commit (`4c522fa`): implementation.
- [ ] CI: full `openwrt` busted suite passes (could not run locally — host lacks `lua` / `busted`; suite runs in CI).
- [ ] CI: Gate 2 fake-mode e2e on the VM image (DNS-env gaps make local e2e indeterminate per the issue, so deferring to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)