### PR TITLE
test(web): de-flake debounced-autosave PATCH tests (#1439)

### DIFF
--- a/web/src/pages/AdminPage.test.tsx
+++ b/web/src/pages/AdminPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('@/api/client', () => ({
@@ -69,29 +69,33 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
   })
 
   it('editing the reset time fires a debounced PATCH {dailyResetTime}', async () => {
-    // Let the initial async `api.household.get()` load fully settle under real
-    // timers BEFORE switching to fake timers. Enabling fake timers up front
-    // makes `findByTestId`'s internal waitFor resolve while a load-driven React
-    // update is still pending, and the next `fireEvent.change` is clobbered by
-    // that unflushed resync — so the controlled input never reaches '06:00' and
-    // the debounce never fires (#1354). Fake timers are only needed for the
-    // deterministic debounce window, so we scope them to it.
+    // Real timers + waitFor, matching the non-flaky tz/enabled/policy sibling
+    // tests below — no fake-timer juggling. The previous fake-timer version
+    // flaked (#1439); the real culprit was a render race, not the clock:
+    // `findByTestId` resolves the moment the card's input commits, which under
+    // CI load can be BEFORE the card's mount passive effects run. One of those
+    // is the value-resync `useEffect(() => setTime(value.dailyResetTime))`. If
+    // it fires AFTER our `fireEvent.change`, it reverts the input from '06:00'
+    // back to '00:00' and the debounce never commits — PATCH is never sent.
+    // `await act` below drains those pending mount effects so they can't
+    // clobber the change.
     render(<AdminPage />)
     const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      // Set the value atomically: typing a `<input type="time">` char-by-char
-      // under fake timers lets the 700ms debounce fire on a transient partial
-      // value (e.g. '00:59') before the full '06:00' lands. fireEvent.change
-      // gives the debounce a single, final value to latch.
-      fireEvent.change(time, { target: { value: '06:00' } })
-      expect(api.household.patch).not.toHaveBeenCalled()
-      await vi.advanceTimersByTimeAsync(700)
+    // Drain the card's pending mount effects (the value-resync) before
+    // interacting, so they run now (a no-op) rather than after our change.
+    await act(async () => {})
 
-      expect(api.household.patch).toHaveBeenCalledWith({ dailyResetTime: '06:00' })
-    } finally {
-      vi.useRealTimers()
-    }
+    // Set the value atomically: typing a `<input type="time">` char-by-char
+    // lets the debounce fire on a transient partial value (e.g. '00:59') before
+    // the full '06:00' lands. fireEvent.change gives the debounce one final
+    // value to latch.
+    fireEvent.change(time, { target: { value: '06:00' } })
+    // The 500ms debounce hasn't elapsed yet, so no save synchronously.
+    expect(api.household.patch).not.toHaveBeenCalled()
+
+    await waitFor(() =>
+      expect(api.household.patch).toHaveBeenCalledWith({ dailyResetTime: '06:00' }),
+    )
   })
 
   it('changing the timezone fires PATCH {dailyResetTz}', async () => {
@@ -111,25 +115,21 @@ describe('AdminPage — daily reset autosave (#1002)', () => {
     (api.household.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new Error('boom from server'),
     )
-    // Settle the initial load under real timers before enabling fake timers —
-    // see the reset-time test for why (#1354).
+    // Real timers + waitFor + an `act` drain of the card's mount effects — see
+    // the reset-time test for why the fake-timer version flaked (#1439).
+    const user = userEvent.setup()
     render(<AdminPage />)
     const time = await screen.findByTestId('household-reset-time') as HTMLInputElement
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      fireEvent.change(time, { target: { value: '06:00' } })
-      await vi.advanceTimersByTimeAsync(700)
+    await act(async () => {})
 
-      const status = screen.getByTestId('household-save-status')
-      await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
-      expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('06:00')
+    fireEvent.change(time, { target: { value: '06:00' } })
 
-      await user.click(screen.getByTestId('household-save-status-retry'))
-      await waitFor(() => expect(api.household.patch).toHaveBeenCalledTimes(2))
-    } finally {
-      vi.useRealTimers()
-    }
+    const status = screen.getByTestId('household-save-status')
+    await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
+    expect((screen.getByTestId('household-reset-time') as HTMLInputElement).value).toBe('06:00')
+
+    await user.click(screen.getByTestId('household-save-status-retry'))
+    await waitFor(() => expect(api.household.patch).toHaveBeenCalledTimes(2))
   })
 })
 
@@ -156,21 +156,20 @@ describe('AdminPage — heartbeat filter autosave (#1002)', () => {
   })
 
   it('editing the bytes threshold fires PATCH {heartbeatFilter:{bytesThreshold}}', async () => {
-    // Settle the initial load under real timers before enabling fake timers —
-    // see the reset-time test for why (#1354).
+    // Real timers + waitFor + an `act` drain of the card's mount effects — see
+    // the reset-time test for why the fake-timer version flaked (#1439).
     render(<AdminPage />)
     const bytes = await screen.findByTestId('heartbeat-filter-bytes') as HTMLInputElement
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    try {
-      fireEvent.change(bytes, { target: { value: '8192' } })
-      await vi.advanceTimersByTimeAsync(700)
+    await act(async () => {})
 
+    fireEvent.change(bytes, { target: { value: '8192' } })
+    expect(api.household.patch).not.toHaveBeenCalled()
+
+    await waitFor(() =>
       expect(api.household.patch).toHaveBeenCalledWith({
         heartbeatFilter: { bytesThreshold: 8192 },
-      })
-    } finally {
-      vi.useRealTimers()
-    }
+      }),
+    )
   })
 })
 

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import type { Device, ProfileDetail, ProfileTimeSummary, User } from '@/types/api'
@@ -541,82 +541,84 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
     expect(within(sub).getByTestId('profile-time-overlap-sum-1')).toBeChecked()
   })
 
+  // Real timers + waitFor throughout (no fake-timer juggling). These debounced
+  // autosave tests previously used `vi.useFakeTimers({ shouldAdvanceTime })`,
+  // which flaked (#1439): the time-limit input's mount value-resync
+  // `useEffect(() => setX(value.x))` can run AFTER our change (its passive
+  // effect hadn't flushed when the element was found under CI load), reverting
+  // the input so the debounce never commits and the PUT is never sent.
+  // `await act` drains those pending mount effects before we interact; `waitFor`
+  // then polls for the real-clock debounce.
   it('autosaves the daily cap after debounce — single PUT, no Save button', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      renderPage()
-      const kidsCard = await screen.findByTestId('profile-card-1')
-      await expand(1, user)
-      await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
 
-      const input = within(kidsCard).getByTestId('profile-time-limit-1')
-      // Set atomically: char-by-char typing under fake timers lets the 700ms
-      // debounce fire on a transient partial value, producing extra PUTs.
-      fireEvent.change(input, { target: { value: '90' } })
+    const input = within(kidsCard).getByTestId('profile-time-limit-1')
+    // Drain the input's pending mount effects (value-resync) before interacting.
+    await act(async () => {})
 
-      // Pre-debounce: no save yet.
-      expect(api.profiles.update).not.toHaveBeenCalled()
+    // Set atomically: char-by-char typing lets the debounce fire on a transient
+    // partial value, producing extra PUTs. fireEvent.change gives one value.
+    fireEvent.change(input, { target: { value: '90' } })
 
-      await vi.advanceTimersByTimeAsync(700)
+    // Pre-debounce: no save yet.
+    expect(api.profiles.update).not.toHaveBeenCalled()
 
+    await waitFor(() => {
       expect(api.profiles.update).toHaveBeenCalledTimes(1)
       expect(api.profiles.update).toHaveBeenLastCalledWith(
         1,
         expect.objectContaining({ timeLimit: 90, name: 'Kids' }),
       )
+    })
 
-      // "Saved" indicator surfaces after the PUT resolves.
-      await waitFor(() => {
-        const status = within(kidsCard).getByTestId('profile-time-status-1')
-        expect(status).toHaveAttribute('data-status', 'saved')
-        expect(status).toHaveTextContent('Saved')
-      })
-    } finally {
-      vi.useRealTimers()
-    }
+    // "Saved" indicator surfaces after the PUT resolves.
+    await waitFor(() => {
+      const status = within(kidsCard).getByTestId('profile-time-status-1')
+      expect(status).toHaveAttribute('data-status', 'saved')
+      expect(status).toHaveTextContent('Saved')
+    })
   })
 
   it('autosaves the cross-device overlap toggle', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      renderPage()
-      const kidsCard = await screen.findByTestId('profile-card-1')
-      await expand(1, user)
-      await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
+    await act(async () => {})
 
-      await user.click(within(kidsCard).getByTestId('profile-time-overlap-dedup-1'))
-      await vi.advanceTimersByTimeAsync(700)
+    await user.click(within(kidsCard).getByTestId('profile-time-overlap-dedup-1'))
 
+    // Poll for the debounced PUT — see the daily-cap test (#1439).
+    await waitFor(() =>
       expect(api.profiles.update).toHaveBeenLastCalledWith(
         1,
         expect.objectContaining({ crossDeviceOverlapMode: 'dedup' }),
-      )
-    } finally {
-      vi.useRealTimers()
-    }
+      ),
+    )
   })
 
   it('clearing the daily cap sends timeLimit:null', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      renderPage()
-      const kidsCard = await screen.findByTestId('profile-card-1')
-      await expand(1, user)
-      await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(within(kidsCard).getByTestId('profile-time-toggle-1'))
+    await act(async () => {})
 
-      await user.clear(within(kidsCard).getByTestId('profile-time-limit-1'))
-      await vi.advanceTimersByTimeAsync(700)
+    await user.clear(within(kidsCard).getByTestId('profile-time-limit-1'))
 
+    // Poll for the debounced PUT — see the daily-cap test (#1439).
+    await waitFor(() =>
       expect(api.profiles.update).toHaveBeenLastCalledWith(
         1,
         expect.objectContaining({ timeLimit: null }),
-      )
-    } finally {
-      vi.useRealTimers()
-    }
+      ),
+    )
   })
 
   it('non-admins see read-only subsection — no editable inputs', async () => {

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { ProfileDetail, User } from '@/types/api'
 
@@ -119,88 +119,87 @@ describe('UsersPage — inline autosave edit (#1001)', () => {
     expect(within(editor).queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument()
   })
 
+  // Real timers + waitFor throughout (no fake-timer juggling). The debounced
+  // autosave tests previously used `vi.useFakeTimers({ shouldAdvanceTime })`,
+  // which flaked (#1439): `findByTestId` resolves the moment the editor input
+  // commits — under CI load that can be BEFORE the editor's mount passive
+  // effects run, including the value-resync `useEffect(() => setX(value.x))`.
+  // If that resync fires AFTER our change it reverts the input and the debounce
+  // never commits, so the PATCH is never sent. `await act` drains those pending
+  // mount effects before we interact; `waitFor` then polls for the real-clock
+  // debounce to fire.
   it('renaming fires a debounced PATCH {username}', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      render(<UsersPage />)
-      await screen.findByText('bob')
-      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
-      const editor = await screen.findByTestId('user-editor-11')
-      const input = within(editor).getByTestId('user-name-input-11')
+    const user = userEvent.setup()
+    render(<UsersPage />)
+    await screen.findByText('bob')
+    await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+    const editor = await screen.findByTestId('user-editor-11')
+    const input = within(editor).getByTestId('user-name-input-11')
+    // Drain the editor's pending mount effects (the value-resync) before
+    // interacting, so they can't revert the change after it lands.
+    await act(async () => {})
 
-      // Set atomically: char-by-char typing under fake timers lets the 700ms
-      // debounce fire on a transient partial value, producing extra PATCHes.
-      fireEvent.change(input, { target: { value: 'bobby' } })
-      expect(api.users.patch).not.toHaveBeenCalled()
-      await vi.advanceTimersByTimeAsync(700)
+    // Set atomically: char-by-char typing lets the debounce fire on a transient
+    // partial value, producing extra PATCHes. fireEvent.change gives one value.
+    fireEvent.change(input, { target: { value: 'bobby' } })
+    expect(api.users.patch).not.toHaveBeenCalled()
 
-      expect(api.users.patch).toHaveBeenCalledWith(11, { username: 'bobby' })
-    } finally {
-      vi.useRealTimers()
-    }
+    await waitFor(() =>
+      expect(api.users.patch).toHaveBeenCalledWith(11, { username: 'bobby' }),
+    )
   })
 
   it('changing role fires PATCH {role}', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      render(<UsersPage />)
-      await screen.findByText('bob')
-      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
-      const editor = await screen.findByTestId('user-editor-11')
+    const user = userEvent.setup()
+    render(<UsersPage />)
+    await screen.findByText('bob')
+    await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+    const editor = await screen.findByTestId('user-editor-11')
+    await act(async () => {})
 
-      await user.click(within(editor).getByRole('button', { name: 'adult' }))
-      await vi.advanceTimersByTimeAsync(700)
+    await user.click(within(editor).getByRole('button', { name: 'adult' }))
 
-      expect(api.users.patch).toHaveBeenCalledWith(11, { role: 'adult' })
-    } finally {
-      vi.useRealTimers()
-    }
+    // Poll for the debounced PATCH — see the rename test (#1439).
+    await waitFor(() =>
+      expect(api.users.patch).toHaveBeenCalledWith(11, { role: 'adult' }),
+    )
   })
 
   it('toggling a profile fires PATCH {profileIds} with full-replace semantics', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      render(<UsersPage />)
-      await screen.findByText('bob')
-      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
-      const editor = await screen.findByTestId('user-editor-11')
+    const user = userEvent.setup()
+    render(<UsersPage />)
+    await screen.findByText('bob')
+    await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+    const editor = await screen.findByTestId('user-editor-11')
+    await act(async () => {})
 
-      // bob currently has Kids (1); add Adults (2)
-      await user.click(within(editor).getByRole('button', { name: 'Adults' }))
-      await vi.advanceTimersByTimeAsync(700)
+    // bob currently has Kids (1); add Adults (2)
+    await user.click(within(editor).getByRole('button', { name: 'Adults' }))
 
-      expect(api.users.patch).toHaveBeenCalledWith(11, { profileIds: [1, 2] })
-    } finally {
-      vi.useRealTimers()
-    }
+    // Poll for the debounced PATCH — see the rename test (#1439).
+    await waitFor(() =>
+      expect(api.users.patch).toHaveBeenCalledWith(11, { profileIds: [1, 2] }),
+    )
   })
 
   it('PATCH failure surfaces inline error + Retry; dirty value retained; Retry re-sends', async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
-    try {
-      (api.users.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
-      render(<UsersPage />)
-      await screen.findByText('bob')
-      await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
-      const editor = await screen.findByTestId('user-editor-11')
-      const input = within(editor).getByTestId('user-name-input-11')
+    (api.users.patch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
+    const user = userEvent.setup()
+    render(<UsersPage />)
+    await screen.findByText('bob')
+    await user.click(within(screen.getByTestId('user-row-11')).getByRole('button', { name: /^edit$/i }))
+    const editor = await screen.findByTestId('user-editor-11')
+    const input = within(editor).getByTestId('user-name-input-11')
+    await act(async () => {})
 
-      fireEvent.change(input, { target: { value: 'bobby' } })
-      await vi.advanceTimersByTimeAsync(700)
+    fireEvent.change(input, { target: { value: 'bobby' } })
 
-      const status = within(editor).getByTestId('user-save-status-11')
-      await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
-      expect(input).toHaveValue('bobby')
+    const status = within(editor).getByTestId('user-save-status-11')
+    await waitFor(() => expect(status).toHaveAttribute('data-status', 'error'))
+    expect(input).toHaveValue('bobby')
 
-      await user.click(within(editor).getByTestId('user-save-status-11-retry'))
-      await waitFor(() => expect(api.users.patch).toHaveBeenCalledTimes(2))
-    } finally {
-      vi.useRealTimers()
-    }
+    await user.click(within(editor).getByTestId('user-save-status-11-retry'))
+    await waitFor(() => expect(api.users.patch).toHaveBeenCalledTimes(2))
   })
 })
 


### PR DESCRIPTION
Fixes #1439.

## The flake
`AdminPage.test.tsx` → "editing the reset time fires a debounced PATCH {dailyResetTime}" failed intermittently in CI with `expected "vi.fn()" to be called with arguments: [ { dailyResetTime: '06:00' } ]`.

## Root cause — a render race, not the debounce clock
`findByTestId` resolves the moment the editor input commits to the DOM. Under CI load that can happen **before** the card's mount passive effects run — including the value-resync `useEffect(() => setX(value.x))`. When that resync fires **after** the test's `fireEvent.change`, it reverts the controlled input back to its loaded value, so the debounce sees the value return to baseline and **never commits** — the PATCH is never sent.

Instrumenting a failing run confirmed it directly: on failure, `patch.mock.calls === []` and the input value had reverted to `00:00`.

The prior `vi.useFakeTimers({ shouldAdvanceTime: true })` setup made it worse by coupling the fake clock to wall-clock time and firing the debounce outside `act` at uncontrolled moments.

## Fix
Drain the pending mount effects with `await act(async () => {})` before interacting, then drive the debounce on **real timers** and poll the assertion with `waitFor` — the pattern the non-flaky sibling autosave tests (tz / enabled / policy) already use. No `--retry` papering-over; the race is removed at the source.

Hardened the same pattern across **all** debounced-autosave tests flagged in the failing run:
- `AdminPage.test.tsx` (#1002) — reset-time, bytes-threshold, PATCH-failure/retry
- `UsersPage.test.tsx` (#1001) — rename, role, profile toggle, PATCH-failure/retry
- `ProfilesPage.test.tsx` — daily-cap, overlap toggle, clear-cap

Test files only — no production source touched.

## Proof (loop under heavy CPU contention)
The flake reproduced reliably under CPU contention before the fix.

| | Before fix | After fix |
|---|---|---|
| reset-time test, isolated | 1/40, then 2/80, up to 5/80 failed | **0 / 100** |
| all three files together | 2/50 failed | **0 / 60** |

Also green: `npm run type-check`, `npm run lint`, and the three files under normal `vitest run`.