### PR TITLE
feat(#1069): named-schedule API — model, CRUD, snapshot expansion, seed/migrate

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -91,10 +91,13 @@ object Main extends ZIOAppDefault {
         // Service handles are pure layer reads (no DB I/O); resolve them up front
         // so the retried DB-init block below is purely the idempotent DB work.
         hsRepo <- ZIO.service[HouseholdSettingsRepo]
-        appRepoForSeed <- ZIO.service[AppRepo]
-        blRepoForSeed  <- ZIO.service[BlocklistRepo]
-        blCacheForSeed <- ZIO.service[BlocklistCache]
-        blFetcher      <- ZIO.service[BlocklistFetcher]
+        appRepoForSeed        <- ZIO.service[AppRepo]
+        blRepoForSeed         <- ZIO.service[BlocklistRepo]
+        blCacheForSeed        <- ZIO.service[BlocklistCache]
+        profileRepoForSeed    <- ZIO.service[ProfileRepo]
+        schedRepoForSeed      <- ZIO.service[ScheduleRepo]
+        namedSchedRepoForSeed <- ZIO.service[NamedScheduleRepo]
+        blFetcher             <- ZIO.service[BlocklistFetcher]
         tz = java.time.ZoneId.systemDefault()
         // #1255: a transient DB outage (a few seconds during a resize/failover/
         // restart) used to throw a Hikari/PSQL connection error straight to
@@ -134,6 +137,18 @@ object Main extends ZIOAppDefault {
             // REPLACE semantics; remote-fetch failures leave existing rows alone.
             _           <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
             _           <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
+            // #1069: migrate any legacy per-profile schedules into the named-schedule model and
+            // seed the default starter set on a fresh household. Idempotent — see ScheduleSeeder.
+            schedSummary <- ScheduleSeeder.seedAndMigrate(
+              namedSchedRepoForSeed,
+              schedRepoForSeed,
+              profileRepoForSeed,
+              tz,
+            )
+            _            <- ZIO.logInfo(
+              s"named schedules: migrated=${schedSummary.migrated} profiles, " +
+                s"seededDefaults=${schedSummary.seededDefaults}",
+            )
           } yield ()
         }
         // #1248: migrations + ensureDefault + seeds are done — flip readiness so
@@ -248,35 +263,36 @@ object Main extends ZIOAppDefault {
       ready: UIO[Boolean],
   ) =
     for {
-      auth          <- ZIO.service[AuthService]
-      userRepo      <- ZIO.service[UserRepo]
-      upRepo        <- ZIO.service[UserProfileRepo]
-      profileRepo   <- ZIO.service[ProfileRepo]
-      schedRepo     <- ZIO.service[ScheduleRepo]
-      hsRepo        <- ZIO.service[HouseholdSettingsRepo]
-      tlRepo        <- ZIO.service[TimeLimitRepo]
-      stlRepo       <- ZIO.service[SiteTimeLimitRepo]
-      deviceRepo    <- ZIO.service[DeviceRepo]
-      blRepo        <- ZIO.service[BlocklistRepo]
-      blCache       <- ZIO.service[BlocklistCache]
-      blFetcher2    <- ZIO.service[BlocklistFetcher]
-      usageRepo     <- ZIO.service[TimeUsageRepo]
-      extRepo       <- ZIO.service[TimeExtensionRepo]
-      routerRepo    <- ZIO.service[RouterRepo]
-      trafficRepo   <- ZIO.service[TrafficReportRepo]
-      rollupRepo2   <- ZIO.service[RollupRepo]
-      connRepo      <- ZIO.service[ConnectionEventRepo]
-      blockEvRepo   <- ZIO.service[BlockEventRepo]
-      alertRepo     <- ZIO.service[AlertRepo]
-      appRepo       <- ZIO.service[AppRepo]
-      notifier      <- ZIO.service[Notifier]
-      policy        <- ZIO.service[PolicyService]
-      timeStatus    <- ZIO.service[wifihaven.api.policy.TimeStatusService]
-      cfg           <- ZIO.service[AppConfig]
-      clock         <- ZIO.service[Clock]
-      timeCache     <- ZIO.service[TimeStatusCache]
-      xa            <- ZIO.service[Transactor[Task]]
-      promPublisher <- ZIO.service[PrometheusPublisher]
+      auth           <- ZIO.service[AuthService]
+      userRepo       <- ZIO.service[UserRepo]
+      upRepo         <- ZIO.service[UserProfileRepo]
+      profileRepo    <- ZIO.service[ProfileRepo]
+      schedRepo      <- ZIO.service[ScheduleRepo]
+      namedSchedRepo <- ZIO.service[NamedScheduleRepo]
+      hsRepo         <- ZIO.service[HouseholdSettingsRepo]
+      tlRepo         <- ZIO.service[TimeLimitRepo]
+      stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+      deviceRepo     <- ZIO.service[DeviceRepo]
+      blRepo         <- ZIO.service[BlocklistRepo]
+      blCache        <- ZIO.service[BlocklistCache]
+      blFetcher2     <- ZIO.service[BlocklistFetcher]
+      usageRepo      <- ZIO.service[TimeUsageRepo]
+      extRepo        <- ZIO.service[TimeExtensionRepo]
+      routerRepo     <- ZIO.service[RouterRepo]
+      trafficRepo    <- ZIO.service[TrafficReportRepo]
+      rollupRepo2    <- ZIO.service[RollupRepo]
+      connRepo       <- ZIO.service[ConnectionEventRepo]
+      blockEvRepo    <- ZIO.service[BlockEventRepo]
+      alertRepo      <- ZIO.service[AlertRepo]
+      appRepo        <- ZIO.service[AppRepo]
+      notifier       <- ZIO.service[Notifier]
+      policy         <- ZIO.service[PolicyService]
+      timeStatus     <- ZIO.service[wifihaven.api.policy.TimeStatusService]
+      cfg            <- ZIO.service[AppConfig]
+      clock          <- ZIO.service[Clock]
+      timeCache      <- ZIO.service[TimeStatusCache]
+      xa             <- ZIO.service[Transactor[Task]]
+      promPublisher  <- ZIO.service[PrometheusPublisher]
       routerAuth = new RouterAuthLive(routerRepo)
       routerMetrics <- RouterMetricsService.make
       dbHealthCheck = sql"SELECT 1".query[Int].unique.transact(xa).unit
@@ -307,7 +323,16 @@ object Main extends ZIOAppDefault {
       val systemRoutes: Routes[Any, Response] =
         VersionRoutes.routes(wifihaven.api.BuildInfo.fromEnv) ++
           AuthRoutes.routes(auth, userRepo, upRepo) ++
-          ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
+          ProfileRoutes.routes(
+            auth,
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            upRepo,
+            userRepo,
+            namedSchedRepo,
+          ) ++
+          ScheduleRoutes.routes(auth, namedSchedRepo) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo) ++
           DeviceRoutes.routes(auth, deviceRepo, upRepo)
 

--- a/api/src/ScheduleSeeder.scala
+++ b/api/src/ScheduleSeeder.scala
@@ -1,0 +1,106 @@
+package wifihaven.api
+
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import zio.*
+
+import java.time.{LocalTime, ZoneId}
+
+/** Outcome of the boot-time named-schedule seed/migrate pass. Logged at startup. */
+final case class ScheduleSeedSummary(migrated: Int, seededDefaults: Int)
+
+/**
+ * #1069: one-time, idempotent boot step that (1) migrates each profile's legacy per-profile
+ * `schedules` rows into the household-scoped `named_schedules` model and links the profile to it,
+ * and (2) seeds a default starter set of schedules on a brand-new household.
+ *
+ * Idempotency:
+ *   - Migration skips any profile that already references a named schedule (`schedule_id` set), so
+ *     a re-run is a no-op once a profile has been migrated. The legacy `schedules` rows are left
+ *     intact — PolicyService unions them with the named windows (identical → same result), and they
+ *     keep the pre-`schedule_id` image enforcing correctly on a rollback. Their removal is a later
+ *     deprecation-window migration.
+ *   - Default seeding is gated on the `named_schedules` table being empty, and runs *before*
+ *     migration so a brand-new install (whose V1-seeded Kids/Bedtime legacy schedule would
+ *     otherwise make the table non-empty after migration) still gets the starter set. The defaults
+ *     are unlinked reusable templates — seeding them changes no enforcement until an operator
+ *     references one — so re-seeding after a full delete is low-harm; a durable "seeded once"
+ *     marker (household_settings column) is a follow-up once a migration can ship for it.
+ */
+object ScheduleSeeder {
+
+  private val AllDays                       = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+  private val Weekdays                      = List("mon", "tue", "wed", "thu", "fri")
+  private val Weekend                       = List("sat", "sun")
+  private def at(h: Int, m: Int): LocalTime = LocalTime.of(h, m)
+
+  // (name, description, windows-as-(days, start, end)). Times are wall-clock in the household zone.
+  private val Defaults: List[(String, String, List[(List[String], LocalTime, LocalTime)])] = List(
+    ("Bedtime", "Daily overnight downtime", List((AllDays, at(20, 0), at(7, 0)))),
+    ("School hours", "Weekday school day", List((Weekdays, at(8, 0), at(15, 0)))),
+    ("Afternoon", "Weekday after school", List((Weekdays, at(15, 0), at(18, 0)))),
+    ("Weekend mornings", "Saturday & Sunday mornings", List((Weekend, at(6, 0), at(10, 0)))),
+  )
+
+  def seedAndMigrate(
+      named: NamedScheduleRepo,
+      legacy: ScheduleRepo,
+      profiles: ProfileRepo,
+      tz: ZoneId,
+  ): Task[ScheduleSeedSummary] =
+    for {
+      // Seed defaults first, gated on an empty table, so a fresh install's V1-seeded legacy
+      // schedule (which migration turns into a named schedule) doesn't suppress the starter set.
+      seeded   <- seedDefaults(named, tz)
+      migrated <- migrateProfiles(named, legacy, profiles)
+    } yield ScheduleSeedSummary(migrated, seeded)
+
+  private def migrateProfiles(
+      named: NamedScheduleRepo,
+      legacy: ScheduleRepo,
+      profiles: ProfileRepo,
+  ): Task[Int] =
+    profiles.listAll.flatMap { ps =>
+      ZIO.foldLeft(ps)(0) { (acc, p) =>
+        named.blockScheduleIdsForProfile(p.id).flatMap { existing =>
+          if existing.nonEmpty then ZIO.succeed(acc) // already migrated
+          else
+            legacy.listForProfile(p.id).flatMap {
+              case Nil  => ZIO.succeed(acc)
+              case rows =>
+                val windows = rows.map(s => ScheduleWindow(s.days, s.startLocal, s.endLocal, s.tz))
+                for {
+                  name <- uniqueName(named, s"${p.name} schedule")
+                  id   <- named.create(name, Some(s"Migrated from ${p.name}'s schedule"), windows)
+                  _    <- named.setProfileBlockSchedules(p.id, List(id))
+                } yield acc + 1
+            }
+        }
+      }
+    }
+
+  // First free "<base>", then "<base> (2)", "<base> (3)", … honouring named_schedules.name UNIQUE.
+  private def uniqueName(named: NamedScheduleRepo, base: String): Task[String] = {
+    def loop(candidate: String, n: Int): Task[String] =
+      named.findByName(candidate).flatMap {
+        case None    => ZIO.succeed(candidate)
+        case Some(_) => loop(s"$base (${n + 1})", n + 1)
+      }
+    loop(base, 1)
+  }
+
+  private def seedDefaults(named: NamedScheduleRepo, tz: ZoneId): Task[Int] =
+    named.listAll.flatMap { existing =>
+      if existing.nonEmpty then ZIO.succeed(0)
+      else
+        ZIO
+          .foreachDiscard(Defaults) { case (name, desc, windows) =>
+            named.create(
+              name,
+              Some(desc),
+              windows.map { case (days, start, end) => ScheduleWindow(days, start, end, tz) },
+            )
+          }
+          .as(Defaults.size)
+    }
+}

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -108,6 +108,71 @@ trait ProfileRepo {
   def setPaused(id: ProfileId, paused: Boolean): Task[Unit]
 }
 
+/**
+ * #1069: CRUD over the household-scoped `named_schedules` table + its typed `schedule_windows`
+ * child rows, plus the `profile_schedule_rules` join that attaches schedules to profiles. No
+ * business logic — name validation and snapshot expansion live in the routes / PolicyService. A
+ * schedule's windows (and a profile's block-schedule set) are replaced wholesale on write (same
+ * shape as [[AppRepo.setHosts]]).
+ */
+trait NamedScheduleRepo {
+  def listAll: Task[List[NamedSchedule]]
+  def findById(id: NamedScheduleId): Task[Option[NamedSchedule]]
+  def findByName(name: String): Task[Option[NamedSchedule]]
+  def create(name: String, description: Option[String], windows: List[ScheduleWindow]): Task[
+    NamedScheduleId,
+  ]
+  def update(
+      id: NamedScheduleId,
+      name: String,
+      description: Option[String],
+      windows: List[ScheduleWindow],
+  ): Task[Unit]
+  def delete(id: NamedScheduleId): Task[Unit]
+
+  // ── profile_schedule_rules (block-mode only for now; allow-mode deferred) ──
+
+  /** Ids of the named schedules attached to `pid` as block schedules. */
+  def blockScheduleIdsForProfile(pid: ProfileId): Task[List[NamedScheduleId]]
+
+  /** Replace `pid`'s block-mode schedule attachments with exactly `ids` (de-duped). */
+  def setProfileBlockSchedules(pid: ProfileId, ids: List[NamedScheduleId]): Task[Unit]
+
+  /**
+   * Windows of every block-mode schedule attached to `pid` (flattened across its
+   * `profile_schedule_rules`), or `Nil` if none. PolicyService folds these into the profile's
+   * scheduled-downtime decision.
+   */
+  def windowsForProfile(pid: ProfileId): Task[List[ScheduleWindow]]
+
+  /** Batched [[windowsForProfile]] for the all-profiles snapshot path — avoids an N+1. */
+  def windowsForAllProfiles: Task[Map[ProfileId, List[ScheduleWindow]]]
+}
+
+/**
+ * No-named-schedules stub. Lets TimeStatusServiceLive's many direct test constructions keep their
+ * existing arity (the real repo is wired via the layer); a profile then has no named-schedule
+ * downtime, leaving the legacy `schedules` behaviour exactly as before.
+ */
+object NoopNamedScheduleRepo extends NamedScheduleRepo {
+  def listAll                       = ZIO.succeed(Nil)
+  def findById(id: NamedScheduleId) = ZIO.succeed(None)
+  def findByName(name: String)      = ZIO.succeed(None)
+  def create(name: String, description: Option[String], windows: List[ScheduleWindow]) =
+    ZIO.succeed(NamedScheduleId(0L))
+  def update(
+      id: NamedScheduleId,
+      name: String,
+      description: Option[String],
+      windows: List[ScheduleWindow],
+  ) = ZIO.unit
+  def delete(id: NamedScheduleId)                                                      = ZIO.unit
+  def blockScheduleIdsForProfile(pid: ProfileId)                           = ZIO.succeed(Nil)
+  def setProfileBlockSchedules(pid: ProfileId, ids: List[NamedScheduleId]) = ZIO.unit
+  def windowsForProfile(pid: ProfileId)                                    = ZIO.succeed(Nil)
+  def windowsForAllProfiles                                                = ZIO.succeed(Map.empty)
+}
+
 trait ScheduleRepo {
   def listAll: Task[List[Schedule]]
   def listForProfile(pid: ProfileId): Task[List[Schedule]]
@@ -2929,11 +2994,134 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
     )
 }
 
+class NamedScheduleRepoLive(xa: Transactor[Task]) extends NamedScheduleRepo {
+  // (days, start_local, end_local, tz) — same typed shape as the V1 schedules columns.
+  private type W = (List[String], LocalTime, LocalTime, ZoneId)
+  private def toWindow(w: W) = ScheduleWindow(w._1, w._2, w._3, w._4)
+
+  private def windowsFor(id: NamedScheduleId): ConnectionIO[List[ScheduleWindow]] =
+    sql"SELECT days,start_local,end_local,tz FROM schedule_windows WHERE schedule_id=$id ORDER BY id"
+      .query[W]
+      .map(toWindow)
+      .to[List]
+
+  private def insertWindows(id: NamedScheduleId, ws: List[ScheduleWindow]): ConnectionIO[Unit] =
+    ws.foldLeft(FC.unit) { (acc, w) =>
+      acc *> sql"""INSERT INTO schedule_windows(schedule_id,days,start_local,end_local,tz)
+                   VALUES($id,${w.days.toArray},${w.startLocal},${w.endLocal},${w.tz})""".update.run.void
+    }
+
+  def listAll =
+    DbMetrics.timed("namedSchedule.listAll")(
+      (for {
+        rows <-
+          sql"SELECT id,name,description FROM named_schedules ORDER BY name"
+            .query[(NamedScheduleId, String, Option[String])]
+            .to[List]
+        out  <- rows.traverse { case (id, name, desc) =>
+          windowsFor(id).map(ws => NamedSchedule(id, name, desc, ws))
+        }
+      } yield out).transact(xa),
+    )
+
+  def findById(id: NamedScheduleId) =
+    (for {
+      row <-
+        sql"SELECT id,name,description FROM named_schedules WHERE id=$id"
+          .query[(NamedScheduleId, String, Option[String])]
+          .option
+      out <- row.traverse { case (rid, name, desc) =>
+        windowsFor(rid).map(ws => NamedSchedule(rid, name, desc, ws))
+      }
+    } yield out).transact(xa)
+
+  def findByName(name: String) =
+    (for {
+      row <-
+        sql"SELECT id,name,description FROM named_schedules WHERE name=$name"
+          .query[(NamedScheduleId, String, Option[String])]
+          .option
+      out <- row.traverse { case (rid, n, desc) =>
+        windowsFor(rid).map(ws => NamedSchedule(rid, n, desc, ws))
+      }
+    } yield out).transact(xa)
+
+  def create(name: String, description: Option[String], windows: List[ScheduleWindow]) =
+    (for {
+      id <-
+        sql"INSERT INTO named_schedules(name,description) VALUES($name,$description) RETURNING id"
+          .query[NamedScheduleId]
+          .unique
+      _  <- insertWindows(id, windows)
+    } yield id).transact(xa)
+
+  def update(
+      id: NamedScheduleId,
+      name: String,
+      description: Option[String],
+      windows: List[ScheduleWindow],
+  ) =
+    (sql"""UPDATE named_schedules SET name=$name, description=$description, updated_at=NOW()
+           WHERE id=$id""".update.run *>
+      sql"DELETE FROM schedule_windows WHERE schedule_id=$id".update.run *>
+      insertWindows(id, windows)).transact(xa).unit
+
+  def delete(id: NamedScheduleId) =
+    sql"DELETE FROM named_schedules WHERE id=$id".update.run.transact(xa).unit
+
+  private val BlockedDuring = "blocked_during"
+
+  def blockScheduleIdsForProfile(pid: ProfileId) =
+    sql"""SELECT schedule_id FROM profile_schedule_rules
+          WHERE profile_id=$pid AND mode=$BlockedDuring
+          ORDER BY schedule_id"""
+      .query[NamedScheduleId]
+      .to[List]
+      .transact(xa)
+
+  def setProfileBlockSchedules(pid: ProfileId, ids: List[NamedScheduleId]) = {
+    val del = sql"""DELETE FROM profile_schedule_rules
+                    WHERE profile_id=$pid AND mode=$BlockedDuring""".update.run
+    val ins = ids.distinct.foldLeft(FC.unit) { (acc, sid) =>
+      acc *> sql"""INSERT INTO profile_schedule_rules(profile_id, schedule_id, mode)
+                   VALUES($pid, $sid, $BlockedDuring)
+                   ON CONFLICT (profile_id, schedule_id, mode) DO NOTHING""".update.run.void
+    }
+    (del *> ins).transact(xa).unit
+  }
+
+  // Block-mode windows attached to a profile: rules -> named_schedules -> windows.
+  def windowsForProfile(pid: ProfileId) =
+    sql"""SELECT sw.days, sw.start_local, sw.end_local, sw.tz
+          FROM schedule_windows sw
+          JOIN profile_schedule_rules psr ON psr.schedule_id = sw.schedule_id
+          WHERE psr.profile_id = $pid AND psr.mode = $BlockedDuring
+          ORDER BY sw.id"""
+      .query[W]
+      .map(toWindow)
+      .to[List]
+      .transact(xa)
+
+  def windowsForAllProfiles =
+    sql"""SELECT psr.profile_id, sw.days, sw.start_local, sw.end_local, sw.tz
+          FROM schedule_windows sw
+          JOIN profile_schedule_rules psr ON psr.schedule_id = sw.schedule_id
+          WHERE psr.mode = $BlockedDuring
+          ORDER BY psr.profile_id, sw.id"""
+      .query[(ProfileId, List[String], LocalTime, LocalTime, ZoneId)]
+      .to[List]
+      .transact(xa)
+      .map(_.groupBy(_._1).map { case (pid, rows) =>
+        pid -> rows.map(r => ScheduleWindow(r._2, r._3, r._4, r._5))
+      })
+}
+
 object Repos {
   val userRepo              = ZLayer.fromFunction(UserRepoLive(_))
   val userProfileRepo       = ZLayer.fromFunction(UserProfileRepoLive(_))
   val profileRepo           = ZLayer.fromFunction(ProfileRepoLive(_))
   val scheduleRepo          = ZLayer.fromFunction(ScheduleRepoLive(_))
+  val namedScheduleRepo     = ZLayer.fromFunction(NamedScheduleRepoLive(_))
   val householdSettingsRepo = ZLayer.fromFunction(HouseholdSettingsRepoLive(_))
   val globalPolicyRepo      = ZLayer.fromFunction(GlobalPolicyRepoLive(_))
   val timeLimitRepo         = ZLayer.fromFunction(TimeLimitRepoLive(_))
@@ -2951,5 +3139,5 @@ object Repos {
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
 }

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -36,6 +36,7 @@ object TypeMeta {
   given Meta[AlertId]               = Meta[Long].imap(AlertId(_))(_.value)
   given Meta[AppId]                 = Meta[Long].imap(AppId(_))(_.value)
   given Meta[AppPolicyAssignmentId] = Meta[Long].imap(AppPolicyAssignmentId(_))(_.value)
+  given Meta[NamedScheduleId]       = Meta[Long].imap(NamedScheduleId(_))(_.value)
 
   // ── UUID-backed ────────────────────────────────────────────────────────
   given Meta[RouterId] = Meta[java.util.UUID].imap(RouterId(_))(_.value)

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -107,6 +107,9 @@ object MetricGuard {
     "wifihaven_rollup_runs_total"               -> Set("rollup_job", "status"),
     "wifihaven_rollup_duration_seconds"         -> Set("rollup_job"),
     "wifihaven_rollup_rows_upserted"            -> Set("rollup_job"),
+    // #1069 named-schedule CRUD — `op` ∈ {create, update, delete}, a fixed enum. Lets an operator
+    // see schedule edits land (and rate-alert on a runaway delete loop) without grepping logs.
+    "wifihaven_schedule_mutations_total"        -> Set("op"),
     // #1243/#1221 HikariCP pool gauges — no labels.
     "wifihaven_db_pool_active_connections"      -> Set.empty[String],
     "wifihaven_db_pool_idle_connections"        -> Set.empty[String],
@@ -216,6 +219,10 @@ object AppMetrics {
 
   def recordAuthFailure(reason: String): UIO[Unit] =
     MetricGuard.counter("auth_failures_total", Map("reason" -> reason))
+
+  // #1069 — a named-schedule create / update / delete landed. `op` is a fixed enum.
+  def scheduleMutation(op: String): UIO[Unit] =
+    MetricGuard.counter("wifihaven_schedule_mutations_total", Map("op" -> op))
 
   // ── #864: traffic_reports rows dropped as zero-bytes-zero-seconds ────────────
   // Replaces the per-request warn-log + TODO marker. A rising rate means the

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -86,6 +86,11 @@ class PolicyServiceLive(
     clock: Clock,
     uiAllowedHosts: List[Hostname] = Nil,
     globalPolicyRepo: GlobalPolicyRepo = NoopGlobalPolicyRepo,
+    // #1069: defaulted to the noop so the many direct test constructions keep their arity. The
+    // snapshot path gets named schedules via TimeStatusService; PolicyServiceLive needs this repo
+    // directly only for the per-host /decision fallback, where the production layer wires the real
+    // one.
+    namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
 ) extends PolicyService {
 
   // #1318: the WifiHaven UI / block-page hosts are fleet-wide always-reachable
@@ -95,6 +100,17 @@ class PolicyServiceLive(
   // hosts when assembling the global section. (The #1307 infra-allow copy is
   // retired separately in #1321.)
   private val uiGlobalAllow: List[Hostname] = uiAllowedHosts
+
+  // #1069: per-host /decision fallback must see the same schedule downtime as the snapshot —
+  // union the legacy per-profile schedules with the windows of every block-mode named schedule
+  // attached to the profile (as synthetic DbSchedules so `scheduleActiveAt` applies unchanged).
+  private def schedulesFor(pid: ProfileId): Task[List[DbSchedule]] =
+    for {
+      v1    <- scheduleRepo.listForProfile(pid)
+      named <- namedScheduleRepo.windowsForProfile(pid)
+    } yield v1 ++ named.map(w =>
+      DbSchedule(ScheduleId(0L), pid, "named-schedule", w.days, w.startLocal, w.endLocal, w.tz),
+    )
 
   def snapshot: Task[PolicySnapshot] =
     (for {
@@ -268,7 +284,7 @@ class PolicyServiceLive(
         case Some(pid) =>
           for {
             pOpt          <- profileRepo.findById(pid)
-            scheds        <- scheduleRepo.listForProfile(pid)
+            scheds        <- schedulesFor(pid)
             tl            <- timeLimitRepo.findForProfile(pid)
             stlims        <- siteTimeLimitRepo.listForProfile(pid)
             // #764: post-migration, extraAllowed/extraBlocked are sourced
@@ -458,9 +474,9 @@ private case class SnapshotCore(
 
 object PolicyService {
   val layer: ZLayer[
-    AppConfig & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo &
-      SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo &
-      AppRepo & GlobalPolicyRepo & TimeStatusService & Clock,
+    AppConfig & ProfileRepo & ScheduleRepo & NamedScheduleRepo & HouseholdSettingsRepo &
+      TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo &
+      TimeExtensionRepo & AppRepo & GlobalPolicyRepo & TimeStatusService & Clock,
     Nothing,
     PolicyService,
   ] = ZLayer.fromFunction {
@@ -468,6 +484,7 @@ object PolicyService {
         cfg: AppConfig,
         pr: ProfileRepo,
         sr: ScheduleRepo,
+        nsr: NamedScheduleRepo,
         hsr: HouseholdSettingsRepo,
         tlr: TimeLimitRepo,
         stlr: SiteTimeLimitRepo,
@@ -495,6 +512,7 @@ object PolicyService {
         clk,
         cfg.policy.uiAllowedHostsParsed,
         gpr,
+        nsr,
       )
   }
 

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -115,7 +115,27 @@ class TimeStatusServiceLive(
     // Defaulting to the noop lets the many call sites in TimeApiSpec / snapshot specs keep their
     // 7-arg constructions — they exercise the all-live path either way.
     rollupRepo: TimeUsedRollupRepo = NoopTimeUsedRollupRepo,
+    // #1069: a profile's attached block-mode named-schedule windows are unioned into the legacy
+    // `schedules` for the blocked-flag decision. Defaults to the noop so existing direct
+    // constructions keep their arity.
+    namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
 ) extends TimeStatusService {
+
+  // #1069: a profile's effective downtime schedules = its legacy per-profile `schedules` rows
+  // unioned with the windows of every named schedule attached to it as a block schedule (via
+  // `profile_schedule_rules`, mode=blocked_during). Named windows become synthetic DbSchedules so
+  // the existing `scheduleActiveAt` math applies unchanged (it reads only days/start/end/tz —
+  // id/profileId/name are irrelevant).
+  private def syntheticWindows(pid: ProfileId, ws: List[ScheduleWindow]): List[DbSchedule] =
+    ws.map(w =>
+      DbSchedule(ScheduleId(0L), pid, "named-schedule", w.days, w.startLocal, w.endLocal, w.tz),
+    )
+
+  private def schedulesFor(pid: ProfileId): Task[List[DbSchedule]] =
+    for {
+      v1    <- scheduleRepo.listForProfile(pid)
+      named <- namedScheduleRepo.windowsForProfile(pid)
+    } yield v1 ++ syntheticWindows(pid, named)
 
   def todaysState(
       now: Instant,
@@ -149,7 +169,7 @@ class TimeStatusServiceLive(
       case None    => ZIO.succeed(None)
       case Some(p) =>
         for {
-          schedules <- scheduleRepo.listForProfile(profileId)
+          schedules <- schedulesFor(profileId)
           tl        <- timeLimitRepo.findForProfile(profileId)
           stls      <- siteTimeLimitRepo.listForProfile(profileId)
           devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
@@ -190,12 +210,15 @@ class TimeStatusServiceLive(
       profiles <- profileRepo.listAll
       devices  <- deviceRepo.listAll
       schedsP  <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      namedP   <- namedScheduleRepo.windowsForAllProfiles
       tlsP     <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
       stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       presence <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
       exts     <- extRepo.snapshotAllByProfile(date)
     } yield {
-      val schedMap = schedsP.toMap
+      val schedMap = schedsP.toMap.map { case (pid, v1) =>
+        pid -> (v1 ++ syntheticWindows(pid, namedP.getOrElse(pid, Nil)))
+      }
       val tlMap    = tlsP.toMap
       val stlMap   = stlsP.toMap
       val devsByP  =
@@ -234,7 +257,7 @@ class TimeStatusServiceLive(
       case None    => ZIO.succeed(None)
       case Some(p) =>
         for {
-          schedules <- scheduleRepo.listForProfile(profileId)
+          schedules <- schedulesFor(profileId)
           tl        <- timeLimitRepo.findForProfile(profileId)
           stls      <- siteTimeLimitRepo.listForProfile(profileId)
           devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
@@ -289,12 +312,15 @@ class TimeStatusServiceLive(
     for {
       devices <- deviceRepo.listAll
       schedsP <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
+      namedP  <- namedScheduleRepo.windowsForAllProfiles
       tlsP    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
       stlsP   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
       exts    <- extRepo.snapshotAllByProfile(date)
     } yield {
-      val schedMap = schedsP.toMap
+      val schedMap = schedsP.toMap.map { case (pid, v1) =>
+        pid -> (v1 ++ syntheticWindows(pid, namedP.getOrElse(pid, Nil)))
+      }
       val tlMap    = tlsP.toMap
       val stlMap   = stlsP.toMap
       val devsByP  =
@@ -336,7 +362,7 @@ object TimeStatusService {
 
   val layer: ZLayer[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo,
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & NamedScheduleRepo,
     Nothing,
     TimeStatusService,
   ] = ZLayer.fromFunction {
@@ -349,7 +375,8 @@ object TimeStatusService {
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
         ru: TimeUsedRollupRepo,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+        nsr: NamedScheduleRepo,
+    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr)
   }
 
   /**

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -191,9 +191,10 @@ object ProfileRoutes {
       timeLimitRepo: TimeLimitRepo,
       userProfileRepo: UserProfileRepo,
       userRepo: UserRepo,
+      namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "profiles"                        ->
+      Method.GET / "api" / "profiles"                            ->
         handler { (req: Request) =>
           for {
             claims      <- requireAuth(req, auth)
@@ -202,28 +203,64 @@ object ProfileRoutes {
             details     <- ZIO
               .foreach(visible) { p =>
                 for {
-                  scheds <- scheduleRepo.listForProfile(p.id)
-                  tl     <- timeLimitRepo.findForProfile(p.id)
-                } yield ProfileDetail(p, scheds, tl)
+                  scheds  <- scheduleRepo.listForProfile(p.id)
+                  tl      <- timeLimitRepo.findForProfile(p.id)
+                  schedId <- namedScheduleRepo.blockScheduleIdsForProfile(p.id)
+                } yield ProfileDetail(p, scheds, tl, schedId)
               }
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(details.toJson)
         },
-      Method.GET / "api" / "profiles" / long("id")           ->
+      Method.GET / "api" / "profiles" / long("id")               ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
-            claims <- requireAuth(req, auth)
-            _      <- requireProfileReadAccess(claims, pid, userProfileRepo)
-            p      <- profileRepo
+            claims  <- requireAuth(req, auth)
+            _       <- requireProfileReadAccess(claims, pid, userProfileRepo)
+            p       <- profileRepo
               .findById(pid)
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
-            scheds <- scheduleRepo.listForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
-            tl     <- timeLimitRepo.findForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
-          } yield Response.json(ProfileDetail(p, scheds, tl).toJson)
+            scheds  <- scheduleRepo.listForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
+            tl      <- timeLimitRepo.findForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
+            schedId <- namedScheduleRepo
+              .blockScheduleIdsForProfile(pid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.json(ProfileDetail(p, scheds, tl, schedId).toJson)
         },
-      Method.POST / "api" / "profiles"                       ->
+      // #1069: replace the set of named schedules attached to this profile as BLOCK schedules
+      // (downtime while active). A profile can reference many; allow-mode is deferred. Kept off the
+      // profile upsert so an ordinary profile save can't clobber the attachments.
+      Method.PUT / "api" / "profiles" / long("id") / "schedules" ->
+        handler { (id: Long, req: Request) =>
+          val pid = ProfileId(id)
+          for {
+            claims <- requireWriter(req, auth)
+            _      <- requireProfileAccess(claims, pid, userProfileRepo)
+            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+            sr     <- ZIO
+              .fromEither(body.fromJson[SetProfileSchedulesRequest])
+              .mapError(Response.badRequest(_))
+            _      <- profileRepo
+              .findById(pid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
+            _      <- ZIO.foreachDiscard(sr.scheduleIds.distinct) { sid =>
+              namedScheduleRepo
+                .findById(sid)
+                .mapError(ErrorMapper.dbErrorToResponse)
+                .flatMap(
+                  ZIO
+                    .fromOption(_)
+                    .orElseFail(Response.notFound(s"Schedule ${sid.value} not found")),
+                )
+            }
+            _      <- namedScheduleRepo
+              .setProfileBlockSchedules(pid, sr.scheduleIds)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+      Method.POST / "api" / "profiles"                           ->
         handler { (req: Request) =>
           for {
             _    <- requireAdmin(req, auth)
@@ -267,7 +304,7 @@ object ProfileRoutes {
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(s"""{"id":${id.value}}""")
         },
-      Method.PUT / "api" / "profiles" / long("id")           ->
+      Method.PUT / "api" / "profiles" / long("id")               ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -315,13 +352,13 @@ object ProfileRoutes {
             }).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },
-      Method.DELETE / "api" / "profiles" / long("id")        ->
+      Method.DELETE / "api" / "profiles" / long("id")            ->
         handler { (id: Long, req: Request) =>
           requireAdmin(req, auth) *>
             profileRepo.delete(ProfileId(id)).mapError(ErrorMapper.dbErrorToResponse) *>
             ZIO.succeed(Response.ok)
         },
-      Method.GET / "api" / "profiles" / long("id") / "users" ->
+      Method.GET / "api" / "profiles" / long("id") / "users"     ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {
@@ -336,7 +373,7 @@ object ProfileRoutes {
             }
           } yield Response.json(summaries.toJson)
         },
-      Method.PUT / "api" / "profiles" / long("id") / "users" ->
+      Method.PUT / "api" / "profiles" / long("id") / "users"     ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
           for {

--- a/api/src/routes/ScheduleRoutes.scala
+++ b/api/src/routes/ScheduleRoutes.scala
@@ -1,0 +1,137 @@
+package wifihaven.api.routes
+
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.*
+import zio.http.*
+import zio.json.*
+
+/**
+ * #1069: CRUD over household-scoped reusable named schedules (`/api/schedules`). A `NamedSchedule`
+ * is the time-window primitive that profiles (and, later, per-app rules #1378 / blocklists #1067)
+ * reference by id. Pure HTTP/validation glue over [[NamedScheduleRepo]] — PolicyService folds the
+ * active windows into the per-MAC BlockRules at snapshot time; the router never sees schedules.
+ */
+object ScheduleRoutes {
+
+  private val ValidDays = Set("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+  // Normalize day tokens to the lowercase 3-letter form `scheduleActiveAt` matches on, and reject
+  // unknown tokens or empty day sets so a window can never be silently never-active.
+  private def validateWindows(ws: List[ScheduleWindow]): Either[String, List[ScheduleWindow]] =
+    ws.foldLeft[Either[String, List[ScheduleWindow]]](Right(Nil)) { (acc, w) =>
+      acc.flatMap { prev =>
+        val days = w.days.map(_.trim.toLowerCase).distinct
+        if days.isEmpty then Left("each window needs at least one day")
+        else if !days.forall(ValidDays.contains) then
+          Left(
+            s"invalid day token(s) in [${w.days.mkString(",")}]; expected mon,tue,wed,thu,fri,sat,sun",
+          )
+        else Right(w.copy(days = days) :: prev)
+      }
+    }.map(_.reverse)
+
+  def routes(
+      auth: AuthService,
+      scheduleRepo: NamedScheduleRepo,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "schedules"                 ->
+        handler { (req: Request) =>
+          for {
+            _    <- requireAuth(req, auth)
+            list <- scheduleRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.json(list.toJson)
+        },
+      Method.GET / "api" / "schedules" / long("id")    ->
+        handler { (id: Long, req: Request) =>
+          for {
+            _ <- requireAuth(req, auth)
+            s <- scheduleRepo
+              .findById(NamedScheduleId(id))
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Schedule not found")))
+          } yield Response.json(s.toJson)
+        },
+      Method.POST / "api" / "schedules"                ->
+        handler { (req: Request) =>
+          for {
+            _    <- requireAdmin(req, auth)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            cr   <- ZIO
+              .fromEither(body.fromJson[CreateNamedScheduleRequest])
+              .mapError(Response.badRequest(_))
+            name = cr.name.trim
+            _       <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
+            windows <- ZIO.fromEither(validateWindows(cr.windows)).mapError(Response.badRequest(_))
+            taken   <- scheduleRepo.findByName(name).mapError(ErrorMapper.dbErrorToResponse)
+            _       <- ZIO
+              .fail(
+                Response
+                  .json(s"""{"error":"name_taken","name":${name.toJson}}""")
+                  .status(Status.Conflict),
+              )
+              .when(taken.isDefined)
+            id      <- scheduleRepo
+              .create(name, cr.description.map(_.trim).filter(_.nonEmpty), windows)
+              .mapError(ErrorMapper.dbErrorToResponse)
+            s       <- scheduleRepo
+              .findById(id)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(
+                ZIO.fromOption(_).orElseFail(Response.internalServerError("Schedule vanished")),
+              )
+            _       <- AppMetrics.scheduleMutation("create")
+          } yield Response.json(s.toJson)
+        },
+      // PATCH carries the full schedule shape (name/description/windows) and replaces — symmetric
+      // with the GET read shape, so the SPA autosaves the whole edit form (#423 / autosave default).
+      Method.PATCH / "api" / "schedules" / long("id")  ->
+        handler { (id: Long, req: Request) =>
+          val sid = NamedScheduleId(id)
+          for {
+            _    <- requireAdmin(req, auth)
+            body <- req.body.asString.orElseFail(Response.badRequest(""))
+            ur   <- ZIO
+              .fromEither(body.fromJson[UpdateNamedScheduleRequest])
+              .mapError(Response.badRequest(_))
+            name = ur.name.trim
+            _       <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
+            windows <- ZIO.fromEither(validateWindows(ur.windows)).mapError(Response.badRequest(_))
+            _       <- scheduleRepo
+              .findById(sid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Schedule not found")))
+            taken   <- scheduleRepo.findByName(name).mapError(ErrorMapper.dbErrorToResponse)
+            _       <- ZIO
+              .fail(
+                Response
+                  .json(s"""{"error":"name_taken","name":${name.toJson}}""")
+                  .status(Status.Conflict),
+              )
+              .when(taken.exists(_.id != sid))
+            _       <- scheduleRepo
+              .update(sid, name, ur.description.map(_.trim).filter(_.nonEmpty), windows)
+              .mapError(ErrorMapper.dbErrorToResponse)
+            s       <- scheduleRepo
+              .findById(sid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+              .flatMap(
+                ZIO.fromOption(_).orElseFail(Response.internalServerError("Schedule vanished")),
+              )
+            _       <- AppMetrics.scheduleMutation("update")
+          } yield Response.json(s.toJson)
+        },
+      Method.DELETE / "api" / "schedules" / long("id") ->
+        handler { (id: Long, req: Request) =>
+          requireAdmin(req, auth) *>
+            scheduleRepo
+              .delete(NamedScheduleId(id))
+              .mapError(ErrorMapper.dbErrorToResponse) *>
+            AppMetrics.scheduleMutation("delete").as(Response.ok)
+        },
+    )
+}

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -178,10 +178,10 @@ object TestDatabase {
    * bootstrap layer always provides it.
    */
   type AllRepos =
-    TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & HouseholdSettingsRepo &
-      GlobalPolicyRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo &
-      TimeUsageRepo & TimeExtensionRepo & RouterRepo & TrafficReportRepo & BlockEventRepo &
-      ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
+    TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & NamedScheduleRepo &
+      HouseholdSettingsRepo & GlobalPolicyRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & RouterRepo & TrafficReportRepo &
+      BlockEventRepo & ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & TestDb & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
@@ -76,8 +76,7 @@ object PolicySnapshotNamedScheduleSpec
       ar,
       tss,
       clk,
-      Nil,
-      nsr,
+      namedScheduleRepo = nsr,
     ): PolicyService
 
   // A profile with NO legacy schedules, linked to a named schedule with a bedtime window.
@@ -99,7 +98,7 @@ object PolicySnapshotNamedScheduleSpec
           ),
         ),
       )
-      _   <- pr.setSchedule(pid, Some(sid))
+      _   <- nsr.setProfileBlockSchedules(pid, List(sid))
       _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", pid)
     } yield (pid, sid)
 

--- a/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
@@ -1,0 +1,154 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDateTime, LocalTime, ZoneId}
+
+/**
+ * #1069: the policy snapshot must fold a profile's *named* schedule (referenced via
+ * profiles.schedule_id) into the per-MAC `blocked` flag, exactly like the legacy per-profile
+ * schedules — so editing the household schedule reflects on the next snapshot rebuild, and the
+ * router never learns schedules exist. These tests pin that the named-schedule path drives
+ * blocked/reason=Schedule on its own (the profile has NO legacy schedules).
+ */
+object PolicySnapshotNamedScheduleSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def blockedMacs(snap: PolicySnapshot): List[(String, String)] =
+    snap.devices.toList.sortBy(_._1).flatMap { case (mac, dev) =>
+      val rules = dev.rules.orElse(dev.profileId.flatMap(snap.profiles.get).map(_.rules))
+      rules.filter(_.blocked).map { r =>
+        mac.value -> r.blockReason.map(MacBlockReason.asString).getOrElse("")
+      }
+    }
+
+  // Build the full PolicyService wiring with the REAL NamedScheduleRepo threaded through both
+  // TimeStatusService (snapshot blocked-flag) and PolicyServiceLive (per-host /decision).
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+      tss = new TimeStatusServiceLive(
+        pr,
+        sr,
+        tlr,
+        stlr,
+        dr,
+        trRepo,
+        er,
+        NoopTimeUsedRollupRepo,
+        nsr,
+      )
+    } yield new PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      tss,
+      clk,
+      Nil,
+      nsr,
+    ): PolicyService
+
+  // A profile with NO legacy schedules, linked to a named schedule with a bedtime window.
+  private def seedBedtimeNamedSchedule =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      nsr <- ZIO.service[NamedScheduleRepo]
+      dr  <- ZIO.service[DeviceRepo]
+      pid <- pr.create("Kids", Nil)
+      sid <- nsr.create(
+        "Bedtime",
+        Some("overnight"),
+        List(
+          ScheduleWindow(
+            List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+            LocalTime.of(21, 0),
+            LocalTime.of(7, 0),
+            ZoneId.of("UTC"),
+          ),
+        ),
+      )
+      _   <- pr.setSchedule(pid, Some(sid))
+      _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", pid)
+    } yield (pid, sid)
+
+  def spec = suite("policy snapshot — named schedules (#1069)")(
+    test("active named-schedule window (bedtime 21:30) → device blocked, reason=Schedule") {
+      for {
+        _    <- cleanDb
+        _    <- seedBedtimeNamedSchedule
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap) == List("aa:bb:cc:11:22:33" -> "Schedule"))
+    },
+    test("outside the window (school-day afternoon) → not blocked") {
+      for {
+        _    <- cleanDb
+        _    <- seedBedtimeNamedSchedule
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap).isEmpty)
+    },
+    test("editing the schedule's window reflects on the next snapshot (no DB profile change)") {
+      for {
+        _      <- cleanDb
+        nsr    <- ZIO.service[NamedScheduleRepo]
+        seeded <- seedBedtimeNamedSchedule
+        (_, sid) = seeded
+        // Narrow the window to mornings only → bedtime 21:30 no longer active.
+        _    <- nsr.update(
+          sid,
+          "Bedtime",
+          Some("mornings only now"),
+          List(
+            ScheduleWindow(List("mon"), LocalTime.of(6, 0), LocalTime.of(7, 0), ZoneId.of("UTC")),
+          ),
+        )
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap).isEmpty)
+    },
+    test("no schedule reference → never blocked by schedule") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        pid  <- pr.create("Adults", Nil)
+        _    <- TestLayers.seedDevice(dr, "aa:bb:cc:44:55:66", "adult-phone", pid)
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap).isEmpty)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ScheduleSeederSpec.scala
+++ b/api/test/src/feature/ScheduleSeederSpec.scala
@@ -36,22 +36,23 @@ object ScheduleSeederSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       out <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
     } yield out
 
-  private def kidsProfile =
-    ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.find(_.name == "Kids").get)
+  private def kidsProfileId =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.find(_.name == "Kids").get.id)
 
   def spec = suite("ScheduleSeeder (#1069)")(
-    test("migrates the V1-seeded Kids/Bedtime legacy schedule into a linked named schedule") {
+    test("migrates the V1-seeded Kids/Bedtime legacy schedule into a linked block schedule") {
       for {
-        _       <- cleanDb
-        nsr     <- ZIO.service[NamedScheduleRepo]
-        before  <- kidsProfile
-        summary <- seedNow
-        after   <- kidsProfile
-        named   <- after.scheduleId.fold(ZIO.succeed(Option.empty[NamedSchedule]))(nsr.findById)
-      } yield assertTrue(before.scheduleId.isEmpty) &&
+        _        <- cleanDb
+        nsr      <- ZIO.service[NamedScheduleRepo]
+        kid      <- kidsProfileId
+        before   <- nsr.blockScheduleIdsForProfile(kid)
+        summary  <- seedNow
+        attached <- nsr.blockScheduleIdsForProfile(kid)
+        named    <- attached.headOption.fold(ZIO.succeed(Option.empty[NamedSchedule]))(nsr.findById)
+      } yield assertTrue(before.isEmpty) &&
         // only Kids has a legacy schedule in the V1 seed → exactly one profile migrated
         assertTrue(summary.migrated == 1) &&
-        assertTrue(after.scheduleId.isDefined) &&
+        assertTrue(attached.length == 1) &&
         assertTrue(named.exists(_.windows.length == 1)) &&
         assertTrue(named.exists(_.windows.head.days.contains("mon")))
     },

--- a/api/test/src/feature/ScheduleSeederSpec.scala
+++ b/api/test/src/feature/ScheduleSeederSpec.scala
@@ -1,0 +1,89 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ScheduleSeeder
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.ZoneId
+
+/**
+ * #1069: the boot-time seed/migrate pass. Migrates each profile's legacy per-profile `schedules`
+ * into the named-schedule model (linking via schedule_id), and seeds the default starter set when
+ * `named_schedules` is empty. Idempotent.
+ *
+ * The migrations (V1) seed a `Kids` + `Adults` profile and a `Bedtime` legacy schedule on `Kids`,
+ * so a freshly-migrated DB already carries exactly that fixture — these tests build on it.
+ */
+object ScheduleSeederSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+  private val UTC     = ZoneId.of("UTC")
+
+  private def seedNow =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      sr  <- ZIO.service[ScheduleRepo]
+      nsr <- ZIO.service[NamedScheduleRepo]
+      out <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
+    } yield out
+
+  private def kidsProfile =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.find(_.name == "Kids").get)
+
+  def spec = suite("ScheduleSeeder (#1069)")(
+    test("migrates the V1-seeded Kids/Bedtime legacy schedule into a linked named schedule") {
+      for {
+        _       <- cleanDb
+        nsr     <- ZIO.service[NamedScheduleRepo]
+        before  <- kidsProfile
+        summary <- seedNow
+        after   <- kidsProfile
+        named   <- after.scheduleId.fold(ZIO.succeed(Option.empty[NamedSchedule]))(nsr.findById)
+      } yield assertTrue(before.scheduleId.isEmpty) &&
+        // only Kids has a legacy schedule in the V1 seed → exactly one profile migrated
+        assertTrue(summary.migrated == 1) &&
+        assertTrue(after.scheduleId.isDefined) &&
+        assertTrue(named.exists(_.windows.length == 1)) &&
+        assertTrue(named.exists(_.windows.head.days.contains("mon")))
+    },
+    test("is idempotent — a second run migrates nothing and adds no duplicate schedule") {
+      for {
+        _           <- cleanDb
+        nsr         <- ZIO.service[NamedScheduleRepo]
+        first       <- seedNow
+        afterFirst  <- nsr.listAll.map(_.length)
+        second      <- seedNow
+        afterSecond <- nsr.listAll.map(_.length)
+      } yield assertTrue(first.migrated == 1) &&
+        assertTrue(second.migrated == 0) &&
+        assertTrue(afterFirst == afterSecond)
+    },
+    test("seeds the default starter set when named_schedules is empty") {
+      for {
+        _       <- cleanDb
+        nsr     <- ZIO.service[NamedScheduleRepo]
+        summary <- seedNow
+        names   <- nsr.listAll.map(_.map(_.name).toSet)
+      } yield assertTrue(summary.seededDefaults == 4) &&
+        assertTrue(
+          Set("Bedtime", "School hours", "Afternoon", "Weekend mornings").subsetOf(names),
+        )
+    },
+    test("does NOT re-seed defaults once named schedules exist") {
+      for {
+        _      <- cleanDb
+        first  <- seedNow
+        second <- seedNow
+      } yield assertTrue(first.seededDefaults == 4) && assertTrue(second.seededDefaults == 0)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/SchedulesApiSpec.scala
+++ b/api/test/src/feature/SchedulesApiSpec.scala
@@ -194,7 +194,7 @@ object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(after.windows.head.days == List("mon", "tue", "wed")) &&
         assertTrue(after.windows.head.startLocal == LocalTime.of(21, 30))
     },
-    test("DELETE removes it and clears a referencing profile's schedule_id") {
+    test("DELETE removes it and cascades away a referencing profile's attachment") {
       for {
         _      <- cleanDb
         token  <- adminToken
@@ -208,25 +208,25 @@ object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         sched  <- ZIO.fromEither(cBody.fromJson[NamedSchedule])
         link   <- put(
           prRs,
-          s"/api/profiles/${pid.value}/schedule",
-          SetProfileScheduleRequest(Some(sched.id)).toJson,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(List(sched.id)).toJson,
           token,
         )
-        linked <- pr.findById(pid)
+        linked <- nsr.blockScheduleIdsForProfile(pid)
         del    <- rs.runZIO(
           Request
             .delete(url(s"/api/schedules/${sched.id.value}"))
             .addHeader(Header.Authorization.Bearer(token)),
         )
-        after  <- pr.findById(pid)
+        after  <- nsr.blockScheduleIdsForProfile(pid)
         remain <- nsr.listAll
       } yield assertTrue(link.status == Status.Ok) &&
-        assertTrue(linked.flatMap(_.scheduleId).contains(sched.id)) &&
+        assertTrue(linked == List(sched.id)) &&
         assertTrue(del.status == Status.Ok) &&
-        assertTrue(after.flatMap(_.scheduleId).isEmpty) &&
+        assertTrue(after.isEmpty) &&
         assertTrue(remain.isEmpty)
     },
-    test("PUT /profiles/{id}/schedule 404s for an unknown schedule id") {
+    test("PUT /profiles/{id}/schedules 404s for an unknown schedule id") {
       for {
         _     <- cleanDb
         token <- adminToken
@@ -235,11 +235,48 @@ object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         pid   <- pr.create("Kids", Nil)
         resp  <- put(
           prRs,
-          s"/api/profiles/${pid.value}/schedule",
-          SetProfileScheduleRequest(Some(NamedScheduleId(9999))).toJson,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(List(NamedScheduleId(9999))).toJson,
           token,
         )
       } yield assertTrue(resp.status == Status.NotFound)
+    },
+    test("a profile can reference MANY schedules; GET detail returns them; re-PUT replaces") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        prRs  <- profileRoutes
+        pr    <- ZIO.service[ProfileRepo]
+        pid   <- pr.create("Kids", Nil)
+        a     <- post(rs, "/api/schedules", CreateNamedScheduleRequest("Bedtime").toJson, token)
+          .flatMap(_.body.asString)
+          .flatMap(b => ZIO.fromEither(b.fromJson[NamedSchedule]))
+        b    <- post(rs, "/api/schedules", CreateNamedScheduleRequest("School hours").toJson, token)
+          .flatMap(_.body.asString)
+          .flatMap(b => ZIO.fromEither(b.fromJson[NamedSchedule]))
+        both <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(List(a.id, b.id)).toJson,
+          token,
+        )
+        detail <- get(prRs, s"/api/profiles/${pid.value}", token)
+          .flatMap(_.body.asString)
+          .flatMap(s => ZIO.fromEither(s.fromJson[ProfileDetail]))
+        // re-PUT with just one → replaces (not appends)
+        _      <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(List(b.id)).toJson,
+          token,
+        )
+        after  <- get(prRs, s"/api/profiles/${pid.value}", token)
+          .flatMap(_.body.asString)
+          .flatMap(s => ZIO.fromEither(s.fromJson[ProfileDetail]))
+      } yield assertTrue(both.status == Status.Ok) &&
+        assertTrue(detail.scheduleIds.toSet == Set(a.id, b.id)) &&
+        assertTrue(after.scheduleIds == List(b.id))
     },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/SchedulesApiSpec.scala
+++ b/api/test/src/feature/SchedulesApiSpec.scala
@@ -1,0 +1,245 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.time.{LocalTime, ZoneId}
+
+/**
+ * #1069: feature tests for the household-scoped named-schedule CRUD (`/api/schedules`) and the
+ * profile→schedule reference route. Full stack against embedded Postgres — no mocks.
+ */
+object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def scheduleRoutes =
+    for {
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      auth <- makeAuth
+    } yield ScheduleRoutes.routes(auth, nsr)
+
+  private def profileRoutes =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      up   <- ZIO.service[UserProfileRepo]
+      ur   <- ZIO.service[UserRepo]
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      auth <- makeAuth
+    } yield ProfileRoutes.routes(auth, pr, sr, tlr, up, ur, nsr)
+
+  private def adminToken =
+    for {
+      auth  <- makeAuth
+      token <- auth.login("admin", "changeme").map(_.token.value)
+    } yield token
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def win(days: List[String], from: (Int, Int), to: (Int, Int)) =
+    ScheduleWindow(
+      days,
+      LocalTime.of(from._1, from._2),
+      LocalTime.of(to._1, to._2),
+      ZoneId.of("UTC"),
+    )
+
+  private def post(rs: Routes[Any, Response], path: String, body: String, token: String) =
+    rs.runZIO(
+      Request
+        .post(url(path), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def patch(rs: Routes[Any, Response], path: String, body: String, token: String) =
+    rs.runZIO(
+      Request
+        .patch(url(path), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def put(rs: Routes[Any, Response], path: String, body: String, token: String) =
+    rs.runZIO(
+      Request
+        .put(url(path), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def get(rs: Routes[Any, Response], path: String, token: String) =
+    rs.runZIO(Request.get(url(path)).addHeader(Header.Authorization.Bearer(token)))
+
+  def spec = suite("Schedules API (#1069)")(
+    test("POST creates a named schedule; GET list + by-id return it with windows") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        body = CreateNamedScheduleRequest(
+          name = "Bedtime",
+          description = Some("overnight"),
+          windows = List(win(List("mon", "tue"), (20, 0), (7, 0))),
+        ).toJson
+        created <- post(rs, "/api/schedules", body, token)
+        cBody   <- created.body.asString
+        sched   <- ZIO.fromEither(cBody.fromJson[NamedSchedule])
+        list    <- get(rs, "/api/schedules", token)
+        lBody   <- list.body.asString
+        all     <- ZIO.fromEither(lBody.fromJson[List[NamedSchedule]])
+        one     <- get(rs, s"/api/schedules/${sched.id.value}", token)
+        oBody   <- one.body.asString
+        byId    <- ZIO.fromEither(oBody.fromJson[NamedSchedule])
+      } yield assertTrue(created.status == Status.Ok) &&
+        assertTrue(sched.name == "Bedtime") &&
+        assertTrue(sched.windows.length == 1) &&
+        assertTrue(sched.windows.head.days == List("mon", "tue")) &&
+        assertTrue(all.length == 1 && all.head.id == sched.id) &&
+        assertTrue(byId.windows == sched.windows)
+    },
+    test("POST normalises day tokens to lowercase") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        body = CreateNamedScheduleRequest(
+          name = "School",
+          windows = List(
+            ScheduleWindow(
+              List("MON", "Tue"),
+              LocalTime.of(8, 0),
+              LocalTime.of(15, 0),
+              ZoneId.of("UTC"),
+            ),
+          ),
+        ).toJson
+        resp  <- post(rs, "/api/schedules", body, token)
+        rBody <- resp.body.asString
+        s     <- ZIO.fromEither(rBody.fromJson[NamedSchedule])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(s.windows.head.days == List("mon", "tue"))
+    },
+    test("POST returns 409 on duplicate name") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        body = CreateNamedScheduleRequest(name = "Bedtime").toJson
+        _    <- post(rs, "/api/schedules", body, token)
+        dupe <- post(rs, "/api/schedules", body, token)
+      } yield assertTrue(dupe.status == Status.Conflict)
+    },
+    test("POST rejects an unknown day token with 400") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        body = CreateNamedScheduleRequest(
+          name = "Bad",
+          windows = List(win(List("funday"), (8, 0), (9, 0))),
+        ).toJson
+        resp <- post(rs, "/api/schedules", body, token)
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("PATCH replaces name + windows") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        c     <- post(
+          rs,
+          "/api/schedules",
+          CreateNamedScheduleRequest(
+            "Bedtime",
+            windows = List(win(List("mon"), (20, 0), (7, 0))),
+          ).toJson,
+          token,
+        )
+        cBody <- c.body.asString
+        sched <- ZIO.fromEither(cBody.fromJson[NamedSchedule])
+        upd = UpdateNamedScheduleRequest(
+          name = "Bedtime (later)",
+          windows = List(win(List("mon", "tue", "wed"), (21, 30), (7, 0))),
+        ).toJson
+        p     <- patch(rs, s"/api/schedules/${sched.id.value}", upd, token)
+        pBody <- p.body.asString
+        after <- ZIO.fromEither(pBody.fromJson[NamedSchedule])
+      } yield assertTrue(p.status == Status.Ok) &&
+        assertTrue(after.name == "Bedtime (later)") &&
+        assertTrue(after.windows.head.days == List("mon", "tue", "wed")) &&
+        assertTrue(after.windows.head.startLocal == LocalTime.of(21, 30))
+    },
+    test("DELETE removes it and clears a referencing profile's schedule_id") {
+      for {
+        _      <- cleanDb
+        token  <- adminToken
+        rs     <- scheduleRoutes
+        prRs   <- profileRoutes
+        pr     <- ZIO.service[ProfileRepo]
+        nsr    <- ZIO.service[NamedScheduleRepo]
+        pid    <- pr.create("Kids", Nil)
+        c      <- post(rs, "/api/schedules", CreateNamedScheduleRequest("Bedtime").toJson, token)
+        cBody  <- c.body.asString
+        sched  <- ZIO.fromEither(cBody.fromJson[NamedSchedule])
+        link   <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedule",
+          SetProfileScheduleRequest(Some(sched.id)).toJson,
+          token,
+        )
+        linked <- pr.findById(pid)
+        del    <- rs.runZIO(
+          Request
+            .delete(url(s"/api/schedules/${sched.id.value}"))
+            .addHeader(Header.Authorization.Bearer(token)),
+        )
+        after  <- pr.findById(pid)
+        remain <- nsr.listAll
+      } yield assertTrue(link.status == Status.Ok) &&
+        assertTrue(linked.flatMap(_.scheduleId).contains(sched.id)) &&
+        assertTrue(del.status == Status.Ok) &&
+        assertTrue(after.flatMap(_.scheduleId).isEmpty) &&
+        assertTrue(remain.isEmpty)
+    },
+    test("PUT /profiles/{id}/schedule 404s for an unknown schedule id") {
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        prRs  <- profileRoutes
+        pr    <- ZIO.service[ProfileRepo]
+        pid   <- pr.create("Kids", Nil)
+        resp  <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedule",
+          SetProfileScheduleRequest(Some(NamedScheduleId(9999))).toJson,
+          token,
+        )
+      } yield assertTrue(resp.status == Status.NotFound)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -529,6 +529,35 @@
           "refId": "B"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Named-schedule mutations (#1069)",
+      "description": "Rate of named-schedule create/update/delete via /api/schedules, by op.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 12, "y": 40 },
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (op) (rate(wifihaven_schedule_mutations_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{op}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",
@@ -572,6 +601,6 @@
   "timezone": "",
   "title": "WifiHaven — API self-metrics",
   "uid": "wifihaven-api-self-metrics",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -182,6 +182,73 @@ case class Schedule(
     tz: ZoneId,
 ) derives JsonCodec
 
+// #1069: household-scoped reusable named schedule. A `NamedSchedule` owns one
+// or more `ScheduleWindow`s; anything time-bound (profiles today, per-app rules
+// #1378 and schedule-driven blocklists #1067 next) references it by id. A
+// window is the exact typed shape of the legacy per-profile `Schedule` (days /
+// startLocal / endLocal / tz) so the existing DST-correct
+// `PolicyService.scheduleActiveAt` evaluates it unchanged. This is an
+// API-internal model — it never reaches the router wire (`PolicySnapshot`):
+// PolicyService folds the active windows into the existing per-MAC BlockRules.
+case class ScheduleWindow(
+    days: List[String],
+    startLocal: LocalTime,
+    endLocal: LocalTime,
+    tz: ZoneId,
+) derives JsonCodec
+
+case class NamedSchedule(
+    id: NamedScheduleId,
+    name: String,
+    description: Option[String],
+    windows: List[ScheduleWindow],
+) derives JsonCodec
+
+// Create/replace bodies for the /api/schedules CRUD. `windows` is the full
+// desired set (replace semantics, mirroring how AppRepo.setHosts replaces).
+case class CreateNamedScheduleRequest(
+    name: String,
+    description: Option[String] = None,
+    windows: List[ScheduleWindow] = Nil,
+) derives JsonCodec
+
+case class UpdateNamedScheduleRequest(
+    name: String,
+    description: Option[String] = None,
+    windows: List[ScheduleWindow] = Nil,
+) derives JsonCodec
+
+// #1069: the (named schedule, mode) attachments on a profile. `mode` decides
+// what an active window does. Profiles are block-only for now (allow-mode is
+// deferred — see the #1069 thread), so the API below sets block schedules; the
+// mode lives here so the model already matches the per-app schedule shape when
+// allow lands.
+enum ScheduleMode { case BlockedDuring, AllowedDuring }
+
+object ScheduleMode {
+  def asString(m: ScheduleMode): String      = m match {
+    case BlockedDuring => "blocked_during"
+    case AllowedDuring => "allowed_during"
+  }
+  def parse(s: String): Option[ScheduleMode] = s match {
+    case "blocked_during" => Some(BlockedDuring)
+    case "allowed_during" => Some(AllowedDuring)
+    case _                => None
+  }
+  given JsonCodec[ScheduleMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown schedule mode: $s"),
+    asString,
+  )
+}
+
+// Body for PUT /api/profiles/{id}/schedules — replace the profile's block
+// schedules with this set (a profile can reference many). Kept off
+// UpsertProfileRequest so an ordinary profile save can't clobber it. Allow-mode
+// profile schedules are deferred, so this carries ids only (block implied).
+case class SetProfileSchedulesRequest(
+    scheduleIds: List[NamedScheduleId] = Nil,
+) derives JsonCodec
+
 case class TimeLimit(
     id: TimeLimitId,
     profileId: ProfileId,
@@ -827,6 +894,9 @@ case class ProfileDetail(
     profile: Profile,
     schedules: List[Schedule],
     timeLimit: Option[TimeLimit],
+    // #1069: ids of the named schedules attached to this profile as block
+    // schedules (downtime while active). Empty until the operator attaches one.
+    scheduleIds: List[NamedScheduleId] = Nil,
 ) derives JsonCodec
 
 /**

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -25,6 +25,7 @@ opaque type TimeUsageId           = Long
 opaque type AlertId               = Long
 opaque type AppId                 = Long
 opaque type AppPolicyAssignmentId = Long
+opaque type NamedScheduleId       = Long
 
 object ProfileId {
   def apply(l: Long): ProfileId            = l
@@ -126,6 +127,15 @@ object AppPolicyAssignmentId {
   extension (a: AppPolicyAssignmentId) def value: Long = a
   given JsonCodec[AppPolicyAssignmentId]               = JsonCodec.long
   given Ordering[AppPolicyAssignmentId]                = Ordering.Long
+}
+
+object NamedScheduleId {
+  def apply(l: Long): NamedScheduleId            = l
+  extension (n: NamedScheduleId) def value: Long = n
+  given JsonCodec[NamedScheduleId]               = JsonCodec.long
+  given JsonFieldEncoder[NamedScheduleId]        = JsonFieldEncoder.long
+  given JsonFieldDecoder[NamedScheduleId]        = JsonFieldDecoder.long
+  given Ordering[NamedScheduleId]                = Ordering.Long
 }
 
 /** UUID-backed router identifier. */


### PR DESCRIPTION
## PR 2 of 3 — API adoption for #1069

Stacked on **#1428** (the schema-only V50 migration: `named_schedules` +
`schedule_windows` + `profile_schedule_rules`). Makes household-scoped reusable
named schedules a first-class API primitive that profiles attach to — **zero
router-side change, snapshot wire shape untouched**.

> Review against base `claude/impl-1069-named-schedules` until #1428 merges,
> then this retargets to `main`.

### Model (per review on #1428)

A profile attaches **many** schedules through the `profile_schedule_rules`
`(profile_id, schedule_id, mode)` join table — not a single column. Each
attachment carries a **mode**:

- **Profiles are block-only for now.** `blocked_during` = the profile is in
  scheduled downtime while any window of the schedule is active (today's
  bedtime semantics, now reusable + multiple). **Allow-mode for profiles is
  deferred** (open question on whether allowed-schedule usage counts against
  the daily limit — see the #1069 thread). The `mode` column + `ScheduleMode`
  enum already exist, so allow lands later with no schema change.
- **Per-app schedules (#1378) keep both modes** via the identical
  `app_policy_schedule_rules` table — profiles and apps share one
  `(entity, schedule, mode)` shape.

### What's here

- **shared**: `NamedSchedule` / `ScheduleWindow` / `Create`+`Update` requests;
  `ScheduleMode`; `SetProfileSchedulesRequest(scheduleIds)`;
  `ProfileDetail.scheduleIds`. `NamedScheduleId` opaque id. `Profile` gains **no**
  wire field — attachments live in the join table.
- **db**: `NamedScheduleRepo` over `named_schedules`/`schedule_windows` **and**
  `profile_schedule_rules` — `blockScheduleIdsForProfile`,
  `setProfileBlockSchedules` (replace), `windowsForProfile`/`windowsForAllProfiles`
  joining `mode = blocked_during`. `NoopNamedScheduleRepo` for back-compat.
- **routes**: `GET/POST/PATCH/DELETE /api/schedules` (admin writes; day tokens
  validated/normalised; dup-name 409; PATCH replaces the full shape for
  autosave). `PUT /api/profiles/{id}/schedules` replaces a profile's block
  schedules (many; replace semantics) — kept off the profile upsert so a normal
  save can't clobber them. GET profile detail returns `scheduleIds`.
- **policy**: `PolicyService` / `TimeStatusService` union a profile's block-mode
  named windows into the `blocked` decision via synthetic `Schedule`s, reusing
  the DST-correct `scheduleActiveAt` unchanged. Snapshot path + per-host
  `/decision`. **The router never learns schedules exist.**
- **boot** (`ScheduleSeeder`): migrates each profile's legacy per-profile
  `schedules` into a named schedule + a `blocked_during` attachment (legacy
  rows left intact for rollback), and seeds a default starter set when
  `named_schedules` is empty. Idempotent.
- **metrics**: `wifihaven_schedule_mutations_total{op}` + a Grafana panel.

### When do legacy profile schedules migrate?

In **app code at boot** (`ScheduleSeeder`), not a SQL migration (a
migration-bearing PR can carry only migration + docs; this PR carries code). The
legacy V1 `schedules` table is **left intact** — PolicyService unions it with
the named windows (identical → same result), so a PR-1-era image keeps enforcing
on rollback. Dropping the legacy table + renaming `named_schedules → schedules`
is a later deprecation-window migration once the fleet rolls forward.

### Back-compat / wire

Snapshot wire shape and `shared/contract/api-to-router/policy_snapshot.json`
untouched (#1069 is server-side snapshot expansion). New repo SQL uses explicit
column lists.

### Tests (TDD: red commit then green)

- `SchedulesApiSpec` — CRUD, token normalisation, dup-name 409, invalid-day 400,
  PATCH replace, DELETE cascades a profile's attachment, **a profile referencing
  many schedules + replace-on-re-PUT**, profile-link 404.
- `PolicySnapshotNamedScheduleSpec` — active block window → `blocked`/Schedule;
  outside → not blocked; **editing the schedule reflects on the next snapshot**;
  no attachment → never schedule-blocked.
- `ScheduleSeederSpec` — migrates V1 Kids/Bedtime into a block attachment;
  idempotent; seeds defaults when empty; no re-seed once non-empty.

Full `mill api.test` (192) + `mill shared.test` (139) pass; `scalafmt --check`
clean.

Refs #1069. Builds on #1428.
