### PR TITLE
refactor(#1570 Stage 2): migrate mid/small route files to ErrorBoundary/ApiError

### DIFF
--- a/api/src/routes/AlertRoutes.scala
+++ b/api/src/routes/AlertRoutes.scala
@@ -19,6 +19,14 @@ import zio.json.*
  * /api/alerts/{id}/approve — writer-auth. For access_request, applies the per- kind grant via
  * existing primitives. For new_device, just records the decision. POST /api/alerts/{id}/deny —
  * writer-auth. Records the decision; no side-effect.
+ *
+ * #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR)
+ * + meters each error. Each case reproduces the EXACT status + body the hand-rolled code produced —
+ * the pending-state `409` keeps its empty body via [[ApiError.Wrapped]], DB failures stay 503 via
+ * [[ApiError.Db]]. Success-channel responses (the `Some/None` post-decide `.map`, the debounce
+ * `Some(a)` hit) are unchanged; the boundary still observes their status. Auth helpers are bridged
+ * via [[ApiError.Wrapped]].
  */
 object AlertRoutes {
 
@@ -46,73 +54,75 @@ object AlertRoutes {
       // ── Public: kid posts an access-request from the block page ─────────
       Method.POST / "api" / "access-requests" ->
         handler { (req: Request) =>
-          for {
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             cr   <- ZIO
               .fromEither(body.fromJson[CreateAccessRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             now  <- clock.instant
             since = now.minusSeconds(AccessRequestDebounceSeconds)
             existing <- alertRepo
               .findRecentAccessRequest(cr.mac, cr.host, since)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             resp     <- existing match {
               case Some(a) => ZIO.succeed(Response.json(a.toJson))
               case None    =>
                 for {
                   device <- deviceRepo
                     .findByMac(cr.mac)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                   pid = device.flatMap(_.profileId)
                   id    <- alertRepo
                     .createAccessRequest(cr.mac, pid, cr.host, cr.kind, cr.note, now)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                   full  <- alertRepo
                     .findById(id)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                   alert <- ZIO
                     .fromOption(full)
-                    .orElseFail(Response.internalServerError("vanished"))
+                    .orElseFail(ApiError.Internal("vanished"))
                   _     <- notifier.alertCreated(alert).forkDaemon
                 } yield Response.json(alert.toJson).status(Status.Created)
             }
           } yield resp
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── Admin list ──────────────────────────────────────────────────────
       Method.GET / "api" / "alerts" ->
         handler { (req: Request) =>
-          for {
-            _ <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             includeAll = req.url
               .queryParam("all")
               .map(_.equalsIgnoreCase("true"))
               .getOrElse(false)
             xs <- alertRepo
               .list(includeAll)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.json(xs.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── Admin approve ───────────────────────────────────────────────────
       Method.POST / "api" / "alerts" / long("id") / "approve" ->
         handler { (id: Long, req: Request) =>
-          val aid = AlertId(id)
-          for {
-            claims  <- requireWriter(req, auth)
+          val aid                                  = AlertId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims  <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
             body    <- req.body.asString.orElse(ZIO.succeed(""))
             apr     <-
               if (body.isEmpty) ZIO.succeed(ApproveAlertRequest())
               else
                 ZIO
                   .fromEither(body.fromJson[ApproveAlertRequest])
-                  .mapError(e => Response.badRequest(e))
+                  .mapError(ApiError.DecodeFailure(_))
             alert   <- alertRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Alert not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Alert not found")))
             _       <- ZIO
-              .fail(Response.status(Status.Conflict))
+              .fail(ApiError.Wrapped(Response.status(Status.Conflict)))
               .when(alert.status != AlertStatus.Pending)
             now     <- clock.instant
             // Side-effect lands before the status transition so we never
@@ -129,10 +139,10 @@ object AlertRoutes {
             )
             n       <- alertRepo
               .decide(aid, AlertStatus.Approved, now, claims.sub, granted)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             resp    <- alertRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .map {
                 case None          => Response.notFound("Alert not found")
                 case Some(updated) =>
@@ -140,21 +150,22 @@ object AlertRoutes {
                   else Response.json(updated.toJson)
               }
           } yield resp
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── Admin deny ──────────────────────────────────────────────────────
       Method.POST / "api" / "alerts" / long("id") / "deny" ->
         handler { (id: Long, req: Request) =>
-          val aid = AlertId(id)
-          for {
-            claims <- requireWriter(req, auth)
+          val aid                                  = AlertId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
             now    <- clock.instant
             n      <- alertRepo
               .decide(aid, AlertStatus.Denied, now, claims.sub, None)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             resp   <- alertRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .map {
                 case None          => Response.notFound("Alert not found")
                 case Some(updated) =>
@@ -162,6 +173,7 @@ object AlertRoutes {
                   else Response.json(updated.toJson)
               }
           } yield resp
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 
@@ -187,7 +199,7 @@ object AlertRoutes {
       appRepo: AppRepo,
       hsRepo: HouseholdSettingsRepo,
       clock: SharedClock,
-  ): ZIO[Any, Response, Option[Int]] =
+  ): ZIO[Any, ApiError, Option[Int]] =
     alert.kind match {
       case AlertKind.NewDevice =>
         ZIO.succeed(None)
@@ -195,19 +207,19 @@ object AlertRoutes {
       case AlertKind.AccessRequest =>
         (alert.requestKind, alert.host) match {
           case (None, _) | (_, None) =>
-            ZIO.fail(Response.internalServerError("access-request row missing requestKind/host"))
+            ZIO.fail(ApiError.Internal("access-request row missing requestKind/host"))
 
           case (Some(AccessRequestKind.Extension), _) =>
             alert.profileId match {
               case None      =>
                 ZIO.fail(
-                  Response.badRequest(
+                  ApiError.BadRequest(
                     "Cannot extend time: device is not assigned to a profile",
                   ),
                 )
               case Some(pid) =>
                 for {
-                  settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+                  settings <- hsRepo.get.mapError(ApiError.Db(_))
                   now      <- clock.instant
                   today =
                     wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
@@ -219,7 +231,7 @@ object AlertRoutes {
                       grantedBy,
                       alert.note.orElse(Some(s"approved alert #${alert.id.value}")),
                     )
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                 } yield Some(requestedMinutes)
             }
 
@@ -232,7 +244,7 @@ object AlertRoutes {
             alert.profileId match {
               case None      =>
                 ZIO.fail(
-                  Response.badRequest(
+                  ApiError.BadRequest(
                     "Cannot grant exemption: device is not assigned to a profile",
                   ),
                 )
@@ -240,22 +252,22 @@ object AlertRoutes {
                 for {
                   existing <- appRepo
                     .findBySlug(host.value)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                   appId    <- existing match {
                     case Some(app) => ZIO.succeed(app.id)
                     case None      =>
                       for {
                         id <- appRepo
                           .create(host.value, host.value, None, None)
-                          .mapError(ErrorMapper.dbErrorToResponse)
+                          .mapError(ApiError.Db(_))
                         _  <- appRepo
                           .setHosts(id, List(host))
-                          .mapError(ErrorMapper.dbErrorToResponse)
+                          .mapError(ApiError.Db(_))
                       } yield id
                   }
                   _        <- appRepo
                     .upsertAssignment(appId, pid, AppMode.Allowed, None, true)
-                    .mapError(ErrorMapper.dbErrorToResponse)
+                    .mapError(ApiError.Db(_))
                 } yield None
             }
 
@@ -263,14 +275,14 @@ object AlertRoutes {
             alert.profileId match {
               case None      =>
                 ZIO.fail(
-                  Response.badRequest(
+                  ApiError.BadRequest(
                     "Cannot unpause: device is not assigned to a profile",
                   ),
                 )
               case Some(pid) =>
                 profileRepo
                   .setPaused(pid, false)
-                  .mapError(ErrorMapper.dbErrorToResponse)
+                  .mapError(ApiError.Db(_))
                   .as(None)
             }
         }

--- a/api/src/routes/AppRoutes.scala
+++ b/api/src/routes/AppRoutes.scala
@@ -10,6 +10,15 @@ import zio.*
 import zio.http.*
 import zio.json.*
 
+/**
+ * #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR)
+ * + meters each error. Every case reproduces the EXACT status + body the hand-rolled code produced
+ * — the structured `slug_taken` (409), `seed_failed` (500), `not_template_derived` (400), and
+ * `unknown_template` (404) JSON bodies are preserved verbatim via [[ApiError.Wrapped]] (the SPA
+ * parses them), DB failures stay 503 via [[ApiError.Db]]. Auth/profile-access helpers still return
+ * `Response` and are bridged via [[ApiError.Wrapped]].
+ */
 object AppRoutes {
 
   // Strip a leading "*." and parse as apex Hostname.
@@ -76,84 +85,89 @@ object AppRoutes {
     Routes(
       Method.GET / "api" / "apps"                                                ->
         handler { (req: Request) =>
-          for {
-            _        <- requireAuth(req, auth)
-            apps     <- appRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _        <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
+            apps     <- appRepo.listAll.mapError(ApiError.Db(_))
             detailed <- ZIO
               .foreach(apps)(detail(appRepo, _))
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.json(detailed.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "apps" / long("id")                                   ->
         handler { (id: Long, req: Request) =>
-          val aid = AppId(id)
-          for {
-            _ <- requireAuth(req, auth)
+          val aid                                  = AppId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             a <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
-            d <- detail(appRepo, a).mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
+            d <- detail(appRepo, a).mapError(ApiError.Db(_))
           } yield Response.json(d.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "apps"                                               ->
         handler { (req: Request) =>
-          for {
-            _    <- requireAdmin(req, auth)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             cr   <- ZIO
               .fromEither(body.fromJson[CreateAppRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             name = cr.name.trim
-            _        <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
+            _        <- ZIO.fail(ApiError.BadRequest("name is required")).when(name.isEmpty)
             slug     <- ZIO
               .fromEither(cr.slug match {
                 case Some(s) => validateSlug(s.trim)
                 case None    => Right(slugify(name))
               })
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.BadRequest(_))
             hosts    <- ZIO
               .fromEither(parseHosts(cr.hosts))
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.BadRequest(_))
             existing <- appRepo
               .findBySlug(slug)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             _        <- ZIO
               .fail(
-                Response
-                  .json(s"""{"error":"slug_taken","slug":"$slug"}""")
-                  .status(Status.Conflict),
+                ApiError.Wrapped(
+                  Response
+                    .json(s"""{"error":"slug_taken","slug":"$slug"}""")
+                    .status(Status.Conflict),
+                ),
               )
               .when(existing.isDefined)
             id       <- appRepo
               .create(name, slug, cr.templateId, cr.icon, cr.iconType.getOrElse(IconType.Emoji))
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             _        <- appRepo
               .setHosts(id, hosts)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .when(hosts.nonEmpty)
             a        <- appRepo
               .findById(id)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.internalServerError("App vanished")))
-            d        <- detail(appRepo, a).mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.Internal("App vanished")))
+            d        <- detail(appRepo, a).mapError(ApiError.Db(_))
           } yield Response.json(d.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.PUT / "api" / "apps" / long("id")                                   ->
         handler { (id: Long, req: Request) =>
-          val aid = AppId(id)
-          for {
-            _    <- requireAdmin(req, auth)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val aid                                  = AppId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             ur   <- ZIO
               .fromEither(body.fromJson[UpdateAppRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             name = ur.name.trim
-            _ <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
+            _ <- ZIO.fail(ApiError.BadRequest("name is required")).when(name.isEmpty)
             a <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
             _ <- appRepo
               .update(
                 a.copy(
@@ -163,56 +177,61 @@ object AppRoutes {
                   templateId = ur.templateId,
                 ),
               )
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "apps" / long("id")                                ->
         handler { (id: Long, req: Request) =>
-          requireAdmin(req, auth) *>
-            appRepo.delete(AppId(id)).mapError(ErrorMapper.dbErrorToResponse) *>
-            ZIO.succeed(Response.ok)
+          val handle: ZIO[Any, ApiError, Response] =
+            requireAdmin(req, auth).mapError(ApiError.Wrapped(_)) *>
+              appRepo.delete(AppId(id)).mapError(ApiError.Db(_)) *>
+              ZIO.succeed(Response.ok)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.PUT / "api" / "apps" / long("id") / "hosts"                         ->
         handler { (id: Long, req: Request) =>
-          val aid = AppId(id)
-          for {
-            _     <- requireAdmin(req, auth)
-            body  <- req.body.asString.orElseFail(Response.badRequest(""))
+          val aid                                  = AppId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _     <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body  <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             sr    <- ZIO
               .fromEither(body.fromJson[SetAppHostsRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             hosts <- ZIO
               .fromEither(parseHosts(sr.hosts))
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.BadRequest(_))
             _     <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
-            _     <- appRepo.setHosts(aid, hosts).mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
+            _     <- appRepo.setHosts(aid, hosts).mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.PUT / "api" / "apps" / long("id") / "policy" / long("profileId")    ->
         handler { (id: Long, profileIdRaw: Long, req: Request) =>
-          val aid = AppId(id)
-          val pid = ProfileId(profileIdRaw)
-          for {
-            claims   <- requireWriter(req, auth)
+          val aid                                  = AppId(id)
+          val pid                                  = ProfileId(profileIdRaw)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims   <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
             _        <- requireProfileAccess(claims, pid, userProfileRepo)
-            body     <- req.body.asString.orElseFail(Response.badRequest(""))
+              .mapError(ApiError.Wrapped(_))
+            body     <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             ar       <- ZIO
               .fromEither(body.fromJson[UpsertAppAssignmentRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             _        <- ZIO
               .fromEither(validateAssignment(ar.mode, ar.dailyMinutes))
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.BadRequest(_))
             _        <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
             _        <- profileRepo
               .findById(pid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
             assignId <- appRepo
               .upsertAssignment(
                 aid,
@@ -221,56 +240,65 @@ object AppRoutes {
                 ar.dailyMinutes,
                 ar.exemptFromDaily.getOrElse(true),
               )
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             // #1379: replace this assignment's per-app schedule rules with the
             // requested set (additive field; existing clients send `Nil`).
             _        <- appRepo
               .setScheduleRules(assignId, ar.scheduleRules.map(r => (r.scheduleId, r.mode)))
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1024: admin-triggered re-run of the startup app-template seeder. Same idempotent
       // semantics as the boot pass (operator host edits preserved) — exposed as a route so the
       // operator can backfill without a redeploy when prod is missing the starter set.
       Method.POST / "api" / "apps" / "seed-from-templates"                       ->
         handler { (req: Request) =>
-          for {
-            _       <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _       <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             summary <- AppTemplates
               .seed(appRepo, templates.values.toList)
               .mapError(e =>
-                Response
-                  .json(s"""{"error":"seed_failed","message":${e.getMessage.toJson}}""")
-                  .status(Status.InternalServerError),
+                ApiError.Wrapped(
+                  Response
+                    .json(s"""{"error":"seed_failed","message":${e.getMessage.toJson}}""")
+                    .status(Status.InternalServerError),
+                ),
               )
           } yield Response.json(summary.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "apps" / long("id") / "reset-to-template"            ->
         handler { (id: Long, req: Request) =>
-          val aid = AppId(id)
-          for {
-            _    <- requireAdmin(req, auth)
+          val aid                                  = AppId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             app  <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
             tid  <- ZIO
               .fromOption(app.templateId)
               .orElseFail(
-                Response
-                  .json("""{"error":"not_template_derived"}""")
-                  .status(Status.BadRequest),
+                ApiError.Wrapped(
+                  Response
+                    .json("""{"error":"not_template_derived"}""")
+                    .status(Status.BadRequest),
+                ),
               )
             tmpl <- ZIO
               .fromOption(templates.get(tid))
               .orElseFail(
-                Response
-                  .json(s"""{"error":"unknown_template","templateId":"${tid.value}"}""")
-                  .status(Status.NotFound),
+                ApiError.Wrapped(
+                  Response
+                    .json(s"""{"error":"unknown_template","templateId":"${tid.value}"}""")
+                    .status(Status.NotFound),
+                ),
               )
-            _    <- appRepo.setHosts(aid, tmpl.hosts).mapError(ErrorMapper.dbErrorToResponse)
-            d    <- detail(appRepo, app).mapError(ErrorMapper.dbErrorToResponse)
+            _    <- appRepo.setHosts(aid, tmpl.hosts).mapError(ApiError.Db(_))
+            d    <- detail(appRepo, app).mapError(ApiError.Db(_))
           } yield Response.json(d.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       // #999: field-scoped partial update. Body is a subset of the App read
       // shape — `name`, `icon` (set/null-to-clear), `iconType`, `templateId`
@@ -278,47 +306,47 @@ object AppRoutes {
       // `slug` is immutable post-create and not patchable.
       Method.PATCH / "api" / "apps" / long("id")                                 ->
         handler { (id: Long, req: Request) =>
-          val aid = AppId(id)
-          for {
-            _         <- requireAdmin(req, auth)
+          val aid                                  = AppId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _         <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             a         <- appRepo
               .findById(aid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("App not found")))
-            body      <- req.body.asString.orElseFail(Response.badRequest(""))
-            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(Response.badRequest(_))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("App not found")))
+            body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(ApiError.BadRequest(_))
             namePatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "name"))
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.BadRequest(_))
             iconPatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "icon"))
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.BadRequest(_))
             iconTypePatch   <- ZIO
               .fromEither(FieldPatch.from[IconType](obj, "iconType"))
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.BadRequest(_))
             templateIdPatch <- ZIO
               .fromEither(FieldPatch.from[AppTemplateId](obj, "templateId"))
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.BadRequest(_))
             hostsPatch      <- ZIO
               .fromEither(FieldPatch.from[List[String]](obj, "hosts"))
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.BadRequest(_))
             newName = namePatch.applyTo(a.name).trim
             _             <- namePatch match {
-              case FieldPatch.Cleared => ZIO.fail(Response.badRequest("name cannot be cleared"))
+              case FieldPatch.Cleared => ZIO.fail(ApiError.BadRequest("name cannot be cleared"))
               case FieldPatch.Set(_) if newName.isEmpty =>
-                ZIO.fail(Response.badRequest("name is required"))
+                ZIO.fail(ApiError.BadRequest("name is required"))
               case _                                    => ZIO.unit
             }
             _             <- iconTypePatch match {
               case FieldPatch.Cleared =>
-                ZIO.fail(Response.badRequest("iconType cannot be cleared"))
+                ZIO.fail(ApiError.BadRequest("iconType cannot be cleared"))
               case _                  => ZIO.unit
             }
             hostsResolved <- hostsPatch match {
               case FieldPatch.Cleared  =>
-                ZIO.fail(Response.badRequest("hosts cannot be cleared (send [] to remove all)"))
+                ZIO.fail(ApiError.BadRequest("hosts cannot be cleared (send [] to remove all)"))
               case FieldPatch.Set(raw) =>
-                ZIO.fromEither(parseHosts(raw)).mapError(Response.badRequest(_)).map(Some(_))
+                ZIO.fromEither(parseHosts(raw)).mapError(ApiError.BadRequest(_)).map(Some(_))
               case FieldPatch.Absent   => ZIO.succeed(None)
             }
             updated = a.copy(
@@ -327,24 +355,27 @@ object AppRoutes {
               iconType = iconTypePatch.applyTo(a.iconType),
               templateId = templateIdPatch.applyToNullable(a.templateId),
             )
-            _             <- appRepo.update(updated).mapError(ErrorMapper.dbErrorToResponse)
+            _             <- appRepo.update(updated).mapError(ApiError.Db(_))
             _             <- hostsResolved match {
-              case Some(hs) => appRepo.setHosts(aid, hs).mapError(ErrorMapper.dbErrorToResponse)
+              case Some(hs) => appRepo.setHosts(aid, hs).mapError(ApiError.Db(_))
               case None     => ZIO.unit
             }
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "apps" / long("id") / "policy" / long("profileId") ->
         handler { (id: Long, profileIdRaw: Long, req: Request) =>
-          val aid = AppId(id)
-          val pid = ProfileId(profileIdRaw)
-          for {
-            claims <- requireWriter(req, auth)
+          val aid                                  = AppId(id)
+          val pid                                  = ProfileId(profileIdRaw)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
             _      <- requireProfileAccess(claims, pid, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
             _      <- appRepo
               .deleteAssignment(aid, pid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 }

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -42,13 +42,18 @@ object DashboardNowRoutes {
     Routes(
       Method.GET / "api" / "dashboard" / "now" ->
         handler { (req: Request) =>
-          for {
-            claims      <- requireAuth(req, auth)
+          // #1570: fail with typed ApiError; ErrorMapper.errorToResponse maps it and the
+          // ErrorBoundary logs (4xx WARN / 5xx ERROR) + meters. Same final Response as before.
+          // Auth/visibility helpers still return Response and are bridged via ApiError.Wrapped.
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims      <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             now         <- clock.instant
-            allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+            allDevices  <- deviceRepo.listAll.mapError(ApiError.Db(_))
             visibleDevs <- filterDevices(claims, allDevices, userProfileRepo)
-            allProfiles <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Wrapped(_))
+            allProfiles <- profileRepo.listAll.mapError(ApiError.Db(_))
             visibleProf <- visibleProfiles(claims, allProfiles, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
             visibleMacs = visibleDevs.map(_.mac)
             // Both inputs in parallel.
             since       = now.minus(TopHostsWindow)
@@ -64,8 +69,8 @@ object DashboardNowRoutes {
                 ),
               )
               .fork
-            lastSeen  <- lastSeenF.join.mapError(ErrorMapper.dbErrorToResponse)
-            rows      <- rowsF.join.mapError(ErrorMapper.dbErrorToResponse)
+            lastSeen  <- lastSeenF.join.mapError(ApiError.Db(_))
+            rows      <- rowsF.join.mapError(ApiError.Db(_))
             response = buildResponse(
               now = now,
               profiles = visibleProf,
@@ -74,6 +79,7 @@ object DashboardNowRoutes {
               rows = rows,
             )
           } yield Response.json(response.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -19,6 +19,12 @@ import zio.json.*
  * Auth: none. Loopback check uses BOTH `req.remoteAddress` (when present) AND the `Host` header.
  * Either being non-loopback returns 403. Every hit logs at INFO so accidentally-leaking installs
  * are obvious in production.
+ *
+ * #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR)
+ * + meters each error. Each case reproduces the EXACT status + body the hand-rolled code produced —
+ * the loopback refusal keeps its empty-body 403 via [[ApiError.Wrapped]], DB failures stay 503 via
+ * [[ApiError.Db]].
  */
 object DebugRoutes {
 
@@ -41,10 +47,10 @@ object DebugRoutes {
           guardLoopback(req, "/api/debug/devices") {
             deviceRepo.listAll
               .mapBoth(
-                ErrorMapper.dbErrorToResponse,
+                ApiError.Db(_),
                 xs => Response.json(xs.toJson),
               )
-          }
+          }.mapError(ErrorMapper.errorToResponse)
         },
         Method.GET / "api" / "debug" / "events"                 -> handler { (req: Request) =>
           guardLoopback(req, "/api/debug/events") {
@@ -56,10 +62,10 @@ object DebugRoutes {
             connEventRepo
               .recent(limit)
               .mapBoth(
-                ErrorMapper.dbErrorToResponse,
+                ApiError.Db(_),
                 xs => Response.json(xs.toJson),
               )
-          }
+          }.mapError(ErrorMapper.errorToResponse)
         },
         Method.GET / "api" / "debug" / "cache-stats"            -> handler { (req: Request) =>
           guardLoopback(req, "/api/debug/cache-stats") {
@@ -74,12 +80,12 @@ object DebugRoutes {
                 ).toJson,
               )
             }
-          }
+          }.mapError(ErrorMapper.errorToResponse)
         },
         Method.POST / "api" / "debug" / "cache-stats" / "reset" -> handler { (req: Request) =>
           guardLoopback(req, "/api/debug/cache-stats/reset") {
             timeStatusCache.invalidateAll.as(Response.ok)
-          }
+          }.mapError(ErrorMapper.errorToResponse)
         },
         Method.GET / "api" / "debug" / "time_usage"             -> handler { (req: Request) =>
           guardLoopback(req, "/api/debug/time_usage") {
@@ -87,7 +93,7 @@ object DebugRoutes {
               today <- clock.today
               snap  <- timeUsageRepo
                 .snapshotAll(today)
-                .mapError(ErrorMapper.dbErrorToResponse)
+                .mapError(ApiError.Db(_))
               // Per-host minutes from `time_usage` over-count wall-clock time when a
               // single 5-min agent bucket touches multiple hosts (each host row holds
               // ~60s for that bucket, summing them inflates "online minutes"). Surface
@@ -97,7 +103,7 @@ object DebugRoutes {
               macs = snap.keys.map(_._1).toList.distinct
               presence <- trafficRepo
                 .listPresenceRows(macs, today)
-                .mapError(ErrorMapper.dbErrorToResponse)
+                .mapError(ApiError.Db(_))
               // Surface raw active-seconds (sum of max-per-bucket activeSeconds) as well as
               // the floor-divided minute count. The e2e D2 minute-granularity test (#516)
               // ceil-divides this to get tight bounds; bucket-counting via floor(/60) drifts
@@ -120,7 +126,7 @@ object DebugRoutes {
                 .toList
                 .toJson,
             )
-          }
+          }.mapError(ErrorMapper.errorToResponse)
         },
       )
 
@@ -152,10 +158,15 @@ object DebugRoutes {
    * surfaces one) and the `Host` request header. If either signal looks non-loopback, refuse. Logs
    * every hit (allowed or refused) at INFO so that an accidentally-enabled debug build is loud in
    * production logs.
+   *
+   * #1570: the refusal fails with [[ApiError.Wrapped]] carrying the EXACT empty-body 403 the
+   * hand-rolled `Response.status(Status.Forbidden)` produced — `ApiError.Forbidden` would attach a
+   * body, so Wrapped preserves the byte-identical response. The hit/refusal INFO/WARN logs here are
+   * the loopback-gate audit trail (not error mapping) and stay inline.
    */
-  private def guardLoopback[A](req: Request, path: String)(
-      inner: IO[Response, Response],
-  ): IO[Response, Response] = {
+  private def guardLoopback(req: Request, path: String)(
+      inner: IO[ApiError, Response],
+  ): IO[ApiError, Response] = {
     val remoteOk  = req.remoteAddress.forall(_.isLoopbackAddress)
     // Read the raw Host header value via `headerOrFail` — zio-http's typed
     // Header.Host parser is strict and rejects "::1" / "[::1]". For a
@@ -170,7 +181,7 @@ object DebugRoutes {
       ZIO.logWarning(
         s"debug endpoint refused (non-loopback): path=$path remote=$remoteStr host=$hostStr",
       ) *>
-        ZIO.fail(Response.status(Status.Forbidden))
+        ZIO.fail(ApiError.Wrapped(Response.status(Status.Forbidden)))
   }
 
   private def isLoopbackHost(raw: String): Boolean = {

--- a/api/src/routes/GlobalPolicyRoutes.scala
+++ b/api/src/routes/GlobalPolicyRoutes.scala
@@ -21,6 +21,13 @@ import zio.json.*
 // These routes are covered by the HTTP middleware's route-templated duration /
 // status series, so per the "new functionality ships with metrics" rule they
 // need no bespoke metric of their own.
+//
+// #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+// [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN /
+// 5xx ERROR) + meters each error. Every case reproduces the EXACT status + body the
+// hand-rolled `Response.badRequest`/`ErrorMapper.dbErrorToResponse` produced before, so the
+// SPA sees identical responses. Auth helpers still return `Response` and are bridged via
+// [[ApiError.Wrapped]] (their migration is Routes.scala's, a later stage).
 object GlobalPolicyRoutes {
   def routes(
       auth: AuthService,
@@ -31,17 +38,17 @@ object GlobalPolicyRoutes {
     // Resolve the acting admin's username (JWT `sub`) to the user id stored in
     // the `added_by` / `removed_by` audit columns. A missing row (e.g. token
     // for a since-deleted user) records `None` rather than failing the write.
-    def actingUserId(claims: JwtClaims): IO[Response, Option[Long]] =
+    def actingUserId(claims: JwtClaims): IO[ApiError, Option[Long]] =
       userRepo
         .findByUsername(claims.sub)
-        .mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
         .map(_.map(_.id.value))
 
-    def view: IO[Response, GlobalPolicyView] =
+    def view: IO[ApiError, GlobalPolicyView] =
       for {
-        rules  <- repo.get.mapError(ErrorMapper.dbErrorToResponse)
-        allow  <- repo.allowAudit.mapError(ErrorMapper.dbErrorToResponse)
-        blocks <- repo.blockAudit.mapError(ErrorMapper.dbErrorToResponse)
+        rules  <- repo.get.mapError(ApiError.Db(_))
+        allow  <- repo.allowAudit.mapError(ApiError.Db(_))
+        blocks <- repo.blockAudit.mapError(ApiError.Db(_))
       } yield GlobalPolicyView(
         allow = allow,
         blocks = blocks,
@@ -51,10 +58,10 @@ object GlobalPolicyRoutes {
         blockIpOnly = rules.blockIpOnly,
       )
 
-    def parseBody[A: JsonDecoder](req: Request): IO[Response, A] =
+    def parseBody[A: JsonDecoder](req: Request): IO[ApiError, A] =
       for {
-        body <- req.body.asString.orElseFail(Response.badRequest(""))
-        a    <- ZIO.fromEither(body.fromJson[A]).mapError(Response.badRequest(_))
+        body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+        a    <- ZIO.fromEither(body.fromJson[A]).mapError(ApiError.DecodeFailure(_))
       } yield a
 
     Routes(
@@ -63,77 +70,84 @@ object GlobalPolicyRoutes {
       // user may view, mirroring the household-settings GET.
       Method.GET / "api" / "global" / "policy" ->
         handler { (req: Request) =>
-          for {
-            _ <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             v <- view
           } yield Response.json(v.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── always-reachable allow set ────────────────────────────────────────
       Method.POST / "api" / "global" / "allow"                    ->
         handler { (req: Request) =>
-          for {
-            claims <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             r      <- parseBody[AddGlobalHostRequest](req)
             uid    <- actingUserId(claims)
-            _      <- repo.addAllow(r.host, r.reason, uid).mapError(ErrorMapper.dbErrorToResponse)
+            _      <- repo.addAllow(r.host, r.reason, uid).mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "global" / "allow" / string("host") ->
         handler { (host: String, req: Request) =>
-          for {
-            claims <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             uid    <- actingUserId(claims)
             _      <- repo
               .removeAllow(Hostname.unsafe(host), uid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── network-wide block set ────────────────────────────────────────────
       Method.POST / "api" / "global" / "blocks"                    ->
         handler { (req: Request) =>
-          for {
-            claims <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             r      <- parseBody[AddGlobalHostRequest](req)
             uid    <- actingUserId(claims)
-            _      <- repo.addBlock(r.host, r.reason, uid).mapError(ErrorMapper.dbErrorToResponse)
+            _      <- repo.addBlock(r.host, r.reason, uid).mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "global" / "blocks" / string("host") ->
         handler { (host: String, req: Request) =>
-          for {
-            claims <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             uid    <- actingUserId(claims)
             _      <- repo
               .removeBlock(Hostname.unsafe(host), uid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── household-global category set (replace wholesale) ─────────────────
       Method.PUT / "api" / "global" / "blocklists" ->
         handler { (req: Request) =>
-          for {
-            claims <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             r      <- parseBody[SetGlobalBlocklistsRequest](req)
             uid    <- actingUserId(claims)
             _      <- repo
               .setBlocklists(r.blocklistIds, uid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
 
       // ── flat global flags (network lockdown + strict-IP floor) ────────────
       Method.PUT / "api" / "global" / "flags" ->
         handler { (req: Request) =>
-          for {
-            _ <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             r <- parseBody[SetGlobalFlagsRequest](req)
             _ <- repo
               .setFlags(r.blocked, r.blockReason, r.blockIpOnly)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
   }

--- a/api/src/routes/RollupAdminRoutes.scala
+++ b/api/src/routes/RollupAdminRoutes.scala
@@ -45,13 +45,16 @@ object RollupAdminRoutes {
     Routes(
       Method.GET / "api" / "admin" / "rollup-status" ->
         handler { (req: Request) =>
-          for {
-            _ <- requireAdmin(req, auth)
+          // #1570: fail with typed ApiError; ErrorMapper.errorToResponse maps it and the
+          // ErrorBoundary logs (4xx WARN / 5xx ERROR) + meters. Same final Response as before.
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             // Cap at 200 to keep the response tiny — fibers tick every 5 min
             // so even 200 covers ~16h of history.
             limit = req.url.queryParam("limit").flatMap(_.toIntOption).getOrElse(50).max(1).min(200)
-            runs <- repo.recentRuns(limit).mapError(ErrorMapper.dbErrorToResponse)
+            runs <- repo.recentRuns(limit).mapError(ApiError.Db(_))
           } yield Response.json(RollupStatusResponse(runs.map(RollupRunDto.from)).toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 }

--- a/api/src/routes/RouterMetricsRoutes.scala
+++ b/api/src/routes/RouterMetricsRoutes.scala
@@ -14,6 +14,13 @@ import zio.json.*
  *
  * A malformed batch is a `400` (logged, not retried — a bad metrics batch is not worth a retry
  * storm); a wrong/missing token is `401`; a body whose `routerId` doesn't match the token is `403`.
+ *
+ * #1570: the handler fails with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN) + meters
+ * each error. Each case reproduces the EXACT status + body the hand-rolled code produced (the 403
+ * keeps its `text/plain` `router_id mismatch` body via [[ApiError.Wrapped]]). The bespoke
+ * `recordRouterMetricsBatch` counters are NOT error-mapping and stay inline. Auth (RouterAuth)
+ * still returns `Response` and is bridged via [[ApiError.Wrapped]].
  */
 object RouterMetricsRoutes {
 
@@ -21,19 +28,22 @@ object RouterMetricsRoutes {
     Routes(
       Method.POST / "api" / "router" / "metrics" ->
         handler { (req: Request) =>
-          for {
-            router <- auth.authenticate(req)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            router <- auth.authenticate(req).mapError(ApiError.Wrapped(_))
+            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             batch  <- ZIO
               .fromEither(body.fromJson[RouterMetricsBatch])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
               .tapError(_ => AppMetrics.recordRouterMetricsBatch("malformed"))
             _      <- (AppMetrics.recordRouterMetricsBatch("router_mismatch") *>
-              ZIO.fail(Response.text("router_id mismatch").status(Status.Forbidden)))
+              ZIO.fail(
+                ApiError.Wrapped(Response.text("router_id mismatch").status(Status.Forbidden)),
+              ))
               .when(batch.routerId != router.id)
             _      <- svc.ingest(batch)
             _      <- AppMetrics.recordRouterMetricsBatch("ok")
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 }

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -16,6 +16,15 @@ import java.util.{Base64, UUID}
  * Routes agent-facing router endpoints. All routes require the router bearer token except
  * `/register`, which uses a one-time enrollment token. `RouterAuth` lives in
  * [[wifihaven.api.routes.RouterAuth]].
+ *
+ * #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR)
+ * + meters each error. Each case reproduces the EXACT status + body the hand-rolled code produced —
+ * the OpenWRT agent branches on status only (4xx = drop, 5xx = retry/back-off), so DB failures stay
+ * 503 via [[ApiError.Db]]; a malformed enrollment is 401; an unknown blocklist slug is 404.
+ * Success-channel responses (the 200 /304 policy/blocklist bodies with ETag headers) are unchanged;
+ * the boundary still observes their status. `RouterAuth` still returns `Response` and is bridged
+ * via [[ApiError.Wrapped]].
  */
 object RouterRoutes {
 
@@ -28,32 +37,33 @@ object RouterRoutes {
     Routes(
       Method.POST / "api" / "router" / "register"      ->
         handler { (req: Request) =>
-          for {
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             rr   <- ZIO
               .fromEither(body.fromJson[RegisterRouterRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             etHash = PolicyService.hashToken(rr.enrollmentToken.value)
             router <- routerRepo
               .findByEnrollmentTokenHash(etHash)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .flatMap(
                 ZIO
                   .fromOption(_)
-                  .orElseFail(Response.unauthorized("invalid enrollment token")),
+                  .orElseFail(ApiError.Unauthorized("invalid enrollment token")),
               )
             routerToken = RouterToken.unsafe(newToken("rt_"))
             tokenHash   = PolicyService.hashToken(routerToken.value)
             _ <- routerRepo
               .completeEnrollment(router.id, tokenHash)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.json(RegisterRouterResponse(router.id, routerToken).toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "router" / "policy"         ->
         handler { (req: Request) =>
-          for {
-            router <- routerAuth.authenticate(req)
-            snap   <- policy.snapshot.mapError(ErrorMapper.dbErrorToResponse)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            router <- routerAuth.authenticate(req).mapError(ApiError.Wrapped(_))
+            snap   <- policy.snapshot.mapError(ApiError.Db(_))
             ifNoneMatch  = req
               .header(Header.IfNoneMatch)
               .map(_.renderedValue)
@@ -67,7 +77,7 @@ object RouterRoutes {
               .filter(_.nonEmpty)
             _ <- routerRepo
               .touch(router.id, Some(snap.etag), agentVersion)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             notMod = ifNoneMatch.exists(etagWeakEquals(_, snap.etag.value))
             // #481: 200s (etag changed) are diagnostic gold for snapshot-propagation
             // failures — log them at INFO so they survive the default log level.
@@ -86,22 +96,23 @@ object RouterRoutes {
                   .json(snap.toJson)
                   .addHeader(Header.ETag.Strong(stripQuotes(snap.etag.value)))
           } yield resp
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "blocklists" / string("id") ->
         handler { (id: String, req: Request) =>
-          for {
-            _    <- routerAuth.authenticate(req)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- routerAuth.authenticate(req).mapError(ApiError.Wrapped(_))
             // Treat malformed slugs (e.g. legacy ".rpz" suffix) the same as
             // "no such blocklist" — 404, not 400. They were a route on a prior
             // version of the API and external callers may still probe them.
             bid  <- ZIO
               .fromEither(BlocklistId.parse(id))
-              .orElseFail(Response.notFound(s"unknown blocklist: $id"))
-            out  <- policy.renderBlocklist(bid).mapError(ErrorMapper.dbErrorToResponse)
+              .orElseFail(ApiError.NotFound(s"unknown blocklist: $id"))
+            out  <- policy.renderBlocklist(bid).mapError(ApiError.Db(_))
             resp <- ZIO
               .fromOption(out)
               .mapBoth(
-                _ => Response.notFound(s"unknown blocklist: $id"),
+                _ => ApiError.NotFound(s"unknown blocklist: $id"),
                 { case (etag, body) =>
                   val ifNone = req.header(Header.IfNoneMatch).map(_.renderedValue)
                   if ifNone.exists(etagWeakEquals(_, etag.value)) then
@@ -120,18 +131,19 @@ object RouterRoutes {
                 },
               )
           } yield resp
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "router" / "decision"      ->
         handler { (req: Request) =>
-          for {
-            router <- routerAuth.authenticate(req)
-            body   <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            router <- routerAuth.authenticate(req).mapError(ApiError.Wrapped(_))
+            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             dreq   <- ZIO
               .fromEither(body.fromJson[RouterDecisionRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             result <- policy
               .decide(dreq.mac.value, dreq.hostname.value)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             _      <- ZIO
               .when(result.decision == ConnectionDecision.Block) {
                 blockEventRepo
@@ -146,9 +158,10 @@ object RouterRoutes {
                       ),
                     ),
                   )
-                  .mapError(ErrorMapper.dbErrorToResponse)
+                  .mapError(ApiError.Db(_))
               }
           } yield Response.json(result.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 
@@ -180,38 +193,41 @@ object AdminRouterRoutes {
     Routes(
       Method.POST / "api" / "admin" / "routers"                  ->
         handler { (req: Request) =>
-          for {
-            _    <- requireAdmin(req, auth)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             cr   <- ZIO
               .fromEither(body.fromJson[CreateRouterRequest])
-              .mapError(e => Response.badRequest(e))
+              .mapError(ApiError.DecodeFailure(_))
             _    <- ZIO
-              .fail(Response.badRequest("name required"))
+              .fail(ApiError.BadRequest("name required"))
               .when(cr.name.trim.isEmpty)
             enrollmentToken = EnrollmentToken.unsafe(newEnrollmentToken())
             etHash          = PolicyService.hashToken(enrollmentToken.value)
             id <- routerRepo
               .create(cr.name.trim, etHash)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
           } yield Response.json(CreateRouterResponse(id, cr.name.trim, enrollmentToken).toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "admin" / "routers"                   ->
         handler { (req: Request) =>
-          for {
-            _   <- requireAdmin(req, auth)
-            all <- routerRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _   <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            all <- routerRepo.listAll.mapError(ApiError.Db(_))
           } yield Response.json(all.map(toSummary).toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "admin" / "routers" / string("id") ->
         handler { (id: String, req: Request) =>
-          for {
-            _   <- requireAdmin(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _   <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
             uid <- ZIO
               .attempt(RouterId(UUID.fromString(id)))
-              .orElseFail(Response.badRequest("bad uuid"))
-            _   <- routerRepo.delete(uid).mapError(ErrorMapper.dbErrorToResponse)
+              .orElseFail(ApiError.BadRequest("bad uuid"))
+            _   <- routerRepo.delete(uid).mapError(ApiError.Db(_))
           } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 

--- a/api/src/routes/ScheduleRoutes.scala
+++ b/api/src/routes/ScheduleRoutes.scala
@@ -14,6 +14,13 @@ import zio.json.*
  * is the time-window primitive that profiles (and, later, per-app rules #1378 / blocklists #1067)
  * reference by id. Pure HTTP/validation glue over [[NamedScheduleRepo]] — PolicyService folds the
  * active windows into the per-MAC BlockRules at snapshot time; the router never sees schedules.
+ *
+ * #1570: handlers fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR)
+ * + meters each error. Every case reproduces the EXACT status + body the hand-rolled code produced
+ * before (the `name_taken` 409 JSON is preserved verbatim via [[ApiError.Wrapped]]), so the SPA
+ * sees identical responses. Auth helpers still return `Response` and are bridged via
+ * [[ApiError.Wrapped]].
  */
 object ScheduleRoutes {
 
@@ -34,6 +41,16 @@ object ScheduleRoutes {
       }
     }.map(_.reverse)
 
+  // 409 + {"error":"name_taken","name":...} — preserved verbatim from the hand-rolled handler
+  // (the SPA distinguishes it from a generic 400). Wrapped so the boundary maps/logs/meters it
+  // without re-deriving the body.
+  private def nameTaken(name: String): ApiError =
+    ApiError.Wrapped(
+      Response
+        .json(s"""{"error":"name_taken","name":${name.toJson}}""")
+        .status(Status.Conflict),
+    )
+
   def routes(
       auth: AuthService,
       scheduleRepo: NamedScheduleRepo,
@@ -41,97 +58,91 @@ object ScheduleRoutes {
     Routes(
       Method.GET / "api" / "schedules"                 ->
         handler { (req: Request) =>
-          for {
-            _    <- requireAuth(req, auth)
-            list <- scheduleRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
+            list <- scheduleRepo.listAll.mapError(ApiError.Db(_))
           } yield Response.json(list.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "schedules" / long("id")    ->
         handler { (id: Long, req: Request) =>
-          for {
-            _ <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             s <- scheduleRepo
               .findById(NamedScheduleId(id))
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Schedule not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Schedule not found")))
           } yield Response.json(s.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "schedules"                ->
         handler { (req: Request) =>
-          for {
-            _    <- requireAdmin(req, auth)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             cr   <- ZIO
               .fromEither(body.fromJson[CreateNamedScheduleRequest])
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.DecodeFailure(_))
             name = cr.name.trim
-            _       <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
-            windows <- ZIO.fromEither(validateWindows(cr.windows)).mapError(Response.badRequest(_))
-            taken   <- scheduleRepo.findByName(name).mapError(ErrorMapper.dbErrorToResponse)
-            _       <- ZIO
-              .fail(
-                Response
-                  .json(s"""{"error":"name_taken","name":${name.toJson}}""")
-                  .status(Status.Conflict),
-              )
-              .when(taken.isDefined)
+            _       <- ZIO.fail(ApiError.BadRequest("name is required")).when(name.isEmpty)
+            windows <- ZIO.fromEither(validateWindows(cr.windows)).mapError(ApiError.BadRequest(_))
+            taken   <- scheduleRepo.findByName(name).mapError(ApiError.Db(_))
+            _       <- ZIO.fail(nameTaken(name)).when(taken.isDefined)
             id      <- scheduleRepo
               .create(name, cr.description.map(_.trim).filter(_.nonEmpty), windows)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             s       <- scheduleRepo
               .findById(id)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .flatMap(
-                ZIO.fromOption(_).orElseFail(Response.internalServerError("Schedule vanished")),
+                ZIO.fromOption(_).orElseFail(ApiError.Internal("Schedule vanished")),
               )
             _       <- AppMetrics.scheduleMutation("create")
           } yield Response.json(s.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       // PATCH carries the full schedule shape (name/description/windows) and replaces — symmetric
       // with the GET read shape, so the SPA autosaves the whole edit form (#423 / autosave default).
       Method.PATCH / "api" / "schedules" / long("id")  ->
         handler { (id: Long, req: Request) =>
-          val sid = NamedScheduleId(id)
-          for {
-            _    <- requireAdmin(req, auth)
-            body <- req.body.asString.orElseFail(Response.badRequest(""))
+          val sid                                  = NamedScheduleId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+            body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
             ur   <- ZIO
               .fromEither(body.fromJson[UpdateNamedScheduleRequest])
-              .mapError(Response.badRequest(_))
+              .mapError(ApiError.DecodeFailure(_))
             name = ur.name.trim
-            _       <- ZIO.fail(Response.badRequest("name is required")).when(name.isEmpty)
-            windows <- ZIO.fromEither(validateWindows(ur.windows)).mapError(Response.badRequest(_))
+            _       <- ZIO.fail(ApiError.BadRequest("name is required")).when(name.isEmpty)
+            windows <- ZIO.fromEither(validateWindows(ur.windows)).mapError(ApiError.BadRequest(_))
             _       <- scheduleRepo
               .findById(sid)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Schedule not found")))
-            taken   <- scheduleRepo.findByName(name).mapError(ErrorMapper.dbErrorToResponse)
-            _       <- ZIO
-              .fail(
-                Response
-                  .json(s"""{"error":"name_taken","name":${name.toJson}}""")
-                  .status(Status.Conflict),
-              )
-              .when(taken.exists(_.id != sid))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Schedule not found")))
+            taken   <- scheduleRepo.findByName(name).mapError(ApiError.Db(_))
+            _       <- ZIO.fail(nameTaken(name)).when(taken.exists(_.id != sid))
             _       <- scheduleRepo
               .update(sid, name, ur.description.map(_.trim).filter(_.nonEmpty), windows)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             s       <- scheduleRepo
               .findById(sid)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
               .flatMap(
-                ZIO.fromOption(_).orElseFail(Response.internalServerError("Schedule vanished")),
+                ZIO.fromOption(_).orElseFail(ApiError.Internal("Schedule vanished")),
               )
             _       <- AppMetrics.scheduleMutation("update")
           } yield Response.json(s.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.DELETE / "api" / "schedules" / long("id") ->
         handler { (id: Long, req: Request) =>
-          requireAdmin(req, auth) *>
-            scheduleRepo
-              .delete(NamedScheduleId(id))
-              .mapError(ErrorMapper.dbErrorToResponse) *>
-            AppMetrics.scheduleMutation("delete").as(Response.ok)
+          val handle: ZIO[Any, ApiError, Response] =
+            requireAdmin(req, auth).mapError(ApiError.Wrapped(_)) *>
+              scheduleRepo
+                .delete(NamedScheduleId(id))
+                .mapError(ApiError.Db(_)) *>
+              AppMetrics.scheduleMutation("delete").as(Response.ok)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 }

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -16,6 +16,14 @@ import java.time.{Duration, Instant, LocalDate, ZoneId}
 //
 // Per-device timeline (#721) and per-profile timeline (#722) share one endpoint.
 // Exactly one of `mac=` or `profileId=` must be set.
+//
+// #1570: handlers (and their helper builders) fail with a typed [[ApiError]] mapped centrally by
+// [[ErrorMapper.errorToResponse]]; the [[wifihaven.api.ErrorBoundary]] logs (4xx WARN / 5xx ERROR) +
+// meters each error. Every case reproduces the EXACT status + body the hand-rolled code produced —
+// the structured `unknown_bucket` / `unknown_groupBy` / `groupBy_not_implemented` 400 JSON bodies
+// map through [[ApiError.BadRequest]] to the identical `Response.badRequest(...)`, DB failures stay
+// 503 via [[ApiError.Db]]. Auth/profile-access helpers still return `Response` and are bridged via
+// [[ApiError.Wrapped]].
 object UsageRoutes {
   def routes(
       auth: AuthService,
@@ -42,20 +50,21 @@ object UsageRoutes {
             userProfileRepo,
             appRepo,
             clock,
-          )
+          ).mapError(ErrorMapper.errorToResponse)
         },
       // #766: recently-visited FQDN apexes for one device, used by the
       // apps create/edit "Pick from recent activity" picker.
       Method.GET / "api" / "devices" / string("mac") / "recent-apexes" ->
         handler { (macRaw: String, req: Request) =>
-          for {
-            claims <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             mac = MacAddress.unsafe(normalizeMac(macRaw))
             device <- deviceRepo
               .findByMac(mac)
-              .mapError(ErrorMapper.dbErrorToResponse)
-              .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Device not found")))
             _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
             windowDays = req.url
               .queryParam("windowDays")
               .flatMap(_.toIntOption)
@@ -72,7 +81,7 @@ object UsageRoutes {
             from = now.minus(Duration.ofDays(windowDays.toLong))
             rows <- trafficRepo
               .listFqdnHostAggregatesForDevice(mac, from, now)
-              .mapError(ErrorMapper.dbErrorToResponse)
+              .mapError(ApiError.Db(_))
             grouped = rows
               .groupBy { case (h, _, _) => Apex.orSelf(h) }
               .iterator
@@ -96,6 +105,7 @@ object UsageRoutes {
               items = grouped,
             )
           } yield Response.json(resp.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1061 — per-app time-used breakdown for one profile over [from,to].
       // Read-only companion to #767's rules editor; powers the per-app subsection
@@ -104,23 +114,24 @@ object UsageRoutes {
       // bucket. Sorted by proportional seconds desc.
       Method.GET / "api" / "profiles" / long("id") / "usage-by-app"    ->
         handler { (id: Long, req: Request) =>
-          val pid = ProfileId(id)
-          for {
-            claims <- requireAuth(req, auth)
+          val pid                                  = ProfileId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             _      <- requireProfileReadAccess(claims, pid, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
             today  <- clock.today
             fromS = req.url.queryParam("from").getOrElse(today.toString)
             toS   = req.url.queryParam("to").getOrElse(fromS)
             from     <- ZIO
               .attempt(LocalDate.parse(fromS))
-              .orElseFail(Response.badRequest(s"invalid from: $fromS"))
+              .orElseFail(ApiError.BadRequest(s"invalid from: $fromS"))
             to       <- ZIO
               .attempt(LocalDate.parse(toS))
-              .orElseFail(Response.badRequest(s"invalid to: $toS"))
+              .orElseFail(ApiError.BadRequest(s"invalid to: $toS"))
             _        <- ZIO
-              .fail(Response.badRequest("from must be <= to"))
+              .fail(ApiError.BadRequest("from must be <= to"))
               .when(from.isAfter(to))
-            settings <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            settings <- hsRepo.get.mapError(ApiError.Db(_))
             resp     <- buildUsageByApp(
               pid,
               from,
@@ -133,11 +144,12 @@ object UsageRoutes {
               settings.presenceContinuationSeconds,
             )
           } yield Response.json(resp.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "usage" / "series"                          ->
         handler { (req: Request) =>
-          for {
-            claims <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             today  <- clock.today
             macOpt = req.url.queryParam("mac").map(s => MacAddress.unsafe(normalizeMac(s)))
             profileIdOpt <- ZIO
@@ -150,18 +162,18 @@ object UsageRoutes {
                       .toRight(s"invalid profileId: $s")
                 },
               )
-              .mapError(Response.badRequest)
+              .mapError(ApiError.BadRequest(_))
             _            <- ZIO
-              .fail(Response.badRequest("exactly one of mac or profileId is required"))
+              .fail(ApiError.BadRequest("exactly one of mac or profileId is required"))
               .when(macOpt.isDefined == profileIdOpt.isDefined)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date <- ZIO
               .attempt(LocalDate.parse(dateStr))
-              .orElseFail(Response.badRequest(s"invalid date: $dateStr"))
+              .orElseFail(ApiError.BadRequest(s"invalid date: $dateStr"))
             tzStr = req.url.queryParam("tz").getOrElse("UTC")
             zone <- ZIO
               .attempt(ZoneId.of(tzStr))
-              .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
+              .orElseFail(ApiError.BadRequest(s"invalid tz: $tzStr"))
             topN       = req.url
               .queryParam("topN")
               .flatMap(_.toIntOption)
@@ -178,7 +190,7 @@ object UsageRoutes {
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
               else ZIO.succeed(UsageSeries.AppAxis.empty)
-            settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            settings  <- hsRepo.get.mapError(ApiError.Db(_))
             resp      <- (macOpt, profileIdOpt) match {
               case (Some(mac), _) =>
                 buildForDevice(
@@ -210,27 +222,28 @@ object UsageRoutes {
                   appLookup,
                   settings,
                 )
-              case _              => ZIO.fail(Response.badRequest("unreachable"))
+              case _              => ZIO.fail(ApiError.BadRequest("unreachable"))
             }
           } yield Response.json(resp.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1099: batched per-profile series. The /profiles page resolves the
       // whole visible profile set in one partition-pruned scan instead of N
       // parallel single-profile requests.
       Method.GET / "api" / "usage" / "series" / "batch"                ->
         handler { (req: Request) =>
-          for {
-            claims <- requireAuth(req, auth)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
             today  <- clock.today
-            pids   <- parseMultiProfileIdParam(req).map(_.distinct)
+            pids   <- parseMultiProfileIdParam(req).mapError(ApiError.Wrapped(_)).map(_.distinct)
             dateStr = req.url.queryParam("date").getOrElse(today.toString)
             date <- ZIO
               .attempt(LocalDate.parse(dateStr))
-              .orElseFail(Response.badRequest(s"invalid date: $dateStr"))
+              .orElseFail(ApiError.BadRequest(s"invalid date: $dateStr"))
             tzStr = req.url.queryParam("tz").getOrElse("UTC")
             zone <- ZIO
               .attempt(ZoneId.of(tzStr))
-              .orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
+              .orElseFail(ApiError.BadRequest(s"invalid tz: $tzStr"))
             topN       = req.url
               .queryParam("topN")
               .flatMap(_.toIntOption)
@@ -241,7 +254,7 @@ object UsageRoutes {
             appLookup <-
               if (groupByApp) loadAppLookup(appRepo)
               else ZIO.succeed(UsageSeries.AppAxis.empty)
-            settings  <- hsRepo.get.mapError(ErrorMapper.dbErrorToResponse)
+            settings  <- hsRepo.get.mapError(ApiError.Db(_))
             resp      <- buildBatch(
               pids,
               date,
@@ -258,6 +271,7 @@ object UsageRoutes {
               settings,
             )
           } yield Response.json(resp.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
         },
     )
 
@@ -280,16 +294,18 @@ object UsageRoutes {
       groupByApp: Boolean,
       appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
-  ): IO[Response, UsageSeriesBatchResponse] =
+  ): IO[ApiError, UsageSeriesBatchResponse] =
     for {
-      _ <- ZIO.foreachDiscard(pids)(pid => requireProfileReadAccess(claims, pid, userProfileRepo))
+      _           <- ZIO.foreachDiscard(pids)(pid =>
+        requireProfileReadAccess(claims, pid, userProfileRepo).mapError(ApiError.Wrapped(_)),
+      )
       profiles    <- ZIO.foreach(pids) { pid =>
         profileRepo
           .findById(pid)
-          .mapError(ErrorMapper.dbErrorToResponse)
-          .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
+          .mapError(ApiError.Db(_))
+          .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
       }
-      allDevices  <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      allDevices  <- deviceRepo.listAll.mapError(ApiError.Db(_))
       // #1492: exempt-from-daily site patterns must match the headline daily total exactly, so
       // load them per profile (same input `usedSecondsForProfile` uses) and carve them out.
       exemptByPid <- ZIO
@@ -299,7 +315,7 @@ object UsageRoutes {
             .map(sl => pid -> sl.filter(_.exemptFromDaily).map(_.domainPattern))
         }
         .map(_.toMap)
-        .mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
       devicesByPid = pids.iterator
         .map(pid => pid -> allDevices.filter(_.profileId.contains(pid)))
         .toMap
@@ -373,19 +389,19 @@ object UsageRoutes {
       appRepo: AppRepo,
       filter: HeartbeatFilter,
       continuationSeconds: Int,
-  ): IO[Response, ProfileUsageByApp] =
+  ): IO[ApiError, ProfileUsageByApp] =
     for {
       profile <- profileRepo
         .findById(pid)
-        .mapError(ErrorMapper.dbErrorToResponse)
-        .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
-      allDevs <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
+        .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
+      allDevs <- deviceRepo.listAll.mapError(ApiError.Db(_))
       macs = allDevs.collect { case d if d.profileId.contains(pid) => d.mac }
       presence <- (if (macs.isEmpty) ZIO.succeed(Nil)
                    else trafficRepo.listPresenceRows(macs, from, to))
-        .mapError(ErrorMapper.dbErrorToResponse)
-      appList  <- appRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-      mappings <- appRepo.listAllHostMappings.mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
+      appList  <- appRepo.listAll.mapError(ApiError.Db(_))
+      mappings <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
     } yield {
       val appById                            = appList.iterator.map(a => a.id -> a).toMap
       // Deterministic host → owning-app: lowest appId wins when a host is in
@@ -473,10 +489,10 @@ object UsageRoutes {
   // can't drift.
   private def loadAppLookup(
       appRepo: AppRepo,
-  ): IO[Response, UsageSeries.AppAxis] =
+  ): IO[ApiError, UsageSeries.AppAxis] =
     for {
-      apps     <- appRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-      mappings <- appRepo.listAllHostMappings.mapError(ErrorMapper.dbErrorToResponse)
+      apps     <- appRepo.listAll.mapError(ApiError.Db(_))
+      mappings <- appRepo.listAllHostMappings.mapError(ApiError.Db(_))
     } yield {
       val appById        = apps.iterator.map(a => a.id -> a).toMap
       val byApex         = mappings
@@ -511,13 +527,14 @@ object UsageRoutes {
       groupByApp: Boolean,
       appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
-  ): IO[Response, UsageSeriesResponse] =
+  ): IO[ApiError, UsageSeriesResponse] =
     for {
       device <- deviceRepo
         .findByMac(mac)
-        .mapError(ErrorMapper.dbErrorToResponse)
-        .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Device not found")))
+        .mapError(ApiError.Db(_))
+        .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Device not found")))
       _      <- requireProfileReadAccess(claims, device.profileId, userProfileRepo)
+        .mapError(ApiError.Wrapped(_))
       rows   <- fetchPresenceDayWindow(trafficRepo, List(mac), date, zone)
       (topHosts, buckets, presenceTotalMins) =
         UsageSeries.build(
@@ -569,15 +586,16 @@ object UsageRoutes {
       groupByApp: Boolean,
       appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
-  ): IO[Response, UsageSeriesResponse] =
+  ): IO[ApiError, UsageSeriesResponse] =
     for {
       _          <- requireProfileReadAccess(claims, pid, userProfileRepo)
+        .mapError(ApiError.Wrapped(_))
       profile    <- profileRepo
         .findById(pid)
-        .mapError(ErrorMapper.dbErrorToResponse)
-        .flatMap(ZIO.fromOption(_).orElseFail(Response.notFound("Profile not found")))
-      all        <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
-      siteLimits <- siteTimeLimitRepo.listForProfile(pid).mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
+        .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
+      all        <- deviceRepo.listAll.mapError(ApiError.Db(_))
+      siteLimits <- siteTimeLimitRepo.listForProfile(pid).mapError(ApiError.Db(_))
       exempt    = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
       devices   = all.filter(_.profileId.contains(pid))
       macs      = devices.map(_.mac)
@@ -636,14 +654,14 @@ object UsageRoutes {
       macs: List[MacAddress],
       date: LocalDate,
       zone: ZoneId,
-  ): IO[Response, List[wifihaven.api.presence.PresenceRow]] =
+  ): IO[ApiError, List[wifihaven.api.presence.PresenceRow]] =
     if (macs.isEmpty) ZIO.succeed(Nil)
     else {
       val from = date.atStartOfDay(zone).toInstant
       val to   = date.plusDays(1).atStartOfDay(zone).toInstant
       trafficRepo
         .listPresenceRowsInWindow(macs, from, to)
-        .mapError(ErrorMapper.dbErrorToResponse)
+        .mapError(ApiError.Db(_))
     }
 
   // ── #846 Traffic Usage page ───────────────────────────────────────────────
@@ -727,14 +745,14 @@ object UsageRoutes {
       userProfileRepo: UserProfileRepo,
       appRepo: AppRepo,
       clock: Clock,
-  ): ZIO[Any, Response, Response] =
+  ): ZIO[Any, ApiError, Response] =
     for {
-      claims <- requireAuth(req, auth)
+      claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
       bucketS = req.url.queryParam("bucket").getOrElse("raw")
       bucket     <- ZIO
         .fromOption(UsageTraffic.Bucket.parse(bucketS))
         .orElseFail(
-          Response.badRequest(s"""{"error":"unknown_bucket","bucket":"$bucketS"}"""),
+          ApiError.BadRequest(s"""{"error":"unknown_bucket","bucket":"$bucketS"}"""),
         )
       // #917: groupBy accepts repeated params (?groupBy=host&groupBy=device).
       // For backwards-compat each value is also comma-split, so the older
@@ -753,21 +771,21 @@ object UsageRoutes {
             ZIO
               .fromOption(UsageTraffic.GroupBy.parse(s))
               .orElseFail(
-                Response.badRequest(s"""{"error":"unknown_groupBy","groupBy":"$s"}"""),
+                ApiError.BadRequest(s"""{"error":"unknown_groupBy","groupBy":"$s"}"""),
               )
           }
           .map(_.toSet)
       }
       _          <- ZIO
         .fail(
-          Response.badRequest(
+          ApiError.BadRequest(
             """{"error":"groupBy_not_implemented","groupBy":"apex","reason":"PSL not available — see #856"}""",
           ),
         )
         .when(groupBySet.contains(UsageTraffic.GroupBy.Apex))
       // #769: groupBy=app is now implemented (joins through app_hosts).
       tzStr = req.url.queryParam("tz").getOrElse("UTC")
-      zone <- ZIO.attempt(ZoneId.of(tzStr)).orElseFail(Response.badRequest(s"invalid tz: $tzStr"))
+      zone <- ZIO.attempt(ZoneId.of(tzStr)).orElseFail(ApiError.BadRequest(s"invalid tz: $tzStr"))
       now  <- clock.now
       // Default range: last 24h if not supplied.
       defaultFrom = now.minus(Duration.ofHours(24))
@@ -775,12 +793,12 @@ object UsageRoutes {
       toS         = req.url.queryParam("to").getOrElse(now.toString)
       fromI <- ZIO
         .attempt(Instant.parse(fromS))
-        .orElseFail(Response.badRequest(s"invalid from: $fromS"))
+        .orElseFail(ApiError.BadRequest(s"invalid from: $fromS"))
       toI   <- ZIO
         .attempt(Instant.parse(toS))
-        .orElseFail(Response.badRequest(s"invalid to: $toS"))
+        .orElseFail(ApiError.BadRequest(s"invalid to: $toS"))
       _     <- ZIO
-        .fail(Response.badRequest("from must be < to"))
+        .fail(ApiError.BadRequest("from must be < to"))
         .when(!fromI.isBefore(toI))
       // #862/#809: the prior 31-day window cap is gone. The aggregated path
       // routes coarse buckets to traffic_hourly / traffic_daily (see
@@ -792,7 +810,7 @@ object UsageRoutes {
       // single value still works ("mac=aa:bb:cc:dd:ee:01"). Empty/absent =
       // no filter on that column.
       macsRaw = parseMultiValueParam(req, "mac").map(s => MacAddress.unsafe(normalizeMac(s)))
-      profileIds <- parseMultiProfileIdParam(req)
+      profileIds <- parseMultiProfileIdParam(req).mapError(ApiError.Wrapped(_))
       // Retention gating per #814 is not yet wired (rollup tables + horizons endpoint
       // are dependencies). We still expose the 409 contract by emitting it when the
       // window straddles a horizon we DO know about — but until #814, the only
@@ -802,17 +820,18 @@ object UsageRoutes {
       // Resolve mac filter from macs / profileIds / "all visible to admin".
       // When both lists are non-empty, intersect: devices that match any
       // selected mac AND belong to any selected profile.
-      allDevices <- deviceRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      allDevices <- deviceRepo.listAll.mapError(ApiError.Db(_))
       macs       <- (macsRaw, profileIds) match {
         case (ms, _) if ms.nonEmpty     =>
           for {
             devs <- ZIO.foreach(ms) { mac =>
               ZIO
                 .fromOption(allDevices.find(_.mac == mac))
-                .orElseFail(Response.notFound(s"Device not found: ${mac.value}"))
+                .orElseFail(ApiError.NotFound(s"Device not found: ${mac.value}"))
             }
             _    <- ZIO.foreach(devs.flatMap(_.profileId).distinct) { pid =>
               requireProfileReadAccess(claims, Some(pid), userProfileRepo)
+                .mapError(ApiError.Wrapped(_))
             }
           } yield
             if (profileIds.isEmpty) devs.map(_.mac)
@@ -820,7 +839,8 @@ object UsageRoutes {
         case (_, pids) if pids.nonEmpty =>
           for {
             _ <- ZIO.foreach(pids)(pid =>
-              requireProfileReadAccess(claims, Some(pid), userProfileRepo),
+              requireProfileReadAccess(claims, Some(pid), userProfileRepo)
+                .mapError(ApiError.Wrapped(_)),
             )
           } yield allDevices.filter(d => d.profileId.exists(pids.contains)).map(_.mac)
         case _                          =>
@@ -829,7 +849,7 @@ object UsageRoutes {
             ZIO.succeed(allDevices.map(_.mac))
           else
             ZIO.fail(
-              Response.forbidden("mac or profileId required for non-admin"),
+              ApiError.Forbidden("mac or profileId required for non-admin"),
             )
       }
       // #858: zero-bytes-zero-seconds rows are filtered at SQL level in
@@ -837,7 +857,7 @@ object UsageRoutes {
       // at ingest into traffic_reports_filtered_zero_bytes_total (see
       // RouterIngestRoutes.handleUsage), so a return of the #858 regression is
       // now a metric rather than a per-request log.
-      profiles   <- profileRepo.listAll.mapError(ErrorMapper.dbErrorToResponse)
+      profiles   <- profileRepo.listAll.mapError(ApiError.Db(_))
       profNames = profiles.iterator.map(p => p.id -> p.name).toMap
       devByMac  = allDevices.iterator.map(d => d.mac -> d).toMap
       // #769: load (host → app memberships) for app grouping. Only fetched
@@ -856,7 +876,7 @@ object UsageRoutes {
                 .get(m.appId)
                 .map(a => m.host.value -> AppMembership(a.slug, a.name, a.icon, Some(a.id)))
             }
-            .groupMap(_._1)(_._2)).mapError(ErrorMapper.dbErrorToResponse)
+            .groupMap(_._1)(_._2)).mapError(ApiError.Db(_))
         else ZIO.succeed(Map.empty[String, List[AppMembership]])
       // #862: cursor + nextCursor replace the old "single fixed window with
       // rawRowsTruncated flag" UX. `limit` is the per-page cap (200 default,
@@ -881,7 +901,7 @@ object UsageRoutes {
                     wifihaven.api.db.Cursor.decode[wifihaven.api.db.Cursor.RawTrafficCursor](s),
                   )
                   .mapBoth(
-                    Response.badRequest,
+                    ApiError.BadRequest(_),
                     c => Some(RawTrafficCursorKey(c.ts, c.mac, c.host)),
                   )
             }
@@ -891,7 +911,7 @@ object UsageRoutes {
               else
                 trafficRepo
                   .listRawInRange(macs, fromI, toI, rawCursor, Some(rawLimit))
-                  .mapError(ErrorMapper.dbErrorToResponse)
+                  .mapError(ApiError.Db(_))
             built   = UsageTraffic.buildRaw(pagedRows, devByMac, profNames)
             nextCur =
               if (pagedRows.size < rawLimit) None
@@ -932,17 +952,17 @@ object UsageRoutes {
                   case SourceTier.Raw    =>
                     trafficRepo
                       .listRawInRange(macs, fromI, toI)
-                      .mapError(ErrorMapper.dbErrorToResponse)
+                      .mapError(ApiError.Db(_))
                   case SourceTier.Hourly =>
                     rollupRepo
                       .listHourlyInRange(macs, fromI, toI)
                       .map(asDbRows)
-                      .mapError(ErrorMapper.dbErrorToResponse)
+                      .mapError(ApiError.Db(_))
                   case SourceTier.Daily  =>
                     rollupRepo
                       .listDailyInRange(macs, fromI, toI)
                       .map(asDbRows)
-                      .mapError(ErrorMapper.dbErrorToResponse)
+                      .mapError(ApiError.Db(_))
                 }
             cursorOpt <- req.url.queryParam("cursor") match {
               case None    => ZIO.succeed(Option.empty[wifihaven.api.db.Cursor.AggCursor])
@@ -951,7 +971,7 @@ object UsageRoutes {
                   .fromEither(
                     wifihaven.api.db.Cursor.decode[wifihaven.api.db.Cursor.AggCursor](s),
                   )
-                  .mapBoth(Response.badRequest, Some(_))
+                  .mapBoth(ApiError.BadRequest(_), Some(_))
             }
             allAgg = UsageTraffic
               .buildAggregate(

--- a/api/test/src/feature/ErrorBoundaryStage2Spec.scala
+++ b/api/test/src/feature/ErrorBoundaryStage2Spec.scala
@@ -1,0 +1,189 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ErrorBoundary
+import wifihaven.api.JwtConfig
+import wifihaven.api.MetricsConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.metrics.MetricsRuntime
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.test.*
+
+/**
+ * #1570 Stage 2: the migrated route files now fail with a typed [[ApiError]] mapped centrally by
+ * [[ErrorMapper.errorToResponse]] and observed by [[ErrorBoundary.observe]]. This spec wraps a few
+ * representative migrated families (Schedules, Apps, Global Policy) in the boundary exactly as
+ * `Main` does and pins, end-to-end against embedded Postgres (no mocks):
+ *
+ *   1. Wire back-compat: each error path returns the EXACT status + body the hand-rolled code
+ *      produced — including the structured `name_taken` / `slug_taken` 409 JSON bodies the SPA
+ *      parses (preserved verbatim through [[ApiError.Wrapped]]). 2. Boundary integration: the
+ *      migrated error responses are now LOGGED (4xx → WARN) and METERED
+ *      (`api_errors_total{route,status}`) in one place — the Stage-1 coverage now extends to these
+ *      routes too. Auth-helper failures bridged via [[ApiError.Wrapped]] are observed identically.
+ *
+ * Stage-1's [[ErrorBoundarySpec]] proves the boundary mechanism + the ingest routes; this is the
+ * Stage-2 analogue for the admin/SPA-facing families.
+ */
+object ErrorBoundaryStage2Spec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher] {
+
+  override val bootstrap =
+    TestDatabase.layer ++
+      TestLayers.withClock(TestClock.schoolDayAfternoon) ++
+      MetricsRuntime.prometheus(100.millis)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def adminToken =
+    for {
+      auth  <- makeAuth
+      token <- auth.login("admin", "changeme").map(_.token.value)
+    } yield token
+
+  private def scheduleRoutes =
+    for {
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      auth <- makeAuth
+    } yield ErrorBoundary.observe(ScheduleRoutes.routes(auth, nsr))
+
+  private def appRoutes =
+    for {
+      appRepo     <- ZIO.service[AppRepo]
+      profileRepo <- ZIO.service[ProfileRepo]
+      upRepo      <- ZIO.service[UserProfileRepo]
+      auth        <- makeAuth
+    } yield ErrorBoundary.observe(AppRoutes.routes(auth, appRepo, profileRepo, upRepo))
+
+  private def globalRoutes =
+    for {
+      repo <- ZIO.service[GlobalPolicyRepo]
+      ur   <- ZIO.service[UserRepo]
+      auth <- makeAuth
+    } yield ErrorBoundary.observe(GlobalPolicyRoutes.routes(auth, repo, ur))
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def post(rs: Routes[Any, Response], path: String, body: String, token: String) =
+    rs.runZIO(
+      Request
+        .post(url(path), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  private def get(rs: Routes[Any, Response], path: String, token: String) =
+    rs.runZIO(Request.get(url(path)).addHeader(Header.Authorization.Bearer(token)))
+
+  private def bodyText(r: Response): UIO[String] = r.body.asString.orElseSucceed("")
+
+  private def scrape: ZIO[PrometheusPublisher, Response, String] =
+    for {
+      pub <- ZIO.service[PrometheusPublisher]
+      routes = MetricsRoutes.routes(MetricsConfig(enabled = true), pub)
+      resp <- routes(Request.get("/metrics"))
+      body <- resp.body.asString.orElseFail(Response.internalServerError("scrape decode failed"))
+    } yield body
+
+  private def meteredStatus(body: String, status: Int): Boolean =
+    body.linesIterator.exists(l =>
+      !l.startsWith("#") && l.startsWith("api_errors_total") && l.contains(s"""status="$status""""),
+    )
+
+  private def warned(logs: Chunk[ZTestLogger.LogEntry], substr: String): Boolean =
+    logs.exists(e => e.logLevel == LogLevel.Warning && e.message().contains(substr))
+
+  def spec = suite("ErrorBoundary Stage 2 — migrated route families (#1570)")(
+    test("Schedules: duplicate name keeps the 409 + name_taken JSON body, logged + metered") {
+      (for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- scheduleRoutes
+        body = CreateNamedScheduleRequest(name = "Bedtime").toJson
+        _       <- post(rs, "/api/schedules", body, token)
+        dupe    <- post(rs, "/api/schedules", body, token)
+        dBody   <- bodyText(dupe)
+        _       <- ZIO.sleep(700.millis)
+        scrapeB <- scrape.catchAll(r => bodyText(r))
+        logs    <- ZTestLogger.logOutput
+      } yield assertTrue(dupe.status == Status.Conflict) &&
+        // back-compat: the SPA parses this exact structured body
+        assertTrue(dBody == """{"error":"name_taken","name":"Bedtime"}""") &&
+        assertTrue(warned(logs, "/api/schedules")) &&
+        assertTrue(meteredStatus(scrapeB, 409)))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("Schedules: GET unknown id is 404 'Schedule not found', logged at WARN + metered") {
+      (for {
+        _       <- cleanDb
+        token   <- adminToken
+        rs      <- scheduleRoutes
+        resp    <- get(rs, "/api/schedules/99999", token)
+        rBody   <- bodyText(resp)
+        _       <- ZIO.sleep(700.millis)
+        scrapeB <- scrape.catchAll(r => bodyText(r))
+        logs    <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.NotFound) &&
+        assertTrue(rBody == "Schedule not found") &&
+        assertTrue(warned(logs, "Schedule not found")) &&
+        assertTrue(meteredStatus(scrapeB, 404)))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("Apps: duplicate slug keeps the 409 + slug_taken JSON body, metered") {
+      (for {
+        _     <- cleanDb
+        token <- adminToken
+        rs    <- appRoutes
+        body = CreateAppRequest(name = "YouTube", slug = Some("youtube")).toJson
+        _       <- post(rs, "/api/apps", body, token)
+        dupe    <- post(rs, "/api/apps", body, token)
+        dBody   <- bodyText(dupe)
+        _       <- ZIO.sleep(700.millis)
+        scrapeB <- scrape.catchAll(r => bodyText(r))
+      } yield assertTrue(dupe.status == Status.Conflict) &&
+        assertTrue(dBody == """{"error":"slug_taken","slug":"youtube"}""") &&
+        assertTrue(meteredStatus(scrapeB, 409)))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+    test("Global policy: a missing token is mapped to 401 and logged at WARN by the boundary") {
+      // requireAuth fails with a Response (Missing token); the migrated handler bridges it via
+      // ApiError.Wrapped, so the boundary still observes the 401 identically.
+      (for {
+        _       <- cleanDb
+        rs      <- globalRoutes
+        resp    <- rs.runZIO(Request.get(url("/api/global/policy")))
+        _       <- ZIO.sleep(700.millis)
+        scrapeB <- scrape.catchAll(r => bodyText(r))
+        logs    <- ZTestLogger.logOutput
+      } yield assertTrue(resp.status == Status.Unauthorized) &&
+        assertTrue(warned(logs, "/api/global/policy")) &&
+        assertTrue(meteredStatus(scrapeB, 401)))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock & PrometheusPublisher](
+          ZTestLogger.default,
+        )
+    } @@ TestAspect.withLiveClock,
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## What

Stage 2 of #1570 (#1579). Migrates the **mid-size and small route files** off bespoke per-endpoint error handling onto the Stage-1 central handler: handlers now `ZIO.fail` a typed `ApiError` (or wrap a collaborator's `Response` via `ApiError.Wrapped`) and end with `.mapError(ErrorMapper.errorToResponse)`, so `ErrorBoundary` produces the Response + logs (4xx WARN / 5xx ERROR) + meters (`api_errors_total{route,status}`) in **one** place. The bespoke `Response.badRequest/notFound/…` inline construction and ad-hoc `.mapError(ErrorMapper.dbErrorToResponse)` plumbing are removed.

## Files migrated
- `AppRoutes` (+ `AdminRouterRoutes` is in `RouterRoutes.scala`)
- `UsageRoutes` (handlers **and** the builder helpers `trafficHandler` / `buildBatch` / `buildForDevice` / `buildForProfile` / `buildUsageByApp` / `loadAppLookup` / `fetchPresenceDayWindow`)
- `AlertRoutes`
- `ScheduleRoutes`
- `RouterRoutes` + `AdminRouterRoutes`
- `GlobalPolicyRoutes`
- `RouterMetricsRoutes`
- `DashboardNowRoutes`
- `DebugRoutes`
- `RollupAdminRoutes`

## Behavior preservation (wire back-compat)
This is a **behavior-preserving refactor**. Every endpoint keeps the **identical status code and body** consumers depend on:
- The OpenWRT agent branches on status only — **DB failures stay `503`** via `ApiError.Db` (same `{"status":"error","db":...}` + `Retry-After:30`).
- The SPA parses structured 4xx JSON bodies — these are **preserved verbatim** through `ApiError.Wrapped` where they aren't a plain `Response.badRequest`/`notFound`:
  - `slug_taken` (409), `seed_failed` (500), `not_template_derived` (400), `unknown_template` (404) — AppRoutes
  - `name_taken` (409) — ScheduleRoutes
  - `unknown_bucket` / `unknown_groupBy` / `groupBy_not_implemented` (400) — UsageRoutes (map through `ApiError.BadRequest` to the identical `Response.badRequest`)
  - empty-body `409` (Alert pending-state), `text/plain` `router_id mismatch` `403` (RouterMetrics), empty-body `403` (Debug loopback refusal) — preserved exactly via `Wrapped`.

These families were **already** wrapped by `ErrorBoundary.observe` in `Main`, so logging/metering *coverage* is unchanged in scope — the migration only swaps inline `Response` construction for typed errors that map to the byte-identical `Response`.

## Intentionally NOT migrated (documented in code)
- **`StaticRoutes`** — builds its 400/404 on the **success channel**; there is no bespoke error-channel plumbing to centralize, and the boundary already observes those responses.
- **`RouterAuth`** — kept as the `Response`-returning collaborator, bridged via `ApiError.Wrapped` (the Stage-1 seam). Migrating it ripples into the already-merged `RouterIngestRoutes`; deferred.

## Tests
- New `ErrorBoundaryStage2Spec` (embedded Postgres, no mocks): wraps Schedules/Apps/GlobalPolicy in `ErrorBoundary.observe` exactly as `Main` does and pins **(1)** wire back-compat — exact `name_taken`/`slug_taken` 409 bodies + the 404 body — and **(2)** boundary integration — the migrated error is logged at WARN and metered by status.
- Existing route specs stay green. **Full `mill api.test`: 833 passed, 0 failed, 0 ignored.**
- `scalafmt --check`: clean.

## Scope / constraints
- Diff limited to `api/src/routes/**` and `api/test/**`. No migration, no wire-shape break.

## Stage-2 progress checklist
- [x] AppRoutes
- [x] UsageRoutes
- [x] AlertRoutes
- [x] ScheduleRoutes
- [x] RouterRoutes (+ AdminRouterRoutes)
- [x] GlobalPolicyRoutes
- [x] RouterMetricsRoutes
- [x] DashboardNowRoutes
- [x] DebugRoutes
- [x] RollupAdminRoutes
- [x] StaticRoutes — N/A (success-channel responses; documented)
- [x] RouterAuth — intentionally kept as the `Wrapped` bridge (documented)
- [ ] **Routes.scala (~185 sites)** — follow-up PR (PR B)

Closes part of #1579; #1570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)