### PR TITLE
refactor(#1545): emit/parse block reasons via typed BlockReason (fix mapReason unknown→extra_blocked mislabel)

### DIFF
--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -303,7 +303,13 @@ class PolicyServiceLive(
       device <- deviceRepo.listAll.map(_.find(_.mac.value.equalsIgnoreCase(mac)))
       result <- device.flatMap(_.profileId) match {
         case None      =>
-          ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
+          ZIO.succeed(
+            RouterDecisionResponse(
+              ConnectionDecision.Allow,
+              BlockReason.asWire(BlockReason.NoProfile),
+              None,
+            ),
+          )
         case Some(pid) =>
           for {
             pOpt            <- profileRepo.findById(pid)
@@ -329,7 +335,13 @@ class PolicyServiceLive(
             appSchedWindows <- appRepo.appScheduleWindowsForProfile(pid)
             res             <- pOpt match {
               case None    =>
-                ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Allow, "no_profile", None))
+                ZIO.succeed(
+                  RouterDecisionResponse(
+                    ConnectionDecision.Allow,
+                    BlockReason.asWire(BlockReason.NoProfile),
+                    None,
+                  ),
+                )
               case Some(p) =>
                 val h = hostname.toLowerCase.stripSuffix(".")
 
@@ -364,17 +376,31 @@ class PolicyServiceLive(
                 // router `ip daddr != @ea_<m>_<a>` carve-out.
                 if matchesAny(h, appAllowed) then
                   ZIO.succeed(
-                    RouterDecisionResponse(ConnectionDecision.Allow, "extra_allowed", None),
+                    RouterDecisionResponse(
+                      ConnectionDecision.Allow,
+                      BlockReason.asWire(BlockReason.ExtraAllowed),
+                      None,
+                    ),
                   )
                 else if p.paused then
-                  ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Block, "paused", None))
+                  ZIO.succeed(
+                    RouterDecisionResponse(
+                      ConnectionDecision.Block,
+                      BlockReason.asWire(MacBlockReason.Paused),
+                      None,
+                    ),
+                  )
                 else
                   scheduleBlock(scheds, now) match {
                     case Some(r) => ZIO.succeed(r)
                     case None    =>
                       if matchesAny(h, appBlocked) then
                         ZIO.succeed(
-                          RouterDecisionResponse(ConnectionDecision.Block, "extra_blocked", None),
+                          RouterDecisionResponse(
+                            ConnectionDecision.Block,
+                            BlockReason.asWire(BlockReason.ExtraBlocked),
+                            None,
+                          ),
                         )
                       else
                         timeLimitBlockFromState(h, now, settings, dayState) match {
@@ -384,10 +410,14 @@ class PolicyServiceLive(
                               case Some(cat) =>
                                 RouterDecisionResponse(
                                   ConnectionDecision.Block,
-                                  s"category:${cat.value}",
+                                  BlockReason.asWire(BlockReason.Category(cat)),
                                   None,
                                 )
                               case None      =>
+                                // #1545: BlockReason.Allow's canonical asWire is "allow"; this
+                                // allow-path has historically emitted the "allowed" alias on the
+                                // wire and the back-compat rules forbid changing it (fromWire
+                                // accepts both → Allow), so this single case stays a literal.
                                 RouterDecisionResponse(ConnectionDecision.Allow, "allowed", None)
                             }
                         }
@@ -407,7 +437,11 @@ class PolicyServiceLive(
       // it's tomorrow's endLocal; otherwise it's today's endLocal (which may be in the
       // past for the "tail" of a previous day's overnight window — handled below).
       val expiresAt = PolicyService.scheduleEndInstantAfter(s, now)
-      RouterDecisionResponse(ConnectionDecision.Block, "schedule", Some(expiresAt.toString))
+      RouterDecisionResponse(
+        ConnectionDecision.Block,
+        BlockReason.asWire(MacBlockReason.Schedule),
+        Some(expiresAt.toString),
+      )
     }
   }
 
@@ -438,7 +472,7 @@ class PolicyServiceLive(
       .map(sd =>
         RouterDecisionResponse(
           ConnectionDecision.Block,
-          s"site_time_limit:${sd.label}",
+          BlockReason.asWire(BlockReason.SiteTimeLimit(sd.label)),
           Some(resetAt),
         ),
       )
@@ -450,7 +484,11 @@ class PolicyServiceLive(
         else
           state.dailyLimitMinutes.flatMap { limit =>
             Option.when(state.usedMinutes >= limit + state.extensionMinutes)(
-              RouterDecisionResponse(ConnectionDecision.Block, "time_limit", Some(resetAt)),
+              RouterDecisionResponse(
+                ConnectionDecision.Block,
+                BlockReason.asWire(MacBlockReason.TimeLimit),
+                Some(resetAt),
+              ),
             )
           }
       }

--- a/api/src/routes/BlockedRoutes.scala
+++ b/api/src/routes/BlockedRoutes.scala
@@ -89,28 +89,40 @@ object BlockedRoutes {
   }
 
   /**
-   * Map the router decision wire-reason to a (reasonClass, categoryName?) pair. The reason strings
-   * here mirror the literals emitted by [[PolicyService.decide]].
+   * Map the router decision wire-reason to a (reasonClass, categoryName?) pair.
+   *
+   * #1545: the wire-reason is parsed once through the canonical [[BlockReason.fromWire]] and the
+   * sealed result is matched exhaustively, so this re-parser can no longer drift from the strings
+   * [[PolicyService.decide]] emits (which now also go through [[BlockReason.asWire]]) — the
+   * compiler fails the build if a new `BlockReason` case is added without a mapping here.
+   *
+   * The old `case _ => ("extra_blocked", None)` fallthrough silently relabeled ANY unrecognized
+   * reason as "a specific site", so a future `decide()` reason an older block-page build hadn't
+   * learned would render the wrong copy. Now `Unknown(raw)` — and every reason that isn't one of
+   * the specific block classes the kid page distinguishes — maps to the generic `"blocked"` class
+   * (the SPA's `copyFor` default → "Access blocked."), never to `extra_blocked`.
    */
   private def mapReason(
       reason: String,
       blocklistRepo: BlocklistRepo,
-  ): Task[(String, Option[String])] = reason match {
-    case "paused"                              => ZIO.succeed(("paused", None))
-    case "schedule"                            => ZIO.succeed(("schedule", None))
-    case "time_limit"                          => ZIO.succeed(("time_limit", None))
-    case "extra_blocked"                       => ZIO.succeed(("extra_blocked", None))
-    case r if r.startsWith("site_time_limit:") => ZIO.succeed(("site_time_limit", None))
-    case r if r.startsWith("category:")        =>
-      val rest = r.drop("category:".length)
-      BlocklistId.parse(rest) match {
-        case Right(id) =>
-          blocklistRepo
-            .findMeta(id)
-            .map(meta => ("category", meta.map(_.name)))
-            .catchAll(_ => ZIO.succeed(("category", None)))
-        case Left(_)   => ZIO.succeed(("category", None))
-      }
-    case _                                     => ZIO.succeed(("extra_blocked", None))
+  ): Task[(String, Option[String])] = BlockReason.fromWire(reason) match {
+    case MacBlockReason.Paused        => ZIO.succeed(("paused", None))
+    case MacBlockReason.Schedule      => ZIO.succeed(("schedule", None))
+    case MacBlockReason.TimeLimit     => ZIO.succeed(("time_limit", None))
+    case BlockReason.ExtraBlocked     => ZIO.succeed(("extra_blocked", None))
+    case BlockReason.SiteTimeLimit(_) => ZIO.succeed(("site_time_limit", None))
+    case BlockReason.Category(id)     =>
+      blocklistRepo
+        .findMeta(id)
+        .map(meta => ("category", meta.map(_.name)))
+        .catchAll(_ => ZIO.succeed(("category", None)))
+    // Generic / unrecognized blocks. `decide()` only reaches mapReason on a Block decision, so the
+    // allow-side cases (Allow/ExtraAllowed/NoProfile) are defensive; Manual/Unmanaged/DefaultDeny/
+    // AppBlocked and any Unknown(raw) wire string render the neutral block copy rather than being
+    // mislabeled as a specific-site block.
+    case BlockReason.Allow | BlockReason.Blocked | BlockReason.ExtraAllowed |
+        BlockReason.NoProfile | BlockReason.AppBlocked(_) | BlockReason.Unknown(_) |
+        MacBlockReason.Manual | MacBlockReason.Unmanaged | MacBlockReason.DefaultDeny =>
+      ZIO.succeed(("blocked", None))
   }
 }

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -143,5 +143,32 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         info <- callBlocked(routes, "aa:bb:cc:11:22:55", "example.com")
       } yield assertTrue(!info.blocked)
     },
+    // #1545: regression for the silent `case _ => extra_blocked` fallthrough in
+    // BlockedRoutes.mapReason. A reason the API doesn't recognize (e.g. a future
+    // `decide()` reason an older block-page build hasn't learned) must render the
+    // GENERIC block copy, NOT be mislabeled as "extra_blocked" ("a specific site").
+    test("unknown block reason → generic reasonClass, NOT mislabeled extra_blocked") {
+      val stubPolicy = new PolicyService {
+        def snapshot: Task[PolicySnapshot]                          =
+          ZIO.dieMessage("snapshot unused in this test")
+        def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]] =
+          ZIO.dieMessage("renderBlocklist unused in this test")
+        def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
+          ZIO.succeed(
+            RouterDecisionResponse(ConnectionDecision.Block, "future_app:slack", None),
+          )
+      }
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        blr <- ZIO.service[BlocklistRepo]
+        routes = BlockedRoutes.routes(stubPolicy, dr, pr, blr)
+        info <- callBlocked(routes, "aa:bb:cc:11:22:99", "weird.example.com")
+      } yield assertTrue(info.blocked) &&
+        assertTrue(!info.reasonClass.contains("extra_blocked")) &&
+        assertTrue(info.reasonClass.contains("blocked")) &&
+        assertTrue(info.categoryName.isEmpty)
+    },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -149,9 +149,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     // GENERIC block copy, NOT be mislabeled as "extra_blocked" ("a specific site").
     test("unknown block reason → generic reasonClass, NOT mislabeled extra_blocked") {
       val stubPolicy = new PolicyService {
-        def snapshot: Task[PolicySnapshot]                          =
+        def snapshot: Task[PolicySnapshot]                                      =
           ZIO.dieMessage("snapshot unused in this test")
-        def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]] =
+        def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]]      =
           ZIO.dieMessage("renderBlocklist unused in this test")
         def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
           ZIO.succeed(

--- a/shared/test/src/types/BlockReasonSpec.scala
+++ b/shared/test/src/types/BlockReasonSpec.scala
@@ -125,6 +125,25 @@ object BlockReasonSpec extends ZIOSpecDefault {
           BlockReason.fromWire("category:UPPER!!!") == BlockReason.Unknown("category:UPPER!!!"),
         )
       },
+      // #1545: pin that every reason `PolicyService.decide` can emit survives a
+      // `fromWire(asWire(r))` round-trip, so routing the emitter and the block-page
+      // re-parser through the typed `BlockReason` cannot silently drop a case.
+      test("every reason decide() can emit round-trips through asWire/fromWire") {
+        val emitted: List[BlockReason] = List(
+          BlockReason.NoProfile,
+          BlockReason.ExtraAllowed,
+          BlockReason.Allow,
+          MacBlockReason.Paused,
+          MacBlockReason.Schedule,
+          BlockReason.ExtraBlocked,
+          MacBlockReason.TimeLimit,
+          BlockReason.Category(ads),
+          BlockReason.SiteTimeLimit("youtube"),
+        )
+        emitted.foldLeft(assertTrue(true)) { (acc, r) =>
+          acc && assertTrue(BlockReason.fromWire(BlockReason.asWire(r)) == r)
+        }
+      },
     ),
     suite("Type-system subtype constraint")(
       test("MacBlockReason is assignable to BlockReason") {


### PR DESCRIPTION
Closes #1545 — sub-issue of #1532 (divergence audit), Finding 2 (HIGH, carried a live latent bug).

## What

The router-decision reason vocabulary (`paused`, `schedule`, `time_limit`, `extra_blocked`, `extra_allowed`, `no_profile`, `allowed`, `site_time_limit:<label>`, `category:<slug>`) lived in **three independent hand-written copies**, while the canonical typed round-trip `BlockReason.asWire`/`fromWire` (`shared/src/Models.scala`) — already used for the connection_events/block_events dual-write — was unused by them. This routes them all through that one source of truth.

### The three collapsed copies
1. **Emitter** — `PolicyServiceLive.decide` (`api/src/policy/PolicyService.scala`) built inline string literals. Now emits each reason via `BlockReason.asWire(...)`.
2. **Re-parser** — `BlockedRoutes.mapReason` (`api/src/routes/BlockedRoutes.scala`) re-matched the literals with its own `case`s. Now parses once via `BlockReason.fromWire` and matches the **sealed** result exhaustively, so the compiler fails the build if a new `BlockReason` case isn't mapped here.
3. **Canonical** — `BlockReason.asWire`/`fromWire` already covered the full vocabulary; no change needed (every case the emitter uses already existed, incl. `Unknown`).

## The live bug — fixed

`mapReason`'s wildcard `case _ => ("extra_blocked", None)` silently relabeled **any** unrecognized reason as "a specific site" (`extra_blocked`), whereas `BlockReason.fromWire` returns `Unknown(raw)`. A future `decide()` reason an older block-page build hadn't learned (e.g. an App-Centric `app:<slug>`) would render the wrong copy with no compile error.

Now `Unknown(raw)` — and every reason that isn't one of the specific block classes the kid page distinguishes — maps to the generic `"blocked"` class (the SPA `copyFor` default → "Access blocked."), **never** `extra_blocked`.

## Wire safety

- **No wire-string change.** Same strings, now type-mediated. The `Allow` path keeps its historical `"allowed"` wire alias verbatim (`asWire(Allow)` is `"allow"`, an accepted `fromWire` alias) rather than retyping the wire — additive-only contract honored.
- **No migration.**
- **Lua/openwrt side untouched** — those literals are a pinned cross-process wire contract; this PR is API-internal only.

## Tests (committed red-first)

- `shared` `BlockReasonSpec`: every reason `decide()` can emit round-trips `fromWire(asWire(r)) == r`.
- `api` `BlockedApiSpec`: an **unknown** wire reason maps through `mapReason` to the generic `"blocked"` class, **not** `extra_blocked` (the live-bug regression). Committed failing first, then made green.
- Existing block-page reason tests + `RouterDecisionSpec` stay green (KNOWN-reason behavior unchanged).

Validated: `scalafmt --check`, `mill shared.test`, `mill api.test` all green.