### PR TITLE
chore(project-board): codify board taxonomy + idempotent sync script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,40 +215,46 @@ upstream as normal; the enforcement plane is nftables on the resolved IPs.)
 ## Project board — every new issue gets an Epic
 
 Open issues are tracked on the **WifiHaven GitHub Project** (org-level Project
-**#1**, <https://github.com/orgs/wifihaven/projects/1>). It is managed in the
-GitHub UI; the conventions (Epic taxonomy, Status meanings, umbrella =
-sub-issue-parent) live in [`docs/project-board.md`](docs/project-board.md).
+**#1**, <https://github.com/orgs/wifihaven/projects/1>) — there is exactly **one**
+board. The board is reconciled from the repo by
+[`scripts/project-board-sync.sh`](scripts/project-board-sync.sh); the issue→epic
+map lives in [`scripts/project-epics.tsv`](scripts/project-epics.tsv) and the
+conventions (Epic taxonomy, Status meanings, umbrella = sub-issue-parent) live in
+[`docs/project-board.md`](docs/project-board.md). **The script + TSV are the
+source of truth — prefer editing them over hand-clicking the UI**, which is what
+let two sessions race and corrupt the board.
 
 New repo issues are **auto-added** to the board (Status defaults to `Todo`) by the
 project's built-in *Auto-add to project* workflow, so they land on the board even
 when no agent is in the loop. The `Epic` is **not** set automatically — set it on
 triage.
 
-**When you file or triage a new issue, make sure it has the right `Epic`.**
-Don't leave a new issue sitting in the `Other` epic when a real thread fits (and
-if it somehow isn't on the board, add it). Steps:
+**When you file or triage a new issue, make sure it has the right `Epic`.** There
+is no `Other` catch-all — every open issue gets a real thread. Steps:
 
-1. Add it if missing: `gh project item-add 1 --owner wifihaven --url <issue-url>`.
-2. Set `Epic` to the matching thread from the taxonomy in
-   `docs/project-board.md` (Observability/Metrics, Global Policy & Default-Deny,
-   Dashboard & UX, Blocklists & Enforcement, CI/CD & Ops, Rollups & Data, Mobile
-   App, Launch & Marketing, E2E Test Coverage, Schedules, or Other) — judge from
-   the title, labels, and body.
-3. Set `Status`: `In Progress` if it carries the `in-progress` label, `Blocked`
-   if `blocked` / `blocked-on-#NNN`, otherwise `Todo`.
+1. Add an `issue<TAB>epic` row to `scripts/project-epics.tsv`, choosing the
+   matching thread from the taxonomy in `docs/project-board.md` (the 18 epics:
+   Observability & Metrics, Global Policy & Default-Deny, Dashboard & UX,
+   Blocklists & Enforcement, DNS-Bypass & Attribution, CI/CD & Ops, E2E Test
+   Coverage, Router Agent & Release, Block Page, Usage & Screen-Time, Database &
+   Data Lifecycle, API Contract & Type Safety, Notifications & Alerting, Security
+   & Access Control, Schedules, Mobile App, Launch Branding & Naming, Cost
+   Reduction) — judge from the title, labels, and body.
+2. Run `scripts/project-board-sync.sh` (or `DRY_RUN=1 …` to preview). It adds any
+   missing item, prunes closed items, and sets every Epic + Status idempotently.
+   Status is derived from labels: `in-progress` → `In Progress`; `blocked` /
+   `blocked-on-#NNN` → `Blocked`; otherwise `Todo`.
 
-**Starting a large new thread? Create a new `Epic` option for it** instead of
-forcing it into `Other`. Only do this for a thread big enough to deserve its own
-swimlane — a new umbrella, or a body of work that will span several issues; a
-one-off still goes in `Other`. Add the option in the Project UI (Epic field →
-add option) or via GraphQL `updateProjectV2Field` (pass the full option list,
-each `{name,color,description}`), then record the new epic in
-`docs/project-board.md` so the taxonomy stays the source of truth.
+**Starting a large new thread? Add a new `Epic` option for it.** Only do this for
+a thread big enough to deserve its own swimlane — a new umbrella, or a body of
+work that will span several issues. Add it to `CANONICAL_EPICS` in
+`scripts/project-board-sync.sh` **and** the taxonomy table in
+`docs/project-board.md`, then re-run the script (it reshapes the Epic options and
+re-asserts every assignment from the TSV).
 
 Field IDs and option IDs are discoverable with
-`gh project field-list 1 --owner wifihaven --format json`; set a field with
-`gh project item-edit --id <itemId> --project-id <projectId> --field-id <fid>
---single-select-option-id <oid>`.
+`gh project field-list 1 --owner wifihaven --format json`; the sync script
+resolves them at runtime so they never need hardcoding.
 
 ## Tech stack decisions
 

--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -4,10 +4,18 @@ The open issues in `wifihaven/wifihaven` are organized on a **GitHub Projects v2
 board so that "give me an update on the big threads" and "what's in progress" are
 answerable from a board view instead of a manual label sweep.
 
-The board is **managed directly in the GitHub UI**. This doc records its
-conventions — the Epic taxonomy, what each Status means, and the
-umbrella = sub-issue-parent convention — so they stay consistent as issues are
-triaged.
+The board's taxonomy and per-issue assignments are reconciled from this repo by
+[`scripts/project-board-sync.sh`](../scripts/project-board-sync.sh) — **that
+script is the source of truth, not hand-edits in the UI.** Two concurrent
+hand-edit sessions once raced and corrupted the Epic options and item
+assignments; running the sync script converges the board back to what the repo
+says. This doc records the conventions (Epic taxonomy, Status meanings,
+umbrella = sub-issue-parent) so they stay consistent.
+
+> **One board.** There is exactly one board. A second, parallel board
+> (`WifiHaven Roadmap`, org Project #2) was created during the corruption episode
+> as a curated subset; it has been consolidated away. Do not create a second
+> project — extend this one.
 
 ## The board
 
@@ -27,31 +35,41 @@ triaged.
 | `Blocked` | Waiting on something else. Mirrors the `blocked` label or any `blocked-on-#NNN` label. |
 | `Done` | Closed/shipped. |
 
-Convention: keep `Status` in agreement with the issue labels — when you move an
-issue to `In Progress` or `Blocked` on the board, set the matching
-`in-progress` / `blocked` label (and vice versa) so the two read surfaces don't
-drift.
+The sync script sets `Status` from issue labels: `in-progress` → `In Progress`;
+`blocked` / `blocked-on-*` → `Blocked` (falling back to `Todo` if the board has
+no `Blocked` option); otherwise `Todo`. Keep `Status` in agreement with the
+labels — when you move an issue on the board, set the matching label (and vice
+versa) so the two read surfaces don't drift.
 
 ### `Epic` (single-select)
 
-Each open issue is assigned to exactly one epic — the long-running thread it
-belongs to. Set it on the item in the board UI.
+Each **open** issue is assigned to exactly one epic — the long-running thread it
+belongs to. The assignment lives in
+[`scripts/project-epics.tsv`](../scripts/project-epics.tsv) (`issue<TAB>epic`);
+edit that file and re-run the sync script rather than setting the field by hand.
+There is intentionally **no `Other` catch-all** — every open issue gets a real
+thread (use best judgment for a new issue and add a row to the TSV).
 
 | Epic | What it covers |
 |------|----------------|
-| `Observability/Metrics` | `/metrics` endpoint, zio-metrics, Grafana dashboards, agent counters, structured logging. Planning threads #471 / #1240. |
-| `Global Policy & Default-Deny` | Household-wide always-on rules, the global allow/block layer, default-deny, unmanaged-MAC policy, infra-allow. Issues #1315–#1322, #1337, #937, #335, #374, #1047. |
-| `Dashboard & UX` | Web SPA — the /dashboard redesign (umbrella #1148), profile/device UX, logs, autosave, dark mode, LuCI status surfaces. |
-| `Blocklists & Enforcement` | The nftables/dnsmasq enforcement plane, block page, blocklist fetch/refresh, DoH/SNI handling, the OPNsense agent, CNAME/IP-only edges. |
-| `CI/CD & Ops` | CI pipelines, release/rollout (canary, rollback), install scripts, deploy safety, infra/ops, Render. |
-| `Rollups & Data` | Traffic/connection-event data, weekly partitions, retention, EXPLAIN/query-perf, screen-time rollups, data-quality filters, PSL apex grouping. |
-| `Mobile App` | The mobile app thread — architecture, auth/pairing, push, distribution, beta. Issues #981–#987. |
-| `Launch & Marketing` | Marketing site, branding/logo system, public-launch readiness. |
+| `Observability & Metrics` | `/metrics` endpoint, zio-metrics, Grafana dashboards, agent counters, structured logging, cardinality/retention. Planning threads #471 / #1240. |
+| `Global Policy & Default-Deny` | Household-wide always-on rules, the global allow/block layer, default-deny, unmanaged-MAC policy, infra-allow. Issues #1315–#1322, #937. |
+| `Dashboard & UX` | Web SPA — the `/dashboard` redesign (umbrella #1148), profile/device UX, logs, autosave, dark mode, profile photos/clone, LuCI status surfaces. |
+| `Blocklists & Enforcement` | The nftables/dnsmasq enforcement plane, blocklist fetch/refresh, category lists, CNAME/IP-only enforcement edges. |
+| `DNS-Bypass & Attribution` | DoH/DoT/hard-coded-IP bypass, `blockIpOnly`, hostname↔IP attribution, unknown-device discovery from DNS. |
+| `CI/CD & Ops` | CI pipelines, release/rollout, install scripts, deploy safety, infra/ops, Render, docker image, internal refactors. |
 | `E2E Test Coverage` | VM/e2e gate coverage, fake-router/fake-API scenarios, test backfill, install-script tests. |
+| `Router Agent & Release` | The OpenWRT/OPNsense agents, agent packaging/self-update, LuCI app, router config/docs. |
+| `Block Page` | The HTTP/80 DNAT block page — content, theming, per-reason copy, the served endpoint. |
+| `Usage & Screen-Time` | Per-device usage tracking, time limits/extensions, site-time limits, screen-time surfacing. |
+| `Database & Data Lifecycle` | Schema/migrations, partitions, retention, rollup tables, dead-index cleanup, data lifecycle. |
+| `API Contract & Type Safety` | Wire request/response shapes, PATCH/symmetric resources, wire versioning (#376), typed domain errors. |
+| `Notifications & Alerting` | Alert rules, contact points / notification policy, paging, and operator-facing notifications. |
+| `Security & Access Control` | Auth, JWT claims, admin vs read-only, router-token handling, access-control hardening. |
 | `Schedules` | Named/reusable schedules, schedule-driven blocklists, schedule enforcement verification. |
-| `Alerting & Paging` | Alert rules, contact points / notification policy, on-call routing, paging strategy, and the declarative alerting Terraform. Turning failure-mode metrics into pages, not just graphable series. Design thread #1381 (split out of #1368 / #1373). |
-| `Cost & Infra Spend` | Cutting recurring infra cost — Render plan sizing (API + Postgres), retention/footprint work that unlocks a downsize, vendor sanity checks. Orchestrator #1386. |
-| `Other` | Cross-cutting refactors, docs, type-safety, wire-versioning, notifications, and anything that doesn't fit a thread above. |
+| `Mobile App` | The mobile app thread — architecture, auth/pairing, push, distribution, beta. Issues #981–#987. |
+| `Launch Branding & Naming` | Marketing site, branding/logo system, naming, public-launch readiness. |
+| `Cost Reduction` | Cutting recurring infra cost — Render plan sizing (API + Postgres), retention/footprint downsizes, service consolidation. Orchestrator #1386. |
 
 ## Umbrellas are native sub-issue parents
 
@@ -59,17 +77,16 @@ Umbrella issues are wired as real **parents** via GitHub's sub-issue feature (no
 just prose lists in the body), so the child issues nest under them in the board
 and on the issue page. Current parents:
 
-- **#1240** — Observability planning thread. Parent of the metrics/Grafana/agent-
-  counter children (#471 #962 #1208 #1210 #1279 #1280 #1281 #1301 #1302 #1304
-  #1305 #1325).
+- **#1240** — Observability planning thread. Parent of the open
+  metrics/Grafana/agent-counter children (#471 #1210 #1280 #1301 #1302 #1325).
 - **#1148** — `/dashboard` holistic redesign. Parent of the dashboard-piece
   issues it supersedes (#849 #856 #859 #860 #862 #892 #951 #995 #1062 #1064
   #1065 #1066 #1078 #1080 #1098).
 - **#844** — Connection Events + Traffic Usage w/ rollups. No open issue
   currently references it; add children as they're filed.
 
-The **global-policy** set (#1316–#1322, #1315, #1337) has **no open parent** — its
-design issue #1308 is closed. Those issues are grouped via the
+The **global-policy** set (#1315–#1322, #937) has **no open parent** — its design
+issue #1308 is closed. Those issues are grouped via the
 `Global Policy & Default-Deny` epic field only, until an open parent exists.
 
 To add a child to an umbrella, use the sub-issue control on the issue page (or the
@@ -79,11 +96,16 @@ GraphQL `addSubIssue` mutation).
 
 - **New issues:** every new repo issue is **auto-added** to the board by the
   built-in *Auto-add to project* workflow (Status defaults to `Todo`). The `Epic`
-  is not set automatically — pick it on triage.
-- **Recategorize:** change the item's `Epic` field.
-- **Status:** keep it aligned with the `in-progress` / `blocked` labels.
+  is not set automatically — add an `issue<TAB>epic` row to
+  `scripts/project-epics.tsv` on triage and re-run the sync script.
+- **Recategorize:** edit the issue's row in `scripts/project-epics.tsv`, re-run
+  the sync script.
+- **Status:** keep it aligned with the `in-progress` / `blocked` labels; the sync
+  script derives it from them.
 - **New epic:** when a genuinely large new thread starts that no existing epic
-  covers, add a new option to the `Epic` field (Epic field → add option) rather
-  than overloading `Other` — then add a row to the taxonomy table above. Reserve
-  this for threads worth their own swimlane (an umbrella / multi-issue body of
-  work); one-offs stay in `Other`.
+  covers, add it to `CANONICAL_EPICS` in the sync script **and** a row to the
+  taxonomy table above, then re-run. Reserve this for threads worth their own
+  swimlane (an umbrella / multi-issue body of work).
+- **Reconcile anytime:** `scripts/project-board-sync.sh` is idempotent. Run it
+  (or `DRY_RUN=1 scripts/project-board-sync.sh` to preview) to prune closed
+  items, add missing open issues, and re-assert every Epic/Status from the repo.

--- a/scripts/project-board-sync.sh
+++ b/scripts/project-board-sync.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# project-board-sync.sh — reconcile the WifiHaven GitHub Projects v2 board to the
+# checked-in source of truth, idempotently.
+#
+# This script is the ONE way the board's Epic taxonomy and per-issue Epic/Status
+# assignments are maintained. Ad-hoc edits in the GitHub UI drift; running this
+# converges the board back to what the repo says. Two concurrent hand-edits once
+# raced and corrupted the board — this script exists so that never recurs.
+#
+# Sources of truth (in this repo):
+#   - scripts/project-epics.tsv  : issue-number <TAB> epic-name  (open issues only)
+#   - docs/project-board.md      : the human-readable taxonomy + conventions
+#   - CANONICAL_EPICS below      : the exact Epic single-select option set
+#
+# What it does (all idempotent — safe to re-run):
+#   1. Ensure the Epic field's options are exactly CANONICAL_EPICS (only mutates
+#      when they differ; option ids are re-fetched at runtime, never hardcoded).
+#   2. Delete board items whose underlying issue is closed (board tracks OPEN only).
+#   3. Add a board item for any open issue that is missing one.
+#   4. Set every open item's Epic (from the TSV) and Status (from issue labels:
+#      in-progress -> In Progress; blocked/blocked-on-* -> Blocked; else Todo).
+#
+# Requirements: gh (authenticated, with project + read:project scopes), jq, python3.
+#
+# Usage:
+#   scripts/project-board-sync.sh            # apply changes
+#   DRY_RUN=1 scripts/project-board-sync.sh  # print intended changes, mutate nothing
+#
+set -euo pipefail
+
+OWNER="${PROJECT_OWNER:-wifihaven}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-1}"
+REPO="${PROJECT_REPO:-wifihaven/wifihaven}"
+DRY_RUN="${DRY_RUN:-0}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TSV="${HERE}/project-epics.tsv"
+
+# The canonical Epic option set. All GRAY except Cost Reduction (GREEN).
+# Keep this list in sync with the taxonomy table in docs/project-board.md.
+CANONICAL_EPICS=(
+  "Observability & Metrics"
+  "Global Policy & Default-Deny"
+  "Dashboard & UX"
+  "Blocklists & Enforcement"
+  "DNS-Bypass & Attribution"
+  "CI/CD & Ops"
+  "E2E Test Coverage"
+  "Router Agent & Release"
+  "Block Page"
+  "Usage & Screen-Time"
+  "Database & Data Lifecycle"
+  "API Contract & Type Safety"
+  "Notifications & Alerting"
+  "Security & Access Control"
+  "Schedules"
+  "Mobile App"
+  "Launch Branding & Naming"
+  "Cost Reduction"
+)
+epic_color() { [[ "$1" == "Cost Reduction" ]] && echo GREEN || echo GRAY; }
+
+log()  { printf '%s\n' "$*" >&2; }
+run()  { if [[ "$DRY_RUN" == "1" ]]; then log "DRY: $*"; else "$@"; fi; }
+
+command -v gh   >/dev/null || { log "gh not found"; exit 1; }
+command -v jq   >/dev/null || { log "jq not found"; exit 1; }
+command -v python3 >/dev/null || { log "python3 not found"; exit 1; }
+[[ -f "$TSV" ]] || { log "missing $TSV"; exit 1; }
+
+# ---- 0. Resolve project + field ids at runtime (never hardcode option ids) ----
+log "==> Resolving project #$PROJECT_NUMBER for @$OWNER"
+PROJECT_JSON="$(gh project view "$PROJECT_NUMBER" --owner "$OWNER" --format json)"
+PROJECT_ID="$(jq -r '.id' <<<"$PROJECT_JSON")"
+[[ -n "$PROJECT_ID" && "$PROJECT_ID" != "null" ]] || { log "could not resolve project id"; exit 1; }
+
+FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100)"
+EPIC_FIELD_ID="$(jq -r '.fields[] | select(.name=="Epic") | .id' <<<"$FIELDS_JSON")"
+STATUS_FIELD_ID="$(jq -r '.fields[] | select(.name=="Status") | .id' <<<"$FIELDS_JSON")"
+[[ -n "$EPIC_FIELD_ID"  && "$EPIC_FIELD_ID"  != "null" ]] || { log "no Epic field";  exit 1; }
+[[ -n "$STATUS_FIELD_ID" && "$STATUS_FIELD_ID" != "null" ]] || { log "no Status field"; exit 1; }
+
+# ---- 1. Ensure Epic options == CANONICAL_EPICS (mutate only on drift) ----
+current_epics="$(jq -r '.fields[] | select(.name=="Epic") | .options[].name' <<<"$FIELDS_JSON")"
+want_epics="$(printf '%s\n' "${CANONICAL_EPICS[@]}")"
+if [[ "$current_epics" == "$want_epics" ]]; then
+  log "==> Epic options already canonical (${#CANONICAL_EPICS[@]})"
+else
+  log "==> Epic options drifted — resetting to the canonical ${#CANONICAL_EPICS[@]}"
+  # Build the full mutation with the option list embedded (no GraphQL variables —
+  # option names are a fixed, quote-free allowlist, so inlining is safe and avoids
+  # gh's complex-variable plumbing). GitHub regenerates option ids on this call,
+  # which clears existing Epic assignments; step 4 re-asserts them all from the TSV.
+  Q="$(CANON="$(printf '%s\x1f' "${CANONICAL_EPICS[@]}" | sed 's/\x1f$//')" \
+       FID="$EPIC_FIELD_ID" python3 - <<'PY'
+import json,os
+names=os.environ["CANON"].split("\x1f")
+fid=os.environ["FID"]
+def color(n): return "GREEN" if n=="Cost Reduction" else "GRAY"
+opts=", ".join('{name:%s, color:%s, description:""}'%(json.dumps(n),color(n)) for n in names)
+print('mutation{updateProjectV2Field(input:{fieldId:%s, singleSelectOptions:[%s]}){'
+      'projectV2Field{... on ProjectV2SingleSelectField{id}}}}' % (json.dumps(fid),opts))
+PY
+)"
+  run gh api graphql -f query="$Q" >/dev/null
+  # re-fetch so option ids reflect the new set
+  FIELDS_JSON="$(gh project field-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 100)"
+fi
+
+# name -> option id maps
+epic_opt_map="$(jq -r '.fields[] | select(.name=="Epic")   | .options[] | "\(.name)\t\(.id)"' <<<"$FIELDS_JSON")"
+status_opt_map="$(jq -r '.fields[] | select(.name=="Status") | .options[] | "\(.name)\t\(.id)"' <<<"$FIELDS_JSON")"
+epic_id_for()   { awk -F'\t' -v n="$1" '$1==n{print $2; exit}' <<<"$epic_opt_map"; }
+status_id_for() { awk -F'\t' -v n="$1" '$1==n{print $2; exit}' <<<"$status_opt_map"; }
+
+# ---- 2/3. Reconcile item set with open issues ----
+log "==> Loading open issues + board items"
+# Stash the large JSON payloads in temp files and read them from python via paths,
+# so issue titles/labels with quotes or backslashes can never break interpolation.
+TMPDIR_SYNC="$(mktemp -d)"; trap 'rm -rf "$TMPDIR_SYNC"' EXIT
+export OPEN_FILE="$TMPDIR_SYNC/open.json"
+export ITEMS_FILE="$TMPDIR_SYNC/items.json"
+export TSV REPO
+gh issue list -R "$REPO" --state open --limit 400 --json number,labels >"$OPEN_FILE"
+gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 800 >"$ITEMS_FILE"
+
+# closed items to delete: board item whose issue is not in the open set
+mapfile -t DELETE_IDS < <(python3 - <<'PY'
+import json,os
+open_set={i["number"] for i in json.load(open(os.environ["OPEN_FILE"]))}
+items=json.load(open(os.environ["ITEMS_FILE"]))["items"]
+for it in items:
+    c=it.get("content") or {}
+    if c.get("type")=="Issue" and c.get("number") not in open_set:
+        print(it["id"])
+PY
+)
+log "    items to delete (closed issues): ${#DELETE_IDS[@]}"
+for iid in "${DELETE_IDS[@]:-}"; do
+  [[ -z "$iid" ]] && continue
+  run gh project item-delete "$PROJECT_NUMBER" --owner "$OWNER" --id "$iid" >/dev/null
+done
+
+# add missing open issues
+mapfile -t ADD_URLS < <(python3 - <<'PY'
+import json,os
+items=json.load(open(os.environ["ITEMS_FILE"]))["items"]
+have={ (it.get("content") or {}).get("number") for it in items if (it.get("content") or {}).get("type")=="Issue" }
+repo=os.environ["REPO"]
+for i in json.load(open(os.environ["OPEN_FILE"])):
+    if i["number"] not in have:
+        print(f"https://github.com/{repo}/issues/{i['number']}")
+PY
+)
+log "    open issues missing an item: ${#ADD_URLS[@]}"
+for url in "${ADD_URLS[@]:-}"; do
+  [[ -z "$url" ]] && continue
+  run gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$url" >/dev/null
+done
+
+# refresh items after add/delete so we have item ids for every open issue
+if [[ "$DRY_RUN" != "1" && ( ${#DELETE_IDS[@]} -gt 0 || ${#ADD_URLS[@]} -gt 0 ) ]]; then
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 800 >"$ITEMS_FILE"
+fi
+
+# ---- 4. Set Epic + Status on every open item ----
+log "==> Asserting Epic + Status on open items"
+# build issue -> {itemId, status-name} and issue -> epic-name(from TSV)
+ASSIGN="$(python3 - <<'PY'
+import json,os
+open_map={}
+for i in json.load(open(os.environ["OPEN_FILE"])):
+    labs={l["name"] for l in i["labels"]}
+    if "in-progress" in labs: st="In Progress"
+    elif any(l=="blocked" or l.startswith("blocked-on") for l in labs): st="Blocked"
+    else: st="Todo"
+    open_map[i["number"]]=st
+epic={}
+with open(os.environ["TSV"]) as f:
+    next(f)
+    for line in f:
+        line=line.rstrip("\n")
+        if not line: continue
+        n,e=line.split("\t"); epic[int(n)]=e
+items=json.load(open(os.environ["ITEMS_FILE"]))["items"]
+for it in items:
+    c=it.get("content") or {}
+    if c.get("type")!="Issue": continue
+    n=c.get("number")
+    if n not in open_map: continue
+    print("\t".join([it["id"], str(n), open_map[n], epic.get(n,"")]))
+PY
+)"
+
+# Status option-id fallback: if 'Blocked' option doesn't exist, fall back to Todo
+blocked_id="$(status_id_for "Blocked")"
+n_set=0; n_skip=0
+while IFS=$'\t' read -r item_id num status_name epic_name; do
+  [[ -z "$item_id" ]] && continue
+  eid="$(epic_id_for "$epic_name")"
+  if [[ -z "$eid" ]]; then
+    log "    WARN #$num: no Epic option for '$epic_name' — skipping epic"; n_skip=$((n_skip+1))
+  else
+    run gh project item-edit --project-id "$PROJECT_ID" --id "$item_id" \
+      --field-id "$EPIC_FIELD_ID" --single-select-option-id "$eid" >/dev/null
+  fi
+  if [[ "$status_name" == "Blocked" && -z "$blocked_id" ]]; then status_name="Todo"; fi
+  sid="$(status_id_for "$status_name")"
+  if [[ -z "$sid" ]]; then
+    log "    WARN #$num: no Status option for '$status_name' — skipping status"
+  else
+    run gh project item-edit --project-id "$PROJECT_ID" --id "$item_id" \
+      --field-id "$STATUS_FIELD_ID" --single-select-option-id "$sid" >/dev/null
+  fi
+  n_set=$((n_set+1))
+done <<<"$ASSIGN"
+
+log "==> Done. items reconciled: $n_set (epic-skips: $n_skip), deleted: ${#DELETE_IDS[@]}, added: ${#ADD_URLS[@]}"

--- a/scripts/project-epics.tsv
+++ b/scripts/project-epics.tsv
@@ -1,0 +1,209 @@
+issue	epic
+376	API Contract & Type Safety
+379	API Contract & Type Safety
+388	API Contract & Type Safety
+389	API Contract & Type Safety
+396	API Contract & Type Safety
+398	API Contract & Type Safety
+399	API Contract & Type Safety
+423	API Contract & Type Safety
+581	API Contract & Type Safety
+597	API Contract & Type Safety
+601	API Contract & Type Safety
+602	API Contract & Type Safety
+623	API Contract & Type Safety
+638	API Contract & Type Safety
+888	API Contract & Type Safety
+335	Block Page
+383	Block Page
+679	Block Page
+701	Block Page
+1174	Block Page
+304	Blocklists & Enforcement
+390	Blocklists & Enforcement
+705	Blocklists & Enforcement
+709	Blocklists & Enforcement
+958	Blocklists & Enforcement
+971	Blocklists & Enforcement
+1047	Blocklists & Enforcement
+1067	Blocklists & Enforcement
+1336	Blocklists & Enforcement
+22	CI/CD & Ops
+33	CI/CD & Ops
+81	CI/CD & Ops
+121	CI/CD & Ops
+122	CI/CD & Ops
+129	CI/CD & Ops
+138	CI/CD & Ops
+158	CI/CD & Ops
+172	CI/CD & Ops
+251	CI/CD & Ops
+257	CI/CD & Ops
+337	CI/CD & Ops
+604	CI/CD & Ops
+625	CI/CD & Ops
+633	CI/CD & Ops
+637	CI/CD & Ops
+652	CI/CD & Ops
+657	CI/CD & Ops
+670	CI/CD & Ops
+675	CI/CD & Ops
+695	CI/CD & Ops
+696	CI/CD & Ops
+834	CI/CD & Ops
+877	CI/CD & Ops
+889	CI/CD & Ops
+906	CI/CD & Ops
+915	CI/CD & Ops
+1011	CI/CD & Ops
+1012	CI/CD & Ops
+1029	CI/CD & Ops
+1194	CI/CD & Ops
+1200	CI/CD & Ops
+1330	CI/CD & Ops
+19	DNS-Bypass & Attribution
+296	DNS-Bypass & Attribution
+384	DNS-Bypass & Attribution
+572	DNS-Bypass & Attribution
+573	DNS-Bypass & Attribution
+574	DNS-Bypass & Attribution
+703	DNS-Bypass & Attribution
+17	Dashboard & UX
+18	Dashboard & UX
+37	Dashboard & UX
+137	Dashboard & UX
+267	Dashboard & UX
+273	Dashboard & UX
+299	Dashboard & UX
+332	Dashboard & UX
+344	Dashboard & UX
+425	Dashboard & UX
+459	Dashboard & UX
+645	Dashboard & UX
+747	Dashboard & UX
+819	Dashboard & UX
+820	Dashboard & UX
+821	Dashboard & UX
+822	Dashboard & UX
+823	Dashboard & UX
+825	Dashboard & UX
+827	Dashboard & UX
+829	Dashboard & UX
+830	Dashboard & UX
+844	Dashboard & UX
+849	Dashboard & UX
+856	Dashboard & UX
+859	Dashboard & UX
+860	Dashboard & UX
+862	Dashboard & UX
+892	Dashboard & UX
+951	Dashboard & UX
+995	Dashboard & UX
+1062	Dashboard & UX
+1064	Dashboard & UX
+1065	Dashboard & UX
+1066	Dashboard & UX
+1098	Dashboard & UX
+1148	Dashboard & UX
+1323	Dashboard & UX
+1341	Dashboard & UX
+136	Database & Data Lifecycle
+798	Database & Data Lifecycle
+808	Database & Data Lifecycle
+810	Database & Data Lifecycle
+812	Database & Data Lifecycle
+1013	Database & Data Lifecycle
+1187	Database & Data Lifecycle
+1401	Database & Data Lifecycle
+57	E2E Test Coverage
+140	E2E Test Coverage
+151	E2E Test Coverage
+154	E2E Test Coverage
+238	E2E Test Coverage
+240	E2E Test Coverage
+241	E2E Test Coverage
+345	E2E Test Coverage
+532	E2E Test Coverage
+693	E2E Test Coverage
+759	E2E Test Coverage
+921	E2E Test Coverage
+923	E2E Test Coverage
+930	E2E Test Coverage
+1110	E2E Test Coverage
+1116	E2E Test Coverage
+1117	E2E Test Coverage
+1126	E2E Test Coverage
+1304	E2E Test Coverage
+1305	E2E Test Coverage
+1362	E2E Test Coverage
+937	Global Policy & Default-Deny
+1315	Global Policy & Default-Deny
+1316	Global Policy & Default-Deny
+1317	Global Policy & Default-Deny
+1318	Global Policy & Default-Deny
+1319	Global Policy & Default-Deny
+1320	Global Policy & Default-Deny
+1321	Global Policy & Default-Deny
+1322	Global Policy & Default-Deny
+560	Launch Branding & Naming
+1171	Launch Branding & Naming
+981	Mobile App
+982	Mobile App
+983	Mobile App
+984	Mobile App
+985	Mobile App
+986	Mobile App
+987	Mobile App
+374	Notifications & Alerting
+578	Notifications & Alerting
+874	Notifications & Alerting
+884	Notifications & Alerting
+1402	Notifications & Alerting
+1403	Notifications & Alerting
+1404	Notifications & Alerting
+1405	Notifications & Alerting
+1406	Notifications & Alerting
+16	Observability & Metrics
+471	Observability & Metrics
+1240	Observability & Metrics
+1280	Observability & Metrics
+1368	Observability & Metrics
+1381	Observability & Metrics
+89	Router Agent & Release
+111	Router Agent & Release
+112	Router Agent & Release
+113	Router Agent & Release
+124	Router Agent & Release
+198	Router Agent & Release
+270	Router Agent & Release
+317	Router Agent & Release
+348	Router Agent & Release
+363	Router Agent & Release
+387	Router Agent & Release
+561	Router Agent & Release
+699	Router Agent & Release
+753	Router Agent & Release
+772	Router Agent & Release
+773	Router Agent & Release
+774	Router Agent & Release
+1023	Router Agent & Release
+1033	Router Agent & Release
+1180	Router Agent & Release
+1216	Router Agent & Release
+1217	Router Agent & Release
+1069	Schedules
+1378	Schedules
+1379	Schedules
+1380	Schedules
+274	Security & Access Control
+369	Security & Access Control
+622	Security & Access Control
+300	Usage & Screen-Time
+726	Usage & Screen-Time
+730	Usage & Screen-Time
+790	Usage & Screen-Time
+842	Usage & Screen-Time
+1078	Usage & Screen-Time
+1080	Usage & Screen-Time
+1084	Usage & Screen-Time
+1089	Usage & Screen-Time


### PR DESCRIPTION
## Why

The org-level Projects v2 board's `Epic` options and per-issue assignments had
drifted after concurrent ad-hoc UI edits, and there were two parallel boards
(`WifiHaven` #1 and a curated-subset `WifiHaven Roadmap` #2) — the kind of split
that lets edits race. This makes the **repo** the source of truth so the board
can be reconciled deterministically instead of hand-clicked, and collapses the
two boards back to one.

## What

- **`scripts/project-epics.tsv`** — `issue<TAB>epic` for every open issue. Each
  open issue maps to exactly one of 18 epics; there is no `Other` catch-all.
- **`scripts/project-board-sync.sh`** — idempotent reconciler (safe to re-run,
  `DRY_RUN=1` to preview). It:
  1. reshapes the `Epic` field to the canonical 18 options **only when they've
     drifted** (option IDs are re-fetched at runtime, never hardcoded);
  2. deletes board items whose issue is closed (the board tracks open issues
     only);
  3. adds an item for any open issue missing one;
  4. asserts each item's `Epic` (from the TSV) and `Status` (from labels:
     `in-progress` -> In Progress, `blocked`/`blocked-on-*` -> Blocked, else Todo).
- **`docs/project-board.md`** — rewritten to the 18-epic taxonomy, records the
  **single-board** rule (the duplicate roadmap board has been consolidated away),
  and points all maintenance at the script + TSV.
- **`AGENTS.md`** — triage steps now go through the TSV + script.

## Applied to the live board

This was run against Project #1: Epic options reset to the canonical 18, 47
stale items (closed issues) pruned, and all 208 open issues assigned an Epic +
Status (0 unassigned). Project #2 ("WifiHaven Roadmap") was deleted — there is
now exactly one board.

## Notes

- No application source, tests, CI, or migrations are touched — repo tooling +
  docs only.
- `bash -n` and `shellcheck -S warning` are clean on the script.