### PR TITLE
feat(#1320): global policy management + audit view + per-profile default-deny toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,23 @@ present, **replaces** the profile rules entirely (it is not a merge). The
 agent resolves device → effective rules once at apply time, then enforcement
 is purely per-MAC. **The enforcement pipeline never sees profiles.**
 
+> **Authored policy has two tiers only: global and profile. There is NO
+> per-device override authoring surface, and we are not adding one (decided
+> 2026-06; [#1452](https://github.com/wifihaven/wifihaven/issues/1452) closed
+> as won't-do).** The `DevicePolicy.rules` override above is a *wire mechanism*,
+> not a feature: the only thing that populates an inline `rules` today is the
+> server-side **unmanaged-MAC block** path (a device with no `profileId` under
+> a `block` household policy). A managed device always inherits its profile's
+> resolved `BlockRules` (`rules = None` on the wire). Operators express policy
+> by editing **global** rules and **profile** rules and assigning devices to
+> profiles — full stop. So: do **not** add a `devices.rules` column, repo
+> method, route, `Device.rules` field, or SPA editor for per-device overrides;
+> do **not** call the `rules` field a user-facing "device override" in docs or
+> UI. The override **wire capability** stays (it is additive, already used by
+> the unmanaged path, and removing it would be a breaking wire change) — but it
+> is off-limits as an authoring concept. See `docs/architecture.md` §0.2
+> "Scope decision (2026-06)".
+
 New policy concepts (a new schedule type, a new failover behaviour, a new
 category model) land in the API server's `PolicyService` and present to
 the router as one of the fields above. **Do not add decision logic — schedule

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -254,6 +254,7 @@ object Main extends ZIOAppDefault {
       profileRepo   <- ZIO.service[ProfileRepo]
       schedRepo     <- ZIO.service[ScheduleRepo]
       hsRepo        <- ZIO.service[HouseholdSettingsRepo]
+      globalRepo    <- ZIO.service[GlobalPolicyRepo]
       tlRepo        <- ZIO.service[TimeLimitRepo]
       stlRepo       <- ZIO.service[SiteTimeLimitRepo]
       deviceRepo    <- ZIO.service[DeviceRepo]
@@ -309,6 +310,7 @@ object Main extends ZIOAppDefault {
           AuthRoutes.routes(auth, userRepo, upRepo) ++
           ProfileRoutes.routes(auth, profileRepo, schedRepo, tlRepo, upRepo, userRepo) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo) ++
+          GlobalPolicyRoutes.routes(auth, globalRepo, userRepo) ++
           DeviceRoutes.routes(auth, deviceRepo, upRepo)
 
       val statsRoutes: Routes[Any, Response] =

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -299,6 +299,20 @@ trait GlobalPolicyRepo {
 
   /** Set the flat global flags (network lockdown + strict-IP floor). */
   def setFlags(blocked: Boolean, reason: Option[MacBlockReason], blockIpOnly: Boolean): Task[Unit]
+
+  /**
+   * Full audit history (active + soft-deleted) of the always-reachable allow set, newest first.
+   * Unlike [[get]], this surfaces the `reason` / `added_by` / `removed_by` columns (resolved to
+   * usernames) so the #1320 SPA can render the security-sensitive bypass-list audit trail. The
+   * active set (rows with `removedAt == None`) is exactly what [[get]] puts on the wire.
+   */
+  def allowAudit: Task[List[GlobalPolicyAuditEntry]]
+
+  /** Full audit history (active + soft-deleted) of the network-wide block set, newest first. */
+  def blockAudit: Task[List[GlobalPolicyAuditEntry]]
+
+  /** Replace the household-global category set (`global.blocklistIds`) wholesale. */
+  def setBlocklists(ids: List[BlocklistId], addedBy: Option[Long]): Task[Unit]
 }
 
 /**
@@ -317,6 +331,9 @@ object NoopGlobalPolicyRepo extends GlobalPolicyRepo {
   def addBlocklist(id: BlocklistId, addedBy: Option[Long]): Task[Unit]                    = ZIO.unit
   def setFlags(blocked: Boolean, reason: Option[MacBlockReason], blockIpOnly: Boolean): Task[Unit] =
     ZIO.unit
+  def allowAudit: Task[List[GlobalPolicyAuditEntry]]                           = ZIO.succeed(Nil)
+  def blockAudit: Task[List[GlobalPolicyAuditEntry]]                           = ZIO.succeed(Nil)
+  def setBlocklists(ids: List[BlocklistId], addedBy: Option[Long]): Task[Unit] = ZIO.unit
 }
 
 trait TimeUsageRepo {
@@ -941,6 +958,40 @@ class GlobalPolicyRepoLive(xa: Transactor[Task]) extends GlobalPolicyRepo {
                 global_block_reason=${reason.map(MacBlockReason.asString)},
                 global_block_ip_only=$blockIpOnly
           WHERE id=1""".update.run.transact(xa).unit
+
+  private def audit(table: doobie.Fragment): Task[List[GlobalPolicyAuditEntry]] =
+    (fr"""SELECT g.host, g.reason, ua.username, g.added_at::TEXT, ur.username, g.removed_at::TEXT
+          FROM""" ++ table ++ fr"""g
+          LEFT JOIN users ua ON ua.id = g.added_by
+          LEFT JOIN users ur ON ur.id = g.removed_by
+          ORDER BY g.added_at DESC, g.id DESC""")
+      .query[(String, Option[String], Option[String], String, Option[String], Option[String])]
+      .to[List]
+      .map(_.map { case (host, reason, addedBy, addedAt, removedBy, removedAt) =>
+        GlobalPolicyAuditEntry(
+          Hostname.unsafe(host),
+          reason,
+          addedBy,
+          addedAt,
+          removedBy,
+          removedAt,
+        )
+      })
+      .transact(xa)
+
+  def allowAudit: Task[List[GlobalPolicyAuditEntry]] =
+    DbMetrics.timed("globalPolicy.allowAudit")(audit(fr"global_allow"))
+
+  def blockAudit: Task[List[GlobalPolicyAuditEntry]] =
+    DbMetrics.timed("globalPolicy.blockAudit")(audit(fr"global_blocks"))
+
+  def setBlocklists(ids: List[BlocklistId], addedBy: Option[Long]): Task[Unit] = {
+    val del = sql"DELETE FROM global_blocklists".update.run
+    val ins = ids.map(id => sql"""INSERT INTO global_blocklists (blocklist_id, added_by)
+                                  VALUES (${id.value}, $addedBy)
+                                  ON CONFLICT (blocklist_id) DO NOTHING""".update.run)
+    (del *> ins.foldLeft(FC.unit)(_ *> _.void)).transact(xa).unit
+  }
 }
 
 class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {

--- a/api/src/routes/GlobalPolicyRoutes.scala
+++ b/api/src/routes/GlobalPolicyRoutes.scala
@@ -1,0 +1,140 @@
+package wifihaven.api.routes
+
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.*
+import zio.http.*
+import zio.json.*
+
+// #1320 / #1308: admin-facing CRUD + audit surface for the household-global
+// policy that PolicyService (#1318) collapses into `PolicySnapshot.global`.
+//
+// `global.extraAllowed` is a SECURITY-SENSITIVE bypass surface — a host here is
+// reachable from EVERY device regardless of any block (it is the top of the
+// precedence ladder, design §5.2). So reads expose the full audit trail
+// (`reason` / `added_by` / `removed_by`, resolved to usernames) and writes
+// require admin. The router never sees any of this — only the flat hostname /
+// category lists assembled by the GlobalPolicyRepo (design §7).
+//
+// These routes are covered by the HTTP middleware's route-templated duration /
+// status series, so per the "new functionality ships with metrics" rule they
+// need no bespoke metric of their own.
+object GlobalPolicyRoutes {
+  def routes(
+      auth: AuthService,
+      repo: GlobalPolicyRepo,
+      userRepo: UserRepo,
+  ): Routes[Any, Response] = {
+
+    // Resolve the acting admin's username (JWT `sub`) to the user id stored in
+    // the `added_by` / `removed_by` audit columns. A missing row (e.g. token
+    // for a since-deleted user) records `None` rather than failing the write.
+    def actingUserId(claims: JwtClaims): IO[Response, Option[Long]] =
+      userRepo
+        .findByUsername(claims.sub)
+        .mapError(ErrorMapper.dbErrorToResponse)
+        .map(_.map(_.id.value))
+
+    def view: IO[Response, GlobalPolicyView] =
+      for {
+        rules  <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
+        allow  <- repo.allowAudit.mapError(ErrorMapper.dbErrorToResponse)
+        blocks <- repo.blockAudit.mapError(ErrorMapper.dbErrorToResponse)
+      } yield GlobalPolicyView(
+        allow = allow,
+        blocks = blocks,
+        blocklistIds = rules.blocklistIds,
+        blocked = rules.blocked,
+        blockReason = rules.blockReason,
+        blockIpOnly = rules.blockIpOnly,
+      )
+
+    def parseBody[A: JsonDecoder](req: Request): IO[Response, A] =
+      for {
+        body <- req.body.asString.orElseFail(Response.badRequest(""))
+        a    <- ZIO.fromEither(body.fromJson[A]).mapError(Response.badRequest(_))
+      } yield a
+
+    Routes(
+      // Full management view: active + soft-deleted history for the allow/block
+      // sets plus the flat global flags. Read access only — any authenticated
+      // user may view, mirroring the household-settings GET.
+      Method.GET / "api" / "global" / "policy" ->
+        handler { (req: Request) =>
+          for {
+            _ <- requireAuth(req, auth)
+            v <- view
+          } yield Response.json(v.toJson)
+        },
+
+      // ── always-reachable allow set ────────────────────────────────────────
+      Method.POST / "api" / "global" / "allow"                    ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAdmin(req, auth)
+            r      <- parseBody[AddGlobalHostRequest](req)
+            uid    <- actingUserId(claims)
+            _      <- repo.addAllow(r.host, r.reason, uid).mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+      Method.DELETE / "api" / "global" / "allow" / string("host") ->
+        handler { (host: String, req: Request) =>
+          for {
+            claims <- requireAdmin(req, auth)
+            uid    <- actingUserId(claims)
+            _      <- repo
+              .removeAllow(Hostname.unsafe(host), uid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+
+      // ── network-wide block set ────────────────────────────────────────────
+      Method.POST / "api" / "global" / "blocks"                    ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAdmin(req, auth)
+            r      <- parseBody[AddGlobalHostRequest](req)
+            uid    <- actingUserId(claims)
+            _      <- repo.addBlock(r.host, r.reason, uid).mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+      Method.DELETE / "api" / "global" / "blocks" / string("host") ->
+        handler { (host: String, req: Request) =>
+          for {
+            claims <- requireAdmin(req, auth)
+            uid    <- actingUserId(claims)
+            _      <- repo
+              .removeBlock(Hostname.unsafe(host), uid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+
+      // ── household-global category set (replace wholesale) ─────────────────
+      Method.PUT / "api" / "global" / "blocklists" ->
+        handler { (req: Request) =>
+          for {
+            claims <- requireAdmin(req, auth)
+            r      <- parseBody[SetGlobalBlocklistsRequest](req)
+            uid    <- actingUserId(claims)
+            _      <- repo
+              .setBlocklists(r.blocklistIds, uid)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+
+      // ── flat global flags (network lockdown + strict-IP floor) ────────────
+      Method.PUT / "api" / "global" / "flags" ->
+        handler { (req: Request) =>
+          for {
+            _ <- requireAdmin(req, auth)
+            r <- parseBody[SetGlobalFlagsRequest](req)
+            _ <- repo
+              .setFlags(r.blocked, r.blockReason, r.blockIpOnly)
+              .mapError(ErrorMapper.dbErrorToResponse)
+          } yield Response.ok
+        },
+    )
+  }
+}

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -256,6 +256,9 @@ object ProfileRoutes {
                   // #1418: omitted pauseMode defaults to Soft (matches the DB
                   // column default and preserves today's pause semantics).
                   upr.pauseMode.getOrElse(PauseMode.Soft),
+                  // #1320: omitted defaultDeny defaults to false on create
+                  // (matches the DB column default).
+                  upr.defaultDeny.getOrElse(false),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -298,6 +301,8 @@ object ProfileRoutes {
                     upr.crossDeviceOverlapMode.getOrElse(p.crossDeviceOverlapMode),
                   // #1418: same preserve-on-omit semantics for the pause mode.
                   pauseMode = upr.pauseMode.getOrElse(p.pauseMode),
+                  // #1320: same preserve-on-omit semantics for default-deny.
+                  defaultDeny = upr.defaultDeny.getOrElse(p.defaultDeny),
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)

--- a/api/test/src/feature/GlobalPolicyApiSpec.scala
+++ b/api/test/src/feature/GlobalPolicyApiSpec.scala
@@ -1,0 +1,271 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+// #1320 / #1308: management + audit surface for the household-global policy
+// (`PolicySnapshot.global`). Exercises the GlobalPolicyRoutes CRUD endpoints
+// (allow / block / blocklists / flags) and the per-profile default-deny toggle
+// the SPA drives via the existing profile PUT.
+object GlobalPolicyApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg  = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def globalRoutesAndToken =
+    for {
+      auth <- makeAuth
+      repo <- ZIO.service[GlobalPolicyRepo]
+      ur   <- ZIO.service[UserRepo]
+      tk   <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (GlobalPolicyRoutes.routes(auth, repo, ur), tk)
+
+  private def send(
+      routes: Routes[Any, Response],
+      req: Request,
+      token: String,
+  ) =
+    routes.runZIO(
+      req
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def getView(routes: Routes[Any, Response], token: String) =
+    for {
+      resp <- send(routes, Request.get(url("/api/global/policy")), token)
+      body <- resp.body.asString
+      view <- ZIO.fromEither(body.fromJson[GlobalPolicyView]).mapError(new RuntimeException(_))
+    } yield (resp.status, view)
+
+  def spec = suite("global policy management (#1320)")(
+    test("GET /api/global/policy returns the assembled view") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- globalRoutesAndToken
+        (st, view)   <- getView(routes, tk)
+      } yield assertTrue(
+        st == Status.Ok,
+        view.allow.isEmpty,
+        view.blocks.isEmpty,
+        view.blocklistIds.isEmpty,
+        !view.blocked,
+        !view.blockIpOnly,
+      )
+    },
+    test("POST /api/global/allow adds a host with audit reason + acting user") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- globalRoutesAndToken
+        resp         <- send(
+          routes,
+          Request.post(
+            url("/api/global/allow"),
+            Body.fromString("""{"host":"pki.example","reason":"PKI"}"""),
+          ),
+          tk,
+        )
+        (_, view)    <- getView(routes, tk)
+        entry = view.allow.headOption
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        view.allow.map(_.host.value) == List("pki.example"),
+        entry.flatMap(_.reason).contains("PKI"),
+        entry.flatMap(_.addedBy).contains("admin"),
+        entry.flatMap(_.removedAt).isEmpty,
+      )
+    },
+    test("DELETE /api/global/allow soft-deletes (active set drops it, history kept)") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- globalRoutesAndToken
+        _            <- send(
+          routes,
+          Request.post(url("/api/global/allow"), Body.fromString("""{"host":"gone.example"}""")),
+          tk,
+        )
+        del          <- send(routes, Request.delete(url("/api/global/allow/gone.example")), tk)
+        repo         <- ZIO.service[GlobalPolicyRepo]
+        active       <- repo.get
+        (_, view)    <- getView(routes, tk)
+      } yield assertTrue(
+        del.status == Status.Ok,
+        // active wire set no longer carries it…
+        active.extraAllowed.isEmpty,
+        // …but the audit history retains the soft-deleted row.
+        view.allow.map(_.host.value) == List("gone.example"),
+        view.allow.headOption.flatMap(_.removedAt).isDefined,
+      )
+    },
+    test("POST/DELETE /api/global/blocks manage the network-wide block set") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- globalRoutesAndToken
+        _            <- send(
+          routes,
+          Request.post(
+            url("/api/global/blocks"),
+            Body.fromString("""{"host":"evil.example","reason":"operator"}"""),
+          ),
+          tk,
+        )
+        repo         <- ZIO.service[GlobalPolicyRepo]
+        afterAdd     <- repo.get
+        _            <- send(routes, Request.delete(url("/api/global/blocks/evil.example")), tk)
+        afterDel     <- repo.get
+        (_, view)    <- getView(routes, tk)
+      } yield assertTrue(
+        afterAdd.extraBlocked.map(_.value) == List("evil.example"),
+        afterDel.extraBlocked.isEmpty,
+        view.blocks.map(_.host.value) == List("evil.example"),
+      )
+    },
+    test("PUT /api/global/blocklists replaces the household-global category set") {
+      for {
+        _            <- cleanDb
+        blr          <- ZIO.service[BlocklistRepo]
+        _            <- blr.upsertMeta(
+          BlocklistId.unsafe("ads"),
+          "Ads",
+          None,
+          bundled = true,
+          None,
+          java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        _            <- blr.upsertMeta(
+          BlocklistId.unsafe("adult"),
+          "Adult",
+          None,
+          bundled = true,
+          None,
+          java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        (routes, tk) <- globalRoutesAndToken
+        _            <- send(
+          routes,
+          Request.put(
+            url("/api/global/blocklists"),
+            Body.fromString("""{"blocklistIds":["ads","adult"]}"""),
+          ),
+          tk,
+        )
+        repo         <- ZIO.service[GlobalPolicyRepo]
+        afterSet     <- repo.get
+        // a second PUT with a narrower set replaces, not appends
+        _            <- send(
+          routes,
+          Request
+            .put(url("/api/global/blocklists"), Body.fromString("""{"blocklistIds":["ads"]}""")),
+          tk,
+        )
+        afterReplace <- repo.get
+      } yield assertTrue(
+        afterSet.blocklistIds.map(_.value).toSet == Set("ads", "adult"),
+        afterReplace.blocklistIds.map(_.value) == List("ads"),
+      )
+    },
+    test("PUT /api/global/flags sets the lockdown + strict-IP flags") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- globalRoutesAndToken
+        resp         <- send(
+          routes,
+          Request.put(
+            url("/api/global/flags"),
+            Body.fromString("""{"blocked":true,"blockReason":"Manual","blockIpOnly":true}"""),
+          ),
+          tk,
+        )
+        repo         <- ZIO.service[GlobalPolicyRepo]
+        after        <- repo.get
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after.blocked,
+        after.blockReason.contains(MacBlockReason.Manual),
+        after.blockIpOnly,
+      )
+    },
+    test("non-admin (read-only) cannot write the global allow set") {
+      for {
+        _    <- cleanDb
+        auth <- makeAuth
+        repo <- ZIO.service[GlobalPolicyRepo]
+        ur   <- ZIO.service[UserRepo]
+        hash <- auth.hashPassword("ro-pass-123")
+        _    <- ur.create("viewer", hash, "child")
+        roTk <- auth.login("viewer", "ro-pass-123").map(_.token.value)
+        routes = GlobalPolicyRoutes.routes(auth, repo, ur)
+        resp  <- send(
+          routes,
+          Request.post(url("/api/global/allow"), Body.fromString("""{"host":"x.example"}""")),
+          roTk,
+        )
+        after <- repo.get
+      } yield assertTrue(resp.status == Status.Forbidden, after.extraAllowed.isEmpty)
+    },
+    test("PUT /api/profiles/:id persists the per-profile default-deny flag") {
+      for {
+        _    <- cleanDb
+        auth <- makeAuth
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        upr  <- ZIO.service[UserProfileRepo]
+        ur   <- ZIO.service[UserRepo]
+        tk   <- auth.login("admin", "changeme").map(_.token.value)
+        pid  <- pr.create("kids", Nil)
+        routes = ProfileRoutes.routes(auth, pr, sr, tlr, upr, ur)
+        resp   <- send(
+          routes,
+          Request.put(
+            url(s"/api/profiles/${pid.value}"),
+            Body.fromString(
+              """{"name":"kids","blockedCategories":[],"paused":false,"schedules":[],"timeLimit":null,"defaultDeny":true}""",
+            ),
+          ),
+          tk,
+        )
+        after  <- pr.findById(pid)
+        // omitting defaultDeny on a later PUT preserves the stored value
+        resp2  <- send(
+          routes,
+          Request.put(
+            url(s"/api/profiles/${pid.value}"),
+            Body.fromString(
+              """{"name":"kids","blockedCategories":[],"paused":false,"schedules":[],"timeLimit":null}""",
+            ),
+          ),
+          tk,
+        )
+        after2 <- pr.findById(pid)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after.exists(_.defaultDeny),
+        resp2.status == Status.Ok,
+        after2.exists(_.defaultDeny),
+      )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,24 @@ def effective(d: DevicePolicy, profiles: Map[ProfileId, ProfilePolicy]): BlockRu
 After this single deref, the agent works with a `Map[MacAddress, BlockRules]`
 and profiles are unreachable.
 
+> **Scope decision (2026-06): authored policy has exactly two tiers — global
+> and profile. There is NO per-device override authoring surface.** The wire
+> shape (`DevicePolicy.rules: Option[BlockRules]`) *can* carry a device-specific
+> override, and `effective` above honours it — but the only thing that populates
+> `rules` today is the server-side **unmanaged-MAC block** path (a device with
+> no `profileId` under a `block` household policy). A managed device always
+> takes its rules from its assigned profile (`rules = None` on the wire).
+>
+> This is deliberate, not a gap: we compose policy from **global ∘ profile**
+> and assign devices to profiles. There is no DB column, repo, route, or SPA
+> editor for a per-device override, and we are **not** adding one right now.
+> Do not build per-device rule authoring, and do not describe the `rules` field
+> as a user-facing "device override" — it is an internal mechanism reserved for
+> the unmanaged-block case. (The `rules`-override **wire capability** stays
+> because it is additive and already used by that path; keeping it costs nothing
+> and removing it would be a breaking wire change.) Tracked/closed:
+> [#1452](https://github.com/wifihaven/wifihaven/issues/1452).
+
 Enforcement plane per field:
 
 | Field | Enforcement |
@@ -599,8 +617,13 @@ Notes:
   connectivity, PKI) — **not** copied into each profile's `extraAllowed`;
   changing them rewrites only `global` and the snapshot `etag`.
 - The first device above takes its rules from the `"kids"` profile.
-- The second device overrides the profile entirely — its `rules` are used
-  verbatim. The override replaces; it does not merge with the profile.
+- The second device carries an inline `rules` that the router uses verbatim
+  (replace, not merge). **This is the wire mechanism only** — today the sole
+  populator of an inline `rules` is the server-side unmanaged-MAC block path.
+  There is no per-device override authoring surface, and we are not adding one
+  (see the "Scope decision (2026-06)" callout in §0.2 above). Read this example
+  as "the router can apply a pre-resolved per-MAC rule," not "operators author
+  per-device overrides."
 - The router resolves each device into a single `BlockRules` once and then
   enforces purely per-MAC. Profiles are not consulted further.
 - All schedule / time-limit / pause / category evaluation has already

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -518,6 +518,12 @@ case class UpsertProfileRequest(
     crossDeviceOverlapMode: Option[CrossDeviceOverlapMode] = None,
     // #1418: omitted → preserve existing value (default 'soft' on create).
     pauseMode: Option[PauseMode] = None,
+    // #1320 / #1308: per-profile default-deny baseline (block-all; only
+    // extraAllowed + global.extraAllowed reachable). Omitted → preserve
+    // existing value (default false on create). Additive optional field, so an
+    // older client that never sends it leaves the profile's default-deny
+    // setting untouched.
+    defaultDeny: Option[Boolean] = None,
 ) derives JsonCodec
 
 case class ScheduleRequest(
@@ -1318,6 +1324,55 @@ case class DevicePolicy(
     profileId: Option[ProfileId],
     name: String,
     rules: Option[BlockRules],
+) derives JsonCodec
+
+// ── Global policy management (#1320 / #1308) ──────────────────────────────
+// Admin-facing read/write surface for the household-global allow/block sets
+// that PolicyService (#1318) collapses into `PolicySnapshot.global`. The wire
+// snapshot carries only the flat hostname / category lists the router needs;
+// the *why* and *who* — the security-sensitive audit trail for the
+// always-reachable bypass list (design §7) — live in the DB and are surfaced
+// ONLY through these management types, never to the router.
+
+// One row of the `global_allow` / `global_blocks` audit history. `removedAt ==
+// None` ⇒ the entry is active and feeds `PolicySnapshot.global`; `Some` ⇒ it
+// was soft-deleted and is retained for audit only. `addedBy`/`removedBy` are
+// resolved to usernames server-side (the DB stores user ids).
+case class GlobalPolicyAuditEntry(
+    host: Hostname,
+    reason: Option[String],
+    addedBy: Option[String],
+    addedAt: String,
+    removedBy: Option[String],
+    removedAt: Option[String],
+) derives JsonCodec
+
+// Full management view of the global section. `allow`/`blocks` include
+// soft-deleted history so the audit trail is visible; the active set feeding
+// `PolicySnapshot.global` is exactly the rows with `removedAt == None`.
+case class GlobalPolicyView(
+    allow: List[GlobalPolicyAuditEntry],
+    blocks: List[GlobalPolicyAuditEntry],
+    blocklistIds: List[BlocklistId],
+    blocked: Boolean,
+    blockReason: Option[MacBlockReason],
+    blockIpOnly: Boolean,
+) derives JsonCodec
+
+// Append a host to the global allow or block set, with an optional audit
+// `reason`. Re-adding a previously-removed host is fine (the soft-deleted row
+// keeps its `removedAt`; a fresh active row is inserted).
+case class AddGlobalHostRequest(host: Hostname, reason: Option[String] = None) derives JsonCodec
+
+// Replace the household-global category set (`global.blocklistIds`) wholesale.
+case class SetGlobalBlocklistsRequest(blocklistIds: List[BlocklistId]) derives JsonCodec
+
+// Set the flat global flags: the network-lockdown kill switch (`blocked` +
+// block-page `blockReason`) and the network-wide strict-IP floor.
+case class SetGlobalFlagsRequest(
+    blocked: Boolean,
+    blockReason: Option[MacBlockReason] = None,
+    blockIpOnly: Boolean,
 ) derives JsonCodec
 
 case class ProfilePolicy(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { AccountPage } from '@/pages/AccountPage'
 import { UsersPage } from '@/pages/UsersPage'
 import { RoutersPage } from '@/pages/RoutersPage'
 import { AdminPage } from '@/pages/AdminPage'
+import { GlobalPolicyPage } from '@/pages/GlobalPolicyPage'
 import { BlockedPage } from '@/pages/BlockedPage'
 import { AppsPage } from '@/pages/AppsPage'
 import { BlocklistsPage } from '@/pages/BlocklistsPage'
@@ -61,6 +62,7 @@ function AppRoutes() {
         <Route path="blocklists"  element={<RequirePwChanged><RequireAdmin><BlocklistsPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="users"     element={<RequirePwChanged><RequireAdmin><UsersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="routers"   element={<RequirePwChanged><RequireAdmin><RoutersPage /></RequireAdmin></RequirePwChanged>} />
+        <Route path="global-policy" element={<RequirePwChanged><RequireAdmin><GlobalPolicyPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="admin"     element={<RequirePwChanged><RequireAdmin><AdminPage /></RequireAdmin></RequirePwChanged>} />
       </Route>
     </Routes>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -2,6 +2,7 @@ import { apiHealth } from '@/api/apiHealth'
 import type {
   Alert, AppDetail, ApproveAlertRequest, BlockedInfoResponse, BlocklistHosts, BlocklistSummary, CreateAppRequest, CreateRouterRequest, CreateRouterResponse, CreateUserRequest,
   DashboardNow, DashboardStats, Device,
+  GlobalPolicyView, AddGlobalHostRequest, SetGlobalBlocklistsRequest, SetGlobalFlagsRequest,
   CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   ConnectionEventSeriesPage, QueryLogPage,
   PatchUserRequest, PatchAppRequest,
@@ -175,6 +176,26 @@ export const api = {
     get: () => req<HouseholdSettings>('GET', '/household/settings'),
     patch: (data: Record<string, unknown>) =>
       req<void>('PATCH', '/household/settings', data),
+  },
+
+  // ── Global policy (#1320 / #1308) ──────────────────────────────────────
+  // Admin-only writes; GET is the management + audit view. `global.extraAllowed`
+  // is a security-sensitive bypass surface, so every mutation is auditable
+  // server-side (reason + acting user). Hosts are sent raw in the DELETE path —
+  // zio-http does not decode percent-encoded chars in path segments, and a
+  // hostname's dots/labels are valid path chars.
+  global: {
+    get: () => req<GlobalPolicyView>('GET', '/global/policy'),
+    addAllow: (data: AddGlobalHostRequest) =>
+      req<void>('POST', '/global/allow', data),
+    removeAllow: (host: string) => req<void>('DELETE', `/global/allow/${host}`),
+    addBlock: (data: AddGlobalHostRequest) =>
+      req<void>('POST', '/global/blocks', data),
+    removeBlock: (host: string) => req<void>('DELETE', `/global/blocks/${host}`),
+    setBlocklists: (blocklistIds: string[]) =>
+      req<void>('PUT', '/global/blocklists', { blocklistIds } as SetGlobalBlocklistsRequest),
+    setFlags: (data: SetGlobalFlagsRequest) =>
+      req<void>('PUT', '/global/flags', data),
   },
 
   // ── Devices ────────────────────────────────────────────────────────────

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -8,7 +8,7 @@
 import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { api } from '@/api/client'
 import type {
-  Alert, DashboardNow, Device, HouseholdSettings, ProfileDetail, ProfileTimeStatus,
+  Alert, DashboardNow, Device, GlobalPolicyView, HouseholdSettings, ProfileDetail, ProfileTimeStatus,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   QueryLog, UsageSeriesResponse,
 } from '@/types/api'
@@ -39,6 +39,7 @@ const STALE = {
 export const qk = {
   profiles: () => ['profiles'] as const,
   devices: () => ['devices'] as const,
+  globalPolicy: () => ['global', 'policy'] as const,
   alerts: (includeAll: boolean) => ['alerts', includeAll] as const,
   dashboardNow: () => ['dashboard', 'now'] as const,
   recentBlocked: () => ['dashboard', 'recent-blocked'] as const,
@@ -256,6 +257,17 @@ export function useProfileUsageByApp(
   })
 }
 
+// #1320 — household-global policy management + audit view. Low-churn admin
+// data, so a generous stale window; the page invalidates on every edit.
+export function useGlobalPolicy(opts?: QueryOpts<GlobalPolicyView>) {
+  return useQuery({
+    queryKey: qk.globalPolicy(),
+    queryFn: () => api.global.get(),
+    staleTime: 60_000,
+    ...opts,
+  })
+}
+
 // Centralised invalidation helpers used by mutation onSuccess handlers.
 // Editing a profile or device can change schedule/limit-derived screen-time
 // rendering, so we invalidate the time/status keys too.
@@ -264,6 +276,7 @@ export function useInvalidators() {
   return {
     profiles: () => qc.invalidateQueries({ queryKey: qk.profiles() }),
     devices: () => qc.invalidateQueries({ queryKey: qk.devices() }),
+    globalPolicy: () => qc.invalidateQueries({ queryKey: qk.globalPolicy() }),
     alerts: () => qc.invalidateQueries({ queryKey: ['alerts'] }),
     dashboardNow: () => qc.invalidateQueries({ queryKey: qk.dashboardNow() }),
     timeStatus: () => qc.invalidateQueries({ queryKey: ['time', 'status'] }),

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -34,6 +34,7 @@ const settingsNav: NavItem[] = [
   },
   { to: '/apps',       label: 'Apps',       icon: '◳', adminOnly: true },
   { to: '/blocklists', label: 'Blocklists', icon: '⊘', adminOnly: true },
+  { to: '/global-policy', label: 'Global Policy', icon: '🌐', adminOnly: true },
   { to: '/users',   label: 'Users',   icon: '◐', adminOnly: true },
   { to: '/routers', label: 'Routers', icon: '⬢', adminOnly: true },
   { to: '/admin',   label: 'Settings', icon: '⚙', adminOnly: true },

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -34,6 +34,7 @@ function makeProfile(id: number, name: string): ProfileDetail {
       failureMode: 'last-known-good',
       crossDeviceOverlapMode: 'sum',
       pauseMode: 'soft',
+      defaultDeny: false,
     },
     schedules: [],
     timeLimit: null,

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -57,11 +57,11 @@ const laptop: Device = {
 }
 
 const kidsProfile: ProfileDetail = {
-  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' },
+  profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false },
   schedules: [], timeLimit: null,
 }
 const adultsProfile: ProfileDetail = {
-  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' },
+  profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false },
   schedules: [], timeLimit: null,
 }
 

--- a/web/src/pages/GlobalPolicyPage.test.tsx
+++ b/web/src/pages/GlobalPolicyPage.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    global: {
+      get: vi.fn(),
+      addAllow: vi.fn(),
+      removeAllow: vi.fn(),
+      addBlock: vi.fn(),
+      removeBlock: vi.fn(),
+      setBlocklists: vi.fn(),
+      setFlags: vi.fn(),
+    },
+    blocklists: {
+      list: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import type { BlocklistSummary, GlobalPolicyView } from '@/types/api'
+import { GlobalPolicyPage } from './GlobalPolicyPage'
+import { withQuery } from '@/test/queryWrapper'
+
+const VIEW: GlobalPolicyView = {
+  allow: [
+    {
+      host: 'ocsp.example.com',
+      reason: 'PKI',
+      addedBy: 'admin',
+      addedAt: '2026-06-01 14:00:00+00',
+      removedBy: null,
+      removedAt: null,
+    },
+    {
+      host: 'old.example.com',
+      reason: null,
+      addedBy: 'admin',
+      addedAt: '2026-05-01 10:00:00+00',
+      removedBy: 'admin',
+      removedAt: '2026-05-02 10:00:00+00',
+    },
+  ],
+  blocks: [
+    {
+      host: 'malware.example.com',
+      reason: 'operator',
+      addedBy: 'admin',
+      addedAt: '2026-06-01 14:00:00+00',
+      removedBy: null,
+      removedAt: null,
+    },
+  ],
+  blocklistIds: ['ads'],
+  blocked: false,
+  blockReason: null,
+  blockIpOnly: false,
+}
+
+const BLOCKLISTS: BlocklistSummary[] = [
+  { id: 'ads', name: 'Ads', bundled: true, hostCount: 100 },
+  { id: 'adult', name: 'Adult', bundled: true, hostCount: 200 },
+]
+
+const fn = (m: unknown) => m as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  fn(api.global.get).mockResolvedValue(VIEW)
+  fn(api.blocklists.list).mockResolvedValue(BLOCKLISTS)
+  fn(api.global.addAllow).mockResolvedValue(undefined)
+  fn(api.global.removeAllow).mockResolvedValue(undefined)
+  fn(api.global.setBlocklists).mockResolvedValue(undefined)
+  fn(api.global.setFlags).mockResolvedValue(undefined)
+})
+
+describe('GlobalPolicyPage (#1320)', () => {
+  it('renders the global allow + block audit view', async () => {
+    render(withQuery(<GlobalPolicyPage />))
+
+    expect(await screen.findByTestId('global-allow-row-ocsp.example.com')).toBeInTheDocument()
+    // active allow shows the host + audit reason + who added it
+    const row = screen.getByTestId('global-allow-row-ocsp.example.com')
+    expect(row).toHaveTextContent('ocsp.example.com')
+    expect(row).toHaveTextContent('PKI')
+    expect(row).toHaveTextContent('admin')
+    // soft-deleted entry is in history, not the active list
+    expect(screen.queryByTestId('global-allow-row-old.example.com')).not.toBeInTheDocument()
+    expect(screen.getByTestId('global-allow-history-toggle')).toHaveTextContent('1 removed')
+    // global block surfaced
+    expect(screen.getByTestId('global-block-row-malware.example.com')).toBeInTheDocument()
+  })
+
+  it('adds an always-allow host via the API', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<GlobalPolicyPage />))
+    await screen.findByTestId('global-allow-card')
+
+    await user.type(screen.getByTestId('global-allow-host-input'), 'captive.apple.com')
+    await user.type(screen.getByTestId('global-allow-reason-input'), 'captive portal')
+    await user.click(screen.getByTestId('global-allow-add'))
+
+    await waitFor(() =>
+      expect(api.global.addAllow).toHaveBeenCalledWith({
+        host: 'captive.apple.com',
+        reason: 'captive portal',
+      }),
+    )
+  })
+
+  it('removes an active allow host via the API', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<GlobalPolicyPage />))
+    await screen.findByTestId('global-allow-row-ocsp.example.com')
+
+    await user.click(screen.getByTestId('global-allow-remove-ocsp.example.com'))
+    await waitFor(() =>
+      expect(api.global.removeAllow).toHaveBeenCalledWith('ocsp.example.com'),
+    )
+  })
+
+  it('toggles a global category blocklist via the API', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<GlobalPolicyPage />))
+    await screen.findByTestId('global-category-adult')
+
+    // 'ads' already selected; clicking 'adult' should set both.
+    await user.click(screen.getByTestId('global-category-adult'))
+    await waitFor(() =>
+      expect(api.global.setBlocklists).toHaveBeenCalledWith(['ads', 'adult']),
+    )
+  })
+
+  it('enables network lockdown via the flags API', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<GlobalPolicyPage />))
+    await screen.findByTestId('global-flags-card')
+
+    await user.click(screen.getByTestId('global-lockdown-toggle'))
+    await waitFor(() =>
+      expect(api.global.setFlags).toHaveBeenCalledWith({
+        blocked: true,
+        blockReason: 'Manual',
+        blockIpOnly: false,
+      }),
+    )
+  })
+})

--- a/web/src/pages/GlobalPolicyPage.tsx
+++ b/web/src/pages/GlobalPolicyPage.tsx
@@ -1,0 +1,524 @@
+import { useState } from 'react'
+import { api } from '@/api/client'
+import type { BlocklistSummary, GlobalPolicyAuditEntry, MacBlockReason } from '@/types/api'
+import { useGlobalPolicy, useInvalidators } from '@/api/queries'
+import { useQuery } from '@tanstack/react-query'
+import { PageLoader } from './DashboardPage'
+
+// #1320 / #1308 — household-global policy management + audit view.
+//
+// `global.extraAllowed` is a SECURITY-SENSITIVE bypass surface: a host here is
+// reachable from EVERY device regardless of any block (it sits at the top of
+// the precedence ladder — design §5.2). So the allow list leads with a prominent
+// audit trail (who added each host, why, and the soft-deleted history). Global
+// blocks are mandatory network-wide drops a profile may NOT un-block; the
+// network-lockdown + strict-IP toggles are the flat global flags.
+//
+// None of this is a new router concept — it all collapses into the one
+// `PolicySnapshot.global : BlockRules` the router already applies (the *why*
+// stays server-side). See AGENTS.md "Architectural model".
+export function GlobalPolicyPage() {
+  const { data: view, isLoading } = useGlobalPolicy()
+  const blocklistsQ = useQuery({
+    queryKey: ['blocklists'],
+    queryFn: () => api.blocklists.list(),
+    staleTime: 60_000,
+  })
+  const invalidators = useInvalidators()
+  const refresh = () => invalidators.globalPolicy()
+
+  if (isLoading || !view) return <PageLoader />
+
+  return (
+    <div className="space-y-6" data-testid="global-policy-page">
+      <div>
+        <h1 className="text-xl font-bold text-brand-ink">Global Policy</h1>
+        <p className="text-sm text-brand-text-muted mt-1">
+          Fleet-wide allow / block rules applied to <strong>every</strong> device, on top of each
+          profile. Resolved server-side into one snapshot the router applies blindly.
+        </p>
+      </div>
+
+      <AlwaysAllowCard entries={view.allow} onChanged={refresh} />
+      <GlobalBlocksCard entries={view.blocks} onChanged={refresh} />
+      <GlobalCategoriesCard
+        selected={view.blocklistIds}
+        all={blocklistsQ.data ?? []}
+        onChanged={refresh}
+      />
+      <NetworkFlagsCard
+        blocked={view.blocked}
+        blockReason={view.blockReason}
+        blockIpOnly={view.blockIpOnly}
+        onChanged={refresh}
+      />
+    </div>
+  )
+}
+
+const REASONS: MacBlockReason[] = ['Manual', 'Paused', 'Schedule', 'TimeLimit', 'DefaultDeny']
+
+function activeOf(entries: GlobalPolicyAuditEntry[]) {
+  return entries.filter(e => e.removedAt === null)
+}
+function historyOf(entries: GlobalPolicyAuditEntry[]) {
+  return entries.filter(e => e.removedAt !== null)
+}
+
+// ── always-reachable allow set ──────────────────────────────────────────────
+
+function AlwaysAllowCard({
+  entries, onChanged,
+}: {
+  entries: GlobalPolicyAuditEntry[]
+  onChanged: () => void
+}) {
+  const [host, setHost] = useState('')
+  const [reason, setReason] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const active = activeOf(entries)
+  const history = historyOf(entries)
+
+  async function add() {
+    const h = host.trim()
+    if (!h) return
+    setBusy(true); setError(null)
+    try {
+      await api.global.addAllow({ host: h, reason: reason.trim() || null })
+      setHost(''); setReason('')
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add host')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(h: string) {
+    setBusy(true); setError(null)
+    try {
+      await api.global.removeAllow(h)
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove host')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section
+      data-testid="global-allow-card"
+      className="bg-white rounded-2xl border border-amber-500/30 p-5 space-y-4"
+    >
+      <div>
+        <h2 className="font-semibold text-brand-ink flex items-center gap-2">
+          <span aria-hidden>⚠️</span> Always-allow
+        </h2>
+        <p className="text-sm text-brand-text-muted mt-1">
+          A bypass surface — hosts here are reachable from every device <em>regardless of any
+          block</em> (profile, schedule, time limit, pause, or a global block). Use only for
+          connectivity / PKI / the WifiHaven UI. Every change is audited below.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-end">
+        <label className="flex flex-col text-xs text-brand-text-muted">
+          Host
+          <input
+            type="text"
+            value={host}
+            onChange={e => setHost(e.target.value)}
+            placeholder="ocsp.example.com"
+            data-testid="global-allow-host-input"
+            className="mt-1 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink font-mono w-64"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-brand-text-muted">
+          Reason (audit)
+          <input
+            type="text"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            placeholder="PKI / OCSP stapling"
+            data-testid="global-allow-reason-input"
+            className="mt-1 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink w-64"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={add}
+          disabled={busy || host.trim() === ''}
+          data-testid="global-allow-add"
+          className="px-4 py-2 rounded-lg bg-brand-accent text-white text-sm font-semibold disabled:opacity-50"
+        >
+          Add
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-700" data-testid="global-allow-error">{error}</p>}
+
+      <AuditTable
+        active={active}
+        history={history}
+        onRemove={remove}
+        emptyLabel="No global allow hosts."
+        testId="global-allow"
+      />
+    </section>
+  )
+}
+
+// ── network-wide block set ──────────────────────────────────────────────────
+
+function GlobalBlocksCard({
+  entries, onChanged,
+}: {
+  entries: GlobalPolicyAuditEntry[]
+  onChanged: () => void
+}) {
+  const [host, setHost] = useState('')
+  const [reason, setReason] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function add() {
+    const h = host.trim()
+    if (!h) return
+    setBusy(true); setError(null)
+    try {
+      await api.global.addBlock({ host: h, reason: reason.trim() || null })
+      setHost(''); setReason('')
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add host')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(h: string) {
+    setBusy(true); setError(null)
+    try {
+      await api.global.removeBlock(h)
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to remove host')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section
+      data-testid="global-blocks-card"
+      className="bg-white rounded-2xl border border-brand-border p-5 space-y-4"
+    >
+      <div>
+        <h2 className="font-semibold text-brand-ink">Global blocks</h2>
+        <p className="text-sm text-brand-text-muted mt-1">
+          Hosts blocked on every device. A profile or device may <strong>not</strong> un-block
+          these — only an always-allow entry above overrides a global block.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-end">
+        <label className="flex flex-col text-xs text-brand-text-muted">
+          Host
+          <input
+            type="text"
+            value={host}
+            onChange={e => setHost(e.target.value)}
+            placeholder="malware.example.com"
+            data-testid="global-block-host-input"
+            className="mt-1 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink font-mono w-64"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-brand-text-muted">
+          Reason (audit)
+          <input
+            type="text"
+            value={reason}
+            onChange={e => setReason(e.target.value)}
+            placeholder="operator policy"
+            data-testid="global-block-reason-input"
+            className="mt-1 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink w-64"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={add}
+          disabled={busy || host.trim() === ''}
+          data-testid="global-block-add"
+          className="px-4 py-2 rounded-lg bg-red-600 text-white text-sm font-semibold disabled:opacity-50"
+        >
+          Block
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-700" data-testid="global-block-error">{error}</p>}
+
+      <AuditTable
+        active={activeOf(entries)}
+        history={historyOf(entries)}
+        onRemove={remove}
+        emptyLabel="No global block hosts."
+        testId="global-block"
+      />
+    </section>
+  )
+}
+
+// ── household-global category set ───────────────────────────────────────────
+
+function GlobalCategoriesCard({
+  selected, all, onChanged,
+}: {
+  selected: string[]
+  all: BlocklistSummary[]
+  onChanged: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const selectedSet = new Set(selected)
+
+  async function toggle(id: string) {
+    const next = selectedSet.has(id)
+      ? selected.filter(x => x !== id)
+      : [...selected, id]
+    setBusy(true); setError(null)
+    try {
+      await api.global.setBlocklists(next)
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update categories')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section
+      data-testid="global-categories-card"
+      className="bg-white rounded-2xl border border-brand-border p-5 space-y-3"
+    >
+      <div>
+        <h2 className="font-semibold text-brand-ink">Global category blocklists</h2>
+        <p className="text-sm text-brand-text-muted mt-1">
+          Category lists applied to every device. Like global host blocks, a profile may not
+          un-block these.
+        </p>
+      </div>
+      {all.length === 0
+        ? <p className="text-xs text-brand-text-muted">No blocklists available.</p>
+        : (
+          <div className="flex flex-wrap gap-2">
+            {all.map(bl => {
+              const on = selectedSet.has(bl.id)
+              return (
+                <button
+                  key={bl.id}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => toggle(bl.id)}
+                  data-testid={`global-category-${bl.id}`}
+                  aria-pressed={on}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors disabled:opacity-50 ${
+                    on
+                      ? 'bg-red-500/10 text-red-700 border-red-500/30'
+                      : 'bg-brand-alt text-brand-text border-brand-border'
+                  }`}
+                >
+                  {bl.name}
+                </button>
+              )
+            })}
+          </div>
+        )
+      }
+      {error && <p className="text-xs text-red-700" data-testid="global-categories-error">{error}</p>}
+    </section>
+  )
+}
+
+// ── flat global flags ───────────────────────────────────────────────────────
+
+function NetworkFlagsCard({
+  blocked, blockReason, blockIpOnly, onChanged,
+}: {
+  blocked: boolean
+  blockReason: MacBlockReason | null
+  blockIpOnly: boolean
+  onChanged: () => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Local copy of the reason so it can be chosen before lockdown is enabled.
+  const [reason, setReason] = useState<MacBlockReason>(blockReason ?? 'Manual')
+
+  async function save(next: { blocked?: boolean; blockReason?: MacBlockReason; blockIpOnly?: boolean }) {
+    setBusy(true); setError(null)
+    try {
+      await api.global.setFlags({
+        blocked: next.blocked ?? blocked,
+        blockReason: next.blockReason ?? reason,
+        blockIpOnly: next.blockIpOnly ?? blockIpOnly,
+      })
+      onChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update flags')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section
+      data-testid="global-flags-card"
+      className="bg-white rounded-2xl border border-brand-border p-5 space-y-4"
+    >
+      <h2 className="font-semibold text-brand-ink">Network controls</h2>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-brand-ink">Network lockdown</p>
+          <p className="text-xs text-brand-text-muted mt-0.5">
+            Drop <strong>all</strong> traffic on every device except the always-allow list above. A
+            household-wide kill switch.
+          </p>
+        </div>
+        <label className="inline-flex items-center cursor-pointer shrink-0">
+          <input
+            type="checkbox"
+            checked={blocked}
+            disabled={busy}
+            onChange={e => save({ blocked: e.target.checked })}
+            data-testid="global-lockdown-toggle"
+            className="sr-only peer"
+          />
+          <span className="w-11 h-6 bg-brand-border rounded-full peer-checked:bg-red-600 relative transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-transform peer-checked:after:translate-x-5" />
+        </label>
+      </div>
+
+      {blocked && (
+        <label className="flex flex-col text-xs text-brand-text-muted w-64">
+          Block-page reason
+          <select
+            value={reason}
+            disabled={busy}
+            onChange={e => {
+              const r = e.target.value as MacBlockReason
+              setReason(r)
+              save({ blockReason: r })
+            }}
+            data-testid="global-lockdown-reason"
+            className="mt-1 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink"
+          >
+            {REASONS.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </label>
+      )}
+
+      <div className="flex items-start justify-between gap-4 border-t border-brand-border pt-4">
+        <div>
+          <p className="text-sm font-medium text-brand-ink">Strict-IP mode (network-wide)</p>
+          <p className="text-xs text-brand-text-muted mt-0.5">
+            Drop any destination IP not resolved through our DNS — blocks DoH / hard-coded-IP
+            bypass on every device.
+          </p>
+        </div>
+        <label className="inline-flex items-center cursor-pointer shrink-0">
+          <input
+            type="checkbox"
+            checked={blockIpOnly}
+            disabled={busy}
+            onChange={e => save({ blockIpOnly: e.target.checked })}
+            data-testid="global-strict-ip-toggle"
+            className="sr-only peer"
+          />
+          <span className="w-11 h-6 bg-brand-border rounded-full peer-checked:bg-brand-accent relative transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-transform peer-checked:after:translate-x-5" />
+        </label>
+      </div>
+      {error && <p className="text-xs text-red-700" data-testid="global-flags-error">{error}</p>}
+    </section>
+  )
+}
+
+// ── shared audit table ──────────────────────────────────────────────────────
+
+function AuditTable({
+  active, history, onRemove, emptyLabel, testId,
+}: {
+  active: GlobalPolicyAuditEntry[]
+  history: GlobalPolicyAuditEntry[]
+  onRemove: (host: string) => void
+  emptyLabel: string
+  testId: string
+}) {
+  const [showHistory, setShowHistory] = useState(false)
+  return (
+    <div data-testid={`${testId}-audit`}>
+      {active.length === 0
+        ? <p className="text-xs text-brand-text-muted">{emptyLabel}</p>
+        : (
+          <ul className="divide-y divide-brand-border border border-brand-border rounded-lg">
+            {active.map(e => (
+              <li
+                key={e.host}
+                data-testid={`${testId}-row-${e.host}`}
+                className="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="font-mono text-brand-ink">{e.host}</span>
+                  {e.reason && <span className="text-brand-text-muted"> — {e.reason}</span>}
+                  <span className="block text-xs text-brand-text-muted">
+                    added by {e.addedBy ?? 'unknown'} · {e.addedAt}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onRemove(e.host)}
+                  data-testid={`${testId}-remove-${e.host}`}
+                  className="text-xs text-red-700 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 px-2 py-1 rounded-lg shrink-0"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+
+      {history.length > 0 && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setShowHistory(s => !s)}
+            data-testid={`${testId}-history-toggle`}
+            className="text-xs text-brand-text-muted hover:text-brand-ink"
+          >
+            {showHistory ? '▾' : '▸'} Audit history ({history.length} removed)
+          </button>
+          {showHistory && (
+            <ul className="mt-1 divide-y divide-brand-border border border-brand-border rounded-lg opacity-70">
+              {history.map((e, i) => (
+                <li
+                  key={`${e.host}-${i}`}
+                  data-testid={`${testId}-history-row`}
+                  className="px-3 py-2 text-xs text-brand-text-muted"
+                >
+                  <span className="font-mono line-through">{e.host}</span>
+                  {e.reason && <span> — {e.reason}</span>}
+                  <span className="block">
+                    added by {e.addedBy ?? 'unknown'} · removed by {e.removedBy ?? 'unknown'}
+                    {e.removedAt ? ` · ${e.removedAt}` : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -39,7 +39,7 @@ const devices: Device[] = [
   { id: 10, mac: 'aa:bb:cc:dd:ee:01', name: "Kid's iPad", profileId: 1, profileName: 'Kids', lastSeenIp: null, lastSeenAt: null },
 ]
 const profileDetails: ProfileDetail[] = [
-  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft' }, schedules: [], timeLimit: null },
+  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false }, schedules: [], timeLimit: null },
 ]
 
 // Surfaces the current URL search string so tests can assert query-param

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -86,6 +86,7 @@ const kidsProfile: ProfileDetail = {
     failureMode: 'block-all',
     crossDeviceOverlapMode: 'sum',
     pauseMode: 'soft',
+    defaultDeny: false,
   },
   schedules: [
     { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
@@ -102,6 +103,7 @@ const adultsProfile: ProfileDetail = {
     failureMode: 'last-known-good',
     crossDeviceOverlapMode: 'sum',
     pauseMode: 'soft',
+    defaultDeny: false,
   },
   schedules: [],
   timeLimit: null,
@@ -1391,5 +1393,31 @@ describe('ProfilesPage — app-policy edits refresh the profile-wide time bar (#
     await user.click(await screen.findByTestId('app-row-60-clear'))
     await waitFor(() => expect(api.apps.deletePolicy).toHaveBeenCalledWith(60, 1))
     await waitFor(() => expect(api.time.summaryAll).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
+  it('toggling default-deny persists via the full-profile PUT, preserving other fields', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+
+    // off by default for the Kids fixture
+    const toggle = await screen.findByTestId('profile-default-deny-toggle-1')
+    expect(toggle).not.toBeChecked()
+
+    await user.click(toggle)
+
+    await waitFor(() => expect(api.profiles.update).toHaveBeenCalled())
+    const calls = (api.profiles.update as unknown as ReturnType<typeof vi.fn>).mock.calls
+    const [id, body] = calls[calls.length - 1]
+    expect(id).toBe(1)
+    expect(body.defaultDeny).toBe(true)
+    // other fields carried through the PUT unchanged
+    expect(body.name).toBe('Kids')
+    expect(body.blockedCategories).toEqual(['adult', 'gambling'])
+    expect(body.failureMode).toBe('block-all')
+    expect(body.timeLimit).toBe(120)
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -29,6 +29,7 @@ interface FormState {
   schedules: ScheduleRequest[]
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
+  defaultDeny: boolean
 }
 
 function detailToForm(pd: ProfileDetail): FormState {
@@ -42,6 +43,7 @@ function detailToForm(pd: ProfileDetail): FormState {
     })),
     failureMode: pd.profile.failureMode,
     crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
+    defaultDeny: pd.profile.defaultDeny,
   }
 }
 
@@ -55,6 +57,7 @@ function formToRequest(f: FormState): UpsertProfileRequest {
     schedules: f.schedules,
     failureMode: f.failureMode,
     crossDeviceOverlapMode: f.crossDeviceOverlapMode,
+    defaultDeny: f.defaultDeny,
   }
 }
 
@@ -789,6 +792,17 @@ function ProfileShellRow({
             />
           )}
 
+          {/* #1320 — per-profile default-deny baseline. Block-all; only the
+              profile's allowed apps/hosts + the household global allowlist are
+              reachable. The inverse of allow-by-default + blocklists. */}
+          {isAdmin && (
+            <DefaultDenySubsection
+              pd={pd}
+              updateProfile={updateProfile}
+              onProfileChanged={onProfileChanged}
+            />
+          )}
+
           {/* #975 — inline time-limit + cross-device overlap subsection.
               Replaces the modal's daily-cap + schedules + overlap blocks for
               this profile. */}
@@ -914,6 +928,70 @@ function timeFormsEqual(a: TimeFormState, b: TimeFormState): boolean {
     for (let j = 0; j < x.days.length; j++) if (x.days[j] !== y.days[j]) return false
   }
   return true
+}
+
+// #1320 — per-profile default-deny toggle. Flips the whole profile to a
+// block-all baseline (only its allowed apps/hosts + the household global
+// allowlist stay reachable). Persists via the existing full-profile PUT —
+// formToRequest carries defaultDeny — so it composes with every other field.
+function DefaultDenySubsection({
+  pd, updateProfile, onProfileChanged,
+}: {
+  pd: ProfileDetail
+  updateProfile: (body: UpsertProfileRequest) => Promise<unknown>
+  onProfileChanged: () => void
+}) {
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const on = pd.profile.defaultDeny
+
+  async function toggle() {
+    if (saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      const body = formToRequest(detailToForm(pd))
+      body.defaultDeny = !on
+      await updateProfile(body)
+      onProfileChanged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div data-testid={`profile-default-deny-${pd.profile.id}`}>
+      <div className="flex items-start justify-between gap-4 bg-brand-alt/40 rounded-xl px-4 py-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-brand-ink">Default-deny</p>
+          <p className="text-xs text-brand-text-muted mt-0.5">
+            {on
+              ? 'Everything is blocked except this profile’s allowed apps/hosts and the household global allowlist.'
+              : 'Allow by default; only blocked categories and blocked hosts are dropped. Turn on to block everything not explicitly allowed.'}
+          </p>
+        </div>
+        <label className="inline-flex items-center cursor-pointer shrink-0">
+          <input
+            type="checkbox"
+            checked={on}
+            disabled={saving}
+            onChange={toggle}
+            data-testid={`profile-default-deny-toggle-${pd.profile.id}`}
+            aria-label="Default-deny"
+            className="sr-only peer"
+          />
+          <span className="w-11 h-6 bg-brand-border rounded-full peer-checked:bg-red-600 relative transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-transform peer-checked:after:translate-x-5" />
+        </label>
+      </div>
+      {error && (
+        <p className="text-xs text-red-700 mt-1" data-testid={`profile-default-deny-error-${pd.profile.id}`}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
 }
 
 function TimeSubsection({

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -25,6 +25,11 @@ export interface Profile {
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
   pauseMode: PauseMode
+  // #1320 / #1308: default-deny baseline. When true the profile blocks all
+  // traffic except its extraAllowed hosts/apps + the household global allowlist
+  // (the inverse of the allow-by-default + blocklists model). Resolved
+  // server-side into the per-MAC `blocked = true`; the router never sees it.
+  defaultDeny: boolean
 }
 
 export interface Schedule {
@@ -647,6 +652,54 @@ export interface UpsertProfileRequest {
   crossDeviceOverlapMode?: CrossDeviceOverlapMode
   // #1418: omit to preserve existing value on update; defaults to 'soft' on create.
   pauseMode?: PauseMode
+  // #1320: omit to preserve existing value on update; defaults to false on create.
+  defaultDeny?: boolean
+}
+
+// #1320 / #1308: admin-facing management + audit view of the household-global
+// policy (`PolicySnapshot.global`). The wire snapshot carries only flat
+// hostname / category lists for the router; the *why* and *who* (the
+// security-sensitive bypass-list audit trail) are surfaced ONLY here.
+
+// One row of the global allow/block audit history. `removedAt == null` ⇒ the
+// entry is active and feeds the snapshot; non-null ⇒ soft-deleted, kept for
+// audit. `addedBy`/`removedBy` are usernames resolved server-side.
+export interface GlobalPolicyAuditEntry {
+  host: string
+  reason: string | null
+  addedBy: string | null
+  addedAt: string
+  removedBy: string | null
+  removedAt: string | null
+}
+
+export type MacBlockReason =
+  | 'Paused' | 'Schedule' | 'TimeLimit' | 'Manual' | 'Unmanaged' | 'DefaultDeny'
+
+export interface GlobalPolicyView {
+  // Full history (active + soft-deleted). The active set feeding the snapshot
+  // is the entries with `removedAt == null`.
+  allow: GlobalPolicyAuditEntry[]
+  blocks: GlobalPolicyAuditEntry[]
+  blocklistIds: string[]
+  blocked: boolean
+  blockReason: MacBlockReason | null
+  blockIpOnly: boolean
+}
+
+export interface AddGlobalHostRequest {
+  host: string
+  reason?: string | null
+}
+
+export interface SetGlobalBlocklistsRequest {
+  blocklistIds: string[]
+}
+
+export interface SetGlobalFlagsRequest {
+  blocked: boolean
+  blockReason?: MacBlockReason | null
+  blockIpOnly: boolean
 }
 
 export interface UpsertDeviceRequest {


### PR DESCRIPTION
Implements [#1320](https://github.com/wifihaven/wifihaven/issues/1320) — the SPA surface for the global policy layer ([#1308](https://github.com/wifihaven/wifihaven/issues/1308), design [`docs/design/global-policy-layer.md`](docs/design/global-policy-layer.md) §7/§8). Builds on the merged shared shape (#1316) and PolicyService assembly (#1318).

## What's here

**Global allow/block management + audit view** (`/global-policy`, admin-only)
- **Always-allow** management leading with a prominent **audit trail** (who added each host, why, and the soft-deleted history). `global.extraAllowed` is a security-sensitive bypass surface — a host here is reachable from every device regardless of any block — so the audit view is front-and-center.
- **Global host blocks** (mandatory network-wide drops a profile may not un-block).
- **Global category blocklists** (toggle the household-global `blocklistIds`).
- **Network controls**: the lockdown kill switch (`global.blocked` + block-page reason) and network-wide strict-IP (`global.blockIpOnly`).

**Per-profile default-deny toggle** on the expanded profile card, with copy that makes the block-all implication explicit ("everything blocked except this profile's allowed apps/hosts + the household global allowlist"). Persists via the existing full-profile PUT.

## API (no new migration — V48 already shipped these columns)

Per AGENTS.md "Adding a new API route". #1318 shipped `GlobalPolicyRepo` reads/writes but no HTTP surface or audit reads, so this adds:
- `GlobalPolicyRepo.allowAudit` / `blockAudit` (join `users` for the `reason`/`added_by`/`removed_by` columns) and `setBlocklists` (replace-wholesale).
- `GlobalPolicyRoutes`: `GET /api/global/policy`, `POST`/`DELETE /api/global/{allow,blocks}`, `PUT /api/global/blocklists`, `PUT /api/global/flags`. Writes are admin-only and record the acting user; the read view is any-authenticated (mirrors the household-settings GET). The router never sees the *why* — only the flat lists `GlobalPolicyRepo` assembles into `PolicySnapshot.global` (design §7).
- `UpsertProfileRequest.defaultDeny` (additive, optional, preserve-on-omit); profile create/update persist it. This is the only wire-shape change and it's additive.

No new metric series: the routes are covered by the existing HTTP middleware's route-templated duration/status series, so no bespoke metric or dashboard panel is required.

## Tests (TDD)

- `GlobalPolicyApiSpec` — GET view, add/remove allow + block (with audit reason + acting user, soft-delete history), set blocklists (replace), set flags, non-admin write rejection, and profile default-deny persist + preserve-on-omit.
- `GlobalPolicyPage.test.tsx` — renders the allow/block audit view; Add / Remove / category-toggle / lockdown-toggle each call the API.
- `ProfilesPage.test.tsx` — toggling default-deny persists via the full-profile PUT, preserving the other fields.
- Full suite green: `mill api.test` (GlobalPolicyApiSpec + all feature specs), web `tsc`/`eslint`/`vitest` (341 tests).

## Deferred — per-device override editor → [#1452](https://github.com/wifihaven/wifihaven/issues/1452)

The third #1320 deliverable (per-device `rules` override editor) is **not** here: the backend doesn't exist yet — there is no `devices.rules` column (V48 added only `profiles.default_deny`), no repo/PolicyService support, and no `Device.rules` field. Authoring it requires a Flyway migration, which must ship in its own code-free PR per the migration-isolation rule. Filed as #1452 with the two-PR sequence (migration → backend → web editor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)