### PR TITLE
feat(metrics): usage retry-queue depth + post-outcome counter (#1033)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -88,6 +88,12 @@ object MetricGuard {
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
     "enforcement_drops_total"                   -> Set("reason", "router_id", "installation_id"),
+    // #1033 — usage-POST retry-queue health. Depth = buckets currently waiting for a backoff to
+    // elapse; `usage_post_total{result}` tracks the immediate-post outcome (`ok` | `queued`) and
+    // drain outcome (`drained` | `drain_failed`). Gives operators a first-class view of "are
+    // usage reports flowing or are they stacking up?" without grepping the ring-buffer syslog.
+    "usage_queue_depth"                         -> Set("router_id", "installation_id"),
+    "usage_post_total"                          -> Set("result", "router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
     // #1243 rollup health — `rollup_job` is a handful of hand-named jobs (traffic_hourly,

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -331,6 +331,70 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Usage retry-queue depth (max + p95)",
+      "description": "max/quantile of usage_queue_depth — bucketed usage reports waiting in each agent's in-memory retry queue (#1033). 0 in steady state; a sustained non-zero value means agents are buffering usage POSTs that aren't reaching the API. Lets operators see the queue stacking up before the per-agent bucket cap drops data, which is what they were blind to during the #1017 outage.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(usage_queue_depth{env=\"$env\"})",
+          "legendFormat": "max",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "quantile(0.95, usage_queue_depth{env=\"$env\"})",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Usage POST outcomes by result",
+      "description": "sum by (result) (rate(usage_post_total[5m])) — result ∈ {ok, queued, drained, drain_failed} (#1033). `ok` = posted on first try; `queued` = post failed, bucket enqueued for retry; `drained` = retry attempt succeeded; `drain_failed` = retry attempt failed and bucket re-armed with the next backoff. Rising `queued`/`drain_failed` is the leading indicator the API is unreachable.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(usage_post_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -700,6 +700,13 @@ conntrack.watch({
         -- a backward wall-clock jump can't freeze the drain (#336).
         local posted = usage.post_with_retry(
           api_url, router_token, report, http_post, usage_queue, mono, nil, log)
+        -- #1033: classify the immediate-post outcome so operators can see whether
+        -- usage reports are flowing (`ok`) or stacking up in the retry queue
+        -- (`queued`). The empty-report short-circuit in post_with_retry also
+        -- returns true, but it never reaches this branch (build_report only
+        -- emits a report with records when there were counters to fold).
+        metrics.inc_counter(mreg, "usage_post_total",
+                            { result = posted and "ok" or "queued" })
         -- Reset counters and tracker regardless of post outcome: the report
         -- is now owned by the retry queue (or already sent), so leaving the
         -- nft counters intact would double-count on the next bucket.
@@ -725,6 +732,12 @@ conntrack.watch({
       -- go backward.
       metrics.set_gauge(mreg, "agent_uptime_seconds", {},
                         mono - agent_started_mono)
+      -- #1033: usage-POST retry-queue depth, sampled right before the push so
+      -- operators see the queue state as of this batch. Drained-to-empty
+      -- naturally renders as 0; a sustained non-zero value means usage
+      -- reports are failing to upload and the operator has time to react
+      -- before the bucket cap (usage.MAX_QUEUE_BUCKETS) starts dropping data.
+      metrics.set_gauge(mreg, "usage_queue_depth", {}, #usage_queue.buckets)
       -- #1325/#1302: fold the external cumulative sources (nftables drop
       -- counters; the dns-tail query-result tally) into the registry just
       -- before the push so the batch carries their latest deltas.
@@ -735,8 +748,28 @@ conntrack.watch({
     end
 
     -- Drain any retry-queued buckets whose backoff has elapsed (monotonic now).
+    -- #1033: bracket the drain so we can credit each removed bucket as
+    -- `drained` and each remaining bucket whose attempts went up as
+    -- `drain_failed`. The drain stops on the first failure (so subsequent
+    -- buckets aren't re-counted), and removals only happen on a successful
+    -- post, which makes the depth delta a faithful success count.
     if #usage_queue.buckets > 0 then
+      local depth_before = #usage_queue.buckets
+      local attempts_before = {}
+      for _, b in ipairs(usage_queue.buckets) do
+        attempts_before[b] = b.attempts
+      end
       usage.drain(api_url, router_token, usage_queue, http_post, mono, nil, log)
+      local drained = depth_before - #usage_queue.buckets
+      if drained > 0 then
+        metrics.inc_counter(mreg, "usage_post_total", { result = "drained" }, drained)
+      end
+      for _, b in ipairs(usage_queue.buckets) do
+        if attempts_before[b] and b.attempts > attempts_before[b] then
+          metrics.inc_counter(mreg, "usage_post_total", { result = "drain_failed" })
+          break -- drain() bails on first failure, so at most one bucket advances
+        end
+      end
     end
   end,
 })


### PR DESCRIPTION
## Summary
- Adds `usage_queue_depth` gauge + `usage_post_total{result}` counter to the agent's `POST /api/router/metrics` push (#1206) so the usage retry queue is visible in Grafana instead of OpenWRT's 16 KB syslog ring buffer.
- Allowlists both series in `MetricGuard.Allowed` with the standard `router_id`/`installation_id` plus a bounded `result ∈ {ok, queued, drained, drain_failed}`.
- Adds two panels to `router-fleet.json`: queue depth (max + p95) and POST outcomes by result.

Why not the issue's original `/api/router/stats` proposal: that was filed before #1206 landed the cumulative-metrics push pipeline. The metrics push is the right vehicle now — a dedicated endpoint, a new `agent_stats` JSONB column, and the `wifihaven-agent --dump-queue` CLI are all unnecessary once depth and per-attempt outcomes show up in Grafana.

Closes #1033. Related: #1017 (the outage that surfaced the gap), #1206 (the metrics push).

## Test plan
- [x] `mill api.test.testOnly wifihaven.api.feature.MetricCardinalityGuardSpec` — gate that asserts every agent-emitted metric name is in the allowlist (passes; would have failed if either side were missing).
- [x] `sh openwrt/test/run_tests.sh test/metrics_spec.lua test/usage_spec.lua test/contract_spec.lua` — agent metric/queue tests pass.
- [x] `python3 -m json.tool deploy/grafana/dashboards/router-fleet.json` — dashboard JSON valid.
- [x] `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`.
- [ ] Operator: confirm `usage_queue_depth` lands as 0 in Grafana after a routine agent push, and that simulating a POST failure flips `usage_post_total{result="queued"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)