### PR TITLE
fix(#1457): router-fleet panel-6 shows current agent version per router

### DIFF
--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -179,29 +179,42 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Agent versions across the fleet",
-      "description": "count by (version) (agent_version{value=1}) — how many routers run each agent version (info-gauge idiom: agent_version is a constant 1 carrying the version label). Use during a rollout to watch routers move to the new build.",
-      "type": "timeseries",
+      "description": "agent_version == 1, evaluated instant — one row per router showing the version it is currently running (info-gauge idiom: agent_version is a constant 1 carrying the version label). Instant (not range) so a version a router has moved off of drops out after Prometheus staleness (~5m) rather than lingering as in-window history — a range/timeseries view kept showing the pre-upgrade version next to the new one (#1457). During a rollout a router may briefly show two rows while the superseded series ages out.",
+      "type": "table",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
       "id": 6,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "unit": "short",
-          "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1, "stacking": { "mode": "normal", "group": "A" } }
+          "color": { "mode": "thresholds" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [{ "displayName": "Router", "desc": false }],
+        "footer": { "show": false, "reducer": ["sum"], "countRows": false, "fields": "" }
       },
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "count by (version) (agent_version{env=\"$env\"})",
-          "legendFormat": "{{version}}",
+          "expr": "agent_version{env=\"$env\"} == 1",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "__auto",
           "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true, "env": true, "instance": true, "job": true, "installation_id": true },
+            "indexByName": { "router_id": 0, "version": 1 },
+            "renameByName": { "router_id": "Router", "version": "Version" }
+          }
         }
       ]
     },


### PR DESCRIPTION
Fixes #1457.

## Root cause — history-in-window artifact, not a persistent stale series

panel-6 ("Agent versions across the fleet") was a **timeseries** plotting
`count by (version) (agent_version{env="$env"})` over the dashboard window
(default 6h), with a `lastNotNull` legend calc.

`agent_version` is an **info-gauge** (constant `1` carrying `version` /
`router_id` labels, emitted once at agent startup — see
`openwrt/files/usr/sbin/wifihaven-agent` and the API re-export allowlist in
`api/src/metrics/Metrics.scala`). A single router can only emit one `version`
label at a time; when it upgrades, the old-version series simply **stops** and
ages out via Prometheus staleness (~5m).

The range/timeseries view, though, plots every version *seen anywhere in the
window*. After router.lan's 0.3.0→0.3.1 upgrade (#1420), the now-dead
`version="0.3.0"` series still showed in the legend table because `lastNotNull`
surfaces its last non-null in-window sample (`1`) next to `0.3.1`. So both
versions appeared for the single prod router. This is **history-in-window**,
not a lingering live series — an instant query at "now" already drops 0.3.0
after staleness.

## Fix

Convert panel-6 to an **instant table**, one row per router at its
currently-running version:

```promql
agent_version{env="$env"} == 1   # instant, format=table
```

An instant query evaluates only the series live at evaluation time, so a
version a router has moved off of drops out after Prometheus staleness instead
of lingering as history. An `organize` transformation keeps `router_id` →
`Router` and `version` → `Version`, dropping the scrape labels
(`__name__`, `env`, `instance`, `job`, `installation_id`, `Time`, `Value`).

- **Single prod router, post-upgrade-settled:** exactly one row — `0.3.1`.
- **During a rollout:** a router may briefly show two rows while the
  superseded series ages out (~5m), which is the real Prometheus staleness
  behavior and self-resolves.

## Validation

- `python3 -m json.tool` on every dashboard JSON — pass.
- `terraform fmt -check -recursive` — pass.
- `terraform init -backend=false && terraform validate` (`infra/grafana`) — `Success! The configuration is valid.`

Dashboard is checked-in JSON deployed by `master-grafana.yml` via the
`infra/grafana` Terraform (now on the HCP remote backend, #1406); a second
apply is a no-op. The corrected panel renders live only after that apply on
merge — final live-dashboard confirmation will be done post-deploy.