### PR TITLE
ci(e2e): de-flake #924 proportional/presence split — drive by presence span, not byte ratio (#1491)

### DIFF
--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -606,6 +606,86 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(kids.devices.length == 2) &&               // both devices in breakdown
           assertTrue(kids.devices.map(_.deviceName).toSet == Set("iPad", "iPhone"))
       },
+      // #1491 / #924 / #1465: per-app `proportionalMins` on `hostUsage` follows the
+      // session-span model (#1488) — the length of a host's stitched
+      // [period_start, period_end] sessions — NOT the old #715 byte-share weighting.
+      // A host present across several contiguous windows stitches into one long
+      // session and dominates a host present in only one window, deterministically
+      // and independent of bytes. This pins the e2e #924 step
+      // (scripts/e2e-router.sh) at the API level so it can't silently regress to a
+      // byte-ratio expectation: heavy924 is active across three contiguous 5-min
+      // windows (→ one ~15-min session) while light924 is active only in the last
+      // (→ one ~5-min session). (If #1466's connection-event-anchored span edges
+      // shift the exact magnitudes, update the 15/5 here in lockstep with the e2e
+      // tolerance — the heavy ≥ 2× light ordering is the stable invariant.)
+      test(
+        "#924/#1465: per-app proportionalMins follows session span — heavy across 3 windows dominates light in 1",
+      ) {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // heavy: buckets 0,1,2 → three contiguous windows that stitch into one
+          // [0, 900s) session. light: bucket 2 only → a single [600s, 900s) window.
+          _               <- seedTraffic(routerId, testMac, "heavy924.example.com", today, 15)
+          _               <- seedTraffic(routerId, testMac, "light924.example.com", today, 5, 2)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode(s"/api/time/status?profileId=${kidsId.value}").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids   = list.find(_.profileId == kidsId).get
+          byHost = kids.hostUsage.map(h => h.host.value -> h).toMap
+          heavy  = byHost("heavy924.example.com")
+          light  = byHost("light924.example.com")
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // session-span: heavy's stitched 15-min session, light's single 5-min window.
+          assertTrue(heavy.proportionalMins == 15) &&
+          assertTrue(light.proportionalMins == 5) &&
+          // the exact invariant the e2e #924 step asserts (heavy ≥ 2× light, both > 0).
+          assertTrue(
+            light.proportionalMins > 0 && heavy.proportionalMins >= 2 * light.proportionalMins,
+          )
+      },
       // #795: per-profile scope so the SPA can fetch one card's worth of data
       // instead of fanning out N sub-rollups. The filter is applied before the
       // per-profile loop runs, so only the requested profile's queries fire.

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -583,16 +583,32 @@ esac
 # wall-clock timestamp is all that's needed.
 # ════════════════════════════════════════════════════════════════════════════
 
-# ── #924: per-FQDN time — proportional (byte-share) vs presence attribution ──
+# ── #924: per-app (per-FQDN) time — session-span presence attribution (#1465) ──
 #
 # Gap from #715: e2e only ever asserted whole-device minutes, never the per-host
-# split on /api/time/status `hostUsage`. Each (mac, period_start) bucket credits
-# every host its FULL duration as `usedMins` (presence) but splits the duration
-# by byte share as `proportionalMins` (#715). Post ONE bucket with two hosts at a
-# 90/10 byte split and assert: the heavy host's proportionalMins exceeds half the
-# (shared) presence minutes, the light host's is strictly below its presence
-# minutes, and heavy > light.
-step "#924: hostUsage proportional vs presence split on /api/time/status"
+# split on /api/time/status `hostUsage`.
+#
+# #1491 / #1465 note: `proportionalMins` USED to be a byte-share weighting of a
+# single bucket's duration (#715). The #1465 presence rework (session-stitch,
+# api/src/presence/Presence.scala `proportionalHostSeconds`, landed in #1488)
+# REPLACED byte-share with a wall-clock session-span model: a host's
+# `proportionalMins` is now the length of its stitched [period_start, period_end]
+# sessions — independent of bytes and of report rate. The old fixture posted one
+# bucket with a 90/10 *byte* split and asserted heavy>light by bytes; under the
+# session model both hosts share the same single 5-min window, so both came out
+# `proportionalMins:5` and the assertion flaked/failed (#1491). The race wasn't in
+# timing — it was the semantics changing under the test as #1488 rolled out to
+# staging.
+#
+# So the differential is now expressed as PRESENCE SPAN, not byte ratio: the heavy
+# host is active across three contiguous 5-min windows (which stitch into one
+# ~15-min session) while the light host is active in only the last window (~5-min
+# session). We poll /api/time/status until the heavy session has settled to
+# clearly dominate the light one. Do NOT reintroduce a byte-ratio expectation
+# here — the byte-share path is gone from this surface. If #1466 (connection-event
+# anchored span edges) later shifts the magnitudes, the ratio tolerance below may
+# need a bump, but `heavy > light` is the stable invariant.
+step "#924: hostUsage per-app session-span split on /api/time/status"
 P924_ID=$(curl -fsS -X POST "$BASE/api/profiles" "${AUTH[@]}" \
   -H 'content-type: application/json' \
   -d "{\"name\":\"e2e-924-${RUN_ID}\",\"blockedCategories\":[],\"extraBlocked\":[],\"extraAllowed\":[],\"paused\":false,\"schedules\":[],\"timeLimit\":null,\"siteTimeLimits\":[]}" \
@@ -605,27 +621,36 @@ curl -fsS -X PUT "$BASE/api/devices" "${AUTH[@]}" \
   -d "{\"mac\":\"$MAC924\",\"name\":\"e2e-924-dev-${RUN_ID}\",\"profileId\":$P924_ID}" >/dev/null
 EXTRA_DEVICES+=("$MAC924")
 
-# 900k vs 100k bytes = 90/10 split, both active the full 300s → presence
-# usedMins=5 for each host; proportional splits 300s into 270s (=4 min) heavy
-# vs 30s (=0 min) light.
-U924_BODY=$(cat <<EOF
-{
-  "routerId": "$RID",
-  "periodStart": "$FIVE_AGO",
-  "periodEnd": "$NOW",
-  "records": [
-    {"mac":"$MAC924","ip":"192.168.4.10","host":{"type":"fqdn","value":"heavy924.example.com"},"activeSeconds":300,"bytesIn":900000,"bytesOut":0},
-    {"mac":"$MAC924","ip":"192.168.4.10","host":{"type":"fqdn","value":"light924.example.com"},"activeSeconds":300,"bytesIn":100000,"bytesOut":0}
-  ]
+# Three contiguous 5-min windows ending ~now. traffic_reports is keyed by
+# (router_id, period_start, mac, host_type, host_value) and one /api/router/usage
+# batch carries a single (periodStart, periodEnd), so each window is its own POST.
+# heavy924 is present in all three windows → stitched into one ~15-min session;
+# light924 only in the last → one ~5-min session. Byte counts are equal and
+# irrelevant under the session model (kept non-trivial just so the records are
+# realistic). Timestamps come from a single clock read so the windows abut exactly
+# (gap 0 ≤ effectiveGap, so they stitch).
+read -r W15 W10 W5 W0 < <(_py "
+from datetime import datetime,timezone,timedelta
+n=datetime.now(timezone.utc)
+f=lambda m:(n-timedelta(minutes=m)).strftime('%Y-%m-%dT%H:%M:%SZ')
+print(f(15),f(10),f(5),f(0))
+")
+HEAVY924_REC="{\"mac\":\"$MAC924\",\"ip\":\"192.168.4.10\",\"host\":{\"type\":\"fqdn\",\"value\":\"heavy924.example.com\"},\"activeSeconds\":300,\"bytesIn\":100000,\"bytesOut\":0}"
+LIGHT924_REC="{\"mac\":\"$MAC924\",\"ip\":\"192.168.4.10\",\"host\":{\"type\":\"fqdn\",\"value\":\"light924.example.com\"},\"activeSeconds\":300,\"bytesIn\":100000,\"bytesOut\":0}"
+post_924_window() { # $1=periodStart $2=periodEnd $3=records JSON array
+  curl -fsS -X POST "$BASE/api/router/usage" "${RAUTH[@]}" \
+    -H 'content-type: application/json' \
+    -d "{\"routerId\":\"$RID\",\"periodStart\":\"$1\",\"periodEnd\":\"$2\",\"records\":$3}" >/dev/null
 }
-EOF
-)
-curl -fsS -X POST "$BASE/api/router/usage" "${RAUTH[@]}" \
-  -H 'content-type: application/json' -d "$U924_BODY" >/dev/null
-pass "#924: posted 1 bucket, 2 hosts, 90/10 byte split"
+post_924_window "$W15" "$W10" "[$HEAVY924_REC]"
+post_924_window "$W10" "$W5"  "[$HEAVY924_REC]"
+post_924_window "$W5"  "$W0"  "[$HEAVY924_REC,$LIGHT924_REC]"
+pass "#924: posted 3 windows — heavy in all (≈15-min session), light in last (≈5-min)"
 
 # today-cache TTL is 30s (api/src/cache/TimeStatusCache.scala); allow up to 40s
-# for a poisoned-empty entry to expire on a staging rollover.
+# for a poisoned-empty entry to expire and for all three windows to ingest. We
+# poll until the heavy session-span has SETTLED to dominate the light one, rather
+# than asserting at a fixed point (the heavy windows may land one at a time).
 H924_OK=""
 deadline=$(( $(date +%s) + 40 ))
 while (( $(date +%s) < deadline )); do
@@ -640,16 +665,19 @@ hu = {h['host'].get('value'): h for h in p.get('hostUsage', []) if h['host'].get
 heavy = hu.get('heavy924.example.com'); light = hu.get('light924.example.com')
 if not heavy or not light:
     print('hosts-missing have=' + ','.join(sorted(hu))); raise SystemExit
-ok = (heavy['proportionalMins'] > heavy['usedMins'] / 2
-      and light['proportionalMins'] < light['usedMins']
-      and heavy['proportionalMins'] > light['proportionalMins'])
+# #1465 session-span: heavy's stitched ~15-min session must clearly dominate
+# light's single ~5-min window. Require >=2x separation + both>0 so a transient
+# tie (before all three heavy windows ingest) keeps the loop polling instead of
+# passing by coincidence.
+ok = (light['proportionalMins'] > 0
+      and heavy['proportionalMins'] >= 2 * light['proportionalMins'])
 print('ok' if ok else 'fail heavy=%s light=%s' % (heavy, light))
 ")
   [ "$H924_OK" = "ok" ] && break
   sleep 2
 done
-[ "$H924_OK" = "ok" ] || fail "#924: proportional/presence split wrong: $H924_OK"
-pass "#924: heavy proportionalMins > ½ presence; light < presence; heavy > light"
+[ "$H924_OK" = "ok" ] || fail "#924: per-app session-span split wrong: $H924_OK"
+pass "#924: heavy session-span proportionalMins ≥ 2× light; both > 0"
 
 # ── #927: household-local day bucketing of usage across the reset boundary ───
 #


### PR DESCRIPTION
Closes #1491.

## What was flaky
`Master API/UI CD` → "Live e2e against staging stack" → "Run router e2e tests" intermittently failed the **#924 proportional/presence split** with both hosts at `usedMins:5, proportionalMins:5`.

## Root cause — not a timing race
`proportionalMins` on `/api/time/status` `hostUsage` used to be the #715 **byte-share** weighting of a single bucket's duration. The #1465 presence rework (session-stitch, `api/src/presence/Presence.scala` `proportionalHostSeconds`) **landed in #1488** and replaced byte-share with a wall-clock **session-span** model: a host's `proportionalMins` is now the length of its stitched `[period_start, period_end]` sessions, independent of bytes and report rate.

The old #924 fixture posted **one** bucket with a 90/10 *byte* split and asserted heavy>light by bytes. Under the session model both hosts share that single 5-min window, so both come out `proportionalMins:5` and the assertion fails. The "intermittent" framing was the semantics changing under the test as #1488 rolled out to staging — the failing run ([job](https://github.com/wifihaven/wifihaven/actions/runs/27042821714/job/79822511724), 22:12Z) is just after #1488 merged (22:05Z).

## Fix
- **Express the differential as presence span, not byte ratio** (`scripts/e2e-router.sh`): the heavy host is active across **three contiguous 5-min windows** (one stitched ~15-min session) while the light host is active only in the **last** (~5-min). Each window is its own `/api/router/usage` POST, since `traffic_reports` is keyed by `(router_id, period_start, mac, host_type, host_value)` and one batch carries a single period.
- **Poll until settled**, not at a fixed point: keep reading `/api/time/status` until the heavy session-span clearly dominates (`heavy >= 2× light`, both `> 0`). No blind `--retry`. This ordering holds under **both** the old byte-share model and the new session-span model, so the test is robust across the #1488 boundary and does not fight #1465.
- **Pin the new semantics** with a deterministic feature test in `TimeApiSpec` (`heavy=15`, `light=5`) so the e2e expectation can't silently regress to a byte ratio.

## The `Unexpected end of input bodyLen=36` warning
A red herring. It's the intentional **"malformed JSON → 4xx"** negative test at `scripts/e2e-router.sh:556`, whose body `{"this is": "not router events JSON"` is exactly **36 chars**. No truncated emitter; no change needed.

## Coordinating with #1465
This assertion now tracks #1465's session-span semantics (it no longer references byte share at all). If #1466 (connection-event-anchored span edges) later shifts the exact magnitudes, update the `15`/`5` in the feature test in lockstep with the e2e tolerance — the `heavy ≥ 2× light` ordering is the stable invariant. Noted inline in both files.

## Stability evidence (before/after)
- **Before:** old fixture under the session-span model → `heavy={…'proportionalMins':5}`, `light={…'proportionalMins':5}` → fail.
- **After, live API (pre-#1488 byte-share):** new 3-window fixture **PASS 25/25** (heavy=12, light=2).
- **After, this branch (post-#1488 session-span):** `TimeApiSpec` feature test **PASS** (heavy=15, light=5), green across the full `api.test` suite (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)