### PR TITLE
fix(#1503): unify infra-allow + heartbeat host lists, expand background suppression

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -373,6 +373,7 @@ object Main extends ZIOAppDefault {
             deviceRepo,
             profileRepo,
             upRepo,
+            hsRepo,
             clock,
           ) ++
           BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists)

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -373,7 +373,6 @@ object Main extends ZIOAppDefault {
             deviceRepo,
             profileRepo,
             upRepo,
-            hsRepo,
             clock,
           ) ++
           BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -570,40 +570,15 @@ object PolicyService {
    * beat the block exactly as the old per-(MAC) ea_ copies did, now from a single fleet-wide source
    * with no per-profile duplication. This stays deliberately functional, not a new snapshot field —
    * the router needs the hosts, not the reason they're allowed (#1311).
+   *
+   * #1503: the host list itself is now derived from the single canonical [[InfraHosts.canonical]]
+   * list, shared with the `Presence` suppression set — "infra we must always allow" and "infra that
+   * must not count as engagement" are the same device-level set, and maintaining two hand-curated
+   * copies let them drift (the #1499 over-count leak). The device-infra-only boundary (no rotating
+   * per-app CDN hosts such as `*.akamai.net` / `*.fastly.net`, which attribute to the app via its
+   * branded domains) and the per-app-CDN rationale now live on [[InfraHosts]] and are unchanged.
    */
-  val infraAllowHosts: List[Hostname] = List(
-    "connectivitycheck.gstatic.com", // Android / Chrome connectivity probe
-    "captive.apple.com",             // iOS / macOS captive-portal probe
-    "ocsp.apple.com",                // Apple OCSP responder
-    "ocsp2.apple.com",               // Apple OCSP responder (secondary)
-    "crl.apple.com",                 // Apple CRL distribution
-    "g.aaplimg.com",                 // Apple geo-edge CDN: OCSP + asset shards
-    "ocsp.pki.goog",                 // Google Trust Services OCSP
-    "ocsp.digicert.com",             // DigiCert OCSP (common CA for app backends)
-    "clientservices.googleapis.com", // Google client-services bootstrap
-    // #1337: Apple's network-connectivity-test CDN — a device-level infra probe,
-    // owned by Apple and stable. Added as an exact host.
-    //
-    // We deliberately did NOT add CDN edge hostnames for specific apps (the
-    // operator originally hit `a1744.dscw154.akamai.net` for Math Academy and
-    // `prod.khan.map.fastly.net` for Khan): those are CDN *mapping* artifacts that
-    // rotate (Khan's `cdn.kastatic.org` is on Fastly now, not Akamai), so pinning
-    // one rots silently. Per-app CDN assets are covered the stable way — by the
-    // app's own branded domains in extraAllowed (e.g. `mathacademy.com`,
-    // `kastatic.org`), whose resolved IPs (including via CNAME to a CDN) belong in
-    // the per-(MAC, host) ea_ set. That carve-out only works once the ea_ set is
-    // actually populated from resolved IPs, which is a separate router-side gap
-    // tracked in its own issue — not something more infra-allow entries can fix.
-    "netcts.cdn-apple.com",          // Apple network connectivity-test CDN
-    // #1411: Google's gvt2.com infra domain — connectivity-check probes,
-    // Play/app asset bootstrap, and download shards (`r1---sn-xxxx.gvt2.com`)
-    // that rotate. These are device-level transitive deps the whole-MAC drop
-    // kills, making otherwise-allowed Google apps appear blocked. Pure Google
-    // infra, not a site users reach directly → low bypass risk. Added as the
-    // apex `gvt2.com` so the router's trailing-suffix match carves out every
-    // `*.gvt2.com` subdomain (incl. the rotating shards), not just one host.
-    "gvt2.com",                      // Google connectivity / Play / download infra (all subdomains)
-  ).map(Hostname.unsafe)
+  val infraAllowHosts: List[Hostname] = InfraHosts.canonical.map(Hostname.unsafe)
 
   /** Content-derived version: first 16 hex chars of SHA-256 over sorted domain list. */
   def blocklistContentVersion(domains: Iterable[String]): String = {

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -305,17 +305,35 @@ object Presence {
    * (`patternMinutesByMac`) and the per-host/per-app breakdown (`hostMinutes`,
    * `proportionalHostSeconds`) — so keepalives no longer inflate per-site time or per-app presence
    * (design §4.2). Each surface takes a `filter` argument (default `Off`); callers pass
-   * `settings.heartbeatFilter`. A row is classified as a heartbeat if the filter is enabled and
-   * total bytes are below `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a
-   * few hundred) or its FQDN matches a heartbeat host pattern.
+   * `settings.heartbeatFilter`. A row is classified as a heartbeat if its FQDN is on the unified
+   * device-infra list (see below) OR — when the filter is enabled — total bytes are below
+   * `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few hundred) or its FQDN
+   * matches an operator-configured heartbeat host pattern.
+   *
+   * #1503: the FQDN check now also consults the canonical [[InfraHosts.canonical]] set — the same
+   * device-level infra `PolicyService.infraAllowHosts` carves out of the block. Maintaining the
+   * suppression list and the allow list as two hand-curated copies let them drift (the #1499
+   * ~93%-background over-count leak: `heartbeatHostPatterns` was missing `gvt2.com`, the OCSP
+   * responders, etc.). Unified-infra suppression keys purely on host *identity* and applies
+   * regardless of `filter.enabled` — device infra is never engagement, mirroring the allow side
+   * consuming the list unconditionally. Because it keys on identity (never on low bytes / short
+   * activity) it cannot re-open the #1446 undercount: a genuine app's sparse, low-byte requests are
+   * not on the list, so they still count.
    */
   def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
-    filter.enabled && (
+    isInfraHost(row) || (filter.enabled && (
       row.bytes < filter.bytesThreshold ||
         row.host.asFqdn.exists(fqdn =>
           filter.heartbeatHostPatterns.exists(p => matchesPattern(fqdn.value, p)),
         )
-    )
+    ))
+
+  /**
+   * #1503: whether the row's FQDN is on the unified device-infra list ([[InfraHosts]]). Keyed on
+   * host identity only — IP-literal hosts never match.
+   */
+  private def isInfraHost(row: PresenceRow): Boolean =
+    row.host.asFqdn.exists(fqdn => InfraHosts.isInfra(fqdn.value))
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
@@ -330,7 +348,12 @@ object Presence {
 
   def classifyRows(rows: List[PresenceRow], filter: HeartbeatFilter): List[Classified] =
     rows.map { r =>
-      val rsns  = scala.collection.mutable.ListBuffer.empty[String]
+      val rsns = scala.collection.mutable.ListBuffer.empty[String]
+      // #1503: unified device-infra is always background, independent of filter.enabled.
+      for {
+        fqdn <- r.host.asFqdn
+        p    <- InfraHosts.matchedPattern(fqdn.value)
+      } rsns += s"infra:$p"
       if filter.enabled then {
         if r.bytes < filter.bytesThreshold then rsns += s"bytes<${filter.bytesThreshold}"
         for {
@@ -339,7 +362,7 @@ object Presence {
           if matchesPattern(fqdn.value, p)
         } rsns += s"host:$p"
       }
-      val label = if filter.enabled && rsns.nonEmpty then "heartbeat" else "active"
+      val label = if rsns.nonEmpty then "heartbeat" else "active"
       Classified(r, label, rsns.toList)
     }
 

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -307,33 +307,29 @@ object Presence {
    * (design §4.2). Each surface takes a `filter` argument (default `Off`); callers pass
    * `settings.heartbeatFilter`. A row is classified as a heartbeat if its FQDN is on the unified
    * device-infra list (see below) OR — when the filter is enabled — total bytes are below
-   * `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few hundred) or its FQDN
-   * matches an operator-configured heartbeat host pattern.
+   * `bytesThreshold` (one TCP keepalive ≈ 60 bytes; a few HTTP/2 PINGs ≈ a few hundred).
    *
-   * #1503: the FQDN check now also consults the canonical [[InfraHosts.canonical]] set — the same
-   * device-level infra `PolicyService.infraAllowHosts` carves out of the block. Maintaining the
-   * suppression list and the allow list as two hand-curated copies let them drift (the #1499
-   * ~93%-background over-count leak: `heartbeatHostPatterns` was missing `gvt2.com`, the OCSP
-   * responders, etc.). Unified-infra suppression keys purely on host *identity* and applies
-   * regardless of `filter.enabled` — device infra is never engagement, mirroring the allow side
-   * consuming the list unconditionally. Because it keys on identity (never on low bytes / short
-   * activity) it cannot re-open the #1446 undercount: a genuine app's sparse, low-byte requests are
-   * not on the list, so they still count.
+   * #1503/#1525: the FQDN check consults the canonical [[InfraHosts]] background set — the same
+   * device-level infra `PolicyService.infraAllowHosts` carves out of the block, plus the
+   * suppress-only tier folded in from the retired `household_settings.heartbeat_host_patterns`
+   * column (#1525). Maintaining a suppression list and an allow list as two hand-curated copies let
+   * them drift (the #1499 ~93%-background over-count leak). Suppression keys purely on host
+   * *identity* and applies regardless of `filter.enabled` — device infra is never engagement,
+   * mirroring the allow side consuming the list unconditionally. Because it keys on identity (never
+   * on low bytes / short activity) it cannot re-open the #1446 undercount: a genuine app's sparse,
+   * low-byte requests are not on the list, so they still count. The `bytesThreshold` keepalive
+   * floor is unchanged and still gated on `filter.enabled`.
    */
   def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
-    isInfraHost(row) || (filter.enabled && (
-      row.bytes < filter.bytesThreshold ||
-        row.host.asFqdn.exists(fqdn =>
-          filter.heartbeatHostPatterns.exists(p => matchesPattern(fqdn.value, p)),
-        )
-    ))
+    isBackgroundHost(row) || (filter.enabled && row.bytes < filter.bytesThreshold)
 
   /**
-   * #1503: whether the row's FQDN is on the unified device-infra list ([[InfraHosts]]). Keyed on
-   * host identity only — IP-literal hosts never match.
+   * #1503/#1525: whether the row's FQDN is device-level background infra
+   * ([[InfraHosts.isBackground]] \= allow+suppress canonical ∪ suppress-only). Keyed on host
+   * identity only — IP-literal hosts never match.
    */
-  private def isInfraHost(row: PresenceRow): Boolean =
-    row.host.asFqdn.exists(fqdn => InfraHosts.isInfra(fqdn.value))
+  private def isBackgroundHost(row: PresenceRow): Boolean =
+    row.host.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value))
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
@@ -349,19 +345,15 @@ object Presence {
   def classifyRows(rows: List[PresenceRow], filter: HeartbeatFilter): List[Classified] =
     rows.map { r =>
       val rsns = scala.collection.mutable.ListBuffer.empty[String]
-      // #1503: unified device-infra is always background, independent of filter.enabled.
+      // #1503/#1525: device-level background infra is always suppressed, independent of
+      // filter.enabled — keyed on host identity via the unified InfraHosts background set.
       for {
         fqdn <- r.host.asFqdn
-        p    <- InfraHosts.matchedPattern(fqdn.value)
+        p    <- InfraHosts.matchedBackgroundPattern(fqdn.value)
       } rsns += s"infra:$p"
-      if filter.enabled then {
-        if r.bytes < filter.bytesThreshold then rsns += s"bytes<${filter.bytesThreshold}"
-        for {
-          fqdn <- r.host.asFqdn
-          p    <- filter.heartbeatHostPatterns
-          if matchesPattern(fqdn.value, p)
-        } rsns += s"host:$p"
-      }
+      // The byte-floor keepalive heuristic is still operator-gated.
+      if filter.enabled && r.bytes < filter.bytesThreshold then
+        rsns += s"bytes<${filter.bytesThreshold}"
       val label = if rsns.nonEmpty then "heartbeat" else "active"
       Classified(r, label, rsns.toList)
     }

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -37,7 +37,6 @@ object DashboardNowRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
-      householdSettingsRepo: HouseholdSettingsRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -50,10 +49,6 @@ object DashboardNowRoutes {
             visibleDevs <- filterDevices(claims, allDevices, userProfileRepo)
             allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             visibleProf <- visibleProfiles(claims, allProfiles, userProfileRepo)
-            // #1503: the now-widget ranks active hosts; route that ranking through the same
-            // heartbeat/infra filter every other usage surface uses so device-level infra
-            // (gvt2, ls.apple, OCSP, …) is never surfaced as "watching X right now".
-            settings    <- householdSettingsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visibleMacs = visibleDevs.map(_.mac)
             // Both inputs in parallel.
             since       = now.minus(TopHostsWindow)
@@ -77,7 +72,6 @@ object DashboardNowRoutes {
               devices = visibleDevs,
               lastSeen = lastSeen,
               rows = rows,
-              filter = settings.heartbeatFilter,
             )
           } yield Response.json(response.toJson)
         },
@@ -86,10 +80,12 @@ object DashboardNowRoutes {
   /**
    * Pure assembly — exposed for unit tests.
    *
-   * `filter` (default `Off`) is applied only to the host *ranking* (`topHosts`, `nowActivity`) via
-   * [[dropBackground]], so device-level infra never surfaces as the active host (#1503). It is
-   * deliberately NOT applied to active-device detection: a device whose only recent traffic is
-   * infra is still "online", it just has no foreground host to show.
+   * The host *ranking* (`topHosts`, `nowActivity`) drops device-level background infra via
+   * [[dropBackground]], so infra never surfaces as the active host (#1503/#1525). Suppression keys
+   * on host IDENTITY only (the unified [[InfraHosts]] set), never the byte floor — so it cannot
+   * hide a genuine low-byte foreground request (the #1446 undercount mechanism). It is deliberately
+   * NOT applied to active-device detection: a device whose only recent traffic is infra is still
+   * "online", it just has no foreground host to show.
    */
   def buildResponse(
       now: Instant,
@@ -97,7 +93,6 @@ object DashboardNowRoutes {
       devices: List[Device],
       lastSeen: Map[MacAddress, Instant],
       rows: List[TrafficRollupRow],
-      filter: HeartbeatFilter = HeartbeatFilter.Off,
   ): DashboardNow = {
     val trafficCutoff                             = now.minus(TrafficActiveWindow)
     val rowsByMac                                 = rows.groupBy(_.mac)
@@ -123,8 +118,8 @@ object DashboardNowRoutes {
             name = d.name,
             mac = d.mac,
             lastSeenSeconds = lastSeenSeconds,
-            topHosts = topHostsFromRows(devRows, filter),
-            nowActivity = nowActivityFromRows(devRows, filter),
+            topHosts = topHostsFromRows(devRows),
+            nowActivity = nowActivityFromRows(devRows),
           )
         }
       }
@@ -144,11 +139,8 @@ object DashboardNowRoutes {
    * bucket and returns its top host. If earlier consecutive buckets share the same top host,
    * reports a `minutes` run (capped at 60); otherwise `minutes = None`. See #852.
    */
-  def nowActivityFromRows(
-      rows: List[TrafficRollupRow],
-      filter: HeartbeatFilter = HeartbeatFilter.Off,
-  ): Option[DashboardNowActivity] = {
-    val buckets = dropBackground(rows, filter)
+  def nowActivityFromRows(rows: List[TrafficRollupRow]): Option[DashboardNowActivity] = {
+    val buckets = dropBackground(rows)
       .groupBy(_.periodEnd)
       .toList
       .sortBy { case (end, _) => -end.getEpochSecond }
@@ -181,11 +173,8 @@ object DashboardNowRoutes {
       .headOption
       .map(_._1)
 
-  def topHostsFromRows(
-      rows: List[TrafficRollupRow],
-      filter: HeartbeatFilter = HeartbeatFilter.Off,
-  ): List[DashboardNowHost] =
-    dropBackground(rows, filter)
+  def topHostsFromRows(rows: List[TrafficRollupRow]): List[DashboardNowHost] =
+    dropBackground(rows)
       .groupBy(_.host)
       .view
       .mapValues(rs => rs.map(_.activeSeconds.toLong).sum)
@@ -195,28 +184,13 @@ object DashboardNowRoutes {
       .map { case (h, s) => DashboardNowHost(h, s) }
 
   /**
-   * #1503: drop device-level background hosts before ranking, so the now-widget never surfaces
-   * infra/telemetry as "watching X right now". Suppression is keyed on host IDENTITY only — never
-   * on the byte floor — so it cannot hide a genuine low-byte foreground request (the #1446
-   * undercount mechanism); a single chatty 60-byte keepalive looks identical to a real
-   * request-driven app at the byte level, so only identity is safe here. Two identity sources:
-   *
-   *   - the unified [[InfraHosts]] canonical set (the same list `PolicyService.infraAllowHosts`
-   *     allows and `Presence` suppresses) — always, independent of the operator's filter toggle.
-   *   - the operator's curated `heartbeatHostPatterns` (e.g. `*.push.apple.com`) — only when the
-   *     heartbeat filter is enabled, matching how the other surfaces honor that toggle.
+   * #1503/#1525: drop device-level background infra before ranking, so the now-widget never
+   * surfaces infra/telemetry as "watching X right now". Suppression is keyed on host IDENTITY only
+   * (the unified [[InfraHosts]] background set — `canonical ∪ suppressOnly`), never on the byte
+   * floor — so it cannot hide a genuine low-byte foreground request (the #1446 undercount
+   * mechanism): a single chatty 60-byte keepalive looks identical to a real request-driven app at
+   * the byte level, so only identity is safe here.
    */
-  private def dropBackground(
-      rows: List[TrafficRollupRow],
-      filter: HeartbeatFilter,
-  ): List[TrafficRollupRow] =
-    rows.filterNot(r => isBackgroundHost(r.host, filter))
-
-  private def isBackgroundHost(host: HostId, filter: HeartbeatFilter): Boolean =
-    host.asFqdn.exists { fqdn =>
-      InfraHosts.isInfra(fqdn.value) ||
-      (filter.enabled && filter.heartbeatHostPatterns.exists(p =>
-        HostMatch.matchesPattern(fqdn.value, p),
-      ))
-    }
+  private def dropBackground(rows: List[TrafficRollupRow]): List[TrafficRollupRow] =
+    rows.filterNot(r => r.host.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value)))
 }

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -37,6 +37,7 @@ object DashboardNowRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      householdSettingsRepo: HouseholdSettingsRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -49,6 +50,10 @@ object DashboardNowRoutes {
             visibleDevs <- filterDevices(claims, allDevices, userProfileRepo)
             allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
             visibleProf <- visibleProfiles(claims, allProfiles, userProfileRepo)
+            // #1503: the now-widget ranks active hosts; route that ranking through the same
+            // heartbeat/infra filter every other usage surface uses so device-level infra
+            // (gvt2, ls.apple, OCSP, …) is never surfaced as "watching X right now".
+            settings    <- householdSettingsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             visibleMacs = visibleDevs.map(_.mac)
             // Both inputs in parallel.
             since       = now.minus(TopHostsWindow)
@@ -72,18 +77,27 @@ object DashboardNowRoutes {
               devices = visibleDevs,
               lastSeen = lastSeen,
               rows = rows,
+              filter = settings.heartbeatFilter,
             )
           } yield Response.json(response.toJson)
         },
     )
 
-  /** Pure assembly — exposed for unit tests. */
+  /**
+   * Pure assembly — exposed for unit tests.
+   *
+   * `filter` (default `Off`) is applied only to the host *ranking* (`topHosts`, `nowActivity`) via
+   * [[dropBackground]], so device-level infra never surfaces as the active host (#1503). It is
+   * deliberately NOT applied to active-device detection: a device whose only recent traffic is
+   * infra is still "online", it just has no foreground host to show.
+   */
   def buildResponse(
       now: Instant,
       profiles: List[Profile],
       devices: List[Device],
       lastSeen: Map[MacAddress, Instant],
       rows: List[TrafficRollupRow],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
   ): DashboardNow = {
     val trafficCutoff                             = now.minus(TrafficActiveWindow)
     val rowsByMac                                 = rows.groupBy(_.mac)
@@ -109,8 +123,8 @@ object DashboardNowRoutes {
             name = d.name,
             mac = d.mac,
             lastSeenSeconds = lastSeenSeconds,
-            topHosts = topHostsFromRows(devRows),
-            nowActivity = nowActivityFromRows(devRows),
+            topHosts = topHostsFromRows(devRows, filter),
+            nowActivity = nowActivityFromRows(devRows, filter),
           )
         }
       }
@@ -130,8 +144,11 @@ object DashboardNowRoutes {
    * bucket and returns its top host. If earlier consecutive buckets share the same top host,
    * reports a `minutes` run (capped at 60); otherwise `minutes = None`. See #852.
    */
-  def nowActivityFromRows(rows: List[TrafficRollupRow]): Option[DashboardNowActivity] = {
-    val buckets = rows
+  def nowActivityFromRows(
+      rows: List[TrafficRollupRow],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+  ): Option[DashboardNowActivity] = {
+    val buckets = dropBackground(rows, filter)
       .groupBy(_.periodEnd)
       .toList
       .sortBy { case (end, _) => -end.getEpochSecond }
@@ -164,8 +181,11 @@ object DashboardNowRoutes {
       .headOption
       .map(_._1)
 
-  def topHostsFromRows(rows: List[TrafficRollupRow]): List[DashboardNowHost] =
-    rows
+  def topHostsFromRows(
+      rows: List[TrafficRollupRow],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+  ): List[DashboardNowHost] =
+    dropBackground(rows, filter)
       .groupBy(_.host)
       .view
       .mapValues(rs => rs.map(_.activeSeconds.toLong).sum)
@@ -173,4 +193,30 @@ object DashboardNowRoutes {
       .sortBy { case (h, s) => (-s, h.value) }
       .take(TopHostsLimit)
       .map { case (h, s) => DashboardNowHost(h, s) }
+
+  /**
+   * #1503: drop device-level background hosts before ranking, so the now-widget never surfaces
+   * infra/telemetry as "watching X right now". Suppression is keyed on host IDENTITY only — never
+   * on the byte floor — so it cannot hide a genuine low-byte foreground request (the #1446
+   * undercount mechanism); a single chatty 60-byte keepalive looks identical to a real
+   * request-driven app at the byte level, so only identity is safe here. Two identity sources:
+   *
+   *   - the unified [[InfraHosts]] canonical set (the same list `PolicyService.infraAllowHosts`
+   *     allows and `Presence` suppresses) — always, independent of the operator's filter toggle.
+   *   - the operator's curated `heartbeatHostPatterns` (e.g. `*.push.apple.com`) — only when the
+   *     heartbeat filter is enabled, matching how the other surfaces honor that toggle.
+   */
+  private def dropBackground(
+      rows: List[TrafficRollupRow],
+      filter: HeartbeatFilter,
+  ): List[TrafficRollupRow] =
+    rows.filterNot(r => isBackgroundHost(r.host, filter))
+
+  private def isBackgroundHost(host: HostId, filter: HeartbeatFilter): Boolean =
+    host.asFqdn.exists { fqdn =>
+      InfraHosts.isInfra(fqdn.value) ||
+      (filter.enabled && filter.heartbeatHostPatterns.exists(p =>
+        HostMatch.matchesPattern(fqdn.value, p),
+      ))
+    }
 }

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -101,9 +101,8 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       dr     <- ZIO.service[DeviceRepo]
       pr     <- ZIO.service[ProfileRepo]
       upRepo <- ZIO.service[UserProfileRepo]
-      hsRepo <- ZIO.service[HouseholdSettingsRepo]
       clock  <- ZIO.service[Clock]
-    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, hsRepo, clock)
+    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, clock)
 
   /**
    * V1__init seeds two profiles ("Kids" and "Adults"). Tests that need a clean slate clear them so

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -247,6 +247,38 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         dev.topHosts.head.activeSeconds == 360L,
       )
     },
+    test("#1503 background infra hosts are excluded from the now-widget's top hosts") {
+      // The "watching X right now" widget must not surface device-level OS/telemetry infra as the
+      // active host. It routes the host ranking through Presence.isHeartbeat, which (post-#1503)
+      // drops the unified InfraHosts set on identity — so the dominant gvt2/ls.apple/OCSP chatter
+      // is excluded and only the genuine app remains, even though infra has more active_seconds.
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        now0     <- Clock.instant
+        t0 = now0.minusSeconds(10 * 60)
+        _      <- insertReport(routerId, mac1, "beacons3.gvt2.com", t0, activeSeconds = 300)
+        _      <- insertReport(routerId, mac1, "gsp-ssl.ls.apple.com", t0, activeSeconds = 300)
+        _      <- insertReport(routerId, mac1, "ocsp.digicert.com", t0, activeSeconds = 300)
+        _      <- insertReport(routerId, mac1, "youtube.com", t0, activeSeconds = 120)
+        _      <- insertConn(routerId, mac1, now0.minusSeconds(15))
+        auth   <- makeAuth
+        token  <- auth.login("admin", "changeme").map(_.token)
+        routes <- buildRoutes(auth)
+        resp   <- getJson(routes, "/api/dashboard/now", token)
+        body   <- resp.body.asString
+        parsed <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(
+        dev.topHosts.map(_.host) == List(HostId.Fqdn(Hostname.unsafe("youtube.com"))),
+        dev.nowActivity.exists(_.topHost == HostId.Fqdn(Hostname.unsafe("youtube.com"))),
+      )
+    },
     test("nowActivity: consistent top host across 3 buckets → topHost + accurate minutes") {
       for {
         _        <- cleanDb

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -101,8 +101,9 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       dr     <- ZIO.service[DeviceRepo]
       pr     <- ZIO.service[ProfileRepo]
       upRepo <- ZIO.service[UserProfileRepo]
+      hsRepo <- ZIO.service[HouseholdSettingsRepo]
       clock  <- ZIO.service[Clock]
-    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, clock)
+    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, hsRepo, clock)
 
   /**
    * V1__init seeds two profiles ("Kids" and "Adults"). Tests that need a clean slate clear them so

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -419,6 +419,72 @@ object PresenceSpec extends ZIOSpecDefault {
         assertTrue(!Presence.isHeartbeat(r, f))
       },
     ),
+    suite("infra-host suppression (#1503)")(
+      test(
+        "canonical infra hosts drop from the daily cap even when absent from heartbeatHostPatterns",
+      ) {
+        // #1499/#1503: the unified canonical infra list (PolicyService.infraAllowHosts ≡ the
+        // presence suppression set) drops device-level OS/telemetry/cert chatter even when the
+        // operator's hand-curated `heartbeatHostPatterns` has drifted and misses it — the ~93%
+        // background over-count leak. bytesThreshold is set so the byte floor does NOT catch
+        // these chatty (>10 KB) rows; only host-IDENTITY suppression removes them.
+        val f       = HeartbeatFilter(
+          enabled = true,
+          bytesThreshold = 10000,
+          heartbeatHostPatterns = List("*.push.apple.com"), // stale: misses the infra below
+        )
+        // ~16 min continuous engaged session on a real (non-infra) app host.
+        val genuine =
+          List(appRow(mac1, 0, "www.tinkercad.com", periodSeconds = 960, bytes = 2_000_000L))
+        // Five background-infra rows, far apart, each above the byte floor. Pre-fix these add
+        // ~10 min of bogus presence; post-fix the canonical list suppresses all five.
+        val infra   = List(
+          appRow(mac1, 3600, "beacons3.gvt2.com", periodSeconds = 120, bytes = 80_000L),
+          appRow(mac1, 7200, "gsp-ssl.ls.apple.com", periodSeconds = 120, bytes = 50_000L),
+          appRow(
+            mac1,
+            10800,
+            "safebrowsingohttpgateway.googleapis.com",
+            periodSeconds = 120,
+            bytes = 60_000L,
+          ),
+          appRow(mac1, 14400, "events.launchdarkly.com", periodSeconds = 120, bytes = 40_000L),
+          appRow(mac1, 18000, "ocsp.digicert.com", periodSeconds = 120, bytes = 30_000L),
+        )
+        assertTrue(Presence.totalMinutesByMac(genuine ++ infra, Nil, f) == Map(mac1 -> 16))
+      },
+      test(
+        "suppression keys on host identity, not bytes — a sparse low-byte genuine app still counts",
+      ) {
+        // #1446 guardrail: a request-driven app emits small/brief rows; those must NOT be dropped
+        // for being small. With the byte floor disabled, the genuine app's full span still counts
+        // while an infra host with an IDENTICAL low-byte/short profile is dropped by identity alone.
+        val f = HeartbeatFilter(enabled = true, bytesThreshold = 0, heartbeatHostPatterns = Nil)
+        val genuine  = appRow(mac1, 0, "app.tinkercad.com", periodSeconds = 600, bytes = 1500L)
+        val infraRow = appRow(mac1, 0, "b1.nel.goog", periodSeconds = 600, bytes = 1500L)
+        assertTrue(
+          !Presence.isHeartbeat(genuine, f),
+          Presence.isHeartbeat(infraRow, f),
+          Presence.totalMinutesByMac(List(genuine), Nil, f) == Map(mac1 -> 10),
+        )
+      },
+      test("isHeartbeat drops canonical infra regardless of the byte-filter toggle (filter Off)") {
+        // Device infra is never engagement; it must not depend on the operator enabling the
+        // byte filter — symmetric with PolicyService consuming the same list unconditionally.
+        val r = appRow(mac1, 0, "r3---sn-abc.gvt2.com", periodSeconds = 120, bytes = 90_000L)
+        assertTrue(Presence.isHeartbeat(r, HeartbeatFilter.Off))
+      },
+      test(
+        "classifyRows surfaces infra:<pattern> for a canonical infra host even with filter Off",
+      ) {
+        val rows = List(appRow(mac1, 0, "beacons2.gvt2.com", periodSeconds = 120, bytes = 90_000L))
+        val out  = Presence.classifyRows(rows, HeartbeatFilter.Off)
+        assertTrue(
+          out.head.classified == "heartbeat",
+          out.head.reasons == List("infra:gvt2.com"),
+        )
+      },
+    ),
     suite("hostMinutes")(
       test("empty rows yields empty map") {
         assertTrue(Presence.hostMinutes(Nil) == Map.empty[HostId, Int])

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -383,38 +383,41 @@ object PresenceSpec extends ZIOSpecDefault {
         assertTrue(out.head.classified == "active") &&
         assertTrue(out.head.reasons.isEmpty)
       },
-      test("#788 host pattern match classifies as heartbeat even when bytes pass") {
-        // Row that would otherwise pass the bytes floor — only the FQDN allowlist trips it.
-        // Confirms host-pattern path is OR'd in correctly.
-        val f = HeartbeatFilter(
-          enabled = true,
-          bytesThreshold = 2048,
-          heartbeatHostPatterns = List("*.push.apple.com"),
-        )
+      test("#1525 suppress-only infra (push.apple.com) is a heartbeat even when bytes pass") {
+        // push.apple.com was folded from the retired heartbeatHostPatterns seed into the
+        // InfraHosts suppress-only tier, so it suppresses by IDENTITY regardless of bytes — and
+        // regardless of any operator heartbeatHostPatterns (now ignored; left empty here).
+        val f = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
         val r =
           row(mac1, 0, "api-push.push.apple.com", secs = 200, bytes = 50_000L, periodSeconds = 300)
         assertTrue(Presence.isHeartbeat(r, f)) &&
         assertTrue(Presence.totalMinutesByMac(List(r), Nil, f) == Map.empty[MacAddress, Int])
       },
-      test("#788 classifyRows surfaces host:<pattern> reason for FQDN match") {
-        val f    = HeartbeatFilter(
+      test(
+        "#1525 heartbeatHostPatterns is no longer read — a host only listed there still counts",
+      ) {
+        // The operator's hand-curated list is deprecated/ignored (#1525). A non-infra host that is
+        // ONLY in heartbeatHostPatterns is NOT suppressed; it counts like any foreground host.
+        val f = HeartbeatFilter(
           enabled = true,
           bytesThreshold = 2048,
-          heartbeatHostPatterns = List("*.push.apple.com", "time.apple.com"),
+          heartbeatHostPatterns = List("*.example.com"),
         )
+        val r = row(mac1, 0, "api.example.com", secs = 200, bytes = 50_000L, periodSeconds = 300)
+        assertTrue(!Presence.isHeartbeat(r, f)) &&
+        assertTrue(Presence.totalMinutesByMac(List(r), Nil, f) == Map(mac1 -> 5))
+      },
+      test("#1525 classifyRows surfaces infra:<pattern> for a suppress-only infra host") {
+        val f    = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
         val rows = List(
           row(mac1, 0, "courier.push.apple.com", secs = 200, bytes = 50_000L, periodSeconds = 300),
         )
         val out  = Presence.classifyRows(rows, f)
         assertTrue(out.head.classified == "heartbeat") &&
-        assertTrue(out.head.reasons == List("host:*.push.apple.com"))
+        assertTrue(out.head.reasons == List("infra:push.apple.com"))
       },
-      test("#788 host pattern only matches FQDNs, not IP literals") {
-        val f = HeartbeatFilter(
-          enabled = true,
-          bytesThreshold = 0,
-          heartbeatHostPatterns = List("*.push.apple.com"),
-        )
+      test("#788 background infra only matches FQDNs, not IP literals") {
+        val f = HeartbeatFilter(enabled = true, bytesThreshold = 0)
         val r = ipRow(mac1, 0, "17.57.146.1", secs = 200, bytes = 50_000L, periodSeconds = 300)
         assertTrue(!Presence.isHeartbeat(r, f))
       },

--- a/docs/design/presence-tuning-overcount.md
+++ b/docs/design/presence-tuning-overcount.md
@@ -195,6 +195,19 @@ composition rule at the end.
 
 ### Fix A (primary) — expand background/infra suppression for the daily cap
 
+> **Status (#1503, shipped).** Fix A + A.1 are implemented **at the code level,
+> not via a migration.** The canonical list now lives in
+> `shared.types.InfraHosts.canonical`, consumed by both `PolicyService.infraAllowHosts`
+> (allow carve-out) and `Presence.isHeartbeat` (suppression). Because it is a code
+> constant there is **no Flyway seed** — the migration-isolation two-PR split the
+> "migration, like V24" wording below would have forced is avoided. The list was
+> expanded with the observed classes (`*.gvt3.com`, `*.ls.apple.com`, `*.nel.goog`,
+> analytics SaaS, the safe-browsing hosts); `*.googleapis.com` is enumerated as
+> *specific* background subdomains only (never the apex) to keep per-app API traffic
+> attributing and counting. The stale `household_settings.heartbeatHostPatterns`
+> column is now an *additive* operator extra on top of the canonical list, not the
+> primary source of truth.
+
 Treat known OS/telemetry/infra/analytics/cert/safe-browsing hosts as
 non-counting for presence, the same way heartbeats are dropped. Concretely:
 

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -700,6 +700,12 @@ object UnmanagedMacPolicy {
 case class HeartbeatFilter(
     enabled: Boolean,
     bytesThreshold: Int,
+    // DEPRECATED (#1525): no longer read for enforcement. Host-identity suppression now lives in the
+    // canonical `shared.types.InfraHosts` code constant (allow+suppress) plus its suppress-only
+    // tier, so this hand-curated per-install list is vestigial — it caused the #1499 drift it was
+    // meant to prevent. Retained on the wire and in `household_settings` for back-compat (older
+    // peers still send it; we accept and ignore). Slated for removal + column drop in a later,
+    // migration-isolated PR once the fleet has rolled forward. Do NOT add new readers.
     heartbeatHostPatterns: List[String] = Nil,
 ) derives JsonCodec
 

--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -1,0 +1,72 @@
+package wifihaven.shared.types
+
+/**
+ * #1503: the single canonical list of *device-level infrastructure* hosts — connectivity /
+ * captive-portal probes, CA OCSP/CRL responders, OS/telemetry/analytics beacons, and safe-browsing
+ * endpoints — that a device reaches without the user initiating anything.
+ *
+ * One list, two consumers (the unification asked for in #1503 / the #1499 over-count analysis §A.1,
+ * `docs/design/presence-tuning-overcount.md`):
+ *
+ *   - `PolicyService.infraAllowHosts` carves these *out of the block* (copied into every profile's
+ *     `extraAllowed`) so an allowed app's transitive deps stay reachable under a whole-MAC block —
+ *     #1307/#1337/#1411.
+ *   - `Presence` suppression drops these from *presence counting* (`Presence.isHeartbeat`) so
+ *     background OS/telemetry chatter does not inflate `usedMins` — #714/#1499.
+ *
+ * Before #1503 these were two hand-curated lists that drifted: the presence side was missing most
+ * of what infra-allow already enumerated (notably `gvt2.com` — 36% of the counted background rows
+ * in the #1499 prod sample — and the OCSP responders), and that drift was the ~93%-background daily
+ * over-count leak. Collapsing them into this one source of truth is the durable fix.
+ *
+ * BOUNDARY — device-level infra ONLY. Do NOT add per-app CDN / asset hosts (`*.akamai.net`,
+ * `*.fastly.net`, or an app's branded asset domains). Those rotate and, more importantly, must
+ * ATTRIBUTE to the app and COUNT (the app host-set work), not be suppressed. That seam is what
+ * keeps this list from re-opening the #1446 undercount: suppression keys on host *identity*, never
+ * on low bytes / short activity. For the same reason this list enumerates *specific* background
+ * `googleapis.com` subdomains (client-services bootstrap, the safe-browsing gateway) rather than
+ * the `googleapis.com` apex — the apex would absorb legitimate per-app API traffic that must
+ * attribute and count.
+ *
+ * Entries are apex- or exact-host patterns (no `*.` prefix, lowercased). An apex such as `gvt2.com`
+ * matches every subdomain via [[HostMatch.matchesPattern]] (and the router's trailing-suffix match
+ * on the allow side). Matching is case-sensitive on the assumption of normalized input
+ * (`Hostname.parse` lowercases).
+ */
+object InfraHosts {
+
+  val canonical: List[String] = List(
+    // ── Connectivity / captive-portal probes ──────────────────────────────
+    "connectivitycheck.gstatic.com", // Android / Chrome connectivity probe
+    "captive.apple.com",             // iOS / macOS captive-portal probe
+    // ── CA OCSP / CRL responders ──────────────────────────────────────────
+    "ocsp.apple.com",                // Apple OCSP responder
+    "ocsp2.apple.com",               // Apple OCSP responder (secondary)
+    "crl.apple.com",                 // Apple CRL distribution
+    "ocsp.pki.goog",                 // Google Trust Services OCSP
+    "ocsp.digicert.com",             // DigiCert OCSP (common CA for app backends)
+    // ── Apple edge / OS infra ─────────────────────────────────────────────
+    "g.aaplimg.com",                 // Apple geo-edge CDN: OCSP + asset shards
+    "netcts.cdn-apple.com",          // #1337 Apple network-connectivity-test CDN
+    "ls.apple.com",                  // #1503 Apple location services (*.ls.apple.com)
+    // ── Google infra ──────────────────────────────────────────────────────
+    "clientservices.googleapis.com", // Google client-services bootstrap
+    "gvt2.com",                // #1411 Google connectivity / Play / download infra (all subdomains)
+    "gvt3.com",                // #1503 Google update beacons (sibling of gvt2)
+    "nel.goog",                // #1503 Network Error Logging beacons (*.nel.goog)
+    // ── Analytics / telemetry SaaS ────────────────────────────────────────
+    "events.launchdarkly.com", // #1503 LaunchDarkly analytics events
+    "adobe.io",                // #1503 Adobe telemetry API (cc-api-data.adobe.io, …)
+    "app-analytics-services.com",             // #1503 app analytics beacons
+    // ── Safe-browsing / security ──────────────────────────────────────────
+    "safebrowsing.google.com",                // #1503 Google Safe Browsing
+    "safebrowsingohttpgateway.googleapis.com",// #1503 Safe Browsing OHTTP gateway
+  )
+
+  /** The first canonical pattern this FQDN matches, if any (used for the classify reason). */
+  def matchedPattern(fqdn: String): Option[String] =
+    canonical.find(p => HostMatch.matchesPattern(fqdn, p))
+
+  /** Whether `fqdn` is device-level infrastructure on the unified [[canonical]] list. */
+  def isInfra(fqdn: String): Boolean = matchedPattern(fqdn).isDefined
+}

--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -32,6 +32,21 @@ package wifihaven.shared.types
  * matches every subdomain via [[HostMatch.matchesPattern]] (and the router's trailing-suffix match
  * on the allow side). Matching is case-sensitive on the assumption of normalized input
  * (`Hostname.parse` lowercases).
+ *
+ * TWO TIERS (#1525). The list has two parts because "allow through the block" and "don't count as
+ * engagement" are *almost* the same set but not quite:
+ *
+ *   - [[canonical]] — allow **and** suppress. Safe to carve out of the block AND drop from
+ *     presence. This is the set `PolicyService.infraAllowHosts` ships.
+ *   - [[suppressOnly]] — suppress **only**, never allowed through the block. Folded in from the
+ *     retired `household_settings.heartbeat_host_patterns` seed (#1525) — device infra that should
+ *     not count as engagement but must NOT be made reachable under a block. The clearest example is
+ *     iCloud Private Relay (`mask*.icloud.com`): allow-carving it would punch an anti-filtering
+ *     tunnel through every block. These were already suppress-only before #1525 (they lived in the
+ *     heartbeat list, never in `infraAllowHosts`), so this split preserves both behaviors exactly.
+ *
+ * Presence/dashboard suppression uses [[isBackground]] (= `canonical ++ suppressOnly`); the policy
+ * allow carve-out uses [[canonical]] only.
  */
 object InfraHosts {
 
@@ -63,10 +78,50 @@ object InfraHosts {
     "safebrowsingohttpgateway.googleapis.com",// #1503 Safe Browsing OHTTP gateway
   )
 
-  /** The first canonical pattern this FQDN matches, if any (used for the classify reason). */
+  /**
+   * #1525: suppress-from-presence ONLY — device infra that must NOT be allow-carved out of the
+   * block. Folded in from the retired `household_settings.heartbeat_host_patterns` V24 seed (the
+   * entries not already on [[canonical]]). These were suppress-only before #1525 too.
+   *
+   * `mask*.icloud.com` is the load-bearing reason this tier is separate from [[canonical]]: it is
+   * iCloud Private Relay, an anti-filtering tunnel — counting it as engagement is wrong, but making
+   * it reachable under a block would defeat the block. Apex form so subdomains match.
+   */
+  val suppressOnly: List[String] = List(
+    "push.apple.com",      // APNs (was *.push.apple.com)
+    "apple-dns.net",       // Apple DNS/edge infra (was *.apple-dns.net)
+    "akadns.net",          // Akamai DNS infra (was *.akadns.net) — NOT allow-carved (CDN-DNS)
+    "ess.apple.com",       // Apple enterprise/identity infra (was *.ess.apple.com)
+    "time.apple.com",      // Apple time sync
+    "gdmf.apple.com",      // Apple software-update metadata
+    "pancake.apple.com",   // Apple Maps/infra
+    "mask.icloud.com",     // iCloud Private Relay — suppress, never allow (bypass)
+    "mask-h2.icloud.com",  // iCloud Private Relay (HTTP/2)
+    "mask-api.icloud.com", // iCloud Private Relay (API)
+    "rcs.telephony.goog",  // RCS messaging infra (was *.rcs.telephony.goog)
+    "mtalk.google.com",    // GCM/FCM push
+    "ntp.org",             // NTP time sync (was *.ntp.org)
+    "time.cloudflare.com", // Cloudflare NTP
+  )
+
+  /** All hosts suppressed from presence counting: allow+suppress plus suppress-only (#1525). */
+  private val background: List[String] = canonical ++ suppressOnly
+
+  /** The first canonical (allow+suppress) pattern this FQDN matches, if any. */
   def matchedPattern(fqdn: String): Option[String] =
     canonical.find(p => HostMatch.matchesPattern(fqdn, p))
 
-  /** Whether `fqdn` is device-level infrastructure on the unified [[canonical]] list. */
+  /**
+   * Whether `fqdn` is on the [[canonical]] allow+suppress list. Drives the policy allow carve-out.
+   */
   def isInfra(fqdn: String): Boolean = matchedPattern(fqdn).isDefined
+
+  /** The first background (allow+suppress or suppress-only) pattern this FQDN matches, if any. */
+  def matchedBackgroundPattern(fqdn: String): Option[String] =
+    background.find(p => HostMatch.matchesPattern(fqdn, p))
+
+  /**
+   * Whether `fqdn` is device-level background infra — the presence/dashboard suppression predicate.
+   */
+  def isBackground(fqdn: String): Boolean = matchedBackgroundPattern(fqdn).isDefined
 }

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -66,5 +66,47 @@ object InfraHostsSpec extends ZIOSpecDefault {
         InfraHosts.canonical.forall(h => !h.startsWith("*.")),
       )
     },
+    test(
+      "#1525 suppress-only tier (folded from heartbeat_host_patterns) is background, not allowed",
+    ) {
+      // These suppress from presence counting (isBackground) but must NOT be allow-carved (isInfra):
+      // allowing iCloud Private Relay through a block would be an anti-filtering bypass.
+      val suppressOnly = List(
+        "api-push.push.apple.com",
+        "x.apple-dns.net",
+        "y.akadns.net",
+        "time.apple.com",
+        "gdmf.apple.com",
+        "mask.icloud.com",
+        "mask-h2.icloud.com",
+        "mtalk.google.com",
+        "z.rcs.telephony.goog",
+        "pool.ntp.org",
+        "time.cloudflare.com",
+      )
+      assertTrue(
+        suppressOnly.forall(InfraHosts.isBackground),
+        suppressOnly.forall(h => !InfraHosts.isInfra(h)),
+        // Private Relay specifically must never be on the allow (canonical) list.
+        !InfraHosts.isInfra("mask.icloud.com"),
+        InfraHosts.isBackground("mask.icloud.com"),
+      )
+    },
+    test("#1525 canonical hosts are both allowed and background; the boundary holds for both") {
+      assertTrue(
+        InfraHosts.isInfra("gvt2.com") && InfraHosts.isBackground("gvt2.com"),
+        // app/CDN hosts are neither allowed nor suppressed.
+        !InfraHosts.isBackground("www.tinkercad.com"),
+        !InfraHosts.isBackground("firestore.googleapis.com"),
+        !InfraHosts.isBackground("a1744.dscw154.akamai.net"),
+      )
+    },
+    test("#1525 every suppressOnly entry is a parseable lowercased apex/exact host") {
+      assertTrue(
+        InfraHosts.suppressOnly.forall(h => Hostname.parse(h).isRight),
+        InfraHosts.suppressOnly.forall(h => h == h.toLowerCase),
+        InfraHosts.suppressOnly.forall(h => !h.startsWith("*.")),
+      )
+    },
   )
 }

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -1,0 +1,70 @@
+package wifihaven.shared.types
+
+import zio.test.*
+
+object InfraHostsSpec extends ZIOSpecDefault {
+
+  def spec = suite("InfraHosts")(
+    test("apex entries match every subdomain (gvt2 download shards, ls.apple services)") {
+      assertTrue(
+        InfraHosts.isInfra("gvt2.com"),
+        InfraHosts.isInfra("r3---sn-abc.gvt2.com"),
+        InfraHosts.isInfra("beacons3.gvt2.com"),
+        InfraHosts.isInfra("gvt3.com"),
+        InfraHosts.isInfra("gsp-ssl.ls.apple.com"),
+        InfraHosts.isInfra("b1.nel.goog"),
+      )
+    },
+    test("exact-host entries match the host and its subdomains") {
+      assertTrue(
+        InfraHosts.isInfra("connectivitycheck.gstatic.com"),
+        InfraHosts.isInfra("safebrowsingohttpgateway.googleapis.com"),
+        InfraHosts.isInfra("events.launchdarkly.com"),
+        InfraHosts.isInfra("ocsp.digicert.com"),
+      )
+    },
+    test("#1503 expansion covers the observed #1499 leaking infra classes") {
+      val expanded = List(
+        "x.gvt2.com",
+        "x.gvt3.com",
+        "x.ls.apple.com",
+        "b1.nel.goog",
+        "events.launchdarkly.com",
+        "cc-api-data.adobe.io",
+        "app-analytics-services.com",
+        "safebrowsing.google.com",
+        "safebrowsingohttpgateway.googleapis.com",
+      )
+      assertTrue(expanded.forall(InfraHosts.isInfra))
+    },
+    test("BOUNDARY: per-app CDN / asset hosts are NOT infra (they must attribute and count)") {
+      // The seam that keeps suppression from re-opening the #1446 undercount: rotating per-app
+      // CDN edges and an app's branded domains attribute to the app (#1505), never suppressed.
+      val appOrCdn = List(
+        "a1744.dscw154.akamai.net",
+        "prod.khan.map.fastly.net",
+        "www.mathacademy.com",
+        "cdn.kastatic.org",
+        "www.youtube.com",
+        "www.tinkercad.com",
+        // the googleapis apex is deliberately NOT on the list — only specific background
+        // subdomains are — so legitimate per-app API traffic still attributes and counts.
+        "firestore.googleapis.com",
+      )
+      assertTrue(appOrCdn.forall(h => !InfraHosts.isInfra(h)))
+    },
+    test("matchedPattern returns the canonical pattern that matched") {
+      assertTrue(
+        InfraHosts.matchedPattern("r3---sn-abc.gvt2.com").contains("gvt2.com"),
+        InfraHosts.matchedPattern("www.tinkercad.com").isEmpty,
+      )
+    },
+    test("every canonical entry is a parseable lowercased hostname (valid for extraAllowed)") {
+      assertTrue(
+        InfraHosts.canonical.forall(h => Hostname.parse(h).isRight),
+        InfraHosts.canonical.forall(h => h == h.toLowerCase),
+        InfraHosts.canonical.forall(h => !h.startsWith("*.")),
+      )
+    },
+  )
+}

--- a/web/src/pages/AdminPage.tsx
+++ b/web/src/pages/AdminPage.tsx
@@ -6,10 +6,6 @@ import { PageLoader } from './DashboardPage'
 import { useDebouncedSave, mergeSaveStatus } from '@/hooks/useDebouncedSave'
 import { SaveStatusBadge } from '@/components/SaveStatusBadge'
 
-function sameStrList(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((x, i) => x === b[i])
-}
-
 export function AdminPage() {
   const [hs, setHs] = useState<HouseholdSettings | null>(null)
   const [loading, setLoading] = useState(true)
@@ -142,13 +138,8 @@ function HeartbeatFilterCard({
 }) {
   const [enabled, setEnabled] = useState(value.heartbeatFilter.enabled)
   const [bytes, setBytes] = useState(value.heartbeatFilter.bytesThreshold)
-  const [hosts, setHosts] = useState<string[]>(value.heartbeatFilter.heartbeatHostPatterns)
   useEffect(() => { setEnabled(value.heartbeatFilter.enabled) }, [value.heartbeatFilter.enabled])
   useEffect(() => { setBytes(value.heartbeatFilter.bytesThreshold) }, [value.heartbeatFilter.bytesThreshold])
-  useEffect(
-    () => { setHosts(value.heartbeatFilter.heartbeatHostPatterns) },
-    [value.heartbeatFilter.heartbeatHostPatterns],
-  )
 
   const bytesValid = Number.isFinite(bytes) && bytes >= 0
 
@@ -167,19 +158,9 @@ function HeartbeatFilterCard({
       await reload()
     },
   )
-  const hostsSave = useDebouncedSave(
-    hosts,
-    async (next) => {
-      await api.household.patch({
-        heartbeatFilter: {
-          heartbeatHostPatterns: next.map(p => p.trim()).filter(p => p.length > 0),
-        },
-      })
-      await reload()
-    },
-    { equals: sameStrList },
-  )
-  const merged = mergeSaveStatus([enabledSave, bytesSave, hostsSave])
+  // #1525: the per-install heartbeat host allowlist editor was removed. Host-identity suppression
+  // now lives in the server-side canonical InfraHosts list; this card only tunes the byte floor.
+  const merged = mergeSaveStatus([enabledSave, bytesSave])
 
   return (
     <div
@@ -199,7 +180,8 @@ function HeartbeatFilterCard({
       <p className="text-xs text-brand-text">
         Excludes low-traffic background "heartbeat" rows from device/profile screen-time
         totals. A row is classified as a heartbeat when its bytes/minute is below the
-        configured floor.
+        configured floor. Known device-level infrastructure (OS/telemetry/cert/safe-browsing
+        hosts) is excluded automatically and is no longer configured here.
       </p>
       {!bytesValid && (
         <div
@@ -232,23 +214,6 @@ function HeartbeatFilterCard({
             className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-sm w-32"
           />
         </div>
-      </div>
-      <div>
-        <label className="block text-xs text-brand-text-muted mb-1">
-          Host allowlist (one pattern per line — `*.foo.com` or `foo.com`)
-        </label>
-        <textarea
-          value={hosts.join('\n')}
-          onChange={e => setHosts(e.target.value.split(/\r?\n/))}
-          data-testid="heartbeat-filter-hosts"
-          rows={8}
-          spellCheck={false}
-          className="bg-white border border-brand-border-strong rounded-lg px-3 py-2 text-brand-ink text-xs font-mono w-full"
-        />
-        <p className="text-xs text-brand-text-muted mt-1">
-          Rows whose host matches any pattern are classified as heartbeats regardless of
-          bytes / active fraction.
-        </p>
       </div>
     </div>
   )

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -76,7 +76,10 @@ export interface NamedScheduleRequest {
 export interface HeartbeatFilter {
   enabled: boolean
   bytesThreshold: number          // bytes/min floor (rows below are heartbeats)
-  heartbeatHostPatterns: string[] // #788 FQDN allowlist; *.foo.com / foo.com semantics
+  // DEPRECATED (#1525): no longer read for enforcement or edited in the UI. Host-identity
+  // suppression lives in the server-side canonical InfraHosts list. Kept on the type because the
+  // API still returns it; removed when the wire field + DB column are dropped.
+  heartbeatHostPatterns: string[]
 }
 
 // #961 — how the household treats MACs that have appeared on the network


### PR DESCRIPTION
Closes #1503. Part of the **Tuning** epic #1445; surfaced by the #1499 over-count analysis (`docs/design/presence-tuning-overcount.md`).

## Problem
`PolicyService.infraAllowHosts` (allow carve-out, #1307/#1337/#1411) and `household_settings.heartbeatHostPatterns` (presence suppression, seeded V24) are the **same conceptual set** — device-level infrastructure the user didn't initiate — kept as two hand-curated lists that **drifted**. The heartbeat side was missing most of what infra-allow already enumerated (notably `gvt2.com` — 36% of the counted background rows in the #1499 prod sample — and the OCSP responders). That drift is the leak that makes the Kids daily cap read ~93% background OS/telemetry/infra.

## The fix

### 1. Unify — one canonical list, both consumers (code-level, no migration)
New `shared.types.InfraHosts.canonical` is the single source of truth:
- `PolicyService.infraAllowHosts` derives from it (now ships via `global.extraAllowed`, per #1321).
- `Presence.isHeartbeat` now also consults it, keyed purely on host **identity** and applied **regardless of `filter.enabled`** — device infra is never engagement, mirroring the allow side. `classifyRows` surfaces an `infra:<pattern>` reason.

Doing this as a **code constant** (not a Flyway seed) deliberately avoids the migration-isolation two-PR split. The stale `heartbeatHostPatterns` column remains an *additive* operator extra. No wire-shape change.

### 2. Expand with the observed leaking infra classes
`*.gvt3.com`, `*.ls.apple.com`, `*.nel.goog`, `events.launchdarkly.com`, `adobe.io` (covers `cc-api-data.adobe.io`), `app-analytics-services.com`, `safebrowsing.google.com`, and the safe-browsing OHTTP gateway — apex/exact-host style.

### 3. Exclude infra from the dashboard "now / watching X" widget
`DashboardNowRoutes` ranked top hosts straight from raw rollup `active_seconds` with **no filtering** — the one host-ranking surface bypassing suppression, so `gvt2.com`/`ls.apple.com`/OCSP could show as what a device is "watching right now." It now drops background hosts by **identity** (the unified `InfraHosts` set always; the operator's `heartbeatHostPatterns` when the filter is enabled) — never the byte floor, so it can't hide a genuine low-byte foreground request (#1446). Active-device detection is unchanged (a device whose only traffic is infra is still listed online, just with no foreground host).

The presence-based graphs (per-app usage, the timeline chart) already route through `isHeartbeat`, so they pick up the unified infra exclusion automatically.

### Boundary preserved (device-level infra ONLY)
No per-app CDN/asset hosts (`*.akamai.net`, `*.fastly.net`, branded app domains) — those must **attribute to the app and count** (#1505), not be suppressed. `*.googleapis.com` is enumerated as **specific background subdomains only, never the apex**, so legit per-app API traffic still attributes/counts. Suppression keys on identity, never on low bytes / short activity — that seam keeps it from re-opening the #1446 undercount.

## Tests (red → green in history)
- `test(#1503)` commits add the failing #1499 background-heavy device-day fixture to `PresenceSpec` and a failing now-widget regression to `DashboardNowApiSpec`; the `fix(#1503)` commits green them.
- New `InfraHostsSpec` covers apex/exact matching, the expansion, the per-app-CDN/googleapis-apex boundary, and entry validity.
- `PresenceSpec` (50), `InfraHostsSpec` (6), `DashboardNowApiSpec` (14), `PolicySnapshotGlobalAllowSpec` (8, now the #1321 global-allow variants) all green. `scalafmt --check` clean. Rebased onto latest `main` (#1321) with the infra-allow doc-comment conflict resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Also in this PR — retire `heartbeatHostPatterns` as an enforcement input (#1525 code removal)
The per-install heartbeat host allowlist was a *second* hand-curated list — the same drift that caused #1499. It is no longer read anywhere; suppression keys solely on the canonical `InfraHosts` set. The V24 seed patterns fold into `InfraHosts` split by safety: a new **`suppressOnly`** tier (suppress-from-counting, **not** allow-carved) holds iCloud Private Relay (`mask*.icloud.com`), Akamai DNS, NTP, APNs, etc. — keeping Private Relay out of the allow path so it cannot tunnel through a block. The SPA host-allowlist editor is removed and the wire field is marked DEPRECATED. The **wire field + DB column drop** is intentionally left for a later, migration-isolated PR (back-compat) — tracked in #1525.