### PR TITLE
refactor(#1544): collapse PolicyService.decide() onto TimeStatusService day-state (drop the hand-mirrored fold)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -3,7 +3,6 @@ package wifihaven.api.policy
 import wifihaven.api.AppConfig
 import wifihaven.api.db.*
 import wifihaven.api.metrics.AppMetrics
-import wifihaven.api.presence.Presence
 import wifihaven.shared.{Schedule as DbSchedule, *}
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
@@ -87,12 +86,16 @@ class PolicyServiceLive(
     // when the legacy table is dropped (the future two-phase destructive PR).
     @scala.annotation.unused scheduleRepo: ScheduleRepo,
     householdSettingsRepo: HouseholdSettingsRepo,
-    timeLimitRepo: TimeLimitRepo,
-    siteTimeLimitRepo: SiteTimeLimitRepo,
+    // #1544: the per-host /decision aggregation now reads `TimeStatusService.todaysState` (the same
+    // ProfileDayState the snapshot consumes) instead of re-folding from these repos directly. They
+    // remain injected to feed the companion `apply` factory's TimeStatusServiceLive and to keep the
+    // constructor arity ~40 test constructions depend on; the class body no longer reads them.
+    @scala.annotation.unused timeLimitRepo: TimeLimitRepo,
+    @scala.annotation.unused siteTimeLimitRepo: SiteTimeLimitRepo,
     deviceRepo: DeviceRepo,
     blocklistRepo: BlocklistRepo,
-    trafficRepo: TrafficReportRepo,
-    extRepo: TimeExtensionRepo,
+    @scala.annotation.unused trafficRepo: TrafficReportRepo,
+    @scala.annotation.unused extRepo: TimeExtensionRepo,
     appRepo: AppRepo,
     timeStatusService: TimeStatusService,
     clock: Clock,
@@ -305,8 +308,14 @@ class PolicyServiceLive(
           for {
             pOpt            <- profileRepo.findById(pid)
             scheds          <- schedulesFor(pid)
-            tl              <- timeLimitRepo.findForProfile(pid)
-            stlims          <- siteTimeLimitRepo.listForProfile(pid)
+            // #1544: the per-profile aggregation (used/extension minutes, the daily-cap-exhausted
+            // gate, per-site usage, and the paused→schedule→time-limit precedence) is read from the
+            // SAME `ProfileDayState` the snapshot consumes — `TimeStatusService.todaysState` — rather
+            // than re-folded by hand here. This collapses the largest hand-maintained mirror in the
+            // policy code (the old `siteGroups`/`byApp`/`exemptPats`/`perMacTot`/`totalMins`/
+            // `capExhausted` re-derivation) so the block-page reason and the snapshot's nftables
+            // enforcement cannot drift. Only the genuinely per-HOST matching stays below.
+            state           <- timeStatusService.todaysState(now, settings, pid)
             // #764: post-migration, extraAllowed/extraBlocked are sourced
             // exclusively from app_policy_assignments. Mirror the snapshot
             // expansion (allowed/blocked modes) here so the per-host
@@ -318,60 +327,24 @@ class PolicyServiceLive(
             // #1379: per-app schedule windows for this profile's assignments, used to fold each
             // app's effective disposition + carve gate exactly as the snapshot does.
             appSchedWindows <- appRepo.appScheduleWindowsForProfile(pid)
-            // Reuse the same per-profile usage calc used by snapshot, scoped to this profile.
-            devs            <- deviceRepo.listAll.map(_.filter(_.profileId.contains(pid)))
-            macs = devs.map(_.mac).toSet
-            pres <- trafficRepo.listPresenceRows(devs.map(_.mac), today)
-            exts <- extRepo.snapshotAllByProfile(today).map(_.getOrElse(pid, 0))
-            res  <- pOpt match {
+            res             <- pOpt match {
               case None    =>
                 ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
               case Some(p) =>
                 val h = hostname.toLowerCase.stripSuffix(".")
 
-                // Per-profile daily usage — computed up front because the #1379 carve gate keys off
-                // whether the daily cap is exhausted, independent of the precedence chain below.
-                val pPres        = pres.filter(r => macs.contains(r.mac))
-                // #1505 + #1504: per-site usage is aggregated per app across its full host-set
-                // (keyed by the synthesized `app:<slug>` label), counted with the #1464
-                // session-stitch primitive and combined across the profile's devices per its
-                // overlap mode — so an off-domain asset host ticks the same limit as the apex, on
-                // engaged wall-clock time. Mirrors `TimeStatusService.siteDayStates`, keeping
-                // decide() consistent with the snapshot's fold and off the legacy bucket-max floor.
-                val siteGroups   = TimeStatusService.groupSiteLimits(stlims)
-                val byApp        = Presence.patternGroupMinutesForProfile(
-                  pPres,
-                  siteGroups.map(g => g._1 -> g._4),
-                  p.crossDeviceOverlapMode,
-                  settings.heartbeatFilter,
-                  settings.presenceContinuationSeconds,
+                // #1544: the canonical day state for this profile (same source as the snapshot).
+                // `todaysState` returns `Some` for any existing profile; default defensively to an
+                // empty state so a race that deletes the profile mid-decision degrades to allow-all
+                // rather than failing.
+                val dayState = state.getOrElse(
+                  ProfileDayState(pid, today, None, 0, 0, None, blocked = false, None, Nil),
                 )
-                val exemptPats   =
-                  stlims.filter(_.exemptFromDaily).map(_.domainPattern)
-                val perMacTot    =
-                  Presence.totalMinutesByMac(
-                    pPres,
-                    exemptPats,
-                    settings.heartbeatFilter,
-                    settings.presenceContinuationSeconds,
-                  )
-                // #751: same branch as snapshot — keeps decide() consistent with the snapshot's
-                // cap evaluation.
-                val totalMins    = p.crossDeviceOverlapMode match {
-                  case CrossDeviceOverlapMode.Sum   =>
-                    devs.iterator.map(d => perMacTot.getOrElse(d.mac, 0)).sum
-                  case CrossDeviceOverlapMode.Dedup =>
-                    Presence.dedupedTotalMinutes(
-                      pPres,
-                      exemptPats,
-                      settings.heartbeatFilter,
-                      settings.presenceContinuationSeconds,
-                    )
-                }
+
                 // #1379: the daily-cap-exhausted condition the AllowedDuring carve gate keys off —
-                // the per-host mirror of `PolicyService.dailyCapExhausted(state)` in the snapshot.
-                val capExhausted =
-                  tl.map(_.dailyMinutes).exists(limit => totalMins >= limit + exts)
+                // read off the shared state (`dailyCapExhausted`) instead of re-folding the per-MAC
+                // totals, so it agrees with the snapshot's gate by construction.
+                val capExhausted = PolicyService.dailyCapExhausted(dayState)
 
                 // #1379: fold each app's effective disposition (schedule windows over base mode) +
                 // the carve gate, exactly as the snapshot does. A non-exempt allowed_during app
@@ -404,16 +377,7 @@ class PolicyServiceLive(
                           RouterDecisionResponse(ConnectionDecision.Block, "extra_blocked", None),
                         )
                       else
-                        timeLimitBlockFromDb(
-                          h,
-                          now,
-                          settings,
-                          tl.map(_.dailyMinutes),
-                          stlims,
-                          byApp,
-                          totalMins,
-                          exts,
-                        ) match {
+                        timeLimitBlockFromState(h, now, settings, dayState) match {
                           case Some(r) => ZIO.succeed(r)
                           case None    =>
                             categoryBlock(p.blockedCategories, h).map {
@@ -447,40 +411,45 @@ class PolicyServiceLive(
     }
   }
 
-  private def timeLimitBlockFromDb(
+  /**
+   * #1544: the per-host site-limit / daily-limit verdict, read off the shared [[ProfileDayState]]
+   * (`state.perSite` for per-app usage + limits, `state.usedMinutes`/`dailyLimitMinutes`/
+   * `extensionMinutes` for the daily cap) rather than re-aggregating from raw rows. The per-HOST
+   * part — matching `hostname` against an app's host-set — stays here; the AGGREGATION comes from
+   * `TimeStatusService`, so this path can no longer drift from the snapshot's
+   * `siteLimitExtraBlocked` / `assemble` cap evaluation. `state.perSite` carries one entry per app,
+   * with `usedMinutes` aggregated across the whole host-set and `dailyLimitMinutes` the app's site
+   * cap — exactly the `sd.usedMinutes >= sd.dailyLimitMinutes` test the snapshot uses to fill
+   * `extraBlocked`.
+   */
+  private def timeLimitBlockFromState(
       hostname: String,
       now: Instant,
       settings: HouseholdSettings,
-      dailyMinutes: Option[Int],
-      siteLimits: List[SiteTimeLimit],
-      // #1505: per-app aggregate minutes keyed by the synthesized `app:<slug>` label, so any of an
-      // app's hosts (apex or off-domain asset) ticks the same limit.
-      minutesByApp: Map[String, Int],
-      totalMinutesUsed: Int,
-      extensionsMinutes: Int,
+      state: ProfileDayState,
   ): Option[RouterDecisionResponse] = {
     // Time-limit blocks expire at the next household daily-reset Instant.
     val resetAt      = PolicyService.nextDailyResetAfter(settings, now).toString
-    val siteLimitHit = siteLimits.find { sl =>
-      HostMatch.matchesPattern(hostname, sl.domainPattern) &&
-      minutesByApp.getOrElse(sl.label, 0) >= sl.dailyMinutes
+    val siteLimitHit = state.perSite.find { sd =>
+      sd.hosts.exists(hp => HostMatch.matchesPattern(hostname, hp)) &&
+      sd.usedMinutes >= sd.dailyLimitMinutes
     }
     siteLimitHit
-      .map(sl =>
+      .map(sd =>
         RouterDecisionResponse(
           ConnectionDecision.Block,
-          s"site_time_limit:${sl.label}",
+          s"site_time_limit:${sd.label}",
           Some(resetAt),
         ),
       )
       .orElse {
-        val isExemptSite = siteLimits.exists { sl =>
-          sl.exemptFromDaily && HostMatch.matchesPattern(hostname, sl.domainPattern)
+        val isExemptSite = state.perSite.exists { sd =>
+          sd.exemptFromDaily && sd.hosts.exists(hp => HostMatch.matchesPattern(hostname, hp))
         }
         if isExemptSite then None
         else
-          dailyMinutes.flatMap { limit =>
-            Option.when(totalMinutesUsed >= limit + extensionsMinutes)(
+          state.dailyLimitMinutes.flatMap { limit =>
+            Option.when(state.usedMinutes >= limit + state.extensionMinutes)(
               RouterDecisionResponse(ConnectionDecision.Block, "time_limit", Some(resetAt)),
             )
           }

--- a/api/test/src/feature/RouterDecisionConsolidationSpec.scala
+++ b/api/test/src/feature/RouterDecisionConsolidationSpec.scala
@@ -1,0 +1,253 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+/**
+ * #1544 anti-divergence pin. `PolicyServiceLive.decide` (the per-host `/decision` fallback that
+ * drives the kid block-page reason) and `PolicyServiceLive.snapshot` (which drives nftables
+ * enforcement) must agree on the per-profile verdict. Before #1544 `decide` hand-re-implemented the
+ * cap/site/schedule fold the snapshot gets from `TimeStatusService`; #1544 collapses it onto the
+ * shared `ProfileDayState`. This spec exercises BOTH paths for the SAME profile + `now` + host and
+ * asserts they encode the same decision across paused / schedule / daily-limit / site-limit /
+ * exempt-app scenarios — so a future edit to the fold that touches only one path is loud.
+ *
+ * Mapping between the two shapes:
+ *   - a whole-MAC block (`paused` / `schedule` / `time_limit`) ⇒ `snapshot.rules.blocked == true`
+ *     with the matching `MacBlockReason`;
+ *   - a per-host site-limit block ⇒ the host appears in `snapshot.rules.extraBlocked`;
+ *   - an exempt-app carve-out ⇒ the host appears in `snapshot.rules.extraAllowed` (which beats the
+ *     whole-MAC block at the router), so both paths allow it.
+ */
+object RouterDecisionConsolidationSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val mac   = "aa:bb:cc:15:44:01"
+  private val today = LocalDate.of(2025, 1, 6) // a Monday
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      nsr    <- ZIO.service[NamedScheduleRepo]
+      ref    <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clk,
+      namedScheduleRepo = nsr,
+    ): PolicyService
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-cons-dec", Sha256Hex.unsafe("d" * 64)))
+
+  /** Seed `minutes/5` non-overlapping 5-min traffic_reports buckets on `host`. */
+  private def seedTraffic(
+      rid: RouterId,
+      host: String,
+      minutes: Int,
+      bucketOffset: Int = 0,
+  ): ZIO[TrafficReportRepo, Throwable, Int] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = today.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds((bucketOffset + i) * 300L)
+        TrafficReportInsert(
+          rid,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(host)),
+          today,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).as(bucketOffset + buckets)
+    }
+
+  /** The MacBlockReason a whole-MAC decide() reason string maps to. */
+  private def reasonToMac(r: String): Option[MacBlockReason] = r match {
+    case "paused"     => Some(MacBlockReason.Paused)
+    case "schedule"   => Some(MacBlockReason.Schedule)
+    case "time_limit" => Some(MacBlockReason.TimeLimit)
+    case _            => None
+  }
+
+  def spec = suite("RouterDecisionConsolidationSpec (#1544)")(
+    test("paused: decide=block:paused matches snapshot blocked+Paused") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- pr.setPaused(kid, true)
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        d    <- ps.decide(mac, "example.com")
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        d.decision == ConnectionDecision.Block,
+        d.reason == "paused",
+        rules.blocked,
+        rules.blockReason == Some(MacBlockReason.Paused),
+        reasonToMac(d.reason) == rules.blockReason,
+      )
+    },
+    test("schedule active: decide=block:schedule matches snapshot blocked+Schedule") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr) // Bedtime 21:00–07:00
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        ps   <- makePsAt(TestClock.bedtime)        // Monday 21:30 → schedule active
+        d    <- ps.decide(mac, "example.com")
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        d.decision == ConnectionDecision.Block,
+        d.reason == "schedule",
+        rules.blocked,
+        rules.blockReason == Some(MacBlockReason.Schedule),
+        reasonToMac(d.reason) == rules.blockReason,
+      )
+    },
+    test("daily limit reached: decide=block:time_limit matches snapshot blocked+TimeLimit") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 120)
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, "cnn.com", 125)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon) // 14:00, no schedule
+        d    <- ps.decide(mac, "cnn.com")
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        d.decision == ConnectionDecision.Block,
+        d.reason == "time_limit",
+        rules.blocked,
+        rules.blockReason == Some(MacBlockReason.TimeLimit),
+        reasonToMac(d.reason) == rules.blockReason,
+      )
+    },
+    test("site limit reached: decide=block:site_time_limit matches snapshot extraBlocked host") {
+      for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        // Site cap 30, non-exempt (counts to daily, but no daily cap set), usage 35 → site hit.
+        _    <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          "youtube.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(30),
+          exemptFromDaily = false,
+        )
+        _    <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        rid  <- seedRouterRow
+        _    <- seedTraffic(rid, "youtube.com", 35)
+        ps   <- makePsAt(TestClock.schoolDayAfternoon)
+        d    <- ps.decide(mac, "youtube.com")
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        d.decision == ConnectionDecision.Block,
+        d.reason.startsWith("site_time_limit:"),
+        // The whole-MAC block is NOT set for a per-site cap; enforcement is via extraBlocked.
+        !rules.blocked,
+        rules.extraBlocked.contains(Hostname.unsafe("youtube.com")),
+      )
+    },
+    test("exempt app under exhausted daily cap: both allow the exempt host, block the non-exempt") {
+      for {
+        _          <- cleanDb
+        pr         <- ZIO.service[ProfileRepo]
+        sr         <- ZIO.service[ScheduleRepo]
+        dr         <- ZIO.service[DeviceRepo]
+        tlr        <- ZIO.service[TimeLimitRepo]
+        ar         <- ZIO.service[AppRepo]
+        kid        <- TestLayers.seedKidsProfile(pr, sr)
+        _          <- tlr.upsert(kid, 30) // daily cap 30
+        // Khan is exempt from the daily cap with plenty of per-site budget.
+        _          <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          "khanacademy.org",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(200),
+          exemptFromDaily = true,
+        )
+        _          <- TestLayers.seedDevice(dr, mac, "kid", kid)
+        rid        <- seedRouterRow
+        // 35 min of non-exempt cnn.com (exhausts the 30 cap) + 10 min of exempt khan.
+        n          <- seedTraffic(rid, "cnn.com", 35)
+        _          <- seedTraffic(rid, "khanacademy.org", 10, bucketOffset = n)
+        ps         <- makePsAt(TestClock.schoolDayAfternoon)
+        dExempt    <- ps.decide(mac, "khanacademy.org")
+        dNonExempt <- ps.decide(mac, "cnn.com")
+        snap       <- ps.snapshot
+        rules = snap.profiles(kid).rules
+      } yield assertTrue(
+        // Daily cap exhausted (exempt time excluded) → whole-MAC TimeLimit on the snapshot…
+        rules.blocked,
+        rules.blockReason == Some(MacBlockReason.TimeLimit),
+        // …but the exempt app is carved out (extraAllowed beats the block at the router) and decide
+        // agrees by allowing it.
+        rules.extraAllowed.contains(Hostname.unsafe("khanacademy.org")),
+        dExempt.decision == ConnectionDecision.Allow,
+        // A non-exempt host is blocked by both paths.
+        !rules.extraAllowed.contains(Hostname.unsafe("cnn.com")),
+        dNonExempt.decision == ConnectionDecision.Block,
+        dNonExempt.reason == "time_limit",
+      )
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
Closes #1544. Sub-issue of #1532 (divergence audit) — Finding 1, the keystone collapse.

## What & why

`PolicyServiceLive.decide()` (the per-host `/api/router/decision` fallback that drives the **kid block-page reason**) hand-re-implemented the per-profile cap/site/schedule fold that `TimeStatusService` already produces for the **snapshot** (which drives nftables enforcement). The two had to agree by hand, and today they do — but any future edit to `fold`/`assemble`/`usedSecondsForProfile`/`siteDayStates` that missed the `decide()` copy would make the block page report a different verdict than nftables enforces (the #1531/#1513 failure mode, one layer down).

This routes `decide()`'s **aggregation** through the same `ProfileDayState` the snapshot consumes (`timeStatusService.todaysState(now, settings, pid)`), keeping only the genuinely per-**host** logic in `decide()`. **Zero behavior change** — pinned by a new cross-path test.

## Exact lines removed → what `state` replaced each

In `decide()` (was ~PolicyService.scala:334–430 on main):

| Removed inline derivation | Replaced by |
|---|---|
| `siteGroups = TimeStatusService.groupSiteLimits(stlims)` + `byApp = Presence.patternGroupMinutesForProfile(...)` | `state.perSite` (per-app `usedMinutes` / `dailyLimitMinutes` / `hosts`) |
| `exemptPats = stlims.filter(_.exemptFromDaily)...` | `state.perSite` `exemptFromDaily` + `hosts` |
| `perMacTot = Presence.totalMinutesByMac(...)` + the `Sum`/`Dedup` `totalMins` match (`// #751: same branch as snapshot`) | `state.usedMinutes` (overlap mode already encoded by `usedSecondsForProfile`) |
| `capExhausted = tl.map(_.dailyMinutes).exists(limit => totalMins >= limit + exts)` (`// per-host mirror of dailyCapExhausted`) | `PolicyService.dailyCapExhausted(state)` |
| `exts = extRepo.snapshotAllByProfile(...)` | `state.extensionMinutes` |
| `tl = timeLimitRepo.findForProfile(pid)` | `state.dailyLimitMinutes` |

`timeLimitBlockFromDb(h, now, settings, dailyMinutes, siteLimits, byApp, totalMins, exts)` → `timeLimitBlockFromState(h, now, settings, state)`, which does the same per-host site-pattern / daily-cap matching off `state.perSite` + `state.usedMinutes` — the same `sd.usedMinutes >= sd.dailyLimitMinutes` test the snapshot's `siteLimitExtraBlocked` uses.

Kept in `decide()`: host→app/category matching, `expandAppDispositions` (shared with the snapshot already), and the schedule `expiresAt` timestamp.

The repos that only fed the removed fold (`timeLimitRepo` / `siteTimeLimitRepo` / `trafficRepo` / `extRepo`) are now unused in the class body — kept injected and marked `@scala.annotation.unused` (same pattern as the existing `scheduleRepo`) so the companion `apply()` factory and the ~40 test constructions keep their constructor arity.

## Anti-divergence test

`RouterDecisionConsolidationSpec` exercises **both** paths for the same profile + `now` + host and asserts they encode the same verdict across paused / schedule-active / daily-limit / site-limit / exempt-app-under-cap. Verified it passes against the **pre-collapse** `decide()` too (stash the source change, suite stays green) — so it genuinely pins the currently-agreeing behavior rather than the new code.

## Validation

- `scalafmt --check` clean on both files.
- Full `mill api.test` green (incl. `RouterDecision*`, `PolicySnapshot*`, `TimeStatus*`). No new flakes.
- Diff scoped to `api/src/policy/**` + `api/test/**`. No wire-shape change, no migration, no reason-string change.

## Note on `todaysState` reads (#1512)

`decide()` now calls `todaysState`, which on the production rollup path does a few extra batched reads vs. the old direct presence query. Per #1512 the snapshot is already ~500ms; this PR prioritizes correctness/collapse and does **not** pre-optimize. Flagging for follow-up if the `/decision` path latency matters.

## Out of scope (sibling collapses from #1532)

- #1545 — typing the block-reason strings (not folded in here; reason strings unchanged).
- #1546 — the remaining sibling collapse.