### PR TITLE
fix(#1494): migrate the profile-editor schedule WRITE path to named schedules

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -299,9 +299,9 @@ object ProfileRoutes {
                 ),
               )
               .mapError(ErrorMapper.dbErrorToResponse)
-            _    <- scheduleRepo
-              .replaceForProfile(id, upr.schedules)
-              .mapError(ErrorMapper.dbErrorToResponse)
+            // #1494: profile upsert no longer writes the legacy `schedules`
+            // table. Block schedules are attached via PUT
+            // /api/profiles/{id}/schedules (named_schedules / profile_schedule_rules).
             _    <- ZIO
               .foreachDiscard(upr.timeLimit)(mins => timeLimitRepo.upsert(id, mins))
               .mapError(ErrorMapper.dbErrorToResponse)
@@ -348,9 +348,9 @@ object ProfileRoutes {
               s"profile updated: id=${pid.value} paused=${p.paused}→${upr.paused} " +
                 s"name=${upr.name}",
             )
-            _      <- scheduleRepo
-              .replaceForProfile(pid, upr.schedules)
-              .mapError(ErrorMapper.dbErrorToResponse)
+            // #1494: profile upsert no longer writes the legacy `schedules`
+            // table. Block schedules are attached via PUT
+            // /api/profiles/{id}/schedules (named_schedules / profile_schedule_rules).
             _      <- (upr.timeLimit match {
               case Some(mins) => timeLimitRepo.upsert(pid, mins)
               case None       => timeLimitRepo.delete(pid)

--- a/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
@@ -117,7 +117,6 @@ object PolicySnapshotBlockIpOnlySpec
             name = "Kids",
             blockedCategories = Nil,
             paused = false,
-            schedules = Nil,
             timeLimit = None,
             blockIpOnly = ipOnly,
           ).toJson
@@ -168,7 +167,6 @@ object PolicySnapshotBlockIpOnlySpec
             name = name,
             blockedCategories = Nil,
             paused = false,
-            schedules = Nil,
             timeLimit = None,
             blockIpOnly = ipOnly,
           ).toJson

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -119,6 +119,36 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           assertTrue(scheds.head.startLocal == java.time.LocalTime.of(22, 0)) &&
           assertTrue(tl.exists(_.dailyMinutes == 180))
       },
+      // #1494: enforcement now reads schedules from named_schedules /
+      // profile_schedule_rules (#1482/#1490). The profile upsert must therefore
+      // STOP writing the dead V1 `schedules` table — an inline `schedules`
+      // array on the request body is ignored, never persisted.
+      test("profile upsert does not write the legacy schedules table (#1494)") {
+        for {
+          _              <- cleanDb
+          profileRepo    <- ZIO.service[ProfileRepo]
+          schedRepo      <- ZIO.service[ScheduleRepo]
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          // Raw JSON deliberately carries a legacy inline `schedules` array; a
+          // newer body would omit the field entirely. Either way nothing may
+          // land in the legacy table.
+          body =
+            """{"name":"NoLegacy","blockedCategories":[],"paused":false,""" +
+              """"schedules":[{"name":"Bedtime","days":["mon"],"startLocal":"21:00","endLocal":"07:00","tz":"UTC"}],""" +
+              """"timeLimit":null}"""
+          req  = Request
+            .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
+            .addHeader(Header.Authorization.Bearer(token))
+            .addHeader(Header.ContentType(MediaType.application.json))
+          resp     <- routes.runZIO(req)
+          profiles <- profileRepo.listAll
+          created  <- ZIO
+            .fromOption(profiles.find(_.name == "NoLegacy"))
+            .orElseFail(new Exception("Profile not found"))
+          scheds   <- schedRepo.listForProfile(created.id)
+        } yield assertTrue(resp.status == Status.Ok) && assertTrue(scheds.isEmpty)
+      },
       test("failureMode defaults to LastKnownGood when omitted from create request (#385)") {
         for {
           _              <- cleanDb

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -79,27 +79,19 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       },
     ),
     suite("POST /api/profiles")(
-      test("admin can create a profile with schedules and time limits") {
+      test("admin can create a profile with categories and time limits") {
         for {
           _              <- cleanDb
           profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
           tlRepo         <- ZIO.service[TimeLimitRepo]
           (auth, routes) <- mkRoutes
           token          <- auth.login("admin", "changeme").map(_.token.value)
+          // #1494: schedules are no longer part of the upsert; block schedules
+          // attach via PUT /api/profiles/{id}/schedules (see SchedulesApiSpec).
           body = UpsertProfileRequest(
             name = "Teenager",
             blockedCategories = List(BlocklistId.unsafe("adult"), BlocklistId.unsafe("gambling")),
             paused = false,
-            schedules = List(
-              ScheduleRequest(
-                "Bedtime",
-                List("mon", "tue", "wed", "thu", "fri"),
-                java.time.LocalTime.of(22, 0),
-                java.time.LocalTime.of(8, 0),
-                java.time.ZoneId.of("UTC"),
-              ),
-            ),
             timeLimit = Some(180),
           ).toJson
           req  = Request
@@ -111,12 +103,9 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           teen     <- ZIO
             .fromOption(profiles.find(_.name == "Teenager"))
             .orElseFail(new Exception("Profile not found"))
-          scheds   <- schedRepo.listForProfile(teen.id)
           tl       <- tlRepo.findForProfile(teen.id)
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(teen.blockedCategories.contains(BlocklistId.unsafe("adult"))) &&
-          assertTrue(scheds.length == 1) &&
-          assertTrue(scheds.head.startLocal == java.time.LocalTime.of(22, 0)) &&
           assertTrue(tl.exists(_.dailyMinutes == 180))
       },
       // #1494: enforcement now reads schedules from named_schedules /
@@ -176,7 +165,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             name = "AdultsAllowAll",
             blockedCategories = Nil,
             paused = false,
-            schedules = Nil,
             timeLimit = None,
             failureMode = Some(FailureMode.AllowAll),
           ).toJson
@@ -201,7 +189,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             name = "Kids",
             blockedCategories = Nil,
             paused = false,
-            schedules = Nil,
             timeLimit = None,
             failureMode = Some(FailureMode.AllowAll),
           ).toJson
@@ -222,7 +209,7 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           hash           <- auth.hashPassword("readpass")
           _              <- userRepo.create("reader", hash, "child")
           token          <- auth.login("reader", "readpass").map(_.token.value)
-          body = UpsertProfileRequest("Test", Nil, false, Nil, None).toJson
+          body = UpsertProfileRequest("Test", Nil, false, None).toJson
           req  = Request
             .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
             .addHeader(Header.Authorization.Bearer(token))
@@ -235,7 +222,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         for {
           _              <- cleanDb
           profileRepo    <- ZIO.service[ProfileRepo]
-          schedRepo      <- ZIO.service[ScheduleRepo]
           tlRepo         <- ZIO.service[TimeLimitRepo]
           (auth, routes) <- mkRoutes
           token          <- auth.login("admin", "changeme").map(_.token.value)
@@ -245,15 +231,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
             name = "Kids Updated",
             blockedCategories = List(BlocklistId.unsafe("adult")),
             paused = false,
-            schedules = List(
-              ScheduleRequest(
-                "Bedtime",
-                List("mon", "tue", "wed", "thu", "fri"),
-                java.time.LocalTime.of(20, 0),
-                java.time.LocalTime.of(7, 0),
-                java.time.ZoneId.of("UTC"),
-              ),
-            ),
             timeLimit = Some(120),
           ).toJson
           req    = Request
@@ -266,11 +243,9 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           resp    <- routes.runZIO(req)
           updated <- profileRepo.findById(kidsId)
           tl      <- tlRepo.findForProfile(kidsId)
-          scheds  <- schedRepo.listForProfile(kidsId)
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(updated.exists(_.name == "Kids Updated")) &&
-          assertTrue(tl.exists(_.dailyMinutes == 120)) &&
-          assertTrue(scheds.exists(_.startLocal == java.time.LocalTime.of(20, 0)))
+          assertTrue(tl.exists(_.dailyMinutes == 120))
       },
     ),
     suite("PUT /api/profiles/:id pause is idempotent (#406)")(
@@ -291,7 +266,6 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
               name = "Kids",
               blockedCategories = Nil,
               paused = paused,
-              schedules = Nil,
               timeLimit = None,
             ).toJson
             Request

--- a/api/test/src/feature/RoleAccessSpec.scala
+++ b/api/test/src/feature/RoleAccessSpec.scala
@@ -136,7 +136,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           upRepo,
           userRepo,
         )
-        body   = UpsertProfileRequest("Hacked", Nil, false, Nil, None).toJson
+        body   = UpsertProfileRequest("Hacked", Nil, false, None).toJson
         req    = Request
           .put(URL.decode(s"/api/profiles/$kidsId").toOption.get, Body.fromString(body))
           .addHeader(Header.Authorization.Bearer(token))
@@ -177,7 +177,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           "Kids Renamed",
           List(BlocklistId.unsafe("adult")),
           false,
-          Nil,
           None,
         ).toJson
         req    = Request
@@ -215,7 +214,6 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           "Pwned",
           Nil,
           false,
-          Nil,
           None,
         ).toJson
         req    = Request
@@ -244,7 +242,7 @@ object RoleAccessSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           upRepo,
           userRepo,
         )
-        body   = UpsertProfileRequest("New", Nil, false, Nil, None).toJson
+        body   = UpsertProfileRequest("New", Nil, false, None).toJson
         req    = Request
           .post(URL.decode("/api/profiles").toOption.get, Body.fromString(body))
           .addHeader(Header.Authorization.Bearer(token))

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -578,7 +578,13 @@ case class UpsertProfileRequest(
     name: String,
     blockedCategories: List[BlocklistId],
     paused: Boolean,
-    schedules: List[ScheduleRequest],
+    // #1494: schedules are NO LONGER carried here. Enforcement reads from
+    // named_schedules / profile_schedule_rules (#1482/#1490); a profile's block
+    // schedules are attached via PUT /api/profiles/{id}/schedules
+    // (SetProfileSchedulesRequest). The legacy inline array wrote the dead V1
+    // `schedules` table, so editing it was a silent no-op — the field is gone.
+    // (An older client that still sends `schedules` is tolerated: ZIO JSON
+    // ignores the unknown field, and nothing acts on it.)
     timeLimit: Option[Int],
     failureMode: Option[FailureMode] = None,
     blockIpOnly: Option[Boolean] = None,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -154,6 +154,11 @@ export const api = {
     update: (id: number, data: UpsertProfileRequest) =>
       req<void>('PUT', `/profiles/${id}`, data),
     delete: (id: number) => req<void>('DELETE', `/profiles/${id}`),
+    // #1494 / #1069 — replace the set of #1069 household named schedules
+    // attached to this profile as BLOCK schedules (downtime while active).
+    // Writes profile_schedule_rules; enforcement reads it (#1490).
+    setSchedules: (id: number, scheduleIds: number[]) =>
+      req<void>('PUT', `/profiles/${id}/schedules`, { scheduleIds }),
     getUsers: (id: number) => req<User[]>('GET', `/profiles/${id}/users`),
     setUsers: (id: number, userIds: number[]) =>
       req<void>('PUT', `/profiles/${id}/users`, { userIds }),

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -13,6 +13,7 @@ vi.mock('@/api/client', () => ({
       update: vi.fn(),
       delete: vi.fn(),
       setUsers: vi.fn(),
+      setSchedules: vi.fn(),
       usageByApp: vi.fn(),
     },
     // #1473 — the inline blocked-categories editor on the profile card
@@ -97,9 +98,11 @@ const kidsProfile: ProfileDetail = {
     pauseMode: 'soft',
     defaultDeny: false,
   },
-  schedules: [
-    { id: 10, profileId: 1, name: 'Bedtime', days: ['mon', 'tue'], startLocal: '21:00', endLocal: '07:00', tz: 'UTC' },
-  ],
+  // #1494: the legacy inline `schedules` read field is now always empty (the
+  // upsert no longer writes the V1 table). A profile's block schedules are the
+  // attached #1069 named-schedule ids.
+  schedules: [],
+  scheduleIds: [10],
   timeLimit: { id: 5, profileId: 1, dailyMinutes: 120 },
 }
 
@@ -115,6 +118,7 @@ const adultsProfile: ProfileDetail = {
     defaultDeny: false,
   },
   schedules: [],
+  scheduleIds: [],
   timeLimit: null,
 }
 
@@ -157,6 +161,7 @@ beforeEach(() => {
   ;(api.profiles.update as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.delete as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.profiles.setUsers as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(api.profiles.setSchedules as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.devices.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([phoneDevice, tabletDevice])
   ;(api.devices.patch as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(api.users.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([aliceUser, bobUser, carolUser])
@@ -308,6 +313,11 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
   })
 
   it('clicking the row toggles the expanded body', async () => {
+    // #1494: the schedule summary now lists the attached named schedule's name
+    // (kidsProfile.scheduleIds = [10]) from the household catalog.
+    (api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      [{ id: 10, name: 'Bedtime', description: null, windows: [] }],
+    )
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
@@ -315,7 +325,6 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
     expect(within(kidsCard).getByText('Bedtime')).toBeInTheDocument()
     expect(within(kidsCard).getByText('120 min')).toBeInTheDocument()
-    expect(within(kidsCard).getByText('21:00 → 07:00')).toBeInTheDocument()
     await user.click(within(kidsCard).getByTestId('profile-row-toggle-1'))
     expect(within(kidsCard).queryByText('Bedtime')).not.toBeInTheDocument()
   })
@@ -564,7 +573,8 @@ describe('ProfilesPage — create (inline name-only, #978)', () => {
       blockedCategories: [],
       paused: false,
       timeLimit: null,
-      schedules: [],
+      // #1494: the create payload no longer carries schedules — they attach via
+      // PUT /profiles/{id}/schedules after the profile exists.
       // #385: column-default for a brand-new profile is LastKnownGood.
       failureMode: 'last-known-good',
       // #751: column-default for a brand-new profile is Sum.
@@ -736,24 +746,29 @@ describe('ProfilesPage — inline time-limit subsection (#975)', () => {
   })
 })
 
-describe('ProfilesPage — inline schedules subsection (#1474)', () => {
-  it('collapsed-by-default subsection summarizes configured windows', async () => {
+// #1494 — the profile editor's schedule section now attaches #1069 household
+// named schedules (via the shared SchedulePicker) and persists them through
+// PUT /api/profiles/{id}/schedules (api.profiles.setSchedules ->
+// profile_schedule_rules), which enforcement reads (#1490). The old inline
+// per-window editor wrote the dead V1 `schedules` table — a silent no-op — and
+// is gone. These tests pin the picker round-trip and that the legacy upsert
+// write path is never used for schedules.
+describe('ProfilesPage — inline schedules subsection (#1494 named-schedule picker)', () => {
+  const bedtime = { id: 10, name: 'Bedtime', description: null, windows: [] }
+  const schoolHours = { id: 11, name: 'School hours', description: null, windows: [] }
+
+  it('collapsed-by-default subsection summarizes attached named schedules', async () => {
+    (api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await expand(1, user)
 
     const sub = within(kidsCard).getByTestId('profile-schedule-subsection-1')
-    // Collapsed: editor hidden, summary lists the configured window(s) — the
-    // schedule lines that used to live under "Time limits" (#1474).
+    // kidsProfile carries scheduleIds: [10] → the catalog name 'Bedtime' shows.
     expect(within(sub).getByText('Bedtime')).toBeInTheDocument()
-    expect(within(sub).getByText(/21:00 → 07:00/)).toBeInTheDocument()
+    // The old inline per-window editor is gone — no window rows.
     expect(within(sub).queryByTestId('profile-schedule-row-1-0')).not.toBeInTheDocument()
-
-    await user.click(within(sub).getByTestId('profile-schedule-toggle-1'))
-    expect(within(sub).getByTestId('profile-schedule-row-1-0')).toBeInTheDocument()
-    expect(within(sub).getByTestId('profile-schedule-start-1-0')).toHaveValue('21:00')
-    expect(within(sub).getByTestId('profile-schedule-end-1-0')).toHaveValue('07:00')
   })
 
   it('empty schedules summary reads "No schedules"', async () => {
@@ -765,41 +780,58 @@ describe('ProfilesPage — inline schedules subsection (#1474)', () => {
     expect(within(sub).getByText(/No schedules/i)).toBeInTheDocument()
   })
 
-  it('adding a schedule autosaves via a single PUT carrying schedules', async () => {
+  it('attaching a named schedule round-trips through setSchedules, not the legacy upsert', async () => {
+    (api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
     const user = userEvent.setup()
     renderPage()
-    const adultsCard = await screen.findByTestId('profile-card-2')
+    const adultsCard = await screen.findByTestId('profile-card-2') // scheduleIds: []
     await expand(2, user)
     const sub = within(adultsCard).getByTestId('profile-schedule-subsection-2')
     await user.click(within(sub).getByTestId('profile-schedule-toggle-2'))
     await act(async () => {})
 
+    await user.selectOptions(within(sub).getByTestId('profile-schedule-picker-2-select'), '11')
     await user.click(within(sub).getByTestId('profile-schedule-add-2'))
 
-    // Poll for the debounced PUT — schedules ride the full-profile PUT.
     await waitFor(() =>
-      expect(api.profiles.update).toHaveBeenLastCalledWith(
-        2,
-        expect.objectContaining({
-          schedules: expect.arrayContaining([
-            expect.objectContaining({ name: 'Bedtime', startLocal: '21:00', endLocal: '07:00' }),
-          ]),
-        }),
-      ),
+      expect(api.profiles.setSchedules).toHaveBeenCalledWith(2, [11]),
     )
+    // The legacy full-profile PUT is NOT used to carry schedules.
+    expect(api.profiles.update).not.toHaveBeenCalled()
   })
 
-  it('non-admins see read-only schedules — no add button', async () => {
+  it('removing an attached schedule persists the reduced id set via setSchedules', async () => {
+    (api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime, schoolHours])
+    const user = userEvent.setup()
+    renderPage()
+    const kidsCard = await screen.findByTestId('profile-card-1') // scheduleIds: [10]
+    await expand(1, user)
+    const sub = within(kidsCard).getByTestId('profile-schedule-subsection-1')
+    await user.click(within(sub).getByTestId('profile-schedule-toggle-1'))
+
+    await user.click(within(sub).getByTestId('profile-schedule-attached-1-10-remove'))
+
+    await waitFor(() =>
+      expect(api.profiles.setSchedules).toHaveBeenCalledWith(1, []),
+    )
+    expect(api.profiles.update).not.toHaveBeenCalled()
+  })
+
+  it('non-admins see read-only schedules — no picker, no attach/remove', async () => {
     mockAuth = { isAdmin: false }
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([bedtime])
     const user = userEvent.setup()
     renderPage()
     const kidsCard = await screen.findByTestId('profile-card-1')
     await expand(1, user)
     const sub = within(kidsCard).getByTestId('profile-schedule-subsection-1')
     await user.click(within(sub).getByTestId('profile-schedule-toggle-1'))
+    // Read-only: no picker, no attach button, no remove control.
     expect(within(sub).queryByTestId('profile-schedule-add-1')).not.toBeInTheDocument()
-    // The schedule name input is rendered read-only (disabled).
-    expect(within(sub).getByTestId('profile-schedule-start-1-0')).toBeDisabled()
+    expect(within(sub).queryByTestId('profile-schedule-picker-1')).not.toBeInTheDocument()
+    expect(within(sub).queryByTestId('profile-schedule-attached-1-10-remove')).not.toBeInTheDocument()
+    // The attached schedule is still listed for reference.
+    expect(within(sub).getByText('Bedtime')).toBeInTheDocument()
   })
 })
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -9,25 +9,21 @@ import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 import { SchedulePicker } from '@/components/SchedulePicker'
 import type {
   AppDetail, AppMode, AppPolicyAssignment, AppScheduleMode, AppScheduleRule,
-  CrossDeviceOverlapMode, Device, FailureMode, HouseholdSettings, PauseMode, ProfileDetail,
+  CrossDeviceOverlapMode, Device, FailureMode, PauseMode, ProfileDetail,
   ProfileTimeSummary,
-  ScheduleRequest, UpsertAppAssignmentRequest, UpsertProfileRequest, User,
+  UpsertAppAssignmentRequest, UpsertProfileRequest, User,
 } from '@/types/api'
-import { TimezonePicker, browserTimezone } from '@/components/TimezonePicker'
 import { AppIcon } from '@/components/AppIcon'
 import { ProfileTimelineChart } from '@/components/usage/ProfileTimelineChart'
 import { EmptyState } from '@/components/EmptyState'
 import { PageLoader } from './DashboardPage'
 import { formatMins } from '@/lib/timeFormat'
 
-const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
-
 interface FormState {
   name: string
   blockedCategories: string[]
   paused: boolean
   timeLimit: string
-  schedules: ScheduleRequest[]
   failureMode: FailureMode
   crossDeviceOverlapMode: CrossDeviceOverlapMode
   defaultDeny: boolean
@@ -39,15 +35,15 @@ function detailToForm(pd: ProfileDetail): FormState {
     blockedCategories: pd.profile.blockedCategories,
     paused: pd.profile.paused,
     timeLimit: pd.timeLimit ? String(pd.timeLimit.dailyMinutes) : '',
-    schedules: pd.schedules.map(s => ({
-      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-    })),
     failureMode: pd.profile.failureMode,
     crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
     defaultDeny: pd.profile.defaultDeny,
   }
 }
 
+// #1494: schedules are no longer carried on the profile upsert — they attach
+// via api.profiles.setSchedules (PUT /profiles/{id}/schedules). So the
+// full-profile PUT this builds never touches schedules.
 function formToRequest(f: FormState): UpsertProfileRequest {
   const tl = f.timeLimit.trim() === '' ? null : Number(f.timeLimit)
   return {
@@ -55,7 +51,6 @@ function formToRequest(f: FormState): UpsertProfileRequest {
     blockedCategories: f.blockedCategories,
     paused: f.paused,
     timeLimit: tl !== null && Number.isFinite(tl) ? tl : null,
-    schedules: f.schedules,
     failureMode: f.failureMode,
     crossDeviceOverlapMode: f.crossDeviceOverlapMode,
     defaultDeny: f.defaultDeny,
@@ -159,7 +154,6 @@ export function ProfilesPage() {
   // unrelated profiles.
   const [pendingUserLinks, setPendingUserLinks] = useState<Set<string>>(new Set())
   const [userLinkErrorByProfile, setUserLinkErrorByProfile] = useState<Map<number, string>>(new Map())
-  const [household, setHousehold] = useState<HouseholdSettings | null>(null)
   const [apps, setApps] = useState<AppDetail[]>([])
   // #972 — collapse-by-default; toggle state lives in-memory only. Persistence
   // across reloads is a deferred enhancement; the design doc calls this out.
@@ -238,13 +232,11 @@ export function ProfilesPage() {
     // #978 — the old modal pulled the blocklist category list for its picker;
     // the inline app-policy subsection owns that surface now, so we don't need
     // to fan out to /blocklists here anymore.
-    const [users, hs, appsList] = await Promise.all([
+    const [users, appsList] = await Promise.all([
       isAdmin ? api.users.list().catch(() => [] as User[]) : Promise.resolve([] as User[]),
-      api.household.get().catch(() => null),
       api.apps.list().catch(() => [] as AppDetail[]),
     ])
     setAllUsers(users)
-    setHousehold(hs)
     setApps([...appsList].sort((a, b) => a.app.name.localeCompare(b.app.name)))
   }
 
@@ -307,7 +299,6 @@ export function ProfilesPage() {
         blockedCategories: [],
         paused: false,
         timeLimit: null,
-        schedules: [],
         failureMode: 'last-known-good',
         crossDeviceOverlapMode: 'sum',
       })
@@ -479,7 +470,6 @@ export function ProfilesPage() {
             isAdmin={isAdmin}
             expanded={expanded.has(pd.profile.id)}
             highlight={highlightId === pd.profile.id}
-            defaultTz={household?.dailyResetTz ?? browserTimezone()}
             onToggle={() => toggleExpanded(pd.profile.id)}
             onDelete={() => del(pd.profile.id, pd.profile.name)}
             onTogglePause={(mode) => togglePause(pd, mode)}
@@ -564,7 +554,7 @@ export function ProfilesPage() {
 // Expanded body holds the inline subsections (#973-#977) that replaced the
 // old per-profile modal, plus the read-only devices listing.
 function ProfileShellRow({
-  pd, summary, devices, allDevices, users, apps, allUsers, isAdmin, expanded, highlight, defaultTz,
+  pd, summary, devices, allDevices, users, apps, allUsers, isAdmin, expanded, highlight,
   onToggle, onDelete, onTogglePause, onGrantTime,
   onAppsChanged, onProfileChanged, updateProfile,
   onToggleUserLink, pendingUserLinks, userLinkError,
@@ -579,7 +569,6 @@ function ProfileShellRow({
   isAdmin: boolean
   expanded: boolean
   highlight: boolean
-  defaultTz: string
   onToggle: () => void
   onDelete: () => void
   onTogglePause: (mode?: PauseMode) => void
@@ -618,9 +607,6 @@ function ProfileShellRow({
         blockedCategories: pd.profile.blockedCategories,
         paused: pd.profile.paused,
         timeLimit: pd.timeLimit ? pd.timeLimit.dailyMinutes : null,
-        schedules: pd.schedules.map(s => ({
-          name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-        })),
         failureMode: pd.profile.failureMode,
         crossDeviceOverlapMode: pd.profile.crossDeviceOverlapMode,
       })
@@ -892,7 +878,7 @@ function ProfileShellRow({
 
           {/* #1474 — schedules subsection (bedtime/windows), split out of the
               Time-limits expander into its own top-level disclosure. */}
-          <ScheduleSubsection pd={pd} isAdmin={isAdmin} defaultTz={defaultTz} />
+          <ScheduleSubsection pd={pd} isAdmin={isAdmin} />
 
           {/* #973: read-only Devices listing for non-admins. Admins get the
               editable DevicesSubsection above; keeping a second copy here for
@@ -999,34 +985,6 @@ function timeFormFromDetail(pd: ProfileDetail): TimeFormState {
 function timeFormsEqual(a: TimeFormState, b: TimeFormState): boolean {
   if (a.timeLimit !== b.timeLimit) return false
   if (a.crossDeviceOverlapMode !== b.crossDeviceOverlapMode) return false
-  return true
-}
-
-// #1474 — schedules are their own subsection now. Local form state +
-// structural equality so the debounced autosave can compare against the
-// last-saved baseline (mirrors TimeSubsection's pattern).
-interface ScheduleFormState {
-  schedules: ScheduleRequest[]
-}
-
-function scheduleFormFromDetail(pd: ProfileDetail): ScheduleFormState {
-  return {
-    schedules: pd.schedules.map(s => ({
-      name: s.name, days: s.days, startLocal: s.startLocal, endLocal: s.endLocal, tz: s.tz,
-    })),
-  }
-}
-
-function scheduleFormsEqual(a: ScheduleFormState, b: ScheduleFormState): boolean {
-  if (a.schedules.length !== b.schedules.length) return false
-  for (let i = 0; i < a.schedules.length; i++) {
-    const x = a.schedules[i]
-    const y = b.schedules[i]
-    if (x.name !== y.name || x.startLocal !== y.startLocal ||
-        x.endLocal !== y.endLocal || x.tz !== y.tz) return false
-    if (x.days.length !== y.days.length) return false
-    for (let j = 0; j < x.days.length; j++) if (x.days[j] !== y.days[j]) return false
-  }
   return true
 }
 
@@ -1402,63 +1360,45 @@ function TimeSubsection({
 }
 
 
-// #1474 — schedules subsection, split out of TimeSubsection. Its own
-// collapsible disclosure with the add/edit/remove schedule editor that used to
-// live under "Time limits". Schedules conceptually belong with bedtime/windows,
-// not screen-time accounting, so they get a sibling top-level subsection.
-//
-// Autosave mirrors TimeSubsection: schedules ride the same debounced
-// full-profile PUT (the wire carries `schedules` on UpsertProfileRequest), so
-// no API/wire change — just a relocated editor + independent collapse state.
+// #1494 — schedules subsection. A profile's block schedules are now #1069
+// household named schedules attached as BLOCK rules (downtime while active),
+// persisted via PUT /api/profiles/{id}/schedules -> profile_schedule_rules,
+// which enforcement reads (#1490). The old inline per-profile window editor
+// wrote the dead V1 `schedules` table — editing it was a silent no-op — so it
+// is gone, replaced by the reusable SchedulePicker (household schedules +
+// "Custom" inline that authors a reusable named schedule). A profile can
+// reference many; add/remove autosaves the full id set (replace semantics),
+// mirroring the per-app schedule-rule editor (#1380).
 function ScheduleSubsection({
-  pd, isAdmin, defaultTz,
+  pd, isAdmin,
 }: {
   pd: ProfileDetail
   isAdmin: boolean
-  defaultTz: string
 }) {
   const invalidators = useInvalidators()
+  const { data: namedSchedules = [] } = useNamedSchedules()
   const [expanded, setExpanded] = useState(false)
-  const [form, setForm] = useState<ScheduleFormState>(() => scheduleFormFromDetail(pd))
   const [status, setStatus] = useState<SaveStatus>('idle')
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [pickId, setPickId] = useState<number | null>(null)
 
-  // Sync local state on upstream pd changes only when there are no pending
-  // local edits (mirrors TimeSubsection's baseline-compare; see its comment).
-  const baselineRef = useRef<ScheduleFormState>(form)
-  const formRef = useRef<ScheduleFormState>(form)
-  formRef.current = form
-  useEffect(() => {
-    const incoming = scheduleFormFromDetail(pd)
-    const local = formRef.current
-    if (scheduleFormsEqual(local, baselineRef.current)) {
-      if (!scheduleFormsEqual(local, incoming)) {
-        setForm(incoming)
-      }
-    }
-    baselineRef.current = incoming
-  }, [pd])
+  const attachedIds = pd.scheduleIds ?? []
+  const scheduleNameById = useMemo(() => {
+    const m = new Map<number, string>()
+    namedSchedules.forEach(s => m.set(s.id, s.name))
+    return m
+  }, [namedSchedules])
 
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => {
-    if (timerRef.current) clearTimeout(timerRef.current)
     if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
   }, [])
 
-  const scheduleSave = (next: ScheduleFormState) => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(() => { void doSave(next) }, 600)
-  }
-
-  async function doSave(next: ScheduleFormState) {
+  async function save(nextIds: number[]) {
     setStatus('saving')
     setErrorMsg(null)
     try {
-      const body = formToRequest(detailToForm(pd))
-      body.schedules = next.schedules
-      await api.profiles.update(pd.profile.id, body)
-      baselineRef.current = next
+      await api.profiles.setSchedules(pd.profile.id, nextIds)
       setStatus('saved')
       void invalidators.profileMutated()
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
@@ -1471,30 +1411,14 @@ function ScheduleSubsection({
     }
   }
 
-  const updateSchedules = (mut: (s: ScheduleRequest[]) => ScheduleRequest[]) => {
-    setForm(prev => {
-      const next = { schedules: mut(prev.schedules) }
-      scheduleSave(next)
-      return next
-    })
+  function attach() {
+    if (pickId == null || attachedIds.includes(pickId)) return
+    const next = [...attachedIds, pickId]
+    setPickId(null)
+    void save(next)
   }
-
-  function addSchedule() {
-    updateSchedules(s => [
-      ...s,
-      { name: 'Bedtime', days: [...DAYS], startLocal: '21:00', endLocal: '07:00', tz: defaultTz },
-    ])
-  }
-  function patchSchedule(i: number, p: Partial<ScheduleRequest>) {
-    updateSchedules(s => s.map((x, idx) => idx === i ? { ...x, ...p } : x))
-  }
-  function removeSchedule(i: number) {
-    updateSchedules(s => s.filter((_, idx) => idx !== i))
-  }
-  function toggleDay(i: number, d: string) {
-    updateSchedules(s => s.map((x, idx) => idx !== i ? x : {
-      ...x, days: x.days.includes(d) ? x.days.filter(y => y !== d) : [...x.days, d],
-    }))
+  function detach(id: number) {
+    void save(attachedIds.filter(x => x !== id))
   }
 
   const statusLabel =
@@ -1530,13 +1454,11 @@ function ScheduleSubsection({
 
       {!expanded && (
         <div className="px-4 pb-3 space-y-1">
-          {pd.schedules.length > 0
-            ? pd.schedules.map(s => (
-              <div key={s.id} className="flex justify-between text-sm bg-brand-alt/50 rounded-lg px-3 py-2">
-                <span className="text-brand-text">{s.name}</span>
-                <span className="text-amber-700 font-mono text-xs">
-                  {s.startLocal} → {s.endLocal} <span className="text-amber-700/60">({s.tz})</span>
-                </span>
+          {attachedIds.length > 0
+            ? attachedIds.map(id => (
+              <div key={id} className="flex justify-between text-sm bg-brand-alt/50 rounded-lg px-3 py-2">
+                <span className="text-brand-text">{scheduleNameById.get(id) ?? `Schedule ${id}`}</span>
+                <span className="text-amber-700 font-mono text-xs">Blocked during</span>
               </div>
             ))
             : <p className="text-xs text-brand-text-muted">No schedules.</p>
@@ -1552,80 +1474,54 @@ function ScheduleSubsection({
             </div>
           )}
 
-          <div>
-            <div className="flex items-center justify-between mb-2">
-              <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider">
-                Schedules
-              </label>
-              {isAdmin && (
+          <div className="space-y-2">
+            <label className="block text-xs font-semibold text-brand-text-muted uppercase tracking-wider">
+              Block schedules
+            </label>
+            <p className="text-xs text-brand-text-muted">
+              Internet is blocked for this profile while an attached schedule's
+              window is active. Schedules are shared household schedules — edit
+              one on the Schedules page and it changes everywhere it's used.
+            </p>
+
+            {attachedIds.length === 0 && (
+              <p className="text-xs text-brand-text-muted italic">No schedules attached.</p>
+            )}
+
+            {attachedIds.map(id => (
+              <div
+                key={id}
+                data-testid={`profile-schedule-attached-${pd.profile.id}-${id}`}
+                className="flex items-center gap-2 bg-brand-surface border border-brand-border-strong rounded-lg px-3 py-2">
+                <span className="flex-1 text-sm text-brand-ink">
+                  {scheduleNameById.get(id) ?? `Schedule ${id}`}
+                </span>
+                {isAdmin && (
+                  <button type="button"
+                    data-testid={`profile-schedule-attached-${pd.profile.id}-${id}-remove`}
+                    aria-label={`Remove ${scheduleNameById.get(id) ?? 'schedule'}`}
+                    onClick={() => detach(id)}
+                    className="text-brand-text-muted hover:text-red-700 transition-colors leading-none text-sm">×</button>
+                )}
+              </div>
+            ))}
+
+            {isAdmin && (
+              <div className="space-y-2 pt-1">
+                <SchedulePicker
+                  value={pickId}
+                  onChange={setPickId}
+                  testId={`profile-schedule-picker-${pd.profile.id}`}
+                />
                 <button type="button"
                   data-testid={`profile-schedule-add-${pd.profile.id}`}
-                  onClick={addSchedule}
-                  className="text-xs text-brand-accent hover:text-brand-accent">
-                  + Add schedule
+                  disabled={pickId == null || attachedIds.includes(pickId)}
+                  onClick={attach}
+                  className="text-xs px-2.5 py-1 rounded-lg bg-brand-accent/10 text-brand-accent font-medium hover:bg-brand-accent/20 disabled:opacity-50">
+                  Attach schedule
                 </button>
-              )}
-            </div>
-            {form.schedules.length === 0 && (
-              <p className="text-xs text-brand-text-muted">No schedules.</p>
+              </div>
             )}
-            <div className="space-y-3">
-              {form.schedules.map((s, i) => (
-                <div key={i} className="bg-brand-surface border border-brand-border-strong rounded-xl p-3 space-y-2"
-                  data-testid={`profile-schedule-row-${pd.profile.id}-${i}`}>
-                  <div className="flex gap-2">
-                    <input type="text"
-                      value={s.name}
-                      disabled={!isAdmin}
-                      onChange={e => patchSchedule(i, { name: e.target.value })}
-                      placeholder="Bedtime"
-                      className="flex-1 bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm disabled:opacity-60" />
-                    {isAdmin && (
-                      <button type="button"
-                        onClick={() => removeSchedule(i)}
-                        className="text-xs text-red-700 hover:text-red-700 bg-red-500/10 px-3 rounded-lg">
-                        Remove
-                      </button>
-                    )}
-                  </div>
-                  <div className="flex gap-2 items-center text-sm">
-                    <input type="time" value={s.startLocal}
-                      disabled={!isAdmin}
-                      onChange={e => patchSchedule(i, { startLocal: e.target.value })}
-                      data-testid={`profile-schedule-start-${pd.profile.id}-${i}`}
-                      className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink disabled:opacity-60" />
-                    <span className="text-brand-text-muted">→</span>
-                    <input type="time" value={s.endLocal}
-                      disabled={!isAdmin}
-                      onChange={e => patchSchedule(i, { endLocal: e.target.value })}
-                      data-testid={`profile-schedule-end-${pd.profile.id}-${i}`}
-                      className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink disabled:opacity-60" />
-                  </div>
-                  <TimezonePicker
-                    value={s.tz}
-                    onChange={tz => patchSchedule(i, { tz })}
-                    testId={`profile-schedule-tz-${pd.profile.id}-${i}`}
-                  />
-                  <div className="flex flex-wrap gap-1">
-                    {DAYS.map(d => {
-                      const on = s.days.includes(d)
-                      return (
-                        <button key={d} type="button"
-                          disabled={!isAdmin}
-                          onClick={() => toggleDay(i, d)}
-                          className={`text-xs px-2.5 py-1 rounded-lg border ${
-                            on
-                              ? 'bg-brand-accent/20 text-brand-accent border-brand-accent/40'
-                              : 'bg-brand-alt text-brand-text-muted border-brand-border-strong'
-                          } disabled:opacity-60`}>
-                          {d}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
           </div>
         </div>
       )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -677,7 +677,10 @@ export interface UpsertProfileRequest {
   name: string
   blockedCategories: string[]
   paused: boolean
-  schedules: ScheduleRequest[]
+  // #1494: schedules are NOT carried here. A profile's block schedules are
+  // #1069 household named schedules attached via PUT /api/profiles/{id}/schedules
+  // (SetProfileSchedulesRequest -> profile_schedule_rules), which enforcement
+  // reads (#1482/#1490). The old inline array wrote the dead V1 schedules table.
   timeLimit: number | null
   failureMode: FailureMode
   // #751: omit to preserve existing value on update; defaults to 'sum' on create.


### PR DESCRIPTION
## Why

After #1482 (PR #1490) enforcement **reads** block schedules from
`named_schedules` / `profile_schedule_rules`, but the profile editor still
**wrote** the legacy V1 `schedules` table via an inline `schedules` array on
the profile upsert. Nothing reads that table anymore, so **editing a profile's
schedule in the editor was a silent no-op** — split-brain: new read path, old
write path. Fixes #1494.

## What changed

**API**
- Removed `schedules` from `UpsertProfileRequest` (shared `Models`). Unknown
  fields are tolerated on input, so an older client that still sends it is
  ignored rather than rejected (no compat shim needed — the SPA ships with the
  API).
- Dropped the `scheduleRepo.replaceForProfile(...)` calls from `POST`/`PUT`
  `/api/profiles`. **Nothing now writes the legacy `schedules` table.** Block
  schedules attach via the existing `PUT /api/profiles/{id}/schedules`
  (`SetProfileSchedulesRequest` → `profile_schedule_rules`), which enforcement
  reads (#1490).

**SPA**
- The profile editor's Schedules subsection now uses the **#1069 reusable
  `SchedulePicker`** (household schedules + "Custom" inline that authors a
  reusable named schedule) to attach/detach household named schedules as BLOCK
  schedules, persisting through `api.profiles.setSchedules`. Removed the inline
  per-window editor and the now-dead `schedules` field from the profile
  form/create/name-edit payloads, plus the dead `household`/`defaultTz`
  threading that only fed the old editor's timezone default.

The model stays consistent with the per-app schedule-rule editor (#1379/#1380):
attach a named schedule by reference, replace-semantics on the id set.

## TDD (red → green)

- `test(#1494)` commit: `ProfileApiSpec` asserts an inline `schedules` array on
  the upsert is **not** persisted to the legacy table — fails on the old write
  path.
- Green commits make it pass and switch the SPA.
- web: the Schedules subsection round-trips through `setSchedules` and the
  legacy `api.profiles.update` write path is never used for schedules.

`mill api.test` (affected specs) + full `web` vitest (382) + `type-check` +
`lint` all green.

## Migration coordination

This is the live-data counterpart to #1482's backfill (existing rows migrated;
this switches **new** edits). Both must be in before the legacy `schedules`
table can be dropped — **#1485 stays blocked until this lands and soaks.**

Refs: #1482 (read-switch + backfill, PR #1490), #1069 (named-schedule UI/picker,
PR #1487), #1485 (legacy-table drop — gated on this + #1482), #1379/#1380
(per-app model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)