### PR TITLE
fix(vm): make orphan-reaper pid-age probe tolerant of vanished sibling qemus (#1369)

### DIFF
--- a/scripts/vm/lib.sh
+++ b/scripts/vm/lib.sh
@@ -142,7 +142,11 @@ wh_bridge_reserved() {
   local f="${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation"
   [[ -f "${f}" ]] || return 1
   local pid
-  pid="$(awk -F= '$1=="pid"{print $2; exit}' "${f}" 2>/dev/null)"
+  # `|| true`: the marker can vanish between the `-f` test above and this awk
+  # (a sibling run clears its own reservation mid-scan); awk then exits non-zero
+  # and, under `set -e`, would abort this assignment. Treat a vanished marker as
+  # "not reserved" (fall through to the rm/return 1 below).
+  pid="$(awk -F= '$1=="pid"{print $2; exit}' "${f}" 2>/dev/null || true)"
   if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
     return 0
   fi
@@ -162,10 +166,19 @@ wh_bridge_reserved() {
 # legitimate run.
 
 # Wall-clock lifetime (whole seconds) of a pid, empty if not running.
+#
+# MUST NOT return non-zero: callers use `age="$(wh_proc_age_secs "${pid}")"`
+# under `set -euo pipefail`, so any non-zero rc — from a non-numeric pid, OR
+# (the #1369 TOCTOU) from the pid exiting between the pgrep and our `ps`, which
+# makes `ps` rc=1 and `pipefail` propagate it — aborts the caller at the
+# assignment, BEFORE its `[[ "${age}" =~ ^[0-9]+$ ]] || continue` guard can
+# skip the vanished pid. Always return 0 with (possibly empty) output and let
+# the guard do its job.
 wh_proc_age_secs() {
-  local pid="$1"
-  [[ "${pid}" =~ ^[0-9]+$ ]] || return 1
-  ps -o etimes= -p "${pid}" 2>/dev/null | tr -d '[:space:]'
+  local pid="$1" out
+  [[ "${pid}" =~ ^[0-9]+$ ]] || return 0
+  out="$(ps -o etimes= -p "${pid}" 2>/dev/null)" || out=""
+  printf '%s' "${out}" | tr -d '[:space:]'
 }
 
 # Longest wall-clock lifetime a *CI* VM can legitimately reach. The VM gates
@@ -322,10 +335,16 @@ wh_pick_lan_bridge() {
   local br
   while IFS= read -r br; do
     local attached
-    attached=$(ls "${WH_SYS_CLASS_NET}/${br}/brif" 2>/dev/null | wc -l)
+    # `|| true`: if `brif` vanishes mid-scan (a sibling tearing down its bridge),
+    # `ls` exits non-zero and `pipefail` makes the whole pipeline non-zero even
+    # though `wc -l` already emitted "0" — which, under `set -e`, would abort
+    # this assignment. `wc` has already written the count, so swallowing the rc
+    # leaves `attached` correct (empty/0 ⇒ treated as free).
+    attached=$(ls "${WH_SYS_CLASS_NET}/${br}/brif" 2>/dev/null | wc -l || true)
     local res="none"
     if [[ -f "${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation" ]]; then
-      res="$(awk -F= '$1=="pid"{print $2; exit}' "${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation" 2>/dev/null)"
+      # `|| true`: same vanish-after-test TOCTOU as wh_bridge_reserved's awk.
+      res="$(awk -F= '$1=="pid"{print $2; exit}' "${WH_BRIDGE_RESERVATION_DIR}/${br}.reservation" 2>/dev/null || true)"
     fi
     log "pick-debug ${br}: attached=${attached} reservation_pid=${res}"
     if (( attached == 0 )) && ! wh_bridge_reserved "${br}"; then

--- a/scripts/vm/test-lan-bridge-pick.sh
+++ b/scripts/vm/test-lan-bridge-pick.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
-# Smoke test for scripts/vm/lib.sh::wh_pick_lan_bridge (#895).
+# Smoke test for scripts/vm/lib.sh::wh_pick_lan_bridge (#895) and the
+# orphan-reaper's TOCTOU tolerance (#1369).
 #
 # Substitutes for a true red-green on the workflow YAML change in #895: the
 # concurrency relaxation relies on the picker failing fast and loud when every
 # pool bridge is already in use, so that a fourth concurrent VM run cannot
 # silently wedge waiting on a slot that will never come free.
 #
-# Two cases:
+# Pick-path cases (need flock(1), Linux-only):
 #   1. Empty pool (no reservations) → picks the lowest-numbered bridge.
 #   2. Every pool bridge reserved   → exits non-zero with a "pool exhausted"
 #      message on stderr.
+#   3. Dead-pid reservations        → reaper reclaims them, pick succeeds.
+#
+# TOCTOU cases (#1369, no flock — run everywhere):
+#   4. wh_proc_age_secs <vanished pid> → rc 0 + empty string (never rc 1,
+#      which under set -e+pipefail would abort the reaper's `age="$(...)"`
+#      assignment BEFORE its numeric-guard `continue` could skip the pid).
+#   5. wh_reap_orphan_bridges with a numeric-but-dead pid on a non-headroom
+#      bridge → completes (rc 0) instead of aborting — i.e. the caller's
+#      guard skips the vanished sibling qemu, matching the prod repro where a
+#      concurrent run's qemu exited between the pgrep and our ps.
 #
 # Runs anywhere; no root, no real bridges, no qemu. Uses tmpdirs for
 # /etc/qemu/bridge.conf, /sys/class/net/<br>, and the reservation dir via the
@@ -20,13 +31,93 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
 FAIL=0
 
+assert() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "${actual}" == *"${expected}"* ]]; then
+    echo "  ok: ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${name}"
+    echo "    expected substring: ${expected}"
+    echo "    actual: ${actual}"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- #1369 TOCTOU cases (no flock required) ----------------------------------
+# PID 2^31-1 is reserved by Linux and never assigned, so it is numeric yet
+# guaranteed dead — exactly the shape of a sibling qemu that exited between the
+# reaper's pgrep and our ps.
+DEAD_PID=2147483647
+
+echo "test-lan-bridge-pick: case 4 — wh_proc_age_secs tolerates a vanished pid"
+# Capture the helper's rc the way a callsite would, but via `|| rc=$?` so we can
+# observe the rc instead of aborting on it. Pre-fix this returned 1 (→ caller
+# abort under set -e); post-fix it returns 0 with empty output.
+proc_age_out="$(
+  exec 2>&1
+  # shellcheck source=lib.sh
+  source "${HERE}/lib.sh"   # sets -euo pipefail
+  rc_dead=0
+  age_dead="$(wh_proc_age_secs "${DEAD_PID}")" || rc_dead=$?
+  rc_nonnum=0
+  age_nonnum="$(wh_proc_age_secs "not-a-pid")" || rc_nonnum=$?
+  printf 'DEAD_RC=%s\n' "${rc_dead}"
+  printf 'DEAD_AGE=[%s]\n' "${age_dead}"
+  printf 'NONNUM_RC=%s\n' "${rc_nonnum}"
+  printf 'NONNUM_AGE=[%s]\n' "${age_nonnum}"
+)"
+assert "dead pid → rc 0" "DEAD_RC=0" "${proc_age_out}"
+assert "dead pid → empty string" "DEAD_AGE=[]" "${proc_age_out}"
+assert "non-numeric pid → rc 0" "NONNUM_RC=0" "${proc_age_out}"
+assert "non-numeric pid → empty string" "NONNUM_AGE=[]" "${proc_age_out}"
+
+echo "test-lan-bridge-pick: case 5 — reaper skips a vanished pid without aborting"
+# Drive the real reaper with wh_qemu_pids_on_bridge overridden to yield a dead
+# numeric pid (simulating a sibling qemu that exited mid-scan). wh-lan0 is the
+# non-headroom bridge, so it enters the age-probe loop. Pre-fix: the bare
+# `age="$(wh_proc_age_secs ...)"` aborts the whole reaper under set -e, so
+# REAPER_DONE never prints and rc is non-zero. Post-fix: the numeric guard
+# `continue`s past the dead pid and the reaper completes.
+reaper_rc=0
+reaper_out="$(
+  exec 2>&1
+  TMP5="$(mktemp -d)"
+  export WH_SYS_CLASS_NET="${TMP5}/sys-class-net"
+  export WH_BRIDGE_RESERVATION_DIR="${TMP5}/reservations"
+  mkdir -p "${WH_SYS_CLASS_NET}" "${WH_BRIDGE_RESERVATION_DIR}"
+  # shellcheck source=lib.sh
+  source "${HERE}/lib.sh"   # sets -euo pipefail
+  # Override AFTER sourcing so the reaper resolves our stub at call time.
+  wh_qemu_pids_on_bridge() { printf '%s\n' "${DEAD_PID}"; }
+  # wh-lan0 (non-headroom) gets the age loop; wh-lan1 is the headroom slot.
+  wh_reap_orphan_bridges wh-lan0 wh-lan1
+  printf 'REAPER_DONE=1\n'
+  rm -rf "${TMP5}"
+)" || reaper_rc=$?
+assert "reaper completes (rc 0)" "REAPER_DONE=1" "${reaper_out}"
+if (( reaper_rc == 0 )); then
+  echo "  ok: reaper subshell exited 0"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: reaper subshell exited ${reaper_rc} (aborted on vanished pid)"
+  echo "    output: ${reaper_out}"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- #895 pick-path cases (need flock(1)) ------------------------------------
 # `flock(1)` ships with util-linux on Linux but is not present by default on
-# macOS. The picker itself can't run without it either, so this test is only
+# macOS. The picker itself can't run without it either, so these cases are only
 # meaningful on the same hosts that run the VM e2e workflows (the self-hosted
-# KVM runner). Skip cleanly elsewhere so `bash scripts/vm/test-lan-bridge-pick.sh`
-# from a dev laptop is a no-op rather than a spurious failure.
+# KVM runner). Skip them cleanly elsewhere so `bash scripts/vm/test-lan-bridge-pick.sh`
+# from a dev laptop still exercises the #1369 cases above rather than aborting.
 if ! command -v flock >/dev/null 2>&1; then
-  echo "test-lan-bridge-pick: SKIP (no flock(1) on PATH — Linux-only test)"
+  echo "test-lan-bridge-pick: SKIP pick-path cases 1-3 (no flock(1) on PATH — Linux-only)"
+  echo
+  echo "test-lan-bridge-pick: passed=${PASS} failed=${FAIL}"
+  if (( FAIL > 0 )); then
+    exit 1
+  fi
   exit 0
 fi
 
@@ -78,19 +169,6 @@ run_pick() {
     echo "WH_LAN_BRIDGE=${WH_LAN_BRIDGE:-}"
   )" || rc=$?
   printf '%s\nRC=%s\n' "${stdout_stderr}" "${rc}"
-}
-
-assert() {
-  local name="$1" expected="$2" actual="$3"
-  if [[ "${actual}" == *"${expected}"* ]]; then
-    echo "  ok: ${name}"
-    PASS=$((PASS + 1))
-  else
-    echo "  FAIL: ${name}"
-    echo "    expected substring: ${expected}"
-    echo "    actual: ${actual}"
-    FAIL=$((FAIL + 1))
-  fi
 }
 
 set +e


### PR DESCRIPTION
## Problem

Master Router CD **Gate 2** intermittently went **fully red on both arms** under concurrency: every scenario test ERRORed at session setup with `RuntimeError: command failed (rc=1): scripts/vm/router-up.sh` and **completely empty stdout AND stderr** (e.g. [run 26958383261](https://github.com/wifihaven/wifihaven/actions/runs/26958383261)). Solo runs always passed — it was concurrency-only.

## Root cause — a TOCTOU race in the #1225 orphan-reaper

`wh_reap_orphan_bridges` (in [`scripts/vm/lib.sh`](scripts/vm/lib.sh)) enumerates qemu pids on **sibling** bridges via `pgrep`, then probes each with `wh_proc_age_secs(pid)` → `ps -o etimes= -p <pid>`.

When a **concurrent run's qemu exits between the `pgrep` and the `ps`** (routine when a sibling arm finishes), `ps` exits non-zero. Under **`pipefail`** the helper's pipeline returned 1, so the command substitution `age="$(wh_proc_age_secs "${pid}")"` failed, and under **`set -e`** `router-up.sh` **aborted at the assignment — before the very next line's numeric guard** `[[ "${age}" =~ ^[0-9]+$ ]] || continue` could skip the vanished pid.

The abort was silent: `ps` stderr → `/dev/null`, `set -e` prints nothing, and the #1225 EXIT trap is silent too → **rc=1, empty output, every (session-scoped) fixture ERRORs**. The CNAME-train PRs didn't regress anything — they just added longer e2e suites → more concurrent VM churn → siblings exit mid-scan more often → higher hit rate.

```
++ wh_proc_age_secs 242181
++ ps -o etimes= -p 242181        # pid already gone → ps rc=1
++ tr -d '[:space:]'
+ age=                            # pipefail propagates rc=1 → set -e aborts here
```

## Fix (surgical)

Stop transient-pid / vanished-tap probes from aborting the reaper under `set -e`, **without** weakening the genuine pool-exhaustion `die` or the real age-reaping logic:

- **`wh_proc_age_secs`** — never returns non-zero. A non-numeric pid returns `0` (empty) instead of `rc 1`, and the `ps` failure is swallowed with `|| out=""` so `pipefail` can't propagate it. The caller's numeric guard then skips the vanished pid as designed.
- **Audited the rest of the pick/reap path** for the same `set -e`+`pipefail` exposure when a sibling vanishes mid-scan, and made each empty/`|| true`-safe:
  - `wh_bridge_reserved` — `awk` on a reservation file that can be cleared after the `-f` test.
  - `wh_pick_lan_bridge` — `ls .../brif | wc -l` (`brif` can vanish; `pipefail` propagated `ls`'s rc even though `wc` had already emitted the count) and the reservation-file `awk`.

`wh_qemu_pids_on_bridge` / `wh_any_qemu_pids_on_bridge` already end in `|| true`; the `headroom` `printf|sort|tail` and `wh_delete_orphan_taps`'s process-substitution `ls` are not exposed.

## Test

Extended [`scripts/vm/test-lan-bridge-pick.sh`](scripts/vm/test-lan-bridge-pick.sh) with two `flock`-free cases (so they exercise on dev laptops too, not just the KVM runner):

- **case 4** — `wh_proc_age_secs <vanished / non-numeric pid>` → rc `0` + empty string.
- **case 5** — `wh_reap_orphan_bridges` with a numeric-but-dead pid on a non-headroom bridge **completes (rc 0)** instead of aborting (the caller's guard skips it).

Both go **red** against the pre-fix `lib.sh` and **green** with the fix (verified locally by running the suite against `origin/main`'s `lib.sh`).

## Validation
- `shellcheck scripts/vm/lib.sh` — no new findings (the two pre-existing `SC1091`/`SC2012` info notes are unchanged from `main`).
- `bash -n` clean on both scripts.
- Test suite: `passed=6 failed=0`.

Gate 2 itself needs the self-hosted KVM runner and could not be run locally.

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)