### PR TITLE
feat(openwrt): three agent metric counters — dns_queries, blocklist_fetch_failures, enforcement_drops (#1301, #1302, #1325)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -61,6 +61,7 @@ object MetricGuard {
     "agent_version"                             -> Set("version", "router_id", "installation_id"),
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
+    "enforcement_drops_total"                   -> Set("reason", "router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
   )

--- a/api/test/src/feature/RouterMetricsIngestSpec.scala
+++ b/api/test/src/feature/RouterMetricsIngestSpec.scala
@@ -191,6 +191,57 @@ object RouterMetricsIngestSpec
         ) &&
         assertTrue(scraped.contains("policy_apply_duration_seconds"))
     },
+    test("agent counter series (#1301/#1302/#1325) re-expose under router_id") {
+      // The agent-sourced counters added after #1206: dns_queries_total{result},
+      // blocklist_fetch_failures_total{status}, enforcement_drops_total{reason}.
+      // All three are on the MetricGuard allowlist with their bounded enum
+      // label, so the generic fold must re-expose them under router_id (the
+      // #1365 re-export path) rather than rejecting them.
+      for {
+        _          <- cleanDb
+        routerRepo <- ZIO.service[RouterRepo]
+        svc        <- RouterMetricsService.make
+        (rid, tok) <- newRouter("r-agent-counters")
+        routes = RouterMetricsRoutes.routes(new RouterAuthLive(routerRepo), svc)
+        body   = batchJson(
+          rid,
+          "2026-05-30T09:00:00Z",
+          counters = List(
+            MetricCounter("dns_queries_total", Map("result" -> "resolved"), 41200),
+            MetricCounter("dns_queries_total", Map("result" -> "nxdomain"), 318),
+            MetricCounter("blocklist_fetch_failures_total", Map("status" -> "5xx"), 4),
+            MetricCounter("enforcement_drops_total", Map("reason" -> "whole_mac"), 1820),
+            MetricCounter("enforcement_drops_total", Map("reason" -> "category_block"), 12990),
+          ),
+        )
+        resp <- post(routes, tok, body)
+        _       <- ZIO.sleep(700.millis)
+        scraped <- scrape.catchAll(r => r.body.asString.orDie)
+      } yield {
+        val ridStr = rid.value.toString
+        assertTrue(resp.status == Status.Ok) &&
+        assertTrue(
+          seriesValue(scraped, "dns_queries_total", s"""router_id="$ridStr"""", "resolved")
+            .contains(41200.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "blocklist_fetch_failures_total", s"""router_id="$ridStr"""", "5xx")
+            .contains(4.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "enforcement_drops_total", s"""router_id="$ridStr"""", "whole_mac")
+            .contains(1820.0),
+        ) &&
+        assertTrue(
+          seriesValue(
+            scraped,
+            "enforcement_drops_total",
+            s"""router_id="$ridStr"""",
+            "category_block",
+          ).contains(12990.0),
+        )
+      }
+    },
     test("missing token → 401; routerId mismatch → 403") {
       for {
         _          <- cleanDb

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven router-fleet agent metrics (#1206): the cumulative counters/gauges/histograms each OpenWRT agent pushes to POST /api/router/metrics every 60s and the API folds into its exposition (RouterMetricsService, #1205). Panels target series actually emitted via that path — dnsmasq_restarts_total, policy_apply_total/_duration_seconds, snapshot_poll_total/_duration_seconds, agent_uptime_seconds, agent_version. The server attaches router_id; panels slice only by the bounded enum labels (reason/result/version) per the §4 cardinality firewall. See docs/design/metrics-observability.md §5.1.",
+  "description": "WifiHaven router-fleet agent metrics (#1206): the cumulative counters/gauges/histograms each OpenWRT agent pushes to POST /api/router/metrics every 60s and the API folds into its exposition (RouterMetricsService, #1205). Panels target series actually emitted via that path — dnsmasq_restarts_total, policy_apply_total/_duration_seconds, snapshot_poll_total/_duration_seconds, agent_uptime_seconds, agent_version, dns_queries_total (#1302), blocklist_fetch_failures_total (#1301), enforcement_drops_total (#1325). The server attaches router_id; panels slice only by the bounded enum labels (reason/result/status/version) per the §4 cardinality firewall. See docs/design/metrics-observability.md §5.1.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -242,6 +242,93 @@
           "expr": "min(agent_uptime_seconds{env=\"$env\"})",
           "legendFormat": "min uptime",
           "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "DNS query rate by result",
+      "description": "sum by (result) (rate(dns_queries_total[5m])) — result ∈ {resolved, nxdomain, servfail, refused, nodata}. Classified by the dns-tail sidecar from dnsmasq's query log and folded into the agent's metrics push (#1302). DNS is never the enforcement plane — this is volume + the resolved:failure ratio, not a block signal. A spike in servfail/refused means upstream resolution trouble.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(dns_queries_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Blocklist fetch failures by status",
+      "description": "sum by (status) (rate(blocklist_fetch_failures_total[5m])) — status ∈ {2xx..5xx, error, mkdir_failed, write_failed}. The agent fetches each category blocklist by URL from the API on every 200 policy poll; a rising rate (especially 4xx/5xx) means category enforcement is degrading because the bl_ ipsets can't be refreshed (#1301).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (status) (rate(blocklist_fetch_failures_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Enforcement forward-drops by reason",
+      "description": "sum by (reason) (rate(enforcement_drops_total[5m])) — packets dropped at the nftables forward chain (the actual enforcement plane), reason ∈ {whole_mac, host_block, category_block, ip_only}. Sourced from the per-rule nft counters the agent folds on each tick (#1325). This is how much traffic is really being blocked and why — the prerequisite signal for the enforcement dashboard (#1280).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 32 },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "pps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(enforcement_drops_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
         }
       ]
     }

--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -16,6 +16,26 @@ local M = {}
 
 local DEFAULT_CACHE_DIR = "/etc/wifihaven/blocklists"
 
+-- classify_fetch_status(status) → bounded status enum (#1301).
+--
+-- The blocklist fetch surfaces as the `status` label of
+-- blocklist_fetch_failures_total. It MUST stay a small bounded enum (§4
+-- cardinality firewall), so a numeric HTTP status collapses to its class
+-- (`4xx` / `5xx` / …) rather than the exact code, and a non-HTTP outcome maps
+-- to a fixed token. #705: the old failure path logged `status=nil` for a
+-- transport failure (curl returned no numeric status); that empty status is now
+-- captured explicitly as "error" so the metric has a real label instead of a
+-- missing one.
+local function classify_fetch_status(status)
+  if type(status) == "number" then
+    local class = math.floor(status / 100)
+    if class >= 1 and class <= 5 then return tostring(class) .. "xx" end
+    return "error"
+  end
+  return "error"
+end
+M.classify_fetch_status = classify_fetch_status
+
 -- Parse a blocklist body: strip comment lines (^#) and blank lines.
 -- Returns a list of hostnames.
 local function parse_body(body)
@@ -56,13 +76,24 @@ end
 --   same failure class as the #1334 arg-order bug, distinct cause). When nil
 --   (e.g. legacy callers / unit tests against an unauthenticated stub) no
 --   Authorization header is sent.
--- Returns: { hosts_by_id = {[id]={hosts}}, errors = {...} }
+-- Returns: { hosts_by_id = {[id]={hosts}}, errors = {...}, failures = {...} }
+--   errors:   human-readable strings for logread.
+--   failures: structured { id?, status } records the agent folds into
+--             blocklist_fetch_failures_total{status} (#1301). `status` is the
+--             bounded enum from classify_fetch_status / a fixed local-IO token.
 function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
   cache_dir = cache_dir or DEFAULT_CACHE_DIR
-  local result = { hosts_by_id = {}, errors = {} }
+  local result = { hosts_by_id = {}, errors = {}, failures = {} }
+
+  -- Record both a human string and a structured {id, status} failure so the
+  -- agent can emit the bounded-cardinality metric without re-parsing strings.
+  local function fail(id, status, msg)
+    result.errors[#result.errors + 1] = msg
+    result.failures[#result.failures + 1] = { id = id, status = status }
+  end
 
   if type(http_get_fn) ~= "function" then
-    result.errors[#result.errors + 1] = "http_get_fn is nil or not a function"
+    fail(nil, "error", "http_get_fn is nil or not a function")
     return result
   end
 
@@ -114,8 +145,8 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_
   if mkdir_fn then
     local mok, merr = mkdir_fn(cache_dir)
     if not mok then
-      result.errors[#result.errors + 1] =
-        string.format("blocklists: mkdir failed for %s: %s", tostring(cache_dir), tostring(merr))
+      fail(nil, "mkdir_failed",
+        string.format("blocklists: mkdir failed for %s: %s", tostring(cache_dir), tostring(merr)))
     end
   end
 
@@ -140,20 +171,20 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_
       -- Send the router bearer token — the route is router-authenticated (#1360).
       local status, body = http_get_fn(url, auth_headers)
       if type(status) ~= "number" or status ~= 200 then
-        result.errors[#result.errors + 1] =
-          string.format("blocklists: fetch failed for %s (status=%s)", tostring(id), tostring(status))
+        fail(id, classify_fetch_status(status),
+          string.format("blocklists: fetch failed for %s (status=%s)", tostring(id), tostring(status)))
       else
         -- Atomic write: tmp → final.
         local tmp_path = path .. ".tmp"
         local ok, err  = write_fn(tmp_path, body or "")
         if not ok then
-          result.errors[#result.errors + 1] =
-            string.format("blocklists: write failed for %s: %s", tostring(id), tostring(err))
+          fail(id, "write_failed",
+            string.format("blocklists: write failed for %s: %s", tostring(id), tostring(err)))
         else
           local rok, rerr = rename_fn(tmp_path, path)
           if not rok then
-            result.errors[#result.errors + 1] =
-              string.format("blocklists: rename failed for %s: %s", tostring(id), tostring(rerr))
+            fail(id, "write_failed",
+              string.format("blocklists: rename failed for %s: %s", tostring(id), tostring(rerr)))
           else
             result.hosts_by_id[id] = parse_body(body or "")
           end

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -19,11 +19,14 @@
 --   instance.tick(now)             -- evict expired entries (cheap; safe to call often)
 --   instance.size() → integer       -- testable
 --
--- TODO(#1302): classify and count DNS query outcomes here
--- (dns_queries_total{result} — resolved / nxdomain / servfail) and feed them
--- into the agent's in-process metrics registry so they ship in the 60 s
--- RouterMetricsBatch push (#1206). Deferred from #1206 to keep that PR focused
--- on the apply/poll/restart telemetry.
+-- #1302: classify DNS query outcomes for the dns_queries_total{result} counter.
+-- classify_query_result(line) below maps a dnsmasq reply/cached line to a
+-- bounded result enum. The dns-tail sidecar tallies these cumulatively and
+-- writes them to paths.dns_metrics; the main agent samples that file on its
+-- metrics tick and folds the deltas into the in-process registry
+-- (metrics.fold_external) so they ship in the 60 s RouterMetricsBatch push
+-- (#1206) — the sidecar runs as a separate procd instance and has no registry
+-- of its own, so the tmpfs file is the IPC, mirroring the ip→host cache (#259).
 
 local M = {}
 
@@ -94,6 +97,39 @@ end
 M._is_ipv6 = is_ipv6
 M._is_ipv4 = is_ipv4
 
+-- classify_query_result(line) → bounded result enum string | nil   (#1302)
+--
+-- Maps a dnsmasq `reply <name> is <value>` / `cached <name> is <value>` line to
+-- the bounded `dns_queries_total{result}` enum. Both `reply` (upstream answer)
+-- and `cached` (answered from dnsmasq's own cache) lines are terminal outcomes
+-- worth counting. The result enum is intentionally small and bounded:
+--
+--   resolved  — an A/AAAA answer (`is <ipv4>` / `is <ipv6>`)
+--   nxdomain  — `is NXDOMAIN`
+--   servfail  — `is SERVFAIL`
+--   refused   — `is REFUSED`
+--   nodata    — `is NODATA` / `is NODATA-IPv4` / `is NODATA-IPv6`
+--
+-- Non-terminal CNAME hops (`is <CNAME>`) return nil so a single resolution
+-- isn't counted once per chain link. This is a per-answer-record tally, not a
+-- per-query one: a multi-record answer emits one `reply` line per record, so
+-- `resolved` slightly over-counts vs. distinct queries. That's acceptable — the
+-- metric exists for query *volume* and the resolved:failure *ratio* an operator
+-- alerts on (#1302), not exact per-query accounting. Query (not reply) lines,
+-- and any line we don't recognise, return nil.
+function M.classify_query_result(line)
+  if type(line) ~= "string" or line == "" then return nil end
+  local verb, value = line:match("%d+%s+%S+/%d+%s+(%a+)%s+%S+%s+is%s+(%S+)")
+  if not verb or (verb ~= "reply" and verb ~= "cached") then return nil end
+  if value == "<CNAME>" then return nil end -- non-terminal hop
+  if is_ipv4(value) or is_ipv6(value) then return "resolved" end
+  if value == "NXDOMAIN" then return "nxdomain" end
+  if value == "SERVFAIL" then return "servfail" end
+  if value == "REFUSED" then return "refused" end
+  if value == "NODATA" or value:match("^NODATA%-") then return "nodata" end
+  return nil
+end
+
 -- parse_resolved_reply(line) → { client_ip, name, ip, family } | nil
 --
 -- Extracts the dnsmasq client IP (the device that issued the query — the
@@ -130,6 +166,35 @@ function M.parse_resolved_reply(line)
   end
   -- <CNAME>, NXDOMAIN, NODATA-IPvX → not a usable answer.
   return nil
+end
+
+-- format_query_results(tbl) → string   (#1302)
+-- Serialise a { [result] = count } tally to newline-delimited "<result>\t<n>"
+-- rows in a stable (sorted) order so the file is byte-stable across flushes.
+-- This is the wire between the dns-tail sidecar (writer) and the agent (reader).
+function M.format_query_results(tbl)
+  local keys = {}
+  for k in pairs(tbl or {}) do keys[#keys + 1] = k end
+  table.sort(keys)
+  local lines = {}
+  for _, k in ipairs(keys) do
+    lines[#lines + 1] = string.format("%s\t%d", k, tbl[k])
+  end
+  return table.concat(lines, "\n") .. (#lines > 0 and "\n" or "")
+end
+
+-- parse_query_results(text) → { [result] = count }   (#1302)
+-- Inverse of format_query_results. Tolerant of an absent/empty file (→ {}).
+function M.parse_query_results(text)
+  local out = {}
+  if type(text) ~= "string" or text == "" then return out end
+  for line in text:gmatch("[^\n]+") do
+    local result, count = line:match("^(%S+)\t(%d+)$")
+    if result and count then
+      out[result] = tonumber(count)
+    end
+  end
+  return out
 end
 
 -- ---------------------------------------------------------------------------

--- a/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/metrics.lua
@@ -20,6 +20,8 @@
 -- Public API:
 --   metrics.new({ router_id, agent_version, started_at, buckets? }) → reg
 --   metrics.inc_counter(reg, name, labels, by?)         -- by defaults to 1
+--   metrics.fold_external(reg, name, label_key, current_by_label, baseline)
+--                                                        -- delta-fold an external cumulative source
 --   metrics.set_gauge(reg, name, labels, value)
 --   metrics.observe(reg, name, labels, value)           -- histogram observation
 --   metrics.build_batch(reg, sampled_at) → batch table  -- §3.2 shape
@@ -98,6 +100,44 @@ function M.inc_counter(reg, name, labels, by)
     reg.counters[key] = c
   end
   c.value = c.value + by
+end
+
+-- Fold an EXTERNAL cumulative counter source into the registry (#1302, #1325).
+--
+-- Some counters are not incremented at a call site inside this process: they
+-- live in the kernel (nftables drop-rule counters, #1325) or in a sibling
+-- process (the dns-tail sidecar's per-result query tally, #1302). On the
+-- metrics tick the agent SAMPLES the external source and folds the growth
+-- since the previous sample into the in-process registry, so the pushed batch
+-- still carries one cumulative `name{label_key=value}` series per value.
+--
+--   current_by_label : { [label_value] = current_cumulative }  (this sample)
+--   baseline         : { [label_value] = last_sampled_value }  (mutated in place)
+--
+-- For each value we inc the registry by the POSITIVE delta since the last
+-- sample. A `current < baseline` means the external source reset (the kernel
+-- ruleset was re-rendered and its anonymous counters restarted at 0, or the
+-- sidecar restarted) — we fold the full current value rather than a negative
+-- delta, mirroring the API server's own re-base-on-reset rule
+-- (RouterMetricsService). The agent's own registry counter is itself never
+-- reset, so the pushed total keeps climbing monotonically.
+--
+-- Caller keeps one `baseline` table per external series and reuses it across
+-- ticks. To avoid losing growth across a KNOWN reset (e.g. an nft re-render),
+-- the caller should fold once more right BEFORE triggering the reset so the
+-- about-to-be-discarded counts are captured first.
+function M.fold_external(reg, name, label_key, current_by_label, baseline)
+  baseline = baseline or {}
+  for value, cur in pairs(current_by_label or {}) do
+    local prev  = baseline[value] or 0
+    local delta = cur - prev
+    if delta < 0 then delta = cur end -- external source reset → re-base from 0
+    if delta > 0 then
+      M.inc_counter(reg, name, { [label_key] = value }, delta)
+    end
+    baseline[value] = cur
+  end
+  return baseline
 end
 
 function M.set_gauge(reg, name, labels, value)

--- a/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
@@ -1,0 +1,137 @@
+-- nft_drops.lua — read the enforcement plane's forward-drop counters and
+-- aggregate them by a bounded reason enum (#1325).
+--
+-- Per the architectural model, enforcement is nftables forward-drop on the
+-- gateway (dnsmasq is only hostname attribution, never the enforcer). render.lua
+-- emits every per-MAC drop rule in the `wifihaven_block` chain carrying a
+-- `counter` statement and a `comment "wh_drop:<mac>:<reason>"` (#1122). This
+-- module reads those rule counters and collapses them into the four bounded
+-- drop reasons an operator alerts on, so the agent can ship
+-- `enforcement_drops_total{reason}` in its 60 s metrics push (#1206).
+--
+-- The comment <reason> field is the router-side per-flow attribution string,
+-- NOT a low-cardinality enum on its own (a whole-MAC drop carries the resolved
+-- MacBlockReason — Paused / Schedule / TimeLimit / Manual / Unmanaged / blocked
+-- — and a category drop carries `category:<blocklistId>`). classify_reason
+-- folds those into the four bounded buckets the §4 cardinality firewall allows:
+--
+--   host        → host_block       (per-(MAC, host) eb_ drop, #515)
+--   ip_only     → ip_only          (blockIpOnly un-resolved-daddr drop, #353)
+--   category:*  → category_block   (per-(MAC, blocklistId) bl_ drop, #352)
+--   <anything   → whole_mac        (whole-MAC @blocked_macs drop carrying a
+--    else>                          MacBlockReason — Paused/Schedule/…/blocked)
+--
+-- There is deliberately NO per-mac / per-host / per-ip / per-blocklist-id
+-- dimension: those are forbidden keys (§4.3). A category drop's blocklist id is
+-- collapsed into the single `category_block` bucket.
+--
+-- Public API:
+--   nft_drops.classify_reason(comment_reason) → bounded enum string
+--   nft_drops.parse_drop_counters(json_str)   → { [reason_enum] = packets }
+--   nft_drops.read(exec_fn?)                   → { [reason_enum] = packets }
+
+local M = {}
+
+-- Whole-MAC drop comment reasons: the resolved MacBlockReason the API server
+-- stamped (PolicyService) plus the "blocked" fallback render.lua uses when no
+-- reason was carried. Anything in here (and anything unrecognised) folds to the
+-- single whole_mac bucket. host / ip_only / category:* are handled explicitly
+-- in classify_reason and never reach this table.
+local WHOLE_MAC_REASONS = {
+  Paused    = true,
+  Schedule  = true,
+  TimeLimit = true,
+  Manual    = true,
+  Unmanaged = true,
+  blocked   = true,
+}
+
+-- classify_reason(comment_reason) → bounded reason enum.
+-- comment_reason is the `<reason>` portion of `wh_drop:<mac>:<reason>`.
+function M.classify_reason(comment_reason)
+  if type(comment_reason) ~= "string" then return "whole_mac" end
+  if comment_reason == "host" then
+    return "host_block"
+  elseif comment_reason == "ip_only" then
+    return "ip_only"
+  elseif comment_reason:match("^category:") then
+    return "category_block"
+  else
+    -- Whole-MAC drops carry a MacBlockReason (or "blocked"); fold them — and
+    -- any unrecognised future string — into the single whole_mac bucket so the
+    -- label space stays bounded regardless of what reasons the server adds.
+    return "whole_mac"
+  end
+end
+
+-- parse_drop_counters(json_str) → { [reason_enum] = packets }
+--
+-- Walks `nft -j list chain inet wifihaven wifihaven_block` and sums each rule's
+-- `counter` packets into its classified reason bucket. Rules without a
+-- `wh_drop:` comment (e.g. the chain's `policy accept`) or without a counter
+-- contribute nothing. Returns an empty table when the chain is absent (cold
+-- boot before the first apply) or the JSON is unparseable — the caller folds an
+-- empty sample as a no-op.
+--
+-- nft JSON rule shape:
+--   { "rule": { "chain": "wifihaven_block",
+--               "comment": "wh_drop:aa:bb:cc:dd:ee:ff:host",
+--               "expr": [ ..., { "counter": { "packets": N, "bytes": M } },
+--                         { "log": {...} }, { "drop": null } ] } }
+function M.parse_drop_counters(json_str)
+  local jsonc   = require("luci.jsonc")
+  local result  = {}
+  if type(json_str) ~= "string" or json_str == "" then return result end
+  local decoded = jsonc.parse(json_str)
+  if not decoded then return result end
+
+  for _, entry in ipairs(decoded.nftables or {}) do
+    local rule = entry.rule
+    -- Only forward-drop rules we stamped carry a wh_drop: comment.
+    local comment = rule and rule.comment
+    if comment and type(comment) == "string" then
+      -- wh_drop:<mac>:<reason>. The MAC is six hex octets joined by colons; the
+      -- reason itself may contain a colon (e.g. `category:7`), so anchor on the
+      -- fixed MAC shape and capture everything after it rather than splitting on
+      -- the last colon (which would mis-parse `category:7` as reason `7`).
+      local cmac_reason =
+        comment:match("^wh_drop:%x%x:%x%x:%x%x:%x%x:%x%x:%x%x:(.+)$")
+      if cmac_reason then
+        -- Find this rule's counter statement (anonymous counter on the rule).
+        local packets
+        for _, ex in ipairs(rule.expr or {}) do
+          if ex.counter and ex.counter.packets then
+            packets = ex.counter.packets
+            break
+          end
+        end
+        if packets then
+          local reason = M.classify_reason(cmac_reason)
+          result[reason] = (result[reason] or 0) + packets
+        end
+      end
+    end
+  end
+
+  return result
+end
+
+-- read(exec_fn?) → { [reason_enum] = packets }
+--
+-- Production helper: shell out to nft and parse. exec_fn(cmd) → stdout string
+-- is injectable for tests; defaults to a popen read. A missing chain (nft
+-- prints nothing / an error to stderr which we discard) yields {} via
+-- parse_drop_counters.
+function M.read(exec_fn)
+  exec_fn = exec_fn or function(cmd)
+    local p = io.popen(cmd .. " 2>/dev/null", "r")
+    if not p then return "" end
+    local out = p:read("*a") or ""
+    p:close()
+    return out
+  end
+  local json = exec_fn("nft -j list chain inet wifihaven wifihaven_block")
+  return M.parse_drop_counters(json)
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -13,6 +13,14 @@ M.block_page_hosts    = "/var/run/wifihaven/blocked_hosts"
 -- ip → hostname cache (#259): wifihaven-dns-tail writes, wifihaven-agent reads.
 M.dns_cache = "/tmp/wifihaven-dns-cache.txt"
 
+-- DNS query-result tally (#1302): wifihaven-dns-tail writes cumulative
+-- per-result counts ("<result>\t<count>" lines) on each flush; wifihaven-agent
+-- samples it on its metrics tick and folds the deltas into
+-- dns_queries_total{result} for the /api/router/metrics push. The sidecar has
+-- no metrics registry of its own, so this tmpfs file is the IPC (same pattern
+-- as dns_cache).
+M.dns_metrics = "/tmp/wifihaven-dns-metrics.txt"
+
 -- blocklist member → bl_ set index (#1348): policy.apply writes after each
 -- snapshot apply (in lockstep with /tmp/dnsmasq.d/wifihaven.conf), the
 -- wifihaven-dns-tail bl_ populator reads it on its set-refresh cadence.

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -21,6 +21,7 @@ local conntrack  = require("wifihaven.conntrack")
 local nflog      = require("wifihaven.nflog")
 local render     = require("wifihaven.render")
 local dns_log    = require("wifihaven.dns_log")
+local nft_drops  = require("wifihaven.nft_drops")
 local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
 local paths      = require("wifihaven.paths")
@@ -101,6 +102,48 @@ end
 -- snapshot_poll_total{result} enum (200 / 304 / error) and increments it.
 local function record_poll(result)
   metrics.inc_counter(mreg, "snapshot_poll_total", { result = result })
+end
+
+-- #1301: emit blocklist_fetch_failures_total{status} from a fetch_and_cache
+-- result. `status` is the bounded enum blocklists.classify_fetch_status /
+-- the local-IO tokens produce (4xx/5xx/error/mkdir_failed/write_failed), so the
+-- §4 cardinality firewall is respected. Failures without a structured status
+-- (shouldn't happen) fall back to "error".
+local function record_blocklist_failures(bl_result)
+  for _, f in ipairs(bl_result.failures or {}) do
+    metrics.inc_counter(mreg, "blocklist_fetch_failures_total",
+                        { status = f.status or "error" })
+  end
+end
+
+-- #1325: enforcement-plane forward-drop counters. The nftables drop rules in
+-- the wifihaven_block chain carry anonymous `counter`s that reset to 0 on every
+-- re-render (`delete table` + recreate). We keep a per-reason baseline and fold
+-- the growth since the last sample into enforcement_drops_total{reason} via
+-- metrics.fold_external, which re-bases on the reset. To avoid losing the
+-- counts a re-render is about to discard, fold_enforcement_drops() is called
+-- once right BEFORE every policy.apply (capturing the about-to-reset totals)
+-- and again on the metrics tick.
+local enforcement_baseline = {}
+local function fold_enforcement_drops()
+  local by_reason = nft_drops.read()
+  metrics.fold_external(mreg, "enforcement_drops_total", "reason",
+                        by_reason, enforcement_baseline)
+end
+
+-- #1302: DNS query-result counters. The dns-tail sidecar writes a cumulative
+-- per-result tally to paths.dns_metrics; sample + fold the deltas into
+-- dns_queries_total{result}. A sidecar restart re-bases the tally from 0, which
+-- fold_external treats as a reset.
+local dns_results_baseline = {}
+local function fold_dns_queries()
+  local f = io.open(paths.dns_metrics, "r")
+  if not f then return end
+  local text = f:read("*a") or ""
+  f:close()
+  local by_result = dns_log.parse_query_results(text)
+  metrics.fold_external(mreg, "dns_queries_total", "result",
+                        by_result, dns_results_baseline)
 end
 
 -- activity_sample_int should evenly divide usage_report_interval, or the last
@@ -515,15 +558,15 @@ conntrack.watch({
       if snap then
         record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
-        -- TODO(#1301): emit blocklist_fetch_failures_total{status} here from
-        -- bl_result.errors once the status enum is designed alongside the
-        -- broader blocklist-application work (#705).
         -- #1360: the blocklist route is router-authenticated, so pass the
         -- router token — without it the fetch 401s and category (bl_)
         -- enforcement silently no-ops (the directly-queried-CNAME bl_ bypass
         -- in e2e G4 plus every real category block).
         local bl_result = blocklists.fetch_and_cache(
           snap, http_get, nil, "/etc/wifihaven/blocklists", api_url, router_token)
+        -- #1301: emit blocklist_fetch_failures_total{status} for each failure
+        -- (bounded status enum) so an operator can rate-alert on fetch failures.
+        record_blocklist_failures(bl_result)
         if #bl_result.errors > 0 then
           for _, e in ipairs(bl_result.errors) do
             log.warn("blocklist fetch: %s", tostring(e))
@@ -535,6 +578,9 @@ conntrack.watch({
         -- Apply with no failover opts. If we were in failover, this
         -- apply already emits a clean ruleset (no failover chain), so we
         -- just need to clear the flag below.
+        -- #1325: capture the enforcement-drop counters this apply is about to
+        -- reset (the ruleset is fully rebuilt) before they're discarded.
+        fold_enforcement_drops()
         local at0 = clock.monotonic_seconds()
         local applied = policy.apply(snap, write_file, run_cmd, log,
                                      { on_apply = record_apply("policy_change") })
@@ -581,6 +627,8 @@ conntrack.watch({
           -- all (cold boot during outage): the #308 boot skeleton stays in
           -- effect and there's nothing useful we can render.
           fo_opts.on_apply = record_apply("policy_change")
+          -- #1325: same pre-reset capture as the main apply above.
+          fold_enforcement_drops()
           local ft0 = clock.monotonic_seconds()
           local fo_applied = policy.apply(last_snapshot, write_file, run_cmd, log, fo_opts)
           metrics.observe(mreg, "policy_apply_duration_seconds", {},
@@ -677,6 +725,11 @@ conntrack.watch({
       -- go backward.
       metrics.set_gauge(mreg, "agent_uptime_seconds", {},
                         mono - agent_started_mono)
+      -- #1325/#1302: fold the external cumulative sources (nftables drop
+      -- counters; the dns-tail query-result tally) into the registry just
+      -- before the push so the batch carries their latest deltas.
+      fold_enforcement_drops()
+      fold_dns_queries()
       local sampled_at = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
       metrics.post(api_url, router_token, mreg, sampled_at, http_post, log)
     end

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -21,7 +21,9 @@ end
 local debug_opt   = uci_get("debug", "0")
 local source_path = "/tmp/wifihaven-dnsmasq.log"
 local cache_path  = paths.dns_cache
-local tmp_path    = cache_path .. ".tmp"
+-- #1302: cumulative per-result DNS query tally, written for the agent to fold
+-- into dns_queries_total{result}. Flushed in lockstep with the hostname cache.
+local dns_metrics_path = paths.dns_metrics
 local bl_index_path = paths.bl_member_index  -- #1348
 local leases_path = "/tmp/dhcp.leases"
 local nft_table   = "inet wifihaven"
@@ -57,18 +59,21 @@ if not handle then
   os.exit(1)
 end
 
+-- Atomic write via a per-path .tmp sibling (each path gets its own tmp so the
+-- hostname cache and the #1302 query-result tally don't clobber each other).
 local function atomic_write(path, content)
-  local f, err = io.open(tmp_path, "w")
+  local tmp = path .. ".tmp"
+  local f, err = io.open(tmp, "w")
   if not f then
-    log.err("dns-tail: open %s failed: %s", tmp_path, tostring(err))
+    log.err("dns-tail: open %s failed: %s", tmp, tostring(err))
     return false
   end
   f:write(content)
   f:close()
-  local ok = os.rename(tmp_path, path)
+  local ok = os.rename(tmp, path)
   if not ok then
-    log.err("dns-tail: rename %s -> %s failed", tmp_path, path)
-    os.remove(tmp_path)
+    log.err("dns-tail: rename %s -> %s failed", tmp, path)
+    os.remove(tmp)
     return false
   end
   return true
@@ -244,6 +249,10 @@ local last_tick        = os.time()
 local last_stats_log   = os.time()
 local lines_ingested   = 0
 local lines_since_stat = 0
+-- #1302: cumulative per-result DNS query tally since sidecar start. The agent
+-- folds the deltas (metrics.fold_external) so a sidecar restart re-bases from 0
+-- without double-counting.
+local dns_results      = {}
 
 while true do
   local line = handle:read("*l")
@@ -255,6 +264,14 @@ while true do
   since_flush      = since_flush + 1
   lines_ingested   = lines_ingested + 1
   lines_since_stat = lines_since_stat + 1
+
+  -- #1302: classify this line's DNS outcome (resolved / nxdomain / servfail /
+  -- refused / nodata) and bump the cumulative tally. nil for query lines and
+  -- non-terminal CNAME hops.
+  local dns_result = dns_log.classify_query_result(line)
+  if dns_result then
+    dns_results[dns_result] = (dns_results[dns_result] or 0) + 1
+  end
 
   local now = os.time()
 
@@ -285,6 +302,9 @@ while true do
   if since_flush >= flush_every or (now - last_tick) >= 30 then
     cache.tick(now)
     atomic_write(cache_path, cache.dump_text())
+    -- #1302: publish the cumulative query-result tally alongside the cache so
+    -- the agent's next metrics tick can fold the deltas.
+    atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))
     log.debug("dns-tail: flushed cache size=%d", cache.size())
     since_flush = 0
     last_tick   = now

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -384,3 +384,55 @@ describe("blocklists.gc", function()
   end)
 
 end)
+
+-- ── structured failures + bounded status enum (#1301) ───────────────────────
+
+describe("blocklists.classify_fetch_status (#1301)", function()
+  it("collapses HTTP statuses to their class", function()
+    assert.equal("4xx", blocklists.classify_fetch_status(404))
+    assert.equal("4xx", blocklists.classify_fetch_status(401))
+    assert.equal("5xx", blocklists.classify_fetch_status(503))
+    assert.equal("3xx", blocklists.classify_fetch_status(302))
+  end)
+
+  it("maps a missing/non-numeric status (transport failure) to error", function()
+    -- #705: the old path logged status=nil; capture it as a real label instead.
+    assert.equal("error", blocklists.classify_fetch_status(nil))
+    assert.equal("error", blocklists.classify_fetch_status("boom"))
+  end)
+end)
+
+describe("blocklists.fetch_and_cache structured failures (#1301)", function()
+  it("records a fetch failure with the HTTP status class", function()
+    local function http_get(_url, _headers) return 503, nil, {} end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+    local result = blocklists.fetch_and_cache(s, http_get, make_fs(), "/etc/wifihaven/blocklists")
+    assert.equal(1, #result.failures)
+    assert.equal("ads", result.failures[1].id)
+    assert.equal("5xx", result.failures[1].status)
+  end)
+
+  it("records a transport failure (nil status) as error", function()
+    local function http_get(_url, _headers) return nil, nil, nil end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+    local result = blocklists.fetch_and_cache(s, http_get, make_fs(), "/etc/wifihaven/blocklists")
+    assert.equal(1, #result.failures)
+    assert.equal("error", result.failures[1].status)
+  end)
+
+  it("records a write failure as write_failed", function()
+    local fs = make_fs()
+    fs.write = function(_p, _c) return nil, "ENOSPC" end
+    local function http_get(_url, _headers) return 200, "doubleclick.net\n", {} end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+    local result = blocklists.fetch_and_cache(s, http_get, fs, "/etc/wifihaven/blocklists")
+    assert.equal("write_failed", result.failures[1].status)
+  end)
+
+  it("emits no failure when every fetch succeeds", function()
+    local function http_get(_url, _headers) return 200, "doubleclick.net\n", {} end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+    local result = blocklists.fetch_and_cache(s, http_get, make_fs(), "/etc/wifihaven/blocklists")
+    assert.equal(0, #result.failures)
+  end)
+end)

--- a/openwrt/test/contract_gen.lua
+++ b/openwrt/test/contract_gen.lua
@@ -300,6 +300,19 @@ local function build_metrics_batch()
   metrics.inc_counter(reg, "snapshot_poll_total", { result = "200" }, 140)
   metrics.inc_counter(reg, "snapshot_poll_total", { result = "304" }, 9300)
   metrics.inc_counter(reg, "snapshot_poll_total", { result = "error" }, 6)
+  -- #1302 dns_queries_total{result}: dns-tail-sourced, folded by the agent.
+  metrics.inc_counter(reg, "dns_queries_total", { result = "resolved" }, 41200)
+  metrics.inc_counter(reg, "dns_queries_total", { result = "nxdomain" }, 318)
+  metrics.inc_counter(reg, "dns_queries_total", { result = "servfail" }, 7)
+  -- #1301 blocklist_fetch_failures_total{status}: bounded status enum.
+  metrics.inc_counter(reg, "blocklist_fetch_failures_total", { status = "5xx" }, 4)
+  metrics.inc_counter(reg, "blocklist_fetch_failures_total", { status = "error" }, 1)
+  -- #1325 enforcement_drops_total{reason}: nftables forward-drop counters,
+  -- reason ∈ {whole_mac, host_block, category_block, ip_only}.
+  metrics.inc_counter(reg, "enforcement_drops_total", { reason = "whole_mac" }, 1820)
+  metrics.inc_counter(reg, "enforcement_drops_total", { reason = "host_block" }, 540)
+  metrics.inc_counter(reg, "enforcement_drops_total", { reason = "category_block" }, 12990)
+  metrics.inc_counter(reg, "enforcement_drops_total", { reason = "ip_only" }, 63)
 
   -- Gauges — instantaneous; agent_version is an info gauge (value 1).
   metrics.set_gauge(reg, "agent_uptime_seconds", {}, 18060)

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -711,3 +711,68 @@ describe("populate_bl (#1348)", function()
     assert.equal(0, #adds)
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- classify_query_result + query-result tally serialization (#1302)
+-- ---------------------------------------------------------------------------
+
+describe("classify_query_result (#1302)", function()
+  local PFX = "Nov 12 10:00:01 dnsmasq[1234]: "
+
+  it("classifies an A-record reply as resolved", function()
+    assert.equal("resolved",
+      dns_log.classify_query_result(PFX .. "7 192.168.1.42/54321 reply youtube.com is 142.250.72.206"))
+  end)
+
+  it("classifies a cached answer as resolved (terminal outcome)", function()
+    assert.equal("resolved",
+      dns_log.classify_query_result(PFX .. "7 192.168.1.42/54321 cached youtube.com is 142.250.72.206"))
+  end)
+
+  it("classifies an AAAA answer as resolved", function()
+    assert.equal("resolved",
+      dns_log.classify_query_result(PFX .. "7 192.168.1.42/53 reply example.com is 2606:2800:220:1:248:1893:25c8:1946"))
+  end)
+
+  it("classifies NXDOMAIN / SERVFAIL / REFUSED / NODATA", function()
+    assert.equal("nxdomain",
+      dns_log.classify_query_result(PFX .. "8 192.168.1.42/53 reply nope.invalid is NXDOMAIN"))
+    assert.equal("servfail",
+      dns_log.classify_query_result(PFX .. "9 192.168.1.42/53 reply broken.test is SERVFAIL"))
+    assert.equal("refused",
+      dns_log.classify_query_result(PFX .. "10 192.168.1.42/53 reply blocked.test is REFUSED"))
+    assert.equal("nodata",
+      dns_log.classify_query_result(PFX .. "11 192.168.1.42/53 reply x.test is NODATA-IPv4"))
+  end)
+
+  it("does NOT count a non-terminal CNAME hop", function()
+    assert.is_nil(
+      dns_log.classify_query_result(PFX .. "7 192.168.1.42/53 reply www.example.com is <CNAME>"))
+  end)
+
+  it("returns nil for a query line and unrecognised lines", function()
+    assert.is_nil(
+      dns_log.classify_query_result(PFX .. "7 192.168.1.42/54321 query[A] youtube.com from 192.168.1.42"))
+    assert.is_nil(dns_log.classify_query_result("garbage"))
+    assert.is_nil(dns_log.classify_query_result(nil))
+  end)
+end)
+
+describe("format_query_results / parse_query_results (#1302)", function()
+  it("round-trips a tally through the IPC file format", function()
+    local tally = { resolved = 41200, nxdomain = 318, servfail = 7 }
+    local text  = dns_log.format_query_results(tally)
+    assert.same(tally, dns_log.parse_query_results(text))
+  end)
+
+  it("emits a stable (sorted) order so the file is byte-stable across flushes", function()
+    local a = dns_log.format_query_results({ resolved = 1, nxdomain = 2 })
+    local b = dns_log.format_query_results({ nxdomain = 2, resolved = 1 })
+    assert.equal(a, b)
+  end)
+
+  it("parses an empty / absent file as an empty tally", function()
+    assert.same({}, dns_log.parse_query_results(""))
+    assert.same({}, dns_log.parse_query_results(nil))
+  end)
+end)

--- a/openwrt/test/metrics_spec.lua
+++ b/openwrt/test/metrics_spec.lua
@@ -103,6 +103,57 @@ describe("metrics counters", function()
   end)
 end)
 
+-- ── metrics.fold_external — delta-fold an external cumulative source (#1302/#1325) ──
+describe("metrics.fold_external", function()
+  it("folds the positive delta since the last sample into the registry", function()
+    local reg = new_reg()
+    local base = {}
+    metrics.fold_external(reg, "dns_queries_total", "result", { resolved = 100 }, base)
+    local c1 = find_series(metrics.build_batch(reg, "t").counters,
+                           "dns_queries_total", "result", "resolved")
+    assert.equal(100, c1.value)
+    -- Next sample is cumulative-larger; only the delta is folded, registry climbs.
+    metrics.fold_external(reg, "dns_queries_total", "result", { resolved = 130 }, base)
+    local c2 = find_series(metrics.build_batch(reg, "t").counters,
+                           "dns_queries_total", "result", "resolved")
+    assert.equal(130, c2.value)
+  end)
+
+  it("re-bases from zero when the external source resets (current < baseline)", function()
+    local reg = new_reg()
+    local base = {}
+    metrics.fold_external(reg, "enforcement_drops_total", "reason", { whole_mac = 500 }, base)
+    -- Source reset (nft re-render): the next sample is smaller. Treat the whole
+    -- current value as the delta rather than decrementing the registry counter.
+    metrics.fold_external(reg, "enforcement_drops_total", "reason", { whole_mac = 20 }, base)
+    local c = find_series(metrics.build_batch(reg, "t").counters,
+                          "enforcement_drops_total", "reason", "whole_mac")
+    assert.equal(520, c.value)
+  end)
+
+  it("keeps a separate baseline per label value", function()
+    local reg = new_reg()
+    local base = {}
+    metrics.fold_external(reg, "enforcement_drops_total", "reason",
+                          { whole_mac = 10, host_block = 4 }, base)
+    metrics.fold_external(reg, "enforcement_drops_total", "reason",
+                          { whole_mac = 15, host_block = 4 }, base)
+    local batch = metrics.build_batch(reg, "t")
+    assert.equal(15, find_series(batch.counters, "enforcement_drops_total",
+                                 "reason", "whole_mac").value)
+    -- host_block didn't grow → no double count.
+    assert.equal(4, find_series(batch.counters, "enforcement_drops_total",
+                                "reason", "host_block").value)
+  end)
+
+  it("is a no-op for an empty sample (absent external source)", function()
+    local reg = new_reg()
+    local base = {}
+    metrics.fold_external(reg, "dns_queries_total", "result", {}, base)
+    assert.is_nil(metrics.build_batch(reg, "t").counters)
+  end)
+end)
+
 describe("metrics gauges", function()
   it("hold the last value set (instantaneous)", function()
     local reg = new_reg()

--- a/openwrt/test/nft_drops_spec.lua
+++ b/openwrt/test/nft_drops_spec.lua
@@ -1,0 +1,106 @@
+-- nft_drops_spec.lua — enforcement-plane forward-drop counter parsing (#1325).
+
+local nft_drops = require("wifihaven.nft_drops")
+
+describe("nft_drops.classify_reason", function()
+  it("maps the per-host eb_ drop to host_block", function()
+    assert.equal("host_block", nft_drops.classify_reason("host"))
+  end)
+
+  it("maps the blockIpOnly drop to ip_only", function()
+    assert.equal("ip_only", nft_drops.classify_reason("ip_only"))
+  end)
+
+  it("collapses any category:<id> drop into category_block", function()
+    assert.equal("category_block", nft_drops.classify_reason("category:7"))
+    assert.equal("category_block", nft_drops.classify_reason("category:adult"))
+  end)
+
+  it("folds every whole-MAC MacBlockReason into whole_mac", function()
+    for _, r in ipairs({ "Paused", "Schedule", "TimeLimit", "Manual", "Unmanaged", "blocked" }) do
+      assert.equal("whole_mac", nft_drops.classify_reason(r))
+    end
+  end)
+
+  it("defaults an unrecognised reason to whole_mac (bounded label space)", function()
+    assert.equal("whole_mac", nft_drops.classify_reason("SomeFutureReason"))
+    assert.equal("whole_mac", nft_drops.classify_reason(nil))
+  end)
+end)
+
+-- A representative `nft -j list chain inet wifihaven wifihaven_block` body: four
+-- drop rules (whole-MAC, eb_ host, bl_ category, blockIpOnly) each carrying a
+-- counter + wh_drop comment, plus a non-drop rule with no comment.
+local CHAIN_JSON = [[
+{ "nftables": [
+  { "metainfo": { "version": "1.0.8" } },
+  { "rule": { "family": "inet", "table": "wifihaven", "chain": "wifihaven_block",
+              "comment": "wh_drop:aa:bb:cc:dd:ee:01:Schedule",
+              "expr": [ { "match": {} },
+                        { "counter": { "packets": 1000, "bytes": 64000 } },
+                        { "log": { "group": 1 } },
+                        { "drop": null } ] } },
+  { "rule": { "family": "inet", "table": "wifihaven", "chain": "wifihaven_block",
+              "comment": "wh_drop:aa:bb:cc:dd:ee:02:host",
+              "expr": [ { "counter": { "packets": 40, "bytes": 2000 } },
+                        { "drop": null } ] } },
+  { "rule": { "family": "inet", "table": "wifihaven", "chain": "wifihaven_block",
+              "comment": "wh_drop:aa:bb:cc:dd:ee:03:category:7",
+              "expr": [ { "counter": { "packets": 250, "bytes": 12000 } },
+                        { "drop": null } ] } },
+  { "rule": { "family": "inet", "table": "wifihaven", "chain": "wifihaven_block",
+              "comment": "wh_drop:aa:bb:cc:dd:ee:04:ip_only",
+              "expr": [ { "counter": { "packets": 9, "bytes": 540 } },
+                        { "drop": null } ] } },
+  { "rule": { "family": "inet", "table": "wifihaven", "chain": "wifihaven_block",
+              "expr": [ { "counter": { "packets": 99999, "bytes": 1 } } ] } }
+] }
+]]
+
+describe("nft_drops.parse_drop_counters", function()
+  it("sums each rule's packets into its classified reason bucket", function()
+    local by = nft_drops.parse_drop_counters(CHAIN_JSON)
+    assert.equal(1000, by.whole_mac)
+    assert.equal(40, by.host_block)
+    assert.equal(250, by.category_block)
+    assert.equal(9, by.ip_only)
+  end)
+
+  it("ignores rules with no wh_drop comment (e.g. accounting/accept rules)", function()
+    local by = nft_drops.parse_drop_counters(CHAIN_JSON)
+    -- The trailing comment-less rule's 99999 packets must not land anywhere.
+    local total = (by.whole_mac or 0) + (by.host_block or 0)
+                + (by.category_block or 0) + (by.ip_only or 0)
+    assert.equal(1000 + 40 + 250 + 9, total)
+  end)
+
+  it("aggregates multiple rules sharing a reason across MACs", function()
+    local json = [[
+{ "nftables": [
+  { "rule": { "comment": "wh_drop:aa:bb:cc:dd:ee:01:host",
+              "expr": [ { "counter": { "packets": 5, "bytes": 1 } }, { "drop": null } ] } },
+  { "rule": { "comment": "wh_drop:aa:bb:cc:dd:ee:02:host",
+              "expr": [ { "counter": { "packets": 7, "bytes": 1 } }, { "drop": null } ] } }
+] }
+]]
+    local by = nft_drops.parse_drop_counters(json)
+    assert.equal(12, by.host_block)
+  end)
+
+  it("returns an empty table for an absent chain / unparseable JSON", function()
+    assert.same({}, nft_drops.parse_drop_counters(""))
+    assert.same({}, nft_drops.parse_drop_counters("not json"))
+    assert.same({}, nft_drops.parse_drop_counters(nil))
+  end)
+end)
+
+describe("nft_drops.read", function()
+  it("parses the injected exec_fn output", function()
+    local by = nft_drops.read(function(cmd)
+      assert.truthy(cmd:find("wifihaven_block", 1, true))
+      return CHAIN_JSON
+    end)
+    assert.equal(1000, by.whole_mac)
+    assert.equal(250, by.category_block)
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -22,6 +22,8 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/version_spec.lua \
          test/update_spec.lua \
          test/metrics_spec.lua \
+         test/dns_log_spec.lua \
+         test/nft_drops_spec.lua \
          "$@"
 
 echo ""

--- a/shared/contract/router-to-api/router_metrics_batch.json
+++ b/shared/contract/router-to-api/router_metrics_batch.json
@@ -5,6 +5,41 @@
   "sampledAt" : "2026-05-30T14:01:00Z",
   "counters" : [
     {
+      "name" : "blocklist_fetch_failures_total",
+      "labels" : {
+        "status" : "5xx"
+      },
+      "value" : 4
+    },
+    {
+      "name" : "blocklist_fetch_failures_total",
+      "labels" : {
+        "status" : "error"
+      },
+      "value" : 1
+    },
+    {
+      "name" : "dns_queries_total",
+      "labels" : {
+        "result" : "nxdomain"
+      },
+      "value" : 318
+    },
+    {
+      "name" : "dns_queries_total",
+      "labels" : {
+        "result" : "resolved"
+      },
+      "value" : 41200
+    },
+    {
+      "name" : "dns_queries_total",
+      "labels" : {
+        "result" : "servfail"
+      },
+      "value" : 7
+    },
+    {
       "name" : "dnsmasq_restarts_total",
       "labels" : {
         "reason" : "boot"
@@ -17,6 +52,34 @@
         "reason" : "policy_change"
       },
       "value" : 12
+    },
+    {
+      "name" : "enforcement_drops_total",
+      "labels" : {
+        "reason" : "category_block"
+      },
+      "value" : 12990
+    },
+    {
+      "name" : "enforcement_drops_total",
+      "labels" : {
+        "reason" : "host_block"
+      },
+      "value" : 540
+    },
+    {
+      "name" : "enforcement_drops_total",
+      "labels" : {
+        "reason" : "ip_only"
+      },
+      "value" : 63
+    },
+    {
+      "name" : "enforcement_drops_total",
+      "labels" : {
+        "reason" : "whole_mac"
+      },
+      "value" : 1820
     },
     {
       "name" : "policy_apply_total",


### PR DESCRIPTION
Implements three router-agent metric counters deferred from the #1206
metrics push. All ship through the existing 60 s cumulative push to
`POST /api/router/metrics`; counters are never reset on the agent (the
server re-bases off `agentStartedAt`).

Closes #1301, closes #1302, closes #1325.

## What's added

### `dns_queries_total{result}` (#1302)
- `dns_log.classify_query_result` maps each dnsmasq `reply`/`cached` line to a
  bounded result enum: `resolved` / `nxdomain` / `servfail` / `refused` /
  `nodata`. Non-terminal CNAME hops are not counted.
- The dns-tail sidecar tallies results cumulatively and writes
  `paths.dns_metrics` (a tmpfs file). The agent samples it on each metrics
  tick and delta-folds it into the registry. The sidecar is a separate procd
  process with no registry of its own, so the file is the IPC — same pattern
  as the ip→host cache (#259).

### `blocklist_fetch_failures_total{status}` (#1301)
- `blocklists.fetch_and_cache` now returns structured `failures` with a
  bounded `status` enum. `classify_fetch_status` collapses HTTP codes to their
  class (`4xx`/`5xx`/…); local-IO failures map to fixed tokens
  (`error`/`mkdir_failed`/`write_failed`).
- #705: a transport failure that previously logged `status=nil` is now
  captured as `status=error`.
- The agent emits one increment per failure at the existing fetch call site
  (replacing the `TODO(#1301)`).

### `enforcement_drops_total{reason}` (#1325)
- New `nft_drops` module reads the `wifihaven_block` chain's per-rule drop
  counters and aggregates by the bounded reason enum
  `{whole_mac, host_block, category_block, ip_only}`, classified from the
  `wh_drop:<mac>:<reason>` rule comments (#1122).
- The agent folds the deltas on each metrics tick **and right before every
  re-render**, because the `delete table` apply resets the anonymous rule
  counters to zero (`metrics.fold_external` re-bases on the reset).
- Server: `enforcement_drops_total` added to `MetricGuard.Allowed`. The
  generic `RouterMetricsService` fold then re-exposes it under `router_id`
  (the #1365 re-export path), so it flows to `/metrics` with no further code.

### Shared / cross-cutting
- `metrics.fold_external` delta-folds an external cumulative source into the
  registry with re-base-on-reset, used by both #1302 and #1325.
- All label sets are bounded enums per the cardinality firewall — no
  per-mac / per-host / per-ip / per-blocklist-id dimension.
- Contract fixture `router_metrics_batch.json` regenerated from the
  production `build_batch` path with a representative series for each counter
  (purely additive).
- Three new Grafana panels on the router-fleet dashboard. The
  enforcement-drops panel is the prerequisite signal for the enforcement
  dashboard (#1280).

## Wire compatibility
Additive only: three new cumulative counter series, no field renamed/removed/
retyped. Agent + API deploy in tandem; no compat shims.

## Test plan
- `openwrt` busted suite (`sh openwrt/test/run_tests.sh`): new
  `nft_drops_spec.lua`; extended `metrics_spec.lua` (fold delta + reset),
  `dns_log_spec.lua` (classifier + tally round-trip), `blocklists_spec.lua`
  (structured failures + status enum). All green.
- `shared.test` `ContractGoldenSpec`: `router_metrics_batch.json` decodes +
  value-round-trips clean after the fixture extension.
- `api.test` `RouterMetricsIngestSpec`: new case asserts a batch carrying all
  three counters ingests and re-exposes on `/metrics` under `router_id`.
- `scalafmt --check` clean; all dashboard JSON validates with
  `python3 -m json.tool`.