### PR TITLE
feat(#1380): per-app schedules — assignment-editor schedule-rule editor

### DIFF
--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -36,6 +36,12 @@ vi.mock('@/api/client', () => ({
       setPolicy: vi.fn(),
       deletePolicy: vi.fn(),
     },
+    // #1380 — the per-app schedule-rule editor embeds the #1069 SchedulePicker,
+    // which reads/writes the household named-schedule catalog.
+    schedules: {
+      list: vi.fn(),
+      create: vi.fn(),
+    },
     time: {
       summaryAll: vi.fn(),
       grantExtension: vi.fn(),
@@ -162,6 +168,8 @@ beforeEach(() => {
   ;(api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
   ;(api.apps.setPolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.apps.deletePolicy as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+  ;(api.schedules.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.usageByApp as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
     profileId: 1, profileName: 'Kids', from: '2026-05-26', to: '2026-05-26', apps: [],
   })
@@ -1181,6 +1189,102 @@ describe('ProfilesPage — apps section (#767)', () => {
     await expand(1, user)
     await user.click(screen.getByTestId('profile-apps-toggle-1'))
     expect(await screen.findByTestId('profile-1-apps-section-manage-link')).toHaveAttribute('href', '/apps')
+  })
+})
+
+// #1380 — per-app schedule rules in the assignment editor. Each rule attaches
+// a #1069 named schedule (via the shared SchedulePicker) with a mode
+// (allowed-during / blocked-during); the rule set rides the assignment's
+// UpsertAppAssignmentRequest as additive `scheduleRules`. Autosave: add/remove
+// persists immediately (no Save button).
+describe('ProfilesPage — per-app schedule rules (#1380)', () => {
+  const bedtime = { id: 10, name: 'Bedtime', description: null, windows: [] }
+  const schoolHours = { id: 11, name: 'School hours', description: null, windows: [] }
+
+  function ytWithRules(scheduleRules: { scheduleId: number; mode: 'allowed_during' | 'blocked_during' }[]) {
+    return {
+      app: { id: 50, name: 'YouTube', slug: 'youtube', templateId: null, icon: '📺', createdAt: '2026-01-01' },
+      hosts: ['youtube.com'],
+      assignments: [
+        { id: 2, appId: 50, profileId: 1, mode: 'allowed' as const, dailyMinutes: null, exemptFromDaily: true, scheduleRules },
+      ],
+    }
+  }
+
+  async function openAppsSection(user: ReturnType<typeof userEvent.setup>) {
+    renderPage()
+    await screen.findByTestId('profile-card-1')
+    await expand(1, user)
+    await user.click(screen.getByTestId('profile-apps-toggle-1'))
+    await screen.findByTestId('app-row-50')
+  }
+
+  it('renders attached schedule rules with their schedule name and mode', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytWithRules([{ scheduleId: 10, mode: 'allowed_during' }])])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
+    const user = userEvent.setup()
+    await openAppsSection(user)
+    const rule = await screen.findByTestId('app-row-50-schedule-rule-10-allowed_during')
+    expect(within(rule).getByText('Bedtime')).toBeInTheDocument()
+    expect(rule.textContent).toMatch(/Allowed during/i)
+  })
+
+  it('attaching a named schedule as allowed-during calls setPolicy with the rule', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytWithRules([])])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
+    const user = userEvent.setup()
+    await openAppsSection(user)
+    await user.selectOptions(screen.getByTestId('app-row-50-schedule-picker-select'), '10')
+    await user.click(screen.getByTestId('app-row-50-schedule-mode-allowed_during'))
+    await user.click(screen.getByTestId('app-row-50-schedule-add'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, {
+        mode: 'allowed',
+        dailyMinutes: null,
+        exemptFromDaily: true,
+        scheduleRules: [{ scheduleId: 10, mode: 'allowed_during' }],
+      }),
+    )
+  })
+
+  it('attaching a named schedule as blocked-during calls setPolicy with the rule', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytWithRules([])])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
+    const user = userEvent.setup()
+    await openAppsSection(user)
+    await user.selectOptions(screen.getByTestId('app-row-50-schedule-picker-select'), '11')
+    await user.click(screen.getByTestId('app-row-50-schedule-mode-blocked_during'))
+    await user.click(screen.getByTestId('app-row-50-schedule-add'))
+    await waitFor(() =>
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, {
+        mode: 'allowed',
+        dailyMinutes: null,
+        exemptFromDaily: true,
+        scheduleRules: [{ scheduleId: 11, mode: 'blocked_during' }],
+      }),
+    )
+  })
+
+  it('removing a rule persists the assignment without it', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytWithRules([{ scheduleId: 10, mode: 'allowed_during' }])])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
+    const user = userEvent.setup()
+    await openAppsSection(user)
+    await user.click(await screen.findByTestId('app-row-50-schedule-rule-10-allowed_during-remove'))
+    await waitFor(() =>
+      // empty rule set → scheduleRules omitted from the additive payload;
+      // the assignment's exemptFromDaily flag is preserved across the replace.
+      expect(api.apps.setPolicy).toHaveBeenCalledWith(50, 1, { mode: 'allowed', dailyMinutes: null, exemptFromDaily: true }),
+    )
+  })
+
+  it('an allowed-during rule surfaces the exempt-from-daily cap copy', async () => {
+    (api.apps.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([ytWithRules([{ scheduleId: 10, mode: 'allowed_during' }])])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime])
+    const user = userEvent.setup()
+    await openAppsSection(user)
+    const exempt = await screen.findByTestId('app-row-50-schedule-exempt')
+    expect(exempt.textContent).toMatch(/daily (time )?limit/i)
   })
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -2,15 +2,16 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
-import { useBlocklists, useProfiles, useDevices, useInvalidators, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
+import { useBlocklists, useProfiles, useDevices, useInvalidators, useNamedSchedules, useProfileUsageByApp, useTimeStatusSummary } from '@/api/queries'
 import { useAuth } from '@/hooks/useAuth'
 import { useDebouncedSave, type SaveStatus } from '@/hooks/useDebouncedSave'
 import { SaveStatusBadge } from '@/components/SaveStatusBadge'
+import { SchedulePicker } from '@/components/SchedulePicker'
 import type {
-  AppDetail, AppMode, AppPolicyAssignment,
+  AppDetail, AppMode, AppPolicyAssignment, AppScheduleMode, AppScheduleRule,
   CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, PauseMode, ProfileDetail,
   ProfileTimeSummary,
-  ScheduleRequest, UpsertProfileRequest, User,
+  ScheduleRequest, UpsertAppAssignmentRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { AppIcon } from '@/components/AppIcon'
@@ -1886,12 +1887,7 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
   // that run `profileMutated()` on success, mirroring `grantMutation`.
   const invalidators = useInvalidators()
   const setPolicyMutation = useMutation({
-    mutationFn: (vars: { mode: AppMode; dailyMinutes: number | null; exemptFromDaily?: boolean }) =>
-      api.apps.setPolicy(app.app.id, profileId, {
-        mode: vars.mode,
-        dailyMinutes: vars.dailyMinutes,
-        ...(vars.exemptFromDaily !== undefined ? { exemptFromDaily: vars.exemptFromDaily } : {}),
-      }),
+    mutationFn: (req: UpsertAppAssignmentRequest) => api.apps.setPolicy(app.app.id, profileId, req),
     onSuccess: () => invalidators.profileMutated(),
   })
   const deletePolicyMutation = useMutation({
@@ -1907,6 +1903,12 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
   )
   const [busy, setBusy] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
+  // #1380 — attached schedule rules, seeded from the persisted assignment and
+  // re-seeded when it changes from outside (mirrors minutesDraft below).
+  const [scheduleRules, setScheduleRules] = useState<AppScheduleRule[]>(
+    () => current?.scheduleRules ?? [],
+  )
+  const rulesSig = JSON.stringify(current?.scheduleRules ?? [])
   // Re-seed the input when the persisted policy changes from outside
   // (e.g. another tab, or after our own setPolicy round-trip lands).
   // Without this the input keeps stale values once `current` updates.
@@ -1916,12 +1918,31 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
       ? String(current.dailyMinutes) : ''
     setMinutesDraft(next)
   }, [current?.mode, current?.dailyMinutes])
+  useEffect(() => {
+    if (busy) return
+    setScheduleRules(current?.scheduleRules ?? [])
+  }, [rulesSig])
 
-  async function apply(mode: AppMode, dailyMinutes: number | null, exemptFromDaily?: boolean) {
+  // PUT replaces the whole assignment, so every write must carry the current
+  // schedule rules (additive `scheduleRules`, omitted when empty so the no-rule
+  // payload shape — and the existing assertions on it — stay unchanged).
+  async function apply(
+    mode: AppMode,
+    dailyMinutes: number | null,
+    exemptFromDaily?: boolean,
+    rules?: AppScheduleRule[],
+  ) {
+    const effectiveRules = rules ?? scheduleRules
+    const req: UpsertAppAssignmentRequest = {
+      mode,
+      dailyMinutes,
+      ...(exemptFromDaily !== undefined ? { exemptFromDaily } : {}),
+      ...(effectiveRules.length > 0 ? { scheduleRules: effectiveRules } : {}),
+    }
     setBusy(true)
     setLocalError(null)
     try {
-      await setPolicyMutation.mutateAsync({ mode, dailyMinutes, exemptFromDaily })
+      await setPolicyMutation.mutateAsync(req)
       await onChanged()
     } catch (e) {
       setLocalError(e instanceof Error ? e.message : 'Failed to update')
@@ -1952,6 +1973,29 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
   const mode = current?.mode ?? null
   const isTimeLimited = mode === 'time_limited'
   const currentMinutes = isTimeLimited ? current?.dailyMinutes ?? null : null
+
+  // #1380 — schedule-rule add/remove and the exempt-from-daily toggle persist
+  // the whole assignment immediately (autosave, no Save button). Re-applying
+  // the current mode/minutes keeps everything but the changed dimension intact.
+  async function addRule(scheduleId: number, ruleMode: AppScheduleMode) {
+    if (mode == null) return
+    if (scheduleRules.some(r => r.scheduleId === scheduleId && r.mode === ruleMode)) return
+    const next = [...scheduleRules, { scheduleId, mode: ruleMode }]
+    setScheduleRules(next)
+    await apply(mode, current?.dailyMinutes ?? null, current?.exemptFromDaily, next)
+  }
+
+  async function removeRule(scheduleId: number, ruleMode: AppScheduleMode) {
+    if (mode == null) return
+    const next = scheduleRules.filter(r => !(r.scheduleId === scheduleId && r.mode === ruleMode))
+    setScheduleRules(next)
+    await apply(mode, current?.dailyMinutes ?? null, current?.exemptFromDaily, next)
+  }
+
+  async function setScheduleExempt(nextExempt: boolean) {
+    if (mode == null) return
+    await apply(mode, current?.dailyMinutes ?? null, nextExempt)
+  }
 
   // Operator feedback: the old UX made you type minutes AND click a
   // separate "Time-limit" button, then showed the duration twice. Now
@@ -2110,9 +2154,176 @@ function AppRow({ app, profileId, onChanged, usedMins }: {
           </span>
         </label>
       )}
+      {mode != null && (
+        <ScheduleRuleEditor
+          appId={app.app.id}
+          rules={scheduleRules}
+          exemptFromDaily={current?.exemptFromDaily ?? true}
+          showExemptToggle={mode !== 'time_limited'}
+          busy={busy}
+          onAdd={addRule}
+          onRemove={removeRule}
+          onSetExempt={setScheduleExempt}
+        />
+      )}
       {localError && (
         <p className="text-xs text-red-700" data-testid={`app-row-${app.app.id}-error`}>{localError}</p>
       )}
+    </div>
+  )
+}
+
+// #1380 — per-app schedule rules on an app's profile assignment. Each rule
+// attaches a #1069 household named schedule (via the shared SchedulePicker)
+// with a mode:
+//   • Allowed during — the app stays reachable while the schedule's window is
+//     active, even during profile downtime (a carve-out). Still subject to the
+//     daily time limit unless the assignment is exempt (rows 9a–9c).
+//   • Blocked during — the app is dropped while the window is active, even when
+//     the profile is otherwise unrestricted.
+// No bespoke time editor here — the named schedule owns its day/time windows
+// (the picker's "Custom" flow authors a reusable one). Add/remove autosaves the
+// assignment (no Save button), consistent with the block/allow toggles above.
+const SCHEDULE_MODE_LABEL: Record<AppScheduleMode, string> = {
+  allowed_during: 'Allowed during',
+  blocked_during: 'Blocked during',
+}
+
+function ScheduleRuleEditor({
+  appId, rules, exemptFromDaily, showExemptToggle, busy,
+  onAdd, onRemove, onSetExempt,
+}: {
+  appId: number
+  rules: AppScheduleRule[]
+  exemptFromDaily: boolean
+  // Hidden for time_limited apps, whose own "Counts toward daily limit" row
+  // already governs the same exemptFromDaily flag (avoid two controls).
+  showExemptToggle: boolean
+  busy: boolean
+  onAdd: (scheduleId: number, mode: AppScheduleMode) => void | Promise<void>
+  onRemove: (scheduleId: number, mode: AppScheduleMode) => void | Promise<void>
+  onSetExempt: (next: boolean) => void | Promise<void>
+}) {
+  const [pickMode, setPickMode] = useState<AppScheduleMode>('allowed_during')
+  const [pickScheduleId, setPickScheduleId] = useState<number | null>(null)
+  const { data: namedSchedules = [] } = useNamedSchedules()
+
+  const scheduleNameById = useMemo(() => {
+    const m = new Map<number, string>()
+    namedSchedules.forEach(s => m.set(s.id, s.name))
+    return m
+  }, [namedSchedules])
+
+  const hasAllowedRule = rules.some(r => r.mode === 'allowed_during')
+
+  function add() {
+    if (pickScheduleId == null) return
+    void onAdd(pickScheduleId, pickMode)
+    setPickScheduleId(null)
+  }
+
+  const modeBtn = 'text-xs px-2.5 py-1 rounded-lg border border-transparent transition-colors disabled:opacity-50'
+  const modeOn = 'bg-brand-accent/20 text-brand-accent'
+  const modeOff = 'bg-brand-alt text-brand-text'
+
+  return (
+    <div
+      data-testid={`app-row-${appId}-schedules`}
+      className="border-t border-brand-border pt-2 space-y-2"
+    >
+      <p className="text-xs font-semibold text-brand-text-muted uppercase tracking-wider">
+        Schedules
+      </p>
+
+      {rules.length === 0 && (
+        <p className="text-xs text-brand-text-muted italic">
+          No schedule rules. Attach a named schedule to make this app reachable
+          or blocked only during a window.
+        </p>
+      )}
+
+      {rules.map(r => (
+        <div
+          key={`${r.scheduleId}-${r.mode}`}
+          data-testid={`app-row-${appId}-schedule-rule-${r.scheduleId}-${r.mode}`}
+          className="flex items-start gap-2 bg-brand-surface border border-brand-border-strong rounded-lg px-2.5 py-1.5"
+        >
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-brand-ink">
+              <span
+                className={`font-medium ${r.mode === 'allowed_during' ? 'text-brand-accent' : 'text-red-700'}`}
+              >
+                {SCHEDULE_MODE_LABEL[r.mode]}
+              </span>
+              {' '}
+              <span className="font-medium">{scheduleNameById.get(r.scheduleId) ?? `schedule ${r.scheduleId}`}</span>
+            </p>
+            <p className="text-[11px] text-brand-text-muted">
+              {r.mode === 'allowed_during'
+                ? 'Reachable while this window is active — even during profile downtime.'
+                : 'Blocked while this window is active — even when the profile is otherwise allowed.'}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid={`app-row-${appId}-schedule-rule-${r.scheduleId}-${r.mode}-remove`}
+            aria-label={`Remove ${SCHEDULE_MODE_LABEL[r.mode]} ${scheduleNameById.get(r.scheduleId) ?? 'schedule'} rule`}
+            disabled={busy}
+            onClick={() => onRemove(r.scheduleId, r.mode)}
+            className="text-brand-text-muted hover:text-red-700 transition-colors leading-none text-sm disabled:opacity-50"
+          >×</button>
+        </div>
+      ))}
+
+      {/* #1380 — exempt-from-daily surfaced alongside an allowed-during rule so
+          the cap-bites-non-exempt behaviour (rows 9a–9c) isn't a surprise. */}
+      {hasAllowedRule && showExemptToggle && (
+        <label
+          data-testid={`app-row-${appId}-schedule-exempt`}
+          className="flex items-start gap-2 text-xs text-brand-text cursor-pointer select-none"
+        >
+          <input
+            type="checkbox"
+            checked={exemptFromDaily}
+            disabled={busy}
+            onChange={e => onSetExempt(e.target.checked)}
+            className="w-3.5 h-3.5 mt-0.5 accent-amber-500"
+          />
+          <span>
+            {exemptFromDaily
+              ? 'Exempt from the daily time limit — reachable in-window even past the cap.'
+              : 'Still blocked by the daily time limit — the cap applies even in-window.'}
+          </span>
+        </label>
+      )}
+
+      <div className="space-y-2">
+        <div className="inline-flex rounded-lg bg-brand-alt p-0.5">
+          {(['allowed_during', 'blocked_during'] as const).map(m => (
+            <button
+              key={m}
+              type="button"
+              data-testid={`app-row-${appId}-schedule-mode-${m}`}
+              disabled={busy}
+              onClick={() => setPickMode(m)}
+              className={`${modeBtn} ${pickMode === m ? modeOn : modeOff}`}
+            >{SCHEDULE_MODE_LABEL[m]}</button>
+          ))}
+        </div>
+        <SchedulePicker
+          value={pickScheduleId}
+          onChange={setPickScheduleId}
+          disabled={busy}
+          testId={`app-row-${appId}-schedule-picker`}
+        />
+        <button
+          type="button"
+          data-testid={`app-row-${appId}-schedule-add`}
+          disabled={busy || pickScheduleId == null}
+          onClick={add}
+          className="text-xs px-2.5 py-1 rounded-lg bg-brand-accent/10 text-brand-accent font-medium hover:bg-brand-accent/20 disabled:opacity-50"
+        >Add rule</button>
+      </div>
     </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -797,6 +797,24 @@ export interface App {
   createdAt: string
 }
 
+// #1380 / #1376 — per-app schedule rules. Each rule attaches a #1069 named
+// schedule (by id) to an app's profile assignment with a mode:
+//   allowed_during — the app stays reachable while the schedule's window is
+//     active, even during profile downtime (a carve-out that beats whole-MAC
+//     blocks per #421). Subject to the daily time limit unless exemptFromDaily.
+//   blocked_during — the app is dropped while the window is active, even when
+//     the profile is otherwise unrestricted.
+// API-internal: PolicyService collapses active rules into the existing per-MAC
+// extraAllowed / extraBlocked snapshot fields — no wire/router change (design
+// doc docs/design/per-app-schedules.md §2–§5). Mirrors the API's ScheduleMode
+// wire strings.
+export type AppScheduleMode = 'allowed_during' | 'blocked_during'
+
+export interface AppScheduleRule {
+  scheduleId: number
+  mode: AppScheduleMode
+}
+
 export interface AppPolicyAssignment {
   id: number
   appId: number
@@ -804,6 +822,9 @@ export interface AppPolicyAssignment {
   mode: AppMode
   dailyMinutes: number | null
   exemptFromDaily: boolean
+  // #1380 — attached per-app schedule rules. Optional/back-compat: omitted by
+  // an API that predates #1379 (defaults to no rules).
+  scheduleRules?: AppScheduleRule[]
 }
 
 export interface AppDetail {
@@ -854,6 +875,9 @@ export interface UpsertAppAssignmentRequest {
   mode: AppMode
   dailyMinutes?: number | null
   exemptFromDaily?: boolean
+  // #1380 — additive (default Nil server-side). The full desired rule set for
+  // this assignment (replace semantics, like SetProfileSchedulesRequest's ids).
+  scheduleRules?: AppScheduleRule[]
 }
 
 // #958: BlocklistSummary as returned by GET /api/blocklists.


### PR DESCRIPTION
Implements #1380 (per-app schedules epic #1376) — the **web UI sub-issue (§7 / sub-issue 3)** of `docs/design/per-app-schedules.md`.

Adds a **Schedules** section to each app's per-profile assignment row (the `AppRow` editor on the Profiles page → app subsection).

## What's here
- **Per-rule editor.** Attach one or more rules to an assignment, each a #1069 **named schedule** + a **mode** toggle — *Allowed during* / *Blocked during*. Rules are deduped on `(scheduleId, mode)`.
- **Reuses the #1069 `SchedulePicker`** (landed in #1487) for schedule selection — so the household named-schedule catalog **and** the inline "Custom (define inline)…" create-a-reusable-schedule flow come for free, exactly as the §7 ask intended ("create-new inline from the same control").
- **Clear semantics in copy.** Allowed-during reads "reachable while this window is active — even during profile downtime"; blocked-during reads "blocked while this window is active — even when the profile is otherwise allowed."
- **`exemptFromDaily` surfaced alongside allowed-during rules** with the cap copy from rows 9a–9c (exempt → reachable in-window past the cap; non-exempt → the daily limit still blocks it), so the cap-bites-non-exempt behaviour is not a surprise. Hidden for `time_limited` apps, whose existing "Counts toward daily limit" row already governs the same flag.
- **Autosave (#995/#423).** Add/remove persists the whole assignment immediately — no Save button — consistent with the existing block/allow/time-limit toggles in the same row.

## Wire shape (depends on #1379)
The assignment payload extends `UpsertAppAssignmentRequest` **additively** with `scheduleRules`. The field is **omitted when empty**, so existing no-rule payloads (and their assertions) are unchanged. The router/snapshot wire is untouched — per the design, per-app schedules collapse server-side into the existing `extraAllowed`/`extraBlocked` fields.

### Assumptions to reconcile once #1379 lands
#1379 (PolicyService eval + `shared/Models.scala` additions) is being built in parallel and is **not merged yet**, so the TS types here are written against the design contract:
- **Rule shape on the wire:** I send `scheduleRules: [{ scheduleId, mode }]`, where `mode` is the string `allowed_during` / `blocked_during` (matching the existing `ScheduleMode` JSON codec in `shared`). The design's `AppScheduleRule` case class also carries `id` / `assignmentId`; for an *upsert authoring* request those aren't known, so I followed the `SetProfileSchedulesRequest` precedent (ids/refs only). **If #1379's request decoder expects a different rule field set, this is the one spot to reconcile** — `web/src/types/api.ts` (`AppScheduleRule`) and the payload built in `AppRow.apply`.
- **Read-back:** `AppPolicyAssignment.scheduleRules?` is optional (back-compat) and rendered when present.

## Rebased onto current main (#1069 landed)
This branch was rebased after #1069's named-schedule web UI (#1487) merged. That PR shipped the named-schedule client (`api.schedules.*`), the `useNamedSchedules` query, the `NamedSchedule`/`ScheduleWindow` types, **and** the reusable `SchedulePicker`. This branch now **reuses all of that** instead of the duplicate plumbing it originally carried — the diff is down to three files (`ProfilesPage.tsx`, `ProfilesPage.test.tsx`, `types/api.ts`) and the only net-new types are the per-app-rule ones (`AppScheduleMode` / `AppScheduleRule` / `scheduleRules`).

## Tests (TDD)
`web/src/pages/ProfilesPage.test.tsx` — new `#1380` describe:
- renders attached rules with schedule name + mode
- attaching allowed-during / blocked-during calls `setPolicy` with the right additive payload
- removing a rule persists the assignment without it (empty → field omitted)
- an allowed-during rule surfaces the exempt-from-daily cap copy

Full web suite green (381 tests), `tsc --noEmit` clean, eslint clean. No Scala touched.

Depends on #1379.