### PR TITLE
feat(#1514): app-aware cross-host gap-bridged appSecondsForProfile presence primitive

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -464,6 +464,12 @@ object Presence {
    * `rows` must already be scoped to the profile's devices. Seconds are summed before any
    * floor-division so the minute view rounds floor-of-sum, matching the daily total. Heartbeat rows
    * are stripped first (#1465); a group with no matching activity is absent from the result.
+   *
+   * #1514: now a thin alias for [[appSecondsForProfile]] — the single per-app time computation
+   * (#1532). The one behavioural change is that the app's host-set is session-stitched as one
+   * stream per device, so an idle gap `< N` between two *different* hosts of the same app bridges
+   * (the apex + off-domain assets count as one engaged span) instead of each host stitching in
+   * isolation and only overlap-merging afterward. See [[appSpansForProfile]] for the rationale.
    */
   def patternGroupSecondsForProfile(
       rows: List[PresenceRow],
@@ -471,22 +477,8 @@ object Presence {
       overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
-  ): Map[String, Long] = {
-    val active = rows.filterNot(r => isHeartbeat(r, filter))
-    val gap    = effectiveGap(active, continuationSeconds)
-    def matchesGroup(r: PresenceRow, pats: List[String]): Boolean =
-      r.host.asFqdn.exists(fqdn => pats.exists(p => matchesPattern(fqdn.value, p)))
-    groups.iterator.flatMap { case (key, pats) =>
-      val matching = active.filter(r => matchesGroup(r, pats))
-      val secs     = overlap match {
-        case CrossDeviceOverlapMode.Sum   =>
-          matching.groupBy(_.mac).valuesIterator.map(ms => unionSeconds(sessionSpans(ms, gap))).sum
-        case CrossDeviceOverlapMode.Dedup =>
-          unionSeconds(sessionSpans(matching, gap))
-      }
-      if secs > 0L then Some(key -> secs) else None
-    }.toMap
-  }
+  ): Map[String, Long] =
+    appSecondsForProfile(rows, groups, overlap, filter, continuationSeconds)
 
   /** Floor-divided minute view of [[patternGroupSecondsForProfile]] (per app host-set group). */
   def patternGroupMinutesForProfile(
@@ -497,6 +489,91 @@ object Presence {
       continuationSeconds: Int = DefaultContinuationSeconds,
   ): Map[String, Int] =
     patternGroupSecondsForProfile(rows, groups, overlap, filter, continuationSeconds).view
+      .mapValues(s => (s / 60).toInt)
+      .filter(_._2 != 0)
+      .toMap
+
+  /**
+   * #1514: per-app session spans, **gap-bridged across the app's whole host-set**, combined across
+   * the profile's devices per `overlap`. A *group* is `(key, patterns)` — an app's `app:<slug>`
+   * label and its full host-set ([[TimeStatusService.groupSiteLimits]]).
+   *
+   * This is the span/union analogue of [[patternSecondsForProfile]] lifted from one pattern to an
+   * app's whole host-set, and the canonical per-app presence primitive every per-app consumer reads
+   * through (the rollup #1516, the per-app graph #1517, the per-app cap #1515) — there is exactly
+   * one per-app time computation, this one (#1532). [[patternGroupSecondsForProfile]] /
+   * [[patternGroupMinutesForProfile]] delegate here.
+   *
+   * The distinction from a naive per-host union: within a device the app's matching rows are
+   * **session-stitched as one stream** (all hosts together) on the idle gap, so an idle gap `< N`
+   * between two *different* hosts of the same app — the apex going quiet while an off-domain asset
+   * / CDN host carries the next request (#1505) — **bridges into one engaged span** rather than
+   * splitting into two. [[sessionSpans]] stitches per `(mac, host)` and would leave that cross-host
+   * gap unbridged; here we stitch the union of the app's hosts per device. Built on the shared
+   * #1464 primitive ([[spanOf]] / [[stitch]] / [[mergeSpans]]) and the same `N ≥ 2 × R` collapse
+   * guard ([[effectiveGap]]), so the per-app surface stays rate-independent and consistent with the
+   * daily cap and the per-host surface.
+   *
+   * Cross-device combination matches the daily total / per-host contract: `Sum` keeps each device's
+   * per-app stitched spans separate (concatenated, so summing their seconds double-counts a host
+   * used on two screens at once); `Dedup` unions a group's per-device spans so simultaneous use
+   * counts once. Heartbeat rows are stripped before stitching (#1465), so a keepalive can neither
+   * start nor bridge a session. `rows` must already be scoped to the profile's devices. A group
+   * with no matching activity is absent from the result.
+   */
+  def appSpansForProfile(
+      rows: List[PresenceRow],
+      groups: List[(String, List[String])],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[String, List[Span]] = {
+    val active = rows.filterNot(r => isHeartbeat(r, filter))
+    val gap    = effectiveGap(active, continuationSeconds)
+    def matchesGroup(r: PresenceRow, pats: List[String]): Boolean =
+      r.host.asFqdn.exists(fqdn => pats.exists(p => matchesPattern(fqdn.value, p)))
+    groups.iterator.flatMap { case (key, pats) =>
+      val matching  = active.filter(r => matchesGroup(r, pats))
+      // Per device, stitch the union of the app's hosts as ONE stream so a gap < N
+      // between different hosts of the same app bridges (vs sessionSpans' per-(mac,host) split).
+      val perDevice =
+        matching.groupBy(_.mac).valuesIterator.map(ms => stitch(ms.map(spanOf), gap)).toList
+      val spans     = overlap match {
+        case CrossDeviceOverlapMode.Sum   => perDevice.flatten
+        case CrossDeviceOverlapMode.Dedup => mergeSpans(perDevice.flatten)
+      }
+      if spans.nonEmpty then Some(key -> spans) else None
+    }.toMap
+  }
+
+  /**
+   * #1514: per-app engaged seconds, gap-bridged across the app's whole host-set — the headline
+   * scalar form of [[appSpansForProfile]] (see it for the union-across-host-set + cross-host gap
+   * bridge + cross-device contract). Summing the span seconds reproduces the right mode for both:
+   * under `Sum` the spans are kept per device so the sum double-counts cross-device overlap; under
+   * `Dedup` they are pre-merged so the sum is the union. A group with no activity is absent.
+   */
+  def appSecondsForProfile(
+      rows: List[PresenceRow],
+      groups: List[(String, List[String])],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[String, Long] =
+    appSpansForProfile(rows, groups, overlap, filter, continuationSeconds).view
+      .mapValues(_.iterator.map(_.seconds).sum)
+      .filter(_._2 > 0L)
+      .toMap
+
+  /** Floor-divided minute view of [[appSecondsForProfile]] (per app host-set group). */
+  def appMinutesForProfile(
+      rows: List[PresenceRow],
+      groups: List[(String, List[String])],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): Map[String, Int] =
+    appSecondsForProfile(rows, groups, overlap, filter, continuationSeconds).view
       .mapValues(s => (s / 60).toInt)
       .filter(_._2 != 0)
       .toMap

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -883,5 +883,159 @@ object PresenceSpec extends ZIOSpecDefault {
         assertTrue(dedupViaSpans.getOrElse(yt, 0L) == 300L)
       },
     ),
+    // ── #1514: app-aware cross-host gap-bridged presence ──────────────────────
+    //
+    // appSecondsForProfile unions the session-stitch spans across the WHOLE app
+    // host-set as one stream, so an idle gap < N between DIFFERENT hosts of the
+    // same app bridges (the apex + off-domain assets of #1505 count once). This
+    // is the span/union analogue of patternSecondsForProfile and the single
+    // source #1516/#1517/#1515 build on.
+    suite("appSecondsForProfile / appSpansForProfile (#1514)")(
+      test("two hosts of one app in adjacent windows with an idle gap < N bridge into one span") {
+        // mathacademy.com [0,60) · gap 60s · mathacademy-cdn.example [120,180).
+        // effectiveGap = max(120, 2×60) = 120 ≥ 60, so the two DIFFERENT-host
+        // windows bridge across the gap into one engaged [0,180) = 180s span —
+        // NOT two 60s sessions (120s). The bridged gap is counted once, and the
+        // short windows are not double-counted.
+        val group = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows  = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 60),
+          appRow(mac1, 120L, "assets.mathacademy-cdn.example", periodSeconds = 60),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group)) == Map("app:math-academy" -> 180L),
+        ) &&
+        assertTrue(
+          Presence.appMinutesForProfile(rows, List(group)) == Map("app:math-academy" -> 3),
+        )
+      },
+      test("an idle gap > N between two of the app's hosts is NOT bridged") {
+        // Same two hosts but 600s apart: gap 540 > effectiveGap(120). They stay
+        // two 60s sessions → 120s, not one bridged 660s span.
+        val group = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows  = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 60),
+          appRow(mac1, 600L, "assets.mathacademy-cdn.example", periodSeconds = 60),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group)) == Map("app:math-academy" -> 120L),
+        )
+      },
+      test("hosts of different apps do NOT bridge into each other") {
+        // app A's host [0,60) and app B's host [120,180): within-app each would
+        // bridge a 60s gap, but they belong to DIFFERENT groups, so each app is
+        // its own [.,60) = 60s session — the gap is never bridged across apps.
+        val rows   = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 60),
+          appRow(mac1, 120L, "www.khanacademy.org", periodSeconds = 60),
+        )
+        val groups = List(
+          "app:math-academy" -> List("mathacademy.com"),
+          "app:khan"         -> List("khanacademy.org"),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, groups) ==
+            Map("app:math-academy" -> 60L, "app:khan" -> 60L),
+        )
+      },
+      test("no-match / empty host-set / no rows → absent (0)") {
+        val rows = List(appRow(mac1, 0L, "www.google.com", periodSeconds = 60))
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List("app:math" -> List("mathacademy.com"))) ==
+            Map.empty[String, Long],
+        ) &&
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List("app:empty" -> Nil)) == Map.empty[String, Long],
+        ) &&
+        assertTrue(
+          Presence.appSecondsForProfile(Nil, List("app:math" -> List("mathacademy.com"))) ==
+            Map.empty[String, Long],
+        )
+      },
+      test("single-host app reconciles with proportionalHostSeconds (no regression)") {
+        // A single-host app stitched as a group equals the existing per-host
+        // engaged seconds for that host — the union-across-host-set degenerates
+        // to the per-host session when the set has one host.
+        val rows    =
+          (0 to 5).toList.map(i => appRow(mac1, i * 60L, "youtube.com", periodSeconds = 10))
+        val perHost = Presence.proportionalHostSeconds(rows).getOrElse(yt, 0L)
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List("app:youtube" -> List("youtube.com"))) ==
+            Map("app:youtube" -> perHost),
+        ) &&
+        assertTrue(perHost == 310L)
+      },
+      test("Sum vs Dedup across two devices behaves like usedSecondsForProfile") {
+        // Same app, two devices, fully overlapping [0,300): Sum adds (600), Dedup
+        // unions (300) — the same cross-device contract the daily total uses.
+        val group = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows  = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 300),
+          appRow(mac2, 0L, "assets.mathacademy-cdn.example", periodSeconds = 300),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group), CrossDeviceOverlapMode.Sum) ==
+            Map("app:math-academy" -> 600L),
+        ) &&
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group), CrossDeviceOverlapMode.Dedup) ==
+            Map("app:math-academy" -> 300L),
+        )
+      },
+      test("appSpansForProfile seconds reconcile with appSecondsForProfile (Sum and Dedup)") {
+        // Two devices on the app in the same window: Sum keeps each device's
+        // spans (sum double-counts overlap), Dedup unions them. Summing the
+        // span seconds reproduces appSecondsForProfile under both modes, so the
+        // hour-clipped #1517 breakdown stays consistent with the headline.
+        val group      = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows       = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 300),
+          appRow(mac2, 0L, "assets.mathacademy-cdn.example", periodSeconds = 300),
+        )
+        val sumSpans   = Presence.appSpansForProfile(rows, List(group), CrossDeviceOverlapMode.Sum)
+        val dedupSpans =
+          Presence.appSpansForProfile(rows, List(group), CrossDeviceOverlapMode.Dedup)
+        val sumSeconds = sumSpans.view.mapValues(_.iterator.map(_.seconds).sum).toMap
+        val dedupSeconds = dedupSpans.view.mapValues(Presence.unionSeconds).toMap
+        assertTrue(
+          sumSeconds == Presence.appSecondsForProfile(rows, List(group), CrossDeviceOverlapMode.Sum),
+        ) &&
+        assertTrue(
+          dedupSeconds == Presence
+            .appSecondsForProfile(rows, List(group), CrossDeviceOverlapMode.Dedup),
+        ) &&
+        assertTrue(sumSeconds.getOrElse("app:math-academy", 0L) == 600L) &&
+        assertTrue(dedupSeconds.getOrElse("app:math-academy", 0L) == 300L)
+      },
+      test("appSpansForProfile bridges across hosts within a device") {
+        // The span form bridges the same cross-host idle gap appSecondsForProfile
+        // does: one [0,180) span, not two.
+        val group = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows  = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 60),
+          appRow(mac1, 120L, "assets.mathacademy-cdn.example", periodSeconds = 60),
+        )
+        val spans =
+          Presence.appSpansForProfile(rows, List(group)).getOrElse("app:math-academy", Nil)
+        assertTrue(spans.map(_.seconds).sum == 180L) &&
+        assertTrue(spans.size == 1)
+      },
+      test("heartbeat rows are stripped before stitching (a keepalive can't bridge across N)") {
+        // mathacademy [0,60) · apns keepalive [60,250) (190s, sub-threshold) ·
+        // cdn [250,310). With the filter on the keepalive is dropped, leaving the
+        // two real windows 190s apart (> N=120) — they do NOT bridge: 60+60=120s.
+        val f     = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val group = "app:math-academy" -> List("mathacademy.com", "mathacademy-cdn.example")
+        val rows  = List(
+          appRow(mac1, 0L, "www.mathacademy.com", periodSeconds = 60),
+          appRow(mac1, 60L, "apns.apple.com", periodSeconds = 190, bytes = 60L),
+          appRow(mac1, 250L, "assets.mathacademy-cdn.example", periodSeconds = 60),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group), filter = f) ==
+            Map("app:math-academy" -> 120L),
+        )
+      },
+    ),
   )
 }


### PR DESCRIPTION
## What

Adds the canonical **app-aware presence primitive** for #1514 (App-Centric / Usage & Screen-Time):

- `Presence.appSpansForProfile(...)` — per-app session **spans**, gap-bridged across the app's whole host-set.
- `Presence.appSecondsForProfile(...)` — the headline scalar form (seconds, for exactness, matching `usedSecondsForProfile`).
- `Presence.appMinutesForProfile(...)` — floor-divided minute view.

## Union-across-host-set + cross-host gap bridge

For a given app's host-set (`app:<slug>` + its full host list, as resolved by
`TimeStatusService.groupSiteLimits` / #1505), the primitive collects each host's
activity and **session-stitches the union of all the app's hosts as one stream
per device**. So an idle gap `< N` (the #1464 continuation gap) between two
*different* hosts of the same app — the apex going quiet while an off-domain
asset / CDN host carries the next request — **bridges into one engaged span**,
counting the multi-host app's engaged time **once** rather than each host ticking
its own budget. A gap `> N` is not bridged; hosts of different apps never bridge
into each other.

This is the span/union analogue of the existing per-site
`patternSecondsForProfile`, built on the **same** #1464 session-stitch primitive
(`spanOf` / `stitch` / `mergeSpans`) and the same `N ≥ 2×R` collapse guard
(`effectiveGap`) — no parallel stitch. It respects `CrossDeviceOverlapMode` with
the same `Sum`/`Dedup` contract as the daily total and per-host surfaces (`Sum`
keeps each device's spans so overlap double-counts; `Dedup` pre-merges so the sum
is the union), and strips heartbeat/background rows before stitching (#1465).
Pure / Clock-injected — no DB calls; callers pass presence rows.

## Single source (#1532)

`patternGroupSecondsForProfile` (and `patternGroupMinutesForProfile`) now
**delegate** to `appSecondsForProfile`, so there is exactly **one** per-app time
computation. This is the single primitive #1516 (rollup), #1517 (per-app graph),
and #1515 (per-app cap) all consume. The only behavioural change to the existing
per-app path is the cross-host gap bridge.

## Scope / compat

- No wire change, no migration — `appSecondsForProfile` is an in-memory primitive
  only. The #1516 rollup that *stores* this lands separately (schema-only, then a
  later adoption PR writes it). This PR is the primitive + tests.
- Diff limited to `api/src/presence/Presence.scala` and its unit spec.

## Tests (TDD — red commit first, then green)

`api/test/src/unit/PresenceSpec.scala`, suite `appSecondsForProfile / appSpansForProfile (#1514)`:

- two hosts of one app in adjacent windows with an idle gap `< N` → **one bridged span** (180s, not 120s);
- an idle gap `> N` is **not** bridged;
- hosts of **different** apps do not bridge into each other;
- no-match / empty host-set / no rows → absent (0);
- single-host app **reconciles** with `proportionalHostSeconds` (no regression);
- `Sum` vs `Dedup` across two devices behaves like the daily-total contract;
- `appSpansForProfile` seconds reconcile with `appSecondsForProfile` (both modes);
- heartbeat rows stripped before stitching (a keepalive can't bridge across `N`).

Validated: `scalafmt --check`, `api.test.compile`, and the `PresenceSpec` /
`TimeStatusServiceSpec` / `AppHostSetAttributionSpec` / `RollupAppAttributionSpec`
/ `TimeApiSpec` / `UsageApiSpec` / `DashboardNowApiSpec` specs all green.

Closes part of #1514.
