### PR TITLE
feat(policy): assemble PolicySnapshot.global, relocate UI hosts, default-deny eval (#1318)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -254,6 +254,71 @@ trait BlocklistRepo {
   def findMeta(id: BlocklistId): Task[Option[wifihaven.shared.BlocklistSummary]]
 }
 
+/**
+ * #1318 / #1308: reads the global-policy surfaces (V48) and assembles the fleet-wide
+ * `PolicySnapshot.global : BlockRules` that applies to every MAC. This repo is the only reader of
+ * the `global_allow` / `global_blocks` / `global_blocklists` tables and the `household_settings`
+ * global flags; the router never sees the audit `reason`/`added_by` columns — only the flat
+ * hostname / category lists the wire needs (design §7). PolicyService calls `get` once per
+ * snapshot.
+ *
+ * The `addAllow` / `addBlock` / `addBlocklist` / `setFlags` writers exist so the assembly path is
+ * exercisable end-to-end (and as the foundation the #1320 SPA editor will reuse); the curated
+ * authoring UI and its permissions are out of scope here.
+ */
+trait GlobalPolicyRepo {
+
+  /**
+   * The fleet-wide `BlockRules` resolved from the global tables + household flags:
+   *   - `extraAllowed` = active `global_allow` hosts (removed_at IS NULL)
+   *   - `extraBlocked` = active `global_blocks` hosts
+   *   - `blocklistIds` = all `global_blocklists` rows
+   *   - `blocked` / `blockReason` / `blockIpOnly` = the `household_settings` global flags
+   * Defaults to `BlockRules.allowAll` (inert) when nothing is configured.
+   */
+  def get: Task[BlockRules]
+
+  /** Append a host to the always-reachable set (carves out every drop). */
+  def addAllow(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit]
+
+  /**
+   * Soft-delete the active `global_allow` row for `host` (sets removed_at); history is retained.
+   */
+  def removeAllow(host: Hostname, removedBy: Option[Long]): Task[Unit]
+
+  /** Append a host to the network-wide block set (un-blockable except by `global_allow`). */
+  def addBlock(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit]
+
+  /**
+   * Soft-delete the active `global_blocks` row for `host` (sets removed_at); history is retained.
+   */
+  def removeBlock(host: Hostname, removedBy: Option[Long]): Task[Unit]
+
+  /** Associate a category blocklist with the household (applies to every MAC). */
+  def addBlocklist(id: BlocklistId, addedBy: Option[Long]): Task[Unit]
+
+  /** Set the flat global flags (network lockdown + strict-IP floor). */
+  def setFlags(blocked: Boolean, reason: Option[MacBlockReason], blockIpOnly: Boolean): Task[Unit]
+}
+
+/**
+ * No-op variant for test wiring that doesn't exercise the global section (e.g. the
+ * `PolicyService.apply` factory used by the legacy snapshot specs). `get` returns the inert
+ * `BlockRules.allowAll`; writes are dropped — so those specs see the pre-global behaviour with no
+ * global carve-out or lockdown.
+ */
+object NoopGlobalPolicyRepo extends GlobalPolicyRepo {
+  def get: Task[BlockRules]                                                               =
+    ZIO.succeed(BlockRules.allowAll)
+  def addAllow(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit] = ZIO.unit
+  def removeAllow(host: Hostname, removedBy: Option[Long]): Task[Unit]                    = ZIO.unit
+  def addBlock(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit] = ZIO.unit
+  def removeBlock(host: Hostname, removedBy: Option[Long]): Task[Unit]                    = ZIO.unit
+  def addBlocklist(id: BlocklistId, addedBy: Option[Long]): Task[Unit]                    = ZIO.unit
+  def setFlags(blocked: Boolean, reason: Option[MacBlockReason], blockIpOnly: Boolean): Task[Unit] =
+    ZIO.unit
+}
+
 trait TimeUsageRepo {
 
   /**
@@ -672,6 +737,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       Boolean,
       String,
       String,
+      Boolean,
   )
   private def toP(r: R)                             = Profile(
     r._1,
@@ -682,10 +748,11 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     r._6,
     CrossDeviceOverlapMode.parse(r._7).getOrElse(CrossDeviceOverlapMode.Sum),
     PauseMode.parse(r._8).getOrElse(PauseMode.Soft),
+    r._9,
   )
   def listAll                                       =
     DbMetrics.timed("profile.listAll")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode FROM profiles ORDER BY id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny FROM profiles ORDER BY id"
         .query[R]
         .map(toP)
         .to[List]
@@ -693,7 +760,7 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
     )
   def findById(id: ProfileId)                       =
     DbMetrics.timed("profile.findById")(
-      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode FROM profiles WHERE id=$id"
+      sql"SELECT id,name,blocked_categories,paused,failure_mode,block_ip_only,cross_device_overlap_mode,pause_mode,default_deny FROM profiles WHERE id=$id"
         .query[R]
         .map(toP)
         .option
@@ -712,7 +779,8 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
             failure_mode=${FailureMode.asString(p.failureMode)},
             block_ip_only=${p.blockIpOnly},
             cross_device_overlap_mode=${CrossDeviceOverlapMode.asString(p.crossDeviceOverlapMode)},
-            pause_mode=${PauseMode.asString(p.pauseMode)}
+            pause_mode=${PauseMode.asString(p.pauseMode)},
+            default_deny=${p.defaultDeny}
           WHERE id=${p.id}""".update.run
       .transact(xa)
       .unit
@@ -794,6 +862,85 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     sql"""INSERT INTO household_settings (id, daily_reset_time, daily_reset_tz)
           VALUES (1, '00:00', ${defaultZone})
           ON CONFLICT (id) DO NOTHING""".update.run.transact(xa).unit
+}
+
+class GlobalPolicyRepoLive(xa: Transactor[Task]) extends GlobalPolicyRepo {
+
+  def get: Task[BlockRules] =
+    DbMetrics.timed("globalPolicy.get") {
+      val allow      =
+        sql"SELECT host FROM global_allow WHERE removed_at IS NULL ORDER BY host"
+          .query[String]
+          .to[List]
+      val block      =
+        sql"SELECT host FROM global_blocks WHERE removed_at IS NULL ORDER BY host"
+          .query[String]
+          .to[List]
+      val blocklists =
+        sql"SELECT blocklist_id FROM global_blocklists ORDER BY blocklist_id"
+          .query[String]
+          .to[List]
+      // global_block_reason stores a MacBlockReason string (block-page copy); only meaningful
+      // when global_blocked is true. A lockdown with no stored reason reports `Manual`.
+      val flags      =
+        sql"""SELECT global_blocked, global_block_reason, global_block_ip_only
+              FROM household_settings WHERE id=1"""
+          .query[(Boolean, Option[String], Boolean)]
+          .option
+
+      (for {
+        a <- allow
+        b <- block
+        c <- blocklists
+        f <- flags
+      } yield {
+        val (blocked, reasonStr, ipOnly)   = f.getOrElse((false, None, false))
+        val reason: Option[MacBlockReason] =
+          if blocked then
+            reasonStr.flatMap(MacBlockReason.parse).orElse(Some(MacBlockReason.Manual))
+          else None
+        BlockRules(
+          blocked = blocked,
+          blockReason = reason,
+          extraBlocked = b.map(Hostname.unsafe),
+          extraAllowed = a.map(Hostname.unsafe),
+          blocklistIds = c.map(BlocklistId.unsafe),
+          blockIpOnly = ipOnly,
+        )
+      }).transact(xa)
+    }
+
+  def addAllow(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit] =
+    sql"""INSERT INTO global_allow (host, reason, added_by)
+          VALUES (${host.value}, $reason, $addedBy)""".update.run.transact(xa).unit
+
+  def removeAllow(host: Hostname, removedBy: Option[Long]): Task[Unit] =
+    sql"""UPDATE global_allow SET removed_at=NOW(), removed_by=$removedBy
+          WHERE host=${host.value} AND removed_at IS NULL""".update.run.transact(xa).unit
+
+  def addBlock(host: Hostname, reason: Option[String], addedBy: Option[Long]): Task[Unit] =
+    sql"""INSERT INTO global_blocks (host, reason, added_by)
+          VALUES (${host.value}, $reason, $addedBy)""".update.run.transact(xa).unit
+
+  def removeBlock(host: Hostname, removedBy: Option[Long]): Task[Unit] =
+    sql"""UPDATE global_blocks SET removed_at=NOW(), removed_by=$removedBy
+          WHERE host=${host.value} AND removed_at IS NULL""".update.run.transact(xa).unit
+
+  def addBlocklist(id: BlocklistId, addedBy: Option[Long]): Task[Unit] =
+    sql"""INSERT INTO global_blocklists (blocklist_id, added_by)
+          VALUES (${id.value}, $addedBy)
+          ON CONFLICT (blocklist_id) DO NOTHING""".update.run.transact(xa).unit
+
+  def setFlags(
+      blocked: Boolean,
+      reason: Option[MacBlockReason],
+      blockIpOnly: Boolean,
+  ): Task[Unit] =
+    sql"""UPDATE household_settings
+            SET global_blocked=$blocked,
+                global_block_reason=${reason.map(MacBlockReason.asString)},
+                global_block_ip_only=$blockIpOnly
+          WHERE id=1""".update.run.transact(xa).unit
 }
 
 class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
@@ -2788,6 +2935,7 @@ object Repos {
   val profileRepo           = ZLayer.fromFunction(ProfileRepoLive(_))
   val scheduleRepo          = ZLayer.fromFunction(ScheduleRepoLive(_))
   val householdSettingsRepo = ZLayer.fromFunction(HouseholdSettingsRepoLive(_))
+  val globalPolicyRepo      = ZLayer.fromFunction(GlobalPolicyRepoLive(_))
   val timeLimitRepo         = ZLayer.fromFunction(TimeLimitRepoLive(_))
   val siteTimeLimitRepo     = ZLayer.fromFunction(SiteTimeLimitRepoLive(_))
   val deviceRepo            = ZLayer.fromFunction(DeviceRepoLive(_))
@@ -2803,5 +2951,5 @@ object Repos {
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
 }

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -76,6 +76,12 @@ object MetricGuard {
     "auth_failures_total"                       -> Set("reason"),
     "agent_connected_routers"                   -> Set.empty[String],
     "traffic_reports_filtered_zero_bytes_total" -> Set.empty[String],
+    // #1318 — global-policy-layer visibility. `global_allow_hosts` is the size of the
+    // security-sensitive fleet-wide always-reachable set (a host here bypasses every block);
+    // `default_deny_profiles` counts profiles running the block-all baseline. Both are unlabelled
+    // household-scoped gauges set each time the policy snapshot is assembled.
+    "wifihaven_global_allow_hosts"              -> Set.empty[String],
+    "wifihaven_default_deny_profiles"           -> Set.empty[String],
     // §5.1 router-sourced, pushed via POST /api/router/metrics (#1205). Every one carries the
     // server-attached `router_id` + `installation_id` plus its own bounded enum label.
     "dnsmasq_restarts_total"                    -> Set("reason", "router_id", "installation_id"),
@@ -231,6 +237,22 @@ object AppMetrics {
 
   def setConnectedRouters(count: Int): UIO[Unit] =
     MetricGuard.gauge("agent_connected_routers", Map.empty, count.toDouble)
+
+  // ── Global policy layer (#1318) ─────────────────────────────────────────────
+  // Emitted from PolicyService.snapshot each time the snapshot is assembled.
+  // `global_allow_hosts` tracks the size of the fleet-wide always-reachable set
+  // (`global.extraAllowed`) — a host on it is reachable from every device past
+  // any block, so operators want to watch it grow. `default_deny_profiles`
+  // counts profiles running the block-all baseline. Both unlabelled, gated by
+  // the cardinality firewall on the name.
+
+  def setGlobalPolicy(globalAllowHosts: Int, defaultDenyProfiles: Int): UIO[Unit] =
+    MetricGuard.gauge("wifihaven_global_allow_hosts", Map.empty, globalAllowHosts.toDouble) *>
+      MetricGuard.gauge(
+        "wifihaven_default_deny_profiles",
+        Map.empty,
+        defaultDenyProfiles.toDouble,
+      )
 
   // ── Router metrics ingest (#1205) ────────────────────────────────────────────
   // One increment per POST /api/router/metrics. `status` ∈ {ok, malformed,

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -2,6 +2,7 @@ package wifihaven.api.policy
 
 import wifihaven.api.AppConfig
 import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.presence.Presence
 import wifihaven.shared.{Schedule as DbSchedule, *}
 import wifihaven.shared.types.*
@@ -37,6 +38,7 @@ object PolicyServiceLive {
       appRepo: AppRepo,
       clock: Clock,
       uiAllowedHosts: List[Hostname] = Nil,
+      globalPolicyRepo: GlobalPolicyRepo = NoopGlobalPolicyRepo,
   ): PolicyServiceLive = {
     val tss = new TimeStatusServiceLive(
       profileRepo,
@@ -64,6 +66,7 @@ object PolicyServiceLive {
       tss,
       clock,
       uiAllowedHosts,
+      globalPolicyRepo,
     )
   }
 }
@@ -82,12 +85,26 @@ class PolicyServiceLive(
     timeStatusService: TimeStatusService,
     clock: Clock,
     uiAllowedHosts: List[Hostname] = Nil,
+    globalPolicyRepo: GlobalPolicyRepo = NoopGlobalPolicyRepo,
 ) extends PolicyService {
 
+  // #1318: the WifiHaven UI / block-page hosts are fleet-wide always-reachable
+  // hosts, so they live in `global.extraAllowed` (carving out every block at the
+  // router) rather than being copied into every profile's `extraAllowed`. The
+  // DB-backed `global_allow` set is unioned with these per-deployment config
+  // hosts when assembling the global section. (The #1307 infra-allow copy is
+  // retired separately in #1321.)
+  private val uiGlobalAllow: List[Hostname] = uiAllowedHosts
+
   def snapshot: Task[PolicySnapshot] =
-    for {
-      settings <- householdSettingsRepo.get
-      now      <- clock.instant
+    (for {
+      settings  <- householdSettingsRepo.get
+      now       <- clock.instant
+      // #1318: the fleet-wide global BlockRules, assembled once from the global-policy tables.
+      // `uiGlobalAllow` (the per-deployment UI / block-page hosts) is unioned into its
+      // `extraAllowed` so those hosts are always reachable for every MAC via `global.extraAllowed`
+      // rather than copied into each profile.
+      globalRaw <- globalPolicyRepo.get
       today = PolicyService.householdLocalDate(now, settings)
       // #1104: today's cap/block state for every profile in one batched read. Same call the
       // /api/time/status/... endpoints use — keeps the snapshot and the UI in lockstep.
@@ -142,7 +159,6 @@ class PolicyServiceLive(
           siteLimits = pSiteLims,
           appExtraAllowed = appAllowedHosts,
           appExtraBlocked = appBlockedHosts,
-          uiAllowedHosts = uiAllowedHosts,
         )
 
         p.id -> ProfilePolicy(name = p.name, rules = rules, failureMode = p.failureMode)
@@ -151,9 +167,10 @@ class PolicyServiceLive(
       // #961: unmanaged-MAC enforcement is applied here at snapshot-build time,
       // not via a new wire field. For devices with no profile assignment we
       // emit explicit per-MAC `rules` keyed off the household policy:
-      //   - policy = "block": Manual-blocked with `uiAllowedHosts` in
-      //     extraAllowed so the SPA hostnames remain reachable from the
-      //     unmanaged device (otherwise the block-page redirect can't load).
+      //   - policy = "block": Manual-blocked. The UI / block-page hosts are no
+      //     longer copied here (#1318) — they live in `global.extraAllowed`,
+      //     which carves out this block too (it carves out every drop, including
+      //     a whole-MAC `blocked`), so the block-page redirect still loads.
       //   - policy = "allow": `rules = None`, same as today (router treats as
       //     unenrolled / allow-all).
       // The router's existing per-MAC override path enforces this without any
@@ -166,7 +183,7 @@ class PolicyServiceLive(
               blocked = true,
               blockReason = Some(MacBlockReason.Unmanaged),
               extraBlocked = Nil,
-              extraAllowed = uiAllowedHosts,
+              extraAllowed = Nil,
               blocklistIds = Nil,
               blockIpOnly = false,
             ),
@@ -185,15 +202,29 @@ class PolicyServiceLive(
         c -> Blocklist(version = version, url = BlocklistUrl.unsafe(s"/api/blocklists/${c.value}"))
       }.toMap
 
-      val core = SnapshotCore(devicePolicies, profilePolicies, pBlocklists)
+      // #1318: union the per-deployment UI / block-page hosts into the DB-backed
+      // global allow set. These are the relocated `uiAllowedHosts` — fleet-wide
+      // always-reachable hosts that carve out every block at the router.
+      val globalRules = globalRaw.copy(
+        extraAllowed = (globalRaw.extraAllowed ++ uiGlobalAllow).distinct,
+      )
+
+      val core = SnapshotCore(globalRules, devicePolicies, profilePolicies, pBlocklists)
       val etag = PolicyService.computeEtag(core)
-      PolicySnapshot(
+      val snap = PolicySnapshot(
         etag = etag,
         generatedAt = now.toString,
+        global = globalRules,
         devices = devicePolicies,
         profiles = profilePolicies,
         blocklists = pBlocklists,
       )
+      (snap, profiles.count(_.defaultDeny))
+    }).flatMap { case (snap, defaultDenyProfiles) =>
+      // #1318: surface the global-section size + default-deny profile count for operators.
+      AppMetrics
+        .setGlobalPolicy(snap.global.extraAllowed.size, defaultDenyProfiles)
+        .as(snap)
     }
 
   def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]] =
@@ -419,6 +450,7 @@ class PolicyServiceLive(
 }
 
 private case class SnapshotCore(
+    global: BlockRules,
     devices: Map[MacAddress, DevicePolicy],
     profiles: Map[ProfileId, ProfilePolicy],
     blocklists: Map[BlocklistId, Blocklist],
@@ -428,7 +460,7 @@ object PolicyService {
   val layer: ZLayer[
     AppConfig & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo &
       SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo &
-      AppRepo & TimeStatusService & Clock,
+      AppRepo & GlobalPolicyRepo & TimeStatusService & Clock,
     Nothing,
     PolicyService,
   ] = ZLayer.fromFunction {
@@ -444,6 +476,7 @@ object PolicyService {
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
         ar: AppRepo,
+        gpr: GlobalPolicyRepo,
         tss: TimeStatusService,
         clk: Clock,
     ) =>
@@ -461,6 +494,7 @@ object PolicyService {
         tss,
         clk,
         cfg.policy.uiAllowedHostsParsed,
+        gpr,
       )
   }
 
@@ -526,6 +560,9 @@ object PolicyService {
   /** Deterministic ETag over snapshot logical content. */
   private[policy] def computeEtag(core: SnapshotCore): ETag = {
     val parts = scala.collection.mutable.ArrayBuffer.empty[String]
+    // #1318: the global section is part of the snapshot's logical content, so a change to it must
+    // move the ETag (and re-poll the fleet) even when no device/profile changed.
+    parts += s"global:${blockRulesSig(core.global)}"
     core.devices.toList.sortBy(_._1.value).foreach { case (mac, d) =>
       val ruleSig = d.rules.fold("-")(blockRulesSig)
       parts += s"dev:${mac.value}|${d.profileId.map(_.value).getOrElse("-")}|${d.name}|$ruleSig"
@@ -552,7 +589,16 @@ object PolicyService {
    * #354 / #1104: collapse a profile's `ProfileDayState` plus its app & site-limit context into the
    * effective `BlockRules` served in the snapshot. `state` carries the canonical `blocked` and
    * `blockReason` already evaluated by `TimeStatusService.fold` (same precedence Paused > Schedule
-   * > TimeLimit). This function only adds the app/site-limit/UI-host wiring around it.
+   * > TimeLimit). This function only adds the app/site-limit wiring around it.
+   *
+   * #1318: two changes.
+   *   1. The UI / block-page hosts are NO LONGER unioned here — they moved to `global.extraAllowed`
+   *      (see `PolicyServiceLive.uiGlobalAllow`), which carves out every block fleet-wide. 2.
+   *      Default-deny (`profile.defaultDeny`): collapse to block-all (`blocked = true` +
+   *      `DefaultDeny` reason, unless a stronger Paused/Schedule/TimeLimit reason already applies)
+   *      with only the profile/device allow list reachable. `extraBlocked` / `blocklistIds` are
+   *      omitted because they are redundant under block-all (design §4). `blockIpOnly` still
+   *      applies — default-deny + `blockIpOnly` is the strictest combination.
    */
   private[policy] def computeBlockRules(
       profile: Profile,
@@ -560,7 +606,6 @@ object PolicyService {
       siteLimits: List[SiteTimeLimit],
       appExtraAllowed: List[Hostname] = Nil,
       appExtraBlocked: List[Hostname] = Nil,
-      uiAllowedHosts: List[Hostname] = Nil,
   ): BlockRules = {
     // Per-site limits exhausted today → host appears in extraBlocked too.
     // domainPattern is a glob string, not a Hostname — we keep it as-is in the
@@ -605,27 +650,48 @@ object PolicyService {
     // extraAllowed-beats-extraBlocked precedence then makes "allow wins" — same
     // semantics it already applies to the per-profile own lists (see
     // feedback_extraallowed_beats_blocked).
-    BlockRules(
-      blocked = state.blocked,
-      blockReason = state.blockReason,
-      extraBlocked = (appExtraBlocked ++ siteLimitExtraBlocked).distinct,
-      // #944: union the deployment's UI hosts into per-profile extraAllowed so
-      // a household device can always reach the admin UI even when this
-      // profile is paused or lists one of these hosts in a blocked-mode app
-      // (allow beats block at the router). Configured via wifihaven.policy
-      // .uiAllowedHosts per-deployment so prod doesn't allow staging through
-      // and vice versa. Will become DB-backed per #937.
-      // #1307: union the curated infra allowlist so connectivity-check / OCSP /
-      // CDN dependencies of an allowed app survive the whole-MAC block. Copied
-      // per-profile for now; the global policy layer (#1308) will dedup this.
-      // #1418: under a hard pause, drop everything except the UI hosts.
-      extraAllowed =
-        if (isHardPause) uiAllowedHosts.distinct
-        else
-          (appExtraAllowed ++ appExemptAllowedHosts ++ uiAllowedHosts ++ infraAllowHosts).distinct,
-      blocklistIds = profile.blockedCategories,
-      blockIpOnly = profile.blockIpOnly,
-    )
+    //
+    // #1307: the curated infra allowlist (connectivity-check / OCSP / CDN deps of
+    // an allowed app) is still copied per-profile here so it survives the
+    // whole-MAC block; #1321 retires this copy once the router consumes
+    // `global.extraAllowed`. The deployment UI hosts moved to the global section
+    // already (#1318), so they are no longer unioned here.
+    //
+    // #1418: under a hard pause, drop even the app/exempt/infra carve-outs —
+    // per-profile `extraAllowed` goes empty. The deployment UI hosts (block page
+    // + admin SPA) still survive because they now live in `global.extraAllowed`,
+    // which the router applies as the top of the precedence ladder and carves out
+    // of every drop (#1319) — so a hard pause is a true off-switch for everything
+    // except the always-reachable global hosts, exactly as before #1318 (when the
+    // UI hosts were the per-profile carve-out the hard pause kept).
+    val profileExtraAllowed =
+      if (isHardPause) Nil
+      else (appExtraAllowed ++ appExemptAllowedHosts ++ infraAllowHosts).distinct
+
+    if (profile.defaultDeny)
+      // #1318: default-deny baseline. Block-all with only the profile/device
+      // allow list reachable; `global.extraAllowed` carves out separately at the
+      // router. `DefaultDeny` is the lowest-precedence reason, so a concurrent
+      // Paused/Schedule/TimeLimit (already folded into `state`) wins the
+      // block-page copy. extraBlocked/blocklistIds omitted — redundant under
+      // block-all.
+      BlockRules(
+        blocked = true,
+        blockReason = state.blockReason.orElse(Some(MacBlockReason.DefaultDeny)),
+        extraBlocked = Nil,
+        extraAllowed = profileExtraAllowed,
+        blocklistIds = Nil,
+        blockIpOnly = profile.blockIpOnly,
+      )
+    else
+      BlockRules(
+        blocked = state.blocked,
+        blockReason = state.blockReason,
+        extraBlocked = (appExtraBlocked ++ siteLimitExtraBlocked).distinct,
+        extraAllowed = profileExtraAllowed,
+        blocklistIds = profile.blockedCategories,
+        blockIpOnly = profile.blockIpOnly,
+      )
   }
 
   // ── #334: timezone-aware time math ────────────────────────────────────────

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -179,9 +179,9 @@ object TestDatabase {
    */
   type AllRepos =
     TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
-      TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TimeUsageRepo &
-      TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo & ConnectionEventRepo &
-      AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
+      GlobalPolicyRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo &
+      TimeUsageRepo & TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo &
+      ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & TestDb & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -487,10 +487,15 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(ea.contains("khanacademy.org")) &&
         assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea))
     },
-    test("#1418: HARD pause still spares the deployment uiAllowedHosts (block page / admin UI)") {
-      // We deliberately keep uiAllowedHosts through a hard pause so the kid sees
-      // the block page and the admin SPA loads on the LAN — only the app/infra
-      // allowlists are cut. extraAllowed must equal exactly the UI hosts.
+    test(
+      "#1418/#1318: HARD pause still spares the deployment uiAllowedHosts via global.extraAllowed",
+    ) {
+      // We deliberately keep the deployment UI hosts reachable through a hard
+      // pause so the kid sees the block page and the admin SPA loads on the LAN —
+      // only the app/infra allowlists are cut. As of #1318 the UI hosts live in
+      // `global.extraAllowed` (not per-profile), and the router carves them out
+      // of every drop (#1319), so the per-profile `extraAllowed` is now empty
+      // while the global section carries exactly the UI hosts.
       val uiHosts = List(Hostname.unsafe("blockpage.wifihaven.lan"))
       for {
         _     <- cleanDb
@@ -529,8 +534,12 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         snap <- svc.snapshot
         rules = snap.profiles(kid).rules
         ea    = rules.extraAllowed.map(_.value).toSet
+        ga    = snap.global.extraAllowed.map(_.value).toSet
       } yield assertTrue(rules.blocked) &&
-        assertTrue(ea == Set("blockpage.wifihaven.lan")) &&
+        // per-profile extraAllowed is empty under hard pause (app/infra cut, UI relocated)
+        assertTrue(ea.isEmpty) &&
+        // the deployment UI hosts survive via the fleet-wide global section
+        assertTrue(ga == Set("blockpage.wifihaven.lan")) &&
         assertTrue(!ea.contains("khanacademy.org")) &&
         assertTrue(!ea.contains("connectivitycheck.gstatic.com"))
     },

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -11,10 +11,12 @@ import zio.{Clock as _, *}
 import zio.test.*
 
 /**
- * #944: deployment-configured UI hosts (wifihaven.policy.uiAllowedHosts) must appear in every
- * profile's snapshot `extraAllowed`, regardless of paused state or whether the profile lists one of
- * them in `extraBlocked`. Router enforces allow-beats-block; this spec pins that the snapshot emits
- * the union. The list is per-deployment so prod doesn't let staging hosts through and vice versa.
+ * #944 → #1318: deployment-configured UI hosts (wifihaven.policy.uiAllowedHosts) are fleet-wide
+ * always-reachable hosts. As of #1318 they are emitted ONCE in `snapshot.global.extraAllowed`
+ * (which carves out every block at the router) rather than copied into every profile's
+ * `extraAllowed`. This spec pins the relocated shape: the UI hosts appear in the global section and
+ * NOT in per-profile `extraAllowed`, while the curated infra-allow hosts (#1307, retired in #1321)
+ * stay copied per-profile for now.
  */
 object PolicySnapshotGlobalAllowSpec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
@@ -27,6 +29,8 @@ object PolicySnapshotGlobalAllowSpec
   private val uiHosts: List[Hostname] =
     List("wifihaven.net", "api.wifihaven.net").map(Hostname.unsafe)
 
+  // makePs wires the real GlobalPolicyRepo so the global section is assembled from the DB +
+  // uiAllowedHosts, exactly as production does.
   private def makePs =
     for {
       pr     <- ZIO.service[ProfileRepo]
@@ -39,6 +43,7 @@ object PolicySnapshotGlobalAllowSpec
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
+      gpr    <- ZIO.service[GlobalPolicyRepo]
       clock  <- ZIO.service[Clock]
     } yield PolicyServiceLive(
       pr,
@@ -53,12 +58,15 @@ object PolicySnapshotGlobalAllowSpec
       ar,
       clock,
       uiHosts,
+      gpr,
     ): PolicyService
 
   private val expected: Set[String] = uiHosts.map(_.value).toSet
 
-  def spec = suite("policy snapshot — global allow hosts (#944)")(
-    test("empty uiAllowedHosts → snapshot extraAllowed is the app-derived list plus infra hosts") {
+  def spec = suite("policy snapshot — global allow hosts (#944 / #1318)")(
+    test(
+      "empty uiAllowedHosts → per-profile extraAllowed is the app-derived list plus infra hosts",
+    ) {
       for {
         _    <- cleanDb
         pr   <- ZIO.service[ProfileRepo]
@@ -71,6 +79,7 @@ object PolicySnapshotGlobalAllowSpec
         trr  <- ZIO.service[TrafficReportRepo]
         er   <- ZIO.service[TimeExtensionRepo]
         ar   <- ZIO.service[AppRepo]
+        gpr  <- ZIO.service[GlobalPolicyRepo]
         clk  <- ZIO.service[Clock]
         ps0  <- pr.listAll
         kids = ps0.find(_.name == "Kids").get
@@ -87,14 +96,18 @@ object PolicySnapshotGlobalAllowSpec
           er,
           ar,
           clk,
-        ) // uiAllowedHosts defaults to Nil
+          Nil, // empty uiAllowedHosts
+          gpr,
+        )
         snap <- svc.snapshot
       } yield assertTrue(
         snap.profiles(kids.id).rules.extraAllowed.map(_.value).toSet ==
           (Set("user.example") ++ PolicyService.infraAllowHosts.map(_.value).toSet),
+        // global is inert (no DB global_allow rows, no ui hosts configured)
+        snap.global.extraAllowed.isEmpty,
       )
     },
-    test("every profile's emitted extraAllowed includes all configured ui hosts (union)") {
+    test("configured ui hosts land in global.extraAllowed once, NOT per-profile") {
       for {
         _         <- cleanDb
         pr        <- ZIO.service[ProfileRepo]
@@ -105,21 +118,38 @@ object PolicySnapshotGlobalAllowSpec
         ps   <- makePs
         snap <- ps.snapshot
       } yield {
-        val perProfileAllowed = snap.profiles.values.map(_.rules.extraAllowed.map(_.value).toSet)
-        val allCover          = perProfileAllowed.forall(expected.subsetOf)
-        val kidsAllowed       = snap.profiles
-          .find(_._2.name == "Kids")
-          .get
-          ._2
-          .rules
-          .extraAllowed
-          .map(_.value)
-        val noDupes           = kidsAllowed.distinct == kidsAllowed
-        val carriesExisting   = kidsAllowed.contains("already-in.example")
-        assertTrue(allCover) && assertTrue(noDupes) && assertTrue(carriesExisting)
+        val globalAllowed = snap.global.extraAllowed.map(_.value).toSet
+        // ui hosts present in the global section exactly once
+        val globalCovers  = expected.subsetOf(globalAllowed)
+        val noGlobalDupes = snap.global.extraAllowed.distinct == snap.global.extraAllowed
+        // ui hosts are NOT copied into any profile's extraAllowed anymore
+        val noProfileCopy = snap.profiles.values.forall(p =>
+          expected.intersect(p.rules.extraAllowed.map(_.value).toSet).isEmpty,
+        )
+        // the profile's own app allow still flows per-profile
+        val kidsAllowed   =
+          snap.profiles(kids.id).rules.extraAllowed.map(_.value)
+        assertTrue(
+          globalCovers,
+          noGlobalDupes,
+          noProfileCopy,
+          kidsAllowed.contains("already-in.example"),
+        )
       }
     },
-    test("paused profile still emits global hosts in extraAllowed") {
+    test(
+      "global section is independent of any profile (carries ui hosts even with zero app allows)",
+    ) {
+      for {
+        _    <- cleanDb
+        ps   <- makePs
+        snap <- ps.snapshot
+      } yield assertTrue(
+        snap.profiles.nonEmpty,
+        expected.subsetOf(snap.global.extraAllowed.map(_.value).toSet),
+      )
+    },
+    test("paused profile blocks but ui hosts stay reachable via global.extraAllowed") {
       for {
         _   <- cleanDb
         pr  <- ZIO.service[ProfileRepo]
@@ -130,17 +160,18 @@ object PolicySnapshotGlobalAllowSpec
         snap <- svc.snapshot
       } yield {
         val rules = snap.profiles(kids.id).rules
-        assertTrue(rules.blocked) &&
-        assertTrue(expected.subsetOf(rules.extraAllowed.map(_.value).toSet))
+        assertTrue(
+          rules.blocked,
+          // ui hosts are NOT in the paused profile's own extraAllowed — they carve out via global
+          expected.intersect(rules.extraAllowed.map(_.value).toSet).isEmpty,
+          expected.subsetOf(snap.global.extraAllowed.map(_.value).toSet),
+        )
       }
     },
     test("every profile's extraAllowed includes the #1337 Apple connectivity-test host") {
       // #1337: Apple's network-connectivity-test CDN is a device-level infra dep that
       // was dropped under a whole-MAC block. It lives in the curated infraAllowHosts
-      // constant, so it must surface in every profile's extraAllowed (copied
-      // per-profile, allow beats the @blocked_macs drop via #421 ea_ enforcement).
-      // App-specific CDN edge hostnames were deliberately NOT added (they rotate);
-      // app assets are covered via the app's branded domains instead.
+      // constant, still copied per-profile (the #1307 copy is retired separately in #1321).
       val newHosts = Set("netcts.cdn-apple.com")
       for {
         _    <- cleanDb
@@ -170,7 +201,7 @@ object PolicySnapshotGlobalAllowSpec
       )
     },
     test(
-      "global host in extraBlocked still appears in extraAllowed (allow-beats-block at router)",
+      "ui host blocked as an app appears in per-profile extraBlocked; global.extraAllowed still saves it",
     ) {
       for {
         _   <- cleanDb
@@ -182,12 +213,15 @@ object PolicySnapshotGlobalAllowSpec
         svc  <- makePs
         snap <- svc.snapshot
       } yield {
-        val rules   = snap.profiles(kids.id).rules
-        val blocked = rules.extraBlocked.map(_.value).toSet
-        val allowed = rules.extraAllowed.map(_.value).toSet
-        assertTrue(blocked.contains("wifihaven.net")) &&
-        assertTrue(allowed.contains("wifihaven.net")) &&
-        assertTrue(expected.subsetOf(allowed))
+        val rules         = snap.profiles(kids.id).rules
+        val blocked       = rules.extraBlocked.map(_.value).toSet
+        val globalAllowed = snap.global.extraAllowed.map(_.value).toSet
+        assertTrue(
+          blocked.contains("wifihaven.net"),
+          // the ui host is allow-listed at the global layer, which beats the per-MAC block at the
+          // router (allow-beats-block, top of the precedence ladder)
+          globalAllowed.contains("wifihaven.net"),
+        )
       }
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
@@ -1,0 +1,205 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+/**
+ * #1318 / #1308: PolicyService assembles `snapshot.global` (a fleet-wide `BlockRules`) from the V48
+ * global-policy tables, and collapses a per-profile `default_deny` flag into block-all +
+ * `DefaultDeny`. This spec covers the global-section assembly, default-deny evaluation, the
+ * precedence of `DefaultDeny` vs. stronger reasons, default-deny + `blockIpOnly`, and that a change
+ * to the global section moves the ETag.
+ *
+ * The router-side composition (`global.extraAllowed` actually carving out a block) is a separate
+ * issue (#1319); here we pin only that the snapshot the API emits is correct.
+ */
+object PolicySnapshotGlobalSectionSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makePs =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      gpr    <- ZIO.service[GlobalPolicyRepo]
+      clock  <- ZIO.service[Clock]
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clock,
+      Nil, // no ui hosts — isolate the DB-backed global section
+      gpr,
+    ): PolicyService
+
+  def spec = suite("policy snapshot — global section + default-deny (#1318)")(
+    test(
+      "global section is assembled from global_allow / global_blocks / global_blocklists + flags",
+    ) {
+      for {
+        _    <- cleanDb
+        blr  <- ZIO.service[BlocklistRepo]
+        gpr  <- ZIO.service[GlobalPolicyRepo]
+        // a blocklist must exist before it can be associated globally (FK)
+        _    <- blr.upsertMeta(
+          BlocklistId.unsafe("ads"),
+          "Ads",
+          None,
+          bundled = true,
+          None,
+          java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        _    <- gpr.addAllow(Hostname.unsafe("infra.example"), Some("pki"), None)
+        _    <- gpr.addBlock(Hostname.unsafe("evil.example"), Some("operator"), None)
+        _    <- gpr.addBlocklist(BlocklistId.unsafe("ads"), None)
+        _    <- gpr.setFlags(blocked = false, None, blockIpOnly = true)
+        ps   <- makePs
+        snap <- ps.snapshot
+      } yield {
+        val g = snap.global
+        assertTrue(
+          g.extraAllowed.map(_.value) == List("infra.example"),
+          g.extraBlocked.map(_.value) == List("evil.example"),
+          g.blocklistIds.map(_.value) == List("ads"),
+          g.blockIpOnly,
+          !g.blocked,
+          g.blockReason.isEmpty,
+        )
+      }
+    },
+    test("soft-deleted global_allow rows are excluded from global.extraAllowed") {
+      for {
+        _    <- cleanDb
+        gpr  <- ZIO.service[GlobalPolicyRepo]
+        _    <- gpr.addAllow(Hostname.unsafe("kept.example"), None, None)
+        _    <- gpr.addAllow(Hostname.unsafe("removed.example"), None, None)
+        _    <- gpr.removeAllow(Hostname.unsafe("removed.example"), None)
+        ps   <- makePs
+        snap <- ps.snapshot
+      } yield assertTrue(
+        snap.global.extraAllowed.map(_.value).toSet == Set("kept.example"),
+      )
+    },
+    test("global lockdown flag → global.blocked + reason from household_settings") {
+      for {
+        _    <- cleanDb
+        gpr  <- ZIO.service[GlobalPolicyRepo]
+        _    <- gpr.setFlags(blocked = true, Some(MacBlockReason.Manual), blockIpOnly = false)
+        ps   <- makePs
+        snap <- ps.snapshot
+      } yield assertTrue(
+        snap.global.blocked,
+        snap.global.blockReason.contains(MacBlockReason.Manual),
+      )
+    },
+    test(
+      "default-deny profile collapses to blocked=true + DefaultDeny, only extraAllowed reachable",
+    ) {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        ar  <- ZIO.service[AppRepo]
+        ps0 <- pr.listAll
+        kids = ps0.find(_.name == "Kids").get
+        // give it an explicit allow + flip default-deny on
+        _    <- TestLayers.seedAppAssignment(ar, kids.id, "pbskids.org", AppMode.Allowed)
+        _    <- pr.update(kids.copy(defaultDeny = true))
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val rules = snap.profiles(kids.id).rules
+        assertTrue(
+          rules.blocked,
+          rules.blockReason.contains(MacBlockReason.DefaultDeny),
+          // only the explicit allow (plus copied infra hosts) is reachable
+          rules.extraAllowed.map(_.value).contains("pbskids.org"),
+          // extraBlocked / blocklistIds are omitted under block-all even though the
+          // profile carries blocked_categories
+          rules.extraBlocked.isEmpty,
+          rules.blocklistIds.isEmpty,
+        )
+      }
+    },
+    test("a NON default-deny profile still emits its blocklistIds (control)") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        ps0 <- pr.listAll
+        kids = ps0.find(_.name == "Kids").get
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield assertTrue(
+        snap.profiles(kids.id).rules.blocklistIds.nonEmpty,
+        snap.profiles(kids.id).rules.blockReason.forall(_ != MacBlockReason.DefaultDeny),
+      )
+    },
+    test("default-deny + a stronger reason (paused) reports the stronger reason") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        ps0 <- pr.listAll
+        kids = ps0.find(_.name == "Kids").get
+        _    <- pr.update(kids.copy(defaultDeny = true, paused = true))
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val rules = snap.profiles(kids.id).rules
+        assertTrue(
+          rules.blocked,
+          // Paused outranks DefaultDeny in the block-page precedence ladder
+          rules.blockReason.contains(MacBlockReason.Paused),
+        )
+      }
+    },
+    test("default-deny honors the profile's blockIpOnly (strictest combination)") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        ps0 <- pr.listAll
+        kids = ps0.find(_.name == "Kids").get
+        _    <- pr.update(kids.copy(defaultDeny = true, blockIpOnly = true))
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val rules = snap.profiles(kids.id).rules
+        assertTrue(rules.blocked, rules.blockIpOnly)
+      }
+    },
+    test("a change to the global section moves the snapshot ETag") {
+      for {
+        _   <- cleanDb
+        gpr <- ZIO.service[GlobalPolicyRepo]
+        svc <- makePs
+        e0  <- svc.snapshot.map(_.etag)
+        _   <- gpr.addAllow(Hostname.unsafe("newinfra.example"), None, None)
+        e1  <- svc.snapshot.map(_.etag)
+      } yield assertTrue(e0 != e1)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -494,6 +494,41 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Global policy layer (#1318)",
+      "description": "wifihaven_global_allow_hosts — size of the fleet-wide always-reachable set (global.extraAllowed); a host here bypasses every block, so watch it grow. wifihaven_default_deny_profiles — profiles running the block-all baseline. Both set per snapshot assembly in PolicyService.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "id": 15,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": [] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "wifihaven_global_allow_hosts{env=\"$env\"}",
+          "legendFormat": "global allow hosts",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "wifihaven_default_deny_profiles{env=\"$env\"}",
+          "legendFormat": "default-deny profiles",
+          "refId": "B"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,11 +214,20 @@ full composition model, precedence table, and per-profile **default-deny**
 mode (`blocked = true` baseline + `MacBlockReason.DefaultDeny`, with
 `extraAllowed` and `global.extraAllowed` carving out).
 
-> **Status (#1308).** This is the target. Until the follow-ups land, the
-> always-reachable hosts are still copied into each profile's `extraAllowed`
-> (`PolicyService.computeBlockRules`); #1307 ships its allowlist the same
-> copy-into-every-profile way as a near-term fix. This design removes that
-> redundancy.
+> **Status (#1308).** Server-side assembly has landed (#1318):
+> `PolicyService` now emits `snapshot.global` (a `BlockRules`) from the V48
+> global-policy tables + the per-deployment UI hosts, evaluates per-profile
+> `default_deny` into `blocked = true` + `MacBlockReason.DefaultDeny`, and the
+> snapshot ETag covers the global section. The **deployment UI / block-page
+> hosts** have moved out of every profile's `extraAllowed` into
+> `global.extraAllowed`. Still outstanding: the **router** does not yet compose
+> the global section (#1319) — an old agent ignores the additive `global` field
+> and keeps enforcing per-MAC exactly as before — and the curated **#1307 infra
+> allowlist is still copied into each profile's `extraAllowed`**
+> (`PolicyService.computeBlockRules`), retired only once the router consumes
+> `global.extraAllowed` (#1321). So in the current window the UI hosts are
+> enforced via the global layer (needs #1319) while the infra hosts are still
+> enforced the per-profile way.
 
 > **Known deviations from this model as of May 2026** (tracked follow-ups,
 > not the canonical design):

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -162,6 +162,14 @@ case class Profile(
     // #1418: soft (default) honors extraAllowed through a pause; hard cuts even
     // allowlisted/global hosts. Only consulted when the profile is paused.
     pauseMode: PauseMode = PauseMode.Soft,
+    // #1318 / #1308: default-deny baseline. When true the profile's effective
+    // BlockRules collapse to block-all (`blocked = true` + `DefaultDeny` reason)
+    // with only `extraAllowed` (plus the fleet-wide `global.extraAllowed`)
+    // reachable — the inverse of the allow-by-default + blocklists model.
+    // Resolved entirely server-side in PolicyService; the router never sees the
+    // flag, only the collapsed `blocked = true`. Default false. Additive field
+    // with a default, so an older client that omits it decodes unchanged.
+    defaultDeny: Boolean = false,
 ) derives JsonCodec
 
 case class Schedule(


### PR DESCRIPTION
Implements #1318 — the PolicyService adoption of the global policy layer (design: [`docs/design/global-policy-layer.md`](docs/design/global-policy-layer.md) §4/§5/§7.1). Builds on the merged foundation: #1316 (`PolicySnapshot.global` + `MacBlockReason.DefaultDeny` types) and #1317 (V48 schema).

## What changed

**Server-side assembly of `snapshot.global` (a `BlockRules`).** A new `GlobalPolicyRepo` reads the V48 surfaces — `global_allow` / `global_blocks` (active, `removed_at IS NULL`) / `global_blocklists`, plus the `household_settings` global flags — and assembles the fleet-wide `BlockRules`. PolicyService emits it once as `snapshot.global`. It applies flat to every MAC at the router (a separate layer, **not** a third merge tier); the router stays a dumb applier.

**Relocated `uiAllowedHosts`.** The deployment UI / block-page hosts no longer copy into every profile's `extraAllowed` (`computeBlockRules`) or the unmanaged-device block path — they move to `global.extraAllowed`, which carves out every block (including a whole-MAC `blocked`) at the router. The #1307 infra-allow per-profile copy is deliberately left in place (retired in #1321).

**Per-profile default-deny.** `profiles.default_deny = true` collapses to `blocked = true` + `MacBlockReason.DefaultDeny` (lowest precedence — a concurrent Paused/Schedule/TimeLimit reports the stronger reason); `extraBlocked` / `blocklistIds` omitted under block-all; `blockIpOnly` still honored (default-deny + blockIpOnly is the strictest combination). `Profile` gains an additive `defaultDeny` field (default false).

**ETag.** The snapshot ETag now covers the global section, so a global-only change re-polls the fleet.

**Metrics + dashboard.** `wifihaven_global_allow_hosts` and `wifihaven_default_deny_profiles` gauges (routed through `MetricGuard`, unlabelled) emitted per snapshot assembly, plus a panel on the `api-self-metrics` Grafana dashboard.

## Wire compatibility

Additive only. `global` defaults to `BlockRules.allowAll`; an older already-deployed agent ignores the field and keeps enforcing per-MAC exactly as before. No router changes here — composition of the global section is #1319.

## Tests (real embedded Postgres, feature-level)

- `PolicySnapshotGlobalSectionSpec` (new): global section assembled from the DB tables + flags; soft-deleted allows excluded; global lockdown flag → `global.blocked` + reason; default-deny → `blocked=true` + `DefaultDeny` with only `extraAllowed` reachable and `extraBlocked`/`blocklistIds` omitted; default-deny + stronger reason reports the stronger reason; default-deny honors `blockIpOnly`; a global change moves the ETag.
- `PolicySnapshotGlobalAllowSpec` (updated): UI hosts now land in `global.extraAllowed` once and are absent from per-profile `extraAllowed`.

## Scope

Unblocks #1319 (router composition) and #1321 (retire the #1307 copy). The router (#1319), web (#1320), copy retirement (#1321), and the broader test matrix (#1322) are sibling issues, not implemented here.
