### PR TITLE
ci(#1454): bump wifihaven-api-staging free → starter so staging serves

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -30,22 +30,17 @@ services:
   - type: web
     runtime: image
     name: wifihaven-api-staging
-    # #1389 / #1386: back to `free` (512 MB / 0.1 CPU, spins down idle) to
-    # save ~$7/mo. The original bump in #1268 was driven by missing CD's
-    # 15-min "serve the new sha" window on 0.1 CPU — the JVM itself started
-    # clean (no OOM in the deploy logs), but the cold-start was right at the
-    # ceiling. The CD wait in master-api-ui.yml's deploy-staging job is now
-    # 30 min (up from 15) so the slower free-tier cold-start has clear room;
-    # historical `starter` deploys here finish in ~100-170s, and JVM time
-    # scales ~5x with CPU, so ~500-900s on free is the expected envelope.
-    # Free spin-down (~15 min idle) doesn't bite CD — smoke-staging,
-    # api-smoke-staging, and gate-3b-api-staging all hit the service
-    # immediately after deploy, so it's still warm. Interactive debugging
-    # absorbs a one-time ~30-60s wake-up. RAM cap is unchanged (free and
-    # starter are both 512 MB), so the -Xmx384m heap envelope carries over.
-    # Bump back to `starter` if free's cold-start drifts beyond the 30-min
-    # window, or to `standard` if OOM actually appears in the logs.
-    plan: free
+    # #1454: starter is the FLOOR for a working staging API — do NOT re-drop
+    # to `free`. #1393's cost pass tried `free` (#1389 / #1386) to save ~$7/mo,
+    # but the free tier cannot keep the JVM API serving: it spins down on idle
+    # and the 0.1 CPU cold-start blew the CD smoke window, so staging returned
+    # 502 and "Gate 1 — API contract smoke (staging)" failed. This is the same
+    # regression #1268 originally fixed (free → starter). starter (~$7/mo) is
+    # the minimum non-spin-down JVM-capable tier; any future staging cost trim
+    # must come from a different lever (e.g. suspend staging when not
+    # deploying), NOT from dropping to free. Bump to `standard` if OOM appears
+    # in the logs (RAM is 512 MB on both free and starter; -Xmx384m heap).
+    plan: starter
     region: oregon
     numInstances: 1
     healthCheckPath: /api/health


### PR DESCRIPTION
Fixes #1454.

## Problem
`Master API/UI CD` → "Gate 1 — API contract smoke (staging)" fails: staging API returns **502**.

PR #1393 (cost reduction) dropped `wifihaven-api-staging` from `plan: starter` → `plan: free`. The **free tier cannot run the JVM API** — it spins down on idle and the 0.1 CPU cold-start blew the CD smoke window, so staging is effectively down (502). This is the same failure #1268 originally fixed; #1393 regressed it.

## Fix
Bump `wifihaven-api-staging` back one tier `free` → `starter` in `render.yaml` (declarative; repo is source of truth — next Render sync picks it up). This is the **only** change needed: RAM is 512 MB on both free and starter, so the `-Xmx384m` heap envelope and all env vars carry over unchanged.

## Cost lesson (for the #1393 Cost Reduction epic)
**Staging cannot be `free`** — the JVM needs a non-spin-down tier. `starter` (~$7/mo) is the floor for a working staging API. Do not re-drop it. Any future staging cost trim must come from a different lever (e.g. suspend staging when not deploying), not from dropping to free. This constraint is now captured in the `render.yaml` comment so the next cost pass doesn't re-break it.

## Verification
After merge (which triggers the Render staging sync), staging should serve again — `POST /api/auth/login` with an empty body returns 400/401 (not 502), the same proof-of-life the Gate 1 smoke uses — and the "Gate 1 — API contract smoke (staging)" job should go green.