### PR TITLE
feat(#1069): named-schedule management UI + reusable schedule picker

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { GlobalPolicyPage } from '@/pages/GlobalPolicyPage'
 import { BlockedPage } from '@/pages/BlockedPage'
 import { AppsPage } from '@/pages/AppsPage'
 import { BlocklistsPage } from '@/pages/BlocklistsPage'
+import { SchedulesPage } from '@/pages/SchedulesPage'
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth()
@@ -60,6 +61,7 @@ function AppRoutes() {
         <Route path="usage/events"   element={<RequirePwChanged><LogsPage /></RequirePwChanged>} />
         <Route path="apps"        element={<RequirePwChanged><RequireAdmin><AppsPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="blocklists"  element={<RequirePwChanged><RequireAdmin><BlocklistsPage /></RequireAdmin></RequirePwChanged>} />
+        <Route path="schedules"   element={<RequirePwChanged><RequireAdmin><SchedulesPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="users"     element={<RequirePwChanged><RequireAdmin><UsersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="routers"   element={<RequirePwChanged><RequireAdmin><RoutersPage /></RequireAdmin></RequirePwChanged>} />
         <Route path="global-policy" element={<RequirePwChanged><RequireAdmin><GlobalPolicyPage /></RequireAdmin></RequirePwChanged>} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   ConnectionEventSeriesPage, QueryLogPage,
   PatchUserRequest, PatchAppRequest,
+  NamedSchedule, NamedScheduleRequest,
   RecentApexesResponse, RouterSummary, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
   PatchDeviceRequest,
@@ -393,6 +394,20 @@ export const api = {
   // ── Dashboard "now" ────────────────────────────────────────────────────
   dashboard: {
     now: () => req<DashboardNow>('GET', '/dashboard/now'),
+  },
+
+  // ── Named schedules (#1069) ────────────────────────────────────────────
+  // Household-scoped reusable time-window primitive. Admin-only writes; the
+  // PATCH carries the full schedule shape (replace semantics) so the edit form
+  // can autosave (#423/#995). Referenced rows cascade-delete their references
+  // server-side, so the SPA warns before deleting a referenced schedule.
+  schedules: {
+    list: () => req<NamedSchedule[]>('GET', '/schedules'),
+    create: (data: NamedScheduleRequest) =>
+      req<NamedSchedule>('POST', '/schedules', data),
+    update: (id: number, data: NamedScheduleRequest) =>
+      req<NamedSchedule>('PATCH', `/schedules/${id}`, data),
+    delete: (id: number) => req<void>('DELETE', `/schedules/${id}`),
   },
 
   // ── Blocklists ─────────────────────────────────────────────────────────

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -8,7 +8,7 @@
 import { useQuery, useQueryClient, type UseQueryOptions } from '@tanstack/react-query'
 import { api } from '@/api/client'
 import type {
-  Alert, BlocklistSummary, DashboardNow, Device, GlobalPolicyView, HouseholdSettings, ProfileDetail,
+  Alert, BlocklistSummary, DashboardNow, Device, GlobalPolicyView, HouseholdSettings, NamedSchedule, ProfileDetail,
   ProfileTimeStatus,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   QueryLog, UsageSeriesResponse,
@@ -42,6 +42,7 @@ export const qk = {
   devices: () => ['devices'] as const,
   globalPolicy: () => ['global', 'policy'] as const,
   alerts: (includeAll: boolean) => ['alerts', includeAll] as const,
+  schedules: () => ['schedules'] as const,
   dashboardNow: () => ['dashboard', 'now'] as const,
   recentBlocked: () => ['dashboard', 'recent-blocked'] as const,
   timeStatusToday: () => ['time', 'status', 'today'] as const,
@@ -102,6 +103,19 @@ export function useBlocklists(opts?: QueryOpts<BlocklistSummary[]>) {
   return useQuery({
     queryKey: ['blocklists'] as const,
     queryFn: () => api.blocklists.list(),
+    staleTime: 5 * MIN,
+    ...opts,
+  })
+}
+
+// #1069 — household named schedules (GET /api/schedules), shared by the
+// Schedules management page and the reusable SchedulePicker dropdown embedded
+// in profile / per-app / blocklist edit forms. Cached so the N pickers on a
+// page don't each fetch. Low-churn admin data; pages invalidate on edit.
+export function useNamedSchedules(opts?: QueryOpts<NamedSchedule[]>) {
+  return useQuery({
+    queryKey: qk.schedules(),
+    queryFn: () => api.schedules.list(),
     staleTime: 5 * MIN,
     ...opts,
   })
@@ -290,6 +304,13 @@ export function useInvalidators() {
     profiles: () => qc.invalidateQueries({ queryKey: qk.profiles() }),
     devices: () => qc.invalidateQueries({ queryKey: qk.devices() }),
     globalPolicy: () => qc.invalidateQueries({ queryKey: qk.globalPolicy() }),
+    // #1069 — schedule edits change profile/app/blocklist downtime, so also
+    // refresh anything whose rendering derives from an active window.
+    schedules: () => Promise.all([
+      qc.invalidateQueries({ queryKey: qk.schedules() }),
+      qc.invalidateQueries({ queryKey: qk.profiles() }),
+      qc.invalidateQueries({ queryKey: ['time', 'status'] }),
+    ]),
     alerts: () => qc.invalidateQueries({ queryKey: ['alerts'] }),
     dashboardNow: () => qc.invalidateQueries({ queryKey: qk.dashboardNow() }),
     timeStatus: () => qc.invalidateQueries({ queryKey: ['time', 'status'] }),

--- a/web/src/components/SchedulePicker.test.tsx
+++ b/web/src/components/SchedulePicker.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    schedules: {
+      list: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import type { NamedSchedule } from '@/types/api'
+import { SchedulePicker, ALWAYS_VALUE } from './SchedulePicker'
+import { withQuery } from '@/test/queryWrapper'
+
+const bedtime: NamedSchedule = {
+  id: 1, name: 'Bedtime', description: null,
+  windows: [{ days: ['mon', 'tue'], startLocal: '20:00', endLocal: '07:00', tz: 'UTC' }],
+}
+const school: NamedSchedule = {
+  id: 2, name: 'School hours', description: null,
+  windows: [{ days: ['mon'], startLocal: '08:00', endLocal: '15:00', tz: 'UTC' }],
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, school])
+  ;(api.schedules.create as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+    id: 99, name: 'Naptime', description: null, windows: [],
+  } satisfies NamedSchedule)
+})
+
+describe('SchedulePicker (#1069)', () => {
+  it('renders household schedules + Always + Custom options', async () => {
+    render(withQuery(<SchedulePicker value={null} onChange={vi.fn()} />))
+    // options appear once the catalog loads
+    expect(await screen.findByRole('option', { name: 'Bedtime' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'School hours' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Always' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /custom \(define inline\)/i })).toBeInTheDocument()
+  })
+
+  it('selecting Always yields null', async () => {
+    const onChange = vi.fn()
+    render(withQuery(<SchedulePicker value={1} onChange={onChange} />))
+    await screen.findByRole('option', { name: 'Bedtime' })
+    await userEvent.selectOptions(screen.getByTestId('schedule-picker-select'), ALWAYS_VALUE)
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('selecting a named schedule yields its id', async () => {
+    const onChange = vi.fn()
+    render(withQuery(<SchedulePicker value={null} onChange={onChange} />))
+    await screen.findByRole('option', { name: 'School hours' })
+    await userEvent.selectOptions(screen.getByTestId('schedule-picker-select'), '2')
+    expect(onChange).toHaveBeenCalledWith(2)
+  })
+
+  it('hides Custom when allowCustom is false', async () => {
+    render(withQuery(<SchedulePicker value={null} onChange={vi.fn()} allowCustom={false} />))
+    await screen.findByRole('option', { name: 'Bedtime' })
+    expect(screen.queryByRole('option', { name: /custom \(define inline\)/i })).not.toBeInTheDocument()
+  })
+
+  it('Custom transparently creates a household schedule and emits its id', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(withQuery(<SchedulePicker value={null} onChange={onChange} />))
+    await screen.findByRole('option', { name: 'Bedtime' })
+
+    await user.selectOptions(screen.getByTestId('schedule-picker-select'), '__custom__')
+    expect(screen.getByTestId('schedule-picker-custom-form')).toBeInTheDocument()
+
+    await user.type(screen.getByTestId('schedule-picker-custom-name'), 'Naptime')
+    await user.click(screen.getByTestId('schedule-picker-custom-create'))
+
+    await waitFor(() => expect(api.schedules.create).toHaveBeenCalledTimes(1))
+    const arg = (api.schedules.create as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(arg.name).toBe('Naptime')
+    expect(Array.isArray(arg.windows)).toBe(true)
+    expect(onChange).toHaveBeenCalledWith(99)
+    // form closes after create
+    await waitFor(() =>
+      expect(screen.queryByTestId('schedule-picker-custom-form')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('blocks custom create with an empty name', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulePicker value={null} onChange={vi.fn()} />))
+    await screen.findByRole('option', { name: 'Bedtime' })
+    await user.selectOptions(screen.getByTestId('schedule-picker-select'), '__custom__')
+    await user.click(screen.getByTestId('schedule-picker-custom-create'))
+    expect(api.schedules.create).not.toHaveBeenCalled()
+    expect(screen.getByTestId('schedule-picker-custom-error')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/SchedulePicker.tsx
+++ b/web/src/components/SchedulePicker.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { api } from '@/api/client'
+import { useNamedSchedules, useInvalidators } from '@/api/queries'
+import type { ScheduleWindow } from '@/types/api'
+import { browserTimezone } from '@/components/TimezonePicker'
+import { ScheduleWindowsEditor, emptyWindow } from '@/components/ScheduleWindowsEditor'
+
+// #1069 — reusable schedule-reference dropdown for any time-bound edit form
+// (per-profile, per-app #1380, per-blocklist #1067). Offers the household's
+// named schedules + "Always" (value = null) + "Custom (define inline)".
+//
+// Design decision (the issue defers this to the implementation): "Custom"
+// **transparently creates a household-scoped named schedule** rather than an
+// inline-only one. Rationale — #1069's whole point is that a schedule is a
+// single shared primitive ("edit bedtime once, it changes everywhere"). An
+// inline-only window would fork the model and re-introduce the per-reference
+// window editing this issue exists to remove. So the inline form authors a
+// real named schedule (it then appears on the Schedules page and is reusable),
+// and the picker emits its new id.
+//
+// `value` is the selected named-schedule id, or null for "Always". The
+// component fetches the catalog itself (shared cached query) so consumers only
+// wire value/onChange.
+export const ALWAYS_VALUE = '__always__'
+const CUSTOM_VALUE = '__custom__'
+
+export function SchedulePicker({
+  value, onChange, disabled = false, allowCustom = true,
+  testId = 'schedule-picker', defaultTz = browserTimezone(),
+}: {
+  value: number | null
+  onChange: (id: number | null) => void
+  disabled?: boolean
+  allowCustom?: boolean
+  testId?: string
+  defaultTz?: string
+}) {
+  const { data: schedules = [] } = useNamedSchedules()
+  const invalidators = useInvalidators()
+
+  const [customOpen, setCustomOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [windows, setWindows] = useState<ScheduleWindow[]>(() => [emptyWindow(defaultTz)])
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function handleSelect(raw: string) {
+    if (raw === ALWAYS_VALUE) {
+      setCustomOpen(false)
+      onChange(null)
+    } else if (raw === CUSTOM_VALUE) {
+      setError(null)
+      setCustomOpen(true)
+    } else {
+      setCustomOpen(false)
+      onChange(Number(raw))
+    }
+  }
+
+  async function createCustom() {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Name is required')
+      return
+    }
+    setCreating(true)
+    setError(null)
+    try {
+      const created = await api.schedules.create({ name: trimmed, windows })
+      await invalidators.schedules()
+      setCustomOpen(false)
+      setName('')
+      setWindows([emptyWindow(defaultTz)])
+      onChange(created.id)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create schedule')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  // Reflect the live selection in the <select>. While the custom form is open,
+  // the select shows the Custom option so the form's presence is explained.
+  const selectValue = customOpen
+    ? CUSTOM_VALUE
+    : value === null
+      ? ALWAYS_VALUE
+      : String(value)
+
+  return (
+    <div data-testid={testId} className="space-y-2">
+      <select
+        value={selectValue}
+        disabled={disabled}
+        data-testid={`${testId}-select`}
+        onChange={e => handleSelect(e.target.value)}
+        className="w-full bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-sm text-brand-ink disabled:opacity-60">
+        <option value={ALWAYS_VALUE}>Always</option>
+        {schedules.map(s => (
+          <option key={s.id} value={String(s.id)}>{s.name}</option>
+        ))}
+        {allowCustom && !disabled && (
+          <option value={CUSTOM_VALUE}>Custom (define inline)…</option>
+        )}
+      </select>
+
+      {customOpen && (
+        <div
+          data-testid={`${testId}-custom-form`}
+          className="bg-brand-surface/40 border border-brand-border rounded-xl p-3 space-y-3">
+          <p className="text-xs text-brand-text-muted">
+            Creates a reusable household schedule you can attach elsewhere.
+          </p>
+          <input type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Schedule name (e.g. Bedtime)"
+            data-testid={`${testId}-custom-name`}
+            className="w-full bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm" />
+          <ScheduleWindowsEditor
+            windows={windows}
+            onChange={setWindows}
+            testId={`${testId}-custom-windows`}
+            defaultTz={defaultTz}
+          />
+          {error && <p className="text-xs text-red-700" data-testid={`${testId}-custom-error`}>{error}</p>}
+          <div className="flex gap-2">
+            <button type="button"
+              onClick={createCustom}
+              disabled={creating}
+              data-testid={`${testId}-custom-create`}
+              className="text-xs bg-brand-accent text-white px-3 py-2 rounded-lg disabled:opacity-60">
+              {creating ? 'Creating…' : 'Create schedule'}
+            </button>
+            <button type="button"
+              onClick={() => { setCustomOpen(false); setError(null) }}
+              data-testid={`${testId}-custom-cancel`}
+              className="text-xs text-brand-text-muted hover:text-brand-ink px-3 py-2 rounded-lg">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/ScheduleWindowsEditor.tsx
+++ b/web/src/components/ScheduleWindowsEditor.tsx
@@ -1,0 +1,104 @@
+import type { ScheduleWindow } from '@/types/api'
+import { TimezonePicker } from '@/components/TimezonePicker'
+
+// #1069 — shared editor for a named schedule's window list. A window is the
+// typed shape PolicyService evaluates: a day set + a local start/end + tz.
+// Used by both the Schedules management page and the SchedulePicker's
+// "Custom (define inline)" form so the two author windows identically.
+export const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
+
+export const WEEKDAYS: string[] = ['mon', 'tue', 'wed', 'thu', 'fri']
+
+export function emptyWindow(tz: string): ScheduleWindow {
+  return { days: [...WEEKDAYS], startLocal: '20:00', endLocal: '07:00', tz }
+}
+
+export function ScheduleWindowsEditor({
+  windows, onChange, disabled = false, testId, defaultTz,
+}: {
+  windows: ScheduleWindow[]
+  onChange: (next: ScheduleWindow[]) => void
+  disabled?: boolean
+  testId: string
+  defaultTz: string
+}) {
+  const patch = (i: number, p: Partial<ScheduleWindow>) =>
+    onChange(windows.map((w, idx) => (idx === i ? { ...w, ...p } : w)))
+  const remove = (i: number) => onChange(windows.filter((_, idx) => idx !== i))
+  const add = () => onChange([...windows, emptyWindow(defaultTz)])
+  const toggleDay = (i: number, d: string) =>
+    patch(i, {
+      days: windows[i].days.includes(d)
+        ? windows[i].days.filter(x => x !== d)
+        : [...windows[i].days, d],
+    })
+
+  return (
+    <div className="space-y-3" data-testid={testId}>
+      {windows.length === 0 && (
+        <p className="text-xs text-brand-text-muted">No windows — this schedule is never active.</p>
+      )}
+      {windows.map((w, i) => (
+        <div key={i}
+          data-testid={`${testId}-window-${i}`}
+          className="bg-brand-surface border border-brand-border-strong rounded-xl p-3 space-y-2">
+          <div className="flex gap-2 items-center text-sm">
+            <input type="time" value={w.startLocal}
+              disabled={disabled}
+              onChange={e => patch(i, { startLocal: e.target.value })}
+              data-testid={`${testId}-start-${i}`}
+              className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink disabled:opacity-60" />
+            <span className="text-brand-text-muted">→</span>
+            <input type="time" value={w.endLocal}
+              disabled={disabled}
+              onChange={e => patch(i, { endLocal: e.target.value })}
+              data-testid={`${testId}-end-${i}`}
+              className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink disabled:opacity-60" />
+            <span className="flex-1" />
+            {!disabled && (
+              <button type="button"
+                onClick={() => remove(i)}
+                data-testid={`${testId}-remove-${i}`}
+                className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-2 rounded-lg">
+                Remove
+              </button>
+            )}
+          </div>
+          <TimezonePicker
+            value={w.tz}
+            onChange={tz => patch(i, { tz })}
+            testId={`${testId}-tz-${i}`}
+          />
+          <div className="flex flex-wrap gap-1">
+            {DAYS.map(d => {
+              const on = w.days.includes(d)
+              return (
+                <button type="button"
+                  key={d}
+                  disabled={disabled}
+                  onClick={() => toggleDay(i, d)}
+                  data-testid={`${testId}-day-${i}-${d}`}
+                  aria-pressed={on}
+                  className={`text-xs px-2 py-1 rounded-lg capitalize disabled:opacity-60 ${
+                    on
+                      ? 'bg-brand-accent text-white'
+                      : 'bg-brand-alt text-brand-text hover:text-brand-ink'
+                  }`}>
+                  {d}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+      {!disabled && (
+        <button type="button"
+          onClick={add}
+          data-testid={`${testId}-add-window`}
+          className="text-xs text-brand-accent hover:text-brand-accent">
+          + Add window
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -34,6 +34,7 @@ const settingsNav: NavItem[] = [
   },
   { to: '/apps',       label: 'Apps',       icon: '◳', adminOnly: true },
   { to: '/blocklists', label: 'Blocklists', icon: '⊘', adminOnly: true },
+  { to: '/schedules',  label: 'Schedules',  icon: '◷', adminOnly: true },
   { to: '/global-policy', label: 'Global Policy', icon: '🌐', adminOnly: true },
   { to: '/users',   label: 'Users',   icon: '◐', adminOnly: true },
   { to: '/routers', label: 'Routers', icon: '⬢', adminOnly: true },

--- a/web/src/pages/SchedulesPage.test.tsx
+++ b/web/src/pages/SchedulesPage.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('@/api/client', () => ({
+  api: {
+    schedules: {
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    profiles: {
+      list: vi.fn(),
+    },
+  },
+}))
+
+import { api } from '@/api/client'
+import type { NamedSchedule, ProfileDetail } from '@/types/api'
+import { SchedulesPage } from './SchedulesPage'
+import { withQuery } from '@/test/queryWrapper'
+
+const bedtime: NamedSchedule = {
+  id: 1, name: 'Bedtime', description: 'overnight',
+  windows: [{ days: ['mon', 'tue'], startLocal: '20:00', endLocal: '07:00', tz: 'UTC' }],
+}
+const school: NamedSchedule = {
+  id: 2, name: 'School hours', description: null,
+  windows: [{ days: ['mon', 'tue', 'wed', 'thu', 'fri'], startLocal: '08:00', endLocal: '15:00', tz: 'UTC' }],
+}
+
+// Kids references Bedtime (id 1); Adults references nothing.
+const kids = {
+  profile: { id: 10, name: 'Kids', blockedCategories: [], paused: false },
+  schedules: [], timeLimit: null, scheduleIds: [1],
+} as unknown as ProfileDetail
+const adults = {
+  profile: { id: 11, name: 'Adults', blockedCategories: [], paused: false },
+  schedules: [], timeLimit: null, scheduleIds: [],
+} as unknown as ProfileDetail
+
+const fn = (f: unknown) => f as unknown as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  fn(api.schedules.list).mockResolvedValue([bedtime, school])
+  fn(api.profiles.list).mockResolvedValue([kids, adults])
+  fn(api.schedules.create).mockResolvedValue({ id: 3, name: 'Afternoon', description: null, windows: [] })
+  fn(api.schedules.update).mockResolvedValue({ ...bedtime })
+  fn(api.schedules.delete).mockResolvedValue(undefined)
+})
+
+describe('SchedulesPage (#1069) — list', () => {
+  it('renders household schedules with their names', async () => {
+    render(withQuery(<SchedulesPage />))
+    expect(await screen.findByDisplayValue('Bedtime')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('School hours')).toBeInTheDocument()
+  })
+
+  it('shows which profiles reference a schedule', async () => {
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('Bedtime')
+    expect(screen.getByTestId('schedule-refs-1')).toHaveTextContent(/Kids/)
+    // School hours is referenced by nobody → no refs line
+    expect(screen.queryByTestId('schedule-refs-2')).not.toBeInTheDocument()
+  })
+})
+
+describe('SchedulesPage (#1069) — create', () => {
+  it('creates a named schedule via the API', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('Bedtime')
+
+    await user.click(screen.getByTestId('schedules-new'))
+    await user.type(screen.getByTestId('schedule-create-name'), 'Afternoon')
+    await user.click(screen.getByTestId('schedule-create-submit'))
+
+    await waitFor(() => expect(api.schedules.create).toHaveBeenCalledTimes(1))
+    const arg = fn(api.schedules.create).mock.calls[0][0]
+    expect(arg.name).toBe('Afternoon')
+    expect(Array.isArray(arg.windows)).toBe(true)
+  })
+
+  it('blocks create with an empty name', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('Bedtime')
+    await user.click(screen.getByTestId('schedules-new'))
+    await user.click(screen.getByTestId('schedule-create-submit'))
+    expect(api.schedules.create).not.toHaveBeenCalled()
+    expect(screen.getByTestId('schedule-create-error')).toBeInTheDocument()
+  })
+})
+
+describe('SchedulesPage (#1069) — edit (autosave)', () => {
+  it('autosaves a renamed schedule via PATCH with the full shape', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('Bedtime')
+
+    const input = screen.getByTestId('schedule-name-1')
+    await user.clear(input)
+    await user.type(input, 'Lights out')
+
+    await waitFor(() => expect(api.schedules.update).toHaveBeenCalled(), { timeout: 2000 })
+    const calls = fn(api.schedules.update).mock.calls
+    const [id, body] = calls[calls.length - 1]
+    expect(id).toBe(1)
+    expect(body.name).toBe('Lights out')
+    expect(Array.isArray(body.windows)).toBe(true)
+  })
+})
+
+describe('SchedulesPage (#1069) — delete', () => {
+  it('deletes an unreferenced schedule after confirm', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('School hours')
+
+    await user.click(screen.getByTestId('schedule-delete-2'))
+    // confirm box appears (no reference warning for School hours)
+    expect(screen.getByTestId('schedule-delete-confirm-2')).toBeInTheDocument()
+    await user.click(screen.getByTestId('schedule-delete-confirm-yes-2'))
+
+    await waitFor(() => expect(api.schedules.delete).toHaveBeenCalledWith(2))
+  })
+
+  it('guards deletion of a referenced schedule with a warning', async () => {
+    const user = userEvent.setup()
+    render(withQuery(<SchedulesPage />))
+    await screen.findByDisplayValue('Bedtime')
+
+    await user.click(screen.getByTestId('schedule-delete-1'))
+    const confirm = screen.getByTestId('schedule-delete-confirm-1')
+    // The warning names the referencing profile so deletion isn't silent.
+    expect(confirm).toHaveTextContent(/Kids/)
+    // Not deleted until the operator confirms past the warning.
+    expect(api.schedules.delete).not.toHaveBeenCalled()
+    await user.click(screen.getByTestId('schedule-delete-confirm-yes-1'))
+    await waitFor(() => expect(api.schedules.delete).toHaveBeenCalledWith(1))
+  })
+})

--- a/web/src/pages/SchedulesPage.tsx
+++ b/web/src/pages/SchedulesPage.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useRef, useState } from 'react'
+import { api } from '@/api/client'
+import { useNamedSchedules, useProfiles, useInvalidators } from '@/api/queries'
+import { useDebouncedSave } from '@/hooks/useDebouncedSave'
+import { SaveStatusBadge } from '@/components/SaveStatusBadge'
+import { EmptyState } from '@/components/EmptyState'
+import { ScheduleWindowsEditor, emptyWindow } from '@/components/ScheduleWindowsEditor'
+import { browserTimezone } from '@/components/TimezonePicker'
+import type { NamedSchedule, ProfileDetail, ScheduleWindow } from '@/types/api'
+import { PageLoader } from './DashboardPage'
+
+// #1069 — Schedules management page. Household-scoped named schedules are the
+// reusable time-window primitive ("Bedtime", "School hours") that profiles
+// (today) and per-app rules / blocklists (next) reference by id. Editing a
+// schedule here reflects everywhere that references it on the next snapshot
+// rebuild — the API folds the active windows into the per-MAC BlockRules; the
+// router never sees schedules (see AGENTS.md "Architectural model").
+//
+// Edits autosave (#995/#423) via PATCH carrying the full schedule shape.
+// Deleting a referenced schedule cascade-removes its references server-side, so
+// the delete is guarded behind a warning listing the profiles that use it.
+export function SchedulesPage() {
+  const { data: schedules, isLoading } = useNamedSchedules()
+  const { data: profiles } = useProfiles()
+  const invalidators = useInvalidators()
+  const [creating, setCreating] = useState(false)
+
+  if (isLoading || !schedules) return <PageLoader />
+
+  const refsByScheduleId = referencesByScheduleId(profiles ?? [])
+
+  return (
+    <div className="space-y-6" data-testid="schedules-page">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold text-brand-ink">Schedules</h1>
+          <p className="text-sm text-brand-text-muted mt-1">
+            Reusable named time windows. Define <strong>Bedtime</strong> once and reference it from
+            profiles, apps, and blocklists — edit it here and every reference updates.
+          </p>
+        </div>
+        {!creating && (
+          <button type="button"
+            onClick={() => setCreating(true)}
+            data-testid="schedules-new"
+            className="shrink-0 text-sm bg-brand-accent text-white px-3 py-2 rounded-lg">
+            + New schedule
+          </button>
+        )}
+      </div>
+
+      {creating && (
+        <CreateScheduleCard
+          onCancel={() => setCreating(false)}
+          onCreated={() => { setCreating(false); void invalidators.schedules() }}
+        />
+      )}
+
+      {schedules.length === 0 && !creating ? (
+        <EmptyState
+          data-testid="schedules-empty"
+          title="No schedules yet"
+          hint="Create a named schedule like “Bedtime” or “School hours” to reuse across profiles."
+        />
+      ) : (
+        <div className="space-y-4">
+          {schedules.map(s => (
+            <ScheduleCard
+              key={s.id}
+              schedule={s}
+              referencedBy={refsByScheduleId.get(s.id) ?? []}
+              onChanged={() => invalidators.schedules()}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Profiles that reference a given schedule id (via ProfileDetail.scheduleIds).
+// Apps / blocklists gain references as those surfaces land (#1380 / #1067);
+// they slot in here the same way.
+function referencesByScheduleId(profiles: ProfileDetail[]): Map<number, string[]> {
+  const m = new Map<number, string[]>()
+  for (const pd of profiles) {
+    for (const sid of pd.scheduleIds ?? []) {
+      const list = m.get(sid) ?? []
+      list.push(pd.profile.name)
+      m.set(sid, list)
+    }
+  }
+  return m
+}
+
+interface ScheduleForm {
+  name: string
+  description: string
+  windows: ScheduleWindow[]
+}
+
+function formFrom(s: NamedSchedule): ScheduleForm {
+  return { name: s.name, description: s.description ?? '', windows: s.windows }
+}
+
+function ScheduleCard({
+  schedule, referencedBy, onChanged,
+}: {
+  schedule: NamedSchedule
+  referencedBy: string[]
+  onChanged: () => void
+}) {
+  const [form, setForm] = useState<ScheduleForm>(() => formFrom(schedule))
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  // Resync from server when there are no pending local edits.
+  const baselineRef = useRef<ScheduleForm>(form)
+  const formRef = useRef<ScheduleForm>(form)
+  formRef.current = form
+  useEffect(() => {
+    const incoming = formFrom(schedule)
+    if (formsEqual(formRef.current, baselineRef.current) && !formsEqual(formRef.current, incoming)) {
+      setForm(incoming)
+    }
+    baselineRef.current = incoming
+  }, [schedule])
+
+  const { status, error, retry } = useDebouncedSave(
+    form,
+    async (v) => {
+      await api.schedules.update(schedule.id, {
+        name: v.name.trim(),
+        description: v.description.trim() || null,
+        windows: v.windows,
+      })
+      onChanged()
+    },
+    { key: schedule.id, equals: formsEqual },
+  )
+
+  const nameInvalid = form.name.trim() === ''
+
+  async function doDelete() {
+    setDeleteError(null)
+    try {
+      await api.schedules.delete(schedule.id)
+      onChanged()
+    } catch (e) {
+      setDeleteError(e instanceof Error ? e.message : 'Failed to delete')
+    }
+  }
+
+  return (
+    <div
+      data-testid={`schedule-card-${schedule.id}`}
+      className="bg-white border border-brand-border rounded-xl p-4 space-y-3">
+      <div className="flex items-center gap-3">
+        <input type="text"
+          value={form.name}
+          onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+          placeholder="Schedule name"
+          data-testid={`schedule-name-${schedule.id}`}
+          className={`flex-1 bg-white border rounded-lg px-3 py-2 text-brand-ink text-sm font-semibold ${
+            nameInvalid ? 'border-red-500' : 'border-brand-border-strong'
+          }`} />
+        <SaveStatusBadge status={status} error={error} onRetry={retry}
+          testId={`schedule-save-${schedule.id}`} />
+        <button type="button"
+          onClick={() => setConfirmDelete(true)}
+          data-testid={`schedule-delete-${schedule.id}`}
+          className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 py-2 rounded-lg">
+          Delete
+        </button>
+      </div>
+
+      <input type="text"
+        value={form.description}
+        onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+        placeholder="Description (optional)"
+        data-testid={`schedule-description-${schedule.id}`}
+        className="w-full bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm" />
+
+      <ScheduleWindowsEditor
+        windows={form.windows}
+        onChange={ws => setForm(f => ({ ...f, windows: ws }))}
+        testId={`schedule-windows-${schedule.id}`}
+        defaultTz={form.windows[0]?.tz ?? browserTimezone()}
+      />
+
+      {referencedBy.length > 0 && (
+        <p className="text-xs text-brand-text-muted" data-testid={`schedule-refs-${schedule.id}`}>
+          Used by {referencedBy.length} profile{referencedBy.length === 1 ? '' : 's'}: {referencedBy.join(', ')}
+        </p>
+      )}
+
+      {confirmDelete && (
+        <div
+          data-testid={`schedule-delete-confirm-${schedule.id}`}
+          className="bg-red-500/10 border border-red-500/30 rounded-lg p-3 space-y-2">
+          <p className="text-xs text-red-700">
+            {referencedBy.length > 0
+              ? `“${schedule.name}” is used by ${referencedBy.join(', ')}. Deleting it removes that downtime from ${referencedBy.length === 1 ? 'that profile' : 'those profiles'}. Continue?`
+              : `Delete “${schedule.name}”? This can't be undone.`}
+          </p>
+          {deleteError && <p className="text-xs text-red-700">{deleteError}</p>}
+          <div className="flex gap-2">
+            <button type="button"
+              onClick={doDelete}
+              data-testid={`schedule-delete-confirm-yes-${schedule.id}`}
+              className="text-xs bg-red-600 text-white px-3 py-2 rounded-lg">
+              Delete schedule
+            </button>
+            <button type="button"
+              onClick={() => { setConfirmDelete(false); setDeleteError(null) }}
+              data-testid={`schedule-delete-confirm-no-${schedule.id}`}
+              className="text-xs text-brand-text-muted hover:text-brand-ink px-3 py-2 rounded-lg">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CreateScheduleCard({
+  onCancel, onCreated,
+}: {
+  onCancel: () => void
+  onCreated: () => void
+}) {
+  const tz = browserTimezone()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [windows, setWindows] = useState<ScheduleWindow[]>(() => [emptyWindow(tz)])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function create() {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Name is required')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await api.schedules.create({
+        name: trimmed,
+        description: description.trim() || null,
+        windows,
+      })
+      onCreated()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create schedule')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="schedule-create-card"
+      className="bg-white border border-brand-border rounded-xl p-4 space-y-3">
+      <h2 className="text-sm font-semibold text-brand-ink">New schedule</h2>
+      <input type="text"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Schedule name (e.g. Bedtime)"
+        data-testid="schedule-create-name"
+        className="w-full bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm" />
+      <input type="text"
+        value={description}
+        onChange={e => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        data-testid="schedule-create-description"
+        className="w-full bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm" />
+      <ScheduleWindowsEditor
+        windows={windows}
+        onChange={setWindows}
+        testId="schedule-create-windows"
+        defaultTz={tz}
+      />
+      {error && <p className="text-xs text-red-700" data-testid="schedule-create-error">{error}</p>}
+      <div className="flex gap-2">
+        <button type="button"
+          onClick={create}
+          disabled={saving}
+          data-testid="schedule-create-submit"
+          className="text-xs bg-brand-accent text-white px-3 py-2 rounded-lg disabled:opacity-60">
+          {saving ? 'Creating…' : 'Create schedule'}
+        </button>
+        <button type="button"
+          onClick={onCancel}
+          data-testid="schedule-create-cancel"
+          className="text-xs text-brand-text-muted hover:text-brand-ink px-3 py-2 rounded-lg">
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function formsEqual(a: ScheduleForm, b: ScheduleForm): boolean {
+  return (
+    a.name === b.name &&
+    a.description === b.description &&
+    a.windows.length === b.windows.length &&
+    a.windows.every((w, i) => {
+      const o = b.windows[i]
+      return (
+        w.startLocal === o.startLocal &&
+        w.endLocal === o.endLocal &&
+        w.tz === o.tz &&
+        w.days.length === o.days.length &&
+        w.days.every((d, j) => d === o.days[j])
+      )
+    })
+  )
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -42,6 +42,34 @@ export interface Schedule {
   tz: string          // IANA timezone, e.g. "America/Los_Angeles"
 }
 
+// #1069 — household-scoped reusable named schedule. One named schedule owns
+// one or more windows; anything time-bound (profiles today, per-app rules
+// #1380, blocklists #1067 next) references it by id. This is the SPA mirror of
+// the API's `NamedSchedule` — it never reaches the router wire; PolicyService
+// folds the active windows into the per-MAC BlockRules at snapshot time.
+export interface ScheduleWindow {
+  days: string[]      // lowercase 3-letter tokens: "mon".."sun"
+  startLocal: string  // "HH:mm" wall-clock time in `tz`
+  endLocal: string    // "HH:mm" wall-clock time in `tz`
+  tz: string          // IANA timezone, e.g. "America/Los_Angeles"
+}
+
+export interface NamedSchedule {
+  id: number
+  name: string
+  description: string | null
+  windows: ScheduleWindow[]
+}
+
+// Create/update bodies for the /api/schedules CRUD. `windows` is the full
+// desired set (replace semantics) — matches the API's
+// Create/UpdateNamedScheduleRequest.
+export interface NamedScheduleRequest {
+  name: string
+  description?: string | null
+  windows: ScheduleWindow[]
+}
+
 // #714 — server-side heartbeat filter for device/profile screen-time totals.
 // Rows classified as heartbeats are excluded from rollups; the filter is
 // household-wide.
@@ -86,6 +114,10 @@ export interface ProfileDetail {
   profile: Profile
   schedules: Schedule[]
   timeLimit: TimeLimit | null
+  // #1069 — ids of the household named schedules attached to this profile as
+  // block schedules (downtime while active). Empty until the operator attaches
+  // one. Optional for back-compat with older API responses that omit it.
+  scheduleIds?: number[]
 }
 
 export interface Device {


### PR DESCRIPTION
Completes the **SPA half of #1069** (household-scoped reusable named schedules). The DB (V50, #1428) and the full API — model, CRUD, snapshot expansion, seed (#1438) — are already merged; this is the remaining §SPA section.

## What's here

### Schedules management page (Advanced → Schedules, admin)
- List / create / edit / delete household named schedules ("Bedtime", "School hours", …).
- Each schedule has a **windows editor** — one or more `{ days, from, to, tz }` windows, matching the API's `ScheduleWindow` shape.
- **Edits autosave** via `PATCH /api/schedules/{id}` carrying the full schedule shape (replace semantics), per the autosave default (#995/#423) and the symmetric-shape pattern.
- **Delete is guarded if referenced.** A schedule used by a profile shows a confirmation that names the referencing profiles before deleting (the server cascade-removes the references, so a silent delete would quietly drop downtime).

### Reusable `SchedulePicker` dropdown
- Household schedules + **"Always"** (value `null`) + **"Custom (define inline)"**.
- **Design decision** (the issue defers this to the implementation): "Custom" **transparently creates a household-scoped named schedule** rather than an inline-only one. Rationale — #1069's whole point is that a schedule is a single shared primitive ("edit bedtime once, it changes everywhere"). An inline-only window would fork the model and re-introduce the per-reference window editing this issue exists to remove. The inline form authors a real named schedule (it then appears on the Schedules page and is reusable) and the picker emits its new id.
- This is the component **#1380** (per-app schedule rules) and **#1067** (blocklist schedules) consume.

### Shared `ScheduleWindowsEditor`
Window-list editor (days toggles + local start/end + tz) used by both the management page and the picker's inline-custom form, so the two author windows identically.

## API / wire
Adds `api.schedules.{list,create,update,delete}` + a `useNamedSchedules` TanStack query and an `invalidators.schedules()` helper, plus the `NamedSchedule` / `ScheduleWindow` / `NamedScheduleRequest` TS types and `ProfileDetail.scheduleIds`. **No router/snapshot wire change** — schedules never reach the snapshot; PolicyService folds active windows into the per-MAC `BlockRules` server-side. No Scala touched.

## Coordination with #1380 / PR #1481
PR #1481 (per-app schedule rule editor, still open) **deferred inline-create** and inlined its own picker that only selects existing schedules, noting "inline create + window authoring should land with the #1069 web surface." This PR is that surface. Once both merge, #1481 should rebase onto this and consume `SchedulePicker` instead of its inline picker, and drop its duplicate `api.schedules.create` / `useNamedSchedules` additions. I'll leave a coordination note on #1481.

## Tests (TDD, red→green in history)
- `web/src/components/SchedulePicker.test.tsx` — renders schedules + Always + Custom; each selection yields the right value; inline-custom creates a household schedule and emits its id; empty-name guard.
- `web/src/pages/SchedulesPage.test.tsx` — list, create, autosave-rename (PATCH full shape), delete unreferenced, and the referenced-delete warning.

Full web suite green (376 tests), `tsc --noEmit` clean, eslint clean.

Closes #1069 (this completes its SPA half; the DB/API are already merged). Unblocks #1380.