### PR TITLE
feat(#1465): session-stitch per-app presence + heartbeat-filter per-host/per-site surfaces

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -362,6 +362,7 @@ object Main extends ZIOAppDefault {
             profileRepo,
             appRepo,
             rollupRepo2,
+            hsRepo,
             clock,
           ) ++
           DashboardNowRoutes.routes(

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -338,7 +338,8 @@ class PolicyServiceLive(
                       else {
                         val pPres      = pres.filter(r => macs.contains(r.mac))
                         val patterns   = stlims.map(_.domainPattern)
-                        val perPat     = Presence.patternMinutesByMac(pPres, patterns)
+                        val perPat     =
+                          Presence.patternMinutesByMac(pPres, patterns, settings.heartbeatFilter)
                         val byDomain   = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
                           val mins = devs.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
                           if mins == 0 then acc else acc.updated(pat, mins)

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -399,8 +399,8 @@ object TimeStatusService {
       now: Instant,
       settings: HouseholdSettings,
   ): ProfileDayState = {
-    val patterns         = siteLimits.map(_.domainPattern)
-    val perPat           = Presence.patternMinutesByMac(presence, patterns)
+    val patterns = siteLimits.map(_.domainPattern)
+    val perPat   = Presence.patternMinutesByMac(presence, patterns, settings.heartbeatFilter)
     val totalSecondsUsed = usedSecondsForProfile(profile, devices, siteLimits, presence, settings)
     val totalMinutesUsed = (totalSecondsUsed / 60L).toInt
 

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -1,6 +1,6 @@
 package wifihaven.api.presence
 
-import wifihaven.shared.HeartbeatFilter
+import wifihaven.shared.{CrossDeviceOverlapMode, HeartbeatFilter}
 import wifihaven.shared.types.*
 import java.time.{Instant, LocalDate}
 
@@ -51,6 +51,60 @@ object Presence {
 
   private def bucketSeconds(bucket: Iterable[PresenceRow]): Long =
     bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
+
+  /**
+   * Default idle/continuation gap `N` in seconds (design §4.1, recommended 120 s, constraint `N ≥ 2
+   * × R`).
+   *
+   * NOTE (#1465 / #1464 coordination): this constant is provisional. The design (§4.6) puts the
+   * configurable knob in `household_settings.presence_continuation_seconds` (migration V52, #1463),
+   * and the sibling rollup PR #1464 threads it from settings into the daily-cap path and the
+   * `time_used_daily` invalidation hook. Until that lands, the per-app/per-host surfaces here read
+   * the default; the call sites pass `continuationSeconds` explicitly once #1464 wires settings
+   * through. Reconcile this constant with #1464's session primitive at merge.
+   */
+  val DefaultContinuationSeconds: Long = 120L
+
+  /** A half-open activity interval `[start, end)` in epoch seconds. */
+  final case class Interval(start: Long, end: Long) {
+    def seconds: Long = math.max(0L, end - start)
+  }
+
+  /**
+   * A `traffic_reports` row's activity interval: `[period_start, period_start + period_seconds)`.
+   */
+  private def rowInterval(r: PresenceRow): Interval = {
+    val s = r.periodStart.getEpochSecond
+    Interval(s, s + r.periodSeconds.toLong)
+  }
+
+  /**
+   * §4.1 session-stitch: fold time-ordered activity intervals into sessions, bridging idle gaps of
+   * at most `gapSeconds` (the continuation gap `N`). Returns the disjoint merged session intervals
+   * in start order. Two intervals join when the later one starts no more than `N` after the earlier
+   * one ends; a gap longer than `N` closes the session. Overlapping or touching intervals always
+   * merge (gap ≤ 0 ≤ N), so `gapSeconds = 0` yields a plain interval union.
+   *
+   * Reading the gap from `period_start` (never assuming a fixed report rate `R`) is what makes the
+   * §4.4-1 invariant hold: when `N < R` contiguous-but-point-anchored windows do not merge and
+   * presence correctly reflects the data instead of a rate-assumed constant.
+   *
+   * NOTE: provisional in #1465 pending #1464, which introduces the canonical primitive in this same
+   * file — reconcile at merge (see [[DefaultContinuationSeconds]]).
+   */
+  def stitchSessions(intervals: Iterable[Interval], gapSeconds: Long): List[Interval] =
+    intervals.toList
+      .sortBy(_.start)
+      .foldLeft(List.empty[Interval]) {
+        case (cur :: rest, iv) if iv.start - cur.end <= gapSeconds =>
+          Interval(cur.start, math.max(cur.end, iv.end)) :: rest
+        case (acc, iv)                                             =>
+          iv :: acc
+      }
+      .reverse
+
+  private def sessionSeconds(intervals: Iterable[Interval], gapSeconds: Long): Long =
+    stitchSessions(intervals, gapSeconds).iterator.map(_.seconds).sum
 
   /**
    * Per-mac total active-seconds for the day, summing each bucket's max activeSeconds
@@ -128,11 +182,14 @@ object Presence {
     (dedupedTotalSeconds(rows, exemptPatterns, filter) / 60).toInt
 
   /**
-   * #714 heartbeat classification, applied ONLY inside `totalSecondsByMac`/`totalMinutesByMac`.
-   * Per-site (`patternMinutesByMac`) and per-host (`hostMinutes`) breakdowns intentionally do not
-   * filter — heartbeats keep counting for per-site time for now; the operator wants to evaluate
-   * that separately. A row is classified as a heartbeat if the filter is enabled and total bytes
-   * are below `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few hundred).
+   * #714 heartbeat classification. As of #1465 the filter applies to every presence surface — the
+   * daily total (`totalSecondsByMac`/`totalMinutesByMac`), the per-site breakdown
+   * (`patternMinutesByMac`) and the per-host/per-app breakdown (`hostMinutes`,
+   * `proportionalHostSeconds`) — so keepalives no longer inflate per-site time or per-app presence
+   * (design §4.2). Each surface takes a `filter` argument (default `Off`); callers pass
+   * `settings.heartbeatFilter`. A row is classified as a heartbeat if the filter is enabled and
+   * total bytes are below `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a
+   * few hundred) or its FQDN matches a heartbeat host pattern.
    */
   def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
     filter.enabled && (
@@ -173,13 +230,16 @@ object Presence {
    * the bucket matches the pattern. Two hosts that both match the same pattern in one bucket still
    * only contribute one bucket's worth of time; the same host matching two patterns contributes one
    * bucket's worth to each (per-pattern caps are independent). IP-literal hosts never match
-   * patterns.
+   * patterns. Heartbeat rows are stripped first (#1465) so a keepalive run never ticks a per-site
+   * cap.
    */
   def patternMinutesByMac(
       rows: List[PresenceRow],
       patterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
   ): Map[(MacAddress, String), Int] = {
-    val buckets = rows.groupBy(r => (r.mac, r.periodStart)).toList
+    val buckets =
+      rows.filterNot(r => isHeartbeat(r, filter)).groupBy(r => (r.mac, r.periodStart)).toList
     val accum   = scala.collection.mutable.Map.empty[(MacAddress, String), Long]
     for {
       pat                <- patterns
@@ -194,11 +254,19 @@ object Presence {
    * the bucket once. Used for the per-profile "what did they spend time on today" breakdown (#262).
    * Note: summing across hosts can exceed the device's daily total — by design, the same bucket of
    * activity contributes its full duration to each host the device touched in that window. The
-   * daily cap still counts the bucket once via `totalMinutesByMac`.
+   * daily cap still counts the bucket once via `totalMinutesByMac`. Heartbeat rows are stripped
+   * first (#1465) so keepalive-only hosts don't pad the per-host breakdown.
    */
-  def hostMinutes(rows: List[PresenceRow]): Map[HostId, Int] = {
+  def hostMinutes(
+      rows: List[PresenceRow],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+  ): Map[HostId, Int] = {
     val accum = scala.collection.mutable.Map.empty[HostId, Long]
-    for ((_, bucket) <- rows.groupBy(r => (r.mac, r.periodStart))) {
+    for (
+      (_, bucket) <- rows
+        .filterNot(r => isHeartbeat(r, filter))
+        .groupBy(r => (r.mac, r.periodStart))
+    ) {
       val secs  = bucketSeconds(bucket)
       val hosts = bucket.iterator.map(_.host).toSet
       for (h <- hosts)
@@ -208,36 +276,69 @@ object Presence {
   }
 
   /**
-   * #715: per-host seconds attributed by byte share within each (mac, period_start) bucket. Each
-   * bucket's wall-clock duration is split across the hosts present in proportion to their share of
-   * the bucket's total bytes (bytes_in + bytes_out). Summing across hosts within one mac's bucket ≈
-   * the bucket duration, so this is a much fairer "wall-clock attention" number than
-   * [[hostMinutes]] (which credits every host the device touched with the bucket's full duration).
+   * #1465: per-host (per-app) presence seconds via session-stitch (design §4.2) — the successor to
+   * the #715 byte-share attribution. For each host (the "app"):
    *
-   * Note: when a bucket carries multiple rows for the same host (e.g. two ipv4-typed rows resolving
-   * to the same fqdn via the read-side LATERAL join), their bytes are summed before the share is
-   * computed so the same host doesn't get a double weight. If the bucket has zero total bytes (an
-   * edge case — the agent only emits records with bytes>0), the bucket is skipped entirely.
+   *   1. Per device, union *that host's* sessions on that device — non-heartbeat activity stitched
+   *      on the idle gap `continuationSeconds` (one device can't be on the host twice at once). 2.
+   *      Combine across the profile's devices by `overlap`: `Sum` (default) adds the per-device
+   *      per-host seconds — same host on two devices double-counts; `Dedup` unions that host's
+   *      intervals across devices so overlap counts once.
+   *
+   * Heartbeat rows are dropped *before* stitching (§4.4-2), so a keepalive window can neither start
+   * nor extend a session; the idle gap bridges across a keepalive only when real sessions sit
+   * within `N` on each side. This replaces byte-share weighting as the keepalive-stripping
+   * mechanism, so a chatty poller no longer shows up at all rather than being weighted down to ~0.
+   *
+   * This is what a future per-app time limit (#127/#301/#64) reads. The per-profile daily total is
+   * NOT the sum of these per-host numbers — within a device, different hosts overlap; the total has
+   * its own (per-device, all-host) union (see `totalSecondsByMac`/`dedupedTotalSeconds`).
+   *
+   * `continuationSeconds` defaults to [[DefaultContinuationSeconds]]; callers thread the configured
+   * `household_settings.presence_continuation_seconds` once #1464 wires it (see the note on
+   * [[DefaultContinuationSeconds]]).
    */
-  def proportionalHostSeconds(rows: List[PresenceRow]): Map[HostId, Double] = {
-    val accum = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, bucket) <- rows.groupBy(r => (r.mac, r.periodStart))) {
-      val secs   = bucketSeconds(bucket).toDouble
-      val byHost = bucket.iterator
-        .map(r => r.host -> r.bytes)
-        .toList
-        .groupMapReduce(_._1)(_._2)(_ + _)
-      val total  = byHost.valuesIterator.sum
-      if (secs > 0.0 && total > 0L)
-        for ((h, b) <- byHost) {
-          val share = b.toDouble / total.toDouble
-          accum.updateWith(h)(prev => Some(prev.getOrElse(0.0) + secs * share))
-        }
+  def proportionalHostSeconds(
+      rows: List[PresenceRow],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Long = DefaultContinuationSeconds,
+  ): Map[HostId, Long] = {
+    // per (device, host) → that host's stitched sessions on that device.
+    val perDeviceHost: Map[(MacAddress, HostId), List[Interval]] =
+      rows
+        .filterNot(r => isHeartbeat(r, filter))
+        .groupBy(r => (r.mac, r.host))
+        .view
+        .mapValues(rs => stitchSessions(rs.map(rowInterval), continuationSeconds))
+        .toMap
+    overlap match {
+      case CrossDeviceOverlapMode.Sum   =>
+        // add per-device per-host session seconds across devices.
+        perDeviceHost.iterator
+          .map { case ((_, h), ivs) => h -> ivs.iterator.map(_.seconds).sum }
+          .toList
+          .groupMapReduce(_._1)(_._2)(_ + _)
+      case CrossDeviceOverlapMode.Dedup =>
+        // union that host's intervals across devices (overlap counts once).
+        perDeviceHost.iterator
+          .map { case ((_, h), ivs) => h -> ivs }
+          .toList
+          .groupMapReduce(_._1)(_._2)(_ ++ _)
+          .view
+          .mapValues(ivs => sessionSeconds(ivs, 0L))
+          .toMap
     }
-    accum.toMap
   }
 
   /** Convenience: floor-divided minute view of [[proportionalHostSeconds]]. */
-  def proportionalHostMinutes(rows: List[PresenceRow]): Map[HostId, Int] =
-    proportionalHostSeconds(rows).view.mapValues(s => (s / 60).toInt).toMap
+  def proportionalHostMinutes(
+      rows: List[PresenceRow],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Long = DefaultContinuationSeconds,
+  ): Map[HostId, Int] =
+    proportionalHostSeconds(rows, overlap, filter, continuationSeconds).view
+      .mapValues(s => (s / 60).toInt)
+      .toMap
 }

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -929,8 +929,14 @@ object TimeRoutes {
       // with zero presence are dropped so the top-10 list isn't padded by
       // hosts that exist only because the bucket touched them at all.
       hostUsage       = {
-        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
-        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        val presenceMins =
+          wifihaven.api.presence.Presence.hostMinutes(presence, settings.heartbeatFilter)
+        val proportional = wifihaven.api.presence.Presence
+          .proportionalHostMinutes(
+            presence,
+            profile.crossDeviceOverlapMode,
+            settings.heartbeatFilter,
+          )
         presenceMins.iterator
           .filter(_._2 > 0)
           .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
@@ -991,8 +997,9 @@ object TimeRoutes {
         DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
       }
       hostUsage       = {
-        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
-        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence, heartbeatFilter)
+        val proportional = wifihaven.api.presence.Presence
+          .proportionalHostMinutes(presence, profile.crossDeviceOverlapMode, heartbeatFilter)
         presenceMins.iterator
           .filter(_._2 > 0)
           .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
@@ -1043,8 +1050,10 @@ object TimeRoutes {
         .totalMinutesByMac(presence, Nil, heartbeatFilter)
       totalUsed = perMac.getOrElse(device.mac, 0)
       hostUsage = {
-        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence)
-        val proportional = wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        val presenceMins = wifihaven.api.presence.Presence.hostMinutes(presence, heartbeatFilter)
+        // Per-device path: only one mac in play, so Sum/Dedup are equivalent.
+        val proportional = wifihaven.api.presence.Presence
+          .proportionalHostMinutes(presence, CrossDeviceOverlapMode.Sum, heartbeatFilter)
         presenceMins.iterator
           .filter(_._2 > 0)
           .map { case (h, m) => HostUsage(h, m, proportional.getOrElse(h, 0)) }
@@ -1164,6 +1173,7 @@ object TimeRoutes {
         .patternMinutesByMac(
           presence,
           stateOpt.toList.flatMap(_.perSite.map(_.domainPattern)),
+          settings.heartbeatFilter,
         )
       siteUsage  = stateOpt.toList.flatMap(_.perSite).map { s =>
         val used = perPat.getOrElse((device.mac, s.domainPattern), 0)

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -25,6 +25,7 @@ object UsageRoutes {
       profileRepo: ProfileRepo,
       appRepo: AppRepo,
       rollupRepo: RollupRepo,
+      hsRepo: HouseholdSettingsRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -109,16 +110,17 @@ object UsageRoutes {
             today  <- clock.today
             fromS = req.url.queryParam("from").getOrElse(today.toString)
             toS   = req.url.queryParam("to").getOrElse(fromS)
-            from <- ZIO
+            from     <- ZIO
               .attempt(LocalDate.parse(fromS))
               .orElseFail(Response.badRequest(s"invalid from: $fromS"))
-            to   <- ZIO
+            to       <- ZIO
               .attempt(LocalDate.parse(toS))
               .orElseFail(Response.badRequest(s"invalid to: $toS"))
-            _    <- ZIO
+            _        <- ZIO
               .fail(Response.badRequest("from must be <= to"))
               .when(from.isAfter(to))
-            resp <- buildUsageByApp(
+            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            resp     <- buildUsageByApp(
               pid,
               from,
               to,
@@ -126,6 +128,7 @@ object UsageRoutes {
               deviceRepo,
               trafficRepo,
               appRepo,
+              settings.heartbeatFilter,
             )
           } yield Response.json(resp.toJson)
         },
@@ -324,6 +327,7 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       appRepo: AppRepo,
+      filter: HeartbeatFilter,
   ): IO[Response, ProfileUsageByApp] =
     for {
       profile <- profileRepo
@@ -357,23 +361,29 @@ object UsageRoutes {
         h => h.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApex))
       }
 
-      val propByHost    = wifihaven.api.presence.Presence.proportionalHostSeconds(presence)
-      val seenByHost    = wifihaven.api.presence.Presence.hostMinutes(presence)
+      val overlap       = profile.crossDeviceOverlapMode
+      // #1465: per-host presence is now the session-stitch span (heartbeat-filtered),
+      // combined across the profile's devices by its `crossDeviceOverlapMode`.
+      val propByHost    =
+        wifihaven.api.presence.Presence.proportionalHostSeconds(presence, overlap, filter)
+      val seenByHost    = wifihaven.api.presence.Presence.hostMinutes(presence, filter)
       val propMinByHost =
-        wifihaven.api.presence.Presence.proportionalHostMinutes(presence)
+        wifihaven.api.presence.Presence.proportionalHostMinutes(presence, overlap, filter)
 
       val appProp    = scala.collection.mutable.Map.empty[Option[AppId], Long]
       val hostsByApp =
         scala.collection.mutable.Map.empty[Option[AppId], List[HostUsage]]
-      for ((h, secs)   <- propByHost) {
+      for ((h, secs) <- propByHost) {
         val key = appOfHost(h)
-        appProp.updateWith(key)(prev => Some(prev.getOrElse(0L) + secs.round))
+        appProp.updateWith(key)(prev => Some(prev.getOrElse(0L) + secs))
         val hu  = HostUsage(h, seenByHost.getOrElse(h, 0), propMinByHost.getOrElse(h, 0))
         hostsByApp.updateWith(key)(prev => Some(hu :: prev.getOrElse(Nil)))
       }
-      // Per-app bucket-dedup for presence-seconds.
+      // Per-app bucket-dedup for presence-seconds (heartbeat rows stripped, #1465).
       val appPresence = scala.collection.mutable.Map.empty[Option[AppId], Long]
-      for ((_, bucket) <- presence.groupBy(r => (r.mac, r.periodStart))) {
+      val activeRows =
+        presence.filterNot(r => wifihaven.api.presence.Presence.isHeartbeat(r, filter))
+      for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
         val secs = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
         val keys = bucket.iterator.map(r => appOfHost(r.host)).toSet
         for (a <- keys)

--- a/api/test/src/feature/RecentApexesApiSpec.scala
+++ b/api/test/src/feature/RecentApexesApiSpec.scala
@@ -123,6 +123,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       profileRepo     <- ZIO.service[ProfileRepo]
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
+      hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -134,6 +135,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         profileRepo,
         appRepo,
         rollupRepo,
+        hsRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -1005,12 +1005,14 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
           assertTrue(kids.usedMins == 0)         // site usage NOT counted in total
       },
-      test("hostUsage exposes byte-share proportionalMins alongside bucket-presence (#715)") {
+      test("hostUsage: heartbeat filter strips keepalive pollers from per-host surfaces (#1465)") {
         // Reproduce the prod shape from #715: device sat at ~60 used minutes
         // but a per-FQDN bucket-presence breakdown lists 10 polling hosts at
-        // 50–80m each because each was touched in every 5-min bucket. With the
-        // byte-share weight, ~all of the attributed minutes go to the host
-        // that actually moved bytes — the screen-time UI shows that number.
+        // 50–80m each because each was touched in every 5-min bucket. The
+        // per-host/per-site surfaces now apply the same heartbeat filter the
+        // daily total uses (#1465), so the sub-threshold pollers drop out
+        // entirely and `proportionalMins` becomes the host's session span (the
+        // default household settings enable the filter at 10 240 bytes).
         for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
@@ -1099,15 +1101,17 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           ytRow    = kids.hostUsage.find(_.host.value == heavy).get
           pollRows = kids.hostUsage.filter(_.host.value.startsWith("poll-"))
         } yield
-        // Daily cap math unchanged: 12 bucket-deduped × 5 min = 60 mins.
+        // Daily cap math unchanged: 12 bucket-deduped × 5 min = 60 mins (the
+        // mixed bucket still counts because youtube moves real bytes).
         assertTrue(kids.usedMins == 60) &&
-          // Bucket-presence still shows every host at the full 60 minutes.
+          // Bucket-presence shows youtube at the full 60 minutes...
           assertTrue(ytRow.usedMins == 60) &&
-          // Proportional: youtube dominates, pollers are ~0.
-          assertTrue(ytRow.proportionalMins == 59) &&
-          assertTrue(pollRows.forall(_.usedMins == 60)) &&
-          assertTrue(pollRows.forall(_.proportionalMins == 0)) &&
-          // Top of the list sorts by proportional, so youtube is first.
+          // ...and `proportionalMins` is now its session span: 12 contiguous
+          // 5-min windows stitch into one 60-min session.
+          assertTrue(ytRow.proportionalMins == 60) &&
+          // The sub-threshold pollers are filtered out of the per-host surface
+          // entirely — that is the #1465 fix (formerly they showed at 60 mins).
+          assertTrue(pollRows.isEmpty) &&
           assertTrue(kids.hostUsage.head.host.value == heavy)
       },
       test("hostUsage breakdown sums across all profile devices, sorted desc (#262)") {

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -83,6 +83,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       profileRepo     <- ZIO.service[ProfileRepo]
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
+      hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -94,6 +95,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         profileRepo,
         appRepo,
         rollupRepo,
+        hsRepo,
         clock,
       ),
       auth,
@@ -1483,6 +1485,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           _           <- appRepo.setHosts(muId, List(Hostname.unsafe("spotify.com")))
           // 1 bucket on youtube.com (5m), 1 bucket on spotify.com (5m),
           // 1 bucket on google.com (not in any app — falls into Other).
+          // Real-traffic byte volume so the default heartbeat filter (10KB floor,
+          // now applied to per-app surfaces too — #1465) keeps these rows.
           start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
           _  <- trafficRepo.insertBatch(
             List(
@@ -1495,8 +1499,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start,
                 start.plusSeconds(300),
                 300,
-                1000L,
-                1000L,
+                500_000L,
+                500_000L,
               ),
               TrafficReportInsert(
                 routerId,
@@ -1507,8 +1511,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start.plusSeconds(300),
                 start.plusSeconds(600),
                 300,
-                200L,
-                200L,
+                500_000L,
+                500_000L,
               ),
               TrafficReportInsert(
                 routerId,
@@ -1519,8 +1523,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start.plusSeconds(600),
                 start.plusSeconds(900),
                 300,
-                100L,
-                100L,
+                500_000L,
+                500_000L,
               ),
             ),
           )
@@ -1586,8 +1590,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start,
                 start.plusSeconds(300),
                 300,
-                1000L,
-                1000L,
+                500_000L,
+                500_000L,
               ),
             ),
           )
@@ -1642,8 +1646,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start,
                 start.plusSeconds(300),
                 300,
-                1000L,
-                1000L,
+                500_000L,
+                500_000L,
               ),
             ),
           )
@@ -1686,7 +1690,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           _           <- appRepo.setHosts(ytId, List(Hostname.unsafe("youtube.com")))
           _           <- appRepo.setHosts(muId, List(Hostname.unsafe("spotify.com")))
           start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
-          // YouTube: 2 buckets (10m). Music: 1 bucket (5m).
+          // YouTube: 2 buckets (10m). Music: 1 bucket (5m). Real-traffic bytes so
+          // the default heartbeat filter (now on per-app surfaces, #1465) keeps them.
           _  <- trafficRepo.insertBatch(
             List(
               TrafficReportInsert(
@@ -1698,8 +1703,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start,
                 start.plusSeconds(300),
                 300,
-                1L,
-                1L,
+                500_000L,
+                500_000L,
               ),
               TrafficReportInsert(
                 routerId,
@@ -1710,8 +1715,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start.plusSeconds(300),
                 start.plusSeconds(600),
                 300,
-                1L,
-                1L,
+                500_000L,
+                500_000L,
               ),
               TrafficReportInsert(
                 routerId,
@@ -1722,8 +1727,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
                 start.plusSeconds(600),
                 start.plusSeconds(900),
                 300,
-                1L,
-                1L,
+                500_000L,
+                500_000L,
               ),
             ),
           )

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -55,6 +55,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       profileRepo     <- ZIO.service[ProfileRepo]
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
+      hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       clock           <- ZIO.service[Clock]
       auth            <- buildAuth
     } yield (
@@ -66,6 +67,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         profileRepo,
         appRepo,
         rollupRepo,
+        hsRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -88,6 +88,7 @@ object UsageSeriesPerfSpec
       profileRepo     <- ZIO.service[ProfileRepo]
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
+      hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -99,6 +100,7 @@ object UsageSeriesPerfSpec
         profileRepo,
         appRepo,
         rollupRepo,
+        hsRepo,
         clock,
       ),
       auth,

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -1,7 +1,7 @@
 package wifihaven.api.unit
 
 import wifihaven.api.presence.{Presence, PresenceRow}
-import wifihaven.shared.HeartbeatFilter
+import wifihaven.shared.{CrossDeviceOverlapMode, HeartbeatFilter}
 import wifihaven.shared.types.*
 import zio.test.*
 
@@ -49,6 +49,31 @@ object PresenceSpec extends ZIOSpecDefault {
       b(bucket),
       HostId.IPv4(IpAddress.unsafe(ip)),
       secs,
+      bytes,
+      periodSeconds,
+    )
+
+  private val yt = HostId.Fqdn(Hostname.unsafe("youtube.com"))
+
+  /**
+   * #1465: a row at an explicit second offset with an explicit window length, for the
+   * session-stitch surfaces. `period_start` / `period_seconds` drive the activity interval `[start,
+   * start+len)`; `active_seconds` is irrelevant to the session model (it set the old
+   * `max(activeSeconds)` floor), so we just mirror the window length into it.
+   */
+  private def appRow(
+      mac: MacAddress,
+      offsetSec: Long,
+      host: String,
+      periodSeconds: Int,
+      bytes: Long = 1_000_000L,
+  ) =
+    PresenceRow(
+      mac,
+      baseDate,
+      base.plusSeconds(offsetSec),
+      HostId.Fqdn(Hostname.unsafe(host)),
+      periodSeconds,
       bytes,
       periodSeconds,
     )
@@ -340,89 +365,114 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
-    // #715: byte-share-weighted per-host attribution. Same input as hostMinutes,
-    // but each bucket's wall-clock duration is split across hosts by byte share
-    // instead of credited in full to each host.
-    suite("proportionalHostMinutes (#715)")(
-      test("80/20 byte split in a single bucket yields a 4:1 minute attribution") {
+    // #1465: per-app presence is now the union of that app's sessions (the §4.1
+    // session-stitch primitive), replacing the #715 byte-share weighting. Within
+    // a device the sessions are unioned; across devices they combine by the
+    // profile's existing `crossDeviceOverlapMode`. Heartbeat keepalives are
+    // stripped *before* stitching (the byte-share weighting used to do that job).
+    suite("proportionalHostSeconds — session-stitch per-app presence (#1465)")(
+      test("a sparse per-app session reads its full span, not the sampled floor") {
+        // youtube pinged every 60s with 10s windows over 5 minutes. The 50s
+        // think-gaps are < N=120s, so the activity stitches into one continuous
+        // [0, 310s) session — 5 min — instead of 6 × 10s sampled windows (1 min).
+        val rows =
+          (0 to 5).toList.map(i => appRow(mac1, i * 60L, "youtube.com", periodSeconds = 10))
+        assertTrue(Presence.proportionalHostSeconds(rows) == Map(yt -> 310L)) &&
+        assertTrue(Presence.proportionalHostMinutes(rows) == Map(yt -> 5))
+      },
+      test("same app on two devices double-counts under Sum, counts once under Dedup") {
+        // Both devices on youtube for the same [0, 300s) window.
         val rows = List(
-          row(mac1, 0, "youtube.com", secs = 300, bytes = 800L),
-          row(mac1, 0, "icloud.com", secs = 300, bytes = 200L),
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 300),
+          appRow(mac2, 0L, "youtube.com", periodSeconds = 300),
         )
-        // bucket = 300s. youtube 800/1000 → 240s = 4m. icloud 200/1000 → 60s = 1m.
         assertTrue(
-          Presence.proportionalHostMinutes(rows) == Map(
-            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 4,
-            HostId.Fqdn(Hostname.unsafe("icloud.com"))  -> 1,
-          ),
+          Presence.proportionalHostSeconds(rows, CrossDeviceOverlapMode.Sum) == Map(yt -> 600L),
+        ) &&
+        assertTrue(
+          Presence.proportionalHostSeconds(rows, CrossDeviceOverlapMode.Dedup) == Map(yt -> 300L),
         )
       },
-      test("ten polling hosts + one heavy host: heavy host dominates proportional minutes") {
-        // Reproduces the prod shape in #715: device shows ~60 used mins, but a
-        // bucket-presence breakdown lists 10 hosts at 50–80m each because each
-        // one was touched in every bucket. With byte-share weighting, ~all of
-        // the attributed minutes go to the host that actually moved bytes.
-        val heavy   = "youtube.com"
+      test("N < R collapses to zero; N ≥ R recovers the full span (§2d(ii) guard)") {
+        // Point-anchored windows (period_seconds=0) spaced R=300s apart. With the
+        // idle gap N=120 < R nothing merges — every window is a zero-span session
+        // and presence collapses to 0. With N=300 ≥ R they stitch into one
+        // [0, 600s) session. This is why the model must keep N ≥ R (§4.4 inv. 1):
+        // the code reads the gap from period_start, never assuming a fixed rate.
+        val rows = List(0L, 300L, 600L).map(o => appRow(mac1, o, "youtube.com", periodSeconds = 0))
+        assertTrue(
+          Presence.proportionalHostSeconds(rows, continuationSeconds = 120L) == Map(yt -> 0L),
+        ) &&
+        assertTrue(
+          Presence.proportionalHostSeconds(rows, continuationSeconds = 300L) == Map(yt -> 600L),
+        )
+      },
+      test("keepalive-only window between two real sessions is bridged (§4.4 inv. 2)") {
+        // youtube [0,60) · apns keepalive [60,120) (sub-threshold bytes) · youtube
+        // [120,180). With the filter on the keepalive is stripped before stitching,
+        // leaving youtube windows 60s apart (< N) which bridge into [0, 180s).
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val rows = List(
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 60),
+          appRow(mac1, 60L, "apns.apple.com", periodSeconds = 60, bytes = 60L),
+          appRow(mac1, 120L, "youtube.com", periodSeconds = 60),
+        )
+        assertTrue(Presence.proportionalHostSeconds(rows, filter = f) == Map(yt -> 180L))
+      },
+      test("a keepalive run longer than N does NOT bridge the two real sessions") {
+        // Same shape, but the two youtube bursts are 190s apart (> N=120s), so
+        // they stay separate: 60 + 60 = 120s, the keepalive span never counted.
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val rows = List(
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 60),
+          appRow(mac1, 60L, "apns.apple.com", periodSeconds = 190, bytes = 60L),
+          appRow(mac1, 250L, "youtube.com", periodSeconds = 60),
+        )
+        assertTrue(Presence.proportionalHostSeconds(rows, filter = f) == Map(yt -> 120L))
+      },
+      test("ten polling hosts + one heavy host: the heartbeat filter removes the pollers") {
+        // The #715 byte-share weighting is gone; the heartbeat filter is now what
+        // strips chatty keepalives from the per-host surface. With the filter on,
+        // only the heavy real-traffic host survives — at its full session span
+        // (12 contiguous 5-min windows → one 60-min session).
         val pollers = (0 until 10).map(i => s"poll-$i.example.com").toList
         val rows    = (0 until 12).toList.flatMap { b =>
-          val heavyRow = row(mac1, b, heavy, secs = 300, bytes = 5_000_000L)
-          val pollRows = pollers.map(p => row(mac1, b, p, secs = 300, bytes = 200L))
+          val heavyRow =
+            appRow(mac1, b * 300L, "youtube.com", periodSeconds = 300, bytes = 5_000_000L)
+          val pollRows =
+            pollers.map(p => appRow(mac1, b * 300L, p, periodSeconds = 300, bytes = 200L))
           heavyRow :: pollRows
         }
-        val out     = Presence.proportionalHostMinutes(rows)
-        // 12 buckets × 5min = 60 wall-clock minutes for the mac. youtube gets
-        // 5_000_000 / (5_000_000 + 10 * 200) ≈ 99.96% of each bucket → ~59 mins.
-        // Each poller gets ~1/(2 500) of each bucket → 0m after the floor /60.
-        assertTrue(out(HostId.Fqdn(Hostname.unsafe(heavy))) == 59) &&
-        // Bucket-presence still shows every poller at 12 × 5 = 60 minutes.
+        val f       = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        assertTrue(Presence.proportionalHostMinutes(rows, filter = f) == Map(yt -> 60))
+      },
+      test("with no devices/rows the per-app surface is empty") {
+        assertTrue(Presence.proportionalHostSeconds(Nil) == Map.empty[HostId, Long])
+      },
+    ),
+    suite("heartbeat filter on per-host / per-site surfaces (#1465)")(
+      test("hostMinutes drops heartbeat rows when the filter is on") {
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val rows = List(
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 60),
+          appRow(mac1, 0L, "apns.apple.com", periodSeconds = 60, bytes = 60L),
+        )
+        assertTrue(Presence.hostMinutes(rows, f) == Map(yt -> 1)) &&
+        // filter off: the keepalive host still shows (legacy behaviour preserved).
+        assertTrue(Presence.hostMinutes(rows).keySet.size == 2)
+      },
+      test("patternMinutesByMac drops heartbeat rows when the filter is on") {
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val rows = List(appRow(mac1, 0L, "apns.apple.com", periodSeconds = 60, bytes = 60L))
         assertTrue(
-          pollers.forall(p => Presence.hostMinutes(rows)(HostId.Fqdn(Hostname.unsafe(p))) == 60),
+          Presence
+            .patternMinutesByMac(rows, List("*.apple.com"), f) == Map
+            .empty[(MacAddress, String), Int],
         ) &&
-        // …but proportionally every poller is below the per-minute floor.
-        assertTrue(pollers.forall(p => out.getOrElse(HostId.Fqdn(Hostname.unsafe(p)), 0) == 0))
-      },
-      test("bucket with zero total bytes contributes nothing") {
-        // Defensive: in the wild the agent only emits rows with bytes > 0, but
-        // we guard the divide-by-zero so test fixtures with bytes=0 don't blow
-        // up. Such a bucket simply doesn't attribute to any host proportionally
-        // — bucket-presence (hostMinutes) is the right view for that case.
-        val rows = List(
-          row(mac1, 0, "a.com", secs = 300, bytes = 0L),
-          row(mac1, 0, "b.com", secs = 300, bytes = 0L),
-        )
-        assertTrue(Presence.proportionalHostMinutes(rows).isEmpty) &&
-        assertTrue(Presence.hostMinutes(rows).valuesIterator.toSet == Set(5))
-      },
-      test("multiple rows for the same host in one bucket collapse before splitting") {
-        // Two ipv4-typed rows resolving to the same fqdn via the read-side
-        // LATERAL join. Bytes for the host must sum before computing share —
-        // otherwise the host would lose weight to itself.
-        val rows = List(
-          row(mac1, 0, "youtube.com", secs = 300, bytes = 400L),
-          row(mac1, 0, "youtube.com", secs = 300, bytes = 400L), // same host
-          row(mac1, 0, "icloud.com", secs = 300, bytes = 200L),
-        )
-        // youtube collapses to 800. share = 800/1000 → 240s = 4m.
+        // filter off: the row still counts toward the per-site total.
         assertTrue(
-          Presence.proportionalHostMinutes(rows) == Map(
-            HostId.Fqdn(Hostname.unsafe("youtube.com")) -> 4,
-            HostId.Fqdn(Hostname.unsafe("icloud.com"))  -> 1,
-          ),
+          Presence.patternMinutesByMac(rows, List("*.apple.com")) == Map((mac1, "*.apple.com") -> 1),
         )
-      },
-      test("sums proportional seconds across buckets and macs") {
-        val rows = List(
-          // bucket 0: mac1 splits youtube 50/50 with poll → 2.5m each
-          row(mac1, 0, "youtube.com", secs = 300, bytes = 500L),
-          row(mac1, 0, "poll.com", secs = 300, bytes = 500L),
-          // bucket 1: mac1 alone on youtube → 5m
-          row(mac1, 1, "youtube.com", secs = 300, bytes = 1_000L),
-          // bucket 2: mac2 alone on poll → 5m
-          row(mac2, 2, "poll.com", secs = 300, bytes = 1_000L),
-        )
-        val out  = Presence.proportionalHostMinutes(rows)
-        assertTrue(out(HostId.Fqdn(Hostname.unsafe("youtube.com"))) == 7) && // 2.5 + 5 = 7.5 → 7
-        assertTrue(out(HostId.Fqdn(Hostname.unsafe("poll.com"))) == 7)       // 2.5 + 5 = 7.5 → 7
       },
     ),
   )

--- a/docs/design/presence-tuning.md
+++ b/docs/design/presence-tuning.md
@@ -432,6 +432,14 @@ new semantics.
    per-app session reads its full span; same-app-on-two-devices double-counts
    under `Sum` and counts once under `Dedup`; the `N < R` collapse guard and the
    keepalive-bridge composition from §4.4.
+   **Shipped — #1465.** `Presence.proportionalHostSeconds` is now the
+   session-stitch per-app span (`stitchSessions` primitive), combined across
+   devices by `crossDeviceOverlapMode`; the heartbeat filter now applies to
+   `hostMinutes`, `patternMinutesByMac` and the per-app surfaces (it replaces
+   byte-share as the keepalive-stripping mechanism). The idle gap reads
+   `Presence.DefaultContinuationSeconds` (120 s) until #2/#1464 threads the
+   configured `household_settings.presence_continuation_seconds` and introduces
+   the canonical primitive — reconcile the two at merge.
 
 4. **Anchor session timing on `connection_events` (rate-independence).** Join
    per-request timestamps (timing) with `traffic_reports` (bytes / heartbeat


### PR DESCRIPTION
Implements #1465 (presence-tuning §4.2 / §5 item 3): per-app presence via the session-stitch primitive, plus heartbeat-filtering the per-host/per-site surfaces. Builds on #1463 (V52 column) and is the sibling of #1464 (daily-cap rewrite + knob wiring).

## What changed

**`Presence.proportionalHostSeconds` is now a session span, not a byte-share split (§4.2).** For each host ("app"):
1. Per device, union *that host's* sessions — non-heartbeat activity stitched on the idle gap `N` (`stitchSessions`).
2. Combine across the profile's devices by its existing `crossDeviceOverlapMode`: `Sum` (default) adds per-device values (same app on two devices double-counts); `Dedup` unions the intervals (overlap counts once).

This is the successor to the #715 byte-share weighting and what a future per-app time limit reads.

**Heartbeat filter now applies to the per-host / per-site surfaces** (`hostMinutes`, `patternMinutesByMac`, and the per-app surfaces) — previously they didn't filter, so keepalives padded per-host breakdowns and ticked per-site caps. The filter *replaces* byte-share as the keepalive-stripping mechanism: a chatty poller now drops out entirely instead of being weighted down to ~0. `settings.heartbeatFilter` and the profile's overlap mode are threaded through the time-status, usage-by-app, and decision call sites (`UsageRoutes` now takes `hsRepo` for the by-app endpoint).

**New primitive `stitchSessions(intervals, gapSeconds)`** folds time-ordered intervals into sessions, bridging idle gaps ≤ N and reading window bounds from `period_start`/`period_seconds` (never assuming the 60 s report rate), so the §4.4-1 rate-independence invariant holds.

## Tests (TDD, red → green in history)

`PresenceSpec` pins the §4.2/§4.4 behavior:
- a sparse per-app session reads its **full span**, not the sampled floor;
- same app on two devices **double-counts under `Sum`, counts once under `Dedup`**;
- the **`N < R` collapse guard** (point-anchored windows collapse to 0 when `N < R`, recover at `N ≥ R`);
- the **keepalive-bridge composition** (a sub-threshold window between two real sessions is bridged when they sit within `N`; a keepalive run longer than `N` is not).

The `TimeApiSpec` #715 feature test is recast to the new mechanism (pollers filtered out, `proportionalMins` = session span). Affected `usage-by-app` fixtures were bumped to real-traffic byte volumes (the default filter is on at 10 240 bytes). Full `api.test`: **699 passed, 0 failed**.

## Coordination with #1464 (flagged)

#1464 introduces the canonical session primitive in this same file and wires `household_settings.presence_continuation_seconds` (V52/#1463) into the rollup + invalidation hook. It had not merged when this was written, so this PR:
- factors against the design's primitive (`stitchSessions`) and marks it **provisional** in code (`DefaultContinuationSeconds`) and in `docs/design/presence-tuning.md` §5 item 3;
- reads the idle gap from the **120 s design default** until #1464 threads the configured value through the call sites.

**Reconcile the two `stitchSessions`/continuation definitions at merge.**

## Scope notes
- No schema change (no migration). No wire-shape change — `HostUsage.proportionalMins` keeps its name; only its server-side derivation changed.
- Per-app aggregation in `usage-by-app` still sums per-host session seconds into each app; a true per-app interval union (vs sum-of-hosts) is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
