### PR TITLE
fix(#1413): extraAllowed beats Paused in the per-host decision

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -215,8 +215,15 @@ class PolicyServiceLive(
   /**
    * Per-host fallback decision. Reads DB rows directly rather than going through the snapshot,
    * since the snapshot's collapsed BlockRules no longer carries the raw schedule / site-limit /
-   * category state needed to make a per-host decision. Precedence: paused > schedule > allowed-app
+   * category state needed to make a per-host decision. Precedence: allowed-app > paused > schedule
    * > blocked-app > site_time_limit > time_limit > category > allow.
+   *
+   * #1413/#421: allowed-app (extraAllowed) is checked FIRST so it beats every whole-MAC block path
+   * — including Paused and Schedule — exactly as the snapshot/router `@blocked_macs` carve-out does
+   * (`ip daddr != @ea_<m>_<a>`). Keeping this endpoint's verdict consistent with what nftables
+   * actually enforces is the whole point of the invariant; otherwise an explicitly-allowed app
+   * would be reported (and, on agents that consult this endpoint, enforced) as blocked while
+   * paused.
    */
   def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
     for {
@@ -263,17 +270,21 @@ class PolicyServiceLive(
                 ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
               case Some(p) =>
                 val h = hostname.toLowerCase.stripSuffix(".")
-                if p.paused then
+                // #1413/#421: extraAllowed beats EVERY whole-MAC block — incl.
+                // Paused/Schedule — so check the allowed-app list first, before
+                // the pause/schedule short-circuits. This matches the snapshot/
+                // router `ip daddr != @ea_<m>_<a>` carve-out.
+                if matchesAny(h, appAllowed) then
+                  ZIO.succeed(
+                    RouterDecisionResponse(ConnectionDecision.Allow, "extra_allowed", None),
+                  )
+                else if p.paused then
                   ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Block, "paused", None))
                 else
                   scheduleBlock(scheds, now) match {
                     case Some(r) => ZIO.succeed(r)
                     case None    =>
-                      if matchesAny(h, appAllowed) then
-                        ZIO.succeed(
-                          RouterDecisionResponse(ConnectionDecision.Allow, "extra_allowed", None),
-                        )
-                      else if matchesAny(h, appBlocked) then
+                      if matchesAny(h, appBlocked) then
                         ZIO.succeed(
                           RouterDecisionResponse(ConnectionDecision.Block, "extra_blocked", None),
                         )

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -373,6 +373,37 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(!eb.contains("mathacademy.com"))
     },
     test(
+      "#1413: AppMode.Allowed app stays in extraAllowed when profile is paused (blocked=Paused)",
+    ) {
+      // Prod miss (Kids/Math Academy, 2026-06): an allowed-mode app got blocked
+      // when the profile was paused. extraAllowed must beat the Paused block at
+      // the snapshot layer (#421), exactly as #1307 locked for TimeLimit. The
+      // Paused-reason sibling of #1307. Mirrors the prod assignment: mode=Allowed,
+      // single apex host, whole-MAC paused.
+      val mac = "aa:bb:cc:dd:ee:23"
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        ar    <- ZIO.service[AppRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- pr.setPaused(kid, true)
+        _     <- TestLayers.seedDevice(dr, mac, "kid-mac", kid)
+        appId <- ar.create("Math Academy", "math-academy", None, None)
+        _     <- ar.setHosts(appId, List(Hostname.unsafe("mathacademy.com")))
+        _     <- ar.upsertAssignment(appId, kid, AppMode.Allowed, None, true)
+        svc   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap  <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
+        assertTrue(ea.contains("mathacademy.com")) &&
+        assertTrue(!eb.contains("mathacademy.com"))
+    },
+    test(
       "#1307: global infra hosts are in every profile's extraAllowed, even when blocked=TimeLimit",
     ) {
       // Allowed-mode apps appeared blocked when the daily cap ran out because

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -237,6 +237,57 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         )
     },
     test(
+      "#1413: paused profile + AppMode.Allowed host → allow:extra_allowed (extraAllowed beats pause)",
+    ) {
+      // Prod miss (Kids/Math Academy, 2026-06): an allowed-mode app was reported
+      // (and, on agents that consult this endpoint, blocked) as paused. Per #421
+      // extraAllowed beats EVERY whole-MAC block — including Paused — exactly as
+      // the snapshot/router @blocked_macs carve-out does. The per-host fallback
+      // must agree: an allowed app stays reachable while the profile is paused,
+      // and no block_event is recorded for it.
+      val mac = "aa:bb:cc:11:22:44"
+      for {
+        _     <- cleanDb
+        rr    <- ZIO.service[RouterRepo]
+        pr    <- ZIO.service[ProfileRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        ar    <- ZIO.service[AppRepo]
+        ber   <- ZIO.service[BlockEventRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- pr.setPaused(kid, true)
+        _     <- TestLayers.seedDevice(dr, mac, "kid-mac", kid)
+        appId <- ar.create("Math Academy", "math-academy", None, None)
+        _     <- ar.setHosts(appId, List(Hostname.unsafe("mathacademy.com")))
+        _     <- ar.upsertAssignment(appId, kid, AppMode.Allowed, None, true)
+        ps    <- makePsDefault
+        routes = RouterRoutes.routes(rr, ps, RouterAuthLive(rr), ber)
+        tok    <- seedAndEnrollRouter(rr, routes)
+        // The allowed app survives the pause.
+        allow  <- callDecide(routes, tok, mac, "mathacademy.com")
+        aBody  <- allow.body.asString
+        aDr    <- ZIO.fromEither(aBody.fromJson[RouterDecisionResponse])
+        // A non-allowlisted host is still blocked by the pause.
+        block  <- callDecide(routes, tok, mac, "example.com")
+        bBody  <- block.body.asString
+        bDr    <- ZIO.fromEither(bBody.fromJson[RouterDecisionResponse])
+        events <- ber.recent(10)
+      } yield assertTrue(aDr.decision == ConnectionDecision.Allow) &&
+        assertTrue(aDr.reason == "extra_allowed") &&
+        assertTrue(bDr.decision == ConnectionDecision.Block) &&
+        assertTrue(bDr.reason == "paused") &&
+        // No block_event for the allowed host; the paused host still records one.
+        assertTrue(
+          !events.exists(_.host == HostId.Fqdn(Hostname.unsafe("mathacademy.com"))),
+        ) &&
+        assertTrue(
+          events.exists(e =>
+            e.host == HostId.Fqdn(Hostname.unsafe("example.com")) &&
+              e.reason == MacBlockReason.Paused,
+          ),
+        )
+    },
+    test(
       "active schedule → block:schedule, expires_at = when schedule ends, block_event recorded",
     ) {
       // Bedtime = Monday 2025-01-06 21:30; schedule is 21:00–07:00 every day.

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -255,9 +255,11 @@ as #763 documents — that behaviour is untouched.
 The per-host fallback (`PolicyService.decide`, ~L216) independently re-derives
 `appAllowed` / `appBlocked` from the assignments. It must apply the same
 per-app effective-disposition resolution **and the same cap gate** so the
-fallback agrees with the snapshot. Note its current precedence chain — "paused >
-schedule > allowed-app > blocked-app > site_time_limit > time_limit > category"
-— places allowed-app *above* time_limit unconditionally; that must change so a
+fallback agrees with the snapshot. Note its current precedence chain — "allowed-app >
+paused > schedule > blocked-app > site_time_limit > time_limit > category"
+(allowed-app moved to the head of the chain in #1413 so `extraAllowed` beats the
+Paused/Schedule whole-MAC blocks too, matching the router carve-out) — places
+allowed-app *above* time_limit unconditionally; that must change so a
 *non-exempt* `allowed_during` app falls **below** time_limit (cap bites), while
 an *exempt* one stays above it. Concretely: an active `allowed_during` window
 short-circuits to Allow only when `exemptFromDaily` OR the cap is not yet

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -667,6 +667,29 @@ describe("render.nft drop rules carry log group + counter + comment (#1122)", fu
       1, true))
   end)
 
+  it("#1413: Paused MAC carves out an allowed app host but still drops other traffic", function()
+    -- Prod miss (Kids/Math Academy, 2026-06): an allowed-mode app appeared
+    -- blocked while the profile was paused. The whole-MAC drop for a Paused MAC
+    -- with extraAllowed must carry `ip daddr != @ea_<m>_<allowed-host>` so the
+    -- allowed app stays reachable, while general traffic (no ea_ carve-out)
+    -- still drops. Reason-agnostic carve-out, locked here for the Paused reason.
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "Paused"
+    s.profiles["3"].rules.extraAllowed = { "mathacademy.com" }
+    local nft = render.nft(s)
+    -- The per-MAC drop spares the allowed host via the ea_ exception (allow wins).
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com log group 1 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Paused\"",
+      1, true))
+    -- The MAC is pulled out of the family-agnostic @blocked_macs set (it has a
+    -- per-MAC carve-out rule instead), so general traffic drops via that rule.
+    assert.is_nil(nft:find("@blocked_macs drop", 1, true))
+    -- No ea_ set is declared for an unrelated host, so non-allowed traffic has
+    -- no carve-out and is dropped by the rule above.
+    assert.is_nil(nft:find("@ea_aa_bb_cc_11_22_33_example_com", 1, true))
+  end)
+
   it("MacBlockReason wire strings: Paused / Schedule / TimeLimit / Manual / Unmanaged", function()
     -- Pin the contract between MacBlockReason.asString in PolicyService and
     -- the strings render.lua emits. The agent's nflog parser depends on this.


### PR DESCRIPTION
## Root cause

The per-host fallback `PolicyService.decide` (`/api/router/decision`, also used
by the kid block-page reason endpoint #959) short-circuited to `Block` on
`p.paused` — and on an active schedule — **before** checking the allowed-app
list. So an explicitly-allowed app (`AppMode.Allowed`, e.g. Math Academy on the
Kids profile) was reported as blocked while the profile was Paused, violating
the #421 invariant that `extraAllowed` beats **every** whole-MAC block path.

This is the **Paused-reason sibling of #1307/#1309** (which made an allowed app
survive the `TimeLimit` block).

### Where the bug was — and wasn't

I verified the invariant at every layer:

- **Snapshot (`computeBlockRules`)** — ✅ already correct. `extraAllowed` is
  built unconditionally regardless of `state.blocked`/reason, so a paused
  profile still ships the allowed app's hosts. (Locked here with a new
  `PolicySnapshotAppsSpec` test mirroring the #1307 TimeLimit lock.)
- **Router render (`render.lua`)** — ✅ already correct. The `@blocked_macs`
  carve-out (`ip daddr != @ea_<m>_<a>`) is **reason-agnostic** — driven by the
  presence of `extraAllowed`, not the block reason — so Paused carves out
  exactly like TimeLimit. (Existing test at `render_spec.lua` already covered
  Paused; added an explicit `#1413` test pinning the mathacademy scenario and
  asserting non-allowed traffic still drops.)
- **`decide()` per-host fallback** — ❌ **the bug.** `allowed-app` already beat
  `time_limit` (checked above it), but **not** `paused`/`schedule` (checked
  below them). Its verdict therefore disagreed with what nftables actually
  enforces.

So if the operator's router is current and the `ea_` ipset is populated, the
connection-layer enforcement was already correct for Paused; the genuine code
defect was this endpoint's verdict (block-page reason text, and enforcement on
any agent that consults `/api/router/decision`).

## Fix

Check the allowed-app list **first**, before the `paused`/`schedule`
short-circuits — mirroring how `allowed-app` already sits above `time_limit`
in the same function. A non-allowlisted host on a paused profile still blocks
as `paused`; only allowlisted hosts are spared.

## Product intent

Confirmed per #421 / `memory/feedback_extraallowed_beats_blocked.md` and the
#1307 precedent: an explicitly-allowed app **should** stay reachable when a
profile is paused. No evidence pause is intended as a hard stop overriding
allowlists. (If the team ever wants pause to be a hard override, that is a
deliberate different design — flag, don't assume.)

## Test plan (red → green visible in history)

- `test(#1413)` commit: adds the failing `RouterDecisionSpec` case (paused
  profile + `AppMode.Allowed` host → expected `allow:extra_allowed`, got
  `paused`) plus snapshot + render locks.
- `fix(#1413)` commit: reorders `decide()`; the red test goes green.
- `mill api.test` — full suite green (all groups 0 failed).
- `busted openwrt/test/render_spec.lua` — 148 passed.

## Operator follow-up (router side, out of scope for this PR)

If mathacademy.com is still blocked while paused after this ships, the remaining
candidates are router-side, not API code: a **stale agent** missing the #1309
carve-out, or the **`ea_` ipset not populated** for the app's hosts (#1342
class). Worth a `nft list ruleset` + agent-version check on the paused profile.

Closes #1413.
