### PR TITLE
feat(#1510): per-(profile,app,date) rollup builder + app-aggregated engaged-minutes read (consumes #1514)

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -185,14 +185,14 @@ object Main extends ZIOAppDefault {
         // a time budget, or a separate small pool for the rollup work. The pool-size
         // bump (this PR) and the dedicated connect EC are the first-order fix; this
         // is the durability follow-up tracked in #1221.
-        timeRollupRepo   <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+        timeRollupRepo    <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
         appRollupRepoForJ <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
-        profileRepoForJ  <- ZIO.service[wifihaven.api.db.ProfileRepo]
-        deviceRepoForJ   <- ZIO.service[wifihaven.api.db.DeviceRepo]
-        stlRepoForJ      <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
-        appRepoForJ      <- ZIO.service[AppRepo]
-        trafficRepoForJ  <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
-        _                <- TimeUsedRollupJob
+        profileRepoForJ   <- ZIO.service[wifihaven.api.db.ProfileRepo]
+        deviceRepoForJ    <- ZIO.service[wifihaven.api.db.DeviceRepo]
+        stlRepoForJ       <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+        appRepoForJ       <- ZIO.service[AppRepo]
+        trafficRepoForJ   <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
+        _                 <- TimeUsedRollupJob
           .loop(
             timeRollupRepo,
             appRollupRepoForJ,
@@ -206,40 +206,40 @@ object Main extends ZIOAppDefault {
             clockForJobs,
           )
           .forkScoped
-        _                <- ZIO.logInfo(
+        _                 <- ZIO.logInfo(
           "rollup fibers forked (hourly + daily + time_used_daily + conn_events_hourly + conn_events_daily)",
         )
         // #1243: poll the HikariCP MXBean into the Prometheus pool gauges. forkDaemon so it lives
         // for the process and never blocks startup.
-        dbPool           <- ZIO.service[Database.DbPool]
-        _                <- DbPoolMetrics.loop(dbPool.dataSource, dbPool.maxSize).forkDaemon
-        _                <- ZIO.logInfo("db-pool metrics fiber forked")
+        dbPool            <- ZIO.service[Database.DbPool]
+        _                 <- DbPoolMetrics.loop(dbPool.dataSource, dbPool.maxSize).forkDaemon
+        _                 <- ZIO.logInfo("db-pool metrics fiber forked")
         // #1204: publish agent_connected_routers — routers seen within the window.
         // forkDaemon: a read-only periodic SELECT, never blocks startup.
-        routerRepoMetric <- ZIO.service[RouterRepo]
-        _                <- RouterPresenceMetrics.loop(routerRepoMetric).forkDaemon
-        _                <- ZIO.logInfo("router-presence metrics fiber forked")
-        _                <- ZIO
+        routerRepoMetric  <- ZIO.service[RouterRepo]
+        _                 <- RouterPresenceMetrics.loop(routerRepoMetric).forkDaemon
+        _                 <- ZIO.logInfo("router-presence metrics fiber forked")
+        _                 <- ZIO
           .logWarning(
             "WIFIHAVEN_SEED_TEST_BLOCKLISTS=1 set — seeding dev test_ads/test_social. " +
               "Disable in production.",
           )
           .when(cfg.seedTestBlocklists)
-        _                <- BundledBlocklists
+        _                 <- BundledBlocklists
           .seed(blRepoForSeed, blCacheForSeed, blFetcher, BundledBlocklists.devTestBlocklists)
           .when(cfg.seedTestBlocklists)
         // #811: daily retention sweep. Forks a daemon fiber that runs at 03:00 UTC.
         // Multi-instance-safe via Postgres advisory lock — losing instances skip
         // the tick rather than racing on the same DELETE.
-        xaForJobs        <- ZIO.service[Transactor[Task]]
-        _                <- RetentionSweepJob.start(xaForJobs)
+        xaForJobs         <- ZIO.service[Transactor[Task]]
+        _                 <- RetentionSweepJob.start(xaForJobs)
         // #1176/#1179: backfill reason_text on connection_events / block_events rows inserted
         // between V40 and V44 (no reason_text column then). Fork-and-forget so a slow scan on a
         // cold Render PG doesn't gate the healthcheck; subsequent restarts re-run safely until
         // no NULLs remain.
-        _                <- ReasonTextBackfill.run(xaForJobs).forkDaemon
+        _                 <- ReasonTextBackfill.run(xaForJobs).forkDaemon
         // Keep the process alive on the already-bound server fiber; exits if it dies.
-        _                <- serverFiber.join
+        _                 <- serverFiber.join
       } yield ())
       .provide(serverEnv)
 

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -186,17 +186,21 @@ object Main extends ZIOAppDefault {
         // bump (this PR) and the dedicated connect EC are the first-order fix; this
         // is the durability follow-up tracked in #1221.
         timeRollupRepo   <- ZIO.service[wifihaven.api.db.TimeUsedRollupRepo]
+        appRollupRepoForJ <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
         profileRepoForJ  <- ZIO.service[wifihaven.api.db.ProfileRepo]
         deviceRepoForJ   <- ZIO.service[wifihaven.api.db.DeviceRepo]
         stlRepoForJ      <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+        appRepoForJ      <- ZIO.service[AppRepo]
         trafficRepoForJ  <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
         _                <- TimeUsedRollupJob
           .loop(
             timeRollupRepo,
+            appRollupRepoForJ,
             rollupRepo,
             profileRepoForJ,
             deviceRepoForJ,
             stlRepoForJ,
+            appRepoForJ,
             trafficRepoForJ,
             hsRepo,
             clockForJobs,

--- a/api/src/db/AppUsedRollupRepo.scala
+++ b/api/src/db/AppUsedRollupRepo.scala
@@ -1,0 +1,112 @@
+package wifihaven.api.db
+
+import doobie.*
+import doobie.implicits.*
+import doobie.postgres.implicits.*
+import wifihaven.api.db.TypeMeta.given
+import wifihaven.shared.types.*
+import zio.*
+import zio.interop.catz.*
+
+import java.time.{Instant, LocalDate}
+
+// #1516 (sub-issue of #1510): per-(profile, app, date) cache of app-aggregated,
+// gap-bridged *engaged* seconds — the engaged-time counterpart of V43's
+// per-(profile, date) `time_used_daily`, sliced by app. Backs the `app_used_daily`
+// table (V53). A row covers the presence buckets on `date` with
+// `period_start < rolled_through`; readers add a live aggregation of this app's
+// host-set over the remaining buckets (`period_start >= rolled_through`) to recover
+// an exact, real-time per-app engaged figure. Stored as seconds (mirroring
+// `time_used_daily.used_seconds`) so the rolled + tail decomposition stays exact —
+// truncation to minutes happens once at read time. See `AppUsedRollupService` for
+// the read path and the V53 migration header for the keying / invalidation rationale.
+
+/** Watermarked per-app rollup row: aggregated engaged seconds and the upper bound (`exclusive`) it covers. */
+final case class RolledAppDay(engagedSeconds: Long, rolledThrough: Instant)
+
+trait AppUsedRollupRepo {
+
+  /** Upsert one (profile, app) rolled (engaged seconds, watermark) for `date`. */
+  def upsertDay(profileId: ProfileId, appId: AppId, date: LocalDate, row: RolledAppDay): Task[Unit]
+
+  /**
+   * Batched upsert — one row per (profile, app) for `date`. The whole tick shares one `rolled_through`
+   * watermark, so callers pass a single `(profile, app) -> RolledAppDay`. Returns the count of rows
+   * touched.
+   */
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]
+
+  /**
+   * Cached rows for a single profile/date, keyed by app. An EMPTY map signals a cache miss for the
+   * profile (no app had engaged activity in the rolled window) and steers the read path to the
+   * all-live fallback, mirroring how `time_used_daily` treats a missing row.
+   */
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]]
+
+  /**
+   * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` alongside the
+   * `time_used_daily` invalidation so any change to the heartbeat filter, the daily-reset boundary,
+   * or the presence session-stitch knob forces the next rollup tick to refill from first principles.
+   * The table is bounded (one row per profile × app × active date), so the DELETE is cheap.
+   */
+  def deleteAll: Task[Unit]
+}
+
+/**
+ * No-op variant for test wiring / read paths that don't exercise the cache. Reads miss (empty map);
+ * writes are dropped. Mirrors [[NoopTimeUsedRollupRepo]].
+ */
+object NoopAppUsedRollupRepo extends AppUsedRollupRepo {
+  def upsertDay(profileId: ProfileId, appId: AppId, date: LocalDate, row: RolledAppDay): Task[Unit] =
+    ZIO.unit
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]         =
+    ZIO.succeed(0)
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]]      =
+    ZIO.succeed(Map.empty)
+  def deleteAll: Task[Unit]                                                                        =
+    ZIO.unit
+}
+
+class AppUsedRollupRepoLive(xa: Transactor[Task]) extends AppUsedRollupRepo {
+
+  def upsertDay(
+      profileId: ProfileId,
+      appId: AppId,
+      date: LocalDate,
+      row: RolledAppDay,
+  ): Task[Unit] =
+    sql"""INSERT INTO app_used_daily (profile_id, app_id, date, engaged_seconds, rolled_through, rolled_at)
+          VALUES ($profileId, $appId, $date, ${row.engagedSeconds}, ${row.rolledThrough}, NOW())
+          ON CONFLICT (profile_id, app_id, date) DO UPDATE
+            SET engaged_seconds = EXCLUDED.engaged_seconds,
+                rolled_through  = EXCLUDED.rolled_through,
+                rolled_at       = EXCLUDED.rolled_at""".update.run.transact(xa).unit
+
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int] =
+    if rows.isEmpty then ZIO.succeed(0)
+    else {
+      val sql      =
+        "INSERT INTO app_used_daily (profile_id, app_id, date, engaged_seconds, rolled_through, rolled_at) " +
+          "VALUES (?, ?, ?, ?, ?, NOW()) " +
+          "ON CONFLICT (profile_id, app_id, date) DO UPDATE " +
+          "SET engaged_seconds = EXCLUDED.engaged_seconds, " +
+          "    rolled_through  = EXCLUDED.rolled_through, " +
+          "    rolled_at       = EXCLUDED.rolled_at"
+      val batch    = rows.toList.map { case ((pid, aid), r) =>
+        (pid, aid, date, r.engagedSeconds, r.rolledThrough)
+      }
+      Update[(ProfileId, AppId, LocalDate, Long, Instant)](sql).updateMany(batch).transact(xa)
+    }
+
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]] =
+    sql"""SELECT app_id, engaged_seconds, rolled_through
+          FROM app_used_daily WHERE profile_id=$profileId AND date=$date"""
+      .query[(AppId, Long, Instant)]
+      .map { case (a, s, t) => a -> RolledAppDay(s, t) }
+      .to[List]
+      .transact(xa)
+      .map(_.toMap)
+
+  def deleteAll: Task[Unit] =
+    sql"DELETE FROM app_used_daily".update.run.transact(xa).unit
+}

--- a/api/src/db/AppUsedRollupRepo.scala
+++ b/api/src/db/AppUsedRollupRepo.scala
@@ -21,7 +21,10 @@ import java.time.{Instant, LocalDate}
 // truncation to minutes happens once at read time. See `AppUsedRollupService` for
 // the read path and the V53 migration header for the keying / invalidation rationale.
 
-/** Watermarked per-app rollup row: aggregated engaged seconds and the upper bound (`exclusive`) it covers. */
+/**
+ * Watermarked per-app rollup row: aggregated engaged seconds and the upper bound (`exclusive`) it
+ * covers.
+ */
 final case class RolledAppDay(engagedSeconds: Long, rolledThrough: Instant)
 
 trait AppUsedRollupRepo {
@@ -30,9 +33,9 @@ trait AppUsedRollupRepo {
   def upsertDay(profileId: ProfileId, appId: AppId, date: LocalDate, row: RolledAppDay): Task[Unit]
 
   /**
-   * Batched upsert — one row per (profile, app) for `date`. The whole tick shares one `rolled_through`
-   * watermark, so callers pass a single `(profile, app) -> RolledAppDay`. Returns the count of rows
-   * touched.
+   * Batched upsert — one row per (profile, app) for `date`. The whole tick shares one
+   * `rolled_through` watermark, so callers pass a single `(profile, app) -> RolledAppDay`. Returns
+   * the count of rows touched.
    */
   def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]
 
@@ -46,8 +49,9 @@ trait AppUsedRollupRepo {
   /**
    * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` alongside the
    * `time_used_daily` invalidation so any change to the heartbeat filter, the daily-reset boundary,
-   * or the presence session-stitch knob forces the next rollup tick to refill from first principles.
-   * The table is bounded (one row per profile × app × active date), so the DELETE is cheap.
+   * or the presence session-stitch knob forces the next rollup tick to refill from first
+   * principles. The table is bounded (one row per profile × app × active date), so the DELETE is
+   * cheap.
    */
   def deleteAll: Task[Unit]
 }
@@ -57,13 +61,18 @@ trait AppUsedRollupRepo {
  * writes are dropped. Mirrors [[NoopTimeUsedRollupRepo]].
  */
 object NoopAppUsedRollupRepo extends AppUsedRollupRepo {
-  def upsertDay(profileId: ProfileId, appId: AppId, date: LocalDate, row: RolledAppDay): Task[Unit] =
+  def upsertDay(
+      profileId: ProfileId,
+      appId: AppId,
+      date: LocalDate,
+      row: RolledAppDay,
+  ): Task[Unit] =
     ZIO.unit
-  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]         =
+  def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int]    =
     ZIO.succeed(0)
-  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]]      =
+  def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]] =
     ZIO.succeed(Map.empty)
-  def deleteAll: Task[Unit]                                                                        =
+  def deleteAll: Task[Unit]                                                                   =
     ZIO.unit
 }
 
@@ -85,14 +94,14 @@ class AppUsedRollupRepoLive(xa: Transactor[Task]) extends AppUsedRollupRepo {
   def upsertBatch(date: LocalDate, rows: Map[(ProfileId, AppId), RolledAppDay]): Task[Int] =
     if rows.isEmpty then ZIO.succeed(0)
     else {
-      val sql      =
+      val sql   =
         "INSERT INTO app_used_daily (profile_id, app_id, date, engaged_seconds, rolled_through, rolled_at) " +
           "VALUES (?, ?, ?, ?, ?, NOW()) " +
           "ON CONFLICT (profile_id, app_id, date) DO UPDATE " +
           "SET engaged_seconds = EXCLUDED.engaged_seconds, " +
           "    rolled_through  = EXCLUDED.rolled_through, " +
           "    rolled_at       = EXCLUDED.rolled_at"
-      val batch    = rows.toList.map { case ((pid, aid), r) =>
+      val batch = rows.toList.map { case ((pid, aid), r) =>
         (pid, aid, date, r.engagedSeconds, r.rolledThrough)
       }
       Update[(ProfileId, AppId, LocalDate, Long, Instant)](sql).updateMany(batch).transact(xa)

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -3260,6 +3260,7 @@ object Repos {
   val appRepo               = ZLayer.fromFunction(AppRepoLive(_))
   val rollupRepo            = ZLayer.fromFunction(RollupRepoLive(_))
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
+  val appUsedRollupRepo     = ZLayer.fromFunction(AppUsedRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ appUsedRollupRepo
 }

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -919,7 +919,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     )
 
   def update(s: HouseholdSettings): Task[Unit] = {
-    val ummJson    = s.unmanagedMacPolicy.toJson
+    val ummJson       = s.unmanagedMacPolicy.toJson
     // #1160 / #1464: invalidate the time-used rollup atomically with the
     // settings update. Any change to the daily-reset boundary (tz / reset hour),
     // the heartbeat filter, or the presence session-stitch knob
@@ -928,7 +928,7 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     // from first principles. The DELETE is wholesale because all of these fields
     // gate the same aggregation — fine-grained invalidation would only add risk
     // of missing a code path that mutates one of them.
-    val upd        =
+    val upd           =
       sql"""UPDATE household_settings
               SET daily_reset_time=${s.dailyResetTime},
                   daily_reset_tz=${s.dailyResetTz},
@@ -939,8 +939,12 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
                   presence_continuation_seconds=${s.presenceContinuationSeconds},
                   updated_at=NOW()
             WHERE id=1""".update.run
-    val invalidate = sql"DELETE FROM time_used_daily".update.run
-    (upd *> invalidate).transact(xa).unit
+    val invalidate    = sql"DELETE FROM time_used_daily".update.run
+    // #1516: the per-app rollup (`app_used_daily`) is gated by the SAME active-minute definition
+    // (heartbeat filter, daily-reset boundary, presence session-stitch knob), so invalidate it
+    // atomically too — the next tick refills both from first principles.
+    val invalidateApp = sql"DELETE FROM app_used_daily".update.run
+    (upd *> invalidate *> invalidateApp).transact(xa).unit
   }
 
   def ensureDefault(defaultZone: ZoneId): Task[Unit] =

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -507,16 +507,17 @@ object TimeStatusService {
     }.flatten
 
   /**
-   * #1516: per-app engaged seconds for a profile, keyed by `app_id`, derived from the SINGLE per-app
-   * presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same gap-bridged,
-   * cross-host union the per-app cap ([[siteDayStates]] / [[Presence.patternGroupMinutesForProfile]])
-   * ticks on. This is the value the `app_used_daily` rollup persists and the per-app series reads,
-   * so the rollup ⇄ cap ⇄ series identities hold by construction (there is exactly one per-app time
-   * computation). `slugToAppId` resolves each `app:<slug>` group key (from [[groupSiteLimits]]) to
-   * its registered `apps.id`; an app whose slug is absent is dropped (defensive — post-V35 every cap
-   * entry is a real registered app, so this never fires in practice). `presence` must already be
-   * scoped to the profile's devices. Seconds (not minutes) so the rolled + tail decomposition stays
-   * exact across the watermark boundary; floor-to-minutes happens once at read time.
+   * #1516: per-app engaged seconds for a profile, keyed by `app_id`, derived from the SINGLE
+   * per-app presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same
+   * gap-bridged, cross-host union the per-app cap ([[siteDayStates]] /
+   * [[Presence.patternGroupMinutesForProfile]]) ticks on. This is the value the `app_used_daily`
+   * rollup persists and the per-app series reads, so the rollup ⇄ cap ⇄ series identities hold by
+   * construction (there is exactly one per-app time computation). `slugToAppId` resolves each
+   * `app:<slug>` group key (from [[groupSiteLimits]]) to its registered `apps.id`; an app whose
+   * slug is absent is dropped (defensive — post-V35 every cap entry is a real registered app, so
+   * this never fires in practice). `presence` must already be scoped to the profile's devices.
+   * Seconds (not minutes) so the rolled + tail decomposition stays exact across the watermark
+   * boundary; floor-to-minutes happens once at read time.
    */
   def appSecondsByApp(
       profile: Profile,

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -519,6 +519,16 @@ object TimeStatusService {
    * Seconds (not minutes) so the rolled + tail decomposition stays exact across the watermark
    * boundary; floor-to-minutes happens once at read time.
    */
+  /**
+   * The `apps.slug` ⇄ `apps.id` resolution shared by the per-app rollup writer
+   * ([[wifihaven.api.usage.TimeUsedRollupJob]]) and reader
+   * ([[wifihaven.api.usage.AppUsedRollupService]]), so both resolve an `app:<slug>` cap group key
+   * to the same registered app identity. Centralized here next to [[appSecondsByApp]] (its
+   * consumer) so the keying convention can't drift between the two sides.
+   */
+  def slugToAppId(apps: List[App]): Map[String, AppId] =
+    apps.iterator.map(a => a.slug -> a.id).toMap
+
   def appSecondsByApp(
       profile: Profile,
       siteLimits: List[SiteTimeLimit],

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -506,6 +506,41 @@ object TimeStatusService {
       case (_, _, exempt, hosts, _) if exempt => hosts
     }.flatten
 
+  /**
+   * #1516: per-app engaged seconds for a profile, keyed by `app_id`, derived from the SINGLE per-app
+   * presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same gap-bridged,
+   * cross-host union the per-app cap ([[siteDayStates]] / [[Presence.patternGroupMinutesForProfile]])
+   * ticks on. This is the value the `app_used_daily` rollup persists and the per-app series reads,
+   * so the rollup ⇄ cap ⇄ series identities hold by construction (there is exactly one per-app time
+   * computation). `slugToAppId` resolves each `app:<slug>` group key (from [[groupSiteLimits]]) to
+   * its registered `apps.id`; an app whose slug is absent is dropped (defensive — post-V35 every cap
+   * entry is a real registered app, so this never fires in practice). `presence` must already be
+   * scoped to the profile's devices. Seconds (not minutes) so the rolled + tail decomposition stays
+   * exact across the watermark boundary; floor-to-minutes happens once at read time.
+   */
+  def appSecondsByApp(
+      profile: Profile,
+      siteLimits: List[SiteTimeLimit],
+      slugToAppId: Map[String, AppId],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): Map[AppId, Long] = {
+    val groups = groupSiteLimits(siteLimits).map(g => g._1 -> g._4)
+    Presence
+      .appSecondsForProfile(
+        presence,
+        groups,
+        profile.crossDeviceOverlapMode,
+        settings.heartbeatFilter,
+        settings.presenceContinuationSeconds,
+      )
+      .iterator
+      .flatMap { case (label, secs) =>
+        slugToAppId.get(label.stripPrefix("app:")).map(_ -> secs)
+      }
+      .toMap
+  }
+
   def usedSecondsForProfile(
       profile: Profile,
       devices: List[Device],

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -71,42 +71,24 @@ class AppUsedRollupServiceLive(
       settings: HouseholdSettings,
       profileId: ProfileId,
   ): Task[Map[AppId, Int]] = {
-    val today = PolicyService.householdLocalDate(now, settings)
-    if (date == today)
-      rollupRepo.getDayForProfile(profileId, date).flatMap { rolled =>
-        // Empty ⇒ cache miss for this profile (no app rolled yet) ⇒ all-live, mirroring how the
-        // `time_used_daily` read treats a missing row.
-        if rolled.isEmpty then liveMinutes(date, settings, profileId)
-        else rolledPlusTailMinutes(date, settings, profileId, rolled)
-      }
-    else liveMinutes(date, settings, profileId)
+    val today  = PolicyService.householdLocalDate(now, settings)
+    // Only today reads the rollup; past dates ignore it (rollup is today-only, like
+    // `time_used_daily`). An empty rolled map — cache miss, or a past date — collapses `aggregate`
+    // to a full-day all-live computation.
+    val rolled =
+      if (date == today) rollupRepo.getDayForProfile(profileId, date)
+      else ZIO.succeed(Map.empty[AppId, RolledAppDay])
+    rolled.flatMap(aggregate(date, settings, profileId, _))
   }
 
-  /** Full live aggregation over the whole day — the cache-miss / past-date path. */
-  private def liveMinutes(
-      date: LocalDate,
-      settings: HouseholdSettings,
-      profileId: ProfileId,
-  ): Task[Map[AppId, Int]] =
-    profileRepo.findById(profileId).flatMap {
-      case None    => ZIO.succeed(Map.empty)
-      case Some(p) =>
-        for {
-          stls    <- siteTimeLimitRepo.listForProfile(profileId)
-          devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
-          apps    <- appRepo.listAll
-          pres    <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
-        } yield toMinutes(
-          TimeStatusService.appSecondsByApp(p, stls, slugToAppId(apps), pres, settings),
-        )
-    }
-
-  // Rolled engaged seconds (period_start < rolled_through) + a live aggregation of this app's
-  // host-set over the buckets the rollup hasn't yet absorbed (period_start >= rolled_through). The
-  // sum floors to minutes once at the end (floor-of-sum), so the result is byte-identical to the
-  // all-live computation — the watermark lands in an idle gap, so no engaged span straddles it
-  // (same exactness argument as `time_used_daily`).
-  private def rolledPlusTailMinutes(
+  // Single read path for both cases. When `rolled` is non-empty, add its engaged seconds to a live
+  // aggregation of the TAIL past the shared watermark (period_start >= rolled_through). When it is
+  // empty (cache miss / past date), the watermark is absent so the whole day is aggregated live and
+  // the rolled contribution is zero — i.e. the all-live path. Either way the floor-of-sum to minutes
+  // happens once at the end, so the result is byte-identical to a full live aggregation (the
+  // watermark lands in an idle gap, so no engaged span straddles it — same exactness argument as
+  // `time_used_daily`).
+  private def aggregate(
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
@@ -115,29 +97,32 @@ class AppUsedRollupServiceLive(
     profileRepo.findById(profileId).flatMap {
       case None    => ZIO.succeed(Map.empty)
       case Some(p) =>
-        val watermark = rolled.values.iterator.map(_.rolledThrough).min
         for {
           stls    <- siteTimeLimitRepo.listForProfile(profileId)
           devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
           apps    <- appRepo.listAll
-          tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
+          macs = devices.map(_.mac)
+          presence <- rolled.values.iterator.map(_.rolledThrough).minOption match {
+            case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
+            case None            => trafficRepo.listPresenceRows(macs, date)
+          }
         } yield {
-          val tailSecs =
-            TimeStatusService.appSecondsByApp(p, stls, slugToAppId(apps), tail, settings)
-          (rolled.keySet ++ tailSecs.keySet).iterator.flatMap { id =>
+          val liveSecs =
+            TimeStatusService.appSecondsByApp(
+              p,
+              stls,
+              TimeStatusService.slugToAppId(apps),
+              presence,
+              settings,
+            )
+          (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
             val secs =
-              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + tailSecs.getOrElse(id, 0L)
+              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
             val mins = (secs / 60L).toInt
             if mins != 0 then Some(id -> mins) else None
           }.toMap
         }
     }
-
-  private def slugToAppId(apps: List[wifihaven.shared.App]): Map[String, AppId] =
-    apps.map(a => a.slug -> a.id).toMap
-
-  private def toMinutes(secs: Map[AppId, Long]): Map[AppId, Int] =
-    secs.view.mapValues(s => (s / 60L).toInt).filter(_._2 != 0).toMap
 }
 
 object AppUsedRollupService {

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.*
+import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.HouseholdSettings
 import wifihaven.shared.types.{AppId, ProfileId}
 import zio.*
@@ -13,8 +14,8 @@ import java.time.{Instant, LocalDate}
  * `time_used_daily` read path in [[wifihaven.api.policy.TimeStatusServiceLive]] and composes the
  * SAME rolled + live-tail way:
  *
- *   engaged_seconds(rows for `date` with period_start <  rolled_through)   ← `app_used_daily` (V53)
- *   + live_aggregate(this app's host-set over rows with period_start >= rolled_through)
+ * engaged_seconds(rows for `date` with period_start < rolled_through) ← `app_used_daily` (V53) +
+ * live_aggregate(this app's host-set over rows with period_start >= rolled_through)
  *
  * floored to minutes once at the end (floor-of-sum, never floor-then-sum). For today it reads the
  * rollup + a small tail; on a cache miss (no app rolled for the profile yet) or for past dates it
@@ -43,9 +44,9 @@ import java.time.{Instant, LocalDate}
 trait AppUsedRollupService {
 
   /**
-   * Per-app engaged minutes for `profileId` on the household-local `date` containing `now`. Apps with
-   * zero engaged minutes are absent from the map. Keyed by `apps.id`, matching the `app_used_daily`
-   * rollup the per-app series reads.
+   * Per-app engaged minutes for `profileId` on the household-local `date` containing `now`. Apps
+   * with zero engaged minutes are absent from the map. Keyed by `apps.id`, matching the
+   * `app_used_daily` rollup the per-app series reads.
    */
   def appEngagedMinutes(
       now: Instant,
@@ -69,18 +70,74 @@ class AppUsedRollupServiceLive(
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
+  ): Task[Map[AppId, Int]] = {
+    val today = PolicyService.householdLocalDate(now, settings)
+    if (date == today)
+      rollupRepo.getDayForProfile(profileId, date).flatMap { rolled =>
+        // Empty ⇒ cache miss for this profile (no app rolled yet) ⇒ all-live, mirroring how the
+        // `time_used_daily` read treats a missing row.
+        if rolled.isEmpty then liveMinutes(date, settings, profileId)
+        else rolledPlusTailMinutes(date, settings, profileId, rolled)
+      }
+    else liveMinutes(date, settings, profileId)
+  }
+
+  /** Full live aggregation over the whole day — the cache-miss / past-date path. */
+  private def liveMinutes(
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
   ): Task[Map[AppId, Int]] =
-    // #1516: STUB — the rolled + tail / all-live aggregation lands in the adoption commit. The deps
-    // are touched so the wiring (and the unused-params lint) is satisfied; the result is empty.
-    for {
-      _ <- profileRepo.findById(profileId)
-      _ <- deviceRepo.listAll
-      _ <- siteTimeLimitRepo.listForProfile(profileId)
-      _ <- appRepo.listAll
-      _ <- trafficRepo.listPresenceRows(Nil, date)
-      _ <- rollupRepo.getDayForProfile(profileId, date)
-      _ = (now, settings)
-    } yield Map.empty
+    profileRepo.findById(profileId).flatMap {
+      case None    => ZIO.succeed(Map.empty)
+      case Some(p) =>
+        for {
+          stls    <- siteTimeLimitRepo.listForProfile(profileId)
+          devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
+          apps    <- appRepo.listAll
+          pres    <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
+        } yield toMinutes(
+          TimeStatusService.appSecondsByApp(p, stls, slugToAppId(apps), pres, settings),
+        )
+    }
+
+  // Rolled engaged seconds (period_start < rolled_through) + a live aggregation of this app's
+  // host-set over the buckets the rollup hasn't yet absorbed (period_start >= rolled_through). The
+  // sum floors to minutes once at the end (floor-of-sum), so the result is byte-identical to the
+  // all-live computation — the watermark lands in an idle gap, so no engaged span straddles it
+  // (same exactness argument as `time_used_daily`).
+  private def rolledPlusTailMinutes(
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+      rolled: Map[AppId, RolledAppDay],
+  ): Task[Map[AppId, Int]] =
+    profileRepo.findById(profileId).flatMap {
+      case None    => ZIO.succeed(Map.empty)
+      case Some(p) =>
+        val watermark = rolled.values.iterator.map(_.rolledThrough).min
+        for {
+          stls    <- siteTimeLimitRepo.listForProfile(profileId)
+          devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
+          apps    <- appRepo.listAll
+          tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
+        } yield {
+          val tailSecs =
+            TimeStatusService.appSecondsByApp(p, stls, slugToAppId(apps), tail, settings)
+          (rolled.keySet ++ tailSecs.keySet).iterator.flatMap { id =>
+            val secs =
+              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + tailSecs.getOrElse(id, 0L)
+            val mins = (secs / 60L).toInt
+            if mins != 0 then Some(id -> mins) else None
+          }.toMap
+        }
+    }
+
+  private def slugToAppId(apps: List[wifihaven.shared.App]): Map[String, AppId] =
+    apps.map(a => a.slug -> a.id).toMap
+
+  private def toMinutes(secs: Map[AppId, Long]): Map[AppId, Int] =
+    secs.view.mapValues(s => (s / 60L).toInt).filter(_._2 != 0).toMap
 }
 
 object AppUsedRollupService {

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -1,0 +1,92 @@
+package wifihaven.api.usage
+
+import wifihaven.api.db.*
+import wifihaven.shared.HouseholdSettings
+import wifihaven.shared.types.{AppId, ProfileId}
+import zio.*
+
+import java.time.{Instant, LocalDate}
+
+/**
+ * #1516 (sub-issue of #1510): the read accessor for per-(profile, app, date) **engaged minutes** —
+ * the gap-bridged, cross-host, cap-relevant per-app figure. It is the per-app counterpart of the
+ * `time_used_daily` read path in [[wifihaven.api.policy.TimeStatusServiceLive]] and composes the
+ * SAME rolled + live-tail way:
+ *
+ *   engaged_seconds(rows for `date` with period_start <  rolled_through)   ← `app_used_daily` (V53)
+ *   + live_aggregate(this app's host-set over rows with period_start >= rolled_through)
+ *
+ * floored to minutes once at the end (floor-of-sum, never floor-then-sum). For today it reads the
+ * rollup + a small tail; on a cache miss (no app rolled for the profile yet) or for past dates it
+ * falls through to the all-live path, so the result is identical to a full live aggregation.
+ *
+ * ── Reconciliation invariant (the #1517 graph series will rely on this) ─────────────────────────
+ * Every per-app number is derived from the ONE per-app primitive
+ * [[TimeStatusService.appSecondsByApp]] → [[wifihaven.api.presence.Presence.appSecondsForProfile]],
+ * so for a profile + date:
+ *
+ *   - '''rollup ⇄ cap''' (EXACT): this accessor's per-app minutes equal the per-app cap aggregate
+ *     ([[wifihaven.api.policy.TimeStatusService.siteDayStates]] /
+ *     `Presence.patternGroupMinutesForProfile`) — same primitive, same floor-of-sum.
+ *   - '''rolled+tail ⇄ live''' (EXACT): rolled + tail equals the all-live computation in seconds,
+ *     because presence buckets are 5-min granular and disjoint on either side of the watermark
+ *     (same argument as `time_used_daily`; watermarks land in idle gaps so no session straddles).
+ *   - '''per-app sum ⇄ profile total''' (RESTRICTED equality): `Σ_app engagedSeconds(app)` equals
+ *     the profile daily total ([[TimeStatusService.usedSecondsForProfile]]) ONLY when every counted
+ *     second belongs to a single, non-exempt-from-daily app and the apps do not overlap in
+ *     wall-clock per device (and, cross-device, under `Sum`). In general the per-app sum may exceed
+ *     the profile total: (a) `exempt_from_daily` apps add to the per-app series but NOT the profile
+ *     total, (b) apps overlapping in the same window are deduped in the total but counted once per
+ *     app, and (c) non-app traffic adds to the total but to no app row. The headline daily total
+ *     remains `time_used_daily`; this accessor is the per-app decomposition, not a partition of it.
+ */
+trait AppUsedRollupService {
+
+  /**
+   * Per-app engaged minutes for `profileId` on the household-local `date` containing `now`. Apps with
+   * zero engaged minutes are absent from the map. Keyed by `apps.id`, matching the `app_used_daily`
+   * rollup the per-app series reads.
+   */
+  def appEngagedMinutes(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Map[AppId, Int]]
+}
+
+class AppUsedRollupServiceLive(
+    profileRepo: ProfileRepo,
+    deviceRepo: DeviceRepo,
+    siteTimeLimitRepo: SiteTimeLimitRepo,
+    appRepo: AppRepo,
+    trafficRepo: TrafficReportRepo,
+    rollupRepo: AppUsedRollupRepo,
+) extends AppUsedRollupService {
+
+  def appEngagedMinutes(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Map[AppId, Int]] =
+    // #1516: STUB — the rolled + tail / all-live aggregation lands in the adoption commit. The deps
+    // are touched so the wiring (and the unused-params lint) is satisfied; the result is empty.
+    for {
+      _ <- profileRepo.findById(profileId)
+      _ <- deviceRepo.listAll
+      _ <- siteTimeLimitRepo.listForProfile(profileId)
+      _ <- appRepo.listAll
+      _ <- trafficRepo.listPresenceRows(Nil, date)
+      _ <- rollupRepo.getDayForProfile(profileId, date)
+      _ = (now, settings)
+    } yield Map.empty
+}
+
+object AppUsedRollupService {
+  val layer: ZLayer[
+    ProfileRepo & DeviceRepo & SiteTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
+    Nothing,
+    AppUsedRollupService,
+  ] = ZLayer.fromFunction(AppUsedRollupServiceLive(_, _, _, _, _, _))
+}

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -6,6 +6,7 @@ import wifihaven.api.db.{
   DeviceRepo,
   HouseholdSettingsRepo,
   ProfileRepo,
+  RolledAppDay,
   RolledDay,
   RollupRepo,
   SiteTimeLimitRepo,
@@ -14,7 +15,7 @@ import wifihaven.api.db.{
 }
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.Clock
-import wifihaven.shared.types.ProfileId
+import wifihaven.shared.types.{AppId, ProfileId}
 import zio.*
 
 import java.time.{Duration, Instant}
@@ -167,38 +168,57 @@ object TimeUsedRollupJob {
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
-  ): Task[Int] = {
-    // #1516: per-(profile, app) engaged-seconds rollup is wired into this tick in the adoption
-    // commit (it derives from TimeStatusService.appSecondsByApp, the single per-app primitive, and
-    // upserts app_used_daily with the same `now` watermark as the profile total). This stub keeps
-    // the wiring/signature in place while writing only the profile total.
-    val _ = (appRollup, appRepo)
-    for {
-      settings <- hs.get
-      today = PolicyService.householdLocalDate(now, settings)
-      profiles <- profileRepo.listAll
-      devices  <- deviceRepo.listAll
-      stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
-      presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-      perProfile: Map[ProfileId, RolledDay] = {
-        val stlMap  = stlsP.toMap
-        val devsByP =
-          devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
-        profiles.iterator.map { p =>
-          val devs = devsByP.getOrElse(p.id, Nil)
-          val mac  = devs.map(_.mac).toSet
-          val pres = presence.filter(r => mac.contains(r.mac))
-          val secs = TimeStatusService.usedSecondsForProfile(
-            p,
-            devs,
-            stlMap.getOrElse(p.id, Nil),
-            pres,
-            settings,
-          )
-          p.id -> RolledDay(secs, now)
-        }.toMap
-      }
-      n <- rollup.upsertBatch(today, perProfile)
-    } yield n
+  ): Task[Int] = for {
+    settings <- hs.get
+    today = PolicyService.householdLocalDate(now, settings)
+    profiles <- profileRepo.listAll
+    devices  <- deviceRepo.listAll
+    apps     <- appRepo.listAll
+    stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+    presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
+    rolls = computeRolls(profiles, devices, apps, stlsP.toMap, presence, settings, now)
+    n <- rollup.upsertBatch(today, rolls._1)
+    _ <- appRollup.upsertBatch(today, rolls._2)
+  } yield n
+
+  // Pure: collapse one presence batch into both the per-profile total roll (`time_used_daily`) and
+  // the per-(profile, app) engaged roll (`app_used_daily`), stamped with the same `now` watermark so
+  // the two compose identically (rolled + tail). The per-app figure derives from the SINGLE per-app
+  // primitive (`TimeStatusService.appSecondsByApp` → `Presence.appSecondsForProfile`), so the rollup
+  // reconciles exactly with the per-app cap and the per-app series. Only apps with engaged activity
+  // get a row (zero-activity apps are absent).
+  private def computeRolls(
+      profiles: List[wifihaven.shared.Profile],
+      devices: List[wifihaven.shared.Device],
+      apps: List[wifihaven.shared.App],
+      stlMap: Map[ProfileId, List[wifihaven.shared.SiteTimeLimit]],
+      presence: List[wifihaven.api.presence.PresenceRow],
+      settings: wifihaven.shared.HouseholdSettings,
+      now: Instant,
+  ): (Map[ProfileId, RolledDay], Map[(ProfileId, AppId), RolledAppDay]) = {
+    val devsByP     =
+      devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+    val slugToAppId = apps.map(a => a.slug -> a.id).toMap
+    def presFor(pid: ProfileId): List[wifihaven.api.presence.PresenceRow] = {
+      val mac = devsByP.getOrElse(pid, Nil).map(_.mac).toSet
+      presence.filter(r => mac.contains(r.mac))
+    }
+    val perProfile = profiles.iterator.map { p =>
+      val secs = TimeStatusService.usedSecondsForProfile(
+        p,
+        devsByP.getOrElse(p.id, Nil),
+        stlMap.getOrElse(p.id, Nil),
+        presFor(p.id),
+        settings,
+      )
+      p.id -> RolledDay(secs, now)
+    }.toMap
+    val perApp     = profiles.iterator.flatMap { p =>
+      TimeStatusService
+        .appSecondsByApp(p, stlMap.getOrElse(p.id, Nil), slugToAppId, presFor(p.id), settings)
+        .iterator
+        .map { case (appId, secs) => (p.id, appId) -> RolledAppDay(secs, now) }
+    }.toMap
+    (perProfile, perApp)
   }
 }

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -1,6 +1,8 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.{
+  AppRepo,
+  AppUsedRollupRepo,
   DeviceRepo,
   HouseholdSettingsRepo,
   ProfileRepo,
@@ -55,10 +57,12 @@ object TimeUsedRollupJob {
    */
   def loop(
       rollup: TimeUsedRollupRepo,
+      appRollup: AppUsedRollupRepo,
       runs: RollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
+      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
@@ -66,7 +70,18 @@ object TimeUsedRollupJob {
     runOnce(
       runs,
       clock,
-      now => doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now),
+      now =>
+        doTick(
+          rollup,
+          appRollup,
+          profileRepo,
+          deviceRepo,
+          siteTimeLimitRepo,
+          appRepo,
+          trafficRepo,
+          hs,
+          now,
+        ),
     )
       .repeat(Schedule.fixed(Interval))
       .unit
@@ -78,13 +93,26 @@ object TimeUsedRollupJob {
    */
   def oneTickForTest(
       rollup: TimeUsedRollupRepo,
+      appRollup: AppUsedRollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
+      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
-  ): Task[Int] = doTick(rollup, profileRepo, deviceRepo, siteTimeLimitRepo, trafficRepo, hs, now)
+  ): Task[Int] =
+    doTick(
+      rollup,
+      appRollup,
+      profileRepo,
+      deviceRepo,
+      siteTimeLimitRepo,
+      appRepo,
+      trafficRepo,
+      hs,
+      now,
+    )
 
   // ── internals ──────────────────────────────────────────────────────────────
 
@@ -131,37 +159,46 @@ object TimeUsedRollupJob {
   // bucket granularity (5 min); the next tick re-rolls with a fresh `now` and supersedes the row.
   private def doTick(
       rollup: TimeUsedRollupRepo,
+      appRollup: AppUsedRollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
+      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
-  ): Task[Int] = for {
-    settings <- hs.get
-    today = PolicyService.householdLocalDate(now, settings)
-    profiles <- profileRepo.listAll
-    devices  <- deviceRepo.listAll
-    stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
-    presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-    perProfile: Map[ProfileId, RolledDay] = {
-      val stlMap  = stlsP.toMap
-      val devsByP =
-        devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
-      profiles.iterator.map { p =>
-        val devs = devsByP.getOrElse(p.id, Nil)
-        val mac  = devs.map(_.mac).toSet
-        val pres = presence.filter(r => mac.contains(r.mac))
-        val secs = TimeStatusService.usedSecondsForProfile(
-          p,
-          devs,
-          stlMap.getOrElse(p.id, Nil),
-          pres,
-          settings,
-        )
-        p.id -> RolledDay(secs, now)
-      }.toMap
-    }
-    n <- rollup.upsertBatch(today, perProfile)
-  } yield n
+  ): Task[Int] = {
+    // #1516: per-(profile, app) engaged-seconds rollup is wired into this tick in the adoption
+    // commit (it derives from TimeStatusService.appSecondsByApp, the single per-app primitive, and
+    // upserts app_used_daily with the same `now` watermark as the profile total). This stub keeps
+    // the wiring/signature in place while writing only the profile total.
+    val _ = (appRollup, appRepo)
+    for {
+      settings <- hs.get
+      today = PolicyService.householdLocalDate(now, settings)
+      profiles <- profileRepo.listAll
+      devices  <- deviceRepo.listAll
+      stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
+      perProfile: Map[ProfileId, RolledDay] = {
+        val stlMap  = stlsP.toMap
+        val devsByP =
+          devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
+        profiles.iterator.map { p =>
+          val devs = devsByP.getOrElse(p.id, Nil)
+          val mac  = devs.map(_.mac).toSet
+          val pres = presence.filter(r => mac.contains(r.mac))
+          val secs = TimeStatusService.usedSecondsForProfile(
+            p,
+            devs,
+            stlMap.getOrElse(p.id, Nil),
+            pres,
+            settings,
+          )
+          p.id -> RolledDay(secs, now)
+        }.toMap
+      }
+      n <- rollup.upsertBatch(today, perProfile)
+    } yield n
+  }
 }

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -198,7 +198,7 @@ object TimeUsedRollupJob {
   ): (Map[ProfileId, RolledDay], Map[(ProfileId, AppId), RolledAppDay]) = {
     val devsByP     =
       devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
-    val slugToAppId = apps.map(a => a.slug -> a.id).toMap
+    val slugToAppId = TimeStatusService.slugToAppId(apps)
     def presFor(pid: ProfileId): List[wifihaven.api.presence.PresenceRow] = {
       val mac = devsByP.getOrElse(pid, Nil).map(_.mac).toSet
       presence.filter(r => mac.contains(r.mac))

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -181,7 +181,8 @@ object TestDatabase {
     TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & NamedScheduleRepo &
       HouseholdSettingsRepo & GlobalPolicyRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
       BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & RouterRepo & TrafficReportRepo &
-      BlockEventRepo & ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo
+      BlockEventRepo & ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo &
+      AppUsedRollupRepo
 
   val layer: ZLayer[Any, Throwable, EmbeddedPostgres & TestDb & Transactor[Task] & AllRepos] = {
     val pg = embeddedPg

--- a/api/test/src/feature/AppUsedRollupSpec.scala
+++ b/api/test/src/feature/AppUsedRollupSpec.scala
@@ -20,8 +20,8 @@ import java.time.{LocalDate, LocalDateTime, ZoneOffset}
  *   - rollup ⇄ cap (EXACT): a multi-host app's engaged minutes via the reader equal the single
  *     per-app primitive (`Presence.appSecondsForProfile`, surfaced as the per-app cap aggregate
  *     `SiteDayState.usedMinutes`), including cross-host idle-gap bridging.
- *   - rolled+tail ⇄ live (EXACT): a planted rollup row + the live tail past the watermark sum to the
- *     all-live computation, with the watermark landing in an idle gap.
+ *   - rolled+tail ⇄ live (EXACT): a planted rollup row + the live tail past the watermark sum to
+ *     the all-live computation, with the watermark landing in an idle gap.
  *   - per-app sum ⇄ profile total (restricted equality): for non-exempt, non-overlapping apps with
  *     no non-app traffic, Σ app_used_daily.engaged_seconds == time_used_daily.used_seconds.
  *   - the re-aggregation tick is idempotent.
@@ -125,7 +125,9 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
     } yield upd
 
   def spec = suite("AppUsedRollupSpec (#1516)")(
-    test("multi-host app: reader engaged-minutes == per-app cap aggregate, with cross-host bridge") {
+    test(
+      "multi-host app: reader engaged-minutes == per-app cap aggregate, with cross-host bridge",
+    ) {
       // social.com @08:00 (5 min) then cdn.social.net @08:10 (5 min). The 300 s cross-host idle gap
       // is < the effective gap (2×R = 600 s for 300 s buckets), so the two different hosts of the
       // SAME app bridge into one [08:00, 08:15] engaged span = 15 min — NOT 5+5. The reader and the
@@ -156,7 +158,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         // The per-app cap aggregate (SiteDayState.usedMinutes) for the same app.
         tsvc   <- makeTimeService
         state  <- tsvc.dayStateLive(now, today, s, kid)
-        capMin  = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
+        capMin = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
       } yield assertTrue(perApp.get(app).contains(15)) &&
         assertTrue(capMin.contains(15))
     },
@@ -216,10 +218,10 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "a.com", today, 10, 8 * 60)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "b.com", today, 15, 9 * 60)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _        <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
-        timeRow  <- ru.getDayForProfile(kid, today)
-        appRows  <- aru.getDayForProfile(kid, today)
-        appSum    = appRows.values.map(_.engagedSeconds).sum
+        _       <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        timeRow <- ru.getDayForProfile(kid, today)
+        appRows <- aru.getDayForProfile(kid, today)
+        appSum = appRows.values.map(_.engagedSeconds).sum
       } yield assertTrue(timeRow.exists(_.usedSeconds == 1500L)) &&
         assertTrue(appSum == 1500L) &&
         assertTrue(appRows.size == 2)
@@ -244,9 +246,9 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         today = LocalDate.of(2025, 1, 6)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:63", "youtube.com", today, 20, 8 * 60)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _     <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
-        first <- aru.getDayForProfile(kid, today)
-        _     <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        first  <- aru.getDayForProfile(kid, today)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
         second <- aru.getDayForProfile(kid, today)
       } yield assertTrue(first.nonEmpty) && assertTrue(first == second)
     },

--- a/api/test/src/feature/AppUsedRollupSpec.scala
+++ b/api/test/src/feature/AppUsedRollupSpec.scala
@@ -1,0 +1,254 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.usage.{AppUsedRollupServiceLive, TimeUsedRollupJob}
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+/**
+ * #1516 (sub-issue of #1510, App-level usage aggregation): the per-(profile, app, date) engaged-
+ * minutes rollup builder + read accessor. These feature tests assert the reconciliation invariant
+ * the per-app series (#1517) relies on, against embedded Postgres (no repo mocks):
+ *
+ *   - rollup ⇄ cap (EXACT): a multi-host app's engaged minutes via the reader equal the single
+ *     per-app primitive (`Presence.appSecondsForProfile`, surfaced as the per-app cap aggregate
+ *     `SiteDayState.usedMinutes`), including cross-host idle-gap bridging.
+ *   - rolled+tail ⇄ live (EXACT): a planted rollup row + the live tail past the watermark sum to the
+ *     all-live computation, with the watermark landing in an idle gap.
+ *   - per-app sum ⇄ profile total (restricted equality): for non-exempt, non-overlapping apps with
+ *     no non-app traffic, Σ app_used_daily.engaged_seconds == time_used_daily.used_seconds.
+ *   - the re-aggregation tick is idempotent.
+ */
+object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makeReader: ZIO[
+    ProfileRepo & DeviceRepo & SiteTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
+    Nothing,
+    AppUsedRollupServiceLive,
+  ] =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      dr  <- ZIO.service[DeviceRepo]
+      stl <- ZIO.service[SiteTimeLimitRepo]
+      ar  <- ZIO.service[AppRepo]
+      trr <- ZIO.service[TrafficReportRepo]
+      aru <- ZIO.service[AppUsedRollupRepo]
+    } yield new AppUsedRollupServiceLive(pr, dr, stl, ar, trr, aru)
+
+  private def makeTimeService: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo,
+    Nothing,
+    TimeStatusService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ru   <- ZIO.service[TimeUsedRollupRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-app", Sha256Hex.unsafe("a" * 64)))
+
+  // A registered app with `slug` and an explicit host-set, assigned `time_limited` to the profile.
+  private def seedApp(
+      appRepo: AppRepo,
+      profileId: ProfileId,
+      slug: String,
+      hosts: List[String],
+      dailyMinutes: Int,
+      exemptFromDaily: Boolean = false,
+  ): Task[AppId] =
+    for {
+      id <- appRepo.create(slug, slug, None, None)
+      _  <- appRepo.setHosts(id, hosts.map(Hostname.unsafe))
+      _  <- appRepo.upsertAssignment(
+        id,
+        profileId,
+        AppMode.TimeLimited,
+        Some(dailyMinutes),
+        exemptFromDaily,
+      )
+    } yield id
+
+  // `minutes/5` consecutive 5-min fully-active buckets starting `startOffsetMin` after midnight UTC.
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+      startOffsetMin: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = date.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(startOffsetMin * 60L)
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def setTz(hsr: HouseholdSettingsRepo, tz: String): Task[HouseholdSettings] =
+    for {
+      cur <- hsr.get
+      upd = cur.copy(dailyResetTz = java.time.ZoneId.of(tz))
+      _ <- hsr.update(upd)
+    } yield upd
+
+  def spec = suite("AppUsedRollupSpec (#1516)")(
+    test("multi-host app: reader engaged-minutes == per-app cap aggregate, with cross-host bridge") {
+      // social.com @08:00 (5 min) then cdn.social.net @08:10 (5 min). The 300 s cross-host idle gap
+      // is < the effective gap (2×R = 600 s for 300 s buckets), so the two different hosts of the
+      // SAME app bridge into one [08:00, 08:15] engaged span = 15 min — NOT 5+5. The reader and the
+      // per-app cap aggregate must both read that bridged 15.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        stl <- ZIO.service[SiteTimeLimitRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:60", "kid", kid)
+        app <- seedApp(ar, kid, "social", List("social.com", "cdn.social.net"), 60)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:60", "social.com", today, 5, 8 * 60)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:60", "cdn.social.net", today, 5, 8 * 60 + 10)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        reader <- makeReader
+        perApp <- reader.appEngagedMinutes(now, today, s, kid)
+        // The per-app cap aggregate (SiteDayState.usedMinutes) for the same app.
+        tsvc   <- makeTimeService
+        state  <- tsvc.dayStateLive(now, today, s, kid)
+        capMin  = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
+      } yield assertTrue(perApp.get(app).contains(15)) &&
+        assertTrue(capMin.contains(15))
+    },
+    test("rolled + live-tail across the watermark == all-live engaged minutes") {
+      // youtube.com active 08:00–08:25 then 10:00–10:30. Watermark 09:00 lands in the idle gap, so
+      // no session straddles it: rolled (25 min) + tail (30 min) == all-live (55 min).
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:61", "kid", kid)
+        app <- seedApp(ar, kid, "yt", List("youtube.com"), 240)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:61", "youtube.com", today, 25, 8 * 60)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:61", "youtube.com", today, 30, 10 * 60)
+        now       = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        watermark = LocalDateTime.of(2025, 1, 6, 9, 0).toInstant(ZoneOffset.UTC)
+        reader   <- makeReader
+        // Rollup empty → all-live path.
+        live     <- reader.appEngagedMinutes(now, today, s, kid)
+        // Plant the rolled prefix (the 25-min first window) and read via rolled+tail.
+        _        <- aru.upsertDay(kid, app, today, RolledAppDay(25L * 60L, watermark))
+        composed <- reader.appEngagedMinutes(now, today, s, kid)
+      } yield assertTrue(live.get(app).contains(55)) &&
+        assertTrue(composed.get(app).contains(55))
+    },
+    test("per-app rollup sum == profile total for non-exempt, non-overlapping apps") {
+      // Two non-exempt apps, single device, Sum mode, disjoint windows and no non-app traffic — the
+      // restricted case where the per-app series partitions the profile total exactly. Both rollups
+      // are written by the same tick from the same presence batch.
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        stl <- ZIO.service[SiteTimeLimitRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        _   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:62", "kid", kid)
+        _   <- seedApp(ar, kid, "a", List("a.com"), 60)
+        _   <- seedApp(ar, kid, "b", List("b.com"), 60)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "a.com", today, 10, 8 * 60)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "b.com", today, 15, 9 * 60)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        _        <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        timeRow  <- ru.getDayForProfile(kid, today)
+        appRows  <- aru.getDayForProfile(kid, today)
+        appSum    = appRows.values.map(_.engagedSeconds).sum
+      } yield assertTrue(timeRow.exists(_.usedSeconds == 1500L)) &&
+        assertTrue(appSum == 1500L) &&
+        assertTrue(appRows.size == 2)
+    },
+    test("re-running the aggregation tick is idempotent") {
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        stl <- ZIO.service[SiteTimeLimitRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        _   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:63", "kid", kid)
+        _   <- seedApp(ar, kid, "yt", List("youtube.com"), 240)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:63", "youtube.com", today, 20, 8 * 60)
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        _     <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        first <- aru.getDayForProfile(kid, today)
+        _     <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        second <- aru.getDayForProfile(kid, today)
+      } yield assertTrue(first.nonEmpty) && assertTrue(first == second)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -79,10 +79,12 @@ object MetricsExportSpec
       (for {
         _              <- cleanDb
         timeRollupRepo <- ZIO.service[TimeUsedRollupRepo]
+        appRollupRepo  <- ZIO.service[AppUsedRollupRepo]
         rollupRepo     <- ZIO.service[RollupRepo]
         profileRepo    <- ZIO.service[ProfileRepo]
         deviceRepo     <- ZIO.service[DeviceRepo]
         stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+        appRepo        <- ZIO.service[AppRepo]
         trafficRepo    <- ZIO.service[TrafficReportRepo]
         hsRepo         <- ZIO.service[HouseholdSettingsRepo]
         clock          <- ZIO.service[Clock]
@@ -91,10 +93,12 @@ object MetricsExportSpec
         fiber          <- TimeUsedRollupJob
           .loop(
             timeRollupRepo,
+            appRollupRepo,
             rollupRepo,
             profileRepo,
             deviceRepo,
             stlRepo,
+            appRepo,
             trafficRepo,
             hsRepo,
             clock,

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -148,6 +148,8 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         sr  <- ZIO.service[ScheduleRepo]
         dr  <- ZIO.service[DeviceRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        ar  <- ZIO.service[AppRepo]
         trr <- ZIO.service[TrafficReportRepo]
         stl <- ZIO.service[SiteTimeLimitRepo]
         s   <- setTz(hsr, "UTC")
@@ -159,7 +161,7 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
         svc    <- makeService
         live   <- svc.dayStateAllLive(now, today, s)
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
         cached <- svc.dayStateAll(now, today, s)
       } yield assertTrue(cached(kid).usedMinutes == live(kid).usedMinutes) &&
         assertTrue(live(kid).usedMinutes == 40)
@@ -234,6 +236,8 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         sr  <- ZIO.service[ScheduleRepo]
         dr  <- ZIO.service[DeviceRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
+        aru <- ZIO.service[AppUsedRollupRepo]
+        ar  <- ZIO.service[AppRepo]
         trr <- ZIO.service[TrafficReportRepo]
         stl <- ZIO.service[SiteTimeLimitRepo]
         _   <- setTz(hsr, "UTC")
@@ -249,12 +253,12 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 0)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 20)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _           <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
         before      <- ru.getDayForProfile(kid, today)
         cur         <- hsr.get
         _           <- hsr.update(cur.copy(presenceContinuationSeconds = 900))
         invalidated <- ru.getDayForProfile(kid, today)
-        _           <- TimeUsedRollupJob.oneTickForTest(ru, pr, dr, stl, trr, hsr, now)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
         after       <- ru.getDayForProfile(kid, today)
       } yield assertTrue(before.exists(_.usedSeconds == 600L)) &&
         assertTrue(invalidated.isEmpty) &&

--- a/docs/design/presence-tuning.md
+++ b/docs/design/presence-tuning.md
@@ -404,6 +404,33 @@ toggle back to the legacy `max(activeSeconds)` path, so there is no
 as it already is for the heartbeat settings, so the next rollup refills with the
 new semantics.
 
+#### Per-app rollup (`app_used_daily`, V53 / #1516)
+
+`app_used_daily` is the **per-(profile, app, date)** counterpart of
+`time_used_daily`: it caches each app's gap-bridged **engaged seconds** with the
+same `rolled_through` watermark, so the two compose identically (rolled + live
+tail). `TimeUsedRollupJob` writes both in one tick from one presence batch, and
+both are `DELETE`-invalidated together by a `household_settings` change. The
+per-app figure derives from the **single** per-app primitive
+(`Presence.appSecondsForProfile`, surfaced as `TimeStatusService.appSecondsByApp`),
+which is also what the per-app cap (#1505) ticks on — so:
+
+- **rollup ⇄ cap** (exact): `AppUsedRollupService.appEngagedMinutes` equals the
+  per-app cap aggregate (`SiteDayState.usedMinutes`), same primitive, same
+  floor-of-sum.
+- **rolled+tail ⇄ live** (exact): same watermark-decomposition argument as
+  `time_used_daily` — the watermark lands in an idle gap so no engaged span
+  straddles it.
+- **per-app sum ⇄ profile total** (restricted equality): `Σ_app engaged_seconds`
+  equals `time_used_daily.used_seconds` only when every counted second belongs to
+  a single, non-exempt, non-overlapping app with no non-app traffic. In general
+  the per-app sum may exceed the profile total (exempt apps, cross-app overlap,
+  and non-app traffic break strict equality). The headline daily total stays
+  `time_used_daily`; the per-app rollup is a decomposition, not a partition.
+
+This is the reconciliation invariant the per-app graph series (#1517) reads
+through: profile total ⇄ per-app rollup ⇄ per-app series.
+
 ## 5. Implementation sub-issues to file
 
 > File these against the Tuning epic (#1445). The eventual tuning change ships


### PR DESCRIPTION
Implements the **aggregation/rollup half** of #1510 (App-Centric Model epic): the code that **writes and reads** the per-`(profile, app, date)` `app_used_daily` table shipped schema-only via #1516 (V53, PR #1548). Builds on #1514's `appSecondsForProfile` as the single source of per-app engaged time.

## What this does
- **`AppUsedRollupRepo`** (`app_used_daily`) — watermarked per-app engaged-seconds rows, idempotent upsert, mirroring `TimeUsedRollupRepo` (`time_used_daily`, V43/#1160).
- **`TimeUsedRollupJob`** now writes `app_used_daily` in the **same tick / cadence** as `time_used_daily`, from one presence batch and one `now` watermark, so the two rolls compose identically (rolled + live tail).
- **`AppUsedRollupService.appEngagedMinutes`** — read accessor returning per-app engaged **minutes** for a profile+date: rolled engaged-seconds + a live tail of buckets past the watermark, floored to minutes once (floor-of-sum); cache-miss / past-date falls through to all-live.
- **`TimeStatusService.appSecondsByApp`** — the single per-app seconds primitive, keyed to `apps.id`, derived from `Presence.appSecondsForProfile` (#1514). No re-implemented app-time math (avoids the #1532 divergence class).
- `household_settings` changes invalidate `app_used_daily` alongside `time_used_daily`.

## Reconciliation invariant (documented in `AppUsedRollupService` scaladoc + `docs/design/presence-tuning.md`)
The invariant #1517 (graph series) will read through — **profile total ⇄ per-app rollup ⇄ per-app series**:
- **rollup ⇄ cap** — *exact*: the reader's per-app minutes equal the per-app cap aggregate (`SiteDayState.usedMinutes` / `patternGroupMinutesForProfile`), same primitive, same floor-of-sum.
- **rolled+tail ⇄ live** — *exact*: same watermark-decomposition argument as `time_used_daily` (watermark lands in an idle gap, no engaged span straddles it).
- **per-app sum ⇄ profile total** — *restricted equality*: `Σ_app engaged_seconds == time_used_daily.used_seconds` only for non-exempt, non-overlapping apps with no non-app traffic. In general the per-app sum may exceed the total (exempt-from-daily apps, cross-app overlap, and non-app traffic break strict equality). The headline daily total stays `time_used_daily`; the per-app rollup is a decomposition, not a partition.

## Prod-volume safety
The read/write path touches only the **bounded** rollup table + a small live tail (mirrors `time_used_daily`); it does **not** add any per-request scan over `traffic_reports` / `connection_events`. No new index needed.

## Tests (TDD — red commit `ce5115b`, green commit `6e09c93`)
`api/test/src/feature/AppUsedRollupSpec.scala`, embedded-Postgres feature tests (no repo mocks):
- multi-host app: reader engaged-minutes == per-app cap aggregate, with cross-host idle-gap bridging
- rolled + live-tail across the watermark == all-live engaged minutes
- per-app rollup sum == profile total for non-exempt, non-overlapping apps
- re-running the aggregation tick is idempotent

`mill api.test` is fully green (incl. updated `TimeUsedRollupSpec`/`MetricsExportSpec` for the job signature); `scalafmt --check` clean.

## Deferred (explicitly out of scope — separate issues)
- #1517 — graph-series wiring (will consume `appEngagedMinutes`)
- #1518 — App-vs-Site identifier naming pass
- #1519 — dropping the "Other" bucket / presentation
- #1526 — per-site → per-app rename

## Constraints honored
No migration in this PR (schema already shipped via #1516); no wire-shape change to existing endpoints; diff limited to `api/src`, `api/test`, and one design-doc update.

Links: #1510 · #1516 · #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)