### PR TITLE
fix(grafana): ingest success-ratio panel shows red on total outage, not "No data" (#1383)

### DIFF
--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -420,7 +420,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics ingest success ratio (#1368)",
-      "description": "sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. At-a-glance health: green ≥ 0.95, red below. This catches the #1365 blind spot where `ok` is simply absent (ratio 0/total): the raw by-status rate panel to the left renders a total outage as a lone `malformed` line that looks like low traffic, whereas this turns red. 0/0 (no batches at all in the window) renders as No data — not red — so a quiet environment does not false-alarm. NOTE: this panel is passive — actually paging on this condition is the alerting-strategy thread (#1381).",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. At-a-glance health: green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is an empty vector and empty/value = empty, so without the coercion the panel would render \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; only a truly idle window (no batches at all → vector(0)/empty) shows No data, so a quiet env does not false-alarm. NOTE: this panel is passive — actually paging on this condition is the alerting-strategy thread (#1381).",
       "type": "stat",
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
       "id": 13,
@@ -452,7 +452,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
+          "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
           "legendFormat": "success ratio",
           "refId": "A"
         }


### PR DESCRIPTION
Closes #1383. Follow-up bug fix on the panel shipped in #1373 (#1368).

## The report

The **"Router metrics ingest success ratio (#1368)"** panel shows **No data**.

## Why — it masks the exact outage it was built to surface

```promql
sum(rate(router_metrics_batches_total{env="$env",status="ok"}[10m]))
  / sum(rate(router_metrics_batches_total{env="$env"}[10m]))
```

When `status="ok"` has **no series at all** (a 100%-malformed outage — the #1365 case), `sum(rate(...{status="ok"}))` is an **empty vector**, and in PromQL `empty / value` = empty → **No data**. So a total ingest outage rendered identically to an idle environment — the panel reintroduced the #1365 blind spot it was meant to close.

## Fix

Coerce the absent numerator to `0`:

```promql
(sum(rate(router_metrics_batches_total{env="$env",status="ok"}[10m])) or vector(0))
  / sum(rate(router_metrics_batches_total{env="$env"}[10m]))
```

| Situation | Before | After |
|-----------|--------|-------|
| ok absent, traffic present (total outage) | No data 😞 | **0 → red** ✅ |
| ok present | ratio (~1 → green) | ratio (~1 → green) |
| no batches at all (idle) | No data | No data (unchanged — no false red on quiet/staging) |

2-line change (expr + description). `python3 -m json.tool` clean.

## If it's *still* No data after this deploys

Then it's a different cause, called out in #1383: check the sibling **"Router metrics batch ingest rate (#1205)"** panel (no `env` filter).
- Sibling shows a `malformed` line, no `ok` → this fix turns the ratio red, **and** you have a real ongoing ingest failure (likely prod routers on the pre-#1366 agent — worth a live look).
- Sibling shows series but this panel still empty → an `env`-label mismatch between `router_metrics_batches_total` and the `$env` template.
- Sibling also empty → routers aren't pushing metrics at all (#1205 transport).

I can investigate the live series to pin down which, with your go-ahead for the prod read (querying Grafana Cloud Prometheus / pulling the relevant creds is gated).

Refs: #1368, #1373, #1365, #1381.