### PR TITLE
ci(#1550): skip Contract Tests on migration-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,16 @@ jobs:
               - 'openwrt/test/build-luci-jsonc.sh'
               - 'openwrt/test/jsonc_shim_spec.lua'
               - 'api/**'
+              # #1550: a schema-only migration PR (only api/resources/db/migration/**
+              # files) cannot change any wire shape, so it must not trigger Contract
+              # Tests. dorny/paths-filter applies leading-'!' patterns as per-file
+              # ignores: a migration file fails to match ['api/**', '!.../migration/**'],
+              # so a migration-only diff resolves contract=false (skipped, treated as
+              # success by the umbrella `ci` job). A PR that also touches real api/**
+              # code still matches and runs contract as before. The `scala` filter is
+              # intentionally left matching api/** so api.test applies the migration —
+              # that is the migration-isolation gate.
+              - '!api/resources/db/migration/**'
               - 'shared/**'
               - 'build.mill'
               - 'scripts/regen-contract-fixtures.sh'


### PR DESCRIPTION
Closes #1550.

## The change

One filter edit in `.github/workflows/ci.yml` — add a negation immediately after the broad `- 'api/**'` line in the **`contract`** paths-filter (only):

```diff
               - 'api/**'
+              - '!api/resources/db/migration/**'
               - 'shared/**'
```

## Why / negation semantics

Migrations live at `api/resources/db/migration/**`, which is under `api/**`, so today a schema-only migration PR matches the `contract` filter and the **Contract Tests (API ↔ Router)** job runs — even though a `.sql` migration cannot change any API↔router wire shape (enforced by `check-migration-isolation.sh`: migrations are SQL + docs only). The PR then sits blocked on an irrelevant job.

`dorny/paths-filter@v3` evaluates a filter as a list of [picomatch](https://github.com/micromatch/picomatch) patterns where a leading `!` marks an **ignore/negation** pattern applied per-file (the README's own example: `'pkg/a/b/c/**'` followed by `'!**/*.md'` ignores changed `.md` files). So:

- **Migration-only diff** → every changed file is an ignored migration file → it fails to match `['api/**', '!api/resources/db/migration/**']` → `contract` resolves **false** → Contract Tests **skipped**.
- **PR that also touches real api code** → those files still match `api/**` → `contract` resolves **true** → Contract Tests run, exactly as today.

Verified v3 supports inline `!` negation against the action README, so no fallback restructuring was needed.

## What is intentionally NOT changed

- **`scala` filter** still matches `api/**`, so `api.test` runs and applies the new migration against embedded Postgres — that is the migration-isolation back-compat gate (CLAUDE.md).
- **`migrations` filter** untouched, so `check-migrations.sh` / `check-migration-isolation.sh` still run on migration PRs.
- **`shared/**` in the contract filter** untouched — migrations aren't under `shared`, so wire goldens stay gated.

For a migration-only diff: `contract == false`, while `scala == true` and `migrations == true`.

## Merge-queue / required-check safety

Branch protection requires the single umbrella **`CI`** job (`if: always()`), which already treats a downstream job result of `skipped` (or `success`/`cancelled`) as satisfied and only fails on a genuine failure. So a migration-only PR's **skipped** `contract-tests` job counts as success and does **not** wedge branch-protection or the merge queue. This mirrors the repo's existing convention exactly — no new skip-handling was invented.

## Validation

- `python3 -m yaml` parse of the edited workflow: OK.
- `actionlint` not installed locally; it runs as the repo's Actionlint CI job on this PR.