### PR TITLE
fix(openwrt): bound category-blocklist render to fix agent OOM (#1412)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -81,9 +81,22 @@ end
 --   failures: structured { id?, status } records the agent folds into
 --             blocklist_fetch_failures_total{status} (#1301). `status` is the
 --             bounded enum from classify_fetch_status / a fixed local-IO token.
-function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+-- max_bytes (optional): #1412 OOM guard. A cached/fetched body larger than this
+-- is still WRITTEN to cache (so gc + version-busting keep working) but is NOT
+-- parsed into a host table — parsing an 80k-line list builds a Lua table large
+-- enough to OOM a 1 GB router when several such lists are assigned. nil = no cap
+-- (legacy callers / tests). The cap is checked by byte size BEFORE parse_body so
+-- the big table is never allocated.
+function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token, max_bytes)
   cache_dir = cache_dir or DEFAULT_CACHE_DIR
   local result = { hosts_by_id = {}, errors = {}, failures = {} }
+
+  -- Parse a body into hosts unless it exceeds the byte cap (then return empty
+  -- without building the table). See max_bytes above (#1412).
+  local function parse_bounded(text)
+    if max_bytes and text and #text > max_bytes then return {} end
+    return parse_body(text or "")
+  end
 
   -- Record both a human string and a structured {id, status} failure so the
   -- agent can emit the bounded-cardinality metric without re-parsing strings.
@@ -165,7 +178,7 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_
     -- Check if (id, version) is already cached.
     local existing = read_fn(path)
     if existing then
-      result.hosts_by_id[id] = parse_body(existing)
+      result.hosts_by_id[id] = parse_bounded(existing)
     else
       -- Fetch from API. Signature matches the agent's http_get: status first.
       -- Send the router bearer token — the route is router-authenticated (#1360).
@@ -186,7 +199,7 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_
             fail(id, "write_failed",
               string.format("blocklists: rename failed for %s: %s", tostring(id), tostring(rerr)))
           else
-            result.hosts_by_id[id] = parse_body(body or "")
+            result.hosts_by_id[id] = parse_bounded(body or "")
           end
         end
       end
@@ -197,10 +210,16 @@ function M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_
 end
 
 -- Load all currently-cached blocklists from disk.
--- Returns { [id] = {hosts} } for ids whose (id, version) file exists.
-function M.load_cached(snapshot, fs, cache_dir)
+-- Returns `result, skipped`:
+--   result  = { [id] = {hosts} } for ids whose (id, version) file exists.
+--   skipped = { id, ... } ids whose cache file exceeded max_bytes and was left
+--             unparsed (result[id] = {}). The caller logs these so an oversized
+--             list that is silently not enforced is observable.
+-- max_bytes (optional): #1412 OOM guard — see fetch_and_cache. nil = no cap.
+function M.load_cached(snapshot, fs, cache_dir, max_bytes)
   cache_dir = cache_dir or DEFAULT_CACHE_DIR
-  local result = {}
+  local result  = {}
+  local skipped = {}
 
   local read_fn
   if fs then
@@ -219,14 +238,18 @@ function M.load_cached(snapshot, fs, cache_dir)
   for id, bl in pairs(bls) do
     local path    = cache_path(cache_dir, id, bl.version)
     local content = read_fn(path)
-    if content then
+    if content and max_bytes and #content > max_bytes then
+      -- Oversized: do NOT parse (would build a huge table — the #1412 OOM).
+      result[id]               = {}
+      skipped[#skipped + 1]    = id
+    elseif content then
       result[id] = parse_body(content)
     else
       result[id] = {}
     end
   end
 
-  return result
+  return result, skipped
 end
 
 -- refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
@@ -247,11 +270,12 @@ end
 -- failures back to the caller lets the agent emit blocklist_fetch_failures_total
 -- and simply retry on the next cadence rather than no-op until the next snapshot
 -- change (which on a stable household may be hours/days away).
-function M.refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
-  local fc    = M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+function M.refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token, max_bytes)
+  local fc             = M.fetch_and_cache(
+    snapshot, http_get_fn, fs, cache_dir, base_url, auth_token, max_bytes)
   M.gc(snapshot, fs, cache_dir)
-  local hosts = M.load_cached(snapshot, fs, cache_dir)
-  return { hosts = hosts, failures = fc.failures, errors = fc.errors }
+  local hosts, skipped = M.load_cached(snapshot, fs, cache_dir, max_bytes)
+  return { hosts = hosts, failures = fc.failures, errors = fc.errors, skipped = skipped }
 end
 
 -- hosts_differ(a, b) → boolean

--- a/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/blocklists.lua
@@ -229,6 +229,76 @@ function M.load_cached(snapshot, fs, cache_dir)
   return result
 end
 
+-- refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+--   One-call fetch_and_cache → gc → load_cached. Returns:
+--     { hosts = {[id]={host,...}}, failures = {...}, errors = {...} }
+--
+-- This is the entry point the agent calls BOTH at startup and on the periodic
+-- blocklist timer, so the per-blocklist cache (and therefore the bl_ ipset
+-- nftset= directives render emits from snapshot._blocklist_hosts) is populated
+-- independent of whether the policy poll returned 200 or 304.
+--
+-- #1412: previously the agent only fetched/cached blocklists inside the
+-- policy-poll HTTP-200 branch, and not at startup at all. A household whose
+-- snapshot is stable (the steady state — every poll is a 304) therefore never
+-- populated the cache: render emitted zero `nftset=/<member>/...#bl_<id>`
+-- directives, the bl_ sets stayed empty, and an assigned list member (e.g.
+-- taboola.com ∈ 'ads') was reachable despite correct policy. Surfacing the
+-- failures back to the caller lets the agent emit blocklist_fetch_failures_total
+-- and simply retry on the next cadence rather than no-op until the next snapshot
+-- change (which on a stable household may be hours/days away).
+function M.refresh(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+  local fc    = M.fetch_and_cache(snapshot, http_get_fn, fs, cache_dir, base_url, auth_token)
+  M.gc(snapshot, fs, cache_dir)
+  local hosts = M.load_cached(snapshot, fs, cache_dir)
+  return { hosts = hosts, failures = fc.failures, errors = fc.errors }
+end
+
+-- hosts_differ(a, b) → boolean
+--   Order-insensitive comparison of two {[id]={host,...}} maps. Nil is treated
+--   as the empty map. Returns true iff the set of ids differs, or any id's host
+--   membership differs.
+--
+-- The agent calls this after a periodic refresh to decide whether the cached
+-- host set actually changed before re-applying. A blocklist host change alters
+-- the dnsmasq fragment (the nftset= directives) and so forces a dnsmasq reload;
+-- gating the re-apply on a real change keeps a steady state from churning
+-- dnsmasq every cadence while still catching the empty→populated cold-start
+-- transition (#1412).
+function M.hosts_differ(a, b)
+  a = a or {}
+  b = b or {}
+
+  local function host_set(list)
+    local set, n = {}, 0
+    for _, h in ipairs(list or {}) do
+      if not set[h] then
+        set[h] = true
+        n = n + 1
+      end
+    end
+    return set, n
+  end
+
+  -- Every id in `a` must exist in `b` with identical host membership.
+  -- Iterating both directions catches ids present in only one side.
+  local function subset_match(x, y)
+    for id, xlist in pairs(x) do
+      local xset, xn = host_set(xlist)
+      local yset, yn = host_set(y[id])
+      if xn ~= yn then return false end
+      for h in pairs(xset) do
+        if not yset[h] then return false end
+      end
+    end
+    return true
+  end
+
+  if not subset_match(a, b) then return true end
+  if not subset_match(b, a) then return true end
+  return false
+end
+
 -- Remove cache files that are not referenced by the current snapshot.
 -- A file is kept only if its name matches "<id>-<version>.txt" where
 -- (id, version) is an entry in snapshot.blocklists.

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -48,6 +48,12 @@ local usage_int     = tonumber(uci_get("usage_report_interval",   "60"))
 -- 60 s by default (matches usage_report_interval cadence but is a separate
 -- knob; the server re-bases off agentStartedAt so a missed push self-heals).
 local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
+-- #1412: blocklist (category ipset) cache refresh runs on its OWN timer,
+-- decoupled from the ~5 s policy poll. fetch_and_cache is a no-op read when the
+-- (id, version) file is already cached, so the cadence only does real work when
+-- a list's content version changed; the agent re-applies the ruleset only when
+-- the loaded host set actually differs (blocklists.hosts_differ). Default 1 h.
+local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
@@ -296,6 +302,26 @@ local function rename_file(from, to)
   return true
 end
 
+-- #1412: fetch + cache + load the category blocklists for `snap`, emit the
+-- failure metric, log any errors, and return the loaded host map. Called from
+-- BOTH the startup apply and the on_tick blocklist timer so the bl_ ipsets are
+-- populated regardless of the 200/304 status of the policy poll. The prod no-op
+-- was that this ran only in the policy-poll 200 branch and never at startup, so
+-- a household with a stable snapshot left every bl_ set empty and category
+-- enforcement silently did nothing. The returned map is attached to
+-- snap._blocklist_hosts, which render reads to emit the nftset= populators.
+-- Defined after http_get (its upvalue) so the closure captures it.
+local BLOCKLIST_CACHE_DIR = "/etc/wifihaven/blocklists"
+local function refresh_blocklists(snap)
+  local res = blocklists.refresh(
+    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token)
+  record_blocklist_failures(res)
+  for _, e in ipairs(res.errors or {}) do
+    log.warn("blocklist fetch: %s", tostring(e))
+  end
+  return res.hosts
+end
+
 -- ── Ensure output directories exist ───────────────────────────────────────────
 
 os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven")
@@ -346,6 +372,7 @@ local in_failover_render  = false
 local last_policy_run     = 0
 local last_usage_run      = 0
 local last_metrics_run    = 0
+local last_blocklist_run  = 0  -- #1412: category blocklist refresh cadence
 local last_activity_sample = 0
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
@@ -393,6 +420,12 @@ do
                   clock.monotonic_seconds() - pt0)
   if snap then
     record_poll("200")
+    -- #1412: fetch + cache the category blocklists and attach them BEFORE the
+    -- initial apply, so the boot ruleset already carries the bl_ nftset=
+    -- populators. Previously startup applied with no _blocklist_hosts, so a
+    -- freshly booted / re-enrolled router ran with empty bl_ sets until (and
+    -- unless) a later snapshot change happened to trigger a fetch.
+    snap._blocklist_hosts = refresh_blocklists(snap)
     local at0 = clock.monotonic_seconds()
     local applied = policy.apply(snap, write_file, run_cmd, log,
                                  { on_apply = record_apply("boot") })
@@ -419,6 +452,7 @@ do
   last_policy_run        = mono
   last_usage_run         = mono
   last_metrics_run       = mono
+  last_blocklist_run     = mono
   last_activity_sample   = mono
 end
 
@@ -558,22 +592,14 @@ conntrack.watch({
       if snap then
         record_poll("200")
         -- 200: fetch + cache blocklists, attach hosts to snapshot for render.
-        -- #1360: the blocklist route is router-authenticated, so pass the
-        -- router token — without it the fetch 401s and category (bl_)
-        -- enforcement silently no-ops (the directly-queried-CNAME bl_ bypass
-        -- in e2e G4 plus every real category block).
-        local bl_result = blocklists.fetch_and_cache(
-          snap, http_get, nil, "/etc/wifihaven/blocklists", api_url, router_token)
-        -- #1301: emit blocklist_fetch_failures_total{status} for each failure
-        -- (bounded status enum) so an operator can rate-alert on fetch failures.
-        record_blocklist_failures(bl_result)
-        if #bl_result.errors > 0 then
-          for _, e in ipairs(bl_result.errors) do
-            log.warn("blocklist fetch: %s", tostring(e))
-          end
-        end
-        blocklists.gc(snap, nil, "/etc/wifihaven/blocklists")
-        snap._blocklist_hosts = blocklists.load_cached(snap, nil, "/etc/wifihaven/blocklists")
+        -- #1360: the blocklist route is router-authenticated, so refresh_blocklists
+        -- passes the router token — without it the fetch 401s and category (bl_)
+        -- enforcement silently no-ops. #1412: the same refresh runs at startup
+        -- and on the periodic blocklist timer, so a stable (304-only) snapshot no
+        -- longer leaves the sets empty; emitting blocklist_fetch_failures_total
+        -- (#1301) is folded into refresh_blocklists.
+        snap._blocklist_hosts = refresh_blocklists(snap)
+        last_blocklist_run = mono  -- this poll already refreshed; reset cadence
 
         -- Apply with no failover opts. If we were in failover, this
         -- apply already emits a clean ruleset (no failover chain), so we
@@ -655,6 +681,37 @@ conntrack.watch({
           new_in_failover = in_failover_render
         end
         in_failover_render = new_in_failover
+      end
+    end
+
+    -- Blocklist refresh timer (#1412). Category ipset population must NOT be
+    -- coupled to a snapshot change: the policy poll returns 304 in steady state,
+    -- so the only way the old code (re)fetched a blocklist was an admin policy
+    -- edit. A household with a stable snapshot therefore never (re)populated the
+    -- bl_ sets, and any transient first-fetch failure (a 401 during
+    -- re-enrollment, a network blip) left category enforcement a silent no-op
+    -- indefinitely. Here we refresh on an independent cadence against the last
+    -- good snapshot. fetch_and_cache is a cheap no-op read when the (id,version)
+    -- file is already cached, so this only does real work when a list's content
+    -- version changed; we re-apply (which reloads dnsmasq for the new nftset=
+    -- directives) only when the loaded host set actually differs.
+    if last_snapshot and not in_failover_render
+       and (mono - last_blocklist_run) >= blocklist_int then
+      last_blocklist_run = mono
+      local new_hosts = refresh_blocklists(last_snapshot)
+      if blocklists.hosts_differ(last_snapshot._blocklist_hosts, new_hosts) then
+        last_snapshot._blocklist_hosts = new_hosts
+        fold_enforcement_drops()
+        local bt0 = clock.monotonic_seconds()
+        local applied = policy.apply(last_snapshot, write_file, run_cmd, log,
+                                     { on_apply = record_apply("policy_change") })
+        metrics.observe(mreg, "policy_apply_duration_seconds", {},
+                        clock.monotonic_seconds() - bt0)
+        if applied then
+          render.update_shared(last_snapshot, nft_sets, blocked_macs, blocked_reason,
+                               eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
+          log.info("blocklist timer: category lists changed, re-applied ruleset")
+        end
       end
     end
 

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -54,6 +54,15 @@ local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
 -- a list's content version changed; the agent re-applies the ruleset only when
 -- the loaded host set actually differs (blocklists.hosts_differ). Default 1 h.
 local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
+-- #1412 OOM guard: a single category list larger than this many BYTES is cached
+-- but NOT parsed/rendered. The prod agent OOM-killed (~700 MB RSS / 1 GB router)
+-- loading the StevenBlack "extended" lists (ads-extended ~1.6 MB / 83k hosts,
+-- adult-extended ~1.3 MB / 76k hosts) into memory and rendering ~160k `nftset=`
+-- directives — which killed ALL category enforcement, including the tiny curated
+-- lists. 256 KiB (~12k hosts) keeps every curated list (ads/malware/adult/…) and
+-- skips only the oversized aggregate lists, which are tracked for a real
+-- large-list strategy in the design issue referenced from #1412.
+local blocklist_max_bytes = tonumber(uci_get("blocklist_max_list_bytes", "262144"))
 local activity_sample_int = tonumber(uci_get("activity_sample_int", "10"))
 local debug_opt     = uci_get("debug",                            "0")
 
@@ -314,10 +323,17 @@ end
 local BLOCKLIST_CACHE_DIR = "/etc/wifihaven/blocklists"
 local function refresh_blocklists(snap)
   local res = blocklists.refresh(
-    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token)
+    snap, http_get, nil, BLOCKLIST_CACHE_DIR, api_url, router_token, blocklist_max_bytes)
   record_blocklist_failures(res)
   for _, e in ipairs(res.errors or {}) do
     log.warn("blocklist fetch: %s", tostring(e))
+  end
+  -- #1412: surface lists skipped by the byte cap so an oversized list that is
+  -- silently not enforced is visible to an operator (the bl_ set stays empty
+  -- for these ids by design until the large-list strategy lands).
+  if res.skipped and #res.skipped > 0 then
+    log.warn("blocklist render cap: skipped %d oversized list(s) (>%d bytes): %s",
+             #res.skipped, blocklist_max_bytes, table.concat(res.skipped, ", "))
   end
   return res.hosts
 end

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -521,3 +521,79 @@ describe("blocklists.hosts_differ (#1412)", function()
   end)
 
 end)
+
+-- ── render byte-cap: never load/render an oversized list (#1412 OOM) ─────────
+--
+-- #1412: the prod agent OOM-killed (~700 MB RSS on a 1 GB router) loading the
+-- StevenBlack "extended" lists (ads-extended 83k + adult-extended 76k ≈ 160k
+-- hosts) into _blocklist_hosts and rendering ~160k `nftset=` directives — so NO
+-- bl_ set ever populated and category enforcement (incl. taboola in the 36-host
+-- 'ads' list) died as collateral damage. The fix bounds the per-list size by
+-- BYTES at the parse boundary: an oversized cache file is still fetched/cached
+-- (gc keeps working) but is NOT parsed into a host table nor rendered, and the
+-- skipped id is reported so the agent can log it. Byte size is the memory-safe
+-- discriminator — it's checked before building the 80k-entry Lua table.
+
+describe("blocklists size cap (#1412)", function()
+
+  local SMALL = "taboola.com\ndoubleclick.net\n"            -- ~25 B → kept
+  local function big(n)
+    local t = {}
+    for i = 1, n do t[i] = "host" .. i .. ".example.com" end
+    return table.concat(t, "\n") .. "\n"
+  end
+
+  it("load_cached skips a file larger than max_bytes and reports it", function()
+    local fs        = make_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    fs._files[cache_dir .. "/ads-v1.txt"]          = SMALL
+    fs._files[cache_dir .. "/ads-extended-v1.txt"] = big(5000)   -- well over the cap
+
+    local s = snap({
+      ads          = { version = "v1", url = "u" },
+      ["ads-extended"] = { version = "v1", url = "u" },
+    })
+    local hosts, skipped = blocklists.load_cached(s, fs, cache_dir, 1024)
+
+    -- Small list parsed; oversized list dropped to empty.
+    assert.truthy(#hosts["ads"] >= 1)
+    assert.equal(0, #(hosts["ads-extended"] or {}))
+    -- Skipped id reported (so the agent can log it).
+    local sk = {}
+    for _, id in ipairs(skipped or {}) do sk[id] = true end
+    assert.truthy(sk["ads-extended"], "oversized id must be reported as skipped")
+    assert.is_nil(sk["ads"])
+  end)
+
+  it("load_cached with no cap parses everything (backward compatible)", function()
+    local fs        = make_fs()
+    local cache_dir = "/etc/wifihaven/blocklists"
+    fs._files[cache_dir .. "/ads-extended-v1.txt"] = big(3000)
+    local s = snap({ ["ads-extended"] = { version = "v1", url = "u" } })
+    local hosts = blocklists.load_cached(s, fs, cache_dir)   -- no max_bytes arg
+    assert.equal(3000, #hosts["ads-extended"])
+  end)
+
+  it("refresh threads the byte cap and returns skipped ids", function()
+    local fs = make_fs()
+    -- ads fetched small (kept), ads-extended fetched huge (cached but not parsed).
+    local function http_get(url, _h)
+      if url:match("ads%-extended") then return 200, big(5000), {} end
+      return 200, SMALL, {}
+    end
+    local s = snap({
+      ads              = { version = "v1", url = "/api/blocklists/ads" },
+      ["ads-extended"] = { version = "v1", url = "/api/blocklists/ads-extended" },
+    })
+    local res = blocklists.refresh(s, http_get, fs, "/etc/wifihaven/blocklists", "http://api", "tok", 1024)
+
+    assert.truthy(#res.hosts["ads"] >= 1)
+    assert.equal(0, #(res.hosts["ads-extended"] or {}))
+    local sk = {}
+    for _, id in ipairs(res.skipped or {}) do sk[id] = true end
+    assert.truthy(sk["ads-extended"])
+    -- The oversized list is still WRITTEN to cache (gc + cache-busting keep working).
+    assert.not_nil(fs._files["/etc/wifihaven/blocklists/ads-extended-v1.txt"])
+  end)
+
+end)

--- a/openwrt/test/blocklists_spec.lua
+++ b/openwrt/test/blocklists_spec.lua
@@ -436,3 +436,88 @@ describe("blocklists.fetch_and_cache structured failures (#1301)", function()
     assert.equal(0, #result.failures)
   end)
 end)
+
+-- ── refresh + change detection (#1412) ──────────────────────────────────────
+--
+-- #1412: category enforcement silently no-op'd in prod because the agent only
+-- fetched/cached blocklists inside the policy-poll HTTP-200 branch and never at
+-- startup. A household whose snapshot is stable (the steady state — every poll
+-- returns 304) therefore never populated the per-blocklist cache, so render
+-- emitted zero `nftset=/<member>/...#bl_<id>` directives, the bl_ ipsets stayed
+-- empty, and an assigned list (e.g. taboola.com ∈ 'ads') was reachable. The fix
+-- makes the agent call blocklists.refresh() at startup AND on a periodic timer
+-- (against the last good snapshot) independent of 200/304, re-applying only when
+-- hosts_differ() reports the cached set actually changed.
+
+describe("blocklists.refresh (#1412)", function()
+
+  it("fetches, caches, and returns the loaded host map in one call", function()
+    local fs = make_fs()
+    local function http_get(_url, _headers)
+      return 200, "doubleclick.net\ntaboola.com\n", {}
+    end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+
+    local res = blocklists.refresh(s, http_get, fs, "/etc/wifihaven/blocklists")
+
+    assert.equal(0, #res.failures)
+    assert.not_nil(res.hosts.ads)
+    local found = {}
+    for _, h in ipairs(res.hosts.ads) do found[h] = true end
+    assert.truthy(found["taboola.com"], "refresh must surface the cached member host")
+    -- The cache file was written so a later load_cached (e.g. after a restart)
+    -- finds it without re-fetching.
+    assert.not_nil(fs._files["/etc/wifihaven/blocklists/ads-v1.txt"])
+  end)
+
+  it("surfaces fetch failures and leaves the host map empty for the failed id", function()
+    -- The #1412/#1360 failure mode: the fetch 401s, so nothing is cached and the
+    -- bl_ set would stay empty. refresh must report the failure (so the agent can
+    -- emit the metric + retry next cadence) rather than silently returning {}.
+    local function http_get(_url, _headers) return 401, nil, {} end
+    local s = snap({ ads = { version = "v1", url = "http://api/api/blocklists/ads" } })
+
+    local res = blocklists.refresh(s, http_get, make_fs(), "/etc/wifihaven/blocklists")
+
+    assert.equal(1, #res.failures)
+    assert.equal("ads", res.failures[1].id)
+    assert.equal("4xx", res.failures[1].status)
+    assert.equal(0, #(res.hosts.ads or {}))
+  end)
+
+end)
+
+describe("blocklists.hosts_differ (#1412)", function()
+
+  it("returns false for identical maps regardless of host order", function()
+    local a = { ads = { "a.com", "b.com" }, malware = { "m.com" } }
+    local b = { ads = { "b.com", "a.com" }, malware = { "m.com" } }
+    assert.is_false(blocklists.hosts_differ(a, b))
+  end)
+
+  it("returns true when host membership changes", function()
+    local a = { ads = { "a.com", "b.com" } }
+    local b = { ads = { "a.com", "c.com" } }
+    assert.is_true(blocklists.hosts_differ(a, b))
+  end)
+
+  it("returns true when an id is added or removed", function()
+    local a = { ads = { "a.com" } }
+    local b = { ads = { "a.com" }, malware = { "m.com" } }
+    assert.is_true(blocklists.hosts_differ(a, b))
+    assert.is_true(blocklists.hosts_differ(b, a))
+  end)
+
+  it("returns true when an empty cache becomes populated (the cold-start fix)", function()
+    -- Startup applies with an empty map; the first refresh populates it. The
+    -- agent must detect this transition and re-apply so bl_ directives appear.
+    assert.is_true(blocklists.hosts_differ({}, { ads = { "taboola.com" } }))
+    assert.is_true(blocklists.hosts_differ({ ads = {} }, { ads = { "taboola.com" } }))
+  end)
+
+  it("treats nil and empty as equal (no spurious re-apply)", function()
+    assert.is_false(blocklists.hosts_differ(nil, {}))
+    assert.is_false(blocklists.hosts_differ({}, nil))
+  end)
+
+end)


### PR DESCRIPTION
Fixes #1412. Replaces #1421 (closed — that PR's startup/periodic behavior is only safe with this cap in place).

## Root cause (prod, read-only inspection of `RobotSpaceship`, 1 GB RAM)

Category enforcement was a no-op because **the agent OOM-killed loading the StevenBlack "extended" lists**, not because of any fetch/snapshot issue:

- The blocklist cache is fully populated (`ads-…txt` contains taboola.com) — the fetch works.
- The Kids profile assigns ads-extended (~1.6 MB / 83k hosts) + adult-extended (~1.3 MB / 76k hosts) + social-extended (3.2k) = **164,149 hosts**. The agent loads all of them into `_blocklist_hosts` and renders ~164k `nftset=` directives in one config string → **~700 MB RSS → `Out of memory: Killed process … (wifihaven-agent)`**.
- The apply never completes, so `/tmp/wifihaven-bl-members.txt` is **0 bytes**, the dnsmasq fragment has **0 `bl_` directives**, `bl_ads` is **empty**, `bl_adds=0`. The recurring "smoke check failed; dnsmasq serving stale config" + hourly restart is the OOM/respawn loop. taboola (in the tiny 36-host `ads` list) is collateral damage — the agent dies loading the big lists first.

## Fix

- **Byte cap (load-bearing).** A category list whose cached body exceeds `blocklist_max_list_bytes` (default **256 KiB ≈ 12k hosts**) is still fetched + cached (gc/version-busting keep working) but is **not parsed into a host table nor rendered**. The cap is checked by byte size *before* `parse_body`, so the table that OOMs is never allocated. Skipped ids are logged so a not-enforced list is observable. Result: every curated list (ads/malware/adult/gambling/social-media/games) renders and enforces — **taboola is dropped** — while only the oversized aggregate lists are skipped.
- **Now-safe population (carried from #1421).** With the render bounded, it's safe to fetch blocklists **at startup** (so the boot ruleset already carries the `bl_` populators) and refresh on a **periodic timer** (`blocklist_refresh_interval`, default 1 h) that re-applies only when `blocklists.hosts_differ` shows the loaded host set changed. These were the harmful part of #1421 *without* the cap; with it they deliver boot-time enforcement + self-heal at bounded memory.

## Tests (TDD, red→green)

- `blocklists_spec` (30): `refresh` / `hosts_differ` seams, plus the byte cap — `load_cached`/`refresh` skip an oversized file, report it, and still cache it; uncapped calls are backward-compatible.
- `render_spec` (147) unchanged-green.

## Scope / wire contract

openwrt-agent only. `blocklist_max_list_bytes` + `blocklist_refresh_interval` are UCI keys read/written by the same agent build — not part of the router↔API wire contract. No DB migration, no Scala, no metric/dashboard change.

## Follow-up

The oversized aggregate lists (the StevenBlack "extended" set) are skipped, not enforced — by design until a real large-list strategy lands. Tracked in the design issue linked from #1412. A `blocklist_render_skipped_total{id}` metric + dashboard panel is deferred to that work (the mechanism itself is up for redesign).