### PR TITLE
feat(#1529): iMessage app template — ess.apple.com edge host-set (APNs excluded, validated vs prod traffic)

### DIFF
--- a/api/resources/app_templates/_index.yml
+++ b/api/resources/app_templates/_index.yml
@@ -18,3 +18,4 @@ slugs:
   - khan-academy
   - math-academy
   - lexia
+  - imessage

--- a/api/resources/app_templates/imessage.yml
+++ b/api/resources/app_templates/imessage.yml
@@ -1,0 +1,27 @@
+slug: imessage
+name: iMessage
+# Emoji fallback: 💬
+icon: "https://icons.duckduckgo.com/ip3/apple.com.ico"
+icon_type: url
+# iMessage rides shared Apple infrastructure, so a fully clean block is NOT
+# possible via a host-set alone — be honest with the operator about this:
+#
+#   * Delivery happens over APNs (push.apple.com / N-courier.push.apple.com,
+#     TCP 5223). APNs is the SAME channel for every Apple push notification
+#     (all apps, FaceTime, Find My), so blocking it breaks notifications
+#     system-wide. It is deliberately EXCLUDED from this set. (Validated
+#     against prod traffic_reports: the courier.push.apple.com hosts are by
+#     far the highest-volume Apple traffic on real devices — collateral if
+#     blocked, #1529.)
+#   * Much of iMessage's transport is IP-based within Apple's 17.0.0.0/8,
+#     which a hostname set can't see; pair with blockIpOnly (#574/#384) to
+#     constrain hard-coded-IP / DoH bypass.
+#
+# So the default target is the iMessage-specific service edge only:
+# `ess.apple.com`. dnsmasq's nftset= directive is suffix-matching, so this one
+# entry covers the iMessage edge subdomains observed on real devices
+# (query.ess.apple.com, identity.ess.apple.com, kt-prod.ess.apple.com — #1529).
+# Blocking it disrupts iMessage activation and send/receive, but may not stop
+# delivery of an already-established session that is still riding APNs.
+hosts:
+  - ess.apple.com

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -102,6 +102,7 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           "khan-academy",
           "math-academy",
           "lexia",
+          "imessage",
         )
         val slugs    = templates.map(_.slug.value).toSet
         assertTrue(slugs == expected) &&
@@ -168,6 +169,24 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         val hosts  = gimkit.hosts.map(_.value).toSet
         assertTrue(hosts.contains("gimkit.com")) &&
         assertTrue(hosts.contains("gimkitconnect.com"))
+      }
+    },
+    test("imessage template targets the iMessage edge and excludes shared APNs hosts (#1529)") {
+      // iMessage rides shared Apple infra, so a clean block isn't possible via
+      // host-set alone (APNs multiplexing + 17.0.0.0/8 IP traffic). The default
+      // set is the iMessage-specific service edge `ess.apple.com` (suffix-matched
+      // by dnsmasq's nftset=, covering the observed query/identity/kt-prod
+      // subdomains). It must NOT contain push.apple.com / courier hosts —
+      // blocking those breaks ALL Apple push notifications system-wide.
+      for {
+        templates <- AppTemplates.loadAll()
+      } yield {
+        val imessage = templates.find(_.slug == AppTemplateId.unsafe("imessage")).get
+        val hosts    = imessage.hosts.map(_.value).toSet
+        assertTrue(imessage.name == "iMessage") &&
+        assertTrue(hosts.contains("ess.apple.com")) &&
+        assertTrue(hosts.forall(h => !h.contains("push.apple.com"))) &&
+        assertTrue(hosts.forall(h => !h.contains("courier")))
       }
     },
     test("each template's hosts parse as apex hostnames") {

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -72,6 +72,20 @@ describe("render.dnsmasq", function()
       1, true))
   end)
 
+  -- #1529: the iMessage app template ships a single suffix host `ess.apple.com`.
+  -- dnsmasq's nftset=/ess.apple.com/ directive is suffix-matching, so it covers
+  -- the observed iMessage edge subdomains (query.ess.apple.com,
+  -- identity.ess.apple.com, kt-prod.ess.apple.com) without enumerating each.
+  -- This is the mechanism that lets a multi-host app target a wildcard edge.
+  it("emits suffix-matching nftset=/ess.apple.com/... for the iMessage edge host (#1529)", function()
+    local s = snap_one()
+    s.profiles["3"].rules.extraBlocked = { "ess.apple.com" }
+    local conf = render.dnsmasq(s)
+    assert.truthy(conf:find(
+      "nftset=/ess.apple.com/4#inet#wifihaven#eb_ess_apple_com,6#inet#wifihaven#eb6_ess_apple_com",
+      1, true))
+  end)
+
   it("does NOT emit nftset= for extraAllowed hosts when extraAllowed is empty", function()
     -- snap_one has extraAllowed = {} so no ea_ nftsets / eatag should appear.
     local conf = render.dnsmasq(snap_one())


### PR DESCRIPTION
Closes #1529.

Adds a built-in **iMessage** app template so iMessage can be blocked / time-limited like the existing YouTube / Math Academy apps.

## Host-set (default)
```
ess.apple.com
```
A single suffix host. dnsmasq's `nftset=/ess.apple.com/...` directive is suffix-matching, so this one entry carves the iMessage **service edge** (and all its subdomains) into the per-`(mac, host)` `eb_`/`eb6_` drop sets. No `*.`/wildcard syntax is needed — suffix hosts are already first-class in the host model (`HostMatch.matchesApex` for attribution, dnsmasq `nftset=` for enforcement), so **no dependency on #1505** turned out to be necessary; the render test pins this.

## Validation against real prod traffic (`traffic_reports`)
Queried `/api/usage/traffic?groupBy=domain` (read-only) for the Apple devices on prod (iPhones, iPads, Macs) over the last 2–30 days and curated from observed hosts. Findings:

- **iMessage edge — under `ess.apple.com` (what we target):**
  - `query.ess.apple.com` — seen on every Apple device
  - `identity.ess.apple.com`
  - `kt-prod.ess.apple.com`
  (`init.ess.apple.com` from Apple's docs did not appear in normal use — activation-only — but it's covered by the suffix entry anyway.)
- **APNs / courier (DELIBERATELY EXCLUDED):** by far the highest-volume Apple traffic — `1-courier.push.apple.com` … `34-courier.push.apple.com` plus `N.courier-push-apple.com.akadns.net` aliases (millions of bytes). This is the shared push channel for *all* Apple notifications, so blocking it breaks notifications system-wide. Not in the set.
- **Other shared Apple infra seen but not iMessage-specific (excluded):** `gdmf.apple.com`, `gs-loc.apple.com`, `gsa.apple.com`, `gsp*-ssl(.ls).apple.com` (account/auth — "Grand Slam"), `*.icloud.com`, `*.smoot.apple.com`, etc. Blocking these would cause Apple-ID/location/iCloud collateral.

## Realistic-blocking limitation (documented in the template)
A fully clean iMessage block isn't possible via host-set alone:
- delivery rides **APNs** (shared push, TCP 5223) — excluded to avoid collateral, so an already-established session may keep receiving;
- much of the transport is **IP-based within `17.0.0.0/8`**, invisible to a hostname set — pair with `blockIpOnly` (#574/#384) to constrain hard-coded-IP / DoH bypass.

These caveats are spelled out in `imessage.yml` comments so the operator isn't surprised. Per the template model (flat host list, no per-option toggles), `push.apple.com` is **not** offered as a clickable "aggressive" option — that would be a footgun in the seeded library — only documented.

## Tests (TDD, red → green in history)
- `AppTemplatesSpec`: `imessage` in the expected slug set + a dedicated test asserting the template targets `ess.apple.com` and excludes `push.apple.com`/`courier` hosts.
- `render_spec.lua`: dnsmasq emits the suffix-matching `nftset=/ess.apple.com/4#...eb_ess_apple_com,6#...eb6_ess_apple_com` line.

`mill api.test.testOnly …AppTemplatesSpec` (25 ✓) and `busted test/render_spec.lua` (176 ✓) pass; `scalafmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
