### PR TITLE
feat(#1492): presence-based per-profile usage graph (reconcile with time-used; per-app contributions)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -363,6 +363,7 @@ object Main extends ZIOAppDefault {
             appRepo,
             rollupRepo2,
             hsRepo,
+            stlRepo,
             clock,
           ) ++
           DashboardNowRoutes.routes(

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -110,9 +110,11 @@ object Presence {
       .reverse
 
   /**
-   * Overlap-merge spans (gap 0) and sum their wall-clock seconds — the within-device/profile union.
+   * Overlap-merge spans (gap 0) into a minimal, sorted, non-overlapping set. Shared by
+   * [[unionSeconds]] and the hour-clipped decomposition (#1492) so the union semantics are
+   * identical whether the caller wants total seconds or a per-hour breakdown.
    */
-  def unionSeconds(spans: List[Span]): Long =
+  def mergeSpans(spans: List[Span]): List[Span] =
     spans
       .sortBy(_.startEpoch)
       .foldLeft(List.empty[Span]) {
@@ -120,8 +122,40 @@ object Presence {
           head.copy(endEpoch = head.endEpoch.max(s.endEpoch)) :: tail
         case (acc, s)                                           => s :: acc
       }
-      .map(_.seconds)
-      .sum
+      .reverse
+
+  /**
+   * Overlap-merge spans (gap 0) and sum their wall-clock seconds — the within-device/profile union.
+   */
+  def unionSeconds(spans: List[Span]): Long =
+    mergeSpans(spans).map(_.seconds).sum
+
+  /**
+   * #1492: distribute spans across the 24 local-hour buckets of `date` in `zone`, in seconds. Each
+   * span is clipped to every hour it overlaps; spans are summed, so the caller controls overlap
+   * semantics by pre-merging (union — one contribution) or concatenating (sum — each counted). The
+   * seconds outside `[date 00:00, date+1 00:00)` are dropped, so summing the map reconciles with
+   * [[unionSeconds]] of the same (merged) spans whenever those spans lie within the day window —
+   * which the day-scoped presence query guarantees. Hours with no overlap are absent.
+   */
+  def secondsByLocalHour(
+      spans: List[Span],
+      date: LocalDate,
+      zone: java.time.ZoneId,
+  ): Map[Int, Long] = {
+    val dayStart = date.atStartOfDay(zone).toInstant.getEpochSecond
+    val acc      = scala.collection.mutable.Map.empty[Int, Long]
+    for {
+      s  <- spans
+      hr <- 0 until 24
+    } {
+      val hourStart = dayStart + hr.toLong * 3600L
+      val hourEnd   = hourStart + 3600L
+      val overlap   = (s.endEpoch.min(hourEnd) - s.startEpoch.max(hourStart)).max(0L)
+      if (overlap > 0L) acc(hr) = acc.getOrElse(hr, 0L) + overlap
+    }
+    acc.toMap
+  }
 
   /**
    * The non-heartbeat, non-exempt rows that bear on the daily cap. A row is dropped if it is a
@@ -211,6 +245,59 @@ object Presence {
       continuationSeconds: Int = DefaultContinuationSeconds,
   ): Int =
     (dedupedTotalSeconds(rows, exemptPatterns, filter, continuationSeconds) / 60).toInt
+
+  /**
+   * #1492: per-mac merged daily session spans — the per-device building block of the daily cap, in
+   * span form. Counts exactly the rows [[totalSecondsByMac]] does (non-heartbeat, non-exempt),
+   * stitches per `(device, app)` on the idle gap, then unions across apps within the device.
+   * `unionSeconds` of a mac's spans equals `totalSecondsByMac(...)` for that mac, so an
+   * hour-clipped decomposition of these spans reconciles with the headline daily total — this is
+   * what makes the per-profile usage graph presence-based (#1492) instead of bucket-max.
+   */
+  def deviceSessionSpans(
+      rows: List[PresenceRow],
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[MacAddress, List[Span]] = {
+    val counted = countedRows(rows, exemptPatterns, filter)
+    val gap     = effectiveGap(counted, continuationSeconds)
+    counted
+      .groupBy(_.mac)
+      .view
+      .mapValues(macRows => mergeSpans(sessionSpans(macRows, gap)))
+      .filter(_._2.nonEmpty)
+      .toMap
+  }
+
+  /**
+   * #1492: per-host (per-app) profile-level session spans — the span form of
+   * [[proportionalHostSeconds]]. `Sum` keeps each device's stitched spans of a host separate (the
+   * same host on two devices double-counts when their seconds are summed); `Dedup` unions a host's
+   * spans across devices so simultaneous use on two screens counts once. Summing a host's span
+   * seconds reproduces [[proportionalHostSeconds]] exactly, so the hour-clipped per-app breakdown
+   * stays consistent with the per-app presence surface (#1465). Heartbeat rows are dropped before
+   * stitching (§4.4-2), same as [[proportionalHostSeconds]].
+   */
+  def hostSessionSpans(
+      rows: List[PresenceRow],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[HostId, List[Span]] = {
+    val active        = rows.filterNot(r => isHeartbeat(r, filter))
+    val gap           = effectiveGap(active, continuationSeconds)
+    val perDeviceHost =
+      active.groupBy(r => (r.mac, r.host)).view.mapValues(rs => stitch(rs.map(spanOf), gap)).toMap
+    val byHost        = perDeviceHost.iterator
+      .map { case ((_, h), spans) => h -> spans }
+      .toList
+      .groupMapReduce(_._1)(_._2)(_ ++ _)
+    overlap match {
+      case CrossDeviceOverlapMode.Sum   => byHost
+      case CrossDeviceOverlapMode.Dedup => byHost.view.mapValues(mergeSpans).toMap
+    }
+  }
 
   /**
    * #714 heartbeat classification. As of #1465 the filter applies to every presence surface — the

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -26,6 +26,7 @@ object UsageRoutes {
       appRepo: AppRepo,
       rollupRepo: RollupRepo,
       hsRepo: HouseholdSettingsRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -177,6 +178,7 @@ object UsageRoutes {
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
               else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+            settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             resp      <- (macOpt, profileIdOpt) match {
               case (Some(mac), _) =>
                 buildForDevice(
@@ -190,6 +192,7 @@ object UsageRoutes {
                   userProfileRepo,
                   groupByApp,
                   appLookup,
+                  settings,
                 )
               case (_, Some(pid)) =>
                 buildForProfile(
@@ -202,8 +205,10 @@ object UsageRoutes {
                   deviceRepo,
                   trafficRepo,
                   userProfileRepo,
+                  siteTimeLimitRepo,
                   groupByApp,
                   appLookup,
+                  settings,
                 )
               case _              => ZIO.fail(Response.badRequest("unreachable"))
             }
@@ -236,6 +241,7 @@ object UsageRoutes {
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
               else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+            settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             resp      <- buildBatch(
               pids,
               date,
@@ -246,8 +252,10 @@ object UsageRoutes {
               deviceRepo,
               trafficRepo,
               userProfileRepo,
+              siteTimeLimitRepo,
               groupByApp,
               appLookup,
+              settings,
             )
           } yield Response.json(resp.toJson)
         },
@@ -268,33 +276,67 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
       groupByApp: Boolean,
       appLookup: HostId => Option[UsageSeries.AppInfo],
+      settings: HouseholdSettings,
   ): IO[Response, UsageSeriesBatchResponse] =
     for {
       _ <- ZIO.foreachDiscard(pids)(pid => requireProfileReadAccess(claims, pid, userProfileRepo))
-      profiles   <- ZIO.foreach(pids) { pid =>
+      profiles    <- ZIO.foreach(pids) { pid =>
         profileRepo
           .findById(pid)
           .mapError(ErrorMapper.dbErrorToResponse)
           .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
       }
-      allDevices <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      // #1492: exempt-from-daily site patterns must match the headline daily total exactly, so
+      // load them per profile (same input `usedSecondsForProfile` uses) and carve them out.
+      exemptByPid <- ZIO
+        .foreach(pids) { pid =>
+          siteTimeLimitRepo
+            .listForProfile(pid)
+            .map(sl => pid -> sl.filter(_.exemptFromDaily).map(_.domainPattern))
+        }
+        .map(_.toMap)
+        .mapError(ErrorMapper.dbErrorToResponse)
       devicesByPid = pids.iterator
         .map(pid => pid -> allDevices.filter(_.profileId.contains(pid)))
         .toMap
-      allMacs      = devicesByPid.valuesIterator.flatten.map(_.mac).toList.distinct
-      rows <- fetchPresenceDayWindow(trafficRepo, allMacs, date, zone)
+      allMacs = devicesByPid.valuesIterator.flatten.map(_.mac).toList.distinct
+      rows        <- fetchPresenceDayWindow(trafficRepo, allMacs, date, zone)
     } yield {
       val series = profiles.map { profile =>
         val devices   = devicesByPid.getOrElse(profile.id, Nil)
         val macSet    = devices.iterator.map(_.mac).toSet
         val nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
         val pRows     = rows.filter(r => macSet.contains(r.mac))
-        val (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
-          UsageSeries.buildProfile(pRows, nameByMac, zone, topN, profile.crossDeviceOverlapMode)
-        val (topEntries, bucketsByEntry)                           =
-          if (groupByApp) UsageSeries.buildEntries(pRows, zone, topN, appLookup)
+        val exempt    = exemptByPid.getOrElse(profile.id, Nil)
+        val (topHosts, bucketsByHost, topDevices, bucketsByDevice, presenceTotalMins) =
+          UsageSeries.buildProfile(
+            pRows,
+            nameByMac,
+            date,
+            zone,
+            topN,
+            profile.crossDeviceOverlapMode,
+            exempt,
+            settings.heartbeatFilter,
+            settings.presenceContinuationSeconds,
+          )
+        val (topEntries, bucketsByEntry)                                              =
+          if (groupByApp)
+            UsageSeries.buildEntries(
+              pRows,
+              date,
+              zone,
+              topN,
+              profile.crossDeviceOverlapMode,
+              exempt,
+              settings.heartbeatFilter,
+              settings.presenceContinuationSeconds,
+              appLookup,
+            )
           else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
         UsageSeriesResponse(
           profileId = Some(profile.id),
@@ -307,6 +349,7 @@ object UsageRoutes {
           bucketsByDevice = bucketsByDevice,
           topEntries = topEntries,
           bucketsByEntry = bucketsByEntry,
+          presenceTotalMins = presenceTotalMins,
         )
       }
       UsageSeriesBatchResponse(series)
@@ -456,6 +499,7 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
       groupByApp: Boolean,
       appLookup: HostId => Option[UsageSeries.AppInfo],
+      settings: HouseholdSettings,
   ): IO[Response, UsageSeriesResponse] =
     for {
       device <- deviceRepo
@@ -464,9 +508,29 @@ object UsageRoutes {
         .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
       _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
       rows   <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
-      (topHosts, buckets)          = UsageSeries.build(rows, zone, topN)
-      (topEntries, bucketsByEntry) =
-        if (groupByApp) UsageSeries.buildEntries(rows, zone, topN, appLookup)
+      (topHosts, buckets, presenceTotalMins) =
+        UsageSeries.build(
+          rows,
+          date,
+          zone,
+          topN,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
+      // Single-device view → per-device union is the total; no cross-device overlap mode applies.
+      (topEntries, bucketsByEntry)           =
+        if (groupByApp)
+          UsageSeries.buildEntries(
+            rows,
+            date,
+            zone,
+            topN,
+            CrossDeviceOverlapMode.Sum,
+            Nil,
+            settings.heartbeatFilter,
+            settings.presenceContinuationSeconds,
+            appLookup,
+          )
         else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
     } yield UsageSeriesResponse(
       deviceMac = Some(mac),
@@ -477,6 +541,7 @@ object UsageRoutes {
       buckets = buckets,
       topEntries = topEntries,
       bucketsByEntry = bucketsByEntry,
+      presenceTotalMins = presenceTotalMins,
     )
 
   private def buildForProfile(
@@ -489,24 +554,49 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
       groupByApp: Boolean,
       appLookup: HostId => Option[UsageSeries.AppInfo],
+      settings: HouseholdSettings,
   ): IO[Response, UsageSeriesResponse] =
     for {
-      _       <- requireProfileReadAccess(claims, pid, userProfileRepo)
-      profile <- profileRepo
+      _          <- requireProfileReadAccess(claims, pid, userProfileRepo)
+      profile    <- profileRepo
         .findById(pid)
         .mapError(ErrorMapper.dbErrorToResponse)
         .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
-      all     <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      all        <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      siteLimits <- siteTimeLimitRepo.listForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
+      exempt    = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
       devices   = all.filter(_.profileId.contains(pid))
       macs      = devices.map(_.mac)
       nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap
       rows <- fetchPresenceDayWindow(trafficRepo, macs, date, zone)
-      (topHosts, bucketsByHost, topDevices, bucketsByDevice) =
-        UsageSeries.buildProfile(rows, nameByMac, zone, topN, profile.crossDeviceOverlapMode)
-      (topEntries, bucketsByEntry)                           =
-        if (groupByApp) UsageSeries.buildEntries(rows, zone, topN, appLookup)
+      (topHosts, bucketsByHost, topDevices, bucketsByDevice, presenceTotalMins) =
+        UsageSeries.buildProfile(
+          rows,
+          nameByMac,
+          date,
+          zone,
+          topN,
+          profile.crossDeviceOverlapMode,
+          exempt,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
+      (topEntries, bucketsByEntry)                                              =
+        if (groupByApp)
+          UsageSeries.buildEntries(
+            rows,
+            date,
+            zone,
+            topN,
+            profile.crossDeviceOverlapMode,
+            exempt,
+            settings.heartbeatFilter,
+            settings.presenceContinuationSeconds,
+            appLookup,
+          )
         else (List.empty[UsageEntityTotal], List.empty[UsageEntityBucket])
     } yield UsageSeriesResponse(
       profileId = Some(pid),
@@ -519,6 +609,7 @@ object UsageRoutes {
       bucketsByDevice = bucketsByDevice,
       topEntries = topEntries,
       bucketsByEntry = bucketsByEntry,
+      presenceTotalMins = presenceTotalMins,
     )
 
   // Pull the requested local-day window as a single partition-pruned query

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -1,296 +1,221 @@
 package wifihaven.api.usage
 
-import wifihaven.api.presence.PresenceRow
+import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.api.presence.Presence.Span
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 
-import java.time.ZoneId
+import java.time.{LocalDate, ZoneId}
 
 /**
- * Hourly per-device usage timeline used by `GET /api/usage/series` (#716, #721).
+ * Hourly usage timeline used by `GET /api/usage/series` (#716, #721, #722).
  *
- * Two facts the routine has to reconcile:
- *   - Bucket-deduped wall-clock minutes per (mac, period_start) — what the daily cap counts.
- *   - Per-host minutes within those buckets — currently bucket-presence (overlapping across hosts),
- *     which over-counts (#715).
+ * #1492: this series is now **presence-based** — sourced from the same session-stitch model
+ * (#1464/#1465) that produces the headline time-used total, not the old bucket-max byte-share
+ * allocation. Previously each hour's minutes were `Σ max(activeSeconds)` per `(mac, period_start)`
+ * bucket while the daily cap used `Presence.totalSecondsByMac` / `dedupedTotalSeconds`; the two
+ * disagreed (a kid showing 56m used whose graph plotted something else). Now:
  *
- * The output proportionally allocates each 5-min bucket's wall-clock duration across the hosts
- * present in that bucket — bytes-weighted (#715) — so each hour's `perHost` + `otherMins` sums
- * exactly to `totalMins`. When the bucket has zero total bytes (an edge case — agent only emits
- * records with bytes>0), we fall back to even-share so the per-host stack still adds up.
+ *   - **Total** per hour comes from the per-device session union (the daily-cap building block),
+ *     combined across devices by the profile's `crossDeviceOverlapMode`, clipped to local hours.
+ *     `presenceTotalMins` carries the day-level number floored once, so it equals the headline
+ *     exactly (summing per-hour floors would lose fractions).
+ *   - **Per-host / per-app / per-device** stacks come from the corresponding session spans
+ *     (`Presence.hostSessionSpans` / `deviceSessionSpans`), clipped to hours. A day-total of an
+ *     entity equals its `proportionalHostSeconds` presence, so per-app contributions reconcile with
+ *     the per-app surface and explain the total (modulo within-device overlap — the total is the
+ *     device union, not the sum of per-app spans, by design §4.3, so stacks may exceed the bar;
+ *     `otherMins` clamps the rendered residual non-negative).
  */
 object UsageSeries {
 
+  // ── span → hour/day minute helpers (#1492) ──────────────────────────────────
+
+  private def hourMins(spans: List[Span], date: LocalDate, zone: ZoneId): Map[Int, Int] =
+    Presence.secondsByLocalHour(spans, date, zone).view.mapValues(s => (s / 60).toInt).toMap
+
+  private def daySecs(spans: List[Span]): Long = spans.iterator.map(_.seconds).sum
+
+  /** The per-hour profile/device total seconds, honoring `crossDeviceOverlapMode`. */
+  private def totalSecondsByHour(
+      deviceSpans: Map[MacAddress, List[Span]],
+      overlap: CrossDeviceOverlapMode,
+      date: LocalDate,
+      zone: ZoneId,
+  ): Map[Int, Long] =
+    overlap match {
+      case CrossDeviceOverlapMode.Sum   =>
+        // Add each device's union seconds per hour — overlap across devices double-counts.
+        deviceSpans.valuesIterator
+          .map(spans => Presence.secondsByLocalHour(spans, date, zone))
+          .foldLeft(Map.empty[Int, Long]) { (acc, m) =>
+            m.foldLeft(acc) { case (a, (h, s)) => a.updatedWith(h)(p => Some(p.getOrElse(0L) + s)) }
+          }
+      case CrossDeviceOverlapMode.Dedup =>
+        // Union all devices' spans first, then clip — overlap across devices counts once.
+        Presence.secondsByLocalHour(
+          Presence.mergeSpans(deviceSpans.valuesIterator.flatten.toList),
+          date,
+          zone,
+        )
+    }
+
+  /** Day total seconds matching `totalSecondsByHour` (and the headline `usedSecondsForProfile`). */
+  private def totalDaySeconds(
+      deviceSpans: Map[MacAddress, List[Span]],
+      overlap: CrossDeviceOverlapMode,
+  ): Long =
+    overlap match {
+      case CrossDeviceOverlapMode.Sum   => deviceSpans.valuesIterator.map(daySecs).sum
+      case CrossDeviceOverlapMode.Dedup =>
+        Presence.unionSeconds(deviceSpans.valuesIterator.flatten.toList)
+    }
+
   /**
-   * Build the per-hour timeline for one device.
-   *
-   * @param rows
-   *   PresenceRow values for the day, single mac.
-   * @param date
-   *   The local-calendar date the operator requested.
-   * @param zone
-   *   Local zone for hour bucketing (UTC bars are useless for parents).
-   * @param topN
-   *   Number of named-host stacks to expose; the long tail collapses to `otherMins`.
+   * Build the per-hour timeline for one device (#716/#721). Presence-based: the device's session
+   * union is the total; per-host stacks are the per-host session spans. No exempt patterns are
+   * applied here (the device timeline has no profile site-limit context).
    */
   def build(
       rows: List[PresenceRow],
+      date: LocalDate,
       zone: ZoneId,
       topN: Int,
-  ): (List[UsageHostTotal], List[UsageBucket]) = {
-    // Group rows into 5-min buckets. activeSeconds is identical for every row
-    // in a bucket (the router emits one batch per window) so max() is fine.
-    // Track per-host bytes (collapsing multiple rows for the same host within a
-    // bucket) so we can do #715 byte-share-weighted allocation.
-    val fiveMin = rows.groupBy(r => r.periodStart).toList.map { case (ps, bucket) =>
-      val hour   = ps.atZone(zone).getHour
-      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
-      val byHost = bucket.iterator
-        .map(r => r.host -> r.bytes)
-        .toList
-        .groupMapReduce(_._1)(_._2)(_ + _)
-      (hour, secs, byHost)
-    }
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = Presence.DefaultContinuationSeconds,
+  ): (List[UsageHostTotal], List[UsageBucket], Int) = {
+    val deviceSpans = Presence.deviceSessionSpans(rows, Nil, filter, continuationSeconds)
+    val totalByHour =
+      totalSecondsByHour(deviceSpans, CrossDeviceOverlapMode.Sum, date, zone)
+    val totalMins   = (totalDaySeconds(deviceSpans, CrossDeviceOverlapMode.Sum) / 60).toInt
 
-    // Day-total per host, byte-share-weighted (even-share fallback if the bucket
-    // recorded zero bytes — agent only emits bytes>0 rows in practice).
-    val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, secs, byHost) <- fiveMin if byHost.nonEmpty) {
-      val totalBytes = byHost.valuesIterator.sum
-      if (totalBytes > 0L)
-        for ((h, b) <- byHost) {
-          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-          perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-        }
-      else {
-        val share = secs.toDouble / byHost.size
-        for (h <- byHost.keys) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-      }
-    }
-
-    // Drop hosts whose proportional day-total floors to 0 — they'd render
-    // as "host.com 0m" in the legend and as invisible stacks. Whatever
-    // seconds they did accrue still land in otherMins via the per-bucket
-    // residual fold below.
-    val ordered = perHostDaySecs.toList
-      .map { case (h, s) => (h, (s / 60).toInt) }
-      .filter { case (_, m) => m > 0 }
+    val hostSpans  =
+      Presence.hostSessionSpans(rows, CrossDeviceOverlapMode.Sum, filter, continuationSeconds)
+    val ordered    = hostSpans.toList
+      .map { case (h, spans) => (h, (daySecs(spans) / 60).toInt) }
+      .filter(_._2 > 0)
       .sortBy { case (h, m) => (-m, h.value) }
+    val topHostIds = ordered.take(topN).map(_._1)
+    val topHosts   = topHostIds.map { h => UsageHostTotal(h, ordered.toMap.apply(h)) }
+    val rank       = topHostIds.zipWithIndex.toMap
+    val topHourly  = topHostIds.map(h => h -> hourMins(hostSpans(h), date, zone)).toMap
 
-    val topHostIds = ordered.take(topN).map(_._1).toSet
-    val topHosts   = ordered.take(topN).map((h, m) => UsageHostTotal(h, m))
-
-    // Stable host ordering within each bucket: top-host daily rank.
-    val rank = topHosts.iterator.map(_.host).zipWithIndex.toMap
-
-    val byHour  = fiveMin.groupBy(_._1)
     val buckets = (0 until 24).map { hr =>
-      val hrBuckets = byHour.getOrElse(hr, Nil)
-      val total     = hrBuckets.iterator.map((_, s, _) => s.toLong).sum
-      val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
-      var other     = 0.0
-      for ((_, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
-        val totalBytes = byHost.valuesIterator.sum
-        if (totalBytes > 0L)
-          for ((h, b) <- byHost) {
-            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-            else other += share
-          }
-        else {
-          val share = secs.toDouble / byHost.size
-          for (h <- byHost.keys)
-            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-            else other += share
-        }
-      }
-      // Floor per-host minutes (consistent with how the daily cap reports
-      // wall-clock minutes) and drop hosts that round to zero — keeps the
-      // legend useful for sparse heartbeat traffic. The flooring residual,
-      // including the 0-min hosts, lands in otherMins so the invariant
-      // sum(perHost.mins) + otherMins == totalMins holds for the chart.
-      val perHostList = perHost.iterator
-        .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }
+      val totalMinsHr = (totalByHour.getOrElse(hr, 0L) / 60).toInt
+      val perHost     = topHostIds
+        .map(h => UsageBucketHost(h, topHourly(h).getOrElse(hr, 0)))
         .filter(_.mins > 0)
-        .toList
         .sortBy(u => rank.getOrElse(u.host, Int.MaxValue))
-      val totalMins = (total / 60).toInt
-      val perHostSum = perHostList.iterator.map(_.mins).sum
+      val perSum      = perHost.iterator.map(_.mins).sum
       UsageBucket(
         hour = hr,
-        totalMins = totalMins,
-        perHost = perHostList,
-        otherMins = (totalMins - perHostSum).max(0),
+        totalMins = totalMinsHr,
+        perHost = perHost,
+        otherMins = (totalMinsHr - perSum).max(0),
       )
     }.toList
 
-    (topHosts, buckets)
+    (topHosts, buckets, totalMins)
   }
 
   /**
-   * Profile-mode build (#722). Aggregates `rows` across one profile's devices for one local day.
+   * Profile-mode build (#722, #1492). Aggregates `rows` across one profile's devices for one local
+   * day, presence-based.
    *
-   * Returns four parallel views of the same activity:
-   *   - `topHosts` / `bucketsByHost` — proportionally allocated within each (mac, period_start)
-   *     bucket, same semantics as the per-device build above.
-   *   - `topDevices` / `bucketsByDevice` — minutes attributed to whichever device's mac the bucket
-   *     belongs to (one bucket → one device); `sum(perDevice) + otherMins == totalMins`.
-   *
-   * Profile total semantics match `Routes.buildProfileTimeStatus`: per-mac bucket-deduped minutes
-   * are summed across devices (overlap is not deduped at the profile level). Per-host stacks use
-   * the same even-share within each (mac, period_start) bucket as the per-device build.
-   *
-   * @param deviceNames
-   *   Display names keyed by mac. Devices missing from the map fall back to the mac string.
-   * @param topN
-   *   Number of named-host / named-device entries; the long tail collapses to `otherMins`.
+   * Returns the per-host and per-device hourly views plus `presenceTotalMins` — the day-level
+   * session-stitch total (floored once) that equals the headline time-used number. The per-hour
+   * `totalMins` is identical across both bucket arrays (both derive from the same session union).
    */
   def buildProfile(
       rows: List[PresenceRow],
       deviceNames: Map[MacAddress, String],
+      date: LocalDate,
       zone: ZoneId,
       topN: Int,
-      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
-  ): (List[UsageHostTotal], List[UsageBucket], List[UsageDeviceTotal], List[UsageDeviceBucket]) = {
-    // Group by (mac, periodStart) — same 5-min bucketing as the per-device build,
-    // but now we keep the mac so we can later stack-by-device.
-    val fiveMin = rows.groupBy(r => (r.mac, r.periodStart)).toList.map { case ((mac, ps), bucket) =>
-      val hour   = ps.atZone(zone).getHour
-      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
-      val byHost = bucket.iterator
-        .map(r => r.host -> r.bytes)
-        .toList
-        .groupMapReduce(_._1)(_._2)(_ + _)
-      (hour, mac, ps, secs, byHost)
-    }
+      overlap: CrossDeviceOverlapMode,
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter,
+      continuationSeconds: Int,
+  ): (
+      List[UsageHostTotal],
+      List[UsageBucket],
+      List[UsageDeviceTotal],
+      List[UsageDeviceBucket],
+      Int,
+  ) = {
+    val deviceSpans = Presence.deviceSessionSpans(rows, exemptPatterns, filter, continuationSeconds)
+    val totalByHour = totalSecondsByHour(deviceSpans, overlap, date, zone)
+    val totalMins   = (totalDaySeconds(deviceSpans, overlap) / 60).toInt
 
-    // ── Per-host day totals (#715 byte-share within each (mac, bucket)) ────
-    val perHostDaySecs = scala.collection.mutable.Map.empty[HostId, Double]
-    for ((_, _, _, secs, byHost) <- fiveMin if byHost.nonEmpty) {
-      val totalBytes = byHost.valuesIterator.sum
-      if (totalBytes > 0L)
-        for ((h, b) <- byHost) {
-          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-          perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-        }
-      else {
-        val share = secs.toDouble / byHost.size
-        for (h <- byHost.keys) perHostDaySecs.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-      }
-    }
-    val orderedHosts = perHostDaySecs.toList
-      .map { case (h, s) => (h, (s / 60).toInt) }
-      .filter { case (_, m) => m > 0 }
+    // ── Per-host stacks (presence spans, profile-combined per overlap) ─────
+    val hostSpans     = Presence.hostSessionSpans(rows, overlap, filter, continuationSeconds)
+    val orderedHosts  = hostSpans.toList
+      .map { case (h, spans) => (h, (daySecs(spans) / 60).toInt) }
+      .filter(_._2 > 0)
       .sortBy { case (h, m) => (-m, h.value) }
-    val topHostIds = orderedHosts.take(topN).map(_._1).toSet
-    val topHosts = orderedHosts.take(topN).map((h, m) => UsageHostTotal(h, m))
-    val hostRank = topHosts.iterator.map(_.host).zipWithIndex.toMap
+    val hostMinByHost = orderedHosts.toMap
+    val topHostIds    = orderedHosts.take(topN).map(_._1)
+    val topHosts      = topHostIds.map(h => UsageHostTotal(h, hostMinByHost(h)))
+    val hostRank      = topHostIds.zipWithIndex.toMap
+    val hostHourly    = topHostIds.map(h => h -> hourMins(hostSpans(h), date, zone)).toMap
 
-    // ── Per-device day totals (one bucket → one device) ───────────────────
-    val perDeviceDaySecs = scala.collection.mutable.Map.empty[MacAddress, Long]
-    for ((_, mac, _, secs, _) <- fiveMin)
-      perDeviceDaySecs.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
-    val orderedDevices = perDeviceDaySecs.toList
-      .map { case (m, s) => (m, (s / 60).toInt) }
-      .filter { case (_, m) => m > 0 }
+    // ── Per-device stacks (each device's session union) ───────────────────
+    val orderedDevices = deviceSpans.toList
+      .map { case (mac, spans) => (mac, (daySecs(spans) / 60).toInt) }
+      .filter(_._2 > 0)
       .sortBy { case (mac, m) => (-m, mac.value) }
-    val topDeviceMacs  = orderedDevices.take(topN).map(_._1).toSet
-    val topDevices     = orderedDevices.take(topN).map { case (mac, mins) =>
-      UsageDeviceTotal(mac, deviceNames.getOrElse(mac, mac.value), mins)
+    val devMinByMac    = orderedDevices.toMap
+    val topDeviceMacs  = orderedDevices.take(topN).map(_._1)
+    val topDevices     = topDeviceMacs.map { mac =>
+      UsageDeviceTotal(mac, deviceNames.getOrElse(mac, mac.value), devMinByMac(mac))
     }
-    val deviceRank     = topDevices.iterator.map(_.deviceMac).zipWithIndex.toMap
+    val deviceRank     = topDeviceMacs.zipWithIndex.toMap
+    val deviceHourly = topDeviceMacs.map(mac => mac -> hourMins(deviceSpans(mac), date, zone)).toMap
 
-    // ── Per-hour aggregation, both views ──────────────────────────────────
-    val byHour          = fiveMin.groupBy(_._1)
+    // ── Per-hour assembly ─────────────────────────────────────────────────
     val bucketsByHost   = scala.collection.mutable.ArrayBuffer.empty[UsageBucket]
     val bucketsByDevice = scala.collection.mutable.ArrayBuffer.empty[UsageDeviceBucket]
     for (hr <- 0 until 24) {
-      val hrBuckets = byHour.getOrElse(hr, Nil)
-      // #751: in Dedup mode the per-hour total collapses to the union of
-      // periodStarts (one bucket → one wall-clock contribution regardless of
-      // how many of the profile's devices were active in it). The per-host
-      // and per-device stacks below stay summed (they're the contribution
-      // breakdown, not a strict reconcile-to-total), so in Dedup mode the
-      // stacks can exceed totalMins; the otherMins clamp keeps the rendered
-      // chart non-negative.
-      val totalSecs = overlap match {
-        case CrossDeviceOverlapMode.Sum   =>
-          hrBuckets.iterator.map((_, _, _, s, _) => s.toLong).sum
-        case CrossDeviceOverlapMode.Dedup =>
-          hrBuckets.iterator
-            .map { case (_, _, ps, s, _) => ps -> s.toLong }
-            .toList
-            .groupMapReduce(_._1)(_._2)(_ max _)
-            .valuesIterator
-            .sum
-      }
-      val totalMins = (totalSecs / 60).toInt
+      val totalMinsHr = (totalByHour.getOrElse(hr, 0L) / 60).toInt
 
-      // Per-host stack within the hour (#715 byte-share within each 5-min bucket).
-      val perHost   = scala.collection.mutable.Map.empty[HostId, Double]
-      var hostOther = 0.0
-      for ((_, _, _, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
-        val totalBytes = byHost.valuesIterator.sum
-        if (totalBytes > 0L)
-          for ((h, b) <- byHost) {
-            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-            else hostOther += share
-          }
-        else {
-          val share = secs.toDouble / byHost.size
-          for (h <- byHost.keys)
-            if (topHostIds.contains(h)) perHost.updateWith(h)(p => Some(p.getOrElse(0.0) + share))
-            else hostOther += share
-        }
-      }
-      val perHostList = perHost.iterator
-        .map { case (h, s) => UsageBucketHost(h, (s / 60).toInt) }
+      val perHost = topHostIds
+        .map(h => UsageBucketHost(h, hostHourly(h).getOrElse(hr, 0)))
         .filter(_.mins > 0)
-        .toList
         .sortBy(u => hostRank.getOrElse(u.host, Int.MaxValue))
-      val perHostSum = perHostList.iterator.map(_.mins).sum
       bucketsByHost += UsageBucket(
         hour = hr,
-        totalMins = totalMins,
-        perHost = perHostList,
-        otherMins = (totalMins - perHostSum).max(0),
+        totalMins = totalMinsHr,
+        perHost = perHost,
+        otherMins = (totalMinsHr - perHost.iterator.map(_.mins).sum).max(0),
       )
 
-      // Per-device stack within the hour (each bucket attributes to its mac).
-      val perDevice = scala.collection.mutable.Map.empty[MacAddress, Long]
-      var devOther  = 0L
-      for ((_, mac, _, secs, _) <- hrBuckets)
-        if (topDeviceMacs.contains(mac))
-          perDevice.updateWith(mac)(p => Some(p.getOrElse(0L) + secs.toLong))
-        else devOther += secs.toLong
-      val perDeviceList = perDevice.iterator
-        .map { case (mac, s) =>
-          UsageBucketDevice(mac, deviceNames.getOrElse(mac, mac.value), (s / 60).toInt)
-        }
+      val perDevice = topDeviceMacs
+        .map(mac =>
+          UsageBucketDevice(
+            mac,
+            deviceNames.getOrElse(mac, mac.value),
+            deviceHourly(mac).getOrElse(hr, 0),
+          ),
+        )
         .filter(_.mins > 0)
-        .toList
         .sortBy(u => deviceRank.getOrElse(u.deviceMac, Int.MaxValue))
-      val perDeviceSum  = perDeviceList.iterator.map(_.mins).sum
       bucketsByDevice += UsageDeviceBucket(
         hour = hr,
-        totalMins = totalMins,
-        perDevice = perDeviceList,
-        otherMins = (totalMins - perDeviceSum).max(0),
+        totalMins = totalMinsHr,
+        perDevice = perDevice,
+        otherMins = (totalMinsHr - perDevice.iterator.map(_.mins).sum).max(0),
       )
     }
 
-    (topHosts, bucketsByHost.toList, topDevices, bucketsByDevice.toList)
+    (topHosts, bucketsByHost.toList, topDevices, bucketsByDevice.toList, totalMins)
   }
 
-  // ── #1079 unified by-app axis ──────────────────────────────────────────────
+  // ── #1079 / #1492 unified by-app axis ───────────────────────────────────────
   //
-  // For each (mac, period_start) bucket, attribute its byte-share-weighted
-  // seconds to either the host's owning app (if it has one — `appOfHost`) or
-  // to the host itself as a first-class entry. Day totals, top-N cap, and a
-  // single 'Other' long-tail bucket are computed over the resulting mixed
-  // entity list. 'Other' is strictly the long tail — non-app hosts that fit
-  // inside top-N surface individually, not lumped together.
+  // Each host's session spans are attributed to its owning app (if any — `appOfHost`) or surface
+  // as a first-class host entry. Per-app minutes are the sum of the app's member-host span seconds
+  // (matching the per-app presence surface, #1465); the per-hour total comes from the same session
+  // union the other axes use, so the app axis reconciles with the headline too.
   case class AppInfo(id: AppId, slug: String, name: String, icon: Option[String])
 
   private def entityRefOf(key: Either[AppInfo, HostId]): UsageEntityRef =
@@ -322,102 +247,48 @@ object UsageSeries {
 
   def buildEntries(
       rows: List[PresenceRow],
+      date: LocalDate,
       zone: ZoneId,
       topN: Int,
+      overlap: CrossDeviceOverlapMode,
+      exemptPatterns: List[String],
+      filter: HeartbeatFilter,
+      continuationSeconds: Int,
       appOfHost: HostId => Option[AppInfo],
   ): (List[UsageEntityTotal], List[UsageEntityBucket]) = {
-    // (hour, bucketSeconds, byHostBytes) — group rows into 5-min buckets per
-    // (mac, period_start) so two devices in the same wall-clock window don't
-    // collapse onto each other.
     type Key = Either[AppInfo, HostId]
 
-    val fiveMin = rows.groupBy(r => (r.mac, r.periodStart)).toList.map { case ((_, ps), bucket) =>
-      val hour   = ps.atZone(zone).getHour
-      val secs   = bucket.iterator.map(_.activeSeconds).maxOption.getOrElse(0)
-      val byHost = bucket.iterator
-        .map(r => r.host -> r.bytes)
-        .toList
-        .groupMapReduce(_._1)(_._2)(_ + _)
-      (hour, secs, byHost)
-    }
+    val deviceSpans = Presence.deviceSessionSpans(rows, exemptPatterns, filter, continuationSeconds)
+    val totalByHour = totalSecondsByHour(deviceSpans, overlap, date, zone)
 
-    // Day totals per entity (byte-share-weighted; even-share if zero bytes).
-    val perEntityDaySecs = scala.collection.mutable.Map.empty[Key, Double]
-    for ((_, secs, byHost) <- fiveMin if byHost.nonEmpty) {
-      val totalBytes = byHost.valuesIterator.sum
-      if (totalBytes > 0L)
-        for ((h, b) <- byHost) {
-          val key   = appOfHost(h).map(Left(_)).getOrElse(Right(h))
-          val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-          perEntityDaySecs.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
-        }
-      else {
-        val share = secs.toDouble / byHost.size
-        for (h <- byHost.keys) {
-          val key = appOfHost(h).map(Left(_)).getOrElse(Right(h))
-          perEntityDaySecs.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
-        }
-      }
-    }
+    // Per-host spans → grouped into entity keys (app rolls up its hosts; non-app host stands alone).
+    val hostSpans = Presence.hostSessionSpans(rows, overlap, filter, continuationSeconds)
+    val entitySpans: Map[Key, List[Span]] = hostSpans.iterator
+      .map { case (h, spans) => appOfHost(h).map(Left(_)).getOrElse(Right(h)) -> spans }
+      .toList
+      .groupMapReduce(_._1)(_._2)(_ ++ _)
 
-    val ordered = perEntityDaySecs.toList
-      .map { case (k, s) => (k, (s / 60).toInt) }
-      .filter { case (_, m) => m > 0 }
+    val ordered    = entitySpans.toList
+      .map { case (k, spans) => (k, (daySecs(spans) / 60).toInt) }
+      .filter(_._2 > 0)
       .sortBy { case (k, m) => (-m, sortKey(k)) }
-
+    val minByKey   = ordered.toMap
     val topKeys    = ordered.take(topN).map(_._1)
-    val topKeySet  = topKeys.toSet
-    val topEntries = ordered.take(topN).map { case (k, m) =>
-      UsageEntityTotal(entityRefOf(k), m)
-    }
-    val rank       = topKeys.iterator.zipWithIndex.toMap
+    val topEntries = topKeys.map(k => UsageEntityTotal(entityRefOf(k), minByKey(k)))
+    val keyHourly  = topKeys.map(k => k -> hourMins(entitySpans(k), date, zone)).toMap
 
-    val byHour  = fiveMin.groupBy(_._1)
     val buckets = (0 until 24).map { hr =>
-      val hrBuckets = byHour.getOrElse(hr, Nil)
-      val total     = hrBuckets.iterator.map { case (_, s, _) => s.toLong }.sum
-      val perEntity = scala.collection.mutable.Map.empty[Key, Double]
-      var other     = 0.0
-      for ((_, secs, byHost) <- hrBuckets if byHost.nonEmpty) {
-        val totalBytes = byHost.valuesIterator.sum
-        if (totalBytes > 0L)
-          for ((h, b) <- byHost) {
-            val key   = appOfHost(h).map(Left(_)).getOrElse(Right(h))
-            val share = secs.toDouble * b.toDouble / totalBytes.toDouble
-            if (topKeySet.contains(key))
-              perEntity.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
-            else other += share
-          }
-        else {
-          val share = secs.toDouble / byHost.size
-          for (h <- byHost.keys) {
-            val key = appOfHost(h).map(Left(_)).getOrElse(Right(h))
-            if (topKeySet.contains(key))
-              perEntity.updateWith(key)(p => Some(p.getOrElse(0.0) + share))
-            else other += share
-          }
-        }
-      }
-      val perEntityListSorted = perEntity.iterator
-        .map { case (k, s) => (k, (s / 60).toInt) }
-        .filter(_._2 > 0)
-        .toList
-        .sortBy { case (k, _) => rank.getOrElse(k, Int.MaxValue) }
-        .map { case (k, m) => UsageBucketEntity(entityRefOf(k), m) }
-      val totalMins = (total / 60).toInt
-      val perSum    = perEntityListSorted.iterator.map(_.mins).sum
-      // Residual minutes either come from the long tail OR from per-host
-      // flooring drift on the top entries. We attribute drift back to the
-      // top entry that lost the fractional second only when no actual tail
-      // contributed in this hour — otherwise drift collapses into the tail.
-      val otherMins =
-        if (other > 0.0) (totalMins - perSum).max(0)
-        else 0
+      val totalMinsHr = (totalByHour.getOrElse(hr, 0L) / 60).toInt
+      // topKeys is already in display rank order, so the filtered list stays ranked.
+      val perEntity   = topKeys
+        .map(k => UsageBucketEntity(entityRefOf(k), keyHourly(k).getOrElse(hr, 0)))
+        .filter(_.mins > 0)
+      val perSum      = perEntity.iterator.map(_.mins).sum
       UsageEntityBucket(
         hour = hr,
-        totalMins = totalMins,
-        perEntity = perEntityListSorted,
-        otherMins = otherMins,
+        totalMins = totalMinsHr,
+        perEntity = perEntity,
+        otherMins = (totalMinsHr - perSum).max(0),
       )
     }.toList
 

--- a/api/test/src/feature/RecentApexesApiSpec.scala
+++ b/api/test/src/feature/RecentApexesApiSpec.scala
@@ -124,6 +124,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
+      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -136,6 +137,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         appRepo,
         rollupRepo,
         hsRepo,
+        stlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -42,6 +42,11 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
   /**
    * Insert one row into traffic_reports at (date, hour:minute UTC) for (mac, hostname). The full
    * bucket is `active_seconds = 300`, matching what the router emits in the wild.
+   *
+   * #1492: the usage series is now presence-based and heartbeat-filters its rows exactly as the
+   * headline daily total does (default filter: drop buckets under 10 KB). The router only ever
+   * emits bytes>0 rows; seed a realistic 50 KB so these buckets are real activity, not keepalives
+   * that the presence model would (correctly) drop.
    */
   private def insertRow(
       routerId: RouterId,
@@ -68,8 +73,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
             start,
             end,
             300,
-            0L,
-            0L,
+            25_000L,
+            25_000L,
           ),
         ),
       )
@@ -84,6 +89,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
+      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -96,6 +102,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         appRepo,
         rollupRepo,
         hsRepo,
+        stlRepo,
         clock,
       ),
       auth,
@@ -340,13 +347,20 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.deviceMac.isEmpty) &&
           assertTrue(out.buckets.length == 24 && out.bucketsByDevice.length == 24) &&
           assertTrue(h14H.totalMins == 15 && h14D.totalMins == 15) &&
-          // Per-device stack: macA 10m + macB 5m, no Other.
+          // Per-device stack: macA 10m + macB 5m, no Other. In Sum mode the per-device
+          // session unions partition the profile total cleanly, so they still reconcile.
           assertTrue(h14D.perDevice.length == 2 && h14D.otherMins == 0) &&
           assertTrue(h14D.perDevice.iterator.map(_.mins).sum + h14D.otherMins == 15) &&
-          // Per-host stack invariant: sum(perHost.mins) + otherMins == totalMins.
-          assertTrue(h14H.perHost.iterator.map(_.mins).sum + h14H.otherMins == 15) &&
-          // Day totals reconcile.
-          assertTrue(out.topDevices.iterator.map(_.dayMins).sum == 15)
+          // #1492: per-host presence is the per-host session span, NOT a within-bucket
+          // partition — google runs on both devices (10m) and youtube on one (10m), so the
+          // per-host stack (20m) legitimately exceeds the 15m device-union total (design §4.3:
+          // the total is the device union, not the sum of per-app spans). otherMins clamps the
+          // rendered residual non-negative.
+          assertTrue(h14H.perHost.iterator.map(_.mins).sum >= h14H.totalMins) &&
+          assertTrue(h14H.otherMins == 0) &&
+          // Day totals reconcile with the headline (sum of per-device session unions).
+          assertTrue(out.topDevices.iterator.map(_.dayMins).sum == 15) &&
+          assertTrue(out.presenceTotalMins == 15)
       },
       test("profileId mode: rejects unknown profile with 404") {
         for {
@@ -492,6 +506,114 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.topEntries.length == 2) &&
           assertTrue(out.topEntries.forall(_.entity.kind == "host")) &&
           assertTrue(out.bucketsByEntry.iterator.map(_.otherMins).sum == 0)
+      },
+      // #1492 — the per-profile usage graph is presence-based: its headline
+      // (`presenceTotalMins`) reconciles with the session-stitch time-used total
+      // that drives the daily cap, and the per-app contributions match the
+      // canonical per-app presence surface. The fixture reproduces the prod
+      // undercount (each 5-min window only sampled 10s of bytes) so the legacy
+      // bucket-max graph would have read ~0 while the kid was present 25 minutes.
+      test("#1492: profile series total reconciles with time-used; per-app contributions match") {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          hsRepo      <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
+          _           <- appRepo.setHosts(ytId, List(Hostname.unsafe("youtube.com")))
+          base  = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          // Each window: full 5-min span, but only 10s sampled active (design §2a
+          // sparse-app undercount). Three contiguous youtube windows + two
+          // khanacademy windows → one bridged 25-min device session.
+          mkRow = (host: String, idx: Int) =>
+            TrafficReportInsert(
+              routerId,
+              MacAddress.unsafe(testMac),
+              None,
+              HostId.Fqdn(Hostname.unsafe(host)),
+              today,
+              base.plusSeconds(idx * 300L),
+              base.plusSeconds(idx * 300L + 300L),
+              10,
+              60_000L,
+              60_000L,
+            )
+          _        <- trafficRepo.insertBatch(
+            List(
+              mkRow("youtube.com", 0),
+              mkRow("youtube.com", 1),
+              mkRow("youtube.com", 2),
+              mkRow("khanacademy.org", 3),
+              mkRow("khanacademy.org", 4),
+            ),
+          )
+          settings <- hsRepo.get
+          rows     <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(testMac)), today)
+          // The canonical time-used total (the number on the profile card / the cap).
+          expectedMins       = wifihaven.api.presence.Presence
+            .totalMinutesByMac(
+              rows,
+              Nil,
+              settings.heartbeatFilter,
+              settings.presenceContinuationSeconds,
+            )
+            .values
+            .sum
+          // What the legacy bucket-max graph would have plotted: Σ max(active_seconds).
+          naiveBucketMaxMins = (rows
+            .groupBy(r => (r.mac, r.periodStart))
+            .values
+            .map(_.map(_.activeSeconds).max.toLong)
+            .sum / 60).toInt
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today&groupBy=app")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp    <- routes.runZIO(req)
+          body    <- resp.body.asString
+          out     <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          // Cross-check the per-app contributions against the canonical per-app surface.
+          ubaResp <- routes.runZIO(
+            Request
+              .get(
+                URL
+                  .decode(s"/api/profiles/${kidsId.value}/usage-by-app?from=$today&to=$today")
+                  .toOption
+                  .get,
+              )
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          ubaBody <- ubaResp.body.asString
+          uba     <- ZIO.fromEither(ubaBody.fromJson[ProfileUsageByApp])
+          ytApp   = uba.apps.find(_.appName == "YouTube").get
+          ytEntry = out.topEntries.find(_.entity.name == "YouTube").get
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // The graph headline equals the session-stitch time-used total, exactly.
+          assertTrue(out.presenceTotalMins == expectedMins) &&
+          assertTrue(expectedMins == 25) &&
+          // ...and it is genuinely presence-based — the legacy bucket-max read ~0.
+          assertTrue(naiveBucketMaxMins == 0 && out.presenceTotalMins > naiveBucketMaxMins) &&
+          // The hourly bars sum to the same number (within per-hour flooring; here exact).
+          assertTrue(out.buckets.iterator.map(_.totalMins).sum == expectedMins) &&
+          // Per-app contributions are visible and reconcile with the per-app presence surface.
+          assertTrue(ytEntry.dayMins == (ytApp.proportionalSeconds / 60).toInt) &&
+          assertTrue(ytEntry.dayMins == 15) &&
+          // The two contributions explain the total (no within-device overlap in this fixture).
+          assertTrue(out.topEntries.map(_.dayMins).sum == expectedMins)
       },
     ) @@ TestAspect.sequential,
     // ── #846 Traffic Usage page ───────────────────────────────────────────

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -56,6 +56,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
+      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- buildAuth
     } yield (
@@ -68,6 +69,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         appRepo,
         rollupRepo,
         hsRepo,
+        stlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -73,8 +73,10 @@ object UsageSeriesPerfSpec
             startUtc,
             startUtc.plusSeconds(300),
             300,
-            100L,
-            100L,
+            // #1492: above the 10 KB heartbeat threshold so the presence-based series counts
+            // these as real activity (the default filter drops sub-10 KB buckets).
+            25_000L,
+            25_000L,
           ),
         ),
       )
@@ -89,6 +91,7 @@ object UsageSeriesPerfSpec
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
+      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -101,6 +104,7 @@ object UsageSeriesPerfSpec
         appRepo,
         rollupRepo,
         hsRepo,
+        stlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -610,5 +610,59 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
+    // ── #1492: hour-clipped decomposition for the presence-based usage graph ──
+    suite("#1492 hour-clip + span surfaces")(
+      test("secondsByLocalHour splits a span across the hour boundary and sums to its length") {
+        val zone   = java.time.ZoneId.of("UTC")
+        // [00:59:30, 01:00:30) — 30s in hour 0, 30s in hour 1.
+        val span   = Presence.Span(
+          base.plusSeconds(3570).getEpochSecond,
+          base.plusSeconds(3630).getEpochSecond,
+        )
+        val byHour = Presence.secondsByLocalHour(List(span), baseDate, zone)
+        assertTrue(byHour.getOrElse(0, 0L) == 30L) &&
+        assertTrue(byHour.getOrElse(1, 0L) == 30L) &&
+        assertTrue(byHour.values.sum == 60L)
+      },
+      test("deviceSessionSpans union reconciles with totalSecondsByMac (the headline total)") {
+        val rows     = List(
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 300),
+          appRow(mac1, 300L, "khanacademy.org", periodSeconds = 300),
+          appRow(mac2, 0L, "youtube.com", periodSeconds = 300),
+        )
+        val viaSpans = Presence
+          .deviceSessionSpans(rows, Nil)
+          .view
+          .mapValues(Presence.unionSeconds)
+          .toMap
+        assertTrue(viaSpans == Presence.totalSecondsByMac(rows, Nil))
+      },
+      test("hostSessionSpans seconds reconcile with proportionalHostSeconds (Sum and Dedup)") {
+        // Same host on two devices in the same window: Sum double-counts, Dedup unions.
+        val rows          = List(
+          appRow(mac1, 0L, "youtube.com", periodSeconds = 300),
+          appRow(mac2, 0L, "youtube.com", periodSeconds = 300),
+        )
+        val sumViaSpans   = Presence
+          .hostSessionSpans(rows, CrossDeviceOverlapMode.Sum)
+          .view
+          .mapValues(_.iterator.map(_.seconds).sum)
+          .toMap
+        val dedupViaSpans = Presence
+          .hostSessionSpans(rows, CrossDeviceOverlapMode.Dedup)
+          .view
+          .mapValues(Presence.unionSeconds)
+          .toMap
+        assertTrue(
+          sumViaSpans == Presence.proportionalHostSeconds(rows, CrossDeviceOverlapMode.Sum),
+        ) &&
+        assertTrue(
+          dedupViaSpans == Presence.proportionalHostSeconds(rows, CrossDeviceOverlapMode.Dedup),
+        ) &&
+        // Sum = 600s (both devices), Dedup = 300s (overlap counts once).
+        assertTrue(sumViaSpans.getOrElse(yt, 0L) == 600L) &&
+        assertTrue(dedupViaSpans.getOrElse(yt, 0L) == 300L)
+      },
+    ),
   )
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1015,6 +1015,11 @@ case class UsageSeriesResponse(
     bucketsByDevice: List[UsageDeviceBucket] = Nil,
     topEntries: List[UsageEntityTotal] = Nil,
     bucketsByEntry: List[UsageEntityBucket] = Nil,
+    // #1492: the day-level session-stitch presence total (floored once), so the graph's headline
+    // reconciles exactly with the time-used number on the profile card. Summing the per-hour
+    // `totalMins` would drop sub-minute fractions and read a few minutes low; clients should show
+    // this as the "total". Additive; older clients ignore it. Defaults to 0 for the empty case.
+    presenceTotalMins: Int = 0,
 ) derives JsonCodec
 
 // #1099: batched per-profile series for the /profiles page. One request

--- a/web/src/pages/ProfileTimelinePage.test.tsx
+++ b/web/src/pages/ProfileTimelinePage.test.tsx
@@ -63,6 +63,10 @@ function richResponse(date: string): UsageSeriesResponse {
     profileName: 'Kids',
     date,
     tz: 'UTC',
+    // #1492 — the session-stitch presence total. Intentionally distinct from the
+    // sum of the per-hour bars (45m below) to prove the headline reads this field,
+    // not the bar sum (which floors per hour and reads low — the prod 56m case).
+    presenceTotalMins: 56,
     topHosts: [
       { host: { type: 'fqdn', value: 'youtube.com' }, dayMins: 30 },
       { host: { type: 'fqdn', value: 'google.com' }, dayMins: 15 },
@@ -214,6 +218,34 @@ describe('ProfileTimelinePage', () => {
     )
     // No long tail in this fixture → no Other entry in the legend.
     expect(screen.queryByTestId('profile-timeline-entry-other')).toBeNull()
+  })
+
+  // #1492 — the graph headline must show the session-stitch presence total
+  // (the number on the profile card), NOT the sum of the floored per-hour bars.
+  it('#1492: headline total shows presenceTotalMins, not the summed hourly bars', async () => {
+    (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      richResponse('2026-05-20'),
+    )
+    renderPage([`/profiles/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
+    )
+    // Bars sum to 45m, but the presence total is 56m — the headline shows 56m.
+    expect(screen.getByText(/56m total/)).toBeInTheDocument()
+    expect(screen.queryByText(/45m total/)).toBeNull()
+  })
+
+  // #1492 — falls back to the bar sum when the API omits presenceTotalMins
+  // (older deploy), so the headline never renders blank.
+  it('#1492: falls back to bar sum when presenceTotalMins is absent', async () => {
+    const resp = richResponse('2026-05-20')
+    delete resp.presenceTotalMins
+    ;(api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(resp)
+    renderPage([`/profiles/${PID}/timeline?date=2026-05-20`])
+    await waitFor(() =>
+      expect(screen.getByTestId('profile-timeline-chart')).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/45m total/)).toBeInTheDocument()
   })
 
   it('reads stackBy=device from URL', async () => {

--- a/web/src/pages/ProfileTimelinePage.tsx
+++ b/web/src/pages/ProfileTimelinePage.tsx
@@ -171,7 +171,13 @@ export function ProfileTimelinePage() {
     stackBy === 'device' ? data?.bucketsByDevice
     : stackBy === 'app'    ? data?.bucketsByEntry
     : data?.buckets
-  const dayTotal = buckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
+  // #1492 — the headline is the session-stitch presence total (the same number
+  // the profile card shows as time-used), not the sum of the per-hour bars.
+  // Summing the floored hourly bars drops sub-minute fractions and reads a few
+  // minutes low; `presenceTotalMins` is floored once at the day level so the
+  // graph and the card agree. Fall back to the bar sum for older API responses.
+  const barSum   = buckets?.reduce((a, b) => a + b.totalMins, 0) ?? 0
+  const dayTotal = data?.presenceTotalMins ?? barSum
   const isEmpty  = dayTotal === 0
 
   return (
@@ -263,15 +269,16 @@ export function ProfileTimelinePage() {
           />
         )}
 
-        {/* Profile total uses sum-of-per-device-minutes semantics. Two siblings
-            both active in the same 5-min window count as 10 minutes here, but
-            the per-host stack still even-shares within each device's bucket
-            (#715). The numbers reconcile with the daily totals shown on the
-            /profiles card, within that overlap caveat. */}
+        {/* #1492 — the graph is presence-based: hourly bars are the session-stitch
+            presence (the same model that drives the time-used total), and the
+            headline `presenceTotalMins` equals the number on the profile card.
+            Per-app/host stacks are each entity's own session presence, so within a
+            device overlapping apps can make the stacks exceed the bar — the total
+            is the device union, not the sum of per-app spans (design §4.3). */}
         <p className="text-[11px] text-brand-text-muted mt-3">
-          Stacks total to wall-clock minutes per hour. Per-host minutes are proportional
-          within each 5-minute window; overlapping device activity counts once per device
-          (matches the daily total shown on the profile card).
+          Presence-based: bars are session minutes per hour and the total matches the
+          time-used shown on the profile card. Per-app contributions are each app's own
+          session time — overlapping apps on one device can sum past the hour's total.
         </p>
       </div>
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -490,6 +490,11 @@ export interface UsageSeriesResponse {
   // #1079 — populated when the request asked groupBy=app.
   topEntries?: UsageEntityTotal[]
   bucketsByEntry?: UsageEntityBucket[]
+  // #1492 — the day-level session-stitch presence total (floored once). This is
+  // the same number the profile card shows as time-used; display it as the graph
+  // headline rather than summing the per-hour bars, which lose sub-minute
+  // fractions and read a few minutes low. Optional: older API responses omit it.
+  presenceTotalMins?: number
 }
 
 // #1099 — batched per-profile series: one round-trip resolves the whole


### PR DESCRIPTION
Closes #1492. Part of the **Tuning** epic (#1445); builds on #1464 (profile presence = session-stitch + interval-union) and #1465 (per-app presence = session span).

## Problem
In prod a kid's profile shows **56m used** (the session-stitch time-used total that drives the daily cap), but the per-profile usage graph plotted something else and disagreed. The graph computed hourly minutes as `Σ max(active_seconds)` per `(mac, period_start)` bucket — the **legacy bucket-max model** — while the headline total comes from the #1464/#1465 session-stitch presence model. For per-10s-sampled sparse apps (educational/reading) the graph reads ~3.3× low (design §2), so the operator couldn't see which apps' usage added up to the total.

## Fix
Source the graph from the **same presence/session model** as the time-used total.

**`Presence` (additive span surfaces):**
- `mergeSpans`, `secondsByLocalHour` (clip a span to local-hour buckets), `deviceSessionSpans` (per-device session union — sums to `totalSecondsByMac`), `hostSessionSpans` (per-host, honoring `crossDeviceOverlapMode` — sums to `proportionalHostSeconds`).
- Each is the span form of an existing aggregate, so an hour-clipped decomposition reconciles **exactly** with the daily cap and the per-app presence surface.

**`UsageSeries` (`build`/`buildProfile`/`buildEntries`):**
- Hourly minutes now come from clipping session spans to local hours, not bucket-max byte-share. The heartbeat filter is applied too, so the graph strips keepalives like the headline does.

**Wire (`UsageSeriesResponse.presenceTotalMins`, additive):**
- The day-level session-stitch total, floored once — equal to the time-used on the profile card. The SPA shows it as the graph headline instead of summing floored per-hour bars (which lose sub-minute fractions and read low).

**SPA (`ProfileTimelinePage`):**
- Headline reads `presenceTotalMins` (falls back to the bar sum for older API responses). Per-app/host stacks are each entity's own session presence; within a device overlapping apps can exceed the bar — the total is the device union, not the sum of per-app spans (design §4.3), and `otherMins` clamps the residual.

## Reconciliation / overlap semantics
Per design §4.3 the total is **not** the sum of per-app numbers (within a device, different apps overlap). The graph honors that honestly: the **total** reconciles with the headline exactly; per-app contributions are each app's session presence and explain the total (and sum to it when there is no within-device overlap).

## Tests (TDD red→green)
- **API feature** (`UsageApiSpec`): a sparse-activity fixture (each 5-min window sampled only 10s of bytes) where the legacy bucket-max graph read ~0 — pins `presenceTotalMins == ` session-stitch time-used (25m), the hourly bars sum to it, and per-app `dayMins` == the `usage-by-app` presence surface.
- **Presence unit** (`PresenceSpec`): the span surfaces reconcile with their seconds aggregates (`deviceSessionSpans`↔`totalSecondsByMac`, `hostSessionSpans`↔`proportionalHostSeconds` for Sum/Dedup), and `secondsByLocalHour` splits across an hour boundary.
- **Web** (`ProfileTimelinePage.test.tsx`): the headline shows `presenceTotalMins` (56m) not the summed bars (45m), with fallback when the field is absent.

Existing usage-series tests updated: seed rows now carry realistic >10 KB byte volume (the presence-based graph correctly heartbeat-filters sub-10 KB keepalives, which the old bucket-max graph never did).

`mill api.test`, `mill shared.test`, web `vitest`/`tsc`/`eslint`, and `scalafmt --check` all pass.

## Wire compatibility
Additive only: `presenceTotalMins` defaults to 0 and older clients ignore it.