### PR TITLE
observability(vm): surface router-up.sh failure cause + serial console on Gate 2/3a failures (#1370)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -188,15 +188,26 @@ jobs:
           WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
         run: scripts/e2e-vm.sh --mode=fake
 
+      # #1370: surface the router/client serial consoles on failure. This step
+      # runs before "Tear down VMs" below, and router-down.sh leaves .run/ in
+      # place, so the logs are present at upload time. Name console.log
+      # explicitly (the diagnostic that was missing for the #1369 reaper race)
+      # alongside the broad .run/** sweep, and use if-no-files-found: warn so an
+      # empty .run/ — a pre-qemu pick-time abort never wrote a serial log — is
+      # logged rather than silently ignored. Control sockets moved to
+      # ${XDG_RUNTIME_DIR}/wh-vm (#1219); serial logs stay under
+      # .run/**/console.log.
       - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-vm-fake-failure-${{ matrix.pkg_format }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            scripts/vm/.run/**/console.log
+            scripts/vm/.run/**/*.log
             scripts/vm/.run/**
             !scripts/vm/.run/**/*.qcow2
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Tear down VMs

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -167,15 +167,26 @@ jobs:
           WH_ROUTER_IMAGE_PATH: ${{ steps.image.outputs.path }}
         run: scripts/e2e-vm.sh --mode=gate3
 
+      # #1370: surface the router/client serial consoles on failure. This step
+      # runs before "Tear down VMs" below, and router-down.sh leaves .run/ in
+      # place, so the logs are present at upload time. Name console.log
+      # explicitly (the diagnostic that was missing for the #1369 reaper race)
+      # alongside the broad .run/** sweep, and use if-no-files-found: warn so an
+      # empty .run/ — a pre-qemu pick-time abort never wrote a serial log — is
+      # logged rather than silently ignored. Control sockets moved to
+      # ${XDG_RUNTIME_DIR}/wh-vm (#1219); serial logs stay under
+      # .run/**/console.log.
       - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-vm-gate3a-failure-${{ matrix.pkg_format }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            scripts/vm/.run/**/console.log
+            scripts/vm/.run/**/*.log
             scripts/vm/.run/**
             !scripts/vm/.run/**/*.qcow2
-          if-no-files-found: ignore
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Tear down VMs

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -77,7 +77,18 @@ def router_up(*, image_path: str | None = None, wait_ssh_timeout: float = 180) -
         env["WH_ROUTER_IMAGE_PATH"] = image_path
     env.setdefault("WH_ROUTER_HTTP_PORT", str(ROUTER_HTTP_PORT))
     env.setdefault("WH_ROUTER_SSH_PORT", str(ROUTER_SSH_PORT))
-    res = run([_vm_script("router-up.sh")], env=env, timeout=300)
+    # #1370: don't let sh.Result.check() raise the bare `rc=1` / empty-stderr
+    # error — a router-up failure (e.g. the #1369 pick-time reaper race) carries
+    # its real cause in the serial console, which router-up.sh's ERR trap also
+    # tails to stderr. Append both so the pytest failure is self-explanatory.
+    res = run([_vm_script("router-up.sh")], env=env, timeout=300, check=False)
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"router-up.sh failed (rc={res.returncode}).\n"
+            f"--- router serial console (tail) ---\n{router_serial_log()}\n"
+            f"--- router-up.sh stderr ---\n{res.stderr or '(empty)'}\n"
+            f"--- router-up.sh stdout ---\n{res.stdout or '(empty)'}"
+        )
     _wait_for_router_ssh(timeout_s=wait_ssh_timeout)
     return res
 
@@ -124,7 +135,12 @@ def _wait_for_router_ssh(*, timeout_s: float = 240, interval_s: float = 3.0) -> 
             except _subprocess.TimeoutExpired:
                 last_err = "ssh probe timed out"
         _time.sleep(interval_s)
-    raise TimeoutError(f"router SSH never came up after {timeout_s}s (last: {last_err})")
+    # #1370: a hung boot returns rc=0 from router-up.sh (it daemonizes once qemu
+    # launches) but never answers SSH, so the serial console is the only clue.
+    raise TimeoutError(
+        f"router SSH never came up after {timeout_s}s (last: {last_err})\n"
+        f"--- router serial console (tail) ---\n{router_serial_log()}"
+    )
 
 
 def router_down() -> Result:

--- a/scripts/vm/router-up.sh
+++ b/scripts/vm/router-up.sh
@@ -36,6 +36,35 @@ _release_reservation_on_fail() {
 }
 trap _release_reservation_on_fail EXIT
 
+# Observability (#1370): under `set -e`, an abort prints nothing and the EXIT
+# trap above is silent, so a router-up failure surfaces in CI as `rc=1` with
+# completely empty stdout/stderr. That blinded the #1369 reaper-race diagnosis
+# (a `set -e` abort inside a command substitution during the bridge pick) — it
+# took an SSH + `bash -x` repro to root-cause. Print the failing line + command
+# and a tail of the router serial console to stderr on any non-zero exit before
+# the VM is confirmed up.
+#
+# Strictly diagnostic: errtrace fires the ERR trap inside functions too, but
+# the trap touches no exit code and is registered separately from the EXIT
+# trap, so the #1225 reservation-release behavior is unchanged. The serial tail
+# is guarded so the trap itself can never fail the script.
+set -o errtrace
+_router_diag_on_err() {
+  local rc=$? line="${BASH_LINENO[0]:-?}"
+  [[ "${_router_booted}" == "1" ]] && return 0
+  {
+    echo "router-up.sh: FAILED (rc=${rc}) at line ${line}: ${BASH_COMMAND}"
+    if [[ -n "${WH_ROUTER_SERIAL_LOG:-}" && -f "${WH_ROUTER_SERIAL_LOG}" ]]; then
+      echo "router-up.sh: --- last 40 lines of ${WH_ROUTER_SERIAL_LOG} ---"
+      tail -n 40 "${WH_ROUTER_SERIAL_LOG}" 2>/dev/null || true
+      echo "router-up.sh: --- end serial console ---"
+    else
+      echo "router-up.sh: (no router serial console at ${WH_ROUTER_SERIAL_LOG:-<unset>} yet — failed before qemu wrote it)"
+    fi
+  } >&2
+}
+trap _router_diag_on_err ERR
+
 "${HERE}/lan-bridge-up.sh"
 
 ensure_openwrt_image


### PR DESCRIPTION
## What

Observability-only fix for #1370. When `scripts/vm/router-up.sh` fails in Gate 2/3a, the e2e harness reported only `rc=1` with **completely empty** stdout/stderr — which made the #1369 reaper TOCTOU race (a `set -e` abort during the bridge pick) impossible to diagnose from CI without an SSH + `bash -x` repro. This makes such failures self-explanatory.

**No change to the boot path, exit codes, or the #1225 reservation-release behavior.**

## Changes

### 1. `scripts/vm/router-up.sh` — diagnostics on failure
- Added `set -o errtrace` + an `ERR` trap that, on any non-zero exit **before** `_router_booted=1`, prints to **stderr**: the failing line (`BASH_LINENO`) + `BASH_COMMAND`, and a 40-line `tail` of `${WH_ROUTER_SERIAL_LOG}` when it exists.
- The serial tail is guarded (`[[ -f ... ]]` + `2>/dev/null || true`) so the trap can never itself fail the script.
- Registered as a **separate** trap from the existing EXIT trap, so the #1225 reservation release is untouched. After boot the trap is a no-op (`_router_booted == 1`).

### 2. `scripts/e2e/lib/vm.py` — real cause in the pytest failure
- `router_up()` now runs `router-up.sh` with `check=False` and, on non-zero exit, raises a `RuntimeError` that includes the serial-console tail (via the existing `router_serial_log()` helper) + the captured stderr/stdout — instead of `sh.Result.check()`'s bare `rc=1` / empty `--stderr--`.
- Also appended the serial tail to the SSH-never-came-up `TimeoutError`: a hung boot returns rc=0 from the daemonizing `router-up.sh`, so the console is the only clue there.

### 3. `e2e-vm-fake.yml` / `e2e-vm-gate3a.yml` — reliably upload serial logs
- The failure-artifact upload named only `scripts/vm/.run/**` with `if-no-files-found: ignore`. The observed `No files were found with the provided path: scripts/vm/.run/**` happens when the failure occurs **before qemu writes any serial log** (the #1369 pick-time abort) — `.run/` is empty/absent — and `ignore` then hid the miss silently.
- Fix: name `scripts/vm/.run/**/console.log` and `**/*.log` explicitly alongside the broad `.run/**` sweep, and switch `if-no-files-found` to `warn`. Serial **logs** stay under `.run/` (only control **sockets** moved to `${XDG_RUNTIME_DIR}/wh-vm` per #1219).
- No reorder needed: the upload step already runs before "Tear down VMs", and `router-down.sh` leaves `.run/` in place, so logs are present at upload time.

## Verification
- `shellcheck scripts/vm/router-up.sh` — clean (only the two pre-existing SC1091 infos on the unchanged `source` lines), `bash -n` passes.
- Exercised the ERR trap locally with a forced pre-boot failure: it prints the failing line + command and the serial tail to stderr, handles a missing serial log gracefully, and leaves the exit code at 1.
- `actionlint` clean on both changed workflows.
- `python3 -m py_compile` clean on the touched libs.

Closes #1370. Refs #1369, #1225, #1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)