### PR TITLE
fix(#1513): carve & limit exempt time_limited apps at the app level (full host-set), not per host

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -681,18 +681,42 @@ object PolicyService {
         Hostname.unsafe(sl.domainPattern)
     }
 
-    // #1105: time_limited app hosts with exemptFromDaily=true carve around the
-    // MAC-level @blocked_macs drop while they still have per-host budget. The
-    // exempt flag's original role was just to exclude the host from the daily
-    // tally; without this carve-out, hitting the profile cap silently dropped
-    // the exempt app too, violating the "Khan doesn't count" contract.
-    // Naturally transitions allow → block as the per-host budget exhausts
-    // (siteLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
-    // at the router; see feedback_extraallowed_beats_blocked).
-    val appExemptAllowedHosts: List[Hostname] = state.perSite.collect {
-      case sd if sd.exemptFromDaily && sd.usedMinutes < sd.dailyLimitMinutes =>
-        Hostname.unsafe(sd.domainPattern)
-    }
+    // #1105/#1513: time_limited app hosts with exemptFromDaily=true carve around
+    // the MAC-level @blocked_macs drop while the app still has budget. The exempt
+    // flag's original role was just to exclude the host from the daily tally;
+    // without this carve-out, hitting the profile cap silently dropped the exempt
+    // app too, violating the "Khan doesn't count" contract.
+    //
+    // #1513: the carve gate AND the "under its own limit" budget check are
+    // evaluated at the APP level over the app's FULL host-set — NOT per host. One
+    // time_limited app emits one `SiteTimeLimit`/`SiteDayState` row PER host, all
+    // sharing the same `label` (= `app:<slug>`), daily limit, and exempt flag
+    // (see SiteTimeLimitRepoLive.listForProfile), so we group by `label` to
+    // recover the owning app. A per-host check was the prod bug: with an app's
+    // real asset/CDN hosts (#1505) it (a) splits the app's usage across hosts so
+    // its own limit never bites, and (b) — when over budget — would still carve
+    // the hosts that are individually under, leaving the app reachable past its
+    // limit. Summing the app's per-host minutes and comparing to its single limit
+    // makes the limit bite on the app as a whole; carve ALL its hosts iff exempt
+    // and under that limit, else none (the whole-MAC block then drops it). With
+    // the apex-only host-sets of today this is identical to the per-host result;
+    // it becomes correct automatically once #1505 maps each app's full host-set.
+    // (#1505 curates non-overlapping branded apexes, so the sum does not
+    // double-count; a nested host-set would only over-count → block sooner, the
+    // safe direction.) Naturally transitions allow → block as the app's budget
+    // exhausts (extraAllowed-beats-extraBlocked at the router; see
+    // feedback_extraallowed_beats_blocked).
+    val appExemptAllowedHosts: List[Hostname] =
+      state.perSite
+        .groupBy(_.label)
+        .collect {
+          case (_, rows)
+              if rows.exists(_.exemptFromDaily) &&
+                rows.map(_.usedMinutes).sum < rows.map(_.dailyLimitMinutes).max =>
+            rows.map(sd => Hostname.unsafe(sd.domainPattern))
+        }
+        .flatten
+        .toList
 
     // #1418: hard pause is a true off-switch. When this profile is paused AND
     // its pause_mode is `hard`, drop even the app/exempt/infra carve-outs — only

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -337,6 +337,91 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(rules.blockReason.contains(MacBlockReason.TimeLimit)) &&
         assertTrue(!ea.contains("youtube.com"))
     },
+    // ── #1513: exempt time_limited app's FULL host-set survives the daily block ──
+    //
+    // Prod bug (Kids/Math Academy, 2026-06): an exempt-from-daily time_limited
+    // app was blocked when the profile hit its DAILY limit. The carve gate +
+    // the "under its own limit" budget check must be evaluated at the APP level
+    // over the app's FULL host-set — not per host. With apex-only host-sets the
+    // two views coincide; once an app carries multiple hosts (#1505) a per-host
+    // check (a) splits the app's usage across hosts so its own limit never bites
+    // and (b) carves only the apex, leaving the app's real traffic to be dropped
+    // by the whole-MAC block. These tests use a multi-host app to lock the
+    // app-level semantics in regardless of #1505's host-set seeding.
+    test(
+      "#1513: exempt multi-host app UNDER its own limit → ENTIRE host-set in extraAllowed under daily block",
+    ) {
+      val mac = "aa:bb:cc:dd:ee:51"
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        ar    <- ZIO.service[AppRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- tlr.upsert(kid, 30)
+        _     <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        appId <- ar.create("Math Academy", "math-academy", None, None)
+        // Apex + an off-domain asset/CDN host (the #1505 shape).
+        _     <- ar.setHosts(
+          appId,
+          List(Hostname.unsafe("mathacademy.com"), Hostname.unsafe("mathacademy-cdn.net")),
+        )
+        _     <- ar.upsertAssignment(appId, kid, AppMode.TimeLimited, Some(30), true)
+        rid   <- seedRouterRow
+        // Profile daily cap (30) exhausted by NON-exempt traffic.
+        _     <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        // App usage split across both hosts, total 20 < its own 30-min limit.
+        _     <- seedTraffic(rid, mac, "mathacademy.com", LocalDate.of(2025, 1, 6), 10)
+        _     <- seedTraffic(rid, mac, "mathacademy-cdn.net", LocalDate.of(2025, 1, 6), 10)
+        svc   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap  <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.TimeLimit)) &&
+        assertTrue(ea.contains("mathacademy.com")) &&
+        assertTrue(ea.contains("mathacademy-cdn.net"))
+    },
+    test(
+      "#1513: exempt multi-host app OVER its own limit (each host individually under) → NOT carved → blocked",
+    ) {
+      val mac = "aa:bb:cc:dd:ee:52"
+      for {
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        tlr   <- ZIO.service[TimeLimitRepo]
+        ar    <- ZIO.service[AppRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- tlr.upsert(kid, 30)
+        _     <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        appId <- ar.create("Math Academy", "math-academy", None, None)
+        _     <- ar.setHosts(
+          appId,
+          List(Hostname.unsafe("mathacademy.com"), Hostname.unsafe("mathacademy-cdn.net")),
+        )
+        // App's own daily limit is 30 min.
+        _     <- ar.upsertAssignment(appId, kid, AppMode.TimeLimited, Some(30), true)
+        rid   <- seedRouterRow
+        // Profile daily cap exhausted by non-exempt traffic → whole-MAC TimeLimit block.
+        _     <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        // Each host is individually UNDER 30 (20 + 20), but the app's TOTAL (40)
+        // exceeds its own 30-min limit → the app must NOT be carved. A per-host
+        // check would carve both (the bug); the app-level check blocks it.
+        _     <- seedTraffic(rid, mac, "mathacademy.com", LocalDate.of(2025, 1, 6), 20)
+        _     <- seedTraffic(rid, mac, "mathacademy-cdn.net", LocalDate.of(2025, 1, 6), 20)
+        svc   <- makePsAt(TestClock.schoolDayAfternoon)
+        snap  <- svc.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
+      } yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.TimeLimit)) &&
+        assertTrue(!ea.contains("mathacademy.com")) &&
+        assertTrue(!ea.contains("mathacademy-cdn.net"))
+    },
     test(
       "#1307: AppMode.Allowed app stays in extraAllowed when daily cap exhausted (blocked=TimeLimit)",
     ) {

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -690,6 +690,27 @@ describe("render.nft drop rules carry log group + counter + comment (#1122)", fu
     assert.is_nil(nft:find("@ea_aa_bb_cc_11_22_33_example_com", 1, true))
   end)
 
+  it("#1513: TimeLimit MAC carves out an exempt app's FULL host-set (every ea_ clause)", function()
+    -- Prod bug (Kids/Math Academy, 2026-06): an exempt time_limited app was
+    -- blocked when the profile hit its DAILY limit because only its apex host
+    -- was carved. The router is a dumb applier — given the app's full host-set
+    -- in extraAllowed, the whole-MAC TimeLimit drop must carry one
+    -- `ip daddr != @ea_<m>_<host>` clause PER host so every host stays
+    -- reachable while general traffic still drops. Hosts render sorted.
+    local s = snap_one()
+    s.profiles["3"].rules.blocked      = true
+    s.profiles["3"].rules.blockReason  = "TimeLimit"
+    s.profiles["3"].rules.extraAllowed = { "mathacademy.com", "mathacademy-cdn.net" }
+    local nft = render.nft(s)
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy-cdn_net ip daddr != @ea_aa_bb_cc_11_22_33_mathacademy_com log group 1 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @ea6_aa_bb_cc_11_22_33_mathacademy-cdn_net ip6 daddr != @ea6_aa_bb_cc_11_22_33_mathacademy_com log group 1 counter drop comment \"wh_drop:aa:bb:cc:11:22:33:TimeLimit\"",
+      1, true))
+    assert.is_nil(nft:find("@blocked_macs drop", 1, true))
+  end)
+
   it("MacBlockReason wire strings: Paused / Schedule / TimeLimit / Manual / Unmanaged", function()
     -- Pin the contract between MacBlockReason.asString in PolicyService and
     -- the strings render.lua emits. The agent's nflog parser depends on this.


### PR DESCRIPTION
## Problem (prod, confirmed)

An **exempt-from-daily time_limited app** (Kids profile / Math Academy) was **blocked when the profile hit its DAILY limit**, even though it was under its own app limit and explicitly exempt. Operator repro: daily 40/30 (over) → whole-MAC `TimeLimit` block; Math Academy showed ~14m (under its own 30m); bumping the daily limit to 60m unblocked it.

## Root cause

The exempt carve-out (`appExemptAllowedHosts`) **and** its "under its own limit" budget check were evaluated **per host**:

- Math Academy's host-set is **apex-only** (`mathacademy.com`), so the carve only protected the apex. The app's real traffic (CDN/asset/API hosts) fell outside `extraAllowed` and was dropped by the whole-MAC `TimeLimit` block. (Same apex-only attribution is why its site usage read 0m.)
- Per-host evaluation also **splits an app's usage across its hosts**, so a multi-host app's own limit never bites — and when over budget, a per-host check would still carve the hosts that are individually under, leaving the app reachable past its limit.

## Fix

`PolicyService.computeBlockRules` now groups the per-host `SiteDayState` rows by their shared `label` (= `app:<slug>` — one time_limited app emits one row **per host**, see `SiteTimeLimitRepoLive.listForProfile`), **sums the app's usage across its hosts**, and carves the app's **ENTIRE host-set** into `extraAllowed` iff it is exempt **and under its single daily limit** — otherwise none, so the whole-MAC block drops it.

- With today's apex-only host-sets this is **identical** to the prior per-host result; it becomes correct automatically once **#1505** maps each app's full asset/CDN host-set. This fix **consumes** that set rather than hardcoding the apex.
- `extraAllowed` beats the whole-MAC block at the router (#421). **The router is unchanged** — it's a dumb applier and already carves every `extraAllowed` host (`render_spec` locks in the multi-host carve under a `TimeLimit` block).
- Non-exempt apps are unaffected (regression guard retained).
- The `decide` per-host fallback is intentionally left as-is: it's not the enforcement plane (the router uses the snapshot) and stays correct for today's apex-only data.

## Secondary finding (observability)

The prod block surfaced **no blocked Connection Events**. `render_spec` confirms the whole-MAC `TimeLimit` drop carries `log group 1 counter drop comment "wh_drop:<mac>:TimeLimit"`, so the nft drop **is** instrumented — the gap is in how the agent surfaces whole-MAC / IP-only drops as Connection Events. Tracked by the enforcement drop-counter work in **#1325**; not expanded here.

## Tests (TDD: red → green)

- `PolicySnapshotAppsSpec` (real embedded Postgres):
  - exempt multi-host app **UNDER** its own limit → **ENTIRE host-set** in `extraAllowed` under the daily block (reachable).
  - exempt multi-host app **OVER** its own limit (each host individually under) → **NOT carved** → blocked. *(This is the red commit — fails on the old per-host logic.)*
  - existing non-exempt / single-host #1105 / #1307 / #1413 guards still pass (20/20).
- `openwrt/test/render_spec.lua`: the whole-MAC `TimeLimit` drop carries one `ip daddr != @ea_<m>_<host>` clause **per host** (v4 + v6) — 176/0.

The red commit (`af807bc3`) precedes the fix commit (`a21c01b7`) so the progression is visible.

Refs #1513. Depends on #1505 (full app host-set beyond the apex).