### PR TITLE
feat(#1433): show per-app time-used on profile/app rows even without a time limit

### DIFF
--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1554,6 +1554,63 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(ot.appName == "Other") &&
           assertTrue(ot.hosts.map(_.host.value).contains("google.com"))
       },
+      test("#1433: an app with usage but no time limit still returns its time-used") {
+        // The profile/app page surfaces today's time-used for every app, not
+        // just time-limited ones. An app assigned with mode=allowed (no daily
+        // cap) that saw traffic must come back with its proportional seconds so
+        // the row can render "Xm today" without a cap.
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
+          _           <- appRepo.setHosts(ytId, List(Hostname.unsafe("youtube.com")))
+          // Allowed, NOT time-limited: no daily cap configured for this app.
+          _           <- appRepo.upsertAssignment(ytId, kidsId, AppMode.Allowed, None, true)
+          start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                1000L,
+                1000L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/profiles/${kidsId.value}/usage-by-app?from=$today&to=$today")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[ProfileUsageByApp])
+          yt = out.apps.find(_.appName == "YouTube").get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(out.apps.exists(_.appName == "YouTube")) &&
+          assertTrue(yt.proportionalSeconds == 300L) &&
+          assertTrue(yt.presenceSeconds == 300L)
+      },
       test("#1161: traffic on FQDN subdomain attributes to apex-form app_hosts entry") {
         // App is registered with apex `khanacademy.org`, but the device actually
         // contacts `m.khanacademy.org`. Pre-fix the row falls into the synthetic

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1241,7 +1241,9 @@ describe('ProfilesPage — per-app usage bar in Apps section (#1061)', () => {
     expect(fill.className).toContain('bg-red-500')
   })
 
-  it('does not render the bar for an app without a daily limit', async () => {
+  // #1433 — a no-limit app no longer shows the used/cap progress bar
+  // (`-usage`), but it DOES surface today's plain time-used (`-used`).
+  it('does not render the cap bar for an app without a daily limit', async () => {
     (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeAllowed])
     ;(api.profiles.usageByApp as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       profileId: 1, profileName: 'Kids', from: '2026-05-26', to: '2026-05-26',
@@ -1257,6 +1259,81 @@ describe('ProfilesPage — per-app usage bar in Apps section (#1061)', () => {
     await user.click(screen.getByTestId('profile-apps-toggle-1'))
     await screen.findByTestId('app-row-50')
     expect(screen.queryByTestId('app-row-50-usage')).not.toBeInTheDocument()
+  })
+})
+
+// #1433 — every app row surfaces today's time-used, not just time-limited
+// ones. Limited apps keep the "used / cap" bar; no-limit apps show a plain
+// "Xm today" readout fed by the same per-app proportional minutes.
+describe('ProfilesPage — per-app time-used for no-limit apps (#1433)', () => {
+  const youtubeAllowed = {
+    app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '📺', createdAt: '2026-01-01' },
+    hosts: ['youtube.com'],
+    assignments: [
+      { id: 2, appId: 50, profileId: 1, mode: 'allowed' as const, dailyMinutes: null, exemptFromDaily: true },
+    ],
+  }
+  const tiktokBlocked = {
+    app: { id: 51, name: 'TikTok', slug: 'tiktok', templateId: null, icon: '🎵', createdAt: '2026-01-01' },
+    hosts: ['tiktok.com'],
+    assignments: [
+      { id: 3, appId: 51, profileId: 1, mode: 'blocked' as const, dailyMinutes: null, exemptFromDaily: true },
+    ],
+  }
+
+  it('renders "Xm today" with no cap for an allowed (no-limit) app', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeAllowed])
+    ;(api.profiles.usageByApp as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      profileId: 1, profileName: 'Kids', from: '2026-05-26', to: '2026-05-26',
+      apps: [{
+        appId: 50, appName: 'YouTube', appIcon: '📺', appIconType: 'emoji',
+        proportionalSeconds: 1380, presenceSeconds: 1380, hosts: [],
+      }],
+    })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(screen.getByTestId('profile-apps-toggle-1'))
+    // 1380s → 23m, shown as plain "23m today" with no "/ cap".
+    const used = await screen.findByTestId('app-row-50-used')
+    expect(used).toHaveTextContent('23m today')
+    expect(used.textContent).not.toContain('/')
+    // No progress-bar variant for a no-limit app.
+    expect(screen.queryByTestId('app-row-50-usage')).not.toBeInTheDocument()
+  })
+
+  it('surfaces time-used for a blocked app too', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([tiktokBlocked])
+    ;(api.profiles.usageByApp as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      profileId: 1, profileName: 'Kids', from: '2026-05-26', to: '2026-05-26',
+      apps: [{
+        appId: 51, appName: 'TikTok', appIcon: '🎵', appIconType: 'emoji',
+        proportionalSeconds: 300, presenceSeconds: 300, hosts: [],
+      }],
+    })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(screen.getByTestId('profile-apps-toggle-1'))
+    const used = await screen.findByTestId('app-row-51-used')
+    expect(used).toHaveTextContent('5m today')
+  })
+
+  it('omits the readout for a no-limit app with zero usage', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([youtubeAllowed])
+    ;(api.profiles.usageByApp as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      profileId: 1, profileName: 'Kids', from: '2026-05-26', to: '2026-05-26',
+      apps: [],
+    })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(screen.getByTestId('profile-apps-toggle-1'))
+    await screen.findByTestId('app-row-50')
+    expect(screen.queryByTestId('app-row-50-used')).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -1717,6 +1717,19 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
           </span>
         </div>
       )}
+      {/* #1433 — surface today's time-used even for apps without a daily
+          limit, so the operator has at-a-glance usage visibility regardless
+          of whether a limit is set. Plain "Xm today" text — no cap and no
+          progress bar (the bar above is reserved for time-limited apps).
+          Hidden until usage loads and only when there is some to show. */}
+      {!isTimeLimited && usedMins != null && usedMins > 0 && (
+        <div
+          data-testid={`app-row-${app.app.id}-used`}
+          className="text-xs font-mono text-brand-text"
+        >
+          {formatMins(usedMins)} today
+        </div>
+      )}
       {mode === 'time_limited' && (
         <label className="flex items-center gap-2 text-xs text-brand-text cursor-pointer select-none">
           <input


### PR DESCRIPTION
## Summary

Closes #1433.

Surfaces each app's **time used today** on the profile Apps subsection for **every** app, not just time-limited ones.

- **web** (`ProfilesPage.tsx`, `AppRow`): time-limited apps keep the existing "used / cap" progress bar; apps with no daily limit (Allow / Block) now render a plain `Xm today` readout (no cap, no bar) under the row. It's fed by the same per-app proportional minutes the bar already uses, so the number matches the screen-time view. Hidden until usage loads and only shown when there is usage to display.
- **API**: no production change needed — `GET /api/profiles/:id/usage-by-app` already returns every app that saw traffic regardless of whether a limit is configured (it reads presence rows from `traffic_reports` and attributes hosts to apps via `app_hosts`, with no filter on assignment/limit). This PR adds a feature test that locks that contract in.

The household-local day boundary is respected via the explicit `from`/`to` (today/today) the subsection already passes; the readout reuses the same `proportionalSeconds → minutes` figure as the time-limited bar, so it can't drift from the screen-time numbers.

## Implementation notes

- New testid `app-row-<id>-used` for the plain readout, kept distinct from `app-row-<id>-usage` (the time-limited progress bar) so the two render paths stay independently assertable. The bar remains absent for no-limit apps.

## Test plan

- **API feature test** (real embedded Postgres) — `UsageApiSpec`: an app assigned `mode=allowed` with traffic but no daily cap returns its proportional time-used in the usage-by-app payload. `mill api.test.testOnly wifihaven.api.feature.UsageApiSpec` → 35 passed.
- **web** — `ProfilesPage.test.tsx`: a no-limit (allowed) app row renders `23m today` with no `/ cap`, a blocked app also surfaces its used time, and the readout is omitted at zero usage. Verified red→green: with the `AppRow` change stashed, the two positive cases fail; with it, all 65 pass. `npx vitest run src/pages/ProfilesPage.test.tsx` (node 22) → 65 passed.
- `scalafmt --check` clean; web `type-check` and `lint` clean.

The two commits show the red (tests) → green (implementation) progression.
