### PR TITLE
fix(#1569): log usage decode failures + skip/meter malformed records instead of dropping the batch

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -76,6 +76,11 @@ object MetricGuard {
     "auth_failures_total"                       -> Set("reason"),
     "agent_connected_routers"                   -> Set.empty[String],
     "traffic_reports_filtered_zero_bytes_total" -> Set.empty[String],
+    // #1569 — usage-ingest records dropped at decode. A single malformed record
+    // (e.g. a host that fails Hostname validation — a CDN CNAME target with
+    // underscores, see #1572) is skipped + metered here instead of 400-ing the
+    // whole batch. `reason` is a small fixed enum (currently just `decode_error`).
+    "usage_records_rejected_total"              -> Set("reason"),
     // #1318 — global-policy-layer visibility. `global_allow_hosts` is the size of the
     // security-sensitive fleet-wide always-reachable set (a host here bypasses every block);
     // `default_deny_profiles` counts profiles running the block-all baseline. Both are unlabelled
@@ -236,6 +241,19 @@ object AppMetrics {
           Map.empty,
           rows.toLong,
         ),
+      )
+      .unit
+
+  // ── #1569: usage records dropped at decode ───────────────────────────────────
+  // A malformed record (host failing Hostname validation, etc.) is skipped at
+  // ingest instead of failing the whole batch. A rising rate flags an agent/DNS
+  // source emitting host values the API rejects (the #1572 CNAME-target case).
+  // `reason` is a small fixed enum — only `decode_error` today.
+
+  def recordUsageRecordsRejected(count: Int, reason: String = "decode_error"): UIO[Unit] =
+    ZIO
+      .when(count > 0)(
+        MetricGuard.counter("usage_records_rejected_total", Map("reason" -> reason), count.toLong),
       )
       .unit
 

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -8,6 +8,7 @@ import wifihaven.shared.types.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
+import zio.json.ast.Json
 
 import java.time.{Duration, Instant}
 
@@ -34,20 +35,48 @@ object RouterIngestRoutes {
       Method.POST / "api" / "router" / "usage"  ->
         handler { (req: Request) =>
           for {
-            router   <- auth.authenticate(req)
-            body     <- req.body.asString.orElseFail(Response.badRequest(""))
-            rep      <- ZIO
-              .fromEither(body.fromJson[UsageReport])
+            router <- auth.authenticate(req)
+            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+            // #1569: decode the *envelope* (routerId, periodStart, periodEnd) +
+            // `records` as a raw JSON array, deferring per-record validation. A
+            // genuinely unparseable envelope (bad routerId/timestamps, not an
+            // object, `records` not an array, truncated body) still 400s — but
+            // now LOGGED (the prior code dropped the zio-json error straight into
+            // the 400 body and never logged it, so the offending field was
+            // invisible server-side; mirrors the #1126 events-handler pattern).
+            raw    <- ZIO
+              .fromEither(body.fromJson[RawUsageReport])
+              .tapError(e =>
+                ZIO.logWarning(
+                  s"router usage: envelope deserialization failed for router=${router.id} " +
+                    s"bodyLen=${body.length} bodySnippet=${snippet(body)} err=$e",
+                ),
+              )
               .mapError(e => Response.badRequest(e))
-            _        <- ZIO
+            _      <- ZIO
               .fail(Response.badRequest("router_id mismatch"))
-              .when(rep.routerId != router.id)
-            ps       <- parseInstant(rep.periodStart)
-            pe       <- parseInstant(rep.periodEnd)
+              .when(raw.routerId != router.id)
+            ps     <- parseInstant(raw.periodStart, router.id)
+            pe     <- parseInstant(raw.periodEnd, router.id)
+            // #1569: decode each record individually. A single malformed record
+            // (e.g. a host value that fails Hostname validation — an Akamai/CDN
+            // CNAME target with underscores, see #1572) used to fail the WHOLE
+            // batch, dropping every valid record with it. Now the bad records are
+            // skipped, logged (bounded), and metered, and the valid ones ingest.
+            decoded  = raw.records.zipWithIndex.map((j, i) => (i, j.as[UsageRecord]))
+            rejected = decoded.collect { case (i, Left(err)) => (i, err) }
+            records  = decoded.collect { case (_, Right(r)) => r }
+            _        <- ZIO.foreachDiscard(rejected) { (i, err) =>
+              ZIO.logWarning(
+                s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
+              )
+            }
+            _        <- AppMetrics.recordUsageRecordsRejected(rejected.size)
             _        <- ZIO.logDebug(
-              s"router usage: router=${router.id} period=$ps..$pe records=${rep.records.size}",
+              s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
+                s"rejected=${rejected.size}",
             )
-            _        <- ZIO.foreachDiscard(rep.records)(r =>
+            _        <- ZIO.foreachDiscard(records)(r =>
               ZIO.logDebug(
                 s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
                   s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
@@ -58,7 +87,7 @@ object RouterIngestRoutes {
               router.id,
               ps,
               pe,
-              rep.records,
+              records,
               settings,
               trafficRepo,
               timeUsageRepo,
@@ -118,8 +147,39 @@ object RouterIngestRoutes {
         },
     )
 
-  private def parseInstant(s: String): IO[Response, Instant] =
-    ZIO.attempt(Instant.parse(s)).orElseFail(Response.badRequest(s"invalid timestamp: $s"))
+  /**
+   * #1569: the wire-decode envelope for `POST /api/router/usage`. Identical field shape to
+   * [[UsageReport]] except `records` is held as a raw JSON array so each element can be decoded
+   * into a [[UsageRecord]] individually — a single malformed record (e.g. a host value that fails
+   * `Hostname` validation, see #1572) is then skipped + logged + metered instead of 400-ing the
+   * whole batch and dropping every valid record with it. The envelope itself (routerId, timestamps,
+   * records-is-an-array) must still parse or the request is a genuine 400. Decode-only; this is a
+   * server-side parse aid, NOT a wire-contract type — unknown fields are still ignored.
+   */
+  private case class RawUsageReport(
+      routerId: RouterId,
+      periodStart: String,
+      periodEnd: String,
+      records: List[Json],
+  ) derives JsonDecoder
+
+  /**
+   * #1569: short, bounded body excerpt for the decode-failure warn log — never the full body (avoid
+   * logging more PII than needed to identify the offending field).
+   */
+  private def snippet(body: String): String = {
+    val max = 200
+    if body.length <= max then body else body.take(max) + s"…(+${body.length - max} more)"
+  }
+
+  private def parseInstant(s: String, routerId: RouterId): IO[Response, Instant] =
+    ZIO
+      .attempt(Instant.parse(s))
+      .orElseFail(s)
+      .tapError(bad =>
+        ZIO.logWarning(s"router usage: invalid timestamp '$bad' from router=$routerId"),
+      )
+      .mapError(bad => Response.badRequest(s"invalid timestamp: $bad"))
 
   private def handleUsage(
       routerId: RouterId,

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -1296,14 +1296,14 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"activeSeconds":60,"bytesIn":100,"bytesOut":50}"""
         body    =
           s"""{"routerId":"$id","periodStart":"${periodStart.toString}","periodEnd":"${periodEnd.toString}","records":[$goodRec,$badRec]}"""
-        resp    <- post(routes, "/api/router/usage", body, Some(tk))
-        sb      <- tu.getSecondsAndBytes(
+        resp  <- post(routes, "/api/router/usage", body, Some(tk))
+        sb    <- tu.getSecondsAndBytes(
           MacAddress.unsafe(knownMac),
           HostId.Fqdn(Hostname.unsafe("youtube.com")),
           testDate,
         )
-        rows    <- tRepo.listForRouter(id, 100)
-        after   <- rejectedCounter.value
+        rows  <- tRepo.listForRouter(id, 100)
+        after <- rejectedCounter.value
       } yield assertTrue(resp.status == Status.Ok) &&
         // the valid record ingested into both traffic_reports and time_usage
         assertTrue(sb == ((240L, 1000L, 500L))) &&
@@ -1321,13 +1321,13 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         routes   <- buildRoutes
         (id, tk) <- seedRouter(rRepo)
         before   <- rejectedCounter.value
-        badRec   =
+        badRec =
           s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"activeSeconds":60,"bytesIn":100,"bytesOut":50}"""
-        body     =
+        body   =
           s"""{"routerId":"$id","periodStart":"${periodStart.toString}","periodEnd":"${periodEnd.toString}","records":[$badRec,$badRec]}"""
-        resp     <- post(routes, "/api/router/usage", body, Some(tk))
-        rows     <- tRepo.listForRouter(id, 100)
-        after    <- rejectedCounter.value
+        resp  <- post(routes, "/api/router/usage", body, Some(tk))
+        rows  <- tRepo.listForRouter(id, 100)
+        after <- rejectedCounter.value
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(rows.isEmpty) &&
         assertTrue(after.count - before.count == 2.0)
@@ -1342,7 +1342,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         routes   <- buildRoutes
         (id, tk) <- seedRouter(rRepo)
         before   <- rejectedCounter.value
-        rawBody  =
+        rawBody =
           s"""{"routerId":"$id","periodStart":"not-a-timestamp","periodEnd":"${periodEnd.toString}","records":[]}"""
         captured <- (for {
           resp <- post(routes, "/api/router/usage", rawBody, Some(tk))

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -10,6 +10,7 @@ import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*
+import zio.metrics.Metric
 import zio.test.*
 
 import java.time.{Instant, LocalDate, LocalDateTime, OffsetDateTime}
@@ -107,6 +108,17 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
 
   private val knownMac   = "aa:bb:cc:11:22:33"
   private val unknownMac = "aa:bb:cc:99:99:99"
+
+  // #1569: the real Akamai CDN CNAME target observed on prod whose underscore
+  // labels fail Hostname validation (see #1572) — the exact value that 400'd the
+  // whole usage batch in the incident.
+  private val badHost =
+    "73-169-39-14_s-23-196-4-147_ts-1780860759-clienttons-s.akamaihd.net"
+
+  // #1569: read the cumulative value of usage_records_rejected_total{reason=decode_error}
+  // straight off the default metric registry MetricGuard emits into.
+  private val rejectedCounter =
+    Metric.counter("usage_records_rejected_total").tagged("reason", "decode_error")
 
   private def seedKnownDevice(dRepo: DeviceRepo, profileRepo: ProfileRepo): Task[Unit] =
     for {
@@ -1256,6 +1268,117 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
           testDate,
         )
       } yield assertTrue(sb == ((60L, 100L, 50L)))
+    },
+    // ── #1569: one malformed record must not drop the whole batch ────────────
+    test(
+      "usage: a batch with one malformed record ingests the valid records and meters the rejection",
+    ) {
+      // Incident #1569: a single host value that fails Hostname validation (an
+      // Akamai CDN CNAME target with underscores) used to fail the WHOLE
+      // UsageReport decode → 400 → every valid record in the ~130-record batch
+      // dropped. Now the bad record is skipped + metered and the valid ones
+      // ingest normally. Hand-rolled JSON so the malformed record is embedded
+      // verbatim (RouterEvent.toJson couldn't even construct the bad Hostname).
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        tRepo    <- ZIO.service[TrafficReportRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        before   <- rejectedCounter.value
+        goodRec =
+          s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"youtube.com"},"activeSeconds":240,"bytesIn":1000,"bytesOut":500}"""
+        badRec  =
+          s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"activeSeconds":60,"bytesIn":100,"bytesOut":50}"""
+        body    =
+          s"""{"routerId":"$id","periodStart":"${periodStart.toString}","periodEnd":"${periodEnd.toString}","records":[$goodRec,$badRec]}"""
+        resp    <- post(routes, "/api/router/usage", body, Some(tk))
+        sb      <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          testDate,
+        )
+        rows    <- tRepo.listForRouter(id, 100)
+        after   <- rejectedCounter.value
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // the valid record ingested into both traffic_reports and time_usage
+        assertTrue(sb == ((240L, 1000L, 500L))) &&
+        assertTrue(rows.size == 1) &&
+        // exactly the one malformed record was metered as rejected
+        assertTrue(after.count - before.count == 1.0)
+    },
+    test("usage: a batch of ONLY malformed records is accepted (200) and meters them all") {
+      // No valid records to ingest, but the envelope is well-formed — so this is
+      // a 200 no-op-ingest, NOT a 400. The bad records are all metered.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        tRepo    <- ZIO.service[TrafficReportRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        before   <- rejectedCounter.value
+        badRec   =
+          s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"activeSeconds":60,"bytesIn":100,"bytesOut":50}"""
+        body     =
+          s"""{"routerId":"$id","periodStart":"${periodStart.toString}","periodEnd":"${periodEnd.toString}","records":[$badRec,$badRec]}"""
+        resp     <- post(routes, "/api/router/usage", body, Some(tk))
+        rows     <- tRepo.listForRouter(id, 100)
+        after    <- rejectedCounter.value
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.isEmpty) &&
+        assertTrue(after.count - before.count == 2.0)
+    },
+    test("usage: a malformed envelope (bad timestamp) returns 400 and logs a warning") {
+      // A genuinely unparseable envelope still 400s — but now the failure is
+      // LOGGED server-side (the #1569 diagnostic gap), and NO record-reject
+      // metric is charged (we never reached per-record decode).
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        before   <- rejectedCounter.value
+        rawBody  =
+          s"""{"routerId":"$id","periodStart":"not-a-timestamp","periodEnd":"${periodEnd.toString}","records":[]}"""
+        captured <- (for {
+          resp <- post(routes, "/api/router/usage", rawBody, Some(tk))
+          logs <- ZTestLogger.logOutput
+        } yield (resp, logs)).provideLayer(ZTestLogger.default)
+        (resp, logs) = captured
+        after    <- rejectedCounter.value
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        assertTrue(
+          logs.exists(e =>
+            e.logLevel == LogLevel.Warning &&
+              e.message().contains("router usage:") &&
+              e.message().contains("invalid timestamp"),
+          ),
+        ) &&
+        assertTrue(after.count - before.count == 0.0)
+    },
+    test("usage: a non-JSON body returns 400 and logs the envelope decode failure") {
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        captured <- (for {
+          resp <- post(routes, "/api/router/usage", "this is not json", Some(tk))
+          logs <- ZTestLogger.logOutput
+        } yield (resp, logs)).provideLayer(ZTestLogger.default)
+        (resp, logs) = captured
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        assertTrue(
+          logs.exists(e =>
+            e.logLevel == LogLevel.Warning &&
+              e.message().contains("router usage: envelope deserialization failed") &&
+              e.message().contains(s"router=$id"),
+          ),
+        )
     },
     test("events: dhcp_lease for a known MAC does NOT raise an alert") {
       for {

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -12,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router\u2192API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md \u00a75.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -20,35 +23,69 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Zero-byte traffic rows filtered (#864)",
-      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) \u2014 usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
           "legendFormat": "filtered rows/s",
           "refId": "A"
@@ -56,24 +93,43 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Zero-byte rows dropped (last 24h)",
-      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) — total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
+      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) \u2014 total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
       "id": 2,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           }
         },
@@ -84,12 +140,21 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "increase(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[24h])",
           "legendFormat": "rows (24h)",
           "refId": "A"
@@ -97,28 +162,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest request rate by endpoint",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) — requests/sec on the three router→API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) \u2014 requests/sec on the three router\u2192API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "reqps",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -126,35 +219,69 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest error rate by endpoint (4xx / 5xx)",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) — rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) \u2014 rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "reqps",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -162,28 +289,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest p95 latency by endpoint",
-      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) — tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms → 5s (HttpDurationBoundaries).",
+      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) \u2014 tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms \u2192 5s (HttpDurationBoundaries).",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 5,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "s",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m])))",
           "legendFormat": "{{route}}",
           "refId": "A"
@@ -191,35 +346,69 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest auth failures (bad_router_token)",
-      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) — router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
+      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) \u2014 router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 6,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\", reason=\"bad_router_token\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -227,28 +416,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Router metrics batch ingest by status (#1205)",
-      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) \u2014 POST /api/router/metrics outcomes. status \u2208 {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 24
+      },
       "id": 7,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
@@ -256,15 +473,25 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Router metrics ingest success ratio (#1368)",
-      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. Green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; a truly idle window (no batches → vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel — paging is the alerting thread (#1381).",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) \u2014 fraction of POST /api/router/metrics batches accepted. Green \u2265 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all \u2014 a 100%-malformed outage, the #1365 case \u2014 sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present \u2192 0 \u2192 red; a truly idle window (no batches \u2192 vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel \u2014 paging is the alerting thread (#1381).",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
       "id": 8,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -272,8 +499,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 0.95 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
             ]
           }
         },
@@ -284,14 +517,158 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
           "legendFormat": "success ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Usage records rejected at decode (#1569)",
+      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) \u2014 per-record usage ingest rejections. A single malformed record (e.g. a host failing Hostname validation \u2014 a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair with the server warn-log ('router usage: skipping malformed record') to see the offending field. reason is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 32
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (reason) (rate(usage_records_rejected_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Usage records rejected (last 24h)",
+      "description": "increase(usage_records_rejected_total[24h]) summed across reasons \u2014 total usage records skipped at decode over the last day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(usage_records_rejected_total{env=\"$env\"}[24h]))",
+          "legendFormat": "rejected (24h)",
           "refId": "A"
         }
       ]
@@ -299,26 +676,46 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["wifihaven", "api", "ingest"],
+  "tags": [
+    "wifihaven",
+    "api",
+    "ingest"
+  ],
   "templating": {
     "list": [
       {
-        "current": { "selected": true, "text": "prod", "value": "prod" },
+        "current": {
+          "selected": true,
+          "text": "prod",
+          "value": "prod"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Environment",
         "multi": false,
         "name": "env",
         "options": [
-          { "selected": true, "text": "prod", "value": "prod" },
-          { "selected": false, "text": "staging", "value": "staging" }
+          {
+            "selected": true,
+            "text": "prod",
+            "value": "prod"
+          },
+          {
+            "selected": false,
+            "text": "staging",
+            "value": "staging"
+          }
         ],
         "query": "prod,staging",
         "skipUrlSync": false,
         "type": "custom"
       },
       {
-        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-wifihaven-prom",
+          "value": "grafanacloud-prom"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -333,10 +730,13 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
-  "title": "WifiHaven — data quality & ingest",
+  "title": "WifiHaven \u2014 data quality & ingest",
   "uid": "wifihaven-data-quality-ingest",
   "version": 1,
   "weekStart": ""

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router\u2192API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md \u00a75.",
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -23,69 +20,35 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Zero-byte traffic rows filtered (#864)",
-      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) \u2014 usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 0
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
       "id": 1,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
           "legendFormat": "filtered rows/s",
           "refId": "A"
@@ -93,43 +56,24 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Zero-byte rows dropped (last 24h)",
-      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) \u2014 total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
+      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) — total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
       "id": 2,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 1000
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 1000 }
             ]
           }
         },
@@ -140,21 +84,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "increase(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[24h])",
           "legendFormat": "rows (24h)",
           "refId": "A"
@@ -162,56 +97,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest request rate by endpoint",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) \u2014 requests/sec on the three router\u2192API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) — requests/sec on the three router→API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "reqps",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -219,69 +126,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest error rate by endpoint (4xx / 5xx)",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) \u2014 rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) — rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "id": 4,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "reqps",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -289,56 +162,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest p95 latency by endpoint",
-      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) \u2014 tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms \u2192 5s (HttpDurationBoundaries).",
+      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) — tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms → 5s (HttpDurationBoundaries).",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
       "id": 5,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "s",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m])))",
           "legendFormat": "{{route}}",
           "refId": "A"
@@ -346,69 +191,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest auth failures (bad_router_token)",
-      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) \u2014 router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
+      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) — router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
       "id": 6,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\", reason=\"bad_router_token\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -416,56 +227,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics batch ingest by status (#1205)",
-      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) \u2014 POST /api/router/metrics outcomes. status \u2208 {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 24
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 24 },
       "id": 7,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
@@ -473,25 +256,15 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics ingest success ratio (#1368)",
-      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) \u2014 fraction of POST /api/router/metrics batches accepted. Green \u2265 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all \u2014 a 100%-malformed outage, the #1365 case \u2014 sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present \u2192 0 \u2192 red; a truly idle window (no batches \u2192 vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel \u2014 paging is the alerting thread (#1381).",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. Green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; a truly idle window (no batches → vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel — paging is the alerting thread (#1381).",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 24
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
       "id": 8,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -499,14 +272,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 0.95
-              }
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0.95 }
             ]
           }
         },
@@ -517,21 +284,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
           "legendFormat": "success ratio",
           "refId": "A"
@@ -539,69 +297,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Usage records rejected at decode (#1569)",
-      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) \u2014 per-record usage ingest rejections. A single malformed record (e.g. a host failing Hostname validation \u2014 a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair with the server warn-log ('router usage: skipping malformed record') to see the offending field. reason is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) — per-record usage-ingest rejections. A single malformed record (e.g. a host failing Hostname validation — a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair it with the server warn-log ('router usage: skipping malformed record') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 32
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 32 },
       "id": 9,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (reason) (rate(usage_records_rejected_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -609,39 +333,23 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Usage records rejected (last 24h)",
-      "description": "increase(usage_records_rejected_total[24h]) summed across reasons \u2014 total usage records skipped at decode over the last day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum(increase(usage_records_rejected_total[24h])) — total usage records skipped at decode over the trailing day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 32
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
       "id": 10,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
             ]
           }
         },
@@ -652,21 +360,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(increase(usage_records_rejected_total{env=\"$env\"}[24h]))",
           "legendFormat": "rejected (24h)",
           "refId": "A"
@@ -676,46 +375,26 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "wifihaven",
-    "api",
-    "ingest"
-  ],
+  "tags": ["wifihaven", "api", "ingest"],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prod",
-          "value": "prod"
-        },
+        "current": { "selected": true, "text": "prod", "value": "prod" },
         "hide": 0,
         "includeAll": false,
         "label": "Environment",
         "multi": false,
         "name": "env",
         "options": [
-          {
-            "selected": true,
-            "text": "prod",
-            "value": "prod"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          }
+          { "selected": true, "text": "prod", "value": "prod" },
+          { "selected": false, "text": "staging", "value": "staging" }
         ],
         "query": "prod,staging",
         "skipUrlSync": false,
         "type": "custom"
       },
       {
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-wifihaven-prom",
-          "value": "grafanacloud-prom"
-        },
+        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -730,13 +409,10 @@
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "timepicker": {},
   "timezone": "",
-  "title": "WifiHaven \u2014 data quality & ingest",
+  "title": "WifiHaven — data quality & ingest",
   "uid": "wifihaven-data-quality-ingest",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
## Incident fix — restore `/api/router/usage` ingest (awaiting expedited review/merge)

Fixes the live ingest loss in #1569. **This is a prod incident fix — please prioritize review/merge.**

### Root cause (confirmed from live router logs, `root@router.lan`)
`POST /api/router/usage` decoded the body as a whole `UsageReport` and mapped the decode error **straight into the 400 response body without logging it**. When a single record carried a host value that fails `Hostname` validation, the **entire batch 400'd and every valid record was dropped** — and the offending field was invisible server-side (the sibling `/events` handler has logged decode failures since #1126; usage never got it).

The offending value, pulled from the router's own `usage.post` log:

```
.records[132].host(invalid hostname label
  '73-169-39-14_s-23-196-4-147_ts-1780860759-clienttons-s' in
   73-169-39-14_s-23-196-4-147_ts-1780860759-clienttons-s.akamaihd.net)
```

An Akamai CDN CNAME-target hostname with **underscores** in a label. `Hostname.LabelPattern` (`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`) rejects it. On prod this stuck whole usage buckets in the agent's in-memory retry queue (observed at retry attempt 6→10, never succeeding), losing per-(mac,host) traffic + time-usage data for those windows.

### What this PR changes
1. **Logs the usage decode failure.** A genuinely unparseable envelope still returns 400, but now emits a warning with router id, body length, a bounded 200-char snippet (no full body / no extra PII), and the zio-json error — mirroring the #1126 events pattern. Timestamp and router-id-mismatch 400s now log too.
2. **Tolerates a single bad record instead of failing the whole batch.** The envelope (`routerId`, `periodStart`, `periodEnd`) + `records` is decoded as a raw JSON array (`RawUsageReport`), then each record is decoded individually. Malformed records are **skipped + logged + metered**; valid records ingest normally. Idempotency / `ON CONFLICT DO NOTHING` and the #864 zero-byte filter are unchanged.
3. **New bounded metric** `usage_records_rejected_total{reason}` (enum: `decode_error` today) via `AppMetrics`/`MetricGuard` (entry added to `MetricGuard.Allowed`), plus two panels on the `data-quality-ingest` Grafana dashboard (timeseries by reason + 24h stat).

### Wire compatibility
Decode is made **strictly more lenient** — additive per the back-compat "tolerate unknown/partial input" rule. No snapshot/request/response shape change; older agents are unaffected, and a well-formed envelope with all-valid records behaves exactly as before.

### Tests (TDD red→green in history)
`api/test/src/feature/RouterIngestSpec.scala`:
- batch with one malformed record (the real prod akamaihd.net host) → **200**, valid record ingests into `traffic_reports` + `time_usage`, `usage_records_rejected_total` += 1.
- all-malformed batch (well-formed envelope) → **200** no-op-ingest, meters each rejected record.
- malformed envelope (bad timestamp) → **400** + a warning is logged + no record-reject metric charged.
- non-JSON body → **400** + envelope-deserialization warning logged (incl. `router=<id>`).
- all existing `RouterIngestSpec` / `UsageApiSpec` / `UsageRoutingSpec` / `RouterMetricsIngestSpec` stay green.

Grafana gate: `terraform fmt -check` + `terraform validate` + `python3 -m json.tool` on every dashboard all pass.

### Follow-up
This restores ingest and surfaces the offending field; it does **not** fix the mis-attribution that produced the bad host. That's #1572 — traffic/usage records still attributed to the resolved CNAME target instead of the queried brand (incomplete #1344).

Closes #1569.
