### PR TITLE
feat(#1540): allow-carve Windows NCSI connectivity probes (msftconnecttest.com, msftncsi.com)

### DIFF
--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -54,16 +54,18 @@ object InfraHosts {
     // ── Connectivity / captive-portal probes ──────────────────────────────
     "connectivitycheck.gstatic.com", // Android / Chrome connectivity probe
     "captive.apple.com",             // iOS / macOS captive-portal probe
+    "msftconnecttest.com",  // #1540 Windows NCSI connectivity probe (www / ipv6 subdomains)
+    "msftncsi.com",         // #1540 Windows NCSI legacy/secondary probe (www / dns subdomains)
     // ── CA OCSP / CRL responders ──────────────────────────────────────────
-    "ocsp.apple.com",                // Apple OCSP responder
-    "ocsp2.apple.com",               // Apple OCSP responder (secondary)
-    "crl.apple.com",                 // Apple CRL distribution
-    "ocsp.pki.goog",                 // Google Trust Services OCSP
-    "ocsp.digicert.com",             // DigiCert OCSP (common CA for app backends)
+    "ocsp.apple.com",       // Apple OCSP responder
+    "ocsp2.apple.com",      // Apple OCSP responder (secondary)
+    "crl.apple.com",        // Apple CRL distribution
+    "ocsp.pki.goog",        // Google Trust Services OCSP
+    "ocsp.digicert.com",    // DigiCert OCSP (common CA for app backends)
     // ── Apple edge / OS infra ─────────────────────────────────────────────
-    "g.aaplimg.com",                 // Apple geo-edge CDN: OCSP + asset shards
-    "netcts.cdn-apple.com",          // #1337 Apple network-connectivity-test CDN
-    "ls.apple.com",                  // #1503 Apple location services (*.ls.apple.com)
+    "g.aaplimg.com",        // Apple geo-edge CDN: OCSP + asset shards
+    "netcts.cdn-apple.com", // #1337 Apple network-connectivity-test CDN
+    "ls.apple.com",         // #1503 Apple location services (*.ls.apple.com)
     // ── Google infra ──────────────────────────────────────────────────────
     "clientservices.googleapis.com", // Google client-services bootstrap
     "gvt2.com",                // #1411 Google connectivity / Play / download infra (all subdomains)

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -53,6 +53,24 @@ object InfraHostsSpec extends ZIOSpecDefault {
       )
       assertTrue(appOrCdn.forall(h => !InfraHosts.isInfra(h)))
     },
+    test("#1540 Windows NCSI connectivity probes are allow-carved and suppressed (apex matches)") {
+      // Windows' Network Connectivity Status Indicator probes are device-level OS connectivity
+      // checks the user never initiates → canonical (allow-carve + presence-suppress), same tier
+      // as the Apple/Android probes. Apex form matches the www/ipv6/dns subdomains.
+      val ncsi = List(
+        "www.msftconnecttest.com",
+        "ipv6.msftconnecttest.com",
+        "www.msftncsi.com",
+        "dns.msftncsi.com",
+      )
+      assertTrue(
+        ncsi.forall(InfraHosts.isInfra),
+        ncsi.forall(InfraHosts.isBackground),
+        // WARP is an encrypted VPN tunnel — allow-carving it would punch an anti-filtering bypass
+        // through every block (same reasoning as iCloud Private Relay in suppressOnly). Not carved.
+        !InfraHosts.isInfra("connectivity.cloudflareclient.com"),
+      )
+    },
     test("matchedPattern returns the canonical pattern that matched") {
       assertTrue(
         InfraHosts.matchedPattern("r3---sn-abc.gvt2.com").contains("gvt2.com"),


### PR DESCRIPTION
Closes #1540.

Adds the Windows NCSI (Network Connectivity Status Indicator) probe hosts to `InfraHosts.canonical` so a Windows device's connectivity check survives a whole-MAC block — previously only Apple (`captive.apple.com`) and Android/Chrome (`connectivitycheck.gstatic.com`) probes were handled.

- `msftconnecttest.com` — Windows NCSI active probe (`www.msftconnecttest.com/connecttest.txt`, `ipv6.msftconnecttest.com`)
- `msftncsi.com` — legacy/secondary NCSI probe (`www.msftncsi.com`, `dns.msftncsi.com`)

**Why apex form:** the file's convention is apex/exact patterns (no `www.`, no `*.`); an apex matches all subdomains via `HostMatch.matchesPattern`, so the single apex entry covers the www/ipv6/dns probe subdomains. `canonical` = both allow-carve and presence-suppress, the correct tier for device-level OS probes the user never initiates.

**Why WARP is excluded:** Cloudflare WARP / `cloudflareclient.com` is an encrypted VPN tunnel — allow-carving it would punch an anti-filtering bypass through every block (same reasoning as the iCloud Private Relay `mask*.icloud.com` entries living in `suppressOnly`, never `canonical`).

No migration, no wire-shape change: `InfraHosts` is a shared compile-time constant; the snapshot copies `canonical` into each profile's `extraAllowed` (wire-additive, backward-compatible).

**Tests** (`shared/test/src/types/InfraHostsSpec.scala`, committed red→green):
- `isInfra` true for `www.msftconnecttest.com`, `ipv6.msftconnecttest.com`, `www.msftncsi.com`, `dns.msftncsi.com` (apex matches subdomains)
- those hosts are also `isBackground` (presence-suppressed)
- guard: `isInfra("connectivity.cloudflareclient.com")` is **false** (WARP not allow-carved)