### PR TITLE
feat(#730): schema — add nullable dest_ip to traffic_reports (PR1/2)

### DIFF
--- a/api/resources/db/migration/V54__traffic_reports_dest_ip.sql
+++ b/api/resources/db/migration/V54__traffic_reports_dest_ip.sql
@@ -1,0 +1,26 @@
+-- V54__traffic_reports_dest_ip.sql
+-- #730: add `dest_ip TEXT NULL` to traffic_reports so router→api UsageRecords
+-- can carry the destination IP that the bytes were attributed to. This is the
+-- foundational schema bump; the follow-up code PR adds the wire field, the
+-- agent emission, and the API persist path.
+--
+-- Why nullable: pre-existing rows have no dest_ip and post-PR1 image-(N-1)
+-- inserts do not supply one. The column stays NULL for those; only new agents
+-- (after the follow-up code PR ships) populate it.
+--
+-- Why we do NOT touch the unique constraint here: the existing
+-- UNIQUE(router_id, period_start, mac, host_type, host_value) provides batch
+-- idempotency for image-(N-1) inserts that do not reference dest_ip. Changing
+-- the conflict target now would break image-(N-1)'s `ON CONFLICT(router_id,
+-- period_start,mac,host_type,host_value)` clause. The follow-up code PR keeps
+-- the same uniqueness shape and persists `dest_ip` as informational metadata
+-- on the row already chosen by the existing key.
+--
+-- Migration cost at prod scale (traffic_reports is an unbounded-growth,
+-- weekly-partitioned table — see V41 / docs/design/db-partitioning.md):
+-- ADD COLUMN ... TEXT NULL on a partitioned parent table propagates to every
+-- partition as a metadata-only change (Postgres stores a NULL default, no
+-- table rewrite, no row-by-row work). Safe on the startup critical path even
+-- against the full prod history.
+
+ALTER TABLE traffic_reports ADD COLUMN dest_ip TEXT;


### PR DESCRIPTION
Schema-only migration for the #730 work — adds a nullable `dest_ip TEXT` column to `traffic_reports` so the follow-up code PR can carry the destination IP from each router→api `UsageRecord` on the row.

## Why this is the right shape

- **Additive, NULL-friendly.** Image-(N-1) does not reference `dest_ip` on the insert path, and the existing `UNIQUE (router_id, period_start, mac, host_type, host_value)` is intentionally untouched — so image-(N-1) continues to insert exactly as today, and any old row that lands while the rollout is in flight just stores `NULL`.
- **Cheap at prod scale.** `traffic_reports` is an unbounded-growth, weekly-RANGE-partitioned table (V41, see `docs/design/db-partitioning.md`). `ALTER TABLE ... ADD COLUMN ... TEXT NULL` on a partitioned parent propagates to every partition as a metadata-only change (no rewrite, no row-by-row work) — safe on the startup critical path per AGENTS.md §migrations-prod-data-volume.
- **Backward compatibility gate.** Existing `api.test` (TestDatabase + embedded Postgres) replays the full Flyway chain including V54 before fixtures hit image-N's code — passing tests prove image-N's source survives DB-at-V54. The follow-up code PR is where the wire, agent, and persist changes land.

## Follow-up

PR2 (code) will:
1. Add `destIp: Option[IpAddress]` to `UsageRecord` (wire, additive — old agents send no field).
2. Have the OpenWRT Lua agent thread `dst_ip` into each emitted record (one record per `(mac, dst_ip)` already — `usage.lua` keys flows that way today via `host_for_ip(dst_ip, …)`).
3. Persist `dest_ip` on `traffic_reports` at ingest.
4. Cover both sides with busted and Scala feature tests.

A subsequent issue covers the larger work described in #730 — write-time FQDN backfill using `dest_ip` to look up `connection_events.resolved_host_value`, and retirement of the read-side LATERAL join annotated `TODO(#730)` in `api/src/db/Repos.scala`. That cleanup has to wait until pre-V54 rows age out of the retention window so dashboards don't regress on historical data.

Refs #730.

## Test plan

- [x] Migration is metadata-only on the partitioned parent (verified by SQL shape).
- [ ] CI: `api.test` proves image-N source survives DB-at-V54.
- [ ] CI: `check-migration-isolation` passes (only `.sql` under `api/resources/db/migration/`).