### PR TITLE
observability(grafana): per-route + per-op rate/latency/success-rate on api-self-metrics (#1382)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -690,11 +690,13 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
         .transact(xa),
     )
   def findById(id: ProfileId)                       =
-    sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
-      .query[R]
-      .map(toP)
-      .option
-      .transact(xa)
+    DbMetrics.timed("profile.findById")(
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
+        .query[R]
+        .map(toP)
+        .option
+        .transact(xa),
+    )
   def create(name: String, cats: List[BlocklistId]) =
     sql"INSERT INTO profiles(name,blocked_categories) VALUES($name,${cats.map(_.value).toArray}) RETURNING id"
       .query[ProfileId]
@@ -726,11 +728,13 @@ class ScheduleRepoLive(xa: Transactor[Task]) extends ScheduleRepo {
       .to[List]
       .transact(xa)
   def listForProfile(pid: ProfileId) =
-    sql"SELECT id,profile_id,name,days,start_local,end_local,tz FROM schedules WHERE profile_id=$pid ORDER BY id"
-      .query[R]
-      .map(toS)
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("schedule.listForProfile")(
+      sql"SELECT id,profile_id,name,days,start_local,end_local,tz FROM schedules WHERE profile_id=$pid ORDER BY id"
+        .query[R]
+        .map(toS)
+        .to[List]
+        .transact(xa),
+    )
   def replaceForProfile(pid: ProfileId, ss: List[ScheduleRequest]) = {
     val del = sql"DELETE FROM schedules WHERE profile_id=$pid".update.run
     val ins = ss.map(s =>
@@ -745,18 +749,20 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
   import wifihaven.shared.UnmanagedMacPolicy
 
   def get: Task[HouseholdSettings] =
-    sql"""SELECT daily_reset_time, daily_reset_tz,
+    DbMetrics.timed("householdSettings.get")(
+      sql"""SELECT daily_reset_time, daily_reset_tz,
                  heartbeat_filter_enabled, heartbeat_bytes_threshold,
                  heartbeat_host_patterns,
                  unmanaged_mac_policy::text
             FROM household_settings WHERE id=1"""
-      .query[(LocalTime, ZoneId, Boolean, Int, List[String], String)]
-      .unique
-      .map { case (t, z, hbEnabled, hbBytes, hbHosts, ummJson) =>
-        val umm = ummJson.fromJson[UnmanagedMacPolicy].getOrElse(UnmanagedMacPolicy.Default)
-        HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts), umm)
-      }
-      .transact(xa)
+        .query[(LocalTime, ZoneId, Boolean, Int, List[String], String)]
+        .unique
+        .map { case (t, z, hbEnabled, hbBytes, hbHosts, ummJson) =>
+          val umm = ummJson.fromJson[UnmanagedMacPolicy].getOrElse(UnmanagedMacPolicy.Default)
+          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts), umm)
+        }
+        .transact(xa),
+    )
 
   def update(s: HouseholdSettings): Task[Unit] = {
     val ummJson    = s.unmanagedMacPolicy.toJson
@@ -789,11 +795,13 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
 
 class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
   def findForProfile(pid: ProfileId)    =
-    sql"SELECT id,profile_id,daily_minutes FROM time_limits WHERE profile_id=$pid"
-      .query[(TimeLimitId, ProfileId, Int)]
-      .map(TimeLimit.apply)
-      .option
-      .transact(xa)
+    DbMetrics.timed("timeLimit.findForProfile")(
+      sql"SELECT id,profile_id,daily_minutes FROM time_limits WHERE profile_id=$pid"
+        .query[(TimeLimitId, ProfileId, Int)]
+        .map(TimeLimit.apply)
+        .option
+        .transact(xa),
+    )
   def upsert(pid: ProfileId, mins: Int) =
     sql"INSERT INTO time_limits(profile_id,daily_minutes) VALUES($pid,$mins) ON CONFLICT(profile_id) DO UPDATE SET daily_minutes=EXCLUDED.daily_minutes".update.run
       .transact(xa)
@@ -814,16 +822,18 @@ class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
     SiteTimeLimit(SiteTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5)
 
   def listForProfile(pid: ProfileId) =
-    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
+    DbMetrics.timed("siteTimeLimit.listForProfile")(
+      sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id
            WHERE apa.profile_id = $pid AND apa.mode = 'time_limited'
            ORDER BY apa.id, ah.host"""
-      .query[R]
-      .map(toS)
-      .to[List]
-      .transact(xa)
+        .query[R]
+        .map(toS)
+        .to[List]
+        .transact(xa),
+    )
 
   def listAll =
     sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
@@ -858,21 +868,23 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
         .transact(xa),
     )
   def findByMac(mac: MacAddress)                                                       =
-    sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id WHERE d.mac=$mac"
-      .query[
-        (
-            DeviceId,
-            MacAddress,
-            String,
-            Option[ProfileId],
-            Option[String],
-            Option[IpAddress],
-            Option[String],
-        ),
-      ]
-      .map(r => Device(r._1, r._2, r._3, r._4, r._5, r._6, r._7))
-      .option
-      .transact(xa)
+    DbMetrics.timed("device.findByMac")(
+      sql"SELECT d.id,d.mac,d.name,d.profile_id,p.name,d.last_seen_ip,d.last_seen_at::TEXT FROM devices d LEFT JOIN profiles p ON p.id=d.profile_id WHERE d.mac=$mac"
+        .query[
+          (
+              DeviceId,
+              MacAddress,
+              String,
+              Option[ProfileId],
+              Option[String],
+              Option[IpAddress],
+              Option[String],
+          ),
+        ]
+        .map(r => Device(r._1, r._2, r._3, r._4, r._5, r._6, r._7))
+        .option
+        .transact(xa),
+    )
   def upsert(mac: MacAddress, name: String, pid: Option[ProfileId], ip: String) =
     // #708: pid=None writes NULL (device unassigned). Devices without a profile
     // are a supported state — same shape auto-discovery produces.
@@ -885,23 +897,29 @@ class DeviceRepoLive(xa: Transactor[Task]) extends DeviceRepo {
       .transact(xa)
       .unit
   def touchLastSeen(mac: MacAddress, ip: Option[IpAddress], at: Instant)               =
-    sql"UPDATE devices SET last_seen_ip=COALESCE($ip,last_seen_ip),last_seen_at=$at WHERE mac=$mac".update.run
-      .transact(xa)
+    DbMetrics.timed("device.touchLastSeen")(
+      sql"UPDATE devices SET last_seen_ip=COALESCE($ip,last_seen_ip),last_seen_at=$at WHERE mac=$mac".update.run
+        .transact(xa),
+    )
   def upsertUnknown(mac: MacAddress, name: String, ip: Option[IpAddress], at: Instant) =
-    sql"""INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at)
+    DbMetrics.timed("device.upsertUnknown")(
+      sql"""INSERT INTO devices(mac,name,profile_id,last_seen_ip,last_seen_at)
           VALUES($mac,$name,NULL,$ip,$at)
           ON CONFLICT(mac) DO UPDATE
           SET last_seen_ip=COALESCE(EXCLUDED.last_seen_ip,devices.last_seen_ip),
               last_seen_at=EXCLUDED.last_seen_at
           RETURNING id"""
-      .query[DeviceId]
-      .unique
-      .transact(xa)
+        .query[DeviceId]
+        .unique
+        .transact(xa),
+    )
   def renameIfAutoGenerated(mac: MacAddress, newName: String)                          = {
     val autoNamePattern = "^device-[0-9a-fA-F]+$"
-    sql"""UPDATE devices SET name=$newName
+    DbMetrics.timed("device.renameIfAutoGenerated")(
+      sql"""UPDATE devices SET name=$newName
           WHERE mac=$mac AND (name='unknown' OR name ~ $autoNamePattern)""".update.run
-      .transact(xa)
+        .transact(xa),
+    )
   }
   def updateProfile(mac: MacAddress, pid: ProfileId)                                   =
     sql"UPDATE devices SET profile_id=$pid WHERE mac=$mac".update.run.transact(xa).unit
@@ -971,11 +989,13 @@ class AlertRepoLive(xa: Transactor[Task]) extends AlertRepo {
     // because the same mac may legitimately have multiple access_request
     // rows over time. WHERE NOT EXISTS keeps this race-free under the
     // SERIALIZABLE-equivalent semantics of a single statement insert.
-    sql"""INSERT INTO alerts (kind, status, mac, created_at)
+    DbMetrics.timed("alert.raiseNewDevice")(
+      sql"""INSERT INTO alerts (kind, status, mac, created_at)
           SELECT 'new_device', 'pending', $mac, $firstSeenAt
           WHERE NOT EXISTS (
             SELECT 1 FROM alerts WHERE mac = $mac AND kind = 'new_device'
-          )""".update.run.transact(xa).unit
+          )""".update.run.transact(xa).unit,
+    )
 
   def createAccessRequest(
       mac: MacAddress,
@@ -1050,22 +1070,26 @@ class BlocklistRepoLive(xa: Transactor[Task]) extends BlocklistRepo {
   ).updateMany(ds).transact(xa)
   def clearCategory(cat: BlocklistId)         =
     sql"DELETE FROM blocklist_domains WHERE category=${cat.value}".update.run.transact(xa).unit
-  def listCategories  = sql"SELECT DISTINCT category FROM blocklist_domains ORDER BY category"
-    .query[BlocklistId]
-    .to[List]
-    .transact(xa)
-  def countByCategory =
+  def listCategories                          = DbMetrics.timed("blocklist.listCategories")(
+    sql"SELECT DISTINCT category FROM blocklist_domains ORDER BY category"
+      .query[BlocklistId]
+      .to[List]
+      .transact(xa),
+  )
+  def countByCategory                         =
     sql"SELECT category,COUNT(*)::INT FROM blocklist_domains GROUP BY category ORDER BY category"
       .query[(BlocklistId, Int)]
       .to[List]
       .transact(xa)
-  def loadCategory(cat: BlocklistId) =
-    sql"SELECT domain FROM blocklist_domains WHERE category=${cat.value}"
-      .query[Hostname]
-      .to[List]
-      .transact(xa)
-      .map(_.toSet)
-  def loadAll                        = sql"SELECT category,domain FROM blocklist_domains"
+  def loadCategory(cat: BlocklistId)          =
+    DbMetrics.timed("blocklist.loadCategory")(
+      sql"SELECT domain FROM blocklist_domains WHERE category=${cat.value}"
+        .query[Hostname]
+        .to[List]
+        .transact(xa)
+        .map(_.toSet),
+    )
+  def loadAll                                 = sql"SELECT category,domain FROM blocklist_domains"
     .query[(BlocklistId, Hostname)]
     .to[List]
     .transact(xa)
@@ -1130,7 +1154,8 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
       bytesOut: Long,
       proportionalSeconds: Long = 0L,
   ): Task[Unit] =
-    sql"""INSERT INTO time_usage(device_mac,host_type,host_value,date,seconds_used,proportional_seconds,bytes_in,bytes_out,last_seen_at)
+    DbMetrics.timed("timeUsage.incrementSecondsAndBytes")(
+      sql"""INSERT INTO time_usage(device_mac,host_type,host_value,date,seconds_used,proportional_seconds,bytes_in,bytes_out,last_seen_at)
           VALUES($mac,${host.kind},${host.value},$d,$seconds,$proportionalSeconds,$bytesIn,$bytesOut,NOW())
           ON CONFLICT(device_mac,host_type,host_value,date) DO UPDATE
           SET seconds_used=time_usage.seconds_used+EXCLUDED.seconds_used,
@@ -1138,8 +1163,9 @@ class TimeUsageRepoLive(xa: Transactor[Task]) extends TimeUsageRepo {
               bytes_in=time_usage.bytes_in+EXCLUDED.bytes_in,
               bytes_out=time_usage.bytes_out+EXCLUDED.bytes_out,
               last_seen_at=NOW()""".update.run
-      .transact(xa)
-      .unit
+        .transact(xa)
+        .unit,
+    )
   def getProportionalSeconds(mac: MacAddress, host: HostId, d: LocalDate): Task[Long]           =
     sql"SELECT COALESCE(proportional_seconds,0) FROM time_usage WHERE device_mac=$mac AND host_type=${host.kind} AND host_value=${host.value} AND date=$d"
       .query[Long]
@@ -1310,11 +1336,13 @@ class TimeExtensionRepoLive(xa: Transactor[Task]) extends TimeExtensionRepo {
       .to[List]
       .transact(xa)
   def snapshotAllByProfile(d: LocalDate)                                                         =
-    sql"SELECT profile_id,SUM(extra_minutes)::INT FROM time_extensions WHERE date=$d AND profile_id IS NOT NULL GROUP BY profile_id"
-      .query[(ProfileId, Int)]
-      .to[List]
-      .transact(xa)
-      .map(_.toMap)
+    DbMetrics.timed("timeExtension.snapshotAllByProfile")(
+      sql"SELECT profile_id,SUM(extra_minutes)::INT FROM time_extensions WHERE date=$d AND profile_id IS NOT NULL GROUP BY profile_id"
+        .query[(ProfileId, Int)]
+        .to[List]
+        .transact(xa)
+        .map(_.toMap),
+    )
 }
 
 class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
@@ -1378,13 +1406,15 @@ class RouterRepoLive(xa: Transactor[Task]) extends RouterRepo {
       .transact(xa)
       .unit
   def touch(id: RouterId, etag: Option[ETag], agentVersion: Option[String]) =
-    sql"""UPDATE routers
+    DbMetrics.timed("router.touch")(
+      sql"""UPDATE routers
           SET last_seen_at=NOW(),
               last_etag=COALESCE($etag,last_etag),
               agent_version=COALESCE($agentVersion,agent_version)
           WHERE id=$id""".update.run
-      .transact(xa)
-      .unit
+        .transact(xa)
+        .unit,
+    )
   def countSeenSince(cutoff: Instant)                                       =
     DbMetrics.timed("router.countSeenSince")(
       sql"SELECT count(*) FROM routers WHERE last_seen_at >= $cutoff"
@@ -1567,13 +1597,15 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                  AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
                  AND """ ++ Fragments.in(fr"tr.mac", nel) ++
             since.fold(fr"")(s => fr"AND tr.period_start >= $s")
-        q.query[Row]
-          .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
-            val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
-            wifihaven.api.presence.PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds)
-          }
-          .to[List]
-          .transact(xa)
+        DbMetrics.timed("traffic.listPresenceRows")(
+          q.query[Row]
+            .map { case (m, d, ps, host, secs, bin, bout, pStart, pEnd) =>
+              val periodSeconds = math.max(0L, pEnd.getEpochSecond - pStart.getEpochSecond).toInt
+              wifihaven.api.presence.PresenceRow(m, d, ps, host, secs, bin + bout, periodSeconds)
+            }
+            .to[List]
+            .transact(xa),
+        )
     }
   }
 
@@ -1628,13 +1660,15 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
     val limitFr    = limit.fold(fr"")(n => fr"LIMIT $n")
     val select     = baseSelect ++ macFilter ++ byCursor ++
       fr"ORDER BY tr.period_start DESC, tr.mac ASC, COALESCE(CASE WHEN tr.host_type IN ('ipv4','ipv6') THEN ce.resolved_host_value END, tr.host_value) ASC " ++ limitFr
-    select
-      .query[Row]
-      .map { case (m, h, ps, pe, secs, bi, bo) =>
-        wifihaven.api.usage.TrafficUsageDbRow(m, h, ps, pe, secs, bi, bo)
-      }
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("traffic.listRawInRange")(
+      select
+        .query[Row]
+        .map { case (m, h, ps, pe, secs, bi, bo) =>
+          wifihaven.api.usage.TrafficUsageDbRow(m, h, ps, pe, secs, bi, bo)
+        }
+        .to[List]
+        .transact(xa),
+    )
   }
 
   def earliestPeriodStart =
@@ -1791,13 +1825,15 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
   // #1176/#1179: dual-write `reason_text` (pre-V40 TEXT wire format) alongside
   // `reason` (post-V40 JSONB). See BlockEventRepoLive for the why.
   def insertBatch(events: List[ConnectionEventInsert]) =
-    Update[(ConnectionEventInsert, String)](
-      "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value,reason_text) " +
-        "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?,?) " +
-        // #806: unique key widened to (event_id, ts) for ts-range partitioning;
-        // a replay carries the same router-supplied ts so dedup is unchanged.
-        "ON CONFLICT (event_id, ts) DO NOTHING",
-    ).updateMany(events.map(e => (e, BlockReason.asWire(e.reason)))).transact(xa)
+    DbMetrics.timed("connectionEvent.insertBatch")(
+      Update[(ConnectionEventInsert, String)](
+        "INSERT INTO connection_events(router_id,mac,host_type,host_value,dest_ip,allowed,reason,ts,event_id,resolved_host_value,reason_text) " +
+          "VALUES(?,?,?,?,?,?,?,?,COALESCE(?, gen_random_uuid()),?,?) " +
+          // #806: unique key widened to (event_id, ts) for ts-range partitioning;
+          // a replay carries the same router-supplied ts so dedup is unchanged.
+          "ON CONFLICT (event_id, ts) DO NOTHING",
+      ).updateMany(events.map(e => (e, BlockReason.asWire(e.reason)))).transact(xa),
+    )
 
   // #720: read paths coalesce a populated resolved_host_value into the host
   // tuple so callers see ('fqdn', resolved) instead of ('ipv4', literal-ip).
@@ -1837,16 +1873,18 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       .transact(xa)
 
   def findRecentFqdnFor(routerId: RouterId, destIp: IpAddress, since: Instant) =
-    sql"""SELECT host_value FROM connection_events
+    DbMetrics.timed("connectionEvent.findRecentFqdnFor")(
+      sql"""SELECT host_value FROM connection_events
           WHERE router_id = $routerId
             AND dest_ip   = $destIp
             AND host_type = 'fqdn'
             AND ts >= $since
           ORDER BY ts DESC
           LIMIT 1"""
-      .query[Hostname]
-      .option
-      .transact(xa)
+        .query[Hostname]
+        .option
+        .transact(xa),
+    )
 
   def backfillResolvedFor(
       routerId: RouterId,
@@ -1854,13 +1892,15 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
       fqdn: Hostname,
       since: Instant,
   ) =
-    sql"""UPDATE connection_events
+    DbMetrics.timed("connectionEvent.backfillResolvedFor")(
+      sql"""UPDATE connection_events
           SET resolved_host_value = ${fqdn.value}
           WHERE router_id = $routerId
             AND dest_ip   = $destIp
             AND host_type IN ('ipv4','ipv6')
             AND resolved_host_value IS NULL
-            AND ts >= $since""".update.run.transact(xa)
+            AND ts >= $since""".update.run.transact(xa),
+    )
 
   // ── Dashboard / log API ──────────────────────────────────────────────────
 
@@ -2606,11 +2646,13 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
   private def toApp(r: R) = App(r._1, r._2, r._3, r._4, r._5, r._6, r._7)
 
   def listAll =
-    sql"SELECT id,name,slug,template_id,icon,icon_type,created_at FROM apps ORDER BY id"
-      .query[R]
-      .map(toApp)
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("app.listAll")(
+      sql"SELECT id,name,slug,template_id,icon,icon_type,created_at FROM apps ORDER BY id"
+        .query[R]
+        .map(toApp)
+        .to[List]
+        .transact(xa),
+    )
 
   def findById(id: AppId) =
     sql"SELECT id,name,slug,template_id,icon,icon_type,created_at FROM apps WHERE id=$id"
@@ -2672,10 +2714,12 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
   }
 
   def getHosts(appId: AppId) =
-    sql"SELECT host FROM app_hosts WHERE app_id=$appId ORDER BY host"
-      .query[Hostname]
-      .to[List]
-      .transact(xa)
+    DbMetrics.timed("app.getHosts")(
+      sql"SELECT host FROM app_hosts WHERE app_id=$appId ORDER BY host"
+        .query[Hostname]
+        .to[List]
+        .transact(xa),
+    )
 
   def currentHostsVersion =
     sql"SELECT version FROM app_hosts_version".query[Long].unique.transact(xa)
@@ -2725,12 +2769,14 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
       .transact(xa)
 
   def listAssignmentsForProfile(profileId: ProfileId) =
-    sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
+    DbMetrics.timed("app.listAssignmentsForProfile")(
+      sql"""SELECT id,app_id,profile_id,mode,daily_minutes,exempt_from_daily
           FROM app_policy_assignments WHERE profile_id=$profileId ORDER BY id"""
-      .query[AR]
-      .map(toAssignment)
-      .to[List]
-      .transact(xa)
+        .query[AR]
+        .map(toAssignment)
+        .to[List]
+        .transact(xa),
+    )
 }
 
 object Repos {

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -47,6 +47,7 @@ object MetricGuard {
     "http_requests_total"                       -> Set("route", "method", "status"),
     "http_request_duration_seconds"             -> Set("route", "method"),
     "db_query_duration_seconds"                 -> Set("op"),
+    "db_queries_total"                          -> Set("op", "status"),
     "auth_failures_total"                       -> Set("reason"),
     "agent_connected_routers"                   -> Set.empty[String],
     "traffic_reports_filtered_zero_bytes_total" -> Set.empty[String],
@@ -140,7 +141,11 @@ object AppMetrics {
 
   // ── DB query timing (#1204) ──────────────────────────────────────────────────
   // Emitted from DbMetrics.timed around the Doobie transact of hot repo methods.
-  // `op` is a hand-named constant per method, never the SQL text.
+  // `op` is a hand-named constant per method, never the SQL text. Two series per
+  // op: the duration histogram (rate via _count, latency via the buckets) and a
+  // db_queries_total{op,status} counter that splits ok vs error so the dashboard
+  // can show a per-op success rate — a slow query and a *failing* query are
+  // different incidents and an operator needs to tell them apart.
 
   /** Sub-millisecond → multi-second DB latency. */
   val DbDurationBoundaries: MetricKeyType.Histogram.Boundaries =
@@ -148,13 +153,14 @@ object AppMetrics {
       Chunk(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
     )
 
-  def recordDbQuery(op: String, durationSeconds: Double): UIO[Unit] =
+  def recordDbQuery(op: String, durationSeconds: Double, status: String): UIO[Unit] =
     MetricGuard.histogram(
       "db_query_duration_seconds",
       Map("op" -> op),
       math.max(0.0, durationSeconds),
       DbDurationBoundaries,
-    )
+    ) *>
+      MetricGuard.counter("db_queries_total", Map("op" -> op, "status" -> status))
 
   // ── Auth failures (#1204) ────────────────────────────────────────────────────
   // `reason` ∈ {bad_password, expired_token, bad_router_token, forbidden_role}.
@@ -290,16 +296,23 @@ object DbPoolMetrics {
 }
 
 /**
- * #1204: time the Doobie transact of a repo method into `db_query_duration_seconds{op}`. `op` is a
- * hand-named constant supplied at the call site — never derived from the SQL — so the label space
- * stays a small, known enum. Records on every exit (success or failure) so a slow failing query is
- * still visible.
+ * #1204: time the Doobie transact of a repo method into `db_query_duration_seconds{op}` and count
+ * it in `db_queries_total{op,status}`. `op` is a hand-named constant supplied at the call site —
+ * never derived from the SQL — so the label space stays a small, known enum. Records on every exit
+ * so a slow failing query is still visible; `status` is `ok` on success and `error` otherwise (a
+ * failure or interruption), which is what drives the per-op success-rate panel.
  */
 object DbMetrics {
   def timed[A](op: String)(query: Task[A]): Task[A] =
     Clock.nanoTime.flatMap { start =>
-      query.onExit { _ =>
-        Clock.nanoTime.flatMap(end => AppMetrics.recordDbQuery(op, (end - start) / 1e9d))
+      query.onExit { exit =>
+        Clock.nanoTime.flatMap(end =>
+          AppMetrics.recordDbQuery(
+            op,
+            (end - start) / 1e9d,
+            if exit.isSuccess then "ok" else "error",
+          ),
+        )
       }
     }
 }

--- a/api/test/src/feature/MetricsSelfMetricsSpec.scala
+++ b/api/test/src/feature/MetricsSelfMetricsSpec.scala
@@ -4,7 +4,7 @@ import wifihaven.api.JwtConfig
 import wifihaven.api.MetricsConfig
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
-import wifihaven.api.metrics.{HttpMetrics, MetricsRuntime}
+import wifihaven.api.metrics.{DbMetrics, HttpMetrics, MetricsRuntime}
 import wifihaven.api.routes.*
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -162,6 +162,27 @@ object MetricsSelfMetricsSpec
         assertTrue(!httpLines.exists(_.contains("ip="))) &&
         assertTrue(!httpLines.exists(_.contains("domain="))) &&
         assertTrue(!httpLines.exists(_.contains("path=")))
+    } @@ TestAspect.withLiveClock,
+    test(
+      "DbMetrics.timed records db_queries_total{op,status} — ok on success, error on failure — so the per-op DB success-rate panel has data",
+    ) {
+      for {
+        _    <- DbMetrics.timed("test.dbOk")(ZIO.succeed(1))
+        // A failing query must still be counted, tagged status=error (not swallowed).
+        _    <- DbMetrics.timed("test.dbErr")(ZIO.fail(new RuntimeException("boom"))).either
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.catchAll(resp => resp.body.asString.orDie)
+        lines = seriesLines(body, "db_queries_total")
+      } yield assertTrue(
+        lines.exists(l => l.contains("""op="test.dbOk"""") && l.contains("""status="ok"""")),
+      ) &&
+        assertTrue(
+          lines.exists(l => l.contains("""op="test.dbErr"""") && l.contains("""status="error"""")),
+        ) &&
+        // The error op must NOT have logged an ok sample (the failure is attributed correctly).
+        assertTrue(
+          !lines.exists(l => l.contains("""op="test.dbErr"""") && l.contains("""status="ok"""")),
+        )
     } @@ TestAspect.withLiveClock,
   ) @@ TestAspect.sequential
 }

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -91,8 +91,8 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "title": "HTTP error ratio (4xx / 5xx)",
-      "description": "Fraction of requests returning 4xx and 5xx. A 5xx spike is the API-fault signal; 4xx tracks auth/validation rejections.",
+      "title": "HTTP error ratio by route (4xx client / 5xx server)",
+      "description": "Per-route fraction of requests returning 4xx vs 5xx: sum by (route) (rate(http_requests_total{status=~\"4..|5..\"}[5m])) / sum by (route) (rate(http_requests_total[5m])). Split because the two mean different things: a 5xx is an API fault, a 4xx is a client/agent fault (auth rejection OR a malformed request the server refused — e.g. #1382, where /api/router/metrics returned 400 on every push from pre-#1365 agents). This single per-endpoint view covers every route, so a router-ingest 400 shows up here as a 4xx on /api/router/metrics — no route-specific panel needed. (3xx, e.g. the 304 ETag path on /api/router/policy, is healthy and excluded.)",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
@@ -114,20 +114,20 @@
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
         "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(http_requests_total{status=~\"5..\", env=\"$env\"}[5m])) / sum(rate(http_requests_total{env=\"$env\"}[5m]))",
-          "legendFormat": "5xx",
+          "expr": "sum by (route) (rate(http_requests_total{status=~\"5..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{route}} 5xx",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum(rate(http_requests_total{status=~\"4..\", env=\"$env\"}[5m])) / sum(rate(http_requests_total{env=\"$env\"}[5m]))",
-          "legendFormat": "4xx",
+          "expr": "sum by (route) (rate(http_requests_total{status=~\"4..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{route}} 4xx",
           "refId": "B"
         }
       ]
@@ -250,8 +250,8 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "title": "Auth failures by reason",
-      "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
+      "title": "Auth failures by reason (401/403 — NOT bad request)",
+      "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. This counts ONLY authn/authz rejections (401/403). A malformed/un-decodable request body is a 400 bad-request and is NOT counted here — it appears as a 4xx on the offending route in 'HTTP error ratio by route' (top-left), never as bad_router_token (e.g. #1382: /api/router/metrics 400s from pre-#1365 agents). A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
       "id": 8,
@@ -411,7 +411,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (status) (rate(router_metrics_batches_total[5m]))",
+          "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
         }

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -24,7 +24,7 @@
       "title": "HTTP request rate by status",
       "description": "sum by (status) (rate(http_requests_total[5m])) — requests/sec across all routes, split by HTTP status. From HttpMetrics.instrument.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 8 },
       "id": 1,
       "fieldConfig": {
         "defaults": {
@@ -53,7 +53,7 @@
       "title": "HTTP request latency (p50 / p95 / p99)",
       "description": "histogram_quantile over http_request_duration_seconds_bucket across all routes. Buckets span 5ms → 5s (HttpDurationBoundaries).",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 8 },
       "id": 2,
       "fieldConfig": {
         "defaults": {
@@ -94,7 +94,7 @@
       "title": "HTTP success rate by route (4xx / 5xx breakout)",
       "description": "Per-route SUCCESS rate (higher = healthier): sum by (route) (rate(http_requests_total{status=~\"2..|3..\"}[5m])) / sum by (route) (rate(http_requests_total[5m])) — 2xx and 3xx (e.g. the 304 ETag path on /api/router/policy) count as success. The 4xx and 5xx series are the breakout of what's eating into it, kept separate because they mean different things: a 5xx is an API fault, a 4xx is a client/agent fault (auth rejection OR a malformed request the server refused — e.g. #1382, where /api/router/metrics returned 400 on every push from pre-#1365 agents). One per-endpoint view covers every route, so a router-ingest 400 shows here as a dip in that route's success line plus a 4xx line — no route-specific panel needed.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
       "id": 3,
       "fieldConfig": {
         "defaults": {
@@ -136,7 +136,7 @@
       "title": "HTTP p95 latency by route",
       "description": "histogram_quantile(0.95, ...) of http_request_duration_seconds_bucket per templated route. `route` is the path template (e.g. /api/devices/:mac), so cardinality is bounded by the route table.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 0 },
       "id": 4,
       "fieldConfig": {
         "defaults": {
@@ -165,7 +165,7 @@
       "title": "Top routes by request rate",
       "description": "topk(10, sum by (route, method) (rate(http_requests_total[5m]))) — busiest templated routes.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 },
       "id": 5,
       "fieldConfig": {
         "defaults": {
@@ -194,7 +194,7 @@
       "title": "DB query rate by op",
       "description": "sum by (op) (rate(db_query_duration_seconds_count[5m])) — queries/sec per instrumented repo method. `op` is a hand-named constant (e.g. device.listAll), never SQL text.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
       "id": 6,
       "fieldConfig": {
         "defaults": {
@@ -223,7 +223,7 @@
       "title": "DB query p95 latency by op",
       "description": "histogram_quantile(0.95, ...) of db_query_duration_seconds_bucket per op — the leading indicator of a missing-index regression (the 2026-05-31 #809 incident) per the query-EXPLAIN rule.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
       "id": 7,
       "fieldConfig": {
         "defaults": {
@@ -252,7 +252,7 @@
       "title": "DB query success rate by op",
       "description": "Per-op SUCCESS rate (higher = healthier): sum by (op) (rate(db_queries_total{status=\"ok\"}[5m])) / sum by (op) (rate(db_queries_total[5m])). The success-rate companion to the rate/latency panels left of it — duration alone can't tell a healthy query from one that's erroring (constraint violation, deadlock, pool-exhaustion timeout). db_queries_total{op,status} is emitted by DbMetrics.timed on every transact, status ∈ {ok,error}. A line dipping below 1 means that repo method is throwing; cross-check the latency panel to tell a slow query from a failing one.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
       "id": 14,
       "fieldConfig": {
         "defaults": {
@@ -290,7 +290,7 @@
       "title": "Auth failures by reason (401/403 — NOT bad request)",
       "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. This counts ONLY authn/authz rejections (401/403). A malformed/un-decodable request body is a 400 bad-request and is NOT counted here — it appears as a 4xx on the offending route in 'HTTP success rate by route' (top-left), never as bad_router_token (e.g. #1382: /api/router/metrics 400s from pre-#1365 agents). A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 8 },
       "id": 8,
       "fieldConfig": {
         "defaults": {
@@ -319,7 +319,7 @@
       "title": "Connected routers",
       "description": "agent_connected_routers — routers whose last_seen_at is within the 10-minute window (RouterPresenceMetrics). The single 'is the fleet alive?' gauge.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
       "id": 9,
       "fieldConfig": {
         "defaults": {
@@ -358,7 +358,7 @@
       "title": "Zero-byte traffic rows filtered (#864)",
       "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 32 },
       "id": 10,
       "fieldConfig": {
         "defaults": {
@@ -394,7 +394,7 @@
       "title": "Metrics rejected (cardinality firewall)",
       "description": "sum by (reason) (rate(metrics_rejected_total[5m])) — emissions blocked by the §4.1 MetricGuard allowlist. reason ∈ {unknown_name, forbidden_label}. Should be flat zero in steady state; a non-zero rate flags a code path attempting an unallowlisted/high-cardinality series.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 32 },
       "id": 11,
       "fieldConfig": {
         "defaults": {
@@ -430,7 +430,7 @@
       "title": "Router metrics batch ingest rate (#1205)",
       "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live router fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent. Fleet-aggregate panels for the router-sourced agent metrics live on the 'Router fleet (agent metrics)' dashboard (#1206); per-(router_id) drill-down is deferred to #1279.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 48 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
       "id": 12,
       "fieldConfig": {
         "defaults": {
@@ -459,7 +459,7 @@
       "title": "Router metrics ingest success ratio (#1368)",
       "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. At-a-glance health: green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is an empty vector and empty/value = empty, so without the coercion the panel would render \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; only a truly idle window (no batches at all → vector(0)/empty) shows No data, so a quiet env does not false-alarm. NOTE: this panel is passive — actually paging on this condition is the alerting-strategy thread (#1381).",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 48 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
       "id": 13,
       "fieldConfig": {
         "defaults": {

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -250,10 +250,47 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "DB query error ratio by op",
+      "description": "Per-op fraction of queries that FAILED: sum by (op) (rate(db_queries_total{status=\"error\"}[5m])) / sum by (op) (rate(db_queries_total[5m])). The success-rate companion to the rate/latency panels left of it — duration alone can't tell a healthy query from one that's erroring (constraint violation, deadlock, pool-exhaustion timeout). db_queries_total{op,status} is emitted by DbMetrics.timed on every transact, status ∈ {ok,error}. A non-zero line here means that repo method is throwing; cross-check the latency panel to tell a slow query from a failing one.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 14,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (op) (rate(db_queries_total{status=\"error\", env=\"$env\"}[5m])) / sum by (op) (rate(db_queries_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Auth failures by reason (401/403 — NOT bad request)",
       "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. This counts ONLY authn/authz rejections (401/403). A malformed/un-decodable request body is a 400 bad-request and is NOT counted here — it appears as a 4xx on the offending route in 'HTTP error ratio by route' (top-left), never as bad_router_token (e.g. #1382: /api/router/metrics 400s from pre-#1365 agents). A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
       "id": 8,
       "fieldConfig": {
         "defaults": {
@@ -282,7 +319,7 @@
       "title": "Connected routers",
       "description": "agent_connected_routers — routers whose last_seen_at is within the 10-minute window (RouterPresenceMetrics). The single 'is the fleet alive?' gauge.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
       "id": 9,
       "fieldConfig": {
         "defaults": {
@@ -321,7 +358,7 @@
       "title": "Zero-byte traffic rows filtered (#864)",
       "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
       "id": 10,
       "fieldConfig": {
         "defaults": {
@@ -357,7 +394,7 @@
       "title": "Metrics rejected (cardinality firewall)",
       "description": "sum by (reason) (rate(metrics_rejected_total[5m])) — emissions blocked by the §4.1 MetricGuard allowlist. reason ∈ {unknown_name, forbidden_label}. Should be flat zero in steady state; a non-zero rate flags a code path attempting an unallowlisted/high-cardinality series.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
       "id": 11,
       "fieldConfig": {
         "defaults": {
@@ -393,7 +430,7 @@
       "title": "Router metrics batch ingest rate (#1205)",
       "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live router fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent. Fleet-aggregate panels for the router-sourced agent metrics live on the 'Router fleet (agent metrics)' dashboard (#1206); per-(router_id) drill-down is deferred to #1279.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 40 },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 48 },
       "id": 12,
       "fieldConfig": {
         "defaults": {
@@ -422,7 +459,7 @@
       "title": "Router metrics ingest success ratio (#1368)",
       "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. At-a-glance health: green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is an empty vector and empty/value = empty, so without the coercion the panel would render \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; only a truly idle window (no batches at all → vector(0)/empty) shows No data, so a quiet env does not false-alarm. NOTE: this panel is passive — actually paging on this condition is the alerting-strategy thread (#1381).",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 40 },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 48 },
       "id": 13,
       "fieldConfig": {
         "defaults": {

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -91,8 +91,8 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "title": "HTTP error ratio by route (4xx client / 5xx server)",
-      "description": "Per-route fraction of requests returning 4xx vs 5xx: sum by (route) (rate(http_requests_total{status=~\"4..|5..\"}[5m])) / sum by (route) (rate(http_requests_total[5m])). Split because the two mean different things: a 5xx is an API fault, a 4xx is a client/agent fault (auth rejection OR a malformed request the server refused — e.g. #1382, where /api/router/metrics returned 400 on every push from pre-#1365 agents). This single per-endpoint view covers every route, so a router-ingest 400 shows up here as a 4xx on /api/router/metrics — no route-specific panel needed. (3xx, e.g. the 304 ETag path on /api/router/policy, is healthy and excluded.)",
+      "title": "HTTP success rate by route (4xx / 5xx breakout)",
+      "description": "Per-route SUCCESS rate (higher = healthier): sum by (route) (rate(http_requests_total{status=~\"2..|3..\"}[5m])) / sum by (route) (rate(http_requests_total[5m])) — 2xx and 3xx (e.g. the 304 ETag path on /api/router/policy) count as success. The 4xx and 5xx series are the breakout of what's eating into it, kept separate because they mean different things: a 5xx is an API fault, a 4xx is a client/agent fault (auth rejection OR a malformed request the server refused — e.g. #1382, where /api/router/metrics returned 400 on every push from pre-#1365 agents). One per-endpoint view covers every route, so a router-ingest 400 shows here as a dip in that route's success line plus a 4xx line — no route-specific panel needed.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
@@ -101,27 +101,20 @@
           "color": { "mode": "palette-classic" },
           "unit": "percentunit",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 },
-              { "color": "red", "value": 0.05 }
-            ]
-          }
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
         "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (route) (rate(http_requests_total{status=~\"5..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
-          "legendFormat": "{{route}} 5xx",
+          "expr": "sum by (route) (rate(http_requests_total{status=~\"2..|3..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{route}} success",
           "refId": "A"
         },
         {
@@ -129,6 +122,12 @@
           "expr": "sum by (route) (rate(http_requests_total{status=~\"4..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{route}} 4xx",
           "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (route) (rate(http_requests_total{status=~\"5..\", env=\"$env\"}[5m])) / sum by (route) (rate(http_requests_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{route}} 5xx",
+          "refId": "C"
         }
       ]
     },
@@ -250,36 +249,37 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "title": "DB query error ratio by op",
-      "description": "Per-op fraction of queries that FAILED: sum by (op) (rate(db_queries_total{status=\"error\"}[5m])) / sum by (op) (rate(db_queries_total[5m])). The success-rate companion to the rate/latency panels left of it — duration alone can't tell a healthy query from one that's erroring (constraint violation, deadlock, pool-exhaustion timeout). db_queries_total{op,status} is emitted by DbMetrics.timed on every transact, status ∈ {ok,error}. A non-zero line here means that repo method is throwing; cross-check the latency panel to tell a slow query from a failing one.",
+      "title": "DB query success rate by op",
+      "description": "Per-op SUCCESS rate (higher = healthier): sum by (op) (rate(db_queries_total{status=\"ok\"}[5m])) / sum by (op) (rate(db_queries_total[5m])). The success-rate companion to the rate/latency panels left of it — duration alone can't tell a healthy query from one that's erroring (constraint violation, deadlock, pool-exhaustion timeout). db_queries_total{op,status} is emitted by DbMetrics.timed on every transact, status ∈ {ok,error}. A line dipping below 1 means that repo method is throwing; cross-check the latency panel to tell a slow query from a failing one.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
       "id": 14,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": { "mode": "thresholds" },
           "unit": "percentunit",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 },
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 },
-              { "color": "red", "value": 0.05 }
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.95 },
+              { "color": "green", "value": 0.99 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "min"] },
+        "tooltip": { "mode": "multi", "sort": "asc" }
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "sum by (op) (rate(db_queries_total{status=\"error\", env=\"$env\"}[5m])) / sum by (op) (rate(db_queries_total{env=\"$env\"}[5m]))",
+          "expr": "sum by (op) (rate(db_queries_total{status=\"ok\", env=\"$env\"}[5m])) / sum by (op) (rate(db_queries_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{op}}",
           "refId": "A"
         }
@@ -288,7 +288,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Auth failures by reason (401/403 — NOT bad request)",
-      "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. This counts ONLY authn/authz rejections (401/403). A malformed/un-decodable request body is a 400 bad-request and is NOT counted here — it appears as a 4xx on the offending route in 'HTTP error ratio by route' (top-left), never as bad_router_token (e.g. #1382: /api/router/metrics 400s from pre-#1365 agents). A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
+      "description": "sum by (reason) (rate(auth_failures_total[5m])). reason ∈ {bad_password, expired_token, bad_router_token, forbidden_role}. This counts ONLY authn/authz rejections (401/403). A malformed/un-decodable request body is a 400 bad-request and is NOT counted here — it appears as a 4xx on the offending route in 'HTTP success rate by route' (top-left), never as bad_router_token (e.g. #1382: /api/router/metrics 400s from pre-#1365 agents). A bad_router_token spike means a fleet agent lost its token; a bad_password spike may be credential-stuffing.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
       "id": 8,


### PR DESCRIPTION
Fixes #1382, and generalizes the api-self-metrics dashboard to per-route and per-op **rate / latency / success-rate**.

## Origin (#1382): it was never auth

Diagnosing against prod (`api.wifihaven.net/metrics`): `auth_failures_total` had only `expired_token` (benign), while `http_requests_total{route="/api/router/metrics",status="400"} = 118` matched `router_metrics_batches_total{status="malformed"}` exactly — **zero 401s on any router route**. The metrics push fails as a **400 bad-request** (pre-#1365 fleet agents send `"labels":[]`, rejected by the decoder; the #1365 agent fix self-heals as the fleet rolls forward). The dashboard, not the auth path, was what made a 400 read as an auth problem.

## Dashboard: success rate everywhere, client vs server broken out

We had aggregate rates but no success-rate, and DB coverage was thin. Now:

**HTTP (per route)** — rate (Top routes), latency (p95 by route), and **"HTTP success rate by route (4xx / 5xx breakout)"**: the per-route success line (2xx+3xx / total) is the headline, with 4xx and 5xx fractions kept as breakout series so a dip is attributable to a client/agent fault vs an API fault. A router-ingest 400 shows here as a dip in `/api/router/metrics`'s success line + a 4xx line — no route-specific panel.

**DB (per op)** — rate + latency already existed; added **"DB query success rate by op"** (ok / total, thresholded green ≥ 0.99), completing the trio. Duration alone can't tell a slow query from a *failing* one.

**Panel-8 "Auth failures"** clarified to count only 401/403 — a 400 is never an auth failure.

## Code: DB success-rate signal + wider instrumentation

- `DbMetrics.timed` ignored success/failure, so there was **no DB SR signal**. It now derives `status` (ok/error) from the exit and emits `db_queries_total{op,status}` alongside the duration histogram (allowlisted, keys `{op,status}`).
- Only **6 of ~127** repo methods were instrumented. Instrumented the **hot read path** (PolicyService.snapshot reads) and **ingest write path** (usage/events writers) plus the `traffic.listRawInRange` growth-table scan — **~29 ops** now. Scoped to hot + unbounded-growth paths rather than all 127, per the cardinality-firewall guidance.

## Tests / gates

- New test: `DbMetrics.timed` records `status=ok` on success, `status=error` on a failing query (never `ok` for the failing op) — so the success-rate panel has data. All metrics specs pass; `mill api.compile` clean.
- `scalafmt --check` clean; dashboard passes `json.tool` + `terraform fmt -check`; grid verified overlap-free.
- PromQL targets only series **actually emitted** (`http_requests_total{route,method,status}`, `db_queries_total{op,status}`, `db_query_duration_seconds_*`, `router_metrics_batches_total{status}`); all groupings use bounded keys.

Verified live on the dev stack (api.lan): API rebuilt from this branch, `db_queries_total{op,status}` emitting across the instrumented ops, and the Grafana dashboard reloaded with both success-rate panels rendering real data.