### PR TITLE
ci(grafana): document HCP workspace prerequisite + clearer CD init error (#1440)

### DIFF
--- a/.github/workflows/master-grafana.yml
+++ b/.github/workflows/master-grafana.yml
@@ -101,5 +101,18 @@ jobs:
           TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
           TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
         run: |
-          terraform init -input=false
+          # The HCP workspace (TF_WORKSPACE=grafana) must already exist — it is a
+          # one-time, operator-gated setup step, NOT created by this pipeline (see
+          # infra/grafana/README.md "One-time backend setup"). If it is missing,
+          # `terraform init` fails with "Invalid workspace selection / failed to
+          # find workspace". Catch that specific case and print the fix, so the
+          # red CD is self-explanatory instead of looking like an apply error.
+          if ! init_out=$(terraform init -input=false 2>&1); then
+            echo "$init_out"
+            if echo "$init_out" | grep -q "Invalid workspace selection"; then
+              echo "::error title=HCP workspace missing::The HCP Terraform workspace '${TF_WORKSPACE}' does not exist in org '${TF_CLOUD_ORGANIZATION}'. This is the one-time backend setup, not an apply error. Create it (Execution Mode = Local, no VCS) per infra/grafana/README.md 'One-time backend setup', then re-run this job."
+            fi
+            exit 1
+          fi
+          echo "$init_out"
           terraform apply -auto-approve -input=false

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -94,12 +94,28 @@ and the GitHub Actions secrets.
 
 ## Prerequisites
 
+> **HARD PREREQUISITE — the HCP workspace must exist before the `cloud {}`
+> block can be used.** The `cloud {}` block in `main.tf` points at HCP
+> Terraform org `wifihaven` / workspace `grafana`. That workspace is **not**
+> created by the CD pipeline — it is a one-time, operator-gated setup step
+> (see [One-time backend setup](#one-time-backend-setup--state-adoption-operator-gated)
+> below). If the workspace is missing, `terraform init` fails with
+> `Invalid workspace selection — Terraform failed to find workspace "grafana"
+> in organization wifihaven`, and **every** `master-grafana.yml` run on `main`
+> goes red at init (this was [#1440](https://github.com/wifihaven/wifihaven/issues/1440),
+> the gap left by the #1406 backend migration; #1357 did this for `cloudflare`).
+> Merging a `cloud {}` block before its workspace exists is therefore a
+> back-compat trap: create the workspace first, then merge the block.
+
 1. A Grafana Cloud stack exists (free tier is fine; see design §6.2) — one
    stack serves every environment. Ours is
    [`wifihaven.grafana.net`](https://wifihaven.grafana.net).
 2. A **Grafana service-account token** for the stack with dashboard write
    scope: Grafana Cloud → Administration → Service accounts → add token.
 3. Terraform ≥ 1.6 installed (`brew install terraform`).
+4. The **`grafana` HCP Terraform workspace** exists in org `wifihaven`,
+   Execution Mode = Local, no VCS attachment — see
+   [One-time backend setup](#one-time-backend-setup--state-adoption-operator-gated).
 
 ## CI / auto-deploy (the normal path)
 
@@ -141,12 +157,26 @@ the existing dashboards by uid** instead of creating duplicates, and after that
 first apply the state tracks all 7 so the **second apply is a no-op**. That is
 the structural reason there is no duplicate-dashboard churn.
 
-1. **Create the HCP workspace.** On https://app.terraform.io, in the existing
-   `wifihaven` org (the same org as `infra/cloudflare`), create a workspace
-   named `grafana`. Set its **Execution Mode = Local** (workspace → Settings →
-   General). Local mode matters: the apply must run on your machine / the runner
+1. **Create the HCP workspace.** In the existing `wifihaven` org (the same org
+   as `infra/cloudflare`), create a workspace named `grafana` with **Execution
+   Mode = Local** and **no VCS attachment** — mirror the `cloudflare` workspace
+   exactly. Local mode matters: the apply must run on your machine / the runner
    where the Grafana provider plugin and `grafana_auth` live, not remotely on
-   HCP.
+   HCP. **The CD pipeline does not create this** — until it exists, every
+   `master-grafana.yml` run on `main` fails at `terraform init` with `Invalid
+   workspace selection` (#1440).
+
+   Either via the **UI** (https://app.terraform.io → `wifihaven` → New workspace
+   → API-driven / CLI-driven → name `grafana` → Settings → General → Execution
+   Mode = Local), or via the **API** (mirrors `cloudflare`):
+
+   ```sh
+   curl -s -X POST \
+     -H "Authorization: Bearer $TF_API_TOKEN" \
+     -H "Content-Type: application/vnd.api+json" \
+     https://app.terraform.io/api/v2/organizations/wifihaven/workspaces \
+     -d '{"data":{"type":"workspaces","attributes":{"name":"grafana","execution-mode":"local","auto-apply":false}}}'
+   ```
 
 2. **Authenticate + point at the workspace:**
 


### PR DESCRIPTION
## What

Master Grafana CD on `main` was red on every push: `terraform init` failed with `Invalid workspace selection — Terraform failed to find workspace "grafana" in organization wifihaven`. The #1406 backend migration added a `cloud {}` block (org `wifihaven` / workspace `grafana`) to `infra/grafana` but the HCP Terraform workspace was never created — the one-time setup #1357 did for `cloudflare`.

**The missing workspace has now been created** (org `wifihaven`, workspace `grafana`, Execution Mode = Local, no VCS — mirrors `cloudflare`), so CD is green again. This PR is the **guardrail** so the same gap can't silently break `main` again:

- **`master-grafana.yml`** — wrap `terraform init` to detect the `Invalid workspace selection` failure and emit a clear `::error` pointing at the one-time backend setup, so a missing-workspace failure reads as a setup gap rather than an apply error.
- **`infra/grafana/README.md`** — document workspace creation as a **HARD prerequisite** of the `cloud {}` backend (a `cloud {}` block must not merge before its workspace exists), with both UI and API recipes.

## Verification (already done out-of-band)

- Workspace created via the TF Cloud API, mirroring `cloudflare` (`execution-mode: local`, no VCS).
- Re-ran the failed CD job → **green**. First apply: `7 added, 0 changed, 0 destroyed` (upsert-by-uid, no duplicate-dashboard churn).
- Re-ran again → **`No changes. ... 0 added, 0 changed, 0 destroyed`** (second apply is a no-op).
- `terraform state pull` from `infra/grafana` confirms the remote HCP backend (7 dashboards tracked).

Docs + workflow only; no Terraform/source behavior change. `actionlint` clean.

Closes #1440.