### PR TITLE
refactor(#1546): collapse per-device totals onto TimeStatusService.usedSecondsByMac (fix Dedup over-count)

### DIFF
--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -490,6 +490,22 @@ object TimeStatusService {
    * source-of-truth invariant). Returning seconds — not minutes — lets the decomposition rolled +
    * tail stay exact across the watermark boundary.
    */
+  /**
+   * #1531: the WHOLE host-set of every exempt-from-daily app — the patterns excluded from the daily
+   * total. Derived from the same per-app collapse (`groupSiteLimits`) the per-app bars and
+   * `computeBlockRules` use, so the displayed `usedMinutes`, the snapshot's `blocked`, and the
+   * per-device summaries (#1546) all read ONE explicit host-set. The previous
+   * `siteLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
+   * emits one row per host; reusing the collapse makes the whole-host-set exemption explicit rather
+   * than an implicit dependency on that row shape, which would silently regress to apex-only the
+   * moment those rows were ever de-duped upstream. Shared by [[usedSecondsForProfile]] and
+   * [[usedSecondsByMac]] so the two can never derive exempt patterns differently.
+   */
+  private[policy] def exemptPatterns(siteLimits: List[SiteTimeLimit]): List[String] =
+    groupSiteLimits(siteLimits).collect {
+      case (_, _, exempt, hosts, _) if exempt => hosts
+    }.flatten
+
   def usedSecondsForProfile(
       profile: Profile,
       devices: List[Device],
@@ -497,19 +513,7 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Long = {
-    // #1531: exclude the WHOLE host-set of every exempt-from-daily app from the daily total — the
-    // counting-side counterpart of the enforcement carve-out (#1513), which keys the exempt
-    // allow-list on the per-app `SiteDayState.hosts`. Derive the exempt patterns from the same
-    // per-app collapse (`groupSiteLimits`) the per-app bars and `computeBlockRules` use, so the
-    // displayed `usedMinutes` and the snapshot's `blocked` read one explicit host-set. The previous
-    // `siteLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
-    // emits one row per host; reusing the collapse makes the whole-host-set exemption explicit
-    // rather than an implicit dependency on that row shape, which would silently regress to
-    // apex-only the moment those rows were ever de-duped upstream.
-    val exemptPats =
-      groupSiteLimits(siteLimits).collect {
-        case (_, _, exempt, hosts, _) if exempt => hosts
-      }.flatten
+    val exemptPats = exemptPatterns(siteLimits)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(
@@ -526,6 +530,67 @@ object TimeStatusService {
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
         )
+    }
+  }
+
+  /**
+   * #1546: the per-mac decomposition of [[usedSecondsForProfile]]. Uses the IDENTICAL
+   * exempt-pattern derivation ([[exemptPatterns]]) and the profile's `crossDeviceOverlapMode`, so
+   * the per-device summaries the `/api/time/status` routes render can no longer drift from the
+   * canonical headline `usedMinutes` (the #1531 class of divergence at per-device granularity). The
+   * collapse invariant, in BOTH modes, is `usedSecondsByMac(...).values.sum ==
+   * usedSecondsForProfile(...)`:
+   *
+   *   - '''Sum''': each mac is credited its own engaged seconds (its per-`(device, app)` session
+   *     union). The profile total is the per-device sum, so this is the natural decomposition and
+   *     the equality is exact.
+   *   - '''Dedup''': the profile total is the cross-device UNION (one human on two screens counts
+   *     once), which is `<=` the sum of per-device engaged seconds. A flat per-device split would
+   *     therefore over-count (the prod divergence: two devices overlapping in the same window each
+   *     showed their full engaged time, totalling 2x the headline). Instead each device is credited
+   *     only the seconds it adds to the union that an earlier device — in `devices` order — has not
+   *     already covered. This disjoint marginal attribution telescopes to exactly the union, and a
+   *     device's own engaged seconds are an upper bound on its share, so no single device can
+   *     exceed the headline and the summaries can never total `>100%`.
+   *
+   * `presence` must already be scoped to the profile's devices (as the live read paths and the
+   * routes both do).
+   */
+  def usedSecondsByMac(
+      profile: Profile,
+      devices: List[Device],
+      siteLimits: List[SiteTimeLimit],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): Map[MacAddress, Long] = {
+    val exemptPats = exemptPatterns(siteLimits)
+    profile.crossDeviceOverlapMode match {
+      case CrossDeviceOverlapMode.Sum   =>
+        val perMac = Presence.totalSecondsByMac(
+          presence,
+          exemptPats,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
+        devices.iterator.map(d => d.mac -> perMac.getOrElse(d.mac, 0L)).toMap
+      case CrossDeviceOverlapMode.Dedup =>
+        val spansByMac = Presence.deviceSessionSpans(
+          presence,
+          exemptPats,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
+        // Disjoint marginal attribution in `devices` order: each mac gets the seconds it adds to the
+        // running union. Σ marginals == unionSeconds(all device spans) == dedupedTotalSeconds.
+        val (out, _)   =
+          devices.foldLeft((Map.empty[MacAddress, Long], List.empty[Presence.Span])) {
+            case ((acc, covered), d) =>
+              val macSpans = spansByMac.getOrElse(d.mac, Nil)
+              val marginal =
+                Presence.unionSeconds(covered ++ macSpans) - Presence.unionSeconds(covered)
+              (acc.updated(d.mac, marginal), Presence.mergeSpans(covered ++ macSpans))
+          }
+        out
     }
   }
 

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -676,6 +676,7 @@ object TimeRoutes {
                       settings,
                       timeStatusService,
                       trafficRepo,
+                      siteTimeLimitRepo,
                     )
                   }
               }
@@ -790,6 +791,7 @@ object TimeRoutes {
               profileRepo,
               timeStatusService,
               trafficRepo,
+              siteTimeLimitRepo,
             )
               .mapError(ErrorMapper.dbErrorToResponse)
           } yield Response.json(status.toJson)
@@ -916,6 +918,7 @@ object TimeRoutes {
       settings: HouseholdSettings,
       timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
   ): Task[ProfileTimeStatus] = {
     val macs = devices.map(_.mac)
     for {
@@ -923,18 +926,15 @@ object TimeRoutes {
       state = stateOpt.getOrElse(
         wifihaven.api.policy.ProfileDayState(profile.id, date, None, 0, 0, None, false, None, Nil),
       )
-      presence <- trafficRepo.listPresenceRows(macs, date)
-      perMacTotal     = {
-        // #1505: exempt the app's whole host-set from the daily cap, not just the representative.
-        val exemptPats = state.perSite.filter(_.exemptFromDaily).flatMap(_.hosts)
-        wifihaven.api.presence.Presence
-          .totalMinutesByMac(
-            presence,
-            exemptPats,
-            settings.heartbeatFilter,
-            settings.presenceContinuationSeconds,
-          )
-      }
+      presence   <- trafficRepo.listPresenceRows(macs, date)
+      siteLimits <- siteTimeLimitRepo.listForProfile(profile.id)
+      // #1546: per-device minutes come from the canonical per-mac decomposition of the headline
+      // total, so they share one exempt-pattern + overlap definition with `state.usedMinutes` and
+      // cannot drift from it (no open-coded `totalMinutesByMac` recompute). Under Dedup this is a
+      // disjoint attribution of the union, so the summaries reconcile with the headline instead of
+      // summing to >100%.
+      perMacSeconds   = wifihaven.api.policy.TimeStatusService
+        .usedSecondsByMac(profile, devices, siteLimits, presence, settings)
       siteUsage       = state.perSite.map { s =>
         SiteUsage(
           s.label,
@@ -945,7 +945,7 @@ object TimeRoutes {
         )
       }
       deviceSummaries = devices.map { d =>
-        DeviceUsageSummary(d.mac, d.name, perMacTotal.getOrElse(d.mac, 0))
+        DeviceUsageSummary(d.mac, d.name, (perMacSeconds.getOrElse(d.mac, 0L) / 60L).toInt)
       }
       // #262 — top-N host attribution across all profile devices for the day.
       // `usedMins` is bucket-presence and `proportionalMins` is the #715
@@ -1180,30 +1180,32 @@ object TimeRoutes {
       profileRepo: ProfileRepo,
       timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
+      siteTimeLimitRepo: SiteTimeLimitRepo,
   ): Task[DeviceTimeStatus] = {
     val pid = device.profileId
     for {
-      stateOpt <- pid.fold(ZIO.succeed(Option.empty[wifihaven.api.policy.ProfileDayState]))(p =>
+      stateOpt   <- pid.fold(ZIO.succeed(Option.empty[wifihaven.api.policy.ProfileDayState]))(p =>
         timeStatusService.dayState(now, date, settings, p),
       )
-      presence <- trafficRepo.listPresenceRows(List(device.mac), date)
-      profile  <- pid.fold(ZIO.succeed("No profile"))(p =>
-        profileRepo.findById(p).map(_.map(_.name).getOrElse("Unknown")),
+      presence   <- trafficRepo.listPresenceRows(List(device.mac), date)
+      profileOpt <- pid.fold(ZIO.succeed(Option.empty[Profile]))(profileRepo.findById)
+      siteLimits <- pid.fold(ZIO.succeed(List.empty[SiteTimeLimit]))(
+        siteTimeLimitRepo.listForProfile,
       )
-      // #1505: exempt + count each app's whole host-set, aggregated per app (one bar per app).
-      exemptPats = stateOpt.toList.flatMap(_.perSite.filter(_.exemptFromDaily).flatMap(_.hosts))
-      totalUsed  = wifihaven.api.presence.Presence
-        .totalMinutesByMac(
-          presence,
-          exemptPats,
-          settings.heartbeatFilter,
-          settings.presenceContinuationSeconds,
-        )
-        .getOrElse(device.mac, 0)
+      profile   = profileOpt.map(_.name).getOrElse(if (pid.isEmpty) "No profile" else "Unknown")
+      // #1546: the per-device headline reads the same per-mac decomposition the profile view's
+      // summaries do, so its exempt-pattern + overlap definition matches the canonical
+      // `state.usedMinutes` (no open-coded `totalMinutesByMac` recompute). Single-device, so Sum
+      // and Dedup coincide — the device is credited its own engaged time.
+      totalUsed = profileOpt.fold(0)(p =>
+        (wifihaven.api.policy.TimeStatusService
+          .usedSecondsByMac(p, List(device), siteLimits, presence, settings)
+          .getOrElse(device.mac, 0L) / 60L).toInt,
+      )
       // #1505 + #1504: per-device per-app usage via the #1464 session-stitch primitive, aggregated
       // across each app's whole host-set (one bar per app). Single-device view, so cross-device
       // overlap mode is moot — Sum and Dedup coincide.
-      perApp     = wifihaven.api.presence.Presence
+      perApp    = wifihaven.api.presence.Presence
         .patternGroupMinutesForProfile(
           presence,
           stateOpt.toList.flatMap(_.perSite).map(s => s.label -> s.hosts),
@@ -1211,7 +1213,7 @@ object TimeRoutes {
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
         )
-      siteUsage  = stateOpt.toList.flatMap(_.perSite).map { s =>
+      siteUsage = stateOpt.toList.flatMap(_.perSite).map { s =>
         val used = perApp.getOrElse(s.label, 0)
         SiteUsage(
           s.label,

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -1214,13 +1214,17 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
-        } yield assertTrue(kids.usedMins == 30) &&                         // union headline
-          assertTrue(kids.devices.map(_.usedMins).sum == kids.usedMins) && // disjoint, sums to union
-          assertTrue(kids.devices.forall(_.usedMins <= kids.usedMins))     // never >100%
+        } yield assertTrue(kids.usedMins == 30) &&                     // union headline
+          assertTrue(
+            kids.devices.map(_.usedMins).sum == kids.usedMins,
+          ) &&                                                         // disjoint, sums to union
+          assertTrue(kids.devices.forall(_.usedMins <= kids.usedMins)) // never >100%
       },
       // #1546 / #1531 at per-device granularity: a device's `usedMins` must exclude exempt-from-daily
       // app time the SAME way the headline does — both derive exempt patterns from `usedSecondsByMac`.
-      test("#1546 exempt-app: per-device usedMins excludes exempt time identically to the headline") {
+      test(
+        "#1546 exempt-app: per-device usedMins excludes exempt time identically to the headline",
+      ) {
         for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
@@ -1291,9 +1295,11 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           )
           devBody <- devResp.body.asString
           dev     <- ZIO.fromEither(devBody.fromJson[DeviceTimeStatus])
-        } yield assertTrue(kids.usedMins == 10) &&                  // exempt 25 min excluded
-          assertTrue(kids.devices.map(_.usedMins).sum == 10) &&     // per-device summary excludes it too
-          assertTrue(dev.usedMins == 10)                            // device endpoint headline agrees
+        } yield assertTrue(kids.usedMins == 10) && // exempt 25 min excluded
+          assertTrue(
+            kids.devices.map(_.usedMins).sum == 10,
+          ) &&                                     // per-device summary excludes it too
+          assertTrue(dev.usedMins == 10)           // device endpoint headline agrees
       },
       test("hostUsage: heartbeat filter strips keepalive pollers from per-host surfaces (#1465)") {
         // Reproduce the prod shape from #715: device sat at ~60 used minutes

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -1085,6 +1085,216 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
           assertTrue(kids.usedMins == 0)         // site usage NOT counted in total
       },
+      // #1546: per-device `deviceSummaries` must share ONE exempt/overlap definition with the
+      // canonical headline `usedMinutes` (via TimeStatusService.usedSecondsByMac), so the summed
+      // per-device minutes reconcile with the headline instead of being independently recomputed.
+      test("#1546 Sum mode: summed deviceSummaries minutes equal the headline usedMinutes") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo) // default overlap = Sum
+          _           <- tlRepo.upsert(kidsId, 120)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Whole-minute amounts so per-mac floor-to-minute and headline floor agree exactly.
+          off1            <- seedTraffic(routerId, mac1, "minecraft.net", today, 20, 0)
+          _               <- seedTraffic(routerId, mac2, "youtube.com", today, 30, off1)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(kids.usedMins == 50) &&
+          assertTrue(kids.devices.map(_.usedMins).sum == kids.usedMins)
+      },
+      // #1546 regression: the prod divergence. Under Dedup the headline `usedMinutes` is a
+      // cross-device UNION, but the route used to SUM each device's own engaged minutes for
+      // `deviceSummaries` — so two devices overlapping in the same window summed to 2× the headline
+      // (>100% display). usedSecondsByMac credits each device only its disjoint marginal, so the
+      // summaries reconcile with the union and no single device exceeds it.
+      test("#1546 Dedup mode: summed deviceSummaries never exceed the headline usedMinutes") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- profileRepo.findById(kidsId).flatMap { opt =>
+            ZIO.foreachDiscard(opt)(p =>
+              profileRepo.update(p.copy(crossDeviceOverlapMode = CrossDeviceOverlapMode.Dedup)),
+            )
+          }
+          _           <- tlRepo.upsert(kidsId, 120)
+          mac1 = "aa:bb:cc:dd:ee:01"
+          mac2 = "aa:bb:cc:dd:ee:02"
+          _        <- TestLayers.seedDevice(deviceRepo, mac1, "iPad", kidsId)
+          _        <- TestLayers.seedDevice(deviceRepo, mac2, "iPhone", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // Both devices active across the SAME 30 minutes → union headline is 30, but each
+          // device's own engaged time is 30. Pre-fix the summaries summed to 60.
+          _               <- seedTraffic(routerId, mac1, "cnn.com", today, 30, 0)
+          _               <- seedTraffic(routerId, mac2, "cnn.com", today, 30, 0)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+        } yield assertTrue(kids.usedMins == 30) &&                         // union headline
+          assertTrue(kids.devices.map(_.usedMins).sum == kids.usedMins) && // disjoint, sums to union
+          assertTrue(kids.devices.forall(_.usedMins <= kids.usedMins))     // never >100%
+      },
+      // #1546 / #1531 at per-device granularity: a device's `usedMins` must exclude exempt-from-daily
+      // app time the SAME way the headline does — both derive exempt patterns from `usedSecondsByMac`.
+      test("#1546 exempt-app: per-device usedMins excludes exempt time identically to the headline") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          tlRepo      <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          auth        <- makeAuth
+          token       <- auth.login("admin", "changeme").map(_.token.value)
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- tlRepo.upsert(kidsId, 120)
+          _           <- TestLayers.seedAppAssignment(
+            appRepo,
+            kidsId,
+            "khan.org",
+            AppMode.TimeLimited,
+            dailyMinutes = Some(60),
+            exemptFromDaily = true,
+          )
+          mac = "aa:bb:cc:dd:ee:01"
+          _        <- TestLayers.seedDevice(deviceRepo, mac, "iPad", kidsId)
+          routerId <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // 25 min exempt khan.org + 10 min counted cnn.com on the one device.
+          off1            <- seedTraffic(routerId, mac, "khan.org", today, 25, 0)
+          _               <- seedTraffic(routerId, mac, "cnn.com", today, 10, off1)
+          userProfileRepo <- ZIO.service[UserProfileRepo]
+          hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+          clock           <- ZIO.service[Clock]
+          tss    = new wifihaven.api.policy.TimeStatusServiceLive(
+            profileRepo,
+            schedRepo,
+            tlRepo,
+            stlRepo,
+            deviceRepo,
+            trafficRepo,
+            extRepo,
+          )
+          routes = TimeRoutes.routes(
+            auth,
+            deviceRepo,
+            tlRepo,
+            stlRepo,
+            trafficRepo,
+            extRepo,
+            profileRepo,
+            userProfileRepo,
+            hsRepo,
+            tss,
+            clock,
+          )
+          resp <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/time/status").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          body <- resp.body.asString
+          list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
+          kids = list.find(_.profileId == kidsId).get
+          // The per-device endpoint headline excludes exempt time the same way.
+          devResp <- routes.runZIO(
+            Request
+              .get(URL.decode(s"/api/time/status/$mac").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          devBody <- devResp.body.asString
+          dev     <- ZIO.fromEither(devBody.fromJson[DeviceTimeStatus])
+        } yield assertTrue(kids.usedMins == 10) &&                  // exempt 25 min excluded
+          assertTrue(kids.devices.map(_.usedMins).sum == 10) &&     // per-device summary excludes it too
+          assertTrue(dev.usedMins == 10)                            // device endpoint headline agrees
+      },
       test("hostUsage: heartbeat filter strips keepalive pollers from per-host surfaces (#1465)") {
         // Reproduce the prod shape from #715: device sat at ~60 used minutes
         // but a per-FQDN bucket-presence breakdown lists 10 polling hosts at


### PR DESCRIPTION
Closes #1546. Sub-issue of #1532 (divergence audit), Finding 3 — #1531 reproduced at per-device granularity.

## The divergence

Per-device "minutes used today" was recomputed in the routes independently of the canonical profile headline:

- **Canonical:** `TimeStatusService.usedSecondsForProfile` (exempt patterns from `groupSiteLimits(siteLimits)`, respecting `crossDeviceOverlapMode`) → `state.usedMinutes`.
- **Open-coded recompute (removed):** `buildProfileTimeStatus` re-ran `Presence.totalMinutesByMac(presence, exemptPats, …)` with `exemptPats` rebuilt from `state.perSite.filter(_.exemptFromDaily).flatMap(_.hosts)` for `deviceSummaries`; `buildDeviceTimeStatus` did the same for the device-headline total.

The two derived exempt patterns two different ways, and under `CrossDeviceOverlapMode.Dedup` they already disagreed: the route **summed** per-mac engaged minutes for `deviceSummaries` while the headline is a cross-device **union** — so summed per-device exceeded the headline (a >100% display inconsistency for Dedup-mode profiles).

## The collapse

Adds `TimeStatusService.usedSecondsByMac(profile, devices, siteLimits, presence, settings): Map[MacAddress, Long]` — the per-mac decomposition of `usedSecondsForProfile`, sharing a new private `exemptPatterns` helper (IDENTICAL `groupSiteLimits`-based derivation, used by both functions) and the profile's overlap mode.

Invariant in **both** modes: `usedSecondsByMac(...).values.sum == usedSecondsForProfile(...)`.

### Dedup decomposition choice

Under Dedup the headline is the cross-device union, which is `<=` the sum of per-device engaged seconds, so a flat per-device split would over-count (the prod bug). Instead each device is credited only the seconds it adds to the running union that an earlier device — in `devices` order — has not already covered (a disjoint marginal attribution: `unionSeconds(covered ++ macSpans) - unionSeconds(covered)`). This telescopes to exactly the union, and a device's own engaged seconds upper-bound its share, so **no single device can exceed the headline and the summaries can never total >100%**. Under Sum each mac is simply credited its own engaged seconds (the natural split).

Both `buildProfileTimeStatus` (deviceSummaries) and `buildDeviceTimeStatus` (device headline) now call `usedSecondsByMac`; the open-coded `exemptPats` rebuild + `Presence.totalMinutesByMac` recompute is gone. Future changes to exempt-host resolution, the session-stitch primitive, or overlap handling now update one definition that the per-device numbers and the headline both read.

## Tests (TDD, red→green visible in history)

`api/test/src/feature/TimeApiSpec.scala`, via the real `/api/time/status` stack on embedded Postgres (no repo mocks):

- **Sum mode** — `sum(deviceSummaries.usedMins) == headline usedMinutes` (exact).
- **Dedup mode** (the prod-divergence regression, committed RED first) — two devices overlapping in the same 30 min: summed per-device `== 30` (the union) and `<= headline`, where it previously summed to 60.
- **Exempt-app** — per-device `usedMins` excludes exempt-from-daily app time identically to the headline (the #1531 invariant at per-device granularity), asserted on both the profile and per-device endpoints.

No wire change; no migration. Diff limited to `TimeStatusService.scala`, `Routes.scala`, and the test.

Part of #1532.