### PR TITLE
infra(render): downsize prod Postgres back to basic-256mb (#1258)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -179,8 +179,16 @@ services:
       # 24 has even more room, and the 1 GB of RAM absorbs 24 backends without
       # the startup-stall pressure that 40+ caused at 256 MB. Confirm against
       # `SHOW max_connections;` post-resize if ever pushing the pool higher.
+      #
+      # #1258 (2026-06-04): downsized prod Postgres back to basic-256mb after
+      # the #1254 rollup index landed and the 4-day post-index window confirmed
+      # the CPU peg was the missing index, not the tier. Pool dropped back to 8
+      # in lockstep ("raise/lower together"), so rolling-deploy peak is 2×8 =
+      # 16 backends + rollup/seed fibers — well under basic-256mb's verified
+      # max_connections=103 and under the 256 MB RAM ceiling now that the
+      # rollup lateral no longer materializes a per-MAC scan.
       - key: WIFIHAVEN_DB_POOL_SIZE
-        value: "12"
+        value: "8"
       # #786 / #785: bumped to `plan: standard` (2 GB / 1 CPU, $25/mo) after
       # prod started flapping under household load on free's 512 MB cap.
       # Heap sized to leave ~600 MB for OS + JIT + native; revisit if OOM
@@ -341,11 +349,24 @@ databases:
   # (measured 0.07–0.10 over 2026-05-31 21:25–21:33 UTC, single instance, no
   # deploy overlap) from steady router-ingest + dashboard + autovacuum, and
   # RAM sat at ~85% (183–220 MB / 256 MB) — also the connection-overlap
-  # pressure behind the deploy startup stalls (#1228/#1248). The 0.1-vCPU peg
-  # is a tier limit, not a workload spike, so rollup-cadence work (#1230/#1231)
-  # cannot create headroom the tier physically lacks. basic-1gb gives 5× CPU
-  # and 4× RAM, clearing both. Pool raised to 12 in tandem — see web_service.
+  # pressure behind the deploy startup stalls (#1228/#1248).
+  #
+  # #1258 (2026-06-04): downsized back to basic-256mb. The CPU peg in #1251
+  # was NOT a tier ceiling — root cause was the missing rollup-attribution
+  # index on connection_events(mac, dest_ip, ts), fixed by #1254/#1256 on
+  # 2026-05-31. With the index in place, prod DB CPU on basic-1gb settled
+  # at a steady ~0.02 vCPU (Render infra metrics, 4 days × ~96 hourly
+  # samples, 2026-05-31 23:00Z → 2026-06-04 21:00Z): min 0.010, p95 0.027,
+  # max 0.043 (excluding the post-upsize warmup hour at 0.27). That is
+  # ~5× under basic-256mb's 0.1-vCPU ceiling — comfortable for autovacuum
+  # + rollup ticks + 7 successful rolling deploys observed in the window.
+  # Pool dropped 12 → 8 in lockstep with the tier (see web_service comment),
+  # so deploy-overlap connection peak is 2×8 + a few rollup/seed fibers,
+  # well under verified max_connections=103. #1248 (bind-port-before-init)
+  # and #1255 (transient-DB resilience) both shipped 2026-05-31, so a brief
+  # restart from a future plan change is a non-event. Saves ~$19/mo
+  # (#1258 / #1386 cost-savings orchestrator).
   - name: wifihaven-pg-prod
-    plan: basic-1gb
+    plan: basic-256mb
     postgresMajorVersion: 16
     region: oregon


### PR DESCRIPTION
## Summary

- Reverses the #1251 prod Postgres upsize: `wifihaven-pg-prod` `basic-1gb` → `basic-256mb` (~$19/mo savings).
- Drops `WIFIHAVEN_DB_POOL_SIZE` 12 → 8 in lockstep with the tier ("raise/lower together" rule).
- Updates both `render.yaml` sizing comments with dated evidence.

Closes [#1258](https://github.com/wifihaven/wifihaven/issues/1258); tracks [#1386](https://github.com/wifihaven/wifihaven/issues/1386) cost-savings orchestrator.

## Why now — evidence

The #1251 upsize was diagnosing a symptom. The CPU peg was the missing rollup-attribution index on `connection_events(mac, dest_ip, ts)` (#1254), not the tier. [#1256](https://github.com/wifihaven/wifihaven/pull/1256) shipped the index on 2026-05-31 and the lateral collapsed from minutes to milliseconds.

Post-index observation window: **4 days × ~96 hourly samples**, 2026-05-31 23:00Z → 2026-06-04 21:00Z (Render infra metrics on `dpg-d856k9h9rddc73a3npng-a`):

| Metric | Observed on basic-1gb | basic-256mb ceiling | Verdict |
|---|---|---|---|
| DB CPU (steady) | min 0.010 / p95 0.027 / max 0.043 vCPU | 0.1 vCPU | ~5× headroom |
| Rolling deploys completed in window | 7 successful (Render API `/v1/services/.../deploys`) — no CPU spikes above the steady envelope | — | survived deploy overlap |
| Verified `max_connections` (read-only psql `SHOW`) | 103 | 103 | unchanged at the tier — pool 8 → deploy peak 2×8 + fibers ≪ 103 |

(The single 0.27-vCPU sample at 2026-05-31 23:00Z is the warmup hour right after the upsize and is excluded.)

Preconditions checked before acting:
- [x] [#1254](https://github.com/wifihaven/wifihaven/issues/1254) merged + deployed (Flyway has the index, not just live prod) — PR [#1256](https://github.com/wifihaven/wifihaven/pull/1256), merged 2026-05-31 22:41Z.
- [x] [#1248](https://github.com/wifihaven/wifihaven/issues/1248) (bind-port-before-init) — PR [#1252](https://github.com/wifihaven/wifihaven/pull/1252), merged 2026-05-31 22:15Z.
- [x] [#1255](https://github.com/wifihaven/wifihaven/issues/1255) (transient-DB resilience) — PR [#1257](https://github.com/wifihaven/wifihaven/pull/1257), merged 2026-05-31 22:45Z.

So the brief Render restart from this `plan:` change is a non-event for the API.

## RAM honest-call

basic-1gb measured higher steady-state RAM (avg ~377 MB, p95 ~670 MB) than basic-256mb ever did (~183–220 MB during the incident). That growth is overwhelmingly tier-driven config — on basic-1gb the Render-managed `shared_buffers=256MB` and `effective_cache_size=768MB` (verified via `pg_settings`); both shrink on basic-256mb. Pre-incident the same workload (minus the bad rollup lateral) survived basic-256mb at ~85% RAM, and the rollup is no longer materializing per-MAC scans, so post-index RAM pressure should be **lower** than the pre-incident baseline. Pool reduction 12 → 8 cuts backend RAM by ~33%.

## Scope discipline

- No source / test / CI changes — declarative `render.yaml` only, per the project's "declarative config first" rule.
- No Flyway migration — migration-isolation rule N/A.

## Test plan

- [ ] CI green (`render-blueprint` validate / fmt).
- [ ] On merge, monitor first deploy: Render plan change triggers a brief Postgres restart; API rides through via [#1255](https://github.com/wifihaven/wifihaven/issues/1255).
- [ ] Within 24h post-deploy: confirm DB CPU still <0.05 vCPU steady on basic-256mb and RAM <85%; confirm a rolling deploy completes without port-scan timeout.
- [ ] Confirm `SHOW max_connections;` still 103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)