### PR TITLE
feat(#1089): weekly per-app screen-time view from app_used_daily rollup

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -293,6 +293,7 @@ object Main extends ZIOAppDefault {
       blockEvRepo    <- ZIO.service[BlockEventRepo]
       alertRepo      <- ZIO.service[AlertRepo]
       appRepo        <- ZIO.service[AppRepo]
+      appRollupRepo  <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
       notifier       <- ZIO.service[Notifier]
       policy         <- ZIO.service[PolicyService]
       timeStatus     <- ZIO.service[wifihaven.api.policy.TimeStatusService]
@@ -374,6 +375,7 @@ object Main extends ZIOAppDefault {
             rollupRepo2,
             hsRepo,
             stlRepo,
+            appRollupRepo,
             clock,
           ) ++
           DashboardNowRoutes.routes(

--- a/api/src/db/AppUsedRollupRepo.scala
+++ b/api/src/db/AppUsedRollupRepo.scala
@@ -47,6 +47,19 @@ trait AppUsedRollupRepo {
   def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]]
 
   /**
+   * #1089 — every rolled `(date, app_id, engaged_seconds)` row for `profileId` whose `date` falls
+   * in `[from, to]` (inclusive). Backs the per-app screen-time weekly view, which is a pure
+   * aggregation of the same rollup the per-app daily cap reads (no parallel pipeline, so the
+   * heartbeat filter applied at write time flows through unchanged). Ordered by date for
+   * predictable test assertions; callers do their own `groupBy`/sum.
+   */
+  def getRangeForProfile(
+      profileId: ProfileId,
+      from: LocalDate,
+      to: LocalDate,
+  ): Task[List[(LocalDate, AppId, Long)]]
+
+  /**
    * Drop every cached row. Called from `HouseholdSettingsRepoLive.update` alongside the
    * `time_used_daily` invalidation so any change to the heartbeat filter, the daily-reset boundary,
    * or the presence session-stitch knob forces the next rollup tick to refill from first
@@ -72,6 +85,12 @@ object NoopAppUsedRollupRepo extends AppUsedRollupRepo {
     ZIO.succeed(0)
   def getDayForProfile(profileId: ProfileId, date: LocalDate): Task[Map[AppId, RolledAppDay]] =
     ZIO.succeed(Map.empty)
+  def getRangeForProfile(
+      profileId: ProfileId,
+      from: LocalDate,
+      to: LocalDate,
+  ): Task[List[(LocalDate, AppId, Long)]] =
+    ZIO.succeed(Nil)
   def deleteAll: Task[Unit]                                                                   =
     ZIO.unit
 }
@@ -115,6 +134,19 @@ class AppUsedRollupRepoLive(xa: Transactor[Task]) extends AppUsedRollupRepo {
       .to[List]
       .transact(xa)
       .map(_.toMap)
+
+  def getRangeForProfile(
+      profileId: ProfileId,
+      from: LocalDate,
+      to: LocalDate,
+  ): Task[List[(LocalDate, AppId, Long)]] =
+    sql"""SELECT date, app_id, engaged_seconds
+          FROM app_used_daily
+          WHERE profile_id=$profileId AND date BETWEEN $from AND $to
+          ORDER BY date, app_id"""
+      .query[(LocalDate, AppId, Long)]
+      .to[List]
+      .transact(xa)
 
   def deleteAll: Task[Unit] =
     sql"DELETE FROM app_used_daily".update.run.transact(xa).unit

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -35,10 +35,11 @@ object UsageRoutes {
       rollupRepo: RollupRepo,
       hsRepo: HouseholdSettingsRepo,
       siteTimeLimitRepo: SiteTimeLimitRepo,
+      appUsedRollupRepo: AppUsedRollupRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
-      Method.GET / "api" / "usage" / "traffic"                         ->
+      Method.GET / "api" / "usage" / "traffic"                                  ->
         handler { (req: Request) =>
           trafficHandler(
             req,
@@ -54,7 +55,7 @@ object UsageRoutes {
         },
       // #766: recently-visited FQDN apexes for one device, used by the
       // apps create/edit "Pick from recent activity" picker.
-      Method.GET / "api" / "devices" / string("mac") / "recent-apexes" ->
+      Method.GET / "api" / "devices" / string("mac") / "recent-apexes"          ->
         handler { (macRaw: String, req: Request) =>
           val handle: ZIO[Any, ApiError, Response] = for {
             claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
@@ -113,7 +114,7 @@ object UsageRoutes {
       // row per app. #1519: hosts NOT in any configured app surface individually
       // in `orphanHosts` (single-host pseudo-apps, per the App-Centric Model) —
       // there is no synthetic "Other" entry on this endpoint.
-      Method.GET / "api" / "profiles" / long("id") / "usage-by-app"    ->
+      Method.GET / "api" / "profiles" / long("id") / "usage-by-app"             ->
         handler { (id: Long, req: Request) =>
           val pid                                  = ProfileId(id)
           val handle: ZIO[Any, ApiError, Response] = for {
@@ -147,7 +148,66 @@ object UsageRoutes {
           } yield Response.json(resp.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
-      Method.GET / "api" / "usage" / "series"                          ->
+      // #1089 — per-app engaged-minutes summed over a 7-day window. Aggregates FROM the
+      // `app_used_daily` rollup (no parallel pipeline), so by construction the weekly figure is the
+      // sum of the same daily numbers the per-app cap reads and the heartbeat filter applied at
+      // rollup-write time flows through unchanged. `to` defaults to household-local today; `from`
+      // is always `to - 6` (trailing 7-day window, matching the #777 `/time/status/summary/week`
+      // convention). Today's row may lag the per-app cap by one rollup tick — the live tail past
+      // the watermark is intentionally NOT folded in here; the screen-time weekly view tolerates
+      // sub-tick staleness.
+      Method.GET / "api" / "profiles" / long("id") / "usage" / "app" / "weekly" ->
+        handler { (id: Long, req: Request) =>
+          val pid                                  = ProfileId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims   <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
+            _        <- requireProfileReadAccess(claims, pid, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
+            settings <- hsRepo.get.mapError(ApiError.Db(_))
+            now      <- clock.instant
+            todayLocal = wifihaven.api.policy.PolicyService.householdLocalDate(now, settings)
+            toStr      = req.url.queryParam("to").getOrElse(todayLocal.toString)
+            to <- ZIO
+              .attempt(LocalDate.parse(toStr))
+              .orElseFail(ApiError.BadRequest(s"invalid to: $toStr"))
+            from = to.minusDays(6)
+            profile <- profileRepo
+              .findById(pid)
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
+            rows    <- appUsedRollupRepo
+              .getRangeForProfile(pid, from, to)
+              .mapError(ApiError.Db(_))
+            appList <- appRepo.listAll.mapError(ApiError.Db(_))
+          } yield {
+            val byId       = appList.iterator.map(a => a.id -> a).toMap
+            val sumByApp   = rows.groupMapReduce(_._2)(_._3)(_ + _)
+            val appRows    = sumByApp.iterator.flatMap { case (aid, secs) =>
+              byId.get(aid).map { a =>
+                ProfileAppWeeklyUsageRow(
+                  appId = aid,
+                  appName = a.name,
+                  appIcon = a.icon,
+                  appIconType = Some(a.iconType),
+                  engagedMinutes = (secs / 60L).toInt,
+                )
+              }
+            }.toList
+            val sortedRows = appRows
+              .filter(_.engagedMinutes > 0)
+              .sortBy(r => (-r.engagedMinutes, r.appName))
+            val resp       = ProfileAppWeeklyUsage(
+              profileId = pid,
+              profileName = profile.name,
+              from = from.toString,
+              to = to.toString,
+              apps = sortedRows,
+            )
+            Response.json(resp.toJson)
+          }
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
+      Method.GET / "api" / "usage" / "series"                                   ->
         handler { (req: Request) =>
           val handle: ZIO[Any, ApiError, Response] = for {
             claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
@@ -231,7 +291,7 @@ object UsageRoutes {
       // #1099: batched per-profile series. The /profiles page resolves the
       // whole visible profile set in one partition-pruned scan instead of N
       // parallel single-profile requests.
-      Method.GET / "api" / "usage" / "series" / "batch"                ->
+      Method.GET / "api" / "usage" / "series" / "batch"                         ->
         handler { (req: Request) =>
           val handle: ZIO[Any, ApiError, Response] = for {
             claims <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))

--- a/api/test/src/feature/AppUsedRollupWeeklySpec.scala
+++ b/api/test/src/feature/AppUsedRollupWeeklySpec.scala
@@ -1,0 +1,112 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{Instant, LocalDate}
+
+/**
+ * #1089 — weekly per-(profile, app) engaged-minutes aggregated FROM the per-(profile, app, date)
+ * `app_used_daily` rollup over a 7-day window. The weekly view is a pure aggregation of the same
+ * primitive the daily view reads, so the heartbeat filter / household-settings invalidation that
+ * shape the daily rollup at write time flow through unchanged (CLAUDE.md §single-source-of-truth —
+ * no parallel pipeline).
+ */
+object AppUsedRollupWeeklySpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def seedApp(
+      appRepo: AppRepo,
+      slug: String,
+      hosts: List[String],
+  ): Task[AppId] =
+    for {
+      id <- appRepo.create(slug, slug, None, None)
+      _  <- appRepo.setHosts(id, hosts.map(Hostname.unsafe))
+    } yield id
+
+  // Plant one rolled row at (profile, app, date) with `engagedSeconds` and an arbitrary watermark.
+  private def plant(
+      aru: AppUsedRollupRepo,
+      profileId: ProfileId,
+      appId: AppId,
+      date: LocalDate,
+      seconds: Long,
+  ): Task[Unit] =
+    aru.upsertDay(
+      profileId,
+      appId,
+      date,
+      RolledAppDay(seconds, Instant.parse("2025-01-01T00:00:00Z")),
+    )
+
+  def spec = suite("AppUsedRollupWeeklySpec (#1089)")(
+    test("getRangeForProfile returns every rollup row in [from,to] inclusive, others excluded") {
+      // 14 days planted; query a 7-day window in the middle returns only those 7 days' rows for the
+      // requested profile, never for a different profile or outside the window.
+      for {
+        _      <- cleanDb
+        pr     <- ZIO.service[ProfileRepo]
+        sr     <- ZIO.service[ScheduleRepo]
+        ar     <- ZIO.service[AppRepo]
+        aru    <- ZIO.service[AppUsedRollupRepo]
+        kid    <- TestLayers.seedKidsProfile(pr, sr)
+        adults <- TestLayers.seedAdultsProfile(pr)
+        ytApp  <- seedApp(ar, "yt", List("youtube.com"))
+        d0 = LocalDate.of(2025, 1, 1)
+        // 14 days, 600 s (10 min) each, kids profile, yt app.
+        _    <- ZIO.foreachDiscard(0 until 14)(i =>
+          plant(aru, kid, ytApp, d0.plusDays(i.toLong), 600L),
+        )
+        // Adults gets one row at d0 — must NOT appear in a kids range query.
+        _    <- plant(aru, adults, ytApp, d0, 99L)
+        // Query days 3..9 inclusive (a 7-day mid window): should return exactly 7 kids rows.
+        rows <- aru.getRangeForProfile(kid, d0.plusDays(3), d0.plusDays(9))
+      } yield assertTrue(rows.size == 7) &&
+        assertTrue(rows.forall(_._3 == 600L)) &&
+        assertTrue(rows.map(_._1).toSet == (3 to 9).map(i => d0.plusDays(i.toLong)).toSet)
+    },
+    test("two weeklies in a 14-day span sum per app correctly") {
+      // Week 1 (Jan 1–7): yt=10 min/day x 7 days = 70 min, social=5 min/day x 4 days = 20 min.
+      // Week 2 (Jan 8–14): yt=20 min/day x 7 days = 140 min, social=0.
+      for {
+        _         <- cleanDb
+        pr        <- ZIO.service[ProfileRepo]
+        sr        <- ZIO.service[ScheduleRepo]
+        ar        <- ZIO.service[AppRepo]
+        aru       <- ZIO.service[AppUsedRollupRepo]
+        kid       <- TestLayers.seedKidsProfile(pr, sr)
+        ytApp     <- seedApp(ar, "yt", List("youtube.com"))
+        socialApp <- seedApp(ar, "social", List("social.com"))
+        w1Start = LocalDate.of(2025, 1, 1)
+        w2Start = LocalDate.of(2025, 1, 8)
+        // Week 1.
+        _      <- ZIO.foreachDiscard(0 until 7)(i =>
+          plant(aru, kid, ytApp, w1Start.plusDays(i.toLong), 600L),
+        )
+        _      <- ZIO.foreachDiscard(0 until 4)(i =>
+          plant(aru, kid, socialApp, w1Start.plusDays(i.toLong), 300L),
+        )
+        // Week 2.
+        _      <- ZIO.foreachDiscard(0 until 7)(i =>
+          plant(aru, kid, ytApp, w2Start.plusDays(i.toLong), 1200L),
+        )
+        w1Rows <- aru.getRangeForProfile(kid, w1Start, w1Start.plusDays(6))
+        w2Rows <- aru.getRangeForProfile(kid, w2Start, w2Start.plusDays(6))
+        sumPerApp1 = w1Rows.groupMapReduce(_._2)(_._3)(_ + _)
+        sumPerApp2 = w2Rows.groupMapReduce(_._2)(_._3)(_ + _)
+      } yield assertTrue(sumPerApp1.get(ytApp).contains(7 * 600L)) &&
+        assertTrue(sumPerApp1.get(socialApp).contains(4 * 300L)) &&
+        assertTrue(sumPerApp2.get(ytApp).contains(7 * 1200L)) &&
+        assertTrue(!sumPerApp2.contains(socialApp))
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/AppUsedRollupWeeklySpec.scala
+++ b/api/test/src/feature/AppUsedRollupWeeklySpec.scala
@@ -1,11 +1,17 @@
 package wifihaven.api.feature
 
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
 import wifihaven.api.db.*
+import wifihaven.api.routes.*
 import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
 import wifihaven.shared.types.*
 import wifihaven.testinfra.*
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
 import zio.test.*
 
 import java.time.{Instant, LocalDate}
@@ -17,9 +23,17 @@ import java.time.{Instant, LocalDate}
  * shape the daily rollup at write time flow through unchanged (CLAUDE.md §single-source-of-truth —
  * no parallel pipeline).
  */
-object AppUsedRollupWeeklySpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+object AppUsedRollupWeeklySpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
-  override val bootstrap = TestDatabase.layer
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
 
   private val cleanDb = TestDatabase.cleanAndMigrate
 
@@ -73,6 +87,88 @@ object AppUsedRollupWeeklySpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
       } yield assertTrue(rows.size == 7) &&
         assertTrue(rows.forall(_._3 == 600L)) &&
         assertTrue(rows.map(_._1).toSet == (3 to 9).map(i => d0.plusDays(i.toLong)).toSet)
+    },
+    test(
+      "GET /api/profiles/:id/usage/app/weekly returns two weekly aggregates summed per app",
+    ) {
+      // Same 14-day seed as below, queried over the HTTP route. The trailing-7 convention means
+      // `to=2025-01-07` → week 1 (Jan 1–7) and `to=2025-01-14` → week 2 (Jan 8–14). Per-app rows
+      // sort by minutes desc, app name asc; zero-minute apps are absent.
+      for {
+        _         <- cleanDb
+        pr        <- ZIO.service[ProfileRepo]
+        sr        <- ZIO.service[ScheduleRepo]
+        ar        <- ZIO.service[AppRepo]
+        aru       <- ZIO.service[AppUsedRollupRepo]
+        kid       <- TestLayers.seedKidsProfile(pr, sr)
+        ytApp     <- seedApp(ar, "yt", List("youtube.com"))
+        socialApp <- seedApp(ar, "social", List("social.com"))
+        w1Start = LocalDate.of(2025, 1, 1)
+        w2Start = LocalDate.of(2025, 1, 8)
+        _               <- ZIO.foreachDiscard(0 until 7)(i =>
+          plant(aru, kid, ytApp, w1Start.plusDays(i.toLong), 600L),
+        )
+        _               <- ZIO.foreachDiscard(0 until 4)(i =>
+          plant(aru, kid, socialApp, w1Start.plusDays(i.toLong), 300L),
+        )
+        _               <- ZIO.foreachDiscard(0 until 7)(i =>
+          plant(aru, kid, ytApp, w2Start.plusDays(i.toLong), 1200L),
+        )
+        deviceRepo      <- ZIO.service[DeviceRepo]
+        trafficRepo     <- ZIO.service[TrafficReportRepo]
+        userProfileRepo <- ZIO.service[UserProfileRepo]
+        appRepoSvc      <- ZIO.service[AppRepo]
+        rollupRepo      <- ZIO.service[RollupRepo]
+        hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+        stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+        clock           <- ZIO.service[Clock]
+        auth            <- makeAuth
+        routes = UsageRoutes.routes(
+          auth,
+          deviceRepo,
+          trafficRepo,
+          userProfileRepo,
+          pr,
+          appRepoSvc,
+          rollupRepo,
+          hsRepo,
+          stlRepo,
+          aru,
+          clock,
+        )
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        path1 = s"/api/profiles/${kid.value}/usage/app/weekly?to=2025-01-07"
+        path2 = s"/api/profiles/${kid.value}/usage/app/weekly?to=2025-01-14"
+        req1  = Request
+          .get(URL.decode(path1).toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        req2  = Request
+          .get(URL.decode(path2).toOption.get)
+          .addHeader(Header.Authorization.Bearer(token))
+        r1 <- routes.runZIO(req1)
+        b1 <- r1.body.asString
+        w1 <- ZIO
+          .fromEither(b1.fromJson[ProfileAppWeeklyUsage])
+          .orElseFail(new RuntimeException(b1))
+        r2 <- routes.runZIO(req2)
+        b2 <- r2.body.asString
+        w2 <- ZIO
+          .fromEither(b2.fromJson[ProfileAppWeeklyUsage])
+          .orElseFail(new RuntimeException(b2))
+        yt1     = w1.apps.find(_.appId == ytApp).map(_.engagedMinutes)
+        social1 = w1.apps.find(_.appId == socialApp).map(_.engagedMinutes)
+        yt2     = w2.apps.find(_.appId == ytApp).map(_.engagedMinutes)
+        social2 = w2.apps.find(_.appId == socialApp)
+      } yield assertTrue(r1.status == Status.Ok) &&
+        assertTrue(r2.status == Status.Ok) &&
+        assertTrue(w1.from == "2025-01-01" && w1.to == "2025-01-07") &&
+        assertTrue(w2.from == "2025-01-08" && w2.to == "2025-01-14") &&
+        // Week 1: 7 × 10 min = 70; 4 × 5 min = 20.
+        assertTrue(yt1.contains(70)) &&
+        assertTrue(social1.contains(20)) &&
+        // Week 2: 7 × 20 min = 140; social absent (no rows).
+        assertTrue(yt2.contains(140)) &&
+        assertTrue(social2.isEmpty)
     },
     test("two weeklies in a 14-day span sum per app correctly") {
       // Week 1 (Jan 1–7): yt=10 min/day x 7 days = 70 min, social=5 min/day x 4 days = 20 min.

--- a/api/test/src/feature/PresenceDefaultsPinSpec.scala
+++ b/api/test/src/feature/PresenceDefaultsPinSpec.scala
@@ -108,6 +108,7 @@ object PresenceDefaultsPinSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[HouseholdSettingsRepo]
       stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+      aruRepo         <- ZIO.service[AppUsedRollupRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield UsageRoutes.routes(
@@ -120,6 +121,7 @@ object PresenceDefaultsPinSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
       rollupRepo,
       hsRepo,
       stlRepo,
+      aruRepo,
       clock,
     )
 

--- a/api/test/src/feature/RecentApexesApiSpec.scala
+++ b/api/test/src/feature/RecentApexesApiSpec.scala
@@ -125,6 +125,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      aruRepo         <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -138,6 +139,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         rollupRepo,
         hsRepo,
         stlRepo,
+        aruRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -92,6 +92,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      aruRepo         <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -105,6 +106,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         rollupRepo,
         hsRepo,
         stlRepo,
+        aruRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -57,6 +57,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      aruRepo         <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
       clock           <- ZIO.service[Clock]
       auth            <- buildAuth
     } yield (
@@ -70,6 +71,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         rollupRepo,
         hsRepo,
         stlRepo,
+        aruRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -92,6 +92,7 @@ object UsageSeriesPerfSpec
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
       stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      aruRepo         <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -105,6 +106,7 @@ object UsageSeriesPerfSpec
         rollupRepo,
         hsRepo,
         stlRepo,
+        aruRepo,
         clock,
       ),
       auth,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1013,6 +1013,30 @@ case class OrphanHostUsage(
     presenceSeconds: Long,
 ) derives JsonCodec
 
+/**
+ * #1089 — per-app engaged minutes summed over a 7-day window, aggregated FROM the `app_used_daily`
+ * rollup. The weekly view is by construction consistent with the daily one (same primitive, summed)
+ * and the heartbeat filter applied at rollup-write time flows through unchanged. Apps with zero
+ * minutes in the window are absent. Distinct from [[ProfileUsageByApp]], which is a presence-rolled
+ * per-host breakdown over a [from,to] window — this row is the *engaged*-time counterpart for one
+ * app, the same quantity the per-app cap reads.
+ */
+case class ProfileAppWeeklyUsageRow(
+    appId: AppId,
+    appName: String,
+    appIcon: Option[String],
+    appIconType: Option[IconType],
+    engagedMinutes: Int,
+) derives JsonCodec
+
+case class ProfileAppWeeklyUsage(
+    profileId: ProfileId,
+    profileName: String,
+    from: String,
+    to: String,
+    apps: List[ProfileAppWeeklyUsageRow],
+) derives JsonCodec
+
 case class ProfileUsageByApp(
     profileId: ProfileId,
     profileName: String,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,7 +3,7 @@ import type {
   Alert, AppDetail, ApproveAlertRequest, BlockedInfoResponse, BlocklistHosts, BlocklistSummary, CreateAppRequest, CreateRouterRequest, CreateRouterResponse, CreateUserRequest,
   DashboardNow, DashboardStats, Device,
   GlobalPolicyView, AddGlobalHostRequest, SetGlobalBlocklistsRequest, SetGlobalFlagsRequest,
-  CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
+  CreateAccessRequest, DeviceTimeStatus, DeviceTimeStatusWeek, HouseholdSettings, LoginResponse, MeResponse, ProfileAppWeeklyUsage, ProfileDetail, ProfileTimeStatus, ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   ConnectionEventSeriesPage, QueryLogPage,
   PatchUserRequest, PatchAppRequest,
   NamedSchedule, NamedScheduleRequest,
@@ -173,6 +173,15 @@ export const api = {
       return req<ProfileUsageByApp>(
         'GET',
         `/profiles/${id}/usage-by-app${tail ? `?${tail}` : ''}`,
+      )
+    },
+    // #1089 — per-app engaged-minutes summed over the trailing 7-day window
+    // ending at `to`. `to` defaults to household-local today on the server.
+    appWeekly: (id: number, to?: string) => {
+      const tail = to ? `?to=${to}` : ''
+      return req<ProfileAppWeeklyUsage>(
+        'GET',
+        `/profiles/${id}/usage/app/weekly${tail}`,
       )
     },
   },

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -10,6 +10,7 @@ import { api } from '@/api/client'
 import type {
   Alert, BlocklistSummary, DashboardNow, Device, GlobalPolicyView, HouseholdSettings, NamedSchedule, ProfileDetail,
   ProfileTimeStatus,
+  ProfileAppWeeklyUsage,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
   QueryLog, UsageSeriesResponse,
 } from '@/types/api'
@@ -65,6 +66,11 @@ export const qk = {
   // #1061 — per-app time-used breakdown for one profile over [from,to].
   profileUsageByApp: (profileId: number, from: string, to: string) =>
     ['profiles', profileId, 'usage-by-app', from, to] as const,
+  // #1089 — per-app engaged-minutes summed over the trailing 7-day window
+  // ending at `to`. Aggregates FROM `app_used_daily`, so by construction it
+  // tracks the daily rollup the per-app cap reads.
+  profileAppWeekly: (profileId: number, to?: string) =>
+    ['profiles', profileId, 'usage', 'app', 'weekly', to ?? 'current'] as const,
 }
 
 type QueryOpts<T> = Omit<UseQueryOptions<T, Error, T, readonly unknown[]>, 'queryKey' | 'queryFn'>
@@ -280,6 +286,20 @@ export function useProfileUsageByApp(
     queryKey: qk.profileUsageByApp(profileId, from, to),
     queryFn: () => api.profiles.usageByApp(profileId, from, to),
     staleTime: STALE.timeStatusToday,
+    ...opts,
+  })
+}
+
+// #1089 — weekly per-app engaged-minutes, aggregated from `app_used_daily`.
+export function useProfileAppWeekly(
+  profileId: number,
+  to?: string,
+  opts?: QueryOpts<ProfileAppWeeklyUsage>,
+) {
+  return useQuery({
+    queryKey: qk.profileAppWeekly(profileId, to),
+    queryFn: () => api.profiles.appWeekly(profileId, to),
+    staleTime: STALE.timeStatusWeek,
     ...opts,
   })
 }

--- a/web/src/components/usage/ProfileAppWeeklyBreakdown.test.tsx
+++ b/web/src/components/usage/ProfileAppWeeklyBreakdown.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { WeeklyBody } from './ProfileAppWeeklyBreakdown'
+import type { ProfileAppWeeklyUsage } from '@/types/api'
+
+function fixture(): ProfileAppWeeklyUsage {
+  return {
+    profileId: 1,
+    profileName: 'Kids',
+    from: '2025-01-01',
+    to: '2025-01-07',
+    apps: [
+      {
+        appId: 10,
+        appName: 'YouTube',
+        appIcon: '📺',
+        appIconType: 'emoji',
+        engagedMinutes: 140,
+      },
+      {
+        appId: 11,
+        appName: 'Social',
+        appIcon: '💬',
+        appIconType: 'emoji',
+        engagedMinutes: 70,
+      },
+    ],
+  }
+}
+
+describe('ProfileAppWeeklyBreakdown — #1089', () => {
+  it('renders one row per app with the engaged-minutes total', () => {
+    render(<WeeklyBody profileId={1} data={fixture()} />)
+    expect(screen.getByTestId('profile-app-weekly-1-app-10')).toHaveTextContent('YouTube')
+    expect(screen.getByTestId('profile-app-weekly-1-app-10-mins')).toHaveTextContent('2:20')
+    expect(screen.getByTestId('profile-app-weekly-1-app-11')).toHaveTextContent('Social')
+    expect(screen.getByTestId('profile-app-weekly-1-app-11-mins')).toHaveTextContent('1:10')
+  })
+
+  it('renders the date-range header so it is unambiguous which 7-day window is shown', () => {
+    render(<WeeklyBody profileId={1} data={fixture()} />)
+    expect(screen.getByTestId('profile-app-weekly-1-range'))
+      .toHaveTextContent('2025-01-01 – 2025-01-07')
+  })
+
+  it('shows an empty-state when the window has no app usage', () => {
+    render(
+      <WeeklyBody
+        profileId={7}
+        data={{
+          profileId: 7,
+          profileName: 'X',
+          from: '2025-01-08',
+          to: '2025-01-14',
+          apps: [],
+        }}
+      />,
+    )
+    const empty = screen.getByTestId('profile-app-weekly-7-empty')
+    expect(empty).toBeInTheDocument()
+    // Date range is part of the empty-state copy so the operator knows what window came back empty.
+    expect(empty).toHaveTextContent('2025-01-08')
+    expect(empty).toHaveTextContent('2025-01-14')
+  })
+})

--- a/web/src/components/usage/ProfileAppWeeklyBreakdown.tsx
+++ b/web/src/components/usage/ProfileAppWeeklyBreakdown.tsx
@@ -1,0 +1,95 @@
+import { useProfileAppWeekly } from '@/api/queries'
+import type { ProfileAppWeeklyUsage, ProfileAppWeeklyUsageRow } from '@/types/api'
+import { formatMins } from '@/lib/timeFormat'
+
+// #1089 — per-profile weekly screen-time breakdown: one row per app showing
+// engaged minutes summed across the trailing 7-day window. Aggregates FROM the
+// `app_used_daily` rollup, so by construction the weekly numbers track the daily
+// view and the heartbeat filter applied at write time flows through unchanged.
+// Sibling to `ProfileUsageBreakdown` (#1519 / #726, which is the per-host
+// per-day presence breakdown).
+
+export function ProfileAppWeeklyBreakdown({ profileId, enabled = true, to }: {
+  profileId: number
+  enabled?: boolean
+  to?: string
+}) {
+  const q = useProfileAppWeekly(profileId, to, { enabled })
+
+  if (!enabled) return null
+  if (q.isLoading) {
+    return (
+      <div
+        data-testid={`profile-app-weekly-${profileId}-loading`}
+        className="text-xs text-brand-text-muted px-2 py-3"
+      >
+        Loading weekly usage…
+      </div>
+    )
+  }
+  if (q.error || !q.data) {
+    return (
+      <div
+        data-testid={`profile-app-weekly-${profileId}-error`}
+        className="text-xs text-red-700 px-2 py-3"
+      >
+        Failed to load weekly usage.
+      </div>
+    )
+  }
+  return <WeeklyBody profileId={profileId} data={q.data} />
+}
+
+export function WeeklyBody({ profileId, data }: {
+  profileId: number
+  data: ProfileAppWeeklyUsage
+}) {
+  if (data.apps.length === 0) {
+    return (
+      <div
+        data-testid={`profile-app-weekly-${profileId}-empty`}
+        className="text-xs text-brand-text-muted px-2 py-3"
+      >
+        No app usage in {data.from} – {data.to}.
+      </div>
+    )
+  }
+  return (
+    <div
+      data-testid={`profile-app-weekly-${profileId}`}
+      className="rounded-xl border border-brand-border bg-brand-surface/30"
+    >
+      <header className="px-4 py-2 text-xs uppercase tracking-wider text-brand-text-muted flex items-center justify-between">
+        <span>Weekly app usage</span>
+        <span data-testid={`profile-app-weekly-${profileId}-range`}>
+          {data.from} – {data.to}
+        </span>
+      </header>
+      <ul className="divide-y divide-brand-border">
+        {data.apps.map(a => (
+          <AppRow key={`week-app-${a.appId}`} profileId={profileId} app={a} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function AppRow({ profileId, app }: { profileId: number; app: ProfileAppWeeklyUsageRow }) {
+  return (
+    <li
+      data-testid={`profile-app-weekly-${profileId}-app-${app.appId}`}
+      className="w-full flex items-center justify-between px-4 py-2"
+    >
+      <span className="flex items-center gap-2">
+        {app.appIcon && <span aria-hidden>{app.appIcon}</span>}
+        <span className="text-sm font-medium text-brand-ink">{app.appName}</span>
+      </span>
+      <span
+        className="text-xs text-brand-text"
+        data-testid={`profile-app-weekly-${profileId}-app-${app.appId}-mins`}
+      >
+        {formatMins(app.engagedMinutes)}
+      </span>
+    </li>
+  )
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -408,6 +408,26 @@ export interface OrphanHostUsage {
   presenceSeconds: number
 }
 
+// #1089 — per-app engaged-minutes summed over a 7-day trailing window. Mirrors
+// the API's `ProfileAppWeeklyUsageRow` / `ProfileAppWeeklyUsage`. The weekly
+// view aggregates FROM the daily rollup (`app_used_daily`), so the heartbeat
+// filter the daily view sees flows through unchanged.
+export interface ProfileAppWeeklyUsageRow {
+  appId: number
+  appName: string
+  appIcon?: string | null
+  appIconType?: IconType | null
+  engagedMinutes: number
+}
+
+export interface ProfileAppWeeklyUsage {
+  profileId: number
+  profileName: string
+  from: string
+  to: string
+  apps: ProfileAppWeeklyUsageRow[]
+}
+
 export interface ProfileUsageByApp {
   profileId: number
   profileName: string


### PR DESCRIPTION
Closes #1089.

## Summary
Adds a per-profile **weekly per-app engaged-minutes** read path, aggregated FROM
the existing `app_used_daily` rollup (the daily per-app primitive #1510 / PR
#1558 built on top of #1514's `appSecondsForProfile`). The weekly view is a
pure sum over a trailing 7-day window — **no parallel pipeline** — so by
construction it tracks the daily rollup the per-app cap reads and the heartbeat
filter applied at rollup-write time flows through unchanged. This is exactly
the shape `AGENTS.md §single-source-of-truth` mandates: one primitive, every
consumer sums from it.

The 7-day trailing convention (`from = to - 6`, `to` defaults to household-local
today) mirrors `/api/time/status/summary/week` (#777).

## What landed
- `AppUsedRollupRepo.getRangeForProfile(profileId, from, to)` — single
  `SELECT … FROM app_used_daily WHERE profile_id=? AND date BETWEEN ? AND ?`.
- `GET /api/profiles/:id/usage/app/weekly?to=YYYY-MM-DD` returning
  `ProfileAppWeeklyUsage` (`profileId`, `profileName`, `from`, `to`, `apps[]`).
- `ProfileAppWeeklyBreakdown` SPA component + vitest.

## Feature tests (TDD red → green: 19a8b0e4 then 32ecfb31)
`api/test/src/feature/AppUsedRollupWeeklySpec.scala` against embedded Postgres:
- `getRangeForProfile` returns exactly the rows in `[from,to]` for the requested
  profile and nothing else (cross-profile isolation, window inclusivity).
- HTTP route: seed 14 days of `app_used_daily` rows for two apps; query
  `?to=2025-01-07` and `?to=2025-01-14`; verify two distinct weekly aggregates
  return the correct per-app sums and that an app with zero rows in week 2 is
  absent from week 2.
- Repo-level: same 14-day seed, two `getRangeForProfile` calls, summed per app.

SPA: `ProfileAppWeeklyBreakdown.test.tsx` covers the renderer (per-app rows,
date-range header, empty-state).

## Query-plan note
`getRangeForProfile`'s only predicate is `(profile_id, date BETWEEN ?, ?)`,
covered exactly by the pre-existing `idx_app_used_daily_profile_date
(profile_id, date DESC)` shipped in V53. `app_used_daily` is bounded
(profiles × apps × days), so the scan touches at most one profile's row band.
No new migration / index needed.

## Test plan
- [x] `mill api.test` green locally (101 + 70 + … all suites; ~3m20s).
- [x] `mill api.test.testOnly wifihaven.api.feature.AppUsedRollupWeeklySpec` green (3/3).
- [x] `npx vitest run src/components/usage/ProfileAppWeeklyBreakdown.test.tsx` green (3/3).
- [x] `tsc --noEmit` clean.
- [x] `eslint --max-warnings 0` clean.
- [x] `scalafmt --check` clean (pre-commit / pre-push).