### PR TITLE
policy(#1321): retire the #1307 per-profile infra-allow copy

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -97,8 +97,8 @@ class PolicyServiceLive(
   // hosts, so they live in `global.extraAllowed` (carving out every block at the
   // router) rather than being copied into every profile's `extraAllowed`. The
   // DB-backed `global_allow` set is unioned with these per-deployment config
-  // hosts when assembling the global section. (The #1307 infra-allow copy is
-  // retired separately in #1321.)
+  // hosts when assembling the global section. (#1321 moved the curated
+  // `infraAllowHosts` onto the same global path, retiring its per-profile copy.)
   private val uiGlobalAllow: List[Hostname] = uiAllowedHosts
 
   // #1069: per-host /decision fallback must see the same schedule downtime as the snapshot —
@@ -218,11 +218,19 @@ class PolicyServiceLive(
         c -> Blocklist(version = version, url = BlocklistUrl.unsafe(s"/api/blocklists/${c.value}"))
       }.toMap
 
-      // #1318: union the per-deployment UI / block-page hosts into the DB-backed
-      // global allow set. These are the relocated `uiAllowedHosts` — fleet-wide
-      // always-reachable hosts that carve out every block at the router.
+      // #1318/#1321: union the fleet-wide always-reachable hosts into the
+      // DB-backed global allow set. Two relocated sources join `global_allow`:
+      //   - `uiGlobalAllow` — the per-deployment UI / block-page hosts (#1318).
+      //   - `infraAllowHosts` — the curated connectivity-check / OCSP / PKI /
+      //     captive-portal / gvt2 device-level deps (#1307), which #1321 stops
+      //     copying into every profile's `extraAllowed` and ships here ONCE.
+      // The router applies `global.extraAllowed` as the top of the precedence
+      // ladder (@global_allow, #1319), carving every drop out for every MAC — so
+      // these hosts beat every block path identically to the old per-(MAC) ea_
+      // copies, with no per-profile duplication and a single ETag-moving source.
       val globalRules = globalRaw.copy(
-        extraAllowed = (globalRaw.extraAllowed ++ uiGlobalAllow).distinct,
+        extraAllowed =
+          (globalRaw.extraAllowed ++ uiGlobalAllow ++ PolicyService.infraAllowHosts).distinct,
       )
 
       val core = SnapshotCore(globalRules, devicePolicies, profilePolicies, pBlocklists)
@@ -523,10 +531,12 @@ object PolicyService {
    * only spares each profile's explicit `extraAllowed` hosts, so without these an allowed app's
    * apex host resolves while its transitive dependencies are dropped and the app *appears* blocked.
    *
-   * We ship these by copying them into every profile's `extraAllowed`; the existing #421 ea_
-   * enforcement then makes them beat the block. This is deliberately functional, not a new snapshot
-   * field — the router needs the hosts, not the reason they're allowed (#1311). The global policy
-   * layer (#1308) will let us state this once instead of per-profile, removing the redundancy.
+   * #1321: these ship ONCE via `global.extraAllowed` (unioned in by `PolicyServiceLive.snapshot`),
+   * not copied into every profile. The router applies the global section as the top of its
+   * precedence ladder (@global_allow, #1319), carving every drop out for every MAC — so they still
+   * beat the block exactly as the old per-(MAC) ea_ copies did, now from a single fleet-wide source
+   * with no per-profile duplication. This stays deliberately functional, not a new snapshot field —
+   * the router needs the hosts, not the reason they're allowed (#1311).
    */
   val infraAllowHosts: List[Hostname] = List(
     "connectivitycheck.gstatic.com", // Android / Chrome connectivity probe
@@ -669,22 +679,24 @@ object PolicyService {
     // semantics it already applies to the per-profile own lists (see
     // feedback_extraallowed_beats_blocked).
     //
-    // #1307: the curated infra allowlist (connectivity-check / OCSP / CDN deps of
-    // an allowed app) is still copied per-profile here so it survives the
-    // whole-MAC block; #1321 retires this copy once the router consumes
-    // `global.extraAllowed`. The deployment UI hosts moved to the global section
-    // already (#1318), so they are no longer unioned here.
+    // #1321: the curated infra allowlist (connectivity-check / OCSP / CDN deps
+    // of an allowed app) is NO LONGER copied per-profile. It moved to
+    // `global.extraAllowed` (see `PolicyServiceLive.snapshot`), which the router
+    // carves out of every drop for every MAC (@global_allow, #1319) — so infra
+    // hosts still beat every block path, now from a single fleet-wide source
+    // instead of duplicated into each profile's `extraAllowed`. The deployment UI
+    // hosts moved to the global section earlier (#1318) for the same reason.
     //
-    // #1418: under a hard pause, drop even the app/exempt/infra carve-outs —
-    // per-profile `extraAllowed` goes empty. The deployment UI hosts (block page
-    // + admin SPA) still survive because they now live in `global.extraAllowed`,
-    // which the router applies as the top of the precedence ladder and carves out
-    // of every drop (#1319) — so a hard pause is a true off-switch for everything
-    // except the always-reachable global hosts, exactly as before #1318 (when the
-    // UI hosts were the per-profile carve-out the hard pause kept).
+    // #1418: under a hard pause, drop even the app/exempt carve-outs — per-profile
+    // `extraAllowed` goes empty so the router drops the MAC unconditionally (no
+    // `ip daddr != @ea_…`). The always-reachable global hosts (UI / block page +
+    // admin SPA, and now the infra allowlist) still survive because they live in
+    // `global.extraAllowed`, the top of the router's precedence ladder (#1319) —
+    // so a hard pause remains a true off-switch for every per-profile carve-out,
+    // sparing only the fleet-wide always-reachable set.
     val profileExtraAllowed =
       if (isHardPause) Nil
-      else (appExtraAllowed ++ appExemptAllowedHosts ++ infraAllowHosts).distinct
+      else (appExtraAllowed ++ appExemptAllowedHosts).distinct
 
     if (profile.defaultDeny)
       // #1318: default-deny baseline. Block-all with only the profile/device

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -212,11 +212,9 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         rules = snap.profiles(kids).rules
       } yield assertTrue(!rules.extraAllowed.map(_.value).contains("noone.example.com")) &&
         assertTrue(!rules.extraBlocked.map(_.value).contains("noone.example.com")) &&
-        // Kids profile defaults preserved: extraAllowed carries only the #1307
-        // global infra allowlist, no app hosts leak in.
-        assertTrue(
-          rules.extraAllowed.map(_.value).toSet == PolicyService.infraAllowHosts.map(_.value).toSet,
-        )
+        // #1321: a profile with no app assignments now has an EMPTY per-profile
+        // extraAllowed — the infra allowlist no longer copies in (it rides global).
+        assertTrue(rules.extraAllowed.isEmpty)
     },
     // ── #1105: time_limited app with exemptFromDaily carves around @blocked_macs ──
     test(
@@ -404,14 +402,15 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(!eb.contains("mathacademy.com"))
     },
     test(
-      "#1307: global infra hosts are in every profile's extraAllowed, even when blocked=TimeLimit",
+      "#1321: infra hosts ride global.extraAllowed (not per-profile) under blocked=TimeLimit",
     ) {
       // Allowed-mode apps appeared blocked when the daily cap ran out because
       // the whole-MAC @blocked_macs drop killed transitive connectivity-check /
-      // OCSP / CDN dependencies. We ship a curated infra allowlist in every
-      // profile's extraAllowed (relying on the existing #421 ea_ enforcement)
-      // until the global policy layer (#1308) removes the per-profile copy. No
-      // snapshot-shape change: this stays functional, not policy-based (#1311).
+      // OCSP / CDN dependencies. The curated infra allowlist now ships ONCE via
+      // global.extraAllowed (#1321), which the router carves out of every drop
+      // for every MAC (#1319/#421) — so the host stays reachable while the
+      // per-profile extraAllowed no longer duplicates it. Functional, not
+      // policy-based (#1311); no snapshot-shape change.
       val mac = "aa:bb:cc:dd:ee:14"
       for {
         _    <- cleanDb
@@ -429,18 +428,26 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         snap <- svc.snapshot
         rules = snap.profiles(kid).rules
         ea    = rules.extraAllowed.map(_.value).toSet
+        ga    = snap.global.extraAllowed.map(_.value).toSet
       } yield assertTrue(rules.blocked) &&
         assertTrue(rules.blockReason.contains(MacBlockReason.TimeLimit)) &&
-        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea)) &&
-        assertTrue(ea.contains("connectivitycheck.gstatic.com"))
+        // infra no longer copied into the per-profile list…
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.intersect(ea).isEmpty) &&
+        // …it lives in the global section, reachable for this (and every) MAC.
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ga)) &&
+        assertTrue(ga.contains("connectivitycheck.gstatic.com"))
     },
     test(
-      "#1418: HARD pause drops the allowed-app host AND infra hosts from extraAllowed",
+      "#1418/#1321: HARD pause empties per-profile extraAllowed; infra survives via global",
     ) {
-      // Hard pause is a true off-switch: unlike soft pause (#421/#1413), even
-      // an allowed-mode app and the #1307 global infra allowlist go dark. With
-      // no uiAllowedHosts configured here, extraAllowed must come back empty so
-      // the router drops the MAC unconditionally (no `ip daddr != @ea_…`).
+      // Hard pause is a true off-switch for per-profile carve-outs: unlike soft
+      // pause (#421/#1413), the allowed-mode app host is dropped from the
+      // profile's own extraAllowed, so the router drops the MAC unconditionally
+      // (no `ip daddr != @ea_…`). As of #1321 the curated infra allowlist no
+      // longer lives per-profile — it rides global.extraAllowed, which the router
+      // carves out of every drop (#1319). So a hard pause still cuts the kid off
+      // from real apps/sites while pure infra probes (OCSP / connectivity-check /
+      // gvt2) stay reachable fleet-wide, exactly like the deployment UI hosts.
       for {
         _     <- cleanDb
         pr    <- ZIO.service[ProfileRepo]
@@ -456,17 +463,21 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         snap  <- svc.snapshot
         rules = snap.profiles(kid).rules
         ea    = rules.extraAllowed.map(_.value).toSet
+        ga    = snap.global.extraAllowed.map(_.value).toSet
       } yield assertTrue(rules.blocked) &&
         assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
+        // per-profile extraAllowed is empty — the app host AND infra are gone from it
         assertTrue(ea.isEmpty) &&
         assertTrue(!ea.contains("khanacademy.org")) &&
-        assertTrue(!ea.contains("connectivitycheck.gstatic.com"))
+        // but infra is still reachable globally (survives the hard pause)
+        assertTrue(ga.contains("connectivitycheck.gstatic.com"))
     },
     test(
-      "#1418: SOFT pause keeps the allowed-app host AND infra hosts (regression guard)",
+      "#1418/#1321: SOFT pause keeps the allowed-app host per-profile; infra rides global",
     ) {
       // The default, unchanged behavior: a soft-paused profile still spares its
-      // extraAllowed hosts (#421/#1413) and the curated infra allowlist (#1307).
+      // own extraAllowed hosts (#421/#1413). The curated infra allowlist now
+      // surfaces via global.extraAllowed (#1321) rather than the per-profile copy.
       for {
         _     <- cleanDb
         pr    <- ZIO.service[ProfileRepo]
@@ -482,20 +493,24 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         snap  <- svc.snapshot
         rules = snap.profiles(kid).rules
         ea    = rules.extraAllowed.map(_.value).toSet
+        ga    = snap.global.extraAllowed.map(_.value).toSet
       } yield assertTrue(rules.blocked) &&
         assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
         assertTrue(ea.contains("khanacademy.org")) &&
-        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea))
+        // infra no longer copied per-profile; it is in the global section
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.intersect(ea).isEmpty) &&
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ga))
     },
     test(
       "#1418/#1318: HARD pause still spares the deployment uiAllowedHosts via global.extraAllowed",
     ) {
       // We deliberately keep the deployment UI hosts reachable through a hard
       // pause so the kid sees the block page and the admin SPA loads on the LAN —
-      // only the app/infra allowlists are cut. As of #1318 the UI hosts live in
-      // `global.extraAllowed` (not per-profile), and the router carves them out
-      // of every drop (#1319), so the per-profile `extraAllowed` is now empty
-      // while the global section carries exactly the UI hosts.
+      // only the per-profile app allowlist is cut. As of #1318 the UI hosts live
+      // in `global.extraAllowed` (not per-profile), and #1321 moves the curated
+      // infra allowlist there too; the router carves the global section out of
+      // every drop (#1319), so the per-profile `extraAllowed` is empty under a
+      // hard pause while the global section carries the UI hosts + infra.
       val uiHosts = List(Hostname.unsafe("blockpage.wifihaven.lan"))
       for {
         _     <- cleanDb
@@ -536,10 +551,12 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         ea    = rules.extraAllowed.map(_.value).toSet
         ga    = snap.global.extraAllowed.map(_.value).toSet
       } yield assertTrue(rules.blocked) &&
-        // per-profile extraAllowed is empty under hard pause (app/infra cut, UI relocated)
+        // per-profile extraAllowed is empty under hard pause (app cut, UI + infra relocated)
         assertTrue(ea.isEmpty) &&
-        // the deployment UI hosts survive via the fleet-wide global section
-        assertTrue(ga == Set("blockpage.wifihaven.lan")) &&
+        // the deployment UI hosts survive via the fleet-wide global section…
+        assertTrue(ga.contains("blockpage.wifihaven.lan")) &&
+        // …alongside the curated infra allowlist, which also now rides global
+        assertTrue(PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ga)) &&
         assertTrue(!ea.contains("khanacademy.org")) &&
         assertTrue(!ea.contains("connectivitycheck.gstatic.com"))
     },

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -14,9 +14,13 @@ import zio.test.*
  * #944 → #1318: deployment-configured UI hosts (wifihaven.policy.uiAllowedHosts) are fleet-wide
  * always-reachable hosts. As of #1318 they are emitted ONCE in `snapshot.global.extraAllowed`
  * (which carves out every block at the router) rather than copied into every profile's
- * `extraAllowed`. This spec pins the relocated shape: the UI hosts appear in the global section and
- * NOT in per-profile `extraAllowed`, while the curated infra-allow hosts (#1307, retired in #1321)
- * stay copied per-profile for now.
+ * `extraAllowed`.
+ *
+ * #1321: the curated infra-allow hosts (#1307 — connectivity-check / OCSP / PKI / captive-portal /
+ * gvt2 device-level deps) now ride the SAME path. They are unioned into `global.extraAllowed` ONCE
+ * and the per-profile copy in `computeBlockRules` is retired, so this spec pins both relocated
+ * sets: UI hosts and infra hosts appear in the global section and NOT in any per-profile
+ * `extraAllowed`.
  */
 object PolicySnapshotGlobalAllowSpec
     extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
@@ -65,7 +69,7 @@ object PolicySnapshotGlobalAllowSpec
 
   def spec = suite("policy snapshot — global allow hosts (#944 / #1318)")(
     test(
-      "empty uiAllowedHosts → per-profile extraAllowed is the app-derived list plus infra hosts",
+      "empty uiAllowedHosts → per-profile extraAllowed is the app-derived list only; infra rides global",
     ) {
       for {
         _    <- cleanDb
@@ -100,12 +104,16 @@ object PolicySnapshotGlobalAllowSpec
           gpr,
         )
         snap <- svc.snapshot
-      } yield assertTrue(
-        snap.profiles(kids.id).rules.extraAllowed.map(_.value).toSet ==
-          (Set("user.example") ++ PolicyService.infraAllowHosts.map(_.value).toSet),
-        // global is inert (no DB global_allow rows, no ui hosts configured)
-        snap.global.extraAllowed.isEmpty,
-      )
+      } yield {
+        val infra = PolicyService.infraAllowHosts.map(_.value).toSet
+        assertTrue(
+          // #1321: per-profile extraAllowed is now ONLY the app-derived list — no infra copy.
+          snap.profiles(kids.id).rules.extraAllowed.map(_.value).toSet == Set("user.example"),
+          // even with no DB global_allow rows and no ui hosts, the global section carries the
+          // curated infra set (it is unioned in from the code constant).
+          infra.subsetOf(snap.global.extraAllowed.map(_.value).toSet),
+        )
+      }
     },
     test("configured ui hosts land in global.extraAllowed once, NOT per-profile") {
       for {
@@ -168,10 +176,10 @@ object PolicySnapshotGlobalAllowSpec
         )
       }
     },
-    test("every profile's extraAllowed includes the #1337 Apple connectivity-test host") {
+    test("#1337 Apple connectivity-test host rides global.extraAllowed, not per-profile") {
       // #1337: Apple's network-connectivity-test CDN is a device-level infra dep that
       // was dropped under a whole-MAC block. It lives in the curated infraAllowHosts
-      // constant, still copied per-profile (the #1307 copy is retired separately in #1321).
+      // constant which, as of #1321, ships ONCE via global.extraAllowed (not per-profile).
       val newHosts = Set("netcts.cdn-apple.com")
       for {
         _    <- cleanDb
@@ -179,17 +187,20 @@ object PolicySnapshotGlobalAllowSpec
         snap <- svc.snapshot
       } yield assertTrue(
         snap.profiles.nonEmpty,
-        snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
+        newHosts.subsetOf(snap.global.extraAllowed.map(_.value).toSet),
+        snap.profiles.values.forall(p =>
+          newHosts.intersect(p.rules.extraAllowed.map(_.value).toSet).isEmpty,
+        ),
       )
     },
-    test("every profile's extraAllowed includes the #1411 gvt2.com Google infra domain") {
+    test("#1411 gvt2.com Google infra domain rides global.extraAllowed, not per-profile") {
       // #1411: gvt2.com is Google's connectivity-check / Play / download infra
       // domain, a device-level transitive dep dropped under a whole-MAC block. It
-      // lives in the curated infraAllowHosts constant, so it must surface in every
-      // profile's extraAllowed (copied per-profile, allow beats the @blocked_macs
-      // drop via #421 ea_ enforcement). Added as the apex `gvt2.com` so the
-      // router's trailing-suffix match carves out every *.gvt2.com subdomain,
-      // including the rotating download shards.
+      // lives in the curated infraAllowHosts constant; as of #1321 it surfaces in
+      // global.extraAllowed (allow beats every block via the router's @global_allow
+      // carve-out, #1319). Added as the apex `gvt2.com` so the router's
+      // trailing-suffix match carves out every *.gvt2.com subdomain, including the
+      // rotating download shards.
       val newHosts = Set("gvt2.com")
       for {
         _    <- cleanDb
@@ -197,8 +208,34 @@ object PolicySnapshotGlobalAllowSpec
         snap <- svc.snapshot
       } yield assertTrue(
         snap.profiles.nonEmpty,
-        snap.profiles.values.forall(p => newHosts.subsetOf(p.rules.extraAllowed.map(_.value).toSet)),
+        newHosts.subsetOf(snap.global.extraAllowed.map(_.value).toSet),
+        snap.profiles.values.forall(p =>
+          newHosts.intersect(p.rules.extraAllowed.map(_.value).toSet).isEmpty,
+        ),
       )
+    },
+    test("#1321: infra host is reachable under a whole-MAC block via global, not per-profile ea") {
+      // Behavior preservation: a paused (whole-MAC blocked) profile carries NO infra
+      // in its own extraAllowed, yet the infra host stays reachable because it now
+      // lives in global.extraAllowed — which the router carves out of every drop,
+      // including @blocked_macs (#1319/#421).
+      val infraHost = "connectivitycheck.gstatic.com"
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        ps0 <- pr.listAll
+        kids = ps0.find(_.name == "Kids").get
+        _    <- pr.setPaused(kids.id, true)
+        svc  <- makePs
+        snap <- svc.snapshot
+      } yield {
+        val rules = snap.profiles(kids.id).rules
+        assertTrue(
+          rules.blocked,
+          !rules.extraAllowed.map(_.value).contains(infraHost),
+          snap.global.extraAllowed.map(_.value).contains(infraHost),
+        )
+      }
     },
     test(
       "ui host blocked as an app appears in per-profile extraBlocked; global.extraAllowed still saves it",

--- a/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
@@ -82,9 +82,16 @@ object PolicySnapshotGlobalSectionSpec
         ps   <- makePs
         snap <- ps.snapshot
       } yield {
-        val g = snap.global
+        val g     = snap.global
+        val ea    = g.extraAllowed.map(_.value).toSet
+        // #1321: the curated infra allowlist is unioned into global.extraAllowed
+        // alongside the DB-backed global_allow rows, so assert membership rather
+        // than an exact list (no ui hosts are configured in this spec).
+        val infra = PolicyService.infraAllowHosts.map(_.value).toSet
         assertTrue(
-          g.extraAllowed.map(_.value) == List("infra.example"),
+          ea.contains("infra.example"),
+          infra.subsetOf(ea),
+          ea == infra + "infra.example",
           g.extraBlocked.map(_.value) == List("evil.example"),
           g.blocklistIds.map(_.value) == List("ads"),
           g.blockIpOnly,
@@ -102,9 +109,15 @@ object PolicySnapshotGlobalSectionSpec
         _    <- gpr.removeAllow(Hostname.unsafe("removed.example"), None)
         ps   <- makePs
         snap <- ps.snapshot
-      } yield assertTrue(
-        snap.global.extraAllowed.map(_.value).toSet == Set("kept.example"),
-      )
+      } yield {
+        val ea = snap.global.extraAllowed.map(_.value).toSet
+        // #1321: kept DB row + the curated infra constant; removed row excluded.
+        assertTrue(
+          ea.contains("kept.example"),
+          !ea.contains("removed.example"),
+          PolicyService.infraAllowHosts.map(_.value).toSet.subsetOf(ea),
+        )
+      }
     },
     test("global lockdown flag → global.blocked + reason from household_settings") {
       for {
@@ -137,7 +150,8 @@ object PolicySnapshotGlobalSectionSpec
         assertTrue(
           rules.blocked,
           rules.blockReason.contains(MacBlockReason.DefaultDeny),
-          // only the explicit allow (plus copied infra hosts) is reachable
+          // only the explicit per-profile allow is reachable here; the curated
+          // infra set carves out separately via global.extraAllowed (#1321)
           rules.extraAllowed.map(_.value).contains("pbskids.org"),
           // extraBlocked / blocklistIds are omitted under block-all even though the
           // profile carries blocked_categories

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,16 +218,15 @@ mode (`blocked = true` baseline + `MacBlockReason.DefaultDeny`, with
 > `PolicyService` now emits `snapshot.global` (a `BlockRules`) from the V48
 > global-policy tables + the per-deployment UI hosts, evaluates per-profile
 > `default_deny` into `blocked = true` + `MacBlockReason.DefaultDeny`, and the
-> snapshot ETag covers the global section. The **deployment UI / block-page
-> hosts** have moved out of every profile's `extraAllowed` into
-> `global.extraAllowed`. Still outstanding: the **router** does not yet compose
-> the global section (#1319) — an old agent ignores the additive `global` field
-> and keeps enforcing per-MAC exactly as before — and the curated **#1307 infra
-> allowlist is still copied into each profile's `extraAllowed`**
-> (`PolicyService.computeBlockRules`), retired only once the router consumes
-> `global.extraAllowed` (#1321). So in the current window the UI hosts are
-> enforced via the global layer (needs #1319) while the infra hosts are still
-> enforced the per-profile way.
+> snapshot ETag covers the global section. The router composes the global
+> section (#1319, `@global_allow` / `@global_block`). Both fleet-wide
+> always-reachable sets — the **deployment UI / block-page hosts** and the
+> curated **#1307 infra allowlist** (connectivity-check / OCSP / PKI /
+> captive-portal / gvt2) — now live in `global.extraAllowed` and are emitted
+> **once**; the per-profile copy in `PolicyService.computeBlockRules` has been
+> retired (#1321). They beat every block path for every MAC via the router's
+> global carve-out, exactly as the old per-(MAC) `ea_` copies did, with no
+> per-profile duplication and a single ETag-moving source.
 
 > **Known deviations from this model as of May 2026** (tracked follow-ups,
 > not the canonical design):
@@ -268,9 +267,12 @@ even when a whole MAC is blocked — an initial attempt added a top-level
 allowed) straight to the router. That was wrong: an always-allowed host is
 functionally indistinguishable from any other `extraAllowed` entry, and the
 router has no need for a separate "infra" channel or for *why* the host is
-allowed. The correct fix resolves the infra hosts server-side and copies them
-into every profile's `extraAllowed`, relying on the enforcement that already
-exists for that field. The router learns nothing new.
+allowed. The correct fix resolves the infra hosts server-side and emits them as
+ordinary always-reachable hosts, relying on the enforcement that already exists
+for `extraAllowed`. The router learns nothing new. (They first shipped copied
+into every profile's `extraAllowed`; #1321 then consolidated them — and the UI
+hosts — into `global.extraAllowed` so the fleet-wide set is carried once. The
+"no new field / no reason on the wire" lesson is unchanged either way.)
 
 **2. No policy *reasons* on the wire except where functionally required.**
 `blockReason: Option[MacBlockReason]` is the single intentional exception, and
@@ -476,15 +478,19 @@ if the future server-push channel above is built. Full design:
 is the same pattern in reverse — a functional override of the carve-out, not
 a new field.** Pause has two modes, stored per-profile in
 `profiles.pause_mode` (`'soft'` | `'hard'`, default `'soft'`). *Soft* pause is
-today's behaviour: the MAC drops except its `extraAllowed` hosts (an allowed
-app + the #1307 infra allowlist survive, per #421/#1413). *Hard* pause is a
-true off-switch — when a profile is paused **and** `pause_mode = 'hard'`,
-`PolicyService.computeBlockRules` ships `blocked = true` with `extraAllowed`
-emptied of the app/exempt/infra hosts, keeping only the deployment's
-`uiAllowedHosts` so the block page and admin SPA still load on the household
-LAN. With an empty `ea_` set the router drops the MAC unconditionally — no
-`ip daddr != @ea_…` exception — so it never learns "hard vs soft"; `blockReason`
-stays `Paused` (block-page copy only). No wire/router change.
+today's behaviour: the MAC drops except its per-profile `extraAllowed` hosts (an
+allowed app survives, per #421/#1413). *Hard* pause is a true off-switch — when a
+profile is paused **and** `pause_mode = 'hard'`,
+`PolicyService.computeBlockRules` ships `blocked = true` with the per-profile
+`extraAllowed` emptied of the app/exempt hosts. With an empty `ea_` set the
+router drops the MAC unconditionally — no `ip daddr != @ea_…` exception — so it
+never learns "hard vs soft"; `blockReason` stays `Paused` (block-page copy
+only). No wire/router change. The fleet-wide always-reachable set
+(`global.extraAllowed` — deployment UI / block-page hosts **and** the curated
+#1307 infra allowlist, consolidated there in #1321) is the top of the router's
+precedence ladder and survives a hard pause, so the block page and admin SPA
+still load on the household LAN and pure infra probes stay reachable; a hard
+pause remains a true off-switch for every *per-profile* carve-out.
 
 ## 6. Router HTTP API
 


### PR DESCRIPTION
Closes #1321. Part of the global policy layer (#1308); depends on #1318 (global section incl. UI hosts) and #1319 (router `@global_allow`), both merged.

## What & why

The #1307 near-term fix copied the curated `PolicyService.infraAllowHosts` list (connectivity-check / OCSP / PKI / captive-portal / netcts / gvt2 — incl. the #1337/#1339/#1411 additions) into **every** profile's `extraAllowed` so it would survive a whole-MAC block. Now that the global section carries fleet-wide always-reachable hosts once (#1318) and the router enforces them flat across all MACs (#1319), this retires the per-profile copy.

- `PolicyServiceLive.snapshot` unions `infraAllowHosts` into `global.extraAllowed` (right next to the relocated UI hosts), so the curated set is emitted **once**. A change to it moves only the global section's ETag, not every profile entry.
- `computeBlockRules` no longer appends `infraAllowHosts` to per-profile `extraAllowed` — the per-`(MAC)` `ea_` duplication is gone.

No wire-shape change: this stays purely functional (#1311). `infraAllowHosts` remains a vetted code constant — it just rides the same global path the UI hosts already use, rather than being seeded into the mutable `global_allow` table.

## Behavior preserved at the router

Infra hosts still beat **every** block path for every MAC — now via the router's `@global_allow` carve-out (top of the precedence ladder, #1319) instead of per-`(MAC)` `ea_` copies. The #421 invariant (allow beats block) is intact.

**Hard pause (#1418):** still empties per-profile `extraAllowed` (the allowed-app host is cut, so the router drops the MAC unconditionally). The difference: infra hosts now survive a hard pause as part of the always-reachable global set — exactly like the deployment UI / block-page hosts already did. A hard pause remains a true off-switch for every *per-profile* carve-out; only the fleet-wide always-reachable set (UI + infra) is spared. (Confirmed as the intended behavior.)

## Tests (TDD red → green, real embedded Postgres)

- Per-profile `extraAllowed` no longer duplicates the infra set; the global section carries it (`PolicySnapshotGlobalAllowSpec`, `PolicySnapshotAppsSpec`, `PolicySnapshotGlobalSectionSpec`).
- Behavior preservation: an infra host (e.g. `connectivitycheck.gstatic.com`, `gvt2.com`) is still reachable for a MAC under a whole-MAC block (paused / time-limit) via `global.extraAllowed`.
- `#1337` / `#1411` hosts asserted in `global.extraAllowed` (not per-profile).
- Hard-pause / soft-pause specs updated: per-profile `extraAllowed` behavior unchanged; infra now verified via the global section.

`mill __.test` — 269 specs green. `scalafmt --check` clean.

## Docs

`docs/architecture.md` status note, §0.3 motivating example, and the hard-pause note updated to reflect the consolidated global path.