### PR TITLE
fix(openwrt): omit empty `labels` so router metric batches decode (#1365)

### DIFF
--- a/api/test/src/feature/RouterMetricsIngestSpec.scala
+++ b/api/test/src/feature/RouterMetricsIngestSpec.scala
@@ -150,6 +150,47 @@ object RouterMetricsIngestSpec
         assertTrue(scraped.contains("policy_apply_duration_seconds"))
       }
     },
+    test("batch that OMITS `labels` on a label-less series ingests + re-exposes (#1365)") {
+      // Real luci.jsonc on the router serializes an empty Lua table as a JSON
+      // array (`[]`), so the agent omits `labels` entirely for a label-less
+      // series rather than emitting `"labels":[]` (which this decoder would
+      // reject, failing the whole batch — every prod batch landed in
+      // router_metrics_batches_total{status="malformed"} and nothing reached
+      // /metrics, leaving the router-fleet dashboard empty). The API must
+      // therefore accept a series with NO `labels` key and default it to the
+      // empty map. This hand-written body mirrors the exact prod wire shape;
+      // the codec-built bodies elsewhere always emit `"labels":{}` and so never
+      // exercised the omitted form.
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-omit")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        ridStr = rid.value.toString
+        body   =
+          s"""{
+             |  "routerId": "$ridStr",
+             |  "agentVersion": "0.3.1",
+             |  "agentStartedAt": "2026-05-30T09:00:00Z",
+             |  "sampledAt": "2026-05-30T14:01:00Z",
+             |  "gauges": [ { "name": "agent_uptime_seconds", "value": 18060.0 } ],
+             |  "histograms": [ {
+             |    "name": "policy_apply_duration_seconds",
+             |    "buckets": [ { "le": "0.05", "count": 3.0 }, { "le": "+Inf", "count": 6.0 } ],
+             |    "sum": 0.4, "count": 6.0
+             |  } ]
+             |}""".stripMargin
+        resp    <- post(routes, tok, body)
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(
+          seriesValue(scraped, "agent_uptime_seconds", s"""router_id="$ridStr"""")
+            .contains(18060.0),
+        ) &&
+        assertTrue(scraped.contains("policy_apply_duration_seconds"))
+    },
     test("missing token → 401; routerId mismatch → 403") {
       for {
         _          <- cleanDb

--- a/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
@@ -133,11 +133,26 @@ local function ordered_list(map)
   return out
 end
 
+-- Whether a labels table has any entries. An empty table is the dangerous
+-- case: real luci.jsonc on the router serializes an empty Lua table as a JSON
+-- *array* (`[]`), not an object (`{}`), so emitting `labels = {}` produces
+-- `"labels":[]` on the wire — which the API's `Map[String,String]` decoder
+-- rejects, failing the WHOLE batch (router_metrics_batches_total{status=
+-- "malformed"}). We therefore OMIT `labels` entirely for a label-less series
+-- and let the API decoder fall back to its `Map.empty` default (#1365). The
+-- lua-cjson test shim masked this: cjson encodes an empty table as `{}`, so
+-- the failure only ever appeared against real luci.jsonc in production.
+local function attach_labels(series, labels)
+  if labels and next(labels) ~= nil then series.labels = labels end
+  return series
+end
+
 -- Build the §3.2 push body from the registry. Pure serializer of current
 -- registry state + the caller-supplied sampledAt — no clock reads, so the
 -- contract generator can drive it deterministically. Empty series lists are
--- omitted entirely (rather than emitted as `{}`), since luci.jsonc encodes an
--- empty Lua table as a JSON object and the API decoder expects arrays.
+-- omitted entirely (the decoder defaults them to empty), and so is an empty
+-- `labels` map (see attach_labels above) — never emit an empty Lua table,
+-- since luci.jsonc renders it as `[]` and the decoder then rejects the batch.
 function M.build_batch(reg, sampled_at)
   local batch = {
     routerId       = reg.router_id,
@@ -148,13 +163,13 @@ function M.build_batch(reg, sampled_at)
 
   local counters = {}
   for _, c in ipairs(ordered_list(reg.counters)) do
-    counters[#counters + 1] = { name = c.name, labels = c.labels, value = c.value }
+    counters[#counters + 1] = attach_labels({ name = c.name, value = c.value }, c.labels)
   end
   if #counters > 0 then batch.counters = counters end
 
   local gauges = {}
   for _, g in ipairs(ordered_list(reg.gauges)) do
-    gauges[#gauges + 1] = { name = g.name, labels = g.labels, value = g.value }
+    gauges[#gauges + 1] = attach_labels({ name = g.name, value = g.value }, g.labels)
   end
   if #gauges > 0 then batch.gauges = gauges end
 
@@ -166,13 +181,12 @@ function M.build_batch(reg, sampled_at)
     end
     -- +Inf overflow == total observation count.
     buckets[#buckets + 1] = { le = "+Inf", count = h.count }
-    histograms[#histograms + 1] = {
+    histograms[#histograms + 1] = attach_labels({
       name    = h.name,
-      labels  = h.labels,
       buckets = buckets,
       sum     = h.sum,
       count   = h.count,
-    }
+    }, h.labels)
   end
   if #histograms > 0 then batch.histograms = histograms end
 

--- a/openwrt/test/contract_gen.lua
+++ b/openwrt/test/contract_gen.lua
@@ -350,11 +350,17 @@ local function build_metrics_batch()
 
   local batch = metrics.build_batch(reg, "2026-05-30T14:01:00Z")
 
-  -- An empty `labels` map must serialize as a JSON object (`{}`), the way
-  -- production luci.jsonc emits it and the way the zio-json
-  -- `Map[String,String]` decoder accepts it — not as an empty array.
+  -- A label-less series is OMITTED of its `labels` field by build_batch
+  -- (#1365): real luci.jsonc on the router serializes an empty Lua table as a
+  -- JSON array (`[]`), which the API's `Map[String,String]` decoder rejects, so
+  -- the agent never emits an empty `labels` at all. The contract fixture pins
+  -- the *canonical decode-stable* form instead — the explicit empty object
+  -- `{}` the decoder normalizes a missing `labels` to and re-emits — so
+  -- ContractGoldenSpec's decode→re-encode round-trip stays a meaningful
+  -- "no silent defaulting" guard. (The genuine prod-wire guard that build_batch
+  -- never emits an empty Lua table lives in openwrt/test/metrics_spec.lua.)
   local function fix_labels(s)
-    if s.labels and next(s.labels) == nil then s.labels = EMPTY_OBJECT end
+    if not s.labels or next(s.labels) == nil then s.labels = EMPTY_OBJECT end
   end
 
   for _, c in ipairs(batch.counters or {}) do

--- a/openwrt/test/metrics_spec.lua
+++ b/openwrt/test/metrics_spec.lua
@@ -151,6 +151,39 @@ describe("metrics histograms", function()
   end)
 end)
 
+-- ── #1365: label-less series must OMIT `labels`, never emit an empty table ──
+--
+-- Real luci.jsonc on the router serializes an empty Lua table as a JSON array
+-- (`[]`), not an object (`{}`). A series carrying `labels = {}` therefore went
+-- on the wire as `"labels":[]`, which the API's `Map[String,String]` decoder
+-- rejects — failing the ENTIRE batch (every prod batch was counted in
+-- router_metrics_batches_total{status="malformed"} and never re-exposed, so
+-- the router-fleet dashboard stayed empty). build_batch must omit `labels`
+-- entirely for a label-less series so the decoder defaults it to an empty map.
+-- (The lua-cjson test shim hid this: cjson encodes an empty table as `{}`.)
+describe("metrics build_batch — empty labels (#1365)", function()
+  it("omits `labels` for a label-less gauge (never emits an empty table)", function()
+    local reg = new_reg()
+    metrics.set_gauge(reg, "agent_uptime_seconds", {}, 18060)
+    local g = find_series(metrics.build_batch(reg, "t").gauges, "agent_uptime_seconds")
+    assert.is_nil(g.labels)
+  end)
+
+  it("omits `labels` for a label-less histogram", function()
+    local reg = new_reg()
+    metrics.observe(reg, "policy_apply_duration_seconds", {}, 0.02)
+    local h = find_series(metrics.build_batch(reg, "t").histograms, "policy_apply_duration_seconds")
+    assert.is_nil(h.labels)
+  end)
+
+  it("still carries `labels` for a series WITH a bounded enum label", function()
+    local reg = new_reg()
+    metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" }, 9300)
+    local c = find_series(metrics.build_batch(reg, "t").counters, "snapshot_poll_total")
+    assert.same({ result = "304" }, c.labels)
+  end)
+end)
+
 describe("metrics.post — retain on failure (self-heal)", function()
   it("never resets the registry on a failed POST; next batch is the full total", function()
     local reg = new_reg()


### PR DESCRIPTION
Fixes #1365. Completes #1279 (router-fleet dashboard).

## Live root cause (confirmed against prod)

The router-fleet dashboard was empty **not** because the re-export bridge was missing (it works), but because **every** router metrics batch was being rejected by the API as malformed, so `RouterMetricsService.ingest` never ran and no router series were ever folded into the Prometheus registry that Alloy scrapes.

Evidence — prod `GET /metrics` (scrape-token auth) contained exactly one router-related series:

```
router_metrics_batches_total{status="malformed"} 872   # and climbing; zero status="ok"
```

Capturing what the deployed agent actually emits (real `luci.jsonc` on the test router) showed the smoking gun:

```json
"gauges":[{"value":18060,"name":"agent_uptime_seconds","labels":[]}]
"histograms":[{ ... "labels":[]}]
```

`build_batch` emitted `labels = {}` (an empty Lua table) for every label-less series (`agent_uptime_seconds`, both duration histograms). **Real `luci.jsonc` serializes an empty Lua table as a JSON array (`"labels":[]`)**, and the shared `Map[String,String]` decoder rejects an array — so the whole `RouterMetricsBatch` failed to decode (`router_metrics_batches_total{status="malformed"}`), short-circuiting before ingest.

### Why CI/tests never caught it

- The OpenWRT test shim `openwrt/test/shim/luci/jsonc.lua` wraps **lua-cjson**, which encodes an empty table as `{}` (object) — decodes fine.
- `ContractGoldenSpec`'s router→API fixture is built by a **custom pretty-printer** with an `EMPTY_OBJECT` sentinel, so it pinned `{}`, not the `[]` real `luci.jsonc` produces.

Both masked the production-only `[]` shape.

## Fix

`build_batch` now **omits `labels` entirely** for a label-less series. The API decoder defaults a missing `labels` to the empty map. This is encoder-independent — no empty Lua table is ever serialized, so neither `{}` nor `[]` can appear.

- `contract_gen.lua`: keep the golden fixture's canonical `{}` form (the shape the decoder normalizes a missing `labels` to and re-emits) so `ContractGoldenSpec`'s decode→re-encode round-trip stays a meaningful "no silent defaulting" guard. Documented why prod omits while the fixture canonicalizes.

## Tests (red→green visible in history)

1. **`openwrt/test/metrics_spec.lua`** (commit 1, red): asserts `build_batch` omits `labels` for label-less gauges/histograms and keeps it for labelled series. Fails against the pre-fix `build_batch` (emits `{}`).
2. **`api/test/src/feature/RouterMetricsIngestSpec.scala`**: POSTs the exact prod wire shape (`labels` omitted) and asserts it ingests + re-exposes under `router_id`. The codec-built bodies elsewhere always emit `"labels":{}` and never exercised the omitted form.

Verified:
- `busted test/metrics_spec.lua` — 19/19 (red→green confirmed by reverting the fix).
- `mill shared.test.testOnly ...ContractGoldenSpec` — 5/5.
- `mill api.test.testOnly ...RouterMetricsIngestSpec` — 6/6.
- `scalafmt --check` clean. Contract-fixture regen produces no drift.
- (`openwrt/test/failover_spec.lua` has 2 failures that pre-exist on clean `main` — a local lua-version artifact, unrelated to this change.)

## Acceptance / follow-up

Once a router on the fixed agent pushes a batch, `router_metrics_batches_total{status="ok"}` starts climbing and `snapshot_poll_total` / `agent_uptime_seconds` / `agent_version` appear under `router_id` (with the `env` label Alloy attaches at scrape) within one scrape interval — populating router-fleet. This requires the agent to roll forward to a build containing this fix.