### PR TITLE
feat(#1515): per-app cap enforcement — block the whole app host-set when its aggregate cap is hit

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -251,6 +251,9 @@ object Main extends ZIOAppDefault {
       ZLayer.fromZIO(ZIO.serviceWith[AppConfig](_.jwt)) >+>
       Clock.live >+>
       AuthService.layer >+>
+      // #1515: per-app rollup read accessor, wired ahead of TimeStatusService so the snapshot's
+      // per-app cap reads `app_used_daily` + a live tail on the rollup path.
+      wifihaven.api.usage.AppUsedRollupService.layer >+>
       TimeStatusService.layer >+>
       PolicyService.layer >+>
       TimeStatusCache.live() >+>

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -370,11 +370,26 @@ class PolicyServiceLive(
                   now = now,
                 )
 
+                // #1515: the per-profile carve set the snapshot puts in `extraAllowed`, reproduced
+                // here so /decision agrees with what nftables enforces. It is the allowed/allowed_during
+                // app hosts PLUS the whole host-set of every exempt-from-daily app still under its own
+                // per-app cap (`exemptUnderCapHosts`) — the latter is the #1513 fix at the /decision
+                // layer: an exempt app under cap must beat a whole-MAC pause/schedule block, so it has
+                // to be checked BEFORE the pause/schedule short-circuits below. Under a HARD pause the
+                // snapshot empties the per-profile `extraAllowed` (only `global` survives), so we drop
+                // the carve here too — keeping the two readings identical (#1532).
+                val isHardPause    =
+                  p.pauseMode == PauseMode.Hard &&
+                    dayState.blockReason.contains(MacBlockReason.Paused)
+                val profileAllowed =
+                  if isHardPause then Nil
+                  else (appAllowed ++ PolicyService.exemptUnderCapHosts(dayState)).distinct
+
                 // #1413/#421: extraAllowed beats EVERY whole-MAC block — incl.
                 // Paused/Schedule — so check the allowed-app list first, before
                 // the pause/schedule short-circuits. This matches the snapshot/
                 // router `ip daddr != @ea_<m>_<a>` carve-out.
-                if matchesAny(h, appAllowed) then
+                if matchesAny(h, profileAllowed) then
                   ZIO.succeed(
                     RouterDecisionResponse(
                       ConnectionDecision.Allow,
@@ -654,28 +669,22 @@ object PolicyService {
       appExtraAllowed: List[Hostname] = Nil,
       appExtraBlocked: List[Hostname] = Nil,
   ): BlockRules = {
-    // Per-site limits exhausted today → the app's hosts appear in extraBlocked too. Hosts are kept
-    // as raw strings wrapped via Hostname.unsafe (the router treats these as patterns, so a glob
-    // like *.youtube.com that isn't a strict hostname is still accepted).
-    // #1505: per-site exhaustion is now per-app — `state.perSite` carries one entry per app with
-    // its usage aggregated across the whole host-set. When an app's aggregate hits its limit, ALL
-    // of the app's hosts go to extraBlocked (and the carve-out below stops carving them).
-    val siteLimitExtraBlocked: List[Hostname] = state.perSite.collect {
-      case sd if sd.usedMinutes >= sd.dailyLimitMinutes => sd.hosts.map(Hostname.unsafe)
-    }.flatten
+    // #1505/#1515: per-app cap exhaustion blocks the app's WHOLE host-set together — `state.perSite`
+    // carries one entry per app with usage aggregated (gap-bridged) across the whole host-set, so
+    // when that aggregate hits the limit ALL of the app's hosts go to extraBlocked, not just the one
+    // whose traffic crossed. Shared with the /decision fallback via `siteCapExhaustedHosts` so the
+    // two cannot diverge (#1532).
+    val siteLimitExtraBlocked: List[Hostname] = siteCapExhaustedHosts(state)
 
-    // #1105: time_limited app hosts with exemptFromDaily=true carve around the
-    // MAC-level @blocked_macs drop while they still have per-host budget. The
-    // exempt flag's original role was just to exclude the host from the daily
-    // tally; without this carve-out, hitting the profile cap silently dropped
-    // the exempt app too, violating the "Khan doesn't count" contract.
-    // Naturally transitions allow → block as the per-host budget exhausts
-    // (siteLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
-    // at the router; see feedback_extraallowed_beats_blocked).
-    val appExemptAllowedHosts: List[Hostname] = state.perSite.collect {
-      case sd if sd.exemptFromDaily && sd.usedMinutes < sd.dailyLimitMinutes =>
-        sd.hosts.map(Hostname.unsafe)
-    }.flatten
+    // #1105/#1515: time_limited app hosts with exemptFromDaily=true carve around the MAC-level
+    // @blocked_macs drop while the app's aggregate is still under its own cap — for the WHOLE
+    // host-set. The exempt flag's original role was just to exclude the app from the daily tally;
+    // without this carve-out, hitting the profile cap silently dropped the exempt app too, violating
+    // the "Khan doesn't count" contract (#1513). Naturally transitions allow → block as the app's
+    // aggregate exhausts (siteLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
+    // at the router; see feedback_extraallowed_beats_blocked). Shared with /decision via
+    // `exemptUnderCapHosts` (#1532).
+    val appExemptAllowedHosts: List[Hostname] = exemptUnderCapHosts(state)
 
     // #1418: hard pause is a true off-switch. When this profile is paused AND
     // its pause_mode is `hard`, drop even the app/exempt/infra carve-outs — only
@@ -751,6 +760,32 @@ object PolicyService {
    */
   def dailyCapExhausted(state: ProfileDayState): Boolean =
     state.dailyLimitMinutes.exists(lim => state.usedMinutes >= lim + state.extensionMinutes)
+
+  /**
+   * #1515: the whole host-set of every per-app cap that is exhausted today — `usedMinutes` (the
+   * gap-bridged aggregate across the app's whole host-set, from `appSecondsForProfile`) has reached
+   * the app's daily limit. These hosts go to `extraBlocked` together so the router drops the WHOLE
+   * app, not just the one host whose traffic crossed. The single per-app cap-block computation,
+   * shared by the snapshot ([[computeBlockRules]]) and the per-host /decision fallback so the two
+   * cannot diverge (#1532). Per-app caps take no extensions — those are profile-level and apply to
+   * the daily total ([[dailyCapExhausted]]), not the per-app budget.
+   */
+  private[policy] def siteCapExhaustedHosts(state: ProfileDayState): List[Hostname] =
+    state.perSite.collect {
+      case sd if sd.usedMinutes >= sd.dailyLimitMinutes => sd.hosts.map(Hostname.unsafe)
+    }.flatten
+
+  /**
+   * #1515: the whole host-set of every exempt-from-daily app still UNDER its own per-app cap — the
+   * complement of [[siteCapExhaustedHosts]] for exempt apps. Carved into `extraAllowed` so it beats
+   * every whole-MAC block (paused / schedule / daily-limit) at the router (#421). Shared by the
+   * snapshot and the /decision fallback so the exempt carve cannot diverge (#1532, #1513).
+   */
+  private[policy] def exemptUnderCapHosts(state: ProfileDayState): List[Hostname] =
+    state.perSite.collect {
+      case sd if sd.exemptFromDaily && sd.usedMinutes < sd.dailyLimitMinutes =>
+        sd.hosts.map(Hostname.unsafe)
+    }.flatten
 
   /** True iff `w` (a #1069 named-schedule window) is active at `now`, via [[scheduleActiveAt]]. */
   def windowActiveAt(w: ScheduleWindow, now: Instant): Boolean =

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -492,20 +492,20 @@ class PolicyServiceLive(
         ),
       )
       .orElse {
-        val isExemptSite = state.perSite.exists { sd =>
-          sd.exemptFromDaily && sd.hosts.exists(hp => HostMatch.matchesPattern(hostname, hp))
-        }
-        if isExemptSite then None
-        else
-          state.dailyLimitMinutes.flatMap { limit =>
-            Option.when(state.usedMinutes >= limit + state.extensionMinutes)(
-              RouterDecisionResponse(
-                ConnectionDecision.Block,
-                BlockReason.asWire(MacBlockReason.TimeLimit),
-                Some(resetAt),
-              ),
-            )
-          }
+        // #1515: no exempt-app guard is needed here anymore. An exempt-from-daily app still under
+        // its own cap is carved into `profileAllowed` and allowed upstream (before this runs), and
+        // one over its cap is caught by `siteLimitHit` above — so by the time we reach the daily cap
+        // the host is never daily-exempt. The daily-cap predicate is the shared
+        // [[dailyCapExhausted]] (the same one the snapshot's `state.blocked` / TimeLimit reason
+        // folds), so the per-host /decision and the snapshot can't fold the daily cap differently
+        // (#1532).
+        Option.when(PolicyService.dailyCapExhausted(state))(
+          RouterDecisionResponse(
+            ConnectionDecision.Block,
+            BlockReason.asWire(MacBlockReason.TimeLimit),
+            Some(resetAt),
+          ),
+        )
       }
   }
 

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -2,6 +2,7 @@ package wifihaven.api.policy
 
 import wifihaven.api.db.*
 import wifihaven.api.presence.{Presence, PresenceRow}
+import wifihaven.api.usage.{AppUsedRollupService, NoopAppUsedRollupService}
 import wifihaven.shared.{Schedule as DbSchedule, *}
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
@@ -129,6 +130,12 @@ class TimeStatusServiceLive(
     // attached to it as a block schedule (via `profile_schedule_rules`, mode=blocked_during).
     // Defaults to the noop so existing direct constructions keep their arity.
     namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
+    // #1515: the #1510 per-app rollup read accessor, used ONLY on the today-rollup read path to fill
+    // each profile's per-app `perSite.usedMinutes` from `app_used_daily` + a live tail — so the
+    // per-app cap enforces once a profile has rolled (the prod steady state), not just on the
+    // all-live path. Defaults to the noop: the all-live path (cache miss / past date) never consults
+    // it, and the many test constructions over `NoopTimeUsedRollupRepo` stay all-live.
+    appUsedRollupService: AppUsedRollupService = NoopAppUsedRollupService,
 ) extends TimeStatusService {
 
   // #1069/#1482: a profile's effective downtime schedules = the windows of every named schedule
@@ -266,7 +273,10 @@ class TimeStatusServiceLive(
           stls      <- siteTimeLimitRepo.listForProfile(profileId)
           devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
           tail <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, rolled.rolledThrough)
-          extMins <- extRepo.getProfileTotalExtension(profileId, date)
+          extMins    <- extRepo.getProfileTotalExtension(profileId, date)
+          // #1515: per-app cap usage from the #1510 per-app rollup + live tail, so the per-app cap
+          // enforces on the rollup path identically to the all-live path.
+          perAppMins <- appUsedRollupService.appCapMinutesByLabel(now, date, settings, profileId)
         } yield {
           val tailSeconds =
             TimeStatusService.usedSecondsForProfile(p, devices, stls, tail, settings)
@@ -281,6 +291,7 @@ class TimeStatusServiceLive(
               extensionMinutes = extMins,
               date = date,
               now = now,
+              perSiteOverride = Some(TimeStatusService.siteDayStatesFromMinutes(stls, perAppMins)),
             ),
           )
         }
@@ -320,6 +331,13 @@ class TimeStatusServiceLive(
       stlsP   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
       exts    <- extRepo.snapshotAllByProfile(date)
+      // #1515: per-app cap usage per profile from the #1510 per-app rollup + live tail. Keyed by the
+      // `app:<slug>` cap-group label so it joins to each profile's per-app cap groups below.
+      perAppMins <- ZIO
+        .foreach(profiles)(p =>
+          appUsedRollupService.appCapMinutesByLabel(now, date, settings, p.id).map(p.id -> _),
+        )
+        .map(_.toMap)
     } yield {
       val schedMap =
         profiles.map(p => p.id -> syntheticWindows(p.id, namedP.getOrElse(p.id, Nil))).toMap
@@ -354,6 +372,12 @@ class TimeStatusServiceLive(
           extensionMinutes = exts.getOrElse(p.id, 0),
           date = date,
           now = now,
+          perSiteOverride = Some(
+            TimeStatusService.siteDayStatesFromMinutes(
+              stlMap.getOrElse(p.id, Nil),
+              perAppMins.getOrElse(p.id, Map.empty),
+            ),
+          ),
         )
       }.toMap
     }
@@ -364,7 +388,8 @@ object TimeStatusService {
 
   val layer: ZLayer[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & NamedScheduleRepo,
+      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & NamedScheduleRepo &
+      AppUsedRollupService,
     Nothing,
     TimeStatusService,
   ] = ZLayer.fromFunction {
@@ -378,7 +403,8 @@ object TimeStatusService {
         er: TimeExtensionRepo,
         ru: TimeUsedRollupRepo,
         nsr: NamedScheduleRepo,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr)
+        aur: AppUsedRollupService,
+    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr, aur)
   }
 
   /**
@@ -415,25 +441,40 @@ object TimeStatusService {
       filter: HeartbeatFilter,
       continuationSeconds: Int,
   ): List[SiteDayState] = {
-    val groups   = groupSiteLimits(siteLimits)
     val perGroup = Presence.patternGroupMinutesForProfile(
       presence,
-      groups.map(g => g._1 -> g._4),
+      groupSiteLimits(siteLimits).map(g => g._1 -> g._4),
       overlap,
       filter,
       continuationSeconds,
     )
-    groups.map { case (label, daily, exempt, hosts, rep) =>
+    siteDayStatesFromMinutes(siteLimits, perGroup)
+  }
+
+  /**
+   * #1515: build the per-app [[SiteDayState]] list from a `label -> usedMinutes` map, where each
+   * key is the `app:<slug>` cap-group label [[groupSiteLimits]] emits. The single place the per-app
+   * cap groups (label / host-set / limit / exempt) are zipped with their used-minutes, regardless
+   * of where the minutes come from: the live presence aggregation ([[siteDayStates]]), the rollup +
+   * live-tail read path ([[TimeStatusServiceLive]], via
+   * [[wifihaven.api.usage.AppUsedRollupService.appCapMinutesByLabel]]), or the zero-usage default
+   * in [[assemble]]. Keeping one zip means the cap groups can't be shaped differently across those
+   * paths (#1532). A label absent from the map contributes zero minutes.
+   */
+  private[policy] def siteDayStatesFromMinutes(
+      siteLimits: List[SiteTimeLimit],
+      minutesByLabel: Map[String, Int],
+  ): List[SiteDayState] =
+    groupSiteLimits(siteLimits).map { case (label, daily, exempt, hosts, rep) =>
       SiteDayState(
         label = label,
         domainPattern = rep,
         dailyLimitMinutes = daily,
-        usedMinutes = perGroup.getOrElse(label, 0),
+        usedMinutes = minutesByLabel.getOrElse(label, 0),
         exemptFromDaily = exempt,
         hosts = hosts,
       )
     }
-  }
 
   /**
    * Pure folder: collapse the per-profile inputs into the canonical day state. Same math the
@@ -694,18 +735,12 @@ object TimeStatusService {
     val remaining = dailyLimit.map(l => (l + extensionMinutes - usedMinutes).max(0))
 
     val perSite = perSiteOverride.getOrElse(
-      // #1505: same per-app grouping as the live path, but with zero usage — this branch is the
-      // rollup+tail read, whose v1 rollup carries only the profile total (no per-site presence).
-      groupSiteLimits(siteLimits).map { case (label, daily, exempt, hosts, rep) =>
-        SiteDayState(
-          label = label,
-          domainPattern = rep,
-          dailyLimitMinutes = daily,
-          usedMinutes = 0,
-          exemptFromDaily = exempt,
-          hosts = hosts,
-        )
-      },
+      // #1505/#1515: same per-app grouping as the live path, but with zero usage. Reached only when
+      // a caller does NOT supply per-app usage; the rollup read paths now pass `perSiteOverride`
+      // built from the #1510 per-app rollup (so the per-app cap enforces on the rollup path too),
+      // and the live `fold` passes the presence-derived one. A bare `assemble` with no override
+      // degrades to "no per-app usage yet".
+      siteDayStatesFromMinutes(siteLimits, Map.empty),
     )
 
     ProfileDayState(

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -54,6 +54,43 @@ trait AppUsedRollupService {
       settings: HouseholdSettings,
       profileId: ProfileId,
   ): Task[Map[AppId, Int]]
+
+  /**
+   * #1515: the same per-app engaged minutes as [[appEngagedMinutes]], re-keyed by the cap group
+   * label `app:<slug>` (the key [[wifihaven.api.policy.TimeStatusService.groupSiteLimits]] emits).
+   * This is what the snapshot's / `/decision`'s per-app cap reads through `perSite` on the rollup
+   * read path: [[wifihaven.api.policy.TimeStatusServiceLive]] joins it to the profile's per-app cap
+   * groups to fill `SiteDayState.usedMinutes`, so a profile that has rolled (the prod steady state)
+   * still caps on the real per-app aggregate instead of zero. Same rolled + live-tail figure, so
+   * the rollup read and the all-live read agree by construction (#1532).
+   */
+  def appCapMinutesByLabel(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Map[String, Int]]
+}
+
+/**
+ * No-op variant for test wiring / read paths that never reach the rollup branch (e.g. a
+ * `TimeStatusServiceLive` over [[wifihaven.api.db.NoopTimeUsedRollupRepo]], which always
+ * cache-misses to the all-live path). Both accessors return empty. Mirrors
+ * [[wifihaven.api.db.NoopAppUsedRollupRepo]].
+ */
+object NoopAppUsedRollupService extends AppUsedRollupService {
+  def appEngagedMinutes(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Map[AppId, Int]] = ZIO.succeed(Map.empty)
+  def appCapMinutesByLabel(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[Map[String, Int]] = ZIO.succeed(Map.empty)
 }
 
 class AppUsedRollupServiceLive(
@@ -70,59 +107,79 @@ class AppUsedRollupServiceLive(
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-  ): Task[Map[AppId, Int]] = {
-    val today  = PolicyService.householdLocalDate(now, settings)
-    // Only today reads the rollup; past dates ignore it (rollup is today-only, like
-    // `time_used_daily`). An empty rolled map — cache miss, or a past date — collapses `aggregate`
-    // to a full-day all-live computation.
-    val rolled =
-      if (date == today) rollupRepo.getDayForProfile(profileId, date)
-      else ZIO.succeed(Map.empty[AppId, RolledAppDay])
-    rolled.flatMap(aggregate(date, settings, profileId, _))
-  }
+  ): Task[Map[AppId, Int]] =
+    aggregate(now, date, settings, profileId).map(_._1)
 
-  // Single read path for both cases. When `rolled` is non-empty, add its engaged seconds to a live
-  // aggregation of the TAIL past the shared watermark (period_start >= rolled_through). When it is
-  // empty (cache miss / past date), the watermark is absent so the whole day is aggregated live and
-  // the rolled contribution is zero — i.e. the all-live path. Either way the floor-of-sum to minutes
-  // happens once at the end, so the result is byte-identical to a full live aggregation (the
-  // watermark lands in an idle gap, so no engaged span straddles it — same exactness argument as
-  // `time_used_daily`).
-  private def aggregate(
+  def appCapMinutesByLabel(
+      now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-      rolled: Map[AppId, RolledAppDay],
-  ): Task[Map[AppId, Int]] =
-    profileRepo.findById(profileId).flatMap {
-      case None    => ZIO.succeed(Map.empty)
-      case Some(p) =>
-        for {
-          stls    <- siteTimeLimitRepo.listForProfile(profileId)
-          devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
-          apps    <- appRepo.listAll
-          macs = devices.map(_.mac)
-          presence <- rolled.values.iterator.map(_.rolledThrough).minOption match {
-            case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
-            case None            => trafficRepo.listPresenceRows(macs, date)
+  ): Task[Map[String, Int]] =
+    aggregate(now, date, settings, profileId).map(_._2)
+
+  // Single read path for both keyings. When the per-app rollup is non-empty, add its engaged seconds
+  // to a live aggregation of the TAIL past the shared watermark (period_start >= rolled_through).
+  // When it is empty (cache miss / past date), the watermark is absent so the whole day is aggregated
+  // live and the rolled contribution is zero — i.e. the all-live path. Either way the floor-of-sum to
+  // minutes happens once at the end, so the result is byte-identical to a full live aggregation (the
+  // watermark lands in an idle gap, so no engaged span straddles it — same exactness argument as
+  // `time_used_daily`). Returns the minutes keyed both by `apps.id` (the per-app series) and by the
+  // `app:<slug>` cap-group label (the per-app cap), computed once.
+  private def aggregate(
+      now: Instant,
+      date: LocalDate,
+      settings: HouseholdSettings,
+      profileId: ProfileId,
+  ): Task[(Map[AppId, Int], Map[String, Int])] = {
+    val today   = PolicyService.householdLocalDate(now, settings)
+    // Only today reads the rollup; past dates ignore it (rollup is today-only, like
+    // `time_used_daily`). An empty rolled map — cache miss, or a past date — collapses to a full-day
+    // all-live computation.
+    val rolledZ =
+      if (date == today) rollupRepo.getDayForProfile(profileId, date)
+      else ZIO.succeed(Map.empty[AppId, RolledAppDay])
+    rolledZ.flatMap { rolled =>
+      profileRepo.findById(profileId).flatMap {
+        case None    => ZIO.succeed((Map.empty[AppId, Int], Map.empty[String, Int]))
+        case Some(p) =>
+          for {
+            stls    <- siteTimeLimitRepo.listForProfile(profileId)
+            devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
+            apps    <- appRepo.listAll
+            macs = devices.map(_.mac)
+            presence <- rolled.values.iterator.map(_.rolledThrough).minOption match {
+              case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
+              case None            => trafficRepo.listPresenceRows(macs, date)
+            }
+          } yield {
+            val liveSecs                  =
+              TimeStatusService.appSecondsByApp(
+                p,
+                stls,
+                TimeStatusService.slugToAppId(apps),
+                presence,
+                settings,
+              )
+            val byApp: Map[AppId, Int]    =
+              (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
+                val secs =
+                  rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
+                val mins = (secs / 60L).toInt
+                if mins != 0 then Some(id -> mins) else None
+              }.toMap
+            // Re-key to the `app:<slug>` cap-group label via the inverse of `slugToAppId` — the same
+            // labelling `groupSiteLimits` uses — so the per-app cap can join by label.
+            val idToSlug                  = TimeStatusService.slugToAppId(apps).map(_.swap)
+            val byLabel: Map[String, Int] =
+              byApp.iterator.flatMap { case (id, mins) =>
+                idToSlug.get(id).map(slug => s"app:$slug" -> mins)
+              }.toMap
+            (byApp, byLabel)
           }
-        } yield {
-          val liveSecs =
-            TimeStatusService.appSecondsByApp(
-              p,
-              stls,
-              TimeStatusService.slugToAppId(apps),
-              presence,
-              settings,
-            )
-          (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
-            val secs =
-              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
-            val mins = (secs / 60L).toInt
-            if mins != 0 then Some(id -> mins) else None
-          }.toMap
-        }
+      }
     }
+  }
 }
 
 object AppUsedRollupService {

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -2,6 +2,7 @@ package wifihaven.api.feature
 
 import wifihaven.api.db.*
 import wifihaven.api.policy.*
+import wifihaven.api.usage.{AppUsedRollupServiceLive, TimeUsedRollupJob}
 import wifihaven.shared.*
 import wifihaven.shared.Clock.TestClock
 import wifihaven.shared.types.*
@@ -78,6 +79,43 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       ar,
       clk,
       namedScheduleRepo = nsr,
+    ): PolicyService
+
+  // #1515: a PolicyService whose TimeStatusService uses the REAL today-rollup repos (TimeUsedRollup +
+  // AppUsedRollup) and the real per-app rollup read accessor — so the snapshot reads the rollup +
+  // live-tail path (the prod steady state), not the all-live path the other `makePs*` helpers force
+  // by wiring `NoopTimeUsedRollupRepo`. Used to prove the per-app cap enforces from `app_used_daily`.
+  private def makePsRollup =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      hsr  <- ZIO.service[HouseholdSettingsRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      stlr <- ZIO.service[SiteTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      blr  <- ZIO.service[BlocklistRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ar   <- ZIO.service[AppRepo]
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      ru   <- ZIO.service[TimeUsedRollupRepo]
+      aru  <- ZIO.service[AppUsedRollupRepo]
+      clk  <- ZIO.service[Clock]
+      aus = new AppUsedRollupServiceLive(pr, dr, stlr, ar, trr, aru)
+      tss = new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr, aus)
+    } yield new PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      stlr,
+      dr,
+      blr,
+      trr,
+      er,
+      ar,
+      tss,
+      clk,
     ): PolicyService
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
@@ -243,6 +281,51 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(atEb.contains("ytimg.com")) &&
         assertTrue(!unEb.contains("youtube.com")) &&
         assertTrue(!unEb.contains("ytimg.com"))
+    },
+    test(
+      "#1515 rollup path: per-app cap enforces from app_used_daily + tail, not just the all-live path",
+    ) {
+      // Regression guard for the gap that the snapshot's per-app cap only fired on the all-live path:
+      // once a profile has rolled (the prod steady state) the snapshot read `perSite.usedMinutes` as
+      // ZERO and the cap never bit. Roll the day up so the snapshot takes the rollup + live-tail
+      // path, and assert the whole host-set is still blocked from `app_used_daily`.
+      for {
+        _     <- cleanDb
+        ar    <- ZIO.service[AppRepo]
+        kids  <- kidsId
+        dr    <- ZIO.service[DeviceRepo]
+        _     <- dr.upsert(MacAddress.unsafe("aa:bb:cc:dd:ee:92"), "iPad", Some(kids), "10.0.0.92")
+        rid   <- seedRouterRow
+        appId <- ar.create("YouTube", "youtube", None, None)
+        _     <- ar.setHosts(
+          appId,
+          List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")),
+        )
+        _     <- ar.upsertAssignment(appId, kids, AppMode.TimeLimited, Some(30), false)
+        today = TestClock.schoolDayAfternoon.toLocalDate
+        // 30 m on the asset host alone → aggregate hits the 30 m cap.
+        _      <- seedTraffic(rid, "aa:bb:cc:dd:ee:92", "ytimg.com", today, 30)
+        // Roll the day up: writes app_used_daily (30 m YouTube) + time_used_daily for every profile,
+        // so the snapshot below reads the ROLLUP path rather than re-aggregating live.
+        pr     <- ZIO.service[ProfileRepo]
+        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        trr    <- ZIO.service[TrafficReportRepo]
+        hsr    <- ZIO.service[HouseholdSettingsRepo]
+        ru     <- ZIO.service[TimeUsedRollupRepo]
+        aru    <- ZIO.service[AppUsedRollupRepo]
+        clk    <- ZIO.service[Clock]
+        now    <- clk.instant
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stlr, ar, trr, hsr, now)
+        // Proves the rollup branch is exercised: the per-app rollup row exists for this profile.
+        rolled <- aru.getDayForProfile(kids, today)
+        svc    <- makePsRollup
+        snap   <- svc.snapshot
+      } yield {
+        val eb = snap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        assertTrue(rolled.nonEmpty) &&
+        assertTrue(eb.contains("youtube.com")) &&
+        assertTrue(eb.contains("ytimg.com"))
+      }
     },
     test("conflicting allowed + blocked apps: host appears in both lists (router lets allow win)") {
       // feedback_extraallowed_beats_blocked: router precedence makes allow win.

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -223,10 +223,10 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         today = TestClock.schoolDayAfternoon.toLocalDate
         // ── at the limit: 30 m on the asset host alone → aggregate == cap → whole set blocked ──
         atApp <- ar.create("YouTube", "youtube", None, None)
-        _     <- ar.setHosts(atApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
-        _     <- ar.upsertAssignment(atApp, kids, AppMode.TimeLimited, Some(30), true)
-        _     <- seedTraffic(rid, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 30)
-        atSnap   <- makePs.flatMap(_.snapshot)
+        _ <- ar.setHosts(atApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _ <- ar.upsertAssignment(atApp, kids, AppMode.TimeLimited, Some(30), true)
+        _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 30)
+        atSnap <- makePs.flatMap(_.snapshot)
         atEb = atSnap.profiles(kids).rules.extraBlocked.map(_.value).toSet
         // ── one under: same app, reseed with 25 m → aggregate < cap → whole set reachable ──
         _     <- cleanDb
@@ -234,10 +234,10 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         _     <- dr.upsert(MacAddress.unsafe("aa:bb:cc:dd:ee:91"), "iPad", Some(kids2), "10.0.0.91")
         rid2  <- seedRouterRow
         unApp <- ar.create("YouTube", "youtube", None, None)
-        _     <- ar.setHosts(unApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
-        _     <- ar.upsertAssignment(unApp, kids2, AppMode.TimeLimited, Some(30), true)
-        _     <- seedTraffic(rid2, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 25)
-        unSnap   <- makePs.flatMap(_.snapshot)
+        _ <- ar.setHosts(unApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _ <- ar.upsertAssignment(unApp, kids2, AppMode.TimeLimited, Some(30), true)
+        _ <- seedTraffic(rid2, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 25)
+        unSnap <- makePs.flatMap(_.snapshot)
         unEb = unSnap.profiles(kids2).rules.extraBlocked.map(_.value).toSet
       } yield assertTrue(atEb.contains("youtube.com")) &&
         assertTrue(atEb.contains("ytimg.com")) &&

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -205,6 +205,45 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         assertTrue(!eb.contains("youtube.com")) && assertTrue(!eb.contains("ytimg.com"))
       }
     },
+    test(
+      "#1515 boundary: aggregate exactly AT the app cap blocks the whole host-set; one minute under does not",
+    ) {
+      // The per-app cap is a `>=` test on the gap-bridged aggregate across the whole host-set. Pin
+      // both sides of the boundary in one test so an off-by-one (`>` vs `>=`) can't slip through:
+      // 30 m on the asset host alone (apex idle) hits the 30 m cap → both hosts blocked; 25 m leaves
+      // 5 m of budget → neither blocked. Both readings come from the SAME aggregate the router caps
+      // on, so the whole app moves together either way.
+      for {
+        _    <- cleanDb
+        ar   <- ZIO.service[AppRepo]
+        kids <- kidsId
+        dr   <- ZIO.service[DeviceRepo]
+        _    <- dr.upsert(MacAddress.unsafe("aa:bb:cc:dd:ee:91"), "iPad", Some(kids), "10.0.0.91")
+        rid  <- seedRouterRow
+        today = TestClock.schoolDayAfternoon.toLocalDate
+        // ── at the limit: 30 m on the asset host alone → aggregate == cap → whole set blocked ──
+        atApp <- ar.create("YouTube", "youtube", None, None)
+        _     <- ar.setHosts(atApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _     <- ar.upsertAssignment(atApp, kids, AppMode.TimeLimited, Some(30), true)
+        _     <- seedTraffic(rid, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 30)
+        atSnap   <- makePs.flatMap(_.snapshot)
+        atEb = atSnap.profiles(kids).rules.extraBlocked.map(_.value).toSet
+        // ── one under: same app, reseed with 25 m → aggregate < cap → whole set reachable ──
+        _     <- cleanDb
+        kids2 <- kidsId
+        _     <- dr.upsert(MacAddress.unsafe("aa:bb:cc:dd:ee:91"), "iPad", Some(kids2), "10.0.0.91")
+        rid2  <- seedRouterRow
+        unApp <- ar.create("YouTube", "youtube", None, None)
+        _     <- ar.setHosts(unApp, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _     <- ar.upsertAssignment(unApp, kids2, AppMode.TimeLimited, Some(30), true)
+        _     <- seedTraffic(rid2, "aa:bb:cc:dd:ee:91", "ytimg.com", today, 25)
+        unSnap   <- makePs.flatMap(_.snapshot)
+        unEb = unSnap.profiles(kids2).rules.extraBlocked.map(_.value).toSet
+      } yield assertTrue(atEb.contains("youtube.com")) &&
+        assertTrue(atEb.contains("ytimg.com")) &&
+        assertTrue(!unEb.contains("youtube.com")) &&
+        assertTrue(!unEb.contains("ytimg.com"))
+    },
     test("conflicting allowed + blocked apps: host appears in both lists (router lets allow win)") {
       // feedback_extraallowed_beats_blocked: router precedence makes allow win.
       // Snapshot is additive — both lists carry the host, and the router enforces

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -565,5 +565,144 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         dr   <- ZIO.fromEither(body.fromJson[RouterDecisionResponse])
       yield assertTrue(dr.decision == ConnectionDecision.Allow)
     },
+    // ── #1515: snapshot ⇄ decide() agreement on the per-app cap ──────────────────────────────────
+    // The snapshot collapses each app's cap into nftables host-sets (`extraBlocked` / `extraAllowed`)
+    // the router applies blind, while /decision answers per host. They MUST agree for the same
+    // profile/now or the block-page reason drifts from what nftables enforces. These tests build ONE
+    // PolicyService and cross-check both readings; `routerAllows` mirrors the router's precedence
+    // (`extraAllowed` beats whole-MAC `blocked` beats `extraBlocked`, #421) so a snapshot verdict can
+    // be compared to a /decision verdict directly.
+    test(
+      "#1515 anti-divergence: over-cap multi-host app — snapshot blocks the whole host-set and decide() agrees",
+    ) {
+      val mac = "aa:bb:cc:11:22:33"
+      for
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app <- ar.create("YouTube", "youtube", None, None)
+        _   <- ar.setHosts(app, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(30), exemptFromDaily = true)
+        rid <- seedRouterRow
+        // 30 m on the off-domain asset host alone → aggregate hits the 30 m cap (apex idle).
+        _   <- seedTraffic(rid, mac, "ytimg.com", LocalDate.of(2025, 1, 6), 30)
+        ps    <- makePsDefault
+        snap  <- ps.snapshot
+        rules  = snap.profiles(kid).rules
+        apex  <- ps.decide(mac, "youtube.com")
+        asset <- ps.decide(mac, "ytimg.com")
+      yield assertTrue(rules.extraBlocked.map(_.value).toSet == Set("youtube.com", "ytimg.com")) &&
+        assertTrue(!routerAllows(rules, "youtube.com")) &&
+        assertTrue(!routerAllows(rules, "ytimg.com")) &&
+        assertTrue(apex.decision == ConnectionDecision.Block) &&
+        assertTrue(asset.decision == ConnectionDecision.Block) &&
+        assertTrue(decisionAllows(asset) == routerAllows(rules, "ytimg.com")) &&
+        assertTrue(decisionAllows(apex) == routerAllows(rules, "youtube.com"))
+    },
+    test(
+      "#1515 anti-divergence: exempt app UNDER cap stays reachable when the profile is PAUSED (snapshot ⇄ decide())",
+    ) {
+      // The #1513 regression class at the /decision layer: an exempt-from-daily app under its own cap
+      // is carved into `extraAllowed` for its WHOLE host-set, which beats the whole-MAC pause block at
+      // the router (#421). /decision must report the same Allow — its pause short-circuit cannot fire
+      // before the exempt carve, or the block page contradicts what nftables actually does.
+      val mac = "aa:bb:cc:11:22:33"
+      for
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- pr.setPaused(kid, true)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app <- ar.create("Khan", "khan", None, None)
+        _   <- ar.setHosts(
+          app,
+          List(Hostname.unsafe("khanacademy.org"), Hostname.unsafe("cdn.kastatic.org")),
+        )
+        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
+        rid <- seedRouterRow
+        // 20 m on the apex alone → aggregate 20 < 60 cap → under-cap, the whole set is carved.
+        _   <- seedTraffic(rid, mac, "khanacademy.org", LocalDate.of(2025, 1, 6), 20)
+        ps    <- makePsDefault
+        snap  <- ps.snapshot
+        rules  = snap.profiles(kid).rules
+        ea     = rules.extraAllowed.map(_.value).toSet
+        apex  <- ps.decide(mac, "khanacademy.org")
+        asset <- ps.decide(mac, "cdn.kastatic.org")
+      yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.Paused)) &&
+        assertTrue(ea.contains("khanacademy.org")) &&
+        assertTrue(ea.contains("cdn.kastatic.org")) &&
+        assertTrue(routerAllows(rules, "khanacademy.org")) &&
+        assertTrue(routerAllows(rules, "cdn.kastatic.org")) &&
+        assertTrue(apex.decision == ConnectionDecision.Allow) &&
+        assertTrue(asset.decision == ConnectionDecision.Allow) &&
+        assertTrue(decisionAllows(apex) == routerAllows(rules, "khanacademy.org")) &&
+        assertTrue(decisionAllows(asset) == routerAllows(rules, "cdn.kastatic.org"))
+    },
+    test(
+      "#1513 invariant: exempt app under cap reachable when the profile DAILY cap is hit (snapshot ⇄ decide())",
+    ) {
+      // The original #1513 prod regression: the profile daily cap is exhausted by OTHER (non-exempt)
+      // traffic, yet the exempt app under its own cap must stay reachable across its whole host-set.
+      val mac = "aa:bb:cc:11:22:33"
+      for
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        ar  <- ZIO.service[AppRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 30)
+        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app <- ar.create("Khan", "khan", None, None)
+        _   <- ar.setHosts(
+          app,
+          List(Hostname.unsafe("khanacademy.org"), Hostname.unsafe("cdn.kastatic.org")),
+        )
+        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
+        rid <- seedRouterRow
+        // 35 m on a non-exempt host exhausts the 30 m profile daily cap; 20 m exempt Khan stays
+        // under its own 60 m cap and does NOT count toward the daily total.
+        _   <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        _   <- seedTraffic(rid, mac, "khanacademy.org", LocalDate.of(2025, 1, 6), 20, bucketOffset = 12)
+        ps    <- makePsDefault
+        snap  <- ps.snapshot
+        rules  = snap.profiles(kid).rules
+        ea     = rules.extraAllowed.map(_.value).toSet
+        apex  <- ps.decide(mac, "khanacademy.org")
+        asset <- ps.decide(mac, "cdn.kastatic.org")
+      yield assertTrue(rules.blocked) &&
+        assertTrue(rules.blockReason.contains(MacBlockReason.TimeLimit)) &&
+        assertTrue(ea.contains("khanacademy.org")) &&
+        assertTrue(ea.contains("cdn.kastatic.org")) &&
+        assertTrue(apex.decision == ConnectionDecision.Allow) &&
+        assertTrue(asset.decision == ConnectionDecision.Allow) &&
+        assertTrue(decisionAllows(apex) == routerAllows(rules, "khanacademy.org")) &&
+        assertTrue(decisionAllows(asset) == routerAllows(rules, "cdn.kastatic.org"))
+    },
   ) @@ TestAspect.sequential
+
+  /** True iff a /decision response allowed the connection. */
+  private def decisionAllows(r: RouterDecisionResponse): Boolean =
+    r.decision == ConnectionDecision.Allow
+
+  /**
+   * The router's effective verdict for `host` from a profile's snapshot `BlockRules`, mirroring the
+   * nftables precedence the agent applies: `extraAllowed` carves out every drop (#421), then a
+   * whole-MAC `blocked` drops everything, then `extraBlocked` drops the host. Used to assert the
+   * /decision endpoint agrees with what the snapshot actually enforces. Hosts in these tests are
+   * exact (no globs), so a literal membership test matches the router's pattern check.
+   */
+  private def routerAllows(rules: BlockRules, host: String): Boolean =
+    if rules.extraAllowed.map(_.value).contains(host) then true
+    else if rules.blocked then false
+    else !rules.extraBlocked.map(_.value).contains(host)
 }

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -577,22 +577,22 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
     ) {
       val mac = "aa:bb:cc:11:22:33"
       for
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        ar  <- ZIO.service[AppRepo]
-        kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
-        app <- ar.create("YouTube", "youtube", None, None)
-        _   <- ar.setHosts(app, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
-        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(30), exemptFromDaily = true)
-        rid <- seedRouterRow
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app  <- ar.create("YouTube", "youtube", None, None)
+        _    <- ar.setHosts(app, List(Hostname.unsafe("youtube.com"), Hostname.unsafe("ytimg.com")))
+        _    <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(30), exemptFromDaily = true)
+        rid  <- seedRouterRow
         // 30 m on the off-domain asset host alone → aggregate hits the 30 m cap (apex idle).
-        _   <- seedTraffic(rid, mac, "ytimg.com", LocalDate.of(2025, 1, 6), 30)
-        ps    <- makePsDefault
-        snap  <- ps.snapshot
-        rules  = snap.profiles(kid).rules
+        _    <- seedTraffic(rid, mac, "ytimg.com", LocalDate.of(2025, 1, 6), 30)
+        ps   <- makePsDefault
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
         apex  <- ps.decide(mac, "youtube.com")
         asset <- ps.decide(mac, "ytimg.com")
       yield assertTrue(rules.extraBlocked.map(_.value).toSet == Set("youtube.com", "ytimg.com")) &&
@@ -612,27 +612,27 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       // before the exempt carve, or the block page contradicts what nftables actually does.
       val mac = "aa:bb:cc:11:22:33"
       for
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        ar  <- ZIO.service[AppRepo]
-        kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- pr.setPaused(kid, true)
-        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
-        app <- ar.create("Khan", "khan", None, None)
-        _   <- ar.setHosts(
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        ar   <- ZIO.service[AppRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- pr.setPaused(kid, true)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app  <- ar.create("Khan", "khan", None, None)
+        _    <- ar.setHosts(
           app,
           List(Hostname.unsafe("khanacademy.org"), Hostname.unsafe("cdn.kastatic.org")),
         )
-        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
-        rid <- seedRouterRow
+        _    <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
+        rid  <- seedRouterRow
         // 20 m on the apex alone → aggregate 20 < 60 cap → under-cap, the whole set is carved.
-        _   <- seedTraffic(rid, mac, "khanacademy.org", LocalDate.of(2025, 1, 6), 20)
-        ps    <- makePsDefault
-        snap  <- ps.snapshot
-        rules  = snap.profiles(kid).rules
-        ea     = rules.extraAllowed.map(_.value).toSet
+        _    <- seedTraffic(rid, mac, "khanacademy.org", LocalDate.of(2025, 1, 6), 20)
+        ps   <- makePsDefault
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
         apex  <- ps.decide(mac, "khanacademy.org")
         asset <- ps.decide(mac, "cdn.kastatic.org")
       yield assertTrue(rules.blocked) &&
@@ -653,30 +653,37 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       // traffic, yet the exempt app under its own cap must stay reachable across its whole host-set.
       val mac = "aa:bb:cc:11:22:33"
       for
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        tlr <- ZIO.service[TimeLimitRepo]
-        ar  <- ZIO.service[AppRepo]
-        kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- tlr.upsert(kid, 30)
-        _   <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
-        app <- ar.create("Khan", "khan", None, None)
-        _   <- ar.setHosts(
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        dr   <- ZIO.service[DeviceRepo]
+        tlr  <- ZIO.service[TimeLimitRepo]
+        ar   <- ZIO.service[AppRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        _    <- tlr.upsert(kid, 30)
+        _    <- TestLayers.seedDevice(dr, mac, "kid-ipad", kid)
+        app  <- ar.create("Khan", "khan", None, None)
+        _    <- ar.setHosts(
           app,
           List(Hostname.unsafe("khanacademy.org"), Hostname.unsafe("cdn.kastatic.org")),
         )
-        _   <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
-        rid <- seedRouterRow
+        _    <- ar.upsertAssignment(app, kid, AppMode.TimeLimited, Some(60), exemptFromDaily = true)
+        rid  <- seedRouterRow
         // 35 m on a non-exempt host exhausts the 30 m profile daily cap; 20 m exempt Khan stays
         // under its own 60 m cap and does NOT count toward the daily total.
-        _   <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
-        _   <- seedTraffic(rid, mac, "khanacademy.org", LocalDate.of(2025, 1, 6), 20, bucketOffset = 12)
-        ps    <- makePsDefault
-        snap  <- ps.snapshot
-        rules  = snap.profiles(kid).rules
-        ea     = rules.extraAllowed.map(_.value).toSet
+        _    <- seedTraffic(rid, mac, "cnn.com", LocalDate.of(2025, 1, 6), 35)
+        _    <- seedTraffic(
+          rid,
+          mac,
+          "khanacademy.org",
+          LocalDate.of(2025, 1, 6),
+          20,
+          bucketOffset = 12,
+        )
+        ps   <- makePsDefault
+        snap <- ps.snapshot
+        rules = snap.profiles(kid).rules
+        ea    = rules.extraAllowed.map(_.value).toSet
         apex  <- ps.decide(mac, "khanacademy.org")
         asset <- ps.decide(mac, "cdn.kastatic.org")
       yield assertTrue(rules.blocked) &&


### PR DESCRIPTION
Closes #1515 (App-Centric Model epic, sub-issue of #1510). Builds on the merged
#1514 (`appSecondsForProfile`), #1505/#1523 (per-app host-set limit aggregation),
#1544 (`decide()` collapsed onto `TimeStatusService`), and #1510 (per-app rollup
writer + `app_used_daily` V53 + `AppUsedRollupService` read accessor).

## What

Per-app cap evaluation in `PolicyService`: when an app's **aggregated** engaged
minutes (gap-bridged, unioned across its whole host-set via `appSecondsForProfile`
— #1514/#1532) reach the app's daily limit, **all** of the app's hosts go to
`extraBlocked` together — not just the one host whose traffic crossed. While under
cap, an `exemptFromDaily` app carves out its **whole** host-set into `extraAllowed`.

This makes that the single per-app cap computation, brings the per-host
`/api/router/decision` fallback into agreement with it, and — critically — makes
the cap actually enforce **on the rollup read path** (the prod steady state), which
it previously did not.

## Changes

- **One per-app cap computation (#1532).** Extracted `siteCapExhaustedHosts`
  (aggregate `>=` app limit → whole host-set blocked) and `exemptUnderCapHosts`
  (exempt + aggregate `<` limit → whole host-set carved) off the shared
  `ProfileDayState`, and routed `computeBlockRules` through them (no snapshot
  behavior change). Removed the now-unreachable `isExemptSite` guard in
  `timeLimitBlockFromState` and folded its daily-cap test through `dailyCapExhausted`.
- **`decide()` agreement (anti-divergence).** `decide()` now reproduces the
  snapshot's per-profile `extraAllowed` (allowed/allowed_during apps **plus** the
  exempt-under-cap whole host-set, emptied under a hard pause) and checks it
  **before** the pause/schedule short-circuits. Previously an exempt app under its
  own cap was reported *blocked* while the profile was paused/scheduled even though
  the snapshot carves it into `extraAllowed` (which beats `blocked` at the router,
  #421) — the #1513 regression class at the `/decision` layer. Day-state still
  comes from `TimeStatusService` (#1544); no app-time math re-derived.
- **Cap enforces on the rollup path (consume #1510).** Previously the cap only
  fired all-live: once a profile had a `time_used_daily` row, `TimeStatusService`'s
  rollup+tail path built `perSite` with **zero** per-app usage, so the cap was a
  silent no-op on prod. #1510 shipped the per-app rollup writer and an
  `AppUsedRollupService` read accessor but wired the accessor to nothing. This wires
  it: a new `appCapMinutesByLabel` (same rolled + live-tail figure as
  `appEngagedMinutes`, re-keyed by the `app:<slug>` cap-group label) feeds
  `perSite.usedMinutes` on both rollup read paths via a shared
  `siteDayStatesFromMinutes` zip (also used by the live path and the zero default,
  so the cap groups are built in one place). `AppUsedRollupService.layer` is wired
  ahead of `TimeStatusService.layer` in `Main`.

## Wire / architecture

- **No new wire field** — expressed via the existing `extraBlocked` / `extraAllowed`
  host lists; the router stays a dumb applier.
- **No migration** — `app_used_daily` (V53) and `appSecondsForProfile` already
  merged via #1510/#1514; this PR only consumes them.
- The per-site→per-app identifier rename (#1526) is **out of scope** — enforcement
  behavior only.
- The rollup+tail per-app figure uses the same `appSecondsByApp` /
  `appSecondsForProfile` primitive as the all-live path, so rollup and all-live
  agree by construction; a per-app rollup cache miss self-heals to all-live.

## Tests (TDD; failing test committed first for the decide() fix)

- `PolicySnapshotAppsSpec`: aggregate **exactly at** the cap blocks the whole
  host-set, one under does not (boundary); and a **rollup-path** test that rolls the
  day up (`oneTickForTest` writes `app_used_daily` + `time_used_daily`) then asserts
  the whole host-set is blocked from the rollup read — fails without the #1510
  wiring (perSite would be zero).
- `RouterDecisionSpec` — snapshot ⇄ `decide()` agreement on the per-app cap verdict
  for the same profile/now (a `routerAllows` helper mirrors `extraAllowed > blocked
  > extraBlocked`): over-cap whole-host-set block; exempt-under-cap **while PAUSED**
  (was red); exempt-under-cap **while the profile daily cap is hit** (#1513).

`mill api.test` green; changed files pass `scalafmt --check`.
