### PR TITLE
db: V49 migration for household-scoped named schedules (#1069)

### DIFF
--- a/api/resources/db/migration/V50__named_schedules.sql
+++ b/api/resources/db/migration/V50__named_schedules.sql
@@ -1,0 +1,129 @@
+-- V50__named_schedules.sql
+-- #1069: household-scoped reusable named schedules ("Bedtime", "School hours",
+-- ...). The foundation primitive that anything time-bound can reference:
+-- profiles today, per-app policy assignments (#1378) and schedule-driven
+-- blocklists (#1067) next. See the #1069 spec and
+-- docs/design/per-app-schedules.md §3.
+--
+-- This is a SCHEMA-ONLY migration (per the migration-isolation rule in
+-- CLAUDE.md): it ships with no source or tests. The Models / repos / routes /
+-- PolicyService snapshot expansion that READ these tables land in the follow-up
+-- API-adoption PR; the Settings -> Schedules SPA lands after that. Until then
+-- the tables are inert — nothing reads `named_schedules` / `schedule_windows` /
+-- `profile_schedule_rules`, the existing per-profile `schedules` table (V1/V16)
+-- still backs all schedule enforcement, so there is NO functional change from
+-- this migration alone. That inertness is exactly what makes it
+-- backward-compatible with image-(N-1): the existing api.test suite applies
+-- this migration against the currently-deployed code and passes unchanged (the
+-- isolation gate).
+--
+-- ── Table-name collision (read this) ──────────────────────────────────────
+-- #1069's spec names the new table `schedules`, but V1 already defines a
+-- profile-scoped `schedules` table that deployed enforcement code still reads
+-- (its current columns, after V16, are: profile_id, name, days TEXT[],
+-- start_local TIME, end_local TIME, tz TEXT). We may NOT drop or retype those
+-- columns here — that would fail the isolation gate and break rollback (#1176
+-- class). So the new household-scoped primitive lands under a distinct name,
+-- `named_schedules`, fully additively. Once the API rolls forward to read
+-- `named_schedules` and the old `schedules` rows are dead, a later
+-- deprecation-window migration can drop the V1 table and rename
+-- `named_schedules` -> `schedules`. (docs/design/per-app-schedules.md §3.3
+-- already anticipates this: "If #1069's final schema names the table
+-- differently, this FK target tracks that name.")
+--
+-- ── Windows are a typed child table, mirroring the V1 schedule columns ─────
+-- A named schedule owns one-or-more windows via the `schedule_windows` child
+-- table, whose columns are exactly the existing V1 `schedules` time columns
+-- (days TEXT[], start_local TIME, end_local TIME, tz TEXT) minus profile_id.
+-- This is deliberate over a JSONB `windows` blob:
+--   * It reuses the existing typed `Schedule` domain model and the
+--     DST-correct `PolicyService.scheduleActiveAt` / `scheduleEndInstantAfter`
+--     time math unchanged — no JSON parsing, no synthetic Schedule rebuild.
+--   * It preserves a per-window `tz` (the V1 schedules table is per-row tz
+--     since V16), so migrating existing profile schedules into this model is a
+--     bit-for-bit `INSERT ... SELECT` with zero behaviour change.
+--   * It matches this codebase's precedent for a named bundle with many
+--     sub-items: `apps` owns `app_hosts` as a typed child table, not JSONB.
+-- Compound schedules (e.g. "school hours: weekdays 08-15, Fri 08-12") are just
+-- multiple `schedule_windows` rows. A window where start_local == end_local is
+-- a never-active empty window (same convention as scheduleActiveAt).
+--
+-- ── A profile has MANY schedules, each block- OR allow-mode ────────────────
+-- A profile references named schedules through the `profile_schedule_rules`
+-- join table, NOT a single `profiles.schedule_id` column — so it can carry more
+-- than one (e.g. "Bedtime" + "School hours"), and each attachment names a mode:
+--   * blocked_during — while any window of the schedule is active, the profile
+--     is in scheduled downtime (today's bedtime semantics).
+--   * allowed_during — while active, the schedule carves the profile open,
+--     beating block-mode windows / default-deny (the #421 allow-beats-block
+--     rule). Paired with a default-deny profile (#1318) this expresses
+--     "internet only during these hours".
+-- This is the SAME (entity, schedule, mode) shape the per-app schedule design
+-- uses (docs/design/per-app-schedules.md §3.3, `app_policy_schedule_rules`) —
+-- profiles and apps converge on one model. The single-reference columns the
+-- #1069 spec sketched (`profiles.schedule_id`, `app_policy_assignments
+-- .schedule_id`) are deliberately NOT added: they can't carry a mode and cap at
+-- one schedule. #1378 adds the analogous `app_policy_schedule_rules` for apps.
+--
+-- ── Single-household ──────────────────────────────────────────────────────
+-- This codebase is single-household (only `household_settings` exists, as a
+-- single-row config). Like `apps.slug`, `named_schedules.name` is uniquely
+-- scoped to that implicit household — no `household_id` column / FK, matching
+-- the spec's UNIQUE (household_id, name) under a one-household model.
+--
+-- ── Prod-volume safety ────────────────────────────────────────────────────
+-- All three tables are bounded metadata surfaces — rows scale with the handful
+-- of schedules (their windows, their per-profile attachments) the operator
+-- defines, NOT with event volume. None is an unbounded-growth table
+-- (traffic_reports, connection_events, block_events, rollups). All index builds
+-- are on empty / tiny surfaces. Safe on the Flyway startup critical path even
+-- at full prod data volume.
+
+CREATE TABLE named_schedules (
+  id           BIGSERIAL PRIMARY KEY,
+  name         TEXT NOT NULL UNIQUE,
+  description  TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One row per window. Columns mirror the V1 `schedules` time columns exactly so
+-- the existing Schedule model + scheduleActiveAt apply unchanged. `days` uses
+-- the same short day-of-week token vocabulary as schedules.days. `start_local`
+-- / `end_local` are wall-clock TIMEs interpreted in `tz`; an overnight window
+-- (start_local > end_local) wraps past midnight, handled by scheduleActiveAt.
+CREATE TABLE schedule_windows (
+  id           BIGSERIAL PRIMARY KEY,
+  schedule_id  BIGINT NOT NULL REFERENCES named_schedules(id) ON DELETE CASCADE,
+  days         TEXT[] NOT NULL,
+  start_local  TIME   NOT NULL,
+  end_local    TIME   NOT NULL,
+  tz           TEXT   NOT NULL
+);
+CREATE INDEX idx_schedule_windows_schedule ON schedule_windows(schedule_id);
+
+-- Per-profile attachments. A profile may reference any number of named
+-- schedules; each row carries the mode that decides what an active window does.
+-- ON DELETE CASCADE on both FKs: deleting a schedule (or a profile) just drops
+-- its attachment rows — the schedule's effect simply stops applying, no orphan.
+-- UNIQUE(profile_id, schedule_id, mode) lets a schedule be attached once per
+-- mode (attaching the same schedule as both blocked_during and allowed_during
+-- is nonsensical but harmless; the unique key just prevents exact dupes).
+CREATE TABLE profile_schedule_rules (
+  id           BIGSERIAL PRIMARY KEY,
+  profile_id   BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  schedule_id  BIGINT NOT NULL REFERENCES named_schedules(id) ON DELETE CASCADE,
+  mode         TEXT NOT NULL CHECK (mode IN ('allowed_during', 'blocked_during')),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (profile_id, schedule_id, mode)
+);
+-- Snapshot builder probes by profile (per-profile fold) and the SPA / cascade
+-- check probes by schedule ("what references this before I delete it").
+CREATE INDEX idx_profile_schedule_rules_profile  ON profile_schedule_rules(profile_id);
+CREATE INDEX idx_profile_schedule_rules_schedule ON profile_schedule_rules(schedule_id);
+
+-- Deliberately NOT added here: a blocklist-subscription schedule reference.
+-- This codebase has no blocklist_subscriptions table — blocklists attach to a
+-- profile via the profiles.blocked_categories TEXT[] array. #1067
+-- (schedule-driven blocklist activation) will introduce a real subscription
+-- model and add its own schedule reference against named_schedules at that time.

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -66,14 +66,13 @@ the `Schedule` domain model in `shared/src/Models.scala`:
 - Overnight wrap (`startLocal > endLocal`), DOW membership, and the tail day
   are all handled by the *already-existing* `PolicyService.scheduleActiveAt`
   and `scheduleEndInstantAfter`. We do not write new time math.
-- **Timezone comes from household settings at read time, never `java.time`
-  directly.** Profile schedules already get their `tz: ZoneId` injected when
-  the `Schedule` is constructed from the row (the `schedules` table stores no
-  zone column); per-app windows follow the same path. All "is W active now?"
-  evaluation goes through the injected `wifihaven.shared.Clock` (`Clock.instant`)
-  projected into that zone, exactly as profile schedules do today. DST is
-  handled transparently by `ZonedDateTime` (see PolicyService §"#334
-  timezone-aware time math").
+- **Each window carries its own IANA `tz`, never `java.time` directly.** The V1
+  `schedules` table stores a per-row `tz` (added in V16), and the #1069
+  `schedule_windows` child table mirrors it per window, so the `Schedule.tz:
+  ZoneId` is read straight off the row. All "is W active now?" evaluation goes
+  through the injected `wifihaven.shared.Clock` (`Clock.instant`) projected into
+  that zone, exactly as profile schedules do today. DST is handled transparently
+  by `ZonedDateTime` (see PolicyService §"#334 timezone-aware time math").
 
 Because we reuse `scheduleActiveAt`, per-app windows inherit overnight-wrap,
 DOW, and DST correctness for free, and the schedule-boundary unit tests can
@@ -88,10 +87,10 @@ per-app schedules reference a named schedule exclusively.** No inline
 
 Rationale:
 
-- #1069 already proposes the household `schedules` table (named, JSONB
-  `windows` supporting compound time blocks) **and** an
-  `app_policy_assignments.schedule_id` reference. Building per-app schedules on
-  that foundation avoids inventing a second, parallel inline-window
+- #1069 already proposes the household named-schedule table (named, with a
+  typed `schedule_windows` child table supporting compound time blocks) **and**
+  an `app_policy_assignments.schedule_id` reference. Building per-app schedules
+  on that foundation avoids inventing a second, parallel inline-window
   representation that would later have to be migrated into the named model
   anyway.
 - A one-off window is just a named schedule the operator creates ad hoc
@@ -99,7 +98,7 @@ Rationale:
   case, so "reference a named schedule, not only inline windows" (the #1376
   ask) is satisfied by *named-only* once #1069 exists — cleaner than carrying
   both, with no `CHECK`-enforced either/or column pair.
-- A named schedule's JSONB `windows` array already covers the compound case
+- A named schedule's `schedule_windows` rows already cover the compound case
   (e.g. "school hours: weekdays 8–15, Fri 8–12"), so per-app schedules inherit
   multi-window support for free without their own one-to-many window rows.
 
@@ -109,21 +108,38 @@ schedule, blocklist activation) converge on the one #1069 primitive.
 
 ### 3.3 What #1069 gives us, and what #1376 adds
 
-#1069 gives an assignment a **single** gating schedule via
-`app_policy_assignments.schedule_id` (its stated use: gate a `time_limited`
-app's budget by a window). #1376 needs two things #1069 does not provide:
+An app needs two things from a schedule reference:
 
-1. a **mode** — *allowed during* vs *blocked during* — which #1069's bare
-   `schedule_id` does not carry; and
+1. a **mode** — *allowed during* vs *blocked during*; and
 2. the ability to attach **more than one** (schedule, mode) pair to a single app
    (e.g. *allowed during* Bedtime **and** *blocked during* Homework).
 
 So #1376 adds a small child table of `(assignment, named-schedule, mode)`
-rules. Because #1069 lands first, the FK target (`schedules`) already exists and
-the FK is created directly — no deferred-constraint dance.
+rules. Because #1069 lands first, the FK target already exists and the FK is
+created directly — no deferred-constraint dance.
 
-New migration (next free version, e.g. `V49__app_policy_schedule_rules.sql`,
-sequenced *after* #1069's migration):
+> **#1069 landed (`V50__named_schedules.sql`).** The new household-scoped
+> primitive is the **`named_schedules`** table (parent: id, name, description,
+> timestamps) plus a typed **`schedule_windows`** child table (`schedule_id`,
+> `days TEXT[]`, `start_local TIME`, `end_local TIME`, `tz TEXT`) — mirroring
+> the V1 `schedules` time columns so the existing `Schedule` model and
+> `scheduleActiveAt` apply unchanged. The name is `named_schedules`, NOT
+> `schedules` — the spec's chosen name collided with the V1 profile-scoped
+> `schedules` table, which deployed enforcement code still reads, so it could
+> not be dropped/renamed in an additive migration.
+>
+> **Profiles reference schedules through a `(profile, schedule, mode)` join
+> table — `profile_schedule_rules` — NOT a single `profiles.schedule_id`
+> column.** #1069 deliberately dropped the single-reference columns its spec
+> sketched (`profiles.schedule_id`, `app_policy_assignments.schedule_id`):
+> they can't carry a mode and cap a profile at one schedule. The
+> `app_policy_schedule_rules` table below is the **exact same shape** for apps,
+> FKing **`named_schedules(id)`**, and is the **next** free version after V50
+> (e.g. `V51__app_policy_schedule_rules.sql`). The two tables are intentionally
+> identical — profiles and apps share one (entity, schedule, mode) model.
+
+New migration (next free version after #1069's `V50`, e.g.
+`V51__app_policy_schedule_rules.sql`, sequenced *after* #1069's migration):
 
 ```sql
 CREATE TABLE app_policy_schedule_rules (
@@ -131,7 +147,7 @@ CREATE TABLE app_policy_schedule_rules (
   assignment_id  BIGINT NOT NULL
                    REFERENCES app_policy_assignments(id) ON DELETE CASCADE,
   schedule_id    BIGINT NOT NULL
-                   REFERENCES schedules(id) ON DELETE CASCADE,   -- #1069 named schedule
+                   REFERENCES named_schedules(id) ON DELETE CASCADE,  -- #1069 named schedule
   mode           TEXT NOT NULL
                    CHECK (mode IN ('allowed_during','blocked_during')),
   created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -141,9 +157,6 @@ CREATE INDEX idx_app_policy_schedule_rules_assignment
   ON app_policy_schedule_rules(assignment_id);
 ```
 
-(If #1069's final schema names the table differently, this FK target tracks
-that name — the dependency is explicit so the names stay in sync.)
-
 **Migration-isolation (AGENTS.md "Schema changes land in their own PR").** This
 is a brand-new table referencing only tables that already exist once #1069 has
 landed, so:
@@ -152,7 +165,7 @@ landed, so:
   never touch `app_policy_schedule_rules`, so the existing `api.test` suite
   (which applies every migration including this one against image-(N-1) code)
   passes unchanged — that is the gate.
-- The migration PR contains **only** the `V49__….sql` plus doc updates. No
+- The migration PR contains **only** the `V51__….sql` plus doc updates. No
   source, no tests, no fixtures. The PolicyService eval, repo methods, and tests
   land in the follow-up PR (§"Sub-issues").
 - **Not a growth table** ("Migrations that are fast on dev … minutes-long on


### PR DESCRIPTION
## PR 1 of 3 — schema-only foundation for #1069

This is the **schema-only** slice of household-scoped reusable named schedules
(#1069). It ships the new `named_schedules` + `schedule_windows` tables and the
reference columns, nothing else — no Scala, no tests, no fixtures — so it lands
cleanly under the migration-isolation rule. API adoption (Models/repos/routes/
PolicyService expansion + seeding + tests) and the SPA follow in PRs 2 and 3.

### What this migration does (`V49__named_schedules.sql`)

- **`named_schedules`** — the household-scoped named primitive: `name` (UNIQUE),
  optional `description`, `created_at`/`updated_at`.
- **`schedule_windows`** — a typed child table owning one-or-more windows per
  schedule. Its columns are **exactly the existing V1 `schedules` time columns**
  (`days TEXT[]`, `start_local TIME`, `end_local TIME`, `tz TEXT`) minus
  `profile_id`. Compound schedules ("school hours: weekdays 08–15, Fri 08–12")
  are just multiple rows. Indexed on `schedule_id`.
- **`profile_schedule_rules`** — a `(profile_id, schedule_id, mode)` join
  table, `mode ∈ {blocked_during, allowed_during}`. A profile can reference
  **many** schedules, and each attachment is either a **block** schedule
  (downtime while active — today's bedtime semantics) or an **allow** schedule
  (carves the profile open while active, beating block windows / default-deny).
  Both FKs `ON DELETE CASCADE`; `UNIQUE(profile_id, schedule_id, mode)`; indexed
  by profile and by schedule.

The single-reference columns the spec sketched (`profiles.schedule_id`,
`app_policy_assignments.schedule_id`) are **deliberately not added** — they
can't carry a mode and cap a profile at one schedule. #1378 adds the identical
`app_policy_schedule_rules` table for apps (same `(entity, schedule, mode)`
shape); its FK target `named_schedules` exists here, so it stays **unblocked**.

### Why a typed child table, not JSONB `windows`

The #1069 spec sketches `windows JSONB`, but a typed `schedule_windows` child
table is the better fit for this codebase and is what shipped here:

- **Reuses the existing time math unchanged.** The columns mirror the V1
  `schedules` shape, so the typed `Schedule` domain model and the DST-correct
  `PolicyService.scheduleActiveAt` / `scheduleEndInstantAfter` apply directly —
  no JSON parsing, no synthetic `Schedule` reconstruction in PR 2.
- **Preserves per-window `tz`.** The V1 table is per-row tz (since V16), so
  migrating existing profile schedules becomes a bit-for-bit `INSERT … SELECT`
  with zero behavior change — the strongest form of the "operator sees no
  behavior change" acceptance criterion.
- **Matches the codebase precedent.** A named household bundle with many
  sub-items already uses a typed child table here: `apps` owns `app_hosts`, not
  JSONB. The JSONB precedents (`unmanaged_mac_policy`, `block_reason`) are
  opaque blobs never fed through shared time math.

Downstream cost is minimal: #1067 / #1378 still just FK `named_schedules(id)` —
only the storage detail (not the reference model) changed; `docs/design/per-app-schedules.md`
is updated accordingly.

### Design decisions called out in the migration header

**Table-name collision (the crux of why this is split this way).** #1069's spec
names the new table `schedules`, but V1 already has a profile-scoped
`schedules` table (now: `profile_id, name, days TEXT[], start_local, end_local,
tz`) that the **currently-deployed** enforcement code still reads. Dropping/
renaming those columns here would fail the isolation gate and break rollback
(the #1176 class). So the new primitive lands additively under a distinct name,
**`named_schedules`**. Once the API rolls forward to read it and the old
`schedules` rows are dead, a **later** deprecation-window migration drops the V1
table and renames `named_schedules` → `schedules`.

**Single-household reality.** This codebase is single-household (only the
single-row `household_settings` exists; there is no `households` table). Like
`apps.slug`, `named_schedules.name` is UNIQUE within the implicit household — no
`household_id` column, the faithful one-household translation of the spec's
`UNIQUE (household_id, name)`.

**Blocklist-subscription reference deferred.** The spec lists a
`blocklist_subscriptions.schedule_id` reference, but this codebase has **no**
`blocklist_subscriptions` table — blocklists attach to a profile via the
`profiles.blocked_categories TEXT[]` array. #1067 will introduce a real
subscription model and add its own `schedule_id` FK against `named_schedules`
at that time.

### Back-compat / gate

- **Additive only.** Two new tables + two nullable columns with no default
  (metadata-only in PG 11+, no table rewrite). No existing column is renamed,
  retyped, or dropped.
- **Isolation gate passes.** All repo SELECTs/INSERTs use explicit column lists
  (no `SELECT *`), so image-(N-1) code is unaffected by the added columns.
  Confirmed by running the existing `api.test` suite against the DB at V49 —
  `TestDatabase` applies every migration including this one before the
  deployed-code feature tests run, and they pass unchanged. That is the gate.
- **Prod-volume safe.** Both new tables are bounded metadata surfaces (rows
  scale with the handful of schedules an operator defines), **not** unbounded-
  growth event tables. All index builds are on empty/tiny surfaces — safe on
  the Flyway startup critical path even at full prod volume.

### Migration of existing profile schedules

Not in this PR. It runs in **PR 2** as a one-time idempotent startup backfill
(app code, alongside the fresh-household seed step) — copying each profile's
existing V1 `schedules` rows into a `named_schedules` row + its
`schedule_windows`, and setting `profiles.schedule_id`. The old V1 `schedules`
table is **left intact** so PR-1-era images keep enforcing from it on rollback;
its removal is the later deprecation-window migration.

### Wire contract

Zero router-side impact. This is API-internal schema; the policy snapshot wire
shape is untouched (#1069 is a server-side snapshot-expansion feature that lands
in PR 2). `shared/contract/api-to-router/policy_snapshot.json` is not touched.

Refs #1069. Unblocks #1378.
