### PR TITLE
fix(#1504): per-site time limit counts engaged minutes via session-stitch (not bucket-max)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -328,13 +328,18 @@ class PolicyServiceLive(
 
                 // Per-profile daily usage — computed up front because the #1379 carve gate keys off
                 // whether the daily cap is exhausted, independent of the precedence chain below.
-                val pPres    = pres.filter(r => macs.contains(r.mac))
-                val patterns = stlims.map(_.domainPattern)
-                val perPat = Presence.patternMinutesByMac(pPres, patterns, settings.heartbeatFilter)
-                val byDomain     = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
-                  val mins = devs.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
-                  if mins == 0 then acc else acc.updated(pat, mins)
-                }
+                val pPres        = pres.filter(r => macs.contains(r.mac))
+                val patterns     = stlims.map(_.domainPattern)
+                // #1504: per-site usage via the #1464 session-stitch primitive, combined across the
+                // profile's devices per its overlap mode — keeps decide() consistent with the
+                // snapshot's TimeStatusService.fold and off the legacy bucket-max undercount.
+                val byDomain     = Presence.patternMinutesForProfile(
+                  pPres,
+                  patterns,
+                  p.crossDeviceOverlapMode,
+                  settings.heartbeatFilter,
+                  settings.presenceContinuationSeconds,
+                )
                 val exemptPats   =
                   stlims.filter(_.exemptFromDaily).map(_.domainPattern)
                 val perMacTot    =

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -396,15 +396,20 @@ object TimeStatusService {
       now: Instant,
       settings: HouseholdSettings,
   ): ProfileDayState = {
-    val patterns = siteLimits.map(_.domainPattern)
-    val perPat   = Presence.patternMinutesByMac(presence, patterns, settings.heartbeatFilter)
+    val patterns         = siteLimits.map(_.domainPattern)
     val totalSecondsUsed = usedSecondsForProfile(profile, devices, siteLimits, presence, settings)
     val totalMinutesUsed = (totalSecondsUsed / 60L).toInt
 
-    val byDomain: Map[String, Int] = patterns.foldLeft(Map.empty[String, Int]) { (acc, pat) =>
-      val mins = devices.iterator.map(d => perPat.getOrElse((d.mac, pat), 0)).sum
-      if mins == 0 then acc else acc.updated(pat, mins)
-    }
+    // #1504: per-site usage uses the same #1464 session-stitch primitive as the daily total above,
+    // combined across the profile's devices per its overlap mode — not the legacy bucket-max model
+    // that bottomed out at the 10s sample floor and made request-driven sites read ~0.
+    val byDomain: Map[String, Int] = Presence.patternMinutesForProfile(
+      presence,
+      patterns,
+      profile.crossDeviceOverlapMode,
+      settings.heartbeatFilter,
+      settings.presenceContinuationSeconds,
+    )
 
     val perSite = siteLimits.map { sl =>
       SiteDayState(

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -37,8 +37,9 @@ case class PresenceRow(
  * `site_time_limits.exempt_from_daily` decides whether a per-site bucket counts toward the daily
  * total. A bucket is excluded from the daily total only when EVERY hostname in it matches an exempt
  * pattern; a single non-exempt hostname pulls the whole bucket back into the total. The per-site
- * (per-pattern) minutes are computed the same way but per pattern, so the per-app limit still ticks
- * independently for its own cap check.
+ * (per-pattern) minutes are computed independently from the same #1464 session-stitch primitive
+ * (#1504: [[patternSecondsForProfile]]), so the per-app limit ticks on engaged wall-clock time for
+ * its own cap check rather than the legacy bucket-max floor.
  */
 object Presence {
 
@@ -344,28 +345,92 @@ object Presence {
     }
 
   /**
-   * Per-(mac, pattern) minutes, counting each bucket once per device per pattern when any host in
-   * the bucket matches the pattern. Two hosts that both match the same pattern in one bucket still
-   * only contribute one bucket's worth of time; the same host matching two patterns contributes one
-   * bucket's worth to each (per-pattern caps are independent). IP-literal hosts never match
-   * patterns. Heartbeat rows are stripped first (#1465) so a keepalive run never ticks a per-site
-   * cap.
+   * #1504: per-(device, pattern) engaged seconds via session-stitch — the per-site counterpart of
+   * the #1464 daily-total fix. For each site-limit pattern, take this device's non-heartbeat rows
+   * whose host matches the pattern, stitch them per `(device, host)` on the idle gap, then union
+   * within the device (two matching hosts active in the same minute count once). Built on the same
+   * [[spanOf]] / [[stitch]] / [[unionSeconds]] primitive as [[totalSecondsByMac]] /
+   * [[proportionalHostSeconds]], so the per-site count no longer inherits the legacy bucket-max
+   * undercount (`max(activeSeconds)` bottoming at the ~10 s sample floor, which made ~16 min of
+   * real presence read ~0). IP-literal hosts never match patterns; heartbeat rows are stripped
+   * first (#1465) so a keepalive run never ticks a per-site cap. A pattern with no matching
+   * activity is absent from the result.
    */
+  def patternSecondsByMac(
+      rows: List[PresenceRow],
+      patterns: List[String],
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[(MacAddress, String), Long] = {
+    val active = rows.filterNot(r => isHeartbeat(r, filter))
+    val gap    = effectiveGap(active, continuationSeconds)
+    val accum  = scala.collection.mutable.Map.empty[(MacAddress, String), Long]
+    for {
+      pat <- patterns
+      matching = active.filter(r => r.host.asFqdn.exists(fqdn => matchesPattern(fqdn.value, pat)))
+      (mac, macRows) <- matching.groupBy(_.mac)
+      secs = unionSeconds(sessionSpans(macRows, gap))
+      if secs > 0L
+    } accum.update((mac, pat), secs)
+    accum.toMap
+  }
+
+  /** Floor-divided minute view of [[patternSecondsByMac]] (per device per pattern). */
   def patternMinutesByMac(
       rows: List[PresenceRow],
       patterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
-  ): Map[(MacAddress, String), Int] = {
-    val buckets =
-      rows.filterNot(r => isHeartbeat(r, filter)).groupBy(r => (r.mac, r.periodStart)).toList
-    val accum   = scala.collection.mutable.Map.empty[(MacAddress, String), Long]
-    for {
-      pat                <- patterns
-      ((mac, _), bucket) <- buckets
-      if bucket.exists(r => r.host.asFqdn.exists(fqdn => matchesPattern(fqdn.value, pat)))
-    } accum.updateWith((mac, pat))(prev => Some(prev.getOrElse(0L) + bucketSeconds(bucket)))
-    accum.view.mapValues(s => (s / 60).toInt).toMap
-  }
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[(MacAddress, String), Int] =
+    patternSecondsByMac(rows, patterns, filter, continuationSeconds).view
+      .mapValues(s => (s / 60).toInt)
+      .filter(_._2 != 0)
+      .toMap
+
+  /**
+   * #1504: profile-level engaged seconds per site-limit pattern, combined across the profile's
+   * devices per `overlap`. `Sum` adds each device's per-pattern session seconds (the same site on
+   * two screens double-counts); `Dedup` unions a pattern's matching-host sessions across every
+   * device so simultaneous use on two screens counts once — exactly the cross-device contract the
+   * daily total uses ([[totalSecondsByMac]] + sum vs [[dedupedTotalSeconds]]). `rows` must already
+   * be scoped to the profile's devices. Seconds are summed before any floor-division so the
+   * per-site minutes round the same way the daily total does (floor-of-sum, not sum-of-floors).
+   */
+  def patternSecondsForProfile(
+      rows: List[PresenceRow],
+      patterns: List[String],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[String, Long] =
+    overlap match {
+      case CrossDeviceOverlapMode.Sum   =>
+        patternSecondsByMac(rows, patterns, filter, continuationSeconds).foldLeft(
+          Map.empty[String, Long],
+        ) { case (acc, ((_, pat), secs)) => acc.updated(pat, acc.getOrElse(pat, 0L) + secs) }
+      case CrossDeviceOverlapMode.Dedup =>
+        val active = rows.filterNot(r => isHeartbeat(r, filter))
+        val gap    = effectiveGap(active, continuationSeconds)
+        patterns.iterator.flatMap { pat =>
+          val matching =
+            active.filter(r => r.host.asFqdn.exists(fqdn => matchesPattern(fqdn.value, pat)))
+          val secs     = unionSeconds(sessionSpans(matching, gap))
+          if secs > 0L then Some(pat -> secs) else None
+        }.toMap
+    }
+
+  /** Floor-divided minute view of [[patternSecondsForProfile]]. */
+  def patternMinutesForProfile(
+      rows: List[PresenceRow],
+      patterns: List[String],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[String, Int] =
+    patternSecondsForProfile(rows, patterns, overlap, filter, continuationSeconds).view
+      .mapValues(s => (s / 60).toInt)
+      .filter(_._2 != 0)
+      .toMap
 
   /**
    * Per-host minutes across all macs, attributing each bucket's duration to every distinct host in

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1190,11 +1190,14 @@ object TimeRoutes {
           settings.presenceContinuationSeconds,
         )
         .getOrElse(device.mac, 0)
+      // #1504: per-device per-site usage via the #1464 session-stitch primitive (this view is a
+      // single device, so cross-device overlap mode is moot) — not the legacy bucket-max model.
       perPat     = wifihaven.api.presence.Presence
         .patternMinutesByMac(
           presence,
           stateOpt.toList.flatMap(_.perSite.map(_.domainPattern)),
           settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
         )
       siteUsage  = stateOpt.toList.flatMap(_.perSite).map { s =>
         val used = perPat.getOrElse((device.mac, s.domainPattern), 0)

--- a/api/test/src/feature/TimeStatusServiceSpec.scala
+++ b/api/test/src/feature/TimeStatusServiceSpec.scala
@@ -70,6 +70,39 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       tr.insertBatch(inserts).unit
     }
 
+  /**
+   * #1504: seed `windows` contiguous 60 s reporting windows where each only sampled the ~10 s
+   * activeSeconds floor — the request-driven app shape. Engaged wall-clock time is `windows`
+   * minutes but `Σ max(activeSeconds)` is only ~`windows/6` minutes, so the legacy bucket-max
+   * per-site count undercounts ~6×. Starts at midnight UTC on `date`.
+   */
+  private def seedSparseTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      windows: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until windows).map { i =>
+        val start = day0.plusSeconds(i * 60L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(60),
+          10,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
   private def settingsWithTz(
       hsr: HouseholdSettingsRepo,
       tz: String,
@@ -249,6 +282,53 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       } yield assertTrue(stOpt.exists(_.usedMinutes == 10)) &&
         assertTrue(
           stOpt.exists(_.perSite.exists(p => p.domainPattern == "khan.org" && p.exemptFromDaily)),
+        )
+    },
+    test("#1504: per-site usage counts engaged minutes, blocking at the true cap not bucket-max") {
+      // 30 contiguous minutes of www.mathacademy.com sampled at the 10 s activeSeconds floor.
+      // Bucket-max credits ~5 min — well under the 30 min site limit, so enforcement would let
+      // the kid run on. Session-stitch credits the real 30 engaged minutes, so the per-site cap
+      // is reached and the domain is blocked.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        s   <- settingsWithTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:07", "kid-ipad", kid)
+        _   <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          "mathacademy.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(30),
+          exemptFromDaily = true,
+        )
+        rid <- seedRouterRow
+        _   <- seedSparseTraffic(
+          rid,
+          "aa:bb:cc:dd:ee:07",
+          "www.mathacademy.com",
+          LocalDate.of(2025, 1, 6),
+          30,
+        )
+        svc <- makeService
+        now = Clock.TestClock.schoolDayAfternoon.toInstant(ZoneOffset.UTC)
+        stOpt <- svc.todaysState(now, s, kid)
+      } yield assertTrue(
+        stOpt.exists(
+          _.perSite.exists(p => p.domainPattern == "mathacademy.com" && p.usedMinutes == 30),
+        ),
+      ) &&
+        assertTrue(
+          stOpt.exists(
+            _.perSite.exists(p =>
+              p.domainPattern == "mathacademy.com" && p.usedMinutes >= p.dailyLimitMinutes,
+            ),
+          ),
         )
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -365,6 +365,30 @@ object PresenceSpec extends ZIOSpecDefault {
             Map((mac1, "mathacademy.com") -> 16),
         )
       },
+      test("#1504: patternMinutesForProfile combines a site across devices per overlap mode") {
+        // Two devices engaged on the same site in the SAME 16 minutes. Sum adds each device's
+        // engaged time (32); Dedup unions the overlapping sessions across devices (16).
+        val rows = (0 until 16).flatMap { i =>
+          List(
+            sparseRow(mac1, i * 60L, "www.mathacademy.com"),
+            sparseRow(mac2, i * 60L, "www.mathacademy.com"),
+          )
+        }.toList
+        assertTrue(
+          Presence.patternMinutesForProfile(
+            rows,
+            List("mathacademy.com"),
+            CrossDeviceOverlapMode.Sum,
+          ) == Map("mathacademy.com" -> 32),
+        ) &&
+        assertTrue(
+          Presence.patternMinutesForProfile(
+            rows,
+            List("mathacademy.com"),
+            CrossDeviceOverlapMode.Dedup,
+          ) == Map("mathacademy.com" -> 16),
+        )
+      },
     ),
     suite("heartbeat filter (#714)")(
       test("filter off: low-byte rows still count toward the daily total") {

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -53,6 +53,31 @@ object PresenceSpec extends ZIOSpecDefault {
       periodSeconds,
     )
 
+  /**
+   * #1504: a row whose sampled `activeSeconds` is far below its reporting window — the
+   * request-driven app shape that bottoms out at the ~10 s sample floor. `period_start` /
+   * `period_seconds` drive the session-stitch interval `[start, start+len)`; `active_seconds` is
+   * what the legacy bucket-max model (mistakenly) credited, so keeping it small is what makes the
+   * two models diverge.
+   */
+  private def sparseRow(
+      mac: MacAddress,
+      offsetSec: Long,
+      host: String,
+      periodSeconds: Int = 60,
+      activeSeconds: Int = 10,
+      bytes: Long = 1_000_000L,
+  ) =
+    PresenceRow(
+      mac,
+      baseDate,
+      base.plusSeconds(offsetSec),
+      HostId.Fqdn(Hostname.unsafe(host)),
+      activeSeconds,
+      bytes,
+      periodSeconds,
+    )
+
   private val yt = HostId.Fqdn(Hostname.unsafe("youtube.com"))
 
   /**
@@ -327,6 +352,17 @@ object PresenceSpec extends ZIOSpecDefault {
         val rows = List(ipRow(mac1, 0, "192.0.2.1"))
         assertTrue(
           Presence.totalMinutesByMac(rows, List("*")) == Map(mac1 -> 5),
+        )
+      },
+      test("#1504: per-site count session-stitches engaged minutes, not bucket-max activeSeconds") {
+        // 16 contiguous 60 s windows of www.mathacademy.com, each sampling only the ~10 s
+        // activeSeconds floor. The legacy bucket-max model credits max(activeSeconds)=10 s per
+        // bucket → ~2 min (the prod undercount that made the site limit read 0). The #1464
+        // session-stitch credits the full [0, 960 s) engaged span → 16 min.
+        val rows = (0 until 16).map(i => sparseRow(mac1, i * 60L, "www.mathacademy.com")).toList
+        assertTrue(
+          Presence.patternMinutesByMac(rows, List("mathacademy.com")) ==
+            Map((mac1, "mathacademy.com") -> 16),
         )
       },
     ),


### PR DESCRIPTION
## Problem

A site-limited app's own limit read **0** despite real use. On prod, Math Academy showed `usedMins 0` against its 30m limit while `www.mathacademy.com` had ~16 min of stitched presence (the profile total was meanwhile 31/30).

Root cause is a **presence-model inconsistency** — the per-site count was the last surface still on the legacy **bucket-max** model:

- Daily total → `Presence.totalMinutesByMac` = the #1464 **session-stitch** model.
- Per-site limit → `Presence.patternMinutesByMac` = `Σ max(activeSeconds)` per bucket, in **both** display (`Routes.buildDeviceTimeStatus`) **and** enforcement (`TimeStatusService.fold` → snapshot `extraBlocked`, and `PolicyService.decide`).

`activeSeconds` bottoms out at the ~10s sample floor, so ~16 min of request-driven presence collapsed to ~0. This hit both directions: the operator saw 0, and enforcement let the kid run well past 30 real minutes before the per-site block triggered.

## Fix

Migrate the per-site count — **display and enforcement** — to a pattern-scoped session-stitch, the per-site counterpart of the #1464 daily-total fix. For each site-limit pattern, stitch the spans (`spanOf`/`stitch`/`unionSeconds`) of the non-heartbeat rows whose host matches the pattern, per `(device, host)`, union within the device, then combine across the profile's devices per its `crossDeviceOverlapMode` — exactly as `totalSecondsByMac`/`proportionalHostSeconds` already do.

- **`Presence.patternSecondsByMac` / `patternMinutesByMac`** — per-`(device, pattern)` engaged seconds/minutes via the #1464 primitive (replaces the bucket-max body; same signature plus a threaded `continuationSeconds`).
- **`Presence.patternSecondsForProfile` / `patternMinutesForProfile`** — profile-level, overlap-aware (`Sum` adds per-device; `Dedup` unions a site's sessions across devices), floor-of-sum rounding to match the daily total.
- Callers migrated off bucket-max: `TimeStatusService.fold` (the snapshot enforcement source), `PolicyService.decide` (per-host `/decision` fallback), and `Routes.buildDeviceTimeStatus` (per-device display).

Exempt-from-daily semantics are unchanged. **No wire-shape change** — `SiteUsage` / `SiteDayState.usedMinutes` keep their shape, just computed correctly (all server-side). This is the **undercount** direction: it reuses the #1464 primitive and does **not** drop low-byte requests — that's the over-count direction (#1503).

## Tests (red → green)

TDD, visible in commit history:

1. `test(#1504)` (failing) — a unit test (`Presence.patternMinutesByMac`) and a feature test (`TimeStatusService` per-site `usedMinutes`) where ~16/30 contiguous minutes of `www.mathacademy.com` sampled at the ~10s `activeSeconds` floor must read ~16/30 engaged minutes. Both fail on bucket-max (~2/5 min), so the per-site limit reads 0-ish and never blocks at the true cap.
2. `fix(#1504)` — the implementation makes them pass: 16→16, and the 30-min fixture reaches the 30-min cap so the per-site block triggers. Adds an overlap-mode unit test (Sum=32, Dedup=16 for two devices engaged on the same site in the same 16 minutes).

Full `mill api.test shared.test` is green.

Closes #1504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)