### PR TITLE
fix(#1539): schedule chip read the dead legacy table, not named schedules

### DIFF
--- a/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
@@ -205,5 +205,46 @@ object PolicySnapshotNamedScheduleSpec
         snap <- ps.snapshot
       } yield assertTrue(blockedMacs(snap).isEmpty)
     },
+    // #1539 invariant guard: two profiles attaching the SAME named schedules
+    // must enforce identically. The prod symptom was divergent enforcement
+    // across profiles sharing 'Bedtime'+'Breakfast'; the evaluation path is
+    // profile-uniform, so this pins that identical attachments → identical
+    // `blocked`/reason for every profile. (Root cause was a display-only chip
+    // reading the dead legacy `schedules` table; this keeps the *server* side
+    // honest in case a future per-profile branch ever creeps in.)
+    test("two profiles sharing the same two named schedules block identically") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        nsr <- ZIO.service[NamedScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        allDays = List("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+        // 'Bedtime' is active at 21:30; 'Breakfast' is inactive then. Both are
+        // attached to BOTH profiles, exactly like the prod setup.
+        bedtime   <- nsr.create(
+          "Bedtime",
+          Some("overnight"),
+          List(ScheduleWindow(allDays, LocalTime.of(21, 0), LocalTime.of(7, 0), ZoneId.of("UTC"))),
+        )
+        breakfast <- nsr.create(
+          "Breakfast",
+          Some("morning"),
+          List(ScheduleWindow(allDays, LocalTime.of(7, 0), LocalTime.of(8, 0), ZoneId.of("UTC"))),
+        )
+        pidA      <- pr.create("Kids", Nil)
+        pidB      <- pr.create("Teens", Nil)
+        _         <- nsr.setProfileBlockSchedules(pidA, List(bedtime, breakfast))
+        _         <- nsr.setProfileBlockSchedules(pidB, List(bedtime, breakfast))
+        _         <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", pidA)
+        _         <- TestLayers.seedDevice(dr, "aa:bb:cc:44:55:66", "teen-phone", pidB)
+        ps        <- makePsAt(TestClock.bedtime)
+        snap      <- ps.snapshot
+      } yield assertTrue(
+        blockedMacs(snap) == List(
+          "aa:bb:cc:11:22:33" -> "Schedule",
+          "aa:bb:cc:44:55:66" -> "Schedule",
+        ),
+      )
+    },
   ) @@ TestAspect.sequential
 }

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
-import type { BlocklistSummary, Device, ProfileDetail, ProfileTimeSummary, User } from '@/types/api'
+import type { BlocklistSummary, Device, NamedSchedule, ProfileDetail, ProfileTimeSummary, User } from '@/types/api'
 import { withQuery } from '@/test/queryWrapper'
 
 vi.mock('@/api/client', () => ({
@@ -1822,5 +1822,74 @@ describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
       .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(defaultDeny.compareDocumentPosition(apps))
       .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+  })
+})
+
+// #1539 — the "Paused (schedule)" chip must reflect the schedules that actually
+// ENFORCE (the household named schedules attached via `scheduleIds`), not the
+// dead legacy `pd.schedules` field. Enforcement (PolicyService) folds the named
+// schedules' windows into the per-MAC `blocked` flag; #1482/#1494 left the V1
+// `schedules` table out of enforcement and the upsert no longer writes it. The
+// chip used to read `pd.schedules`, so two profiles sharing the SAME named
+// schedules could show divergent chips (one "Paused (schedule)", one "Active")
+// purely from stale/per-profile legacy rows — the prod symptom in #1539.
+describe('ProfilesPage — schedule chip reads named schedules, not legacy (#1539)', () => {
+  // Two windows whose union covers the whole local day on every weekday, so the
+  // chip is "active now" regardless of when the test runs (no wall-clock flake).
+  const alwaysActive: NamedSchedule = {
+    id: 10,
+    name: 'Bedtime',
+    description: 'always active for the test',
+    windows: [
+      { days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '00:00', endLocal: '12:00', tz: 'UTC' },
+      { days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '12:00', endLocal: '00:00', tz: 'UTC' },
+    ],
+  }
+
+  it('identical named-schedule attachments yield identical chips (legacy rows empty)', async () => {
+    // Both profiles attach the SAME named schedule (id 10), both with an EMPTY
+    // legacy `schedules` array — proving the chip comes from the named source.
+    const p1: ProfileDetail = {
+      ...kidsProfile,
+      profile: { ...kidsProfile.profile, id: 1, name: 'Kids', paused: false },
+      schedules: [], scheduleIds: [10], timeLimit: null,
+    }
+    const p2: ProfileDetail = {
+      ...kidsProfile,
+      profile: { ...kidsProfile.profile, id: 2, name: 'Teens', paused: false },
+      schedules: [], scheduleIds: [10], timeLimit: null,
+    }
+    ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([p1, p2])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([alwaysActive])
+    ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    renderPage()
+    const c1 = await screen.findByTestId('profile-pause-chip-1')
+    const c2 = await screen.findByTestId('profile-pause-chip-2')
+    expect(c1).toHaveAttribute('data-chip', 'paused-schedule')
+    expect(c2).toHaveAttribute('data-chip', 'paused-schedule')
+  })
+
+  it('ignores the dead legacy `schedules` field (active legacy row, no named attachment → Active)', async () => {
+    // A profile with an active-now LEGACY schedule but NO named attachment must
+    // read "Active" — the legacy table is not an enforcement source (#1482), so
+    // the chip must not be driven by it.
+    const legacyOnly: ProfileDetail = {
+      ...kidsProfile,
+      profile: { ...kidsProfile.profile, id: 1, name: 'Kids', paused: false },
+      schedules: [
+        { id: 1, profileId: 1, name: 'legacy-am', days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '00:00', endLocal: '12:00', tz: 'UTC' },
+        { id: 2, profileId: 1, name: 'legacy-pm', days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '12:00', endLocal: '00:00', tz: 'UTC' },
+      ],
+      scheduleIds: [],
+      timeLimit: null,
+    }
+    ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([legacyOnly])
+    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+    ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
+
+    renderPage()
+    const chip = await screen.findByTestId('profile-pause-chip-1')
+    expect(chip).toHaveAttribute('data-chip', 'active')
   })
 })

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -10,7 +10,7 @@ import { SchedulePicker } from '@/components/SchedulePicker'
 import type {
   AppDetail, AppMode, AppPolicyAssignment, AppScheduleMode, AppScheduleRule,
   CrossDeviceOverlapMode, Device, FailureMode, PauseMode, ProfileDetail,
-  ProfileTimeSummary,
+  ProfileTimeSummary, ScheduleWindow,
   UpsertAppAssignmentRequest, UpsertProfileRequest, User,
 } from '@/types/api'
 import { AppIcon } from '@/components/AppIcon'
@@ -58,8 +58,18 @@ function formToRequest(f: FormState): UpsertProfileRequest {
 }
 
 // #972: chip states reflect the at-a-glance "what's this profile doing right
-// now" answer. Schedule-active check is approximated locally from the cached
-// ProfileDetail.schedules; subsection #973 may move this server-side.
+// now" answer. The schedule-active check is approximated locally — but it must
+// read the SAME source the server enforces from.
+//
+// #1539: that source is the household NAMED schedules attached via
+// `scheduleIds` (PolicyService folds their windows into the per-MAC `blocked`
+// flag), NOT the dead legacy `ProfileDetail.schedules` field. The legacy V1
+// `schedules` table stopped being an enforcement source in #1482/#1490 and the
+// upsert stopped writing it in #1494, so its rows are stale and vary per
+// profile. Driving the chip from it made profiles that share the same named
+// schedules show divergent chips ("Paused (schedule)" vs "Active") even though
+// enforcement was identical — the prod symptom in #1539. The chip now resolves
+// the attached named schedules' windows so display matches enforcement.
 type PauseChip = 'active' | 'paused-manual' | 'paused-schedule' | 'time-exceeded'
 
 const WEEKDAY_SHORT_TO_KEY: Record<string, string> = {
@@ -109,10 +119,17 @@ function previousWeekday(k: string): string {
   return ORDER[(i + 6) % 7]
 }
 
-function computeChip(pd: ProfileDetail, summary: ProfileTimeSummary | undefined): PauseChip {
+// `scheduleWindows` are the windows of the NAMED schedules attached to this
+// profile (resolved from `pd.scheduleIds` against the household catalog) — the
+// enforcement source. See the #1539 note above.
+function computeChip(
+  pd: ProfileDetail,
+  summary: ProfileTimeSummary | undefined,
+  scheduleWindows: ScheduleWindow[],
+): PauseChip {
   if (pd.profile.paused) return 'paused-manual'
   if (summary && summary.remainingMins != null && summary.remainingMins <= 0) return 'time-exceeded'
-  if (pd.schedules.some(s => isScheduleActiveNow(s))) return 'paused-schedule'
+  if (scheduleWindows.some(w => isScheduleActiveNow(w))) return 'paused-schedule'
   return 'active'
 }
 
@@ -581,7 +598,16 @@ function ProfileShellRow({
   userLinkError: string | null
 }) {
   const linkedUserIds = useMemo(() => new Set(users.map(u => u.id)), [users])
-  const chip = computeChip(pd, summary)
+  // #1539: resolve the windows of the NAMED schedules attached to this profile
+  // (the enforcement source) so the chip matches what PolicyService enforces —
+  // not the dead legacy `pd.schedules`. The catalog is shared/cached across all
+  // cards by useNamedSchedules, so this adds no extra fetch.
+  const { data: namedSchedules = [] } = useNamedSchedules()
+  const attachedScheduleWindows = useMemo(() => {
+    const attached = new Set(pd.scheduleIds ?? [])
+    return namedSchedules.filter(s => attached.has(s.id)).flatMap(s => s.windows)
+  }, [namedSchedules, pd.scheduleIds])
+  const chip = computeChip(pd, summary, attachedScheduleWindows)
   const hasLimit = summary?.dailyLimitMins != null
   const usedMins = summary?.usedMins ?? 0
   const limitBase = hasLimit ? (summary!.dailyLimitMins ?? 0) + (summary!.extensionMins ?? 0) : 0


### PR DESCRIPTION
## Root cause (proved)

The prod symptom in #1539 — profiles sharing the **same** named schedules
('Bedtime'+'Breakfast') showing **divergent** "paused for Schedule" state —
was a **display-only** bug in the SPA chip, not in enforcement.

The "Paused (schedule)" chip (`computeChip` in `web/src/pages/ProfilesPage.tsx`)
computed schedule-active from `ProfileDetail.schedules` — the **legacy V1
`schedules` table**. That table stopped being an enforcement source in
#1482/#1490, and the profile upsert stopped writing it in #1494
(`GET /api/profiles[/{id}]` still returns it from `scheduleRepo.listForProfile`
purely for back-compat). Its rows are therefore **stale and vary per profile**.

Enforcement, by contrast, folds the attached household **named** schedules'
windows (`scheduleIds` → `profile_schedule_rules`) into the per-MAC `blocked`
flag in `PolicyService`. So two profiles with identical named attachments
enforce identically, but the chip — reading the unrelated legacy rows — could
show "Paused (schedule)" for one and "Active" for the other. That is exactly the
reported divergence, and it explains why it was observable in the UI yet the
router/snapshot were uniform.

This confirms the issue's conclusion (**evaluation is profile-uniform**) and
identifies the divergence as a **dual-source read** — a fresh instance of the
named-vs-legacy split tracked in **#1532**.

### What I ruled out
- **Evaluation path** — uniform, per the issue; not touched.
- **Write/data divergence** in `profile_schedule_rules` — `setProfileBlockSchedules`
  is an atomic delete+insert; the route validates ids; `ScheduleSeeder.migrateProfiles`
  only writes when `blockScheduleIdsForProfile` is empty, so it cannot clobber an
  operator-set named attachment (overlaps #1538 — no double-implementation needed).
- **TimeStatusCache boundary staleness** — `ProfileTimeStatus` (the cached
  `/api/time/status` payload) carries **no** schedule/`blocked` field, so the chip
  never read the cache. Not the surface. (The PUT `/schedules` route also doesn't
  invalidate the cache, but since the cache doesn't carry schedule state that's a
  no-op here; it's the same invalidation family as #1538-B and best handled there.)

## Fix

`computeChip` now takes the windows of the **named** schedules attached to the
profile (resolved from `pd.scheduleIds` against the shared, cached
`useNamedSchedules` catalog — no extra fetch) and evaluates those. Display now
matches enforcement; the dead `pd.schedules` field is no longer read by the page.
No wire-shape change; no migration.

## Tests

- **Web (red→green in history):** `ProfilesPage.test.tsx` — two profiles sharing
  the same active named schedule (legacy `schedules` empty) must both show
  `paused-schedule`; and a profile with an active **legacy** row but no named
  attachment must show `active`. Both fail on `main` (chip reads legacy), pass
  after the fix.
- **Scala (regression guard):** `PolicySnapshotNamedScheduleSpec` — two profiles
  attaching the same two named schedules both block with reason `Schedule`. Pins
  the server-side invariant "identical attachments → identical enforcement".

Validated locally: `api.test` green (incl. the new guard); `vitest`
ProfilesPage + SchedulePicker green; `tsc`/`eslint`/`scalafmt --check` clean.

## Related
- **#1532** — dual-source divergence (named vs legacy schedule tables); this is
  another instance.
- **#1538** — boot-time resurrection + cache invalidation; shares the
  `setProfileBlockSchedules` / `TimeStatusCache` surfaces. No overlap implemented
  here — the cache is not the chip's source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)