### PR TITLE
docs(#1563): standard PR review checklist + AGENTS rule (independent review every PR)

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,15 @@
+---
+description: Independent, read-only adversarial review of a PR using the standard WifiHaven checklist
+---
+
+Run the standard WifiHaven **independent PR review** pass. Load the full
+checklist and follow it verbatim:
+
+@docs/pr-review-checklist.md
+
+Review the PR referenced in `$ARGUMENTS` (a PR number, or the current branch if
+empty). Read the PR body and the diff (`gh pr diff <n>`, or local
+`git diff origin/main...HEAD` — three-dot merge-base, never two-dot). Review
+ONLY the changes, cite `file:line`, classify every finding BLOCKER / SHOULD-FIX
+/ NIT, do not modify files, and end with VERDICT: APPROVE or REQUEST-CHANGES
+(never APPROVE with an open BLOCKER) plus a 3-line summary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,6 +789,20 @@ For any new feature or bug fix, follow test-driven development:
 
 This applies to both unit tests and feature tests — pick whichever level fits the change (see "Testing philosophy" below).
 
+## Independent PR review (required before merge) {#independent-pr-review}
+
+**Every PR gets an independent review pass before merge using
+[`docs/pr-review-checklist.md`](docs/pr-review-checklist.md).** Spawn a review
+subagent against the diff (or run `/code-review` / the equivalent review
+command); treat **BLOCKERS as merge-gating**. The author should self-run the
+checklist before opening the PR, but the **independent pass — a separate agent,
+not the author self-reviewing — is the gate.** It is read-only and adversarial:
+the reviewer cites `file:line`, classifies findings BLOCKER / SHOULD-FIX / NIT,
+and ends with APPROVE or REQUEST-CHANGES, never approving with an open BLOCKER.
+The checklist leads with duplicated-logic / single-source-of-truth (see
+[Single source of truth](#single-source-of-truth)) and test-integrity, the two
+failure modes behind our recurring prod incidents.
+
 ## Testing philosophy
 
 ### Feature tests first, unit tests for edge cases only

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -1,0 +1,212 @@
+# Standard PR review checklist (read-only, adversarial)
+
+This is the prompt for the **independent review pass** every WifiHaven PR gets
+before it is authorized to merge (see the *Independent PR review* rule in
+[`AGENTS.md`](../AGENTS.md)). Hand it to a review subagent verbatim, or run the
+equivalent review command (`/code-review`). The reviewer is a **separate
+agent** — not the author self-reviewing. The author self-runs this checklist
+before opening the PR, but the independent pass is the gate.
+
+Our prod incidents cluster around a few recurring failure modes — duplicated
+logic paths that drift ([#1531](https://github.com/wifihaven/wifihaven/issues/1531) /
+[#1539](https://github.com/wifihaven/wifihaven/issues/1539), audit
+[#1532](https://github.com/wifihaven/wifihaven/issues/1532)) and test changes
+that silently hide regressions (the migration-isolation lesson). A consistent,
+checked-in review gate catches them before merge instead of depending on
+whoever happens to look.
+
+> Keep this file in sync with the orchestrator-side prompt in
+> `reference_pr_review_prompt.md` — they are the same review and must not drift.
+
+---
+
+## How to run this review
+
+You are an **independent reviewer** for a PR on the wifihaven repo. Read the PR
+body and the diff:
+
+- GitHub PR: `gh pr diff <n>`.
+- Local branch: diff the **merge base** with three-dot syntax
+  (`git diff origin/main...HEAD`), **never** two-dot — two-dot over-reports when
+  `main` has advanced since the branch diverged.
+
+Review **only** the changes in the diff. Be specific — **cite `file:line`** for
+every finding. **Do NOT modify files** — this is a read-only pass.
+
+Classify every finding:
+
+- **BLOCKER** — must be fixed before merge. Merge-gating.
+- **SHOULD-FIX** — fix now unless there's a good reason not to; reviewer's call.
+- **NIT** — minor / stylistic; non-blocking.
+
+End with **VERDICT: APPROVE** or **VERDICT: REQUEST-CHANGES**. **Never APPROVE
+while an open BLOCKER exists.**
+
+---
+
+## 1. Duplicated logic / single source of truth — HIGHEST priority
+
+Shipped real prod bugs ([#1531](https://github.com/wifihaven/wifihaven/issues/1531) /
+[#1539](https://github.com/wifihaven/wifihaven/issues/1539)); this is the first
+thing to check. Cross-reference the
+[single-source-of-truth convention](../AGENTS.md#single-source-of-truth) added
+in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
+
+- **Re-derivation = BLOCKER.** Does new code compute a quantity or decision that
+  already exists — minutes-used, is-blocked, block-reason, app engaged-seconds,
+  a wire string? If so it MUST call the existing primitive rather than
+  recomputing it. The named primitives:
+  - `TimeStatusService` day-state / `usedSecondsForProfile` / `usedSecondsByMac`
+    — time-used and daily-limit state.
+  - `Presence.appSecondsForProfile` — per-app engaged seconds.
+  - `BlockReason.asWire` / `BlockReason.fromWire` — the block-reason wire string.
+- **"Keep in sync" comments are a smell.** Any `// must mirror`, `// same branch
+  as`, `// keep in sync`, hand-copied precedence, or a list duplicated across
+  files signals divergence risk. Recommend COLLAPSE (one source) or
+  TYPE-ENFORCE (make the compiler prevent drift) — never "keep in sync by hand."
+- **Display vs. enforcement source mismatch** (the
+  [#1539](https://github.com/wifihaven/wifihaven/issues/1539) trap): does a
+  display / UI path read a DIFFERENT source than the enforcement path for the
+  same fact? They will drift. Flag it.
+- **OK — not a finding:** the intentional wire-shape redundancy the architecture
+  mandates. Copying the infra allowlist into every profile's `extraAllowed`
+  ([#1311](https://github.com/wifihaven/wifihaven/issues/1311)) and the
+  `profiles` map dedup are deliberate; do not flag them as duplication.
+
+## 2. Testing integrity — critical
+
+- **TDD red→green visible in history.** For a new feature or bug fix, is there a
+  failing-test commit before the implementation commit (autonomous sessions), or
+  a test the user validated (interactive)?
+- **BLOCK any change to existing tests that could hide a regression.** Weakened
+  or deleted assertions, fixtures retrofitted to match new output, tolerance
+  widened without justification, a test skipped / disabled / `ignore`d — any
+  such change is a **BLOCKER** unless the PR explains why the OLD assertion was
+  actually wrong. (The migration-isolation lesson: test edits silently bypass
+  gates, so the gate only holds if test weakening is caught here.)
+- **Is the new behavior actually asserted** — not merely compiled or exercised
+  without a check? Are negative / edge / boundary cases covered?
+- **Right level.** Feature tests through the full stack
+  (HTTP → route → service → repo → embedded Postgres) are preferred; unit tests
+  are reserved for pure edge cases (policy logic, schedule boundaries, pattern
+  matching, time arithmetic).
+- **No forbidden mocks.** Never mock repositories, `AuthService`, or `Clock`.
+  `Clock` comes via `TestClock`; the DB layer uses real embedded Postgres.
+- **Bug fix → regression test that FAILS without the fix.** Confirm the test
+  actually pins the bug, not just adjacent behavior.
+
+## 3. Architectural invariants
+
+- **DNS never enforces.** Blocking is connection-layer (nftables forward-drop);
+  the block page is HTTP DNAT, not a DNS sinkhole / NXDOMAIN / RPZ. Reject any
+  "resolved ⇒ reachable / allowed" reasoning, and any fix described as "allow
+  the domain's DNS."
+- **Router is a dumb applier.** No schedule evaluation, time accounting,
+  category lookup, or role-based defaults added to the openwrt / opnsense agent.
+  All decision logic lives server-side in `PolicyService`.
+- **Snapshot stays the minimal wire vocabulary.** No NEW top-level field that
+  names a *concept* an existing field can carry
+  (`extraAllowed` / `extraBlocked` / `blocklistIds` / `blockIpOnly` /
+  `blocked` / `blockReason`). Express new policy through the existing functional
+  fields.
+- **`extraAllowed` beats every block path** — it must override `blocked` and
+  every other drop.
+- **`Clock` injected** — no direct `java.time` `now`. **ZIO effects** — no
+  `throw`; typed sealed errors, not strings. **Config via `zio-config`** — no
+  `sys.env` or hardcoded values.
+
+## 4. Backwards compatibility / wire contract
+
+The router↔API request/response shapes (and the policy snapshot in particular)
+are a public contract — API and agents deploy independently.
+
+- **Additive only** on any wire-visible shape (snapshot, usage/event ingest,
+  API request/response bodies). No renaming, removing, retyping, or
+  meaning-changing of an existing field.
+- **Tolerate unknown fields on input** — both sides ignore fields they don't
+  recognize.
+- **Breaking changes are gated on
+  [#376](https://github.com/wifihaven/wifihaven/issues/376)** (wire versioning +
+  capability negotiation). Until that lands, treat breaking wire changes as off
+  the table.
+
+## 5. Migrations
+
+- **Migration PRs are isolated.** A PR that adds a Flyway migration may contain
+  ONLY the `*.sql` migration(s) and `*.md` docs — no source, no test, no CI, no
+  fixtures, no build files. (`check-migration-isolation.sh` enforces this; verify
+  it would pass, or that `migration-coupled-justified` is set with a reason.)
+- **Never edit an applied migration.** New schema = new `V{n}__….sql` with a
+  unique sequential number.
+- **Prod-volume safety.** Does the migration scan, rewrite, copy, re-index, or
+  `ATTACH`/`VALIDATE` a growth table (`traffic_reports`, `connection_events`,
+  `block_events`, or a derived rollup)? If so, assume minutes not seconds at
+  prod scale — flag startup-critical-path risk. `CREATE INDEX CONCURRENTLY`
+  avoids the long lock but cannot run inside a transaction (Flyway wraps each
+  migration in one). Distrust any "this is fast" comment measured on dev/staging.
+- **EXPLAIN-validated index for new SQL.** New or materially changed SQL on a
+  growth table must ship the supporting index in the same PR, with an
+  `EXPLAIN (ANALYZE, BUFFERS)` plan (prod or prod-shaped) showing an index scan,
+  not a sequential scan whose runtime tracks table size.
+
+## 6. Metrics + dashboard
+
+- **New meaningful path emits a metric.** A new route, background job, poller,
+  external call, or ingest/enforcement step should emit a metric in the SAME PR
+  — a `*_total{reason}` counter for failures/rejections, a
+  `*_duration_seconds` histogram for latency/volume, or a gauge for system
+  state.
+- **Routed through `AppMetrics` / `MetricGuard`** (not a bare `Metric.*`), with
+  the new `(name -> allowed keys)` entry added to `MetricGuard.Allowed`.
+- **Bounded labels only** — `route` (templated), `op`, `reason`, `status`,
+  `job`. **Never** a per-mac / per-domain / per-device / per-ip / per-user
+  value; those are forbidden and will be rejected by the cardinality firewall.
+- **Ships with a Grafana panel** — checked-in JSON under
+  `deploy/grafana/dashboards/`, registered in `infra/grafana/main.tf` when it's
+  a new dashboard. Query targets the series actually emitted, slices only by
+  bounded labels.
+
+## 7. Scope / hygiene
+
+- **Focused diff.** Limited to the intended files; no unrelated drive-by edits.
+- **No dead code or leftover debug logging.** TODOs reference an issue:
+  `TODO(#n)`.
+- **NO Claude / Anthropic / AI mentions** in commit messages or the PR title /
+  body. A `Co-Authored-By` trailer is fine.
+- **Branch-diff checks use merge-base (three-dot)** vs `origin/main`, never
+  two-dot.
+
+## 8. Security
+
+- **No secrets / credentials committed** (config files with DB creds stay out of
+  the repo).
+- **Parameterized SQL only** — no string interpolation into SQL; Doobie
+  parameters throughout.
+- **New routes enforce auth + role.** JWT-authenticated, with the correct
+  Admin / ReadOnly check via the middleware.
+
+---
+
+## Output format
+
+Report findings in this order, then the verdict:
+
+```
+BLOCKERS
+1. <file:line> — <what's wrong and why it's merge-gating>
+2. ...
+(none — if there are no blockers)
+
+SHOULD-FIX
+1. <file:line> — <issue and suggested fix>
+...
+
+NITS
+1. <file:line> — <minor note>
+...
+
+VERDICT: APPROVE | REQUEST-CHANGES
+<3-line summary of the change and the basis for the verdict>
+```
+
+Never emit **VERDICT: APPROVE** while any BLOCKER is listed.


### PR DESCRIPTION
Closes #1563.

## What

Codify a **standard, independent PR-review pass** before merge, driven by a checked-in checklist — the consistent gate #1563 asks for.

- **`docs/pr-review-checklist.md`** — a read-only, adversarial review prompt a review subagent can be handed verbatim (or run via `/code-review`). The reviewer cites `file:line`, classifies each finding BLOCKER / SHOULD-FIX / NIT, and ends with VERDICT APPROVE / REQUEST-CHANGES — **never APPROVE with an open BLOCKER**. Eight sections, led by the two failure modes behind our recurring prod incidents:
  1. **Duplicated logic / single source of truth** (highest priority) — reuse `TimeStatusService` day-state / `usedSecondsForProfile` / `usedSecondsByMac`, `Presence.appSecondsForProfile`, `BlockReason.asWire/fromWire`; flag "keep in sync" comments and display-vs-enforcement source mismatches (#1531 / #1539 / audit #1532); carve out the intentional #1311 wire-shape redundancy.
  2. **Testing integrity** — TDD red→green; BLOCK regression-hiding test edits; real embedded Postgres; no forbidden mocks.
  3. Architectural invariants · 4. Wire back-compat (#376 gate) · 5. Migrations · 6. Metrics + dashboard · 7. Scope/hygiene · 8. Security.
- **AGENTS.md rule** — new *Independent PR review (required before merge)* section pointing at the checklist; BLOCKERS merge-gating, the independent pass is the gate, author self-runs first. **`CLAUDE.md` is a symlink to `AGENTS.md`, so the two stay in sync automatically.**
- **`.claude/commands/pr-review.md`** — thin helper so `/pr-review` loads the checklist.

## Links

- Closes #1563
- Cross-links the #1561 single-source-of-truth convention (anchor `#single-source-of-truth`) and the #1311 wire-shape-redundancy carve-out; references audit #1532.

## Constraints

- **Docs-only** (+ the optional `.claude/commands/` helper). No source, no migration. `git diff --name-only origin/main...HEAD` → `AGENTS.md`, `docs/pr-review-checklist.md`, `.claude/commands/pr-review.md` only.
- AGENTS.md / CLAUDE.md confirmed in sync (symlink).