### PR TITLE
db(#1378): V51 migration for per-app schedule rules (schema-only)

### DIFF
--- a/api/resources/db/migration/V51__app_policy_schedule_rules.sql
+++ b/api/resources/db/migration/V51__app_policy_schedule_rules.sql
@@ -1,0 +1,73 @@
+-- V51__app_policy_schedule_rules.sql
+-- #1378 (per-app schedules epic #1376): let an individual app carry its own
+-- time window, layered on top of the profile's general schedule — "allowed
+-- during W" (reachable even during profile downtime) or "blocked during W"
+-- (dropped even when the profile is otherwise unrestricted). See the merged
+-- design docs/design/per-app-schedules.md §3.3.
+--
+-- This is a SCHEMA-ONLY migration (per the migration-isolation rule in
+-- CLAUDE.md): it ships with no source and no tests. The Models / repo / route /
+-- PolicyService evaluation that READ this table land in the follow-up
+-- API-adoption PR (#1379). Until then the table is inert — nothing reads
+-- `app_policy_schedule_rules`, so there is NO functional change from this
+-- migration alone. That inertness is exactly what makes it backward-compatible
+-- with image-(N-1): the existing api.test suite applies this migration against
+-- the currently-deployed code and passes unchanged (the isolation gate).
+--
+-- ── Shape: (assignment, named-schedule, mode), identical to V50's profile rules
+-- This is the EXACT same shape as V50's `profile_schedule_rules`, but for apps:
+-- it FKs an `app_policy_assignments` row (the per-(app, profile) policy row from
+-- V28) instead of a `profiles` row, and references the #1069 household-scoped
+-- `named_schedules` table (V50) — NOT the V1 profile-scoped `schedules` table
+-- (the name collision and why named_schedules exists are documented in V50).
+-- Profiles and apps deliberately converge on one (entity, schedule, mode) model
+-- (design §3.3). A schedule's day/time math lives entirely in its
+-- `schedule_windows` rows (V50), so this table carries no inline windows — a
+-- compound schedule is just multiple windows on the referenced named schedule.
+--
+-- ── Many rules per app, each block- OR allow-mode ──────────────────────────
+-- An app may attach more than one (schedule, mode) pair to a single assignment
+-- (e.g. "allowed during Bedtime" AND "blocked during Homework"), so this is a
+-- child table, not a single `app_policy_assignments.schedule_id` column — the
+-- single-reference column was deliberately rejected in V50 (can't carry a mode,
+-- caps at one schedule). Each row's mode decides what an active window does:
+--   * allowed_during — while any window of the schedule is active, the app's
+--     hosts are carved into extraAllowed, beating the profile's whole-MAC block
+--     (#421 allow-beats-block) — the headline "reachable during bedtime" case.
+--   * blocked_during — while active, the app's hosts go to extraBlocked, even
+--     when the profile is otherwise unrestricted.
+-- The server-side collapse into the existing extraAllowed/extraBlocked wire
+-- fields (no snapshot/router change) lives in PolicyService — design §4.
+--
+-- ── ON DELETE CASCADE on both FKs ─────────────────────────────────────────
+-- Deleting an assignment (or a named schedule) just drops its rule rows — the
+-- rule's effect simply stops applying, no orphan. UNIQUE(assignment_id,
+-- schedule_id, mode) lets a schedule be attached once per mode and prevents
+-- exact dupes (attaching the same schedule as both modes is nonsensical but
+-- harmless).
+--
+-- ── Prod-volume safety ─────────────────────────────────────────────────────
+-- Bounded metadata surface — rows scale with apps × profiles × rules (tens of
+-- rows), NOT with event volume. Not an unbounded-growth table (traffic_reports,
+-- connection_events, block_events, rollups). Index builds are on an empty
+-- surface. Safe on the Flyway startup critical path even at full prod volume.
+
+CREATE TABLE app_policy_schedule_rules (
+  id             BIGSERIAL PRIMARY KEY,
+  assignment_id  BIGINT NOT NULL
+                   REFERENCES app_policy_assignments(id) ON DELETE CASCADE,
+  schedule_id    BIGINT NOT NULL
+                   REFERENCES named_schedules(id) ON DELETE CASCADE,  -- #1069 named schedule
+  mode           TEXT NOT NULL
+                   CHECK (mode IN ('allowed_during', 'blocked_during')),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (assignment_id, schedule_id, mode)
+);
+-- The snapshot builder / decide fallback probe by assignment (per-app fold over
+-- an assignment's rules — design §4.1); the SPA / cascade check probes by
+-- schedule ("what references this named schedule before I delete it"). Mirrors
+-- the two indexes V50 added on profile_schedule_rules.
+CREATE INDEX idx_app_policy_schedule_rules_assignment
+  ON app_policy_schedule_rules(assignment_id);
+CREATE INDEX idx_app_policy_schedule_rules_schedule
+  ON app_policy_schedule_rules(schedule_id);

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -141,6 +141,13 @@ created directly — no deferred-constraint dance.
 New migration (next free version after #1069's `V50`, e.g.
 `V51__app_policy_schedule_rules.sql`, sequenced *after* #1069's migration):
 
+> **Landed (`V51__app_policy_schedule_rules.sql`, #1378).** The table below
+> ships as the schema-only foundation PR, FKing `app_policy_assignments(id)`
+> (V28) and the #1069 `named_schedules(id)` (V50). It mirrors V50's
+> `profile_schedule_rules` exactly — same `(entity, schedule, mode)` shape, same
+> two indexes (by assignment for the per-app fold, by schedule for the
+> cascade-delete probe). Inert until #1379 adds the PolicyService evaluation.
+
 ```sql
 CREATE TABLE app_policy_schedule_rules (
   id             BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## What

Adds the `app_policy_schedule_rules` table — the schema-only foundation for the per-app schedules epic (#1376), per the merged design [`docs/design/per-app-schedules.md` §3.3](docs/design/per-app-schedules.md).

A row attaches a `(app-assignment, named-schedule, mode)` rule to an app, letting it carry an **allowed during** / **blocked during** window layered on top of the profile's general schedule:

- `allowed_during` — app stays reachable while the window is active, even during profile downtime (headline: educational app reachable during bedtime).
- `blocked_during` — app is dropped while the window is active, even when the profile is otherwise unrestricted.

```sql
CREATE TABLE app_policy_schedule_rules (
  id             BIGSERIAL PRIMARY KEY,
  assignment_id  BIGINT NOT NULL REFERENCES app_policy_assignments(id) ON DELETE CASCADE,
  schedule_id    BIGINT NOT NULL REFERENCES named_schedules(id) ON DELETE CASCADE,
  mode           TEXT NOT NULL CHECK (mode IN ('allowed_during','blocked_during')),
  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  UNIQUE (assignment_id, schedule_id, mode)
);
CREATE INDEX idx_app_policy_schedule_rules_assignment ON app_policy_schedule_rules(assignment_id);
CREATE INDEX idx_app_policy_schedule_rules_schedule   ON app_policy_schedule_rules(schedule_id);
```

## Design fidelity

- FK targets exist on `main`: `app_policy_assignments(id)` (V28) and the #1069 household-scoped `named_schedules(id)` (V50). The design's note about tracking #1069's final table name resolves to **`named_schedules`**, not the V1 profile-scoped `schedules` (V50 documents the name collision).
- This is the **exact same shape** as V50's `profile_schedule_rules` — profiles and apps converge on one `(entity, schedule, mode)` model. No inline windows: day/time math lives in the referenced schedule's `schedule_windows` rows.
- Both indexes mirror V50: by `assignment_id` for the per-app fold the PolicyService eval (#1379) will do, by `schedule_id` for the cascade-delete / reverse-reference probe — avoiding the #1254/V38-class index miss.

## Migration-isolation (AGENTS.md)

Schema-only PR: **only** the `V51__….sql` plus the design-doc status note. No source, no tests, no fixtures — confirmed by `check-migration-isolation.sh` (passes). The runtime evaluation, repo methods, models, and tests land in the follow-up **#1379**.

## Prod-volume safety

Bounded metadata table (apps × profiles × rules — tens of rows), not a growth table. Index builds on an empty surface; metadata-only, safe on the Flyway startup critical path even at full prod volume.

Closes #1378. Foundation for #1379.