### PR TITLE
ci(#1461): remove manual production-approval gates (API/UI + router)

### DIFF
--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -15,7 +15,7 @@ name: VM e2e (Gate 3a — router-side staging smoke)
 #
 # Triggers:
 #   - workflow_call    — invoked from master-router.yml as a needs: of
-#                        approve-production (parallel to gate-2-router-fake-api)
+#                        publish-openwrt (parallel to gate-2-router-fake-api)
 #   - workflow_dispatch — manual debugging from the Actions tab
 #
 # Concurrency / host capacity (#895):

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -13,8 +13,8 @@ name: VM e2e (Gate 3b — API/UI-side staging smoke)
 # that's the whole point of running against the last-published router.
 #
 # Triggers:
-#   - workflow_call    — invoked from master-api-ui.yml as a needs: of
-#                        approve-production (alongside smoke-staging +
+#   - workflow_call    — invoked from master-api-ui.yml as a needs: of the
+#                        deploy-production jobs (alongside smoke-staging +
 #                        api-smoke-staging)
 #   - workflow_dispatch — manual debugging from the Actions tab
 #

--- a/.github/workflows/master-api-ui.yml
+++ b/.github/workflows/master-api-ui.yml
@@ -18,11 +18,12 @@ name: Master API/UI CD
 #     → api-smoke-staging            (Gate 1 — admin + router API contract smoke against staging)
 #     → gate-3b-api-staging          (Gate 3b — last-published qemu router + freshly-deployed
 #                                     staging API; #655)
-#     → approve-production           (manual-approval gate — GitHub `production`
-#                                     environment; required reviewer must click
-#                                     "Approve and deploy" before the deploy-production
-#                                     jobs run; see #498)
-#     → deploy-production            (parallel jobs; all gated on approve-production):
+#     → deploy-production            (parallel jobs; gated directly on the staging
+#                                     gates above — smoke-staging + api-smoke-staging +
+#                                     gate-3b-api-staging. No human-approval pause: the
+#                                     manual `production`-environment gate was removed in
+#                                     #1461; staging smoke + #695 prod smoke/auto-rollback
+#                                     + #1194 deploy-safety guardrails are the safety net):
 #                                       • retag-latest       — promote sha-<commit> → :latest
 #                                                              via `docker buildx imagetools create`
 #                                       • deploy-prod-render — curl prod deploy hook + health poll
@@ -34,9 +35,10 @@ name: Master API/UI CD
 # infra/grafana/** — see the `paths:` exclusions below.
 #
 # OpenWRT release lives on master-router.yml. shared/** wire-schema changes
-# fire BOTH pipelines until #597 (capability negotiation) lands — the
-# `production` environment serializes approval prompts so tandem releases
-# stay coordinated.
+# fire BOTH pipelines until #597 (capability negotiation) lands. Each pipeline
+# now deploys automatically once its own staging gates are green (the manual
+# `production`-environment approval that used to serialize the two was removed
+# in #1461).
 #
 # TODO(#597): the wire-schema bump (capability negotiation framework) gets
 # coordinated across both pipelines once #597's mechanism lands.
@@ -156,8 +158,8 @@ jobs:
         run: scripts/smoke-prod.sh
 
   # VM e2e on the API/UI side is Gate 3b (gate-3b-api-staging, below),
-  # which gates approve-production. The old monolithic e2e-vm.yml that
-  # gated nothing was retired in #656.
+  # which gates the deploy-production jobs. The old monolithic e2e-vm.yml
+  # that gated nothing was retired in #656.
 
   # ── 3. Build the API image (sha-<commit> + `staging` tags only) ──────────
   # `:latest` is NOT pushed here. Promotion to `:latest` happens in the
@@ -484,14 +486,14 @@ jobs:
   # pause → Paused, schedule → Schedule, HostId variants, etag round-trip,
   # legacy `hostname` rejection) plus 401 / 4xx negatives per endpoint.
   # Blocks API publish (retag-latest, deploy-prod-render) and the SPA prod
-  # deploy by sitting on `approve-production`'s `needs:`.
+  # deploy by sitting directly on their `needs:`.
   api-smoke-staging:
     name: Gate 1 — API contract smoke (staging)
     if: github.ref == 'refs/heads/main'
     # Runs in parallel with smoke-staging — both `needs: [deploy-staging]`,
-    # both feed approve-production. smoke-staging covers the SPA bundle +
-    # CORS plane; this job covers the admin + router API plane. Either
-    # going red still blocks prod via approve-production's `needs:`.
+    # both gate the deploy-production jobs. smoke-staging covers the SPA
+    # bundle + CORS plane; this job covers the admin + router API plane.
+    # Either going red still blocks prod via the deploy jobs' `needs:`.
     needs: [deploy-staging]
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -514,18 +516,16 @@ jobs:
         run: scripts/e2e-router.sh
 
   # ════════════════════════════════════════════════════════════════════════
-  # ── DEPLOY-PRODUCTION ── (manual-approval gate + parallel jobs) ─────────
+  # ── DEPLOY-PRODUCTION ── (parallel jobs; no human gate) ─────────────────
   # ════════════════════════════════════════════════════════════════════════
-  # An `approve-production` sentinel job carries `environment: production` so
-  # GitHub pauses the run for manual approval before any consumer-facing
-  # surface is touched. All three deploy-production jobs `needs:
-  # [approve-production]`, so a single approval gates them atomically;
-  # denial blocks every one of them.
-  #
-  # The router pipeline (master-router.yml) has its own approve-production
-  # job pointing at the same `production` environment, so GitHub serializes
-  # approval prompts across the two pipelines when shared/** changes fire
-  # both sides.
+  # The manual `approve-production` sentinel (GitHub `production` environment,
+  # required-reviewer click) was removed in #1461: it was rubber-stamped every
+  # release, adding latency and stale-prod-image risk without real safety. The
+  # deploy-production jobs now gate directly on the staging gates that actually
+  # matter — smoke-staging, api-smoke-staging, and gate-3b-api-staging — so a
+  # bad build is still blocked by a red staging smoke; it just no longer waits
+  # for a human click. The automated safety net is #695 (post-deploy prod smoke
+  # + auto-rollback) and #1194 (deploy-safety guardrails).
 
   # ── 5c. Gate 3b — last-published router vs freshly-deployed staging ────
   # Boots the *last published* qemu OpenWRT router image (from the
@@ -542,27 +542,17 @@ jobs:
     uses: ./.github/workflows/e2e-vm-gate3b.yml
     secrets: inherit
 
-  approve-production:
-    name: Manual approval (production gate)
-    if: github.ref == 'refs/heads/main'
-    needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]
-    runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://api.wifihaven.net
-    steps:
-      - name: Approved
-        run: echo "Production deploy approved — releasing API image + SPA."
-
   # 6a. Retag sha-<commit> → :latest. No rebuild — `imagetools create`
   # operates on the registry-side manifest. The sha image has already been
   # gated by ci + staging smoke, so this is a pure pointer move.
   # Chose `docker buildx imagetools create` over `regctl` to avoid pulling
   # in another tool; buildx is already set up on github-hosted runners.
+  # #1461: gates directly on the staging gates (smoke-staging, api-smoke-
+  # staging, gate-3b-api-staging) now that the manual approval job is gone.
   retag-latest:
     name: Promote sha → :latest (deploy-production)
     if: github.ref == 'refs/heads/main'
-    needs: [approve-production]
+    needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -593,13 +583,14 @@ jobs:
   deploy-prod-render:
     name: Deploy production (Render)
     if: github.ref == 'refs/heads/main'
-    needs: [approve-production, retag-latest]
+    # retag-latest transitively depends on all three staging gates, so naming
+    # it here is sufficient to keep prod behind a green staging smoke (#1461).
+    needs: [retag-latest]
     runs-on: ubuntu-latest
     steps:
       # #1390: checkout for the composite annotation action. Derive the short
       # sha locally rather than threading build-image's output through
-      # retag-latest + approve-production — `github.sha` is the same commit
-      # that built this image.
+      # retag-latest — `github.sha` is the same commit that built this image.
       - uses: actions/checkout@v6
 
       - name: Derive short SHA
@@ -666,7 +657,7 @@ jobs:
   deploy-spa-prod:
     name: Deploy SPA to Cloudflare Pages (prod) (deploy-production)
     if: github.ref == 'refs/heads/main'
-    needs: [approve-production]
+    needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/master-router.yml
+++ b/.github/workflows/master-router.yml
@@ -18,10 +18,12 @@ name: Master Router CD
 #       │                        workflow artifacts)
 #       → gate-2-router-fake-api  (boots the uploaded VM image + fake API)
 #       ‖ gate-3a-router-staging  (boots the uploaded VM image + staging API)
-#         → approve-production    (manual gate, `production` environment)
-#           → publish-openwrt     (DOWNLOADS the tested artifacts → rolling
+#         → publish-openwrt       (DOWNLOADS the tested artifacts → rolling
 #                                  openwrt-latest + versioned v<X.Y.Z>; no
-#                                  rebuild, no version re-derivation)
+#                                  rebuild, no version re-derivation. Gated
+#                                  directly on Gates 2 + 3a — the manual
+#                                  `production`-environment approval was
+#                                  removed in #1461)
 #
 # Gates 2 and 3a both share the e2e-vm self-hosted-runner concurrency
 # group (#657 capacity follow-up), so in practice they serialize on the
@@ -145,37 +147,21 @@ jobs:
       consume_vm_image_artifact: true
     secrets: inherit
 
-  # Manual-approval gate. Carries `environment: production` so GitHub pauses
-  # the run for an approval click before the rolling release is touched.
-  # API/UI prod approval lives on its own gate in master-api-ui.yml; both
-  # queue on the same `production` environment, so GitHub serializes
-  # approval prompts across the two pipelines.
-  approve-production:
-    name: Manual approval (router production gate)
-    if: github.ref == 'refs/heads/main'
-    needs: [gate-2-router-fake-api, gate-3a-router-staging]
-    runs-on: ubuntu-latest
-    permissions: {}
-    environment:
-      name: production
-      url: https://github.com/wifihaven/wifihaven/releases/tag/openwrt-latest
-    steps:
-      - name: Approved
-        run: echo "Router release approved — publishing openwrt-latest."
-
   # #1224: download-and-release ONLY. publish-openwrt-release.yml pulls the
   # release-assets artifact built pre-gate by build-release-artifacts and
   # attaches those exact, already-tested bytes — no recompile, no version
   # re-derivation. The version is threaded verbatim from the build job's
   # output, preserving the coordinated-version invariant (#499/#1134).
-  # `needs` build-release-artifacts (transitively satisfied via the gates,
-  # but listed explicitly so its `version` output is in scope here).
-  # Intentionally has NO concurrency group: once approval lands, this job
+  # #1461: gates directly on Gates 2 + 3a now that the manual approval job is
+  # gone — the rolling release publishes automatically once both router gates
+  # are green. `needs` build-release-artifacts explicitly so its `version`
+  # output is in scope here (transitively satisfied via the gates anyway).
+  # Intentionally has NO concurrency group: once the gates pass, this job
   # must run to completion regardless of any later main push.
   publish-openwrt:
     name: Publish OpenWRT release
     if: github.ref == 'refs/heads/main'
-    needs: [build-release-artifacts, approve-production]
+    needs: [build-release-artifacts, gate-2-router-fake-api, gate-3a-router-staging]
     permissions:
       contents: write
     uses: ./.github/workflows/publish-openwrt-release.yml

--- a/.github/workflows/publish-openwrt-release.yml
+++ b/.github/workflows/publish-openwrt-release.yml
@@ -5,7 +5,7 @@ name: Publish OpenWRT release
 # `release-assets` artifact produced by build-release-artifacts.yml earlier in
 # the same Master Router CD run and attaches those exact bytes to the GitHub
 # Release. A publish can therefore no longer fail on a rebuild after the gates
-# passed and a human approved (the #1224 failure mode).
+# passed (the #1224 failure mode).
 #
 # The release version is NOT recomputed here — it is passed in verbatim via
 # the `version` input, threaded from build-release-artifacts.yml's `version`
@@ -13,7 +13,8 @@ name: Publish OpenWRT release
 #
 # Triggers:
 #   - workflow_call — invoked by master-router.yml's publish-openwrt job,
-#     behind the approve-production manual gate.
+#     gated directly on the router e2e gates (Gates 2 + 3a). The manual
+#     approve-production gate was removed in #1461.
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Closes #1461.

## What

Removes the **manual production-approval gate** from both CD pipelines. The
`production` GitHub Environment's required-reviewers rule (reviewer:
`sameerparekh`) was rubber-stamped every release — it added latency and is the
#1 cause of stale prod images per the live-debug playbook, without adding real
safety. Prod now deploys automatically once the **staging smoke gates** are
green; a red staging smoke still blocks prod.

## Changes

**Workflow YAML**
- `master-api-ui.yml`: removed the `approve-production` job. Rewired:
  - `retag-latest` → `needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]`
  - `deploy-prod-render` → `needs: [retag-latest]` (which transitively depends on all three staging gates)
  - `deploy-spa-prod` → `needs: [smoke-staging, api-smoke-staging, gate-3b-api-staging]`
- `master-router.yml`: removed the `approve-production` job. Rewired:
  - `publish-openwrt` → `needs: [build-release-artifacts, gate-2-router-fake-api, gate-3a-router-staging]`
- Updated the header-comment flow diagrams in both, plus stale
  `approve-production` references in `e2e-vm-gate3a.yml`, `e2e-vm-gate3b.yml`,
  and `publish-openwrt-release.yml`.
- `master-grafana.yml` had no gate — left as-is.
- No new job-level `permissions:` introduced (avoids the reusable-workflow
  load-time permission-cap failure).

**Repo setting (not expressible in workflow YAML) — already applied to the live repo**
- Dropped the `required_reviewers` protection rule from the `production`
  environment. The environment itself is **kept** (it currently scopes no
  secrets/vars; keeping it preserves deployment history and any future
  env-scoped secrets). `protection_rules` is now `[]`. Reproduced with:
  ```
  echo '{"wait_timer":0,"prevent_self_review":false,"reviewers":null,"deployment_branch_policy":null}' \
    | gh api -X PUT repos/wifihaven/wifihaven/environments/production --input -
  ```

## Resulting job graph

**API/UI (`master-api-ui.yml`)**
```
ci-tests + bootstrap-smoke + e2e + prod-stack-smoke
  → build-image → deploy-staging ‖ deploy-spa-staging
  → smoke-staging + api-smoke-staging + gate-3b-api-staging   (the staging gate)
  → retag-latest → deploy-prod-render
  ‖ deploy-spa-prod
```
No human pause. Prod is reached automatically on green main; a failing
`smoke-staging` / `api-smoke-staging` / `gate-3b-api-staging` still blocks
every deploy-production job.

**Router (`master-router.yml`)**
```
ci-tests → build-release-artifacts
  → gate-2-router-fake-api ‖ gate-3a-router-staging
  → publish-openwrt
```
`publish-openwrt` publishes automatically once both router gates pass.

## Verification
- `actionlint` clean on all five touched workflows.
- No dangling `needs:` to the removed `approve-production` job (grep clean;
  remaining mentions are explanatory "removed in #1461" comments).
- No `environment: production` references remain.

## Safety net (follow-ups)
The human gate is replaced by automated gates:
- **Staging smoke is preserved** — still gates prod on both pipelines.
- **#695** (post-deploy prod smoke + auto-rollback) and **#1194**
  (deploy-safety guardrails) are the automated replacement for the human gate.
  ⚠️ If #695 is not yet shipped, the residual risk is that a bad image can reach
  prod without auto-rollback. Recommend prioritizing #695.