### PR TITLE
fix(#1538): stop migrated block-schedules resurrecting on restart + invalidate cache on schedule detach

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -332,6 +332,9 @@ object Main extends ZIOAppDefault {
             upRepo,
             userRepo,
             namedSchedRepo,
+            // #1538: same cache instance TimeRoutes uses, so a schedule detach busts the
+            // per-profile time-status entry instead of leaving a stale "paused for schedule".
+            timeCache,
           ) ++
           ScheduleRoutes.routes(auth, namedSchedRepo) ++
           HouseholdSettingsRoutes.routes(auth, hsRepo) ++

--- a/api/src/ScheduleSeeder.scala
+++ b/api/src/ScheduleSeeder.scala
@@ -15,11 +15,14 @@ final case class ScheduleSeedSummary(migrated: Int, seededDefaults: Int)
  * and (2) seeds a default starter set of schedules on a brand-new household.
  *
  * Idempotency:
- *   - Migration skips any profile that already references a named schedule (`schedule_id` set), so
- *     a re-run is a no-op once a profile has been migrated. The legacy `schedules` rows are left
- *     intact — PolicyService unions them with the named windows (identical → same result), and they
- *     keep the pre-`schedule_id` image enforcing correctly on a rollback. Their removal is a later
- *     deprecation-window migration.
+ *   - Migration skips any profile that has ALREADY been migrated, keyed off a durable fact: the
+ *     existence of the migrated `named_schedules` row (its deterministic "Migrated from …"
+ *     description), NOT the mutable profile→schedule attachment. Keying off the attachment was the
+ *     #1538 resurrection bug — detaching the schedule made the guard re-migrate the still-retained
+ *     legacy row on the next boot. The legacy `schedules` rows are left intact — PolicyService
+ *     unions them with the named windows (identical → same result), and they keep the
+ *     pre-`schedule_id` image enforcing correctly on a rollback. Their removal is a later
+ *     deprecation-window migration (#1485).
  *   - Default seeding is gated on the `named_schedules` table being empty, and runs *before*
  *     migration so a brand-new install (whose V1-seeded Kids/Bedtime legacy schedule would
  *     otherwise make the table non-empty after migration) still gets the starter set. The defaults
@@ -55,15 +58,35 @@ object ScheduleSeeder {
       migrated <- migrateProfiles(named, legacy, profiles)
     } yield ScheduleSeedSummary(migrated, seeded)
 
+  // TODO(#1485): once the legacy `schedules` table is dropped (gated ~Jun 2026, post-soak),
+  // `legacy.listForProfile` has nothing left to read and this whole migrate pass becomes a
+  // permanent no-op — remove it (and its callers) then. It must not be invoked against a
+  // non-existent table, so coordinate the removal with that migration.
   private def migrateProfiles(
       named: NamedScheduleRepo,
       legacy: ScheduleRepo,
       profiles: ProfileRepo,
   ): Task[Int] =
-    profiles.listAll.flatMap { ps =>
-      ZIO.foldLeft(ps)(0) { (acc, p) =>
-        named.blockScheduleIdsForProfile(p.id).flatMap { existing =>
-          if existing.nonEmpty then ZIO.succeed(acc) // already migrated
+    for {
+      ps              <- profiles.listAll
+      // #1538: anchor idempotency to a DURABLE fact — the migrated `named_schedules` row exists —
+      // NOT to the (mutable) attachment. The old guard skipped only when the profile CURRENTLY had
+      // a block-mode named schedule attached, so an operator detaching the schedule (deleting the
+      // profile_schedule_rules row) made the guard read "not migrated" while the legacy `schedules`
+      // row was still retained for rollback safety. The next boot then re-migrated that retained
+      // row and resurrected the removed schedule. The migrated named_schedules row survives a
+      // profile-level detach, so its presence is the correct one-shot signal. Snapshot all
+      // descriptions once — each profile is migrated at most once per run and profile names are
+      // distinct markers, so the in-loop creates can't affect another profile's guard.
+      migratedMarkers <- named.listAll.map(_.flatMap(_.description).toSet)
+      migrated        <- ZIO.foldLeft(ps)(0) { (acc, p) =>
+        val alreadyMigrated = migratedMarkers.contains(migratedDescription(p.name))
+        named.blockScheduleIdsForProfile(p.id).flatMap { attached =>
+          // Skip if it's currently attached OR a migrated row already exists for this profile.
+          // (Attachment is kept as a belt-and-braces signal — e.g. a profile renamed after
+          // migration, whose marker no longer matches its current name, still won't re-migrate
+          // while it remains attached.)
+          if attached.nonEmpty || alreadyMigrated then ZIO.succeed(acc)
           else
             legacy.listForProfile(p.id).flatMap {
               case Nil  => ZIO.succeed(acc)
@@ -71,13 +94,19 @@ object ScheduleSeeder {
                 val windows = rows.map(s => ScheduleWindow(s.days, s.startLocal, s.endLocal, s.tz))
                 for {
                   name <- uniqueName(named, s"${p.name} schedule")
-                  id   <- named.create(name, Some(s"Migrated from ${p.name}'s schedule"), windows)
+                  id   <- named.create(name, Some(migratedDescription(p.name)), windows)
                   _    <- named.setProfileBlockSchedules(p.id, List(id))
                 } yield acc + 1
             }
         }
       }
-    }
+    } yield migrated
+
+  // #1069: the deterministic description stamped on the named schedule a profile's legacy
+  // `schedules` rows migrate into. #1538 keys idempotency off the *existence* of this row, so the
+  // marker is the durable "this profile was already migrated" fact.
+  private def migratedDescription(profileName: String): String =
+    s"Migrated from $profileName's schedule"
 
   // First free "<base>", then "<base> (2)", "<base> (3)", … honouring named_schedules.name UNIQUE.
   private def uniqueName(named: NamedScheduleRepo, base: String): Task[String] = {

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -192,6 +192,10 @@ object ProfileRoutes {
       userProfileRepo: UserProfileRepo,
       userRepo: UserRepo,
       namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
+      // #1538: the shared per-profile time-status cache, so the schedule-attach/detach PUT below
+      // can bust the cached ProfileTimeStatus the same way `/api/time/extend` does. Defaulted so
+      // the many test call sites that don't exercise caching keep their existing arity.
+      cache: TimeStatusCache = TimeStatusCache.makeUnsafe(),
   ): Routes[Any, Response] =
     Routes(
       Method.GET / "api" / "profiles"                            ->

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -262,6 +262,10 @@ object ProfileRoutes {
             _      <- namedScheduleRepo
               .setProfileBlockSchedules(pid, sr.scheduleIds)
               .mapError(ErrorMapper.dbErrorToResponse)
+            // #1538: attaching/detaching a block schedule changes whether this profile is "paused
+            // for schedule", so bust its cached ProfileTimeStatus the same way /api/time/extend
+            // does — otherwise a detach keeps showing a stale block for up to the today-TTL.
+            _      <- cache.invalidateProfile(pid)
           } yield Response.ok
         },
       Method.POST / "api" / "profiles"                           ->

--- a/api/test/src/feature/ScheduleSeederSpec.scala
+++ b/api/test/src/feature/ScheduleSeederSpec.scala
@@ -68,6 +68,27 @@ object ScheduleSeederSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         assertTrue(second.migrated == 0) &&
         assertTrue(afterFirst == afterSecond)
     },
+    test("#1538: a detached migrated schedule is NOT resurrected on the next migrate run") {
+      // Regression for the resurrection loop: the old guard skipped migration only when the
+      // profile CURRENTLY had a block-mode named schedule attached. Detaching it (deleting the
+      // profile_schedule_rules row) while the legacy `schedules` row was still retained for
+      // rollback safety made the guard see "not migrated" again, so the next boot re-migrated the
+      // retained legacy row and re-attached the schedule the operator had just removed.
+      for {
+        _        <- cleanDb
+        nsr      <- ZIO.service[NamedScheduleRepo]
+        kid      <- kidsProfileId
+        _        <- seedNow // migrate: creates + attaches Kids' named schedule
+        attached <- nsr.blockScheduleIdsForProfile(kid)
+        _        <- nsr.setProfileBlockSchedules(
+          kid,
+          Nil,
+        ) // operator detaches; legacy `schedules` row stays
+        _        <- seedNow // boot again — must NOT re-attach
+        after    <- nsr.blockScheduleIdsForProfile(kid)
+      } yield assertTrue(attached.length == 1) &&
+        assertTrue(after.isEmpty)
+    },
     test("seeds the default starter set when named_schedules is empty") {
       for {
         _       <- cleanDb

--- a/api/test/src/feature/SchedulesApiSpec.scala
+++ b/api/test/src/feature/SchedulesApiSpec.scala
@@ -2,6 +2,7 @@ package wifihaven.api.feature
 
 import wifihaven.api.JwtConfig
 import wifihaven.api.auth.*
+import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
 import wifihaven.api.routes.*
 import wifihaven.shared.*
@@ -14,7 +15,7 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 
-import java.time.{LocalTime, ZoneId}
+import java.time.{LocalDate, LocalTime, ZoneId}
 
 /**
  * #1069: feature tests for the household-scoped named-schedule CRUD (`/api/schedules`) and the
@@ -51,6 +52,22 @@ object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       nsr  <- ZIO.service[NamedScheduleRepo]
       auth <- makeAuth
     } yield ProfileRoutes.routes(auth, pr, sr, tlr, up, ur, nsr)
+
+  // #1538: same as `profileRoutes`, but wires a caller-supplied cache so a test can observe that
+  // the schedule-attach/detach PUT busts the shared per-profile time-status entry.
+  private def profileRoutesWithCache(cache: TimeStatusCache) =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      up   <- ZIO.service[UserProfileRepo]
+      ur   <- ZIO.service[UserRepo]
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      auth <- makeAuth
+    } yield ProfileRoutes.routes(auth, pr, sr, tlr, up, ur, nsr, cache)
+
+  private def sentinel(pid: ProfileId, date: LocalDate, usedMins: Int) =
+    ProfileTimeStatus(pid, "Kids", date.toString, None, usedMins, 0, None, Nil, Nil, Nil)
 
   private def adminToken =
     for {
@@ -277,6 +294,49 @@ object SchedulesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       } yield assertTrue(both.status == Status.Ok) &&
         assertTrue(detail.scheduleIds.toSet == Set(a.id, b.id)) &&
         assertTrue(after.scheduleIds == List(b.id))
+    },
+    test("#1538: detaching a profile's schedules invalidates its time-status cache") {
+      // Bug B: the PUT /profiles/{id}/schedules handler used to call setProfileBlockSchedules
+      // without busting the per-profile TimeStatusCache, so a detached profile kept showing a
+      // stale "paused for schedule" for up to the today-TTL. ProfileTimeStatus carries no blocked
+      // field, so we observe the fix at the cache layer: prime the shared cache, run the real
+      // detach PUT, and assert the entry was dropped (the next load recomputes).
+      for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        pr    <- ZIO.service[ProfileRepo]
+        cache = TimeStatusCache.makeUnsafe()
+        prRs   <- profileRoutesWithCache(cache)
+        clock  <- ZIO.service[Clock]
+        today  <- clock.today
+        pid    <- pr.create("Kids", Nil)
+        sched  <- post(rs, "/api/schedules", CreateNamedScheduleRequest("Bedtime").toJson, token)
+          .flatMap(_.body.asString)
+          .flatMap(b => ZIO.fromEither(b.fromJson[NamedSchedule]))
+        attach <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(List(sched.id)).toJson,
+          token,
+        )
+        // prime the cache, then confirm it really is cached (a 2nd load with a new value is ignored)
+        primed <- cache.getOrLoadDaily(pid, today, today)(ZIO.succeed(sentinel(pid, today, 111)))
+        cached <- cache.getOrLoadDaily(pid, today, today)(ZIO.succeed(sentinel(pid, today, 222)))
+        // detach via the real PUT handler — this must invalidate the cache
+        detach <- put(
+          prRs,
+          s"/api/profiles/${pid.value}/schedules",
+          SetProfileSchedulesRequest(Nil).toJson,
+          token,
+        )
+        // next load recomputes because the entry was dropped
+        fresh  <- cache.getOrLoadDaily(pid, today, today)(ZIO.succeed(sentinel(pid, today, 333)))
+      } yield assertTrue(attach.status == Status.Ok) &&
+        assertTrue(detach.status == Status.Ok) &&
+        assertTrue(primed.usedMins == 111) &&
+        assertTrue(cached.usedMins == 111) && // proves it was genuinely cached
+        assertTrue(fresh.usedMins == 333)     // proves the detach invalidated it
     },
   ) @@ TestAspect.sequential
 }


### PR DESCRIPTION
Fixes #1538.

## Root cause
Two code-only defects, both shipped here (no migration, no wire change).

**A — schedule resurrection on restart (primary).** `ScheduleSeeder.migrateProfiles` runs on every API boot and its idempotency guard keyed off the *mutable* attachment (`blockScheduleIdsForProfile(p.id).nonEmpty`) rather than a durable "already migrated" fact. When an operator detaches a migrated schedule, the `profile_schedule_rules` row is deleted but the V1/V16 legacy `schedules` row is intentionally retained for rollback safety — so the next boot read "not migrated", re-migrated the retained legacy row, and resurrected the removed schedule. The fix anchors the guard to the *existence* of the migrated `named_schedules` row (its deterministic `"Migrated from <name>'s schedule"` description), which survives a profile-level detach; current attachment is kept only as a belt-and-braces signal.

**B — detach skips cache invalidation (secondary).** `PUT /api/profiles/{id}/schedules` set the attachments but never busted the `TimeStatusCache`, so a detached profile kept showing a stale "paused for schedule" for up to the today-TTL (~30s). Added `cache.invalidateProfile(pid)`, mirroring the `/api/time/extend` handler (this required threading the shared `timeCache` into `ProfileRoutes.routes`, defaulted so other call sites are unchanged).

## Interaction with #1485
The resurrection vector disappears on its own once #1485 drops the legacy `schedules` table (gated ~Jun 2026, post-soak — **not** pulled forward here). Until then it is live in prod. Fix A is the durable guard that's correct independent of #1485; a `TODO(#1485)` notes that `migrateProfiles` becomes a permanent no-op and should be removed when that table is dropped.

## Tests (red→green visible in history)
- `ScheduleSeederSpec` — migrate Kids, detach the named schedule while the legacy row remains, re-run `seedAndMigrate`, assert it is **not** re-attached (the resurrection regression).
- `SchedulesApiSpec` — prime the shared per-profile `TimeStatusCache`, run the real detach `PUT`, assert the entry was dropped (proves cache invalidation). `ProfileTimeStatus` carries no `blocked` field, so the fix is observed at the cache layer.

`mill api.test` and `mill shared.test` are fully green.