### PR TITLE
fix(openwrt): populate category blocklists at startup + periodic timer (#1412)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -229,6 +229,76 @@ function M.load_cached(snapshot, fs, cache_dir)
   return result
 end
 
+-- refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+--   One-call fetch_and_cache → gc → load_cached. Returns:
+--     { hosts = {[id]={host,...}}, failures = {...}, errors = {...} }
+--
+-- This is the entry point the agent calls BOTH at startup and on the periodic
+-- blocklist timer, so the per-blocklist cache (and therefore the bl_ ipset
+-- nftset= directives render emits from snapshot._blocklist_hosts) is populated
+-- independent of whether the policy poll returned 200 or 304.
+--
+-- #1412: previously the agent only fetched/cached blocklists inside the
+-- policy-poll HTTP-200 branch, and not at startup at all. A household whose
+-- snapshot is stable (the steady state — every poll is a 304) therefore never
+-- populated the cache: render emitted zero `nftset=/<member>/...#bl_<id>`
+-- directives, the bl_ sets stayed empty, and an assigned list member (e.g.
+-- taboola.com ∈ 'ads') was reachable despite correct policy. Surfacing the
+-- failures back to the caller lets the agent emit blocklist_fetch_failures_total
+-- and simply retry on the next cadence rather than no-op until the next snapshot
+-- change (which on a stable household may be hours/days away).
+function M.refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+  local fc    = M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+  M.gc(snapshot, fs, cache_dir)
+  local hosts = M.load_cached(snapshot, fs, cache_dir)
+  return { hosts = hosts, failures = fc.failures, errors = fc.errors }
+end
+
+-- hosts_differ(a, b) → boolean
+--   Order-insensitive comparison of two {[id]={host,...}} maps. Nil is treated
+--   as the empty map. Returns true iff the set of ids differs, or any id's host
+--   membership differs.
+--
+-- The agent calls this after a periodic refresh to decide whether the cached
+-- host set actually changed before re-applying. A blocklist host change alters
+-- the dnsmasq fragment (the nftset= directives) and so forces a dnsmasq reload;
+-- gating the re-apply on a real change keeps a steady state from churning
+-- dnsmasq every cadence while still catching the empty→populated cold-start
+-- transition (#1412).
+function M.hosts_differ(a, b)
+  a = a or {}
+  b = b or {}
+
+  local function host_set(list)
+    local set, n = {}, 0
+    for _, h in ipairs(list or {}) do
+      if not set[h] then
+        set[h] = true
+        n = n + 1
+      end
+    end
+    return set, n
+  end
+
+  -- Every id in `a` must exist in `b` with identical host membership.
+  -- Iterating both directions catches ids present in only one side.
+  local function subset_match(x, y)
+    for id, xlist in pairs(x) do
+      local xset, xn = host_set(xlist)
+      local yset, yn = host_set(y[id])
+      if xn ~= yn then return false end
+      for h in pairs(xset) do
+        if not yset[h] then return false end
+      end
+    end
+    return true
+  end
+
+  if not subset_match(a, b) then return true end
+  if not subset_match(b, a) then return true end
+  return false
+end
+
 -- Remove cache files that are not referenced by the current snapshot.
 -- A file is kept only if its name matches "<id>-<version>.txt" where
 -- (id, version) is an entry in snapshot.blocklists.

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -48,6 +48,12 @@ local usage_int     = tonumber(uci_get("usage_report_interval",   "60"))
 -- 60 s by default (matches usage_report_interval cadence but is a separate
 -- knob; the server re-bases off agentStartedAt so a missed push self-heals).
 local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
+-- #1412: blocklist (category ipset) cache refresh runs on its OWN timer,
+-- decoupled from the ~5 s policy poll. fetch_and_cache is a no-op read when the
+-- (id, version) file is already cached, so the cadence only does real work when
+-- a list's content version changed; the agent re-applies the ruleset only when
+-- the loaded host set actually differs (blocklists.hosts_differ). Default 1 h.
+local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
@@ -296,6 +302,26 @@ local function rename_file(from, to)
   return true
 end
 
+-- #1412: fetch + cache + load the category blocklists for `snap`, emit the
+-- failure metric, log any errors, and return the loaded host map. Called from
+-- BOTH the startup apply and the on_tick blocklist timer so the bl_ ipsets are
+-- populated regardless of the 200/304 status of the policy poll. The prod no-op
+-- was that this ran only in the policy-poll 200 branch and never at startup, so
+-- a household with a stable snapshot left every bl_ set empty and category
+-- enforcement silently did nothing. The returned map is attached to
+-- snap._blocklist_hosts, which render reads to emit the nftset= populators.
+-- Defined after http_get (its upvalue) so the closure captures it.
+local BLOCKLIST_CACHE_DIR = "/etc/wifihaven/blocklists"
+local function refresh_blocklists(snap)
+  local res = blocklists.refresh(
+    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token)
+  record_blocklist_failures(res)
+  for _, e in ipairs(res.errors or {}) do
+    log.warn("blocklist fetch: %s", tostring(e))
+  end
+  return res.hosts
+end
+
 -- ── Ensure output directories exist ───────────────────────────────────────────
 
 os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven")
@@ -346,6 +372,7 @@ local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
 local last_metrics_run    = 0
+local last_blocklist_run  = 0  -- #1412: category blocklist refresh cadence
 local last_activity_sample = 0
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
@@ -393,6 +420,12 @@ do
                   clock.monotonic_seconds() - pt0)
   if snap then
     record_poll("200")
+    -- #1412: fetch + cache the category blocklists and attach them BEFORE the
+    -- initial apply, so the boot ruleset already carries the bl_ nftset=
+    -- populators. Previously startup applied with no _blocklist_hosts, so a
+    -- freshly booted / re-enrolled router ran with empty bl_ sets until (and
+    -- unless) a later snapshot change happened to trigger a fetch.
+    snap._blocklist_hosts = refresh_blocklists(snap)
     local at0 = clock.monotonic_seconds()
     local applied = policy.apply(snap, write_file, run_cmd, log,
                                  { on_apply = record_apply("boot") })
@@ -419,6 +452,7 @@ do
   last_policy_run        = mono
   last_usage_run         = mono
   last_metrics_run       = mono
+  last_blocklist_run     = mono
   last_activity_sample   = mono
 end
 
@@ -558,22 +592,14 @@ conntrack.watch({
       if snap then
         record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
-        -- #1360: the blocklist route is router-authenticated, so pass the
-        -- router token — without it the fetch 401s and category (bl_)
-        -- enforcement silently no-ops (the directly-queried-CNAME bl_ bypass
-        -- in e2e G4 plus every real category block).
-        local bl_result = blocklists.fetch_and_cache(
-          snap, http_get, nil, "/etc/wifihaven/blocklists", api_url, router_token)
-        -- #1301: emit blocklist_fetch_failures_total{status} for each failure
-        -- (bounded status enum) so an operator can rate-alert on fetch failures.
-        record_blocklist_failures(bl_result)
-        if #bl_result.errors > 0 then
-          for _, e in ipairs(bl_result.errors) do
-            log.warn("blocklist fetch: %s", tostring(e))
-          end
-        end
-        blocklists.gc(snap, nil, "/etc/wifihaven/blocklists")
-        snap._blocklist_hosts = blocklists.load_cached(snap, nil, "/etc/wifihaven/blocklists")
+        -- #1360: the blocklist route is router-authenticated, so refresh_blocklists
+        -- passes the router token — without it the fetch 401s and category (bl_)
+        -- enforcement silently no-ops. #1412: the same refresh runs at startup
+        -- and on the periodic blocklist timer, so a stable (304-only) snapshot no
+        -- longer leaves the sets empty; emitting blocklist_fetch_failures_total
+        -- (#1301) is folded into refresh_blocklists.
+        snap._blocklist_hosts = refresh_blocklists(snap)
+        last_blocklist_run = mono  -- this poll already refreshed; reset cadence
 
         -- Apply with no failover opts. If we were in failover, this
         -- apply already emits a clean ruleset (no failover chain), so we
@@ -655,6 +681,37 @@ conntrack.watch({
           new_in_failover = in_failover_render
         end
         in_failover_render = new_in_failover
+      end
+    end
+
+    -- Blocklist refresh timer (#1412). Category ipset population must NOT be
+    -- coupled to a snapshot change: the policy poll returns 304 in steady state,
+    -- so the only way the old code (re)fetched a blocklist was an admin policy
+    -- edit. A household with a stable snapshot therefore never (re)populated the
+    -- bl_ sets, and any transient first-fetch failure (a 401 during
+    -- re-enrollment, a network blip) left category enforcement a silent no-op
+    -- indefinitely. Here we refresh on an independent cadence against the last
+    -- good snapshot. fetch_and_cache is a cheap no-op read when the (id,version)
+    -- file is already cached, so this only does real work when a list's content
+    -- version changed; we re-apply (which reloads dnsmasq for the new nftset=
+    -- directives) only when the loaded host set actually differs.
+    if last_snapshot and not in_failover_render
+       and (mono - last_blocklist_run) >= blocklist_int then
+      last_blocklist_run = mono
+      local new_hosts = refresh_blocklists(last_snapshot)
+      if blocklists.hosts_differ(last_snapshot._blocklist_hosts, new_hosts) then
+        last_snapshot._blocklist_hosts = new_hosts
+        fold_enforcement_drops()
+        local bt0 = clock.monotonic_seconds()
+        local applied = policy.apply(last_snapshot, write_file, run_cmd, log,
+                                     { on_apply = record_apply("policy_change") })
+        metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                        clock.monotonic_seconds() - bt0)
+        if applied then
+          render.update_shared(last_snapshot, nft_sets, blocked_macs, blocked_reason,
+                               eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+          log.info("blocklist timer: category lists changed, re-applied ruleset")
+        end
       end
     end
 

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -436,3 +436,88 @@ describe("blocklists.fetch_and_cache structured failures (#1301)", function()
     assert.equal(0, #result.failures)
   end)
 end)
+
+-- ── refresh + change detection (#1412) ──────────────────────────────────────
+--
+-- #1412: category enforcement silently no-op'd in prod because the agent only
+-- fetched/cached blocklists inside the policy-poll HTTP-200 branch and never at
+-- startup. A household whose snapshot is stable (the steady state — every poll
+-- returns 304) therefore never populated the per-blocklist cache, so render
+-- emitted zero `nftset=/<member>/...#bl_<id>` directives, the bl_ ipsets stayed
+-- empty, and an assigned list (e.g. taboola.com ∈ 'ads') was reachable. The fix
+-- makes the agent call blocklists.refresh() at startup AND on a periodic timer
+-- (against the last good snapshot) independent of 200/304, re-applying only when
+-- hosts_differ() reports the cached set actually changed.
+
+describe("blocklists.refresh (#1412)", function()
+
+  it("fetches, caches, and returns the loaded host map in one call", function()
+    local fs = make_fs()
+    local function http_get(_url, _headers)
+      return 200, "doubleclick.net\ntaboola.com\n", {}
+    end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+
+    local res = blocklists.refresh(s, http_get, fs, "/etc/wifihaven/blocklists")
+
+    assert.equal(0, #res.failures)
+    assert.not_nil(res.hosts.ads)
+    local found = {}
+    for _, h in ipairs(res.hosts.ads) do found[h] = true end
+    assert.truthy(found["taboola.com"], "refresh must surface the cached member host")
+    -- The cache file was written so a later load_cached (e.g. after a restart)
+    -- finds it without re-fetching.
+    assert.not_nil(fs._files["/etc/wifihaven/blocklists/ads-v1.txt"])
+  end)
+
+  it("surfaces fetch failures and leaves the host map empty for the failed id", function()
+    -- The #1412/#1360 failure mode: the fetch 401s, so nothing is cached and the
+    -- bl_ set would stay empty. refresh must report the failure (so the agent can
+    -- emit the metric + retry next cadence) rather than silently returning {}.
+    local function http_get(_url, _headers) return 401, nil, {} end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+
+    local res = blocklists.refresh(s, http_get, make_fs(), "/etc/wifihaven/blocklists")
+
+    assert.equal(1, #res.failures)
+    assert.equal("ads", res.failures[1].id)
+    assert.equal("4xx", res.failures[1].status)
+    assert.equal(0, #(res.hosts.ads or {}))
+  end)
+
+end)
+
+describe("blocklists.hosts_differ (#1412)", function()
+
+  it("returns false for identical maps regardless of host order", function()
+    local a = { ads = { "a.com", "b.com" }, malware = { "m.com" } }
+    local b = { ads = { "b.com", "a.com" }, malware = { "m.com" } }
+    assert.is_false(blocklists.hosts_differ(a, b))
+  end)
+
+  it("returns true when host membership changes", function()
+    local a = { ads = { "a.com", "b.com" } }
+    local b = { ads = { "a.com", "c.com" } }
+    assert.is_true(blocklists.hosts_differ(a, b))
+  end)
+
+  it("returns true when an id is added or removed", function()
+    local a = { ads = { "a.com" } }
+    local b = { ads = { "a.com" }, malware = { "m.com" } }
+    assert.is_true(blocklists.hosts_differ(a, b))
+    assert.is_true(blocklists.hosts_differ(b, a))
+  end)
+
+  it("returns true when an empty cache becomes populated (the cold-start fix)", function()
+    -- Startup applies with an empty map; the first refresh populates it. The
+    -- agent must detect this transition and re-apply so bl_ directives appear.
+    assert.is_true(blocklists.hosts_differ({}, { ads = { "taboola.com" } }))
+    assert.is_true(blocklists.hosts_differ({ ads = {} }, { ads = { "taboola.com" } }))
+  end)
+
+  it("treats nil and empty as equal (no spurious re-apply)", function()
+    assert.is_false(blocklists.hosts_differ(nil, {}))
+    assert.is_false(blocklists.hosts_differ({}, nil))
+  end)
+
+end)


### PR DESCRIPTION
Fixes #1412.

## Live root cause (router-side, reproduced)

Server-side is fully correct — verified against **prod** (`api.wifihaven.net`):

- The operator's profile ("Sameer") snapshot ships `blocklistIds: [malware, ads, ads-extended]` for the laptop MAC.
- `snapshot.blocklists.ads = {version: e60fd5ae…, url: /api/blocklists/ads}`; the router-facing fetch returns the body with **taboola.com** present (36/36 hosts).
- The deployed agent reports **v0.3.0**, which already contains #1334 / #1350 / #1360 / #1363. Stale-agent ruled out.

The failure is in the agent's fetch orchestration, reproduced on the test router (also v0.3.0):

- `/etc/wifihaven/blocklists/` **did not exist**, the dnsmasq fragment had **0 `bl_` nftset directives** (50 `ea_`, 0 `bl_`), and the last blocklist-fetch attempt was **hours stale** despite a 5 s poll.
- The agent ran `fetch_and_cache` **only inside the policy-poll HTTP-200 branch, and not at startup at all.** In steady state the poll returns 304, so the only thing that ever triggered a blocklist fetch was an admin policy edit. A household with a stable snapshot therefore **never populated the `bl_` sets** → render emitted no `nftset=/<member>/...#bl_<id>` directives → category enforcement was a silent no-op. Any transient first-fetch failure (a 401 during re-enrollment, a network blip) had the same permanent effect.

> Per the architecture model, this is connection-layer: taboola resolving in DNS is not evidence it's unblocked. The bug is that the per-`(member host)` `bl_` ipset is never populated, so the nftables forward-drop has nothing to match.

## Fix

- **Startup fetch.** Fetch + cache blocklists and attach `_blocklist_hosts` **before** the initial apply, so the boot ruleset already carries the `bl_` populators.
- **Periodic refresh timer** (`blocklist_refresh_interval`, default 1 h) against the last good snapshot, **independent of 200/304**, re-applying only when `blocklists.hosts_differ` reports the loaded host set actually changed. This self-heals a failed boot fetch and matches the "periodic cadence" the architecture already documents. `fetch_and_cache` is a cheap cached read when the `(id,version)` file already exists, so steady state does no real work and no dnsmasq churn.
- Both paths route through one `refresh_blocklists` helper that folds in the `blocklist_fetch_failures_total` metric + error logging.

## Tests (TDD, red→green)

- `test(openwrt)` commit adds failing unit tests for the two new seams.
- `fix(openwrt)` commit implements `blocklists.refresh` + `blocklists.hosts_differ`.
- `openwrt/test/blocklists_spec.lua` (27) and `render_spec.lua` (147) pass. `render_spec` already proves a `bl_` member yields both the `nftset=` populator and the `ether saddr <mac> ip daddr @bl_<id> … drop` rule for an assigned MAC; these commits close the orchestration gap that left the set empty.

## Wire contract

No wire change. `blocklist_refresh_interval` is a UCI key read and written by the same agent build (not part of the router↔API contract). No DB migration, no Scala.

## Acceptance

After this ships in the next agent release and the prod router updates, a freshly-booted router populates `bl_ads` with taboola's resolved IPs from boot, and the forward-drop matches — taboola.com is dropped for the assigned profile while a non-member control host stays reachable.