### PR TITLE
db: migration for profiles.pause_mode — hard-pause foundation (#1418)

### DIFF
--- a/api/resources/db/migration/V49__add_pause_mode.sql
+++ b/api/resources/db/migration/V49__add_pause_mode.sql
@@ -1,0 +1,38 @@
+-- V49__add_pause_mode.sql
+-- #1418: per-profile "hard pause" — a true off-switch that blocks even the
+-- otherwise-allowlisted hosts (an allowed-mode app's hosts, the #1105 exempt
+-- carve-out, and the #1307 global infra allowlist).
+--
+-- Today's pause is "soft": a paused profile drops all forwarded traffic EXCEPT
+-- its `extraAllowed` hosts, so an allowed app + the infra allowlist stay
+-- reachable through a pause (#421/#1413). "Hard pause" is the opposite — no
+-- carve-outs.
+--
+-- No new wire field: hard pause is expressed *functionally* in the snapshot per
+-- the wire-shape rules in CLAUDE.md ("express new policy via existing functional
+-- fields — never add a field for the concept itself"). When a profile is
+-- hard-paused, PolicyService.computeBlockRules ships `blocked = true` with
+-- `extraAllowed` emptied (only the block-page / admin-UI hosts survive) for that
+-- MAC. The router's @blocked_macs carve-out is driven purely by the presence of
+-- `extraAllowed`, so an empty list ⇒ the MAC drops unconditionally with no
+-- `ip daddr != @ea_…` exception. The router stays oblivious to "hard vs soft".
+--
+-- This is a SCHEMA-ONLY migration (per the migration-isolation rule in
+-- CLAUDE.md): it ships with no source or tests. The PolicyService /
+-- ProfileRepo / route / SPA changes that READ and WRITE this column are the
+-- follow-up PR. Until then the column is inert — nothing reads it, every
+-- existing profile is 'soft', and behavior is unchanged.
+--
+-- `profiles` is a small metadata table, NOT one of the unbounded-growth event
+-- tables (traffic_reports, connection_events, …). Adding a column with a
+-- constant default is metadata-only in PG 11+ (no table rewrite), so this is
+-- safe on the Flyway startup critical path even at prod data volume.
+--
+-- Nullable-by-default contract: the column has a NOT NULL DEFAULT 'soft', so
+-- image-(N-1) — which never names `pause_mode` in any INSERT/UPDATE — keeps
+-- working unchanged; existing rows and any new rows it writes are 'soft', i.e.
+-- today's behavior.
+
+ALTER TABLE profiles
+  ADD COLUMN pause_mode TEXT NOT NULL DEFAULT 'soft'
+    CHECK (pause_mode IN ('soft', 'hard'));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -463,6 +463,20 @@ the next poll after a window edge recomputes against the current instant
 if the future server-push channel above is built. Full design:
 [`docs/design/per-app-schedules.md`](design/per-app-schedules.md).
 
+**Hard pause ([#1418](https://github.com/wifihaven/wifihaven/issues/1418))
+is the same pattern in reverse — a functional override of the carve-out, not
+a new field.** Pause has two modes, stored per-profile in
+`profiles.pause_mode` (`'soft'` | `'hard'`, default `'soft'`). *Soft* pause is
+today's behaviour: the MAC drops except its `extraAllowed` hosts (an allowed
+app + the #1307 infra allowlist survive, per #421/#1413). *Hard* pause is a
+true off-switch — when a profile is paused **and** `pause_mode = 'hard'`,
+`PolicyService.computeBlockRules` ships `blocked = true` with `extraAllowed`
+emptied of the app/exempt/infra hosts, keeping only the deployment's
+`uiAllowedHosts` so the block page and admin SPA still load on the household
+LAN. With an empty `ea_` set the router drops the MAC unconditionally — no
+`ip daddr != @ea_…` exception — so it never learns "hard vs soft"; `blockReason`
+stays `Paused` (block-page copy only). No wire/router change.
+
 ## 6. Router HTTP API
 
 All endpoints below are served by the existing API process under


### PR DESCRIPTION
## Part of #1418 (schema only; code in follow-up)

Schema foundation for a profile-level **hard pause** — a true off-switch that, unlike today's soft pause, blocks even the otherwise-allowlisted hosts.

### What this adds

A single per-profile column on `profiles`:

```sql
ALTER TABLE profiles
  ADD COLUMN pause_mode TEXT NOT NULL DEFAULT 'soft'
    CHECK (pause_mode IN ('soft', 'hard'));
```

`'soft'` (the default) is today's behavior: a paused profile drops all forwarded traffic **except** its `extraAllowed` hosts, so an allowed-mode app + the #1307 global infra allowlist stay reachable through the pause (#421/#1413). `'hard'` will be the opposite — no carve-outs.

### Why a `text` enum column (not `hard_paused boolean`)

Mirrors the existing enum-as-text columns on this table (`failure_mode`, `cross_device_overlap_mode`): self-documenting, CHECK-constrained, and extensible if pause ever grows a third mode. Functionally equivalent to a boolean for now.

### Design choices being settled (implemented in the follow-up)

- **No new wire/snapshot field.** Per the wire-shape rules in `CLAUDE.md` ("express new policy via existing functional fields — never add a field for the concept itself"), hard pause is expressed *functionally*: when a profile is hard-paused, `PolicyService.computeBlockRules` ships `blocked = true` with `extraAllowed` emptied of the app/exempt/infra hosts for that MAC. The router's `@blocked_macs` carve-out is driven purely by the presence of `extraAllowed`, so an empty list ⇒ unconditional drop with no `ip daddr != @ea_…` exception. The router stays oblivious to "hard vs soft".
- **Block page / admin UI is spared.** Hard pause keeps the deployment's `uiAllowedHosts` so the kid still sees *why* they're cut off and the admin SPA still loads on the LAN — only the app/infra allowlists go dark. `blockReason` stays `Paused` (block-page copy only).

### Why this is its own PR

Per the migration-isolation rule (`CLAUDE.md` §migrations-back-compat), a PR that adds a Flyway migration may contain **only** the migration + docs. This PR is exactly that (the `V49` SQL plus an `docs/architecture.md` paragraph). The `PolicyService` / `ProfileRepo` / route / SPA code that reads and writes the column lands in the **stacked follow-up PR**, which is gated on this one merging and deploying first.

### Backwards compatibility

- `NOT NULL DEFAULT 'soft'` ⇒ image-(N-1), which never names `pause_mode` in any INSERT/UPDATE, keeps working unchanged; existing and newly-written rows are `'soft'` (today's behavior).
- `profiles` is a small metadata table (not an unbounded-growth event table), so the constant-default `ADD COLUMN` is metadata-only in PG 11+ — no table rewrite, fast on the Flyway startup path at prod volume.

### Test plan

The existing `api.test` feature suite is the back-compat gate. `TestDatabase` applies **every** migration on the classpath — including `V49` — before any test runs, and the fixtures exercise image-(N-1)'s production code paths in `api/src/**`. Green ⇒ the new schema is backward-compatible with the currently-deployed image. No source/test changes ship here (they'd bypass the gate), so the column is inert until the follow-up.
