### PR TITLE
feat(#1517): per-app graph series from app-aggregated engaged minutes (reconcile with rollup + cap)

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -177,7 +177,7 @@ object UsageRoutes {
             groupByApp = req.url.queryParam("groupBy").exists(_.split(',').contains("app"))
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
-              else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+              else ZIO.succeed(UsageSeries.AppAxis.empty)
             settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             resp      <- (macOpt, profileIdOpt) match {
               case (Some(mac), _) =>
@@ -240,7 +240,7 @@ object UsageRoutes {
             groupByApp = req.url.queryParam("groupBy").exists(_.split(',').contains("app"))
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
-              else ZIO.succeed((_: HostId) => Option.empty[UsageSeries.AppInfo])
+              else ZIO.succeed(UsageSeries.AppAxis.empty)
             settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
             resp      <- buildBatch(
               pids,
@@ -278,7 +278,7 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       groupByApp: Boolean,
-      appLookup: HostId => Option[UsageSeries.AppInfo],
+      appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
   ): IO[Response, UsageSeriesBatchResponse] =
     for {
@@ -464,28 +464,39 @@ object UsageRoutes {
       )
     }
 
-  // #1079 — build the host → owning-app lookup used by the unified-axis
-  // builder. Mirrors the deterministic "lowest appId wins" tiebreak from
-  // #1061 and the apex-aware match from #1085 so subdomain traffic attributes
-  // to the apex-form app entry.
+  // #1079 — build the by-app axis used by the unified-axis builder. `appOf` mirrors the
+  // deterministic "lowest appId wins" tiebreak from #1061 and the apex-aware match from #1085 so
+  // subdomain traffic attributes to the apex-form app entry. #1517: also carry each app's full
+  // host-set (`patternsBySlug`) so the per-app series spans are gap-bridged over the SAME host-set
+  // the per-app cap aggregate and the #1510 rollup use (via Presence.appSpansForProfile), keyed by
+  // slug. Both are built from one `app_hosts` snapshot so the attribution and the span host-set
+  // can't drift.
   private def loadAppLookup(
       appRepo: AppRepo,
-  ): IO[Response, HostId => Option[UsageSeries.AppInfo]] =
+  ): IO[Response, UsageSeries.AppAxis] =
     for {
       apps     <- appRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
       mappings <- appRepo.listAllHostMappings.mapError(ErrorMapper.dbErrorToResponse)
     } yield {
-      val appById = apps.iterator.map(a => a.id -> a).toMap
-      val byApex  = mappings
+      val appById        = apps.iterator.map(a => a.id -> a).toMap
+      val byApex         = mappings
         .groupBy(_.host.value)
         .view
         .mapValues(ms => ms.iterator.map(_.appId).minBy(_.value))
         .toMap
-      (h: HostId) =>
+      val appOf          = (h: HostId) =>
         h.asFqdn
           .flatMap(fqdn => HostMatch.lookupApex(fqdn.value, byApex))
           .flatMap(appById.get)
           .map(a => UsageSeries.AppInfo(a.id, a.slug, a.name, a.icon))
+      val patternsBySlug = mappings
+        .groupBy(_.appId)
+        .iterator
+        .flatMap { case (aid, ms) =>
+          appById.get(aid).map(a => a.slug -> ms.map(_.host.value).distinct)
+        }
+        .toMap
+      UsageSeries.AppAxis(appOf, patternsBySlug)
     }
 
   private def buildForDevice(
@@ -498,7 +509,7 @@ object UsageRoutes {
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
       groupByApp: Boolean,
-      appLookup: HostId => Option[UsageSeries.AppInfo],
+      appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
   ): IO[Response, UsageSeriesResponse] =
     for {
@@ -556,7 +567,7 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
       groupByApp: Boolean,
-      appLookup: HostId => Option[UsageSeries.AppInfo],
+      appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
   ): IO[Response, UsageSeriesResponse] =
     for {

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -20,12 +20,16 @@ import java.time.{LocalDate, ZoneId}
  *     combined across devices by the profile's `crossDeviceOverlapMode`, clipped to local hours.
  *     `presenceTotalMins` carries the day-level number floored once, so it equals the headline
  *     exactly (summing per-hour floors would lose fractions).
- *   - **Per-host / per-app / per-device** stacks come from the corresponding session spans
- *     (`Presence.hostSessionSpans` / `deviceSessionSpans`), clipped to hours. A day-total of an
- *     entity equals its `proportionalHostSeconds` presence, so per-app contributions reconcile with
- *     the per-app surface and explain the total (modulo within-device overlap — the total is the
- *     device union, not the sum of per-app spans, by design §4.3, so stacks may exceed the bar;
- *     `otherMins` clamps the rendered residual non-negative).
+ *   - **Per-host / per-device** stacks come from the corresponding session spans
+ *     (`Presence.hostSessionSpans` / `deviceSessionSpans`), clipped to hours.
+ *   - **Per-app** stacks (the `groupBy=app` axis, #1079/#1517) come from the single per-app
+ *     primitive `Presence.appSpansForProfile` (#1514/#1532) — the app's host-set gap-bridged +
+ *     overlap-deduped as one stream — so an app's series total equals the per-app cap aggregate and
+ *     the #1510 per-app rollup, not the per-host span sum. See `buildEntries`.
+ *
+ * In all cases the per-hour `totalMins` is the device session union (the daily-cap building block),
+ * so stacks may exceed the bar (the total is the union, not the sum of per-app/-host spans, by
+ * design §4.3); `otherMins` clamps the rendered residual non-negative.
  */
 object UsageSeries {
 
@@ -210,13 +214,37 @@ object UsageSeries {
     (topHosts, bucketsByHost.toList, topDevices, bucketsByDevice.toList, totalMins)
   }
 
-  // ── #1079 / #1492 unified by-app axis ───────────────────────────────────────
+  // ── #1079 / #1492 / #1517 unified by-app axis ────────────────────────────────
   //
-  // Each host's session spans are attributed to its owning app (if any — `appOfHost`) or surface
-  // as a first-class host entry. Per-app minutes are the sum of the app's member-host span seconds
-  // (matching the per-app presence surface, #1465); the per-hour total comes from the same session
-  // union the other axes use, so the app axis reconciles with the headline too.
+  // Each host's session spans are attributed to its owning app (if any — `axis.appOf`) or surface
+  // as a first-class host entry. An app entity's spans are the **gap-bridged union of its whole
+  // host-set** from the single per-app presence primitive ([[Presence.appSpansForProfile]],
+  // #1514/#1532) — NOT the concatenation of the app's per-host stitched spans, which neither
+  // bridges the idle gap between two different hosts of the same app (the apex going quiet while an
+  // off-domain asset / CDN host carries the next request, #1505) nor dedups their within-app
+  // overlap, and so disagreed with the per-app cap aggregate ([[Presence.appSecondsForProfile]]) and
+  // the #1510 per-app daily rollup. Reading the same primitive the cap and rollup read makes the
+  // app's series total reconcile with both by construction (#1517 — the #1492 "graphs reconcile
+  // with the headline total" invariant, extended to the app dimension). The per-hour total still
+  // comes from the device session union the other axes use, so the app axis reconciles with the
+  // headline too.
   case class AppInfo(id: AppId, slug: String, name: String, icon: Option[String])
+
+  /**
+   * The by-app axis input for [[buildEntries]]. `appOf` attributes a host to its owning app (apex-
+   * aware, lowest-appId tiebreak — #1061/#1085); `patternsBySlug` is each app's full host-set
+   * (apex-form patterns from `app_hosts`) so the per-app spans are computed over the SAME host-set
+   * the cap aggregate and rollup use ([[Presence.appSpansForProfile]] / `groupSiteLimits`), keyed
+   * by `apps.slug`. The two are built together from one `app_hosts` snapshot ([[loadAppLookup]]).
+   */
+  final case class AppAxis(
+      appOf: HostId => Option[AppInfo],
+      patternsBySlug: Map[String, List[String]],
+  )
+
+  object AppAxis {
+    val empty: AppAxis = AppAxis(_ => None, Map.empty)
+  }
 
   private def entityRefOf(key: Either[AppInfo, HostId]): UsageEntityRef =
     key match {
@@ -254,19 +282,46 @@ object UsageSeries {
       exemptPatterns: List[String],
       filter: HeartbeatFilter,
       continuationSeconds: Int,
-      appOfHost: HostId => Option[AppInfo],
+      axis: AppAxis,
   ): (List[UsageEntityTotal], List[UsageEntityBucket]) = {
     type Key = Either[AppInfo, HostId]
 
     val deviceSpans = Presence.deviceSessionSpans(rows, exemptPatterns, filter, continuationSeconds)
     val totalByHour = totalSecondsByHour(deviceSpans, overlap, date, zone)
 
-    // Per-host spans → grouped into entity keys (app rolls up its hosts; non-app host stands alone).
+    // Per-host spans classify which apps are present and which hosts surface standalone.
     val hostSpans = Presence.hostSessionSpans(rows, overlap, filter, continuationSeconds)
-    val entitySpans: Map[Key, List[Span]] = hostSpans.iterator
-      .map { case (h, spans) => appOfHost(h).map(Left(_)).getOrElse(Right(h)) -> spans }
-      .toList
-      .groupMapReduce(_._1)(_._2)(_ ++ _)
+    val appsPresent: Map[String, AppInfo] =
+      hostSpans.keysIterator.flatMap(axis.appOf).map(a => a.slug -> a).toMap
+
+    // #1517: an app's spans are the gap-bridged union of its WHOLE host-set via the single per-app
+    // primitive (#1514/#1532) — same groups/overlap/filter/continuation the per-app cap aggregate
+    // (`TimeStatusService.siteDayStates` / `appSecondsByApp`) and the #1510 rollup read, so the per-
+    // app series total equals the cap and the rollup by construction (not the per-host concat, which
+    // neither bridges cross-host idle gaps nor dedups within-app overlap).
+    val appSpans: Map[String, List[Span]] =
+      Presence.appSpansForProfile(
+        rows,
+        appsPresent.valuesIterator
+          .map(a => a.slug -> axis.patternsBySlug.getOrElse(a.slug, Nil))
+          .toList,
+        overlap,
+        filter,
+        continuationSeconds,
+      )
+
+    val entitySpans: Map[Key, List[Span]] = {
+      val appEntries: Iterator[(Key, List[Span])]  =
+        appsPresent.iterator.map { case (slug, info) =>
+          (Left(info): Key) -> appSpans.getOrElse(slug, Nil)
+        }
+      // Non-app hosts surface standalone with their own per-host spans.
+      val hostEntries: Iterator[(Key, List[Span])] =
+        hostSpans.iterator.collect {
+          case (h, spans) if axis.appOf(h).isEmpty => (Right(h): Key) -> spans
+        }
+      (appEntries ++ hostEntries).toMap
+    }
 
     val ordered    = entitySpans.toList
       .map { case (k, spans) => (k, (daySecs(spans) / 60).toInt) }

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -110,6 +110,137 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       auth,
     )
 
+  // #1517 — the numbers along the per-app reconciliation chain for a single time-limited app, read
+  // the way an operator would: the #1510 rollup accessor, the per-app cap aggregate
+  // (`SiteDayState.usedMinutes`), the per-app graph series (`/usage/series?groupBy=app`), the profile
+  // headline total, the legacy per-host proportional sum (what the un-bridged series plotted), and
+  // the app's per-hour series minutes.
+  private case class AppReco(
+      status: Status,
+      seriesDayMins: Option[Int],
+      rollupMins: Option[Int],
+      capMins: Option[Int],
+      presenceTotalMins: Int,
+      perHostPropMins: Int,
+      appHourMins: Seq[Int],
+  )
+
+  // Seed one time-limited multi-host app + its traffic, then read every number on the chain. `traffic`
+  // is a list of (host, hour, minute) 5-min buckets. Shared by the #1517 tests so the gap-bridge and
+  // the overlap fixture exercise the exact same read path.
+  private def appReco(
+      appName: String,
+      appSlug: String,
+      hosts: List[String],
+      traffic: List[(String, Int, Int)],
+  ): ZIO[TestDatabase.AllRepos & EmbeddedPostgres & Clock, Any, AppReco] = {
+    val today = TestClock.schoolDayAfternoon.toLocalDate
+    for {
+      _           <- cleanDb
+      hsr         <- ZIO.service[HouseholdSettingsRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      schedRepo   <- ZIO.service[ScheduleRepo]
+      deviceRepo  <- ZIO.service[DeviceRepo]
+      trafficRepo <- ZIO.service[TrafficReportRepo]
+      appRepo     <- ZIO.service[AppRepo]
+      timeLimRepo <- ZIO.service[TimeLimitRepo]
+      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+      extRepo     <- ZIO.service[TimeExtensionRepo]
+      ruRepo      <- ZIO.service[TimeUsedRollupRepo]
+      aruRepo     <- ZIO.service[AppUsedRollupRepo]
+      // Pin the household reset tz to UTC so `now`'s local date is `today`.
+      cur         <- hsr.get
+      settings = cur.copy(dailyResetTz = ZoneOffset.UTC)
+      _        <- hsr.update(settings)
+      kidsId   <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+      _        <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+      routerId <- seedRouter
+      appId    <- appRepo.create(appName, appSlug, None, Some("💬"))
+      _        <- appRepo.setHosts(appId, hosts.map(Hostname.unsafe))
+      _        <- appRepo.upsertAssignment(appId, kidsId, AppMode.TimeLimited, Some(60), false)
+      _        <- ZIO.foreachDiscard(traffic) { case (h, hr, mn) =>
+        insertRow(routerId, testMac, h, today, hr, mn)
+      }
+      now = LocalDateTime
+        .of(today.getYear, today.getMonthValue, today.getDayOfMonth, 12, 0)
+        .toInstant(ZoneOffset.UTC)
+      // #1510 rollup read accessor (gap-bridged engaged minutes per app).
+      _ <- TimeUsedRollupJob.oneTickForTest(
+        ruRepo,
+        aruRepo,
+        profileRepo,
+        deviceRepo,
+        stlRepo,
+        appRepo,
+        trafficRepo,
+        hsr,
+        now,
+      )
+      reader = new AppUsedRollupServiceLive(
+        profileRepo,
+        deviceRepo,
+        stlRepo,
+        appRepo,
+        trafficRepo,
+        aruRepo,
+      )
+      rollup <- reader.appEngagedMinutes(now, today, settings, kidsId)
+      // Per-app cap aggregate (SiteDayState.usedMinutes).
+      tsvc = new TimeStatusServiceLive(
+        profileRepo,
+        schedRepo,
+        timeLimRepo,
+        stlRepo,
+        deviceRepo,
+        trafficRepo,
+        extRepo,
+        ruRepo,
+      )
+      state <- tsvc.dayStateLive(now, today, settings, kidsId)
+      capMin = state.flatMap(_.perSite.find(_.label == s"app:$appSlug").map(_.usedMinutes))
+      // The legacy per-host proportional sum (what the un-bridged series plotted).
+      rows <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(testMac)), today)
+      perHostPropMins = (wifihaven.api.presence.Presence
+        .proportionalHostSeconds(
+          rows,
+          CrossDeviceOverlapMode.Sum,
+          settings.heartbeatFilter,
+          settings.presenceContinuationSeconds,
+        )
+        .values
+        .sum / 60L).toInt
+      // The per-app graph series via the endpoint.
+      rb <- buildRoutes
+      (routes, auth) = rb
+      token <- auth.login("admin", "changeme").map(_.token.value)
+      req = Request
+        .get(
+          URL
+            .decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today&groupBy=app")
+            .toOption
+            .get,
+        )
+        .addHeader(Header.Authorization.Bearer(token))
+      resp <- routes.runZIO(req)
+      body <- resp.body.asString
+      out  <- ZIO
+        .fromEither(body.fromJson[UsageSeriesResponse])
+        .orElseFail(new RuntimeException(body))
+      entry    = out.topEntries.find(_.entity.name == appName)
+      hourMins = out.bucketsByEntry.map(b =>
+        b.perEntity.find(_.entity.name == appName).map(_.mins).getOrElse(0),
+      )
+    } yield AppReco(
+      resp.status,
+      entry.map(_.dayMins),
+      rollup.get(appId),
+      capMin,
+      out.presenceTotalMins,
+      perHostPropMins,
+      hourMins,
+    )
+  }
+
   def spec = suite("Usage API")(
     suite("GET /api/usage/series")(
       test("requires mac param") {
@@ -619,109 +750,68 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       },
       // #1517 — the per-app graph series must derive from the SINGLE per-app presence primitive
       // (`Presence.appSpansForProfile`, #1514/#1532): an app's host-set is gap-bridged + overlap-
-      // deduped across its whole host-set, NOT the concatenation of its per-host stitched spans.
-      // Fixture: app "social" owns social.com + cdn.social.net. social.com is active 08:50–08:55
-      // and cdn.social.net 09:00–09:05. The 300 s cross-host idle gap is < the effective gap
-      // (2×R = 600 s for 300 s buckets), so the two DIFFERENT hosts of the same app bridge into one
-      // [08:50, 09:05] engaged span = 15 min — NOT 5 + 5. The legacy per-host concat would plot the
-      // un-bridged 10 min and disagree with the per-app cap aggregate and the #1510 rollup.
+      // deduped across its WHOLE host-set, NOT the concatenation of its per-host stitched spans.
       //
-      // This asserts the #1492 "graphs reconcile with the headline total" invariant extended to the
-      // APP dimension — the chain profile total ⇄ per-app rollup (#1510) ⇄ per-app cap ⇄ per-app
-      // series all read 15 — and that hour-clipping the bridged span sums back to the per-app daily
-      // total (10 min in hour 8 + 5 min in hour 9).
+      // Cross-host idle-gap bridge: app "Social" owns social.com + cdn.social.net. social.com is
+      // active 08:50–08:55, cdn.social.net 09:00–09:05. The 300 s cross-host gap is < the effective
+      // gap (2×R = 600 s for 300 s buckets), so the apex going quiet while the off-domain CDN host
+      // (#1505) carries the next request bridges into one [08:50, 09:05] engaged span = 15 min — NOT
+      // 5 + 5. The legacy per-host concat plotted the un-bridged 10 min and disagreed with the per-app
+      // cap aggregate and the #1510 rollup. The per-app series now reads the bridged 15 the cap and
+      // rollup read, and hour-clipping that span sums back to the per-app daily total (10 in h8, 5 in
+      // h9). NOTE: the profile *headline* total is 10 here, not 15 — it stitches per-(mac,host) and so
+      // does NOT bridge the cross-host gap; per-app exceeding the headline under cross-host bridging
+      // is the documented restricted-equality case (AppUsedRollupService). The overlap fixture below
+      // is where the full profile-total ⇄ per-app chain holds exactly.
       test(
-        "#1517: multi-host app series is gap-bridged + hour-clipped, reconciling with rollup + cap (not per-host sum)",
+        "#1517: multi-host app series is gap-bridged + hour-clipped, reconciling with rollup + cap",
       ) {
-        val today = TestClock.schoolDayAfternoon.toLocalDate
         for {
-          _           <- cleanDb
-          hsr         <- ZIO.service[HouseholdSettingsRepo]
-          profileRepo <- ZIO.service[ProfileRepo]
-          schedRepo   <- ZIO.service[ScheduleRepo]
-          deviceRepo  <- ZIO.service[DeviceRepo]
-          trafficRepo <- ZIO.service[TrafficReportRepo]
-          appRepo     <- ZIO.service[AppRepo]
-          timeLimRepo <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
-          extRepo     <- ZIO.service[TimeExtensionRepo]
-          ruRepo      <- ZIO.service[TimeUsedRollupRepo]
-          aruRepo     <- ZIO.service[AppUsedRollupRepo]
-          // Pin the household reset tz to UTC so `now`'s local date is `today`.
-          cur     <- hsr.get
-          settings = cur.copy(dailyResetTz = ZoneOffset.UTC)
-          _       <- hsr.update(settings)
-          kidsId  <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
-          _       <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
-          routerId <- seedRouter
-          // App "social" with a two-host set, assigned a time-limited cap (so it lands in the cap
-          // aggregate and the #1510 per-app rollup).
-          socialId <- appRepo.create("Social", "social", None, Some("💬"))
-          _        <- appRepo.setHosts(
-            socialId,
-            List(Hostname.unsafe("social.com"), Hostname.unsafe("cdn.social.net")),
+          r <- appReco(
+            "Social",
+            "social",
+            List("social.com", "cdn.social.net"),
+            List(("social.com", 8, 50), ("cdn.social.net", 9, 0)),
           )
-          _        <- appRepo.upsertAssignment(socialId, kidsId, AppMode.TimeLimited, Some(60), false)
-          // social.com 08:50–08:55, cdn.social.net 09:00–09:05 — a 300 s cross-host gap that bridges,
-          // and a span that straddles the 09:00 hour boundary so hour-clipping is exercised.
-          _ <- insertRow(routerId, testMac, "social.com", today, 8, 50)
-          _ <- insertRow(routerId, testMac, "cdn.social.net", today, 9, 0)
-          now = LocalDateTime.of(today.getYear, today.getMonthValue, today.getDayOfMonth, 12, 0)
-            .toInstant(ZoneOffset.UTC)
-          // ── #1510 rollup read accessor (gap-bridged engaged minutes per app) ──
-          _      <- TimeUsedRollupJob
-            .oneTickForTest(ruRepo, aruRepo, profileRepo, deviceRepo, stlRepo, appRepo, trafficRepo, hsr, now)
-          reader  = new AppUsedRollupServiceLive(profileRepo, deviceRepo, stlRepo, appRepo, trafficRepo, aruRepo)
-          rollup <- reader.appEngagedMinutes(now, today, settings, kidsId)
-          // ── per-app cap aggregate (SiteDayState.usedMinutes) ──
-          tsvc    = new TimeStatusServiceLive(
-            profileRepo, schedRepo, timeLimRepo, stlRepo, deviceRepo, trafficRepo, extRepo, ruRepo,
-          )
-          state  <- tsvc.dayStateLive(now, today, settings, kidsId)
-          capMin  = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
-          // ── the legacy per-host proportional sum (what the un-bridged series plotted) ──
-          rows   <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(testMac)), today)
-          perHostPropMins = {
-            val byHost = wifihaven.api.presence.Presence.proportionalHostSeconds(
-              rows,
-              CrossDeviceOverlapMode.Sum,
-              settings.heartbeatFilter,
-              settings.presenceContinuationSeconds,
-            )
-            (byHost.values.sum / 60L).toInt
-          }
-          // ── the per-app graph series via the endpoint ──
-          rb <- buildRoutes
-          (routes, auth) = rb
-          token <- auth.login("admin", "changeme").map(_.token.value)
-          req = Request
-            .get(
-              URL
-                .decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today&groupBy=app")
-                .toOption
-                .get,
-            )
-            .addHeader(Header.Authorization.Bearer(token))
-          resp <- routes.runZIO(req)
-          body <- resp.body.asString
-          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
-          socialEntry = out.topEntries.find(_.entity.name == "Social")
-          // Per-hour minutes for the Social app across the 24 buckets.
-          appHourMins = out.bucketsByEntry.map(b =>
-            b.perEntity.find(_.entity.name == "Social").map(_.mins).getOrElse(0),
-          )
-        } yield assertTrue(resp.status == Status.Ok) &&
-          // The app's series day total is the gap-bridged 15 min — NOT the per-host concat 10 min.
-          assertTrue(socialEntry.map(_.dayMins).contains(15)) &&
-          assertTrue(perHostPropMins == 10 && !socialEntry.map(_.dayMins).contains(perHostPropMins)) &&
-          // Reconciliation chain: per-app series ⇄ #1510 rollup ⇄ per-app cap aggregate.
-          assertTrue(rollup.get(socialId).contains(15)) &&
-          assertTrue(capMin.contains(15)) &&
-          // Profile headline total (single non-exempt app, no other traffic) ⇄ the per-app number.
-          assertTrue(out.presenceTotalMins == 15) &&
+        } yield assertTrue(r.status == Status.Ok) &&
+          // Series day total is the gap-bridged 15 — NOT the per-host concat 10.
+          assertTrue(r.seriesDayMins.contains(15)) &&
+          assertTrue(r.perHostPropMins == 10 && !r.seriesDayMins.contains(r.perHostPropMins)) &&
+          // Reconciliation: per-app series ⇄ #1510 rollup ⇄ per-app cap aggregate.
+          assertTrue(r.rollupMins.contains(15)) &&
+          assertTrue(r.capMins.contains(15)) &&
           // Hour-clipping the bridged span sums back to the per-app daily total: 10 (h8) + 5 (h9).
-          assertTrue(appHourMins(8) == 10 && appHourMins(9) == 5) &&
-          assertTrue(appHourMins.sum == 15)
+          assertTrue(r.appHourMins(8) == 10 && r.appHourMins(9) == 5) &&
+          assertTrue(r.appHourMins.sum == 15)
+      },
+      // #1517 — within-app cross-host OVERLAP: both hosts of app "Social" are active in the SAME three
+      // contiguous windows 08:00–08:15. The per-host concat double-counts the overlap (15 + 15 = 30
+      // min), but the per-app union counts it once = 15 min. Here the full reconciliation chain holds
+      // exactly: profile headline total ⇄ #1510 per-app rollup ⇄ per-app cap aggregate ⇄ per-app
+      // series, all 15 — the #1492 "graphs reconcile with the headline total" invariant at the app
+      // dimension — while the legacy per-host sum (30) is what the un-deduped series plotted.
+      test(
+        "#1517: within-app cross-host overlap — full chain (profile total ⇄ rollup ⇄ series) holds",
+      ) {
+        for {
+          r <- appReco(
+            "Social",
+            "social",
+            List("social.com", "cdn.social.net"),
+            (0 until 3).toList.flatMap(i =>
+              List(("social.com", 8, i * 5), ("cdn.social.net", 8, i * 5)),
+            ),
+          )
+        } yield assertTrue(r.status == Status.Ok) &&
+          // Series day total is the overlap-deduped 15 — NOT the per-host concat 30.
+          assertTrue(r.seriesDayMins.contains(15)) &&
+          assertTrue(r.perHostPropMins == 30 && !r.seriesDayMins.contains(r.perHostPropMins)) &&
+          // Full chain reconciles exactly at 15.
+          assertTrue(r.rollupMins.contains(15)) &&
+          assertTrue(r.capMins.contains(15)) &&
+          assertTrue(r.presenceTotalMins == 15) &&
+          // All 15 engaged minutes land in hour 8 and the per-hour series sums to the daily total.
+          assertTrue(r.appHourMins(8) == 15 && r.appHourMins.sum == 15)
       },
     ) @@ TestAspect.sequential,
     // ── #846 Traffic Usage page ───────────────────────────────────────────

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -3,7 +3,9 @@ package wifihaven.api.feature
 import wifihaven.api.JwtConfig
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
+import wifihaven.api.policy.TimeStatusServiceLive
 import wifihaven.api.routes.*
+import wifihaven.api.usage.{AppUsedRollupServiceLive, TimeUsedRollupJob}
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import wifihaven.shared.Clock.TestClock
@@ -14,7 +16,7 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 
-import java.time.{LocalDate, ZoneOffset}
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
@@ -614,6 +616,112 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(ytEntry.dayMins == 15) &&
           // The two contributions explain the total (no within-device overlap in this fixture).
           assertTrue(out.topEntries.map(_.dayMins).sum == expectedMins)
+      },
+      // #1517 — the per-app graph series must derive from the SINGLE per-app presence primitive
+      // (`Presence.appSpansForProfile`, #1514/#1532): an app's host-set is gap-bridged + overlap-
+      // deduped across its whole host-set, NOT the concatenation of its per-host stitched spans.
+      // Fixture: app "social" owns social.com + cdn.social.net. social.com is active 08:50–08:55
+      // and cdn.social.net 09:00–09:05. The 300 s cross-host idle gap is < the effective gap
+      // (2×R = 600 s for 300 s buckets), so the two DIFFERENT hosts of the same app bridge into one
+      // [08:50, 09:05] engaged span = 15 min — NOT 5 + 5. The legacy per-host concat would plot the
+      // un-bridged 10 min and disagree with the per-app cap aggregate and the #1510 rollup.
+      //
+      // This asserts the #1492 "graphs reconcile with the headline total" invariant extended to the
+      // APP dimension — the chain profile total ⇄ per-app rollup (#1510) ⇄ per-app cap ⇄ per-app
+      // series all read 15 — and that hour-clipping the bridged span sums back to the per-app daily
+      // total (10 min in hour 8 + 5 min in hour 9).
+      test(
+        "#1517: multi-host app series is gap-bridged + hour-clipped, reconciling with rollup + cap (not per-host sum)",
+      ) {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          hsr         <- ZIO.service[HouseholdSettingsRepo]
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          timeLimRepo <- ZIO.service[TimeLimitRepo]
+          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          extRepo     <- ZIO.service[TimeExtensionRepo]
+          ruRepo      <- ZIO.service[TimeUsedRollupRepo]
+          aruRepo     <- ZIO.service[AppUsedRollupRepo]
+          // Pin the household reset tz to UTC so `now`'s local date is `today`.
+          cur     <- hsr.get
+          settings = cur.copy(dailyResetTz = ZoneOffset.UTC)
+          _       <- hsr.update(settings)
+          kidsId  <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _       <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId <- seedRouter
+          // App "social" with a two-host set, assigned a time-limited cap (so it lands in the cap
+          // aggregate and the #1510 per-app rollup).
+          socialId <- appRepo.create("Social", "social", None, Some("💬"))
+          _        <- appRepo.setHosts(
+            socialId,
+            List(Hostname.unsafe("social.com"), Hostname.unsafe("cdn.social.net")),
+          )
+          _        <- appRepo.upsertAssignment(socialId, kidsId, AppMode.TimeLimited, Some(60), false)
+          // social.com 08:50–08:55, cdn.social.net 09:00–09:05 — a 300 s cross-host gap that bridges,
+          // and a span that straddles the 09:00 hour boundary so hour-clipping is exercised.
+          _ <- insertRow(routerId, testMac, "social.com", today, 8, 50)
+          _ <- insertRow(routerId, testMac, "cdn.social.net", today, 9, 0)
+          now = LocalDateTime.of(today.getYear, today.getMonthValue, today.getDayOfMonth, 12, 0)
+            .toInstant(ZoneOffset.UTC)
+          // ── #1510 rollup read accessor (gap-bridged engaged minutes per app) ──
+          _      <- TimeUsedRollupJob
+            .oneTickForTest(ruRepo, aruRepo, profileRepo, deviceRepo, stlRepo, appRepo, trafficRepo, hsr, now)
+          reader  = new AppUsedRollupServiceLive(profileRepo, deviceRepo, stlRepo, appRepo, trafficRepo, aruRepo)
+          rollup <- reader.appEngagedMinutes(now, today, settings, kidsId)
+          // ── per-app cap aggregate (SiteDayState.usedMinutes) ──
+          tsvc    = new TimeStatusServiceLive(
+            profileRepo, schedRepo, timeLimRepo, stlRepo, deviceRepo, trafficRepo, extRepo, ruRepo,
+          )
+          state  <- tsvc.dayStateLive(now, today, settings, kidsId)
+          capMin  = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
+          // ── the legacy per-host proportional sum (what the un-bridged series plotted) ──
+          rows   <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(testMac)), today)
+          perHostPropMins = {
+            val byHost = wifihaven.api.presence.Presence.proportionalHostSeconds(
+              rows,
+              CrossDeviceOverlapMode.Sum,
+              settings.heartbeatFilter,
+              settings.presenceContinuationSeconds,
+            )
+            (byHost.values.sum / 60L).toInt
+          }
+          // ── the per-app graph series via the endpoint ──
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(
+              URL
+                .decode(s"/api/usage/series?profileId=${kidsId.value}&date=$today&groupBy=app")
+                .toOption
+                .get,
+            )
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          socialEntry = out.topEntries.find(_.entity.name == "Social")
+          // Per-hour minutes for the Social app across the 24 buckets.
+          appHourMins = out.bucketsByEntry.map(b =>
+            b.perEntity.find(_.entity.name == "Social").map(_.mins).getOrElse(0),
+          )
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // The app's series day total is the gap-bridged 15 min — NOT the per-host concat 10 min.
+          assertTrue(socialEntry.map(_.dayMins).contains(15)) &&
+          assertTrue(perHostPropMins == 10 && !socialEntry.map(_.dayMins).contains(perHostPropMins)) &&
+          // Reconciliation chain: per-app series ⇄ #1510 rollup ⇄ per-app cap aggregate.
+          assertTrue(rollup.get(socialId).contains(15)) &&
+          assertTrue(capMin.contains(15)) &&
+          // Profile headline total (single non-exempt app, no other traffic) ⇄ the per-app number.
+          assertTrue(out.presenceTotalMins == 15) &&
+          // Hour-clipping the bridged span sums back to the per-app daily total: 10 (h8) + 5 (h9).
+          assertTrue(appHourMins(8) == 10 && appHourMins(9) == 5) &&
+          assertTrue(appHourMins.sum == 15)
       },
     ) @@ TestAspect.sequential,
     // ── #846 Traffic Usage page ───────────────────────────────────────────


### PR DESCRIPTION
Closes #1517 (App-Centric Model epic; sub-issue of #1510).

## Problem

The per-app graph series (`GET /api/usage/series?groupBy=app`) was built in
`UsageSeries.buildEntries` by grouping each app's **per-host** stitched spans
and concatenating them (`_ ++ _`). That concatenation:

- never **bridges the cross-host idle gap** a multi-host app spans (the apex
  going quiet while an off-domain asset / CDN host carries the next request,
  #1505), and
- never **dedups within-app overlap** (two hosts of the same app active in the
  same window double-count).

So the per-app series disagreed with the **gap-bridged per-app cap aggregate**
(`TimeStatusService.siteDayStates` / `appSecondsByApp`) and the **#1510 per-app
daily rollup** — both of which read the single per-app primitive
`Presence.appSpansForProfile` (#1514/#1532).

## Fix

Derive each app entity's spans from that same single primitive
`Presence.appSpansForProfile` over the app's **whole host-set** — the
gap-bridged, overlap-deduped, cross-host union the cap and the rollup already
read. Non-app hosts still surface standalone with their per-host spans. The
per-hour **total** bar is unchanged (the device session union), so the
host/device axes and the #1492 headline reconciliation are untouched.

`buildEntries` now takes an `AppAxis` (per-host attribution + per-app host-set
patterns), built once from one `app_hosts` snapshot in
`UsageRoutes.loadAppLookup`, so attribution and the span host-set can't drift
(single source of truth, #1532). The app-time math is **consumed, not
re-implemented** (#1514/#1510).

## Reconciliation invariant (#1492 extended to the app dimension)

For a profile + date, per app:

> **per-app series ⇄ #1510 per-app rollup ⇄ per-app cap aggregate** — all read
> the same gap-bridged engaged seconds, floor-of-sum.

and, in the non-bridged / non-overlapping / non-exempt case, the chain also
reconciles with the **profile headline total** (the restricted equality
documented on `AppUsedRollupService` — under cross-host bridging a per-app
number can exceed the per-`(mac,host)` headline, which is expected).

## Tests (TDD — failing test committed first)

Two embedded-Postgres feature tests in `UsageApiSpec`, both reading the live
chain (the #1510 rollup accessor, the per-app cap aggregate, and the series
endpoint):

- **cross-host gap-bridge**: app `Social` = `social.com` + `cdn.social.net`,
  active 08:50–08:55 then 09:00–09:05 (300 s cross-host gap < effective gap).
  Series day total = **15** (bridged) = rollup = cap, **not** the per-host
  proportional sum (10); hour-clipping sums back (10 in h8 + 5 in h9).
- **within-app overlap**: both hosts active in the same three windows. Series =
  **15** (overlap-deduped), and the **full chain holds exactly**: profile total
  ⇄ rollup ⇄ cap ⇄ series, all 15, while the per-host sum (30) is what the old
  un-deduped series plotted.

The red commit shows the series returning `Some(10)` while the rollup/cap
already read 15 — pinpointing the series as the broken link.

## Wire compatibility

Response shape is **unchanged** (`topEntries` / `bucketsByEntry`) — additive,
the SPA is unaffected. No migration (the series is presence-based off raw
rows; it does not read rollup tables). No new metric series, so no dashboard
change.

## Deferred to siblings (out of scope here)

- App-vs-Site naming pass → #1518
- `Other` bucket handling → #1519
