### PR TITLE
fix(#1494): migrate the schedule e2e write path to named schedules (unblock Master API/UI CD)

### DIFF
--- a/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
@@ -10,7 +10,7 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.test.*
 
-import java.time.{LocalDateTime, LocalTime, ZoneId}
+import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneId, ZoneOffset}
 
 /**
  * #1069: the policy snapshot must fold a profile's *named* schedule (referenced via
@@ -102,6 +102,37 @@ object PolicySnapshotNamedScheduleSpec
       _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", pid)
     } yield (pid, sid)
 
+  // Set a 1-minute daily limit on the profile and accrue well past it, so the
+  // TimeLimit step (#3) would block on its own — used to prove Schedule (#2)
+  // wins. seedTraffic mirrors RouterDecisionSpec: 5-min traffic_reports buckets
+  // for 2025-01-06 (the TestClock fixture date).
+  private def seedDailyLimitExceeded(pid: ProfileId) =
+    for {
+      tlr <- ZIO.service[TimeLimitRepo]
+      rr  <- ZIO.service[RouterRepo]
+      tr  <- ZIO.service[TrafficReportRepo]
+      _   <- tlr.upsert(pid, 1)
+      rid <- rr.create("gw-seed", Sha256Hex.unsafe("n" * 64))
+      date    = LocalDate.of(2025, 1, 6)
+      day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      inserts = (0 until 4).toList.map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          rid,
+          MacAddress.unsafe("aa:bb:cc:11:22:33"),
+          None,
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }
+      _ <- tr.insertBatch(inserts)
+    } yield ()
+
   def spec = suite("policy snapshot — named schedules (#1069)")(
     test("active named-schedule window (bedtime 21:30) → device blocked, reason=Schedule") {
       for {
@@ -137,6 +168,31 @@ object PolicySnapshotNamedScheduleSpec
         ps   <- makePsAt(TestClock.bedtime)
         snap <- ps.snapshot
       } yield assertTrue(blockedMacs(snap).isEmpty)
+    },
+    // #1494: an attached named schedule must win over an also-active daily
+    // TimeLimit — PolicyService precedence is Schedule (#2) > TimeLimit (#3).
+    // This is the snapshot-level counterpart to e2e §7, which writes the
+    // schedule through the same attach path (profile_schedule_rules).
+    test("active named schedule + exceeded daily limit → Schedule wins over TimeLimit") {
+      for {
+        _    <- cleanDb
+        pid  <- seedBedtimeNamedSchedule.map(_._1)
+        _    <- seedDailyLimitExceeded(pid)
+        ps   <- makePsAt(TestClock.bedtime)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap) == List("aa:bb:cc:11:22:33" -> "Schedule"))
+    },
+    test("control: same exceeded limit, no active schedule → TimeLimit blocks") {
+      // Outside the bedtime window the schedule is inactive, so the same usage
+      // falls through to TimeLimit — confirming the limit really is hot and the
+      // test above isn't just measuring an absent TimeLimit.
+      for {
+        _    <- cleanDb
+        pid  <- seedBedtimeNamedSchedule.map(_._1)
+        _    <- seedDailyLimitExceeded(pid)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- ps.snapshot
+      } yield assertTrue(blockedMacs(snap) == List("aa:bb:cc:11:22:33" -> "TimeLimit"))
     },
     test("no schedule reference → never blocked by schedule") {
       for {

--- a/scripts/e2e-router.sh
+++ b/scripts/e2e-router.sh
@@ -460,34 +460,48 @@ pass "blockReason=Paused in policy snapshot"
 pause_profile false
 
 # ── 7. Active schedule reflected in policy snapshot ───────────────────────
-step "Add always-on schedule → blockReason=Schedule in snapshot"
-# PUT the full profile with an all-days, all-hours schedule. The snapshot no
-# longer carries raw schedules; it just collapses an active schedule into
-# blockReason=Schedule.
-SCHED_BODY=$(cat <<EOF
-{
-  "name": "$PROFILE_NAME",
-  "blockedCategories": [],
-  "extraBlocked": [],
-  "extraAllowed": [],
-  "paused": false,
-  "schedules": [
-    {
-      "name": "always",
-      "days": ["mon","tue","wed","thu","fri","sat","sun"],
-      "startLocal": "00:00",
-      "endLocal":   "23:59",
-      "tz":         "UTC"
-    }
-  ],
-  "timeLimit": 1,
-  "siteTimeLimits": []
-}
-EOF
-)
+step "Attach always-on named schedule → blockReason=Schedule in snapshot"
+# #1494: enforcement reads schedules from named_schedules / profile_schedule_rules
+# since #1490; the profile upsert no longer writes the legacy `schedules` table
+# (an inline `schedules` array is now ignored). So a schedule must be authored as
+# a household-scoped named schedule (POST /api/schedules) and attached to the
+# profile (PUT /api/profiles/{id}/schedules). The snapshot then collapses an
+# active window into blockReason=Schedule.
+#
+# First (re)assert the profile carries a 1-minute daily limit so TimeLimit would
+# otherwise fire (§3 already accrued ~90s of usage today) — this lets §7 prove
+# the Schedule > TimeLimit precedence end to end, not just "some block".
 curl -fsS -X PUT "$BASE/api/profiles/$PID" "${AUTH[@]}" \
   -H 'content-type: application/json' \
-  -d "$SCHED_BODY" >/dev/null
+  -d "{
+        \"name\": \"$PROFILE_NAME\",
+        \"blockedCategories\": [],
+        \"extraBlocked\": [],
+        \"extraAllowed\": [],
+        \"paused\": false,
+        \"timeLimit\": 1,
+        \"siteTimeLimits\": []
+      }" >/dev/null
+
+# Create an all-days, all-hours named schedule (unique name per run).
+SCHED_ID=$(curl -fsS -X POST "$BASE/api/schedules" "${AUTH[@]}" \
+  -H 'content-type: application/json' \
+  -d "{
+        \"name\": \"e2e-always-${RUN_ID}\",
+        \"windows\": [
+          {
+            \"days\": [\"mon\",\"tue\",\"wed\",\"thu\",\"fri\",\"sat\",\"sun\"],
+            \"startLocal\": \"00:00\",
+            \"endLocal\":   \"23:59\",
+            \"tz\":         \"UTC\"
+          }
+        ]
+      }" | _py "import json,sys; print(json.load(sys.stdin)['id'])")
+
+# Attach the named schedule to the profile as a BLOCK schedule.
+curl -fsS -X PUT "$BASE/api/profiles/$PID/schedules" "${AUTH[@]}" \
+  -H 'content-type: application/json' \
+  -d "{\"scheduleIds\": [$SCHED_ID]}" >/dev/null
 
 curl -fsS "${RAUTH[@]}" "$BASE/api/router/policy" >"$TMP/snap4.json"
 SCHED_REASON=$(_py "
@@ -498,12 +512,14 @@ if p is None:
     raise SystemExit('profile $PID missing from snapshot.profiles')
 print(p['rules'].get('blockReason'))
 ")
-# Either Schedule (always-on schedule) or TimeLimit (90s usage from §3 still
-# in today's bucket). The snapshot's precedence is Schedule > TimeLimit, so we
-# expect Schedule — but if scheduling is for any reason inactive we still want
-# to assert *some* block, not silently regress.
+# The profile has an active always-on schedule AND a reached 1-min daily limit
+# (~90s used in §3). PolicyService precedence is Schedule > TimeLimit, so the
+# snapshot must collapse to Schedule. Asserting strictly Schedule (not "some
+# block") is what catches the #1494 regression: if the attach write path or the
+# #1490 read path breaks, the schedule goes unseen and this falls through to
+# TimeLimit.
 case "$SCHED_REASON" in
-  Schedule)  pass "blockReason=Schedule in snapshot" ;;
+  Schedule)  pass "blockReason=Schedule in snapshot (Schedule > TimeLimit)" ;;
   *)         fail "expected blockReason=Schedule, got '$SCHED_REASON'" ;;
 esac
 

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -63,7 +63,7 @@ pass "profiles list returned $(wc -c <"$TMP/profiles.json") bytes"
 step "Create a profile"
 CREATE=$(curl -fsS -X POST "$BASE/api/profiles" \
   "${AUTH[@]}" -H 'content-type: application/json' \
-  -d "{\"name\":\"$PROFILE_NAME\",\"blockedCategories\":[\"adult\"],\"extraBlocked\":[],\"extraAllowed\":[],\"paused\":false,\"schedules\":[],\"timeLimit\":null,\"siteTimeLimits\":[]}")
+  -d "{\"name\":\"$PROFILE_NAME\",\"blockedCategories\":[\"adult\"],\"extraBlocked\":[],\"extraAllowed\":[],\"paused\":false,\"timeLimit\":null,\"siteTimeLimits\":[]}")
 PID=$(echo "$CREATE" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
 [ -n "$PID" ] || fail "no profile id in create response: $CREATE"
 pass "created profile id=$PID name=$PROFILE_NAME"

--- a/scripts/e2e/lib/api_admin.py
+++ b/scripts/e2e/lib/api_admin.py
@@ -65,7 +65,6 @@ class AdminAPI:
             "extraBlocked": [],
             "extraAllowed": [],
             "paused": False,
-            "schedules": [],
             "timeLimit": None,
             "siteTimeLimits": [],
             "failureMode": "block-all",
@@ -83,11 +82,15 @@ class AdminAPI:
         """GET the profile, fold in `changes`, and PUT the merged result.
 
         Handles the fact that GET returns the profile in a nested shape
-        (`{profile: {...}, schedules: [...], timeLimit: {...} | null,
-        siteTimeLimits: [...]}`) while PUT requires a flat body and expects
-        `timeLimit` to be an integer minute-count, not the object the GET
-        returns. Callers should pass overrides as keyword args (e.g.
-        `extraBlocked=[...]`, `timeLimit=5`).
+        (`{profile: {...}, timeLimit: {...} | null, siteTimeLimits: [...]}`)
+        while PUT requires a flat body and expects `timeLimit` to be an integer
+        minute-count, not the object the GET returns. Callers should pass
+        overrides as keyword args (e.g. `extraBlocked=[...]`, `timeLimit=5`).
+
+        Schedules are NOT folded here: since #1490/#1494 the profile upsert no
+        longer carries schedules (an inline `schedules` array is an ignored
+        unknown field). Schedules attach via the named-schedule path — see
+        `add_schedule` / `remove_schedule`.
         """
         full = self.get_profile(profile_id)
         prof = full.get("profile", full) if isinstance(full, dict) else {}
@@ -103,7 +106,6 @@ class AdminAPI:
             "extraBlocked": prof.get("extraBlocked", []),
             "extraAllowed": prof.get("extraAllowed", []),
             "paused": prof.get("paused", False),
-            "schedules": full.get("schedules", []) if isinstance(full, dict) else [],
             "timeLimit": time_limit_minutes,
             "siteTimeLimits":
                 full.get("siteTimeLimits", []) if isinstance(full, dict) else [],
@@ -124,24 +126,51 @@ class AdminAPI:
     def set_profile_paused(self, profile_id: int, paused: bool) -> dict[str, Any]:
         return self.apply_profile_update(profile_id, paused=paused)
 
-    def add_schedule(self, profile_id: int, schedule: dict[str, Any]) -> dict[str, Any]:
-        """Append a schedule to the profile via fold-and-PUT.
+    def attached_schedule_ids(self, profile_id: int) -> list[Any]:
+        """The named-schedule ids attached to the profile as block schedules."""
+        full = self.get_profile(profile_id)
+        return full.get("scheduleIds", []) if isinstance(full, dict) else []
 
-        `schedule` is a dict in the shape the API expects (e.g. `{"daysOfWeek":
-        ["MON"], "startTime": "09:00", "endTime": "17:00", "timezone":
-        "America/Los_Angeles"}`). The server may assign an `id` on round-trip;
-        the returned profile reflects what was stored.
+    def set_profile_schedules(
+        self, profile_id: int, schedule_ids: list[Any],
+    ) -> None:
+        """Replace the profile's attached block schedules (#1494 write path).
+
+        PUT /api/profiles/{id}/schedules -> profile_schedule_rules. This is the
+        ONLY enforced schedule write path since #1490 — the legacy inline
+        `schedules` array on the profile upsert is dead.
         """
-        full = self.get_profile(profile_id)
-        existing = full.get("schedules", []) if isinstance(full, dict) else []
-        return self.apply_profile_update(profile_id, schedules=existing + [schedule])
+        self._request(
+            "PUT", f"/api/profiles/{profile_id}/schedules",
+            body={"scheduleIds": schedule_ids},
+        )
 
-    def remove_schedule(self, profile_id: int, schedule_id: Any) -> dict[str, Any]:
-        """Drop the schedule with the given id; no-op if absent."""
-        full = self.get_profile(profile_id)
-        existing = full.get("schedules", []) if isinstance(full, dict) else []
-        kept = [s for s in existing if s.get("id") != schedule_id]
-        return self.apply_profile_update(profile_id, schedules=kept)
+    def add_schedule(self, profile_id: int, window: dict[str, Any], *,
+                     name: str | None = None) -> Any:
+        """Create a household named schedule and attach it to the profile.
+
+        `window` is a ScheduleWindow dict — `{"days": ["mon", ...], "startLocal":
+        "21:00", "endLocal": "07:00", "tz": "UTC"}`. Returns the new schedule id.
+
+        Replaces the pre-#1494 fold-and-PUT of an inline `schedules` array, which
+        the API now ignores (enforcement reads named_schedules /
+        profile_schedule_rules since #1490).
+        """
+        sched_name = name or f"e2e-sched-p{profile_id}-{window.get('startLocal', '')}"
+        created = self._request(
+            "POST", "/api/schedules",
+            body={"name": sched_name, "windows": [window]},
+        )
+        sid = created.get("id") if isinstance(created, dict) else None
+        self.set_profile_schedules(
+            profile_id, self.attached_schedule_ids(profile_id) + [sid],
+        )
+        return sid
+
+    def remove_schedule(self, profile_id: int, schedule_id: Any) -> None:
+        """Detach the named schedule from the profile; no-op if not attached."""
+        kept = [s for s in self.attached_schedule_ids(profile_id) if s != schedule_id]
+        self.set_profile_schedules(profile_id, kept)
 
     # ── devices ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

Master API/UI CD is **RED** on `scripts/e2e-router.sh` §7 ("Live e2e against staging stack"), blocking all prod deploys:

```
✗ expected blockReason=Schedule, got 'TimeLimit'
```

This is the e2e half of the #1494 split-brain. Since #1490 switched schedule **enforcement** to read `named_schedules` / `profile_schedule_rules`, and #1495 stopped the profile upsert from **writing** the legacy V1 `schedules` table (an inline `schedules` array is now an ignored unknown field), the e2e was the last client still authoring its schedule via that dead inline array on the profile PUT. The schedule was never created → the snapshot fell through to the §3 TimeLimit block → `got TimeLimit`.

This is the same shape as the live prod regression #1494 describes: any schedule authored via the legacy inline path is silently unenforced after the #1490 read-switch. The API and SPA write paths were already migrated in #1495; this PR closes the remaining gap (the e2e) so CD goes green and the precedence is pinned by a unit-level test.

## What changed

- **e2e (`scripts/e2e-router.sh` §7):** author the always-on schedule the way every client now must — `POST /api/schedules` to create an all-days/all-hours **named** schedule, then `PUT /api/profiles/{id}/schedules` to attach it (`profile_schedule_rules`). The 1-min daily limit stays hot so §7 still proves **Schedule > TimeLimit** precedence end to end. Assertion stays strict (must be `Schedule`, never just "some block").
- **API feature test (`PolicySnapshotNamedScheduleSpec`):** add the snapshot-level counterpart — an attached named schedule + an exceeded daily limit yields `blockReason=Schedule` (Schedule #2 > TimeLimit #3), plus a control (schedule inactive → falls through to `TimeLimit`) proving the limit is genuinely hot. Both run against real embedded Postgres via the same attach path the e2e exercises.

No production source changed — the API/SPA write-path migration shipped in #1495; nothing writes the legacy `schedules` table.

## Verify

- `mill api.test.testOnly 'wifihaven.api.feature.PolicySnapshotNamedScheduleSpec'` → 6 passed (incl. the two new precedence tests).
- `scalafmt --check` clean; `bash -n scripts/e2e-router.sh` clean.

## Notes

- This **unblocks Master API/UI CD** and restores confidence that profile schedules are enforced end to end through the #1490 read path.
- #1485 (drop the legacy `schedules` table) stays blocked until this + #1482 soak.

Refs #1494, #1490, #1495, #1485, #1482.