### PR TITLE
feat: profile-level hard pause (#1418)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -671,6 +671,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       String,
       Boolean,
       String,
+      String,
   )
   private def toP(r: R)                             = Profile(
     r._1,
@@ -680,10 +681,11 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     FailureMode.parse(r._5).getOrElse(FailureMode.LastKnownGood),
     r._6,
     CrossDeviceOverlapMode.parse(r._7).getOrElse(CrossDeviceOverlapMode.Sum),
+    PauseMode.parse(r._8).getOrElse(PauseMode.Soft),
   )
   def listAll                                       =
     DbMetrics.timed("profile.listAll")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles ORDER BY id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode FROM profiles ORDER BY id"
         .query[R]
         .map(toP)
         .to[List]
@@ -691,7 +693,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     )
   def findById(id: ProfileId)                       =
     DbMetrics.timed("profile.findById")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode FROM profiles WHERE id=$id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode FROM profiles WHERE id=$id"
         .query[R]
         .map(toP)
         .option
@@ -709,7 +711,8 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
             paused=${p.paused},
             failure_mode=${FailureMode.asString(p.failureMode)},
             block_ip_only=${p.blockIpOnly},
-            cross_device_overlap_mode=${CrossDeviceOverlapMode.asString(p.crossDeviceOverlapMode)}
+            cross_device_overlap_mode=${CrossDeviceOverlapMode.asString(p.crossDeviceOverlapMode)},
+            pause_mode=${PauseMode.asString(p.pauseMode)}
           WHERE id=${p.id}""".update.run
       .transact(xa)
       .unit

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -588,6 +588,18 @@ object PolicyService {
         Hostname.unsafe(sd.domainPattern)
     }
 
+    // #1418: hard pause is a true off-switch. When this profile is paused AND
+    // its pause_mode is `hard`, drop even the app/exempt/infra carve-outs — only
+    // the deployment's UI hosts survive so the kid still sees the block page and
+    // the admin SPA loads on the household LAN. We gate on the *effective* block
+    // reason being Paused (not merely the flag) so the hard mode only bites when
+    // the profile is actually paused; a hard-mode profile blocked for some other
+    // reason (schedule, time limit) keeps the normal soft carve-outs. The router
+    // stays oblivious: an empty `extraAllowed` simply means no `ea_` carve-out,
+    // so the @blocked_macs drop is unconditional — no "hard vs soft" on the wire.
+    val isHardPause =
+      profile.pauseMode == PauseMode.Hard && state.blockReason.contains(MacBlockReason.Paused)
+
     // #763: app expansion is additive. A host in both an allowed-mode app and
     // a blocked-mode app will appear in both lists; the router's
     // extraAllowed-beats-extraBlocked precedence then makes "allow wins" — same
@@ -606,8 +618,11 @@ object PolicyService {
       // #1307: union the curated infra allowlist so connectivity-check / OCSP /
       // CDN dependencies of an allowed app survive the whole-MAC block. Copied
       // per-profile for now; the global policy layer (#1308) will dedup this.
+      // #1418: under a hard pause, drop everything except the UI hosts.
       extraAllowed =
-        (appExtraAllowed ++ appExemptAllowedHosts ++ uiAllowedHosts ++ infraAllowHosts).distinct,
+        if (isHardPause) uiAllowedHosts.distinct
+        else
+          (appExtraAllowed ++ appExemptAllowedHosts ++ uiAllowedHosts ++ infraAllowHosts).distinct,
       blocklistIds = profile.blockedCategories,
       blockIpOnly = profile.blockIpOnly,
     )

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -253,6 +253,9 @@ object ProfileRoutes {
                   // (matches the DB column default and preserves
                   // pre-#751 per-profile semantics).
                   upr.crossDeviceOverlapMode.getOrElse(CrossDeviceOverlapMode.Sum),
+                  // #1418: omitted pauseMode defaults to Soft (matches the DB
+                  // column default and preserves today's pause semantics).
+                  upr.pauseMode.getOrElse(PauseMode.Soft),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -293,6 +296,8 @@ object ProfileRoutes {
                   // #751: same preserve-on-omit semantics.
                   crossDeviceOverlapMode =
                     upr.crossDeviceOverlapMode.getOrElse(p.crossDeviceOverlapMode),
+                  // #1418: same preserve-on-omit semantics for the pause mode.
+                  pauseMode = upr.pauseMode.getOrElse(p.pauseMode),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -434,6 +434,121 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea)) &&
         assertTrue(ea.contains("connectivitycheck.gstatic.com"))
     },
+    test(
+      "#1418: HARD pause drops the allowed-app host AND infra hosts from extraAllowed",
+    ) {
+      // Hard pause is a true off-switch: unlike soft pause (#421/#1413), even
+      // an allowed-mode app and the #1307 global infra allowlist go dark. With
+      // no uiAllowedHosts configured here, extraAllowed must come back empty so
+      // the router drops the MAC unconditionally (no `ip daddr != @ea_…`).
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        ar    <- ZIO.service[AppRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        appId <- ar.create("Khan", "khan", None, None)
+        _     <- ar.setHosts(appId, List(Hostname.unsafe("khanacademy.org")))
+        _     <- ar.upsertAssignment(appId, kid, AppMode.Allowed, None, true)
+        p     <- pr.findById(kid).map(_.get)
+        _     <- pr.update(p.copy(paused = true, pauseMode = PauseMode.Hard))
+        svc   <- makePs
+        snap  <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
+        assertTrue(ea.isEmpty) &&
+        assertTrue(!ea.contains("khanacademy.org")) &&
+        assertTrue(!ea.contains("connectivitycheck.gstatic.com"))
+    },
+    test(
+      "#1418: SOFT pause keeps the allowed-app host AND infra hosts (regression guard)",
+    ) {
+      // The default, unchanged behavior: a soft-paused profile still spares its
+      // extraAllowed hosts (#421/#1413) and the curated infra allowlist (#1307).
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        ar    <- ZIO.service[AppRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        appId <- ar.create("Khan", "khan", None, None)
+        _     <- ar.setHosts(appId, List(Hostname.unsafe("khanacademy.org")))
+        _     <- ar.upsertAssignment(appId, kid, AppMode.Allowed, None, true)
+        p     <- pr.findById(kid).map(_.get)
+        _     <- pr.update(p.copy(paused = true, pauseMode = PauseMode.Soft))
+        svc   <- makePs
+        snap  <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
+        assertTrue(ea.contains("khanacademy.org")) &&
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea))
+    },
+    test("#1418: HARD pause still spares the deployment uiAllowedHosts (block page / admin UI)") {
+      // We deliberately keep uiAllowedHosts through a hard pause so the kid sees
+      // the block page and the admin SPA loads on the LAN — only the app/infra
+      // allowlists are cut. extraAllowed must equal exactly the UI hosts.
+      val uiHosts = List(Hostname.unsafe("blockpage.wifihaven.lan"))
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        hsr   <- ZIO.service[HouseholdSettingsRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        stlr  <- ZIO.service[SiteTimeLimitRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        trr   <- ZIO.service[TrafficReportRepo]
+        er    <- ZIO.service[TimeExtensionRepo]
+        ar    <- ZIO.service[AppRepo]
+        clk   <- ZIO.service[Clock]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        appId <- ar.create("Khan", "khan", None, None)
+        _     <- ar.setHosts(appId, List(Hostname.unsafe("khanacademy.org")))
+        _     <- ar.upsertAssignment(appId, kid, AppMode.Allowed, None, true)
+        p     <- pr.findById(kid).map(_.get)
+        _     <- pr.update(p.copy(paused = true, pauseMode = PauseMode.Hard))
+        svc =
+          PolicyServiceLive(
+            pr,
+            sr,
+            hsr,
+            tlr,
+            stlr,
+            dr,
+            blr,
+            trr,
+            er,
+            ar,
+            clk,
+            uiHosts,
+          ): PolicyService
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(ea == Set("blockpage.wifihaven.lan")) &&
+        assertTrue(!ea.contains("khanacademy.org")) &&
+        assertTrue(!ea.contains("connectivitycheck.gstatic.com"))
+    },
+    test("#1418: profile round-trips pauseMode through the repo") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        p0  <- pr.findById(kid).map(_.get)
+        _   <- pr.update(p0.copy(pauseMode = PauseMode.Hard))
+        p1  <- pr.findById(kid).map(_.get)
+        _   <- pr.update(p1.copy(pauseMode = PauseMode.Soft))
+        p2  <- pr.findById(kid).map(_.get)
+      } yield assertTrue(p0.pauseMode == PauseMode.Soft) &&
+        assertTrue(p1.pauseMode == PauseMode.Hard) &&
+        assertTrue(p2.pauseMode == PauseMode.Soft)
+    },
     test("#1105: same app assigned to two profiles with different exempt flags → independent") {
       for {
         _     <- cleanDb

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -125,6 +125,32 @@ object CrossDeviceOverlapMode {
   )
 }
 
+// #1418: pause has two modes. `Soft` is today's behavior — a paused profile
+// drops all forwarded traffic except its `extraAllowed` hosts (an allowed app +
+// the #1307 infra allowlist survive, per #421/#1413). `Hard` is a true
+// off-switch: when paused, even those allowlisted/global hosts go dark. Carried
+// per-profile; collapsed server-side into the functional snapshot (empty
+// `extraAllowed`) — never a wire field of its own.
+enum PauseMode {
+  case Soft, Hard
+}
+
+object PauseMode {
+  def asString(m: PauseMode): String      = m match {
+    case Soft => "soft"
+    case Hard => "hard"
+  }
+  def parse(s: String): Option[PauseMode] = s.toLowerCase match {
+    case "soft" => Some(Soft)
+    case "hard" => Some(Hard)
+    case _      => None
+  }
+  given JsonCodec[PauseMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown pauseMode: $s"),
+    asString,
+  )
+}
+
 case class Profile(
     id: ProfileId,
     name: String,
@@ -133,6 +159,9 @@ case class Profile(
     failureMode: FailureMode = FailureMode.LastKnownGood,
     blockIpOnly: Boolean = false,
     crossDeviceOverlapMode: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+    // #1418: soft (default) honors extraAllowed through a pause; hard cuts even
+    // allowlisted/global hosts. Only consulted when the profile is paused.
+    pauseMode: PauseMode = PauseMode.Soft,
 ) derives JsonCodec
 
 case class Schedule(
@@ -479,6 +508,8 @@ case class UpsertProfileRequest(
     failureMode: Option[FailureMode] = None,
     blockIpOnly: Option[Boolean] = None,
     crossDeviceOverlapMode: Option[CrossDeviceOverlapMode] = None,
+    // #1418: omitted → preserve existing value (default 'soft' on create).
+    pauseMode: Option[PauseMode] = None,
 ) derives JsonCodec
 
 case class ScheduleRequest(

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -33,6 +33,7 @@ function makeProfile(id: number, name: string): ProfileDetail {
       paused: false,
       failureMode: 'last-known-good',
       crossDeviceOverlapMode: 'sum',
+      pauseMode: 'soft',
     },
     schedules: [],
     timeLimit: null,

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -57,11 +57,11 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' },
+  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' },
   schedules: [], timeLimit: null,
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum' },
+  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' },
   schedules: [], timeLimit: null,
 }
 

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -39,7 +39,7 @@ const devices: Device[] = [
   { id: 10, mac: 'aa:bb:cc:dd:ee:01', name: "Kid's iPad", profileId: 1, profileName: 'Kids', lastSeenIp: null, lastSeenAt: null },
 ]
 const profileDetails: ProfileDetail[] = [
-  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum' }, schedules: [], timeLimit: null },
+  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' }, schedules: [], timeLimit: null },
 ]
 
 function renderAt(path = '/usage/events') {

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -85,6 +85,7 @@ const kidsProfile: ProfileDetail = {
     paused: false,
     failureMode: 'block-all',
     crossDeviceOverlapMode: 'sum',
+    pauseMode: 'soft',
   },
   schedules: [
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
@@ -100,6 +101,7 @@ const adultsProfile: ProfileDetail = {
     paused: true,
     failureMode: 'last-known-good',
     crossDeviceOverlapMode: 'sum',
+    pauseMode: 'soft',
   },
   schedules: [],
   timeLimit: null,

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -8,7 +8,7 @@ import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
 import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import type {
   AppDetail, AppMode, AppPolicyAssignment,
-  CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, ProfileDetail,
+  CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, PauseMode, ProfileDetail,
   ProfileTimeSummary,
   ScheduleRequest, UpsertProfileRequest, User,
 } from '@/types/api'
@@ -886,6 +886,7 @@ interface TimeFormState {
   timeLimit: string
   schedules: ScheduleRequest[]
   crossDeviceOverlapMode: CrossDeviceOverlapMode
+  pauseMode: PauseMode
 }
 
 function timeFormFromDetail(pd: ProfileDetail): TimeFormState {
@@ -895,12 +896,14 @@ function timeFormFromDetail(pd: ProfileDetail): TimeFormState {
       name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
     })),
     crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
+    pauseMode: pd.profile.pauseMode,
   }
 }
 
 function timeFormsEqual(a: TimeFormState, b: TimeFormState): boolean {
   if (a.timeLimit !== b.timeLimit) return false
   if (a.crossDeviceOverlapMode !== b.crossDeviceOverlapMode) return false
+  if (a.pauseMode !== b.pauseMode) return false
   if (a.schedules.length !== b.schedules.length) return false
   for (let i = 0; i < a.schedules.length; i++) {
     const x = a.schedules[i]
@@ -968,6 +971,7 @@ function TimeSubsection({
       body.timeLimit = tl !== null && Number.isFinite(tl) && tl > 0 ? tl : null
       body.schedules = next.schedules
       body.crossDeviceOverlapMode = next.crossDeviceOverlapMode
+      body.pauseMode = next.pauseMode
       await api.profiles.update(pd.profile.id, body)
       baselineRef.current = next
       setStatus('saved')
@@ -1209,6 +1213,52 @@ function TimeSubsection({
                   <span className="text-brand-text-muted"> (one profile = one human)</span>
                   <span className="block text-xs text-brand-text mt-0.5">
                     union the per-device active windows. Two devices both active in the same 5-minute window count as 5 minutes against the daily cap. Right when one person carries an iPad and a phone for the same profile.
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* #1418 pause-mode radios: soft (default) keeps allowlisted apps +
+              the block page reachable through a pause; hard is a true off-switch. */}
+          <div>
+            <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider mb-2">
+              Pause mode
+            </label>
+            <div className="space-y-2">
+              <label className="flex items-start gap-3 text-sm text-brand-text cursor-pointer">
+                <input
+                  type="radio"
+                  name={`pause-mode-${pd.profile.id}`}
+                  data-testid={`profile-pause-mode-soft-${pd.profile.id}`}
+                  disabled={!isAdmin}
+                  checked={form.pauseMode === 'soft'}
+                  onChange={() => update({ pauseMode: 'soft' })}
+                  className="mt-1 w-4 h-4 accent-brand-accent"
+                />
+                <span>
+                  <span className="font-medium text-brand-ink">Soft pause</span>
+                  <span className="text-brand-text-muted"> (default)</span>
+                  <span className="block text-xs text-brand-text mt-0.5">
+                    block the internet but keep explicitly-allowed apps reachable (e.g. a homework app), plus the block page. Best for "dinner time, but homework still works."
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 text-sm text-brand-text cursor-pointer">
+                <input
+                  type="radio"
+                  name={`pause-mode-${pd.profile.id}`}
+                  data-testid={`profile-pause-mode-hard-${pd.profile.id}`}
+                  disabled={!isAdmin}
+                  checked={form.pauseMode === 'hard'}
+                  onChange={() => update({ pauseMode: 'hard' })}
+                  className="mt-1 w-4 h-4 accent-brand-accent"
+                />
+                <span>
+                  <span className="font-medium text-brand-ink">Hard pause</span>
+                  <span className="text-brand-text-muted"> (true off-switch)</span>
+                  <span className="block text-xs text-brand-text mt-0.5">
+                    cut everything, including allowed apps. Only the block page stays reachable. For discipline, a lost device, or an emergency. Applies the next time you pause this profile.
                   </span>
                 </span>
               </label>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -10,6 +10,13 @@ export type FailureMode = 'block-all' | 'allow-all' | 'last-known-good'
 // is `sum` (preserves pre-#751 semantics).
 export type CrossDeviceOverlapMode = 'sum' | 'dedup'
 
+// #1418: pause has two modes. `soft` (default) is today's behavior — a paused
+// profile still spares its allowlisted hosts (an allowed app + the global infra
+// allowlist stay reachable). `hard` is a true off-switch: even those go dark,
+// keeping only the block-page / admin-UI hosts. Wire form matches
+// shared/src/Models.scala PauseMode.asString.
+export type PauseMode = 'soft' | 'hard'
+
 export interface Profile {
   id: number
   name: string
@@ -17,6 +24,7 @@ export interface Profile {
   paused: boolean
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
+  pauseMode: PauseMode
 }
 
 export interface Schedule {
@@ -637,6 +645,8 @@ export interface UpsertProfileRequest {
   failureMode: FailureMode
   // #751: omit to preserve existing value on update; defaults to 'sum' on create.
   crossDeviceOverlapMode?: CrossDeviceOverlapMode
+  // #1418: omit to preserve existing value on update; defaults to 'soft' on create.
+  pauseMode?: PauseMode
 }
 
 export interface UpsertDeviceRequest {


### PR DESCRIPTION
## Closes #1418 — stacked on #1424

> **Stacked PR.** This PR's base is `claude/hardpause-1418` (the schema-only PR #1424), so its diff here is **code only** — the `V49` migration belongs to #1424 and must merge & deploy first. After #1424 merges, this PR retargets to `main`. CI's migration-isolation gate diffs against the PR base, so with the base set to #1424's branch this PR correctly shows no added migration.

Implements the profile-level **hard pause** — a true off-switch that, unlike today's soft pause, blocks even the otherwise-allowlisted hosts. Root cause / design / approach below.

### The two pause modes

- **Soft** (default, unchanged): a paused profile drops all forwarded traffic **except** its `extraAllowed` hosts. An explicitly-allowed app + the #1307 global infra allowlist stay reachable through the pause (#421/#1413). Right for "dinner time, but homework app still works."
- **Hard** (new): block **everything** — even allowlisted apps and the infra hosts go dark. For discipline, a lost/stolen device, an emergency.

### Approach — no new wire/snapshot field

Per the wire-shape rules in `CLAUDE.md` ("express new policy via existing functional fields — never add a field for the concept itself"), hard pause is expressed **functionally**, entirely server-side in `PolicyService.computeBlockRules`:

- When a profile is **paused and `pause_mode = 'hard'`**, `extraAllowed` is emptied of the app/exempt/infra carve-outs for that MAC; `blocked = true` and `blockReason = Paused` are untouched (block-page copy only).
- The router's `@blocked_macs` carve-out is driven purely by the presence of `extraAllowed`. An empty list ⇒ the MAC drops unconditionally with **no `ip daddr != @ea_…` exception**. The router never learns "hard vs soft" — no router change, no snapshot-shape change.

### Open design questions — settled

- **Does hard pause spare the block page / admin UI (`uiAllowedHosts`)? → YES.** We keep `uiAllowedHosts` through a hard pause so the kid still sees *why* they're cut off and the admin SPA loads on the household LAN. Only the app/infra allowlists (`appExtraAllowed`, the #1105 exempt carve-out, `infraAllowHosts`) are dropped. So `extraAllowed = uiAllowedHosts` under hard pause.
- **Gating.** Hard mode only bites when the *effective* block reason is `Paused` — a hard-mode profile blocked for schedule / time-limit reasons keeps the normal soft carve-outs. Hard pause is a property *of pause*, not a global lockdown.
- **`blockIpOnly`.** Already not carved by `ea_`, so no change needed — confirmed.

### What changed (code only)

- `shared/Models.scala`: `PauseMode` enum (`Soft`/`Hard`, text codec), `Profile.pauseMode` (default `Soft`), `UpsertProfileRequest.pauseMode: Option` (preserve-on-omit). All **additive** — old peers ignore the field, satisfying the wire back-compat contract.
- `ProfileRepo` (`Repos.scala`): read/write the `pause_mode` column (added by #1424).
- `PolicyService.computeBlockRules`: empty `extraAllowed` (keep UI hosts) under a hard pause.
- `Routes.scala`: create + PUT `/api/profiles` carry `pauseMode` with the same preserve-on-omit semantics as the other optional knobs.
- Web SPA: `PauseMode` type, a "Pause mode" radio group (soft default / hard) in the profile time-settings subsection, autosaved through the existing debounced PUT.

### Test plan (TDD — red → green visible in history)

`api/test/src/feature/PolicySnapshotAppsSpec.scala`, mirroring the existing #1413/#1307 paused tests:

- **HARD pause drops the allowed-app host AND infra hosts** from `extraAllowed` (empty when no `uiAllowedHosts`); `blocked`, `blockReason = Paused`.
- **HARD pause still spares `uiAllowedHosts`** (block page / admin UI) — `extraAllowed` equals exactly the configured UI hosts.
- **SOFT pause keeps app + infra hosts** — regression guard for today's behavior.
- **pauseMode round-trips through the repo.**

Commit `e584fdeb` adds these as **failing** tests + the plumbing they need to compile; commit `66495607` makes them pass (the `computeBlockRules` implementation). Web: `npm run build` + `vitest run ProfilesPage` green; full `api.test` suite green.
