### PR TITLE
feat(#1482): read schedule enforcement from named schedules, not the legacy table

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -39,6 +39,11 @@ object PolicyServiceLive {
       clock: Clock,
       uiAllowedHosts: List[Hostname] = Nil,
       globalPolicyRepo: GlobalPolicyRepo = NoopGlobalPolicyRepo,
+      // #1482: schedule downtime is read from the named-schedule model, so specs that assert
+      // schedule blocking pass the real repo here; it threads into both the snapshot
+      // (TimeStatusService) and the per-host /decision path. Defaults to the noop so the many specs
+      // that don't exercise schedules keep their positional constructions unchanged.
+      namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
   ): PolicyServiceLive = {
     val tss = new TimeStatusServiceLive(
       profileRepo,
@@ -51,6 +56,7 @@ object PolicyServiceLive {
       // Snapshot specs only exercise today; today is always live. A real rollup repo would be
       // ignored on this path, so wire a noop and avoid threading the repo through every test.
       NoopTimeUsedRollupRepo,
+      namedScheduleRepo,
     )
     new PolicyServiceLive(
       profileRepo,
@@ -67,13 +73,19 @@ object PolicyServiceLive {
       clock,
       uiAllowedHosts,
       globalPolicyRepo,
+      namedScheduleRepo,
     )
   }
 }
 
 class PolicyServiceLive(
     profileRepo: ProfileRepo,
-    scheduleRepo: ScheduleRepo,
+    // #1482: the legacy per-profile `schedules` table is no longer an enforcement source — schedule
+    // downtime is read exclusively from `named_schedules` / `profile_schedule_rules` (both the
+    // snapshot, via TimeStatusService, and the per-host /decision fallback below). Retained
+    // injected-but-unused to keep the constructor arity ~40 test constructions depend on; removed
+    // when the legacy table is dropped (the future two-phase destructive PR).
+    @scala.annotation.unused scheduleRepo: ScheduleRepo,
     householdSettingsRepo: HouseholdSettingsRepo,
     timeLimitRepo: TimeLimitRepo,
     siteTimeLimitRepo: SiteTimeLimitRepo,
@@ -101,16 +113,17 @@ class PolicyServiceLive(
   // retired separately in #1321.)
   private val uiGlobalAllow: List[Hostname] = uiAllowedHosts
 
-  // #1069: per-host /decision fallback must see the same schedule downtime as the snapshot —
-  // union the legacy per-profile schedules with the windows of every block-mode named schedule
-  // attached to the profile (as synthetic DbSchedules so `scheduleActiveAt` applies unchanged).
+  // #1069/#1482: per-host /decision fallback must see the same schedule downtime as the snapshot —
+  // the windows of every block-mode named schedule attached to the profile (as synthetic
+  // DbSchedules so `scheduleActiveAt` applies unchanged). Named schedules are the sole source.
   private def schedulesFor(pid: ProfileId): Task[List[DbSchedule]] =
-    for {
-      v1    <- scheduleRepo.listForProfile(pid)
-      named <- namedScheduleRepo.windowsForProfile(pid)
-    } yield v1 ++ named.map(w =>
-      DbSchedule(ScheduleId(0L), pid, "named-schedule", w.days, w.startLocal, w.endLocal, w.tz),
-    )
+    namedScheduleRepo
+      .windowsForProfile(pid)
+      .map(
+        _.map(w =>
+          DbSchedule(ScheduleId(0L), pid, "named-schedule", w.days, w.startLocal, w.endLocal, w.tz),
+        ),
+      )
 
   def snapshot: Task[PolicySnapshot] =
     (for {

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -106,7 +106,12 @@ trait TimeStatusService {
 
 class TimeStatusServiceLive(
     profileRepo: ProfileRepo,
-    scheduleRepo: ScheduleRepo,
+    // #1482: the legacy per-profile `schedules` table is no longer an enforcement source —
+    // `named_schedules` / `profile_schedule_rules` is now the single source of truth (existing
+    // rows were folded in by the boot-time `ScheduleSeeder`). The repo stays injected but unused
+    // here to preserve the constructor arity that ~40 test constructions depend on; it is removed
+    // wholesale when the legacy table is dropped (the future two-phase destructive PR).
+    @scala.annotation.unused scheduleRepo: ScheduleRepo,
     timeLimitRepo: TimeLimitRepo,
     siteTimeLimitRepo: SiteTimeLimitRepo,
     deviceRepo: DeviceRepo,
@@ -115,27 +120,23 @@ class TimeStatusServiceLive(
     // Defaulting to the noop lets the many call sites in TimeApiSpec / snapshot specs keep their
     // 7-arg constructions — they exercise the all-live path either way.
     rollupRepo: TimeUsedRollupRepo = NoopTimeUsedRollupRepo,
-    // #1069: a profile's attached block-mode named-schedule windows are unioned into the legacy
-    // `schedules` for the blocked-flag decision. Defaults to the noop so existing direct
-    // constructions keep their arity.
+    // #1069/#1482: a profile's downtime schedules come from the windows of every named schedule
+    // attached to it as a block schedule (via `profile_schedule_rules`, mode=blocked_during).
+    // Defaults to the noop so existing direct constructions keep their arity.
     namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
 ) extends TimeStatusService {
 
-  // #1069: a profile's effective downtime schedules = its legacy per-profile `schedules` rows
-  // unioned with the windows of every named schedule attached to it as a block schedule (via
-  // `profile_schedule_rules`, mode=blocked_during). Named windows become synthetic DbSchedules so
-  // the existing `scheduleActiveAt` math applies unchanged (it reads only days/start/end/tz —
-  // id/profileId/name are irrelevant).
+  // #1069/#1482: a profile's effective downtime schedules = the windows of every named schedule
+  // attached to it as a block schedule (via `profile_schedule_rules`, mode=blocked_during). Named
+  // windows become synthetic DbSchedules so the existing `scheduleActiveAt` math applies unchanged
+  // (it reads only days/start/end/tz — id/profileId/name are irrelevant).
   private def syntheticWindows(pid: ProfileId, ws: List[ScheduleWindow]): List[DbSchedule] =
     ws.map(w =>
       DbSchedule(ScheduleId(0L), pid, "named-schedule", w.days, w.startLocal, w.endLocal, w.tz),
     )
 
   private def schedulesFor(pid: ProfileId): Task[List[DbSchedule]] =
-    for {
-      v1    <- scheduleRepo.listForProfile(pid)
-      named <- namedScheduleRepo.windowsForProfile(pid)
-    } yield v1 ++ syntheticWindows(pid, named)
+    namedScheduleRepo.windowsForProfile(pid).map(syntheticWindows(pid, _))
 
   def todaysState(
       now: Instant,
@@ -209,16 +210,14 @@ class TimeStatusServiceLive(
     for {
       profiles <- profileRepo.listAll
       devices  <- deviceRepo.listAll
-      schedsP  <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
       namedP   <- namedScheduleRepo.windowsForAllProfiles
       tlsP     <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
       stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       presence <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
       exts     <- extRepo.snapshotAllByProfile(date)
     } yield {
-      val schedMap = schedsP.toMap.map { case (pid, v1) =>
-        pid -> (v1 ++ syntheticWindows(pid, namedP.getOrElse(pid, Nil)))
-      }
+      val schedMap =
+        profiles.map(p => p.id -> syntheticWindows(p.id, namedP.getOrElse(p.id, Nil))).toMap
       val tlMap    = tlsP.toMap
       val stlMap   = stlsP.toMap
       val devsByP  =
@@ -311,16 +310,14 @@ class TimeStatusServiceLive(
     val watermark = rolled.values.iterator.map(_.rolledThrough).min
     for {
       devices <- deviceRepo.listAll
-      schedsP <- ZIO.foreach(profiles)(p => scheduleRepo.listForProfile(p.id).map(p.id -> _))
       namedP  <- namedScheduleRepo.windowsForAllProfiles
       tlsP    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
       stlsP   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
       exts    <- extRepo.snapshotAllByProfile(date)
     } yield {
-      val schedMap = schedsP.toMap.map { case (pid, v1) =>
-        pid -> (v1 ++ syntheticWindows(pid, namedP.getOrElse(pid, Nil)))
-      }
+      val schedMap =
+        profiles.map(p => p.id -> syntheticWindows(p.id, namedP.getOrElse(p.id, Nil))).toMap
       val tlMap    = tlsP.toMap
       val stlMap   = stlsP.toMap
       val devsByP  =

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -199,9 +199,28 @@ object TestLayers {
     Clock.TestClock.make(dt)
 
   /** Seed helpers */
-  def seedKidsProfile(profileRepo: ProfileRepo, scheduleRepo: ScheduleRepo): Task[ProfileId] =
+
+  // The legacy 21:00–07:00 daily "Bedtime" window this fixture has always attached to Kids.
+  private val kidsBedtimeWindow =
+    wifihaven.shared.ScheduleWindow(
+      List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+      java.time.LocalTime.of(21, 0),
+      java.time.LocalTime.of(7, 0),
+      java.time.ZoneId.of("UTC"),
+    )
+
+  // #1482: enforcement now reads schedule downtime exclusively from the named-schedule model
+  // (`named_schedules` / `profile_schedule_rules`), so the Kids fixture attaches its Bedtime window
+  // there. The legacy `schedules` row is still written (it backs the legacy profile-CRUD/display
+  // surface until that table is dropped), mirroring the post-boot-migration production shape where
+  // both representations coexist. Requires a `NamedScheduleRepo` in the environment — every test
+  // runs under `TestDatabase.layer`, which provides it, so call sites are unchanged.
+  def seedKidsProfile(
+      profileRepo: ProfileRepo,
+      scheduleRepo: ScheduleRepo,
+  ): ZIO[NamedScheduleRepo, Throwable, ProfileId] =
     for {
-      id <- profileRepo.create(
+      id  <- profileRepo.create(
         "Kids",
         List(
           BlocklistId.unsafe("adult"),
@@ -209,18 +228,23 @@ object TestLayers {
           BlocklistId.unsafe("social_media"),
         ),
       )
-      _  <- scheduleRepo.replaceForProfile(
+      _   <- scheduleRepo.replaceForProfile(
         id,
         List(
           wifihaven.shared.ScheduleRequest(
             "Bedtime",
-            List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
-            java.time.LocalTime.of(21, 0),
-            java.time.LocalTime.of(7, 0),
-            java.time.ZoneId.of("UTC"),
+            kidsBedtimeWindow.days,
+            kidsBedtimeWindow.startLocal,
+            kidsBedtimeWindow.endLocal,
+            kidsBedtimeWindow.tz,
           ),
         ),
       )
+      nsr <- ZIO.service[NamedScheduleRepo]
+      // Name is suffixed with the profile id so repeated seeds in one test don't collide on the
+      // UNIQUE(name) constraint.
+      sid <- nsr.create(s"Bedtime#${id.value}", Some("Kids bedtime"), List(kidsBedtimeWindow))
+      _   <- nsr.setProfileBlockSchedules(id, List(sid))
     } yield id
 
   def seedAdultsProfile(profileRepo: ProfileRepo): Task[ProfileId] =

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -39,6 +39,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
     } yield PolicyServiceLive(
@@ -53,6 +54,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       er,
       ar,
       clk,
+      namedScheduleRepo = nsr,
     ): PolicyService
 
   private def callBlocked(

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -62,6 +62,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
     } yield PolicyServiceLive(
@@ -76,6 +77,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       er,
       ar,
       clk,
+      namedScheduleRepo = nsr,
     ): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -51,6 +51,7 @@ object PolicySnapshotBlockedMacsSpec
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
     } yield PolicyServiceLive(
@@ -65,6 +66,7 @@ object PolicySnapshotBlockedMacsSpec
       er,
       ar,
       clk,
+      namedScheduleRepo = nsr,
     ): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =

--- a/api/test/src/feature/PolicySnapshotGlobalPrecedenceSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalPrecedenceSpec.scala
@@ -10,7 +10,7 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.test.*
 
-import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
 
 /**
  * #1322 (test coverage for the #1308 global-policy layer + per-profile default-deny): pins the
@@ -54,6 +54,7 @@ object PolicySnapshotGlobalPrecedenceSpec
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
       gpr    <- ZIO.service[GlobalPolicyRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
     } yield PolicyServiceLive(
@@ -70,6 +71,7 @@ object PolicySnapshotGlobalPrecedenceSpec
       clk,
       Nil,
       gpr,
+      nsr,
     ): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
@@ -120,9 +122,9 @@ object PolicySnapshotGlobalPrecedenceSpec
       for {
         _   <- cleanDb
         pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
         ps0 <- pr.listAll
         kids = ps0.find(_.name == "Kids").get
+        _    <- attachKidsBedtime(kids.id)
         _    <- pr.update(kids.copy(defaultDeny = true))
         svc  <- makePsAt(TestClock.bedtime)
         snap <- svc.snapshot
@@ -167,6 +169,7 @@ object PolicySnapshotGlobalPrecedenceSpec
         ar  <- ZIO.service[AppRepo]
         ps0 <- pr.listAll
         kids = ps0.find(_.name == "Kids").get
+        _    <- attachKidsBedtime(kids.id)
         _    <- TestLayers.seedAppAssignment(ar, kids.id, "pbskids.org", AppMode.Allowed)
         _    <- pr.update(kids.copy(defaultDeny = true))
         svc  <- makePsAt(TestClock.bedtime) // inside the bedtime schedule window
@@ -193,8 +196,8 @@ object PolicySnapshotGlobalPrecedenceSpec
       )
     },
     test("global.extraAllowed is present regardless of why a MAC is blocked (schedule)") {
-      assertGlobalAllowIndependentOfBlock { (_, _) =>
-        ZIO.unit // the seeded Kids profile already has a bedtime schedule
+      assertGlobalAllowIndependentOfBlock { (_, kids) =>
+        attachKidsBedtime(kids.id) // attach the bedtime window as a block-mode named schedule
       }(TestClock.bedtime, MacBlockReason.Schedule)
     },
     test("global.extraAllowed is present regardless of why a MAC is blocked (default-deny)") {
@@ -258,8 +261,29 @@ object PolicySnapshotGlobalPrecedenceSpec
    * global allow host is present in `snap.global.extraAllowed` (i.e. the global section did not
    * change because of the per-MAC block).
    */
+  // #1482: enforcement reads schedule downtime only from the named-schedule model, so the V1-seeded
+  // Kids profile's bedtime must be attached as a block-mode named schedule (the legacy `schedules`
+  // row V1 seeds is no longer an enforcement source). Mirrors the 21:00–07:00 window V1 seeds.
+  private def attachKidsBedtime(kid: ProfileId): ZIO[NamedScheduleRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[NamedScheduleRepo] { nsr =>
+      nsr
+        .create(
+          "Bedtime",
+          Some("overnight"),
+          List(
+            ScheduleWindow(
+              List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+              LocalTime.of(21, 0),
+              LocalTime.of(7, 0),
+              ZoneId.of("UTC"),
+            ),
+          ),
+        )
+        .flatMap(sid => nsr.setProfileBlockSchedules(kid, List(sid)))
+    }
+
   private def assertGlobalAllowIndependentOfBlock(
-      block: (ProfileRepo, Profile) => Task[Unit],
+      block: (ProfileRepo, Profile) => ZIO[NamedScheduleRepo, Throwable, Unit],
   )(at: LocalDateTime, expectedReason: MacBlockReason) =
     for {
       _   <- cleanDb

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -35,6 +35,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       trRepo <- ZIO.service[TrafficReportRepo]
       er     <- ZIO.service[TimeExtensionRepo]
       ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
     } yield PolicyServiceLive(
@@ -49,6 +50,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       er,
       ar,
       clk,
+      namedScheduleRepo = nsr,
     ): PolicyService
 
   private def makePsDefault = makePsAt(TestClock.schoolDayAfternoon)

--- a/api/test/src/feature/ScheduleMigrationBehaviorSpec.scala
+++ b/api/test/src/feature/ScheduleMigrationBehaviorSpec.scala
@@ -1,0 +1,173 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ScheduleSeeder
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, Schedule as _, *}
+import zio.test.*
+
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
+
+/**
+ * #1482: the legacy per-profile `schedules` table is migrated into the named-schedule model
+ * (`named_schedules` / `profile_schedule_rules`) by the boot-time `ScheduleSeeder`, and enforcement
+ * now reads schedule downtime EXCLUSIVELY from that model — the legacy table is no longer an
+ * enforcement source.
+ *
+ * The migration is a representation change, NOT a behaviour change, so this spec pins the critical
+ * invariant: for a profile whose schedule was authored as a legacy row and then migrated, the
+ * named-only snapshot blocks at EXACTLY the instants the original legacy schedule would have — the
+ * same `PolicyService.scheduleActiveAt` math the pre-migration read path used. We probe the awkward
+ * boundaries the issue calls out: exact on/off edges, the overnight wrap + its tail day, a non-UTC
+ * timezone, and day-of-week membership.
+ *
+ * The equivalence is asserted directly: at each probed instant the named-only `snapshot.blocked`
+ * for the device equals `scheduleActiveAt(<the original legacy row>, instant)`. Equality with that
+ * function — the very function the legacy read path evaluated — IS the byte-for-byte preservation
+ * proof. (The migration's structural correctness — one named schedule + window + profile rule per
+ * legacy row — is pinned separately by ScheduleSeederSpec.)
+ */
+object ScheduleMigrationBehaviorSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+  private val UTC     = ZoneId.of("UTC")
+  private val NY      = ZoneId.of("America/New_York")
+
+  // A profile carrying an overnight, all-days window in UTC (the classic bedtime shape).
+  private val overnightMac = "aa:bb:cc:00:00:01"
+  private val overnight    = ScheduleRequest(
+    "Overnight",
+    List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+    LocalTime.of(21, 0),
+    LocalTime.of(7, 0),
+    UTC,
+  )
+
+  // A profile carrying a weekday-only daytime window in a non-UTC zone (DST-correct via the row tz).
+  private val schoolMac = "aa:bb:cc:00:00:02"
+  private val school    = ScheduleRequest(
+    "School",
+    List("mon", "tue", "wed", "thu", "fri"),
+    LocalTime.of(8, 0),
+    LocalTime.of(15, 0),
+    NY,
+  )
+
+  private def utc(d: LocalDate, h: Int, m: Int): Instant =
+    LocalDateTime.of(d, LocalTime.of(h, m)).toInstant(ZoneOffset.UTC)
+
+  private val mon = LocalDate.of(2025, 1, 6) // Monday
+  private val tue = LocalDate.of(2025, 1, 7)
+  private val sat = LocalDate.of(2025, 1, 11)
+
+  // Instants chosen to straddle every boundary the issue calls out. NY is UTC-5 in January, so
+  // 08:00 NY = 13:00 UTC and 15:00 NY = 20:00 UTC.
+  private val probes: List[Instant] = List(
+    utc(mon, 20, 59), // overnight: 1 min before the start edge
+    utc(mon, 21, 0),  // overnight: exact start (inclusive)
+    utc(mon, 23, 30), // overnight: mid-window
+    utc(tue, 6, 59),  // overnight: tail day, 1 min before the end edge
+    utc(tue, 7, 0),   // overnight: exact end (exclusive)
+    utc(tue, 12, 0),  // overnight: well outside
+    utc(mon, 12, 59), // school: 07:59 NY — before start
+    utc(mon, 13, 0),  // school: 08:00 NY — exact start
+    utc(mon, 19, 59), // school: 14:59 NY — mid/just-before end
+    utc(mon, 20, 0),  // school: 15:00 NY — exact end (exclusive)
+    utc(sat, 13, 0),  // school: 08:00 NY on Saturday — DOW excludes it
+  )
+
+  // Build a named-only PolicyService at `at`, with the REAL NamedScheduleRepo wired (so schedule
+  // downtime is read from the migrated named schedules, never the legacy table).
+  private def makePsAt(at: Instant) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      ref    <- Ref.make(LocalDateTime.ofInstant(at, UTC))
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clk,
+      namedScheduleRepo = nsr,
+    ): PolicyService
+
+  private def isScheduleBlocked(snap: PolicySnapshot, mac: String): Boolean =
+    snap.devices
+      .collectFirst { case (m, dev) if m.value.equalsIgnoreCase(mac) => dev }
+      .flatMap(dev => dev.rules.orElse(dev.profileId.flatMap(snap.profiles.get).map(_.rules)))
+      .exists(r => r.blocked && r.blockReason.contains(MacBlockReason.Schedule))
+
+  private def seedLegacyProfile(name: String, mac: String, sched: ScheduleRequest) =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      sr  <- ZIO.service[ScheduleRepo]
+      dr  <- ZIO.service[DeviceRepo]
+      pid <- pr.create(name, Nil)
+      _   <- sr.replaceForProfile(pid, List(sched))
+      _   <- TestLayers.seedDevice(dr, mac, s"$name-dev", pid)
+    } yield pid
+
+  private def active(leg: List[Schedule], t: Instant): Boolean =
+    leg.exists(s => PolicyService.scheduleActiveAt(s, t))
+
+  def spec = suite("schedule migration — behaviour preservation (#1482)")(
+    test("migrated profiles block at exactly the instants the original legacy schedule did") {
+      for {
+        _     <- cleanDb
+        sr    <- ZIO.service[ScheduleRepo]
+        nsr   <- ZIO.service[NamedScheduleRepo]
+        pr    <- ZIO.service[ProfileRepo]
+        p1    <- seedLegacyProfile("Overnight", overnightMac, overnight)
+        p2    <- seedLegacyProfile("School", schoolMac, school)
+        // Run the real boot-time migration: legacy rows → named schedules + profile rules.
+        _     <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
+        // The original legacy rows are read back ONLY to compute the pre-migration expectation —
+        // they are no longer an enforcement source.
+        leg1  <- sr.listForProfile(p1)
+        leg2  <- sr.listForProfile(p2)
+        // For every probe instant, the named-only snapshot must agree with scheduleActiveAt over
+        // the original legacy schedule — i.e. enforcement is unchanged by the migration.
+        agree <- ZIO.foreach(probes) { t =>
+          makePsAt(t).flatMap(_.snapshot).map { snap =>
+            (isScheduleBlocked(snap, overnightMac) == active(leg1, t)) &&
+            (isScheduleBlocked(snap, schoolMac) == active(leg2, t))
+          }
+        }
+      } yield assertTrue(agree.forall(identity)) &&
+        // Guard against a vacuous pass: the probes exercise BOTH blocked and unblocked outcomes for
+        // each profile, so the equivalence above is meaningful, not "always false == always false".
+        assertTrue(
+          probes.exists(active(leg1, _)),
+          probes.exists(t => !active(leg1, t)),
+          probes.exists(active(leg2, _)),
+          probes.exists(t => !active(leg2, t)),
+        )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/docs/design/per-app-schedules.md
+++ b/docs/design/per-app-schedules.md
@@ -125,8 +125,21 @@ created directly — no deferred-constraint dance.
 > the V1 `schedules` time columns so the existing `Schedule` model and
 > `scheduleActiveAt` apply unchanged. The name is `named_schedules`, NOT
 > `schedules` — the spec's chosen name collided with the V1 profile-scoped
-> `schedules` table, which deployed enforcement code still reads, so it could
-> not be dropped/renamed in an additive migration.
+> `schedules` table, which deployed enforcement code still read at the time, so
+> it could not be dropped/renamed in an additive migration.
+>
+> **#1482 made `named_schedules` the single enforcement source.** The boot-time
+> `ScheduleSeeder` migrates each profile's legacy `schedules` rows into the named
+> model, and `PolicyService` / `TimeStatusService` now read schedule downtime
+> **exclusively** from `named_schedules` / `profile_schedule_rules` (the legacy
+> union is gone). The V1 `schedules` table still exists — it backs the legacy
+> profile-CRUD/display surface and keeps the pre-migration image enforcing on a
+> rollback — but it is no longer an enforcement source. Retiring it is staged as
+> **two** further PRs, honouring the migration-isolation rule: first a code/test
+> PR that removes the now-dead legacy `ScheduleRepo` (its repo, the
+> profile-upsert `schedules` write/read, the `@unused` injection retained here
+> for arity, and the fixtures that seed it), then a migration-only PR that drops
+> the table — done once the named path has fully rolled out.
 >
 > **Profiles reference schedules through a `(profile, schedule, mode)` join
 > table — `profile_schedule_rules` — NOT a single `profiles.schedule_id`


### PR DESCRIPTION
## What

Switches schedule **enforcement** to read exclusively from the household-scoped named-schedule model (`named_schedules` / `schedule_windows` / `profile_schedule_rules`, #1069/V50), removing the legacy per-profile `schedules` table from the enforcement read path. There is now **one** schedule system backing enforcement.

Closes #1482.

## Why this is one PR, not two

#1482 was framed as a Flyway data-migration PR + a read-path-switch PR. On recon, the **data migration already happens at boot**: `ScheduleSeeder.seedAndMigrate` (merged in #1438, wired in [`Main.scala`](api/src/Main.scala)) idempotently folds every profile's legacy `schedules` rows into `named_schedules` + `profile_schedule_rules` (mode `blocked_during`) on each startup. A separate Flyway migration would be redundant and would double-migrate already-booted DBs. So this ships as a single code PR — the read-path switch. (Scope note added to [#1482](https://github.com/wifihaven/wifihaven/issues/1482).)

## Changes

- `PolicyService.schedulesFor` (per-host `/decision` fallback) and `TimeStatusService` (snapshot `blocked` flag, both the single-profile and batched paths) now read schedule downtime **only** from `namedScheduleRepo.windowsForProfile` / `windowsForAllProfiles`. The legacy `scheduleRepo.listForProfile` union is gone.
- The legacy `ScheduleRepo` stays **injected but unused** (`@scala.annotation.unused`) in both services to preserve the constructor arity ~40 test constructions depend on; it is removed wholesale when the legacy table is dropped (the future two-phase destructive PR — out of scope, per #1482).
- `PolicyServiceLive.apply` (test factory) gains an additive `namedScheduleRepo` param (defaulted to the noop) and threads it into both the snapshot and the `/decision` path, so schedule-asserting specs wire the real repo.

**Zero router / wire change.** Snapshot expansion stays API-side; `shared/contract/api-to-router/policy_snapshot.json` is untouched.

## Behaviour preservation (the critical invariant)

The migration is a representation change, not a behaviour change. New feature test [`ScheduleMigrationBehaviorSpec`](api/test/src/feature/ScheduleMigrationBehaviorSpec.scala) pins it against real embedded Postgres: it seeds profiles with **legacy** schedules (an overnight all-days UTC window + a weekday-only non-UTC window), runs the real `ScheduleSeeder` migration, then asserts that the **named-only** snapshot blocks at *exactly* the instants `PolicyService.scheduleActiveAt` over the **original legacy row** did — across exact on/off edges, the overnight wrap and its tail day, a non-UTC (`America/New_York`) timezone, and day-of-week membership. (Migration structure — one named schedule + window + profile rule per legacy row — remains pinned by the existing `ScheduleSeederSpec`.)

Test fixtures that relied on legacy schedules were moved to the named model: `TestLayers.seedKidsProfile` now also attaches a `blocked_during` named "Bedtime", and the V1-seed-dependent `PolicySnapshotGlobalPrecedenceSpec` attaches a named bedtime to the seeded Kids profile.

## Merge ordering ⚠️

Must merge **after** the in-flight PR that stops the SPA writing legacy `schedules`. Until that lands, the profile-upsert path still writes legacy rows that — created after boot — wouldn't be migrated, and so wouldn't enforce under a named-only read path.
