### PR TITLE
feat(#1379): per-app schedule evaluation in PolicyService

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2904,6 +2904,34 @@ trait AppRepo {
   def deleteAssignment(appId: AppId, profileId: ProfileId): Task[Unit]
   def listAssignmentsForApp(appId: AppId): Task[List[AppPolicyAssignment]]
   def listAssignmentsForProfile(profileId: ProfileId): Task[List[AppPolicyAssignment]]
+
+  // ── #1379: per-app schedule rules (`app_policy_schedule_rules`, V51) ──────
+
+  /**
+   * Replace the full set of schedule rules on an assignment with exactly `rules` (de-duped on
+   * (scheduleId, mode)). Replace semantics, mirroring [[setHosts]] — an empty list clears them.
+   */
+  def setScheduleRules(
+      assignmentId: AppPolicyAssignmentId,
+      rules: List[(NamedScheduleId, AppScheduleMode)],
+  ): Task[Unit]
+
+  /** The schedule rules attached to a single assignment (no window resolution). */
+  def scheduleRulesForAssignment(
+      assignmentId: AppPolicyAssignmentId,
+  ): Task[List[AppScheduleRule]]
+
+  /**
+   * For every assignment under `profileId`, the flattened (mode, window) pairs of its schedule
+   * rules — each rule's referenced #1069 named schedule resolved to its `schedule_windows` rows.
+   * PolicyService folds these into the per-app effective disposition (design §4.1): an
+   * `allowed_during` / `blocked_during` rule is "active at now" iff ANY of its windows is, so the
+   * per-rule grouping is irrelevant and we flatten to (mode, window) pairs per assignment.
+   * Assignments with no rules are absent from the map.
+   */
+  def appScheduleWindowsForProfile(
+      profileId: ProfileId,
+  ): Task[Map[AppPolicyAssignmentId, List[(AppScheduleMode, ScheduleWindow)]]]
 }
 
 class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
@@ -3043,6 +3071,46 @@ class AppRepoLive(xa: Transactor[Task]) extends AppRepo {
         .to[List]
         .transact(xa),
     )
+
+  // ── #1379: per-app schedule rules ─────────────────────────────────────────
+
+  def setScheduleRules(
+      assignmentId: AppPolicyAssignmentId,
+      rules: List[(NamedScheduleId, AppScheduleMode)],
+  ) = {
+    val del =
+      sql"DELETE FROM app_policy_schedule_rules WHERE assignment_id=$assignmentId".update.run
+    val ins = rules.distinct.foldLeft(FC.unit) { case (acc, (sid, mode)) =>
+      acc *> sql"""INSERT INTO app_policy_schedule_rules(assignment_id, schedule_id, mode)
+                   VALUES($assignmentId, $sid, ${AppScheduleMode.asString(mode)})
+                   ON CONFLICT (assignment_id, schedule_id, mode) DO NOTHING""".update.run.void
+    }
+    (del *> ins).transact(xa).unit
+  }
+
+  def scheduleRulesForAssignment(assignmentId: AppPolicyAssignmentId) =
+    sql"""SELECT id, assignment_id, schedule_id, mode
+          FROM app_policy_schedule_rules WHERE assignment_id=$assignmentId ORDER BY id"""
+      .query[(AppScheduleRuleId, AppPolicyAssignmentId, NamedScheduleId, AppScheduleMode)]
+      .map { case (id, aid, sid, mode) => AppScheduleRule(sid, mode, id, aid) }
+      .to[List]
+      .transact(xa)
+
+  // Resolve each assignment's rules to flattened (mode, window) pairs in one join:
+  // app_policy_schedule_rules -> assignment (for the profile filter) -> schedule_windows.
+  def appScheduleWindowsForProfile(profileId: ProfileId) =
+    sql"""SELECT apsr.assignment_id, apsr.mode, sw.days, sw.start_local, sw.end_local, sw.tz
+          FROM app_policy_schedule_rules apsr
+          JOIN app_policy_assignments apa ON apa.id = apsr.assignment_id
+          JOIN schedule_windows sw        ON sw.schedule_id = apsr.schedule_id
+          WHERE apa.profile_id = $profileId
+          ORDER BY apsr.assignment_id, apsr.id, sw.id"""
+      .query[(AppPolicyAssignmentId, AppScheduleMode, List[String], LocalTime, LocalTime, ZoneId)]
+      .to[List]
+      .transact(xa)
+      .map(_.groupBy(_._1).map { case (aid, rows) =>
+        aid -> rows.map(r => (r._2, ScheduleWindow(r._3, r._4, r._5, r._6)))
+      })
 }
 
 class NamedScheduleRepoLive(xa: Transactor[Task]) extends NamedScheduleRepo {

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -2,7 +2,15 @@ package wifihaven.api.db
 
 import doobie.*
 import doobie.postgres.implicits.*
-import wifihaven.shared.{AppMode, BlockReason, FailureMode, IconType, MacBlockReason, UserRole}
+import wifihaven.shared.{
+  AppMode,
+  AppScheduleMode,
+  BlockReason,
+  FailureMode,
+  IconType,
+  MacBlockReason,
+  UserRole,
+}
 import wifihaven.shared.types.*
 import org.postgresql.util.PGobject
 import zio.json.*
@@ -37,6 +45,7 @@ object TypeMeta {
   given Meta[AppId]                 = Meta[Long].imap(AppId(_))(_.value)
   given Meta[AppPolicyAssignmentId] = Meta[Long].imap(AppPolicyAssignmentId(_))(_.value)
   given Meta[NamedScheduleId]       = Meta[Long].imap(NamedScheduleId(_))(_.value)
+  given Meta[AppScheduleRuleId]     = Meta[Long].imap(AppScheduleRuleId(_))(_.value)
 
   // ── UUID-backed ────────────────────────────────────────────────────────
   given Meta[RouterId] = Meta[java.util.UUID].imap(RouterId(_))(_.value)
@@ -87,6 +96,12 @@ object TypeMeta {
       .parse(s)
       .getOrElse(throw new IllegalStateException(s"DB has unknown icon type: $s")),
   )(IconType.asString)
+
+  given Meta[AppScheduleMode] = Meta[String].imap(s =>
+    AppScheduleMode
+      .parse(s)
+      .getOrElse(throw new IllegalStateException(s"DB has unknown app schedule mode: $s")),
+  )(AppScheduleMode.asString)
 
   given Meta[MacBlockReason] = Meta[String].imap(s =>
     MacBlockReason

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -137,38 +137,42 @@ class PolicyServiceLive(
       appAssigns  <- ZIO.foreach(profiles)(p =>
         appRepo.listAssignmentsForProfile(p.id).map(p.id -> _),
       )
+      // #1379: per-app schedule rules, resolved to (mode, window) pairs per assignment.
+      // Folded into the per-app effective disposition below, before app-mode bucketing.
+      appSched    <- ZIO.foreach(profiles)(p =>
+        appRepo.appScheduleWindowsForProfile(p.id).map(p.id -> _),
+      )
       appHostsMap = appHostsRaw.toMap
       appAssignsMap = appAssigns.toMap
+      appSchedMap   = appSched.toMap
       stlMap        = stlims.toMap
     } yield {
       val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
         val pSiteLims = stlMap.getOrElse(p.id, Nil)
 
-        // #763/#764: expand this profile's app assignments into wire-shape
-        // buckets. Post-#764, time_limited apps are surfaced via
-        // SiteTimeLimitRepo (which itself synthesizes from app tables), so
-        // here we only handle allowed/blocked modes.
-        val pAssigns                        = appAssignsMap.getOrElse(p.id, Nil)
-        val appAllowedHosts: List[Hostname] = pAssigns
-          .collect {
-            case a if a.mode == AppMode.Allowed =>
-              appHostsMap.getOrElse(a.appId, Nil)
-          }
-          .flatten
-          .distinct
-        val appBlockedHosts: List[Hostname] = pAssigns
-          .collect {
-            case a if a.mode == AppMode.Blocked =>
-              appHostsMap.getOrElse(a.appId, Nil)
-          }
-          .flatten
-          .distinct
-
         // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
+        // Computed before app bucketing because the #1379 carve gate keys off the raw daily-cap
+        // condition (used/limit/extensions), independent of the collapsed blockReason.
         val state = dayStates.getOrElse(
           p.id,
           ProfileDayState(p.id, today, None, 0, 0, None, blocked = false, None, Nil),
         )
+
+        // #763/#764/#1379: expand this profile's app assignments into wire-shape buckets.
+        // Each assignment's effective disposition at `now` folds its per-app schedule windows
+        // over its base mode (an active window overrides the base), then the AllowedDuring carve
+        // is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5). Post-#764,
+        // time_limited apps are surfaced via SiteTimeLimitRepo, so they contribute nothing here.
+        val pAssigns                           = appAssignsMap.getOrElse(p.id, Nil)
+        val (appAllowedHosts, appBlockedHosts) =
+          PolicyService.expandAppDispositions(
+            assigns = pAssigns,
+            hostsByApp = appHostsMap,
+            schedWindows = appSchedMap.getOrElse(p.id, Map.empty),
+            capExhausted = PolicyService.dailyCapExhausted(state),
+            now = now,
+          )
+
         val rules = PolicyService.computeBlockRules(
           profile = p,
           state = state,
@@ -283,32 +287,23 @@ class PolicyServiceLive(
           ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
         case Some(pid) =>
           for {
-            pOpt          <- profileRepo.findById(pid)
-            scheds        <- schedulesFor(pid)
-            tl            <- timeLimitRepo.findForProfile(pid)
-            stlims        <- siteTimeLimitRepo.listForProfile(pid)
+            pOpt            <- profileRepo.findById(pid)
+            scheds          <- schedulesFor(pid)
+            tl              <- timeLimitRepo.findForProfile(pid)
+            stlims          <- siteTimeLimitRepo.listForProfile(pid)
             // #764: post-migration, extraAllowed/extraBlocked are sourced
             // exclusively from app_policy_assignments. Mirror the snapshot
             // expansion (allowed/blocked modes) here so the per-host
             // fallback agrees with the snapshot's precedence.
-            appAssigns    <- appRepo.listAssignmentsForProfile(pid)
-            appHostsByApp <- ZIO
+            appAssigns      <- appRepo.listAssignmentsForProfile(pid)
+            appHostsByApp   <- ZIO
               .foreach(appAssigns.map(_.appId).distinct)(aid => appRepo.getHosts(aid).map(aid -> _))
               .map(_.toMap)
-            appAllowed = appAssigns
-              .collect {
-                case a if a.mode == AppMode.Allowed => appHostsByApp.getOrElse(a.appId, Nil)
-              }
-              .flatten
-              .distinct
-            appBlocked = appAssigns
-              .collect {
-                case a if a.mode == AppMode.Blocked => appHostsByApp.getOrElse(a.appId, Nil)
-              }
-              .flatten
-              .distinct
+            // #1379: per-app schedule windows for this profile's assignments, used to fold each
+            // app's effective disposition + carve gate exactly as the snapshot does.
+            appSchedWindows <- appRepo.appScheduleWindowsForProfile(pid)
             // Reuse the same per-profile usage calc used by snapshot, scoped to this profile.
-            devs          <- deviceRepo.listAll.map(_.filter(_.profileId.contains(pid)))
+            devs            <- deviceRepo.listAll.map(_.filter(_.profileId.contains(pid)))
             macs = devs.map(_.mac).toSet
             pres <- trafficRepo.listPresenceRows(devs.map(_.mac), today)
             exts <- extRepo.snapshotAllByProfile(today).map(_.getOrElse(pid, 0))
@@ -317,6 +312,45 @@ class PolicyServiceLive(
                 ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
               case Some(p) =>
                 val h = hostname.toLowerCase.stripSuffix(".")
+
+                // Per-profile daily usage — computed up front because the #1379 carve gate keys off
+                // whether the daily cap is exhausted, independent of the precedence chain below.
+                val pPres        = pres.filter(r => macs.contains(r.mac))
+                val patterns     = stlims.map(_.domainPattern)
+                val perPat       = Presence.patternMinutesByMac(pPres, patterns)
+                val byDomain     = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
+                  val mins = devs.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
+                  if mins == 0 then acc else acc.updated(pat, mins)
+                }
+                val exemptPats   =
+                  stlims.filter(_.exemptFromDaily).map(_.domainPattern)
+                val perMacTot    =
+                  Presence.totalMinutesByMac(pPres, exemptPats, settings.heartbeatFilter)
+                // #751: same branch as snapshot — keeps decide() consistent with the snapshot's
+                // cap evaluation.
+                val totalMins    = p.crossDeviceOverlapMode match {
+                  case CrossDeviceOverlapMode.Sum   =>
+                    devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
+                  case CrossDeviceOverlapMode.Dedup =>
+                    Presence.dedupedTotalMinutes(pPres, exemptPats, settings.heartbeatFilter)
+                }
+                // #1379: the daily-cap-exhausted condition the AllowedDuring carve gate keys off —
+                // the per-host mirror of `PolicyService.dailyCapExhausted(state)` in the snapshot.
+                val capExhausted =
+                  tl.map(_.dailyMinutes).exists(limit => totalMins >= limit + exts)
+
+                // #1379: fold each app's effective disposition (schedule windows over base mode) +
+                // the carve gate, exactly as the snapshot does. A non-exempt allowed_during app
+                // whose cap is exhausted is NOT carved, so it correctly falls through to the
+                // time_limit block below; an exempt one (or one under cap) is carved and beats it.
+                val (appAllowed, appBlocked) = PolicyService.expandAppDispositions(
+                  assigns = appAssigns,
+                  hostsByApp = appHostsByApp,
+                  schedWindows = appSchedWindows,
+                  capExhausted = capExhausted,
+                  now = now,
+                )
+
                 // #1413/#421: extraAllowed beats EVERY whole-MAC block — incl.
                 // Paused/Schedule — so check the allowed-app list first, before
                 // the pause/schedule short-circuits. This matches the snapshot/
@@ -335,30 +369,7 @@ class PolicyServiceLive(
                         ZIO.succeed(
                           RouterDecisionResponse(ConnectionDecision.Block, "extra_blocked", None),
                         )
-                      else {
-                        val pPres      = pres.filter(r => macs.contains(r.mac))
-                        val patterns   = stlims.map(_.domainPattern)
-                        val perPat     = Presence.patternMinutesByMac(pPres, patterns)
-                        val byDomain   = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
-                          val mins = devs.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
-                          if mins == 0 then acc else acc.updated(pat, mins)
-                        }
-                        val exemptPats =
-                          stlims.filter(_.exemptFromDaily).map(_.domainPattern)
-                        val perMacTot  =
-                          Presence.totalMinutesByMac(pPres, exemptPats, settings.heartbeatFilter)
-                        // #751: same branch as snapshot — keeps decide()
-                        // consistent with the snapshot's cap evaluation.
-                        val totalMins  = p.crossDeviceOverlapMode match {
-                          case CrossDeviceOverlapMode.Sum   =>
-                            devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
-                          case CrossDeviceOverlapMode.Dedup =>
-                            Presence.dedupedTotalMinutes(
-                              pPres,
-                              exemptPats,
-                              settings.heartbeatFilter,
-                            )
-                        }
+                      else
                         timeLimitBlockFromDb(
                           h,
                           now,
@@ -382,7 +393,6 @@ class PolicyServiceLive(
                                 RouterDecisionResponse(ConnectionDecision.Allow, "allowed", None)
                             }
                         }
-                      }
                   }
             }
           } yield res
@@ -710,6 +720,82 @@ object PolicyService {
         blocklistIds = profile.blockedCategories,
         blockIpOnly = profile.blockIpOnly,
       )
+  }
+
+  // ── #1379: per-app schedules ──────────────────────────────────────────────
+
+  /**
+   * The daily-cap-exhausted condition the AllowedDuring carve gate (§4.1, §5) keys off — computed
+   * directly from `ProfileDayState` (used / limit / extensions), independent of the collapsed
+   * `blockReason`. This matters because when schedule downtime and cap exhaustion coincide,
+   * `blockReason` reports `Schedule` (higher precedence) yet the budget is still exhausted, so the
+   * gate must read the raw cap condition, not the reason.
+   */
+  def dailyCapExhausted(state: ProfileDayState): Boolean =
+    state.dailyLimitMinutes.exists(lim => state.usedMinutes >= lim + state.extensionMinutes)
+
+  /** True iff `w` (a #1069 named-schedule window) is active at `now`, via [[scheduleActiveAt]]. */
+  def windowActiveAt(w: ScheduleWindow, now: Instant): Boolean =
+    scheduleActiveAt(
+      DbSchedule(
+        ScheduleId(0L),
+        ProfileId(0L),
+        "app-window",
+        w.days,
+        w.startLocal,
+        w.endLocal,
+        w.tz,
+      ),
+      now,
+    )
+
+  /**
+   * #1379: collapse each app assignment into the `(extraAllowed, extraBlocked)` host buckets,
+   * folding its per-app schedule windows over its base mode (design §4.1):
+   *
+   *   - any `allowed_during` window active → AllowedDuring candidate (carve gate below);
+   *   - else any `blocked_during` window active → Blocked;
+   *   - else the assignment's base [[AppMode]].
+   *
+   * `allowed_during` beats `blocked_during` on simultaneous overlap (consistent with #421
+   * allow-beats-block). The AllowedDuring carve into `extraAllowed` is gated by the daily cap:
+   * `carve = NOT (capExhausted AND NOT exemptFromDaily)`. A non-exempt app whose cap is exhausted
+   * is therefore NOT carved — it stays subject to the whole-MAC block, so the daily limit still
+   * bites without any wire/router change (design §5 rows 9a–9c). An AllowedDuring candidate that
+   * fails the gate is added to neither bucket. `TimeLimited` base apps contribute nothing here
+   * (surfaced via the site-limit path, #764). Shared by `snapshot` and `decide` so they agree.
+   */
+  private[policy] def expandAppDispositions(
+      assigns: List[AppPolicyAssignment],
+      hostsByApp: Map[AppId, List[Hostname]],
+      schedWindows: Map[AppPolicyAssignmentId, List[(AppScheduleMode, ScheduleWindow)]],
+      capExhausted: Boolean,
+      now: Instant,
+  ): (List[Hostname], List[Hostname]) = {
+    val allowed = scala.collection.mutable.ListBuffer.empty[Hostname]
+    val blocked = scala.collection.mutable.ListBuffer.empty[Hostname]
+    assigns.foreach { a =>
+      val hosts         = hostsByApp.getOrElse(a.appId, Nil)
+      val pairs         = schedWindows.getOrElse(a.id, Nil)
+      val allowedActive = pairs.exists { case (m, w) =>
+        m == AppScheduleMode.AllowedDuring && windowActiveAt(w, now)
+      }
+      val blockedActive = pairs.exists { case (m, w) =>
+        m == AppScheduleMode.BlockedDuring && windowActiveAt(w, now)
+      }
+      if (allowedActive) {
+        // Carve gate: withhold the carve for a non-exempt app whose cap is exhausted.
+        if (!(capExhausted && !a.exemptFromDaily)) allowed ++= hosts
+      } else if (blockedActive) {
+        blocked ++= hosts
+      } else
+        a.mode match {
+          case AppMode.Allowed     => allowed ++= hosts
+          case AppMode.Blocked     => blocked ++= hosts
+          case AppMode.TimeLimited => () // site-limit path (#764)
+        }
+    }
+    (allowed.toList.distinct, blocked.toList.distinct)
   }
 
   // ── #334: timezone-aware time math ────────────────────────────────────────

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -196,24 +196,24 @@ object AppRoutes {
           val aid = AppId(id)
           val pid = ProfileId(profileIdRaw)
           for {
-            claims <- requireWriter(req, auth)
-            _      <- requireProfileAccess(claims, pid, userProfileRepo)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
-            ar     <- ZIO
+            claims   <- requireWriter(req, auth)
+            _        <- requireProfileAccess(claims, pid, userProfileRepo)
+            body     <- req.body.asString.orElseFail(Response.badRequest(""))
+            ar       <- ZIO
               .fromEither(body.fromJson[UpsertAppAssignmentRequest])
               .mapError(e => Response.badRequest(e))
-            _      <- ZIO
+            _        <- ZIO
               .fromEither(validateAssignment(ar.mode, ar.dailyMinutes))
               .mapError(e => Response.badRequest(e))
-            _      <- appRepo
+            _        <- appRepo
               .findById(aid)
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
-            _      <- profileRepo
+            _        <- profileRepo
               .findById(pid)
               .mapError(ErrorMapper.dbErrorToResponse)
               .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
-            _      <- appRepo
+            assignId <- appRepo
               .upsertAssignment(
                 aid,
                 pid,
@@ -221,6 +221,11 @@ object AppRoutes {
                 ar.dailyMinutes,
                 ar.exemptFromDaily.getOrElse(true),
               )
+              .mapError(ErrorMapper.dbErrorToResponse)
+            // #1379: replace this assignment's per-app schedule rules with the
+            // requested set (additive field; existing clients send `Nil`).
+            _        <- appRepo
+              .setScheduleRules(assignId, ar.scheduleRules.map(r => (r.scheduleId, r.mode)))
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.ok
         },

--- a/api/test/src/feature/PolicySnapshotPerAppScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotPerAppScheduleSpec.scala
@@ -1,0 +1,365 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
+
+/**
+ * #1379: per-app schedules collapse, server-side, into the EXISTING `extraAllowed` / `extraBlocked`
+ * snapshot fields — no wire/router change. These feature tests run the full snapshot build over an
+ * embedded Postgres and pin the design's precedence table (docs/design/per-app-schedules.md §5):
+ *
+ *   - row 1: an `allowed_during` window carves an app's host into `extraAllowed` during profile
+ *     downtime (beats the whole-MAC Schedule block, #421);
+ *   - rows 9a–9c: the carve yields to the daily time limit unless the app is `exemptFromDaily` —
+ *     and the gate keys off the raw cap, not the (higher-precedence) blockReason;
+ *   - row 3: a `blocked_during` window drops a base-Allowed app's host while active;
+ *   - the deterministic ETag flips across a window edge (pull-based freshness, §6).
+ *
+ * The result is carried purely in `extraAllowed` / `extraBlocked`; no `PolicySnapshot` field exists
+ * for per-app schedules.
+ */
+object PolicySnapshotPerAppScheduleSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+  private val UTC     = ZoneId.of("UTC")
+  private val allDays = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clk,
+    ): PolicyService
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", Sha256Hex.unsafe("o" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val today0  = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = today0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  /**
+   * Seed a single-host app assigned to `pid` with the given base mode, then attach one per-app
+   * schedule rule (a fresh named schedule with `window`, in `mode`). Returns the app host.
+   */
+  private def seedScheduledApp(
+      ar: AppRepo,
+      nsr: NamedScheduleRepo,
+      pid: ProfileId,
+      name: String,
+      host: String,
+      baseMode: AppMode,
+      ruleMode: AppScheduleMode,
+      window: ScheduleWindow,
+      exemptFromDaily: Boolean = true,
+      dailyMinutes: Option[Int] = None,
+  ): Task[String] =
+    for {
+      appId    <- ar.create(name, name, None, None)
+      _        <- ar.setHosts(appId, List(Hostname.unsafe(host)))
+      assignId <- ar.upsertAssignment(appId, pid, baseMode, dailyMinutes, exemptFromDaily)
+      sid      <- nsr.create(s"$name-sched", None, List(window))
+      _        <- ar.setScheduleRules(assignId, List((sid, ruleMode)))
+    } yield host
+
+  private def kidsBlockReason(snap: PolicySnapshot, pid: ProfileId): Option[String] =
+    snap.profiles(pid).rules.blockReason.map(MacBlockReason.asString)
+
+  def spec = suite("PolicySnapshot — per-app schedules (#1379)")(
+    test("row 1: allowed_during window carves app host into extraAllowed during bedtime downtime") {
+      // Kids carries a legacy bedtime 21:00–07:00 schedule → whole-MAC Schedule block at 21:30.
+      // The base-Blocked app's allowed_during overnight window is active then → host reachable.
+      val bedtimeWin = ScheduleWindow(allDays, LocalTime.of(21, 0), LocalTime.of(7, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Edu",
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          bedtimeWin,
+        )
+        svc  <- makePsAt(TestClock.bedtime)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(kidsBlockReason(snap, kid).contains("Schedule")) &&
+        assertTrue(ea.contains(host)) &&
+        assertTrue(!eb.contains(host))
+    },
+    test("row 1 (control): outside the window the base-Blocked app stays blocked") {
+      // Same app, evaluated at a school-day afternoon — window inactive, no whole-MAC block.
+      val bedtimeWin = ScheduleWindow(allDays, LocalTime.of(21, 0), LocalTime.of(7, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Edu",
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          bedtimeWin,
+        )
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(eb.contains(host)) && assertTrue(!ea.contains(host))
+    },
+    test("9a: exempt app over the daily cap → allowed_during still carves it into extraAllowed") {
+      val mac        = "aa:bb:cc:dd:e9:0a"
+      val daytimeWin = ScheduleWindow(allDays, LocalTime.of(8, 0), LocalTime.of(18, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 30)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Edu",
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          daytimeWin,
+          exemptFromDaily = true,
+        )
+        rid  <- seedRouterRow
+        _   <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35) // exhausts 30-min cap
+        svc <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(kidsBlockReason(snap, kid).contains("TimeLimit")) &&
+        assertTrue(ea.contains(host))
+    },
+    test(
+      "9b: NON-exempt app over the daily cap → allowed_during does NOT carve (cap still bites)",
+    ) {
+      val mac        = "aa:bb:cc:dd:e9:0b"
+      val daytimeWin = ScheduleWindow(allDays, LocalTime.of(8, 0), LocalTime.of(18, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 30)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Game",
+          "game.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          daytimeWin,
+          exemptFromDaily = false,
+        )
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(kidsBlockReason(snap, kid).contains("TimeLimit")) &&
+        assertTrue(!ea.contains(host)) &&
+        assertTrue(!eb.contains(host)) // not carved AND not in eb — left to the whole-MAC block
+    },
+    test(
+      "9c: coincident bedtime downtime + cap exhausted, NON-exempt → not carved though reason=Schedule",
+    ) {
+      // At bedtime the whole-MAC reason is Schedule (higher precedence than TimeLimit), but the
+      // raw daily cap IS exhausted — the carve gate keys off the cap, not the reason, so a
+      // non-exempt allowed_during app is still withheld.
+      val mac        = "aa:bb:cc:dd:e9:0c"
+      val bedtimeWin = ScheduleWindow(allDays, LocalTime.of(21, 0), LocalTime.of(7, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 30)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Game",
+          "game.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          bedtimeWin,
+          exemptFromDaily = false,
+        )
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        svc  <- makePsAt(TestClock.bedtime)
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(kidsBlockReason(snap, kid).contains("Schedule")) &&
+        assertTrue(!ea.contains(host))
+    },
+    test("row 3: blocked_during window drops a base-Allowed app's host while active") {
+      // No whole-MAC block (school-day afternoon); the app is base-Allowed but its blocked_during
+      // window covers the afternoon → host goes to extraBlocked.
+      val homeworkWin = ScheduleWindow(allDays, LocalTime.of(13, 0), LocalTime.of(16, 0), UTC)
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        ar   <- ZIO.service[AppRepo]
+        nsr  <- ZIO.service[NamedScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        host <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Game",
+          "game.example.com",
+          AppMode.Allowed,
+          AppScheduleMode.BlockedDuring,
+          homeworkWin,
+        )
+        svc  <- makePsAt(TestClock.schoolDayAfternoon) // Monday 14:00 — inside 13:00–16:00
+        snap <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+        eb    = rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(!rules.blocked) &&
+        assertTrue(eb.contains(host)) &&
+        assertTrue(!ea.contains(host))
+    },
+    test("ETag flips across a per-app window edge (15:00 exclusive end)") {
+      // A base-Blocked app with an allowed_during 08:00–15:00 window. At 14:59 the host is carved
+      // into extraAllowed; at 15:00 (end exclusive) it is not → the deterministic ETag must change.
+      val win = ScheduleWindow(allDays, LocalTime.of(8, 0), LocalTime.of(15, 0), UTC)
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        ar  <- ZIO.service[AppRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "Edu",
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          win,
+        )
+        inWin = LocalDateTime.of(2025, 1, 6, 14, 59, 0)
+        atEnd = LocalDateTime.of(2025, 1, 6, 15, 0, 0)
+        svcIn   <- makePsAt(inWin)
+        svcEnd  <- makePsAt(atEnd)
+        snapIn  <- svcIn.snapshot
+        snapEnd <- svcEnd.snapshot
+      } yield assertTrue(snapIn.etag != snapEnd.etag) &&
+        assertTrue(
+          snapIn.profiles(kid).rules.extraAllowed.map(_.value).contains("edu.example.com"),
+        ) &&
+        assertTrue(
+          !snapEnd.profiles(kid).rules.extraAllowed.map(_.value).contains("edu.example.com"),
+        )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/RouterDecisionPerAppScheduleSpec.scala
+++ b/api/test/src/feature/RouterDecisionPerAppScheduleSpec.scala
@@ -1,0 +1,210 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
+
+/**
+ * #1379 (§4.2): the per-host `/decision` fallback must mirror the snapshot's per-app
+ * effective-disposition + cap gate, so a router that consults the endpoint agrees with what
+ * nftables enforces. An active `allowed_during` window makes the app's host `extra_allowed` (beats
+ * Paused/Schedule), unless the app is non-exempt and the daily cap is exhausted — then it yields to
+ * the `time_limit` block. A `blocked_during` window drops a base-Allowed host.
+ */
+object RouterDecisionPerAppScheduleSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+  private val UTC     = ZoneId.of("UTC")
+  private val allDays = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+  private val mac     = "aa:bb:cc:de:c1:de"
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clk): PolicyService
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-seed", Sha256Hex.unsafe("d" * 64)))
+
+  private def seedTraffic(
+      routerId: RouterId,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val today0  = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until minutes / 5).map { i =>
+        val start = today0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def seedScheduledApp(
+      ar: AppRepo,
+      nsr: NamedScheduleRepo,
+      pid: ProfileId,
+      host: String,
+      baseMode: AppMode,
+      ruleMode: AppScheduleMode,
+      window: ScheduleWindow,
+      exemptFromDaily: Boolean,
+  ): Task[Unit] =
+    for {
+      appId    <- ar.create("App-" + host, host, None, None)
+      _        <- ar.setHosts(appId, List(Hostname.unsafe(host)))
+      assignId <- ar.upsertAssignment(appId, pid, baseMode, None, exemptFromDaily)
+      sid      <- nsr.create("sched-" + host, None, List(window))
+      _        <- ar.setScheduleRules(assignId, List((sid, ruleMode)))
+    } yield ()
+
+  def spec = suite("decide — per-app schedules (#1379 §4.2)")(
+    test("allowed_during active during bedtime → Allow extra_allowed (beats Schedule block)") {
+      val bedtimeWin = ScheduleWindow(allDays, LocalTime.of(21, 0), LocalTime.of(7, 0), UTC)
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _   <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          bedtimeWin,
+          exemptFromDaily = true,
+        )
+        ps  <- makePsAt(TestClock.bedtime)
+        res <- ps.decide(mac, "edu.example.com")
+      } yield assertTrue(res.decision == ConnectionDecision.Allow) &&
+        assertTrue(res.reason == "extra_allowed")
+    },
+    test("blocked_during active over base-Allowed → Block extra_blocked") {
+      val homeworkWin = ScheduleWindow(allDays, LocalTime.of(13, 0), LocalTime.of(16, 0), UTC)
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _   <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "game.example.com",
+          AppMode.Allowed,
+          AppScheduleMode.BlockedDuring,
+          homeworkWin,
+          exemptFromDaily = true,
+        )
+        ps  <- makePsAt(TestClock.schoolDayAfternoon) // 14:00, inside 13:00–16:00
+        res <- ps.decide(mac, "game.example.com")
+      } yield assertTrue(res.decision == ConnectionDecision.Block) &&
+        assertTrue(res.reason == "extra_blocked")
+    },
+    test("NON-exempt allowed_during + cap exhausted → yields to time_limit (Block)") {
+      val daytimeWin = ScheduleWindow(allDays, LocalTime.of(8, 0), LocalTime.of(18, 0), UTC)
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ar  <- ZIO.service[AppRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 30)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _   <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "game.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          daytimeWin,
+          exemptFromDaily = false,
+        )
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        res <- ps.decide(mac, "game.example.com")
+      } yield assertTrue(res.decision == ConnectionDecision.Block) &&
+        assertTrue(res.reason == "time_limit")
+    },
+    test("EXEMPT allowed_during + cap exhausted → still Allow extra_allowed") {
+      val daytimeWin = ScheduleWindow(allDays, LocalTime.of(8, 0), LocalTime.of(18, 0), UTC)
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ar  <- ZIO.service[AppRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 30)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        _   <- seedScheduledApp(
+          ar,
+          nsr,
+          kid,
+          "edu.example.com",
+          AppMode.Blocked,
+          AppScheduleMode.AllowedDuring,
+          daytimeWin,
+          exemptFromDaily = true,
+        )
+        rid <- seedRouterRow
+        _   <- seedTraffic(rid, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        res <- ps.decide(mac, "edu.example.com")
+      } yield assertTrue(res.decision == ConnectionDecision.Allow) &&
+        assertTrue(res.reason == "extra_allowed")
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/unit/PerAppScheduleSpec.scala
+++ b/api/test/src/unit/PerAppScheduleSpec.scala
@@ -1,0 +1,283 @@
+package wifihaven.api.policy
+
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import zio.test.*
+
+import java.time.{Instant, LocalTime, ZoneId, ZonedDateTime}
+
+/**
+ * #1379: per-app schedule evaluation — the pure server-side collapse of an app's (schedule, mode)
+ * rules into the existing `extraAllowed` / `extraBlocked` host buckets. These unit tests pin the
+ * schedule-boundary behaviour ([[PolicyService.windowActiveAt]] reuses the DST-correct
+ * [[PolicyService.scheduleActiveAt]]), the effective-disposition resolution
+ * ([[PolicyService.expandAppDispositions]] — window overrides base mode, allowed beats blocked),
+ * and the daily-cap carve gate ([[PolicyService.dailyCapExhausted]]). No wire shape is touched —
+ * the only outputs are the two host lists.
+ */
+object PerAppScheduleSpec extends ZIOSpecDefault {
+
+  private val UTC = ZoneId.of("UTC")
+  private val LA  = ZoneId.of("America/Los_Angeles")
+  private val NY  = ZoneId.of("America/New_York")
+
+  private val allDays = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+  private def instantAt(
+      year: Int,
+      month: Int,
+      day: Int,
+      hour: Int,
+      min: Int,
+      zone: ZoneId,
+  ): Instant =
+    ZonedDateTime.of(year, month, day, hour, min, 0, 0, zone).toInstant
+
+  private def win(
+      start: LocalTime,
+      end: LocalTime,
+      days: List[String] = allDays,
+      tz: ZoneId = UTC,
+  ): ScheduleWindow =
+    ScheduleWindow(days, start, end, tz)
+
+  // The single app under test, host = "app.example.com", appId = 10.
+  private val appHost                                = "app.example.com"
+  private val appId                                  = AppId(10L)
+  private val hostsByApp: Map[AppId, List[Hostname]] =
+    Map(appId -> List(Hostname.unsafe(appHost)))
+
+  private def assign(
+      mode: AppMode,
+      exempt: Boolean = true,
+      id: Long = 1L,
+  ): AppPolicyAssignment =
+    AppPolicyAssignment(AppPolicyAssignmentId(id), appId, ProfileId(1L), mode, None, exempt)
+
+  /** Run the disposition fold for a single assignment with the given rules. */
+  private def expand(
+      a: AppPolicyAssignment,
+      rules: List[(AppScheduleMode, ScheduleWindow)],
+      capExhausted: Boolean,
+      now: Instant,
+  ): (Set[String], Set[String]) = {
+    val (allowed, blocked) = PolicyService.expandAppDispositions(
+      assigns = List(a),
+      hostsByApp = hostsByApp,
+      schedWindows = Map(a.id -> rules),
+      capExhausted = capExhausted,
+      now = now,
+    )
+    (allowed.map(_.value).toSet, blocked.map(_.value).toSet)
+  }
+
+  // A weekday-bedtime UTC window: 21:00 → 07:00 (overnight wrap), all days.
+  private val bedtime   = win(LocalTime.of(21, 0), LocalTime.of(7, 0))
+  // Wed 2026-05-13 22:30 UTC — inside bedtime.
+  private val atBedtime = instantAt(2026, 5, 13, 22, 30, UTC)
+  // Wed 2026-05-13 12:00 UTC — outside bedtime.
+  private val atNoon    = instantAt(2026, 5, 13, 12, 0, UTC)
+
+  def spec = suite("per-app schedules (#1379)")(
+    suite("windowActiveAt — boundaries reuse scheduleActiveAt")(
+      test("exact start is inclusive (active)") {
+        val w = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        assertTrue(PolicyService.windowActiveAt(w, instantAt(2026, 5, 13, 9, 0, UTC)))
+      },
+      test("exact end is exclusive (inactive)") {
+        val w = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        assertTrue(!PolicyService.windowActiveAt(w, instantAt(2026, 5, 13, 17, 0, UTC)))
+      },
+      test("one minute before start → inactive") {
+        val w = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        assertTrue(!PolicyService.windowActiveAt(w, instantAt(2026, 5, 13, 8, 59, UTC)))
+      },
+      test("day-of-week membership excludes other days") {
+        val w = win(LocalTime.of(9, 0), LocalTime.of(17, 0), days = List("mon"))
+        // 2026-05-13 is a Wednesday.
+        assertTrue(!PolicyService.windowActiveAt(w, instantAt(2026, 5, 13, 12, 0, UTC)))
+      },
+      test("overnight wrap: tail of the prior day is active") {
+        val w = win(LocalTime.of(23, 30), LocalTime.of(6, 0), tz = NY)
+        // 2026-05-14 02:00 NY is the tail of the window that started 2026-05-13 23:30 NY.
+        assertTrue(PolicyService.windowActiveAt(w, instantAt(2026, 5, 14, 2, 0, NY)))
+      },
+      test("DST spring-forward: 21:00→07:00 LA active at 06:30 PDT the next morning") {
+        val w = win(LocalTime.of(21, 0), LocalTime.of(7, 0), tz = LA)
+        // Spring-forward 2026-03-08 02:00 PST → 03:00 PDT; 06:30 PDT must still be in-window.
+        assertTrue(PolicyService.windowActiveAt(w, instantAt(2026, 3, 8, 6, 30, LA)))
+      },
+    ),
+    suite("effective disposition — window overrides base mode")(
+      test("allowed_during active over base Blocked → host carved into extraAllowed only") {
+        val (ea, eb) =
+          expand(
+            assign(AppMode.Blocked),
+            List(AppScheduleMode.AllowedDuring -> bedtime),
+            false,
+            atBedtime,
+          )
+        assertTrue(ea == Set(appHost)) && assertTrue(eb.isEmpty)
+      },
+      test("allowed_during INACTIVE → falls back to base Blocked") {
+        val (ea, eb) =
+          expand(
+            assign(AppMode.Blocked),
+            List(AppScheduleMode.AllowedDuring -> bedtime),
+            false,
+            atNoon,
+          )
+        assertTrue(ea.isEmpty) && assertTrue(eb == Set(appHost))
+      },
+      test("blocked_during active over base Allowed → host in extraBlocked only (row 3)") {
+        val w        = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        val (ea, eb) =
+          expand(assign(AppMode.Allowed), List(AppScheduleMode.BlockedDuring -> w), false, atNoon)
+        assertTrue(eb == Set(appHost)) && assertTrue(ea.isEmpty)
+      },
+      test("blocked_during INACTIVE on base Allowed → falls back to extraAllowed") {
+        val w        = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        val (ea, eb) =
+          expand(
+            assign(AppMode.Allowed),
+            List(AppScheduleMode.BlockedDuring -> w),
+            false,
+            atBedtime,
+          )
+        assertTrue(ea == Set(appHost)) && assertTrue(eb.isEmpty)
+      },
+      test("no rules → pure base mode (Blocked)") {
+        val (ea, eb) = expand(assign(AppMode.Blocked), Nil, false, atBedtime)
+        assertTrue(ea.isEmpty) && assertTrue(eb == Set(appHost))
+      },
+      test("TimeLimited base with no active window contributes to neither bucket") {
+        val (ea, eb) = expand(assign(AppMode.TimeLimited), Nil, false, atBedtime)
+        assertTrue(ea.isEmpty) && assertTrue(eb.isEmpty)
+      },
+    ),
+    suite("allowed_during beats blocked_during on simultaneous overlap")(
+      test("both windows active → AllowedDuring wins, host in extraAllowed only") {
+        val rules    = List(
+          AppScheduleMode.AllowedDuring -> bedtime,
+          AppScheduleMode.BlockedDuring -> win(LocalTime.of(21, 0), LocalTime.of(7, 0)),
+        )
+        val (ea, eb) = expand(assign(AppMode.Blocked), rules, false, atBedtime)
+        assertTrue(ea == Set(appHost)) && assertTrue(eb.isEmpty)
+      },
+    ),
+    suite("multi-window named schedule — active iff ANY window active")(
+      test("second window active → allowed_during fires") {
+        // Two windows on the rule (school hours + evening); evaluate during the evening one.
+        val rules    = List(
+          AppScheduleMode.AllowedDuring -> win(LocalTime.of(8, 0), LocalTime.of(15, 0)),
+          AppScheduleMode.AllowedDuring -> win(LocalTime.of(20, 0), LocalTime.of(23, 0)),
+        )
+        val now      = instantAt(2026, 5, 13, 21, 0, UTC)
+        val (ea, eb) = expand(assign(AppMode.Blocked), rules, false, now)
+        assertTrue(ea == Set(appHost)) && assertTrue(eb.isEmpty)
+      },
+      test("neither window active → base mode") {
+        val rules    = List(
+          AppScheduleMode.AllowedDuring -> win(LocalTime.of(8, 0), LocalTime.of(15, 0)),
+          AppScheduleMode.AllowedDuring -> win(LocalTime.of(20, 0), LocalTime.of(23, 0)),
+        )
+        val now      = instantAt(2026, 5, 13, 17, 0, UTC) // 5pm — between both windows
+        val (ea, eb) = expand(assign(AppMode.Blocked), rules, false, now)
+        assertTrue(ea.isEmpty) && assertTrue(eb == Set(appHost))
+      },
+    ),
+    suite("daily-cap carve gate — allowed_during yields to the cap unless exempt")(
+      test("exempt + cap exhausted → still carved (9a)") {
+        val (ea, _) = expand(
+          assign(AppMode.Blocked, exempt = true),
+          List(AppScheduleMode.AllowedDuring -> bedtime),
+          capExhausted = true,
+          atBedtime,
+        )
+        assertTrue(ea == Set(appHost))
+      },
+      test("NON-exempt + cap exhausted → NOT carved (9b): neither bucket") {
+        val (ea, eb) = expand(
+          assign(AppMode.Blocked, exempt = false),
+          List(AppScheduleMode.AllowedDuring -> bedtime),
+          capExhausted = true,
+          atBedtime,
+        )
+        assertTrue(ea.isEmpty) && assertTrue(eb.isEmpty)
+      },
+      test("NON-exempt + cap NOT exhausted → carved") {
+        val (ea, _) = expand(
+          assign(AppMode.Blocked, exempt = false),
+          List(AppScheduleMode.AllowedDuring -> bedtime),
+          capExhausted = false,
+          atBedtime,
+        )
+        assertTrue(ea == Set(appHost))
+      },
+      test("exempt + cap NOT exhausted → carved") {
+        val (ea, _) = expand(
+          assign(AppMode.Blocked, exempt = true),
+          List(AppScheduleMode.AllowedDuring -> bedtime),
+          capExhausted = false,
+          atBedtime,
+        )
+        assertTrue(ea == Set(appHost))
+      },
+      test("cap gate does NOT touch blocked_during (always drops)") {
+        val w        = win(LocalTime.of(9, 0), LocalTime.of(17, 0))
+        val (ea, eb) = expand(
+          assign(AppMode.Allowed, exempt = false),
+          List(AppScheduleMode.BlockedDuring -> w),
+          capExhausted = true,
+          atNoon,
+        )
+        assertTrue(eb == Set(appHost)) && assertTrue(ea.isEmpty)
+      },
+    ),
+    suite("dailyCapExhausted — keyed off raw ProfileDayState, not blockReason")(
+      test("used >= limit + extensions → exhausted") {
+        val st = ProfileDayState(
+          ProfileId(1L),
+          java.time.LocalDate.of(2026, 5, 13),
+          Some(30),
+          usedMinutes = 35,
+          extensionMinutes = 0,
+          remainingMinutes = Some(0),
+          blocked = true,
+          blockReason =
+            Some(MacBlockReason.Schedule), // higher-precedence reason; gate must ignore it
+          perSite = Nil,
+        )
+        assertTrue(PolicyService.dailyCapExhausted(st))
+      },
+      test("extensions push used below the effective cap → not exhausted") {
+        val st = ProfileDayState(
+          ProfileId(1L),
+          java.time.LocalDate.of(2026, 5, 13),
+          Some(30),
+          usedMinutes = 35,
+          extensionMinutes = 10, // effective cap = 40 > 35
+          remainingMinutes = Some(5),
+          blocked = false,
+          blockReason = None,
+          perSite = Nil,
+        )
+        assertTrue(!PolicyService.dailyCapExhausted(st))
+      },
+      test("no daily limit set → never exhausted") {
+        val st = ProfileDayState(
+          ProfileId(1L),
+          java.time.LocalDate.of(2026, 5, 13),
+          None,
+          usedMinutes = 999,
+          extensionMinutes = 0,
+          remainingMinutes = None,
+          blocked = false,
+          blockReason = None,
+          perSite = Nil,
+        )
+        assertTrue(!PolicyService.dailyCapExhausted(st))
+      },
+    ),
+  )
+}

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -359,10 +359,52 @@ case class UpdateAppRequest(
 
 case class SetAppHostsRequest(hosts: List[String]) derives JsonCodec
 
+// #1379: per-app schedule rules. Each rule attaches a #1069 named schedule
+// (NamedScheduleId, V50 `named_schedules`) to an app's (app, profile) assignment
+// with a mode:
+//   - AllowedDuring — while any window of the schedule is active, the app's hosts
+//     are carved into `extraAllowed`, beating the profile's whole-MAC block (#421)
+//     — the headline "reachable during bedtime" case.
+//   - BlockedDuring — while active, the app's hosts go to `extraBlocked`, even when
+//     the profile is otherwise unrestricted.
+// API-internal only: this is NEVER a `PolicySnapshot` field. PolicyService folds
+// the active windows into the existing per-MAC `extraAllowed` / `extraBlocked`
+// (docs/design/per-app-schedules.md §2, §4) — no wire/router change.
+enum AppScheduleMode { case AllowedDuring, BlockedDuring }
+
+object AppScheduleMode {
+  def asString(m: AppScheduleMode): String      = m match {
+    case AllowedDuring => "allowed_during"
+    case BlockedDuring => "blocked_during"
+  }
+  def parse(s: String): Option[AppScheduleMode] = s match {
+    case "allowed_during" => Some(AllowedDuring)
+    case "blocked_during" => Some(BlockedDuring)
+    case _                => None
+  }
+  given JsonCodec[AppScheduleMode]              = JsonCodec[String].transformOrFail(
+    s => parse(s).toRight(s"unknown app schedule mode: $s"),
+    asString,
+  )
+}
+
+// A single (assignment, named-schedule, mode) rule row (`app_policy_schedule_rules`,
+// V51). `id` / `assignmentId` are server-assigned and default to placeholders so the
+// request shape below only needs `{scheduleId, mode}` on input.
+case class AppScheduleRule(
+    scheduleId: NamedScheduleId,
+    mode: AppScheduleMode,
+    id: AppScheduleRuleId = AppScheduleRuleId(0L),
+    assignmentId: AppPolicyAssignmentId = AppPolicyAssignmentId(0L),
+) derives JsonCodec
+
 case class UpsertAppAssignmentRequest(
     mode: AppMode,
     dailyMinutes: Option[Int] = None,
     exemptFromDaily: Option[Boolean] = None,
+    // #1379: additive — the full desired set of per-app schedule rules (replace
+    // semantics, like SetAppHostsRequest.hosts). Existing clients omit it (`Nil`).
+    scheduleRules: List[AppScheduleRule] = Nil,
 ) derives JsonCodec
 
 case class AppDetail(

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -26,6 +26,7 @@ opaque type AlertId               = Long
 opaque type AppId                 = Long
 opaque type AppPolicyAssignmentId = Long
 opaque type NamedScheduleId       = Long
+opaque type AppScheduleRuleId     = Long
 
 object ProfileId {
   def apply(l: Long): ProfileId            = l
@@ -136,6 +137,13 @@ object NamedScheduleId {
   given JsonFieldEncoder[NamedScheduleId]        = JsonFieldEncoder.long
   given JsonFieldDecoder[NamedScheduleId]        = JsonFieldDecoder.long
   given Ordering[NamedScheduleId]                = Ordering.Long
+}
+
+object AppScheduleRuleId {
+  def apply(l: Long): AppScheduleRuleId            = l
+  extension (a: AppScheduleRuleId) def value: Long = a
+  given JsonCodec[AppScheduleRuleId]               = JsonCodec.long
+  given Ordering[AppScheduleRuleId]                = Ordering.Long
 }
 
 /** UUID-backed router identifier. */


### PR DESCRIPTION
Implements per-app schedules server-side in `PolicyService`, collapsing each app's `(named schedule, mode)` rules into the **existing** per-MAC `extraAllowed` / `extraBlocked` fields. **No `PolicySnapshot`/wire change, no router change** — the router stays a dumb applier (AGENTS.md "Architectural model"; `docs/design/per-app-schedules.md` §2, §4). Builds on the merged foundations #1378 (`V51 app_policy_schedule_rules`) and #1069 (`named_schedules`).

Closes #1379. Unblocks #1380 (web assignment-editor Schedules section).

## What this does

For each `(app, profile)` assignment, resolve an **effective disposition at `now`** that layers per-app schedule windows on top of the static base mode, then collapse into the wire's existing host buckets (`docs/design/per-app-schedules.md` §4.1, §5):

| App window @ now | Effect |
|---|---|
| `allowed_during` active | host → `extraAllowed` (beats every whole-MAC block, #421) — *subject to the cap gate* |
| `blocked_during` active | host → `extraBlocked` |
| no active window | base `AppMode` (unchanged from today) |

`allowed_during` beats `blocked_during` on simultaneous overlap. The `AllowedDuring` carve is gated by the daily cap:

```
carve = AllowedDuring AND NOT (dailyCapExhausted AND NOT exemptFromDaily)
```

so a **non-exempt** `allowed_during` app still yields to the daily time limit (rows 9b/9c) while an **exempt** one survives it (row 9a). `dailyCapExhausted` is read straight off `ProfileDayState` (used/limit/extensions), **independent of the collapsed `blockReason`** — so the cap binds even when `blockReason` reports the higher-precedence `Schedule` (9c).

The same fold runs in **both** `PolicyService.snapshot` and the per-host `decide` fallback (§4.2), keeping them in lockstep.

## Changes
- **shared**: `AppScheduleMode` + `AppScheduleRule` (API-internal — never a `PolicySnapshot` field), `AppScheduleRuleId` opaque id; additive `scheduleRules: List[AppScheduleRule] = Nil` on `UpsertAppAssignmentRequest` (back-compatible default).
- **repo**: `setScheduleRules` / `scheduleRulesForAssignment` / `appScheduleWindowsForProfile` (one join `app_policy_schedule_rules → assignment → schedule_windows`, flattened to `(mode, window)` pairs). The assignment route persists the requested rules.
- **PolicyService**: `expandAppDispositions` (shared by snapshot + decide), `dailyCapExhausted`, `windowActiveAt` (reuses the DST-correct `scheduleActiveAt`).
- **No migration in this PR** — `V51` already shipped in #1378.

## Confirmed invariants
- No new `PolicySnapshot` field; outputs are only `extraAllowed` / `extraBlocked`.
- No new wire reason; the ETag flips across a window edge via the existing `blockRulesSig` fold (pull-based freshness, §6).
- No compat shims.

## Tests (TDD — red commit precedes green)
- **Unit** (`PerAppScheduleSpec`, 23): exact on/off boundaries, DOW membership, overnight wrap, DST spring-forward, `allowed_during`-beats-`blocked_during` tiebreak, multi-window named-schedule resolution, the cap gate (exempt-over-cap carves, non-exempt-over-cap does not, either-under-cap carves), and `dailyCapExhausted`.
- **Feature snapshot** (`PolicySnapshotPerAppScheduleSpec`, 7): `extraAllowed` carve during downtime (row 1), cap-gate exempt 9a vs non-exempt 9b, coincident schedule+cap 9c, `extraBlocked` during `blocked_during` (row 3), ETag flip across a window edge.
- **Feature decide** (`RouterDecisionPerAppScheduleSpec`, 4): the §4.2 per-host mirror.
- Full `mill api.test` + `mill shared.test` green; `scalafmt --check` clean.