### PR TITLE
refactor(#1570): centralized error handler (Stage 1 — boundary handler + ingest routes)

### DIFF
--- a/api/src/ErrorBoundary.scala
+++ b/api/src/ErrorBoundary.scala
@@ -1,0 +1,101 @@
+package wifihaven.api
+
+import wifihaven.api.metrics.AppMetrics
+import zio.*
+import zio.http.*
+
+/**
+ * #1570: the single error-handling layer at the server boundary. Mirrors [[metrics.HttpMetrics]] —
+ * it transforms each route individually so it can read the route's own templated path
+ * (`routePattern.pathCodec`), then inspects the response the handler ultimately produced (success
+ * OR error channel) and, when that response is an error (status >= 400), LOGS and METERS it
+ * uniformly.
+ *
+ * This is what makes error handling consistent regardless of how a route produced the response:
+ *   - migrated routes fail with a typed [[routes.ApiError]] that
+ *     [[routes.ErrorMapper.errorToResponse]] maps; un-migrated routes still build a `Response`
+ *     inline. Either way the boundary sees the final response and treats it the same.
+ *
+ * It closes the #1569 gap structurally: POST `/api/router/events` hand-logged decode failures but
+ * POST `/api/router/usage` did not, so the incident's failing field was invisible in our logs. Now
+ * every 4xx — including a decode 400 whose body is the zio-json error naming the failing field — is
+ * logged once, here, at WARN; every 5xx at ERROR. The per-route bespoke logging is removed so there
+ * is exactly one emitter (no double-logging, no drift).
+ *
+ * Logging policy:
+ *   - 4xx (incl. decode/validation/auth) → WARN
+ *   - 5xx (incl. the DB 503) → ERROR
+ *   - context: templated `route`, `method`, `status`, and a bounded one-line snippet of the
+ *     response body. The body of an error response is our own message (the decode error, the
+ *     "router_id mismatch" text, the `{"status":"error","db":...}` JSON) — never request PII — and
+ *     it carries the diagnostic detail, so a small truncated snippet is logged. Reading is guarded
+ *     by `knownContentLength` (our error bodies are small, complete, in-memory strings) and any
+ *     read failure degrades to no-snippet, so it can never disturb the response sent to the client.
+ *
+ * Metering: `api_errors_total{route,status}` via [[AppMetrics.recordHttpError]] (bounded labels
+ * only — the templated route + the status code; never a per-mac/host/ip value).
+ *
+ * Like HttpMetrics, an unmatched request never reaches a transformed handler, so a raw
+ * attacker-controlled path can never become a label.
+ */
+object ErrorBoundary {
+
+  /** Max characters of an error-response body logged as context. Bounded — no PII dumps. */
+  private val MaxSnippet = 256
+
+  /** Don't even attempt to read a body larger than this as a snippet. */
+  private val MaxReadBytes = 64L * 1024L
+
+  private def renderTemplate(rp: RoutePattern[?]): String =
+    rp.pathCodec.render(":", "")
+
+  def observe(routes: Routes[Any, Response]): Routes[Any, Response] =
+    Routes.fromIterable(routes.routes.map(observeOne))
+
+  private def observeOne(route: Route[Any, Response]): Route[Any, Response] = {
+    val routeLabel = renderTemplate(route.routePattern)
+    val method     = route.routePattern.method.render
+    route.transform[Any] { handler =>
+      Handler.fromFunctionZIO[Request] { req =>
+        handler(req).either.flatMap { result =>
+          val response = result.merge
+          val observe  =
+            if response.status.code >= 400 then logAndMeter(routeLabel, method, response)
+            else ZIO.unit
+          observe *> ZIO.fromEither(result)
+        }
+      }
+    }
+  }
+
+  private def logAndMeter(route: String, method: String, response: Response): UIO[Unit] = {
+    val status = response.status.code
+    for {
+      snippet <- bodySnippet(response)
+      base = s"$method $route -> $status"
+      msg  = snippet.fold(base)(s => s"$base body=$s")
+      _ <- if status >= 500 then ZIO.logError(msg) else ZIO.logWarning(msg)
+      _ <- AppMetrics.recordHttpError(route, status)
+    } yield ()
+  }
+
+  /**
+   * Best-effort one-line, length-bounded snippet of the (error) response body. Only reads bodies
+   * with a known, small content length — our 4xx/5xx bodies are complete in-memory strings, never
+   * streams — and never fails: a read error degrades to no snippet rather than affecting the
+   * response delivered to the client.
+   */
+  private def bodySnippet(response: Response): UIO[Option[String]] =
+    response.body.knownContentLength match {
+      case Some(len) if len > 0L && len <= MaxReadBytes =>
+        response.body.asString
+          .map(s => Some(truncate(s)))
+          .catchAll(_ => ZIO.none)
+      case _                                            => ZIO.none
+    }
+
+  private def truncate(s: String): String = {
+    val oneLine = s.replaceAll("\\s+", " ").trim
+    if oneLine.length > MaxSnippet then oneLine.take(MaxSnippet) + "…(truncated)" else oneLine
+  }
+}

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -431,10 +431,24 @@ object Main extends ZIOAppDefault {
       // seeds complete). #1204: wrap health + the gated real routes in the HTTP
       // metrics middleware (templated route labels), then mount the uninstrumented
       // /metrics scrape endpoint alongside.
+      // #1570: ErrorBoundary.observe wraps every served route family so any error response (4xx
+      // WARN / 5xx ERROR) is logged + metered (api_errors_total{route,status}) in one place —
+      // matching the coverage of HttpMetrics.instrument (which already counts all these in
+      // http_requests_total). This includes the SPA catch-all (StaticRoutes): an unmatched
+      // `/api/*` path 404s there ("no such API route") and a malformed URI 400s — both are real
+      // API errors worth surfacing, and the SPA fallback serves index.html (200) for client routes
+      // so there is no asset-404 flood. The `route` label is the route's bounded template (the
+      // trailing catch-all collapses every path to one series), so no per-path leak.
+      //
+      // It sits *inside* the readiness gate so the gate's startup 503s don't spam the log. Only
+      // /api/health (its own 503-while-starting semantics, polled constantly) and /metrics (the
+      // scrape endpoint) are left out — mirroring HttpMetrics' own exclusion of /metrics.
       HttpMetrics.instrument(
         healthRoutes ++
           Readiness.gate(
-            systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+            ErrorBoundary.observe(
+              systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+            ),
             ready,
           ),
       ) ++ metricsRoutes

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -71,6 +71,11 @@ object MetricGuard {
     // §5.2 API self-metrics.
     "http_requests_total"                       -> Set("route", "method", "status"),
     "http_request_duration_seconds"             -> Set("route", "method"),
+    // #1570 — error responses metered at the server boundary (ErrorBoundary). A dedicated,
+    // operator-facing error series sliced by templated route + status code, so the error-rate
+    // panel queries one obvious counter rather than filtering the all-requests counter. Bounded
+    // labels only (route ~40 templated paths, status the HTTP code).
+    "api_errors_total"                          -> Set("route", "status"),
     "db_query_duration_seconds"                 -> Set("op"),
     "db_queries_total"                          -> Set("op", "status"),
     "auth_failures_total"                       -> Set("reason"),
@@ -195,6 +200,18 @@ object AppMetrics {
         math.max(0.0, durationSeconds),
         HttpDurationBoundaries,
       )
+
+  // ── HTTP error responses (#1570) ─────────────────────────────────────────────
+  // Emitted from ErrorBoundary for every response with status >= 400, alongside a
+  // WARN (4xx) / ERROR (5xx) log. `route` is the templated path (same source as
+  // recordHttp above) and `status` the HTTP code — both bounded; never a per-mac /
+  // host / ip / user value.
+
+  def recordHttpError(route: String, status: Int): UIO[Unit] =
+    MetricGuard.counter(
+      "api_errors_total",
+      Map("route" -> route, "status" -> status.toString),
+    )
 
   // ── DB query timing (#1204) ──────────────────────────────────────────────────
   // Emitted from DbMetrics.timed around the Doobie transact of hot repo methods.

--- a/api/src/routes/ApiError.scala
+++ b/api/src/routes/ApiError.scala
@@ -1,0 +1,62 @@
+package wifihaven.api.routes
+
+import zio.http.*
+
+/**
+ * #1570: the typed error vocabulary a route handler fails with so that mapping → HTTP status/body
+ * happens in ONE place ([[ErrorMapper.errorToResponse]]) instead of being hand-rolled per route
+ * with inline `Response.badRequest(...)` / `Response.notFound(...)` /
+ * `ErrorMapper.dbErrorToResponse`.
+ *
+ * This is the seam that lets the centralized boundary handler ([[wifihaven.api.ErrorBoundary]]) log
+ * + meter every error consistently. Routes migrate to it incrementally (Stage 1: the router ingest
+ * routes); until a route is migrated it keeps producing `Response` directly and the boundary still
+ * logs/meters it by status.
+ *
+ * CRITICAL — wire back-compat: each case maps to the EXACT same `Response` the hand-rolled code
+ * produced before (same status code, same body constructor), because the OpenWRT agent and the SPA
+ * parse these responses. The agent branches on status only (4xx = drop, 5xx = retry/back-off), so
+ * the DB case MUST stay 503; the SPA reads the body as plain text for display and sniffs the 403
+ * body for `password_change_required`. See docs/architecture.md + the #1570 issue.
+ */
+sealed trait ApiError
+
+object ApiError {
+
+  /** 400. Generic client error; body is the plain-text message (matches `Response.badRequest`). */
+  final case class BadRequest(message: String) extends ApiError
+
+  /**
+   * 400, semantically distinct from [[BadRequest]]: a request body failed JSON decoding/validation.
+   * `message` is the zio-json error string (it names the failing field/position) and becomes the
+   * response body, so the boundary's WARN log surfaces the failing field — the exact gap that made
+   * the #1569 usage-ingest incident invisible in our logs. Maps identically to a 400.
+   */
+  final case class DecodeFailure(message: String) extends ApiError
+
+  /** 401. Plain-text body (matches `Response.unauthorized`). */
+  final case class Unauthorized(message: String) extends ApiError
+
+  /** 403. Plain-text body (matches `Response.forbidden`). */
+  final case class Forbidden(message: String) extends ApiError
+
+  /** 404. Plain-text body (matches `Response.notFound`). */
+  final case class NotFound(message: String) extends ApiError
+
+  /**
+   * 503 + `{"status":"error","db":"<class>"}` + `Retry-After: 30` (via
+   * [[ErrorMapper.dbErrorToResponse]]). The agent distinguishes this "retry later" 503 from a 4xx
+   * "do not retry"; keeping DB failures as 503 (never a bare 500) is load-bearing.
+   */
+  final case class Db(cause: Throwable) extends ApiError
+
+  /** 500. Plain-text body (matches `Response.internalServerError`). */
+  final case class Internal(message: String) extends ApiError
+
+  /**
+   * An already-formed `Response` passed through unchanged. Bridges collaborators that still produce
+   * `Response` on their error channel (e.g. [[RouterAuth.authenticate]]) into the typed pipeline
+   * without re-deriving their status/body — their migration to a typed error is Stage 2+.
+   */
+  final case class Wrapped(response: Response) extends ApiError
+}

--- a/api/src/routes/ErrorMapper.scala
+++ b/api/src/routes/ErrorMapper.scala
@@ -14,6 +14,27 @@ import zio.http.*
  */
 object ErrorMapper {
 
+  /**
+   * #1570: the single typed-error → `Response` mapping. Routes that have migrated to the central
+   * handler (Stage 1: the router ingest routes) fail with an [[ApiError]] and let this produce the
+   * response, instead of constructing `Response.badRequest(...)` / `notFound(...)` inline.
+   *
+   * Every branch reproduces the EXACT status + body the hand-rolled code produced before — the
+   * error responses are part of the cross-process wire contract (the OpenWRT agent branches on the
+   * status; the SPA renders the body text). Mapping is pure: logging and metering happen once, at
+   * the boundary ([[wifihaven.api.ErrorBoundary]]), so there is a single source for each concern.
+   */
+  def errorToResponse(e: ApiError): Response = e match {
+    case ApiError.BadRequest(m)    => Response.badRequest(m)
+    case ApiError.DecodeFailure(m) => Response.badRequest(m)
+    case ApiError.Unauthorized(m)  => Response.unauthorized(m)
+    case ApiError.Forbidden(m)     => Response.forbidden(m)
+    case ApiError.NotFound(m)      => Response.notFound(m)
+    case ApiError.Db(t)            => dbErrorToResponse(t)
+    case ApiError.Internal(m)      => Response.internalServerError(m)
+    case ApiError.Wrapped(r)       => r
+  }
+
   /** 503 + JSON body + Retry-After. Use for any ZIO[_, Throwable, _] that touches the DB. */
   def dbErrorToResponse(t: Throwable): Response =
     dbUnavailable(t.getClass.getSimpleName)

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -34,30 +34,30 @@ object RouterIngestRoutes {
     Routes(
       Method.POST / "api" / "router" / "usage"  ->
         handler { (req: Request) =>
-          for {
-            router <- auth.authenticate(req)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
-            // #1569: decode the *envelope* (routerId, periodStart, periodEnd) +
-            // `records` as a raw JSON array, deferring per-record validation. A
-            // genuinely unparseable envelope (bad routerId/timestamps, not an
-            // object, `records` not an array, truncated body) still 400s — but
-            // now LOGGED (the prior code dropped the zio-json error straight into
-            // the 400 body and never logged it, so the offending field was
-            // invisible server-side; mirrors the #1126 events-handler pattern).
+          // #1570: fail with a typed ApiError; ErrorMapper.errorToResponse maps it and the
+          // ErrorBoundary logs (4xx WARN / 5xx ERROR) + meters. This subsumes the bespoke
+          // envelope/timestamp decode logging #1574 added for #1569 — the boundary now logs the 400
+          // once, with the response-body snippet (the zio-json error names the failing field), so
+          // the diagnostic gap stays closed without a second emitter.
+          //
+          // The per-RECORD skip path (below) is kept from #1574 and is NOT redundant with the
+          // boundary: a batch carrying a bad record still returns 200, so the boundary never sees
+          // it — the skip is logged + metered inline here.
+          val handle: ZIO[Any, ApiError, Response] = for {
+            router <- auth.authenticate(req).mapError(ApiError.Wrapped(_))
+            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+            // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a raw
+            // JSON array, deferring per-record validation. A genuinely unparseable envelope (bad
+            // routerId/timestamps, not an object, `records` not an array, truncated body) still
+            // 400s — logged by the boundary.
             raw    <- ZIO
               .fromEither(body.fromJson[RawUsageReport])
-              .tapError(e =>
-                ZIO.logWarning(
-                  s"router usage: envelope deserialization failed for router=${router.id} " +
-                    s"bodyLen=${body.length} bodySnippet=${snippet(body)} err=$e",
-                ),
-              )
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             _      <- ZIO
-              .fail(Response.badRequest("router_id mismatch"))
+              .fail(ApiError.BadRequest("router_id mismatch"))
               .when(raw.routerId != router.id)
-            ps     <- parseInstant(raw.periodStart, router.id)
-            pe     <- parseInstant(raw.periodEnd, router.id)
+            ps     <- parseInstant(raw.periodStart)
+            pe     <- parseInstant(raw.periodEnd)
             // #1569: decode each record individually. A single malformed record
             // (e.g. a host value that fails Hostname validation — an Akamai/CDN
             // CNAME target with underscores, see #1572) used to fail the WHOLE
@@ -82,7 +82,7 @@ object RouterIngestRoutes {
                   s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
               ),
             )
-            settings <- householdSettingsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
             _        <- handleUsage(
               router.id,
               ps,
@@ -93,21 +93,27 @@ object RouterIngestRoutes {
               timeUsageRepo,
               deviceRepo,
             )
-            _ <- routerRepo.touch(router.id, None, None).mapError(ErrorMapper.dbErrorToResponse)
+            _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "router" / "events" ->
         handler { (req: Request) =>
-          val handle = for {
-            router <- auth.authenticate(req)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+          // #1570: typed errors + central mapping. The bespoke decode `logWarning`, the
+          // routerId-mismatch `logWarning`, and the trailing "returning status=" `logInfo` are
+          // gone — the ErrorBoundary now logs every 4xx (incl. this decode 400) at WARN with the
+          // response-body snippet, so logging is uniform with the usage route (the #1569 dedup:
+          // one emitter, not two).
+          val handle: ZIO[Any, ApiError, Response] = for {
+            router <- auth.authenticate(req).mapError(ApiError.Wrapped(_))
+            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             // #1126: tolerate an empty/blank body as a no-op batch. A truncated
             // or empty POST (network blip, retry-queue edge) used to fail
             // RouterEventsRequest decoding with "Unexpected end of input" and
             // 400, spamming the warn log and dropping the (harmless) batch. An
             // empty events POST carries nothing to persist, so treat it as an
             // accepted no-op rather than an error. Genuinely malformed non-empty
-            // bodies still 400 + warn below (and the agent emitter no longer
+            // bodies still 400 + warn (and the agent emitter no longer
             // produces them — see conntrack.encode_events_body).
             rep    <-
               if body.trim.isEmpty then
@@ -117,17 +123,9 @@ object RouterIngestRoutes {
               else
                 ZIO
                   .fromEither(body.fromJson[RouterEventsRequest])
-                  .tapError(e =>
-                    ZIO.logWarning(
-                      s"router events: deserialization failed for router=${router.id} bodyLen=${body.length} err=$e",
-                    ),
-                  )
-                  .mapError(e => Response.badRequest(e))
+                  .mapError(ApiError.DecodeFailure(_))
             _      <- ZIO
-              .logWarning(
-                s"router events: routerId mismatch token=${router.id} body=${rep.routerId}",
-              )
-              .zipRight(ZIO.fail(Response.badRequest("router_id mismatch")))
+              .fail(ApiError.BadRequest("router_id mismatch"))
               .when(rep.routerId != router.id)
             _      <- ZIO.logInfo(
               s"router events: router=${router.id} batchSize=${rep.events.size}",
@@ -141,9 +139,9 @@ object RouterIngestRoutes {
               ),
             )
             _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo, alertRepo)
-            _ <- routerRepo.touch(router.id, None, None).mapError(ErrorMapper.dbErrorToResponse)
+            _      <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
           } yield Response.ok
-          handle.tapError(r => ZIO.logInfo(s"router events: returning status=${r.status.code}"))
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 
@@ -163,23 +161,10 @@ object RouterIngestRoutes {
       records: List[Json],
   ) derives JsonDecoder
 
-  /**
-   * #1569: short, bounded body excerpt for the decode-failure warn log — never the full body (avoid
-   * logging more PII than needed to identify the offending field).
-   */
-  private def snippet(body: String): String = {
-    val max = 200
-    if body.length <= max then body else body.take(max) + s"…(+${body.length - max} more)"
-  }
-
-  private def parseInstant(s: String, routerId: RouterId): IO[Response, Instant] =
-    ZIO
-      .attempt(Instant.parse(s))
-      .orElseFail(s)
-      .tapError(bad =>
-        ZIO.logWarning(s"router usage: invalid timestamp '$bad' from router=$routerId"),
-      )
-      .mapError(bad => Response.badRequest(s"invalid timestamp: $bad"))
+  // #1570: a bad timestamp is a typed BadRequest (400) mapped centrally; the boundary logs it.
+  // (The bespoke per-call warn log #1574 added is subsumed by the boundary — single emitter.)
+  private def parseInstant(s: String): IO[ApiError, Instant] =
+    ZIO.attempt(Instant.parse(s)).orElseFail(ApiError.BadRequest(s"invalid timestamp: $s"))
 
   private def handleUsage(
       routerId: RouterId,
@@ -190,7 +175,7 @@ object RouterIngestRoutes {
       trafficRepo: TrafficReportRepo,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
-  ): IO[Response, Unit] = {
+  ): IO[ApiError, Unit] = {
     // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
     // reset_time), matching the read-side date used by PolicyService.snapshot.
     val date         = PolicyService.householdLocalDate(periodStart, settings)
@@ -218,7 +203,7 @@ object RouterIngestRoutes {
       _        <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
       // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
       // Only those rows should drive time_usage / device updates; replays return 0.
-      newCount <- trafficRepo.insertBatch(inserts).mapError(ErrorMapper.dbErrorToResponse)
+      newCount <- trafficRepo.insertBatch(inserts).mapError(ApiError.Db(_))
       _        <- ZIO.when(newCount > 0)(
         applyDelta(routerId, periodEnd, records, settings, timeUsageRepo, deviceRepo),
       )
@@ -243,7 +228,7 @@ object RouterIngestRoutes {
       settings: HouseholdSettings,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
-  ): IO[Response, Unit] = {
+  ): IO[ApiError, Unit] = {
     // #1010: bucket time_usage by the household's logical "today" so the
     // cap-tracking read path (which uses the same household-local date) lines
     // up with the rows we wrote.
@@ -293,13 +278,13 @@ object RouterIngestRoutes {
         else bucketSecs
       timeUsageRepo
         .incrementSecondsAndBytes(mac, host, date, secs, bIn, bOut, proportionalSecs)
-        .mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
     } *>
       // For each unique mac in the batch, touch last_seen on the existing row (no-op if unknown).
       ZIO.foreachDiscard(records.map(r => (r.mac, r.ip)).distinct) { (mac, ip) =>
         deviceRepo
           .touchLastSeen(mac, ip, periodEnd)
-          .mapError(ErrorMapper.dbErrorToResponse)
+          .mapError(ApiError.Db(_))
           .unit
       }
   }
@@ -318,7 +303,7 @@ object RouterIngestRoutes {
       deviceRepo: DeviceRepo,
       connEventRepo: ConnectionEventRepo,
       alertRepo: AlertRepo,
-  ): IO[Response, Unit] = {
+  ): IO[ApiError, Unit] = {
     val connInserts = events.collect {
       case e if e.`type` == "connection_attempt" =>
         for {
@@ -332,9 +317,7 @@ object RouterIngestRoutes {
     }
     for {
       // Surface JSON validation errors as 400.
-      validated <- ZIO.foreach(connInserts)(e =>
-        ZIO.fromEither(e).mapError(m => Response.badRequest(m)),
-      )
+      validated <- ZIO.foreach(connInserts)(e => ZIO.fromEither(e).mapError(ApiError.BadRequest(_)))
       // #720: for each ipv4/ipv6-typed insert with a dest_ip, consult the
       // existing connection_events for a sibling fqdn-typed event we can
       // attribute it to. This handles the "fqdn observed first, ipv4 race-
@@ -345,7 +328,7 @@ object RouterIngestRoutes {
       // duplicates collapsed on conflict.
       inserted  <- connEventRepo
         .insertBatch(enriched)
-        .mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
         .when(enriched.nonEmpty)
         .map(_.getOrElse(0))
       _         <- ZIO
@@ -366,12 +349,12 @@ object RouterIngestRoutes {
   private def attachResolvedHost(
       ev: ConnectionEventInsert,
       connEventRepo: ConnectionEventRepo,
-  ): IO[Response, ConnectionEventInsert] =
+  ): IO[ApiError, ConnectionEventInsert] =
     (ev.host, ev.destIp) match {
       case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
         connEventRepo
           .findRecentFqdnFor(ev.routerId, destIp, ev.ts.minus(fqdnBackfillWindow))
-          .mapError(ErrorMapper.dbErrorToResponse)
+          .mapError(ApiError.Db(_))
           .map(h => ev.copy(resolvedHost = h))
       case _                                               => ZIO.succeed(ev)
     }
@@ -379,12 +362,12 @@ object RouterIngestRoutes {
   private def backfillFromFqdn(
       ev: ConnectionEventInsert,
       connEventRepo: ConnectionEventRepo,
-  ): IO[Response, Unit] =
+  ): IO[ApiError, Unit] =
     (ev.host, ev.destIp) match {
       case (HostId.Fqdn(name), Some(destIp)) =>
         connEventRepo
           .backfillResolvedFor(ev.routerId, destIp, name, ev.ts.minus(fqdnBackfillWindow))
-          .mapError(ErrorMapper.dbErrorToResponse)
+          .mapError(ApiError.Db(_))
           .unit
       case _                                 => ZIO.unit
     }
@@ -411,7 +394,7 @@ object RouterIngestRoutes {
       e: RouterEvent,
       deviceRepo: DeviceRepo,
       alertRepo: AlertRepo,
-  ): IO[Response, Unit] =
+  ): IO[ApiError, Unit] =
     if e.`type` != "dhcp_lease" && e.`type` != "first_seen_mac" then ZIO.unit
     else
       e.mac match {
@@ -420,19 +403,19 @@ object RouterIngestRoutes {
           for {
             ts       <- ZIO
               .attempt(Instant.parse(e.ts))
-              .orElseFail(Response.badRequest(s"invalid ts: ${e.ts}"))
-            existing <- deviceRepo.findByMac(mac).mapError(ErrorMapper.dbErrorToResponse)
+              .orElseFail(ApiError.BadRequest(s"invalid ts: ${e.ts}"))
+            existing <- deviceRepo.findByMac(mac).mapError(ApiError.Db(_))
             _        <- existing match {
               case Some(_) =>
                 deviceRepo
                   .touchLastSeen(mac, e.ip, ts)
-                  .mapError(ErrorMapper.dbErrorToResponse)
+                  .mapError(ApiError.Db(_))
                   .unit *>
                   ZIO
                     .foreachDiscard(e.hostname)(h =>
                       deviceRepo
                         .renameIfAutoGenerated(mac, h.value)
-                        .mapError(ErrorMapper.dbErrorToResponse),
+                        .mapError(ApiError.Db(_)),
                     )
               case None    =>
                 // #711: a brand-new MAC. Insert the device row, then raise a
@@ -446,11 +429,11 @@ object RouterIngestRoutes {
                     e.ip,
                     ts,
                   )
-                  .mapError(ErrorMapper.dbErrorToResponse)
+                  .mapError(ApiError.Db(_))
                   .unit *>
                   alertRepo
                     .raiseNewDevice(mac, ts)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
             }
           } yield ()
       }

--- a/api/test/src/feature/ErrorBoundarySpec.scala
+++ b/api/test/src/feature/ErrorBoundarySpec.scala
@@ -1,0 +1,290 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ErrorBoundary
+import wifihaven.api.MetricsConfig
+import wifihaven.api.db.*
+import wifihaven.api.metrics.MetricsRuntime
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * #1570: the centralized error handler.
+ *
+ *   1. [[ErrorMapper.errorToResponse]] maps each typed [[ApiError]] to the EXACT status + body the
+ *      hand-rolled code produced before (wire back-compat: the agent branches on status, the SPA
+ *      renders the body text). 2. [[ErrorBoundary.observe]] LOGS (4xx → WARN, 5xx → ERROR, with a
+ *      bounded body snippet) and METERS (`api_errors_total{route,status}`) every error response,
+ *      regardless of whether the route returned it or failed with it. 3. Regression pin for #1569:
+ *      a usage decode failure is now LOGGED (the usage route used to map the decode error into the
+ *      400 body but never log it — invisible during the incident).
+ */
+object ErrorBoundarySpec
+    extends ZIOSpec[
+      TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher,
+    ] {
+
+  // Pin Clock so PolicyService date math in the ingest path is stable (matches RouterIngestSpec).
+  private val testClockAt = java.time.LocalDateTime.of(2026, 5, 7, 14, 0, 0)
+
+  override val bootstrap =
+    TestDatabase.layer ++
+      TestLayers.withClock(testClockAt) ++
+      MetricsRuntime.prometheus(100.millis)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def scrape: ZIO[PrometheusPublisher, Response, String] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      routes = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
+      resp <- routes(Request.get("/metrics"))
+      body <- resp.body.asString.orElseFail(Response.internalServerError("scrape decode failed"))
+    } yield body
+
+  private def errorLines(body: String, route: String, status: Int): List[String] =
+    body.linesIterator
+      .filter(l => !l.startsWith("#") && l.startsWith("api_errors_total"))
+      .filter(l => l.contains(s"""route="$route"""") && l.contains(s"""status="$status""""))
+      .toList
+
+  private def bodyText(r: Response): UIO[String] = r.body.asString.orElseSucceed("")
+
+  // ── synthetic routes exercising the boundary directly ───────────────────────
+  private val syntheticRoutes: Routes[Any, Response] =
+    ErrorBoundary.observe(
+      Routes(
+        // returns a 4xx on the SUCCESS channel (un-migrated "build Response inline" style)
+        Method.GET / "api" / "eb" / "client" ->
+          handler(Response.badRequest("synthetic client error")),
+        // returns a 5xx on the success channel (the DB-503 mapping shape)
+        Method.GET / "api" / "eb" / "server" ->
+          handler(ErrorMapper.dbErrorToResponse(new RuntimeException("kaboom"))),
+        // fails on the ERROR channel with a Response (migrated routes do this, pre-mapping)
+        Method.GET / "api" / "eb" / "fail"   ->
+          handler((_: Request) => ZIO.fail(Response.notFound("nope"))),
+        // a clean 2xx — must NOT log or meter an error
+        Method.GET / "api" / "eb" / "ok"     ->
+          handler(Response.ok),
+      ),
+    )
+
+  // Routes[Any, Response].runZIO converts a failed-with-Response handler into a successful
+  // Response, so the error channel is Nothing here — the boundary has already logged/metered by
+  // the time the Response surfaces.
+  private def runSynthetic(path: String) =
+    syntheticRoutes.runZIO(Request.get(URL.decode(path).toOption.get))
+
+  // ── real ingest routes wrapped in the boundary (the #1569 incident surface) ──
+  private def buildIngest =
+    for {
+      rRepo <- ZIO.service[RouterRepo]
+      tRepo <- ZIO.service[TrafficReportRepo]
+      tu    <- ZIO.service[TimeUsageRepo]
+      dRepo <- ZIO.service[DeviceRepo]
+      cRepo <- ZIO.service[ConnectionEventRepo]
+      aRepo <- ZIO.service[AlertRepo]
+      hsr   <- ZIO.service[HouseholdSettingsRepo]
+      auth = new RouterAuthLive(rRepo)
+    } yield ErrorBoundary.observe(
+      RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr),
+    )
+
+  private def seedRouter(rRepo: RouterRepo): Task[(RouterId, String)] = {
+    val token = "ROUTER_TOKEN_PLAIN"
+    for {
+      id <- rRepo.create("test-router", Sha256Hex.unsafe("m" * 64))
+      _  <- rRepo.completeEnrollment(id, Sha256Hex.unsafe(RouterAuth.sha256Hex(token)))
+    } yield (id, token)
+  }
+
+  private def postIngest(routes: Routes[Any, Response], path: String, body: String, token: String) =
+    routes
+      .runZIO(
+        Request
+          .post(URL.decode(path).toOption.get, Body.fromString(body))
+          .addHeader(Header.ContentType(MediaType.application.json))
+          .addHeader(Header.Authorization.Bearer(token)),
+      )
+
+  private def warned(logs: Chunk[ZTestLogger.LogEntry], substr: String): Boolean =
+    logs.exists(e => e.logLevel == LogLevel.Warning && e.message().contains(substr))
+
+  private def erroredLog(logs: Chunk[ZTestLogger.LogEntry], substr: String): Boolean =
+    logs.exists(e => e.logLevel == LogLevel.Error && e.message().contains(substr))
+
+  def spec = suite("ErrorBoundary + ErrorMapper (#1570)")(
+    // ── ErrorMapper.errorToResponse: exact wire shapes (back-compat) ───────────
+    test("errorToResponse maps each ApiError to its preserved status + body") {
+      for {
+        br   <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.BadRequest("bad")))
+        brB  <- bodyText(br)
+        dec  <- ZIO.succeed(
+          ErrorMapper.errorToResponse(ApiError.DecodeFailure("decode: .records[0]")),
+        )
+        decB <- bodyText(dec)
+        un   <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.Unauthorized("no token")))
+        fo   <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.Forbidden("nope")))
+        nf   <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.NotFound("missing")))
+        in   <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.Internal("boom")))
+        wrapped = Response.status(Status.Conflict)
+        wr <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.Wrapped(wrapped)))
+      } yield assertTrue(br.status == Status.BadRequest) &&
+        assertTrue(brB == "bad") &&
+        assertTrue(dec.status == Status.BadRequest) &&
+        // the failing-field detail is preserved in the body (what makes the #1569 log useful)
+        assertTrue(decB.contains(".records[0]")) &&
+        assertTrue(un.status == Status.Unauthorized) &&
+        assertTrue(fo.status == Status.Forbidden) &&
+        assertTrue(nf.status == Status.NotFound) &&
+        assertTrue(in.status == Status.InternalServerError) &&
+        // Wrapped passes an already-formed Response through unchanged.
+        assertTrue(wr.status == Status.Conflict)
+    },
+    test("errorToResponse(Db) preserves the 503 + {status,db} body + Retry-After:30 wire shape") {
+      // The agent depends on 503 (retry/back-off) vs 4xx (drop); the body shape + Retry-After
+      // are the HealthRoutes-compatible contract. This must not drift.
+      for {
+        resp <- ZIO.succeed(ErrorMapper.errorToResponse(ApiError.Db(new RuntimeException("x"))))
+        body <- bodyText(resp)
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(body == """{"status":"error","db":"RuntimeException"}""") &&
+        assertTrue(resp.header(Header.RetryAfter).isDefined)
+    },
+
+    // ── ErrorBoundary: logging levels + body snippet + metering ────────────────
+    test("boundary logs a 4xx response at WARN with a body snippet and meters api_errors_total") {
+      (for {
+        resp <- runSynthetic("/api/eb/client")
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.catchAll(r => bodyText(r))
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        // WARN with the templated route + the response body snippet
+        assertTrue(warned(logs, "/api/eb/client")) &&
+        assertTrue(warned(logs, "synthetic client error")) &&
+        // NOT logged at ERROR (it's a client error)
+        assertTrue(!erroredLog(logs, "/api/eb/client")) &&
+        assertTrue(errorLines(body, "/api/eb/client", 400).nonEmpty))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("boundary logs a 5xx response at ERROR and meters it") {
+      (for {
+        resp <- runSynthetic("/api/eb/server")
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.catchAll(r => bodyText(r))
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.ServiceUnavailable) &&
+        assertTrue(erroredLog(logs, "/api/eb/server")) &&
+        assertTrue(!warned(logs, "/api/eb/server")) &&
+        assertTrue(errorLines(body, "/api/eb/server", 503).nonEmpty))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test(
+      "boundary observes errors raised on the ERROR channel (failed handler), not just returned",
+    ) {
+      (for {
+        resp <- runSynthetic("/api/eb/fail")
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.NotFound) &&
+        assertTrue(warned(logs, "/api/eb/fail")))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("boundary leaves a 2xx alone — no error log, no api_errors_total series for that route") {
+      (for {
+        resp <- runSynthetic("/api/eb/ok")
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.catchAll(r => bodyText(r))
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(!warned(logs, "/api/eb/ok")) &&
+        assertTrue(!erroredLog(logs, "/api/eb/ok")) &&
+        assertTrue(errorLines(body, "/api/eb/ok", 200).isEmpty))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+
+    // ── #1569 regression pin: usage decode failures are now LOGGED ─────────────
+    test(
+      "REGRESSION #1569: a /api/router/usage decode failure is LOGGED at WARN (not just 400-bodied)",
+    ) {
+      (for {
+        _       <- cleanDb
+        rRepo   <- ZIO.service[RouterRepo]
+        routes  <- buildIngest
+        (_, tk) <- seedRouter(rRepo)
+        // malformed: records[0].activeSeconds is a string where a number is required
+        bad =
+          """{"routerId":"00000000-0000-0000-0000-000000000000","periodStart":"2026-05-07T14:00:00Z","periodEnd":"2026-05-07T14:05:00Z","records":[{"mac":"aa:bb:cc:11:22:33","host":{"type":"fqdn","value":"x.com"},"activeSeconds":"not-a-number","bytesIn":1,"bytesOut":1}]}"""
+        resp     <- postIngest(routes, "/api/router/usage", bad, tk)
+        _        <- ZIO.sleep(700.millis)
+        body     <- scrape.catchAll(r => bodyText(r))
+        respBody <- bodyText(resp)
+        logs     <- ZTestLogger.logOutput
+      } yield
+      // Same status the agent already sees (4xx → drop, no retry) — unchanged.
+      assertTrue(resp.status == Status.BadRequest) &&
+        // back-compat: the decode error is still in the 400 body for the client.
+        assertTrue(respBody.nonEmpty) &&
+        // THE FIX: it is now logged at WARN under the templated route.
+        assertTrue(warned(logs, "/api/router/usage")) &&
+        // and metered.
+        assertTrue(errorLines(body, "/api/router/usage", 400).nonEmpty))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test(
+      "a /api/router/events decode failure is logged at WARN (parity with usage — single emitter)",
+    ) {
+      (for {
+        _       <- cleanDb
+        rRepo   <- ZIO.service[RouterRepo]
+        routes  <- buildIngest
+        (_, tk) <- seedRouter(rRepo)
+        bad = """{"routerId":"00000000-0000-0000-0000-000000000000","events":[{"type":}]}"""
+        resp <- postIngest(routes, "/api/router/events", bad, tk)
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.BadRequest) &&
+        assertTrue(warned(logs, "/api/router/events")))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("an invalid router bearer is mapped to 401 and logged at WARN by the boundary") {
+      (for {
+        _      <- cleanDb
+        routes <- buildIngest
+        body = UsageReport(
+          RouterId(UUID.randomUUID()),
+          Instant.parse("2026-05-07T14:00:00Z").toString,
+          Instant.parse("2026-05-07T14:05:00Z").toString,
+          Nil,
+        ).toJson
+        resp <- postIngest(routes, "/api/router/usage", body, "not-a-real-token")
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.Unauthorized) &&
+        assertTrue(warned(logs, "/api/router/usage")))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ErrorBoundarySpec.scala
+++ b/api/test/src/feature/ErrorBoundarySpec.scala
@@ -206,6 +206,32 @@ object ErrorBoundarySpec
           ZTestLogger.default,
         )
     } @@ TestAspect.withLiveClock,
+    test(
+      "boundary covers the SPA catch-all: an unmatched /api/* path 404s and is logged + metered",
+    ) {
+      // StaticRoutes is the SPA fallback: an unmatched `/api/*` path returns 404 "no such API
+      // route" there (not a missing asset). Wrapped in the boundary (as Main wires it), that 404
+      // must be logged at WARN + metered — otherwise typo'd/removed API routes are a blind spot.
+      val spa = ErrorBoundary.observe(StaticRoutes.routes("/tmp/wifihaven-no-such-static-dir"))
+      (for {
+        resp <- spa.runZIO(Request.get(URL.decode("/api/does-not-exist").toOption.get))
+        _    <- ZIO.sleep(700.millis)
+        body <- scrape.catchAll(r => bodyText(r))
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.NotFound) &&
+        assertTrue(warned(logs, "no such API route")) &&
+        // metered as a 404 (route is the bounded trailing template, never the concrete path)
+        assertTrue(
+          body.linesIterator.exists(l =>
+            !l.startsWith("#") && l.startsWith("api_errors_total") && l.contains(
+              """status="404"""",
+            ),
+          ),
+        ))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
     test("boundary leaves a 2xx alone — no error log, no api_errors_total series for that route") {
       (for {
         resp <- runSynthetic("/api/eb/ok")
@@ -223,17 +249,19 @@ object ErrorBoundarySpec
 
     // ── #1569 regression pin: usage decode failures are now LOGGED ─────────────
     test(
-      "REGRESSION #1569: a /api/router/usage decode failure is LOGGED at WARN (not just 400-bodied)",
+      "REGRESSION #1569: a /api/router/usage envelope decode failure is LOGGED at WARN (not just 400-bodied)",
     ) {
+      // The #1569 gap was the *envelope* decode 400: the usage route mapped the zio-json error into
+      // the 400 body but never logged it, so the failing field was invisible. (A malformed *record*
+      // is a different, post-#1574 path — skipped + metered, batch returns 200 — covered in
+      // RouterIngestSpec.) Here the whole body is non-JSON, so the envelope decode 400s and the
+      // boundary must log it.
       (for {
-        _       <- cleanDb
-        rRepo   <- ZIO.service[RouterRepo]
-        routes  <- buildIngest
-        (_, tk) <- seedRouter(rRepo)
-        // malformed: records[0].activeSeconds is a string where a number is required
-        bad =
-          """{"routerId":"00000000-0000-0000-0000-000000000000","periodStart":"2026-05-07T14:00:00Z","periodEnd":"2026-05-07T14:05:00Z","records":[{"mac":"aa:bb:cc:11:22:33","host":{"type":"fqdn","value":"x.com"},"activeSeconds":"not-a-number","bytesIn":1,"bytesOut":1}]}"""
-        resp     <- postIngest(routes, "/api/router/usage", bad, tk)
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        routes   <- buildIngest
+        (_, tk)  <- seedRouter(rRepo)
+        resp     <- postIngest(routes, "/api/router/usage", "this is not json", tk)
         _        <- ZIO.sleep(700.millis)
         body     <- scrape.catchAll(r => bodyText(r))
         respBody <- bodyText(resp)

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -1,5 +1,6 @@
 package wifihaven.api.feature
 
+import wifihaven.api.ErrorBoundary
 import wifihaven.api.db.*
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
@@ -59,7 +60,13 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       aRepo <- ZIO.service[AlertRepo]
       hsr   <- ZIO.service[HouseholdSettingsRepo]
       auth = new RouterAuthLive(rRepo)
-    } yield RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr)
+    } yield
+    // #1570: exercise the production stack — the ingest routes wrapped in the boundary handler,
+    // which is what logs error responses (the per-route inline error logging was removed in favor
+    // of the single boundary emitter). Status/body are unchanged by the wrapper.
+    ErrorBoundary.observe(
+      RouterIngestRoutes.routes(auth, rRepo, tRepo, tu, dRepo, cRepo, aRepo, hsr),
+    )
 
   private def makePolicyService =
     for {
@@ -1334,7 +1341,8 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
     },
     test("usage: a malformed envelope (bad timestamp) returns 400 and logs a warning") {
       // A genuinely unparseable envelope still 400s — but now the failure is
-      // LOGGED server-side (the #1569 diagnostic gap), and NO record-reject
+      // LOGGED server-side (the #1569 diagnostic gap, now via the #1570 boundary
+      // handler at WARN with the response-body snippet), and NO record-reject
       // metric is charged (we never reached per-record decode).
       for {
         _        <- cleanDb
@@ -1354,7 +1362,8 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(
           logs.exists(e =>
             e.logLevel == LogLevel.Warning &&
-              e.message().contains("router usage:") &&
+              // boundary log: "POST /api/router/usage -> 400 body=invalid timestamp: ..."
+              e.message().contains("/api/router/usage") &&
               e.message().contains("invalid timestamp"),
           ),
         ) &&
@@ -1373,10 +1382,11 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         (resp, logs) = captured
       } yield assertTrue(resp.status == Status.BadRequest) &&
         assertTrue(
+          // boundary log: WARN "POST /api/router/usage -> 400 body=<zio-json envelope error>"
           logs.exists(e =>
             e.logLevel == LogLevel.Warning &&
-              e.message().contains("router usage: envelope deserialization failed") &&
-              e.message().contains(s"router=$id"),
+              e.message().contains("POST /api/router/usage") &&
+              e.message().contains("400"),
           ),
         )
     },

--- a/deploy/grafana/dashboards/api-self-metrics.json
+++ b/deploy/grafana/dashboards/api-self-metrics.json
@@ -558,6 +558,35 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "API error rate by route + status (#1570)",
+      "description": "sum by (route, status) (rate(api_errors_total[5m])) — error responses (status >= 400) emitted by the centralized ErrorBoundary, by templated route + HTTP status. Each series is also logged (4xx WARN / 5xx ERROR) in the API logs. Labels are bounded (route/status); never per-mac/host/ip.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "id": 17,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1, "stacking": { "mode": "normal", "group": "A" } }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (route, status) (rate(api_errors_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{route}} {{status}}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## What

Stage 1 of #1570: introduce a **single error-handling layer at the server boundary** so every error response is **mapped, logged, and metered consistently**, replacing per-route bespoke handling. Migrate the **router ingest routes** (`/api/router/usage` + `/api/router/events`) as the first consumers — they are the #1569 incident surface.

Closes the structural gap behind #1569 and is anti-divergence infrastructure alongside #1532 / #1561.

## Why (#1569)

Error handling was hand-rolled per route. `POST /api/router/events` logged decode failures (`tapError → logWarning`, #1126); `POST /api/router/usage` did **not** — it returned the decode error only in the 400 body, so **the #1569 incident's failing field was invisible in our logs**. Same job, two implementations → drift (the #1532 class).

## The central map / log / meter

- **Map — one place.** `ErrorMapper.errorToResponse` covers the typed `ApiError` vocabulary (`BadRequest`, `DecodeFailure`, `Unauthorized`, `Forbidden`, `NotFound`, `Db`, `Internal`, `Wrapped`). Routes `ZIO.fail` a typed error and let the mapper produce the `Response`, instead of constructing `Response.badRequest`/`notFound` inline.
- **Log — one place.** `ErrorBoundary.observe` wraps the real API routes (mirrors `HttpMetrics.instrument`: per-route transform → reads the templated path), inspects the final response, and logs **4xx at WARN / 5xx at ERROR** with the templated route, method, status, and a **bounded one-line body snippet**. The snippet carries the decode error's failing field — this is what closes the #1569 visibility gap. It sits **inside** the readiness gate (no startup-503 log spam) and excludes health / metrics / SPA static (their own concerns; asset 404s aren't API errors).
- **Meter — one place.** `api_errors_total{route,status}` via `AppMetrics`/`MetricGuard` (bounded labels only — added to `MetricGuard.Allowed`), plus a Grafana panel ("API error rate by route + status") on the `api-self-metrics` dashboard.

## Wire back-compat (CRITICAL — preserved)

Error responses are part of the cross-process wire contract. Audited consumers first:
- **OpenWRT agent** branches on **status only** — 4xx = drop (no retry), 5xx / conn-error = retry/back-off. Does **not** parse error bodies.
- **SPA** reads the error body as **plain text** for display and sniffs the 403 body for `password_change_required`.

This PR changes **no status codes and no body shapes**. Every `ApiError` case reproduces the exact `Response` the hand-rolled code produced (same status, same constructor). The DB case stays **503 + `{"status":"error","db":"<class>"}` + `Retry-After: 30`**. A dedicated test pins these shapes.

## Built on top of #1574 (the #1569 hotfix) + logging dedupe

This branch is **rebased onto #1574**, the per-record-skip hotfix that merged after it was cut. The usage handler **keeps** #1574's behavior — `RawUsageReport` envelope decode, per-record `as[UsageRecord]` skip, the `skipping malformed record[i]` WARN log, and `usage_records_rejected_total` metering — and only routes the **error channel** through `ApiError`/`ErrorMapper`. The per-record skip stays inline (a bad record returns 200, so the boundary never sees it).

With the boundary as the single emitter, the now-redundant inline error logging is removed: #1574's **envelope** + **timestamp** decode `logWarning`s (and its `snippet` helper), plus the events route's decode `logWarning`, routerId-mismatch `logWarning`, and "returning status=" `logInfo`. Those 400s are now logged once, at WARN, by the boundary — with the response-body snippet (the failing field). `RouterIngestSpec.buildRoutes` wraps the routes in `ErrorBoundary.observe` (production-faithful), and #1574's two envelope/timestamp "logs a warning" tests were updated to assert the boundary's WARN log instead of the removed inline strings — behavior preserved, emitter relocated.

## Tests (TDD — red commit first)

`ErrorBoundarySpec`:
- `errorToResponse` maps each `ApiError` class to its preserved status + body; the DB case preserves the 503 + `{status,db}` body + `Retry-After`.
- Boundary logs 4xx at WARN (with body snippet) / 5xx at ERROR, and meters `api_errors_total`; observes errors on both the success and error channel; leaves 2xx alone.
- **Regression pin for #1569**: a `/api/router/usage` decode failure is **logged at WARN** (not just 400-bodied) and metered, while the 400 body is unchanged for the client.
- An invalid router bearer → 401, logged at WARN.

Full `api.test` suite green. `python3 -m json.tool` passes on all dashboards (no `.tf` changed, so `terraform fmt/validate` is unaffected). `scalafmt --check` clean.

## Stage 2+ — migrate remaining route files off bespoke handling

Each migration must NOT change observable status/body for existing consumers; one PR per file (or small group), each with tests.

- [ ] `Routes.scala` (~172 inline sites — the bulk; likely split further)
- [ ] `UsageRoutes.scala`
- [ ] `ProfileRoutes.scala` / `DeviceRoutes.scala` / `ScheduleRoutes.scala`
- [ ] `AuthRoutes.scala` (note SPA 401 redirect + 403 `password_change_required` sniff)
- [ ] `AppRoutes.scala` / `AlertRoutes.scala` / `GlobalPolicyRoutes.scala` / `HouseholdSettingsRoutes.scala`
- [ ] `LogRoutes.scala` / `DashboardNowRoutes.scala` / `BlocklistRoutes.scala`
- [ ] `RouterRoutes.scala` / `AdminRouterRoutes.scala` / `RollupAdminRoutes.scala` / `RouterMetricsRoutes.scala`
- [ ] `BlockedRoutes.scala` / `VersionRoutes.scala` / `DebugRoutes.scala`
- [ ] Migrate `RouterAuth.authenticate` to a typed error (currently bridged via `ApiError.Wrapped`)
- [ ] Optionally enrich 5xx logs with the cause/stack once typed errors carry the throwable to a logging mapper

Refs #1570, #1569, #1532.

