### PR TITLE
fix(#1531): exclude exempt-from-daily app time from displayed daily total

### DIFF
--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -497,7 +497,19 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Long = {
-    val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
+    // #1531: exclude the WHOLE host-set of every exempt-from-daily app from the daily total — the
+    // counting-side counterpart of the enforcement carve-out (#1513), which keys the exempt
+    // allow-list on the per-app `SiteDayState.hosts`. Derive the exempt patterns from the same
+    // per-app collapse (`groupSiteLimits`) the per-app bars and `computeBlockRules` use, so the
+    // displayed `usedMinutes` and the snapshot's `blocked` read one explicit host-set. The previous
+    // `siteLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
+    // emits one row per host; reusing the collapse makes the whole-host-set exemption explicit
+    // rather than an implicit dependency on that row shape, which would silently regress to
+    // apex-only the moment those rows were ever de-duped upstream.
+    val exemptPats =
+      groupSiteLimits(siteLimits).collect {
+        case (_, _, exempt, hosts, _) if exempt => hosts
+      }.flatten
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -2156,5 +2156,161 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         } yield assertTrue(resp.status == Status.NotFound)
       },
     ) @@ TestAspect.sequential,
+    // #1531: the displayed per-profile daily total must exclude presence on the WHOLE host-set of
+    // every exempt-from-daily app — not just the app's apex host. This mirrors, on the counting/
+    // display side, the multi-host-set generalization #1505/#1523 did for enforcement (#1513 is the
+    // enforcement-side sibling). The headline `usedMins` powering the dashboard tile
+    // (`/api/time/status/summary`) must equal `TimeStatusService.usedSecondsForProfile` exactly, so
+    // it cannot drift from the snapshot's `blocked` decision (#1160 single-source-of-truth).
+    suite("exempt-from-daily multi-host exclusion (#1531)")(
+      test(
+        "displayed daily total excludes the whole exempt app host-set; under cap → not blocked",
+      ) {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 30)
+          // One exempt-from-daily app ("Math Academy") with a TWO-host set. The apex (shortest host)
+          // is `a.example`; `b.example` is an equally-named off-domain asset host. An apex-only
+          // exclusion would still count `b.example` toward the daily total.
+          appId       <- appRepo.create("Math Academy", "mathacademy", None, None)
+          _           <- appRepo.setHosts(
+            appId,
+            List(Hostname.unsafe("a.example"), Hostname.unsafe("b.example")),
+          )
+          _        <- appRepo.upsertAssignment(appId, kidsId, AppMode.TimeLimited, Some(60), true)
+          _        <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // 45 min total presence split across the two exempt hosts and one non-exempt host. Only
+          // the 15 min on `c.unexempt.example` counts toward the 30-min daily cap.
+          off1            <- seedTraffic(routerId, testMac, "a.example", today, 15)
+          off2            <- seedTraffic(routerId, testMac, "b.example", today, 15, off1)
+          _               <- seedTraffic(routerId, testMac, "c.unexempt.example", today, 15, off2)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          settings        <- hsRepo.get
+          now             <- clock.instant
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status/summary").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeSummary]])
+          kids = list.find(_.profileId == kidsId).get
+          // Single source of truth: the same day-state that drives the snapshot's `blocked`.
+          state <- tss.dayState(now, today, settings, kidsId).map(_.get)
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Only `c.unexempt.example` (15 m) counts — both `a.example` AND `b.example` excluded.
+          assertTrue(kids.usedMins == 15) &&
+          assertTrue(kids.usedMins <= 30) &&
+          assertTrue(state.usedMinutes == 15) &&
+          assertTrue(!state.blocked)
+      },
+      test("non-exempt presence past the cap → blocked, even with exempt app traffic present") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 30)
+          appId       <- appRepo.create("Math Academy", "mathacademy", None, None)
+          _           <- appRepo.setHosts(
+            appId,
+            List(Hostname.unsafe("a.example"), Hostname.unsafe("b.example")),
+          )
+          _        <- appRepo.upsertAssignment(appId, kidsId, AppMode.TimeLimited, Some(60), true)
+          _        <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Same two exempt hosts, but non-exempt browsing now pushes past the 30-min cap.
+          off1            <- seedTraffic(routerId, testMac, "a.example", today, 15)
+          off2            <- seedTraffic(routerId, testMac, "b.example", today, 15, off1)
+          _               <- seedTraffic(routerId, testMac, "c.unexempt.example", today, 35, off2)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          settings        <- hsRepo.get
+          now             <- clock.instant
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status/summary").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeSummary]])
+          kids = list.find(_.profileId == kidsId).get
+          state <- tss.dayState(now, today, settings, kidsId).map(_.get)
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Only the 35 m of non-exempt presence counts — exempt hosts still excluded.
+          assertTrue(kids.usedMins == 35) &&
+          assertTrue(state.usedMinutes == 35) &&
+          assertTrue(state.blocked)
+      },
+    ) @@ TestAspect.sequential,
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
Closes #1531.

## What was diverging

The per-profile **used vs daily** tile on the dashboard (ProfilesPage → `summary?.usedMins`) is served by `/api/time/status/summary` → `ProfileTimeSummary.usedMins`, which reads `ProfileDayState.usedMinutes` from `TimeStatusService.dayStateAll`. The snapshot's `blocked` decision reads the **same** `dayStateAll` (`PolicyService.snapshot` line 140 → `computeBlockRules`, which gates `TimeLimit` on `state.usedMinutes`). Both therefore collapse to one number out of `TimeStatusService.usedSecondsForProfile`.

The exempt-from-daily exclusion inside that function lived at **`api/src/policy/TimeStatusService.scala:500`**:

```scala
val exemptPats = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
```

`domainPattern` is a single host per `SiteTimeLimit` row. This spans an exempt app's **whole** host-set *only by accident* of `SiteTimeLimitRepo.listForProfile` emitting one row per host (`JOIN app_hosts`). It is the apex-only fragility #1513 named on the enforcement side, on the counting side: the instant those rows were ever collapsed/de-duped upstream, the exemption would silently regress to the apex representative and an app's off-domain asset/CDN minutes would count toward the daily cap — the #1531 symptom (`45 / 30` displayed).

The enforcement side already avoids this: `computeBlockRules` keys both its exempt allow-list (`appExemptAllowedHosts`) and per-app block on the explicit per-app `SiteDayState.hosts` (#1513, `PolicyService.scala:656-671`).

## The fix

`api/src/policy/TimeStatusService.scala` — derive the exempt patterns from the **same** per-app collapse (`groupSiteLimits`) the per-app bars and `computeBlockRules` use, so the counting side reads one explicit whole-host-set, symmetric with enforcement:

```scala
val exemptPats =
  groupSiteLimits(siteLimits).collect {
    case (_, _, exempt, hosts, _) if exempt => hosts
  }.flatten
```

Behaviour is unchanged today (both forms yield the full `app_hosts` set); the change removes the implicit row-shape dependency and makes the whole-host-set exemption explicit. Single source of truth preserved — no new display-only total is introduced (#1160 invariant).

## Note on the symptom

The user-visible divergence (display over cap while enforcement does not block) was already eliminated for the headline tile by **#1523**'s per-host plumbing: display and `blocked` read the same `usedSecondsForProfile`, so they cannot disagree on the total. This PR (a) adds the regression coverage the counting/display side never had for the multi-host exempt case, and (b) hardens `usedSecondsForProfile` so the whole-host-set exemption can't silently regress to apex-only — closing the #1531/#1513 family on the counting side.

## Test plan

New suite `exempt-from-daily multi-host exclusion (#1531)` in `api/test/src/feature/TimeApiSpec.scala` (embedded Postgres, full stack):

- **displayed daily total excludes the whole exempt app host-set; under cap → not blocked** — Kids profile `dailyMinutes=30`, one exempt app host-set `{a.example, b.example}`, 45 min presence split across both exempt hosts + `c.unexempt.example`. Asserts `/api/time/status/summary` `usedMins == 15` (only the non-exempt host counts) and `dayState.blocked == false`.
- **non-exempt presence past the cap → blocked** — same shape, non-exempt presence bumped to 35 min → `usedMins == 35`, `blocked == true`.

Both cover multi-host: `a.example` *and* `b.example` are excluded. Verified the test is a real guard — temporarily collapsing the exemption to the apex representative turns both assertions red (`usedMins` 30/50, `blocked`).

`mill api.test` green (192/192); `scalafmt --check` clean.

Depends-on: #1523 (per-app host-set plumbing). Sibling: #1513 (apex-only host-set on the enforcement side — same root, opposite surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)