### PR TITLE
feat(web): Connection Events — All/Blocked/Allowed status filter (#1432)

### DIFF
--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -251,7 +251,7 @@ describe('LogsPage — status filter (#1432)', () => {
     // server filters; mock returns only blocked rows when asked for blocked-only
     const blockedLog: QueryLog = {
       ...log1, id: 2, host: { type: 'fqdn', value: 'pornhub.com' },
-      blocked: true, reason: { kind: 'category' },
+      blocked: true, reason: { kind: 'category', slug: 'adult' },
     }
     queryMock.mockImplementation((p: { blocked?: boolean }) =>
       Promise.resolve({ rows: p.blocked ? [blockedLog] : [log1, blockedLog], nextCursor: null }),

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -237,6 +237,67 @@ describe('LogsPage — infinite scroll (#862)', () => {
 
 })
 
+describe('LogsPage — status filter (#1432)', () => {
+  it('defaults to All — /api/logs called without a blocked filter', async () => {
+    const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
+    renderAt()
+    await waitFor(() => expect(queryMock).toHaveBeenCalled())
+    expect(queryMock.mock.calls[0][0].blocked).toBeUndefined()
+    expect(screen.getByTestId('ce-status-all').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('selecting Blocked sets ?status=blocked and passes blocked=true to /api/logs', async () => {
+    const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
+    // server filters; mock returns only blocked rows when asked for blocked-only
+    const blockedLog: QueryLog = {
+      ...log1, id: 2, host: { type: 'fqdn', value: 'pornhub.com' },
+      blocked: true, reason: { kind: 'category' },
+    }
+    queryMock.mockImplementation((p: { blocked?: boolean }) =>
+      Promise.resolve({ rows: p.blocked ? [blockedLog] : [log1, blockedLog], nextCursor: null }),
+    )
+    renderAt()
+    await screen.findByText('example.com')
+
+    await userEvent.click(screen.getByTestId('ce-status-blocked'))
+    await waitFor(() => {
+      const last = queryMock.mock.calls[queryMock.mock.calls.length - 1][0]
+      expect(last.blocked).toBe(true)
+    })
+    // only the blocked row renders
+    expect(await screen.findByText('pornhub.com')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('example.com')).not.toBeInTheDocument())
+    expect(screen.getByTestId('ce-status-blocked').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('selecting Allowed passes blocked=false to /api/logs', async () => {
+    const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
+    renderAt()
+    await screen.findByText('example.com')
+    await userEvent.click(screen.getByTestId('ce-status-allowed'))
+    await waitFor(() => {
+      const last = queryMock.mock.calls[queryMock.mock.calls.length - 1][0]
+      expect(last.blocked).toBe(false)
+    })
+  })
+
+  it('initializes from ?status=blocked and passes blocked=true on first fetch', async () => {
+    const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
+    renderAt('/usage/events?status=blocked')
+    await waitFor(() => expect(queryMock).toHaveBeenCalled())
+    expect(queryMock.mock.calls[0][0].blocked).toBe(true)
+    expect(screen.getByTestId('ce-status-blocked').getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('aggregated view also passes the blocked filter to /connection-events/series', async () => {
+    const seriesMock = api.logs.series as unknown as ReturnType<typeof vi.fn>
+    renderAt('/usage/events?status=blocked')
+    await userEvent.click(screen.getByTestId('bucket-1h'))
+    await waitFor(() => expect(seriesMock).toHaveBeenCalled())
+    expect(seriesMock.mock.calls[0][0].blocked).toBe(true)
+  })
+})
+
 describe('LogsPage — jump-to-date (#951)', () => {
   it('setting the picker re-anchors `until` on /api/logs and updates the URL', async () => {
     const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import type { ConnectionEventAggRow, Device, ProfileDetail, QueryLog } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
@@ -42,10 +42,18 @@ const profileDetails: ProfileDetail[] = [
   { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' }, schedules: [], timeLimit: null },
 ]
 
+// Surfaces the current URL search string so tests can assert query-param
+// persistence under MemoryRouter (which doesn't touch window.location).
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location-search">{loc.search}</div>
+}
+
 function renderAt(path = '/usage/events') {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <LogsPage />
+      <LocationProbe />
     </MemoryRouter>,
   )
 }
@@ -238,15 +246,18 @@ describe('LogsPage — infinite scroll (#862)', () => {
 })
 
 describe('LogsPage — status filter (#1432)', () => {
-  it('defaults to All — /api/logs called without a blocked filter', async () => {
+  it('defaults to All — /api/logs called without a blocked filter, funnel inactive', async () => {
     const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
     renderAt()
     await waitFor(() => expect(queryMock).toHaveBeenCalled())
     expect(queryMock.mock.calls[0][0].blocked).toBeUndefined()
-    expect(screen.getByTestId('ce-status-all').getAttribute('aria-pressed')).toBe('true')
+    // The status filter is a funnel on the Status column header, like the
+    // device/profile filters — inactive (no count badge) by default.
+    expect(screen.getAllByTestId('ce-filter-status').length).toBeGreaterThan(0)
+    expect(screen.queryByTestId('ce-filter-status-count')).not.toBeInTheDocument()
   })
 
-  it('selecting Blocked sets ?status=blocked and passes blocked=true to /api/logs', async () => {
+  it('checking Blocked in the Status header filter sets ?status=blocked and passes blocked=true', async () => {
     const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
     // server filters; mock returns only blocked rows when asked for blocked-only
     const blockedLog: QueryLog = {
@@ -259,25 +270,42 @@ describe('LogsPage — status filter (#1432)', () => {
     renderAt()
     await screen.findByText('example.com')
 
-    await userEvent.click(screen.getByTestId('ce-status-blocked'))
+    await userEvent.click(screen.getByTestId('ce-filter-status'))
+    await userEvent.click(screen.getByTestId('ce-filter-status-opt-blocked'))
     await waitFor(() => {
       const last = queryMock.mock.calls[queryMock.mock.calls.length - 1][0]
       expect(last.blocked).toBe(true)
     })
+    // URL persists the selection.
+    await waitFor(() =>
+      expect(screen.getByTestId('location-search').textContent).toContain('status=blocked'),
+    )
     // only the blocked row renders
     expect(await screen.findByText('pornhub.com')).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText('example.com')).not.toBeInTheDocument())
-    expect(screen.getByTestId('ce-status-blocked').getAttribute('aria-pressed')).toBe('true')
   })
 
-  it('selecting Allowed passes blocked=false to /api/logs', async () => {
+  it('checking Allowed passes blocked=false to /api/logs', async () => {
     const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
     renderAt()
     await screen.findByText('example.com')
-    await userEvent.click(screen.getByTestId('ce-status-allowed'))
+    await userEvent.click(screen.getByTestId('ce-filter-status'))
+    await userEvent.click(screen.getByTestId('ce-filter-status-opt-allowed'))
     await waitFor(() => {
       const last = queryMock.mock.calls[queryMock.mock.calls.length - 1][0]
       expect(last.blocked).toBe(false)
+    })
+  })
+
+  it('checking both Blocked and Allowed clears the filter (Blocked OR Allowed = all)', async () => {
+    const queryMock = api.logs.query as unknown as ReturnType<typeof vi.fn>
+    renderAt('/usage/events?status=blocked')
+    await screen.findByText('example.com')
+    await userEvent.click(screen.getByTestId('ce-filter-status'))
+    await userEvent.click(screen.getByTestId('ce-filter-status-opt-allowed'))
+    await waitFor(() => {
+      const last = queryMock.mock.calls[queryMock.mock.calls.length - 1][0]
+      expect(last.blocked).toBeUndefined()
     })
   })
 
@@ -286,7 +314,8 @@ describe('LogsPage — status filter (#1432)', () => {
     renderAt('/usage/events?status=blocked')
     await waitFor(() => expect(queryMock).toHaveBeenCalled())
     expect(queryMock.mock.calls[0][0].blocked).toBe(true)
-    expect(screen.getByTestId('ce-status-blocked').getAttribute('aria-pressed')).toBe('true')
+    // funnel shows its active count badge
+    expect(screen.getByTestId('ce-filter-status-count')).toBeInTheDocument()
   })
 
   it('aggregated view also passes the blocked filter to /connection-events/series', async () => {

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -30,6 +30,65 @@ type EventsBucket  = TrafficUsageBucket  // shared with Traffic page; raw = /api
 
 const EVENTS_GROUP_KEYS: EventsGroupBy[] = ['domain', 'device', 'profile', 'app']
 
+// #1432 — result/status filter. "Blocked" = the event's stored connection-layer
+// result (not DNS — blocked hosts still resolve). All / Blocked / Allowed maps
+// to the server-side `blocked` filter on /api/logs and /connection-events/series:
+// undefined (all), true, false respectively. Persisted via ?status= so it's
+// shareable and survives refresh, consistent with ?groupBy / ?until.
+type StatusFilter = 'all' | 'blocked' | 'allowed'
+
+const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: 'all',     label: 'All' },
+  { value: 'blocked', label: 'Blocked' },
+  { value: 'allowed', label: 'Allowed' },
+]
+
+function parseStatus(sp: URLSearchParams): StatusFilter {
+  const s = sp.get('status')
+  return s === 'blocked' || s === 'allowed' ? s : 'all'
+}
+
+// undefined = no server-side filter (All).
+function statusToBlocked(s: StatusFilter): boolean | undefined {
+  return s === 'all' ? undefined : s === 'blocked'
+}
+
+function StatusFilterControl({
+  value, onChange,
+}: { value: StatusFilter; onChange: (v: StatusFilter) => void }) {
+  return (
+    <div className="inline-flex items-center gap-2">
+      <span className="text-[11px] uppercase tracking-wide text-brand-text-muted">Status</span>
+      <div
+        role="group"
+        aria-label="Filter by status"
+        data-testid="ce-status-filter"
+        className="inline-flex rounded border border-brand-border overflow-hidden"
+      >
+        {STATUS_OPTIONS.map(opt => {
+          const active = opt.value === value
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              data-testid={`ce-status-${opt.value}`}
+              aria-pressed={active}
+              onClick={() => onChange(opt.value)}
+              className={`px-3 py-1 text-xs ${
+                active
+                  ? 'bg-brand-accent text-white'
+                  : 'bg-white/40 text-brand-text hover:text-brand-accent'
+              }`}
+            >
+              {opt.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 function parseEventsGroupBy(sp: URLSearchParams): EventsGroupBy[] {
   // #917: repeated ?groupBy=device&groupBy=domain serialization; comma form
   // still accepted for back-compat.
@@ -64,6 +123,8 @@ export function LogsPage() {
   // #951: optional anchor for the right edge of the window. null = "now".
   // Round-trips through ?until=<ISO> in the URL.
   const [until, setUntilState]          = useState<string | null>(() => searchParams.get('until'))
+  // #1432: result/status filter, round-tripped through ?status=.
+  const [status, setStatusState]        = useState<StatusFilter>(() => parseStatus(searchParams))
   const [devices, setDevices]   = useState<Device[]>([])
   const [profiles, setProfiles] = useState<ProfileDetail[]>([])
   // #769: surface the "no apps yet" empty-state when the operator drills on
@@ -83,6 +144,16 @@ export function LogsPage() {
     else sp.delete('until')
     setSearchParams(sp, { replace: true })
   }
+
+  function setStatus(next: StatusFilter) {
+    setStatusState(next)
+    const sp = new URLSearchParams(searchParams)
+    if (next === 'all') sp.delete('status')
+    else sp.set('status', next)
+    setSearchParams(sp, { replace: true })
+  }
+
+  const blocked = statusToBlocked(status)
 
   function toggleGroup(key: string) {
     setGroupBy(prev => {
@@ -120,10 +191,13 @@ export function LogsPage() {
         onUntilChange={setUntil}
       />
 
+      <StatusFilterControl value={status} onChange={setStatus} />
+
       {bucket === 'raw'
         ? <RawEventsView
             macs={macs}
             profileIds={profileIds}
+            blocked={blocked}
             devices={devices}
             profiles={profiles}
             until={until}
@@ -136,6 +210,7 @@ export function LogsPage() {
             onToggleGroup={toggleGroup}
             macs={macs}
             profileIds={profileIds}
+            blocked={blocked}
             devices={devices}
             profiles={profiles}
             appCount={appCount}
@@ -178,13 +253,14 @@ interface FilterApi {
 
 interface RawProps extends FilterApi {
   until: string | null
+  blocked: boolean | undefined
 }
 
 // #862: infinite scroll. Initial fetch anchored at NOW (or `until`); cursor
 // walks back. /api/logs still requires `hours`, so we ask for a wide band
 // (1y) and let the row cap bound.
 function RawEventsView({
-  macs, profileIds, devices, profiles, until, onMacsChange, onProfileIdsChange,
+  macs, profileIds, blocked, devices, profiles, until, onMacsChange, onProfileIdsChange,
 }: RawProps) {
   const [logs, setLogs]       = useState<QueryLog[]>([])
   const [cursor, setCursor]   = useState<string | null>(null)
@@ -202,7 +278,7 @@ function RawEventsView({
     return ids.length ? ids : undefined
   }, [macs, devices])
 
-  const filterKey = `${deviceIds?.join(',') ?? ''}|${profileIds.join(',')}|${until ?? ''}`
+  const filterKey = `${deviceIds?.join(',') ?? ''}|${profileIds.join(',')}|${until ?? ''}|${blocked ?? ''}`
 
   const load = useCallback(
     async (curs: string | null) => {
@@ -213,6 +289,7 @@ function RawEventsView({
           hours:      RAW_HOURS_BAND,
           deviceIds,
           profileIds: profileIds.length ? profileIds : undefined,
+          blocked,
           limit:      RAW_PAGE_SIZE,
           until:      until ?? undefined,
           cursor:     curs ?? undefined,
@@ -227,7 +304,7 @@ function RawEventsView({
         setLoading(false)
       }
     },
-    [deviceIds, profileIds, until],
+    [deviceIds, profileIds, until, blocked],
   )
 
   useEffect(() => {
@@ -383,11 +460,12 @@ interface AggProps extends FilterApi {
   onToggleGroup: (key: string) => void
   appCount: number | null
   until: string | null
+  blocked: boolean | undefined
 }
 
 function AggregatedEventsView({
   bucket, groupBy, onToggleGroup,
-  macs, profileIds, devices, profiles, appCount, until,
+  macs, profileIds, blocked, devices, profiles, appCount, until,
   onMacsChange, onProfileIdsChange,
 }: AggProps) {
   const [rows, setRows]       = useState<ConnectionEventAggRow[]>([])
@@ -397,7 +475,7 @@ function AggregatedEventsView({
   const [error, setError]     = useState<string | null>(null)
   const sentinelRef           = useRef<HTMLDivElement | null>(null)
 
-  const filterKey = `${bucket}|${groupBy.join(',')}|${macs.join(',')}|${profileIds.join(',')}|${until ?? ''}`
+  const filterKey = `${bucket}|${groupBy.join(',')}|${macs.join(',')}|${profileIds.join(',')}|${until ?? ''}|${blocked ?? ''}`
 
   const load = useCallback(
     async (curs: string | null) => {
@@ -409,6 +487,7 @@ function AggregatedEventsView({
           groupBy,
           macs:       macs.length ? macs : undefined,
           profileIds: profileIds.length ? profileIds : undefined,
+          blocked,
           hours:      AGG_HOURS_BAND,
           limit:      AGG_PAGE_SIZE,
           until:      until ?? undefined,
@@ -424,7 +503,7 @@ function AggregatedEventsView({
         setLoading(false)
       }
     },
-    [bucket, groupBy, macs, profileIds, until],
+    [bucket, groupBy, macs, profileIds, until, blocked],
   )
 
   useEffect(() => {

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -30,18 +30,13 @@ type EventsBucket  = TrafficUsageBucket  // shared with Traffic page; raw = /api
 
 const EVENTS_GROUP_KEYS: EventsGroupBy[] = ['domain', 'device', 'profile', 'app']
 
-// #1432 — result/status filter. "Blocked" = the event's stored connection-layer
-// result (not DNS — blocked hosts still resolve). All / Blocked / Allowed maps
-// to the server-side `blocked` filter on /api/logs and /connection-events/series:
-// undefined (all), true, false respectively. Persisted via ?status= so it's
-// shareable and survives refresh, consistent with ?groupBy / ?until.
+// #1432 — result/status filter, lives in the Status column header as a funnel
+// popover, exactly like the Device / Profile header filters. "Blocked" = the
+// event's stored connection-layer result (not DNS — blocked hosts still
+// resolve). It maps to the server-side `blocked` filter on /api/logs and
+// /connection-events/series. Persisted via ?status= so it's shareable and
+// survives refresh, consistent with ?groupBy / ?until.
 type StatusFilter = 'all' | 'blocked' | 'allowed'
-
-const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
-  { value: 'all',     label: 'All' },
-  { value: 'blocked', label: 'Blocked' },
-  { value: 'allowed', label: 'Allowed' },
-]
 
 function parseStatus(sp: URLSearchParams): StatusFilter {
   const s = sp.get('status')
@@ -53,39 +48,24 @@ function statusToBlocked(s: StatusFilter): boolean | undefined {
   return s === 'all' ? undefined : s === 'blocked'
 }
 
-function StatusFilterControl({
+// Adapts the single-value status filter onto the multi-select HeaderFilter
+// shape used by every other column. The two checkboxes (Blocked / Allowed)
+// are logical opposites, so neither-or-both checked = no filter (Blocked OR
+// Allowed = every event), one checked = that result only.
+function StatusHeaderFilter({
   value, onChange,
 }: { value: StatusFilter; onChange: (v: StatusFilter) => void }) {
   return (
-    <div className="inline-flex items-center gap-2">
-      <span className="text-[11px] uppercase tracking-wide text-brand-text-muted">Status</span>
-      <div
-        role="group"
-        aria-label="Filter by status"
-        data-testid="ce-status-filter"
-        className="inline-flex rounded border border-brand-border overflow-hidden"
-      >
-        {STATUS_OPTIONS.map(opt => {
-          const active = opt.value === value
-          return (
-            <button
-              key={opt.value}
-              type="button"
-              data-testid={`ce-status-${opt.value}`}
-              aria-pressed={active}
-              onClick={() => onChange(opt.value)}
-              className={`px-3 py-1 text-xs ${
-                active
-                  ? 'bg-brand-accent text-white'
-                  : 'bg-white/40 text-brand-text hover:text-brand-accent'
-              }`}
-            >
-              {opt.label}
-            </button>
-          )
-        })}
-      </div>
-    </div>
+    <HeaderFilter
+      testId="ce-filter-status"
+      title="Filter status"
+      options={[
+        { value: 'blocked', label: 'Blocked' },
+        { value: 'allowed', label: 'Allowed' },
+      ]}
+      selected={value === 'all' ? [] : [value]}
+      onChange={next => onChange(next.length === 1 ? (next[0] as StatusFilter) : 'all')}
+    />
   )
 }
 
@@ -153,8 +133,6 @@ export function LogsPage() {
     setSearchParams(sp, { replace: true })
   }
 
-  const blocked = statusToBlocked(status)
-
   function toggleGroup(key: string) {
     setGroupBy(prev => {
       const next = prev.includes(key as EventsGroupBy)
@@ -191,18 +169,17 @@ export function LogsPage() {
         onUntilChange={setUntil}
       />
 
-      <StatusFilterControl value={status} onChange={setStatus} />
-
       {bucket === 'raw'
         ? <RawEventsView
             macs={macs}
             profileIds={profileIds}
-            blocked={blocked}
+            status={status}
             devices={devices}
             profiles={profiles}
             until={until}
             onMacsChange={setMacs}
             onProfileIdsChange={setProfileIds}
+            onStatusChange={setStatus}
           />
         : <AggregatedEventsView
             bucket={bucket}
@@ -210,13 +187,14 @@ export function LogsPage() {
             onToggleGroup={toggleGroup}
             macs={macs}
             profileIds={profileIds}
-            blocked={blocked}
+            status={status}
             devices={devices}
             profiles={profiles}
             appCount={appCount}
             until={until}
             onMacsChange={setMacs}
             onProfileIdsChange={setProfileIds}
+            onStatusChange={setStatus}
           />}
     </div>
   )
@@ -245,23 +223,26 @@ function ErrorBanner({ message }: { message: string }) {
 interface FilterApi {
   macs: string[]
   profileIds: number[]
+  status: StatusFilter
   devices: Device[]
   profiles: ProfileDetail[]
   onMacsChange: (v: string[]) => void
   onProfileIdsChange: (v: number[]) => void
+  onStatusChange: (v: StatusFilter) => void
 }
 
 interface RawProps extends FilterApi {
   until: string | null
-  blocked: boolean | undefined
 }
 
 // #862: infinite scroll. Initial fetch anchored at NOW (or `until`); cursor
 // walks back. /api/logs still requires `hours`, so we ask for a wide band
 // (1y) and let the row cap bound.
 function RawEventsView({
-  macs, profileIds, blocked, devices, profiles, until, onMacsChange, onProfileIdsChange,
+  macs, profileIds, status, devices, profiles, until,
+  onMacsChange, onProfileIdsChange, onStatusChange,
 }: RawProps) {
+  const blocked = statusToBlocked(status)
   const [logs, setLogs]       = useState<QueryLog[]>([])
   const [cursor, setCursor]   = useState<string | null>(null)
   const [hasMore, setHasMore] = useState(true)
@@ -356,7 +337,12 @@ function RawEventsView({
               </span>
             </th>
             <th className="text-left px-2 py-1">Domain</th>
-            <th className="text-left px-2 py-1">Status</th>
+            <th className="text-left px-2 py-1">
+              <span className="inline-flex items-center gap-1">
+                <span>Status</span>
+                <StatusHeaderFilter value={status} onChange={onStatusChange} />
+              </span>
+            </th>
             <th className="text-left px-2 py-1 hidden sm:table-cell">Reason</th>
             <th className="text-left px-2 py-1 hidden lg:table-cell">Location</th>
           </tr>
@@ -460,14 +446,14 @@ interface AggProps extends FilterApi {
   onToggleGroup: (key: string) => void
   appCount: number | null
   until: string | null
-  blocked: boolean | undefined
 }
 
 function AggregatedEventsView({
   bucket, groupBy, onToggleGroup,
-  macs, profileIds, blocked, devices, profiles, appCount, until,
-  onMacsChange, onProfileIdsChange,
+  macs, profileIds, status, devices, profiles, appCount, until,
+  onMacsChange, onProfileIdsChange, onStatusChange,
 }: AggProps) {
+  const blocked = statusToBlocked(status)
   const [rows, setRows]       = useState<ConnectionEventAggRow[]>([])
   const [cursor, setCursor]   = useState<string | null>(null)
   const [hasMore, setHasMore] = useState(true)
@@ -581,7 +567,12 @@ function AggregatedEventsView({
                 onToggle={onToggleGroup} testIdPrefix="ce-group" />
             </th>
             <th className="text-right px-2 py-1">OK</th>
-            <th className="text-right px-2 py-1">Blocked</th>
+            <th className="text-right px-2 py-1">
+              <span className="inline-flex items-center gap-1 justify-end">
+                <span>Blocked</span>
+                <StatusHeaderFilter value={status} onChange={onStatusChange} />
+              </span>
+            </th>
             <th className="text-left px-2 py-1 hidden sm:table-cell">Last seen</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary

Adds a **status filter** (Blocked / Allowed, default = no filter) to the **Connection Events** page (`web/src/pages/LogsPage.tsx`), closing #1432. The operator frequently wants to see just what was dropped (the same need behind the #1338 "most recently blocked" panel, here as a filter on the full log page).

- **Lives in the column header**, as a funnel popover — identical look/behavior to the existing **Device** and **Profile** header filters. It sits on the **Status** column (raw view) and the **Blocked** column (aggregated view). No separate toolbar control.
- The single status filter maps onto the shared `HeaderFilter` multi-select: the **Blocked** / **Allowed** checkboxes are logical opposites, so neither-or-both checked = no filter (Blocked OR Allowed = every event) and one checked = that result only.
- **URL-persisted** via `?status=blocked|allowed` (absent = All), so the selection is shareable/bookmarkable and survives refresh — consistent with the page's existing `?groupBy` / `?until` params.
- **Server-side filtering.** The selection threads the existing `blocked` param into **both** `/api/logs` (raw view) and `/api/connection-events/series` (aggregated view) instead of fetching-all-then-filtering client-side, so it respects the paged/aggregated query shape. Composes additively with the device/profile header filters.
- **"Blocked" = the event's stored connection-layer result, not DNS** — blocked hosts still resolve by design (`memory/blocking_is_traffic_layer_not_dns.md`).

### API note

The API side was **already fully implemented and tested**: `LogFilter.blocked` is parsed from `?blocked=true|false` in `Routes.scala` and applied server-side across the raw (`query`), series (`querySeries`), and rollup (`querySeriesRollup`) SQL paths, with feature coverage in `api/test/src/feature/LogApiSpec.scala` (`?blocked=true` raw, `#1338` recently-blocked, series pass-through, and the `#1265` rollup split). No API changes were needed — this PR wires the existing UI to it. No new wire fields; no compat shims.

## Test plan

TDD, red→green visible in commit history (failing tests committed first, then implementation).

`web/src/pages/LogsPage.test.tsx` cases (#1432):
- Default = no filter → `/api/logs` called with no `blocked` param; funnel inactive (no count badge).
- Checking **Blocked** in the Status header funnel → URL gets `?status=blocked` (asserted via a `useLocation` probe), `/api/logs` called with `blocked=true`, only blocked rows render.
- Checking **Allowed** → `/api/logs` called with `blocked=false`.
- Checking **both** Blocked + Allowed → filter clears (`blocked` undefined).
- Initializing from `?status=blocked` → `blocked=true` on first fetch, funnel shows its active count badge.
- Aggregated view passes the `blocked` filter to `/connection-events/series`.

Verification:
- `npx vitest run` (node 22) — **332 passed (29 files)**, including the new cases.
- `npx tsc --noEmit` — clean.
- `eslint` — clean.

Refs #1338, #1341, #847, #829.