### PR TITLE
feat(grafana): data-quality-ingest dashboard for ingest health + zero-byte filter (#1281)

### DIFF
--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -1,0 +1,343 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Zero-byte traffic rows filtered (#864)",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
+          "legendFormat": "filtered rows/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Zero-byte rows dropped (last 24h)",
+      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) — total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "increase(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[24h])",
+          "legendFormat": "rows (24h)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Ingest request rate by endpoint",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) — requests/sec on the three router→API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m]))",
+          "legendFormat": "{{route}} {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Ingest error rate by endpoint (4xx / 5xx)",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) — rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m]))",
+          "legendFormat": "{{route}} {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Ingest p95 latency by endpoint",
+      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) — tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms → 5s (HttpDurationBoundaries).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m])))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Ingest auth failures (bad_router_token)",
+      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) — router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\", reason=\"bad_router_token\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Router metrics batch ingest by status (#1205)",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 24 },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Router metrics ingest success ratio (#1368)",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. Green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; a truly idle window (no batches → vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel — paging is the alerting thread (#1381).",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
+          "legendFormat": "success ratio",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["wifihaven", "api", "ingest"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": true, "text": "prod", "value": "prod" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Environment",
+        "multi": false,
+        "name": "env",
+        "options": [
+          { "selected": true, "text": "prod", "value": "prod" },
+          { "selected": false, "text": "staging", "value": "staging" }
+        ],
+        "query": "prod,staging",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "WifiHaven — data quality & ingest",
+  "uid": "wifihaven-data-quality-ingest",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -59,7 +59,7 @@ provider "grafana" {
 
 locals {
   folder     = var.folder_uid != "" ? var.folder_uid : null
-  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health"]
+  dashboards = ["api-health", "api-self-metrics", "router-fleet", "rollup-health", "db-health", "data-quality-ingest"]
   dashfiles  = { for name in local.dashboards : name => "${path.module}/../../deploy/grafana/dashboards/${name}.json" }
 }
 


### PR DESCRIPTION
Closes #1281. Follow-up to #1209; the `data-quality-ingest` dashboard was drafted in #1272 but pulled before merge because neither source series was emitted yet. Both blockers are now closed/merged — #864 (`traffic_reports_filtered_zero_bytes_total`) and #1204 (`http_requests_total` / `http_request_duration_seconds`) — so it ships here.

## What this adds
- `deploy/grafana/dashboards/data-quality-ingest.json` — uid `wifihaven-data-quality-ingest`, templated `${datasource}` + `$env` picker, tags `wifihaven/api/ingest`.
- Registers it in `infra/grafana/main.tf`'s `dashboards` list so `master-grafana.yml` provisions it via the #1270/#1272/#1283 pipeline.

## Panels (each → the emitted series it queries)
Every panel was written against a series **grep-verified as emitted in `api/src`** (`AppMetrics` / `HttpMetrics`), not the design-doc §5 catalog.

| Panel | Series (emitted by) |
|---|---|
| Zero-byte traffic rows filtered (rate) | `rate(traffic_reports_filtered_zero_bytes_total[5m])` — `AppMetrics.recordZeroByteFiltered` (#864) |
| Zero-byte rows dropped (last 24h) | `increase(traffic_reports_filtered_zero_bytes_total[24h])` (#864) |
| Ingest request rate by endpoint | `sum by (route, status) (rate(http_requests_total{route=~".*/router/(usage\|events\|metrics)"}[5m]))` — `HttpMetrics.instrument` (#1204) |
| Ingest error rate by endpoint (4xx/5xx) | same, `status=~"4..\|5.."` (#1204) |
| Ingest p95 latency by endpoint | `histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~".*/router/(usage\|events\|metrics)"}[5m])))` (#1204) |
| Ingest auth failures (bad_router_token) | `sum by (reason) (rate(auth_failures_total{reason="bad_router_token"}[5m]))` — `AppMetrics.recordAuthFailure` (#1204) |
| Router metrics batch ingest by status | `sum by (status) (rate(router_metrics_batches_total[5m]))` — `AppMetrics.recordRouterMetricsBatch` (#1205) |
| Router metrics ingest success ratio | `(sum(rate(router_metrics_batches_total{status="ok"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m]))` — `or vector(0)` guard per #1383 (#1368) |

## Env labels
All eight panels target **API-emitted** series, which carry the scrape-time `env` label, so the `$env` picker applies to every query. No router-pushed series (`policy_apply_total`, `snapshot_poll_total`, etc.) are used, so the #1365 "router series may lack `env`" caveat does not apply here.

## Omitted for no-data (follow-ups)
- **Per-`route` ingest body-size / payload-size** — no byte-size metric is emitted on the ingest handlers; would need new instrumentation in `RouterIngestRoutes`/`RouterMetricsRoutes`. Deferred.
- **Per-`router_id` ingest drill-down** — the server-side ingest counters here are fleet-aggregate only; per-router breakdown is the deferred #1279 work.

## Note for a separate change
The #1204 middleware also unblocks the request-rate / latency / 5xx panels that were removed from `api-health.json` in #1272 — those already live on `api-self-metrics.json` (added in #1287/#1288). The ingest-scoped views here are the dedicated data-quality surface; folding the general HTTP panels back into `api-health` (if still wanted) is left to a follow-up to keep this PR focused.

## Validation
- `python3 -m json.tool deploy/grafana/dashboards/data-quality-ingest.json` ✓
- `terraform fmt -check` ✓ · `terraform validate` ✓ (the `grafana-terraform` CI gate)
