### PR TITLE
feat(shared): PolicySnapshot.global + MacBlockReason.DefaultDeny — global-policy foundation (#1316)

### DIFF
--- a/shared/contract/api-to-router/policy_snapshot.json
+++ b/shared/contract/api-to-router/policy_snapshot.json
@@ -1,6 +1,17 @@
 {
   "etag" : "\"sha256:abc123def4567890\"",
   "generatedAt" : "2026-05-17T14:00:00Z",
+  "global" : {
+    "blocked" : false,
+    "extraBlocked" : [],
+    "extraAllowed" : [
+      "connectivitycheck.gstatic.com",
+      "captive.apple.com",
+      "wifihaven.local"
+    ],
+    "blocklistIds" : [],
+    "blockIpOnly" : false
+  },
   "devices" : {
     "aa:bb:cc:11:22:33" : {
       "profileId" : 3,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1287,9 +1287,23 @@ case class ProfilePolicy(
     failureMode: FailureMode,
 ) derives JsonCodec
 
+// `global` carries fleet-wide policy ONCE per snapshot (#1308 design,
+// docs/design/global-policy-layer.md §3.1). It reuses `BlockRules` verbatim —
+// no new struct, no "why" metadata — so each field has the same router meaning
+// it has on a profile, just applied to every MAC: `extraAllowed` is the
+// always-reachable list that carves out every drop (the relocated infra /
+// UI / block-page hosts), `extraBlocked` / `blocklistIds` / `blocked` are
+// mandatory network-wide blocks a profile may NOT un-block, and `blockIpOnly`
+// is a network-wide strict-IP floor. The global section is NOT a third merge
+// tier: composition precedence (`global.extraAllowed` outranks everything;
+// global blocks outrank per-MAC allow) resolves server-side and the router
+// applies it as one more `BlockRules` (§5.2). Defaults to `allowAll` (inert)
+// so a snapshot with no global policy — and an older snapshot JSON predating
+// this field — decodes to a no-op. PolicyService assembly lands in #1318.
 case class PolicySnapshot(
     etag: ETag,
     generatedAt: String,
+    global: BlockRules = BlockRules.allowAll,
     devices: Map[MacAddress, DevicePolicy],
     profiles: Map[ProfileId, ProfilePolicy],
     blocklists: Map[BlocklistId, Blocklist],
@@ -1308,30 +1322,37 @@ sealed trait BlockReason
 
 sealed trait MacBlockReason extends BlockReason
 object MacBlockReason {
-  case object Paused    extends MacBlockReason
-  case object Schedule  extends MacBlockReason
-  case object TimeLimit extends MacBlockReason
-  case object Manual    extends MacBlockReason
+  case object Paused      extends MacBlockReason
+  case object Schedule    extends MacBlockReason
+  case object TimeLimit   extends MacBlockReason
+  case object Manual      extends MacBlockReason
   // #1122: default-block path for devices with no profile assignment when
   // settings.unmanagedMacPolicy.policy=="block". Distinct from Manual (which
   // is an admin block on a known device) so the Logs page and block-page can
   // surface a more specific reason.
-  case object Unmanaged extends MacBlockReason
+  case object Unmanaged   extends MacBlockReason
+  // #1316 / #1308: a profile in default-deny mode collapses to `blocked = true`
+  // with this reason (block-page text only). Lowest-precedence reason — it is
+  // the steady-state baseline, so a concurrent Paused/Schedule/TimeLimit
+  // reports the stronger reason instead (see docs/design/global-policy-layer.md §3.3).
+  case object DefaultDeny extends MacBlockReason
 
   def asString(r: MacBlockReason): String      = r match {
-    case Paused    => "Paused"
-    case Schedule  => "Schedule"
-    case TimeLimit => "TimeLimit"
-    case Manual    => "Manual"
-    case Unmanaged => "Unmanaged"
+    case Paused      => "Paused"
+    case Schedule    => "Schedule"
+    case TimeLimit   => "TimeLimit"
+    case Manual      => "Manual"
+    case Unmanaged   => "Unmanaged"
+    case DefaultDeny => "DefaultDeny"
   }
   def parse(s: String): Option[MacBlockReason] = s match {
-    case "Paused"    => Some(Paused)
-    case "Schedule"  => Some(Schedule)
-    case "TimeLimit" => Some(TimeLimit)
-    case "Manual"    => Some(Manual)
-    case "Unmanaged" => Some(Unmanaged)
-    case _           => None
+    case "Paused"      => Some(Paused)
+    case "Schedule"    => Some(Schedule)
+    case "TimeLimit"   => Some(TimeLimit)
+    case "Manual"      => Some(Manual)
+    case "Unmanaged"   => Some(Unmanaged)
+    case "DefaultDeny" => Some(DefaultDeny)
+    case _             => None
   }
 
   given JsonCodec[MacBlockReason] = JsonCodec[String].transformOrFail(
@@ -1373,6 +1394,7 @@ object BlockReason {
     case "time_limit" | "TimeLimit"                            => MacBlockReason.TimeLimit
     case "manual" | "Manual"                                   => MacBlockReason.Manual
     case "unmanaged_mac" | "Unmanaged" | "device_not_enrolled" => MacBlockReason.Unmanaged
+    case "default_deny" | "DefaultDeny"                        => MacBlockReason.DefaultDeny
     case s if s.startsWith("category:")                        =>
       BlocklistId
         .parse(s.stripPrefix("category:"))
@@ -1399,43 +1421,45 @@ object BlockReason {
    * second `fromWire` reparse still produces the same `Unknown(raw)`.
    */
   def asWire(r: BlockReason): String = r match {
-    case Allow                    => "allow"
-    case Blocked                  => "blocked"
-    case ExtraAllowed             => "extra_allowed"
-    case ExtraBlocked             => "extra_blocked"
-    case NoProfile                => "no_profile"
-    case MacBlockReason.Paused    => "paused"
-    case MacBlockReason.Schedule  => "schedule"
-    case MacBlockReason.TimeLimit => "time_limit"
-    case MacBlockReason.Manual    => "manual"
-    case MacBlockReason.Unmanaged => "unmanaged_mac"
-    case Category(slug)           => s"category:${slug.value}"
-    case SiteTimeLimit(label)     => s"site_time_limit:$label"
-    case AppBlocked(appId)        => s"app:$appId"
-    case Unknown(raw)             => raw
+    case Allow                      => "allow"
+    case Blocked                    => "blocked"
+    case ExtraAllowed               => "extra_allowed"
+    case ExtraBlocked               => "extra_blocked"
+    case NoProfile                  => "no_profile"
+    case MacBlockReason.Paused      => "paused"
+    case MacBlockReason.Schedule    => "schedule"
+    case MacBlockReason.TimeLimit   => "time_limit"
+    case MacBlockReason.Manual      => "manual"
+    case MacBlockReason.Unmanaged   => "unmanaged_mac"
+    case MacBlockReason.DefaultDeny => "default_deny"
+    case Category(slug)             => s"category:${slug.value}"
+    case SiteTimeLimit(label)       => s"site_time_limit:$label"
+    case AppBlocked(appId)          => s"app:$appId"
+    case Unknown(raw)               => raw
   }
 
   // Kind-tagged JSON. Encoder/Decoder are written by hand to keep the wire
   // format stable independent of source-order rearrangement, and to give a
   // single source of truth for the strings the SPA pattern-matches on.
   given JsonEncoder[BlockReason] = JsonEncoder[Json].contramap {
-    case Allow                    => Json.Obj("kind" -> Json.Str("allow"))
-    case Blocked                  => Json.Obj("kind" -> Json.Str("blocked"))
-    case ExtraAllowed             => Json.Obj("kind" -> Json.Str("extraAllowed"))
-    case ExtraBlocked             => Json.Obj("kind" -> Json.Str("extraBlocked"))
-    case NoProfile                => Json.Obj("kind" -> Json.Str("noProfile"))
-    case MacBlockReason.Paused    => Json.Obj("kind" -> Json.Str("paused"))
-    case MacBlockReason.Schedule  => Json.Obj("kind" -> Json.Str("schedule"))
-    case MacBlockReason.TimeLimit => Json.Obj("kind" -> Json.Str("timeLimit"))
-    case MacBlockReason.Manual    => Json.Obj("kind" -> Json.Str("manual"))
-    case MacBlockReason.Unmanaged => Json.Obj("kind" -> Json.Str("unmanaged"))
-    case Category(slug)           =>
+    case Allow                      => Json.Obj("kind" -> Json.Str("allow"))
+    case Blocked                    => Json.Obj("kind" -> Json.Str("blocked"))
+    case ExtraAllowed               => Json.Obj("kind" -> Json.Str("extraAllowed"))
+    case ExtraBlocked               => Json.Obj("kind" -> Json.Str("extraBlocked"))
+    case NoProfile                  => Json.Obj("kind" -> Json.Str("noProfile"))
+    case MacBlockReason.Paused      => Json.Obj("kind" -> Json.Str("paused"))
+    case MacBlockReason.Schedule    => Json.Obj("kind" -> Json.Str("schedule"))
+    case MacBlockReason.TimeLimit   => Json.Obj("kind" -> Json.Str("timeLimit"))
+    case MacBlockReason.Manual      => Json.Obj("kind" -> Json.Str("manual"))
+    case MacBlockReason.Unmanaged   => Json.Obj("kind" -> Json.Str("unmanaged"))
+    case MacBlockReason.DefaultDeny => Json.Obj("kind" -> Json.Str("defaultDeny"))
+    case Category(slug)             =>
       Json.Obj("kind" -> Json.Str("category"), "slug" -> Json.Str(slug.value))
-    case SiteTimeLimit(label)     =>
+    case SiteTimeLimit(label)       =>
       Json.Obj("kind" -> Json.Str("siteTimeLimit"), "label" -> Json.Str(label))
-    case AppBlocked(appId)        =>
+    case AppBlocked(appId)          =>
       Json.Obj("kind" -> Json.Str("appBlocked"), "appId" -> Json.Str(appId))
-    case Unknown(raw)             =>
+    case Unknown(raw)               =>
       Json.Obj("kind" -> Json.Str("unknown"), "raw" -> Json.Str(raw))
   }
 
@@ -1458,6 +1482,7 @@ object BlockReason {
         case "timeLimit"     => Right(MacBlockReason.TimeLimit)
         case "manual"        => Right(MacBlockReason.Manual)
         case "unmanaged"     => Right(MacBlockReason.Unmanaged)
+        case "defaultDeny"   => Right(MacBlockReason.DefaultDeny)
         case "category"      =>
           field("slug").flatMap(s =>
             BlocklistId.parse(s).map(Category(_)).left.map(_ => s"invalid category slug: $s"),

--- a/shared/test/src/PolicySnapshotGlobalSpec.scala
+++ b/shared/test/src/PolicySnapshotGlobalSpec.scala
@@ -1,0 +1,114 @@
+package wifihaven.shared
+
+import wifihaven.shared.types.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+/**
+ * #1316 / #1308: the global-policy foundation. `PolicySnapshot` gains a single `global: BlockRules`
+ * field carrying fleet-wide policy once, reusing the existing `BlockRules` shape (no new struct —
+ * see docs/design/global-policy-layer.md §3.1). These tests pin the wire shape and codec behaviour
+ * the follow-ups (#1318 server, #1319 router, #1320 web) build on.
+ */
+object PolicySnapshotGlobalSpec extends ZIOSpecDefault {
+
+  private val mac     = MacAddress.parse("aa:bb:cc:11:22:33").toOption.get
+  private val pid     = ProfileId(3L)
+  private val ads     = BlocklistId.parse("ads").toOption.get
+  private val conn    = Hostname.parse("connectivitycheck.gstatic.com").toOption.get
+  private val uiHost  = Hostname.parse("wifihaven.local").toOption.get
+  private val blocked = Hostname.parse("evil.example.com").toOption.get
+
+  private def snapshot(global: BlockRules): PolicySnapshot =
+    PolicySnapshot(
+      etag = ETag.unsafe("\"sha256:deadbeefcafe0001\""),
+      generatedAt = "2026-06-04T00:00:00Z",
+      global = global,
+      devices = Map(
+        mac -> DevicePolicy(profileId = Some(pid), name = "kid-ipad", rules = None),
+      ),
+      profiles = Map(
+        pid -> ProfilePolicy(
+          name = "kids",
+          rules = BlockRules.allowAll.copy(blocklistIds = List(ads)),
+          failureMode = FailureMode.BlockAll,
+        ),
+      ),
+      blocklists = Map(
+        ads -> Blocklist(
+          version = BlocklistVersion.unsafe("2026.06.01"),
+          url = BlocklistUrl.unsafe("/api/blocklists/ads"),
+        ),
+      ),
+    )
+
+  def spec = suite("PolicySnapshot.global (#1316)")(
+    test("snapshot with a populated global round-trips through the codec") {
+      val global = BlockRules.allowAll.copy(extraAllowed = List(conn, uiHost))
+      val snap   = snapshot(global)
+      assertTrue(snap.toJson.fromJson[PolicySnapshot].contains(snap))
+    },
+    test("the global section reuses the BlockRules shape (every field on the wire)") {
+      val global = BlockRules(
+        blocked = true,
+        blockReason = Some(MacBlockReason.Manual),
+        extraBlocked = List(blocked),
+        extraAllowed = List(conn, uiHost),
+        blocklistIds = List(ads),
+        blockIpOnly = true,
+      )
+      val obj    = snapshot(global).toJson.fromJson[Json].toOption.get.asInstanceOf[Json.Obj]
+      val g      = obj.fields.toMap.apply("global").asInstanceOf[Json.Obj].fields.map(_._1).toSet
+      assertTrue(
+        g == Set(
+          "blocked",
+          "blockReason",
+          "extraBlocked",
+          "extraAllowed",
+          "blocklistIds",
+          "blockIpOnly",
+        ),
+      )
+    },
+    test("global decodes as a full BlockRules value, not a flattened/renamed shape") {
+      val global  = BlockRules.allowAll.copy(extraAllowed = List(conn), blockIpOnly = true)
+      val decoded = snapshot(global).toJson.fromJson[PolicySnapshot]
+      assertTrue(decoded.map(_.global).contains(global))
+    },
+    // The field defaults to allowAll so an older snapshot JSON that predates
+    // `global` still decodes (additive wire change, per design §9). The router
+    // sees an inert global and enforces exactly as before.
+    test("a snapshot JSON omitting `global` decodes to the inert allowAll default") {
+      val full    = snapshot(BlockRules.allowAll)
+      val obj     = full.toJson.fromJson[Json].toOption.get.asInstanceOf[Json.Obj]
+      val without = Json.Obj(obj.fields.filterNot(_._1 == "global")).toJson
+      val decoded = without.fromJson[PolicySnapshot]
+      assertTrue(decoded.map(_.global).contains(BlockRules.allowAll))
+    },
+    test("constructing a snapshot without specifying global yields allowAll") {
+      val snap = PolicySnapshot(
+        etag = ETag.unsafe("\"sha256:0000000000000000\""),
+        generatedAt = "2026-06-04T00:00:00Z",
+        devices = Map.empty,
+        profiles = Map.empty,
+        blocklists = Map.empty,
+      )
+      assertTrue(snap.global == BlockRules.allowAll)
+    },
+    // global is independent of any device/profile: a global block carved out by
+    // global.extraAllowed must serialize alongside per-MAC rules untouched.
+    test("global composes on the wire beside per-MAC rules without interfering") {
+      val global = BlockRules.allowAll.copy(
+        blocked = true,
+        blockReason = Some(MacBlockReason.Manual),
+        extraAllowed = List(uiHost),
+      )
+      val snap   = snapshot(global)
+      val rt     = snap.toJson.fromJson[PolicySnapshot]
+      assertTrue(rt.map(_.global).contains(global)) &&
+      assertTrue(rt.map(_.profiles).contains(snap.profiles)) &&
+      assertTrue(rt.map(_.devices).contains(snap.devices))
+    },
+  )
+}

--- a/shared/test/src/contract/ContractFixtures.scala
+++ b/shared/test/src/contract/ContractFixtures.scala
@@ -36,10 +36,20 @@ object ContractFixtures {
     val adultList  = BlocklistId.parse("adult").toOption.get
     val tiktok     = Hostname.parse("tiktok.com").toOption.get
     val khan       = Hostname.parse("khanacademy.org").toOption.get
+    val connCheck  = Hostname.parse("connectivitycheck.gstatic.com").toOption.get
+    val captive    = Hostname.parse("captive.apple.com").toOption.get
+    val uiHost     = Hostname.parse("wifihaven.local").toOption.get
 
     PolicySnapshot(
       etag = ETag.unsafe("\"sha256:abc123def4567890\""),
       generatedAt = "2026-05-17T14:00:00Z",
+      // #1316 / #1308: fleet-wide policy carried once. Here only the
+      // always-reachable allowlist (connectivity check, captive portal, the
+      // WifiHaven UI / block-page host) is set; the block dimensions stay at
+      // their inert allowAll defaults. The router applies this to every MAC.
+      global = BlockRules.allowAll.copy(
+        extraAllowed = List(connCheck, captive, uiHost),
+      ),
       devices = Map(
         macKid     -> DevicePolicy(
           profileId = Some(kidsPid),

--- a/shared/test/src/types/BlockReasonSpec.scala
+++ b/shared/test/src/types/BlockReasonSpec.scala
@@ -24,9 +24,28 @@ object BlockReasonSpec extends ZIOSpecDefault {
           MacBlockReason.TimeLimit,
           MacBlockReason.Manual,
           MacBlockReason.Unmanaged,
+          MacBlockReason.DefaultDeny,
         ).foldLeft(assertTrue(true)) { (acc, r) =>
           acc && assertTrue(r.toJson.fromJson[MacBlockReason].contains(r))
         }
+      },
+      // #1316 / #1308: DefaultDeny is the new per-profile default-deny baseline
+      // reason. It must serialize distinctly from every existing case.
+      test("DefaultDeny encodes as its own capitalized string") {
+        val r: MacBlockReason = MacBlockReason.DefaultDeny
+        assertTrue(r.toJson == "\"DefaultDeny\"") &&
+        assertTrue("\"DefaultDeny\"".fromJson[MacBlockReason].contains(r))
+      },
+      test("DefaultDeny is distinct from every other MacBlockReason wire form") {
+        val others = List[MacBlockReason](
+          MacBlockReason.Paused,
+          MacBlockReason.Schedule,
+          MacBlockReason.TimeLimit,
+          MacBlockReason.Manual,
+          MacBlockReason.Unmanaged,
+        )
+        val dd     = (MacBlockReason.DefaultDeny: MacBlockReason).toJson
+        assertTrue(others.forall(o => o.toJson != dd))
       },
       test("rejects unknown reason") {
         assertTrue("\"Whatever\"".fromJson[MacBlockReason].isLeft)
@@ -56,6 +75,11 @@ object BlockReasonSpec extends ZIOSpecDefault {
         assertTrue(r.toJson == "{\"kind\":\"paused\"}") &&
         assertTrue(r.toJson.fromJson[BlockReason].contains(MacBlockReason.Paused))
       },
+      test("DefaultDeny encodes in kind-tagged BlockReason form") {
+        val r: BlockReason = MacBlockReason.DefaultDeny
+        assertTrue(r.toJson == "{\"kind\":\"defaultDeny\"}") &&
+        assertTrue(r.toJson.fromJson[BlockReason].contains(MacBlockReason.DefaultDeny))
+      },
       test("decoder rejects unknown kind") {
         assertTrue("{\"kind\":\"frobnicate\"}".fromJson[BlockReason].isLeft)
       },
@@ -75,6 +99,15 @@ object BlockReasonSpec extends ZIOSpecDefault {
         assertTrue(BlockReason.fromWire("Schedule") == MacBlockReason.Schedule) &&
         assertTrue(BlockReason.fromWire("TimeLimit") == MacBlockReason.TimeLimit) &&
         assertTrue(BlockReason.fromWire("Manual") == MacBlockReason.Manual)
+      },
+      test("DefaultDeny parses from both wire forms and round-trips asWire") {
+        assertTrue(BlockReason.fromWire("default_deny") == MacBlockReason.DefaultDeny) &&
+        assertTrue(BlockReason.fromWire("DefaultDeny") == MacBlockReason.DefaultDeny) &&
+        assertTrue(BlockReason.asWire(MacBlockReason.DefaultDeny) == "default_deny") &&
+        assertTrue(
+          BlockReason.fromWire(BlockReason.asWire(MacBlockReason.DefaultDeny)) ==
+            MacBlockReason.DefaultDeny,
+        )
       },
       test("category:<slug>") {
         assertTrue(BlockReason.fromWire("category:ads") == BlockReason.Category(ads))


### PR DESCRIPTION
## Summary

Shared-types **foundation** for the global-policy epic (#1308 design,
[`docs/design/global-policy-layer.md`](docs/design/global-policy-layer.md)).
Adds the wire shape the follow-ups build against — no behavior change yet.

Closes #1316.

### What changed (`shared/` only)

- **`PolicySnapshot.global: BlockRules`** — fleet-wide policy carried **once**
  per snapshot and applied flat to every MAC at the router. Reuses the existing
  `BlockRules` shape verbatim (no new struct, no "why" metadata), so each field
  keeps its router meaning, just network-wide: `extraAllowed` is the
  always-reachable list that carves out every drop (the relocated infra / UI /
  block-page hosts), `extraBlocked` / `blocklistIds` / `blocked` are blocks a
  profile may not un-block, `blockIpOnly` is a network-wide strict floor.
  Composition precedence resolves **server-side**; the router stays a dumb
  applier. Defaults to `BlockRules.allowAll` so the field is inert until
  PolicyService assembles it, and an older snapshot JSON predating the field
  still decodes (additive wire change, design §9).
- **`MacBlockReason.DefaultDeny`** — new case for per-profile default-deny
  block-page text; the lowest-precedence reason. All exhaustive matches updated
  (`MacBlockReason.asString`/`parse`, `BlockReason.fromWire`/`asWire`/JSON
  codec).
- **ContractFixtures + the api→router golden** show a populated
  `global.extraAllowed` so the router contract (#1319) has a representative
  shape. The golden change is purely additive (one new `global` key); the
  OpenWRT contract spec asserts only known keys, so it is unaffected.

Matches the already-merged `docs/architecture.md` §0.2 / §0.3.

### Tests (TDD red→green)

Commit history shows the failing-tests commit before the implementation commit.

- `PolicySnapshotGlobalSpec` — `global` round-trips; the wire object has exactly
  the six `BlockRules` keys; a JSON omitting `global` decodes to the inert
  `allowAll` default.
- `BlockReasonSpec` — `DefaultDeny` serializes distinctly from every existing
  `MacBlockReason` case in both wire forms and round-trips through
  `fromWire`/`asWire`.

`mill shared.test` green; `mill api.compile` green (the default keeps existing
`PolicySnapshot(...)` call sites compiling untouched); `scalafmt --check` clean.

### Scope / out of scope

This PR is the **foundation** for the sibling issues — it deliberately stops at
the shared types so they can build against this:

- #1318 — PolicyService assembles the `global` section + default-deny eval
- #1319 — router global composition (`@global_allow` / `@global_block`)
- #1320 — web management + audit view, default-deny toggle
- #1317 — DB migration (schema-only)

No PolicyService / router / web / DB logic here.
