### PR TITLE
feat(#730): wire destIp through UsageRecord → traffic_reports (PR2/2)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -479,6 +479,10 @@ case class TrafficReportInsert(
     activeSeconds: Int,
     bytesIn: Long,
     bytesOut: Long,
+    // #730: destination IP the bytes were attributed to. Optional because
+    // pre-#730 agents do not emit it; stored as NULL on traffic_reports.dest_ip
+    // for those records.
+    destIp: Option[IpAddress] = None,
 )
 
 case class BlockEventInsert(
@@ -1719,7 +1723,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
   def insertBatch(reports: List[TrafficReportInsert]) =
     DbMetrics.timed("traffic.insertBatch")(
       Update[TrafficReportInsert](
-        "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out) VALUES(?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
+        "INSERT INTO traffic_reports(router_id,mac,ip,host_type,host_value,date,period_start,period_end,active_seconds,bytes_in,bytes_out,dest_ip) VALUES(?,?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT(router_id,period_start,mac,host_type,host_value) DO NOTHING",
       ).updateMany(reports).transact(xa),
     )
   // TODO(#730): remove this read-side join once usage records carry dest_ip.

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -197,6 +197,12 @@ object RouterIngestRoutes {
         r.activeSeconds.toInt,
         r.bytesIn,
         r.bytesOut,
+        // #730: pass through the per-record destination IP. INSERT ... ON
+        // CONFLICT DO NOTHING means colliding records on the existing
+        // (router_id, period_start, mac, host_type, host_value) key keep the
+        // first row's dest_ip — same byte/seconds behaviour as today; #730 just
+        // adds the column the follow-up write-time FQDN backfill will consume.
+        r.destIp,
       ),
     )
     for {

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -9,6 +9,8 @@ import wifihaven.shared.types.*
 import wifihaven.testinfra.*
 import doobie.Transactor
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.db.TypeMeta.given
+import zio.interop.catz.*
 import zio.{Clock as _, *}
 import zio.http.*
 import zio.json.*

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -7,6 +7,7 @@ import wifihaven.api.routes.*
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import wifihaven.testinfra.*
+import doobie.Transactor
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
 import zio.http.*
@@ -31,7 +32,8 @@ private object SeenParser {
   }
 }
 
-object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+object RouterIngestSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock & Transactor[Task]] {
 
   // Pin Clock to 2026-05-07 14:00 so PolicyService.snapshot's `today` matches
   // the period_end date used by the ingest fixtures below.
@@ -457,6 +459,107 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         d <- dRepo.findByMac(MacAddress.unsafe(knownMac))
       } yield assertTrue(d.exists(_.lastSeenIp.contains(IpAddress.unsafe("192.168.1.42")))) &&
         assertTrue(d.flatMap(_.lastSeenAt).map(SeenParser.toInstant).contains(periodEnd))
+    },
+    test("usage: persists destIp from UsageRecord onto traffic_reports row (#730)") {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          Some(IpAddress.unsafe("192.168.1.42")),
+          HostId.Fqdn(Hostname.unsafe("youtube.com")),
+          60L,
+          100L,
+          50L,
+          Some(IpAddress.unsafe("142.250.72.142")),
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        resp   <- post(routes, "/api/router/usage", body, Some(tk))
+        stored <- sql"""SELECT dest_ip FROM traffic_reports
+                         WHERE router_id = $id
+                           AND mac = ${MacAddress.unsafe(knownMac)}
+                           AND host_value = 'youtube.com'"""
+          .query[Option[String]]
+          .unique
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(stored.contains("142.250.72.142"))
+    },
+    test("usage: accepts records with destIp omitted (back-compat, #730)") {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        // No destIp argument — pre-#730 agents do not emit the field.
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          Some(IpAddress.unsafe("192.168.1.42")),
+          HostId.Fqdn(Hostname.unsafe("google.com")),
+          60L,
+          100L,
+          50L,
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        resp   <- post(routes, "/api/router/usage", body, Some(tk))
+        stored <- sql"""SELECT dest_ip FROM traffic_reports
+                         WHERE router_id = $id
+                           AND mac = ${MacAddress.unsafe(knownMac)}
+                           AND host_value = 'google.com'"""
+          .query[Option[String]]
+          .unique
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(stored.isEmpty)
+    },
+    test("usage: decodes the wire JSON with a destIp field present (#730)") {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        // Hand-crafted JSON matching the on-the-wire shape an updated Lua agent posts.
+        body = s"""{
+          "routerId": "${id}",
+          "periodStart": "${periodStart.toString}",
+          "periodEnd": "${periodEnd.toString}",
+          "records": [
+            { "mac": "$knownMac",
+              "ip": "192.168.1.42",
+              "host": { "type": "ipv4", "value": "203.0.113.7" },
+              "activeSeconds": 60,
+              "bytesIn": 10,
+              "bytesOut": 20,
+              "destIp": "203.0.113.7" }
+          ]
+        }"""
+        resp   <- post(routes, "/api/router/usage", body, Some(tk))
+        stored <- sql"""SELECT dest_ip FROM traffic_reports
+                         WHERE router_id = $id
+                           AND mac = ${MacAddress.unsafe(knownMac)}
+                           AND host_value = '203.0.113.7'"""
+          .query[Option[String]]
+          .unique
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(stored.contains("203.0.113.7"))
     },
     test("usage: unknown mac in records does NOT create a device row (events does that)") {
       for {

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -351,6 +351,11 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
         -- bytes_out = rx) and the swap happens only at the wire boundary.
         bytesIn       = c.bytes_out or 0,
         bytesOut      = c.bytes     or 0,
+        -- #730: destination IP these bytes were attributed to. Our accumulator
+        -- is already keyed (mac, dst_ip), so this is a direct pass-through.
+        -- The API persists it on traffic_reports.dest_ip and a follow-up uses
+        -- it for write-time FQDN backfill against connection_events.
+        destIp        = c.dst_ip,
       }
       if leases then
         rec.ip = leases[c.mac]  -- may be nil if MAC not in lease table

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -441,6 +441,48 @@ describe("usage.build_report", function()
     assert.not_nil(rec.bytesIn)
   end)
 
+  -- #730: each record carries the destination IP the bytes were attributed to,
+  -- so the API can (in a follow-up) re-attribute race-loser ipv4-typed rows to
+  -- the FQDN that conntrack resolved against the same dest_ip. The agent's
+  -- internal granularity is already (mac, dst_ip), so the field is just a
+  -- pass-through of c.dst_ip onto the emitted record.
+  describe("destIp field (#730)", function()
+    it("sets destIp to the dst_ip of the underlying counter (fqdn host)", function()
+      local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
+                                   nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S)
+      local by_host = {}
+      for _, rec in ipairs(r.records) do by_host[rec.host.value] = rec end
+      assert.equal("1.2.3.4", by_host["youtube.com"].destIp)
+      assert.equal("8.8.8.8", by_host["google.com"].destIp)
+    end)
+
+    it("sets destIp on ipv4-fallback records (no DNS attribution)", function()
+      local unk = { { mac = "aa:bb:cc:11:22:33", dst_ip = "9.9.9.9",
+                      bytes = 100, packets = 3 } }
+      local r = usage.build_report(unk, NF_SETS, P_START, P_END, ROUTER,
+                                   nil, nil, full_tracker(unk), SAMPLE_S, BUCKET_S)
+      assert.equal("9.9.9.9", r.records[1].destIp)
+    end)
+
+    it("sets destIp on ipv6 records", function()
+      local unk = { { mac = "aa:bb:cc:11:22:33", dst_ip = "2001:db8::1",
+                      bytes = 100, packets = 3 } }
+      local r = usage.build_report(unk, NF_SETS, P_START, P_END, ROUTER,
+                                   nil, nil, full_tracker(unk), SAMPLE_S, BUCKET_S)
+      assert.equal("2001:db8::1", r.records[1].destIp)
+    end)
+
+    it("JSON-encodes destIp on each record", function()
+      local json = require("cjson")
+      local r    = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
+                                      nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S)
+      local dec  = json.decode(json.encode(r))
+      for _, rec in ipairs(dec.records) do
+        assert.not_nil(rec.destIp)
+      end
+    end)
+  end)
+
   it("handles an empty counters list (zero records)", function()
     local r = usage.build_report({}, NF_SETS, P_START, P_END, ROUTER,
                                  nil, nil, usage.new_tracker(), SAMPLE_S, BUCKET_S)

--- a/shared/contract/router-to-api/usage_report.json
+++ b/shared/contract/router-to-api/usage_report.json
@@ -12,7 +12,8 @@
       },
       "activeSeconds" : 240,
       "bytesIn" : 8388608,
-      "bytesOut" : 1048576
+      "bytesOut" : 1048576,
+      "destIp" : "151.101.65.69"
     },
     {
       "mac" : "76:2d:95:47:d1:8e",
@@ -22,7 +23,8 @@
       },
       "activeSeconds" : 60,
       "bytesIn" : 16384,
-      "bytesOut" : 4096
+      "bytesOut" : 4096,
+      "destIp" : "192.168.10.99"
     }
   ]
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1271,6 +1271,12 @@ case class UsageRecord(
     activeSeconds: Long,
     bytesIn: Long,
     bytesOut: Long,
+    // #730: the destination IP these bytes/seconds were attributed to. The
+    // OpenWRT agent's accumulator is already keyed (mac, dst_ip), so this is a
+    // pass-through of that dst_ip onto the wire record. Optional for
+    // backward-compat with pre-#730 agents that do not emit the field; the
+    // API stores NULL on traffic_reports.dest_ip when absent.
+    destIp: Option[IpAddress] = None,
 ) derives JsonCodec
 
 case class UsageReport(


### PR DESCRIPTION
End-to-end pass-through of the destination IP each \`UsageRecord\` was attributed to, building on the V54 schema add in #1581.

## What changes

**Wire** — \`shared/src/Models.scala\`
- \`UsageRecord\` grows \`destIp: Option[IpAddress] = None\`. Optional + defaulted for backward compat per AGENTS.md §Backwards-compatibility: pre-#730 agents omit the field, the zio-json decoder fills \`None\`, and old API responses simply have no field for new agent's encoders to ignore.

**Router** — \`openwrt/files/usr/lib/lua/wifihaven/usage.lua\`
- \`build_report\` stamps \`destIp = c.dst_ip\` on every emitted record. The accumulator is already keyed \`(mac, dst_ip)\` (\`usage.merge_counters\` + \`host_for_ip(dst_ip, …)\`), so this is a direct pass-through — no granularity change, no rendering work, no new ipsets.

**API ingest** — \`api/src/db/Repos.scala\`, \`api/src/routes/RouterIngestRoutes.scala\`
- \`TrafficReportInsert\` grows a defaulted \`destIp\` field; the INSERT now persists \`dest_ip\` on \`traffic_reports\`.
- The \`ON CONFLICT\` target is intentionally **unchanged** at \`(router_id, period_start, mac, host_type, host_value)\` so byte/seconds-vs-retry semantics keep working exactly as today. The follow-up issue (see below) is where the now-stored \`dest_ip\` actually gets consumed.

## Tests

The PR ships red→green in commit history per AGENTS.md §TDD:

- **\`test(#730): failing tests …\`** (commit 1) — adds the \"destIp field (#730)\" describe block to \`openwrt/test/usage_spec.lua\` and three new tests to \`RouterIngestSpec\` covering persisted-destIp, omitted-destIp (NULL), and the on-the-wire JSON shape an updated agent posts. The Scala compile fails on the new tests until the model field is added.
- **\`feat(#730): wire destIp …\`** (commit 2) — implementation. Lua busted suite green (74/74); \`mill api.test.testOnly … RouterIngestSpec\` green (44/44).

\`RouterIngestSpec\` reaches \`traffic_reports.dest_ip\` via raw doobie (deliberately keeping \`TrafficReport\` / \`listForRouter\` untouched in this PR — fewer SPA reverberations).

## Scope this PR does NOT take

- **No write-time FQDN backfill yet** — the issue's later acceptance bullets (\"race-loser ipv4 attributed under its resolved FQDN\", \"no double-counting\", \"read-side join removed\") require a separate PR that does ipset/connection_events resolution on the \`/api/router/usage\` hot path and aggregates per (mac, resolved_fqdn) before insert. That has prod-scale plan validation work (AGENTS.md §query-explain-before-merge) and can't fully retire the read-side join until pre-V54 ipv4-typed \`time_usage\` rows age out of retention.
- Filed as #1585 — \"router→api: write-time FQDN backfill for traffic_reports (uses #730's dest_ip)\".

I've left #730 to be closed by #1585 when the read-side join is actually retired — this PR ships the foundation only.

## Dependencies

- Depends on #1581 (V54 schema migration) being merged + deployed first; otherwise \`INSERT INTO traffic_reports(..., dest_ip)\` errors at runtime.

## Test plan

- [x] busted suite green (\`cd openwrt && LUA_PATH=… busted test/usage_spec.lua\`)
- [x] \`mill api.test.testOnly wifihaven.api.feature.RouterIngestSpec\` green
- [x] scalafmt clean
- [ ] CI green
- [ ] After #1581 lands and deploys: rebase this PR onto main and verify integration tests still pass

Refs #730. Closing handled by #1585.