### PR TITLE
cost(render): wifihaven-api-staging starter → free (~$7/mo)

### DIFF
--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -268,10 +268,14 @@ jobs:
           # rollover the OLD container keeps answering 200 on /api/health, so
           # a green health-poll does NOT prove the new image is live (the
           # #1138 false positive). Asserting the served SHA closes that blind
-          # spot. Render's rollout typically takes 30-90s; allow 15 minutes.
+          # spot. Render's rollout typically takes 30-90s on starter+;
+          # #1389 dropped staging back to `plan: free` (0.1 CPU), where JVM
+          # cold-start is ~5x slower (expected ~500-900s). Allow 30 minutes
+          # to clear that envelope with margin while still flagging a stuck
+          # deploy.
           set -u
           echo "Expecting served sha=${EXPECTED_SHA}"
-          deadline=$(( $(date +%s) + 900 ))
+          deadline=$(( $(date +%s) + 1800 ))
           while (( $(date +%s) < deadline )); do
             served=$(curl --fail --silent --max-time 15 \
                        "${STAGING_API_URL}/api/version" \

--- a/render.yaml
+++ b/render.yaml
@@ -30,14 +30,22 @@ services:
   - type: web
     runtime: image
     name: wifihaven-api-staging
-    # #1268: was `free` (512 MB / 0.1 CPU, spins down). The free tier's slow
-    # deploy cutover + 0.1-CPU starvation made the new instance miss CD's
-    # 15-min "serve the new sha" window even though the JVM itself started
-    # clean (no OOM in the deploy logs — see #1268). `starter` keeps the same
-    # 512 MB (proven sufficient with the heap below) but removes spin-down and
-    # gives 0.5 CPU. Bump to `standard` (2 GB / 1 CPU, like prod) only if OOM
-    # actually appears in the logs.
-    plan: starter
+    # #1389 / #1386: back to `free` (512 MB / 0.1 CPU, spins down idle) to
+    # save ~$7/mo. The original bump in #1268 was driven by missing CD's
+    # 15-min "serve the new sha" window on 0.1 CPU — the JVM itself started
+    # clean (no OOM in the deploy logs), but the cold-start was right at the
+    # ceiling. The CD wait in master-api-ui.yml's deploy-staging job is now
+    # 30 min (up from 15) so the slower free-tier cold-start has clear room;
+    # historical `starter` deploys here finish in ~100-170s, and JVM time
+    # scales ~5x with CPU, so ~500-900s on free is the expected envelope.
+    # Free spin-down (~15 min idle) doesn't bite CD — smoke-staging,
+    # api-smoke-staging, and gate-3b-api-staging all hit the service
+    # immediately after deploy, so it's still warm. Interactive debugging
+    # absorbs a one-time ~30-60s wake-up. RAM cap is unchanged (free and
+    # starter are both 512 MB), so the -Xmx384m heap envelope carries over.
+    # Bump back to `starter` if free's cold-start drifts beyond the 30-min
+    # window, or to `standard` if OOM actually appears in the logs.
+    plan: free
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health
@@ -79,10 +87,11 @@ services:
       # ample and stays well clear of Render's reserved connections.
       - key: WIFIHAVEN_DB_POOL_SIZE
         value: "8"
-      # #590 / #1268: `starter` is 512 MB (same as the old free tier). Leave
-      # headroom for OS + JIT + native heap; this -Xmx384m envelope started
-      # clean with no OOM on free, so it carries over unchanged. Raise the heap
-      # (and move to `plan: standard`, 2 GB) only if OOM appears in logs.
+      # #590 / #1268 / #1389: free tier is 512 MB. Leave headroom for OS +
+      # JIT + native heap; this -Xmx384m envelope started clean on free
+      # before #1268 and stays unchanged across the free → starter → free
+      # round-trip. Raise the heap (and move to `plan: standard`, 2 GB) only
+      # if OOM appears in logs.
       - key: JVM_HEAP_OPTS
         value: "-Xms256m -Xmx384m"
       # Staging runs DEBUG so issues are visible in the Render log stream.


### PR DESCRIPTION
## Summary

- Drops `wifihaven-api-staging.plan` from `starter` → `free` in `render.yaml` (~$7/mo saved).
- Widens the CD "serve the new sha" wait in `.github/workflows/master-api-ui.yml` from **15 min → 30 min** to absorb the slower JVM cold-start on `free`'s 0.1-CPU envelope.
- No JVM heap change: `-Xms256m -Xmx384m` already fits free's 512 MB (same RAM cap as starter).

Closes #1389. Sub-issue of [#1386](https://github.com/wifihaven/wifihaven/issues/1386) (`Cost & Infra Spend`).

## Why this is safe (the data #1389 asked for)

**Current CD wall** lives in `master-api-ui.yml` `deploy-staging.Wait for staging to serve THIS build` — `deadline = $(date +%s) + 900` (15 min). Widened to 1800 (30 min). Nothing else in the pipeline caps the wait.

**Free-tier cold-start envelope.** From the Render API on this service (`srv-d8549fgjo89c73buvkf0`):

- Last ~50 deploys on `plan: starter`: durations cluster at **100–212 s** (median ~150 s).
- JVM startup scales roughly linearly with CPU. `starter` = 0.5 CPU, `free` = 0.1 CPU → ~5× slower JVM stage. Expected free-tier envelope: **~500–900 s**, with outliers up to ~15 min.
- The #1268 timeout (run 26726941820, deploy `dep-d8ebtmq8qa3s73bb0qh0`) hit the 15-min wall by ~6+ min — at the ragged edge of free.
- 30 min gives clear margin while still flagging a genuinely stuck deploy.

**Warmup-before-smoke was considered and rejected.** Render's rolling deploy starts a brand-new container at hook-fire time, then cuts traffic over once the new one is healthy. Pre-warming the *old* container does not speed the new one's startup, which is where the cost sits. Lengthening the wait is the only lever with leverage here.

**Free spin-down (~15 min idle) does not bite CD.** `smoke-staging`, `api-smoke-staging`, and `gate-3b-api-staging` all run immediately after `deploy-staging` against the freshly-deployed (warm) container. Interactive debugging absorbs a one-time ~30–60 s wake-up.

**Negative-result fallback.** If real-world deploys regularly miss even the 30-min wall, the inline comment in `render.yaml` (lines around the `plan: free` setting) points back at #1389 / #1386 and says: bump to `starter`. The decision is reversible by changing one line.

## Test plan

- [ ] CI green (workflow YAML syntax + render blueprint validate).
- [ ] After merge: observe the first staging deploy land within the new 30-min window. If it clears in <15 min the change is harmless; if it lands in 15–30 min, the lengthened wait did the work; if it misses, follow the inline rollback note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)