### PR TITLE
db(#1463): household_settings presence-tuning column (schema-only)

### DIFF
--- a/api/resources/db/migration/V52__presence_tuning_settings.sql
+++ b/api/resources/db/migration/V52__presence_tuning_settings.sql
@@ -1,0 +1,42 @@
+-- V52__presence_tuning_settings.sql
+-- #1463: presence-tuning knob on household_settings (schema-only foundation).
+--
+-- Background: presence (the minutes that drive screen-time totals, time-limit
+-- enforcement, and the dashboards) is today derived from a per-10-second
+-- activity sample that only ticks when *new bytes* are observed. For
+-- request-driven apps with long local "think time" (the educational / reading
+-- apps), most 60-second buckets register only the floor 10 s of a fully-engaged
+-- minute, so presence reads ~3.3× low for the kid devices (analysis: #1446 /
+-- PR #1449, docs/design/presence-tuning.md). The fix replaces fixed-bucket
+-- presence with an activity-session model stitched on a wall-clock idle gap.
+--
+-- The session model is unconditional and global — there is no toggle back to
+-- the legacy max(activeSeconds) path, so this migration adds only the one tuning
+-- knob the model needs:
+--
+--   - presence_continuation_seconds — the idle gap `N` that ends a session.
+--     Per (device, app), activity is merged into a session as long as the gap
+--     to the next activity is ≤ N; a session's presence is its first→last
+--     span. Default 120 (the knee of the measured think-gap distribution).
+--     Spec requires N ≥ 2 × usage_report_interval; that validation lives in
+--     the follow-up code, not here.
+--
+-- This is a SCHEMA-ONLY migration (per the migration-isolation rule in
+-- CLAUDE.md / AGENTS.md §migrations-back-compat): it ships with no source and
+-- no tests. The rollup / repo / route / invalidation-hook changes that READ
+-- and WRITE this column are the follow-up PRs (#1464 / #1465). Until then the
+-- column is inert — nothing reads it, every existing row gets the default, and
+-- behavior is unchanged.
+--
+-- `household_settings` is a small singleton-style metadata table, NOT one of
+-- the unbounded-growth event tables (traffic_reports, connection_events, …).
+-- Adding a column with a constant default is metadata-only in PG 11+ (no table
+-- rewrite), so this is safe on the Flyway startup critical path even at prod
+-- data volume.
+--
+-- Nullable-by-default contract: the column is NOT NULL DEFAULT, so image-(N-1)
+-- — which never names it in any INSERT/UPDATE — keeps working unchanged;
+-- existing rows and any new rows it writes get the default.
+
+ALTER TABLE household_settings
+  ADD COLUMN presence_continuation_seconds INTEGER NOT NULL DEFAULT 120;

--- a/docs/design/presence-tuning.md
+++ b/docs/design/presence-tuning.md
@@ -380,10 +380,12 @@ fix and is blocked on the agent freeze.
 Add to `household_settings` (a **small** table — no growth-table migration risk):
 
 - `presence_continuation_seconds` — default **120**; validated `≥ 2 × R`.
-- `presence_model` — `session` (recommended default) | `legacy` (the current
-  `max(activeSeconds)` path, kept for one deprecation window).
 
-`time_used_daily` must be invalidated (`DELETE`) on any change to these, exactly
+The session model is **global and unconditional** — there is no per-household
+toggle back to the legacy `max(activeSeconds)` path, so there is no
+`presence_model` column. The session computation simply replaces the old one.
+
+`time_used_daily` must be invalidated (`DELETE`) on any change to this, exactly
 as it already is for the heartbeat settings, so the next rollup refills with the
 new semantics.
 
@@ -394,9 +396,12 @@ new semantics.
 > (cf. #790)**. Note the **migration-isolation two-PR rule**: any schema change
 > lands in its own migration-only PR before the code that adopts it.
 
-1. **DB: `household_settings` presence-tuning columns (schema-only PR).** Add
-   `presence_continuation_seconds` (default 120) and `presence_model` (default
-   `session`). Migration + docs only. Small table → no prod-volume concern.
+1. **DB: `household_settings` presence-tuning column (schema-only PR).** Add
+   `presence_continuation_seconds` (default 120). Migration + docs only. Small
+   table → no prod-volume concern. The session model is global and
+   unconditional, so there is **no** `presence_model` toggle column.
+   **Shipped — #1463, migration `V52__presence_tuning_settings.sql`.** The
+   column is inert until the adopting code lands (#1464 / #1465).
 
 2. **API rollup: session-stitch primitive + interval-union daily cap.** Replace
    `bucketSeconds = max(activeSeconds)` and the `period_start`-grid dedup in
@@ -405,10 +410,11 @@ new semantics.
    devices by the profile's existing `crossDeviceOverlapMode` (`Sum` = add
    per-device totals → `totalSecondsByMac`+sum today; `Dedup` = union across
    devices → `dedupedTotalSeconds` today — preserve both). Read window bounds
-   from `period_start`/`period_end`; **enforce `N ≥ 2 × R`**. Keep the
-   `legacy` path behind `presence_model`. **Wire the new knobs into the
+   from `period_start`/`period_end`; **enforce `N ≥ 2 × R`**. The session model
+   replaces the legacy path outright — there is no `presence_model` toggle.
+   **Wire the new knob into the
    `time_used_daily` invalidation hook** — changing `presence_continuation_seconds`
-   or `presence_model` must `DELETE` the affected cached rollups exactly as a
+   must `DELETE` the affected cached rollups exactly as a
    heartbeat-setting change already does (the cache is keyed on the old
    semantics; without this, stale minutes survive a knob change until the row
    ages out). Tests pin: (a) a continuous sparse session reads its full span,
@@ -439,8 +445,8 @@ new semantics.
    each `N`, and the re-bucketing invariance check) over a week of prod data, as
    the go/no-go gate on the defaults.
 
-6. **e2e default-pinning gate (extends #930).** Pin `presence_model = session`
-   and `presence_continuation_seconds = 120` end-to-end so a future PR — or a
+6. **e2e default-pinning gate (extends #930).** Pin
+   `presence_continuation_seconds = 120` end-to-end so a future PR — or a
    change to `usage_report_interval` — can't shift the visible numbers silently.
 
 7. **(Complementary, not blocking) router-side foreground-host heuristic


### PR DESCRIPTION
## What

Schema-only Flyway migration adding one presence-tuning knob to `household_settings`:

- `presence_continuation_seconds` `INTEGER NOT NULL DEFAULT 120` — the idle gap `N` that ends an activity session in the new presence model.

This is the **schema-only foundation** for the presence-tuning fix (sparse-app undercount) per `docs/design/presence-tuning.md` §5 item 1, from analysis #1446 / PR #1449. The column is **inert** in this PR — the rollup/repo/route/cache-invalidation code that reads it lands in the follow-ups (#1464 / #1465).

The new session presence model is **global and unconditional** — it replaces the legacy `max(activeSeconds)` path outright, so there is **no** `presence_model` toggle column.

## Why migration-only

Per the migration-isolation two-PR rule (AGENTS.md §migrations-back-compat, CI gate #696): a PR that adds a Flyway migration may contain only the migration `.sql` plus docs `.md`. No source, no tests. The existing `api.test` suite is the back-compat gate — it applies every classpath migration (including this V52) before running fixtures that exercise image-(N-1) code paths, so it verifies the migration is backward-compatible without any new test here. The adopting code and its tests come in the follow-up PR.

## Safety at prod scale

`household_settings` is a small singleton-style metadata table, **not** one of the unbounded-growth event tables. The column adds with a constant default, which is metadata-only in PG 11+ (no table rewrite, no long lock) — safe on the Flyway startup critical path even at prod data volume.

## Back-compat

The column is `NOT NULL DEFAULT 120`, so image-(N-1) — which never names it in any `INSERT`/`UPDATE` — keeps working unchanged; existing and new rows get the default.

Refs #1463. Foundation for #1464 / #1465. Part of the Tuning epic #1445.