### PR TITLE
infra-allow: add gvt2.com Google infra host (#1411)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -489,6 +489,16 @@ object PolicyService {
     // actually populated from resolved IPs, which is a separate router-side gap
     // tracked in its own issue — not something more infra-allow entries can fix.
     "netcts.cdn-apple.com",          // Apple network connectivity-test CDN
+    // #1411: Google's gvt2.com connectivity-check / infra endpoint — a
+    // device-level transitive dep (connectivity probe, Play/app asset bootstrap)
+    // that the whole-MAC drop kills, making otherwise-allowed Google apps appear
+    // blocked. Pure Google infra, not a site users reach directly → low bypass
+    // risk. Added as an exact host: the ea_ ipset is populated from resolved
+    // hostnames and suffix/wildcard ipset population isn't wired (the #1337 open
+    // question), so rotating download shards (`*.gvt2.com`, e.g.
+    // `r1---sn-xxxx.gvt2.com`) are deliberately out of scope here — pinning them
+    // would rot, same call as the akamai CDN-edge decision above.
+    "www.gvt2.com",                  // Google connectivity-check / infra endpoint
   ).map(Hostname.unsafe)
 
   /** Content-derived version: first 16 hex chars of SHA-256 over sorted domain list. */

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -489,16 +489,14 @@ object PolicyService {
     // actually populated from resolved IPs, which is a separate router-side gap
     // tracked in its own issue — not something more infra-allow entries can fix.
     "netcts.cdn-apple.com",          // Apple network connectivity-test CDN
-    // #1411: Google's gvt2.com connectivity-check / infra endpoint — a
-    // device-level transitive dep (connectivity probe, Play/app asset bootstrap)
-    // that the whole-MAC drop kills, making otherwise-allowed Google apps appear
-    // blocked. Pure Google infra, not a site users reach directly → low bypass
-    // risk. Added as an exact host: the ea_ ipset is populated from resolved
-    // hostnames and suffix/wildcard ipset population isn't wired (the #1337 open
-    // question), so rotating download shards (`*.gvt2.com`, e.g.
-    // `r1---sn-xxxx.gvt2.com`) are deliberately out of scope here — pinning them
-    // would rot, same call as the akamai CDN-edge decision above.
-    "www.gvt2.com",                  // Google connectivity-check / infra endpoint
+    // #1411: Google's gvt2.com infra domain — connectivity-check probes,
+    // Play/app asset bootstrap, and download shards (`r1---sn-xxxx.gvt2.com`)
+    // that rotate. These are device-level transitive deps the whole-MAC drop
+    // kills, making otherwise-allowed Google apps appear blocked. Pure Google
+    // infra, not a site users reach directly → low bypass risk. Added as the
+    // apex `gvt2.com` so the router's trailing-suffix match carves out every
+    // `*.gvt2.com` subdomain (incl. the rotating shards), not just one host.
+    "gvt2.com",                      // Google connectivity / Play / download infra (all subdomains)
   ).map(Hostname.unsafe)
 
   /** Content-derived version: first 16 hex chars of SHA-256 over sorted domain list. */

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -151,6 +151,25 @@ object PolicySnapshotGlobalAllowSpec
         snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
       )
     },
+    test("every profile's extraAllowed includes the #1411 gvt2.com Google infra host") {
+      // #1411: www.gvt2.com is Google's connectivity-check / infra endpoint, a
+      // device-level transitive dep dropped under a whole-MAC block. It lives in
+      // the curated infraAllowHosts constant, so it must surface in every
+      // profile's extraAllowed (copied per-profile, allow beats the @blocked_macs
+      // drop via #421 ea_ enforcement). Added as an exact host: the ea_ ipset is
+      // populated from resolved hostnames and suffix/wildcard population isn't
+      // wired, so rotating download shards (*.gvt2.com) are out of scope here,
+      // same call as the akamai/apple decision in #1337/#1339.
+      val newHosts = Set("www.gvt2.com")
+      for {
+        _    <- cleanDb
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield assertTrue(
+        snap.profiles.nonEmpty,
+        snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
+      )
+    },
     test(
       "global host in extraBlocked still appears in extraAllowed (allow-beats-block at router)",
     ) {

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -151,16 +151,15 @@ object PolicySnapshotGlobalAllowSpec
         snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
       )
     },
-    test("every profile's extraAllowed includes the #1411 gvt2.com Google infra host") {
-      // #1411: www.gvt2.com is Google's connectivity-check / infra endpoint, a
-      // device-level transitive dep dropped under a whole-MAC block. It lives in
-      // the curated infraAllowHosts constant, so it must surface in every
+    test("every profile's extraAllowed includes the #1411 gvt2.com Google infra domain") {
+      // #1411: gvt2.com is Google's connectivity-check / Play / download infra
+      // domain, a device-level transitive dep dropped under a whole-MAC block. It
+      // lives in the curated infraAllowHosts constant, so it must surface in every
       // profile's extraAllowed (copied per-profile, allow beats the @blocked_macs
-      // drop via #421 ea_ enforcement). Added as an exact host: the ea_ ipset is
-      // populated from resolved hostnames and suffix/wildcard population isn't
-      // wired, so rotating download shards (*.gvt2.com) are out of scope here,
-      // same call as the akamai/apple decision in #1337/#1339.
-      val newHosts = Set("www.gvt2.com")
+      // drop via #421 ea_ enforcement). Added as the apex `gvt2.com` so the
+      // router's trailing-suffix match carves out every *.gvt2.com subdomain,
+      // including the rotating download shards.
+      val newHosts = Set("gvt2.com")
       for {
         _    <- cleanDb
         svc  <- makePs


### PR DESCRIPTION
## What

Adds the apex domain `gvt2.com` to the curated `PolicyService.infraAllowHosts` list, following the akamai/apple infra-host pattern from #1337/#1339.

`gvt2.com` is Google's infrastructure domain (connectivity checks, Play services, app/asset download shards). It's a device-level transitive dependency dropped under a whole-MAC block (paused / schedule / daily-limit), which makes otherwise-allowed Google apps *appear* blocked. We ship it by copying it into every profile's `extraAllowed`, so the existing #421 ea_ enforcement makes it beat the `@blocked_macs` drop. Pure Google infra, not a site users reach directly → low bypass risk.

## Apex domain, not an exact host

Entered as the bare apex `gvt2.com` (not `www.gvt2.com`). The router renders it as a dnsmasq `nftset=/gvt2.com/...` directive (`render.lua:307-315`), and dnsmasq's nftset domain match is a **trailing-suffix match** — the same rule as `--address`/`--server` — so it carves out `gvt2.com` *and every* `*.gvt2.com` subdomain into the `ea_` set:

- **Direct suffix match (primary):** the device's own lookups of `www.gvt2.com`, `r1---sn-xxxx.gvt2.com`, etc. end in `gvt2.com`, so their resolved IPs land in the set. This covers the rotating Play/download shards that an exact host could never enumerate.
- **CNAME chains:** dnsmasq also checks every name in the resolution chain, so any host that CNAMEs into `*.gvt2.com` gets its final IPs added too.

## Tests (TDD red→green)

Extends `PolicySnapshotGlobalAllowSpec` (mirroring the existing #1337 infra-host test) to assert `gvt2.com` surfaces in every profile's `extraAllowed`; the broader `PolicySnapshotAppsSpec` subset assertion already covers the whole list. `PolicySnapshotGlobalAllowSpec` passes locally (6/6).

Closes #1411