### PR TITLE
docs: design for per-app schedules (#1376)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -453,10 +453,11 @@ the profile's general schedule. This is a `PolicyService`-only feature with
 **no wire or router change**: at snapshot-compute time the window is evaluated
 (reusing `scheduleActiveAt`, household-local zone via the injected `Clock`) and
 collapsed into the *existing* fields — `allowed_during` while active → the app's
-hosts in `extraAllowed` (which beats every whole-MAC block per #421, including
-TimeLimit), `blocked_during` while active → `extraBlocked`. The agent never
-learns that per-app schedules exist; it still sees only the per-MAC
-`BlockRules`. Freshness rides the same pull-based path as profile schedules —
+hosts in `extraAllowed` (which beats Schedule/Paused/Manual whole-MAC blocks per
+#421; whether it also beats the *daily time limit* is a server-side choice keyed
+on the app's `exemptFromDaily` flag, not a router behaviour), `blocked_during`
+while active → `extraBlocked`. The agent never learns that per-app schedules
+exist; it still sees only the per-MAC `BlockRules`. Freshness rides the same pull-based path as profile schedules —
 the next poll after a window edge recomputes against the current instant
 (worst-case one poll interval). A precomputed boundary scheduler is needed only
 if the future server-push channel above is built. Full design:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -446,6 +446,22 @@ The architectural invariant: **every new policy concept lands in
 `BlockRules`**. Adding decision logic to the agent (schedule evaluation,
 time accounting, category lookup, role-based defaults) is a bug.
 
+**Per-app schedules ([#1376](https://github.com/wifihaven/wifihaven/issues/1376))
+are an instance of this invariant, not an exception to it.** An app can carry
+its own time window meaning "allowed during W" or "blocked during W" on top of
+the profile's general schedule. This is a `PolicyService`-only feature with
+**no wire or router change**: at snapshot-compute time the window is evaluated
+(reusing `scheduleActiveAt`, household-local zone via the injected `Clock`) and
+collapsed into the *existing* fields — `allowed_during` while active → the app's
+hosts in `extraAllowed` (which beats every whole-MAC block per #421, including
+TimeLimit), `blocked_during` while active → `extraBlocked`. The agent never
+learns that per-app schedules exist; it still sees only the per-MAC
+`BlockRules`. Freshness rides the same pull-based path as profile schedules —
+the next poll after a window edge recomputes against the current instant
+(worst-case one poll interval). A precomputed boundary scheduler is needed only
+if the future server-push channel above is built. Full design:
+[`docs/design/per-app-schedules.md`](design/per-app-schedules.md).
+
 ## 6. Router HTTP API
 
 All endpoints below are served by the existing API process under

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -79,74 +79,84 @@ Because we reuse `scheduleActiveAt`, per-app windows inherit overnight-wrap,
 DOW, and DST correctness for free, and the schedule-boundary unit tests can
 reuse the existing fixtures.
 
-### 3.2 Inline windows *and* named-schedule references (#1069)
+### 3.2 Named schedules land first — references only, no inline windows
 
-The feature must support **both**:
+**Sequencing decision: [#1069](https://github.com/wifihaven/wifihaven/issues/1069)
+(household-scoped reusable named schedules) lands before per-app schedules, and
+per-app schedules reference a named schedule exclusively.** No inline
+`{days, from, until}` table is introduced.
 
-- **Inline window** — `days` + `from` + `until` stored directly on the per-app
-  schedule row. Available now; #1069 is not yet built.
-- **Named-schedule reference** ([#1069](https://github.com/wifihaven/wifihaven/issues/1069)) —
-  a foreign key to a household-scoped reusable schedule ("Bedtime", "School
-  hours"). When #1069 lands, an operator can attach a named schedule to an app
-  window instead of re-typing the times. This is forward-compatible: the column
-  is added nullable now, and the FK constraint to the `named_schedules` table is
-  added in the follow-up that ships #1069 (the target table does not exist yet).
+Rationale:
 
-Exactly one of `{schedule_id}` or `{days, from, until}` is populated per row,
-enforced by a table `CHECK`.
+- #1069 already proposes the household `schedules` table (named, JSONB
+  `windows` supporting compound time blocks) **and** an
+  `app_policy_assignments.schedule_id` reference. Building per-app schedules on
+  that foundation avoids inventing a second, parallel inline-window
+  representation that would later have to be migrated into the named model
+  anyway.
+- A one-off window is just a named schedule the operator creates ad hoc
+  ("Math homework block"). The reusable-named primitive subsumes the inline
+  case, so "reference a named schedule, not only inline windows" (the #1376
+  ask) is satisfied by *named-only* once #1069 exists — cleaner than carrying
+  both, with no `CHECK`-enforced either/or column pair.
+- A named schedule's JSONB `windows` array already covers the compound case
+  (e.g. "school hours: weekdays 8–15, Fri 8–12"), so per-app schedules inherit
+  multi-window support for free without their own one-to-many window rows.
 
-This composes with **#1067** (schedule-driven blocklist activation): both are
-"a schedule drives a policy effect." They should converge on the same named-
-schedule references once #1069 exists, but neither blocks the other.
+This also lines up with **#1067** (schedule-driven blocklist activation), which
+references the same named schedules — all three (profile schedule, per-app
+schedule, blocklist activation) converge on the one #1069 primitive.
 
-### 3.3 DB migration shape
+### 3.3 What #1069 gives us, and what #1376 adds
 
-The window is a **child of the per-app-per-profile assignment**
-(`app_policy_assignments`), not of the app itself — the same app can have
-different windows under different profiles, exactly as it already has different
-`mode`s. One-to-many (an assignment may carry several windows), mirroring how
-`schedules` is one-to-many under `profiles`.
+#1069 gives an assignment a **single** gating schedule via
+`app_policy_assignments.schedule_id` (its stated use: gate a `time_limited`
+app's budget by a window). #1376 needs two things #1069 does not provide:
 
-New migration (next free version, currently `V48__app_policy_schedules.sql`):
+1. a **mode** — *allowed during* vs *blocked during* — which #1069's bare
+   `schedule_id` does not carry; and
+2. the ability to attach **more than one** (schedule, mode) pair to a single app
+   (e.g. *allowed during* Bedtime **and** *blocked during* Homework).
+
+So #1376 adds a small child table of `(assignment, named-schedule, mode)`
+rules. Because #1069 lands first, the FK target (`schedules`) already exists and
+the FK is created directly — no deferred-constraint dance.
+
+New migration (next free version, e.g. `V49__app_policy_schedule_rules.sql`,
+sequenced *after* #1069's migration):
 
 ```sql
-CREATE TABLE app_policy_schedules (
+CREATE TABLE app_policy_schedule_rules (
   id             BIGSERIAL PRIMARY KEY,
   assignment_id  BIGINT NOT NULL
                    REFERENCES app_policy_assignments(id) ON DELETE CASCADE,
+  schedule_id    BIGINT NOT NULL
+                   REFERENCES schedules(id) ON DELETE CASCADE,   -- #1069 named schedule
   mode           TEXT NOT NULL
                    CHECK (mode IN ('allowed_during','blocked_during')),
-  -- inline window (mirrors the schedules table); used when schedule_id IS NULL
-  days           TEXT[],
-  window_from    TEXT,            -- 'HH:MM', household-local
-  window_until   TEXT,            -- 'HH:MM', household-local
-  -- #1069 named-schedule reference; FK added in the follow-up that ships #1069
-  schedule_id    BIGINT,
   created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CHECK (
-    (schedule_id IS NOT NULL
-       AND days IS NULL AND window_from IS NULL AND window_until IS NULL)
-    OR
-    (schedule_id IS NULL
-       AND days IS NOT NULL AND window_from IS NOT NULL AND window_until IS NOT NULL)
-  )
+  UNIQUE (assignment_id, schedule_id, mode)
 );
-CREATE INDEX idx_app_policy_schedules_assignment
-  ON app_policy_schedules(assignment_id);
+CREATE INDEX idx_app_policy_schedule_rules_assignment
+  ON app_policy_schedule_rules(assignment_id);
 ```
 
+(If #1069's final schema names the table differently, this FK target tracks
+that name — the dependency is explicit so the names stay in sync.)
+
 **Migration-isolation (AGENTS.md "Schema changes land in their own PR").** This
-is a brand-new table referencing only existing tables, so:
+is a brand-new table referencing only tables that already exist once #1069 has
+landed, so:
 
 - It is trivially backward-compatible with image-(N-1): the old image's queries
-  never touch `app_policy_schedules`, so the existing `api.test` suite (which
-  applies every migration including this one against image-(N-1) code) passes
-  unchanged — that is the gate.
-- The migration PR contains **only** `V48__….sql` plus doc updates. No source,
-  no tests, no fixtures. The PolicyService eval, repo methods, and tests land in
-  the follow-up PR (§"Sub-issues").
+  never touch `app_policy_schedule_rules`, so the existing `api.test` suite
+  (which applies every migration including this one against image-(N-1) code)
+  passes unchanged — that is the gate.
+- The migration PR contains **only** the `V49__….sql` plus doc updates. No
+  source, no tests, no fixtures. The PolicyService eval, repo methods, and tests
+  land in the follow-up PR (§"Sub-issues").
 - **Not a growth table** ("Migrations that are fast on dev … minutes-long on
-  prod"): `app_policy_schedules` is bounded by `apps × profiles × windows`
+  prod"): `app_policy_schedule_rules` is bounded by `apps × profiles × rules`
   (tens of rows), not by event volume. The migration is metadata-only — safe on
   the startup critical path.
 
@@ -158,24 +168,20 @@ These are API-internal models consumed by `PolicyService`; **none of them is a
 ```scala
 enum AppScheduleMode { case AllowedDuring, BlockedDuring }
 
-case class AppScheduleWindow(
-    id: AppScheduleWindowId,
+case class AppScheduleRule(
+    id: AppScheduleRuleId,
     assignmentId: AppPolicyAssignmentId,
+    scheduleId: ScheduleId,        // #1069 named schedule
     mode: AppScheduleMode,
-    // inline window (None when referencing a named schedule)
-    days: Option[List[String]],
-    startLocal: Option[LocalTime],
-    endLocal: Option[LocalTime],
-    // #1069 reference (None when inline)
-    scheduleId: Option[ScheduleId],
 )
 ```
 
-At evaluation time each `AppScheduleWindow` is resolved into a `Schedule`
-(inline fields or the referenced named schedule), the household `tz` is
-injected, and `PolicyService.scheduleActiveAt` decides activity. The
-`UpsertAppAssignmentRequest` gains an additive `schedules: List[…] = Nil`
-field (back-compatible default).
+At evaluation time each `AppScheduleRule` resolves its referenced named
+schedule to that schedule's window list (#1069 `windows`), the household `tz` is
+injected, and `PolicyService.scheduleActiveAt` is applied **per window** — the
+rule is "active at `now`" iff any of the named schedule's windows is active. The
+`UpsertAppAssignmentRequest` gains an additive
+`scheduleRules: List[AppScheduleRule] = Nil` field (back-compatible default).
 
 ## 4. PolicyService evaluation
 
@@ -192,11 +198,14 @@ buckets. This matters because a naive union would let the router's
 allow-beats-block rule defeat a `blocked_during` window on a base-`Allowed`
 app.
 
+A rule is "active at `now`" iff its referenced named schedule (#1069) has any
+window active at `now` (§3.4).
+
 ```
-effectiveDisposition(assignment, windows, now):
-  if any allowed_during window active at now  -> AllowedDuring  // carve-out CANDIDATE (see gate)
-  else if any blocked_during window active     -> Blocked
-  else                                         -> base mode      // Allowed / Blocked / TimeLimited
+effectiveDisposition(assignment, scheduleRules, now):
+  if any allowed_during rule active at now   -> AllowedDuring  // carve-out CANDIDATE (see gate)
+  else if any blocked_during rule active      -> Blocked
+  else                                        -> base mode      // Allowed / Blocked / TimeLimited
 ```
 
 - **`allowed_during` wins over `blocked_during`** when an app has overlapping
@@ -395,20 +404,20 @@ Consequences for per-app schedules:
 In the app/profile assignment editor, each app's assignment row gains a
 **Schedules** section:
 
-- An **add-window** control producing one or more window rows (one-to-many,
+- An **add-rule** control producing one or more rule rows (one-to-many,
   matching the data model).
-- Per window: a **mode** toggle — *Allowed during* / *Blocked during* — and
-  either
-  - a **named-schedule picker** (when #1069 ships), or
-  - an **inline window editor** reusing the existing profile-schedule editor
-    component (day-of-week multiselect + `from`/`until` time pickers). Times are
-    household-local; the editor shows the household zone.
+- Per rule: a **mode** toggle — *Allowed during* / *Blocked during* — plus a
+  **named-schedule picker** (the #1069 picker; "Bedtime", "School hours", or
+  create-new inline from the same control). No bespoke time editor here — the
+  named-schedule primitive owns day/time editing, and a one-off is just a new
+  named schedule. Times are household-local; the picker shows the household
+  zone.
 - **Autosave** ([#995](https://github.com/wifihaven/wifihaven/issues/995) /
   [#423](https://github.com/wifihaven/wifihaven/issues/423)): debounced PATCH of
   the assignment, no explicit Save button, consistent with the autosave-default
   preference. The request shape extends `UpsertAppAssignmentRequest` additively
-  with `schedules: List[AppScheduleWindow]` (default `Nil`, so existing clients
-  keep working).
+  with `scheduleRules: List[AppScheduleRule]` (default `Nil`, so existing
+  clients keep working).
 - The editor should surface the §5 semantic plainly. A hint on `allowed_during`
   should read like "this app stays reachable during this window even during
   bedtime" — and, because cap-immunity is governed by the assignment's
@@ -428,40 +437,40 @@ server-side `PolicyService` collapse into the existing `extraAllowed` /
 `extraBlocked` fields with **no wire or router change**, and that the router
 remains a dumb applier. (Added in the same PR as this design doc.)
 
-## 9. Sub-issues to file (do not file yet — operator/orchestration)
+## 9. Sub-issues (filed under this epic — Schedules)
 
-In dependency order. The first three honour the migration-isolation two-PR
-split.
+**Prerequisite: [#1069](https://github.com/wifihaven/wifihaven/issues/1069)
+(named schedules) lands first.** Per-app schedules reference the #1069
+`schedules` table directly (§3.2–3.4), so every issue below is **blocked on
+#1069**. Filed as native sub-issues of the #1376 epic, Epic = `Schedules`.
 
-1. **DB migration (schema-only PR).** `V48__app_policy_schedules.sql` per §3.3,
-   plus doc updates only. No source, no tests. Gate: existing `api.test` passes
-   against image-(N-1) code with the new table present.
-2. **PolicyService eval + repo + models (follow-up PR).** Add
-   `AppScheduleWindow` / `AppScheduleMode` to `shared/Models.scala`; repo method
-   to load windows per assignment; the §4.1 effective-disposition resolution in
-   both `PolicyService.snapshot` and `PolicyService.decide`; extend
-   `UpsertAppAssignmentRequest` additively. Confirm **no** `PolicySnapshot`
-   field is added.
-3. **Schedule-boundary unit tests.** Pure tests over the effective-disposition
-   resolver + `scheduleActiveAt` reuse: exact on/off edges, overnight wrap, DOW
-   membership, DST transition, `allowed_during`-beats-`blocked_during` tiebreak,
-   the cap gate (`carveIntoExtraAllowed` true for exempt-over-cap, false for
-   non-exempt-over-cap, true for either when under cap), and inline vs
-   named-schedule resolution. Use `Clock.TestClock` fixtures; never
-   `java.time` directly.
-4. **Feature tests.** End-to-end snapshot assertions proving the app's hosts
-   land in `extraAllowed` during an `allowed_during` window while the profile is
-   in scheduled downtime (row 1); that an **exempt** app *is* carved out when the
-   profile is over its daily cap (row 9a) while a **non-exempt** one is *not*
-   (row 9b) — the cap-gate split; the coincident schedule+cap case for a
-   non-exempt app (row 9c); and `extraBlocked` during a `blocked_during` window
-   (row 3). Drive time with `TestClock`; assert the ETag flips across a window
-   edge.
-5. **Web UI.** The §7 assignment-editor Schedules section with autosave;
-   inline editor now, named-schedule picker gated on #1069.
-6. **(Optional, compose-with) Named-schedule FK.** Once #1069 lands, add the
-   `app_policy_schedules.schedule_id` FK to `named_schedules` and the picker
-   wiring. Tracked against #1069, not a blocker for inline windows.
+In dependency order, honouring the migration-isolation two-PR split:
+
+1. **DB migration (schema-only PR).** `app_policy_schedule_rules` per §3.3
+   (FK to the #1069 `schedules` table + `mode`), plus doc updates only. No
+   source, no tests. Gate: existing `api.test` passes against image-(N-1) code
+   with the new table present. Blocked on #1069's migration.
+2. **PolicyService eval + repo + models + tests (follow-up PR, TDD).** Add
+   `AppScheduleRule` / `AppScheduleMode` to `shared/Models.scala`; repo method
+   to load rules per assignment; the §4.1 effective-disposition resolution +
+   cap gate in **both** `PolicyService.snapshot` and `PolicyService.decide`;
+   extend `UpsertAppAssignmentRequest` additively. Confirm **no**
+   `PolicySnapshot` field is added. Ships with its tests per TDD:
+   - *Schedule-boundary unit tests* — exact on/off edges, overnight wrap, DOW
+     membership, DST transition, `allowed_during`-beats-`blocked_during`
+     tiebreak, multi-window named-schedule resolution, and the cap gate
+     (`carveIntoExtraAllowed` true for exempt-over-cap, false for
+     non-exempt-over-cap, true for either under cap). `Clock.TestClock`
+     fixtures; never `java.time` directly.
+   - *Feature tests* — `extraAllowed` carve during downtime (row 1); the
+     cap-gate split exempt (9a) vs non-exempt (9b); coincident schedule+cap
+     non-exempt (9c); `extraBlocked` during a `blocked_during` rule (row 3);
+     ETag flips across a window edge.
+   Blocked on issue 1.
+3. **Web UI.** The §7 assignment-editor Schedules section: per-rule mode toggle
+   (*Allowed during* / *Blocked during*) + named-schedule picker (the #1069
+   picker), the `exemptFromDaily` flag surfaced alongside, autosave (#995/#423).
+   Additive `scheduleRules` on the assignment payload. Blocked on issue 2.
 
 ## 10. Cross-references
 

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -1,0 +1,433 @@
+# Per-app schedules — design
+
+Tracking: [#1376](https://github.com/wifihaven/wifihaven/issues/1376).
+Status: **design only** — this document specifies the feature; no code ships
+with it.
+
+## 1. Goal
+
+Let an individual **app** (a household-scoped bundle of host patterns; see
+[#761](https://github.com/wifihaven/wifihaven/issues/761)) carry its own time
+window, layered on top of the profile's general schedule. The window means one
+of two things:
+
+- **Allowed during W** — the app stays reachable while W is active, even when
+  the profile is otherwise in scheduled downtime (the headline case: an
+  educational app reachable during bedtime).
+- **Blocked during W** — the app is dropped while W is active, even when the
+  profile is otherwise unrestricted (e.g. a game blocked during homework
+  hours).
+
+This extends the existing schedule abstraction — today a profile-wide downtime
+window — down to the per-app layer.
+
+## 2. The hard constraint, and why it holds
+
+**API-logic only. No snapshot/wire change. No router change.** Per-app
+schedules are a `PolicyService` feature that collapses, at snapshot-compute
+time, into the *existing* per-MAC `BlockRules` fields. The router stays a dumb
+applier (AGENTS.md "Architectural model" §0.2): it never learns that schedules
+exist, per-profile or per-app.
+
+The mapping is exact and uses only fields the wire already carries:
+
+| App window state at instant `now` | Effect on the per-MAC `BlockRules` |
+|---|---|
+| `allowed_during W`, W active | app's hosts → **`extraAllowed`** (beats every whole-MAC block per [#421](https://github.com/wifihaven/wifihaven/issues/421)) |
+| `allowed_during W`, W inactive | app contributes nothing from the window; falls back to its base mode |
+| `blocked_during W`, W active | app's hosts → **`extraBlocked`** |
+| `blocked_during W`, W inactive | app contributes nothing from the window; falls back to its base mode |
+
+`extraAllowed` / `extraBlocked` already enforce per-`(MAC, host)` at the router
+(`ea_` / `eb_` ipsets populated from resolved IPs). The snapshot's wire
+vocabulary is untouched: `blocked`, `blockReason`, `extraAllowed`,
+`extraBlocked`, `blocklistIds`, `blockIpOnly`. **No new field, no new reason on
+the wire.** This is the same discipline #763 used to expand `AppMode` into the
+existing buckets — per-app schedules are just another input to that
+server-side collapse.
+
+> **Confirmed: every case is expressible in the current fields.** There is no
+> case in this feature that forces a wire change. The one semantic that is
+> *not* expressible without a wire change — "reachable during downtime **but
+> still** subject to the daily time-limit cap" — is resolved below (§5) by
+> deciding it the way the wire already implies, not by adding a field. See that
+> section for the justification.
+
+## 3. Data model
+
+### 3.1 Reuse the existing `Schedule` representation
+
+A per-app window reuses the exact shape of the profile `schedules` table and
+the `Schedule` domain model in `shared/src/Models.scala`:
+
+- `days: List[String]` — day-of-week set (`["Mon","Tue",...]`).
+- `startLocal` / `endLocal` — wall-clock `HH:MM` in **household-local time**.
+- Overnight wrap (`startLocal > endLocal`), DOW membership, and the tail day
+  are all handled by the *already-existing* `PolicyService.scheduleActiveAt`
+  and `scheduleEndInstantAfter`. We do not write new time math.
+- **Timezone comes from household settings at read time, never `java.time`
+  directly.** Profile schedules already get their `tz: ZoneId` injected when
+  the `Schedule` is constructed from the row (the `schedules` table stores no
+  zone column); per-app windows follow the same path. All "is W active now?"
+  evaluation goes through the injected `wifihaven.shared.Clock` (`Clock.instant`)
+  projected into that zone, exactly as profile schedules do today. DST is
+  handled transparently by `ZonedDateTime` (see PolicyService §"#334
+  timezone-aware time math").
+
+Because we reuse `scheduleActiveAt`, per-app windows inherit overnight-wrap,
+DOW, and DST correctness for free, and the schedule-boundary unit tests can
+reuse the existing fixtures.
+
+### 3.2 Inline windows *and* named-schedule references (#1069)
+
+The feature must support **both**:
+
+- **Inline window** — `days` + `from` + `until` stored directly on the per-app
+  schedule row. Available now; #1069 is not yet built.
+- **Named-schedule reference** ([#1069](https://github.com/wifihaven/wifihaven/issues/1069)) —
+  a foreign key to a household-scoped reusable schedule ("Bedtime", "School
+  hours"). When #1069 lands, an operator can attach a named schedule to an app
+  window instead of re-typing the times. This is forward-compatible: the column
+  is added nullable now, and the FK constraint to the `named_schedules` table is
+  added in the follow-up that ships #1069 (the target table does not exist yet).
+
+Exactly one of `{schedule_id}` or `{days, from, until}` is populated per row,
+enforced by a table `CHECK`.
+
+This composes with **#1067** (schedule-driven blocklist activation): both are
+"a schedule drives a policy effect." They should converge on the same named-
+schedule references once #1069 exists, but neither blocks the other.
+
+### 3.3 DB migration shape
+
+The window is a **child of the per-app-per-profile assignment**
+(`app_policy_assignments`), not of the app itself — the same app can have
+different windows under different profiles, exactly as it already has different
+`mode`s. One-to-many (an assignment may carry several windows), mirroring how
+`schedules` is one-to-many under `profiles`.
+
+New migration (next free version, currently `V48__app_policy_schedules.sql`):
+
+```sql
+CREATE TABLE app_policy_schedules (
+  id             BIGSERIAL PRIMARY KEY,
+  assignment_id  BIGINT NOT NULL
+                   REFERENCES app_policy_assignments(id) ON DELETE CASCADE,
+  mode           TEXT NOT NULL
+                   CHECK (mode IN ('allowed_during','blocked_during')),
+  -- inline window (mirrors the schedules table); used when schedule_id IS NULL
+  days           TEXT[],
+  window_from    TEXT,            -- 'HH:MM', household-local
+  window_until   TEXT,            -- 'HH:MM', household-local
+  -- #1069 named-schedule reference; FK added in the follow-up that ships #1069
+  schedule_id    BIGINT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (
+    (schedule_id IS NOT NULL
+       AND days IS NULL AND window_from IS NULL AND window_until IS NULL)
+    OR
+    (schedule_id IS NULL
+       AND days IS NOT NULL AND window_from IS NOT NULL AND window_until IS NOT NULL)
+  )
+);
+CREATE INDEX idx_app_policy_schedules_assignment
+  ON app_policy_schedules(assignment_id);
+```
+
+**Migration-isolation (AGENTS.md "Schema changes land in their own PR").** This
+is a brand-new table referencing only existing tables, so:
+
+- It is trivially backward-compatible with image-(N-1): the old image's queries
+  never touch `app_policy_schedules`, so the existing `api.test` suite (which
+  applies every migration including this one against image-(N-1) code) passes
+  unchanged — that is the gate.
+- The migration PR contains **only** `V48__….sql` plus doc updates. No source,
+  no tests, no fixtures. The PolicyService eval, repo methods, and tests land in
+  the follow-up PR (§"Sub-issues").
+- **Not a growth table** ("Migrations that are fast on dev … minutes-long on
+  prod"): `app_policy_schedules` is bounded by `apps × profiles × windows`
+  (tens of rows), not by event volume. The migration is metadata-only — safe on
+  the startup critical path.
+
+### 3.4 Domain model (`shared/src/Models.scala`, follow-up PR — API-internal)
+
+These are API-internal models consumed by `PolicyService`; **none of them is a
+`PolicySnapshot` field** — they never reach the wire.
+
+```scala
+enum AppScheduleMode { case AllowedDuring, BlockedDuring }
+
+case class AppScheduleWindow(
+    id: AppScheduleWindowId,
+    assignmentId: AppPolicyAssignmentId,
+    mode: AppScheduleMode,
+    // inline window (None when referencing a named schedule)
+    days: Option[List[String]],
+    startLocal: Option[LocalTime],
+    endLocal: Option[LocalTime],
+    // #1069 reference (None when inline)
+    scheduleId: Option[ScheduleId],
+)
+```
+
+At evaluation time each `AppScheduleWindow` is resolved into a `Schedule`
+(inline fields or the referenced named schedule), the household `tz` is
+injected, and `PolicyService.scheduleActiveAt` decides activity. The
+`UpsertAppAssignmentRequest` gains an additive `schedules: List[…] = Nil`
+field (back-compatible default).
+
+## 4. PolicyService evaluation
+
+### 4.1 Per-app effective disposition (the key step)
+
+Today the snapshot builder (`PolicyService.snapshot`, ~L116–130) buckets each
+assignment by its static `mode` into `appAllowedHosts` / `appBlockedHosts`,
+then `computeBlockRules` folds those into `extraAllowed` / `extraBlocked`.
+
+Per-app schedules insert one step **before** bucketing: resolve each
+assignment to a single **effective disposition at `now`**, so a window
+*overrides* the base mode for that app rather than blindly unioning into both
+buckets. This matters because a naive union would let the router's
+allow-beats-block rule defeat a `blocked_during` window on a base-`Allowed`
+app.
+
+```
+effectiveDisposition(assignment, windows, now):
+  if any allowed_during window active at now  -> Allowed      // carve-out
+  else if any blocked_during window active     -> Blocked
+  else                                         -> base mode    // Allowed / Blocked / TimeLimited
+```
+
+- **`allowed_during` wins over `blocked_during`** when an app has overlapping
+  windows of both kinds active simultaneously. This is consistent with the
+  system-wide "allow beats block" invariant (#421) and with the headline
+  intent ("keep this reachable"). Overlapping same-app allowed+blocked windows
+  are a config oddity the SPA should discourage; the tiebreak is defined so the
+  outcome is never ambiguous.
+- The base mode still applies whenever no window is active — outside every
+  window, the app behaves exactly as it does today.
+
+After resolution, the existing bucketing is unchanged:
+`Allowed → appAllowedHosts (→ extraAllowed)`,
+`Blocked → appBlockedHosts (→ extraBlocked)`,
+`TimeLimited → site-limit path (unchanged, #764)`.
+
+Cross-app host collisions continue to resolve allow-wins at the router exactly
+as #763 documents — that behaviour is untouched.
+
+### 4.2 `decide` fallback must mirror it
+
+The per-host fallback (`PolicyService.decide`, ~L216) independently re-derives
+`appAllowed` / `appBlocked` from the assignments. It must apply the same
+per-app effective-disposition resolution so the fallback agrees with the
+snapshot. (Its precedence comment — "paused > schedule > allowed-app >
+blocked-app > …" — already places allowed-app above blocked-app, consistent
+with §4.1.)
+
+### 4.3 Interaction with the #1105 exempt-app carve-out
+
+The existing `appExemptAllowedHosts` path (time_limited apps with
+`exemptFromDaily=true` and remaining budget → `extraAllowed`) is orthogonal and
+unchanged. An `allowed_during` window is a *stronger, time-boxed* form of the
+same idea (full carve-out regardless of budget, but only while W is active).
+Both feed `extraAllowed`; the union is harmless.
+
+## 5. Precedence / interaction table
+
+Evaluated server-side, per `(MAC, app, host)` at instant `now`. "Whole-MAC
+block" = `blocked=true` (one of Paused / profile-Schedule / TimeLimit / Manual
+— all collapse to `@blocked_macs` at the router). Outcome is what the router
+enforces after #421 allow-beats-block.
+
+| # | Profile whole-MAC block? | App base mode | App window @ now | App host bucket | **Router outcome for the app** |
+|---|---|---|---|---|---|
+| 1 | Schedule downtime active | any | `allowed_during` active | `extraAllowed` | **Reachable** (carve-out beats downtime) — the headline case |
+| 2 | none | any | `allowed_during` active | `extraAllowed` | Reachable (no-op carve-out; already allowed) |
+| 3 | none | Allowed | `blocked_during` active | `extraBlocked` | **Blocked** (window overrides base Allowed, §4.1) |
+| 4 | none | Blocked | `blocked_during` active | `extraBlocked` | Blocked (consistent) |
+| 5 | Schedule downtime active | any | `blocked_during` active | `extraBlocked` | Blocked (already blocked; window redundant but valid) |
+| 6 | none | Allowed | no active window | `extraAllowed` | Reachable (base mode) |
+| 7 | none | Blocked | no active window | `extraBlocked` | Blocked (base mode) |
+| 8 | Schedule downtime active | Allowed | no active window | `extraAllowed` | Reachable — note base `Allowed` *already* carves out of downtime today |
+| 9 | **TimeLimit reached** | any | `allowed_during` active | `extraAllowed` | **Reachable** — see decision below |
+| 10 | Manual block | any | `allowed_during` active | `extraAllowed` | Reachable (Manual is a whole-MAC block; carve-out beats it) |
+| 11 | Paused | any | `allowed_during` active | `extraAllowed` | Reachable (Paused is a whole-MAC block; carve-out beats it) |
+
+### Decision: "allowed during W" beats the daily time limit (row 9)
+
+**An app with an active `allowed_during` window stays reachable even when the
+profile has hit its daily time limit.**
+
+Justification:
+
+1. **It is what the wire forces.** TimeLimit, like Schedule and Manual,
+   collapses to `blocked=true` → `@blocked_macs`. `extraAllowed` beats
+   `@blocked_macs` unconditionally (#421); the router has no way to make a
+   carve-out beat *Schedule*-block but yield to *TimeLimit*-block, because it
+   never sees the reason (`blockReason` is block-page copy only, never read for
+   enforcement). Distinguishing them would require a new wire field — which is
+   off the table (§2, and the wire-versioning gate #376).
+2. **It is the defensible default.** Designating an app "always reachable
+   during this window" is precisely an *exception* statement; the apps you'd
+   put on an `allowed_during` window (educational, communication-with-parents)
+   are the same class #1105 already exempts from the daily cap via
+   `exemptFromDaily`. Uniform "carve-out beats all whole-MAC blocks" matches
+   that established contract and avoids a surprising "your always-allowed app
+   went dark at the cap" failure mode.
+3. **The escape hatch is a different mode.** An operator who wants an app
+   reachable during downtime *but still* charged against / gated by the daily
+   cap should not use `allowed_during`; they should use a **`time_limited`**
+   app (its own budget, naturally transitions allow→block as budget exhausts,
+   #1105). That intent is already expressible without per-app schedules, so the
+   `allowed_during` semantics need not try to cover it.
+
+This is the **one place** the issue asked to resolve explicitly, and it is
+resolved *within* the existing fields — not as a wire-change exception.
+
+### Default-deny (#1316–#1322)
+
+Per-app schedules compose cleanly with default-deny because they only ever
+produce `extraAllowed` / `extraBlocked` — the exact vocabulary default-deny
+also speaks:
+
+- Under a default-deny profile, an `allowed_during` window adds the app's hosts
+  to `extraAllowed` while W is active → reachable during W; outside W the
+  default-deny baseline drops them (unless another allow covers). This is the
+  natural and desirable behaviour.
+- A `blocked_during` window under default-deny is usually redundant (the
+  baseline already blocks) but remains valid for an app that some *other* allow
+  would otherwise permit.
+- Per-app schedules are **per-profile** and feed the profile's `extraAllowed`/
+  `extraBlocked`. The global policy layer's `global.extraAllowed`/`extraBlocked`
+  (#1316) is a separate, higher tier evaluated independently; per-app schedules
+  do **not** write the `global` section. Global-allow still beats everything,
+  per that layer's own precedence — unchanged here.
+
+### Category blocklists
+
+`blocklistIds` drop is a per-`(MAC, blocklist)` ipset drop. `extraAllowed`
+beats it (#421), so an `allowed_during` window also carves a category-blocked
+host out while W is active — same mechanism as a static allowed-mode app today.
+A `blocked_during` window adds to `extraBlocked`, independent of categories.
+
+## 6. Snapshot-freshness implications
+
+**The snapshot is computed on-demand on every poll using `Clock.instant`;
+there is no precomputed boundary scheduler.** Each `GET /api/router/policy`
+re-evaluates `scheduleActiveAt(window, now)` for the current instant, rebuilds
+`extraAllowed` / `extraBlocked`, recomputes the deterministic `etag`
+(`blockRulesSig` already folds `ea`/`eb` into the ETag — see PolicyService
+`computeEtag`/`blockRulesSig`), and returns `200` with the fresh body or `304`
+if nothing changed.
+
+Consequences for per-app schedules:
+
+- **Correctness is automatic.** The first poll after a window edge (≤ one poll
+  interval, ~60 s — architecture.md §5) recomputes activity and flips the
+  affected MAC's `extraAllowed`/`extraBlocked` and ETag. Worst-case staleness is
+  one poll interval, identical to profile schedules today. No new mechanism is
+  needed — per-app schedules ride the *same* pull-based freshness path profile
+  schedules already rely on.
+- **No per-poll compute increase.** Every poll already recomputes the whole
+  snapshot; adding window evaluation is a handful of `scheduleActiveAt` calls
+  per assignment. Negligible at single-household scale.
+- **What does grow: the number of distinct ETag-flip instants per day.** Today
+  a MAC's ETag flips at profile-schedule edges, midnight reset, and time-limit
+  exhaustion. Per-app windows add up to **2 edges per window per profile**. The
+  only effect is that the router receives a few more `200`s (vs `304`s) across
+  the day — more full-snapshot transfers, not more work per poll. Fine for the
+  single-household deployment.
+- **Flag for the future push channel.** Architecture.md §5 notes a possible
+  server-push (websocket/SSE) channel for instant blocks. *That* design would
+  need an explicit "next boundary" scheduler to know when to push; per-app
+  windows enlarge that wakeup set (every app-window edge becomes a wake
+  instant). The existing `scheduleEndInstantAfter` is the building block for
+  computing those edges. This is **out of scope for #1376** — pull-based
+  freshness needs nothing — but should be called out when the push channel is
+  designed.
+
+## 7. SPA configuration surface (specify, don't build)
+
+In the app/profile assignment editor, each app's assignment row gains a
+**Schedules** section:
+
+- An **add-window** control producing one or more window rows (one-to-many,
+  matching the data model).
+- Per window: a **mode** toggle — *Allowed during* / *Blocked during* — and
+  either
+  - a **named-schedule picker** (when #1069 ships), or
+  - an **inline window editor** reusing the existing profile-schedule editor
+    component (day-of-week multiselect + `from`/`until` time pickers). Times are
+    household-local; the editor shows the household zone.
+- **Autosave** ([#995](https://github.com/wifihaven/wifihaven/issues/995) /
+  [#423](https://github.com/wifihaven/wifihaven/issues/423)): debounced PATCH of
+  the assignment, no explicit Save button, consistent with the autosave-default
+  preference. The request shape extends `UpsertAppAssignmentRequest` additively
+  with `schedules: List[AppScheduleWindow]` (default `Nil`, so existing clients
+  keep working).
+- The editor should surface the §5 semantic plainly — e.g. a hint on
+  `allowed_during` that "this app stays reachable during this window even during
+  bedtime **and even if the daily time limit is reached**" — so the row-9
+  decision is not a surprise.
+
+This is specified for a web sub-issue to pick up; it is not built here.
+
+## 8. Architecture.md note
+
+A short note is added to `docs/architecture.md` under the "Architectural model"
+/ snapshot-freshness discussion, reaffirming that per-app schedules are a
+server-side `PolicyService` collapse into the existing `extraAllowed` /
+`extraBlocked` fields with **no wire or router change**, and that the router
+remains a dumb applier. (Added in the same PR as this design doc.)
+
+## 9. Sub-issues to file (do not file yet — operator/orchestration)
+
+In dependency order. The first three honour the migration-isolation two-PR
+split.
+
+1. **DB migration (schema-only PR).** `V48__app_policy_schedules.sql` per §3.3,
+   plus doc updates only. No source, no tests. Gate: existing `api.test` passes
+   against image-(N-1) code with the new table present.
+2. **PolicyService eval + repo + models (follow-up PR).** Add
+   `AppScheduleWindow` / `AppScheduleMode` to `shared/Models.scala`; repo method
+   to load windows per assignment; the §4.1 effective-disposition resolution in
+   both `PolicyService.snapshot` and `PolicyService.decide`; extend
+   `UpsertAppAssignmentRequest` additively. Confirm **no** `PolicySnapshot`
+   field is added.
+3. **Schedule-boundary unit tests.** Pure tests over the effective-disposition
+   resolver + `scheduleActiveAt` reuse: exact on/off edges, overnight wrap, DOW
+   membership, DST transition, `allowed_during`-beats-`blocked_during` tiebreak,
+   inline vs named-schedule resolution. Use `Clock.TestClock` fixtures; never
+   `java.time` directly.
+4. **Feature tests.** End-to-end snapshot assertions proving the app's hosts
+   land in `extraAllowed` during an `allowed_during` window while the profile is
+   in scheduled downtime / over the daily cap (rows 1 and 9), and in
+   `extraBlocked` during a `blocked_during` window (row 3). Drive time with
+   `TestClock`; assert the ETag flips across a window edge.
+5. **Web UI.** The §7 assignment-editor Schedules section with autosave;
+   inline editor now, named-schedule picker gated on #1069.
+6. **(Optional, compose-with) Named-schedule FK.** Once #1069 lands, add the
+   `app_policy_schedules.schedule_id` FK to `named_schedules` and the picker
+   wiring. Tracked against #1069, not a blocker for inline windows.
+
+## 10. Cross-references
+
+- [#1376](https://github.com/wifihaven/wifihaven/issues/1376) — this epic.
+- [#421](https://github.com/wifihaven/wifihaven/issues/421) — `extraAllowed`
+  beats every block (the mechanism the whole mapping rests on).
+- [#763](https://github.com/wifihaven/wifihaven/issues/763) /
+  [#764](https://github.com/wifihaven/wifihaven/issues/764) — app → per-MAC
+  bucket expansion; the path this feature extends.
+- [#1105](https://github.com/wifihaven/wifihaven/issues/1105) — exempt-app
+  carve-out; the precedent for "allowed beats the cap."
+- [#1069](https://github.com/wifihaven/wifihaven/issues/1069) — reusable named
+  schedules (referenced, not required).
+- [#1067](https://github.com/wifihaven/wifihaven/issues/1067) —
+  schedule-driven blocklist activation (sibling "schedule drives an effect").
+- [#937](https://github.com/wifihaven/wifihaven/issues/937),
+  [#1316](https://github.com/wifihaven/wifihaven/issues/1316)–[#1322](https://github.com/wifihaven/wifihaven/issues/1322)
+  — global policy + default-deny; per-app schedules compose underneath.
+- [#995](https://github.com/wifihaven/wifihaven/issues/995) /
+  [#423](https://github.com/wifihaven/wifihaven/issues/423) — autosave + PATCH.
+- [#376](https://github.com/wifihaven/wifihaven/issues/376) — wire-versioning
+  gate (why no wire change is on the table).

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -47,11 +47,12 @@ existing buckets — per-app schedules are just another input to that
 server-side collapse.
 
 > **Confirmed: every case is expressible in the current fields.** There is no
-> case in this feature that forces a wire change. The one semantic that is
-> *not* expressible without a wire change — "reachable during downtime **but
-> still** subject to the daily time-limit cap" — is resolved below (§5) by
-> deciding it the way the wire already implies, not by adding a field. See that
-> section for the justification.
+> case in this feature that forces a wire change — including the subtle one,
+> "reachable during downtime **but still** subject to the daily time-limit cap."
+> That case *is* expressible, because the server decides whether to emit the
+> `extraAllowed` carve at all: it withholds the carve for a non-exempt app whose
+> daily cap is exhausted, so the cap still bites without the router ever knowing
+> why. See §5 (rows 9a–9c) for the full decision.
 
 ## 3. Data model
 
@@ -193,9 +194,9 @@ app.
 
 ```
 effectiveDisposition(assignment, windows, now):
-  if any allowed_during window active at now  -> Allowed      // carve-out
+  if any allowed_during window active at now  -> AllowedDuring  // carve-out CANDIDATE (see gate)
   else if any blocked_during window active     -> Blocked
-  else                                         -> base mode    // Allowed / Blocked / TimeLimited
+  else                                         -> base mode      // Allowed / Blocked / TimeLimited
 ```
 
 - **`allowed_during` wins over `blocked_during`** when an app has overlapping
@@ -207,10 +208,35 @@ effectiveDisposition(assignment, windows, now):
 - The base mode still applies whenever no window is active — outside every
   window, the app behaves exactly as it does today.
 
-After resolution, the existing bucketing is unchanged:
-`Allowed → appAllowedHosts (→ extraAllowed)`,
+**The `AllowedDuring` carve is gated by the daily-cap / exempt check (§5).**
+Placing the app's hosts in `extraAllowed` beats *every* whole-MAC block at the
+router (#421), so whether the app survives the daily time limit is decided
+*here*, server-side, by whether we carve at all — not by the router:
+
+```
+carveIntoExtraAllowed(assignment) =
+  effectiveDisposition == AllowedDuring
+  AND NOT (dailyCapExhausted(state) AND NOT assignment.exemptFromDaily)
+
+dailyCapExhausted(state) =
+  state.dailyLimitMinutes.exists(lim => state.usedMinutes >= lim + state.extensionMinutes)
+  // equivalently state.remainingMinutes.contains(0)
+```
+
+`dailyCapExhausted` is computed **directly from `ProfileDayState`**, independent
+of the collapsed `blockReason` — important because when schedule downtime and
+cap exhaustion coincide, `blockReason` reports `Schedule` (higher precedence)
+yet the budget is still exhausted. The window must still beat the *schedule*
+block while *yielding* to the *budget* block for a non-exempt app, so the carve
+gate keys off the raw cap condition, not the reason.
+
+After this gate, the existing bucketing is unchanged:
+`AllowedDuring (carved) / base Allowed → appAllowedHosts (→ extraAllowed)`,
 `Blocked → appBlockedHosts (→ extraBlocked)`,
 `TimeLimited → site-limit path (unchanged, #764)`.
+An `AllowedDuring` candidate that fails the gate is *not* added to either
+bucket — it simply remains subject to the profile's whole-MAC block (it is
+blocked because the cap is exhausted, which is the intent).
 
 Cross-app host collisions continue to resolve allow-wins at the router exactly
 as #763 documents — that behaviour is untouched.
@@ -219,18 +245,27 @@ as #763 documents — that behaviour is untouched.
 
 The per-host fallback (`PolicyService.decide`, ~L216) independently re-derives
 `appAllowed` / `appBlocked` from the assignments. It must apply the same
-per-app effective-disposition resolution so the fallback agrees with the
-snapshot. (Its precedence comment — "paused > schedule > allowed-app >
-blocked-app > …" — already places allowed-app above blocked-app, consistent
-with §4.1.)
+per-app effective-disposition resolution **and the same cap gate** so the
+fallback agrees with the snapshot. Note its current precedence chain — "paused >
+schedule > allowed-app > blocked-app > site_time_limit > time_limit > category"
+— places allowed-app *above* time_limit unconditionally; that must change so a
+*non-exempt* `allowed_during` app falls **below** time_limit (cap bites), while
+an *exempt* one stays above it. Concretely: an active `allowed_during` window
+short-circuits to Allow only when `exemptFromDaily` OR the cap is not yet
+exhausted; otherwise it does not, and the time_limit branch decides. This is the
+per-host mirror of the §4.1 `carveIntoExtraAllowed` gate.
 
 ### 4.3 Interaction with the #1105 exempt-app carve-out
 
 The existing `appExemptAllowedHosts` path (time_limited apps with
 `exemptFromDaily=true` and remaining budget → `extraAllowed`) is orthogonal and
-unchanged. An `allowed_during` window is a *stronger, time-boxed* form of the
-same idea (full carve-out regardless of budget, but only while W is active).
-Both feed `extraAllowed`; the union is harmless.
+unchanged. An `allowed_during` window reuses the **same `exemptFromDaily` flag**
+to decide cap-immunity (§4.1 gate, §5): the window governs the *schedule* axis
+(which apps are reachable during a downtime window), while `exemptFromDaily`
+governs the *budget* axis (whether the daily cap binds the app). They are
+deliberately the same knob #1105 already exposes — the window does not invent a
+second, implicit form of cap-immunity. Both paths feed `extraAllowed`; the
+union is harmless.
 
 ## 5. Precedence / interaction table
 
@@ -239,47 +274,56 @@ block" = `blocked=true` (one of Paused / profile-Schedule / TimeLimit / Manual
 — all collapse to `@blocked_macs` at the router). Outcome is what the router
 enforces after #421 allow-beats-block.
 
-| # | Profile whole-MAC block? | App base mode | App window @ now | App host bucket | **Router outcome for the app** |
-|---|---|---|---|---|---|
-| 1 | Schedule downtime active | any | `allowed_during` active | `extraAllowed` | **Reachable** (carve-out beats downtime) — the headline case |
-| 2 | none | any | `allowed_during` active | `extraAllowed` | Reachable (no-op carve-out; already allowed) |
-| 3 | none | Allowed | `blocked_during` active | `extraBlocked` | **Blocked** (window overrides base Allowed, §4.1) |
-| 4 | none | Blocked | `blocked_during` active | `extraBlocked` | Blocked (consistent) |
-| 5 | Schedule downtime active | any | `blocked_during` active | `extraBlocked` | Blocked (already blocked; window redundant but valid) |
-| 6 | none | Allowed | no active window | `extraAllowed` | Reachable (base mode) |
-| 7 | none | Blocked | no active window | `extraBlocked` | Blocked (base mode) |
-| 8 | Schedule downtime active | Allowed | no active window | `extraAllowed` | Reachable — note base `Allowed` *already* carves out of downtime today |
-| 9 | **TimeLimit reached** | any | `allowed_during` active | `extraAllowed` | **Reachable** — see decision below |
-| 10 | Manual block | any | `allowed_during` active | `extraAllowed` | Reachable (Manual is a whole-MAC block; carve-out beats it) |
-| 11 | Paused | any | `allowed_during` active | `extraAllowed` | Reachable (Paused is a whole-MAC block; carve-out beats it) |
+"Exempt?" is the assignment's `exemptFromDaily` flag. The `AllowedDuring`
+carve gate (§4.1) is `windowActive AND NOT (dailyCapExhausted AND NOT exempt)`.
 
-### Decision: "allowed during W" beats the daily time limit (row 9)
+| # | Profile whole-MAC block? | App base mode | App window @ now | Exempt? | App host bucket | **Router outcome for the app** |
+|---|---|---|---|---|---|---|
+| 1 | Schedule downtime active | any | `allowed_during` active | n/a | `extraAllowed` | **Reachable** (carve-out beats downtime) — the headline case |
+| 2 | none | any | `allowed_during` active | n/a | `extraAllowed` | Reachable (no-op carve-out; already allowed) |
+| 3 | none | Allowed | `blocked_during` active | n/a | `extraBlocked` | **Blocked** (window overrides base Allowed, §4.1) |
+| 4 | none | Blocked | `blocked_during` active | n/a | `extraBlocked` | Blocked (consistent) |
+| 5 | Schedule downtime active | any | `blocked_during` active | n/a | `extraBlocked` | Blocked (already blocked; window redundant but valid) |
+| 6 | none | Allowed | no active window | n/a | `extraAllowed` | Reachable (base mode) |
+| 7 | none | Blocked | no active window | n/a | `extraBlocked` | Blocked (base mode) |
+| 8 | Schedule downtime active | Allowed | no active window | n/a | `extraAllowed` | Reachable — note base `Allowed` *already* carves out of downtime today |
+| 9a | **TimeLimit reached** | any | `allowed_during` active | **yes** | `extraAllowed` | **Reachable** — exempt app survives the cap (see decision) |
+| 9b | **TimeLimit reached** | any | `allowed_during` active | **no** | *(not carved)* | **Blocked** — non-exempt app: the daily cap still bites (see decision) |
+| 9c | Schedule downtime **and** TimeLimit reached | any | `allowed_during` active | no | *(not carved)* | **Blocked** — cap binds even though `blockReason` reports `Schedule`; gate keys off raw cap, not reason (§4.1) |
+| 10 | Manual block | any | `allowed_during` active | n/a | `extraAllowed` | Reachable (Manual is a whole-MAC block, not a budget; carve-out beats it) |
+| 11 | Paused | any | `allowed_during` active | n/a | `extraAllowed` | Reachable (Paused is a whole-MAC block, not a budget; carve-out beats it) |
 
-**An app with an active `allowed_during` window stays reachable even when the
-profile has hit its daily time limit.**
+### Decision: "allowed during W" yields to the daily time limit unless the app is exempt (rows 9a–9c)
+
+**An app with an active `allowed_during` window stays reachable past the
+profile's daily time limit *only if* its assignment is `exemptFromDaily`. A
+non-exempt app, once the daily cap is exhausted, is blocked — window or no
+window.**
 
 Justification:
 
-1. **It is what the wire forces.** TimeLimit, like Schedule and Manual,
-   collapses to `blocked=true` → `@blocked_macs`. `extraAllowed` beats
-   `@blocked_macs` unconditionally (#421); the router has no way to make a
-   carve-out beat *Schedule*-block but yield to *TimeLimit*-block, because it
-   never sees the reason (`blockReason` is block-page copy only, never read for
-   enforcement). Distinguishing them would require a new wire field — which is
-   off the table (§2, and the wire-versioning gate #376).
-2. **It is the defensible default.** Designating an app "always reachable
-   during this window" is precisely an *exception* statement; the apps you'd
-   put on an `allowed_during` window (educational, communication-with-parents)
-   are the same class #1105 already exempts from the daily cap via
-   `exemptFromDaily`. Uniform "carve-out beats all whole-MAC blocks" matches
-   that established contract and avoids a surprising "your always-allowed app
-   went dark at the cap" failure mode.
-3. **The escape hatch is a different mode.** An operator who wants an app
-   reachable during downtime *but still* charged against / gated by the daily
-   cap should not use `allowed_during`; they should use a **`time_limited`**
-   app (its own budget, naturally transitions allow→block as budget exhausts,
-   #1105). That intent is already expressible without per-app schedules, so the
-   `allowed_during` semantics need not try to cover it.
+1. **It is a server-side choice, not a wire constraint.** Yes, `extraAllowed`
+   beats `@blocked_macs` unconditionally at the router (#421) regardless of the
+   block reason. But *whether the host is in `extraAllowed`* is decided by
+   `PolicyService`, which has `ProfileDayState` (used / limit / extensions) and
+   the assignment's `exemptFromDaily`. So the server simply withholds the carve
+   when the cap is exhausted and the app is not exempt. No new wire field, no
+   router change — the cap can still bite. (My earlier framing of this as
+   "wire-forced" was wrong: the router can't tell reasons apart, but the server
+   never has to put the host on the wire in the first place.)
+2. **It keeps two axes separate.** A window is a *schedule* layer — which apps
+   are reachable during a downtime window. The daily time limit is a *budget*
+   layer — total screen time. "Educational app reachable during bedtime" should
+   not silently also mean "reachable after you've burned your whole daily
+   allowance." Conflating them would let any `allowed_during` window become an
+   accidental, unlimited cap bypass.
+3. **It reuses the existing knob.** `exemptFromDaily` already means exactly
+   "this app isn't bound by the daily budget" (#1105, for time_limited apps).
+   An `allowed_during` window that needs cap-immunity sets the same flag; one
+   that should respect the cap leaves it `false`. No second, implicit form of
+   cap-immunity is invented. (Manual / Paused / Schedule blocks are *not*
+   budgets, so the window beats them irrespective of `exemptFromDaily` — rows 1,
+   10, 11.)
 
 This is the **one place** the issue asked to resolve explicitly, and it is
 resolved *within* the existing fields — not as a wire-change exception.
@@ -365,10 +409,14 @@ In the app/profile assignment editor, each app's assignment row gains a
   preference. The request shape extends `UpsertAppAssignmentRequest` additively
   with `schedules: List[AppScheduleWindow]` (default `Nil`, so existing clients
   keep working).
-- The editor should surface the §5 semantic plainly — e.g. a hint on
-  `allowed_during` that "this app stays reachable during this window even during
-  bedtime **and even if the daily time limit is reached**" — so the row-9
-  decision is not a surprise.
+- The editor should surface the §5 semantic plainly. A hint on `allowed_during`
+  should read like "this app stays reachable during this window even during
+  bedtime" — and, because cap-immunity is governed by the assignment's
+  `exemptFromDaily` flag (rows 9a–9c), the editor should show that flag
+  alongside the window with copy such as "still counts against / is blocked by
+  the daily time limit when off" vs "exempt from the daily time limit." This
+  makes the exempt-vs-non-exempt distinction explicit at config time so the
+  cap-bites-non-exempt behaviour is not a surprise.
 
 This is specified for a web sub-issue to pick up; it is not built here.
 
@@ -397,13 +445,18 @@ split.
 3. **Schedule-boundary unit tests.** Pure tests over the effective-disposition
    resolver + `scheduleActiveAt` reuse: exact on/off edges, overnight wrap, DOW
    membership, DST transition, `allowed_during`-beats-`blocked_during` tiebreak,
-   inline vs named-schedule resolution. Use `Clock.TestClock` fixtures; never
+   the cap gate (`carveIntoExtraAllowed` true for exempt-over-cap, false for
+   non-exempt-over-cap, true for either when under cap), and inline vs
+   named-schedule resolution. Use `Clock.TestClock` fixtures; never
    `java.time` directly.
 4. **Feature tests.** End-to-end snapshot assertions proving the app's hosts
    land in `extraAllowed` during an `allowed_during` window while the profile is
-   in scheduled downtime / over the daily cap (rows 1 and 9), and in
-   `extraBlocked` during a `blocked_during` window (row 3). Drive time with
-   `TestClock`; assert the ETag flips across a window edge.
+   in scheduled downtime (row 1); that an **exempt** app *is* carved out when the
+   profile is over its daily cap (row 9a) while a **non-exempt** one is *not*
+   (row 9b) — the cap-gate split; the coincident schedule+cap case for a
+   non-exempt app (row 9c); and `extraBlocked` during a `blocked_during` window
+   (row 3). Drive time with `TestClock`; assert the ETag flips across a window
+   edge.
 5. **Web UI.** The §7 assignment-editor Schedules section with autosave;
    inline editor now, named-schedule picker gated on #1069.
 6. **(Optional, compose-with) Named-schedule FK.** Once #1069 lands, add the


### PR DESCRIPTION
## Summary

Design + sub-issue breakdown for the **per-app schedules** epic (#1376) — an individual app can carry its own "allowed during W" / "blocked during W" time window on top of the profile's general schedule (headline case: an educational app stays reachable during bedtime). **Docs only** — no implementation, no sub-issues filed.

Adds:
- `docs/design/per-app-schedules.md` — the full design.
- A note in `docs/architecture.md` under the "Architectural model" / freshness section, consistent with the existing dumb-applier invariant.

## The hard constraint holds (validated)

This is a **`PolicyService`-only** feature. **No snapshot/wire field, no router change.** At snapshot-compute time the window collapses into the *existing* per-MAC `BlockRules`:
- `allowed_during W` active → app hosts in **`extraAllowed`** (beats every whole-MAC block per #421).
- `blocked_during W` active → app hosts in **`extraBlocked`**.
- Outside the window, the app falls back to its base mode, exactly as today.

The router never learns schedules exist. Confirmed there is **no case that forces a wire change** — the doc documents this explicitly rather than proposing a new field.

## What the doc covers

- **Data model** — reuses the existing `Schedule` repr (overnight wrap, DOW, household-local TZ via injected `Clock`, never `java.time`); supports both inline windows and #1069 named-schedule references; new `app_policy_schedules` child table of `app_policy_assignments`.
- **DB migration shape** — schema-only PR per the migration-isolation rule; bounded (non-growth) table, safe on the startup path.
- **Precedence/interaction table** — profile schedule, daily time limits (incl. #1105 exempt apps), per-app modes, manual block, default-deny (#1316–#1322), category blocklists. Per-app windows resolve to a single *effective disposition* (window overrides base mode) before bucketing.
- **Resolved decision (row 9):** an app "allowed during W" **stays reachable even when the profile hit its daily time limit** — justified as both the wire-forced outcome and the defensible default (with the `time_limited`-mode escape hatch for the cap-respecting case).
- **Snapshot-freshness** — freshness is pull-based and on-demand; per-app schedules need no new mechanism. Flags that the boundary set only matters for a *future* server-push channel.
- **SPA surface** — assignment-editor Schedules section, autosave (#995/#423); specified, not built.
- **Sub-issue breakdown** — DB migration, PolicyService eval, schedule-boundary unit + feature tests, web UI (listed, not filed).

Closes #1376 once the listed sub-issues ship (this PR is design only).