### PR TITLE
feat(#1519,#726): per-app + per-orphan-host rows on usage-by-app, drop 'Other' bucket

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -99,9 +99,10 @@ object UsageRoutes {
         },
       // #1061 — per-app time-used breakdown for one profile over [from,to].
       // Read-only companion to #767's rules editor; powers the per-app subsection
-      // on the expanded /profiles card. Joins through `app_hosts` and folds rows
-      // whose host isn't in any app into a synthetic `appId=null` ("Other")
-      // bucket. Sorted by proportional seconds desc.
+      // on the expanded /profiles card. Joins through `app_hosts` and returns one
+      // row per app. #1519: hosts NOT in any configured app surface individually
+      // in `orphanHosts` (single-host pseudo-apps, per the App-Centric Model) —
+      // there is no synthetic "Other" entry on this endpoint.
       Method.GET / "api" / "profiles" / long("id") / "usage-by-app"    ->
         handler { (id: Long, req: Request) =>
           val pid = ProfileId(id)
@@ -362,7 +363,13 @@ object UsageRoutes {
   //   - presenceSeconds: each (mac, period_start) bucket contributes once per
   //     distinct app touched in that bucket. Not additive across apps (this is
   //     intentional — surfaces "was this app touched at all" volume).
-  // Hosts not in any app land in the synthetic `appId=null` "Other" bucket.
+  //
+  // #1519 — hosts NOT in any configured app are NOT lumped into a synthetic
+  // "Other" app. Per the App-Centric Model, a non-app host is its own
+  // single-host app. They surface individually in `orphanHosts`, each with the
+  // same proportionalSeconds/presenceSeconds units as an app row, so the SPA
+  // can render them side-by-side with real apps. "Other" only ever appears as
+  // a top-N display rollup at the SPA layer.
   private def buildUsageByApp(
       pid: ProfileId,
       from: LocalDate,
@@ -437,11 +444,14 @@ object UsageRoutes {
           appPresence.updateWith(a)(prev => Some(prev.getOrElse(0L) + secs))
       }
 
-      val allKeys = (appProp.keySet ++ appPresence.keySet).toList
-      val rows    = allKeys.map { key =>
-        val name  = key.flatMap(appById.get).map(_.name).getOrElse("Other")
-        val icon  = key.flatMap(appById.get).flatMap(_.icon)
-        val it    = key.flatMap(appById.get).map(_.iconType)
+      // #1519: real-app rows ONLY. Drop the `None` key — those hosts surface as
+      // individual orphanHosts entries below.
+      val appKeys = (appProp.keySet ++ appPresence.keySet).iterator.flatten.toList.distinct
+      val rows    = appKeys.map { aid =>
+        val key   = Some(aid)
+        val name  = appById.get(aid).map(_.name).getOrElse(aid.value.toString)
+        val icon  = appById.get(aid).flatMap(_.icon)
+        val it    = appById.get(aid).map(_.iconType)
         val hosts = hostsByApp
           .getOrElse(key, Nil)
           .sortBy(hu => (-hu.proportionalMins, -hu.usedMins, hu.host.value))
@@ -455,12 +465,36 @@ object UsageRoutes {
           hosts = hosts,
         )
       }
+
+      // #1519: orphan rows = non-app hosts, each rendered as its own single-host
+      // pseudo-app. proportional = the per-host attention sum already gathered;
+      // presence = dedupe (mac, periodStart) buckets PER HOST (each host's
+      // presence is its own bucket-deduped wall-clock seconds — same shape as
+      // the per-app presence, but one row per host).
+      val orphanHostSet  = propByHost.keysIterator.filter(h => appOfHost(h).isEmpty).toSet
+      val orphanPresence = scala.collection.mutable.Map.empty[HostId, Long]
+      for ((_, bucket) <- activeRows.groupBy(r => (r.mac, r.periodStart))) {
+        val secs      = bucket.iterator.map(_.activeSeconds.toLong).maxOption.getOrElse(0L)
+        val hostsHere = bucket.iterator.map(_.host).filter(orphanHostSet.contains).toSet
+        for (h <- hostsHere)
+          orphanPresence.updateWith(h)(prev => Some(prev.getOrElse(0L) + secs))
+      }
+      val orphanRows = orphanHostSet.toList.map { h =>
+        OrphanHostUsage(
+          host = h,
+          proportionalSeconds = propByHost.getOrElse(h, 0L),
+          presenceSeconds = orphanPresence.getOrElse(h, 0L),
+        )
+      }
+
       ProfileUsageByApp(
         profileId = pid,
         profileName = profile.name,
         from = from.toString,
         to = to.toString,
         apps = rows.sortBy(r => (-r.proportionalSeconds, -r.presenceSeconds, r.appName)),
+        orphanHosts = orphanRows
+          .sortBy(o => (-o.proportionalSeconds, -o.presenceSeconds, o.host.value)),
       )
     }
 

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -1787,7 +1787,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
     ) @@ TestAspect.sequential,
     // #1061 — per-app time-used breakdown for one profile.
     suite("GET /api/profiles/:id/usage-by-app")(
-      test("two apps with 5 minutes each → 2 rows, hosts not in any app → Other") {
+      test("#1519: two apps + one non-app host → 2 app rows, 1 orphan row, NO 'Other' app row") {
         val today = TestClock.schoolDayAfternoon.toLocalDate
         for {
           _           <- cleanDb
@@ -1862,21 +1862,24 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           resp <- routes.runZIO(req)
           body <- resp.body.asString
           out  <- ZIO.fromEither(body.fromJson[ProfileUsageByApp])
-          yt = out.apps.find(_.appName == "YouTube").get
-          mu = out.apps.find(_.appName == "Music").get
-          ot = out.apps.find(_.appId.isEmpty).get
+          yt     = out.apps.find(_.appName == "YouTube").get
+          mu     = out.apps.find(_.appName == "Music").get
+          orphan = out.orphanHosts.find(_.host.value == "google.com").get
         } yield assertTrue(resp.status == Status.Ok) &&
-          assertTrue(out.apps.length == 3) &&
+          // Only the two real apps: no synthetic "Other" row anywhere in `apps`.
+          assertTrue(out.apps.length == 2) &&
+          assertTrue(!out.apps.exists(_.appName == "Other")) &&
+          assertTrue(!out.apps.exists(_.appId.isEmpty)) &&
           // Each app saw one 5-min bucket → 300 presence seconds, ~300 proportional seconds.
           assertTrue(yt.presenceSeconds == 300L) &&
           assertTrue(mu.presenceSeconds == 300L) &&
-          assertTrue(ot.presenceSeconds == 300L) &&
           assertTrue(yt.proportionalSeconds == 300L) &&
           assertTrue(mu.proportionalSeconds == 300L) &&
-          assertTrue(ot.proportionalSeconds == 300L) &&
           assertTrue(yt.appIcon.contains("📺")) &&
-          assertTrue(ot.appName == "Other") &&
-          assertTrue(ot.hosts.map(_.host.value).contains("google.com"))
+          // The non-app host surfaces as a per-host orphan row, not as an "Other" bucket.
+          assertTrue(out.orphanHosts.length == 1) &&
+          assertTrue(orphan.proportionalSeconds == 300L) &&
+          assertTrue(orphan.presenceSeconds == 300L)
       },
       test("#1433: an app with usage but no time limit still returns its time-used") {
         // The profile/app page surfaces today's time-used for every app, not
@@ -1991,7 +1994,9 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(ka.get.proportionalSeconds == 300L) &&
           assertTrue(ka.get.presenceSeconds == 300L) &&
           assertTrue(ka.get.hosts.map(_.host.value).contains("m.khanacademy.org")) &&
-          assertTrue(!out.apps.exists(_.appId.isEmpty))
+          assertTrue(!out.apps.exists(_.appId.isEmpty)) &&
+          // #1519: an apex-matched host MUST attribute to its app, not surface as an orphan row.
+          assertTrue(out.orphanHosts.isEmpty)
       },
       test("sorted by proportionalSeconds desc") {
         val today = TestClock.schoolDayAfternoon.toLocalDate
@@ -2067,6 +2072,120 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(out.apps.map(_.appName) == List("YouTube", "Music")) &&
           assertTrue(out.apps.head.proportionalSeconds == 600L) &&
           assertTrue(out.apps(1).proportionalSeconds == 300L)
+      },
+      test(
+        "#1519/#726: one app with 3 hosts + 2 orphan hosts → 1 app row (summed) + 2 orphan rows",
+      ) {
+        val today = TestClock.schoolDayAfternoon.toLocalDate
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          deviceRepo  <- ZIO.service[DeviceRepo]
+          trafficRepo <- ZIO.service[TrafficReportRepo]
+          appRepo     <- ZIO.service[AppRepo]
+          kidsId      <- TestLayers.seedKidsProfile(profileRepo, schedRepo)
+          _           <- TestLayers.seedDevice(deviceRepo, testMac, "iPad", kidsId)
+          routerId    <- seedRouter
+          ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
+          _           <- appRepo.setHosts(
+            ytId,
+            List(
+              Hostname.unsafe("youtube.com"),
+              Hostname.unsafe("ytimg.com"),
+              Hostname.unsafe("googlevideo.com"),
+            ),
+          )
+          start = today.atStartOfDay(ZoneOffset.UTC).toInstant.plusSeconds(14 * 3600L)
+          // 3 buckets for the app (across its three hosts) + 2 buckets for two orphan hosts.
+          _  <- trafficRepo.insertBatch(
+            List(
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("youtube.com")),
+                today,
+                start,
+                start.plusSeconds(300),
+                300,
+                500_000L,
+                500_000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("ytimg.com")),
+                today,
+                start.plusSeconds(300),
+                start.plusSeconds(600),
+                300,
+                500_000L,
+                500_000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("googlevideo.com")),
+                today,
+                start.plusSeconds(600),
+                start.plusSeconds(900),
+                300,
+                500_000L,
+                500_000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("wikipedia.org")),
+                today,
+                start.plusSeconds(900),
+                start.plusSeconds(1200),
+                300,
+                500_000L,
+                500_000L,
+              ),
+              TrafficReportInsert(
+                routerId,
+                MacAddress.unsafe(testMac),
+                None,
+                HostId.Fqdn(Hostname.unsafe("example.com")),
+                today,
+                start.plusSeconds(1200),
+                start.plusSeconds(1500),
+                300,
+                500_000L,
+                500_000L,
+              ),
+            ),
+          )
+          rb <- buildRoutes
+          (routes, auth) = rb
+          token <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode(s"/api/profiles/${kidsId.value}/usage-by-app").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp <- routes.runZIO(req)
+          body <- resp.body.asString
+          out  <- ZIO.fromEither(body.fromJson[ProfileUsageByApp])
+          yt          = out.apps.find(_.appName == "YouTube").get
+          orphanHosts = out.orphanHosts.map(_.host.value).toSet
+        } yield assertTrue(resp.status == Status.Ok) &&
+          // Exactly 1 app row (the configured YouTube app-set, aggregated across 3 hosts).
+          assertTrue(out.apps.length == 1) &&
+          assertTrue(yt.proportionalSeconds == 900L) &&
+          assertTrue(
+            yt.hosts.map(_.host.value).toSet ==
+              Set("youtube.com", "ytimg.com", "googlevideo.com"),
+          ) &&
+          // 2 per-orphan rows, NO "Other" bucket.
+          assertTrue(out.orphanHosts.length == 2) &&
+          assertTrue(orphanHosts == Set("wikipedia.org", "example.com")) &&
+          assertTrue(out.orphanHosts.forall(_.proportionalSeconds == 300L)) &&
+          assertTrue(!out.apps.exists(_.appName == "Other"))
       },
       test("404 on unknown profile id") {
         for {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -998,12 +998,33 @@ case class ProfileAppUsage(
     hosts: List[HostUsage],
 ) derives JsonCodec
 
+/**
+ * #1519 — a non-app host: a host that doesn't belong to any configured app's host-set. Per the
+ * App-Centric Model (CLAUDE.md "App"), such a host **is its own single-host app** — there is no
+ * semantic "Other" app. "Other" only ever appears as a display rollup (top-N + "+N more sites") at
+ * the SPA layer, never as a wire entity.
+ *
+ * Units match the parallel app row ([[ProfileAppUsage]]) so the SPA can render orphans and apps
+ * side-by-side with one formatter.
+ */
+case class OrphanHostUsage(
+    host: HostId,
+    proportionalSeconds: Long,
+    presenceSeconds: Long,
+) derives JsonCodec
+
 case class ProfileUsageByApp(
     profileId: ProfileId,
     profileName: String,
     from: String,
     to: String,
+    // #1519: only "real" apps (rows whose host is mapped through `app_hosts`). The synthetic
+    // `appId=null` "Other" row that earlier shipped here is gone; non-app hosts surface
+    // individually in `orphanHosts` below.
     apps: List[ProfileAppUsage],
+    // #1519/#726: per non-app host, one entry. Additive (defaults to Nil) so older clients keep
+    // working; new clients render these as single-host pseudo-app rows.
+    orphanHosts: List[OrphanHostUsage] = Nil,
 ) derives JsonCodec
 
 // #716 / #721 — per-device hourly usage timeline. The endpoint returns 24

--- a/web/src/components/usage/ProfileUsageBreakdown.test.tsx
+++ b/web/src/components/usage/ProfileUsageBreakdown.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BreakdownBody } from './ProfileUsageBreakdown'
+import type { ProfileUsageByApp } from '@/types/api'
+
+function fixture(): ProfileUsageByApp {
+  return {
+    profileId: 1,
+    profileName: 'Kids',
+    from: '2026-06-07',
+    to: '2026-06-07',
+    apps: [
+      {
+        appId: 10,
+        appName: 'YouTube',
+        appIcon: '📺',
+        appIconType: null,
+        proportionalSeconds: 900,
+        presenceSeconds: 900,
+        hosts: [
+          { host: { type: 'fqdn', value: 'youtube.com' }, usedMins: 5, proportionalMins: 5 },
+          { host: { type: 'fqdn', value: 'ytimg.com' }, usedMins: 5, proportionalMins: 5 },
+          { host: { type: 'fqdn', value: 'googlevideo.com' }, usedMins: 5, proportionalMins: 5 },
+        ],
+      },
+    ],
+    orphanHosts: [
+      { host: { type: 'fqdn', value: 'wikipedia.org' }, proportionalSeconds: 300, presenceSeconds: 300 },
+      { host: { type: 'fqdn', value: 'example.com' }, proportionalSeconds: 180, presenceSeconds: 180 },
+    ],
+  }
+}
+
+describe('ProfileUsageBreakdown — #1519/#726', () => {
+  it('renders one row per configured app and one row per orphan host, NO "Other" bucket', () => {
+    render(<BreakdownBody profileId={1} data={fixture()} />)
+    // App row present
+    expect(screen.getByTestId('profile-usage-breakdown-1-app-10')).toBeInTheDocument()
+    // Per-orphan rows present (single-host pseudo-apps)
+    expect(screen.getByTestId('profile-usage-breakdown-1-orphan-wikipedia.org')).toBeInTheDocument()
+    expect(screen.getByTestId('profile-usage-breakdown-1-orphan-example.com')).toBeInTheDocument()
+    // Nothing labelled "Other" anywhere
+    expect(screen.queryByText(/^Other$/)).not.toBeInTheDocument()
+  })
+
+  it('drills into per-FQDN breakdown when the app row is expanded (#726)', async () => {
+    render(<BreakdownBody profileId={1} data={fixture()} />)
+    // Host rows hidden by default
+    expect(
+      screen.queryByTestId('profile-usage-breakdown-1-app-10-hosts'),
+    ).not.toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('profile-usage-breakdown-1-app-10-toggle'))
+    const hostList = screen.getByTestId('profile-usage-breakdown-1-app-10-hosts')
+    expect(hostList).toHaveTextContent('youtube.com')
+    expect(hostList).toHaveTextContent('ytimg.com')
+    expect(hostList).toHaveTextContent('googlevideo.com')
+  })
+
+  it('orphan-list "+N more sites" expander is labelled explicitly as a UI rollup, not an "Other" bucket', async () => {
+    const data = fixture()
+    // 12 orphans → top-10 visible + "+2 more sites"
+    data.orphanHosts = Array.from({ length: 12 }).map((_, i) => ({
+      host: { type: 'fqdn', value: `host${i}.example.com` },
+      proportionalSeconds: 300 - i,
+      presenceSeconds: 300 - i,
+    }))
+    render(<BreakdownBody profileId={1} data={data} />)
+    expect(screen.queryByTestId('profile-usage-breakdown-1-orphan-host10.example.com'))
+      .not.toBeInTheDocument()
+    const expand = screen.getByTestId('profile-usage-breakdown-1-orphan-expand')
+    expect(expand).toHaveTextContent(/\+2 more sites/)
+    // The copy MUST clarify these are individual sites, not an "Other" bucket
+    expect(expand).toHaveTextContent(/not an "Other" bucket/i)
+    await userEvent.click(expand)
+    expect(screen.getByTestId('profile-usage-breakdown-1-orphan-host10.example.com'))
+      .toBeInTheDocument()
+  })
+
+  it('renders an empty-state when there is no usage at all', () => {
+    render(
+      <BreakdownBody
+        profileId={7}
+        data={{
+          profileId: 7,
+          profileName: 'X',
+          from: '2026-06-07',
+          to: '2026-06-07',
+          apps: [],
+          orphanHosts: [],
+        }}
+      />,
+    )
+    expect(screen.getByTestId('profile-usage-breakdown-7-empty')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/usage/ProfileUsageBreakdown.tsx
+++ b/web/src/components/usage/ProfileUsageBreakdown.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from 'react'
+import { useProfileUsageByApp } from '@/api/queries'
+import type {
+  HostUsage, OrphanHostUsage, ProfileAppUsage, ProfileUsageByApp,
+} from '@/types/api'
+import { formatMins } from '@/lib/timeFormat'
+
+// #1519 / #726 — per-profile usage breakdown: one row per configured app
+// (drillable to its per-host minutes — the #726 per-FQDN breakdown), then one
+// row per non-app host (each rendered as its own single-host pseudo-app, per
+// the App-Centric Model — there is NO semantic "Other" app).
+//
+// "Other" only appears here as a PRESENTATION affordance: the orphan list's
+// long tail collapses behind a "+N more sites" expander, labelled explicitly
+// as a top-N rollup, not as a bucket the API ships.
+
+const ORPHAN_TOP_N = 10
+
+function secondsToMins(s: number): number {
+  return Math.round(s / 60)
+}
+
+function today(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function ProfileUsageBreakdown({ profileId, enabled = true, from, to }: {
+  profileId: number
+  enabled?: boolean
+  from?: string
+  to?: string
+}) {
+  const f = from ?? today()
+  const t = to ?? f
+  const q = useProfileUsageByApp(profileId, f, t, { enabled })
+
+  if (!enabled) return null
+  if (q.isLoading) {
+    return (
+      <div
+        data-testid={`profile-usage-breakdown-${profileId}-loading`}
+        className="text-xs text-brand-text-muted px-2 py-3"
+      >
+        Loading usage…
+      </div>
+    )
+  }
+  if (q.error || !q.data) {
+    return (
+      <div
+        data-testid={`profile-usage-breakdown-${profileId}-error`}
+        className="text-xs text-red-700 px-2 py-3"
+      >
+        Failed to load usage.
+      </div>
+    )
+  }
+  return <BreakdownBody profileId={profileId} data={q.data} />
+}
+
+export function BreakdownBody({ profileId, data }: {
+  profileId: number
+  data: ProfileUsageByApp
+}) {
+  const apps = data.apps
+  const orphans = data.orphanHosts ?? []
+  if (apps.length === 0 && orphans.length === 0) {
+    return (
+      <div
+        data-testid={`profile-usage-breakdown-${profileId}-empty`}
+        className="text-xs text-brand-text-muted px-2 py-3"
+      >
+        No usage in this window.
+      </div>
+    )
+  }
+  return (
+    <div
+      data-testid={`profile-usage-breakdown-${profileId}`}
+      className="rounded-xl border border-brand-border bg-brand-surface/30"
+    >
+      <header className="px-4 py-2 text-xs uppercase tracking-wider text-brand-text-muted">
+        Usage by app
+      </header>
+      <ul className="divide-y divide-brand-border">
+        {apps.map(a => (
+          <AppRow key={`app-${a.appId ?? a.appName}`} profileId={profileId} app={a} />
+        ))}
+        <OrphanList profileId={profileId} orphans={orphans} />
+      </ul>
+    </div>
+  )
+}
+
+function AppRow({ profileId, app }: { profileId: number; app: ProfileAppUsage }) {
+  const [open, setOpen] = useState(false)
+  const mins = secondsToMins(app.proportionalSeconds)
+  return (
+    <li data-testid={`profile-usage-breakdown-${profileId}-app-${app.appId ?? 'na'}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-4 py-2 text-left"
+        data-testid={`profile-usage-breakdown-${profileId}-app-${app.appId ?? 'na'}-toggle`}
+      >
+        <span className="flex items-center gap-2">
+          <span className={`text-brand-text-muted transition-transform text-xs ${open ? 'rotate-90' : ''}`}>▸</span>
+          {app.appIcon && <span aria-hidden>{app.appIcon}</span>}
+          <span className="text-sm font-medium text-brand-ink">{app.appName}</span>
+        </span>
+        <span
+          className="text-xs text-brand-text"
+          data-testid={`profile-usage-breakdown-${profileId}-app-${app.appId ?? 'na'}-mins`}
+        >
+          {formatMins(mins)}
+        </span>
+      </button>
+      {open && (
+        <ul
+          data-testid={`profile-usage-breakdown-${profileId}-app-${app.appId ?? 'na'}-hosts`}
+          className="px-8 pb-2"
+        >
+          {app.hosts.length === 0 && (
+            <li className="text-xs text-brand-text-muted py-1">No host activity in window.</li>
+          )}
+          {app.hosts.map(h => <HostRow key={h.host.value} host={h} />)}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+function HostRow({ host }: { host: HostUsage }) {
+  return (
+    <li className="flex items-center justify-between text-xs py-1">
+      <span className="text-brand-text">{host.host.value}</span>
+      <span className="text-brand-text-muted">{formatMins(host.proportionalMins)}</span>
+    </li>
+  )
+}
+
+function OrphanList({ profileId, orphans }: {
+  profileId: number
+  orphans: OrphanHostUsage[]
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const sorted = useMemo(
+    () => [...orphans].sort((a, b) => b.proportionalSeconds - a.proportionalSeconds),
+    [orphans],
+  )
+  if (sorted.length === 0) return null
+  const visible = expanded ? sorted : sorted.slice(0, ORPHAN_TOP_N)
+  const remainder = sorted.length - visible.length
+  return (
+    <>
+      {visible.map(o => (
+        <li
+          key={`orphan-${o.host.value}`}
+          data-testid={`profile-usage-breakdown-${profileId}-orphan-${o.host.value}`}
+          className="flex items-center justify-between px-4 py-2"
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden className="text-brand-text-muted text-xs">·</span>
+            <span className="text-sm text-brand-ink">{o.host.value}</span>
+          </span>
+          <span
+            className="text-xs text-brand-text"
+            data-testid={`profile-usage-breakdown-${profileId}-orphan-${o.host.value}-mins`}
+          >
+            {formatMins(secondsToMins(o.proportionalSeconds))}
+          </span>
+        </li>
+      ))}
+      {remainder > 0 && (
+        <li className="px-4 py-2">
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="text-xs text-brand-text-muted underline"
+            data-testid={`profile-usage-breakdown-${profileId}-orphan-expand`}
+          >
+            {`+${remainder} more sites (top-${ORPHAN_TOP_N} shown — these are individual non-app sites, not an "Other" bucket)`}
+          </button>
+        </li>
+      )}
+    </>
+  )
+}

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@/types/api'
 import { AppIcon } from '@/components/AppIcon'
 import { ProfileTimelineChart } from '@/components/usage/ProfileTimelineChart'
+import { ProfileUsageBreakdown } from '@/components/usage/ProfileUsageBreakdown'
 import { EmptyState } from '@/components/EmptyState'
 import { PageLoader } from './DashboardPage'
 import { formatMins } from '@/lib/timeFormat'
@@ -836,6 +837,13 @@ function ProfileShellRow({
               group-by + Other drill-in that the deleted /time page used to
               own. Read-only; lives above the edit subsections. */}
           <ProfileTimelineChart profileId={pd.profile.id} />
+
+          {/* #1519/#726 — per-app usage breakdown: one row per configured app
+              (drillable to its host-set, the per-FQDN view from #726), then
+              one row per non-app host as its own single-host pseudo-app (per
+              the App-Centric Model — no semantic "Other" bucket). Top-N + a
+              "+N more sites" expander is a presentation rollup only. */}
+          <ProfileUsageBreakdown profileId={pd.profile.id} enabled={expanded} />
 
           {/* #1320 — per-profile default-deny baseline. Block-all; only the
               profile's allowed apps/hosts + the household global allowlist are

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -383,11 +383,11 @@ export interface ProfileTimeStatus {
 }
 
 // #1061 — per-app time-used breakdown for one profile over a date window.
-// `appId = null` is the synthetic "Other" bucket: hosts not in any app_hosts
-// membership. `proportionalSeconds` is the wall-clock-attention number (#715),
+// `proportionalSeconds` is the wall-clock-attention number (#715),
 // `presenceSeconds` is bucket-deduped at the app level. The drill-down `hosts`
 // list reuses HostUsage so the SPA renders rows with the same Attention/Seen
-// formatter.
+// formatter. #1519: `apps` carries only real (mapped) apps; non-app hosts
+// surface in `orphanHosts`, never in a synthetic "Other" entry here.
 export interface ProfileAppUsage {
   appId: number | null
   appName: string
@@ -398,12 +398,24 @@ export interface ProfileAppUsage {
   hosts: HostUsage[]
 }
 
+// #1519 — a host not in any configured app's host-set. Per the App-Centric
+// Model it IS its own single-host app (there is no semantic "Other"). The SPA
+// renders these side-by-side with real app rows; "Other" only ever exists as a
+// presentation-level top-N + "+N more sites" affordance.
+export interface OrphanHostUsage {
+  host: HostId
+  proportionalSeconds: number
+  presenceSeconds: number
+}
+
 export interface ProfileUsageByApp {
   profileId: number
   profileName: string
   from: string
   to: string
   apps: ProfileAppUsage[]
+  // #1519: additive — older API responses omit it; SPA treats undefined as [].
+  orphanHosts?: OrphanHostUsage[]
 }
 
 // #716 / #721 — per-device hourly usage timeline. `totalMins` is the device's


### PR DESCRIPTION
Closes #1519. Closes #726.

## Summary

Makes the per-profile usage-by-app endpoint and its SPA presentation match the App-Centric Model spelled out in `AGENTS.md`: an app is a host-set, and **a host not in any configured app is its own single-host app** — there is no semantic "Other" app. "Other" only ever appears as a presentation-layer top-N rollup, never as a wire entity.

## API — `GET /api/profiles/:id/usage-by-app`

- `ProfileUsageByApp.apps` no longer contains the synthetic `appId=null` "Other" row.
- New additive `orphanHosts: List[OrphanHostUsage]` carries each non-app host as its own row, with the same `proportionalSeconds` / `presenceSeconds` units as `ProfileAppUsage`, so the SPA can render them side-by-side.
- Per-host bucket-deduped presence is computed the same way per-app presence is computed (one dedupe per `(mac, periodStart)` × host), so the two surfaces stay aligned at the source — no re-derivation of app-aggregated minutes (matches the single-source-of-truth rule).
- `OrphanHostUsage` is additive — older clients that ignore the new field keep working.

## SPA

- New `ProfileUsageBreakdown` component (`web/src/components/usage/`):
  - One row per configured app, expandable to its host-set (the #726 per-FQDN breakdown).
  - One row per orphan host, rendered as a single-host pseudo-app.
  - Long-tail orphans collapse behind a "+N more sites" expander, explicitly labelled as a top-N affordance, NOT an "Other" bucket.
- Mounted under the timeline chart on the expanded `/profiles` card, gated on the card being open.

## Tests (TDD red → green)

- **Red commit** writes the new wire shape + updates feature tests to assert per-app rows and per-orphan rows (no synthetic "Other"), plus a fresh acceptance test seeding 1 app over 3 hosts + 2 unmatched hosts → 1 app row + 2 orphan rows.
- **Green commit** implements `buildUsageByApp` to emit orphans and drops the "Other" key.
- Vitest covers the renderer end-to-end: apps + orphans render, drill-down expands per-FQDN, top-N expander copy clarifies it is NOT an "Other" bucket, empty state.

## Test plan

- [x] `mill 'api.test.testOnly' wifihaven.api.feature.UsageApiSpec` — 39 tests pass
- [x] `npx vitest run src/components/usage/ProfileUsageBreakdown.test.tsx` — 4 tests pass
- [x] `npx vitest run src/pages/ProfilesPage.test.tsx` — 89 tests pass (integration not broken)
- [x] `npx tsc --noEmit` — clean
- [x] `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll` — clean