### PR TITLE
feat(#1472): hoist default-deny selector to top of expanded profile

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -1422,4 +1422,23 @@ describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
     expect(body.failureMode).toBe('block-all')
     expect(body.timeLimit).toBe(120)
   })
+
+  // #1472 — default-deny is the profile's most fundamental posture, so it
+  // renders FIRST in the expanded card, before the devices and apps subsections.
+  it('renders the default-deny subsection before the devices and apps subsections', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+
+    const defaultDeny = await screen.findByTestId('profile-default-deny-1')
+    const devices     = screen.getByTestId('profile-devices-subsection-1')
+    const apps        = screen.getByTestId('profile-apps-subsection-1')
+
+    // default-deny precedes both devices and apps in DOM order
+    expect(defaultDeny.compareDocumentPosition(devices))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(defaultDeny.compareDocumentPosition(apps))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -758,6 +758,20 @@ function ProfileShellRow({
               own. Read-only; lives above the edit subsections. */}
           <ProfileTimelineChart profileId={pd.profile.id} />
 
+          {/* #1320 — per-profile default-deny baseline. Block-all; only the
+              profile's allowed apps/hosts + the household global allowlist are
+              reachable. The inverse of allow-by-default + blocklists. #1472 —
+              hoisted to the top of the expanded view: default-deny is the
+              profile's most fundamental posture, so it reads first, before
+              devices / categories / apps. */}
+          {isAdmin && (
+            <DefaultDenySubsection
+              pd={pd}
+              updateProfile={updateProfile}
+              onProfileChanged={onProfileChanged}
+            />
+          )}
+
           {/* #973: inline devices subsection. Name is edited inline in the
               card header above (no redundant collapsible). Devices autosave
               per-row via PATCH /devices. Post-#978 the Edit-modal escape
@@ -789,17 +803,6 @@ function ProfileShellRow({
               onAppsChanged={onAppsChanged}
               onProfileChanged={onProfileChanged}
               updateProfile={updateProfile}
-            />
-          )}
-
-          {/* #1320 — per-profile default-deny baseline. Block-all; only the
-              profile's allowed apps/hosts + the household global allowlist are
-              reachable. The inverse of allow-by-default + blocklists. */}
-          {isAdmin && (
-            <DefaultDenySubsection
-              pd={pd}
-              updateProfile={updateProfile}
-              onProfileChanged={onProfileChanged}
             />
           )}
 


### PR DESCRIPTION
## What

Moves `DefaultDenySubsection` (#1320) to the **top** of the expanded profile card in `web/src/pages/ProfilesPage.tsx` — it now renders directly under `ProfileTimelineChart`, before the devices, blocked-categories, and apps subsections.

Default-deny is the profile's most fundamental posture (allow-by-default vs block-everything-not-allowed), so it should be the first thing you see when expanding a profile.

## Scope

- Pure JSX render-order change. No behavior, wire, schema, or API change.
- `isAdmin` guard preserved exactly as-is.
- SPA-only. Epic: Dashboard & UX.

## TDD

- Red→green visible in commit history: first commit adds a failing DOM-order test asserting the default-deny subsection precedes the devices/apps subsections (via `compareDocumentPosition`); second commit does the reorder and the test passes.
- `npm test` (342 tests) green; `npm run build` (tsc + vite) green.

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)