### PR TITLE
fix(openwrt): detect installed luci-app version via apk list on apk-tools v3 (#1420)

### DIFF
--- a/openwrt/files/usr/sbin/wifihaven-update
+++ b/openwrt/files/usr/sbin/wifihaven-update
@@ -233,7 +233,17 @@ update_package "wifihaven" "$AGENT_PKG_NAME_RE" "$AGENT_STAMP" "$AGENT_INSTALLED
 LUCI_INSTALLED=
 case "$PM" in
   opkg) LUCI_INSTALLED=$(opkg info luci-app-wifihaven 2>/dev/null | awk '/^Version:/{print $2; exit}' | sed 's/-.*//') ;;
-  apk)  LUCI_INSTALLED=$(apk info -v luci-app-wifihaven 2>/dev/null | head -1 | sed 's/^luci-app-wifihaven-//; s/-r.*//') ;;
+  # apk-tools v3 (`apk info -v <pkg>`) emits the package *description* block,
+  # not a `pkgname-version` line, so the old parse captured the description
+  # string as the version (#1420). `apk list --installed <pkg>` is the
+  # reliable source: its first token is `luci-app-wifihaven-<ver>-r<n>`, e.g.
+  #   luci-app-wifihaven-0.3.0-r1 noarch {luci-app-wifihaven} (MIT) [installed]
+  # from which we strip the name prefix and the `-r<n>` apk revision suffix.
+  apk)  LUCI_INSTALLED=$(apk list --installed luci-app-wifihaven 2>/dev/null \
+          | grep -E '^luci-app-wifihaven-[0-9]' \
+          | head -1 \
+          | awk '{print $1}' \
+          | sed 's/^luci-app-wifihaven-//; s/-r[0-9]*$//') ;;
 esac
 
 # Reload uhttpd so the new LuCI Lua files are picked up without a full reboot.

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -31,6 +31,7 @@ sh test/init_spec.sh
 sh test/init_boot_spec.sh
 sh test/boot_skeleton_spec.sh
 sh test/update_spec.sh
+sh test/update_multi_pkg_spec.sh
 sh test/install_spec.sh
 sh test/nft_log_dep_spec.sh
 sh test/agent_spec.sh

--- a/openwrt/test/update_multi_pkg_spec.sh
+++ b/openwrt/test/update_multi_pkg_spec.sh
@@ -214,7 +214,6 @@ luci_stamp()   { cat "$STATE/last_update_version.luci-app-wifihaven" 2>/dev/null
 downloads()    { cat "$TESTDIR/downloads.log" 2>/dev/null || echo ""; }
 wh_restarts()  { grep -c '^restart' "$TESTDIR/initd-wifihaven.calls" 2>/dev/null || echo 0; }
 uhttpd_reloads() { grep -c '^reload' "$TESTDIR/initd-uhttpd.calls" 2>/dev/null || echo 0; }
-apk_adds()     { grep -c '^add' "$TESTDIR/apk.calls" 2>/dev/null || echo 0; }
 logger_out()   { cat "$TESTDIR/logger.out" 2>/dev/null || echo ""; }
 
 # ── Case 1: both packages on new version → both upgraded, both stamps ────────
@@ -353,13 +352,16 @@ export MOCK_LUCI_INSTALLED="0.2.8"        # luci installed & current per apk db
 PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
 
 DL=$(downloads)
-printf '%s' "$DL" | grep -vq 'luci-app-wifihaven' \
-  && check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" ok \
-  || check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" "downloads: $DL"
-N=$(apk_adds)
-[ "$N" = "0" ] \
-  && check "[apk v3 current] apk add NOT called" ok \
-  || check "[apk v3 current] apk add NOT called" "apk add count $N; calls: $(cat "$TESTDIR/apk.calls" 2>/dev/null)"
+if printf '%s' "$DL" | grep -q 'luci-app-wifihaven'; then
+  check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" "downloads: $DL"
+else
+  check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" ok
+fi
+if grep -q '^add' "$TESTDIR/apk.calls" 2>/dev/null; then
+  check "[apk v3 current] apk add NOT called" "apk calls: $(cat "$TESTDIR/apk.calls" 2>/dev/null)"
+else
+  check "[apk v3 current] apk add NOT called" ok
+fi
 N=$(uhttpd_reloads)
 [ "$N" = "0" ] \
   && check "[apk v3 current] uhttpd NOT reloaded" ok \

--- a/openwrt/test/update_multi_pkg_spec.sh
+++ b/openwrt/test/update_multi_pkg_spec.sh
@@ -144,11 +144,42 @@ case "$expr" in
 esac
 EOF
 
-  # Mocks for apk and uhttpd init.d
+  # Mocks for apk and uhttpd init.d.
+  #
+  # The apk mock reproduces the apk-tools v3 output shapes (verified live on
+  # openwrt.lan, apk-tools 3.0.5) so the version-detection parse is exercised
+  # against realistic output:
+  #   - `apk info -v <pkg>` emits the package DESCRIPTION block, NOT a
+  #     pkgname-version line — this is exactly what broke LUCI_INSTALLED.
+  #   - `apk list --installed <pkg>` emits a `pkgname-version-rN ...` token
+  #     line, which is the reliable source of the installed semver.
+  # MOCK_LUCI_INSTALLED sets the installed luci-app version (empty = not
+  # installed). The agent's apk fallback is never hit in these tests because
+  # the baked-in VERSION file is always present.
   cat > "$BINDIR/apk" <<APKEOF
 #!/bin/sh
 printf '%s\n' "\$*" >> "$TESTDIR/apk.calls"
-exit \${MOCK_APK_EXIT:-0}
+_cmd="\$1"
+_pkg=""
+for _a in "\$@"; do _pkg="\$_a"; done
+case "\$_cmd" in
+  info)
+    printf '%s: LuCI web UI for the WifiHaven router agent\n' "\$_pkg"
+    printf '%s: https://github.com/wifihaven/wifihaven\n' "\$_pkg"
+    printf '%s: 15 KiB\n' "\$_pkg"
+    exit 0
+    ;;
+  list)
+    if [ "\$_pkg" = "luci-app-wifihaven" ] && [ -n "\${MOCK_LUCI_INSTALLED:-}" ]; then
+      printf 'luci-app-wifihaven-%s-r1 noarch {luci-app-wifihaven} (MIT) [installed]\n' "\${MOCK_LUCI_INSTALLED}"
+    fi
+    exit 0
+    ;;
+  add)
+    exit \${MOCK_APK_EXIT:-0}
+    ;;
+esac
+exit 0
 APKEOF
 
   INITD_WIFIHAVEN="$BINDIR/wifihaven-initd"
@@ -183,6 +214,8 @@ luci_stamp()   { cat "$STATE/last_update_version.luci-app-wifihaven" 2>/dev/null
 downloads()    { cat "$TESTDIR/downloads.log" 2>/dev/null || echo ""; }
 wh_restarts()  { grep -c '^restart' "$TESTDIR/initd-wifihaven.calls" 2>/dev/null || echo 0; }
 uhttpd_reloads() { grep -c '^reload' "$TESTDIR/initd-uhttpd.calls" 2>/dev/null || echo 0; }
+apk_adds()     { grep -c '^add' "$TESTDIR/apk.calls" 2>/dev/null || echo 0; }
+logger_out()   { cat "$TESTDIR/logger.out" 2>/dev/null || echo ""; }
 
 # ── Case 1: both packages on new version → both upgraded, both stamps ────────
 setup_mocks
@@ -303,6 +336,60 @@ PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
 [ "$(agent_stamp)" = "0.2.8" ] \
   && check "[migration] agent stamp present after migration" ok \
   || check "[migration] agent stamp present after migration" "stamp='$(agent_stamp)'"
+rm -rf "$TESTDIR"
+
+# ── Case 6: apk v3 installed-version detection — luci already current ─────────
+# Regression for #1420: on apk-tools v3, `apk info -v` emits the description
+# block, so the old parse captured "luci-app-wifihaven: LuCI web UI ..." as the
+# installed version instead of the semver. With NO stamp present (so the stamp
+# can't mask the bug), a correctly-detected installed version equal to LATEST
+# must make the luci run a complete no-op: no download, no `apk add`, no uhttpd
+# reload. With the broken parse the bogus string never equals LATEST, so the
+# script wastefully "upgrades".
+setup_mocks
+printf '0.2.8\n' > "$VERS_DIR/VERSION"   # agent already current → agent no-op
+export MOCK_LUCI_INSTALLED="0.2.8"        # luci installed & current per apk db
+# Deliberately no luci stamp file.
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+
+DL=$(downloads)
+printf '%s' "$DL" | grep -vq 'luci-app-wifihaven' \
+  && check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" ok \
+  || check "[apk v3 current] luci-app NOT downloaded (installed==latest detected)" "downloads: $DL"
+N=$(apk_adds)
+[ "$N" = "0" ] \
+  && check "[apk v3 current] apk add NOT called" ok \
+  || check "[apk v3 current] apk add NOT called" "apk add count $N; calls: $(cat "$TESTDIR/apk.calls" 2>/dev/null)"
+N=$(uhttpd_reloads)
+[ "$N" = "0" ] \
+  && check "[apk v3 current] uhttpd NOT reloaded" ok \
+  || check "[apk v3 current] uhttpd NOT reloaded" "got $N"
+unset MOCK_LUCI_INSTALLED
+rm -rf "$TESTDIR"
+
+# ── Case 7: apk v3 installed-version detection — bare semver in upgrade log ───
+# When luci IS behind, the upgrade must run AND the log line must show the bare
+# semver (e.g. "version 0.2.7 -> 0.2.8"), not the description string the broken
+# parse produced ("version luci-app-wifihaven: LuCI web UI ... -> 0.2.8").
+setup_mocks
+printf '0.2.8\n' > "$VERS_DIR/VERSION"   # agent current → only luci moves
+export MOCK_LUCI_INSTALLED="0.2.7"        # luci behind by one version
+PATH="$BINDIR:/usr/bin:/bin" "$PATCHED" >/dev/null 2>&1 || true
+
+LOG=$(logger_out)
+printf '%s' "$LOG" | grep -q 'luci-app-wifihaven: version 0.2.7 -> 0.2.8' \
+  && check "[apk v3 behind] upgrade log shows bare semver 0.2.7 -> 0.2.8" ok \
+  || check "[apk v3 behind] upgrade log shows bare semver 0.2.7 -> 0.2.8" "log: $LOG"
+if printf '%s' "$LOG" | grep -q 'version luci-app-wifihaven: LuCI web UI'; then
+  check "[apk v3 behind] installed version is not the description string" "description leaked into log: $LOG"
+else
+  check "[apk v3 behind] installed version is not the description string" ok
+fi
+DL=$(downloads)
+printf '%s' "$DL" | grep -q 'luci-app-wifihaven_0.2.8-1_all.apk' \
+  && check "[apk v3 behind] luci-app asset downloaded" ok \
+  || check "[apk v3 behind] luci-app asset downloaded" "downloads: $DL"
+unset MOCK_LUCI_INSTALLED
 rm -rf "$TESTDIR"
 
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"

--- a/openwrt/test/update_multi_pkg_spec.test.sh
+++ b/openwrt/test/update_multi_pkg_spec.test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Thin shim: auto-discovered by the CI shell-tests job (*.test.sh pattern in
+# .github/workflows/ci.yml) and delegates to update_multi_pkg_spec.sh, which is
+# the canonical home for the wifihaven-update multi-package assertions.
+#
+# update_multi_pkg_spec.sh expects to be invoked with openwrt/ as its working
+# directory.
+set -euo pipefail
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+sh "${OPENWRT_DIR}/test/update_multi_pkg_spec.sh"


### PR DESCRIPTION
Closes #1420. Follow-up spotted during #1414 (PR #1419).

## Problem

On apk-tools v3 (OpenWRT 24.10+), `wifihaven-update` mis-detects the installed `luci-app-wifihaven` version. `apk info -v <pkg>` emits the package *description* block, not a `pkgname-version` line, so `LUCI_INSTALLED` captured the description string instead of the semver. Observed live on `openwrt.lan` (apk-tools 3.0.5):

```
wifihaven: update: luci-app-wifihaven: version luci-app-wifihaven: LuCI web UI for the WifiHaven router agent -> 0.3.0; upgrading via apk
```

**Cosmetic, not functional.** The bogus string never equals `LATEST_VERSION`, so the comparison falls through to "install" and the per-package stamp then short-circuits subsequent runs. The only damage is a malformed log line and one wasteful version comparison per fresh router. The agent (`wifihaven`) path is unaffected — it uses the baked-in `/usr/lib/wifihaven/VERSION` file — and is **not** touched here.

## Real apk-tools v3 output (verified live, apk-tools 3.0.5)

```
$ apk info -v luci-app-wifihaven
luci-app-wifihaven: LuCI web UI for the WifiHaven router agent
luci-app-wifihaven: https://github.com/wifihaven/wifihaven
luci-app-wifihaven: 15 KiB

$ apk list --installed luci-app-wifihaven
luci-app-wifihaven-0.3.0-r1 noarch {luci-app-wifihaven} (MIT) [installed]
```

## Fix

Parse `apk list --installed luci-app-wifihaven`, whose first token is `luci-app-wifihaven-<ver>-r<n>`, and strip the name prefix + `-r<n>` apk revision suffix. Verified against the live router: the parse yields `0.3.0`.

## Tests (TDD)

Extends `openwrt/test/update_multi_pkg_spec.sh` with an `apk` mock that reproduces the real v3 output shapes (`info -v` → description block; `list --installed` → version token). New assertions, committed red first (5 failures against the old parse), then green:

- **already-current luci-app run is a no-op** — no download, no `apk add`, no uhttpd reload — when no stamp file is present to mask the mis-parse;
- **behind luci-app run logs the bare semver** (`0.2.7 -> 0.2.8`), not the description string.

Also wires the multi-package spec into `run_tests.sh` and adds a `*.test.sh` CI shim so it actually gates (it previously ran nowhere automatically).

```
test/update_multi_pkg_spec.sh → 33 passed, 0 failed
test/update_spec.sh           → 38 passed, 0 failed
```

No Scala touched. (Two pre-existing `failover_spec.lua` failures on this host are environmental — `nft` binary not available — and unrelated to this change.)