### PR TITLE
fix(#1460): merge per-host nftset= directives so dnsmasq fires every set

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -387,92 +387,86 @@ function M.dnsmasq(snapshot)
   -- runs `nft add element` for the right per-MAC set instead. See
   -- openwrt/files/usr/sbin/wifihaven-dns-tail.
 
-  -- #421: per-(MAC, host) extraAllowed nftset populators. One line per
-  -- (mac, host) pair; the set is named per-(mac, host) but populated by
-  -- any client's resolution of host. The MAC scoping happens in the nft
-  -- rule (`ether saddr <mac> ... != @ea_<mac>_<host>`), not at DNS time.
-  -- (#496: dnsmasq 2.91's `nftset=` does NOT parse a `tag:` prefix — the
-  -- earlier tag-scoped form was silently rejected, leaving every ea_ set
-  -- empty and turning the per-MAC drop rule into an unconditional drop.)
-  do
-    local ea_macs = {}
-    for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
-    table.sort(ea_macs)
-    if #ea_macs > 0 then
-      emit("# extraAllowed → per-(MAC, host) ea_ nftsets (#421, #496)")
-      for _, mac in ipairs(ea_macs) do
-        for _, host in ipairs(ea_by_mac[mac]) do
-          emit(string.format(
-            "nftset=/%s/4#inet#wifihaven#%s,6#inet#wifihaven#%s",
-            host,
-            ea_set_name(mac, host), ea6_set_name(mac, host)))
-        end
-      end
-      emit("")
-    end
-  end
-
-  -- #351: extraBlocked is enforced at the connection layer (per-MAC nft
-  -- drop), not via DNS sinkhole. dnsmasq's only role here is to populate
-  -- an nftables set with the resolved IPs of each blocked host, so the
-  -- forward-hook drop can match by `ip daddr ∈ @eb_<host>`. DNS still
-  -- resolves the host normally — see docs/architecture.md §0.1 (Truth 1).
+  -- nftset= populators for every host the snapshot cares about, across all
+  -- channels: per-(MAC, host) extraAllowed (ea_/ea6_, #421/#496), per-host
+  -- extraBlocked (eb_/eb6_, #351/#392), per-category blocklist members
+  -- (bl_/bl6_, #352/#392), and the fleet-wide #1319 global policy sets
+  -- (@global_allow / @global_block).
   --
-  -- OpenWRT 23.05+ ships dnsmasq-full without HAVE_IPSET; the legacy
-  -- ipset framework was dropped in favour of native nftables sets, so we
-  -- emit `nftset=` and populate the per-host nft set in the `inet
-  -- wifihaven` table directly. Syntax:
-  --   nftset=/<host>/<af>#<family>#<table>#<set>[,<af>#...]
-  -- The `4#` / `6#` address-family prefix selects which dnsmasq response
-  -- type routes to which set (#392): A → v4 set, AAAA → v6 set. One
-  -- comma-joined directive per host keeps the config compact.
-  emit("# extraBlocked → per-host nftset populated at resolve time (#351, #392)")
-  for _, host in ipairs(effective_extra_blocked_hosts(snapshot)) do
-    emit(string.format(
-      "nftset=/%s/4#inet#wifihaven#%s,6#inet#wifihaven#%s",
-      host, eb_set_name(host), eb6_set_name(host)))
-  end
-  emit("")
-
-  -- #352: category blocklists — populate bl_<id> / bl6_<id> sets at DNS
-  -- resolve time. snapshot._blocklist_hosts = { [id] = {host1, ...} } is
-  -- populated by the agent before calling render (so tests can inject
-  -- without filesystem). Same nftset= migration as eb_ above (#392).
+  -- Syntax: nftset=/<host>/<af>#<family>#<table>#<set>[,<af>#...]
+  -- The `4#` / `6#` prefix selects which response type routes to which set:
+  -- A → v4 set, AAAA → v6 set. DNS still resolves normally (Truth 1 —
+  -- blocking is the connection layer); these directives only populate the
+  -- nft sets that the forward-chain rules consume.
+  --
+  -- **One merged directive per host.** dnsmasq matches `nftset=/<host>/...`
+  -- directives by domain, and when multiple separate directives target the
+  -- same domain only ONE wins — the others are silently dropped (resulting
+  -- in empty sets and a silent enforcement gap). Concretely: if profile.
+  -- extraAllowed names a host that global.extraBlocked also names, an
+  -- ea_ directive emitted before a global_block directive would leave
+  -- @global_block empty and the global block would never fire. The H3
+  -- scenario from scripts/e2e/scenarios_fake/test_global_policy.py (and
+  -- issue #1460) reproduces this on a real router. Merging every set for
+  -- a given host into ONE comma-joined directive sidesteps the parser quirk
+  -- (verified live with dnsmasq 2.91 on OpenWRT 23.05).
   local bl_hosts = snapshot._blocklist_hosts or {}
   local bl_ids   = sorted_keys(snapshot.blocklists or {})
-  if #bl_ids > 0 then
-    emit("# blocklist nftsets → resolved at DNS time (#352, #392)")
-    for _, id in ipairs(bl_ids) do
-      local hosts   = bl_hosts[id] or {}
-      local set4    = bl_set_name(id)
-      local set6    = bl6_set_name(id)
-      for _, host in ipairs(hosts) do
-        emit(string.format(
-          "nftset=/%s/4#inet#wifihaven#%s,6#inet#wifihaven#%s",
-          host, set4, set6))
-      end
-    end
-    emit("")
-  end
-
-  -- #1319: global policy nftsets. global.extraAllowed → @global_allow /
-  -- @global_allow6 (fleet-wide carve-out, suppresses every drop); global
-  -- blocks (extraBlocked ∪ blocklistIds members) → @global_block /
-  -- @global_block6. Populated at DNS resolve time exactly like eb_/bl_; DNS
-  -- still resolves normally (Truth 1 — blocking is the connection layer).
   local ga_hosts = global_allow_hosts(snapshot)
   local gb_hosts = global_block_hosts(snapshot)
-  if #ga_hosts > 0 or #gb_hosts > 0 then
-    emit("# global policy nftsets → resolved at DNS time (#1319)")
-    for _, host in ipairs(ga_hosts) do
-      emit(string.format(
-        "nftset=/%s/4#inet#wifihaven#%s,6#inet#wifihaven#%s",
-        host, GLOBAL_ALLOW4, GLOBAL_ALLOW6))
+
+  -- host_order preserves first-seen ordering (deterministic by source);
+  -- host_specs accumulates the per-host spec list. Source order:
+  --   1. ea_  (per-MAC, sorted by mac then host)
+  --   2. eb_  (per-host, in effective_extra_blocked_hosts order)
+  --   3. bl_  (per-category, in bl_ids order; hosts in source order)
+  --   4. ga_  (global allow, sorted)
+  --   5. gb_  (global block, sorted)
+  -- Within each source the v4 spec precedes v6.
+  local host_order, host_specs = {}, {}
+  local function add_spec(host, spec)
+    if not host_specs[host] then
+      host_specs[host] = {}
+      host_order[#host_order + 1] = host
     end
-    for _, host in ipairs(gb_hosts) do
-      emit(string.format(
-        "nftset=/%s/4#inet#wifihaven#%s,6#inet#wifihaven#%s",
-        host, GLOBAL_BLOCK4, GLOBAL_BLOCK6))
+    host_specs[host][#host_specs[host] + 1] = spec
+  end
+
+  local ea_macs = {}
+  for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
+  table.sort(ea_macs)
+  for _, mac in ipairs(ea_macs) do
+    for _, host in ipairs(ea_by_mac[mac]) do
+      add_spec(host, "4#inet#wifihaven#" .. ea_set_name(mac, host))
+      add_spec(host, "6#inet#wifihaven#" .. ea6_set_name(mac, host))
+    end
+  end
+  for _, host in ipairs(effective_extra_blocked_hosts(snapshot)) do
+    add_spec(host, "4#inet#wifihaven#" .. eb_set_name(host))
+    add_spec(host, "6#inet#wifihaven#" .. eb6_set_name(host))
+  end
+  for _, id in ipairs(bl_ids) do
+    local set4 = bl_set_name(id)
+    local set6 = bl6_set_name(id)
+    for _, host in ipairs(bl_hosts[id] or {}) do
+      add_spec(host, "4#inet#wifihaven#" .. set4)
+      add_spec(host, "6#inet#wifihaven#" .. set6)
+    end
+  end
+  for _, host in ipairs(ga_hosts) do
+    add_spec(host, "4#inet#wifihaven#" .. GLOBAL_ALLOW4)
+    add_spec(host, "6#inet#wifihaven#" .. GLOBAL_ALLOW6)
+  end
+  for _, host in ipairs(gb_hosts) do
+    add_spec(host, "4#inet#wifihaven#" .. GLOBAL_BLOCK4)
+    add_spec(host, "6#inet#wifihaven#" .. GLOBAL_BLOCK6)
+  end
+
+  if #host_order > 0 then
+    emit("# nftset populators — merged per host so dnsmasq fires every set")
+    emit("# (ea+eb+bl+global; see issues 421, 496, 351, 392, 352, 1319 above)")
+    for _, host in ipairs(host_order) do
+      emit(string.format("nftset=/%s/%s", host, table.concat(host_specs[host], ",")))
     end
     emit("")
   end

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1102,17 +1102,24 @@ describe("render blocklist enforcement (#352)", function()
       1, true))
   end)
 
-  it("emits one nftset= line per (host, id) when the same host appears in two blocklists", function()
+  it("merges both bl_ specs into ONE nftset= directive when the same host appears in two blocklists (#1460)", function()
+    -- Post-#1460 contract: every nft set targeting a given host lands in ONE
+    -- comma-joined `nftset=/<host>/...` directive. dnsmasq honours only the
+    -- first matching `nftset=/<host>/...` directive per domain and silently
+    -- drops the rest, which is the H3 enforcement-gap bug: an ea_ directive
+    -- emitted before a global_block directive for the same host leaves
+    -- @global_block empty. Two bl_ sets covering the same host are the
+    -- closest pre-existing analogue.
     local s = snap_bl()
     s.blocklists["test_social"] = { version = "v1", url = "http://api/api/blocklists/test_social" }
     s._blocklist_hosts["test_social"] = { "doubleclick.net", "facebook.com" }
     local conf = render.dnsmasq(s)
+    local _, dir_count = conf:gsub("nftset=/doubleclick%.net/", "")
+    assert.equals(1, dir_count)
     assert.truthy(conf:find(
-      "nftset=/doubleclick.net/4#inet#wifihaven#bl_test_ads,6#inet#wifihaven#bl6_test_ads",
-      1, true))
+      "4#inet#wifihaven#bl_test_ads,6#inet#wifihaven#bl6_test_ads", 1, true))
     assert.truthy(conf:find(
-      "nftset=/doubleclick.net/4#inet#wifihaven#bl_test_social,6#inet#wifihaven#bl6_test_social",
-      1, true))
+      "4#inet#wifihaven#bl_test_social,6#inet#wifihaven#bl6_test_social", 1, true))
   end)
 
   it("emits no nftset= lines when _blocklist_hosts is absent or empty", function()
@@ -2078,9 +2085,12 @@ describe("render.dnsmasq global section (#1319)", function()
     s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
     s._blocklist_hosts = { ads = { "ad.doubleclick.net" } }
     local conf = render.dnsmasq(s)
+    -- The member host gets the global_block specs (alongside any bl_ specs
+    -- if a profile/global also names the "ads" category — dnsmasq fires
+    -- every spec in the merged directive, see #1460).
+    assert.truthy(conf:find("nftset=/ad.doubleclick.net/", 1, true))
     assert.truthy(conf:find(
-      "nftset=/ad.doubleclick.net/4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6",
-      1, true))
+      "4#inet#wifihaven#global_block,6#inet#wifihaven#global_block6", 1, true))
   end)
 
   it("emits no global nftset= lines when the global section is empty", function()
@@ -2091,6 +2101,36 @@ describe("render.dnsmasq global section (#1319)", function()
 
   it("is byte-identical to a snapshot with no global key when global is empty", function()
     assert.equals(render.dnsmasq(snap_one()), render.dnsmasq(snap_global()))
+  end)
+
+  -- ── #1460 H3 regression: the merge invariant ────────────────────────────
+  --
+  -- dnsmasq honours only ONE matching `nftset=/<host>/...` directive per
+  -- domain and silently drops the rest. When a host appears in BOTH a
+  -- per-profile extraAllowed (ea_) and global.extraBlocked (@global_block),
+  -- emitting two separate directives leaves @global_block empty and the
+  -- fleet-wide block never fires — the exact gap H3 in
+  -- scripts/e2e/scenarios_fake/test_global_policy.py reproduces on a real
+  -- router. render.dnsmasq must merge every spec for a given host into one
+  -- directive so all sets fire on every reply.
+  it("merges ea_ and global_block specs for the same host into ONE directive (#1460 H3)", function()
+    local s = snap_global()
+    -- Set up the H3 shape: profile allows example.org, global blocks it.
+    s.profiles["3"].rules.extraAllowed = { "example.org" }
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    s.global.extraBlocked = { "example.org" }
+    local conf = render.dnsmasq(s)
+    -- Exactly one nftset= directive for example.org.
+    local _, count = conf:gsub("nftset=/example%.org/", "")
+    assert.equals(1, count)
+    -- That single directive carries BOTH the ea_ and global_block specs.
+    assert.truthy(conf:find(
+      "4#inet#wifihaven#ea_aa_bb_cc_11_22_33_example_org", 1, true))
+    assert.truthy(conf:find(
+      "6#inet#wifihaven#ea6_aa_bb_cc_11_22_33_example_org", 1, true))
+    assert.truthy(conf:find("4#inet#wifihaven#global_block", 1, true))
+    assert.truthy(conf:find("6#inet#wifihaven#global_block6", 1, true))
   end)
 end)
 

--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -74,6 +74,7 @@ scripts/e2e/
     test_time_limit.py · test_reassignment.py
     test_blocked_mac_events.py · test_install_health.py
     test_port_alloc.py · test_snapshot_builder.py
+    test_global_policy.py             suite H (#1460) — @global_allow / @global_block
   gate3/                              Gate 3 smoke + conftest
     test_smoke.py
 ```

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -18,6 +18,7 @@ markers =
     install_health: post-install router health asserts (#922 — cron, etc.)
     nflog: #1122 — forward-drop visibility via nflog (per-MAC drop comment + agent emission)
     cname_direct_requery: suite G (#1351) — ea_/eb_ population for directly-queried CNAME targets
+    global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true
 log_cli_level = INFO

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -170,6 +170,54 @@ def wait_bl_set_populated(bl_id: str, *, timeout_s: float = 90) -> list[str]:
     )
 
 
+# ── #1319 global policy sets (@global_allow / @global_block) ─────────────────
+#
+# Fleet-wide ipsets render.lua declares when the snapshot carries a populated
+# `global` section. Unlike the per-(MAC, host) `ea_<mac>_<host>` sets, these
+# are NOT keyed by MAC — one `global_allow` / `global_block` set applies to
+# every MAC. Populated at DNS resolve time by dnsmasq `nftset=` callbacks, same
+# as eb_/bl_. See render.lua GLOBAL_ALLOW4 / GLOBAL_BLOCK4.
+
+GLOBAL_ALLOW_SET = "global_allow"
+GLOBAL_BLOCK_SET = "global_block"
+
+
+def _wait_set_populated(name: str, *, timeout_s: float = 90) -> list[str]:
+    def probe():
+        elems = router_nft_set(name)
+        return elems if elems else None
+    return wait_until(
+        probe, timeout_s=timeout_s, interval_s=3,
+        description=f"nft set {name} to gain at least one element",
+    )
+
+
+def wait_global_allow_populated(*, timeout_s: float = 90) -> list[str]:
+    """Wait until the fleet-wide @global_allow v4 set has >=1 resolved IP."""
+    return _wait_set_populated(GLOBAL_ALLOW_SET, timeout_s=timeout_s)
+
+
+def wait_global_block_populated(*, timeout_s: float = 90) -> list[str]:
+    """Wait until the fleet-wide @global_block v4 set has >=1 resolved IP."""
+    return _wait_set_populated(GLOBAL_BLOCK_SET, timeout_s=timeout_s)
+
+
+def ea_set_exists_for_mac(mac: str) -> bool:
+    """True iff any per-(MAC, host) ea_<mac>_<host> allow-set has been rendered.
+
+    Used to prove the global allow carve-out is genuinely *global* (a single
+    @global_allow set), not silently degraded into per-MAC ea_ sets. render.lua
+    names ea_ sets `ea_<sanmac>_<sanhost>`; a `nft list table` scan for the
+    `ea_<sanmac>_` prefix tells us whether the MAC got a per-MAC allow path.
+    """
+    prefix = "ea_" + _san(mac) + "_"
+    res = router_ssh(
+        "nft list table inet wifihaven 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return prefix.lower() in (res.stdout or "").lower()
+
+
 def wait_event_for_mac(fake_api, mac: str, *, allowed: bool, reason: str,
                        timeout_s: float = 60):
     """Block until fake captured a connection_attempt event matching predicates."""

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -42,7 +42,7 @@ def wait_mac_in_blocked_set(mac: str, *, present: bool, timeout_s: float = 180) 
 
 
 def mac_drop_rule_present(mac: str) -> bool:
-    """True iff the agent has rendered a per-MAC whole-MAC drop rule for `mac`.
+    """True iff the agent has rendered a **whole-MAC** drop rule for `mac`.
 
     The correct "this MAC is blocked right now" observable for a MAC whose
     effective rules have ``blocked = true`` — and the only correct one when the
@@ -53,17 +53,25 @@ def mac_drop_rule_present(mac: str) -> bool:
     deliberately ABSENT from ``blocked_macs`` while still fully blocked — asserting
     set membership there would never succeed (the #1360 G2 false-failure).
 
-    We look for a forward-chain drop rule scoped to this MAC. render.lua tags
-    every drop with ``comment "wh_drop:<mac>:<reason>"`` (#1122), so a match on
-    ``wh_drop:<mac>`` confirms the agent applied a blocked policy for it
-    regardless of whether the drop went via @blocked_macs or the per-MAC ea path.
+    We look for a forward-chain drop rule scoped to this MAC whose reason is a
+    ``MacBlockReason`` (Paused / Schedule / TimeLimit / Manual / generic
+    ``blocked``). render.lua tags every drop with ``comment "wh_drop:<mac>:<reason>"``
+    (#1122); destination-scoped reasons like ``host``, ``category:<id>``,
+    ``global_block`` (#1319/#1460), and ``ip_only`` ALSO use the
+    ``wh_drop:<mac>:`` prefix but they drop only a specific daddr subset, not
+    the whole MAC. Filter on the reason suffix so the check stays a true
+    whole-MAC observable.
     """
     res = router_ssh(
         "nft list table inet wifihaven 2>/dev/null || true",
         check=False, timeout=10,
     )
     out = (res.stdout or "").lower()
-    return f"wh_drop:{norm_mac(mac)}" in out
+    prefix = f"wh_drop:{norm_mac(mac)}:"
+    # MacBlockReason cases — see shared/.../BlockReason.scala. Lowercased to
+    # match the lowercased nft dump above.
+    whole_mac_reasons = ("paused", "schedule", "timelimit", "manual", "blocked")
+    return any((prefix + r) in out for r in whole_mac_reasons)
 
 
 def wait_mac_drop_rule_present(mac: str, *, timeout_s: float = 180) -> None:

--- a/scripts/e2e/scenarios_fake/snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/snapshot_builder.py
@@ -61,6 +61,11 @@ class SnapshotBuilder:
         self._profiles: dict[str, dict[str, Any]] = {}
         self._devices: dict[str, dict[str, Any]] = {}
         self._blocklists: dict[str, dict[str, Any]] = {}
+        # The fleet-wide `global` BlockRules (#1316/#1318). None until
+        # `set_global()` is called, so snapshots that don't exercise the global
+        # layer omit the key entirely and render byte-identically to pre-#1319
+        # (render.lua treats an absent `global` as BlockRules.allowAll).
+        self._global: dict[str, Any] | None = None
 
     def add_profile(
         self,
@@ -124,6 +129,45 @@ class SnapshotBuilder:
         self._devices[mac] = entry
         return self
 
+    def set_global(
+        self,
+        *,
+        blocked: bool = False,
+        block_reason: str | None = None,
+        extra_blocked: list[str] | None = None,
+        extra_allowed: list[str] | None = None,
+        blocklist_ids: list[str] | None = None,
+        block_ip_only: bool = False,
+    ) -> "SnapshotBuilder":
+        """Populate the snapshot's fleet-wide `global` BlockRules (#1318/#1319).
+
+        Applied to *every* MAC by the agent alongside that MAC's resolved
+        per-MAC rules, with the precedence ladder from
+        `docs/design/global-policy-layer.md` §5.2:
+
+          - `extra_allowed` → `@global_allow` — carves out **every** drop
+            (per-MAC or global), all MACs. Top of the ladder.
+          - `extra_blocked` / `blocklist_ids` → `@global_block` — blocks
+            fleet-wide; a per-profile `extraAllowed` may **not** un-block them,
+            only `global.extraAllowed` can.
+          - `blocked` → whole-network lockdown; only `global.extraAllowed`
+            survives it.
+
+        Unlike `add_profile(blocked=True)` this does **not** require a
+        `block_reason`: a global lockdown's reason is cosmetic (block-page copy
+        only) and has no `MacBlockReason` enum case. Pass one if a test asserts
+        on the rendered block-page text.
+        """
+        self._global = profile_rules(
+            blocked=blocked,
+            block_reason=block_reason,
+            extra_blocked=extra_blocked,
+            extra_allowed=extra_allowed,
+            blocklist_ids=blocklist_ids,
+            block_ip_only=block_ip_only,
+        )
+        return self
+
     def add_blocklist(
         self,
         *,
@@ -149,13 +193,19 @@ class SnapshotBuilder:
                     f"device {mac} references unknown profileId={pid}; "
                     f"declared profiles: {sorted(self._profiles)}"
                 )
-        return {
+        snap: dict[str, Any] = {
             "etag": etag,
             "generatedAt": self._generated_at,
             "devices": dict(self._devices),
             "profiles": dict(self._profiles),
             "blocklists": dict(self._blocklists),
         }
+        # Emit `global` only when explicitly set, so the default top-level key
+        # set stays {etag, generatedAt, devices, profiles, blocklists} for the
+        # scenarios (and test_snapshot_builder) that don't touch it.
+        if self._global is not None:
+            snap["global"] = dict(self._global)
+        return snap
 
 
 # ── Convenience helpers kept for the #683 canary (test_pause) ───────────────

--- a/scripts/e2e/scenarios_fake/test_global_policy.py
+++ b/scripts/e2e/scenarios_fake/test_global_policy.py
@@ -1,0 +1,249 @@
+"""Suite H — global policy layer enforcement on a real OpenWRT agent (#1460).
+
+VM-level end-to-end proof that a deployed agent actually enforces the
+snapshot's fleet-wide `global` BlockRules (#1318) via the `@global_allow` /
+`@global_block` nftables sets (#1319). The feature/unit coverage (#1322,
+`api/test/**`, `openwrt/test/**`) proves the *shape* and the *render*; this
+proves the *enforced behaviour against live traffic*.
+
+This is the **gate for #1321 / PR #1459**. That PR removes the #1307
+per-profile infra-allow copy and relies entirely on `global.extraAllowed`
+(`@global_allow`) to keep connectivity-check / OCSP / PKI / captive-portal
+hosts reachable under a whole-MAC block. If the live `@global_allow` path has
+any gap, retiring the per-profile safety net would silently break infra
+reachability fleet-wide. A router/agent version that passes this suite must be
+deployed before #1459 un-drafts.
+
+Reachability here is a **connection-layer** assertion (nftables forward-drop /
+block-page DNAT), never "DNS resolved ⇒ allowed". A successful DNS lookup
+proves nothing — DNS always resolves; the resolved IP is exactly what the
+forward-drop acts on. See `docs/architecture.md` and the AGENTS.md anti-pattern
+callout.
+
+Precedence ladder under test (`docs/design/global-policy-layer.md` §5.2):
+    1. global.extraAllowed  — carves out EVERY drop, all MACs (top)
+    2. global block         — beaten only by (1); a per-profile allow can't
+    3. per-MAC extraAllowed — carves out per-MAC drops only (#421)
+    4. per-MAC blocks
+"""
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from ._observers import (
+    ea_set_exists_for_mac,
+    mac_drop_rule_present,
+    wait_block_page,
+    wait_global_allow_populated,
+    wait_global_block_populated,
+    wait_http_succeeds,
+    wait_mac_drop_rule_present,
+)
+from .snapshot_builder import SnapshotBuilder
+
+pytestmark = pytest.mark.global_policy
+
+# A host that is ONLY ever reachable via @global_allow in these scenarios —
+# never in any profile's own extraAllowed. example.com has stable real DNS +
+# routable IPs and is the allowed-browsing host the rest of the suite uses.
+GLOBAL_ALLOW_HOST = "example.com"
+# A host the fleet-wide block acts on. example.org (used by test_03) — distinct
+# from the allow host so a single snapshot can allow one and block the other.
+GLOBAL_BLOCK_HOST = "example.org"
+
+KIDS_PID = 700
+ADULTS_PID = 701
+
+
+def _alloc_free_port() -> int:
+    """Kernel-assigned free TCP port for a second client VM's SSH hostfwd.
+
+    Mirrors conftest.alloc_free_port — the default `client` fixture pins
+    CLIENT_SSH_PORT_DEFAULT, so a concurrently-booted second client needs its
+    own port.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ── H1 — global.extraAllowed beats a whole-MAC block (direct #1321 guard) ────
+
+
+@pytest.mark.smoke
+def test_global_allow_beats_whole_mac_block(router, client, fake_api):
+    """H1: a paused (blocked=true) MAC still reaches a host that is ONLY in
+    `global.extraAllowed` — not in its profile's own extraAllowed.
+
+    This is the exact connectivity #1459 leans on: under a whole-MAC block,
+    `@global_allow` must carve the host's resolved IPs out of the
+    `@blocked_macs` drop. If it doesn't, retiring the per-profile infra copy
+    breaks infra reachability fleet-wide.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h1-paused", blocked=True, block_reason="Paused")
+        .add_device(mac=client.mac, name="e2e-h1-dev", profile_id=KIDS_PID)
+        .set_global(extra_allowed=[GLOBAL_ALLOW_HOST])
+        .build(etag='"sha256:h1-global-allow-beats-block-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # The MAC is genuinely blocked: render.lua pulls a blocked-with-carve-out
+    # MAC out of @blocked_macs into per-MAC forward-chain drop rules tagged
+    # `wh_drop:<mac>` (#421/#1319). Asserting the drop rule exists proves the
+    # reachability below is the @global_allow carve-out at work, not an absent
+    # block.
+    wait_mac_drop_rule_present(client.mac, timeout_s=180)
+
+    # Connection-layer reachability: HTTP/80 to the global-allowed host returns
+    # a real upstream response, NOT the block page. Each probe re-queries DNS,
+    # which fires the dnsmasq nftset= callback that populates @global_allow.
+    probe = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert probe.http_code is not None and 200 <= probe.http_code < 400
+
+    # Router-state corroboration: the fleet-wide @global_allow set holds the
+    # resolved IP, and the host did NOT get a per-MAC ea_ set (it lives only in
+    # the global layer for this MAC).
+    members = wait_global_allow_populated(timeout_s=30)
+    assert members, "expected @global_allow to carry >=1 resolved IP"
+    assert not ea_set_exists_for_mac(client.mac), (
+        "global-only allow host must not produce a per-MAC ea_ set; the carve-out "
+        "is the fleet-wide @global_allow, not a per-(MAC, host) allow"
+    )
+
+
+# ── H2 — global.extraAllowed is flat across the fleet (every MAC) ────────────
+
+
+def test_global_allow_applies_to_every_mac(router, client, client_factory, fake_api):
+    """H2: the same global-allowed host is reachable from a SECOND,
+    differently-profiled, also-blocked MAC — proving `@global_allow` is one
+    fleet-wide set, not silently keyed per-(MAC).
+
+    Both devices are on distinct, paused profiles with empty per-profile
+    extraAllowed; only `global.extraAllowed` keeps the host reachable. If the
+    carve-out were per-MAC, MAC-B (never individually allowed) would hit the
+    block page.
+    """
+    kids = client  # MAC-A, Kids profile (paused)
+    adults = client_factory(
+        mac="02:e2:fa:70:00:02", name="client2", ssh_port=_alloc_free_port(),
+    )
+
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h2-kids", blocked=True, block_reason="Paused")
+        .add_profile(id=ADULTS_PID, name="e2e-h2-adults", blocked=True, block_reason="Paused")
+        .add_device(mac=kids.mac, name="e2e-h2-kids-dev", profile_id=KIDS_PID)
+        .add_device(mac=adults.mac, name="e2e-h2-adults-dev", profile_id=ADULTS_PID)
+        .set_global(extra_allowed=[GLOBAL_ALLOW_HOST])
+        .build(etag='"sha256:h2-global-allow-every-mac-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Both MACs are genuinely blocked.
+    wait_mac_drop_rule_present(kids.mac, timeout_s=180)
+    wait_mac_drop_rule_present(adults.mac, timeout_s=180)
+
+    # The global-allowed host is reachable from BOTH differently-profiled MACs.
+    p_kids = wait_http_succeeds(kids, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_kids.http_code is not None and 200 <= p_kids.http_code < 400
+    p_adults = wait_http_succeeds(adults, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_adults.http_code is not None and 200 <= p_adults.http_code < 400
+
+    # Neither MAC got a per-MAC ea_ set — the carve-out is the single shared
+    # @global_allow, applied flat across the fleet.
+    assert not ea_set_exists_for_mac(kids.mac)
+    assert not ea_set_exists_for_mac(adults.mac)
+
+
+# ── H3 — global.extraBlocked blocks fleet-wide, per-profile allow can't save ─
+
+
+def test_global_block_not_unblockable_by_profile_allow(router, client, fake_api):
+    """H3: a host in `global.extraBlocked` is blocked even when the MAC's
+    profile lists it in `extraAllowed`. Only `global.extraAllowed` carves out a
+    global block — a per-profile allow does NOT (precedence ladder §5.2, step
+    2 beats step 3).
+
+    Guards the asymmetry that makes a global block *mandatory*: an operator's
+    fleet-wide block must not be loosenable per-profile.
+    """
+    snap = (
+        SnapshotBuilder()
+        # The profile TRIES to allow the host — this must not win.
+        .add_profile(
+            id=KIDS_PID,
+            name="e2e-h3-kids",
+            extra_allowed=[GLOBAL_BLOCK_HOST],
+        )
+        .add_device(mac=client.mac, name="e2e-h3-dev", profile_id=KIDS_PID)
+        .set_global(extra_blocked=[GLOBAL_BLOCK_HOST])
+        .build(etag='"sha256:h3-global-block-beats-profile-allow-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Despite the per-profile extraAllowed, HTTP/80 to the globally-blocked host
+    # hits the block page (global block wins). Each probe re-queries DNS, firing
+    # the nftset= callback that populates @global_block.
+    probe = wait_block_page(client, host=GLOBAL_BLOCK_HOST, timeout_s=120)
+    assert probe is not None and probe.http_code == 200
+
+    members = wait_global_block_populated(timeout_s=30)
+    assert members, "expected @global_block to carry >=1 resolved IP"
+
+    # Control: the MAC is NOT wholesale blocked — a host that is neither
+    # globally blocked nor per-profile blocked stays reachable. Confirms H3's
+    # block is the targeted @global_block, not a stray whole-MAC drop.
+    assert not mac_drop_rule_present(client.mac)
+    p_ok = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_ok.http_code is not None and 200 <= p_ok.http_code < 400
+
+
+# ── H4 (stretch) — global.blocked lockdown, global.extraAllowed survives ─────
+
+
+def test_global_blocked_lockdown_with_allow_carveout(router, client, fake_api):
+    """H4: `global.blocked = true` is a whole-network kill switch — every MAC
+    drops all forwarded traffic — EXCEPT hosts in `global.extraAllowed`.
+
+    Asserts both directions of the lockdown: a non-allowed host hits the block
+    page (DNAT), while the global-allowed host still reaches its real upstream.
+    The profile is otherwise permissive, so the only thing blocking traffic is
+    the global lockdown.
+    """
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=KIDS_PID, name="e2e-h4-open")  # not blocked, no extras
+        .add_device(mac=client.mac, name="e2e-h4-dev", profile_id=KIDS_PID)
+        .set_global(
+            blocked=True,
+            block_reason="Manual",  # cosmetic — drives block-page copy only
+            extra_allowed=[GLOBAL_ALLOW_HOST],
+        )
+        .build(etag='"sha256:h4-global-lockdown-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    # Lockdown drops every MAC; render.lua tags the per-MAC drop wh_drop:<mac>
+    # (the global-allow carve-out forces the per-family rule path).
+    wait_mac_drop_rule_present(client.mac, timeout_s=180)
+
+    # A non-allowed host is dropped → DNATed to the local block page.
+    probe = wait_block_page(client, host=GLOBAL_BLOCK_HOST, timeout_s=120)
+    assert probe is not None and probe.http_code == 200
+
+    # The global-allowed host still reaches its real upstream through the
+    # lockdown.
+    p_ok = wait_http_succeeds(client, host=GLOBAL_ALLOW_HOST, timeout_s=120)
+    assert p_ok.http_code is not None and 200 <= p_ok.http_code < 400
+
+    members = wait_global_allow_populated(timeout_s=30)
+    assert members, "expected @global_allow to carry >=1 resolved IP under lockdown"

--- a/scripts/e2e/scenarios_fake/test_snapshot_builder.py
+++ b/scripts/e2e/scenarios_fake/test_snapshot_builder.py
@@ -158,3 +158,61 @@ def test_snapshot_with_assigned_device_canary_shape():
     rules = snap["profiles"]["100"]["rules"]
     assert rules["blocked"] is True
     assert rules["blockReason"] == "Paused"
+
+
+# ── Global section (#1460) ────────────────────────────────────────────────────
+
+
+def test_global_omitted_unless_set():
+    """Without set_global(), the snapshot carries no `global` key — keeping the
+    default top-level shape (test_empty_build_has_top_level_contract_keys) and
+    rendering byte-identically to pre-#1319 (render.lua treats absent global as
+    allowAll)."""
+    snap = SnapshotBuilder().build(etag='"sha256:no-global"')
+    assert "global" not in snap
+
+
+def test_set_global_emits_blockrules_shape():
+    """set_global() produces a BlockRules dict under `global` with the contract
+    field set the agent reads (matches the golden's `global` row)."""
+    snap = (
+        SnapshotBuilder()
+        .set_global(
+            extra_allowed=["connectivitycheck.gstatic.com"],
+            extra_blocked=["malware.example"],
+        )
+        .build(etag='"sha256:with-global"')
+    )
+    g = snap["global"]
+    assert set(g) == {
+        "blocked", "extraBlocked", "extraAllowed", "blocklistIds", "blockIpOnly",
+    }
+    assert g["extraAllowed"] == ["connectivitycheck.gstatic.com"]
+    assert g["extraBlocked"] == ["malware.example"]
+    assert g["blocked"] is False
+    assert g["blockIpOnly"] is False
+
+
+def test_set_global_matches_golden_global_keys():
+    """The builder's `global` key set lines up with the contract golden's, so
+    the fake serves bytes the agent decodes."""
+    g = _golden()["global"]
+    built = SnapshotBuilder().set_global(
+        extra_allowed=g["extraAllowed"],
+    ).build(etag='"sha256:golden-global"')["global"]
+    assert set(built) == set(g)
+
+
+def test_set_global_lockdown_allows_optional_reason():
+    """Unlike add_profile(blocked=True), set_global(blocked=True) does NOT
+    require a block_reason — a global lockdown's reason is cosmetic."""
+    snap = SnapshotBuilder().set_global(blocked=True).build(etag='"sha256:lockdown"')
+    assert snap["global"]["blocked"] is True
+    assert "blockReason" not in snap["global"]
+    # ...but it may be set when a test asserts on block-page copy.
+    snap2 = (
+        SnapshotBuilder()
+        .set_global(blocked=True, block_reason="Manual")
+        .build(etag='"sha256:lockdown2"')
+    )
+    assert snap2["global"]["blockReason"] == "Manual"


### PR DESCRIPTION
## Summary

Fix the H3 enforcement gap surfaced by the VM e2e suite added in #1469.

When a host appears in both a per-profile `extraAllowed` (`ea_…`) and `global.extraBlocked` (`@global_block`), `render.dnsmasq()` previously emitted two separate `nftset=/<host>/…` directives. **dnsmasq honours only ONE matching directive per domain and silently drops the rest** — so `@global_block` stayed empty, the forward-chain drop never matched, and the fleet-wide block was effectively a no-op when any profile listed the same host as allowed.

Verified on the live router (OpenWRT 23.05 / dnsmasq 2.91): two directives → only one `nftset add` log line per resolve; one merged comma-joined directive → all sets populated.

### Fix

- `openwrt/files/usr/lib/lua/wifihaven/render.lua` — aggregate every per-(MAC, host) `ea_`, per-host `eb_`, per-(category, host) `bl_`, and fleet-wide `@global_allow` / `@global_block` spec for a given host into ONE `nftset=/<host>/…` directive. Per-source iteration is preserved (deterministic ordering ea→eb→bl→ga→gb, v4 before v6); only the emission shape collapses.
- `openwrt/test/render_spec.lua` — update two tests whose substring assertions hard-coded the pre-merge per-source layout; add a new `#1460 H3` regression test that pins the merged-directive contract directly (host on both `ea_` and `global_block` → exactly one directive carrying every spec).
- `scripts/e2e/scenarios_fake/_observers.py` — tighten `mac_drop_rule_present` to match its docstring (true whole-MAC drop). The previous loose `wh_drop:<mac>:` prefix match also matched the per-MAC `@global_block` forward drop (`wh_drop:<mac>:global_block`) once #1460's render correctly emits it, which made H3's control assertion "MAC not wholesale-blocked" misfire. Filter on `MacBlockReason` suffix (`paused` / `schedule` / `timelimit` / `manual` / generic `blocked`) so destination-scoped reasons don't count.

### Validation (local KVM host)

- `openwrt/test/render_spec.lua` — **170 passed / 0 failed / 1 pending** (busted, lua5.1).
- `scripts/e2e-vm.sh --mode=fake -- -m global_policy` — **H1–H4 all 4 passed** (264s).
- `scripts/e2e-vm.sh --mode=fake` (full Gate 2) — **40 passed / 1 pre-existing skip / 2 pre-existing xfail** (28m49s); no regressions in the other 39 scenarios.

## Test plan

- [ ] CI green on `e2e-vm-fake.yml` (both ipk and apk arms).
- [ ] Once green, this unblocks #1469 as the e2e gate for #1321 / PR #1459.
