### PR TITLE
feat(grafana): alert on router-metrics ingest failure (#1368)

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -70,6 +70,59 @@ templated `${datasource}` variable resolved at view time, so the same JSON
 loads in both Grafana Cloud and a self-hosted provisioned Grafana, #1207),
 and the GitHub Actions secrets.
 
+## Alerting (#1368 — first rule of the #1381 strategy)
+
+[`alerting.tf`](alerting.tf) adds the first **Grafana-managed alert**: a
+router-metrics ingest failure (alert **C4** in
+[`docs/design/alerting.md`](../../docs/design/alerting.md) §7.1) now pages the
+operator instead of only being graphable. It reuses the exact success-ratio
+PromQL from the `api-self-metrics` ingest panel (#1373/#1384), adds a
+zero-traffic guard, fires `< 0.95 for 15m`, and routes it `critical`. It ships
+with the shared plumbing the rest of the §7 catalog extends:
+
+- `grafana_folder.alerts` — holds the rule group (a rule group requires a
+  `folder_uid`).
+- `grafana_contact_point` ×3 — `wifihaven-critical`, `wifihaven-warning`,
+  `wifihaven-staging`, all **email** to the single household operator. Distinct
+  resources so `critical` can later be re-pointed at a real pager with zero rule
+  churn (§4 — no invented transport).
+- `grafana_notification_policy` — the singleton root tree routing by
+  `severity` / `env` (staging matched first → notify, never page).
+- `grafana_rule_group.router_metrics_ingest` — C4 (prod, critical) + its
+  staging twin (warning).
+
+### Hard prerequisite: remote Terraform state (#1406)
+
+**These alerting resources cannot be applied by the current stateless CD.**
+Unlike `grafana_dashboard` (upserted by uid with `overwrite = true`), contact
+points, the notification policy, the folder, and the rule group are stateful
+with no upsert escape hatch — against the empty-every-run CD they 409 or
+accumulate duplicates (the same reason `main.tf` refuses to manage a folder for
+dashboards). So `infra/grafana` must first migrate onto an **HCP Terraform
+remote backend** — filed as the blocking prerequisite
+[#1406](https://github.com/wifihaven/wifihaven/issues/1406) (mirrors #1357 for
+`infra/cloudflare`). See [`docs/design/alerting.md`](../../docs/design/alerting.md)
+§3.1 and §9.
+
+This PR is therefore **stacked on #1406**:
+
+- It is CI-lint-clean today (`terraform fmt -check` + `validate -backend=false`
+  in the `grafana-terraform` job), which gates the PR.
+- The live `terraform apply` in `master-grafana.yml` must not run these rules
+  until #1406 lands the `cloud {}` backend, the workflow wiring, and the
+  operator's one-time HCP `grafana` workspace.
+
+### New variables
+
+- `operator_email` (**required**, no default) — recipient for all three contact
+  points. In CD fed from an `OPERATOR_EMAIL` secret (wired with #1406); locally
+  via `terraform.tfvars` / `TF_VAR_operator_email`. Marked `sensitive` to keep
+  PII out of plan/apply logs.
+- `prometheus_datasource_uid` (default `grafanacloud-prom`) — managed alert
+  rules evaluate server-side and need a concrete datasource uid (dashboards
+  resolve a templated variable at view time and don't). Override for a
+  self-hosted stack.
+
 ## Prerequisites
 
 1. A Grafana Cloud stack exists (free tier is fine; see design §6.2) — one

--- a/infra/grafana/alerting.tf
+++ b/infra/grafana/alerting.tf
@@ -1,0 +1,300 @@
+# Grafana-managed alerting for wifihaven (#1368, first rule of the #1381
+# alerting strategy — docs/design/alerting.md).
+#
+# This is the concrete alert that starts the alerting thread: a router-metrics
+# ingest failure now PAGES the operator instead of only being graphable. It is
+# alert **C4** in docs/design/alerting.md §7.1 — the direct successor to the
+# at-a-glance success-ratio stat panel that shipped on the api-self-metrics
+# dashboard (#1373/#1384). It reuses that panel's exact PromQL, adds the
+# zero-traffic guard, and routes it `critical`.
+#
+# ── Hard prerequisite: remote Terraform state (#1406) ────────────────────────
+# Everything in THIS file is stateful — grafana_contact_point,
+# grafana_notification_policy (a singleton root tree), grafana_folder, and
+# grafana_rule_group have no "upsert by uid / overwrite=true" escape hatch the
+# way grafana_dashboard does (main.tf). Applied against the stateless,
+# empty-every-run CD that infra/grafana uses today they would 409 on a fixed
+# identifier or accumulate duplicates across runs.
+#
+# So these resources MUST NOT be applied until infra/grafana is migrated onto
+# an HCP Terraform remote backend — filed as the blocking prerequisite #1406
+# (mirrors #1357 for infra/cloudflare). This PR therefore STACKS ON #1406:
+# - The grafana-terraform CI lint (`terraform fmt -check` + `validate
+#   -backend=false`) passes today and gates this PR.
+# - The live `terraform apply` in master-grafana.yml must not run this until
+#   #1406 lands (the `cloud {}` backend + workflow wiring + the operator's
+#   one-time HCP `grafana` workspace + `operator_email` plumbing).
+# See docs/design/alerting.md §3.1 and §9 for the full sequencing.
+#
+# The catalog in docs/design/alerting.md §7 (C1–C7 critical, W1–W5 warning)
+# extends THIS plumbing — same contact points, same notification policy, more
+# grafana_rule_group resources — rather than replacing it (#1402/#1403/#1404).
+
+# ── Folder ──────────────────────────────────────────────────────────────────
+# Alert rules must live in a folder (folder_uid is required on a rule group).
+# Unlike the dashboards (main.tf deliberately does not manage a folder, to stay
+# stateless-idempotent), this is safe to manage here precisely because the
+# alerting resources already require remote state (#1406) — under managed state
+# a folder is upserted by uid, not recreated every run.
+resource "grafana_folder" "alerts" {
+  title = "WifiHaven Alerts"
+  uid   = "wifihaven-alerts"
+}
+
+# ── Contact points ───────────────────────────────────────────────────────────
+# Three points, all email to the single household operator (no invented pager /
+# Slack transport with no consumer — docs/design/alerting.md §4). They are
+# distinct resources, not one, so the `critical` point can later be re-pointed
+# at a real pager integration without touching warning routing or any rule.
+resource "grafana_contact_point" "critical" {
+  name = "wifihaven-critical"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven CRITICAL] {{ .CommonLabels.alertname }}"
+    message   = "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}"
+  }
+}
+
+resource "grafana_contact_point" "warning" {
+  name = "wifihaven-warning"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven warning] {{ .CommonLabels.alertname }}"
+    message   = "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}"
+  }
+}
+
+resource "grafana_contact_point" "staging" {
+  name = "wifihaven-staging"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven staging] {{ .CommonLabels.alertname }}"
+    message   = "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}"
+  }
+}
+
+# ── Notification policy (singleton root tree) ────────────────────────────────
+# Severity/env routing in front of the contact points so swapping email for a
+# real pager later is a one-resource edit, not a re-architecture
+# (docs/design/alerting.md §4). Order matters: env="staging" is matched FIRST
+# so a staging alert is only ever notified (never paged), short-circuiting
+# before the severity matches. Grouping/throttle keeps a single firing alert
+# from re-mailing the household operator every few minutes.
+resource "grafana_notification_policy" "root" {
+  group_by      = ["alertname", "env"]
+  contact_point = grafana_contact_point.warning.name # default for anything unmatched
+
+  group_wait      = "30s"
+  group_interval  = "5m"
+  repeat_interval = "4h"
+
+  # First match wins: staging never pages.
+  policy {
+    matcher {
+      label = "env"
+      match = "="
+      value = "staging"
+    }
+    contact_point = grafana_contact_point.staging.name
+    group_by      = ["alertname", "env"]
+  }
+
+  policy {
+    matcher {
+      label = "severity"
+      match = "="
+      value = "critical"
+    }
+    contact_point = grafana_contact_point.critical.name
+    group_by      = ["alertname", "env"]
+  }
+
+  policy {
+    matcher {
+      label = "severity"
+      match = "="
+      value = "warning"
+    }
+    contact_point = grafana_contact_point.warning.name
+    group_by      = ["alertname", "env"]
+  }
+}
+
+# ── Rule group: router-metrics ingest health ─────────────────────────────────
+# Alert C4 (docs/design/alerting.md §7.1) + its staging twin at severity
+# `warning` (§6 — staging exercises this path but a staging blip must not
+# page). Evaluated every 60s.
+#
+# Each rule is the standard Grafana-managed three-stage shape:
+#   A — success ratio (instant PromQL; the EXACT #1373/#1384 panel expression)
+#   B — traffic guard  (instant PromQL; batch rate over the window)
+#   C — math: fire when ratio < 0.95 AND there is traffic
+# Condition = C. A math result of 1 (true) is the firing condition.
+#
+# Threshold + `for` rationale (docs/design/alerting.md §7.1 C4):
+#   - ratio < 0.95: the literal #1365 condition — `ok=0, malformed>0` drives the
+#     ratio to 0 (the `or vector(0)` coercion makes ok-absent read as 0, not
+#     empty, exactly as the dashboard panel does), which is < 0.95.
+#   - guard `> 0`: an idle env yields 0/0 = empty; without the guard the rule
+#     would flap or fire perpetually against no traffic. no_data_state = "OK"
+#     belts-and-braces this so a genuinely quiet window stays Normal.
+#   - for: 15m — matches the 10m rate window plus margin, so a single bad batch
+#     during a deploy does not page.
+resource "grafana_rule_group" "router_metrics_ingest" {
+  name             = "wifihaven-router-metrics-ingest"
+  folder_uid       = grafana_folder.alerts.uid
+  interval_seconds = 60
+
+  # C4 — prod, critical (pages).
+  rule {
+    name      = "Router metrics ingest failure"
+    condition = "C"
+    for       = "15m"
+
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+
+    labels = {
+      severity = "critical"
+      env      = "prod"
+    }
+
+    annotations = {
+      summary     = "Router-metrics ingest success ratio < 95% (prod)"
+      description = "POST /api/router/metrics is rejecting batches: the success ratio (status=ok / all) over 10m is below 0.95 with traffic present. This is the #1365 silent-failure shape (ok=0, malformed climbing). Check router_metrics_batches_total{status} on the api-self-metrics dashboard and the agent fleet's metrics push."
+      runbook_url = "https://github.com/wifihaven/wifihaven/blob/main/docs/design/alerting.md#71-critical--page-now"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        editorMode    = "code"
+        expr          = "(sum(rate(router_metrics_batches_total{env=\"prod\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"prod\"}[10m]))"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "B"
+        editorMode    = "code"
+        expr          = "sum(rate(router_metrics_batches_total{env=\"prod\"}[10m]))"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "math"
+        expression = "$A < 0.95 && $B > 0"
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+      })
+    }
+  }
+
+  # C4 staging twin — warning (notifies, never pages; routed by env="staging").
+  rule {
+    name      = "Router metrics ingest failure (staging)"
+    condition = "C"
+    for       = "15m"
+
+    no_data_state  = "OK"
+    exec_err_state = "Error"
+
+    labels = {
+      severity = "warning"
+      env      = "staging"
+    }
+
+    annotations = {
+      summary     = "Router-metrics ingest success ratio < 95% (staging)"
+      description = "Staging POST /api/router/metrics success ratio over 10m is below 0.95 with traffic present. Notify-only (staging never pages); investigate before it reaches prod."
+      runbook_url = "https://github.com/wifihaven/wifihaven/blob/main/docs/design/alerting.md#71-critical--page-now"
+    }
+
+    data {
+      ref_id         = "A"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "A"
+        editorMode    = "code"
+        expr          = "(sum(rate(router_metrics_batches_total{env=\"staging\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"staging\"}[10m]))"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id         = "B"
+      datasource_uid = var.prometheus_datasource_uid
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId         = "B"
+        editorMode    = "code"
+        expr          = "sum(rate(router_metrics_batches_total{env=\"staging\"}[10m]))"
+        instant       = true
+        range         = false
+        intervalMs    = 1000
+        maxDataPoints = 43200
+      })
+    }
+
+    data {
+      ref_id         = "C"
+      datasource_uid = "__expr__"
+      relative_time_range {
+        from = 600
+        to   = 0
+      }
+      model = jsonencode({
+        refId      = "C"
+        type       = "math"
+        expression = "$A < 0.95 && $B > 0"
+        datasource = {
+          type = "__expr__"
+          uid  = "__expr__"
+        }
+      })
+    }
+  }
+}

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -13,3 +13,13 @@ grafana_auth = "<Grafana service-account token — Administration → Service ac
 # to use the stack's General folder. Not managed as a resource (keeps the
 # apply stateless-idempotent in CD).
 # folder_uid = "wifihaven"
+
+# ── Alerting (#1368 / docs/design/alerting.md) ───────────────────────────────
+# Required once the alerting resources (alerting.tf) are applied — gated on the
+# #1406 remote-state migration. In CD, fed from an OPERATOR_EMAIL secret.
+operator_email = "you@example.com"
+
+# Optional: Prometheus datasource uid the alert rules evaluate against.
+# Defaults to Grafana Cloud's built-in "grafanacloud-prom"; override for a
+# self-hosted stack.
+# prometheus_datasource_uid = "grafanacloud-prom"

--- a/infra/grafana/variables.tf
+++ b/infra/grafana/variables.tf
@@ -15,3 +15,20 @@ variable "folder_uid" {
   default     = ""
   description = "Optional uid of a pre-existing Grafana folder to place the dashboards in. Leave empty to use the stack's General folder. We do not manage the folder as a resource so the apply stays stateless-idempotent in CD (see main.tf)."
 }
+
+# ── Alerting (#1368 / docs/design/alerting.md) ───────────────────────────────
+# Required only once the alerting resources (alerting.tf) are applied, which is
+# gated on the #1406 remote-state migration. No default: alerting must not ship
+# with a placeholder recipient. In CD this is fed from an OPERATOR_EMAIL secret
+# (wired alongside the #1406 backend), the same handling as grafana_auth.
+variable "operator_email" {
+  type        = string
+  sensitive   = true
+  description = "Email address that alert notifications are sent to (the single household operator). Used by the wifihaven-critical / -warning / -staging contact points. Not a secret per se, but marked sensitive to keep PII out of plan/apply logs. Never committed."
+}
+
+variable "prometheus_datasource_uid" {
+  type        = string
+  default     = "grafanacloud-prom"
+  description = "UID of the Prometheus datasource the alert rules evaluate against. Unlike dashboards (which resolve a templated datasource variable at view time), managed alert rules evaluate server-side and need a concrete datasource uid. Default is Grafana Cloud's built-in Prometheus uid; override for a self-hosted stack. Find it under Connections -> Data sources -> Prometheus -> the uid in the URL."
+}


### PR DESCRIPTION
## What

The concrete alert that starts the alerting thread (#1368). A router-metrics ingest failure now **pages the operator** instead of only being graphable — closing the gap that let the #1365 silent 100%-malformed outage go unnoticed.

This implements alert **C4** from the shipped alerting strategy ([`docs/design/alerting.md`](../blob/main/docs/design/alerting.md) §7.1, from #1381), plus the shared contact-point / notification-policy plumbing the rest of that catalog extends — coordinated with #1381 so its C1–C7 / W1–W5 rules *add more rule groups* against the same plumbing rather than replacing it.

### The rule
- Reuses the **exact** success-ratio PromQL from the shipped `api-self-metrics` ingest panel (#1373/#1384) — no invented series; `router_metrics_batches_total{status}` is grep-confirmed emitted at `api/src/metrics/Metrics.scala:240`.
- `(sum(rate(...{status="ok"}[10m])) or vector(0)) / sum(rate(...[10m]))` with a **zero-traffic guard** `sum(rate(...[10m])) > 0`.
- Fires `ratio < 0.95 for 15m`, severity `critical`.
- **Total-outage nuance (the #1384 fix):** the `or vector(0)` coercion makes `ok=0, malformed>0` read as `0` (→ `< 0.95`, fires) instead of empty/No-data. The guard + `no_data_state = "OK"` keep a genuinely idle env from false-firing.
- **`for: 15m`** rationale: matches the 10m rate window plus margin, so a single bad batch during a deploy doesn't page.
- A **staging twin** at `severity=warning` (staging exercises this path but must never page).

### The plumbing (§4)
- `grafana_folder.alerts` (a rule group needs a `folder_uid`).
- `grafana_contact_point` ×3 — `wifihaven-critical` / `-warning` / `-staging`, **all email** to the single household operator. No invented pager/Slack transport with no consumer; distinct resources so `critical` can later re-point at a real pager with zero rule churn.
- `grafana_notification_policy` — singleton root tree, routes by `severity`/`env` (staging matched first → notify, never page), with household-friendly grouping/throttle.
- New vars: `operator_email` (required, sensitive) and `prometheus_datasource_uid` (default `grafanacloud-prom`).

## ⚠️ Stacked on #1406 — do not merge first

These resources are **stateful** (contact points, notification policy, folder, rule group) and have no `overwrite=true`/upsert-by-uid escape hatch the way `grafana_dashboard` does. Against the current **stateless** Grafana CD (empty-every-run state) they'd 409 or accumulate duplicates — the exact reason `main.tf` already refuses to manage a folder for dashboards.

Per [`docs/design/alerting.md`](../blob/main/docs/design/alerting.md) §3.1/§9, `infra/grafana` must first migrate to an **HCP Terraform remote backend** — the blocking prerequisite **#1406** (mirrors #1357 for `infra/cloudflare`). This PR:
- is **CI-lint-clean today** (`terraform fmt -check` + `validate -backend=false` in the `grafana-terraform` job);
- must **land after #1406** so the live `terraform apply` in `master-grafana.yml` (with the `cloud {}` backend, workflow wiring, and the operator's one-time HCP `grafana` workspace + `OPERATOR_EMAIL` secret) can apply it idempotently.

## Validation
- `terraform fmt -check` ✅ and `terraform validate` ✅ (provider schema-checked) in `infra/grafana`.
- Rule expression validated by **reuse**: byte-identical to the already-deployed, already-reviewed success-ratio panel (`deploy/grafana/dashboards/api-self-metrics.json`), against a grep-confirmed emitted series. A forced-condition firing (point a throwaway `curl` at `POST /api/router/metrics` with a malformed batch, per `alerting.md` §10) becomes possible once #1406 makes the rule live.

Refs #1368, #1381, #1373, #1384, #1365, #1406