### PR TITLE
fix(openwrt): block page redirects to public SPA host, not api_url (#1174 pt.1)

### DIFF
--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -2,6 +2,16 @@ config wifihaven 'wifihaven'
 	# Base URL of the wifihaven API server (HTTP, no trailing slash)
 	option api_url 'http://192.168.1.1:8080'
 
+	# Base URL of the public SPA that serves the /blocked page (no trailing
+	# slash). The block page redirects blocked clients here. Leave unset to
+	# fall back to api_url — correct for self-hosted installs, where the SPA is
+	# bundled into the API image and served on the same host. In the cloud
+	# deploy the SPA is on a SEPARATE host (Cloudflare Pages), so set this to
+	# the public SPA host, e.g. 'https://wifihaven.net' (post-#1171 cutover:
+	# 'https://app.wifihaven.net'). This is router-side config, not on the
+	# API↔router wire. (#1174)
+	# option block_page_url 'https://wifihaven.net'
+
 	# Long-lived router bearer token obtained during enrollment
 	option router_token ''
 

--- a/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
@@ -81,12 +81,26 @@ end
 M.html_escape = html_escape
 M.url_encode  = url_encode
 
--- Build the destination URL on the API server. Reason and mac are passed
--- through as-is; the API's React BlockedPage matches against the wire-format
+-- Resolve the block-page redirect base. The block-page (SPA /blocked route)
+-- host is deployment config, distinct from the API URL the router polls: in
+-- the cloud deploy the SPA lives on a different host (wifihaven.net /
+-- post-#1171 app.wifihaven.net) than the API (api.wifihaven.net), so the
+-- redirect must target the SPA host, not api_url. Falls back to api_url when
+-- the block-page URL is unset — the self-hosted / back-compat case, where the
+-- SPA is bundled into the API image and served on the same host. (#1174)
+function M.resolve_base(block_page_url, api_url)
+  if block_page_url and block_page_url ~= "" then return block_page_url end
+  return api_url
+end
+
+-- Build the destination URL on the block-page host. Reason and mac are passed
+-- through as-is; the SPA's React BlockedPage matches against the wire-format
 -- MacBlockReason strings ("Paused", "Schedule", "TimeLimit", "Manual").
-function M.build_dest_url(api_url, host, mac, reason)
-  if not api_url or api_url == "" then return nil end
-  return api_url .. "/blocked"
+-- `base_url` is the resolved block-page host (see resolve_base), not
+-- necessarily the API URL. (#1174)
+function M.build_dest_url(base_url, host, mac, reason)
+  if not base_url or base_url == "" then return nil end
+  return base_url .. "/blocked"
       .. "?host="   .. url_encode(host)
       .. "&reason=" .. url_encode(reason or "")
       .. "&mac="    .. url_encode(mac or "")
@@ -114,11 +128,12 @@ function M.inline_copy_for(reason)
   return INLINE_COPY[reason] or "This site is blocked."
 end
 
--- Render the HTML body for the block page. If api_url is set, returns a tiny
+-- Render the HTML body for the block page. If base_url is set, returns a tiny
 -- redirect document (meta refresh + JS for compatibility). Otherwise returns a
--- self-contained page with inline copy keyed on `reason`.
-function M.render_html(api_url, host, mac, reason)
-  local dest = M.build_dest_url(api_url, host, mac, reason)
+-- self-contained page with inline copy keyed on `reason`. `base_url` is the
+-- resolved block-page host (see resolve_base), not necessarily the API URL.
+function M.render_html(base_url, host, mac, reason)
+  local dest = M.build_dest_url(base_url, host, mac, reason)
   local copy = M.inline_copy_for(reason)
   local site_line = (host and host ~= "")
     and ("Site: " .. html_escape(host)) or ""

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -25,6 +25,7 @@ local nft_drops  = require("wifihaven.nft_drops")
 local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
 local paths      = require("wifihaven.paths")
+local block_page = require("wifihaven.block_page")
 local selfheal   = require("wifihaven.selfheal")
 local version    = require("wifihaven.version")
 
@@ -36,6 +37,14 @@ local function uci_get(opt, default)
 end
 
 local api_url       = uci_get("api_url",              "http://192.168.1.1:8080")
+-- #1174: block-page redirect base. The SPA that serves /blocked is, in the
+-- cloud deploy, on a different host (wifihaven.net / post-#1171
+-- app.wifihaven.net) than the API the router polls (api.wifihaven.net), so the
+-- block page must redirect to this host, NOT api_url. Defaults to api_url so
+-- self-hosted installs (SPA bundled into the API image, same host) and any
+-- router that never sets it keep today's behavior exactly. This is router-side
+-- deployment config (UCI), not policy, so it is not on the API↔router wire.
+local block_page_url = block_page.resolve_base(uci_get("block_page_url", ""), api_url)
 local router_token  = uci_get("router_token",         "")
 local router_id     = uci_get("router_id",            "")
 local lan_prefix    = uci_get("lan_prefix",           "192.168.1.")
@@ -71,8 +80,8 @@ log.init({ debug = debug_opt })
 -- nil on a checkout / older install — header is then simply omitted.
 local agent_version = version.read()
 local policy_opts   = { agent_version = agent_version }
-log.info("wifihaven-agent: starting api_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds metrics_int=%ds activity_sample_int=%ds agent_version=%s",
-         api_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, metrics_int, activity_sample_int, tostring(agent_version))
+log.info("wifihaven-agent: starting api_url=%s block_page_url=%s router_id=%s debug=%s policy_int=%ds usage_int=%ds metrics_int=%ds activity_sample_int=%ds agent_version=%s",
+         api_url, block_page_url, router_id, tostring(log.debug_enabled()), policy_int, usage_int, metrics_int, activity_sample_int, tostring(agent_version))
 
 -- ── Metrics registry (#1206) ─────────────────────────────────────────────────
 -- In-process cumulative counters since process start. NEVER reset on the
@@ -348,6 +357,11 @@ os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifi
 -- blocked clients, and /var/run/wifihaven/blocked_reasons (written below by
 -- render.write_blocked_reasons after every snapshot apply) to look up the
 -- per-MAC reason for the current device.
+--
+-- #1174: the value written here is the resolved block-page base
+-- (block_page_url), which is api_url for self-hosted installs but the public
+-- SPA host (wifihaven.net) in the cloud deploy. The IPC file name is left as
+-- api_url for back-compat with an already-installed handler.lua.
 
 local BLOCK_PAGE_API_URL_PATH  = paths.block_page_api_url
 local BLOCK_PAGE_REASONS_PATH  = paths.block_page_reasons
@@ -355,7 +369,7 @@ local BLOCK_PAGE_HOSTS_PATH    = paths.block_page_hosts  -- #594
 
 do
   local f = io.open(BLOCK_PAGE_API_URL_PATH, "w")
-  if f then f:write(api_url); f:close() end
+  if f then f:write(block_page_url); f:close() end
 end
 
 -- Persist the per-MAC block reasons for the block-page handler. Called after

--- a/openwrt/install.sh
+++ b/openwrt/install.sh
@@ -133,6 +133,21 @@ prompt API_URL          "API server URL" "https://api.wifihaven.net"
 [ -n "${API_URL:-}" ] || err "API URL is required"
 API_URL=${API_URL%/}
 
+# #1174: the block page redirects blocked clients to the public SPA that serves
+# the /blocked route. In the cloud deploy the SPA lives on a SEPARATE host
+# (Cloudflare Pages, e.g. https://wifihaven.net) from the API
+# (api.wifihaven.net), so the redirect must target the SPA host, not the API.
+# Self-hosted installs bundle the SPA into the API image on the same host, so
+# the block-page URL is just the API URL there. Default to the known public SPA
+# host when enrolling against the managed cloud API; otherwise default to the
+# API URL (correct for self-hosted).
+case "$API_URL" in
+  *api.wifihaven.net*) block_page_default="https://wifihaven.net" ;;
+  *)                   block_page_default="$API_URL" ;;
+esac
+prompt BLOCK_PAGE_URL   "Public SPA URL for the block page" "$block_page_default"
+BLOCK_PAGE_URL=${BLOCK_PAGE_URL%/}
+
 prompt ENROLLMENT_TOKEN "One-time enrollment token (admin UI -> Routers -> Add router)"
 [ -n "${ENROLLMENT_TOKEN:-}" ] || err "enrollment token is required"
 
@@ -224,6 +239,7 @@ fi
 # Write base UCI config before enrolling so a re-run after a failed enroll
 # does not have to re-enter these.
 uci set wifihaven.@wifihaven[0].api_url="$API_URL"
+uci set wifihaven.@wifihaven[0].block_page_url="$BLOCK_PAGE_URL"  # #1174
 uci set wifihaven.@wifihaven[0].lan_prefix="$LAN_PREFIX"
 uci commit wifihaven
 
@@ -297,6 +313,7 @@ Done. Router enrolled successfully.
 
   Router ID:   $router_id
   API URL:     $API_URL
+  Block page:  $BLOCK_PAGE_URL
   LAN prefix:  $LAN_PREFIX
 
 Watch the agent log:

--- a/openwrt/test/block_page_spec.lua
+++ b/openwrt/test/block_page_spec.lua
@@ -106,6 +106,30 @@ describe("block_page.parse_blocked_hosts (#594)", function()
   end)
 end)
 
+describe("block_page.resolve_base (#1174)", function()
+  -- The block-page redirect base is deployment config, separate from the API
+  -- URL. In the cloud deploy the SPA (which serves /blocked) lives on a
+  -- different host (wifihaven.net) than the API (api.wifihaven.net), so the
+  -- redirect must target the SPA host, not api_url. resolve_base picks the
+  -- configured block-page URL when set and falls back to api_url otherwise
+  -- (the self-hosted / back-compat case, where the SPA is bundled with the API
+  -- on the same host).
+  it("returns the block-page URL when it differs from api_url (cloud case)", function()
+    assert.equals("https://wifihaven.net",
+      bp.resolve_base("https://wifihaven.net", "https://api.wifihaven.net"))
+  end)
+
+  it("falls back to api_url when the block-page URL is unset (self-hosted/back-compat)", function()
+    assert.equals("https://api.wifihaven.net", bp.resolve_base(nil, "https://api.wifihaven.net"))
+    assert.equals("https://api.wifihaven.net", bp.resolve_base("", "https://api.wifihaven.net"))
+  end)
+
+  it("post-#1171 cutover is a pure config change (app.wifihaven.net)", function()
+    assert.equals("https://app.wifihaven.net",
+      bp.resolve_base("https://app.wifihaven.net", "https://api.wifihaven.net"))
+  end)
+end)
+
 describe("block_page.build_dest_url", function()
   it("emits a fully-formed /blocked URL with host, reason, and mac", function()
     local u = bp.build_dest_url(
@@ -114,6 +138,15 @@ describe("block_page.build_dest_url", function()
     assert.truthy(u:find("host=youtube.com", 1, true))
     assert.truthy(u:find("reason=Paused", 1, true))
     assert.truthy(u:find("mac=aa%3Abb%3Acc%3A11%3A22%3A33", 1, true))
+  end)
+
+  -- #1174: when the block-page base is the public SPA host (not api_url), the
+  -- redirect targets the SPA, not the API host.
+  it("targets the SPA host when given the block-page base (#1174)", function()
+    local base = bp.resolve_base("https://wifihaven.net", "https://api.wifihaven.net")
+    local u = bp.build_dest_url(base, "youtube.com", "aa:bb:cc:11:22:33", "Schedule")
+    assert.truthy(u:find("https://wifihaven.net/blocked", 1, true))
+    assert.is_nil(u:find("api.wifihaven.net", 1, true))
   end)
 
   it("returns nil when api_url is not configured", function()
@@ -150,6 +183,15 @@ describe("block_page.render_html", function()
   it("inline fallback includes viewport meta (#580)", function()
     local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33", "Paused")
     assert.truthy(html:find('name="viewport"', 1, true))
+  end)
+
+  -- #1174: render_html redirects to whatever base it is given. With the SPA
+  -- host as base, the redirect document points at the SPA, not the API host.
+  it("redirect document points at the block-page base, not api_url (#1174)", function()
+    local base = bp.resolve_base("https://wifihaven.net", "https://api.wifihaven.net")
+    local html = bp.render_html(base, "youtube.com", "aa:bb:cc:11:22:33", "Schedule")
+    assert.truthy(html:find("https://wifihaven.net/blocked", 1, true))
+    assert.is_nil(html:find("api.wifihaven.net", 1, true))
   end)
 
   it("falls back to inline copy when api_url is missing", function()


### PR DESCRIPTION
Fixes point **(1)** of #1174 — the block-page redirect landing on the wrong host. Point (2) (the `wifihaven.net` carve during scheduled downtime) is intentionally **out of scope** and left for a follow-up.

## Root cause

The router's block page redirected HTTP/80-blocked clients to `api_url .. "/blocked"`. `api_url` is the API endpoint the router *polls* (UCI `wifihaven.api_url`). In the **cloud** deploy the SPA that actually serves `/blocked` is on a **separate** host — `https://wifihaven.net` (Cloudflare Pages; see the "SPA hosting split" in `CLAUDE.md`) — while the API is `https://api.wifihaven.net`. So blocked clients were sent to `api.wifihaven.net/blocked`, the wrong host. (On prod, the router was additionally enrolled against the LAN API, so the redirect even resolved to a LAN IP `192.168.10.43` — that enrollment misconfig is separate, but the redirect-from-`api_url` bug is the code defect fixed here.)

In the **self-hosted** deploy the SPA is bundled into the API image and served on the same host, so `api_url/blocked` is correct there — the fix preserves that exactly.

## Fix — UCI config, not a wire/snapshot change

The block-page host is **deployment config**, not per-policy data, so it belongs in the router's UCI config alongside `api_url`, **not** in the policy snapshot. Adding a snapshot field would violate the snapshot's "minimal functional shape" rule and trip the backwards-compat wire-contract rules. UCI keys written/read by the same agent build are explicitly **not** part of the API↔router wire contract, so this is a safe, self-contained change.

- New UCI option `wifihaven.block_page_url` (public SPA base), read by the agent and written to the block-page IPC file (`/var/run/wifihaven/api_url`, name kept for back-compat with an already-installed `handler.lua`) that the uhttpd handler reads.
- **Defaults to `api_url`** via `block_page.resolve_base(uci_get("block_page_url", ""), api_url)`, so self-hosted installs and any router that never sets it keep today's behavior — **backward compatible**.
- The SPA host is **never hardcoded in Lua**, so the #1171 `wifihaven.net` → `app.wifihaven.net` cutover is a pure config change, not a code change.

## How the cloud/prod router gets the SPA host

`openwrt/install.sh` now prompts for the public SPA URL and writes `block_page_url`. It defaults to `https://wifihaven.net` when enrolling against `api.wifihaven.net`, and to `api_url` otherwise (self-hosted same-host). For the existing prod router, the operator sets it directly:

```
uci set wifihaven.@wifihaven[0].block_page_url='https://wifihaven.net'
uci commit wifihaven
/etc/init.d/wifihaven restart
```

(post-#1171: `https://app.wifihaven.net`).

## TDD

- `openwrt/test/block_page_spec.lua`: new `resolve_base` tests (cloud host ≠ api_url; fallback to api_url when unset — the self-hosted/back-compat case; #1171 cutover as config), plus `build_dest_url`/`render_html` assertions that the redirect targets the SPA host and never `api.wifihaven.net` when given the SPA base.
- Red→green is visible in history: the failing-test commit (`resolve_base` nil) precedes the implementation commit.
- `cd openwrt && busted test/block_page_spec.lua` → **31/31 green**. Full `test/` suite: the only delta vs. `origin/main` is these 5 block_page tests flipping error→pass (490→495 successes, 40→35 errors); the remaining 35 errors are the pre-existing `luci.jsonc` env gap in unrelated specs.

## Acceptance

- A blocked client's redirect targets the configured public SPA host (`https://wifihaven.net/blocked?…`, or `app.wifihaven.net` post-#1171).
- Self-hosted (no `block_page_url` set) still redirects to `api_url/blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)