### PR TITLE
fix(#1489): cap merged nftset directive at dnsmasq's 1024-byte line limit

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -64,9 +64,13 @@ jobs:
       || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, kvm]
     # Local wall time for the full fake-mode pack is ~15–20m (per #685
-    # validation: ipk arm green 3x at 18m avg). 30m covers a cold image
-    # build on the runner plus headroom.
-    timeout-minutes: 30
+    # validation: ipk arm green 3x at 18m avg). Bumped from 30→40m after
+    # run 27045183975 timed out the ipk arm at exactly 30m while the apk
+    # arm finished at 28m26s — the cold-image-build + shared-host load on
+    # api.lan now eats most of the headroom, so 30m no longer covers the
+    # tail. 40m re-establishes the safety margin without masking a real
+    # regression in the scenario pack itself.
+    timeout-minutes: 40
     # #685: matrix over ipk-23.05 and apk-25.12 router images. fail-fast=false
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -497,7 +497,42 @@ function M.dnsmasq(snapshot)
     emit("# nftset populators — merged per host so dnsmasq fires every set")
     emit("# (ea+eb+bl+global; see issues 421, 496, 351, 392, 352, 1319 above)")
     for _, host in ipairs(host_order) do
-      emit(string.format("nftset=/%s/%s", host, table.concat(host_specs[host], ",")))
+      local specs = host_specs[host]
+      local line  = string.format("nftset=/%s/%s", host, table.concat(specs, ","))
+      -- #1489 follow-up: the global-extraAllowed skip above only spares a
+      -- host that lives in @global_allow. A host in many profiles'
+      -- extraAllowed but NOT in global.extraAllowed still piles one ea_ spec
+      -- per device onto a single merged line and overflows dnsmasq's 1024-
+      -- byte config-line buffer (Gate 3a staging-smoke regression after
+      -- #1493 shipped). When that happens, drop the per-(MAC,host) ea_/ea6_
+      -- specs from the merged directive: dns-tail (#1346) repopulates the
+      -- ea_ sets from live replies, so the per-MAC carve-out is only delayed
+      -- until the first reply lands for that host, not lost. Crashing
+      -- dnsmasq (which takes :53 down for every device) is strictly worse.
+      if #line > 1024 then
+        local kept, dropped = {}, 0
+        for _, s in ipairs(specs) do
+          if s:find("#ea_", 1, true) or s:find("#ea6_", 1, true) then
+            dropped = dropped + 1
+          else
+            kept[#kept + 1] = s
+          end
+        end
+        emit(string.format(
+          "# wifihaven: dropped %d per-(MAC,host) ea_ spec(s) for %s to fit dnsmasq's 1024-byte line limit (#1489); dns-tail (#1346) repopulates ea_ sets from live replies",
+          dropped, host))
+        if #kept > 0 then
+          line = string.format("nftset=/%s/%s", host, table.concat(kept, ","))
+        else
+          -- Only ea_ specs existed for this host. With them gone there is
+          -- nothing left to emit; the host carries no surviving nftset=
+          -- directive. dns-tail still populates the ea_ sets from live
+          -- replies, so the (MAC,host) carve-out is recovered after the
+          -- first resolution. Keeping dnsmasq alive is the goal.
+          line = nil
+        end
+      end
+      if line then emit(line) end
     end
     emit("")
   end

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2209,6 +2209,84 @@ describe("render.dnsmasq global section (#1319)", function()
         #line, line:sub(1, 72)))
     end
   end)
+
+  -- ── #1489 follow-up: line-length cap, not just global-skip ─────────────
+  --
+  -- The Gate 3a staging-smoke failure after #1493 shipped is the same
+  -- "connection refused on :53" — but for a host that is in many profiles'
+  -- extraAllowed AND is NOT in global.extraAllowed (e.g. a manually-allowed
+  -- host like khanacademy.org carried by lots of profiles). The
+  -- global-extraAllowed skip from #1493 has no effect there, so the merged
+  -- nftset directive still piles up one ea_ spec per device and overflows
+  -- dnsmasq's 1024-byte config-line buffer.
+  --
+  -- render.dnsmasq must bound EVERY merged directive to 1024 bytes. The
+  -- per-(MAC,host) ea_ populator is droppable: dns-tail (#1346) repopulates
+  -- ea_ sets from live replies, so a missing dnsmasq populator at startup
+  -- only delays the first per-MAC carve-out for that host — far better than
+  -- dnsmasq refusing to start and taking :53 down for everyone.
+  it("caps the merged directive even when the heavy host is NOT in global.extraAllowed (#1489)", function()
+    local s = snap_global()
+    s.devices = {}
+    s.profiles = {}
+    -- 30 profiles each allow the same non-global host. With ea_/ea6_ specs
+    -- ~62 bytes each plus comma, that's ~3700 bytes on one line pre-cap.
+    for i = 1, 30 do
+      local mac = string.format("aa:bb:cc:%02x:%02x:%02x", i, i, i)
+      s.devices[mac] = { profileId = i }
+      s.profiles[tostring(i)] = {
+        name = "p" .. i,
+        failureMode = "last-known-good",
+        rules = {
+          blocked = false, extraBlocked = {}, blocklistIds = {},
+          extraAllowed = { "khanacademy.org" },
+        },
+      }
+    end
+    -- Deliberately NOT in global.extraAllowed — exercises the cap path.
+    local conf = render.dnsmasq(s)
+    for line in (conf .. "\n"):gmatch("([^\n]*)\n") do
+      assert.is_true(#line <= 1024, string.format(
+        "nftset line exceeds dnsmasq's 1024-byte config-line limit (%d bytes): %s…",
+        #line, line:sub(1, 72)))
+    end
+    -- A trace comment must name the host so the operator can see what was
+    -- dropped (rather than silently degrading).
+    assert.truthy(conf:find("khanacademy.org", 1, true))
+    assert.truthy(conf:find("dropped", 1, true))
+  end)
+
+  -- Mixed case: a heavy host also carries a non-ea_ spec (e.g. it appears
+  -- in a blocklist). Capping drops the ea_ specs but keeps the bl_ spec, so
+  -- the surviving merged directive is still emitted and still under 1024.
+  it("preserves non-ea_ specs when capping an overflowing heavy host (#1489)", function()
+    local s = snap_global()
+    s.devices = {}
+    s.profiles = {}
+    for i = 1, 30 do
+      local mac = string.format("aa:bb:cc:%02x:%02x:%02x", i, i, i)
+      s.devices[mac] = { profileId = i }
+      s.profiles[tostring(i)] = {
+        name = "p" .. i,
+        failureMode = "last-known-good",
+        rules = {
+          blocked = false, extraBlocked = {}, blocklistIds = { "ads" },
+          extraAllowed = { "shared.example" },
+        },
+      }
+    end
+    s.blocklists = { ads = { version = "v1", url = "/api/blocklists/ads" } }
+    s._blocklist_hosts = { ads = { "shared.example" } }
+    local conf = render.dnsmasq(s)
+    for line in (conf .. "\n"):gmatch("([^\n]*)\n") do
+      assert.is_true(#line <= 1024, string.format(
+        "nftset line exceeds 1024 bytes (%d): %s…", #line, line:sub(1, 72)))
+    end
+    -- The bl_ad / bl6_ad specs survive — only the ea_ specs were dropped.
+    assert.truthy(conf:find(
+      "nftset=/shared.example/4#inet#wifihaven#bl_ads,6#inet#wifihaven#bl6_ads",
+      1, true))
+  end)
 end)
 
 describe("render.nft global composition (#1319)", function()


### PR DESCRIPTION
## Summary
- Master Router CD on `main` is red (run [27045183975](https://github.com/wifihaven/wifihaven/actions/runs/27045183975)) — Gate 3a apk + ipk both fail at fixture setup with `;; communications error to <router-ULA>::1#53: connection refused`, dnsmasq refusing to start on the freshly-built router image. Attempt 2 reproduces it.
- #1493's fix for #1489 only spares hosts that live in `global.extraAllowed`. A host carried by many profiles' `extraAllowed` but NOT in the global layer (e.g. a manually-allowed host) still piles one `ea_` spec per device onto a single merged `nftset=/<host>/...` directive and overflows dnsmasq's MAXDNAME(1025)-byte config-line buffer — dnsmasq then refuses to start.
- Cap every merged directive at 1024 bytes by dropping the per-(MAC,host) `ea_`/`ea6_` specs and emitting a trace comment. `dns-tail` (#1346) already repopulates `ea_` sets from live replies via `maybe_populate_ea`, so the per-MAC carve-out is only delayed to the first reply for that host, not lost — strictly better than dnsmasq crashing and taking `:53` down for every device on the LAN.
- Also bumps Gate 2's `e2e-vm-fake.yml` `timeout-minutes` from 30→40: ipk arm of the same run timed out at exactly 30m while the apk arm finished at 28m26s.

## Test plan
- [x] New `render_spec.lua` case: 30 profiles allow the same non-global host → assert no `nftset=` line exceeds 1024 bytes and a trace comment names the host. Red on `main`, green with the cap.
- [x] New `render_spec.lua` case: mixed (heavy `ea_` + `bl_` membership for the same host) → surviving directive carries `bl_/bl6_` intact, only `ea_` dropped.
- [ ] CI: OpenWrt Lua Tests, Master Router CD Gate 2 + Gate 3a (apk + ipk).
- [ ] Confirm Gate 3a no longer gets `:53 connection refused` against staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)