### PR TITLE
feat(#1575): PR-review posts to the PR + iterative re-review (addressed-check + incremental delta)

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,15 +1,61 @@
 ---
-description: Independent, read-only adversarial review of a PR using the standard WifiHaven checklist
+description: Independent, read-only adversarial review of a PR — posts a marked comment and re-runs incrementally on each push
 ---
 
-Run the standard WifiHaven **independent PR review** pass. Load the full
-checklist and follow it verbatim:
+Run the standard WifiHaven **independent PR review** pass, **post it to the PR**,
+and on a re-run **status the prior findings + review only the new delta**. Load
+the full checklist and follow it verbatim — including its **Posting & re-runs**
+section, which is authoritative:
 
 @docs/pr-review-checklist.md
 
-Review the PR referenced in `$ARGUMENTS` (a PR number, or the current branch if
-empty). Read the PR body and the diff (`gh pr diff <n>`, or local
-`git diff origin/main...HEAD` — three-dot merge-base, never two-dot). Review
-ONLY the changes, cite `file:line`, classify every finding BLOCKER / SHOULD-FIX
-/ NIT, do not modify files, and end with VERDICT: APPROVE or REQUEST-CHANGES
-(never APPROVE with an open BLOCKER) plus a 3-line summary.
+Target PR: `$ARGUMENTS` (a PR number, or the current branch's PR if empty).
+
+Apply the checklist's 8 dimensions to the diff, cite `file:line`, classify every
+finding BLOCKER / SHOULD-FIX / NIT, do **not** modify files, and end with
+VERDICT: APPROVE or REQUEST-CHANGES (never APPROVE with an open BLOCKER) plus a
+3-line summary. Then post per the algorithm below.
+
+## Flow
+
+1. **Resolve the PR number `<n>` and head SHA.**
+
+   ```bash
+   gh pr view <n> --repo wifihaven/wifihaven --json headRefOid -q .headRefOid
+   ```
+
+2. **Look for a prior marked review comment** (the marker is
+   `<!-- wifihaven-pr-review reviewed-sha=<sha> -->`):
+
+   ```bash
+   gh api "repos/wifihaven/wifihaven/issues/<n>/comments" --paginate \
+     --jq '[.[] | select(.body | contains("<!-- wifihaven-pr-review reviewed-sha="))] | last'
+   ```
+
+   - **Empty / null → first run.** Review the full merge-base diff
+     `git diff origin/main...HEAD` (three-dot, never two-dot) against the 8
+     dimensions.
+   - **Found → re-run.** Extract its prior SHA
+     (`grep -oE 'reviewed-sha=[0-9a-f]+' | head -1`) and its findings, then:
+     a. **Status each prior finding** ADDRESSED / NOT-ADDRESSED / PARTIAL by
+        re-checking the `file:line` it cited in current code.
+     b. **Review the incremental delta** `git diff <reviewed-sha>...HEAD`
+        (three-dot) — the latest push(es) plus context the fix touched — for NEW
+        findings.
+
+3. **Post one marked comment** as a **non-approving** PR comment (never
+   `gh pr review --approve/--request-changes` — it can interfere with required
+   human reviews / the merge queue). Write the body to a temp file, leading with
+   the marker for the **current** HEAD SHA:
+
+   ```bash
+   printf '<!-- wifihaven-pr-review reviewed-sha=%s -->\n' "$HEAD_SHA" > /tmp/pr-review-body.md
+   # ...append the review body (re-run: prior-findings status table → new findings → VERDICT)...
+   gh pr comment <n> --repo wifihaven/wifihaven --body-file /tmp/pr-review-body.md
+   ```
+
+4. **Merge gate.** A prior BLOCKER clears only when ADDRESSED *and* the latest
+   push introduced no new BLOCKER. Any open BLOCKER (still NOT-ADDRESSED /
+   PARTIAL, or newly introduced) keeps the verdict at REQUEST-CHANGES and stays
+   merge-gating. Post exactly one updated comment per run — don't duplicate a
+   comment for the same SHA.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,6 +803,20 @@ The checklist leads with duplicated-logic / single-source-of-truth (see
 [Single source of truth](#single-source-of-truth)) and test-integrity, the two
 failure modes behind our recurring prod incidents.
 
+**The review is POSTED to the PR and RE-RUN on each push.** The reviewer posts
+its findings as a marked, **non-approving** PR comment (`gh pr comment` — never a
+GitHub `--approve` / `--request-changes` review, so it can't interfere with
+required human reviews or the merge queue), leading with a machine-findable
+marker that records the reviewed commit
+(`<!-- wifihaven-pr-review reviewed-sha=<sha> -->`). On a subsequent push the
+review re-runs incrementally: it finds the prior marked comment, **statuses each
+prior finding** ADDRESSED / NOT-ADDRESSED / PARTIAL against current code, reviews
+only the **incremental delta** (`git diff <reviewed-sha>...HEAD`) for new
+findings, and posts an updated marked comment. A BLOCKER clears only when
+ADDRESSED *and* no new BLOCKER was introduced; any open BLOCKER stays
+merge-gating. See the *Posting & re-runs* section of the checklist for the full
+algorithm.
+
 ## Testing philosophy
 
 ### Feature tests first, unit tests for edge cases only

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -210,3 +210,99 @@ VERDICT: APPROVE | REQUEST-CHANGES
 ```
 
 Never emit **VERDICT: APPROVE** while any BLOCKER is listed.
+
+---
+
+## Posting & re-runs
+
+The review does not just get *returned* — it is **posted to the PR** as a
+comment, and **re-run on every subsequent push**, statusing the prior findings
+and reviewing only the incremental delta. This keeps a single living review on
+the PR whose verdict tracks the latest commit.
+
+### The marker
+
+Every posted review comment **leads with a stable, machine-findable marker**
+that records the exact commit reviewed:
+
+```
+<!-- wifihaven-pr-review reviewed-sha=<HEAD-sha> -->
+```
+
+followed by the standard body (BLOCKERS / SHOULD-FIX / NITS / VERDICT +
+summary). The marker is what the next run greps for to find the prior review
+and learn which commit it last covered. `<HEAD-sha>` is the full 40-char SHA of
+the commit the review covers — the PR head at review time.
+
+### Post as a comment, never as a GitHub review
+
+Post with **`gh pr comment <n>`** — a plain, **non-approving** PR comment. Do
+**NOT** use `gh pr review --approve` / `--request-changes`: an automated GitHub
+*review* can satisfy or conflict with required-human-review rules and interfere
+with the merge queue. The APPROVE / REQUEST-CHANGES verdict lives in the comment
+body as text, not as a GitHub review state.
+
+Use `--body-file` (write the body to a temp file) rather than `--body` for the
+long, multi-line body, so markdown and special characters survive shell quoting:
+
+```bash
+gh pr comment <n> --repo wifihaven/wifihaven --body-file /tmp/pr-review-body.md
+```
+
+### First run (no prior marked comment)
+
+1. Resolve the PR head SHA: `gh pr view <n> --json headRefOid -q .headRefOid`
+   (or `git rev-parse HEAD` when reviewing the checked-out branch).
+2. Review the **full merge-base diff** `git diff origin/main...HEAD`
+   (three-dot — never two-dot) against the 8 dimensions above.
+3. Post the marked comment for that SHA.
+
+### Re-run (a prior marked comment exists)
+
+1. **Find the latest prior review comment** by the marker and extract its
+   `reviewed-sha` and its findings:
+
+   ```bash
+   # latest comment carrying the marker (null if none → this is a first run)
+   gh api "repos/wifihaven/wifihaven/issues/<n>/comments" --paginate \
+     --jq '[.[] | select(.body | contains("<!-- wifihaven-pr-review reviewed-sha="))] | last'
+   ```
+
+   Pull the prior SHA out of that comment's body:
+   `grep -oE 'reviewed-sha=[0-9a-f]+' | head -1`. (PR-conversation comments live
+   on the `issues/<n>/comments` endpoint — PR review comments are a different
+   endpoint we deliberately don't use.)
+
+2. **Status each prior finding** against the *current* code by re-checking the
+   `file:line` it cited:
+   - **ADDRESSED** — the cited problem is gone / fixed in current code.
+   - **NOT-ADDRESSED** — still present, unchanged.
+   - **PARTIAL** — partly fixed; state what remains.
+
+3. **Review the incremental delta** `git diff <reviewed-sha>...HEAD` (three-dot)
+   — the latest push(es) plus the context the fix newly touched — against the 8
+   dimensions, for **NEW** findings. This is what catches a fix that introduces
+   a fresh problem.
+
+4. **Post one updated marked comment** carrying the **new** HEAD `reviewed-sha`,
+   containing, in order:
+   - a **prior-findings status table** (each prior finding →
+     ADDRESSED / NOT-ADDRESSED / PARTIAL),
+   - the **new** findings from the delta (classified BLOCKER / SHOULD-FIX / NIT),
+   - an **updated VERDICT** + summary.
+
+### Merge gate across re-runs
+
+- A prior **BLOCKER clears only when it is ADDRESSED *and* the latest push
+  introduced no new BLOCKER.**
+- **Any open BLOCKER** — a prior one still NOT-ADDRESSED / PARTIAL, *or* a newly
+  introduced one — keeps the verdict at **REQUEST-CHANGES** and stays
+  merge-gating.
+
+### Idempotent, non-spammy
+
+Post **one** updated comment per run. Appending a fresh marked comment (with the
+new `reviewed-sha`) is fine and preserves the review history — the marker's SHA
+distinguishes runs, and the re-run logic always reads the **latest** marked
+comment, so old comments don't cause double-review. Do not post duplicate
+comments for the same SHA.


### PR DESCRIPTION
Closes #1575. Follow-up to #1563 (the standard PR-review tooling: `docs/pr-review-checklist.md` + the AGENTS "Independent PR review" rule + the `/pr-review` command). Docs/command only — **no source, no migration**.

## What changes

Two capabilities added to the existing review (the 8 review dimensions are unchanged):

### 1. Post the review to the PR
The reviewer **posts** its findings as a **non-approving** PR comment via `gh pr comment <n>` — *not* a GitHub `--approve` / `--request-changes` review, so an automated review can't satisfy/conflict with required human reviews or interfere with the merge queue. The verdict lives in the comment body as text.

The comment **leads with a stable, machine-findable marker** that records the reviewed commit:
```
<!-- wifihaven-pr-review reviewed-sha=<HEAD-sha> -->
```
followed by the standard body (BLOCKERS / SHOULD-FIX / NITS / VERDICT + summary).

### 2. Iterative re-review on subsequent pushes
- **First run** (no prior marked comment): review the full merge-base diff `git diff origin/main...HEAD`, post the marked comment.
- **Re-run** (prior marked comment exists):
  1. Find the latest prior comment by the marker (`gh api repos/.../issues/<n>/comments` + jq), extract its `reviewed-sha` and findings.
  2. **Status each prior finding** ADDRESSED / NOT-ADDRESSED / PARTIAL by re-checking the cited `file:line` in current code.
  3. **Review the incremental delta** `git diff <reviewed-sha>...HEAD` (latest push(es) + context the fix touched) for NEW findings — catches a fix that introduces a fresh problem.
  4. Post an updated marked comment (new `reviewed-sha`) with a prior-findings status table + new findings + updated VERDICT.
- **Merge gate:** a BLOCKER clears only when ADDRESSED *and* no new BLOCKER was introduced; any open BLOCKER (unaddressed/partial or newly-introduced) stays merge-gating.
- **Idempotent / non-spammy:** one updated comment per run; appending with the new `reviewed-sha` preserves history, and the re-run always reads the *latest* marked comment.

## Files
- `docs/pr-review-checklist.md` — new **Posting & re-runs** section (authoritative); 8 dimensions untouched.
- `.claude/commands/pr-review.md` — wires in the find-prior → status + review-delta → post flow; references the checklist.
- `AGENTS.md` (CLAUDE.md is a symlink to it) — "Independent PR review" rule notes the review is posted + re-run on each push.

## Validation
- `git diff --name-only origin/main...HEAD` → only those 3 files.
- The `gh` marker-find / sha-extract / head-resolve commands were tested against live PR comment JSON (a marked review comment already exists on #1574 from the orchestrator-side prompt): the latest-marked-comment jq returns the comment, `grep -oE 'reviewed-sha=[0-9a-f]+'` extracts the SHA, and an unmarked PR yields empty (the first-run signal).
- Kept `docs/pr-review-checklist.md` in sync with the orchestrator reference prompt — same review.
