### PR TITLE
feat(grafana): at-a-glance router-metrics ingest success-ratio panel (#1368)

### DIFF
--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -416,6 +416,47 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Router metrics ingest success ratio (#1368)",
+      "description": "sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. At-a-glance health: green ≥ 0.95, red below. This catches the #1365 blind spot where `ok` is simply absent (ratio 0/total): the raw by-status rate panel to the left renders a total outage as a lone `malformed` line that looks like low traffic, whereas this turns red. 0/0 (no batches at all in the window) renders as No data — not red — so a quiet environment does not false-alarm. NOTE: this panel is passive — actually paging on this condition is the alerting-strategy thread (#1381).",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
+      "id": 13,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
+          "legendFormat": "success ratio",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -49,6 +49,7 @@ belongs to. Set it on the item in the board UI.
 | `Launch & Marketing` | Marketing site, branding/logo system, public-launch readiness. |
 | `E2E Test Coverage` | VM/e2e gate coverage, fake-router/fake-API scenarios, test backfill, install-script tests. |
 | `Schedules` | Named/reusable schedules, schedule-driven blocklists, schedule enforcement verification. |
+| `Alerting & Paging` | Alert rules, contact points / notification policy, on-call routing, paging strategy, and the declarative alerting Terraform. Turning failure-mode metrics into pages, not just graphable series. Design thread #1381 (split out of #1368 / #1373). |
 | `Other` | Cross-cutting refactors, docs, type-safety, wire-versioning, notifications, and anything that doesn't fit a thread above. |
 
 ## Umbrellas are native sub-issue parents


### PR DESCRIPTION
Partially addresses #1368 — ships the **dashboard** half. The **alerting** half is split out into the new **Alerting & Paging** epic, design thread #1381.

## Problem

During #1365, **100% of router metrics ingests failed for a long window** — prod exposed `router_metrics_batches_total{status="malformed"}` climbing with **zero** `status="ok"` — and nobody noticed until the empty router-fleet dashboard was hand-investigated. The metric and a by-status rate panel already existed (`api-self-metrics.json`, "Router metrics batch ingest rate (#1205)"), but a raw by-status rate makes a *total* failure (`ok` absent) look like low traffic — just a lone `malformed` line on an otherwise-quiet graph.

## What this PR does

Adds a **"Router metrics ingest success ratio (#1368)"** `stat` panel to the `api-self-metrics` dashboard:

```promql
sum(rate(router_metrics_batches_total{env="$env",status="ok"}[10m]))
  / sum(rate(router_metrics_batches_total{env="$env"}[10m]))
```

- `percentunit`, **green ≥ 0.95 / red below** — a glance now shows "ingest broken" instead of requiring the reader to notice an absent `ok` line.
- `0/0` (no batches at all in the window) renders as **No data**, not red, so a quiet environment reads neutral rather than alarming.
- Sliced only by bounded labels (`status`, templated `env`) per the cardinality rules. Surgical 41-line diff that preserves the dashboard's formatting.

Also records the new epic in `docs/project-board.md`.

## Why alerting was split out

The original draft of this PR added Grafana alert rules + a remote-state migration. That's the right *direction*, but it's a strategy decision, not a one-metric bolt-on: where alert rules live, the `infra/grafana` stateless→remote-state migration, contact-point/notification-policy routing, the severity model, and the full first-alert catalog (`auth_failures_total`, `metrics_rejected_total`, `traffic_reports_filtered_zero_bytes_total`, `blocklist_fetch_failures_total`, fleet liveness). Those now live under the new **Alerting & Paging** epic and are designed in **#1381**. The success-ratio condition worked out here is captured there for reuse.

## Validation

- `python3 -m json.tool` on every dashboard — clean.
- PromQL checked against the emitted series: `router_metrics_batches_total{status}` (`AppMetrics.recordRouterMetricsBatch`, `api/src/metrics/Metrics.scala`); `env` attached by the Alloy scrape.

## Follow-up

- #1381 — Design the alerting strategy (the paging half of #1368).