### PR TITLE
fix(#1489): keep merged nftset directive under dnsmasq's line limit

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -410,6 +410,18 @@ function M.dnsmasq(snapshot)
   -- issue #1460) reproduces this on a real router. Merging every set for
   -- a given host into ONE comma-joined directive sidesteps the parser quirk
   -- (verified live with dnsmasq 2.91 on OpenWRT 23.05).
+  --
+  -- **The merged directive must stay within dnsmasq's line limit (#1489).**
+  -- dnsmasq reads config lines into a fixed MAXDNAME(1025)-byte buffer with no
+  -- line continuation, so a directive over 1024 bytes is truncated and its
+  -- remainder is parsed as a bogus option — dnsmasq then refuses to start and
+  -- :53 returns "connection refused" (the Gate 3a staging-smoke regression in
+  -- #1489). Because only one directive per host is honoured we cannot split a
+  -- host across lines, so the per-host spec count must stay bounded. The only
+  -- per-host spec that scales with device count is the per-(MAC,host) ea_
+  -- populator — the #1307 infra-allow copy lands the same host in every
+  -- profile's extraAllowed, so one ea_ spec per device would pile onto a
+  -- single line. We skip the redundant ones in the ea_ loop below.
   local bl_hosts = snapshot._blocklist_hosts or {}
   local bl_ids   = sorted_keys(snapshot.blocklists or {})
   local ga_hosts = global_allow_hosts(snapshot)
@@ -422,23 +434,42 @@ function M.dnsmasq(snapshot)
   --   3. bl_  (per-category, in bl_ids order; hosts in source order)
   --   4. ga_  (global allow, sorted)
   --   5. gb_  (global block, sorted)
-  -- Within each source the v4 spec precedes v6.
-  local host_order, host_specs = {}, {}
+  -- Within each source the v4 spec precedes v6. add_spec de-duplicates
+  -- identical specs per host (e.g. the same host listed twice in one
+  -- blocklist) so the merged directive never carries a redundant comma entry.
+  local host_order, host_specs, host_seen = {}, {}, {}
   local function add_spec(host, spec)
     if not host_specs[host] then
       host_specs[host] = {}
+      host_seen[host] = {}
       host_order[#host_order + 1] = host
     end
-    host_specs[host][#host_specs[host] + 1] = spec
+    if not host_seen[host][spec] then
+      host_seen[host][spec] = true
+      host_specs[host][#host_specs[host] + 1] = spec
+    end
   end
+
+  -- #1489: a host that is also in global.extraAllowed needs NO per-(MAC,host)
+  -- ea_ populator. @global_allow already carves it out of every drop for every
+  -- MAC (render.nft's ga_suffix), so the ea_ specs are pure redundancy — and
+  -- they are the only per-host nftset spec that scales with device count, so
+  -- emitting one per device is what overflows dnsmasq's config-line buffer
+  -- above. Skip them; enforcement rides on @global_allow, and dns-tail (#1346)
+  -- still populates the per-(MAC,host) ea_ sets from live replies regardless.
+  -- This mirrors the #1307→#1321 redundancy the global-allow layer retires.
+  local ga_host_set = {}
+  for _, h in ipairs(ga_hosts) do ga_host_set[h] = true end
 
   local ea_macs = {}
   for m in pairs(ea_by_mac) do ea_macs[#ea_macs + 1] = m end
   table.sort(ea_macs)
   for _, mac in ipairs(ea_macs) do
     for _, host in ipairs(ea_by_mac[mac]) do
-      add_spec(host, "4#inet#wifihaven#" .. ea_set_name(mac, host))
-      add_spec(host, "6#inet#wifihaven#" .. ea6_set_name(mac, host))
+      if not ga_host_set[host] then
+        add_spec(host, "4#inet#wifihaven#" .. ea_set_name(mac, host))
+        add_spec(host, "6#inet#wifihaven#" .. ea6_set_name(mac, host))
+      end
     end
   end
   for _, host in ipairs(effective_extra_blocked_hosts(snapshot)) do

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2132,6 +2132,83 @@ describe("render.dnsmasq global section (#1319)", function()
     assert.truthy(conf:find("4#inet#wifihaven#global_block", 1, true))
     assert.truthy(conf:find("6#inet#wifihaven#global_block6", 1, true))
   end)
+
+  -- ── #1489 regression: over-long merged nftset line crashes dnsmasq ───────
+  --
+  -- dnsmasq honours only ONE nftset directive per host (domain_find_sets
+  -- returns a single longest-suffix match), so render.dnsmasq merges every set
+  -- for a host into one comma-joined directive (#1460). dnsmasq also reads
+  -- config lines into a fixed MAXDNAME(1025)-byte buffer with NO line
+  -- continuation: a directive longer than 1024 bytes is truncated and its
+  -- remainder is parsed as a bogus option, so dnsmasq refuses to start and
+  -- :53 returns "connection refused" — exactly the Gate 3a staging-smoke
+  -- failure in #1489 (regression from #1483's merge).
+  --
+  -- The per-(MAC,host) ea_ populator is the ONLY per-host spec that scales
+  -- with device count. The #1307 infra-allow copy puts the same host into
+  -- every profile's extraAllowed, so one ea_ spec per device lands on a
+  -- single merged line. When that host is also in global.extraAllowed those
+  -- ea_ specs are pure redundancy — @global_allow already carves the host out
+  -- of every drop for every MAC (render.nft ga_suffix) — so render.dnsmasq
+  -- must not emit them.
+  it("omits redundant per-(MAC,host) ea_ populators for a global.extraAllowed host (#1489)", function()
+    local s = snap_global()
+    s.profiles["3"].rules.extraAllowed = { "infra.wifihaven.net" }
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    s.global.extraAllowed = { "infra.wifihaven.net" }
+    local conf = render.dnsmasq(s)
+    -- Enforcement is preserved: the host still drives the fleet-wide allow set.
+    assert.truthy(conf:find(
+      "nftset=/infra.wifihaven.net/4#inet#wifihaven#global_allow,6#inet#wifihaven#global_allow6",
+      1, true))
+    -- ...but the redundant per-(MAC,host) ea_ spec is gone.
+    assert.is_nil(conf:find("ea_aa_bb_cc_11_22_33_infra_wifihaven_net", 1, true))
+    assert.is_nil(conf:find("ea6_aa_bb_cc_11_22_33_infra_wifihaven_net", 1, true))
+  end)
+
+  it("still emits per-(MAC,host) ea_ populators for a host NOT in global.extraAllowed", function()
+    -- A normal per-device allow (not in the global layer) keeps its ea_ set —
+    -- only the redundant global-allow copies are skipped.
+    local s = snap_global()
+    s.profiles["3"].rules.extraAllowed = { "khanacademy.org" }
+    s.profiles["3"].rules.extraBlocked = {}
+    s.profiles["3"].rules.blocklistIds = {}
+    s.global.extraAllowed = { "infra.wifihaven.net" }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find(
+      "nftset=/khanacademy.org/4#inet#wifihaven#ea_aa_bb_cc_11_22_33_khanacademy_org,6#inet#wifihaven#ea6_aa_bb_cc_11_22_33_khanacademy_org",
+      1, true))
+  end)
+
+  it("keeps every merged nftset directive within dnsmasq's 1024-byte line limit (#1489)", function()
+    -- Many devices each carry the same global-allowed infra host in their
+    -- effective extraAllowed (the #1307 per-profile copy). Pre-#1489 this
+    -- produced one ea_ spec per device on a single merged line, overflowing
+    -- dnsmasq's config-line buffer and stopping it from starting.
+    local s = snap_global()
+    s.devices = {}
+    s.profiles = {}
+    for i = 1, 24 do
+      local mac = string.format("aa:bb:cc:%02x:%02x:%02x", i, i, i)
+      s.devices[mac] = { profileId = i }
+      s.profiles[tostring(i)] = {
+        name = "p" .. i,
+        failureMode = "last-known-good",
+        rules = {
+          blocked = false, extraBlocked = {}, blocklistIds = {},
+          extraAllowed = { "infra.wifihaven.net" },
+        },
+      }
+    end
+    s.global.extraAllowed = { "infra.wifihaven.net" }
+    local conf = render.dnsmasq(s)
+    for line in (conf .. "\n"):gmatch("([^\n]*)\n") do
+      assert.is_true(#line <= 1024, string.format(
+        "nftset line exceeds dnsmasq's 1024-byte config-line limit (%d bytes): %s…",
+        #line, line:sub(1, 72)))
+    end
+  end)
 end)
 
 describe("render.nft global composition (#1319)", function()


### PR DESCRIPTION
Fixes #1489. Regression from #1483 — Master Router CD has been RED on `main`
because dnsmasq won't start on the staging router, and Gate 3a's smoke fixture
times out waiting for port 53.

## Root cause

#1483 correctly collapsed the per-host nftset specs into ONE
`nftset=/<host>/...` directive per host (dnsmasq's `domain_find_sets`
honours only one nftset entry per domain — verified in dnsmasq 2.90 source).
But dnsmasq reads each config line into a fixed `MAXDNAME` (1025-byte) buffer
with NO line continuation (`option.c` `read_file`: `fgets(buff, MAXDNAME, f)`),
so any directive over 1024 bytes is truncated and its tail re-parsed as a
bogus option — dnsmasq aborts startup with `bad option`.

The only per-host nftset spec that scales with device count is the
per-`(MAC, host)` `ea_` populator. Since #1307 lands the global infra
allowlist by copying its hosts into every profile's `extraAllowed`, and #1318
turned the global section on in staging, a shared infra host accumulates one
`ea_` spec per device on a single merged line — pushing it past 1024 bytes.

## Fix (render-only)

`render.dnsmasq` now skips the per-`(MAC, host)` `ea_` populator for any
host that is also in `global.extraAllowed`. `@global_allow` already carves
that host out of every drop for every MAC via `render.nft`'s `ga_suffix`,
so those `ea_` specs were pure redundancy; dns-tail (#1346) still populates
the `ea_` sets from live replies regardless. Adds a per-host de-dup guard on
identical specs as belt-and-braces.

- No `nft.lua` / dns-tail / e2e-observer changes.
- Preserves the #1460 H3 merge invariant (H3 lives in `global.extraBlocked`,
  not `extraAllowed`, so this code path doesn't touch it).
- Express new policy via existing functional fields — no new wire field.

## Validation

**1. Full OpenWRT Lua suite (`openwrt/test/run_tests.sh`)** — green; the three
new `#1489` tests in `render_spec.lua` pass:
- `omits redundant per-(MAC,host) ea_ populators for a global.extraAllowed host`
- `still emits per-(MAC,host) ea_ populators for a host NOT in global.extraAllowed`
- `keeps every merged nftset directive within dnsmasq's 1024-byte line limit`

**2. Real HAVE_NFTSET dnsmasq 2.90 against a staging-shaped snapshot**
(infra host in `global.extraAllowed` + 24 devices each copying it into their
profile's `extraAllowed`):

```
=== BEFORE (parent of fix; e729a44^^ render.lua) ===
nftset line length: 2896 bytes
dnsmasq --test: dnsmasq: bad option at line 32 of /work/before.conf
exit=1

=== AFTER (this branch) ===
nftset line length: 88 bytes  (1 directive, comma-joined)
dnsmasq --test: dnsmasq: syntax check OK.
exit=0
```

**3. `scripts/e2e` collect-only**: 43 tests collected, no import breakage.
Real Gate 2 / Gate 3a run in CI.

## Impact

Unblocks Master Router CD (Gate 3a staging smoke), which in turn unblocks
#1460 → #1321 / #1459.

🤖 Generated with [Claude Code](https://claude.com/claude-code)