### PR TITLE
feat(#1506): app-aware background suppression — app-attributed hosts count, never suppressed as infra

### DIFF
--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -506,6 +506,19 @@ object TimeStatusService {
       case (_, _, exempt, hosts, _) if exempt => hosts
     }.flatten
 
+  /**
+   * #1506: the union of EVERY active app's host-set for this profile — the app-attribution set fed
+   * to [[Presence.isHeartbeat]] so a host an active app genuinely depends on is never dropped as
+   * background infra (attribution beats suppression). Derived from the same per-app collapse
+   * (`groupSiteLimits`) the per-app bars and `exemptPatterns` use, so the daily total and the
+   * per-app surfaces agree on what counts as an "active app host". Includes exempt apps' hosts too:
+   * exclusion from the daily total is handled separately by [[exemptPatterns]] in
+   * [[Presence.countedRows]] (attribution only prevents suppression, not exemption), so an exempt
+   * app's host is still excluded — it is simply no longer mis-classified as a heartbeat first.
+   */
+  private[policy] def appHostPatterns(siteLimits: List[SiteTimeLimit]): List[String] =
+    groupSiteLimits(siteLimits).flatMap(_._4)
+
   def usedSecondsForProfile(
       profile: Profile,
       devices: List[Device],
@@ -514,6 +527,7 @@ object TimeStatusService {
       settings: HouseholdSettings,
   ): Long = {
     val exemptPats = exemptPatterns(siteLimits)
+    val appPats    = appHostPatterns(siteLimits)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(
@@ -521,6 +535,7 @@ object TimeStatusService {
           exemptPats,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
+          appPats,
         )
         devices.iterator.map(d => perMac.getOrElse(d.mac, 0L)).sum
       case CrossDeviceOverlapMode.Dedup =>
@@ -529,6 +544,7 @@ object TimeStatusService {
           exemptPats,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
+          appPats,
         )
     }
   }
@@ -564,6 +580,7 @@ object TimeStatusService {
       settings: HouseholdSettings,
   ): Map[MacAddress, Long] = {
     val exemptPats = exemptPatterns(siteLimits)
+    val appPats    = appHostPatterns(siteLimits)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(
@@ -571,6 +588,7 @@ object TimeStatusService {
           exemptPats,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
+          appPats,
         )
         devices.iterator.map(d => d.mac -> perMac.getOrElse(d.mac, 0L)).toMap
       case CrossDeviceOverlapMode.Dedup =>
@@ -579,6 +597,7 @@ object TimeStatusService {
           exemptPats,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
+          appPats,
         )
         // Disjoint marginal attribution in `devices` order: each mac gets the seconds it adds to the
         // running union. Σ marginals == unionSeconds(all device spans) == dedupedTotalSeconds.

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -170,10 +170,14 @@ object Presence {
       rows: List[PresenceRow],
       exemptPatterns: List[String],
       filter: HeartbeatFilter,
+      appHostPatterns: List[String] = Nil,
   ): List[PresenceRow] = {
     def isExempt(h: HostId) =
       h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
-    rows.filterNot(r => isHeartbeat(r, filter)).filterNot(r => isExempt(r.host))
+    // #1506: app attribution beats background/byte suppression; exempt-from-daily filtering is a
+    // separate concern and still applies afterward (an exempt app's host is still excluded from the
+    // daily total even though it is no longer suppressed as a heartbeat).
+    rows.filterNot(r => isHeartbeat(r, filter, appHostPatterns)).filterNot(r => isExempt(r.host))
   }
 
   /** Per-`(device, app)` sessions for a counted row-set, where `app = host` (design §4.1). */
@@ -196,8 +200,9 @@ object Presence {
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
+      appHostPatterns: List[String] = Nil,
   ): Map[MacAddress, Long] = {
-    val counted = countedRows(rows, exemptPatterns, filter)
+    val counted = countedRows(rows, exemptPatterns, filter, appHostPatterns)
     val gap     = effectiveGap(counted, continuationSeconds)
     counted
       .groupBy(_.mac)
@@ -216,8 +221,9 @@ object Presence {
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
+      appHostPatterns: List[String] = Nil,
   ): Map[MacAddress, Int] =
-    totalSecondsByMac(rows, exemptPatterns, filter, continuationSeconds).view
+    totalSecondsByMac(rows, exemptPatterns, filter, continuationSeconds, appHostPatterns).view
       .mapValues(s => (s / 60).toInt)
       .filter(_._2 != 0)
       .toMap
@@ -233,8 +239,9 @@ object Presence {
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
+      appHostPatterns: List[String] = Nil,
   ): Long = {
-    val counted = countedRows(rows, exemptPatterns, filter)
+    val counted = countedRows(rows, exemptPatterns, filter, appHostPatterns)
     val gap     = effectiveGap(counted, continuationSeconds)
     unionSeconds(sessionSpans(counted, gap))
   }
@@ -244,8 +251,15 @@ object Presence {
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
+      appHostPatterns: List[String] = Nil,
   ): Int =
-    (dedupedTotalSeconds(rows, exemptPatterns, filter, continuationSeconds) / 60).toInt
+    (dedupedTotalSeconds(
+      rows,
+      exemptPatterns,
+      filter,
+      continuationSeconds,
+      appHostPatterns,
+    ) / 60).toInt
 
   /**
    * #1492: per-mac merged daily session spans — the per-device building block of the daily cap, in
@@ -260,8 +274,9 @@ object Presence {
       exemptPatterns: List[String],
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
+      appHostPatterns: List[String] = Nil,
   ): Map[MacAddress, List[Span]] = {
-    val counted = countedRows(rows, exemptPatterns, filter)
+    val counted = countedRows(rows, exemptPatterns, filter, appHostPatterns)
     val gap     = effectiveGap(counted, continuationSeconds)
     counted
       .groupBy(_.mac)
@@ -320,9 +335,39 @@ object Presence {
    * on low bytes / short activity) it cannot re-open the #1446 undercount: a genuine app's sparse,
    * low-byte requests are not on the list, so they still count. The `bytesThreshold` keepalive
    * floor is unchanged and still gated on `filter.enabled`.
+   *
+   * #1506: ATTRIBUTION BEATS SUPPRESSION. `appHostPatterns` is the union of the host-sets of the
+   * apps active for the profile/MAC being counted (from #1505
+   * [[TimeStatusService.groupSiteLimits]]). A row whose host matches any of those patterns is
+   * attributed to a real app, so it can NEVER be dropped as background infra OR as a
+   * sub-threshold-byte keepalive — it must count toward that app. This is the runtime guard for the
+   * boundary [[InfraHosts]] documents (device-level infra only; per-app asset hosts must attribute
+   * and count) and closes the #1499 over-suppression seam: an asset/CDN host an app genuinely
+   * depends on that happens to match a background pattern is rescued by its app membership. Only
+   * hosts attributed to NO active app fall through to background/byte suppression, so device infra
+   * with nothing behind it stays suppressed exactly as before. Callers that have no app context
+   * pass `Nil` (the default), preserving prior behavior. This is the single app-aware predicate
+   * every counting surface routes through — do not re-derive suppression elsewhere (the #1532
+   * divergence lesson).
    */
-  def isHeartbeat(row: PresenceRow, filter: HeartbeatFilter): Boolean =
-    isBackgroundHost(row) || (filter.enabled && row.bytes < filter.bytesThreshold)
+  def isHeartbeat(
+      row: PresenceRow,
+      filter: HeartbeatFilter,
+      appHostPatterns: List[String] = Nil,
+  ): Boolean =
+    !isAppAttributed(row, appHostPatterns) &&
+      (isBackgroundHost(row) || (filter.enabled && row.bytes < filter.bytesThreshold))
+
+  /**
+   * #1506: whether the row's FQDN is attributed to one of the active apps' host-sets — the
+   * predicate that lets attribution win over suppression in [[isHeartbeat]]. Keyed on host identity
+   * via the shared [[matchesPattern]] (so apex patterns match subdomains, same as the app-presence
+   * surfaces); IP-literal hosts never match patterns. An empty `appHostPatterns` (no app context)
+   * is never attributed.
+   */
+  def isAppAttributed(row: PresenceRow, appHostPatterns: List[String]): Boolean =
+    appHostPatterns.nonEmpty &&
+      row.host.asFqdn.exists(fqdn => appHostPatterns.exists(p => matchesPattern(fqdn.value, p)))
 
   /**
    * #1503/#1525: whether the row's FQDN is device-level background infra
@@ -528,8 +573,12 @@ object Presence {
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
   ): Map[String, List[Span]] = {
-    val active = rows.filterNot(r => isHeartbeat(r, filter))
-    val gap    = effectiveGap(active, continuationSeconds)
+    // #1506: the active apps ARE these groups, so their union host-set is the app-attribution set —
+    // a host on an app's host-set that also matches a background pattern (an off-domain asset / CDN
+    // host, #1505) attributes to the app and counts here instead of being suppressed as infra.
+    val appHostPatterns = groups.flatMap(_._2)
+    val active          = rows.filterNot(r => isHeartbeat(r, filter, appHostPatterns))
+    val gap             = effectiveGap(active, continuationSeconds)
     def matchesGroup(r: PresenceRow, pats: List[String]): Boolean =
       r.host.asFqdn.exists(fqdn => pats.exists(p => matchesPattern(fqdn.value, p)))
     groups.iterator.flatMap { case (key, pats) =>

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -1037,5 +1037,97 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
+    // ── #1506: app-aware background suppression ───────────────────────────────
+    //
+    // Attribution BEATS suppression. A host that is BOTH a background/infra
+    // pattern AND a member of an ACTIVE app's host-set must NOT be dropped as
+    // device infra — it attributes to the app and COUNTS. Only hosts attributed
+    // to no active app fall through to background suppression, so device-level
+    // infra (connectivity probes, OCSP, telemetry) with no app behind it stays
+    // suppressed exactly as before (#1499 over-count protection preserved).
+    suite("app-aware background suppression (#1506)")(
+      test("a background host that IS in an active app's host-set is NOT a heartbeat") {
+        // clientservices.googleapis.com is canonical device infra (suppressed by
+        // identity). But if an app's host-set claims it, attribution wins: the
+        // app-aware predicate does not classify it as a heartbeat.
+        val f       = HeartbeatFilter(enabled = true, bytesThreshold = 10000)
+        val r       =
+          appRow(mac1, 0L, "clientservices.googleapis.com", periodSeconds = 300, bytes = 90_000L)
+        val appPats = List("clientservices.googleapis.com")
+        assertTrue(
+          Presence.isHeartbeat(r, f, appPats) == false,
+          // With NO app attribution the same host is still suppressed (no regression).
+          Presence.isHeartbeat(r, f, Nil) == true,
+        )
+      },
+      test("app attribution beats the byte floor too (a low-byte app host still counts)") {
+        // The #1446 guardrail extended: a sparse, low-byte request to a host the
+        // app genuinely depends on must count even when the byte filter is on.
+        val f       = HeartbeatFilter(enabled = true, bytesThreshold = 2048)
+        val r       = row(mac1, 0, "dl.gvt2.com", secs = 60, bytes = 60L, periodSeconds = 60)
+        val appPats = List("gvt2.com")
+        assertTrue(
+          Presence.isHeartbeat(r, f, appPats) == false,
+          Presence.isHeartbeat(r, f, Nil) == true,
+        )
+      },
+      test("device-level infra with NO app attribution stays suppressed") {
+        // connectivitycheck.gstatic.com behind no active app → still infra.
+        val f = HeartbeatFilter.Off
+        val r = appRow(mac1, 0L, "connectivitycheck.gstatic.com", periodSeconds = 300)
+        assertTrue(
+          Presence.isHeartbeat(r, f, Nil) == true,
+          // and an unrelated active app's host-set does not rescue it.
+          Presence.isHeartbeat(r, f, List("youtube.com")) == true,
+        )
+      },
+      test("daily total: an app's background asset host counts when app-attributed") {
+        // www.fooapp.com [0,600) · dl.gvt2.com [600,1200): gvt2.com is canonical
+        // background infra. Without app attribution it is suppressed → only the
+        // 10-min genuine span counts. With the app's host-set carrying gvt2.com
+        // the asset attributes to the app: the two adjacent spans union into
+        // [0,1200) = 20 min.
+        val f       = HeartbeatFilter.Off
+        val genuine = appRow(mac1, 0L, "www.fooapp.com", periodSeconds = 600, bytes = 2_000_000L)
+        val asset   = appRow(mac1, 600L, "dl.gvt2.com", periodSeconds = 600, bytes = 80_000L)
+        val rows    = List(genuine, asset)
+        assertTrue(
+          Presence.totalMinutesByMac(rows, Nil, f) == Map(mac1 -> 10),
+          Presence.totalMinutesByMac(rows, Nil, f, appHostPatterns = List("gvt2.com")) ==
+            Map(mac1 -> 20),
+        )
+      },
+      test("reconciliation: a multi-host app's suppressed asset now contributes to the app") {
+        // The #1506 seam: an app whose off-domain asset host happens to be a
+        // background/infra pattern. Pre-fix the asset is dropped as infra and the
+        // app under-counts; post-fix the app-aware predicate (driven by the app's
+        // OWN host-set) lets it attribute and bridge.
+        //   www.fooapp.com [0,60) · gap 60s · dl.gvt2.com [120,180).
+        // gvt2.com is background infra but it is part of this app's host-set, so
+        // it counts and the cross-host gap < N bridges into one [0,180) = 180s.
+        val group = "app:fooapp" -> List("fooapp.com", "gvt2.com")
+        val rows  = List(
+          appRow(mac1, 0L, "www.fooapp.com", periodSeconds = 60),
+          appRow(mac1, 120L, "dl.gvt2.com", periodSeconds = 60),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group)) == Map("app:fooapp" -> 180L),
+        )
+      },
+      test("an app whose host-set does NOT include the infra host still under-counts it") {
+        // Control for the test above: the SAME infra row, but the app's host-set
+        // does not claim gvt2.com. The asset is correctly suppressed as infra and
+        // only the genuine apex window counts (60s) — attribution is keyed on the
+        // app's declared host-set, not on mere co-occurrence.
+        val group = "app:fooapp" -> List("fooapp.com")
+        val rows  = List(
+          appRow(mac1, 0L, "www.fooapp.com", periodSeconds = 60),
+          appRow(mac1, 120L, "dl.gvt2.com", periodSeconds = 60),
+        )
+        assertTrue(
+          Presence.appSecondsForProfile(rows, List(group)) == Map("app:fooapp" -> 60L),
+        )
+      },
+    ),
   )
 }

--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -28,6 +28,11 @@ package wifihaven.shared.types
  * the `googleapis.com` apex — the apex would absorb legitimate per-app API traffic that must
  * attribute and count.
  *
+ * #1506 enforces this boundary at runtime: even if an entry here also appears in an ACTIVE app's
+ * host-set, [[wifihaven.api.presence.Presence.isHeartbeat]] treats app attribution as winning over
+ * suppression, so that host counts toward the app instead of being dropped as infra. This list is
+ * therefore the *fallback* — it suppresses a host only when no active app claims it.
+ *
  * Entries are apex- or exact-host patterns (no `*.` prefix, lowercased). An apex such as `gvt2.com`
  * matches every subdomain via [[HostMatch.matchesPattern]] (and the router's trailing-suffix match
  * on the allow side). Matching is case-sensitive on the assumption of normalized input


### PR DESCRIPTION
Closes #1506 (Tuning epic #1445). Builds on #1514 (`appSecondsForProfile`) and #1505 (app host-sets).

## Problem

Background/infra suppression (`InfraHosts.isBackground` / the heartbeat filter in `Presence`) dropped a host from presence counting purely by host *identity*. A host an app genuinely depends on — an off-domain asset/CDN host that happens to match a background pattern — was silently suppressed, re-opening the #1446 undercount. This is the seam `InfraHosts.scala` explicitly calls out ("per-app asset hosts must **attribute** to the app and **count**, not be suppressed") and the #1499 over-suppression class.

## Fix — attribution beats suppression, through one predicate

The architectural invariant is that app attribution wins over suppression for app hosts. Implemented as a **single** app-aware predicate every counting surface routes through (the #1532 divergence lesson — no second copy of the suppression logic):

- **`Presence.isHeartbeat` is now app-aware.** It takes `appHostPatterns` (the union of the host-sets of the profile/MAC's active apps). A row whose host matches any active-app pattern is **never** a heartbeat — beating **both** the `InfraHosts` identity match **and** the sub-threshold byte floor. So a sparse, low-byte request to an app's host still counts (the #1446 guard, extended). Callers with no app context pass `Nil` (the default), preserving prior behavior. `countedRows` is the one chokepoint the daily-total surfaces share.
- **`appSpansForProfile` derives its attribution set from its own groups' host-sets.** The active apps *are* the groups, so an app's off-domain asset/CDN host (#1505) that matches a background pattern now attributes to the app and counts instead of being suppressed.
- **`TimeStatusService` threads the profile's full app host-set** (new `appHostPatterns` helper, from the same `groupSiteLimits` collapse `exemptPatterns` uses) into the daily-total paths (`totalSecondsByMac` / `dedupedTotalSeconds` / `deviceSessionSpans`).

Precedence: **app-attributed (count) BEATS background-suppression.** Only hosts attributed to no active app fall through to background/byte suppression — device-level infra (connectivity probes, OCSP, OS telemetry) with nothing behind it stays suppressed exactly as before, so there is no #1499 regression. Exempt-from-daily filtering is a separate concern that still applies *after* attribution, so an exempt app's host stays excluded from the daily total — it's simply no longer mis-classified as a heartbeat first.

## Tests (TDD: red commit `22e7ee6`, green `c5f52c9`)

New `app-aware background suppression (#1506)` suite in `PresenceSpec`:
- A background host **in** an active app's host-set → **not** a heartbeat; the same host with **no** app attribution → still suppressed (no regression).
- App attribution beats the **byte floor** too (a low-byte app host counts).
- **Device-level infra** (`connectivitycheck.gstatic.com`) with no app behind it stays suppressed, and an unrelated app's host-set does not rescue it.
- **Daily total**: an app's background asset host counts toward `totalMinutesByMac` once app-attributed.
- **Reconciliation**: a multi-host app whose asset host was previously suppressed now contributes to `appSecondsForProfile` (and the control — host-set without that host — still under-counts it).

Full `mill api.test` + `shared.test` green; `scalafmt --check` clean.

## Constraints honored

No wire change; no migration. Diff limited to `api/src/presence`, `api/src/policy/TimeStatusService.scala` (call sites), `shared/src/types/InfraHosts.scala` (boundary doc), and tests.

Note: `DashboardNowRoutes.dropBackground` is a host-*ranking* path (not a counting surface) and has no per-profile app host-set context loaded; it stays identity-only and is out of scope here. Wiring app context into the now-widget can follow separately.
