### PR TITLE
docs(#1561): single-source-of-truth — never duplicate a decision/computation path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,56 @@ Field IDs and option IDs are discoverable with
 - **Formatting**: `scalafmt` enforced in CI. Run `mill __.reformat` before committing.
 - **Imports**: managed by `scalafix OrganizeImports`. Run `mill __.fix` before committing.
 
+## Single source of truth — never duplicate a decision or computation {#single-source-of-truth}
+
+**The same logical quantity or decision must be computed in exactly ONE
+place; every other consumer calls it.** "Minutes used today", "is this MAC
+blocked", "the block reason", "engaged seconds for an app", a wire reason
+string — each of these is one function, not a pattern re-derived at each
+call site. Duplicated logic drifts: one copy gets updated, the others don't,
+and the surfaces silently disagree. Every recent prod incident in this class
+was a divergence — [#1531](https://github.com/wifihaven/wifihaven/issues/1531)
+(displayed daily total didn't subtract exempt-from-daily app time while the
+cap-evaluation path did) and
+[#1539](https://github.com/wifihaven/wifihaven/issues/1539) (the SPA schedule
+chip read a dead legacy table while enforcement read named schedules) were
+both display-vs-enforcement drift.
+
+- **Reuse the existing primitive — don't re-derive.** Before adding a new
+  path that computes such a value, search for the one that already does it
+  and call it. The canonical ones present today include
+  `TimeStatusService`'s day-state / `usedSecondsForProfile` /
+  `usedSecondsByMac`, `Presence.appSecondsForProfile`, and
+  `BlockReason.asWire` / `BlockReason.fromWire` for wire reason strings.
+- **Resolve unavoidable proximity two ways.** **COLLAPSE** — extract a shared
+  function, or have one path call the other. Or **TYPE-ENFORCE** — a shared
+  sealed type, or a wire round-trip the compiler keeps exhaustive (e.g.
+  `BlockReason.asWire`/`fromWire`). Treat any `must mirror X` / `same branch
+  as Y` / `keep in sync` comment as a defect to remove, not a pattern to
+  copy.
+- **If two paths genuinely must stay separate, ACCEPT + TEST-PIN.** Add a
+  test that fails the moment they diverge, so the coupling is enforced by CI
+  rather than by a comment.
+- **Carve-out — intentional wire-shape redundancy is NOT a violation.** Where
+  the architecture *mandates* duplication on the wire — the infra allowlist
+  copied into every profile's `extraAllowed`
+  ([#1311](https://github.com/wifihaven/wifihaven/issues/1311)), or the
+  `profiles` map as a wire dedup aid — that is the correct shape, not a
+  divergence to collapse. See the **"Redundancy and wire-shape are separate
+  concerns"** bullet under the Architectural model above; this rule and that
+  one are consistent — wire-shape duplication is data, not a second copy of a
+  decision.
+
+The worked example and outstanding backlog is the audit umbrella
+[#1532](https://github.com/wifihaven/wifihaven/issues/1532), which already
+drove several collapses:
+[#1544](https://github.com/wifihaven/wifihaven/issues/1544) (`decide()`
+hand-mirrored the whole snapshot fold),
+[#1545](https://github.com/wifihaven/wifihaven/issues/1545) (block-reason
+strings in three hand-written copies, fixing a live mislabel), and
+[#1546](https://github.com/wifihaven/wifihaven/issues/1546) (per-device totals
+recomputed off the canonical total, fixing a live over-count).
+
 ## Prefer declarative config over dashboard toggles
 
 Anywhere a piece of infrastructure can be configured declaratively in-repo


### PR DESCRIPTION
Closes #1561. Part of the #1532 audit thread.

## What
Adds a new **"Single source of truth — never duplicate a decision or computation"** subsection under *Coding conventions* in `AGENTS.md`. The convention:

- Each logical quantity/decision ("minutes used today", "is this MAC blocked", "the block reason", "engaged seconds for an app", a wire reason string) is computed in exactly ONE place; all other consumers call it.
- Reuse the existing primitive before re-deriving (names the real ones: `TimeStatusService` day-state / `usedSecondsForProfile` / `usedSecondsByMac`, `Presence.appSecondsForProfile`, `BlockReason.asWire`/`fromWire`).
- Resolve proximity by **COLLAPSE** or **TYPE-ENFORCE**; treat "must mirror"/"keep in sync" comments as defects. If two paths must stay separate, **ACCEPT + TEST-PIN**.
- Carve-out: intentional **wire-shape** redundancy the architecture mandates (infra allowlist → every profile's `extraAllowed`, #1311; the `profiles` dedup map) is NOT a violation — cross-references the existing "Redundancy and wire-shape are separate concerns" callout so the two stay consistent.
- Cites the worked examples: prod bugs #1531 and #1539, and the #1532 audit umbrella (#1544/#1545/#1546).

## Scope
Docs-only — no code, no migration. `CLAUDE.md` is a symlink to `AGENTS.md`, so the two cannot drift (fitting, given the topic).