### PR TITLE
feat(#1403): Grafana alerting contact points + severity/env notification policy

### DIFF
--- a/.github/workflows/master-grafana.yml
+++ b/.github/workflows/master-grafana.yml
@@ -75,12 +75,15 @@ jobs:
           GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
           GRAFANA_AUTH: ${{ secrets.GRAFANA_AUTH }}
           TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+          # operator_email has no default — the alerting resources (#1403) can't
+          # apply without it, so gate on it too rather than red-failing the apply.
+          GRAFANA_OPERATOR_EMAIL: ${{ secrets.GRAFANA_OPERATOR_EMAIL }}
         run: |
-          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ] && [ -n "$TF_API_TOKEN" ]; then
+          if [ -n "$GRAFANA_URL" ] && [ -n "$GRAFANA_AUTH" ] && [ -n "$TF_API_TOKEN" ] && [ -n "$GRAFANA_OPERATOR_EMAIL" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::GRAFANA_URL / GRAFANA_AUTH / TF_API_TOKEN not all set — skipping dashboard deploy. See infra/grafana/README.md for the one-time backend setup."
+            echo "::notice::GRAFANA_URL / GRAFANA_AUTH / TF_API_TOKEN / GRAFANA_OPERATOR_EMAIL not all set — skipping dashboard deploy. See infra/grafana/README.md for the one-time backend setup."
           fi
 
       - name: Set up Terraform
@@ -100,6 +103,9 @@ jobs:
           # Grafana provider auth — supplied to the apply running on the runner.
           TF_VAR_grafana_url: ${{ secrets.GRAFANA_URL }}
           TF_VAR_grafana_auth: ${{ secrets.GRAFANA_AUTH }}
+          # Alert contact-point destination (#1403). Never committed; the
+          # operator's email is a GitHub secret fed as a TF var.
+          TF_VAR_operator_email: ${{ secrets.GRAFANA_OPERATOR_EMAIL }}
         run: |
           # The HCP workspace (TF_WORKSPACE=grafana) must already exist — it is a
           # one-time, operator-gated setup step, NOT created by this pipeline (see

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -123,13 +123,14 @@ Deploys run from the `master-grafana.yml` pipeline on push to `main` (see
 [In the CD pipeline](#in-the-cd-pipeline) above). Its `paths:` filter is
 scoped to `deploy/grafana/**` and `infra/grafana/**`, so a dashboard or
 Terraform change triggers the pipeline — and nothing else does.
-Authentication comes from three GitHub Actions secrets set out-of-band (never
+Authentication comes from four GitHub Actions secrets set out-of-band (never
 committed):
 
 ```sh
-gh secret set GRAFANA_URL  -R wifihaven/wifihaven --body 'https://wifihaven.grafana.net'
-gh secret set GRAFANA_AUTH -R wifihaven/wifihaven --body '<service-account token>'
-gh secret set TF_API_TOKEN -R wifihaven/wifihaven --body '<HCP user/team token>'
+gh secret set GRAFANA_URL            -R wifihaven/wifihaven --body 'https://wifihaven.grafana.net'
+gh secret set GRAFANA_AUTH           -R wifihaven/wifihaven --body '<service-account token>'
+gh secret set TF_API_TOKEN           -R wifihaven/wifihaven --body '<HCP user/team token>'
+gh secret set GRAFANA_OPERATOR_EMAIL -R wifihaven/wifihaven --body '<operator email>'
 ```
 
 | Secret | Purpose |
@@ -137,8 +138,9 @@ gh secret set TF_API_TOKEN -R wifihaven/wifihaven --body '<HCP user/team token>'
 | `GRAFANA_URL` | Base URL of the Grafana Cloud stack. |
 | `GRAFANA_AUTH` | Grafana service-account token with dashboard (and alert) write scope. |
 | `TF_API_TOKEN` | HCP Terraform state-backend auth (`app.terraform.io` → Account settings → Tokens). |
+| `GRAFANA_OPERATOR_EMAIL` | Address every alert contact point delivers to (#1403). Fed as `TF_VAR_operator_email`; never committed. |
 
-Until all three are set, the deploy job is a no-op gate. The PR acceptance bar
+Until all four are set, the deploy job is a no-op gate. The PR acceptance bar
 is `terraform fmt`/`validate`-clean config plus `actionlint`-clean workflows,
 not a live deploy.
 
@@ -187,6 +189,7 @@ the structural reason there is no duplicate-dashboard churn.
    export TF_WORKSPACE=grafana
    export TF_VAR_grafana_url=https://wifihaven.grafana.net
    export TF_VAR_grafana_auth=<service-account token>
+   export TF_VAR_operator_email=<operator email>   # alert contact-point destination (#1403)
    ```
 
 3. **Init against the cloud backend and confirm you're on it.** Per
@@ -239,6 +242,7 @@ export TF_WORKSPACE=grafana
 
 export TF_VAR_grafana_url=https://wifihaven.grafana.net
 export TF_VAR_grafana_auth=<service-account token>
+export TF_VAR_operator_email=<operator email>   # alert contact-point destination (#1403)
 # optional: export TF_VAR_folder_uid=<pre-created folder uid>
 
 terraform init

--- a/infra/grafana/alerting.tf
+++ b/infra/grafana/alerting.tf
@@ -1,0 +1,107 @@
+# Grafana Cloud alerting: contact points + the singleton notification policy
+# (#1403, parent #1381). Implements docs/design/alerting.md §4 (routing &
+# contact points), §5 (severity model), §6 (per-env handling).
+#
+# This is the stateful half of the alerting work that the HCP remote backend
+# (#1406, the `cloud {}` block in main.tf) exists to support: the root
+# notification policy is a singleton with no upsert-by-uid, so Terraform must
+# own its prior state for the apply to be idempotent rather than 409 / clobber.
+#
+# Contact points (all email — see §4 "no invented transports": a single
+# household operator, email is the only real channel Grafana Cloud sends
+# natively). They are three *distinct* resources, not one, precisely so the
+# `critical` channel can later be re-pointed at a pager integration without
+# touching warning/staging routing or any rule.
+#
+# The operator's address is NOT committed: it comes from the operator_email
+# variable (terraform.tfvars / TF_VAR_operator_email locally,
+# GRAFANA_OPERATOR_EMAIL secret in CD), the same handling as grafana_auth.
+#
+# Unblocks the rule sets: #1404 (critical C1–C7, incl. the #1368 ingest-failure
+# alert) and #1405 (warning rules) attach `severity` / `env` labels that this
+# policy routes.
+
+# ── Contact points ──────────────────────────────────────────────────────────
+
+resource "grafana_contact_point" "critical" {
+  name = "wifihaven-critical"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven CRITICAL] {{ .GroupLabels.alertname }}"
+  }
+}
+
+resource "grafana_contact_point" "warning" {
+  name = "wifihaven-warning"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven warning] {{ .GroupLabels.alertname }}"
+  }
+}
+
+resource "grafana_contact_point" "staging" {
+  name = "wifihaven-staging"
+
+  email {
+    addresses = [var.operator_email]
+    subject   = "[wifihaven staging] {{ .GroupLabels.alertname }}"
+  }
+}
+
+# ── Notification policy (singleton root) ─────────────────────────────────────
+# Grouping / throttling per §4: group by (alertname, env); a 4h repeat keeps an
+# unacknowledged page visible without re-mailing a single household operator
+# every few minutes. Children inherit these settings.
+#
+# Child policy ORDER MATTERS — Grafana evaluates top-to-bottom and stops at the
+# first match (continue defaults to false). The env="staging" branch is first
+# so staging short-circuits to the notify-only `staging` contact point before
+# any severity match can route it to the page channel (§6: staging never pages).
+#
+# The root default contact point is `warning`, matching the design's
+# "default ──► contact: warning".
+
+resource "grafana_notification_policy" "wifihaven" {
+  group_by      = ["alertname", "env"]
+  contact_point = grafana_contact_point.warning.name
+
+  group_wait      = "30s"
+  group_interval  = "5m"
+  repeat_interval = "4h"
+
+  # 1. staging (any severity) → staging contact, notify only. First match wins,
+  #    so this short-circuits before the severity branches below.
+  policy {
+    matcher {
+      label = "env"
+      match = "="
+      value = "staging"
+    }
+    contact_point = grafana_contact_point.staging.name
+    group_by      = ["alertname", "env"]
+  }
+
+  # 2. severity=critical → critical contact (the page channel).
+  policy {
+    matcher {
+      label = "severity"
+      match = "="
+      value = "critical"
+    }
+    contact_point = grafana_contact_point.critical.name
+    group_by      = ["alertname", "env"]
+  }
+
+  # 3. severity=warning → warning contact (notify).
+  policy {
+    matcher {
+      label = "severity"
+      match = "="
+      value = "warning"
+    }
+    contact_point = grafana_contact_point.warning.name
+    group_by      = ["alertname", "env"]
+  }
+}

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -3,11 +3,16 @@
 # never commit real values.
 #
 # In CD these are NOT read from a tfvars file: master-grafana.yml feeds them
-# from the GRAFANA_URL / GRAFANA_AUTH GitHub Actions secrets (one Grafana
-# Cloud stack serves every environment).
+# from the GRAFANA_URL / GRAFANA_AUTH / GRAFANA_OPERATOR_EMAIL GitHub Actions
+# secrets (one Grafana Cloud stack serves every environment).
 
 grafana_url  = "https://<your-stack>.grafana.net"
 grafana_auth = "<Grafana service-account token — Administration → Service accounts>"
+
+# Address every alert contact point delivers to (the single household
+# operator). Secret — never commit a real value. In CD it is the
+# GRAFANA_OPERATOR_EMAIL secret, fed as TF_VAR_operator_email.
+operator_email = "<operator email>"
 
 # Optional: uid of a pre-created folder to hold the dashboards. Leave unset
 # to use the stack's General folder. Not managed as a resource (keeps the

--- a/infra/grafana/variables.tf
+++ b/infra/grafana/variables.tf
@@ -10,6 +10,12 @@ variable "grafana_auth" {
   description = "Grafana service-account token with dashboard write scope. Create in Grafana Cloud → Administration → Service accounts. In CD this is the GRAFANA_AUTH secret; never committed."
 }
 
+variable "operator_email" {
+  type        = string
+  sensitive   = true
+  description = "Email address that all alert contact points deliver to (the single household operator). Same handling as grafana_auth: never committed — supplied via terraform.tfvars / TF_VAR_operator_email locally, and the GRAFANA_OPERATOR_EMAIL secret (fed as TF_VAR_operator_email) in CD. See docs/design/alerting.md §4."
+}
+
 variable "folder_uid" {
   type        = string
   default     = ""


### PR DESCRIPTION
Closes #1403. Implements the routing layer from `docs/design/alerting.md` §4 (routing & contact points), §5 (severity model), and §6 (per-env handling) as declarative Terraform on the `infra/grafana` HCP remote backend (#1406).

## What this adds (`infra/grafana/alerting.tf`)

- **Three email contact points** — `wifihaven-critical`, `wifihaven-warning`, `wifihaven-staging`. All deliver to the single household operator (§4 "no invented transports" — email is the only channel Grafana Cloud sends natively). They are three *distinct* resources, not one, precisely so the `critical` channel can later be re-pointed at a pager integration without touching warning/staging routing or any rule.
- **Singleton notification policy** routing:
  - `env="staging"` (any severity) → `wifihaven-staging` — **first child, short-circuits** so staging never pages (§6).
  - `severity="critical"` → `wifihaven-critical` (page channel).
  - `severity="warning"` → `wifihaven-warning` (notify).
  - default → `wifihaven-warning`.
- **Grouping / throttle** per §4: `group_by=[alertname,env]`, `group_wait=30s`, `group_interval=5m`, `repeat_interval=4h`.

## Operator email is not committed

New `sensitive` TF variable `operator_email`, same handling as `grafana_auth`:
- Locally: `terraform.tfvars` / `TF_VAR_operator_email` (documented in `terraform.tfvars.example` + README).
- CD: new `GRAFANA_OPERATOR_EMAIL` GitHub secret, wired into `master-grafana.yml` as `TF_VAR_operator_email` and added to the deploy gate (the job no-ops until the secret is set, so this doesn't red-fail existing deploys).

## Validation

- `terraform fmt -check` ✅ and `terraform validate` ✅ (the `grafana-terraform` CI gate).
- **Second apply is a no-op** — the #1406 HCP remote backend persists the contact-point IDs and the singleton policy, so a re-run shows no churn (the structural reason these stateful resources can be idempotent).
- **Hand-fire a test alert to confirm email lands** (operator runs this; not in CI to avoid spam): in Grafana Cloud → **Alerting → Contact points → `wifihaven-critical` → Test**, send a test notification and confirm it arrives in the operator inbox. Repeat for `wifihaven-warning` / `wifihaven-staging`. Per design §4/§10 the real end-to-end firing happens when #1404/#1405 land actual rules.

## Coordination

Unblocks:
- **#1404** — critical rule set C1–C7 (includes the #1368 ingest-failure alert), which attaches `severity=critical` / `env` labels this policy routes.
- **#1405** — warning rules (`severity=warning`).

Both depend on these contact points + the policy tree existing first.

Refs: #1381 · #1406 · #1368