### PR TITLE
feat(#1405): Grafana warning alert rules W1–W5 in Terraform

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -92,6 +92,29 @@ templated `${datasource}` variable resolved at view time, so the same JSON
 loads in both Grafana Cloud and a self-hosted provisioned Grafana, #1207),
 and the GitHub Actions secrets.
 
+## Alerting
+
+The alerting half of the design (`docs/design/alerting.md`) is managed here
+too:
+
+- **Contact points + notification policy** ([`alerting.tf`](alerting.tf), #1403)
+  — three email contact points and the singleton severity/env routing tree.
+- **A managed alerts folder** ([`alerting-rules.tf`](alerting-rules.tf)) that
+  the rule groups live in. Unlike the dashboards, a Grafana managed alert rule
+  group needs a concrete, non-empty folder, so this one is managed in-repo
+  (idempotent now that the HCP backend owns its state).
+- **Warning rule group** ([`alerting-rules-warning.tf`](alerting-rules-warning.tf),
+  #1405) — W1–W5 (§7.2). W5 ships **disabled** (`is_paused`) because its
+  series is router-pushed and not yet trustworthy in prod (§8, #1382).
+- **Critical rule group** ([`alerting-rules-critical.tf`](alerting-rules-critical.tf),
+  #1404) — C1–C7 (§7.1).
+
+Unlike the dashboards, the alert rules reference a **concrete** Prometheus
+datasource UID (managed rules cannot use a templated `${datasource}`). It
+comes from the `prometheus_datasource_uid` variable, default `grafanacloud-prom`
+(the built-in Grafana Cloud hosted Prometheus); override
+`TF_VAR_prometheus_datasource_uid` only for a self-hosted stack. Not a secret.
+
 ## Prerequisites
 
 > **HARD PREREQUISITE — the HCP workspace must exist before the `cloud {}`

--- a/infra/grafana/alerting-rules-warning.tf
+++ b/infra/grafana/alerting-rules-warning.tf
@@ -1,0 +1,149 @@
+# Warning (notify, look-today) alert rules — W1–W5
+# (#1405, parent #1381). Implements docs/design/alerting.md §7.2.
+#
+# Every expression is grounded in a series emitted today (§2 "alert only on
+# series that exist"; grep api/src) — except W5, which is shipped DISABLED
+# (is_paused = true) because its series is router-pushed and not yet
+# trustworthy in prod (§8 + #1382). It is authored now so it activates with a
+# one-line flip once the fleet rolls forward.
+#
+# All five carry severity=warning + env=prod labels, which the notification
+# policy in alerting.tf routes to the wifihaven-warning (email) contact point.
+# None of these are ratio queries, so unlike the critical set (§7.1) they need
+# no zero-traffic guard — a counter that never increments is simply absent
+# (no_data_state = OK), which must not fire.
+#
+# Threshold model: each rule is a two-node Grafana managed condition — an
+# instant Prometheus query (ref A) feeding a threshold expression (ref C, the
+# condition). The `gt` evaluator parameter is the design's threshold; `for`
+# and the rate/increase window come straight from §7.2.
+
+locals {
+  # Keyed w1..w5 (stable resource addressing). `window_s` bounds the data fetch
+  # and must cover the rate/increase window in `expr`. `paused` ships W5 off.
+  warning_rules = {
+    w1 = {
+      title    = "W1 Rollup failures"
+      expr     = "increase(wifihaven_rollup_runs_total{status=\"error\",env=\"prod\"}[1h])"
+      window_s = 3600
+      gt       = 0
+      for      = "10m"
+      paused   = false
+      summary  = "A prod rollup run errored in the last hour — analytics tables silently rot. Does not affect live enforcement. Check /api/admin/rollup-status and the rollup-health dashboard."
+    }
+    w2 = {
+      title    = "W2 Cardinality firewall rejections"
+      expr     = "sum(rate(metrics_rejected_total{env=\"prod\"}[10m]))"
+      window_s = 600
+      gt       = 0
+      for      = "15m"
+      paused   = false
+      summary  = "Code is emitting a metric series the MetricGuard allowlist forbids (wrong name or a forbidden label) — a bug in the emitting code, not an attack. Degrades observability, not the service."
+    }
+    w3 = {
+      title    = "W3 Zero-byte traffic rows filtered"
+      expr     = "rate(traffic_reports_filtered_zero_bytes_total{env=\"prod\"}[15m])"
+      window_s = 900
+      gt       = 0
+      for      = "30m"
+      paused   = false
+      summary  = "Rising rate of filtered zero-byte traffic rows — the #858 agent regression (empty rows) may have returned (#864 sentinel). Slow-burning; long for: avoids paging on a blip."
+    }
+    w4 = {
+      title    = "W4 Auth-failure spike"
+      expr     = "sum(rate(auth_failures_total{env=\"prod\"}[5m]))"
+      window_s = 300
+      gt       = 0.5
+      for      = "10m"
+      paused   = false
+      summary  = "Sustained burst of bad_password / bad_router_token (>~30/min) — the household's only brute-force signal. Threshold sits well above a fat-fingered login; tune up if noisy."
+    }
+    w5 = {
+      title    = "W5 Blocklist fetch failures"
+      expr     = "sum(rate(blocklist_fetch_failures_total{env=\"prod\"}[15m]))"
+      window_s = 900
+      gt       = 0
+      for      = "30m"
+      # DISABLED: blocklist_fetch_failures_total is router-pushed and not yet
+      # trustworthy in prod (§8, #1382). Flip to false once the fleet rolls
+      # forward and the counter is reliable.
+      paused  = true
+      summary = "Blocklist fetches are failing on the router (category enforcement degrades). DISABLED until the router-pushed counter is trustworthy in prod (#1382)."
+    }
+  }
+}
+
+resource "grafana_rule_group" "warning" {
+  name             = "wifihaven-warning"
+  folder_uid       = grafana_folder.alerts.uid
+  interval_seconds = 60
+
+  dynamic "rule" {
+    for_each = local.warning_rules
+    content {
+      name      = rule.value.title
+      condition = "C"
+      for       = rule.value.for
+      is_paused = rule.value.paused
+
+      # A never-incremented counter is absent, not zero — absence is healthy,
+      # so no-data must resolve OK rather than fire. Genuine eval errors surface
+      # as Error in Grafana (visible) without notifying as the alert.
+      no_data_state  = "OK"
+      exec_err_state = "Error"
+
+      labels = {
+        severity = "warning"
+        env      = "prod"
+      }
+
+      annotations = {
+        summary = rule.value.summary
+      }
+
+      # Node A: instant Prometheus query.
+      data {
+        ref_id = "A"
+        relative_time_range {
+          from = rule.value.window_s
+          to   = 0
+        }
+        datasource_uid = var.prometheus_datasource_uid
+        model = jsonencode({
+          refId         = "A"
+          datasource    = { type = "prometheus", uid = var.prometheus_datasource_uid }
+          editorMode    = "code"
+          expr          = rule.value.expr
+          instant       = true
+          range         = false
+          intervalMs    = 1000
+          maxDataPoints = 43200
+        })
+      }
+
+      # Node C: threshold expression over A (the rule condition). Fires when the
+      # last value of A is greater than the design threshold.
+      data {
+        ref_id = "C"
+        relative_time_range {
+          from = rule.value.window_s
+          to   = 0
+        }
+        datasource_uid = "__expr__"
+        model = jsonencode({
+          refId      = "C"
+          datasource = { type = "__expr__", uid = "__expr__" }
+          type       = "threshold"
+          expression = "A"
+          conditions = [{
+            type      = "query"
+            evaluator = { type = "gt", params = [rule.value.gt] }
+            operator  = { type = "and" }
+            query     = { params = ["C"] }
+            reducer   = { type = "last", params = [] }
+          }]
+        })
+      }
+    }
+  }
+}

--- a/infra/grafana/alerting-rules.tf
+++ b/infra/grafana/alerting-rules.tf
@@ -1,0 +1,22 @@
+# Shared infrastructure for the Grafana managed alert rule groups
+# (docs/design/alerting.md §7). The rule sets themselves live in sibling files
+# so the two parallel work streams stay separable:
+#   - alerting-rules-warning.tf  → the `warning` group  (#1405, W1–W5)
+#   - alerting-rules-critical.tf → the `critical` group (#1404, C1–C7)
+#
+# Both rule groups attach to the single folder below and query the Prometheus
+# datasource named by var.prometheus_datasource_uid.
+#
+# Why a managed folder here (the dashboards deliberately do NOT manage one):
+# a Grafana managed alert rule group requires a concrete, non-empty folder_uid
+# — there is no "General folder" fallback for rules the way there is for
+# dashboards. The dashboards stayed folder-less to keep their apply
+# stateless-idempotent, but that argument is moot now: the alerting resources
+# are stateful by nature and the HCP remote backend (#1406) already owns their
+# state, so a managed folder reconciles idempotently alongside them. Keeping it
+# in-repo (rather than a hand-created folder + a uid variable) keeps the apply
+# fully reproducible per the repo's declarative-config preference.
+
+resource "grafana_folder" "alerts" {
+  title = "WifiHaven Alerts"
+}

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -18,3 +18,9 @@ operator_email = "<operator email>"
 # to use the stack's General folder. Not managed as a resource (keeps the
 # apply stateless-idempotent in CD).
 # folder_uid = "wifihaven"
+
+# Optional: UID of the Prometheus datasource the alert rules query. Defaults
+# to grafanacloud-prom (the built-in Grafana Cloud hosted Prometheus).
+# Override only for a self-hosted stack whose datasource UID differs. Not a
+# secret. (The alerts folder itself is managed in-repo; see alerting-rules.tf.)
+# prometheus_datasource_uid = "grafanacloud-prom"

--- a/infra/grafana/variables.tf
+++ b/infra/grafana/variables.tf
@@ -21,3 +21,9 @@ variable "folder_uid" {
   default     = ""
   description = "Optional uid of a pre-existing Grafana folder to place the dashboards in. Leave empty to use the stack's General folder. We do not manage the folder as a resource so the apply stays stateless-idempotent in CD (see main.tf)."
 }
+
+variable "prometheus_datasource_uid" {
+  type        = string
+  default     = "grafanacloud-prom"
+  description = "UID of the Prometheus datasource the alert rules query. Unlike the dashboards (which use a templated $${datasource} resolved at view time), Grafana managed alert rules must reference a concrete datasource UID. Defaults to grafanacloud-prom, the UID of the built-in Grafana Cloud hosted Prometheus. Override (TF_VAR_prometheus_datasource_uid) only for a self-hosted stack whose datasource UID differs. Not a secret. See docs/design/alerting.md §3."
+}


### PR DESCRIPTION
Adds the **warning** (notify, look-today) alert rule set from
[`docs/design/alerting.md`](docs/design/alerting.md) §7.2 to `infra/grafana`
as a `grafana_rule_group`, routed to the `wifihaven-warning` email contact
point by the notification policy already shipped in #1405's prereq (#1403,
PR #1447). HCP remote backend (#1406) is the other merged prereq.

Closes #1405.

## Rules (all grounded in series emitted today — grep `api/src`)

| | Query | Threshold | `for` |
|---|---|---|---|
| **W1** rollup failures | `increase(wifihaven_rollup_runs_total{status="error",env="prod"}[1h])` | `> 0` | 10m |
| **W2** cardinality firewall rejects | `sum(rate(metrics_rejected_total{env="prod"}[10m]))` | `> 0` | 15m |
| **W3** zero-byte traffic rows (#864 sentinel) | `rate(traffic_reports_filtered_zero_bytes_total{env="prod"}[15m])` | `> 0` | 30m |
| **W4** auth-failure spike | `sum(rate(auth_failures_total{env="prod"}[5m]))` | `> 0.5` | 10m |
| **W5** blocklist fetch failures | `sum(rate(blocklist_fetch_failures_total{env="prod"}[15m]))` | `> 0` | 30m |

Each carries `severity=warning` + `env=prod` labels for the policy to route. No
zero-traffic guard is needed (none are ratio queries; a never-incremented
counter is absent → `no_data_state = OK`, which must not fire).

### W5 ships disabled
`blocklist_fetch_failures_total` is router-pushed and **not yet trustworthy in
prod** (§8, #1382), so W5 is authored but `is_paused = true`. It flips on with a
one-line change once the fleet rolls forward — per the design's "alert only on
emitted series" rule.

## Supporting infra
Grafana managed rules can't use the dashboards' templated `${datasource}` or
the "General folder" fallback, so this adds:
- A **managed alerts folder** (`alerting-rules.tf`) — idempotent now that the
  HCP backend owns its state. **Shared with the critical set (#1404)**; the
  rule group itself lives in its own file (`alerting-rules-warning.tf`) to stay
  separable.
- A `prometheus_datasource_uid` variable (default `grafanacloud-prom`, the
  built-in Grafana Cloud hosted Prometheus; not a secret).

## Coordination with #1404
Both warning (#1405) and critical (#1404) rule sets share `infra/grafana`. They
share the alerts folder + datasource variable but keep separate rule-group
files. Expect a small reconcile if both land the shared `grafana_folder.alerts`
/ `prometheus_datasource_uid` — whichever merges first wins; the second drops
its duplicate.

## Validation
- `terraform fmt -check` — clean
- `terraform validate` (provider `grafana ~> 3.0` schema) — **Success! The configuration is valid.**
- Second-apply no-op / live firing: requires the HCP backend token + Grafana
  service-account auth (CI `master-grafana.yml`), not available locally. The
  resources are managed + idempotent under the remote backend by construction.

> Note: the GitHub issue titles/bodies for #1403/#1404/#1405 are internally
> scrambled (each body describes a neighbor's work). This PR follows the #1405
> **title** + the explicit task scope (warning rules W1–W5), matching
> design §7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)