### PR TITLE
metrics: cardinality + retention review gate before first prod scrape (#1210)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -37,6 +37,31 @@ object MetricGuard {
     )
 
   /**
+   * #1210 — the small, known label-key vocabulary. Every key in any [[Allowed]] entry MUST be
+   * listed here, and nothing here may also be a [[ForbiddenKeys]] (both invariants are enforced by
+   * `MetricCardinalityGuardSpec`). This is the standing cardinality gate: introducing *any* new
+   * label key forces a deliberate edit to this set, which is the review checkpoint #1210 makes
+   * permanent. Each key is bounded and known at code-write time (§4.2): `route` (~40 templated
+   * paths), `method` (~5), `status` (HTTP codes / bounded ingest enum), `op` (~30 hand-named DB
+   * ops), `reason`/`result` (fixed per-metric enums), `version` (slow-moving agent versions),
+   * `rollup_job` (handful of rollup job names), and `router_id` / `installation_id` (bounded
+   * fleet/install dimensions).
+   */
+  val KnownLabelKeys: Set[String] =
+    Set(
+      "route",
+      "method",
+      "status",
+      "op",
+      "reason",
+      "result",
+      "version",
+      "rollup_job",
+      "router_id",
+      "installation_id",
+    )
+
+  /**
    * §5.1/§5.2 — metric name → its permitted label keys. The only (name, keys) pairs that may be
    * emitted. `router_id` (and `installation_id`, once that concept lands) are bounded fleet-size
    * dimensions the server attaches to every router-pushed series (§4.2) — they are deliberately NOT
@@ -63,6 +88,17 @@ object MetricGuard {
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
+    // #1243 rollup health — `rollup_job` is a handful of hand-named jobs (traffic_hourly,
+    // traffic_daily, time_used_daily), `status` ∈ {ok, error}. Bounded; routed through the guard.
+    "wifihaven_rollup_runs_total"               -> Set("rollup_job", "status"),
+    "wifihaven_rollup_duration_seconds"         -> Set("rollup_job"),
+    "wifihaven_rollup_rows_upserted"            -> Set("rollup_job"),
+    // #1243/#1221 HikariCP pool gauges — no labels.
+    "wifihaven_db_pool_active_connections"      -> Set.empty[String],
+    "wifihaven_db_pool_idle_connections"        -> Set.empty[String],
+    "wifihaven_db_pool_total_connections"       -> Set.empty[String],
+    "wifihaven_db_pool_threads_awaiting_connection" -> Set.empty[String],
+    "wifihaven_db_pool_max_size"                    -> Set.empty[String],
   )
 
   private val rejected = Metric.counter("metrics_rejected_total")
@@ -210,40 +246,43 @@ object AppMetrics {
   // ── Rollup health (#1243) ──────────────────────────────────────────────────
   // Emitted from RollupRepoLive.recordRun — the single completion point both the
   // hourly/daily byte-rollup fibers and the time_used_daily fiber funnel through.
-
-  private val rollupRuns = Metric.counter("wifihaven_rollup_runs_total")
+  // Routed through MetricGuard (#1210) so the cardinality firewall covers these
+  // series too, not just the HTTP/router-pushed ones.
 
   // Sub-second to multi-minute coverage: a prod rollup over a growth table can
   // run for minutes (#1197), so the boundaries span 0.05s → ~200s.
-  private val rollupDuration = Metric.histogram(
-    "wifihaven_rollup_duration_seconds",
-    MetricKeyType.Histogram.Boundaries.exponential(0.05, 2.0, 13),
-  )
-
-  private val rollupRows = Metric.gauge("wifihaven_rollup_rows_upserted")
+  val RollupDurationBoundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.exponential(0.05, 2.0, 13)
 
   /** Record a completed rollup run. `status` is "ok" or "error". */
   def recordRollup(job: String, status: String, durationSeconds: Double, rows: Int): UIO[Unit] =
-    rollupRuns.tagged("rollup_job", job).tagged("status", status).update(1L) *>
-      rollupDuration.tagged("rollup_job", job).update(math.max(0.0, durationSeconds)) *>
-      rollupRows.tagged("rollup_job", job).update(rows.toDouble)
+    MetricGuard.counter(
+      "wifihaven_rollup_runs_total",
+      Map("rollup_job" -> job, "status" -> status),
+    ) *>
+      MetricGuard.histogram(
+        "wifihaven_rollup_duration_seconds",
+        Map("rollup_job" -> job),
+        math.max(0.0, durationSeconds),
+        RollupDurationBoundaries,
+      ) *>
+      MetricGuard.gauge("wifihaven_rollup_rows_upserted", Map("rollup_job" -> job), rows.toDouble)
 
   // ── DB connection pool (#1243, #1221) ───────────────────────────────────────
   // Set from the polling fiber in DbPoolMetrics. threads_awaiting was the
-  // leading indicator of the 2026-05-31 pool-exhaustion crash loop.
-
-  private val dbActive  = Metric.gauge("wifihaven_db_pool_active_connections")
-  private val dbIdle    = Metric.gauge("wifihaven_db_pool_idle_connections")
-  private val dbTotal   = Metric.gauge("wifihaven_db_pool_total_connections")
-  private val dbWaiting = Metric.gauge("wifihaven_db_pool_threads_awaiting_connection")
-  private val dbMax     = Metric.gauge("wifihaven_db_pool_max_size")
+  // leading indicator of the 2026-05-31 pool-exhaustion crash loop. Routed
+  // through MetricGuard (#1210) — unlabelled, but the firewall still gates the name.
 
   def setDbPool(stats: DbPoolStats): UIO[Unit] =
-    dbActive.update(stats.active.toDouble) *>
-      dbIdle.update(stats.idle.toDouble) *>
-      dbTotal.update(stats.total.toDouble) *>
-      dbWaiting.update(stats.threadsAwaiting.toDouble) *>
-      dbMax.update(stats.maxSize.toDouble)
+    MetricGuard.gauge("wifihaven_db_pool_active_connections", Map.empty, stats.active.toDouble) *>
+      MetricGuard.gauge("wifihaven_db_pool_idle_connections", Map.empty, stats.idle.toDouble) *>
+      MetricGuard.gauge("wifihaven_db_pool_total_connections", Map.empty, stats.total.toDouble) *>
+      MetricGuard.gauge(
+        "wifihaven_db_pool_threads_awaiting_connection",
+        Map.empty,
+        stats.threadsAwaiting.toDouble,
+      ) *>
+      MetricGuard.gauge("wifihaven_db_pool_max_size", Map.empty, stats.maxSize.toDouble)
 }
 
 /** Point-in-time HikariCP pool snapshot. */

--- a/api/test/src/feature/MetricCardinalityGuardSpec.scala
+++ b/api/test/src/feature/MetricCardinalityGuardSpec.scala
@@ -1,0 +1,111 @@
+package wifihaven.api.feature
+
+import wifihaven.api.metrics.MetricGuard
+import zio.*
+import zio.metrics.*
+import zio.test.*
+
+import java.nio.file.{Files, Path, Paths}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * #1210: the cardinality review gate, made a standing automated check rather than a one-time
+ * review. The gate is the §4 hard rule from `docs/design/metrics-observability.md`: a metric label
+ * may only exist if its value-set is bounded, small, and known at code-write time.
+ *
+ * The defenses this spec locks in:
+ *
+ *   1. Every metric series emitted in `api/src` goes through the [[MetricGuard]] allowlist — a new
+ *      series added with a bare `Metric.counter/gauge/histogram(...)` that bypasses the firewall
+ *      fails the build until it is allowlisted (or routed through the guard). 2. Every metric name
+ *      the OpenWRT agent pushes is in the allowlist, so a new agent counter can't silently land in
+ *      `metrics_rejected_total` on prod. 3. No allowlisted series may carry a label key outside the
+ *      small, known [[MetricGuard.KnownLabelKeys]] vocabulary — introducing *any* new label key
+ *      forces a deliberate edit there, which is the review checkpoint. Forbidden keys (§4.3) can
+ *      never be in that vocabulary. 4. The firewall actually rejects (and counts) a
+ *      deliberately-unbounded label and an unknown name — proving the gate works, not just that it
+ *      is configured.
+ */
+object MetricCardinalityGuardSpec extends ZIOSpecDefault {
+
+  /** Walk up from the test's working directory to the repo root (the dir containing `api/src`). */
+  private val repoRoot: Path = {
+    var cur: Path = Paths.get(sys.props.getOrElse("user.dir", ".")).toAbsolutePath
+    while cur != null && !Files.isDirectory(cur.resolve("api/src")) do cur = cur.getParent
+    if cur == null then sys.error("could not locate repo root (api/src) from user.dir")
+    cur
+  }
+
+  private def readAll(p: Path): String = new String(Files.readAllBytes(p))
+
+  private def scalaFilesUnder(rel: String): List[Path] = {
+    val dir = repoRoot.resolve(rel)
+    if !Files.isDirectory(dir) then Nil
+    else
+      Files
+        .walk(dir)
+        .iterator()
+        .asScala
+        .filter(p => Files.isRegularFile(p) && p.toString.endsWith(".scala"))
+        .toList
+  }
+
+  // Bare `Metric.counter("name"...)` / `.gauge` / `.histogram` / `.summary` / `.frequency` with a
+  // *string-literal* name. The guard's own internals use a `name` variable (no quote), so they
+  // don't match — only hand-written literal series do.
+  private val BareEmit =
+    """Metric\.(?:counter|gauge|histogram|summary|frequency)\(\s*"([^"]+)"""".r
+
+  // `metrics.inc_counter(reg, "name", ...)` / `set_gauge` / `observe` in the Lua agent.
+  private val AgentEmit =
+    """metrics\.(?:inc_counter|set_gauge|observe)\(\s*[A-Za-z_][A-Za-z0-9_]*\s*,\s*"([^"]+)"""".r
+
+  // The firewall's own reject counter is emitted with a bare literal by design — it is the gate, so
+  // it does not itself live in the allowlist.
+  private val GuardInternal = Set("metrics_rejected_total")
+
+  def spec = suite("MetricCardinalityGuardSpec")(
+    test("every bare Metric.* series in api/src is allowlisted (no firewall bypass)") {
+      val names     =
+        scalaFilesUnder("api/src")
+          .flatMap(p => BareEmit.findAllMatchIn(readAll(p)).map(_.group(1)))
+          .toSet
+      val unallowed = names -- MetricGuard.Allowed.keySet -- GuardInternal
+      assertTrue(unallowed.isEmpty)
+    },
+    test("every metric name the OpenWRT agent emits is allowlisted") {
+      val agent     = repoRoot.resolve("openwrt/files/usr/sbin/wifihaven-agent")
+      val names     =
+        if Files.exists(agent) then AgentEmit.findAllMatchIn(readAll(agent)).map(_.group(1)).toSet
+        else Set.empty[String]
+      val unallowed = names -- MetricGuard.Allowed.keySet
+      assertTrue(names.nonEmpty) && assertTrue(unallowed.isEmpty)
+    },
+    test("no allowlisted series carries a label key outside the known vocabulary") {
+      val unknownKeys = MetricGuard.Allowed.values.flatten.toSet -- MetricGuard.KnownLabelKeys
+      assertTrue(unknownKeys.isEmpty)
+    },
+    test("the known label vocabulary never overlaps a forbidden key") {
+      assertTrue((MetricGuard.KnownLabelKeys & MetricGuard.ForbiddenKeys).isEmpty)
+    },
+    test("a deliberately-unbounded (forbidden) label is rejected and counted") {
+      val rejected = Metric.counter("metrics_rejected_total").tagged("reason", "forbidden_label")
+      for {
+        before <- rejected.value
+        // `http_requests_total` allows {route,method,status} — `mac` is a forbidden per-device key.
+        _      <- MetricGuard.counter("http_requests_total", Map("mac" -> "aa:bb:cc:dd:ee:ff"))
+        after  <- rejected.value
+        // `>= 1` rather than `== 1`: the reject counter is a global registry series, so a spec
+        // running concurrently could also increment it between the two reads.
+      } yield assertTrue(after.count - before.count >= 1.0)
+    },
+    test("an unknown metric name is rejected and counted") {
+      val rejected = Metric.counter("metrics_rejected_total").tagged("reason", "unknown_name")
+      for {
+        before <- rejected.value
+        _      <- MetricGuard.counter("totally_made_up_series_total", Map.empty)
+        after  <- rejected.value
+      } yield assertTrue(after.count - before.count >= 1.0)
+    },
+  )
+}

--- a/docs/design/metrics-observability.md
+++ b/docs/design/metrics-observability.md
@@ -588,6 +588,13 @@ the declarative-config preference).
 - Sanity-check actual active-series count in a staging scrape against the
   §7 estimate before pointing prod at it.
 
+> **Done (#1210).** This checklist is signed off in §11, which records the
+> audit of every emitted series, the firewall-coverage gap that was found
+> and fixed (rollup/db-pool series now routed through `MetricGuard`), the
+> retention decision, and the standing `MetricCardinalityGuardSpec` that
+> keeps the gate enforced. The only item left to the operator is the live
+> staging series-count reading (§11.2) before the first prod scrape.
+
 ---
 
 ## 10. Implementation sub-issues
@@ -637,3 +644,144 @@ feature-test stack; for the Lua agent, `busted` unit tests with injected
 
 The §10 numbering above predates these issues being filed; the filed
 issue set is #1204–#1210 (items 1–7) plus #1244/#1245 (items 8–9).
+
+---
+
+## 11. Cardinality audit & standing gate (#1210)
+
+This section records the **first-prod-scrape review** required by §9, and
+the **automated guard** that makes the gate permanent rather than a
+one-time review. It audits what the code **emits**, not the §5 design
+catalog (the two had already drifted — see the rollup/db-pool note below).
+
+### 11.1 Audited series (every emitted series, as of #1210)
+
+Source of truth: a grep of `api/src` for `Metric.*` / `MetricGuard.*` /
+`AppMetrics.*` call sites and of `openwrt/files/usr/sbin/wifihaven-agent`
+for the agent's `metrics.inc_counter/set_gauge/observe` emissions. **All
+application series are now routed through `MetricGuard`** (the §4.1
+firewall); `MetricGuard.Allowed` is the canonical name→label-keys map.
+
+`router_id` multiplies a router-sourced series by the fleet size **R**
+(~50 assumed in §7.2); `installation_id` is reserved in the allowlist but
+not yet attached by the ingest path, so it is a ×1 factor today. Histogram
+series expand to `(#buckets + 2)` Prometheus series (`_bucket{le}` per
+boundary incl. `+Inf`, plus `_sum` and `_count`).
+
+**API self-metrics** (no `router_id`):
+
+| Series | Type | Label keys | Worst-case bound |
+|--------|------|-----------|------------------|
+| `http_requests_total` | counter | `route`,`method`,`status` | ~40 routes × ~5 methods × ~15 statuses (only realized combos exist) |
+| `http_request_duration_seconds` | histogram | `route`,`method` | ~40 × 5 × (10+2) |
+| `db_query_duration_seconds` | histogram | `op` | ~30 ops × (11+2) |
+| `auth_failures_total` | counter | `reason` | 4 (`bad_password`,`expired_token`,`bad_router_token`,`forbidden_role`) |
+| `agent_connected_routers` | gauge | — | 1 |
+| `traffic_reports_filtered_zero_bytes_total` | counter | — | 1 |
+| `router_metrics_batches_total` | counter | `status` | 3 (`ok`,`malformed`,`router_mismatch`) |
+| `metrics_rejected_total` | counter | `reason` | 2 (`unknown_name`,`forbidden_label`) |
+| `wifihaven_rollup_runs_total` | counter | `rollup_job`,`status` | ~3 jobs × 2 statuses |
+| `wifihaven_rollup_duration_seconds` | histogram | `rollup_job` | ~3 × (13+2) |
+| `wifihaven_rollup_rows_upserted` | gauge | `rollup_job` | ~3 |
+| `wifihaven_db_pool_{active,idle,total,threads_awaiting,max_size}` | gauge | — | 5 |
+| JVM / ZIO runtime | gauges/counters | (collector-defined) | bounded, process-level |
+
+**Router-sourced** (re-exposed server-side via `RouterMetricsService`,
+each × **R** routers):
+
+| Series | Type | Label keys (+`router_id`,`installation_id`) | Per-router bound |
+|--------|------|---------|------------------|
+| `dnsmasq_restarts_total` | counter | `reason` | 3 (`policy_change`,`boot`,`manual`) |
+| `policy_apply_total` | counter | `result` | 4 (`ok`,`write_failed`,`nft_failed`,`smoke_warn`) |
+| `policy_apply_duration_seconds` | histogram | — | (6+2) |
+| `snapshot_poll_total` | counter | `result` | 3 (`200`,`304`,`error`) |
+| `snapshot_poll_duration_seconds` | histogram | — | (6+2) |
+| `agent_uptime_seconds` | gauge | — | 1 |
+| `agent_version` | gauge | `version` | small (slow-moving) |
+| `dns_queries_total` *(allowlisted, not yet emitted — #1301/#1302)* | counter | `result` | 4 |
+| `blocklist_fetch_failures_total` *(allowlisted, not yet emitted — #1301)* | counter | `status` | bounded HTTP codes |
+
+An external `env` label (`prod`/`staging`) is attached at **scrape time**
+by Grafana Alloy (`deploy/alloy/config.alloy`), not in code — a ×2 factor
+on every cloud series. The self-hosted Prometheus scrape adds no extra
+label.
+
+**Findings & fixes (all resolved in this PR):**
+
+1. **No forbidden label leaked.** No emitted series carries
+   `mac`/`domain`/`device_id`/`ip`/`hostname`/`user_id`/`profile_id`. The
+   HTTP `route` label is the *templated* path (`/api/devices/:mac`), never
+   a concrete id — locked by `MetricsSelfMetricsSpec`.
+2. **Firewall coverage gap closed.** The `wifihaven_rollup_*` and
+   `wifihaven_db_pool_*` series (added in #1243, after the §5 catalog was
+   written) were emitted via bare `Metric.*` calls that **bypassed**
+   `MetricGuard`. They are now routed through the guard and added to
+   `MetricGuard.Allowed`, so the firewall covers **every** application
+   series. (JVM/ZIO collector metrics are intentionally not gated — they
+   are bounded, library-defined process metrics.)
+3. **`op` / `reason` / `result` are bounded enums** — confirmed
+   hand-named at the call sites, never derived from SQL text or free input.
+
+### 11.2 Active-series estimate vs. the §7.2 budget
+
+The audited set adds ~70 series beyond the §5 catalog (rollup ≈ 54,
+db-pool 5, `router_metrics_batches_total` 3, `metrics_rejected_total` 2,
+plus the ×2 `env` factor on the cloud path). This stays **comfortably
+within an order of magnitude of the §7.2 ~3,500–4,000 estimate**: the
+dominant term is still `http_*` × route/method/status realized combos and
+the per-router fan-out, both unchanged.
+
+**Live staging confirmation (operator step before flipping prod, #1208):**
+`/metrics` is not publicly reachable (scraped only over the internal
+network / by Alloy), so the literal active-series count is confirmed in
+the staging Grafana Cloud stack, not from this repo:
+
+```promql
+count({__name__=~".+", env="staging"})
+```
+
+Record the number on #1210 and confirm it is within an order of magnitude
+of the estimate above before pointing prod at `/metrics`. A reading far
+above ~10k means a high-cardinality label slipped the guard via a path
+this audit didn't cover (e.g. a future router-pushed label) — stop and
+investigate before the prod scrape.
+
+### 11.3 Retention
+
+| Environment | Backend | Retention | Where set |
+|-------------|---------|-----------|-----------|
+| Self-hosted | local Prometheus | **90 d** | `--storage.tsdb.retention.time=90d` in `deploy/docker-compose.metrics.yml` (declarative) |
+| Staging / prod cloud | Grafana Cloud free tier | **plan-driven (~14 d)** | not code-configurable; set by the Grafana Cloud plan |
+
+- **Self-hosted disk:** ~46 MB/day at the §7.2 sizing → ~4–5 GB over 90 d.
+  Provision the `promdata` volume with **~10 GB** headroom on the host.
+  (Docker named volumes have no fixed cap; this is a host-capacity note,
+  not a compose setting.)
+- **Cloud retention is plan-driven, not declarative.** The free tier's
+  ~14 d window is sufficient for operational regression-spotting; the only
+  in-repo knobs are the Alloy scrape interval (`30s`) and `remote_write`
+  target in `deploy/alloy/config.alloy`. Longer history is a paid-tier or
+  self-hosted-remote-write decision, out of scope here (§7.2).
+- Consistent with the repo's rollup/retention philosophy: long-horizon and
+  per-entity questions are answered from the rolled-up DB tables, **not**
+  from Prometheus — metrics are bounded-cardinality operational signals
+  with a short-to-medium horizon.
+
+### 11.4 The standing gate
+
+`MetricCardinalityGuardSpec` (`api/test/src/feature/`) makes this review
+permanent. It fails the build if:
+
+- a bare `Metric.*` series in `api/src` is not in `MetricGuard.Allowed`
+  (i.e. a new series bypasses the firewall),
+- an OpenWRT-agent-emitted metric name is not allowlisted,
+- any allowlisted series carries a label key outside
+  `MetricGuard.KnownLabelKeys` — the small, known vocabulary; **adding any
+  new label key forces a deliberate edit there, which is the review
+  checkpoint**,
+- `KnownLabelKeys` ever overlaps `ForbiddenKeys`,
+
+and it proves the firewall actually rejects + counts a deliberately
+forbidden label and an unknown name (`metrics_rejected_total`). New work
+that adds a counter (e.g. #1301/#1302/#1325) must keep this spec green —
+its labels have to pass the gate.


### PR DESCRIPTION
Closes #1210. The cardinality + retention review gate required before pointing prod (Grafana Cloud / Prometheus) at the API `/metrics` — and the green-light for #1208's first live scrape. Audits what the code **emits** (per `feedback_dashboards_match_emitted_metrics`), not the §5 design catalog (they had drifted).

## 1. Cardinality audit

Source of truth: grep of `api/src` for `Metric.*` / `MetricGuard.*` / `AppMetrics.*`, and of the OpenWRT agent (`wifihaven-agent`) for `metrics.inc_counter/set_gauge/observe`. Full table + worst-case bounds in `docs/design/metrics-observability.md` §11.1.

**API self-metrics** (no `router_id`): `http_requests_total{route,method,status}`, `http_request_duration_seconds{route,method}`, `db_query_duration_seconds{op}`, `auth_failures_total{reason}`, `agent_connected_routers`, `traffic_reports_filtered_zero_bytes_total`, `router_metrics_batches_total{status}`, `metrics_rejected_total{reason}`, `wifihaven_rollup_runs_total{rollup_job,status}`, `wifihaven_rollup_duration_seconds{rollup_job}`, `wifihaven_rollup_rows_upserted{rollup_job}`, `wifihaven_db_pool_*` (5 gauges), plus JVM/ZIO collector metrics.

**Router-sourced** (× fleet `router_id`): `dnsmasq_restarts_total{reason}`, `policy_apply_total{result}`, `policy_apply_duration_seconds`, `snapshot_poll_total{result}`, `snapshot_poll_duration_seconds`, `agent_uptime_seconds`, `agent_version{version}`. (`dns_queries_total`/`blocklist_fetch_failures_total` are allowlisted but not yet emitted — #1301/#1302.) `env` (prod/staging) is attached at scrape time by Alloy, not in code.

**Findings:**
1. ✅ **No forbidden label leaked** — no `mac`/`domain`/`device_id`/`ip`/`hostname`/`user_id`/`profile_id` on any series; HTTP `route` is templated (`/api/devices/:mac`), never a concrete id.
2. ⚠️→✅ **Firewall-coverage gap fixed.** `wifihaven_rollup_*` and `wifihaven_db_pool_*` (added in #1243, after the §5 catalog and the #1285 firewall) were emitted via bare `Metric.*` calls that **bypassed** `MetricGuard`. Now routed through the guard and added to `MetricGuard.Allowed` — the firewall covers every application series. (JVM/ZIO collector metrics intentionally not gated: bounded, library-defined.)
3. ✅ `op`/`reason`/`result` confirmed bounded hand-named enums.

## 2. Retention

| Environment | Backend | Retention | Where set |
|---|---|---|---|
| Self-hosted | local Prometheus | **90 d** | `--storage.tsdb.retention.time=90d` in `deploy/docker-compose.metrics.yml` (declarative; already present) |
| Staging / prod cloud | Grafana Cloud free tier | **plan-driven ~14 d** | not code-configurable |

~46 MB/day → ~4–5 GB over 90 d; provision `promdata` ~10 GB headroom (host-capacity note). Cloud retention is plan-driven — only the Alloy scrape interval / `remote_write` target are in-repo. Aligns with the rollup/retention philosophy: long-horizon & per-entity questions come from the DB rollups, not Prometheus.

## 3. The guard (standing gate)

`MetricGuard.KnownLabelKeys` — a small, known label-key vocabulary. `MetricCardinalityGuardSpec` fails the build if:
- a bare `Metric.*` series in `api/src` isn't allowlisted (bypasses the firewall),
- an agent-emitted metric name isn't allowlisted,
- an allowlisted series carries a label key outside `KnownLabelKeys` (**any new label key forces a deliberate edit — the review checkpoint**),
- `KnownLabelKeys` overlaps `ForbiddenKeys`,

and it proves the firewall rejects + counts a deliberately-forbidden label and an unknown name (`metrics_rejected_total`). TDD: the failing spec is its own commit before the implementation. New counters in flight (#1301/#1302/#1325) must keep this green — their labels have to pass the gate.

## 4. Active-series sanity check

Audited set adds ~70 series beyond the §5 catalog — comfortably within an order of magnitude of the §7.2 ~3,500–4,000 estimate. `/metrics` isn't publicly reachable (scraped only internally / by Alloy), so the literal live count is an **operator step** before the first prod scrape (§11.2): `count({__name__=~".+", env="staging"})` in the staging Grafana Cloud stack, recorded on this issue.

## Test plan
- `MetricCardinalityGuardSpec` (6 tests) green.
- Existing `MetricsSelfMetricsSpec` / `MetricsExportSpec` / `RouterMetricsIngestSpec` / `MetricsApiSpec` / `RollupRepoSpec` unaffected by the rewiring.
- `scalafmt --check` + `mill __.compile` + `mill api.test` all pass.
