### PR TITLE
chore(board): reproducible sync for GitHub Project #2 (epics + status)

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -4,17 +4,44 @@ The open issues in `wifihaven/wifihaven` are organized on a **GitHub Projects v2
 board so that "give me an update on the big threads" and "what's in progress" are
 answerable from a board view instead of a manual label sweep.
 
-The board is **managed directly in the GitHub UI**. This doc records its
-conventions — the Epic taxonomy, what each Status means, and the
-umbrella = sub-issue-parent convention — so they stay consistent as issues are
+The board's **Epic** and **Status** fields are reproducible from the repo: the
+issue→epic assignment lives in [`scripts/project-epics.tsv`](../scripts/project-epics.tsv)
+and is applied by [`scripts/project-board-sync.sh`](../scripts/project-board-sync.sh).
+This doc records the conventions — the Epic taxonomy, what each Status means, and
+the umbrella = sub-issue-parent convention — so they stay consistent as issues are
 triaged.
 
 ## The board
 
-- **Title:** `WifiHaven`
+- **Title:** `WifiHaven Roadmap`
 - **Owner:** `wifihaven` (org-level Project v2)
-- **Number:** 1
-- **URL:** https://github.com/orgs/wifihaven/projects/1
+- **Number:** 2
+- **URL:** https://github.com/orgs/wifihaven/projects/2
+- **Project node id:** `PVT_kwDOEQNiBs4BZwFe`
+
+## Reproducing the board
+
+The board is populated from the repo, not by hand:
+
+```bash
+# Re-applies Epic (from the TSV) and Status (from each issue's labels)
+# to every open issue on Project #2. Idempotent — safe to re-run.
+scripts/project-board-sync.sh
+```
+
+`scripts/project-board-sync.sh` is idempotent: it adds any open issue that isn't
+yet an item, reads its Epic from `scripts/project-epics.tsv`, and derives its
+Status from the issue's labels. Re-running it reconciles the board after issues
+are filed, closed, or relabeled. When you (re)categorize an issue, edit the TSV
+and re-run the script rather than only clicking in the UI, so the repo stays the
+source of truth.
+
+The script resolves the Epic/Status field ids and every single-select **option
+id by name** from the live project definition at runtime. This is deliberate:
+Projects v2 regenerates all of a field's option ids whenever the field is edited
+(e.g. to add an option), so hardcoded ids silently rot. Resolving by name means
+adding a new Epic option never breaks the sync — only the taxonomy table below
+and the TSV need updating.
 
 ## Fields
 
@@ -22,36 +49,42 @@ triaged.
 
 | Status | Meaning |
 |--------|---------|
-| `Todo` | Not started. The default for any issue without an `in-progress`/`blocked` signal. |
+| `Todo` | Not started. The default for any issue without an `in-progress` signal. Blocked issues (`blocked` / `blocked-on-#NNN` labels) also rest here until the board grows a dedicated Blocked column. |
 | `In Progress` | Actively being worked. Mirrors the `in-progress` label. |
-| `Blocked` | Waiting on something else. Mirrors the `blocked` label or any `blocked-on-#NNN` label. |
 | `Done` | Closed/shipped. |
 
-Convention: keep `Status` in agreement with the issue labels — when you move an
-issue to `In Progress` or `Blocked` on the board, set the matching
-`in-progress` / `blocked` label (and vice versa) so the two read surfaces don't
-drift.
+`Status` is **derived from labels** by the sync script: an issue carrying the
+`in-progress` label maps to `In Progress`; everything else maps to `Todo`.
+Keep the label and the board column in agreement — set `in-progress` on the
+issue when you start work and the next sync moves it.
 
 ### `Epic` (single-select)
 
 Each open issue is assigned to exactly one epic — the long-running thread it
-belongs to. Set it on the item in the board UI.
+belongs to. The assignment is stored in `scripts/project-epics.tsv` and applied
+by the sync script. There is intentionally **no `Other` bucket**: every issue
+lands in the closest real thread.
 
 | Epic | What it covers |
 |------|----------------|
-| `Observability/Metrics` | `/metrics` endpoint, zio-metrics, Grafana dashboards, agent counters, structured logging. Planning threads #471 / #1240. |
-| `Global Policy & Default-Deny` | Household-wide always-on rules, the global allow/block layer, default-deny, unmanaged-MAC policy, infra-allow. Issues #1315–#1322, #1337, #937, #335, #374, #1047. |
-| `Dashboard & UX` | Web SPA — the /dashboard redesign (umbrella #1148), profile/device UX, logs, autosave, dark mode, LuCI status surfaces. |
-| `Blocklists & Enforcement` | The nftables/dnsmasq enforcement plane, block page, blocklist fetch/refresh, DoH/SNI handling, the OPNsense agent, CNAME/IP-only edges. |
-| `CI/CD & Ops` | CI pipelines, release/rollout (canary, rollback), install scripts, deploy safety, infra/ops, Render. |
-| `Rollups & Data` | Traffic/connection-event data, weekly partitions, retention, EXPLAIN/query-perf, screen-time rollups, data-quality filters, PSL apex grouping. |
+| `Observability & Metrics` | `/metrics` endpoint, zio-metrics, Grafana dashboards, agent counters (dns/blocklist/nftables), cardinality/retention review, structured logging. Planning threads #471 / #1240. |
+| `Global Policy & Default-Deny` | Household-wide always-on rules, the global allow/block layer, default-deny, infra-allow, the global-profile thread. Issues #1315–#1322, #937. |
+| `Dashboard & UX` | Web SPA — the `/dashboard` redesign (umbrella #1148), profile/device UX, logs, autosave, dark mode, the per-section freshness/collapse work. |
+| `Blocklists & Enforcement` | Blocklist sourcing/fetch/refresh, category enforcement, schedule-driven blocklist activation, unmanaged-MAC enforcement, render_spec fixtures. |
+| `DNS-Bypass & Attribution` | DoH/DoT egress blocking, SNI-based attribution, `blockIpOnly` carve-outs, port-aware traffic, flow-offload compatibility. |
+| `CI/CD & Ops` | CI pipelines, caching, release/deploy safety + auto-rollback, install scripts, Render/infra cost, smoke tests, build matrices. |
+| `E2E Test Coverage` | VM/e2e gate coverage, fake-router/fake-API scenarios, resilience suites, install-script tests, test backfill. |
+| `Router Agent & Release` | OpenWRT/OPNsense agent behavior, LuCI, staged rollout/canary/rollback, agent health/retry-queue, websocket transport, agent-side renames. |
+| `Block Page` | Block-page architecture — captive-portal approach, HTTPS variant, scheduled-downtime reachability, extension-request flow. |
+| `Usage & Screen-Time` | Traffic stats, per-site/FQDN breakdowns, screen-time rollups, heartbeat-filter replay, foreground-host heuristics, dest_ip enrichment. |
+| `Database & Data Lifecycle` | Schema, weekly partitions, partition-drop retention, future-partition jobs, EXPLAIN/query-perf audits, index cleanup. |
+| `API Contract & Type Safety` | Wire-schema versioning, PATCH/symmetric shapes, typed dates/MAC/Hostname/BlockReason, OpenAPI, code structure refactors. |
+| `Notifications & Alerting` | New-device alerts (web push / webhook / email), unmanaged-MAC alerting, the alerting strategy/rules/routing design. |
+| `Security & Access Control` | Pre-launch security audit, multi-tenant, non-admin/role-scoped views. |
+| `Schedules` | Named/reusable household schedules, per-app schedules (models/repo/eval/UI/migration). |
 | `Mobile App` | The mobile app thread — architecture, auth/pairing, push, distribution, beta. Issues #981–#987. |
-| `Launch & Marketing` | Marketing site, branding/logo system, public-launch readiness. |
-| `E2E Test Coverage` | VM/e2e gate coverage, fake-router/fake-API scenarios, test backfill, install-script tests. |
-| `Schedules` | Named/reusable schedules, schedule-driven blocklists, schedule enforcement verification. |
-| `Alerting & Paging` | Alert rules, contact points / notification policy, on-call routing, paging strategy, and the declarative alerting Terraform. Turning failure-mode metrics into pages, not just graphable series. Design thread #1381 (split out of #1368 / #1373). |
-| `Cost & Infra Spend` | Cutting recurring infra cost — Render plan sizing (API + Postgres), retention/footprint work that unlocks a downsize, vendor sanity checks. Orchestrator #1386. |
-| `Other` | Cross-cutting refactors, docs, type-safety, wire-versioning, notifications, and anything that doesn't fit a thread above. |
+| `Launch Branding & Naming` | Marketing site, branding/naming, leftover familydns→wifihaven rename sweeps. |
+| `Cost Reduction` | Cutting recurring infra spend — Render plan sizing (API + Postgres), retention/footprint work that unlocks a downsize, vendor/region sanity checks. Orchestrator #1386, children #1388–#1392, #1258. |
 
 ## Umbrellas are native sub-issue parents
 
@@ -60,17 +93,17 @@ just prose lists in the body), so the child issues nest under them in the board
 and on the issue page. Current parents:
 
 - **#1240** — Observability planning thread. Parent of the metrics/Grafana/agent-
-  counter children (#471 #962 #1208 #1210 #1279 #1280 #1281 #1301 #1302 #1304
-  #1305 #1325).
+  counter children.
+- **#471** — Metrics & observability architecture plan. Sibling planning thread
+  under the same epic.
 - **#1148** — `/dashboard` holistic redesign. Parent of the dashboard-piece
-  issues it supersedes (#849 #856 #859 #860 #862 #892 #951 #995 #1062 #1064
-  #1065 #1066 #1078 #1080 #1098).
-- **#844** — Connection Events + Traffic Usage w/ rollups. No open issue
-  currently references it; add children as they're filed.
+  issues it supersedes.
+- **#1069** — Reusable named schedules. Parent of the per-app-schedule
+  implementation issues (#1378 #1379 #1380).
 
-The **global-policy** set (#1316–#1322, #1315, #1337) has **no open parent** — its
-design issue #1308 is closed. Those issues are grouped via the
-`Global Policy & Default-Deny` epic field only, until an open parent exists.
+The **global-policy** set (#1315–#1322, #937) is grouped via the
+`Global Policy & Default-Deny` epic field only; its design issue #1308 is closed,
+so there is no open parent to nest them under.
 
 To add a child to an umbrella, use the sub-issue control on the issue page (or the
 GraphQL `addSubIssue` mutation).
@@ -79,11 +112,12 @@ GraphQL `addSubIssue` mutation).
 
 - **New issues:** every new repo issue is **auto-added** to the board by the
   built-in *Auto-add to project* workflow (Status defaults to `Todo`). The `Epic`
-  is not set automatically — pick it on triage.
-- **Recategorize:** change the item's `Epic` field.
-- **Status:** keep it aligned with the `in-progress` / `blocked` labels.
+  is not set automatically — add a row to `scripts/project-epics.tsv` and re-run
+  the sync script on triage.
+- **Recategorize:** edit the issue's row in `scripts/project-epics.tsv`, then
+  re-run `scripts/project-board-sync.sh`.
+- **Status:** keep the `in-progress` label aligned; the sync script reads it.
 - **New epic:** when a genuinely large new thread starts that no existing epic
-  covers, add a new option to the `Epic` field (Epic field → add option) rather
-  than overloading `Other` — then add a row to the taxonomy table above. Reserve
-  this for threads worth their own swimlane (an umbrella / multi-issue body of
-  work); one-offs stay in `Other`.
+  covers, add an option to the `Epic` field (Epic field → add option) and add a
+  row to the taxonomy table above. The sync script resolves options by name, so
+  it needs no change. Reserve new epics for threads worth their own swimlane.

--- a/scripts/project-board-sync.sh
+++ b/scripts/project-board-sync.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# project-board-sync.sh — idempotently sync open issues onto WifiHaven Project #2.
+#
+# For every open issue in wifihaven/wifihaven this script:
+#   1. ensures the issue is an item on org Project #2,
+#   2. sets its Epic from scripts/project-epics.tsv (issue -> epic name),
+#   3. sets its Status from the issue's labels (in-progress -> In Progress, else Todo).
+#
+# It is safe to re-run: items already on the board are reused, and field writes
+# are no-ops when the value already matches.
+#
+# Requires: gh (authenticated, with the `project` + `read:project` scopes), jq.
+#
+set -euo pipefail
+
+OWNER="wifihaven"
+REPO="wifihaven/wifihaven"
+PROJECT_NUMBER=2
+PROJECT_ID="PVT_kwDOEQNiBs4BZwFe"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TSV="${SCRIPT_DIR}/project-epics.tsv"
+
+# Single-select option ids are NOT stable across field edits: recreating a field
+# (e.g. to add an option) regenerates every option id. So we resolve them by NAME
+# at runtime from the live field definition instead of hardcoding them.
+echo "==> Resolving field + option ids from Project #${PROJECT_NUMBER}"
+FIELDS_JSON="$(gh project field-list "${PROJECT_NUMBER}" --owner "${OWNER}" --format json --limit 100)"
+
+field_id() { echo "${FIELDS_JSON}" | jq -r --arg n "$1" '.fields[]|select(.name==$n)|.id'; }
+option_id() { echo "${FIELDS_JSON}" | jq -r --arg f "$1" --arg o "$2" '.fields[]|select(.name==$f)|.options[]|select(.name==$o)|.id'; }
+
+EPIC_FIELD_ID="$(field_id Epic)"
+STATUS_FIELD_ID="$(field_id Status)"
+STATUS_TODO="$(option_id Status Todo)"
+STATUS_IN_PROGRESS="$(option_id Status 'In Progress')"
+
+[[ -n "${EPIC_FIELD_ID}" && -n "${STATUS_FIELD_ID}" && -n "${STATUS_TODO}" && -n "${STATUS_IN_PROGRESS}" ]] \
+  || { echo "FATAL: could not resolve Epic/Status field or Status options" >&2; exit 1; }
+
+echo "==> Loading epic assignments from ${TSV}"
+declare -A EPIC_OF
+while IFS=$'\t' read -r num epic; do
+  [[ -z "${num}" || "${num}" == \#* ]] && continue
+  EPIC_OF["${num}"]="${epic}"
+done < "${TSV}"
+
+echo "==> Fetching open issues (number + labels) from ${REPO}"
+ISSUES_JSON="$(gh issue list -R "${REPO}" --state open --limit 300 --json number,url,labels)"
+
+echo "==> Fetching existing project items"
+ITEMS_JSON="$(gh project item-list "${PROJECT_NUMBER}" --owner "${OWNER}" --format json --limit 1000)"
+declare -A ITEM_OF
+while IFS=$'\t' read -r num itemid; do
+  [[ -z "${num}" || "${num}" == "null" ]] && continue
+  ITEM_OF["${num}"]="${itemid}"
+done < <(echo "${ITEMS_JSON}" | jq -r '.items[] | select(.content.number != null) | "\(.content.number)\t\(.id)"')
+
+added=0; skipped=0
+declare -A IN_PROGRESS
+
+while IFS=$'\t' read -r num url labels; do
+  [[ -z "${num}" ]] && continue
+
+  # Derive status from labels.
+  status_opt="${STATUS_TODO}"
+  if echo "${labels}" | tr ',' '\n' | grep -qx "in-progress"; then
+    status_opt="${STATUS_IN_PROGRESS}"
+    IN_PROGRESS["${num}"]=1
+  fi
+
+  # Ensure the issue is on the board.
+  item_id="${ITEM_OF[${num}]:-}"
+  if [[ -z "${item_id}" ]]; then
+    item_id="$(gh project item-add "${PROJECT_NUMBER}" --owner "${OWNER}" --url "${url}" --format json | jq -r '.id')"
+    ITEM_OF["${num}"]="${item_id}"
+    added=$((added+1))
+    echo "  + added #${num} -> ${item_id}"
+  else
+    skipped=$((skipped+1))
+  fi
+
+  # Set Epic (option id resolved by name from the live field).
+  epic="${EPIC_OF[${num}]:-}"
+  if [[ -n "${epic}" ]]; then
+    epic_opt="$(option_id Epic "${epic}")"
+    if [[ -z "${epic_opt}" ]]; then
+      echo "  ! #${num}: unknown epic '${epic}' — skipping epic set" >&2
+    else
+      gh project item-edit --id "${item_id}" --project-id "${PROJECT_ID}" \
+        --field-id "${EPIC_FIELD_ID}" --single-select-option-id "${epic_opt}" >/dev/null
+    fi
+  else
+    echo "  ! #${num}: no epic in TSV" >&2
+  fi
+
+  # Set Status.
+  gh project item-edit --id "${item_id}" --project-id "${PROJECT_ID}" \
+    --field-id "${STATUS_FIELD_ID}" --single-select-option-id "${status_opt}" >/dev/null
+
+done < <(echo "${ISSUES_JSON}" | jq -r '.[] | "\(.number)\t\(.url)\t\([.labels[].name] | join(","))"')
+
+echo "==> Done. added=${added} reused=${skipped} in-progress=${#IN_PROGRESS[@]}"

--- a/scripts/project-epics.tsv
+++ b/scripts/project-epics.tsv
@@ -1,0 +1,220 @@
+# issue	epic
+# Epic must match a Project #2 "Epic" single-select option name exactly.
+# Status is derived live from the issue's labels (in-progress -> In Progress, else Todo);
+# it is intentionally NOT stored here so the board re-syncs correctly as labels change.
+1386	Cost Reduction
+1382	Observability & Metrics
+1381	Observability & Metrics
+1380	Schedules
+1379	Schedules
+1378	Schedules
+1368	Observability & Metrics
+1362	E2E Test Coverage
+1341	Dashboard & UX
+1336	Blocklists & Enforcement
+1330	CI/CD & Ops
+1325	Observability & Metrics
+1323	Dashboard & UX
+1322	Global Policy & Default-Deny
+1321	Global Policy & Default-Deny
+1320	Global Policy & Default-Deny
+1319	Global Policy & Default-Deny
+1318	Global Policy & Default-Deny
+1317	Global Policy & Default-Deny
+1316	Global Policy & Default-Deny
+1315	Global Policy & Default-Deny
+1305	E2E Test Coverage
+1304	E2E Test Coverage
+1302	Observability & Metrics
+1301	Observability & Metrics
+1281	Observability & Metrics
+1280	Observability & Metrics
+1258	Cost Reduction
+1240	Observability & Metrics
+1217	Router Agent & Release
+1216	Router Agent & Release
+1210	Observability & Metrics
+1208	Observability & Metrics
+1200	CI/CD & Ops
+1194	CI/CD & Ops
+1187	Database & Data Lifecycle
+1180	Router Agent & Release
+1174	Block Page
+1171	Launch Branding & Naming
+1148	Dashboard & UX
+1126	E2E Test Coverage
+1117	E2E Test Coverage
+1116	E2E Test Coverage
+1110	E2E Test Coverage
+1098	Dashboard & UX
+1089	Usage & Screen-Time
+1084	Usage & Screen-Time
+1080	Usage & Screen-Time
+1078	Usage & Screen-Time
+1069	Schedules
+1067	Blocklists & Enforcement
+1066	Dashboard & UX
+1065	Dashboard & UX
+1064	Dashboard & UX
+1062	Dashboard & UX
+1047	Blocklists & Enforcement
+1033	Router Agent & Release
+1029	CI/CD & Ops
+1023	Router Agent & Release
+1013	Database & Data Lifecycle
+1012	CI/CD & Ops
+1011	CI/CD & Ops
+995	Dashboard & UX
+987	Mobile App
+986	Mobile App
+985	Mobile App
+984	Mobile App
+983	Mobile App
+982	Mobile App
+981	Mobile App
+971	Blocklists & Enforcement
+958	Blocklists & Enforcement
+951	Dashboard & UX
+937	Global Policy & Default-Deny
+930	E2E Test Coverage
+923	E2E Test Coverage
+921	E2E Test Coverage
+915	CI/CD & Ops
+906	CI/CD & Ops
+892	Dashboard & UX
+889	CI/CD & Ops
+888	API Contract & Type Safety
+884	Notifications & Alerting
+877	CI/CD & Ops
+874	Notifications & Alerting
+862	Dashboard & UX
+860	Dashboard & UX
+859	Dashboard & UX
+856	Dashboard & UX
+849	Dashboard & UX
+844	Dashboard & UX
+842	Usage & Screen-Time
+834	CI/CD & Ops
+830	Dashboard & UX
+829	Dashboard & UX
+827	Dashboard & UX
+825	Dashboard & UX
+823	Dashboard & UX
+822	Dashboard & UX
+821	Dashboard & UX
+820	Dashboard & UX
+819	Dashboard & UX
+812	Database & Data Lifecycle
+810	Database & Data Lifecycle
+808	Database & Data Lifecycle
+798	Database & Data Lifecycle
+790	Usage & Screen-Time
+774	Router Agent & Release
+773	Router Agent & Release
+772	Router Agent & Release
+759	E2E Test Coverage
+753	Router Agent & Release
+747	Dashboard & UX
+730	Usage & Screen-Time
+726	Usage & Screen-Time
+709	Blocklists & Enforcement
+705	Blocklists & Enforcement
+703	DNS-Bypass & Attribution
+701	Block Page
+699	Router Agent & Release
+696	CI/CD & Ops
+695	CI/CD & Ops
+693	E2E Test Coverage
+679	Block Page
+675	CI/CD & Ops
+670	CI/CD & Ops
+657	CI/CD & Ops
+652	CI/CD & Ops
+645	Dashboard & UX
+638	API Contract & Type Safety
+637	CI/CD & Ops
+633	CI/CD & Ops
+625	CI/CD & Ops
+623	API Contract & Type Safety
+622	Security & Access Control
+604	CI/CD & Ops
+602	API Contract & Type Safety
+601	API Contract & Type Safety
+597	API Contract & Type Safety
+581	API Contract & Type Safety
+578	Block Page
+574	DNS-Bypass & Attribution
+573	DNS-Bypass & Attribution
+572	DNS-Bypass & Attribution
+561	Router Agent & Release
+560	Launch Branding & Naming
+532	E2E Test Coverage
+471	Observability & Metrics
+459	Dashboard & UX
+425	Dashboard & UX
+423	API Contract & Type Safety
+399	API Contract & Type Safety
+398	API Contract & Type Safety
+396	API Contract & Type Safety
+390	Router Agent & Release
+389	API Contract & Type Safety
+388	API Contract & Type Safety
+387	Router Agent & Release
+384	DNS-Bypass & Attribution
+383	Block Page
+379	API Contract & Type Safety
+376	API Contract & Type Safety
+374	Notifications & Alerting
+369	Security & Access Control
+363	Router Agent & Release
+348	Router Agent & Release
+345	E2E Test Coverage
+344	Dashboard & UX
+337	E2E Test Coverage
+335	Block Page
+332	Dashboard & UX
+317	Router Agent & Release
+304	Blocklists & Enforcement
+300	Usage & Screen-Time
+299	Dashboard & UX
+296	DNS-Bypass & Attribution
+274	Security & Access Control
+273	Dashboard & UX
+270	Router Agent & Release
+267	Dashboard & UX
+257	CI/CD & Ops
+251	CI/CD & Ops
+241	E2E Test Coverage
+240	E2E Test Coverage
+238	E2E Test Coverage
+198	Router Agent & Release
+172	CI/CD & Ops
+158	CI/CD & Ops
+154	E2E Test Coverage
+151	E2E Test Coverage
+140	E2E Test Coverage
+138	CI/CD & Ops
+137	API Contract & Type Safety
+136	Database & Data Lifecycle
+129	CI/CD & Ops
+124	Router Agent & Release
+122	API Contract & Type Safety
+121	API Contract & Type Safety
+113	Router Agent & Release
+112	Router Agent & Release
+111	Router Agent & Release
+89	Router Agent & Release
+81	CI/CD & Ops
+57	E2E Test Coverage
+37	Dashboard & UX
+33	CI/CD & Ops
+22	CI/CD & Ops
+19	Usage & Screen-Time
+18	Dashboard & UX
+17	Dashboard & UX
+16	Usage & Screen-Time
+1392	Cost Reduction
+1391	Cost Reduction
+1390	Cost Reduction
+1389	Cost Reduction
+1388	Cost Reduction


### PR DESCRIPTION
## What

Populates the org-level **WifiHaven Roadmap** Projects v2 board (project
[#2](https://github.com/orgs/wifihaven/projects/2)) with every open issue, and
checks in a reproducible artifact so the board's **Epic** and **Status** fields
can be re-derived from the repo instead of hand-maintained in the UI.

## Added

- **`scripts/project-epics.tsv`** — the issue → Epic assignment. One row per
  open issue; the source of truth for categorization.
- **`scripts/project-board-sync.sh`** — idempotent sync. For every open issue
  it ensures a board item exists, sets **Epic** from the TSV, and derives
  **Status** from labels (`in-progress` → In Progress, else Todo). Field and
  single-select **option ids are resolved by name at runtime** — Projects v2
  regenerates option ids whenever a field is edited (e.g. adding an option), so
  hardcoded ids silently rot; resolving by name makes the script durable and
  re-runnable.
- **`docs/project-board.md`** — rewritten to document board #2: the Epic
  taxonomy, the Status convention, the reproduce-from-repo workflow, and the
  umbrella = native sub-issue-parent convention.

## Board result

- **211 open issues** on the board, each with an Epic and a Status.
- Status: `In Progress` mirrors the `in-progress` label; everything else (incl.
  `blocked` / `blocked-on-#NNN`) rests in `Todo`.
- Umbrellas are wired as native GitHub sub-issue parents (#1148, #1240→incl.
  #471, and the per-app-schedule set under #1376); no body edits.

## Re-running

```bash
scripts/project-board-sync.sh   # idempotent; reconciles the board to the TSV + current labels
```

To recategorize an issue, edit its row in `scripts/project-epics.tsv` and
re-run. To add an Epic, add the option in the project UI and a row to the
taxonomy table in `docs/project-board.md` — the script needs no change.