### PR TITLE
infra(grafana): migrate to HCP Terraform remote backend (#1406)

### DIFF
--- a/.github/workflows/master-grafana.yml
+++ b/.github/workflows/master-grafana.yml
@@ -21,6 +21,15 @@ name: Master Grafana CD
 # grafana_dashboard is upserted by its stable uid (overwrite = true) — so a
 # re-run just reconciles the stack to the repo.
 #
+# State + locking live on HCP Terraform (the `cloud {}` block in
+# infra/grafana/main.tf, #1406); the apply itself runs here on the runner (HCP
+# workspace in *local* execution mode), exactly like the Cloudflare pipeline
+# (#1357). Remote state is the hard prerequisite for the alerting resources
+# (#1403/#1404/#1405): a create against fresh-every-run empty state would 409 or
+# accumulate duplicates. With the migrated state, a re-run with no repo edits
+# reports "No changes". The one-time state migration + the TF_API_TOKEN secret
+# are operator-gated — see infra/grafana/README.md.
+#
 # No production-approval gate: a dashboard change is low-risk and independent
 # of the API/SPA release, so it ships straight from a push to main (the change
 # already went through PR review + the ci.yml grafana-terraform lint job).
@@ -36,11 +45,14 @@ on:
       - '.github/workflows/master-grafana.yml'
   workflow_dispatch:
 
-# Scoped to this pipeline's own group — a newer dashboard push pre-empts an
-# in-flight apply (the next run reconciles to the latest repo state anyway).
+# Scoped to this pipeline's own group. Now that state lives on HCP (#1406) we do
+# NOT cancel in-progress runs: killing `terraform apply` mid-run could orphan the
+# HCP state lock and block the next apply (mirrors master-cloudflare.yml).
+# Queueing lets the in-flight apply finish, then the next push reconciles to the
+# latest repo state.
 concurrency:
   group: master-grafana-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -57,17 +69,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check Grafana secrets are configured
+      - name: Check Grafana + HCP secrets are configured
         id: gate
         env:
           GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
           GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH }}
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
         run: |
-          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ]; then
+          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ] && [ -n "$TF_API_TOKEN" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GRAFANA_URL / GRAFANA_AUTH not set — skipping dashboard deploy."
+            echo "::notice::GRAFANA_URL / GRAFANA_AUTH / TF_API_TOKEN not all set — skipping dashboard deploy. See infra/grafana/README.md for the one-time backend setup."
           fi
 
       - name: Set up Terraform
@@ -80,6 +93,11 @@ jobs:
         if: steps.gate.outputs.configured == 'true'
         working-directory: infra/grafana
         env:
+          # HCP Terraform: remote state + locking (workspace in local exec mode).
+          TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
+          TF_CLOUD_ORGANIZATION: wifihaven
+          TF_WORKSPACE: grafana
+          # Grafana provider auth — supplied to the apply running on the runner.
           TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
           TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
         run: |

--- a/infra/grafana/.gitignore
+++ b/infra/grafana/.gitignore
@@ -1,5 +1,7 @@
-# State files: hold resource IDs and may include sensitive values. Local
-# state only for now — TODO(#1270) to move to a remote backend.
+# State files: now stored remotely on HCP Terraform (the `cloud {}` block in
+# main.tf, #1406). Any *.tfstate left locally is a stale/transient artifact
+# (e.g. the pre-migration local backend) and must never be committed — it can
+# hold per-resource sensitive values.
 *.tfstate
 *.tfstate.*
 

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -50,19 +50,41 @@ environment-agnostic: each selects its data via the templated
 whichever Prometheus the viewer points it at. The target stack is selected
 purely by the `grafana_url` / `grafana_auth` variables.
 
-### Stateless by design
+### State backend — remote (HCP Terraform)
 
-The CD job runs on an ephemeral runner with no persisted Terraform state, so
-every apply starts empty. That is safe because each `grafana_dashboard` is
-upserted by its stable `uid` (`overwrite = true`) — applying against an
-empty state updates the existing dashboard rather than erroring on a
-duplicate. We deliberately do **not** manage a `grafana_folder` resource (a
-folder create would 409 on a fixed uid, or accumulate duplicate folders
-across stateless runs). To organize the dashboards, pre-create a folder once
-per stack and pass its uid via the optional `folder_uid` variable; when
-unset the dashboards land in the stack's General folder. A consequence of
-statelessness: a dashboard removed from the repo is not auto-deleted from
-the stack — delete it by hand.
+State lives on **HCP Terraform** (Terraform Cloud, free tier) via the
+`cloud {}` block in `main.tf`, not a local file (#1406). The dashboards were
+upsert-by-uid idempotent and survived empty state on their own, but the
+**alerting** work this unblocks — contact points, the singleton notification
+policy, and rule groups (#1403/#1404/#1405) — is stateful: a create against
+fresh-every-run empty state either 409s on a fixed identifier or accumulates
+duplicates, and the root notification policy has no upsert-by-uid. Remote
+state gives Terraform a canonical prior state so those resources reconcile
+idempotently. The state holds resource IDs but no secrets (the Grafana token
+comes from `grafana_auth` / the `GRAFANA_AUTH` secret, not the state). This
+mirrors the `infra/cloudflare` backend (#1357).
+
+- **Org / workspace**: from the `TF_CLOUD_ORGANIZATION` and `TF_WORKSPACE` env
+  vars (the workflow sets them to `wifihaven` / `grafana`; local operators
+  export the same). The `cloud {}` block is intentionally empty so it stays
+  account- and creds-agnostic.
+- **Auth**: the `TF_TOKEN_app_terraform_io` env var (an HCP user/team API
+  token). In CI it is the `TF_API_TOKEN` repo secret.
+- **Execution mode**: the workspace runs in **Local** mode — HCP only stores
+  state + provides locking; `terraform apply` runs on the GitHub runner, so
+  the Grafana service-account token stays a GitHub secret and never moves into
+  HCP. Same pattern as `infra/cloudflare`.
+
+We still deliberately do **not** manage a `grafana_folder` resource here — to
+organize the dashboards, pre-create a folder once per stack and pass its uid
+via the optional `folder_uid` variable; when unset the dashboards land in the
+stack's General folder.
+
+> **Drift caveat** (`memory/cloudflare_tf_backend.md`): a local checkout
+> *missing* the `cloud {}` block (or without the `TF_CLOUD_ORGANIZATION` /
+> `TF_WORKSPACE` env exported) silently falls back to **local** state and can
+> propose recreating live resources. After `terraform init`, confirm you are
+> on the remote backend with `terraform state pull` before any `apply`.
 
 **Not managed here**: the Grafana Cloud stack itself (created once in the
 dashboard), the Prometheus datasource (dashboards use a
@@ -85,38 +107,120 @@ Deploys run from the `master-grafana.yml` pipeline on push to `main` (see
 [In the CD pipeline](#in-the-cd-pipeline) above). Its `paths:` filter is
 scoped to `deploy/grafana/**` and `infra/grafana/**`, so a dashboard or
 Terraform change triggers the pipeline — and nothing else does.
-Authentication comes from two GitHub Actions secrets set out-of-band (never
+Authentication comes from three GitHub Actions secrets set out-of-band (never
 committed):
 
 ```sh
 gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://wifihaven.grafana.net'
 gh secret set GRAFANA_AUTH -R wifihaven/wifihaven --body '<service-account token>'
+gh secret set TF_API_TOKEN -R wifihaven/wifihaven --body '<HCP user/team token>'
 ```
 
-Until both are set, the deploy job is a no-op gate. The PR acceptance bar is
-`terraform fmt`/`validate`-clean config plus `actionlint`-clean workflows,
+| Secret | Purpose |
+|--------|---------|
+| `GRAFANA_URL` | Base URL of the Grafana Cloud stack. |
+| `GRAFANA_AUTH` | Grafana service-account token with dashboard (and alert) write scope. |
+| `TF_API_TOKEN` | HCP Terraform state-backend auth (`app.terraform.io` → Account settings → Tokens). |
+
+Until all three are set, the deploy job is a no-op gate. The PR acceptance bar
+is `terraform fmt`/`validate`-clean config plus `actionlint`-clean workflows,
 not a live deploy.
 
 `terraform fmt -check` + `terraform validate` for this directory also run in
 CI as the `grafana-terraform` lint job (mirrors the `render-blueprint`
 precedent).
 
+## One-time backend setup + state adoption (operator-gated)
+
+Do this **once**, locally, before merging anything that triggers the pipeline.
+Unlike `infra/cloudflare` (which migrated a real local `terraform.tfstate`),
+this directory was **stateless by design** — there is no persisted local state
+to migrate. So adoption relies on the dashboards' `overwrite = true` /
+stable-`uid` upsert: the very first apply against the empty HCP state **updates
+the existing dashboards by uid** instead of creating duplicates, and after that
+first apply the state tracks all 7 so the **second apply is a no-op**. That is
+the structural reason there is no duplicate-dashboard churn.
+
+1. **Create the HCP workspace.** On https://app.terraform.io, in the existing
+   `wifihaven` org (the same org as `infra/cloudflare`), create a workspace
+   named `grafana`. Set its **Execution Mode = Local** (workspace → Settings →
+   General). Local mode matters: the apply must run on your machine / the runner
+   where the Grafana provider plugin and `grafana_auth` live, not remotely on
+   HCP.
+
+2. **Authenticate + point at the workspace:**
+
+   ```sh
+   cd infra/grafana
+   export TF_TOKEN_app_terraform_io=<HCP user/team token>   # or run: terraform login
+   export TF_CLOUD_ORGANIZATION=wifihaven
+   export TF_WORKSPACE=grafana
+   export TF_VAR_grafana_url=https://wifihaven.grafana.net
+   export TF_VAR_grafana_auth=<service-account token>
+   ```
+
+3. **Init against the cloud backend and confirm you're on it.** Per
+   `memory/cloudflare_tf_backend.md`, a checkout that silently fell back to
+   **local** state is the failure mode to guard against — so verify before any
+   apply:
+
+   ```sh
+   terraform init
+   terraform state pull | head        # must show the HCP-backed (cloud) state
+   ```
+
+   > If you do happen to have a leftover local `terraform.tfstate` from a past
+   > manual apply, run `terraform init -migrate-state` instead and answer "yes"
+   > to copy it up — but the clean case here has none.
+
+4. **First apply adopts the dashboards; second apply proves the no-op.**
+
+   ```sh
+   terraform apply                     # adopts all 7 dashboards by uid (no dupes)
+   terraform apply                     # Expect: "No changes." — the acceptance bar
+   terraform state list                # the 7 dashboards below
+   ```
+
+   `terraform state list` should show exactly:
+
+   ```
+   grafana_dashboard.wifihaven["api-health"]
+   grafana_dashboard.wifihaven["api-self-metrics"]
+   grafana_dashboard.wifihaven["router-fleet"]
+   grafana_dashboard.wifihaven["rollup-health"]
+   grafana_dashboard.wifihaven["db-health"]
+   grafana_dashboard.wifihaven["data-quality-ingest"]
+   grafana_dashboard.wifihaven["enforcement"]
+   ```
+
+5. **Set the CI secrets** (`GRAFANA_URL`, `GRAFANA_AUTH`, `TF_API_TOKEN`) as
+   above. From here, merges to `main` apply automatically.
+
 ## Manual apply (one environment)
 
 ```sh
 cd infra/grafana
+
+# HCP remote state (skip the org/workspace exports only if you've already run
+# `terraform login` AND the cloud{} block's workspace is set some other way).
+export TF_TOKEN_app_terraform_io=<HCP user/team token>
+export TF_CLOUD_ORGANIZATION=wifihaven
+export TF_WORKSPACE=grafana
 
 export TF_VAR_grafana_url=https://wifihaven.grafana.net
 export TF_VAR_grafana_auth=<service-account token>
 # optional: export TF_VAR_folder_uid=<pre-created folder uid>
 
 terraform init
+terraform state pull | head   # confirm remote backend before planning
 terraform plan
 terraform apply
 ```
 
-Or copy `terraform.tfvars.example` → `terraform.tfvars` (gitignored — both
-values are secrets) and fill it in. Apply creates 2 dashboard resources.
+The dashboard secrets can also go in `terraform.tfvars` (gitignored — both
+values are secrets); the HCP org/workspace must stay env vars (the `cloud {}`
+block is intentionally empty). With migrated state, `apply` is a no-op on an
+unchanged repo.
 
 ## Subsequent changes
 

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -14,16 +14,22 @@
 # `${datasource}` variable at view time — so a per-environment dashboard copy
 # is unnecessary.
 #
-# Stateless by design. The CD jobs run on ephemeral runners with no
-# persisted state, so every apply starts from an empty state. That is safe
-# here because each grafana_dashboard is upserted by its stable `uid`
-# (overwrite = true) — applying against an empty state updates the existing
-# dashboard rather than erroring on a duplicate. We deliberately do NOT
-# manage a grafana_folder resource: a folder create would either 409 on a
-# fixed uid or accumulate duplicate folders across stateless runs. Instead a
-# pre-existing folder can be targeted via the optional `folder_uid` variable
-# (the operator creates it once per stack, like the stack itself); when unset
-# the dashboards land in the stack's General folder.
+# State: remote backend on HCP Terraform (the `cloud {}` block below), free
+# tier, with native state locking. The dashboards themselves are upsert-by-uid
+# idempotent and would survive empty state, but the alerting work this unblocks
+# (contact points, the singleton notification policy, rule groups — #1403/#1404/
+# #1405) is *stateful*: a create against fresh-every-run empty state either 409s
+# on a fixed identifier or accumulates duplicates, and the root notification
+# policy has no upsert-by-uid. So Terraform must own its prior state. Migrating
+# to the remote backend now (#1406) is the hard prerequisite for that chain;
+# the dashboards keep reconciling unchanged. State holds resource IDs but no
+# secrets (the Grafana token comes from the grafana_auth var / GRAFANA_AUTH
+# secret, not the state). Mirrors the infra/cloudflare backend (#1357); see
+# README.md for the one-time backend setup + local-state migration runbook.
+#
+# A pre-existing folder can still be targeted via the optional `folder_uid`
+# variable (the operator creates it once per stack, like the stack itself);
+# when unset the dashboards land in the stack's General folder.
 #
 # Does NOT manage:
 #   - The Grafana Cloud stack / instance itself (created once via the Grafana
@@ -37,6 +43,22 @@
 
 terraform {
   required_version = ">= 1.6"
+
+  # Remote state on HCP Terraform (Terraform Cloud), free tier. Native state
+  # locking means CI applies can't race or clobber each other, and a fresh CI
+  # checkout reads the canonical state instead of starting empty — which is what
+  # lets the stateful alerting resources (#1403/#1404/#1405) be idempotent
+  # rather than 409ing or duplicating on every run (#1406).
+  #
+  # Org + workspace come from TF_CLOUD_ORGANIZATION / TF_WORKSPACE env vars
+  # (set in .github/workflows/master-grafana.yml and documented in README.md),
+  # so this block stays account- and creds-agnostic. Auth is the
+  # TF_TOKEN_app_terraform_io env var. The workspace runs in *local* execution
+  # mode: HCP only stores state + provides locking, while `terraform apply` runs
+  # on the GitHub runner with the Grafana token from the GRAFANA_AUTH secret —
+  # mirrors the infra/cloudflare pipeline (#1357).
+  cloud {}
+
   required_providers {
     grafana = {
       source  = "grafana/grafana"


### PR DESCRIPTION
Closes #1406. **Hard prerequisite** for the alerting chain — must land first.

## Why

`infra/grafana` is **stateless by design** today: the CD job runs on an ephemeral runner with no persisted state, and each `grafana_dashboard` is upserted by its stable `uid` with `overwrite = true`. That trick works *only* for dashboards. The alerting resources this unblocks — `grafana_contact_point`, the singleton `grafana_notification_policy`, and `grafana_rule_group` — are **stateful**: a create against fresh-every-run empty state either 409s on a fixed identifier or accumulates duplicates, and the root notification policy has no upsert-by-uid. So Terraform must own its prior state (`docs/design/alerting.md` §3.1).

## What

Mirrors what #1357 did for `infra/cloudflare`:

- **`infra/grafana/main.tf`** — add a `cloud {}` block: HCP Terraform, org `wifihaven`, workspace `grafana`, **Local** execution mode (HCP stores state + provides locking; `terraform apply` runs on the runner where the Grafana provider + `grafana_auth` live). The block is empty so it stays creds-agnostic; org/workspace come from env.
- **`.github/workflows/master-grafana.yml`** — wire `init`/`apply` to the backend: `TF_TOKEN_app_terraform_io` / `TF_CLOUD_ORGANIZATION=wifihaven` / `TF_WORKSPACE=grafana`; the secrets gate now also requires `TF_API_TOKEN`; concurrency switched to `cancel-in-progress: false` so a killed apply can't orphan the HCP state lock (matches `master-cloudflare.yml`). The existing `paths:` filter already covers `infra/grafana/**`, so no trigger change is needed.
- **`infra/grafana/README.md`** + **`.gitignore`** — document the remote backend, the operator-gated one-time workspace creation + state adoption, and the `terraform state pull` drift check (per `memory/cloudflare_tf_backend.md`: a checkout missing the `cloud {}` block silently uses **local** state).

## No duplicate-dashboard churn

Unlike `infra/cloudflare` (which migrated a real local `terraform.tfstate`), this directory had **no persisted local state** to migrate. Adoption is structural: the first apply against the empty HCP state **updates the existing 7 dashboards by `uid`** via `overwrite = true` rather than creating duplicates, and the second apply is then a **no-op**. That is the no-op acceptance bar, and the reason there is no churn.

## Validation

- `terraform fmt -check` ✅ and `terraform init -backend=false && terraform validate` ✅ (the `grafana-terraform` CI gate).
- HCP `wifihaven` org confirmed reachable; today it holds only the `cloudflare` workspace (Local mode) — the `grafana` workspace is created in the operator-gated one-time step (README), exactly as #1357 handled it.
- The live second-apply no-op runs during that operator migration, since it needs the `GRAFANA_AUTH` service-account token (a GitHub secret, not available at PR time).

## Unblocks

#1403 (contact points) → #1404 (critical rules, incl. the #1368 ingest alert) → #1405 (warning rules).

Refs: #1381 · #1357 · #1368