### PR TITLE
feat(#1507): surface background/infra suppression on per-device drill-in

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -388,6 +388,38 @@ object Presence {
       reasons: List[String],
   )
 
+  /**
+   * #1507: aggregate per-host bytes / bucket-count for rows the canonical [[isHeartbeat]] predicate
+   * suppresses — the same rows excluded from session-stitch counting. Lets the dashboard surface
+   * "background / infra (no engaged time)" without re-implementing the predicate (the
+   * single-source-of-truth lesson; see AGENTS.md §1532). `appHostPatterns` flows straight into
+   * [[isHeartbeat]] so app-attributed hosts (after #1506) are NOT reported as suppressed — they're
+   * counted as engagement. IP-literal hosts never appear because the suppression list keys on
+   * FQDNs.
+   *
+   * #1560 will collapse the per-device span and suppression-list call sites into one entry point;
+   * until then, callers should pass the same `appHostPatterns` they pass to [[deviceSessionSpans]]
+   * / [[hostSessionSpans]] so the two views can't disagree.
+   */
+  case class SuppressedHostRow(host: HostId, bytes: Long, buckets: Int, reason: String)
+
+  def suppressedHostUsage(
+      rows: List[PresenceRow],
+      filter: HeartbeatFilter,
+      appHostPatterns: List[String] = Nil,
+  ): List[SuppressedHostRow] =
+    rows
+      .filter(r => isHeartbeat(r, filter, appHostPatterns))
+      .groupBy(_.host)
+      .iterator
+      .map { case (h, rs) =>
+        val isInfra = h.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value))
+        val reason  = if (isInfra) "infra" else "bytes-below-threshold"
+        SuppressedHostRow(h, rs.iterator.map(_.bytes).sum, rs.size, reason)
+      }
+      .toList
+      .sortBy(r => (-r.bytes, r.host.value))
+
   def classifyRows(rows: List[PresenceRow], filter: HeartbeatFilter): List[Classified] =
     rows.map { r =>
       val rsns = scala.collection.mutable.ListBuffer.empty[String]

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -564,7 +564,7 @@ object UsageRoutes {
       bucketsByEntry = bucketsByEntry,
       presenceTotalMins = presenceTotalMins,
       suppressedHosts =
-        suppressedHostRows.map(r => SuppressedHostUsage(r.host, r.bytes, r.buckets, r.reason), ),
+        suppressedHostRows.map(r => SuppressedHostUsage(r.host, r.bytes, r.buckets, r.reason)),
     )
 
   private def buildForProfile(

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -528,6 +528,16 @@ object UsageRoutes {
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
         )
+      // #1507: surface what the engaged-time calculation excluded so the drill-in can show a
+      // collapsed "background / infra" group. App-aware via [[appLookup]] — a host attributed to
+      // any app's host-set is NOT reported here, matching the post-#1506 attribution-beats-
+      // suppression semantics. #1560 will centralize this with the per-host-span call site.
+      suppressedHostRows                     =
+        wifihaven.api.presence.Presence.suppressedHostUsage(
+          rows,
+          settings.heartbeatFilter,
+          appLookup.patternsBySlug.valuesIterator.flatten.toList.distinct,
+        )
       // Single-device view → per-device union is the total; no cross-device overlap mode applies.
       (topEntries, bucketsByEntry)           =
         if (groupByApp)
@@ -553,6 +563,8 @@ object UsageRoutes {
       topEntries = topEntries,
       bucketsByEntry = bucketsByEntry,
       presenceTotalMins = presenceTotalMins,
+      suppressedHosts =
+        suppressedHostRows.map(r => SuppressedHostUsage(r.host, r.bytes, r.buckets, r.reason), ),
     )
 
   private def buildForProfile(

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -379,6 +379,50 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           // is what enables the per-device 'other' drill-in to see the full tail.
           assertTrue(out.topHosts.length == 30)
       },
+      // #1507 — surface background/infra suppression on the per-device drill-in. The same predicate
+      // the rollup builder uses (`Presence.isHeartbeat`/`InfraHosts.isBackground`) tags rows whose
+      // host is device-level infra; those rows contribute 0 engaged minutes but the bytes still
+      // happened. The drill-in must show the operator what was excluded and why.
+      test("surfaces background/infra hosts in suppressedHosts with bytes summed") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          today = TestClock.schoolDayAfternoon.toLocalDate
+          // One engaged host (youtube.com) and two device-level infra hosts (canonical +
+          // suppress-only) — both must be reported in `suppressedHosts` and must NOT contribute to
+          // engaged minutes (totalMins reflects only youtube.com).
+          _  <- insertRow(routerId, testMac, "youtube.com", today, 14, 0)
+          _  <- insertRow(routerId, testMac, "ocsp.apple.com", today, 14, 5)
+          _  <- insertRow(routerId, testMac, "ocsp.apple.com", today, 14, 10)
+          _  <- insertRow(routerId, testMac, "push.apple.com", today, 14, 15)
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/usage/series?mac=$testMac&date=$today").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[UsageSeriesResponse])
+          ocsp = out.suppressedHosts.find(_.host.value == "ocsp.apple.com")
+          push = out.suppressedHosts.find(_.host.value == "push.apple.com")
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Engaged surface: only youtube.com is a real host; infra never shows up here.
+          assertTrue(out.topHosts.exists(_.host.value == "youtube.com")) &&
+          assertTrue(!out.topHosts.exists(_.host.value == "ocsp.apple.com")) &&
+          assertTrue(!out.topHosts.exists(_.host.value == "push.apple.com")) &&
+          // suppressedHosts surface: both infra hosts present, bytes summed across the two ocsp rows
+          // (50 KB/row × 2 rows = 100 KB), one row for push.apple.com (50 KB).
+          assertTrue(ocsp.exists(_.bytes == 100_000L)) &&
+          assertTrue(ocsp.exists(_.reason == "infra")) &&
+          assertTrue(push.exists(_.bytes == 50_000L)) &&
+          assertTrue(push.exists(_.reason == "infra"))
+      },
       test("tz parameter buckets by local-hour") {
         for {
           _           <- cleanDb

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1074,6 +1074,28 @@ case class UsageSeriesResponse(
     // `totalMins` would drop sub-minute fractions and read a few minutes low; clients should show
     // this as the "total". Additive; older clients ignore it. Defaults to 0 for the empty case.
     presenceTotalMins: Int = 0,
+    // #1507: hosts whose traffic was reached during the window but contributed 0 engaged-minutes
+    // because they were classified as device-level background/infra (Apple OCSP, Google
+    // connectivity probes, …) or fell under the keepalive byte-floor. Surfaced so the operator can
+    // see what the engaged-time calculation excluded and why — the bytes did happen, they just
+    // don't drive engagement. Additive; older clients ignore it. Derived from the same
+    // [[wifihaven.api.presence.Presence.isHeartbeat]] predicate the rollup builder uses, so the
+    // "excluded" view can't drift from the "counted" view (single-source-of-truth, AGENTS.md
+    // §1532). #1560 will collapse the per-device span and suppression-list call sites to one entry
+    // point so this stays canonical.
+    suppressedHosts: List[SuppressedHostUsage] = Nil,
+) derives JsonCodec
+
+// #1507: one device-level-infra / keepalive host that traffic was seen for, with the bytes the
+// router observed and the reason the heartbeat predicate fired. `reason` is a small enum the SPA
+// reads to group rows ("infra" = matched the InfraHosts background list; "bytes-below-threshold"
+// = filter-enabled keepalive floor). `buckets` is the number of 5-min traffic-report rows the
+// host appeared in over the window, useful for "how chatty was this thing."
+case class SuppressedHostUsage(
+    host: HostId,
+    bytes: Long,
+    buckets: Int,
+    reason: String,
 ) derives JsonCodec
 
 // #1099: batched per-profile series for the /profiles page. One request

--- a/web/src/pages/DeviceTimelinePage.test.tsx
+++ b/web/src/pages/DeviceTimelinePage.test.tsx
@@ -205,6 +205,61 @@ describe('DeviceTimelinePage', () => {
       expect(screen.queryByTestId('device-timeline-other-entry-host-top0.com')).toBeNull()
     })
 
+  })
+
+  describe('background/infra suppression panel (#1507)', () => {
+    function withSuppressedResponse(date: string): UsageSeriesResponse {
+      return {
+        deviceMac: MAC,
+        deviceName: "Kid's iPad",
+        date,
+        tz: 'UTC',
+        topHosts: [],
+        buckets: Array.from({ length: 24 }, (_, hour) => ({ hour, totalMins: 0, perHost: [], otherMins: 0 })),
+        topEntries: [
+          {
+            entity: { kind: 'host' as const, id: 'engaged.com', name: 'engaged.com',
+              host: { type: 'fqdn' as const, value: 'engaged.com' } },
+            dayMins: 5,
+          },
+        ],
+        bucketsByEntry: Array.from({ length: 24 }, (_, hour) => ({ hour, totalMins: 0, perEntity: [], otherMins: 0 })),
+        suppressedHosts: [
+          { host: { type: 'fqdn', value: 'ocsp.apple.com' }, bytes: 100_000, buckets: 2, reason: 'infra' },
+          { host: { type: 'fqdn', value: 'push.apple.com' }, bytes: 50_000, buckets: 1, reason: 'infra' },
+        ],
+      }
+    }
+
+    it('lists each suppressed host with formatted bytes; engaged surface unchanged', async () => {
+      (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        withSuppressedResponse('2026-05-20'),
+      )
+      renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+      await waitFor(() =>
+        expect(screen.getByTestId('device-timeline-suppressed')).toBeInTheDocument(),
+      )
+      expect(screen.getByTestId('device-timeline-suppressed-ocsp.apple.com')).toBeInTheDocument()
+      expect(screen.getByTestId('device-timeline-suppressed-push.apple.com')).toBeInTheDocument()
+      // Bytes are surfaced — not asserting on the exact format string so the formatter can change,
+      // just that the byte count is reachable somewhere in the row.
+      expect(screen.getByTestId('device-timeline-suppressed-ocsp.apple.com').textContent ?? '')
+        .toMatch(/100|KB|kB/)
+      // Engaged group is still rendered separately from the suppressed group.
+      expect(screen.getByTestId('device-timeline-entry-host-engaged.com')).toBeInTheDocument()
+    })
+
+    it('hides the panel when no suppressed hosts are reported', async () => {
+      (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        emptyDayResponse('2026-05-20'),
+      )
+      renderPage([`/devices/${MAC}/timeline?date=2026-05-20`])
+      await waitFor(() =>
+        expect(screen.getByTestId('device-timeline-empty')).toBeInTheDocument(),
+      )
+      expect(screen.queryByTestId('device-timeline-suppressed')).toBeNull()
+    })
+
     it('hides the affordance when there is no Other bucket on any hour', async () => {
       (api.usage.series as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
         emptyDayResponse('2026-05-20'),

--- a/web/src/pages/DeviceTimelinePage.tsx
+++ b/web/src/pages/DeviceTimelinePage.tsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts'
 import { api } from '@/api/client'
 import type {
-  DeviceTimeStatusWeek, UsageEntityBucket, UsageSeriesResponse,
+  DeviceTimeStatusWeek, SuppressedHostUsage, UsageEntityBucket, UsageSeriesResponse,
 } from '@/types/api'
 import { PageLoader } from './DashboardPage'
 import { HostCell } from '@/components/HostCell'
@@ -328,6 +328,10 @@ export function DeviceTimelinePage() {
         </div>
       )}
 
+      {window === 'today' && (dayData?.suppressedHosts ?? []).length > 0 && (
+        <SuppressedHostsPanel hosts={dayData?.suppressedHosts ?? []} />
+      )}
+
       {window === 'week' && weekHosts.length > 0 && (
         <div className="bg-white rounded-2xl border border-brand-border p-5">
           <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider mb-3">
@@ -373,6 +377,74 @@ export function DeviceTimelinePage() {
           topN={TOP_N}
           onClose={() => setOtherOpen(false)}
         />
+      )}
+    </div>
+  )
+}
+
+// #1507 — collapsed panel surfacing hosts the engaged-time calculation excluded
+// (device-level infra: Apple OCSP, Google connectivity probes, push, …; or sub-
+// keepalive-threshold bytes). The same `Presence.isHeartbeat` predicate the
+// rollup builder uses tags these rows, so the "excluded" view can't drift from
+// the "counted" view. Bytes still happened; they just don't drive engagement.
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function SuppressedHostsPanel({ hosts }: { hosts: SuppressedHostUsage[] }) {
+  const [open, setOpen] = useState(true)
+  const sorted = [...hosts].sort((a, b) => b.bytes - a.bytes)
+  const totalBytes = sorted.reduce((a, h) => a + h.bytes, 0)
+  return (
+    <div
+      data-testid="device-timeline-suppressed"
+      className="bg-white rounded-2xl border border-brand-border p-5"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-center justify-between text-left"
+        aria-expanded={open}
+      >
+        <h2 className="text-sm font-semibold text-brand-text uppercase tracking-wider">
+          Background / infra (no engaged time)
+        </h2>
+        <span className="text-xs text-brand-text-muted font-mono">
+          {sorted.length} {sorted.length === 1 ? 'host' : 'hosts'} · {formatBytes(totalBytes)}
+          <span className="ml-2">{open ? '▾' : '▸'}</span>
+        </span>
+      </button>
+      {open && (
+        <>
+          <ul className="mt-3 space-y-1.5">
+            {sorted.map(h => (
+              <li
+                key={`${h.host.type}:${h.host.value}`}
+                data-testid={`device-timeline-suppressed-${h.host.value}`}
+                className="flex items-center justify-between text-xs text-brand-text bg-brand-alt/50 rounded-lg px-3 py-2"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <span className="truncate font-mono">{h.host.value}</span>
+                  <span className="text-[10px] text-brand-text-muted uppercase shrink-0">
+                    {h.reason === 'infra' ? 'infra' : 'keepalive'}
+                  </span>
+                </span>
+                <span className="text-brand-text-muted font-mono shrink-0 ml-2 tabular-nums">
+                  {formatBytes(h.bytes)}
+                  <span className="text-brand-text-muted"> · {h.buckets} bkt</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+          <p className="text-[11px] text-brand-text-muted mt-3">
+            Hosts shown as background are reached during app sessions but didn’t drive engagement
+            (CDN, telemetry, keepalives). They contribute 0 to engaged-minutes; their bytes are
+            still counted.
+          </p>
+        </>
       )}
     </div>
   )

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -498,6 +498,22 @@ export interface UsageSeriesResponse {
   // headline rather than summing the per-hour bars, which lose sub-minute
   // fractions and read a few minutes low. Optional: older API responses omit it.
   presenceTotalMins?: number
+  // #1507 — hosts that traffic was seen for but that contributed 0 engaged-
+  // minutes because they were classified as device-level background/infra (Apple
+  // OCSP, Google connectivity probes, …) or fell under the keepalive byte-floor.
+  // Surfaced on the per-device drill-in so the operator can see what the engaged-
+  // time calculation excluded and why. Optional: older API responses omit it.
+  suppressedHosts?: SuppressedHostUsage[]
+}
+
+// #1507 — one device-level-infra / keepalive host with the bytes observed.
+// `reason`: 'infra' = matched the InfraHosts background list; 'bytes-below-
+// threshold' = filter-enabled keepalive floor.
+export interface SuppressedHostUsage {
+  host: HostId
+  bytes: number
+  buckets: number
+  reason: 'infra' | 'bytes-below-threshold' | string
 }
 
 // #1099 — batched per-profile series: one round-trip resolves the whole


### PR DESCRIPTION
Closes #1507.

## Summary
- New additive `suppressedHosts: List[SuppressedHostUsage]` field on `UsageSeriesResponse` (per-device drill-in only). Each row carries `host`, `bytes`, `buckets`, `reason` (`infra` | `bytes-below-threshold`).
- Derived from the same `Presence.isHeartbeat` predicate the rollup builder uses via a new `Presence.suppressedHostUsage` helper — single-source-of-truth (AGENTS.md §1532). App-aware after #1506: a host attributed to any app's host-set is **not** reported as suppressed.
- SPA renders a collapsed "Background / infra (no engaged time)" panel on the device timeline with a tooltip-style footnote: *"Hosts shown as background are reached during app sessions but didn't drive engagement (CDN, telemetry, keepalives). They contribute 0 to engaged-minutes; their bytes are still counted."*

## Test plan
- [x] `mill api.test.testOnly wifihaven.api.feature.UsageApiSpec` — 39 tests pass; new feature test seeds `youtube.com` + `ocsp.apple.com` (×2) + `push.apple.com` and asserts the engaged surface excludes infra while `suppressedHosts` reports them with bytes summed.
- [x] `npx vitest run` — 388 tests pass; two new tests cover the panel + the "no suppressed hosts → no panel" case.
- [x] `npx tsc --noEmit` clean.
- [x] `mill scalafmtCheckAll` clean.

## Followup
[#1560](https://github.com/wifihaven/wifihaven/issues/1560): collapse the per-device span and suppression-list call sites into one entry point. `UsageSeries.build`'s per-host stack doesn't yet thread `appHostPatterns` through `hostSessionSpans`, so the engaged-view is not app-aware while the suppression-list IS — out of scope here. Calling this out so reviewers don't re-litigate.