### PR TITLE
feat(#1464): session-stitch presence primitive + profile interval-union daily cap

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -906,26 +906,28 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
       sql"""SELECT daily_reset_time, daily_reset_tz,
                  heartbeat_filter_enabled, heartbeat_bytes_threshold,
                  heartbeat_host_patterns,
-                 unmanaged_mac_policy::text
+                 unmanaged_mac_policy::text,
+                 presence_continuation_seconds
             FROM household_settings WHERE id=1"""
-        .query[(LocalTime, ZoneId, Boolean, Int, List[String], String)]
+        .query[(LocalTime, ZoneId, Boolean, Int, List[String], String, Int)]
         .unique
-        .map { case (t, z, hbEnabled, hbBytes, hbHosts, ummJson) =>
+        .map { case (t, z, hbEnabled, hbBytes, hbHosts, ummJson, presenceCont) =>
           val umm = ummJson.fromJson[UnmanagedMacPolicy].getOrElse(UnmanagedMacPolicy.Default)
-          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts), umm)
+          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts), umm, presenceCont)
         }
         .transact(xa),
     )
 
   def update(s: HouseholdSettings): Task[Unit] = {
     val ummJson    = s.unmanagedMacPolicy.toJson
-    // #1160: invalidate the time-used rollup atomically with the settings
-    // update. Any change to the daily-reset boundary (tz / reset hour) or the
-    // heartbeat filter changes the active-minute definition for every cached
-    // day; deleting the cache forces the next rollup tick to refill from
-    // first principles. The DELETE is wholesale because all three fields gate
-    // the same aggregation — fine-grained invalidation would only add risk of
-    // missing a code path that mutates the filter.
+    // #1160 / #1464: invalidate the time-used rollup atomically with the
+    // settings update. Any change to the daily-reset boundary (tz / reset hour),
+    // the heartbeat filter, or the presence session-stitch knob
+    // (`presence_continuation_seconds`) changes the active-minute definition for
+    // every cached day; deleting the cache forces the next rollup tick to refill
+    // from first principles. The DELETE is wholesale because all of these fields
+    // gate the same aggregation — fine-grained invalidation would only add risk
+    // of missing a code path that mutates one of them.
     val upd        =
       sql"""UPDATE household_settings
               SET daily_reset_time=${s.dailyResetTime},
@@ -934,6 +936,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
                   heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
                   heartbeat_host_patterns=${s.heartbeatFilter.heartbeatHostPatterns.toArray},
                   unmanaged_mac_policy=${ummJson}::jsonb,
+                  presence_continuation_seconds=${s.presenceContinuationSeconds},
                   updated_at=NOW()
             WHERE id=1""".update.run
     val invalidate = sql"DELETE FROM time_used_daily".update.run

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -346,7 +346,12 @@ class PolicyServiceLive(
                         val exemptPats =
                           stlims.filter(_.exemptFromDaily).map(_.domainPattern)
                         val perMacTot  =
-                          Presence.totalMinutesByMac(pPres, exemptPats, settings.heartbeatFilter)
+                          Presence.totalMinutesByMac(
+                            pPres,
+                            exemptPats,
+                            settings.heartbeatFilter,
+                            settings.presenceContinuationSeconds,
+                          )
                         // #751: same branch as snapshot — keeps decide()
                         // consistent with the snapshot's cap evaluation.
                         val totalMins  = p.crossDeviceOverlapMode match {
@@ -357,6 +362,7 @@ class PolicyServiceLive(
                               pPres,
                               exemptPats,
                               settings.heartbeatFilter,
+                              settings.presenceContinuationSeconds,
                             )
                         }
                         timeLimitBlockFromDb(

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -449,10 +449,20 @@ object TimeStatusService {
     val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
-        val perMac = Presence.totalSecondsByMac(presence, exemptPats, settings.heartbeatFilter)
+        val perMac = Presence.totalSecondsByMac(
+          presence,
+          exemptPats,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
         devices.iterator.map(d => perMac.getOrElse(d.mac, 0L)).sum
       case CrossDeviceOverlapMode.Dedup =>
-        Presence.dedupedTotalSeconds(presence, exemptPats, settings.heartbeatFilter)
+        Presence.dedupedTotalSeconds(
+          presence,
+          exemptPats,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
     }
   }
 

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -52,10 +52,105 @@ object Presence {
   private def bucketSeconds(bucket: Iterable[PresenceRow]): Long =
     bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
 
+  /** Default idle gap `N` (seconds) for the session-stitch model; mirrors migration V52. */
+  val DefaultContinuationSeconds: Int = 120
+
+  // ── Session-stitch primitive (#1464, design §4) ──────────────────────────────
+  //
+  // Presence is no longer "credit a bucket": that under-counts the request-driven
+  // apps whose `activeSeconds` bottoms out at the 10 s sample floor (~3.3× low on
+  // prod, docs/design/presence-tuning.md §2). Instead we sessionize activity on
+  // wall-clock timestamps so bucket size / report rate `R` is only the resolution
+  // of the evidence, never a term in the formula (§2d). The primitive below is
+  // shared by the daily-cap aggregates here and reused by the per-app surface
+  // (#1465) — keep it cleanly factored.
+
+  /** A wall-clock activity span in epoch seconds, `[startEpoch, endEpoch]` with `end ≥ start`. */
+  final case class Span(startEpoch: Long, endEpoch: Long) {
+    def seconds: Long = (endEpoch - startEpoch).max(0L)
+  }
+
   /**
-   * Per-mac total active-seconds for the day, summing each bucket's max activeSeconds
-   * (bucket-deduplicated across hosts) once. A bucket counts iff at least one host in the bucket is
-   * NOT in `exemptPatterns`. IP-literal hosts are never exempt (patterns only match FQDNs).
+   * Each non-heartbeat `traffic_reports` row contributes its full `[period_start, period_end]`
+   * interval as evidence of activity (design §4.1) — NOT its sampled `activeSeconds`, which is the
+   * undercount driver. The trailing edge carries up to one report-interval of uncertainty until the
+   * `connection_events`-anchored timing lands (#1466).
+   */
+  def spanOf(r: PresenceRow): Span = {
+    val start = r.periodStart.getEpochSecond
+    Span(start, start + r.periodSeconds.toLong.max(0L))
+  }
+
+  /**
+   * The idle gap actually used: the configured `N`, raised to the `2 × R` collapse guard (design
+   * §4.4 invariant 1). `R` is read from the data (`period_seconds`), never assumed to be 60 s. When
+   * `N < R` contiguous reporting windows stop merging and presence collapses to ~0 (§2d (ii));
+   * clamping up to `2 × R` keeps a misconfigured / coarse-reporting fleet from silently zeroing
+   * out.
+   */
+  def effectiveGap(rows: Iterable[PresenceRow], continuationSeconds: Int): Long = {
+    val r = rows.iterator.map(_.periodSeconds.toLong).maxOption.getOrElse(0L)
+    continuationSeconds.toLong.max(2L * r)
+  }
+
+  /**
+   * Session-stitch one time-ordered activity stream (design §4.1): fold spans into sessions,
+   * merging while the wall-clock idle gap to the next span is ≤ `gapSeconds`; a larger gap ends the
+   * session. A session's presence is its `[first, last]` span — every span in between counts as
+   * continuous. Caller is responsible for streaming one logical `(device, app)` partition.
+   */
+  def stitch(spans: List[Span], gapSeconds: Long): List[Span] =
+    spans
+      .sortBy(s => (s.startEpoch, s.endEpoch))
+      .foldLeft(List.empty[Span]) {
+        case (head :: tail, s) if s.startEpoch - head.endEpoch <= gapSeconds =>
+          head.copy(endEpoch = head.endEpoch.max(s.endEpoch)) :: tail
+        case (acc, s)                                                        => s :: acc
+      }
+      .reverse
+
+  /**
+   * Overlap-merge spans (gap 0) and sum their wall-clock seconds — the within-device/profile union.
+   */
+  def unionSeconds(spans: List[Span]): Long =
+    spans
+      .sortBy(_.startEpoch)
+      .foldLeft(List.empty[Span]) {
+        case (head :: tail, s) if s.startEpoch <= head.endEpoch =>
+          head.copy(endEpoch = head.endEpoch.max(s.endEpoch)) :: tail
+        case (acc, s)                                           => s :: acc
+      }
+      .map(_.seconds)
+      .sum
+
+  /**
+   * The non-heartbeat, non-exempt rows that bear on the daily cap. A row is dropped if it is a
+   * heartbeat (#714) or if its host matches an `exemptFromDaily` site pattern. Because each row
+   * spans its whole reporting window, dropping the exempt rows reproduces the old "bucket counts
+   * iff at least one non-exempt host" semantic exactly: a window with a non-exempt host keeps that
+   * host's full span; a window of only exempt hosts contributes nothing. IP-literal hosts are never
+   * exempt (patterns only match FQDNs).
+   */
+  private def countedRows(
+      rows: List[PresenceRow],
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter,
+  ): List[PresenceRow] = {
+    def isExempt(h: HostId) =
+      h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
+    rows.filterNot(r => isHeartbeat(r, filter)).filterNot(r => isExempt(r.host))
+  }
+
+  /** Per-`(device, app)` sessions for a counted row-set, where `app = host` (design §4.1). */
+  private def sessionSpans(rows: List[PresenceRow], gap: Long): List[Span] =
+    rows.groupBy(r => (r.mac, r.host)).values.flatMap(hr => stitch(hr.map(spanOf), gap)).toList
+
+  /**
+   * Per-mac total active-seconds for the day (design §4.3): per-`(device, app)` session-stitch on
+   * the idle gap, then union those sessions within the device (two apps in the same minute count
+   * once). A row counts iff it is non-heartbeat and not on an `exemptFromDaily` host. The cross-
+   * device combination (`Sum` adds these; `Dedup` unions instead) lives in the caller / in
+   * [[dedupedTotalSeconds]].
    *
    * Surfaces raw seconds rather than floor-divided minutes so callers that need the precision (see
    * #516 e2e test) can ceil-divide themselves; minute-resolution callers should use
@@ -65,67 +160,57 @@ object Presence {
       rows: List[PresenceRow],
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
   ): Map[MacAddress, Long] = {
-    def isExempt(h: HostId) =
-      h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
-    rows.iterator
-      .filterNot(r => isHeartbeat(r, filter))
-      .toList
-      .groupBy(r => (r.mac, r.periodStart))
-      .toList
-      .collect {
-        case ((mac, _), bucket) if bucket.exists(r => !isExempt(r.host)) =>
-          mac -> bucketSeconds(bucket)
-      }
-      .groupMapReduce(_._1)(_._2)(_ + _)
+    val counted = countedRows(rows, exemptPatterns, filter)
+    val gap     = effectiveGap(counted, continuationSeconds)
+    counted
+      .groupBy(_.mac)
+      .view
+      .mapValues(macRows => unionSeconds(sessionSpans(macRows, gap)))
+      .filter(_._2 > 0L)
+      .toMap
   }
 
   /**
-   * Per-mac total minutes for the day, counting each bucket once. A bucket counts iff at least one
-   * host in the bucket is NOT in `exemptPatterns` — i.e. the device was active on something that
-   * bears on the daily cap. IP-literal hosts are never exempt (patterns only match FQDNs).
+   * Per-mac total minutes for the day. A device's minutes are the union of its per-app sessions
+   * (design §4.3); IP-literal hosts are never exempt (patterns only match FQDNs).
    */
   def totalMinutesByMac(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
   ): Map[MacAddress, Int] =
-    totalSecondsByMac(rows, exemptPatterns, filter).view.mapValues(s => (s / 60).toInt).toMap
+    totalSecondsByMac(rows, exemptPatterns, filter, continuationSeconds).view
+      .mapValues(s => (s / 60).toInt)
+      .filter(_._2 != 0)
+      .toMap
 
   /**
-   * #751: profile-scoped active-bucket union across multiple macs. Each `period_start` instant
-   * counts once regardless of how many of the profile's devices were active in it — the right
-   * semantic when one profile = one human with multiple devices. A bucket counts iff at least one
-   * (mac, host) row in the bucket is non-heartbeat AND non-exempt; its contribution is the max
-   * `activeSeconds` across all macs present in that bucket (the longest-active device sets the
-   * wall-clock floor). Use [[totalSecondsByMac]] + sum when the operator wants per-device totals
-   * added (the `sum` mode).
+   * #751 / #1464: profile-scoped session union across ALL of the profile's devices — the `Dedup`
+   * cross-device mode. Sessions are stitched per `(device, app)` then unioned across every device
+   * and app, so one human on two screens at the same instant counts once. Use [[totalSecondsByMac]]
+   * + sum when the operator wants per-device totals added (the `Sum` mode).
    */
   def dedupedTotalSeconds(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
   ): Long = {
-    def isExempt(h: HostId) =
-      h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
-    rows.iterator
-      .filterNot(r => isHeartbeat(r, filter))
-      .toList
-      .groupBy(_.periodStart)
-      .iterator
-      .collect {
-        case (_, bucket) if bucket.exists(r => !isExempt(r.host)) =>
-          bucketSeconds(bucket)
-      }
-      .sum
+    val counted = countedRows(rows, exemptPatterns, filter)
+    val gap     = effectiveGap(counted, continuationSeconds)
+    unionSeconds(sessionSpans(counted, gap))
   }
 
   def dedupedTotalMinutes(
       rows: List[PresenceRow],
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
   ): Int =
-    (dedupedTotalSeconds(rows, exemptPatterns, filter) / 60).toInt
+    (dedupedTotalSeconds(rows, exemptPatterns, filter, continuationSeconds) / 60).toInt
 
   /**
    * #714 heartbeat classification, applied ONLY inside `totalSecondsByMac`/`totalMinutesByMac`.

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -598,14 +598,24 @@ object TimeRoutes {
               val macSet  = devices.map(_.mac).toSet
               val pRows   = presence.filter(r => macSet.contains(r.mac))
               val perMac  = wifihaven.api.presence.Presence
-                .totalMinutesByMac(pRows, Nil, settings.heartbeatFilter)
+                .totalMinutesByMac(
+                  pRows,
+                  Nil,
+                  settings.heartbeatFilter,
+                  settings.presenceContinuationSeconds,
+                )
               // #751: same Sum/Dedup branch as the daily summary.
               val total   = p.crossDeviceOverlapMode match {
                 case CrossDeviceOverlapMode.Sum   =>
                   devices.iterator.map(d => perMac.getOrElse(d.mac, 0)).sum
                 case CrossDeviceOverlapMode.Dedup =>
                   wifihaven.api.presence.Presence
-                    .dedupedTotalMinutes(pRows, Nil, settings.heartbeatFilter)
+                    .dedupedTotalMinutes(
+                      pRows,
+                      Nil,
+                      settings.heartbeatFilter,
+                      settings.presenceContinuationSeconds,
+                    )
               }
               ProfileTimeSummaryWeek(
                 p.id,
@@ -909,7 +919,12 @@ object TimeRoutes {
       perMacTotal     = {
         val exemptPats = state.perSite.filter(_.exemptFromDaily).map(_.domainPattern)
         wifihaven.api.presence.Presence
-          .totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
+          .totalMinutesByMac(
+            presence,
+            exemptPats,
+            settings.heartbeatFilter,
+            settings.presenceContinuationSeconds,
+          )
       }
       siteUsage       = state.perSite.map { s =>
         SiteUsage(
@@ -1158,7 +1173,12 @@ object TimeRoutes {
       )
       exemptPats = stateOpt.toList.flatMap(_.perSite.filter(_.exemptFromDaily).map(_.domainPattern))
       totalUsed  = wifihaven.api.presence.Presence
-        .totalMinutesByMac(presence, exemptPats, settings.heartbeatFilter)
+        .totalMinutesByMac(
+          presence,
+          exemptPats,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
         .getOrElse(device.mac, 0)
       perPat     = wifihaven.api.presence.Presence
         .patternMinutesByMac(
@@ -1526,6 +1546,7 @@ object HouseholdSettingsRoutes {
                   upd.dailyResetTz,
                   upd.heartbeatFilter,
                   upd.unmanagedMacPolicy,
+                  upd.presenceContinuationSeconds,
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -1575,11 +1596,15 @@ object HouseholdSettingsRoutes {
               case Some(_)           =>
                 ZIO.fail(Response.badRequest("unmanagedMacPolicy must be a JSON object"))
             }
+            // #1464: presence_continuation_seconds is an API/config-side rollup
+            // knob with no SPA surface, so PATCH preserves the stored value
+            // rather than exposing it as a patchable field.
             merged = HouseholdSettings(
               dailyResetTime = timePatch.applyTo(existing.dailyResetTime),
               dailyResetTz = tzPatch.applyTo(existing.dailyResetTz),
               heartbeatFilter = mergedFilter,
               unmanagedMacPolicy = mergedUmm,
+              presenceContinuationSeconds = existing.presenceContinuationSeconds,
             )
             _            <- repo.update(merged).mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -29,8 +29,9 @@ import java.time.{Duration, Instant}
  * per-profile screen-time figures (#1099); past-day reads are cold.
  *
  * Invalidation is wholesale via `TimeUsedRollupRepo.deleteAll` (called from
- * `HouseholdSettingsRepoLive.update` — covers the heartbeat filter, daily reset time, and tz). The
- * next tick refills.
+ * `HouseholdSettingsRepoLive.update` — covers the heartbeat filter, daily reset time, tz, and the
+ * #1464 presence session-stitch knob `presence_continuation_seconds`). The next tick refills with
+ * the new semantics.
  *
  * Multi-instance note: only one fiber should be writing each row at a time, but UPSERT keyed on
  * `(profile_id, date)` with a monotonically-advancing `rolled_through` makes redundant writes

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -224,6 +224,42 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         post <- ru.getDayMap(today)
       } yield assertTrue(pre.contains(kid)) && assertTrue(!post.contains(kid))
     },
+    test(
+      "#1464 (d) presence-continuation change invalidates the rollup and the refill reflects it",
+    ) {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        stl <- ZIO.service[SiteTimeLimitRepo]
+        _   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:50", "kid", kid)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        // Two 5-min sessions 900s apart (gap = 20·60 − 300 = 900s). At the default N=120 (clamped
+        // up to the 2×R=600 collapse guard for these 300s buckets) the gap is NOT bridged → two
+        // 5-min sessions = 600s. Raising N to 900 bridges the think-gap into one [0, 1500] session
+        // → 1500s. The knob change must DELETE the cached row so the next tick refills with the new
+        // semantics.
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 0)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 20)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        before      <- ru.getDayForProfile(kid, today)
+        cur         <- hsr.get
+        _           <- hsr.update(cur.copy(presenceContinuationSeconds = 900))
+        invalidated <- ru.getDayForProfile(kid, today)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        after       <- ru.getDayForProfile(kid, today)
+      } yield assertTrue(before.exists(_.usedSeconds == 600L)) &&
+        assertTrue(invalidated.isEmpty) &&
+        assertTrue(after.exists(_.usedSeconds == 1500L))
+    },
     test("daily-reset-tz change invalidates the rollup") {
       for {
         _   <- cleanDb

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -99,14 +99,138 @@ object PresenceSpec extends ZIOSpecDefault {
           Presence.totalMinutesByMac(rows, List("*.youtube.com")) == Map.empty[MacAddress, Int],
         )
       },
-      test("uses max active_seconds in the bucket as duration") {
-        // The agent emits the same bucket duration on every row, but if multiple ticks land in
-        // the same period (shouldn't happen in practice) we trust the largest value.
+      test("#1464 session span ignores active_seconds — full period span is the evidence") {
+        // The session model credits each non-heartbeat row its full [period_start, period_end]
+        // span (300s here), NOT the sampled active_seconds. So a row that sampled only 60s of its
+        // 300s window still contributes the whole window — this is the within-minute undercount
+        // fix (docs/design/presence-tuning.md §4.1).
         val rows = List(
-          row(mac1, 0, "a.com", 60),
-          row(mac1, 0, "b.com", 300),
+          row(mac1, 0, "a.com", secs = 60),
+          row(mac1, 0, "b.com", secs = 300),
         )
         assertTrue(Presence.totalMinutesByMac(rows, Nil) == Map(mac1 -> 5))
+      },
+      test("#1464 (a) a continuous sparse session reads its full span, not the sampled floor") {
+        // Five contiguous 60s windows, each sampling only the 10s activity floor — a kid working
+        // a problem locally between requests. Old bucket model: Σ max(activeSeconds) = 50s → 0 min.
+        // Session model: the five windows stitch into one [0, 300] session → 5 min.
+        val rows = (0 until 5).toList.map { i =>
+          PresenceRow(
+            mac1,
+            baseDate,
+            base.plusSeconds(i * 60L),
+            HostId.Fqdn(Hostname.unsafe("mathacademy.com")),
+            activeSeconds = 10,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          )
+        }
+        assertTrue(Presence.totalSecondsByMac(rows, Nil) == Map(mac1 -> 300L)) &&
+        assertTrue(Presence.totalMinutesByMac(rows, Nil) == Map(mac1 -> 5))
+      },
+      test("#1464 (b) re-bucketing the same day at R=10s vs R=300s yields the same minutes") {
+        // §2d rate-independence: 300s of continuous activity, expressed once as 30 fine (10s)
+        // windows and once as a single coarse (300s) window. Both must read 300s = 5 min — bucket
+        // size is only the resolution of the evidence, never a term in the formula.
+        val fine   = (0 until 30).toList.map { i =>
+          PresenceRow(
+            mac1,
+            baseDate,
+            base.plusSeconds(i * 10L),
+            HostId.Fqdn(Hostname.unsafe("khanacademy.org")),
+            activeSeconds = 10,
+            bytes = 200_000L,
+            periodSeconds = 10,
+          )
+        }
+        val coarse = List(
+          PresenceRow(
+            mac1,
+            baseDate,
+            base,
+            HostId.Fqdn(Hostname.unsafe("khanacademy.org")),
+            activeSeconds = 10,
+            bytes = 200_000L,
+            periodSeconds = 300,
+          ),
+        )
+        assertTrue(
+          Presence.totalSecondsByMac(fine, Nil) == Presence.totalSecondsByMac(coarse, Nil),
+        ) &&
+        assertTrue(Presence.totalMinutesByMac(fine, Nil) == Map(mac1 -> 5))
+      },
+      test(
+        "#1464 (c) two concurrent apps in one minute count as one minute (within-device union)",
+      ) {
+        // Same 60s window, two different apps. One human on one screen: the device's per-app
+        // sessions union, so the minute counts once — not twice.
+        val rows = List(
+          PresenceRow(
+            mac1,
+            baseDate,
+            base,
+            HostId.Fqdn(Hostname.unsafe("mathacademy.com")),
+            activeSeconds = 60,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          ),
+          PresenceRow(
+            mac1,
+            baseDate,
+            base,
+            HostId.Fqdn(Hostname.unsafe("youtube.com")),
+            activeSeconds = 60,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          ),
+        )
+        assertTrue(Presence.totalSecondsByMac(rows, Nil) == Map(mac1 -> 60L))
+      },
+      test("#1464 collapse guard: N below 2×R is raised so contiguous windows still merge") {
+        // A misconfigured N (10s) below 2×R (R=60s) would, unguarded, stop contiguous windows from
+        // merging and zero out presence (§2d (ii)). The effectiveGap clamp to 2×R keeps the two
+        // contiguous windows stitched into one 120s session.
+        val rows = (0 until 2).toList.map { i =>
+          PresenceRow(
+            mac1,
+            baseDate,
+            base.plusSeconds(i * 60L),
+            HostId.Fqdn(Hostname.unsafe("mathacademy.com")),
+            activeSeconds = 60,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          )
+        }
+        assertTrue(
+          Presence.totalSecondsByMac(rows, Nil, continuationSeconds = 10) == Map(mac1 -> 120L),
+        )
+      },
+      test("#1464 a real idle gap beyond N is NOT bridged (sessions stay separate)") {
+        // Two 60s windows 600s apart (gap = 540s > N=120). They must remain two 60s sessions →
+        // 120s total, not one bridged 660s span.
+        val rows = List(
+          PresenceRow(
+            mac1,
+            baseDate,
+            base,
+            HostId.Fqdn(Hostname.unsafe("mathacademy.com")),
+            activeSeconds = 60,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          ),
+          PresenceRow(
+            mac1,
+            baseDate,
+            base.plusSeconds(600L),
+            HostId.Fqdn(Hostname.unsafe("mathacademy.com")),
+            activeSeconds = 60,
+            bytes = 200_000L,
+            periodSeconds = 60,
+          ),
+        )
+        assertTrue(
+          Presence.totalSecondsByMac(rows, Nil, continuationSeconds = 120) == Map(mac1 -> 120L),
+        )
       },
     ),
     suite("patternMinutesByMac")(

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -606,13 +606,24 @@ case class HouseholdSettings(
     dailyResetTz: ZoneId,
     heartbeatFilter: HeartbeatFilter,
     unmanagedMacPolicy: UnmanagedMacPolicy = UnmanagedMacPolicy.Default,
+    // #1464: idle gap `N` (seconds) for the presence session-stitch model. Per
+    // (device, app), activity merges into one session as long as the wall-clock
+    // gap to the next activity is ≤ N; a larger gap ends the session and its
+    // presence is the [first, last]-activity span. Default 120 (migration V52);
+    // the rollup raises it to the 2×R collapse guard at compute time.
+    presenceContinuationSeconds: Int = HouseholdSettings.DefaultPresenceContinuationSeconds,
 ) derives JsonCodec
+
+object HouseholdSettings {
+  val DefaultPresenceContinuationSeconds: Int = 120
+}
 
 case class UpdateHouseholdSettingsRequest(
     dailyResetTime: LocalTime,
     dailyResetTz: ZoneId,
     heartbeatFilter: HeartbeatFilter,
     unmanagedMacPolicy: UnmanagedMacPolicy = UnmanagedMacPolicy.Default,
+    presenceContinuationSeconds: Int = HouseholdSettings.DefaultPresenceContinuationSeconds,
 ) derives JsonCodec
 
 /**


### PR DESCRIPTION
Closes #1464. Adopts the schema-only foundation from #1463 (migration `V52`, `presence_continuation_seconds` default 120).

## What changed

Replaces the `bucketSeconds = max(activeSeconds)` undercount and the `period_start`-grid dedup in `Presence.totalSecondsByMac` / `dedupedTotalSeconds` with the **session-stitch model** from [`docs/design/presence-tuning.md`](docs/design/presence-tuning.md) §4 / §5 item 2:

- Each non-heartbeat `traffic_reports` row contributes its full `[period_start, period_end]` span as activity evidence — **not** the sampled `activeSeconds` floor that reads ~3.3× low (§2).
- Per-`(device, app)` streams stitch into sessions on the idle gap `N` (gap ≤ N continues, gap > N ends). Within a device the sessions **union** (two apps in one minute count once). Across devices the profile's existing `crossDeviceOverlapMode` decides — `Sum` adds per-device totals (→ `totalSecondsByMac` + sum), `Dedup` unions across devices (→ `dedupedTotalSeconds`). **Both paths preserved.**
- Window bounds are read from the data; the idle gap is raised to the **2×R collapse guard** so a coarse/misconfigured report interval can't silently zero out presence (§2d invariant).
- The primitive (`Span` / `stitch` / `unionSeconds` / `spanOf`) is factored as public methods so the per-app surface (#1465) reuses it — expect to reconcile at merge.
- `HouseholdSettings` carries `presenceContinuationSeconds`; the repo reads/writes it and a change flows through the **existing wholesale `time_used_daily` invalidation** in `HouseholdSettingsRepoLive.update`, exactly like a heartbeat/tz change.

The per-host surfaces (`hostMinutes` / `patternMinutesByMac` / `proportionalHostSeconds`) intentionally stay on the bucket model — they are #1465's scope.

## Note on `presence_model`

The issue text mentioned keeping a legacy path behind a `presence_model` toggle, but the shipped foundation does **not** include one: both design §4.6 and the merged `V52` migration specify the session model as **global and unconditional with no `presence_model` column**. So the session model replaces the old computation outright; there is no legacy switch. (Adding such a column here would also violate the migration-isolation rule.)

## Scope

The configurable `N` is threaded through the authoritative daily-cap paths where `settings` is in scope (rollup `usedSecondsForProfile`, `PolicyService` decision, the daily/weekly status routes). The informational weekly/hourly helpers that receive only a `HeartbeatFilter` keep the default `N = 120` (the prod/column default).

## TDD pins (§4.4 / §5 item 2)

- **(a)** a continuous sparse session reads its full span, not the sampled floor — `PresenceSpec`
- **(b)** the same logical day re-bucketed at R=10s vs 300s yields the same minutes (rate-independence §2d) — `PresenceSpec`
- **(c)** two concurrent apps in one minute = one minute (within-device union) — `PresenceSpec`
- **(d)** editing the presence knob invalidates `time_used_daily` and the next rollup reflects the new value (600s → 1500s as N rises) — `TimeUsedRollupSpec`
- plus collapse-guard and real-idle-gap-not-bridged pins.

`mill api.test` + `mill shared.test` green; `scalafmt --check` clean. No migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)