### PR TITLE
test(#1460): VM e2e for @global_allow / @global_block enforcement

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -74,6 +74,7 @@ scripts/e2e/
     test_time_limit.py · test_reassignment.py
     test_blocked_mac_events.py · test_install_health.py
     test_port_alloc.py · test_snapshot_builder.py
+    test_global_policy.py             suite H (#1460) — @global_allow / @global_block
   gate3/                              Gate 3 smoke + conftest
     test_smoke.py
 ```

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -18,6 +18,7 @@ markers =
     install_health: post-install router health asserts (#922 — cron, etc.)
     nflog: #1122 — forward-drop visibility via nflog (per-MAC drop comment + agent emission)
     cname_direct_requery: suite G (#1351) — ea_/eb_ population for directly-queried CNAME targets
+    global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -170,6 +170,54 @@ def wait_bl_set_populated(bl_id: str, *, timeout_s: float = 90) -> list[str]:
     )
 
 
+# ── #1319 global policy sets (@global_allow / @global_block) ─────────────────
+#
+# Fleet-wide ipsets render.lua declares when the snapshot carries a populated
+# `global` section. Unlike the per-(MAC, host) `ea_<mac>_<host>` sets, these
+# are NOT keyed by MAC — one `global_allow` / `global_block` set applies to
+# every MAC. Populated at DNS resolve time by dnsmasq `nftset=` callbacks, same
+# as eb_/bl_. See render.lua GLOBAL_ALLOW4 / GLOBAL_BLOCK4.
+
+GLOBAL_ALLOW_SET = "global_allow"
+GLOBAL_BLOCK_SET = "global_block"
+
+
+def _wait_set_populated(name: str, *, timeout_s: float = 90) -> list[str]:
+    def probe():
+        elems = router_nft_set(name)
+        return elems if elems else None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {name} to gain at least one element",
+    )
+
+
+def wait_global_allow_populated(*, timeout_s: float = 90) -> list[str]:
+    """Wait until the fleet-wide @global_allow v4 set has >=1 resolved IP."""
+    return _wait_set_populated(GLOBAL_ALLOW_SET, timeout_s=timeout_s)
+
+
+def wait_global_block_populated(*, timeout_s: float = 90) -> list[str]:
+    """Wait until the fleet-wide @global_block v4 set has >=1 resolved IP."""
+    return _wait_set_populated(GLOBAL_BLOCK_SET, timeout_s=timeout_s)
+
+
+def ea_set_exists_for_mac(mac: str) -> bool:
+    """True iff any per-(MAC, host) ea_<mac>_<host> allow-set has been rendered.
+
+    Used to prove the global allow carve-out is genuinely *global* (a single
+    @global_allow set), not silently degraded into per-MAC ea_ sets. render.lua
+    names ea_ sets `ea_<sanmac>_<sanhost>`; a `nft list table` scan for the
+    `ea_<sanmac>_` prefix tells us whether the MAC got a per-MAC allow path.
+    """
+    prefix = "ea_" + _san(mac) + "_"
+    res = router_ssh(
+        "nft list table inet wifihaven 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return prefix.lower() in (res.stdout or "").lower()
+
+
 def wait_event_for_mac(fake_api, mac: str, *, allowed: bool, reason: str,
                        timeout_s: float = 60):
     """Block until fake captured a connection_attempt event matching predicates."""

--- a/scripts/e2e/scenarios_fake/snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/snapshot_builder.py
@@ -61,6 +61,11 @@ class SnapshotBuilder:
         self._profiles: dict[str, dict[str, Any]] = {}
         self._devices: dict[str, dict[str, Any]] = {}
         self._blocklists: dict[str, dict[str, Any]] = {}
+        # The fleet-wide `global` BlockRules (#1316/#1318). None until
+        # `set_global()` is called, so snapshots that don't exercise the global
+        # layer omit the key entirely and render byte-identically to pre-#1319
+        # (render.lua treats an absent `global` as BlockRules.allowAll).
+        self._global: dict[str, Any] | None = None
 
     def add_profile(
         self,
@@ -124,6 +129,45 @@ class SnapshotBuilder:
         self._devices[mac] = entry
         return self
 
+    def set_global(
+        self,
+        *,
+        blocked: bool = False,
+        block_reason: str | None = None,
+        extra_blocked: list[str] | None = None,
+        extra_allowed: list[str] | None = None,
+        blocklist_ids: list[str] | None = None,
+        block_ip_only: bool = False,
+    ) -> "SnapshotBuilder":
+        """Populate the snapshot's fleet-wide `global` BlockRules (#1318/#1319).
+
+        Applied to *every* MAC by the agent alongside that MAC's resolved
+        per-MAC rules, with the precedence ladder from
+        `docs/design/global-policy-layer.md` §5.2:
+
+          - `extra_allowed` → `@global_allow` — carves out **every** drop
+            (per-MAC or global), all MACs. Top of the ladder.
+          - `extra_blocked` / `blocklist_ids` → `@global_block` — blocks
+            fleet-wide; a per-profile `extraAllowed` may **not** un-block them,
+            only `global.extraAllowed` can.
+          - `blocked` → whole-network lockdown; only `global.extraAllowed`
+            survives it.
+
+        Unlike `add_profile(blocked=True)` this does **not** require a
+        `block_reason`: a global lockdown's reason is cosmetic (block-page copy
+        only) and has no `MacBlockReason` enum case. Pass one if a test asserts
+        on the rendered block-page text.
+        """
+        self._global = profile_rules(
+            blocked=blocked,
+            block_reason=block_reason,
+            extra_blocked=extra_blocked,
+            extra_allowed=extra_allowed,
+            blocklist_ids=blocklist_ids,
+            block_ip_only=block_ip_only,
+        )
+        return self
+
     def add_blocklist(
         self,
         *,
@@ -149,13 +193,19 @@ class SnapshotBuilder:
                     f"device {mac} references unknown profileId={pid}; "
                     f"declared profiles: {sorted(self._profiles)}"
                 )
-        return {
+        snap: dict[str, Any] = {
             "etag": etag,
             "generatedAt": self._generated_at,
             "devices": dict(self._devices),
             "profiles": dict(self._profiles),
             "blocklists": dict(self._blocklists),
         }
+        # Emit `global` only when explicitly set, so the default top-level key
+        # set stays {etag, generatedAt, devices, profiles, blocklists} for the
+        # scenarios (and test_snapshot_builder) that don't touch it.
+        if self._global is not None:
+            snap["global"] = dict(self._global)
+        return snap
 
 
 # ── Convenience helpers kept for the #683 canary (test_pause) ───────────────

--- a/scripts/e2e/scenarios_fake/test_global_policy.py
+++ b/scripts/e2e/scenarios_fake/test_global_policy.py
@@ -1,0 +1,249 @@
+"""Suite H — global policy layer enforcement on a real OpenWRT agent (#1460).
+
+VM-level end-to-end proof that a deployed agent actually enforces the
+snapshot's fleet-wide `global` BlockRules (#1318) via the `@global_allow` /
+`@global_block` nftables sets (#1319). The feature/unit coverage (#1322,
+`api/test/**`, `openwrt/test/**`) proves the *shape* and the *render*; this
+proves the *enforced behaviour against live traffic*.
+
+This is the **gate for #1321 / PR #1459**. That PR removes the #1307
+per-profile infra-allow copy and relies entirely on `global.extraAllowed`
+(`@global_allow`) to keep connectivity-check / OCSP / PKI / captive-portal
+hosts reachable under a whole-MAC block. If the live `@global_allow` path has
+any gap, retiring the per-profile safety net would silently break infra
+reachability fleet-wide. A router/agent version that passes this suite must be
+deployed before #1459 un-drafts.
+
+Reachability here is a **connection-layer** assertion (nftables forward-drop /
+block-page DNAT), never "DNS resolved ⇒ allowed". A successful DNS lookup
+proves nothing — DNS always resolves; the resolved IP is exactly what the
+forward-drop acts on. See `docs/architecture.md` and the AGENTS.md anti-pattern
+callout.
+
+Precedence ladder under test (`docs/design/global-policy-layer.md` §5.2):
+    1. global.extraAllowed  — carves out EVERY drop, all MACs (top)
+    2. global block         — beaten only by (1); a per-profile allow can't
+    3. per-MAC extraAllowed — carves out per-MAC drops only (#421)
+    4. per-MAC blocks
+"""
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from ._observers import (
+    ea_set_exists_for_mac,
+    mac_drop_rule_present,
+    wait_block_page,
+    wait_global_allow_populated,
+    wait_global_block_populated,
+    wait_http_succeeds,
+    wait_mac_drop_rule_present,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.global_policy
+
+# A host that is ONLY ever reachable via @global_allow in these scenarios —
+# never in any profile's own extraAllowed. example.com has stable real DNS +
+# routable IPs and is the allowed-browsing host the rest of the suite uses.
+GLOBAL_ALLOW_HOST = "example.com"
+# A host the fleet-wide block acts on. example.org (used by test_03) — distinct
+# from the allow host so a single snapshot can allow one and block the other.
+GLOBAL_BLOCK_HOST = "example.org"
+
+KIDS_PID = 700
+ADULTS_PID = 701
+
+
+def _alloc_free_port() -> int:
+    """Kernel-assigned free TCP port for a second client VM's SSH hostfwd.
+
+    Mirrors conftest.alloc_free_port — the default `client` fixture pins
+    CLIENT_SSH_PORT_DEFAULT, so a concurrently-booted second client needs its
+    own port.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ── H1 — global.extraAllowed beats a whole-MAC block (direct #1321 guard) ────
+
+
+@pytest.mark.smoke
+def test_global_allow_beats_whole_mac_block(router, client, fake_api):
+    """H1: a paused (blocked=true) MAC still reaches a host that is ONLY in
+    `global.extraAllowed` — not in its profile's own extraAllowed.
+
+    This is the exact connectivity #1459 leans on: under a whole-MAC block,
+    `@global_allow` must carve the host's resolved IPs out of the
+    `@blocked_macs` drop. If it doesn't, retiring the per-profile infra copy
+    breaks infra reachability fleet-wide.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h1-paused", blocked=True, block_reason="Paused")
+        .add_device(mac=client.mac, name="e2e-h1-dev", profile_id=KIDS_PID)
+        .set_global(extra_allowed=[GLOBAL_ALLOW_HOST])
+        .build(etag='"sha256:h1-global-allow-beats-block-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # The MAC is genuinely blocked: render.lua pulls a blocked-with-carve-out
+    # MAC out of @blocked_macs into per-MAC forward-chain drop rules tagged
+    # `wh_drop:<mac>` (#421/#1319). Asserting the drop rule exists proves the
+    # reachability below is the @global_allow carve-out at work, not an absent
+    # block.
+    wait_mac_drop_rule_present(client.mac, timeout_s=180)
+
+    # Connection-layer reachability: HTTP/80 to the global-allowed host returns
+    # a real upstream response, NOT the block page. Each probe re-queries DNS,
+    # which fires the dnsmasq nftset= callback that populates @global_allow.
+    probe = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert probe.http_code is not None and 200 <= probe.http_code < 400
+
+    # Router-state corroboration: the fleet-wide @global_allow set holds the
+    # resolved IP, and the host did NOT get a per-MAC ea_ set (it lives only in
+    # the global layer for this MAC).
+    members = wait_global_allow_populated(timeout_s=30)
+    assert members, "expected @global_allow to carry >=1 resolved IP"
+    assert not ea_set_exists_for_mac(client.mac), (
+        "global-only allow host must not produce a per-MAC ea_ set; the carve-out "
+        "is the fleet-wide @global_allow, not a per-(MAC, host) allow"
+    )
+
+
+# ── H2 — global.extraAllowed is flat across the fleet (every MAC) ────────────
+
+
+def test_global_allow_applies_to_every_mac(router, client, client_factory, fake_api):
+    """H2: the same global-allowed host is reachable from a SECOND,
+    differently-profiled, also-blocked MAC — proving `@global_allow` is one
+    fleet-wide set, not silently keyed per-(MAC).
+
+    Both devices are on distinct, paused profiles with empty per-profile
+    extraAllowed; only `global.extraAllowed` keeps the host reachable. If the
+    carve-out were per-MAC, MAC-B (never individually allowed) would hit the
+    block page.
+    """
+    kids = client  # MAC-A, Kids profile (paused)
+    adults = client_factory(
+        mac="02:e2:fa:70:00:02", name="client2", ssh_port=_alloc_free_port(),
+    )
+
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h2-kids", blocked=True, block_reason="Paused")
+        .add_profile(id=ADULTS_PID, name="e2e-h2-adults", blocked=True, block_reason="Paused")
+        .add_device(mac=kids.mac, name="e2e-h2-kids-dev", profile_id=KIDS_PID)
+        .add_device(mac=adults.mac, name="e2e-h2-adults-dev", profile_id=ADULTS_PID)
+        .set_global(extra_allowed=[GLOBAL_ALLOW_HOST])
+        .build(etag='"sha256:h2-global-allow-every-mac-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Both MACs are genuinely blocked.
+    wait_mac_drop_rule_present(kids.mac, timeout_s=180)
+    wait_mac_drop_rule_present(adults.mac, timeout_s=180)
+
+    # The global-allowed host is reachable from BOTH differently-profiled MACs.
+    p_kids = wait_http_succeeds(kids, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_kids.http_code is not None and 200 <= p_kids.http_code < 400
+    p_adults = wait_http_succeeds(adults, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_adults.http_code is not None and 200 <= p_adults.http_code < 400
+
+    # Neither MAC got a per-MAC ea_ set — the carve-out is the single shared
+    # @global_allow, applied flat across the fleet.
+    assert not ea_set_exists_for_mac(kids.mac)
+    assert not ea_set_exists_for_mac(adults.mac)
+
+
+# ── H3 — global.extraBlocked blocks fleet-wide, per-profile allow can't save ─
+
+
+def test_global_block_not_unblockable_by_profile_allow(router, client, fake_api):
+    """H3: a host in `global.extraBlocked` is blocked even when the MAC's
+    profile lists it in `extraAllowed`. Only `global.extraAllowed` carves out a
+    global block — a per-profile allow does NOT (precedence ladder §5.2, step
+    2 beats step 3).
+
+    Guards the asymmetry that makes a global block *mandatory*: an operator's
+    fleet-wide block must not be loosenable per-profile.
+    """
+    snap = (
+        SnapshotBuilder()
+        # The profile TRIES to allow the host — this must not win.
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-h3-kids",
+            extra_allowed=[GLOBAL_BLOCK_HOST],
+        )
+        .add_device(mac=client.mac, name="e2e-h3-dev", profile_id=KIDS_PID)
+        .set_global(extra_blocked=[GLOBAL_BLOCK_HOST])
+        .build(etag='"sha256:h3-global-block-beats-profile-allow-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Despite the per-profile extraAllowed, HTTP/80 to the globally-blocked host
+    # hits the block page (global block wins). Each probe re-queries DNS, firing
+    # the nftset= callback that populates @global_block.
+    probe = wait_block_page(client, host=GLOBAL_BLOCK_HOST, timeout_s=120)
+    assert probe is not None and probe.http_code == 200
+
+    members = wait_global_block_populated(timeout_s=30)
+    assert members, "expected @global_block to carry >=1 resolved IP"
+
+    # Control: the MAC is NOT wholesale blocked — a host that is neither
+    # globally blocked nor per-profile blocked stays reachable. Confirms H3's
+    # block is the targeted @global_block, not a stray whole-MAC drop.
+    assert not mac_drop_rule_present(client.mac)
+    p_ok = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_ok.http_code is not None and 200 <= p_ok.http_code < 400
+
+
+# ── H4 (stretch) — global.blocked lockdown, global.extraAllowed survives ─────
+
+
+def test_global_blocked_lockdown_with_allow_carveout(router, client, fake_api):
+    """H4: `global.blocked = true` is a whole-network kill switch — every MAC
+    drops all forwarded traffic — EXCEPT hosts in `global.extraAllowed`.
+
+    Asserts both directions of the lockdown: a non-allowed host hits the block
+    page (DNAT), while the global-allowed host still reaches its real upstream.
+    The profile is otherwise permissive, so the only thing blocking traffic is
+    the global lockdown.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h4-open")  # not blocked, no extras
+        .add_device(mac=client.mac, name="e2e-h4-dev", profile_id=KIDS_PID)
+        .set_global(
+            blocked=True,
+            block_reason="Manual",  # cosmetic — drives block-page copy only
+            extra_allowed=[GLOBAL_ALLOW_HOST],
+        )
+        .build(etag='"sha256:h4-global-lockdown-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Lockdown drops every MAC; render.lua tags the per-MAC drop wh_drop:<mac>
+    # (the global-allow carve-out forces the per-family rule path).
+    wait_mac_drop_rule_present(client.mac, timeout_s=180)
+
+    # A non-allowed host is dropped → DNATed to the local block page.
+    probe = wait_block_page(client, host=GLOBAL_BLOCK_HOST, timeout_s=120)
+    assert probe is not None and probe.http_code == 200
+
+    # The global-allowed host still reaches its real upstream through the
+    # lockdown.
+    p_ok = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_ok.http_code is not None and 200 <= p_ok.http_code < 400
+
+    members = wait_global_allow_populated(timeout_s=30)
+    assert members, "expected @global_allow to carry >=1 resolved IP under lockdown"

--- a/scripts/e2e/scenarios_fake/test_snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/test_snapshot_builder.py
@@ -158,3 +158,61 @@ def test_snapshot_with_assigned_device_canary_shape():
     rules = snap["profiles"]["100"]["rules"]
     assert rules["blocked"] is True
     assert rules["blockReason"] == "Paused"
+
+
+# ── Global section (#1460) ────────────────────────────────────────────────────
+
+
+def test_global_omitted_unless_set():
+    """Without set_global(), the snapshot carries no `global` key — keeping the
+    default top-level shape (test_empty_build_has_top_level_contract_keys) and
+    rendering byte-identically to pre-#1319 (render.lua treats absent global as
+    allowAll)."""
+    snap = SnapshotBuilder().build(etag='"sha256:no-global"')
+    assert "global" not in snap
+
+
+def test_set_global_emits_blockrules_shape():
+    """set_global() produces a BlockRules dict under `global` with the contract
+    field set the agent reads (matches the golden's `global` row)."""
+    snap = (
+        SnapshotBuilder()
+        .set_global(
+            extra_allowed=["connectivitycheck.gstatic.com"],
+            extra_blocked=["malware.example"],
+        )
+        .build(etag='"sha256:with-global"')
+    )
+    g = snap["global"]
+    assert set(g) == {
+        "blocked", "extraBlocked", "extraAllowed", "blocklistIds", "blockIpOnly",
+    }
+    assert g["extraAllowed"] == ["connectivitycheck.gstatic.com"]
+    assert g["extraBlocked"] == ["malware.example"]
+    assert g["blocked"] is False
+    assert g["blockIpOnly"] is False
+
+
+def test_set_global_matches_golden_global_keys():
+    """The builder's `global` key set lines up with the contract golden's, so
+    the fake serves bytes the agent decodes."""
+    g = _golden()["global"]
+    built = SnapshotBuilder().set_global(
+        extra_allowed=g["extraAllowed"],
+    ).build(etag='"sha256:golden-global"')["global"]
+    assert set(built) == set(g)
+
+
+def test_set_global_lockdown_allows_optional_reason():
+    """Unlike add_profile(blocked=True), set_global(blocked=True) does NOT
+    require a block_reason — a global lockdown's reason is cosmetic."""
+    snap = SnapshotBuilder().set_global(blocked=True).build(etag='"sha256:lockdown"')
+    assert snap["global"]["blocked"] is True
+    assert "blockReason" not in snap["global"]
+    # ...but it may be set when a test asserts on block-page copy.
+    snap2 = (
+        SnapshotBuilder()
+        .set_global(blocked=True, block_reason="Manual")
+        .build(etag='"sha256:lockdown2"')
+    )
+    assert snap2["global"]["blockReason"] == "Manual"


### PR DESCRIPTION
Closes #1460.

VM-level end-to-end coverage proving a **real OpenWRT agent** enforces the
snapshot's fleet-wide `global` section (#1318) via the `@global_allow` /
`@global_block` nftables sets (#1319). The prior #1322 work covered this at the
feature/unit level (`api/test/**`, `openwrt/test/**`); this adds the missing
proof that a deployed agent applies it against **live traffic**.

## This is the gate for #1321 / PR #1459

PR #1459 removes the #1307 per-profile infra-allow copy and relies **entirely**
on `global.extraAllowed` (`@global_allow`) to keep connectivity-check / OCSP /
PKI / captive-portal hosts reachable under a whole-MAC block. If the live
`@global_allow` path has any gap, retiring the per-profile safety net would
silently break infra reachability **fleet-wide** — the exact failure the "DNS
resolves ≠ reachable" model hides. **A router/agent version that passes this
suite must be deployed to the fleet before #1459 un-drafts.** (This PR does not
touch #1459 or its branch.)

## Scenarios — `scripts/e2e/scenarios_fake/test_global_policy.py`

All assertions are **connection-layer** (nftables forward-drop / block-page
DNAT), never "DNS resolved ⇒ allowed".

| | Asserts |
|---|---|
| **H1** `global.extraAllowed` beats a whole-MAC block | A paused (`blocked=true`) MAC still reaches a host that is **only** in `global.extraAllowed` (not the profile's own allow). Proves `@global_allow` carves the resolved IPs out of the `@blocked_macs` drop. Corroborated by the per-MAC `wh_drop:<mac>` rule being present (the block is real) and no per-MAC `ea_` set existing. **Direct #1321 regression guard.** |
| **H2** `global.extraAllowed` is flat across the fleet | Boots a **second, differently-profiled, also-blocked** client VM; the same global-allowed host is reachable from **both** MACs. Proves the carve-out is one fleet-wide set, not silently per-`(MAC)`. |
| **H3** `global.extraBlocked` blocks fleet-wide | A host in `global.extraBlocked` is blocked **even though** the MAC's profile lists it in `extraAllowed` — only `global.extraAllowed` carves out a global block (precedence ladder §5.2, step 2 beats step 3). Control host stays reachable + MAC not wholesale-blocked. |
| **H4** (stretch) `global.blocked` lockdown | `global.blocked=true` drops all forwarded traffic for every MAC while a `global.extraAllowed` host still reaches its upstream; a non-allowed host hits the block page. |

## Harness changes (in scope per the issue)

- `snapshot_builder.SnapshotBuilder.set_global()` — emits a populated `global`
  `BlockRules`. Omitted from `build()` unless set, so the default top-level
  shape is unchanged and snapshots without it render byte-identically to
  pre-#1319 (render.lua treats an absent `global` as `allowAll`).
- `_observers` — `wait_global_allow_populated` / `wait_global_block_populated`
  read the fleet-wide `@global_allow` / `@global_block` nft sets;
  `ea_set_exists_for_mac` proves the carve-out is the shared global set, not a
  per-`(MAC, host)` `ea_` set.
- `pytest.ini` — new `global_policy` marker (suite H). `README.md` scenario list.

No production code touched (`api/src` untouched, no Flyway migration) — this is
e2e-only.

## Checks run

- ✅ `pytest scenarios_fake/test_snapshot_builder.py` — 12 passed, including the
  4 new pure-dict `set_global` tests (run locally, no VM).
- ✅ `pytest scenarios_fake --collect-only` — full suite collects (43 tests);
  the 4 new H scenarios collect with the registered marker under
  `--strict-markers`.
- ✅ `py_compile` on all touched modules.
- ⏳ The H1–H4 VM scenarios require KVM and run on the **`e2e-vm-fake.yml`** CI
  gate (no local KVM on this machine). No repo Python linter is configured for
  `scripts/e2e`, so none was run.