### PR TITLE
refactor(#1526): rename Site* → App*; unmatched hosts become single-host apps

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -189,7 +189,7 @@ object Main extends ZIOAppDefault {
         appRollupRepoForJ <- ZIO.service[wifihaven.api.db.AppUsedRollupRepo]
         profileRepoForJ   <- ZIO.service[wifihaven.api.db.ProfileRepo]
         deviceRepoForJ    <- ZIO.service[wifihaven.api.db.DeviceRepo]
-        stlRepoForJ       <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+        stlRepoForJ       <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
         appRepoForJ       <- ZIO.service[AppRepo]
         trafficRepoForJ   <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
         _                 <- TimeUsedRollupJob
@@ -279,7 +279,7 @@ object Main extends ZIOAppDefault {
       hsRepo         <- ZIO.service[HouseholdSettingsRepo]
       globalRepo     <- ZIO.service[GlobalPolicyRepo]
       tlRepo         <- ZIO.service[TimeLimitRepo]
-      stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+      atlRepo        <- ZIO.service[AppTimeLimitRepo]
       deviceRepo     <- ZIO.service[DeviceRepo]
       blRepo         <- ZIO.service[BlocklistRepo]
       blCache        <- ZIO.service[BlocklistCache]
@@ -353,7 +353,7 @@ object Main extends ZIOAppDefault {
           auth,
           deviceRepo,
           tlRepo,
-          stlRepo,
+          atlRepo,
           trafficRepo,
           extRepo,
           profileRepo,
@@ -373,7 +373,7 @@ object Main extends ZIOAppDefault {
             appRepo,
             rollupRepo2,
             hsRepo,
-            stlRepo,
+            atlRepo,
             clock,
           ) ++
           DashboardNowRoutes.routes(

--- a/api/src/ReasonTextBackfill.scala
+++ b/api/src/ReasonTextBackfill.scala
@@ -46,7 +46,7 @@ object ReasonTextBackfill {
            WHEN 'manual'        THEN 'manual'
            WHEN 'unmanaged'     THEN 'unmanaged_mac'
            WHEN 'category'      THEN 'category:'        || (reason->>'slug')
-           WHEN 'siteTimeLimit' THEN 'site_time_limit:' || (reason->>'label')
+           WHEN 'siteTimeLimit' THEN 'site_time_limit:' || (reason->>'label') -- FROZEN wire token (#376): keep literal until wire versioning
            WHEN 'appBlocked'    THEN 'app:'             || (reason->>'appId')
            WHEN 'unknown'       THEN reason->>'raw'
          END"""

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -196,13 +196,13 @@ trait TimeLimitRepo {
 
 /**
  * Post-#764 the `site_time_limits` table is dropped. This repo now synthesizes the legacy
- * `SiteTimeLimit` shape from `app_policy_assignments` rows with mode='time_limited', emitting one
+ * `AppTimeLimit` shape from `app_policy_assignments` rows with mode='time_limited', emitting one
  * row per (assignment × host) — mirroring the snapshot expansion in `PolicyService`. Synthetic ids
  * are 0L; callers that need stable ids should switch to AppRepo directly.
  */
-trait SiteTimeLimitRepo {
-  def listForProfile(pid: ProfileId): Task[List[SiteTimeLimit]]
-  def listAll: Task[List[SiteTimeLimit]]
+trait AppTimeLimitRepo {
+  def listForProfile(pid: ProfileId): Task[List[AppTimeLimit]]
+  def listAll: Task[List[AppTimeLimit]]
 }
 
 trait DeviceRepo {
@@ -1088,14 +1088,14 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
     .transact(xa)
 }
 
-class SiteTimeLimitRepoLive(xa: Transactor[Task]) extends SiteTimeLimitRepo {
+class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
   // (profileId, host, dailyMinutes, slug, exemptFromDaily)
   private type R = (ProfileId, String, Int, String, Boolean)
   private def toS(r: R) =
-    SiteTimeLimit(SiteTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5)
+    AppTimeLimit(AppTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5)
 
   def listForProfile(pid: ProfileId) =
-    DbMetrics.timed("siteTimeLimit.listForProfile")(
+    DbMetrics.timed("appTimeLimit.listForProfile")(
       sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
@@ -3253,7 +3253,7 @@ object Repos {
   val householdSettingsRepo = ZLayer.fromFunction(HouseholdSettingsRepoLive(_))
   val globalPolicyRepo      = ZLayer.fromFunction(GlobalPolicyRepoLive(_))
   val timeLimitRepo         = ZLayer.fromFunction(TimeLimitRepoLive(_))
-  val siteTimeLimitRepo     = ZLayer.fromFunction(SiteTimeLimitRepoLive(_))
+  val appTimeLimitRepo      = ZLayer.fromFunction(AppTimeLimitRepoLive(_))
   val deviceRepo            = ZLayer.fromFunction(DeviceRepoLive(_))
   val blocklistRepo         = ZLayer.fromFunction(BlocklistRepoLive(_))
   val timeUsageRepo         = ZLayer.fromFunction(TimeUsageRepoLive(_))
@@ -3268,5 +3268,5 @@ object Repos {
   val timeUsedRollupRepo    = ZLayer.fromFunction(TimeUsedRollupRepoLive(_))
   val appUsedRollupRepo     = ZLayer.fromFunction(AppUsedRollupRepoLive(_))
   val all                   =
-    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ siteTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ appUsedRollupRepo
+    userRepo ++ userProfileRepo ++ profileRepo ++ scheduleRepo ++ namedScheduleRepo ++ householdSettingsRepo ++ globalPolicyRepo ++ timeLimitRepo ++ appTimeLimitRepo ++ deviceRepo ++ blocklistRepo ++ timeUsageRepo ++ timeExtRepo ++ routerRepo ++ trafficReportRepo ++ blockEventRepo ++ connEventRepo ++ alertRepo ++ appRepo ++ rollupRepo ++ timeUsedRollupRepo ++ appUsedRollupRepo
 }

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2461,7 +2461,7 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
     // traffic-usage aggregator (#1085) and PolicyService. We deliberately do
     // NOT match in SQL: app_hosts stores apex-form hosts ("youtube.com"), but
     // connection_events carry FQDNs ("www.youtube.com"), so an exact SQL join
-    // would drop subdomains into __other__. Instead we fetch the apex→app
+    // would drop subdomains into single-host apps. Instead we fetch the apex→app
     // inventory + the distinct in-window hosts, run lookupApex per host, and
     // feed the resolved concrete (fqdn → app) pairs back into the aggregation
     // as a VALUES join. A host in N apps yields N pairs (fan-out preserved).
@@ -2494,15 +2494,17 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
         val hasAppMap = wantsApp && appPairs.nonEmpty
 
         // App expressions. With resolved pairs we COALESCE off the VALUES alias
-        // `am`; when grouping by app but nothing matched, everything collapses to
-        // __other__; otherwise NULL (un-drilled path keeps its constant shape).
+        // `am`; #1526: when no app row matches, the host IS its own single-host
+        // app — fall back to the domain itself for both slug and display name
+        // (NOT a shared "__other__" bucket). Un-drilled path keeps NULLs so the
+        // constant shape is preserved.
         val appSlugExpr =
-          if (hasAppMap) fr"COALESCE(am.slug, '__other__')"
-          else if (wantsApp) fr"'__other__'::TEXT"
+          if (hasAppMap) fr"COALESCE(am.slug, " ++ domainExpr ++ fr")"
+          else if (wantsApp) domainExpr
           else fr"NULL::TEXT"
         val appNameExpr =
-          if (hasAppMap) fr"COALESCE(am.name, 'Other')"
-          else if (wantsApp) fr"'Other'::TEXT"
+          if (hasAppMap) fr"COALESCE(am.name, " ++ domainExpr ++ fr")"
+          else if (wantsApp) domainExpr
           else fr"NULL::TEXT"
         val appIconExpr = if (hasAppMap) fr"am.icon" else fr"NULL::TEXT"
         val appIdExpr   = if (hasAppMap) fr"am.app_id" else fr"NULL::BIGINT"
@@ -2680,9 +2682,9 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
                 soleProfile = if (wantsProfile) None else spr,
                 soleDomain = if (wantsDomain) None else sdo,
                 soleApp = if (wantsApp) None else sap,
-                // appId is the BIGINT primary key for the apps table; the
-                // synthetic "__other__" bucket has no row in apps so app_id is
-                // NULL on the wire.
+                // appId is the BIGINT primary key for the apps table; #1526:
+                // host-keyed single-host apps (unmatched hosts) have no row in
+                // apps so app_id is NULL on the wire.
                 appId = if (wantsApp) gid.map(AppId(_)) else None,
                 appName = if (wantsApp) gan else None,
                 appIcon = if (wantsApp) gai else None,
@@ -2894,9 +2896,9 @@ trait AppRepo {
 
   /**
    * #769: full (host, app_id) inventory across all apps. Used by the group-by-app aggregation paths
-   * for Connection Events + Traffic Usage to bucket rows into their owning app, with `__other__`
-   * for hosts not in any app. One row per (host, app) pair — a host that's in two apps yields two
-   * entries.
+   * for Connection Events + Traffic Usage to bucket rows into their owning app. #1526: a host that
+   * matches no app is its own single-host app (keyed by the host itself); there is no semantic
+   * "Other" bucket. One row per (host, app) pair — a host that's in two apps yields two entries.
    */
   def listAllHostMappings: Task[List[AppHost]]
 

--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -33,7 +33,7 @@ object TypeMeta {
   given Meta[DeviceId]              = Meta[Long].imap(DeviceId(_))(_.value)
   given Meta[ScheduleId]            = Meta[Long].imap(ScheduleId(_))(_.value)
   given Meta[TimeLimitId]           = Meta[Long].imap(TimeLimitId(_))(_.value)
-  given Meta[SiteTimeLimitId]       = Meta[Long].imap(SiteTimeLimitId(_))(_.value)
+  given Meta[AppTimeLimitId]        = Meta[Long].imap(AppTimeLimitId(_))(_.value)
   given Meta[TimeExtensionId]       = Meta[Long].imap(TimeExtensionId(_))(_.value)
   given Meta[UserId]                = Meta[Long].imap(UserId(_))(_.value)
   given Meta[BlockEventId]          = Meta[Long].imap(BlockEventId(_))(_.value)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -29,7 +29,7 @@ object PolicyServiceLive {
       scheduleRepo: ScheduleRepo,
       householdSettingsRepo: HouseholdSettingsRepo,
       timeLimitRepo: TimeLimitRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       deviceRepo: DeviceRepo,
       blocklistRepo: BlocklistRepo,
       trafficRepo: TrafficReportRepo,
@@ -48,7 +48,7 @@ object PolicyServiceLive {
       profileRepo,
       scheduleRepo,
       timeLimitRepo,
-      siteTimeLimitRepo,
+      appTimeLimitRepo,
       deviceRepo,
       trafficRepo,
       extRepo,
@@ -62,7 +62,7 @@ object PolicyServiceLive {
       scheduleRepo,
       householdSettingsRepo,
       timeLimitRepo,
-      siteTimeLimitRepo,
+      appTimeLimitRepo,
       deviceRepo,
       blocklistRepo,
       trafficRepo,
@@ -91,7 +91,7 @@ class PolicyServiceLive(
     // remain injected to feed the companion `apply` factory's TimeStatusServiceLive and to keep the
     // constructor arity ~40 test constructions depend on; the class body no longer reads them.
     @scala.annotation.unused timeLimitRepo: TimeLimitRepo,
-    @scala.annotation.unused siteTimeLimitRepo: SiteTimeLimitRepo,
+    @scala.annotation.unused appTimeLimitRepo: AppTimeLimitRepo,
     deviceRepo: DeviceRepo,
     blocklistRepo: BlocklistRepo,
     @scala.annotation.unused trafficRepo: TrafficReportRepo,
@@ -174,7 +174,7 @@ class PolicyServiceLive(
         // Each assignment's effective disposition at `now` folds its per-app schedule windows
         // over its base mode (an active window overrides the base), then the AllowedDuring carve
         // is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5). Post-#764,
-        // time_limited apps are surfaced via SiteTimeLimitRepo, so they contribute nothing here.
+        // time_limited apps are surfaced via AppTimeLimitRepo, so they contribute nothing here.
         val pAssigns                           = appAssignsMap.getOrElse(p.id, Nil)
         val (appAllowedHosts, appBlockedHosts) =
           PolicyService.expandAppDispositions(
@@ -462,11 +462,11 @@ class PolicyServiceLive(
 
   /**
    * #1544: the per-host site-limit / daily-limit verdict, read off the shared [[ProfileDayState]]
-   * (`state.perSite` for per-app usage + limits, `state.usedMinutes`/`dailyLimitMinutes`/
+   * (`state.perApp` for per-app usage + limits, `state.usedMinutes`/`dailyLimitMinutes`/
    * `extensionMinutes` for the daily cap) rather than re-aggregating from raw rows. The per-HOST
    * part — matching `hostname` against an app's host-set — stays here; the AGGREGATION comes from
    * `TimeStatusService`, so this path can no longer drift from the snapshot's
-   * `siteLimitExtraBlocked` / `assemble` cap evaluation. `state.perSite` carries one entry per app,
+   * `appLimitExtraBlocked` / `assemble` cap evaluation. `state.perApp` carries one entry per app,
    * with `usedMinutes` aggregated across the whole host-set and `dailyLimitMinutes` the app's site
    * cap — exactly the `sd.usedMinutes >= sd.dailyLimitMinutes` test the snapshot uses to fill
    * `extraBlocked`.
@@ -478,23 +478,23 @@ class PolicyServiceLive(
       state: ProfileDayState,
   ): Option[RouterDecisionResponse] = {
     // Time-limit blocks expire at the next household daily-reset Instant.
-    val resetAt      = PolicyService.nextDailyResetAfter(settings, now).toString
-    val siteLimitHit = state.perSite.find { sd =>
+    val resetAt     = PolicyService.nextDailyResetAfter(settings, now).toString
+    val appLimitHit = state.perApp.find { sd =>
       sd.hosts.exists(hp => HostMatch.matchesPattern(hostname, hp)) &&
       sd.usedMinutes >= sd.dailyLimitMinutes
     }
-    siteLimitHit
+    appLimitHit
       .map(sd =>
         RouterDecisionResponse(
           ConnectionDecision.Block,
-          BlockReason.asWire(BlockReason.SiteTimeLimit(sd.label)),
+          BlockReason.asWire(BlockReason.AppTimeLimit(sd.label)),
           Some(resetAt),
         ),
       )
       .orElse {
         // #1515: no exempt-app guard is needed here anymore. An exempt-from-daily app still under
         // its own cap is carved into `profileAllowed` and allowed upstream (before this runs), and
-        // one over its cap is caught by `siteLimitHit` above — so by the time we reach the daily cap
+        // one over its cap is caught by `appLimitHit` above — so by the time we reach the daily cap
         // the host is never daily-exempt. The daily-cap predicate is the shared
         // [[dailyCapExhausted]] (the same one the snapshot's `state.blocked` / TimeLimit reason
         // folds), so the per-host /decision and the snapshot can't fold the daily cap differently
@@ -543,7 +543,7 @@ private case class SnapshotCore(
 object PolicyService {
   val layer: ZLayer[
     AppConfig & ProfileRepo & ScheduleRepo & NamedScheduleRepo & HouseholdSettingsRepo &
-      TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo &
+      TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & BlocklistRepo & TrafficReportRepo &
       TimeExtensionRepo & AppRepo & GlobalPolicyRepo & TimeStatusService & Clock,
     Nothing,
     PolicyService,
@@ -555,7 +555,7 @@ object PolicyService {
         nsr: NamedScheduleRepo,
         hsr: HouseholdSettingsRepo,
         tlr: TimeLimitRepo,
-        stlr: SiteTimeLimitRepo,
+        atlr: AppTimeLimitRepo,
         dr: DeviceRepo,
         blr: BlocklistRepo,
         trr: TrafficReportRepo,
@@ -570,7 +570,7 @@ object PolicyService {
         sr,
         hsr,
         tlr,
-        stlr,
+        atlr,
         dr,
         blr,
         trr,
@@ -669,19 +669,19 @@ object PolicyService {
       appExtraAllowed: List[Hostname] = Nil,
       appExtraBlocked: List[Hostname] = Nil,
   ): BlockRules = {
-    // #1505/#1515: per-app cap exhaustion blocks the app's WHOLE host-set together — `state.perSite`
+    // #1505/#1515: per-app cap exhaustion blocks the app's WHOLE host-set together — `state.perApp`
     // carries one entry per app with usage aggregated (gap-bridged) across the whole host-set, so
     // when that aggregate hits the limit ALL of the app's hosts go to extraBlocked, not just the one
     // whose traffic crossed. Shared with the /decision fallback via `siteCapExhaustedHosts` so the
     // two cannot diverge (#1532).
-    val siteLimitExtraBlocked: List[Hostname] = siteCapExhaustedHosts(state)
+    val appLimitExtraBlocked: List[Hostname] = siteCapExhaustedHosts(state)
 
     // #1105/#1515: time_limited app hosts with exemptFromDaily=true carve around the MAC-level
     // @blocked_macs drop while the app's aggregate is still under its own cap — for the WHOLE
     // host-set. The exempt flag's original role was just to exclude the app from the daily tally;
     // without this carve-out, hitting the profile cap silently dropped the exempt app too, violating
     // the "Khan doesn't count" contract (#1513). Naturally transitions allow → block as the app's
-    // aggregate exhausts (siteLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
+    // aggregate exhausts (appLimitExtraBlocked above takes over and extraAllowed-beats-extraBlocked
     // at the router; see feedback_extraallowed_beats_blocked). Shared with /decision via
     // `exemptUnderCapHosts` (#1532).
     val appExemptAllowedHosts: List[Hostname] = exemptUnderCapHosts(state)
@@ -742,7 +742,7 @@ object PolicyService {
       BlockRules(
         blocked = state.blocked,
         blockReason = state.blockReason,
-        extraBlocked = (appExtraBlocked ++ siteLimitExtraBlocked).distinct,
+        extraBlocked = (appExtraBlocked ++ appLimitExtraBlocked).distinct,
         extraAllowed = profileExtraAllowed,
         blocklistIds = profile.blockedCategories,
         blockIpOnly = profile.blockIpOnly,
@@ -771,7 +771,7 @@ object PolicyService {
    * the daily total ([[dailyCapExhausted]]), not the per-app budget.
    */
   private[policy] def siteCapExhaustedHosts(state: ProfileDayState): List[Hostname] =
-    state.perSite.collect {
+    state.perApp.collect {
       case sd if sd.usedMinutes >= sd.dailyLimitMinutes => sd.hosts.map(Hostname.unsafe)
     }.flatten
 
@@ -782,7 +782,7 @@ object PolicyService {
    * snapshot and the /decision fallback so the exempt carve cannot diverge (#1532, #1513).
    */
   private[policy] def exemptUnderCapHosts(state: ProfileDayState): List[Hostname] =
-    state.perSite.collect {
+    state.perApp.collect {
       case sd if sd.exemptFromDaily && sd.usedMinutes < sd.dailyLimitMinutes =>
         sd.hosts.map(Hostname.unsafe)
     }.flatten

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -26,7 +26,7 @@ final case class ProfileDayState(
     remainingMinutes: Option[Int],
     blocked: Boolean,
     blockReason: Option[MacBlockReason],
-    perSite: List[SiteDayState],
+    perApp: List[AppDayState],
 )
 
 /**
@@ -35,7 +35,7 @@ final case class ProfileDayState(
  * devices, computed the same way regardless of whether the consumer is the snapshot (deciding which
  * sites land in extraBlocked) or a route (rendering the per-site bars in the UI).
  */
-final case class SiteDayState(
+final case class AppDayState(
     label: String,
     domainPattern: String,
     dailyLimitMinutes: Int,
@@ -119,7 +119,7 @@ class TimeStatusServiceLive(
     // wholesale when the legacy table is dropped (the future two-phase destructive PR).
     @scala.annotation.unused scheduleRepo: ScheduleRepo,
     timeLimitRepo: TimeLimitRepo,
-    siteTimeLimitRepo: SiteTimeLimitRepo,
+    appTimeLimitRepo: AppTimeLimitRepo,
     deviceRepo: DeviceRepo,
     trafficRepo: TrafficReportRepo,
     extRepo: TimeExtensionRepo,
@@ -131,7 +131,7 @@ class TimeStatusServiceLive(
     // Defaults to the noop so existing direct constructions keep their arity.
     namedScheduleRepo: NamedScheduleRepo = NoopNamedScheduleRepo,
     // #1515: the #1510 per-app rollup read accessor, used ONLY on the today-rollup read path to fill
-    // each profile's per-app `perSite.usedMinutes` from `app_used_daily` + a live tail — so the
+    // each profile's per-app `perApp.usedMinutes` from `app_used_daily` + a live tail — so the
     // per-app cap enforces once a profile has rolled (the prod steady state), not just on the
     // all-live path. Defaults to the noop: the all-live path (cache miss / past date) never consults
     // it, and the many test constructions over `NoopTimeUsedRollupRepo` stay all-live.
@@ -184,7 +184,7 @@ class TimeStatusServiceLive(
         for {
           schedules <- schedulesFor(profileId)
           tl        <- timeLimitRepo.findForProfile(profileId)
-          stls      <- siteTimeLimitRepo.listForProfile(profileId)
+          atls      <- appTimeLimitRepo.listForProfile(profileId)
           devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
           presence  <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
           extMins   <- extRepo.getProfileTotalExtension(profileId, date)
@@ -194,7 +194,7 @@ class TimeStatusServiceLive(
             schedules = schedules,
             devices = devices,
             dailyLimit = tl.map(_.dailyMinutes),
-            siteLimits = stls,
+            appLimits = atls,
             presence = presence,
             extensionMinutes = extMins,
             date = date,
@@ -224,14 +224,14 @@ class TimeStatusServiceLive(
       devices  <- deviceRepo.listAll
       namedP   <- namedScheduleRepo.windowsForAllProfiles
       tlsP     <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
-      stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      atlsP    <- ZIO.foreach(profiles)(p => appTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
       presence <- trafficRepo.listPresenceRows(devices.map(_.mac), date)
       exts     <- extRepo.snapshotAllByProfile(date)
     } yield {
       val schedMap =
         profiles.map(p => p.id -> syntheticWindows(p.id, namedP.getOrElse(p.id, Nil))).toMap
       val tlMap    = tlsP.toMap
-      val stlMap   = stlsP.toMap
+      val atlMap   = atlsP.toMap
       val devsByP  =
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
       profiles.iterator.map { p =>
@@ -244,7 +244,7 @@ class TimeStatusServiceLive(
           schedules = schedMap.getOrElse(p.id, Nil),
           devices = devs,
           dailyLimit = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
-          siteLimits = stlMap.getOrElse(p.id, Nil),
+          appLimits = atlMap.getOrElse(p.id, Nil),
           presence = pPres,
           extensionMinutes = extMins,
           date = date,
@@ -270,7 +270,7 @@ class TimeStatusServiceLive(
         for {
           schedules <- schedulesFor(profileId)
           tl        <- timeLimitRepo.findForProfile(profileId)
-          stls      <- siteTimeLimitRepo.listForProfile(profileId)
+          atls      <- appTimeLimitRepo.listForProfile(profileId)
           devices   <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
           tail <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, rolled.rolledThrough)
           extMins    <- extRepo.getProfileTotalExtension(profileId, date)
@@ -279,19 +279,19 @@ class TimeStatusServiceLive(
           perAppMins <- appUsedRollupService.appCapMinutesByLabel(now, date, settings, profileId)
         } yield {
           val tailSeconds =
-            TimeStatusService.usedSecondsForProfile(p, devices, stls, tail, settings)
+            TimeStatusService.usedSecondsForProfile(p, devices, atls, tail, settings)
           val totalUsed   = ((rolled.usedSeconds + tailSeconds) / 60L).toInt
           Some(
             TimeStatusService.assemble(
               profile = p,
               schedules = schedules,
               dailyLimit = tl.map(_.dailyMinutes),
-              siteLimits = stls,
+              appLimits = atls,
               usedMinutes = totalUsed,
               extensionMinutes = extMins,
               date = date,
               now = now,
-              perSiteOverride = Some(TimeStatusService.siteDayStatesFromMinutes(stls, perAppMins)),
+              perAppOverride = Some(TimeStatusService.appDayStatesFromMinutes(atls, perAppMins)),
             ),
           )
         }
@@ -325,12 +325,12 @@ class TimeStatusServiceLive(
     // per-profile filtering handle any per-row over-fetch.
     val watermark = rolled.values.iterator.map(_.rolledThrough).min
     for {
-      devices <- deviceRepo.listAll
-      namedP  <- namedScheduleRepo.windowsForAllProfiles
-      tlsP    <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
-      stlsP   <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
-      tail    <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
-      exts    <- extRepo.snapshotAllByProfile(date)
+      devices    <- deviceRepo.listAll
+      namedP     <- namedScheduleRepo.windowsForAllProfiles
+      tlsP       <- ZIO.foreach(profiles)(p => timeLimitRepo.findForProfile(p.id).map(p.id -> _))
+      atlsP      <- ZIO.foreach(profiles)(p => appTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+      tail       <- trafficRepo.listPresenceRowsSince(devices.map(_.mac), date, watermark)
+      exts       <- extRepo.snapshotAllByProfile(date)
       // #1515: per-app cap usage per profile from the #1510 per-app rollup + live tail. Keyed by the
       // `app:<slug>` cap-group label so it joins to each profile's per-app cap groups below.
       perAppMins <- ZIO
@@ -342,7 +342,7 @@ class TimeStatusServiceLive(
       val schedMap =
         profiles.map(p => p.id -> syntheticWindows(p.id, namedP.getOrElse(p.id, Nil))).toMap
       val tlMap    = tlsP.toMap
-      val stlMap   = stlsP.toMap
+      val atlMap   = atlsP.toMap
       val devsByP  =
         devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
       profiles.iterator.map { p =>
@@ -358,7 +358,7 @@ class TimeStatusServiceLive(
           TimeStatusService.usedSecondsForProfile(
             p,
             devs,
-            stlMap.getOrElse(p.id, Nil),
+            atlMap.getOrElse(p.id, Nil),
             pTail,
             settings,
           )
@@ -367,14 +367,14 @@ class TimeStatusServiceLive(
           profile = p,
           schedules = schedMap.getOrElse(p.id, Nil),
           dailyLimit = tlMap.getOrElse(p.id, None).map(_.dailyMinutes),
-          siteLimits = stlMap.getOrElse(p.id, Nil),
+          appLimits = atlMap.getOrElse(p.id, Nil),
           usedMinutes = totalUsed,
           extensionMinutes = exts.getOrElse(p.id, 0),
           date = date,
           now = now,
-          perSiteOverride = Some(
-            TimeStatusService.siteDayStatesFromMinutes(
-              stlMap.getOrElse(p.id, Nil),
+          perAppOverride = Some(
+            TimeStatusService.appDayStatesFromMinutes(
+              atlMap.getOrElse(p.id, Nil),
               perAppMins.getOrElse(p.id, Map.empty),
             ),
           ),
@@ -387,9 +387,8 @@ class TimeStatusServiceLive(
 object TimeStatusService {
 
   val layer: ZLayer[
-    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & NamedScheduleRepo &
-      AppUsedRollupService,
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
+      TimeExtensionRepo & TimeUsedRollupRepo & NamedScheduleRepo & AppUsedRollupService,
     Nothing,
     TimeStatusService,
   ] = ZLayer.fromFunction {
@@ -397,28 +396,28 @@ object TimeStatusService {
         pr: ProfileRepo,
         sr: ScheduleRepo,
         tlr: TimeLimitRepo,
-        stlr: SiteTimeLimitRepo,
+        atlr: AppTimeLimitRepo,
         dr: DeviceRepo,
         trr: TrafficReportRepo,
         er: TimeExtensionRepo,
         ru: TimeUsedRollupRepo,
         nsr: NamedScheduleRepo,
         aur: AppUsedRollupService,
-    ) => new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr, aur)
+    ) => new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er, ru, nsr, aur)
   }
 
   /**
-   * #1505: collapse the per-(assignment × host) [[SiteTimeLimit]] rows into one group per app
-   * (keyed by `label`, which is `app:<slug>`), carrying the app's full host-set. `dailyMinutes` and
+   * #1505: collapse the per-(assignment × host) [[AppTimeLimit]] rows into one group per app (keyed
+   * by `label`, which is `app:<slug>`), carrying the app's full host-set. `dailyMinutes` and
    * `exemptFromDaily` are uniform across an app's synthesized rows, so we take them off any row.
    * The representative `domainPattern` is the apex (shortest host) — used only for the wire/UI; the
    * `hosts` list drives every per-app computation. Stable order (by label) for deterministic
    * output.
    */
   private[policy] def groupSiteLimits(
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
   ): List[(String, Int, Boolean, List[String], String)] =
-    siteLimits
+    appLimits
       .groupBy(_.label)
       .toList
       .sortBy(_._1)
@@ -429,44 +428,44 @@ object TimeStatusService {
       }
 
   /**
-   * #1505 + #1504: per-app [[SiteDayState]] list — one entry per app, with `usedMinutes` aggregated
+   * #1505 + #1504: per-app [[AppDayState]] list — one entry per app, with `usedMinutes` aggregated
    * across the app's whole host-set and counted via the #1464 session-stitch primitive
    * ([[Presence.patternGroupMinutesForProfile]]), combined across the profile's devices per
    * `overlap`. `presence` must already be scoped to the profile's devices.
    */
-  private[policy] def siteDayStates(
-      siteLimits: List[SiteTimeLimit],
+  private[policy] def appDayStates(
+      appLimits: List[AppTimeLimit],
       presence: List[PresenceRow],
       overlap: CrossDeviceOverlapMode,
       filter: HeartbeatFilter,
       continuationSeconds: Int,
-  ): List[SiteDayState] = {
+  ): List[AppDayState] = {
     val perGroup = Presence.patternGroupMinutesForProfile(
       presence,
-      groupSiteLimits(siteLimits).map(g => g._1 -> g._4),
+      groupSiteLimits(appLimits).map(g => g._1 -> g._4),
       overlap,
       filter,
       continuationSeconds,
     )
-    siteDayStatesFromMinutes(siteLimits, perGroup)
+    appDayStatesFromMinutes(appLimits, perGroup)
   }
 
   /**
-   * #1515: build the per-app [[SiteDayState]] list from a `label -> usedMinutes` map, where each
-   * key is the `app:<slug>` cap-group label [[groupSiteLimits]] emits. The single place the per-app
-   * cap groups (label / host-set / limit / exempt) are zipped with their used-minutes, regardless
-   * of where the minutes come from: the live presence aggregation ([[siteDayStates]]), the rollup +
+   * #1515: build the per-app [[AppDayState]] list from a `label -> usedMinutes` map, where each key
+   * is the `app:<slug>` cap-group label [[groupSiteLimits]] emits. The single place the per-app cap
+   * groups (label / host-set / limit / exempt) are zipped with their used-minutes, regardless of
+   * where the minutes come from: the live presence aggregation ([[appDayStates]]), the rollup +
    * live-tail read path ([[TimeStatusServiceLive]], via
    * [[wifihaven.api.usage.AppUsedRollupService.appCapMinutesByLabel]]), or the zero-usage default
    * in [[assemble]]. Keeping one zip means the cap groups can't be shaped differently across those
    * paths (#1532). A label absent from the map contributes zero minutes.
    */
-  private[policy] def siteDayStatesFromMinutes(
-      siteLimits: List[SiteTimeLimit],
+  private[policy] def appDayStatesFromMinutes(
+      appLimits: List[AppTimeLimit],
       minutesByLabel: Map[String, Int],
-  ): List[SiteDayState] =
-    groupSiteLimits(siteLimits).map { case (label, daily, exempt, hosts, rep) =>
-      SiteDayState(
+  ): List[AppDayState] =
+    groupSiteLimits(appLimits).map { case (label, daily, exempt, hosts, rep) =>
+      AppDayState(
         label = label,
         domainPattern = rep,
         dailyLimitMinutes = daily,
@@ -489,22 +488,22 @@ object TimeStatusService {
       schedules: List[DbSchedule],
       devices: List[Device],
       dailyLimit: Option[Int],
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
       presence: List[PresenceRow],
       extensionMinutes: Int,
       date: LocalDate,
       now: Instant,
       settings: HouseholdSettings,
   ): ProfileDayState = {
-    val totalSecondsUsed = usedSecondsForProfile(profile, devices, siteLimits, presence, settings)
+    val totalSecondsUsed = usedSecondsForProfile(profile, devices, appLimits, presence, settings)
     val totalMinutesUsed = (totalSecondsUsed / 60L).toInt
 
     // #1505 + #1504: one limit per app (label), aggregated across the app's full host-set, counted
     // with the #1464 session-stitch primitive (not bucket-max) and combined across the profile's
-    // devices per its overlap mode. `siteDayStates` groups the per-(assignment × host) rows into
+    // devices per its overlap mode. `appDayStates` groups the per-(assignment × host) rows into
     // one (label, host-set) per app and counts engaged wall-clock time once across the whole set.
-    val perSite = siteDayStates(
-      siteLimits,
+    val perApp = appDayStates(
+      appLimits,
       presence,
       profile.crossDeviceOverlapMode,
       settings.heartbeatFilter,
@@ -515,12 +514,12 @@ object TimeStatusService {
       profile = profile,
       schedules = schedules,
       dailyLimit = dailyLimit,
-      siteLimits = siteLimits,
+      appLimits = appLimits,
       usedMinutes = totalMinutesUsed,
       extensionMinutes = extensionMinutes,
       date = date,
       now = now,
-      perSiteOverride = Some(perSite),
+      perAppOverride = Some(perApp),
     )
   }
 
@@ -536,21 +535,21 @@ object TimeStatusService {
    * total. Derived from the same per-app collapse (`groupSiteLimits`) the per-app bars and
    * `computeBlockRules` use, so the displayed `usedMinutes`, the snapshot's `blocked`, and the
    * per-device summaries (#1546) all read ONE explicit host-set. The previous
-   * `siteLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
+   * `appLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
    * emits one row per host; reusing the collapse makes the whole-host-set exemption explicit rather
    * than an implicit dependency on that row shape, which would silently regress to apex-only the
    * moment those rows were ever de-duped upstream. Shared by [[usedSecondsForProfile]] and
    * [[usedSecondsByMac]] so the two can never derive exempt patterns differently.
    */
-  private[policy] def exemptPatterns(siteLimits: List[SiteTimeLimit]): List[String] =
-    groupSiteLimits(siteLimits).collect {
+  private[policy] def exemptPatterns(appLimits: List[AppTimeLimit]): List[String] =
+    groupSiteLimits(appLimits).collect {
       case (_, _, exempt, hosts, _) if exempt => hosts
     }.flatten
 
   /**
    * #1516: per-app engaged seconds for a profile, keyed by `app_id`, derived from the SINGLE
    * per-app presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same
-   * gap-bridged, cross-host union the per-app cap ([[siteDayStates]] /
+   * gap-bridged, cross-host union the per-app cap ([[appDayStates]] /
    * [[Presence.patternGroupMinutesForProfile]]) ticks on. This is the value the `app_used_daily`
    * rollup persists and the per-app series reads, so the rollup ⇄ cap ⇄ series identities hold by
    * construction (there is exactly one per-app time computation). `slugToAppId` resolves each
@@ -572,12 +571,12 @@ object TimeStatusService {
 
   def appSecondsByApp(
       profile: Profile,
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
       slugToAppId: Map[String, AppId],
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Map[AppId, Long] = {
-    val groups = groupSiteLimits(siteLimits).map(g => g._1 -> g._4)
+    val groups = groupSiteLimits(appLimits).map(g => g._1 -> g._4)
     Presence
       .appSecondsForProfile(
         presence,
@@ -603,18 +602,18 @@ object TimeStatusService {
    * [[Presence.countedRows]] (attribution only prevents suppression, not exemption), so an exempt
    * app's host is still excluded — it is simply no longer mis-classified as a heartbeat first.
    */
-  private[policy] def appHostPatterns(siteLimits: List[SiteTimeLimit]): List[String] =
-    groupSiteLimits(siteLimits).flatMap(_._4)
+  private[policy] def appHostPatterns(appLimits: List[AppTimeLimit]): List[String] =
+    groupSiteLimits(appLimits).flatMap(_._4)
 
   def usedSecondsForProfile(
       profile: Profile,
       devices: List[Device],
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Long = {
-    val exemptPats = exemptPatterns(siteLimits)
-    val appPats    = appHostPatterns(siteLimits)
+    val exemptPats = exemptPatterns(appLimits)
+    val appPats    = appHostPatterns(appLimits)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(
@@ -662,12 +661,12 @@ object TimeStatusService {
   def usedSecondsByMac(
       profile: Profile,
       devices: List[Device],
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Map[MacAddress, Long] = {
-    val exemptPats = exemptPatterns(siteLimits)
-    val appPats    = appHostPatterns(siteLimits)
+    val exemptPats = exemptPatterns(appLimits)
+    val appPats    = appHostPatterns(appLimits)
     profile.crossDeviceOverlapMode match {
       case CrossDeviceOverlapMode.Sum   =>
         val perMac = Presence.totalSecondsByMac(
@@ -706,19 +705,19 @@ object TimeStatusService {
    * cached-read path produces the same precedence Paused > Schedule > TimeLimit as the live path —
    * the source-of-truth invariant is enforced here by construction.
    *
-   * `perSiteOverride = None` means the caller did not load per-site presence; per-site usage is
+   * `perAppOverride = None` means the caller did not load per-site presence; per-site usage is
    * emitted as zero against the configured site limits (the v1 rollup is profile-total only).
    */
   def assemble(
       profile: Profile,
       schedules: List[DbSchedule],
       dailyLimit: Option[Int],
-      siteLimits: List[SiteTimeLimit],
+      appLimits: List[AppTimeLimit],
       usedMinutes: Int,
       extensionMinutes: Int,
       date: LocalDate,
       now: Instant,
-      perSiteOverride: Option[List[SiteDayState]] = None,
+      perAppOverride: Option[List[AppDayState]] = None,
   ): ProfileDayState = {
     val (blocked, reason) =
       if profile.paused then (true, Some(MacBlockReason.Paused: MacBlockReason))
@@ -734,13 +733,13 @@ object TimeStatusService {
 
     val remaining = dailyLimit.map(l => (l + extensionMinutes - usedMinutes).max(0))
 
-    val perSite = perSiteOverride.getOrElse(
+    val perApp = perAppOverride.getOrElse(
       // #1505/#1515: same per-app grouping as the live path, but with zero usage. Reached only when
-      // a caller does NOT supply per-app usage; the rollup read paths now pass `perSiteOverride`
+      // a caller does NOT supply per-app usage; the rollup read paths now pass `perAppOverride`
       // built from the #1510 per-app rollup (so the per-app cap enforces on the rollup path too),
       // and the live `fold` passes the presence-derived one. A bare `assemble` with no override
       // degrades to "no per-app usage yet".
-      siteDayStatesFromMinutes(siteLimits, Map.empty),
+      appDayStatesFromMinutes(appLimits, Map.empty),
     )
 
     ProfileDayState(
@@ -752,7 +751,7 @@ object TimeStatusService {
       remainingMinutes = remaining,
       blocked = blocked,
       blockReason = reason,
-      perSite = perSite,
+      perApp = perApp,
     )
   }
 }

--- a/api/src/routes/BlockedRoutes.scala
+++ b/api/src/routes/BlockedRoutes.scala
@@ -106,12 +106,15 @@ object BlockedRoutes {
       reason: String,
       blocklistRepo: BlocklistRepo,
   ): Task[(String, Option[String])] = BlockReason.fromWire(reason) match {
-    case MacBlockReason.Paused        => ZIO.succeed(("paused", None))
-    case MacBlockReason.Schedule      => ZIO.succeed(("schedule", None))
-    case MacBlockReason.TimeLimit     => ZIO.succeed(("time_limit", None))
-    case BlockReason.ExtraBlocked     => ZIO.succeed(("extra_blocked", None))
-    case BlockReason.SiteTimeLimit(_) => ZIO.succeed(("site_time_limit", None))
-    case BlockReason.Category(id)     =>
+    case MacBlockReason.Paused       => ZIO.succeed(("paused", None))
+    case MacBlockReason.Schedule     => ZIO.succeed(("schedule", None))
+    case MacBlockReason.TimeLimit    => ZIO.succeed(("time_limit", None))
+    case BlockReason.ExtraBlocked    => ZIO.succeed(("extra_blocked", None))
+    case BlockReason.AppTimeLimit(_) =>
+      ZIO.succeed(
+        ("site_time_limit", None),
+      ) // FROZEN wire token (#376): keep literal until wire versioning
+    case BlockReason.Category(id)    =>
       blocklistRepo
         .findMeta(id)
         .map(meta => ("category", meta.map(_.name)))

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -568,7 +568,7 @@ object TimeRoutes {
       auth: AuthService,
       deviceRepo: DeviceRepo,
       timeLimitRepo: TimeLimitRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       trafficRepo: TrafficReportRepo,
       extRepo: TimeExtensionRepo,
       profileRepo: ProfileRepo,
@@ -728,7 +728,7 @@ object TimeRoutes {
                         settings,
                         timeStatusService,
                         trafficRepo,
-                        siteTimeLimitRepo,
+                        appTimeLimitRepo,
                       )
                     }
                 }
@@ -850,7 +850,7 @@ object TimeRoutes {
               profileRepo,
               timeStatusService,
               trafficRepo,
-              siteTimeLimitRepo,
+              appTimeLimitRepo,
             )
               .mapError(ApiError.Db(_))
           } yield Response.json(status.toJson)
@@ -985,7 +985,7 @@ object TimeRoutes {
       settings: HouseholdSettings,
       timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
   ): Task[ProfileTimeStatus] = {
     val macs = devices.map(_.mac)
     for {
@@ -993,17 +993,17 @@ object TimeRoutes {
       state = stateOpt.getOrElse(
         wifihaven.api.policy.ProfileDayState(profile.id, date, None, 0, 0, None, false, None, Nil),
       )
-      presence   <- trafficRepo.listPresenceRows(macs, date)
-      siteLimits <- siteTimeLimitRepo.listForProfile(profile.id)
+      presence  <- trafficRepo.listPresenceRows(macs, date)
+      appLimits <- appTimeLimitRepo.listForProfile(profile.id)
       // #1546: per-device minutes come from the canonical per-mac decomposition of the headline
       // total, so they share one exempt-pattern + overlap definition with `state.usedMinutes` and
       // cannot drift from it (no open-coded `totalMinutesByMac` recompute). Under Dedup this is a
       // disjoint attribution of the union, so the summaries reconcile with the headline instead of
       // summing to >100%.
       perMacSeconds   = wifihaven.api.policy.TimeStatusService
-        .usedSecondsByMac(profile, devices, siteLimits, presence, settings)
-      siteUsage       = state.perSite.map { s =>
-        SiteUsage(
+        .usedSecondsByMac(profile, devices, appLimits, presence, settings)
+      appUsage        = state.perApp.map { s =>
+        AppUsage(
           s.label,
           s.domainPattern,
           s.dailyLimitMinutes,
@@ -1044,7 +1044,7 @@ object TimeRoutes {
       state.usedMinutes,
       state.extensionMinutes,
       state.remainingMinutes,
-      siteUsage,
+      appUsage,
       deviceSummaries,
       hostUsage,
     )
@@ -1247,7 +1247,7 @@ object TimeRoutes {
       profileRepo: ProfileRepo,
       timeStatusService: wifihaven.api.policy.TimeStatusService,
       trafficRepo: TrafficReportRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
   ): Task[DeviceTimeStatus] = {
     val pid = device.profileId
     for {
@@ -1256,8 +1256,8 @@ object TimeRoutes {
       )
       presence   <- trafficRepo.listPresenceRows(List(device.mac), date)
       profileOpt <- pid.fold(ZIO.succeed(Option.empty[Profile]))(profileRepo.findById)
-      siteLimits <- pid.fold(ZIO.succeed(List.empty[SiteTimeLimit]))(
-        siteTimeLimitRepo.listForProfile,
+      appLimits  <- pid.fold(ZIO.succeed(List.empty[AppTimeLimit]))(
+        appTimeLimitRepo.listForProfile,
       )
       profile   = profileOpt.map(_.name).getOrElse(if (pid.isEmpty) "No profile" else "Unknown")
       // #1546: the per-device headline reads the same per-mac decomposition the profile view's
@@ -1266,7 +1266,7 @@ object TimeRoutes {
       // and Dedup coincide — the device is credited its own engaged time.
       totalUsed = profileOpt.fold(0)(p =>
         (wifihaven.api.policy.TimeStatusService
-          .usedSecondsByMac(p, List(device), siteLimits, presence, settings)
+          .usedSecondsByMac(p, List(device), appLimits, presence, settings)
           .getOrElse(device.mac, 0L) / 60L).toInt,
       )
       // #1505 + #1504: per-device per-app usage via the #1464 session-stitch primitive, aggregated
@@ -1275,14 +1275,14 @@ object TimeRoutes {
       perApp    = wifihaven.api.presence.Presence
         .patternGroupMinutesForProfile(
           presence,
-          stateOpt.toList.flatMap(_.perSite).map(s => s.label -> s.hosts),
+          stateOpt.toList.flatMap(_.perApp).map(s => s.label -> s.hosts),
           wifihaven.shared.CrossDeviceOverlapMode.Sum,
           settings.heartbeatFilter,
           settings.presenceContinuationSeconds,
         )
-      siteUsage = stateOpt.toList.flatMap(_.perSite).map { s =>
+      appUsage  = stateOpt.toList.flatMap(_.perApp).map { s =>
         val used = perApp.getOrElse(s.label, 0)
-        SiteUsage(
+        AppUsage(
           s.label,
           s.domainPattern,
           s.dailyLimitMinutes,
@@ -1300,7 +1300,7 @@ object TimeRoutes {
       totalUsed,
       stateOpt.map(_.extensionMinutes).getOrElse(0),
       stateOpt.flatMap(_.remainingMinutes),
-      siteUsage,
+      appUsage,
     )
   }
 

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -34,7 +34,7 @@ object UsageRoutes {
       appRepo: AppRepo,
       rollupRepo: RollupRepo,
       hsRepo: HouseholdSettingsRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -218,7 +218,7 @@ object UsageRoutes {
                   deviceRepo,
                   trafficRepo,
                   userProfileRepo,
-                  siteTimeLimitRepo,
+                  appTimeLimitRepo,
                   groupByApp,
                   appLookup,
                   settings,
@@ -266,7 +266,7 @@ object UsageRoutes {
               deviceRepo,
               trafficRepo,
               userProfileRepo,
-              siteTimeLimitRepo,
+              appTimeLimitRepo,
               groupByApp,
               appLookup,
               settings,
@@ -291,7 +291,7 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       groupByApp: Boolean,
       appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
@@ -311,7 +311,7 @@ object UsageRoutes {
       // load them per profile (same input `usedSecondsForProfile` uses) and carve them out.
       exemptByPid <- ZIO
         .foreach(pids) { pid =>
-          siteTimeLimitRepo
+          appTimeLimitRepo
             .listForProfile(pid)
             .map(sl => pid -> sl.filter(_.exemptFromDaily).map(_.domainPattern))
         }
@@ -628,21 +628,21 @@ object UsageRoutes {
       deviceRepo: DeviceRepo,
       trafficRepo: TrafficReportRepo,
       userProfileRepo: UserProfileRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       groupByApp: Boolean,
       appLookup: UsageSeries.AppAxis,
       settings: HouseholdSettings,
   ): IO[ApiError, UsageSeriesResponse] =
     for {
-      _          <- requireProfileReadAccess(claims, pid, userProfileRepo)
+      _         <- requireProfileReadAccess(claims, pid, userProfileRepo)
         .mapError(ApiError.Wrapped(_))
-      profile    <- profileRepo
+      profile   <- profileRepo
         .findById(pid)
         .mapError(ApiError.Db(_))
         .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
-      all        <- deviceRepo.listAll.mapError(ApiError.Db(_))
-      siteLimits <- siteTimeLimitRepo.listForProfile(pid).mapError(ApiError.Db(_))
-      exempt    = siteLimits.filter(_.exemptFromDaily).map(_.domainPattern)
+      all       <- deviceRepo.listAll.mapError(ApiError.Db(_))
+      appLimits <- appTimeLimitRepo.listForProfile(pid).mapError(ApiError.Db(_))
+      exempt    = appLimits.filter(_.exemptFromDaily).map(_.domainPattern)
       devices   = all.filter(_.profileId.contains(pid))
       macs      = devices.map(_.mac)
       nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -27,7 +27,7 @@ import java.time.{Instant, LocalDate}
  * so for a profile + date:
  *
  *   - '''rollup ⇄ cap''' (EXACT): this accessor's per-app minutes equal the per-app cap aggregate
- *     ([[wifihaven.api.policy.TimeStatusService.siteDayStates]] /
+ *     ([[wifihaven.api.policy.TimeStatusService.appDayStates]] /
  *     `Presence.patternGroupMinutesForProfile`) — same primitive, same floor-of-sum.
  *   - '''rolled+tail ⇄ live''' (EXACT): rolled + tail equals the all-live computation in seconds,
  *     because presence buckets are 5-min granular and disjoint on either side of the watermark
@@ -58,9 +58,9 @@ trait AppUsedRollupService {
   /**
    * #1515: the same per-app engaged minutes as [[appEngagedMinutes]], re-keyed by the cap group
    * label `app:<slug>` (the key [[wifihaven.api.policy.TimeStatusService.groupSiteLimits]] emits).
-   * This is what the snapshot's / `/decision`'s per-app cap reads through `perSite` on the rollup
+   * This is what the snapshot's / `/decision`'s per-app cap reads through `perApp` on the rollup
    * read path: [[wifihaven.api.policy.TimeStatusServiceLive]] joins it to the profile's per-app cap
-   * groups to fill `SiteDayState.usedMinutes`, so a profile that has rolled (the prod steady state)
+   * groups to fill `AppDayState.usedMinutes`, so a profile that has rolled (the prod steady state)
    * still caps on the real per-app aggregate instead of zero. Same rolled + live-tail figure, so
    * the rollup read and the all-live read agree by construction (#1532).
    */
@@ -96,7 +96,7 @@ object NoopAppUsedRollupService extends AppUsedRollupService {
 class AppUsedRollupServiceLive(
     profileRepo: ProfileRepo,
     deviceRepo: DeviceRepo,
-    siteTimeLimitRepo: SiteTimeLimitRepo,
+    appTimeLimitRepo: AppTimeLimitRepo,
     appRepo: AppRepo,
     trafficRepo: TrafficReportRepo,
     rollupRepo: AppUsedRollupRepo,
@@ -144,7 +144,7 @@ class AppUsedRollupServiceLive(
         case None    => ZIO.succeed((Map.empty[AppId, Int], Map.empty[String, Int]))
         case Some(p) =>
           for {
-            stls    <- siteTimeLimitRepo.listForProfile(profileId)
+            atls    <- appTimeLimitRepo.listForProfile(profileId)
             devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
             apps    <- appRepo.listAll
             macs = devices.map(_.mac)
@@ -156,7 +156,7 @@ class AppUsedRollupServiceLive(
             val liveSecs                  =
               TimeStatusService.appSecondsByApp(
                 p,
-                stls,
+                atls,
                 TimeStatusService.slugToAppId(apps),
                 presence,
                 settings,
@@ -184,7 +184,7 @@ class AppUsedRollupServiceLive(
 
 object AppUsedRollupService {
   val layer: ZLayer[
-    ProfileRepo & DeviceRepo & SiteTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
+    ProfileRepo & DeviceRepo & AppTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
     Nothing,
     AppUsedRollupService,
   ] = ZLayer.fromFunction(AppUsedRollupServiceLive(_, _, _, _, _, _))

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -2,6 +2,7 @@ package wifihaven.api.usage
 
 import wifihaven.api.db.{
   AppRepo,
+  AppTimeLimitRepo,
   AppUsedRollupRepo,
   DeviceRepo,
   HouseholdSettingsRepo,
@@ -9,7 +10,6 @@ import wifihaven.api.db.{
   RolledAppDay,
   RolledDay,
   RollupRepo,
-  SiteTimeLimitRepo,
   TimeUsedRollupRepo,
   TrafficReportRepo,
 }
@@ -62,7 +62,7 @@ object TimeUsedRollupJob {
       runs: RollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
@@ -77,7 +77,7 @@ object TimeUsedRollupJob {
           appRollup,
           profileRepo,
           deviceRepo,
-          siteTimeLimitRepo,
+          appTimeLimitRepo,
           appRepo,
           trafficRepo,
           hs,
@@ -97,7 +97,7 @@ object TimeUsedRollupJob {
       appRollup: AppUsedRollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
@@ -108,7 +108,7 @@ object TimeUsedRollupJob {
       appRollup,
       profileRepo,
       deviceRepo,
-      siteTimeLimitRepo,
+      appTimeLimitRepo,
       appRepo,
       trafficRepo,
       hs,
@@ -163,7 +163,7 @@ object TimeUsedRollupJob {
       appRollup: AppUsedRollupRepo,
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
-      siteTimeLimitRepo: SiteTimeLimitRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
@@ -174,9 +174,9 @@ object TimeUsedRollupJob {
     profiles <- profileRepo.listAll
     devices  <- deviceRepo.listAll
     apps     <- appRepo.listAll
-    stlsP    <- ZIO.foreach(profiles)(p => siteTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
+    atlsP    <- ZIO.foreach(profiles)(p => appTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
     presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-    rolls = computeRolls(profiles, devices, apps, stlsP.toMap, presence, settings, now)
+    rolls = computeRolls(profiles, devices, apps, atlsP.toMap, presence, settings, now)
     n <- rollup.upsertBatch(today, rolls._1)
     _ <- appRollup.upsertBatch(today, rolls._2)
   } yield n
@@ -191,7 +191,7 @@ object TimeUsedRollupJob {
       profiles: List[wifihaven.shared.Profile],
       devices: List[wifihaven.shared.Device],
       apps: List[wifihaven.shared.App],
-      stlMap: Map[ProfileId, List[wifihaven.shared.SiteTimeLimit]],
+      atlMap: Map[ProfileId, List[wifihaven.shared.AppTimeLimit]],
       presence: List[wifihaven.api.presence.PresenceRow],
       settings: wifihaven.shared.HouseholdSettings,
       now: Instant,
@@ -207,7 +207,7 @@ object TimeUsedRollupJob {
       val secs = TimeStatusService.usedSecondsForProfile(
         p,
         devsByP.getOrElse(p.id, Nil),
-        stlMap.getOrElse(p.id, Nil),
+        atlMap.getOrElse(p.id, Nil),
         presFor(p.id),
         settings,
       )
@@ -215,7 +215,7 @@ object TimeUsedRollupJob {
     }.toMap
     val perApp     = profiles.iterator.flatMap { p =>
       TimeStatusService
-        .appSecondsByApp(p, stlMap.getOrElse(p.id, Nil), slugToAppId, presFor(p.id), settings)
+        .appSecondsByApp(p, atlMap.getOrElse(p.id, Nil), slugToAppId, presFor(p.id), settings)
         .iterator
         .map { case (appId, secs) => (p.id, appId) -> RolledAppDay(secs, now) }
     }.toMap

--- a/api/src/usage/UsageSeries.scala
+++ b/api/src/usage/UsageSeries.scala
@@ -296,7 +296,7 @@ object UsageSeries {
 
     // #1517: an app's spans are the gap-bridged union of its WHOLE host-set via the single per-app
     // primitive (#1514/#1532) — same groups/overlap/filter/continuation the per-app cap aggregate
-    // (`TimeStatusService.siteDayStates` / `appSecondsByApp`) and the #1510 rollup read, so the per-
+    // (`TimeStatusService.appDayStates` / `appSecondsByApp`) and the #1510 rollup read, so the per-
     // app series total equals the cap and the rollup by construction (not the per-host concat, which
     // neither bridges cross-host idle gaps nor dedups within-app overlap).
     val appSpans: Map[String, List[Span]] =

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -11,8 +11,8 @@ import java.time.temporal.{ChronoUnit, TemporalAdjusters}
  * uses this to bucket rows by app slug. #1526: a host that belongs to no registered app is its own
  * **single-host app** — synthesized via [[AppMembership.forUnmatchedHost]], keyed by the host
  * itself. There is no semantic "Other" app; "Other" only ever appears as a presentation top-N
- * rollup applied AFTER attribution. Mapping is built once per request and held in memory — apps
- * are household-scoped and typically number in the tens, so the full join table fits comfortably.
+ * rollup applied AFTER attribution. Mapping is built once per request and held in memory — apps are
+ * household-scoped and typically number in the tens, so the full join table fits comfortably.
  */
 case class AppMembership(
     slug: String,

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -8,9 +8,11 @@ import java.time.temporal.{ChronoUnit, TemporalAdjusters}
 
 /**
  * #769: per-host attribution to an app, sourced from `app_hosts` joined with `apps`. The aggregator
- * uses this to bucket rows by app slug; hosts not in any app fall into the synthetic `__other__`
- * bucket with `name="Other"`. Mapping is built once per request and held in memory — apps are
- * household-scoped and typically number in the tens, so the full join table fits comfortably.
+ * uses this to bucket rows by app slug. #1526: a host that belongs to no registered app is its own
+ * **single-host app** — synthesized via [[AppMembership.forUnmatchedHost]], keyed by the host
+ * itself. There is no semantic "Other" app; "Other" only ever appears as a presentation top-N
+ * rollup applied AFTER attribution. Mapping is built once per request and held in memory — apps
+ * are household-scoped and typically number in the tens, so the full join table fits comfortably.
  */
 case class AppMembership(
     slug: String,
@@ -20,7 +22,11 @@ case class AppMembership(
 )
 
 object AppMembership {
-  val Other: AppMembership = AppMembership("__other__", "Other", None, None)
+  // #1526: hosts not in any registered app become their own single-host app,
+  // keyed by the host itself so two unmatched hosts produce two distinct
+  // memberships (NOT one shared `__other__` bucket).
+  def forUnmatchedHost(host: HostId): AppMembership =
+    AppMembership(slug = host.value, name = host.value, icon = None, appId = None)
 }
 
 /**
@@ -201,7 +207,8 @@ object UsageTraffic {
       // canonicalizes at create/edit). #1085 added suffix-aware lookup so
       // traffic rows on `www.youtube.com` attribute to the `youtube.com` apex
       // entry. A host in two apps appears under both when grouping by app.
-      // Hosts that match no apex bucket to __other__.
+      // #1526: hosts that match no apex become their own single-host app
+      // (synthesized in `membershipsFor`), not a shared `__other__` bucket.
       appsByHost: Map[String, List[AppMembership]] = Map.empty,
   ): List[TrafficUsageAggregateRow] = {
     val step = stepOf(bucket)
@@ -218,10 +225,10 @@ object UsageTraffic {
     // rows carry FQDNs (`www.youtube.com`). Delegate to HostMatch.lookupApex,
     // which is the single host→apex matcher shared with PolicyService and
     // Presence — keeps usage attribution semantically aligned with the
-    // policy enforcement path.
+    // policy enforcement path. #1526: unmatched → single-host synthetic app.
     def membershipsFor(host: HostId): List[AppMembership] = {
       val matched = host.asFqdn.flatMap(fqdn => HostMatch.lookupApex(fqdn.value, appsByHost))
-      matched.getOrElse(List(AppMembership.Other))
+      matched.getOrElse(List(AppMembership.forUnmatchedHost(host)))
     }
 
     val wantsApp = groupBy.contains(GroupBy.App)

--- a/api/test/src/TestDatabase.scala
+++ b/api/test/src/TestDatabase.scala
@@ -179,7 +179,7 @@ object TestDatabase {
    */
   type AllRepos =
     TestDb & UserRepo & UserProfileRepo & ProfileRepo & ScheduleRepo & NamedScheduleRepo &
-      HouseholdSettingsRepo & GlobalPolicyRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
+      HouseholdSettingsRepo & GlobalPolicyRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo &
       BlocklistRepo & TimeUsageRepo & TimeExtensionRepo & RouterRepo & TrafficReportRepo &
       BlockEventRepo & ConnectionEventRepo & AlertRepo & AppRepo & RollupRepo & TimeUsedRollupRepo &
       AppUsedRollupRepo

--- a/api/test/src/feature/AppHostSetAttributionSpec.scala
+++ b/api/test/src/feature/AppHostSetAttributionSpec.scala
@@ -190,7 +190,11 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
       )
       ZIO.succeed(
         assertTrue(agg.exists(r => r.soleApp.isEmpty && r.appName.contains("Math Academy"))) &&
-          assertTrue(!agg.exists(_.groups.get("app").contains(AppMembership.Other.slug))),
+          // #1526: no "__other__" sentinel — assert both hosts attribute to the
+          // registered app, not a synthetic bucket. (Unmatched hosts would each
+          // get their own host-keyed single-host app, but here both hosts ARE
+          // matched, so they roll up into "Math Academy" only.)
+          assertTrue(agg.flatMap(_.groups.get("app")).toSet == Set(appSlug)),
       )
     },
   )

--- a/api/test/src/feature/AppHostSetAttributionSpec.scala
+++ b/api/test/src/feature/AppHostSetAttributionSpec.scala
@@ -95,7 +95,7 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
         _           <- cleanDb
         profileRepo <- ZIO.service[ProfileRepo]
         tlRepo      <- ZIO.service[TimeLimitRepo]
-        stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+        atlRepo     <- ZIO.service[AppTimeLimitRepo]
         schedRepo   <- ZIO.service[ScheduleRepo]
         deviceRepo  <- ZIO.service[DeviceRepo]
         trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -126,7 +126,7 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
           profileRepo,
           schedRepo,
           tlRepo,
-          stlRepo,
+          atlRepo,
           deviceRepo,
           trafficRepo,
           extRepo,
@@ -135,7 +135,7 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
           auth,
           deviceRepo,
           tlRepo,
-          stlRepo,
+          atlRepo,
           trafficRepo,
           extRepo,
           profileRepo,
@@ -151,7 +151,7 @@ object AppHostSetAttributionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedde
         body   <- resp.body.asString
         status <- ZIO.fromEither(body.fromJson[DeviceTimeStatus])
       } yield {
-        val mathBars = status.siteUsage.filter(_.label == s"app:$appSlug")
+        val mathBars = status.appUsage.filter(_.label == s"app:$appSlug")
         // The whole app is ONE limit: a single bar, both hosts aggregated to 20 of 30 minutes.
         assertTrue(mathBars.size == 1) &&
         assertTrue(mathBars.head.usedMins == 20) &&

--- a/api/test/src/feature/AppUsedRollupSpec.scala
+++ b/api/test/src/feature/AppUsedRollupSpec.scala
@@ -19,7 +19,7 @@ import java.time.{LocalDate, LocalDateTime, ZoneOffset}
  *
  *   - rollup ⇄ cap (EXACT): a multi-host app's engaged minutes via the reader equal the single
  *     per-app primitive (`Presence.appSecondsForProfile`, surfaced as the per-app cap aggregate
- *     `SiteDayState.usedMinutes`), including cross-host idle-gap bridging.
+ *     `AppDayState.usedMinutes`), including cross-host idle-gap bridging.
  *   - rolled+tail ⇄ live (EXACT): a planted rollup row + the live tail past the watermark sum to
  *     the all-live computation, with the watermark landing in an idle gap.
  *   - per-app sum ⇄ profile total (restricted equality): for non-exempt, non-overlapping apps with
@@ -33,22 +33,22 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
   private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeReader: ZIO[
-    ProfileRepo & DeviceRepo & SiteTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
+    ProfileRepo & DeviceRepo & AppTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
     Nothing,
     AppUsedRollupServiceLive,
   ] =
     for {
       pr  <- ZIO.service[ProfileRepo]
       dr  <- ZIO.service[DeviceRepo]
-      stl <- ZIO.service[SiteTimeLimitRepo]
+      stl <- ZIO.service[AppTimeLimitRepo]
       ar  <- ZIO.service[AppRepo]
       trr <- ZIO.service[TrafficReportRepo]
       aru <- ZIO.service[AppUsedRollupRepo]
     } yield new AppUsedRollupServiceLive(pr, dr, stl, ar, trr, aru)
 
   private def makeTimeService: ZIO[
-    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo,
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
+      TimeExtensionRepo & TimeUsedRollupRepo,
     Nothing,
     TimeStatusService,
   ] =
@@ -56,12 +56,12 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
       pr   <- ZIO.service[ProfileRepo]
       sr   <- ZIO.service[ScheduleRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       trr  <- ZIO.service[TrafficReportRepo]
       er   <- ZIO.service[TimeExtensionRepo]
       ru   <- ZIO.service[TimeUsedRollupRepo]
-    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er, ru)
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-app", Sha256Hex.unsafe("a" * 64)))
@@ -141,7 +141,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         ar  <- ZIO.service[AppRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
         aru <- ZIO.service[AppUsedRollupRepo]
-        stl <- ZIO.service[SiteTimeLimitRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
         trr <- ZIO.service[TrafficReportRepo]
         s   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
@@ -155,10 +155,10 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
         reader <- makeReader
         perApp <- reader.appEngagedMinutes(now, today, s, kid)
-        // The per-app cap aggregate (SiteDayState.usedMinutes) for the same app.
+        // The per-app cap aggregate (AppDayState.usedMinutes) for the same app.
         tsvc   <- makeTimeService
         state  <- tsvc.dayStateLive(now, today, s, kid)
-        capMin = state.flatMap(_.perSite.find(_.label == "app:social").map(_.usedMinutes))
+        capMin = state.flatMap(_.perApp.find(_.label == "app:social").map(_.usedMinutes))
       } yield assertTrue(perApp.get(app).contains(15)) &&
         assertTrue(capMin.contains(15))
     },
@@ -206,7 +206,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         ar  <- ZIO.service[AppRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
         aru <- ZIO.service[AppUsedRollupRepo]
-        stl <- ZIO.service[SiteTimeLimitRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
         trr <- ZIO.service[TrafficReportRepo]
         _   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
@@ -236,7 +236,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         ar  <- ZIO.service[AppRepo]
         ru  <- ZIO.service[TimeUsedRollupRepo]
         aru <- ZIO.service[AppUsedRollupRepo]
-        stl <- ZIO.service[SiteTimeLimitRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
         trr <- ZIO.service[TrafficReportRepo]
         _   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -33,7 +33,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -47,7 +47,7 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/LogApiSpec.scala
+++ b/api/test/src/feature/LogApiSpec.scala
@@ -1082,7 +1082,8 @@ object LogApiSpec
         auth     <- makeAuth
         token    <- auth.login("admin", "changeme").map(_.token.value)
         // One app ("YouTube") owning two hosts; a third host belongs to no
-        // app and should bucket under __other__.
+        // app and should attribute as its own single-host app keyed by the
+        // host itself (#1526 — no shared "Other" bucket).
         ytId     <- appRepo.create("YouTube", "youtube", None, Some("📺"))
         _        <- appRepo.setHosts(
           ytId,
@@ -1134,7 +1135,8 @@ object LogApiSpec
         page <- ZIO.fromEither(body.fromJson[ConnectionEventSeriesPage])
         rows = page.rows
         yt   = rows.find(_.groups.getOrElse("app", "") == "youtube").get
-        ot   = rows.find(_.groups.getOrElse("app", "") == "__other__").get
+        // #1526: facebook.com isn't in any app → single-host app keyed by the host.
+        ot   = rows.find(_.groups.getOrElse("app", "") == "facebook.com").get
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(rows.length == 2) &&
         assertTrue(yt.countSucceeded == 2) &&
@@ -1144,7 +1146,7 @@ object LogApiSpec
         assertTrue(yt.appId.isDefined) &&
         assertTrue(ot.countSucceeded == 1) &&
         assertTrue(ot.countBlocked == 0) &&
-        assertTrue(ot.appName.contains("Other")) &&
+        assertTrue(ot.appName.contains("facebook.com")) &&
         assertTrue(ot.appId.isEmpty)
     },
     test("#769: GET /api/connection-events/series with host in 2 apps fans out") {
@@ -1188,7 +1190,7 @@ object LogApiSpec
     // — the same matcher the traffic-usage path uses (#1085). app_hosts stores
     // the apex form ("youtube.com"); a subdomain event ("www.youtube.com")
     // must attribute to the youtube app, while a lookalike ("notyoutube.com")
-    // must NOT match and falls into __other__.
+    // must NOT match — #1526: it becomes its own single-host app keyed by the host.
     test("#857: GET /api/connection-events/series attributes subdomains to the apex app") {
       for {
         _        <- cleanDb
@@ -1237,7 +1239,8 @@ object LogApiSpec
         page <- ZIO.fromEither(body.fromJson[ConnectionEventSeriesPage])
         rows = page.rows
         yt   = rows.find(_.groups.getOrElse("app", "") == "youtube")
-        ot   = rows.find(_.groups.getOrElse("app", "") == "__other__")
+        // #1526: notyoutube.com → its own single-host app keyed by the host.
+        ot   = rows.find(_.groups.getOrElse("app", "") == "notyoutube.com")
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(rows.length == 2) &&
         assertTrue(yt.exists(_.countSucceeded == 1)) &&

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -83,7 +83,7 @@ object MetricsExportSpec
         rollupRepo     <- ZIO.service[RollupRepo]
         profileRepo    <- ZIO.service[ProfileRepo]
         deviceRepo     <- ZIO.service[DeviceRepo]
-        stlRepo        <- ZIO.service[SiteTimeLimitRepo]
+        atlRepo        <- ZIO.service[AppTimeLimitRepo]
         appRepo        <- ZIO.service[AppRepo]
         trafficRepo    <- ZIO.service[TrafficReportRepo]
         hsRepo         <- ZIO.service[HouseholdSettingsRepo]
@@ -97,7 +97,7 @@ object MetricsExportSpec
             rollupRepo,
             profileRepo,
             deviceRepo,
-            stlRepo,
+            atlRepo,
             appRepo,
             trafficRepo,
             hsRepo,

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -30,7 +30,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -42,7 +42,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,
@@ -57,7 +57,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -71,7 +71,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,
@@ -91,7 +91,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       sr   <- ZIO.service[ScheduleRepo]
       hsr  <- ZIO.service[HouseholdSettingsRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       blr  <- ZIO.service[BlocklistRepo]
       trr  <- ZIO.service[TrafficReportRepo]
@@ -101,14 +101,14 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       ru   <- ZIO.service[TimeUsedRollupRepo]
       aru  <- ZIO.service[AppUsedRollupRepo]
       clk  <- ZIO.service[Clock]
-      aus = new AppUsedRollupServiceLive(pr, dr, stlr, ar, trr, aru)
-      tss = new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru, nsr, aus)
+      aus = new AppUsedRollupServiceLive(pr, dr, atlr, ar, trr, aru)
+      tss = new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er, ru, nsr, aus)
     } yield new PolicyServiceLive(
       pr,
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trr,
@@ -286,7 +286,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       "#1515 rollup path: per-app cap enforces from app_used_daily + tail, not just the all-live path",
     ) {
       // Regression guard for the gap that the snapshot's per-app cap only fired on the all-live path:
-      // once a profile has rolled (the prod steady state) the snapshot read `perSite.usedMinutes` as
+      // once a profile has rolled (the prod steady state) the snapshot read `perApp.usedMinutes` as
       // ZERO and the cap never bit. Roll the day up so the snapshot takes the rollup + live-tail
       // path, and assert the whole host-set is still blocked from `app_used_daily`.
       for {
@@ -308,14 +308,14 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         // Roll the day up: writes app_used_daily (30 m YouTube) + time_used_daily for every profile,
         // so the snapshot below reads the ROLLUP path rather than re-aggregating live.
         pr     <- ZIO.service[ProfileRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         trr    <- ZIO.service[TrafficReportRepo]
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         ru     <- ZIO.service[TimeUsedRollupRepo]
         aru    <- ZIO.service[AppUsedRollupRepo]
         clk    <- ZIO.service[Clock]
         now    <- clk.instant
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stlr, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, atlr, ar, trr, hsr, now)
         // Proves the rollup branch is exercised: the per-app rollup row exists for this profile.
         rolled <- aru.getDayForProfile(kids, today)
         svc    <- makePsRollup
@@ -666,7 +666,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         sr    <- ZIO.service[ScheduleRepo]
         hsr   <- ZIO.service[HouseholdSettingsRepo]
         tlr   <- ZIO.service[TimeLimitRepo]
-        stlr  <- ZIO.service[SiteTimeLimitRepo]
+        atlr  <- ZIO.service[AppTimeLimitRepo]
         dr    <- ZIO.service[DeviceRepo]
         blr   <- ZIO.service[BlocklistRepo]
         trr   <- ZIO.service[TrafficReportRepo]
@@ -685,7 +685,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
             sr,
             hsr,
             tlr,
-            stlr,
+            atlr,
             dr,
             blr,
             trr,

--- a/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockIpOnlySpec.scala
@@ -51,7 +51,7 @@ object PolicySnapshotBlockIpOnlySpec
         pr     <- ZIO.service[ProfileRepo]
         sr     <- ZIO.service[ScheduleRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
         blr    <- ZIO.service[BlocklistRepo]
         trRepo <- ZIO.service[TrafficReportRepo]
@@ -59,7 +59,7 @@ object PolicySnapshotBlockIpOnlySpec
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         ar     <- ZIO.service[AppRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
         profiles0 <- pr.listAll
         kidsId   = profiles0.find(_.name == "Kids").get.id
         adultsId = profiles0.find(_.name == "Adults").get.id
@@ -75,7 +75,7 @@ object PolicySnapshotBlockIpOnlySpec
         pr     <- ZIO.service[ProfileRepo]
         sr     <- ZIO.service[ScheduleRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
         blr    <- ZIO.service[BlocklistRepo]
         trRepo <- ZIO.service[TrafficReportRepo]
@@ -83,7 +83,7 @@ object PolicySnapshotBlockIpOnlySpec
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         ar     <- ZIO.service[AppRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
         profiles0 <- pr.listAll
         kids = profiles0.find(_.name == "Kids").get
         _     <- pr.update(kids.copy(blockIpOnly = false))

--- a/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotBlockedMacsSpec.scala
@@ -45,7 +45,7 @@ object PolicySnapshotBlockedMacsSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -59,7 +59,7 @@ object PolicySnapshotBlockedMacsSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
+++ b/api/test/src/feature/PolicySnapshotConsolidationSpec.scala
@@ -80,7 +80,7 @@ object PolicySnapshotConsolidationSpec extends ZIOSpec[TestDatabase.AllRepos & E
       sr   <- ZIO.service[ScheduleRepo]
       hsr  <- ZIO.service[HouseholdSettingsRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       blr  <- ZIO.service[BlocklistRepo]
       trr  <- ZIO.service[TrafficReportRepo]
@@ -88,21 +88,21 @@ object PolicySnapshotConsolidationSpec extends ZIOSpec[TestDatabase.AllRepos & E
       ar   <- ZIO.service[AppRepo]
       ref  <- Ref.make(now)
       clk = new Clock.TestClock(ref)
-    } yield PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trr, er, ar, clk)
+    } yield PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trr, er, ar, clk)
 
   private def buildTss: ZIO[AllReposLite, Nothing, TimeStatusService] =
     for {
       pr   <- ZIO.service[ProfileRepo]
       sr   <- ZIO.service[ScheduleRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       trr  <- ZIO.service[TrafficReportRepo]
       er   <- ZIO.service[TimeExtensionRepo]
-    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er)
 
   private type AllReposLite =
-    ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo & SiteTimeLimitRepo &
+    ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo & AppTimeLimitRepo &
       DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo & AppRepo
 
   /** One fixture row → the spec runs the equalities against every row. */

--- a/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
+++ b/api/test/src/feature/PolicySnapshotFailureModeSpec.scala
@@ -32,14 +32,14 @@ object PolicySnapshotFailureModeSpec
         sr     <- ZIO.service[ScheduleRepo]
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
         blr    <- ZIO.service[BlocklistRepo]
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         ar     <- ZIO.service[AppRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
         profiles0 <- pr.listAll
         kidsId   = profiles0.find(_.name == "Kids").get.id
         adultsId = profiles0.find(_.name == "Adults").get.id
@@ -65,14 +65,14 @@ object PolicySnapshotFailureModeSpec
         sr     <- ZIO.service[ScheduleRepo]
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
         blr    <- ZIO.service[BlocklistRepo]
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         ar     <- ZIO.service[AppRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
         profiles0 <- pr.listAll
         _         <- pr.update(
           profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),
@@ -92,14 +92,14 @@ object PolicySnapshotFailureModeSpec
         sr     <- ZIO.service[ScheduleRepo]
         hsr    <- ZIO.service[HouseholdSettingsRepo]
         tlr    <- ZIO.service[TimeLimitRepo]
-        stlr   <- ZIO.service[SiteTimeLimitRepo]
+        atlr   <- ZIO.service[AppTimeLimitRepo]
         dr     <- ZIO.service[DeviceRepo]
         blr    <- ZIO.service[BlocklistRepo]
         trRepo <- ZIO.service[TrafficReportRepo]
         er     <- ZIO.service[TimeExtensionRepo]
         ar     <- ZIO.service[AppRepo]
         clock  <- ZIO.service[Clock]
-        svc = PolicyServiceLive(pr, sr, hsr, tlr, stlr, dr, blr, trRepo, er, ar, clock)
+        svc = PolicyServiceLive(pr, sr, hsr, tlr, atlr, dr, blr, trRepo, er, ar, clock)
         profiles0 <- pr.listAll
         _         <- pr.update(
           profiles0.find(_.name == "Kids").get.copy(failureMode = FailureMode.BlockAll),

--- a/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalAllowSpec.scala
@@ -41,7 +41,7 @@ object PolicySnapshotGlobalAllowSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -54,7 +54,7 @@ object PolicySnapshotGlobalAllowSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,
@@ -77,7 +77,7 @@ object PolicySnapshotGlobalAllowSpec
         sr   <- ZIO.service[ScheduleRepo]
         hsr  <- ZIO.service[HouseholdSettingsRepo]
         tlr  <- ZIO.service[TimeLimitRepo]
-        stlr <- ZIO.service[SiteTimeLimitRepo]
+        atlr <- ZIO.service[AppTimeLimitRepo]
         dr   <- ZIO.service[DeviceRepo]
         blr  <- ZIO.service[BlocklistRepo]
         trr  <- ZIO.service[TrafficReportRepo]
@@ -93,7 +93,7 @@ object PolicySnapshotGlobalAllowSpec
           sr,
           hsr,
           tlr,
-          stlr,
+          atlr,
           dr,
           blr,
           trr,

--- a/api/test/src/feature/PolicySnapshotGlobalPrecedenceSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalPrecedenceSpec.scala
@@ -47,7 +47,7 @@ object PolicySnapshotGlobalPrecedenceSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -62,7 +62,7 @@ object PolicySnapshotGlobalPrecedenceSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
+++ b/api/test/src/feature/PolicySnapshotGlobalSectionSpec.scala
@@ -34,7 +34,7 @@ object PolicySnapshotGlobalSectionSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -47,7 +47,7 @@ object PolicySnapshotGlobalSectionSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotNamedScheduleSpec.scala
@@ -44,7 +44,7 @@ object PolicySnapshotNamedScheduleSpec
       nsr    <- ZIO.service[NamedScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -56,7 +56,7 @@ object PolicySnapshotNamedScheduleSpec
         pr,
         sr,
         tlr,
-        stlr,
+        atlr,
         dr,
         trRepo,
         er,
@@ -68,7 +68,7 @@ object PolicySnapshotNamedScheduleSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/PolicySnapshotPerAppScheduleSpec.scala
+++ b/api/test/src/feature/PolicySnapshotPerAppScheduleSpec.scala
@@ -43,7 +43,7 @@ object PolicySnapshotPerAppScheduleSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -57,7 +57,7 @@ object PolicySnapshotPerAppScheduleSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/PresenceDefaultsPinSpec.scala
+++ b/api/test/src/feature/PresenceDefaultsPinSpec.scala
@@ -107,7 +107,7 @@ object PresenceDefaultsPinSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[HouseholdSettingsRepo]
-      stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+      atlRepo         <- ZIO.service[AppTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield UsageRoutes.routes(
@@ -119,7 +119,7 @@ object PresenceDefaultsPinSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
       appRepo,
       rollupRepo,
       hsRepo,
-      stlRepo,
+      atlRepo,
       clock,
     )
 

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -21,8 +21,8 @@ import zio.test.Assertion.*
  * These exercise the full stack: HTTP handler → service → real Postgres. No mocks except Clock and
  * upstream DNS socket.
  *
- * Post-#764: profile-side `extraBlocked`/`extraAllowed`/`siteTimeLimits` were migrated into the
- * apps schema and dropped from the wire — those concerns are exercised via app endpoints/specs.
+ * Post-#764: profile-side `extraBlocked`/`extraAllowed`/`appTimeLimits` were migrated into the apps
+ * schema and dropped from the wire — those concerns are exercised via app endpoints/specs.
  */
 object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 

--- a/api/test/src/feature/ReasonTextBackfillSpec.scala
+++ b/api/test/src/feature/ReasonTextBackfillSpec.scala
@@ -49,18 +49,18 @@ object ReasonTextBackfillSpec
    * pre-V40 wire string the backfill should produce in `reason_text`.
    */
   private val cases: List[(String, String)] = List(
-    """{"kind":"allow"}"""                             -> "allow",
-    """{"kind":"blocked"}"""                           -> "blocked",
-    """{"kind":"extraAllowed"}"""                      -> "extra_allowed",
-    """{"kind":"extraBlocked"}"""                      -> "extra_blocked",
-    """{"kind":"noProfile"}"""                         -> "no_profile",
-    """{"kind":"paused"}"""                            -> "paused",
-    """{"kind":"schedule"}"""                          -> "schedule",
-    """{"kind":"timeLimit"}"""                         -> "time_limit",
-    """{"kind":"manual"}"""                            -> "manual",
-    """{"kind":"unmanaged"}"""                         -> "unmanaged_mac",
-    """{"kind":"category","slug":"social-media"}"""    -> "category:social-media",
-    """{"kind":"siteTimeLimit","label":"youtube"}"""   -> "site_time_limit:youtube",
+    """{"kind":"allow"}"""                          -> "allow",
+    """{"kind":"blocked"}"""                        -> "blocked",
+    """{"kind":"extraAllowed"}"""                   -> "extra_allowed",
+    """{"kind":"extraBlocked"}"""                   -> "extra_blocked",
+    """{"kind":"noProfile"}"""                      -> "no_profile",
+    """{"kind":"paused"}"""                         -> "paused",
+    """{"kind":"schedule"}"""                       -> "schedule",
+    """{"kind":"timeLimit"}"""                      -> "time_limit",
+    """{"kind":"manual"}"""                         -> "manual",
+    """{"kind":"unmanaged"}"""                      -> "unmanaged_mac",
+    """{"kind":"category","slug":"social-media"}""" -> "category:social-media",
+    """{"kind":"siteTimeLimit","label":"youtube"}""" -> "site_time_limit:youtube", // FROZEN wire token (#376): keep literal until wire versioning
     """{"kind":"appBlocked","appId":"netflix"}"""      -> "app:netflix",
     """{"kind":"unknown","raw":"some-legacy-value"}""" -> "some-legacy-value",
   )

--- a/api/test/src/feature/ReasonTextDualWriteSpec.scala
+++ b/api/test/src/feature/ReasonTextDualWriteSpec.scala
@@ -64,7 +64,7 @@ object ReasonTextDualWriteSpec
     MacBlockReason.Manual                                    -> "manual",
     MacBlockReason.Unmanaged                                 -> "unmanaged_mac",
     BlockReason.Category(BlocklistId.unsafe("social-media")) -> "category:social-media",
-    BlockReason.SiteTimeLimit("youtube")                     -> "site_time_limit:youtube",
+    BlockReason.AppTimeLimit("youtube")                      -> "site_time_limit:youtube",
     BlockReason.AppBlocked("netflix")                        -> "app:netflix",
     BlockReason.Unknown("weird")                             -> "weird",
   )

--- a/api/test/src/feature/RecentApexesApiSpec.scala
+++ b/api/test/src/feature/RecentApexesApiSpec.scala
@@ -124,7 +124,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
-      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      atlRepo         <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -137,7 +137,7 @@ object RecentApexesApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         appRepo,
         rollupRepo,
         hsRepo,
-        stlRepo,
+        atlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/RouterApiSpec.scala
+++ b/api/test/src/feature/RouterApiSpec.scala
@@ -39,7 +39,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -51,7 +51,7 @@ object RouterApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & 
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/RouterDecisionConsolidationSpec.scala
+++ b/api/test/src/feature/RouterDecisionConsolidationSpec.scala
@@ -45,7 +45,7 @@ object RouterDecisionConsolidationSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -59,7 +59,7 @@ object RouterDecisionConsolidationSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/RouterDecisionPerAppScheduleSpec.scala
+++ b/api/test/src/feature/RouterDecisionPerAppScheduleSpec.scala
@@ -36,7 +36,7 @@ object RouterDecisionPerAppScheduleSpec
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -50,7 +50,7 @@ object RouterDecisionPerAppScheduleSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/RouterDecisionSpec.scala
+++ b/api/test/src/feature/RouterDecisionSpec.scala
@@ -29,7 +29,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -43,7 +43,7 @@ object RouterDecisionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -74,7 +74,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       sr     <- ZIO.service[ScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -86,7 +86,7 @@ object RouterIngestSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/ScheduleMigrationBehaviorSpec.scala
+++ b/api/test/src/feature/ScheduleMigrationBehaviorSpec.scala
@@ -94,7 +94,7 @@ object ScheduleMigrationBehaviorSpec
       nsr    <- ZIO.service[NamedScheduleRepo]
       hsr    <- ZIO.service[HouseholdSettingsRepo]
       tlr    <- ZIO.service[TimeLimitRepo]
-      stlr   <- ZIO.service[SiteTimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
       dr     <- ZIO.service[DeviceRepo]
       blr    <- ZIO.service[BlocklistRepo]
       trRepo <- ZIO.service[TrafficReportRepo]
@@ -107,7 +107,7 @@ object ScheduleMigrationBehaviorSpec
       sr,
       hsr,
       tlr,
-      stlr,
+      atlr,
       dr,
       blr,
       trRepo,

--- a/api/test/src/feature/TimeApiSpec.scala
+++ b/api/test/src/feature/TimeApiSpec.scala
@@ -93,7 +93,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
@@ -110,7 +110,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -119,7 +119,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -145,7 +145,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -166,7 +166,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -175,7 +175,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -198,7 +198,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -229,7 +229,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -238,7 +238,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -256,7 +256,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         } yield assertTrue(status.usedMins == 60) && // YouTube NOT counted in total
           assertTrue(status.remainingMins.contains(60)) &&
           assertTrue(
-            status.siteUsage.exists(su =>
+            status.appUsage.exists(su =>
               su.label == "app:*.youtube.com" && su.usedMins == 20 && su.remainingMins == 10,
             ),
           )
@@ -266,7 +266,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -296,7 +296,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -305,7 +305,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -323,7 +323,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         yield assertTrue(status.usedMins == 60) &&         // YouTube IS counted in total
           assertTrue(status.remainingMins.contains(60)) && // 120 - 60 = 60
           assertTrue(
-            status.siteUsage.exists(su =>
+            status.appUsage.exists(su =>
               su.label == "app:*.youtube.com" && su.usedMins == 60 && su.remainingMins == 0,
             ),
           )
@@ -335,7 +335,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -355,7 +355,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -364,7 +364,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -394,7 +394,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
@@ -411,7 +411,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -420,7 +420,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -446,7 +446,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
@@ -465,7 +465,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -474,7 +474,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -495,7 +495,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _               <- cleanDb
           profileRepo     <- ZIO.service[ProfileRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
@@ -512,7 +512,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -521,7 +521,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -558,7 +558,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -576,7 +576,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -585,7 +585,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -625,7 +625,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -648,7 +648,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -657,7 +657,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -694,7 +694,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -728,7 +728,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -737,7 +737,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -769,7 +769,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -794,7 +794,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -803,7 +803,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -835,7 +835,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -860,7 +860,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -869,7 +869,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -893,7 +893,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -924,7 +924,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -933,7 +933,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -957,7 +957,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -987,7 +987,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -996,7 +996,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1020,7 +1020,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1054,7 +1054,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1063,7 +1063,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1079,7 +1079,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           body <- resp.body.asString
           list <- ZIO.fromEither(body.fromJson[List[ProfileTimeStatus]])
           kids = list.find(_.profileId == kidsId).get
-          yt   = kids.siteUsage.find(_.label == "app:youtube.com").get
+          yt   = kids.appUsage.find(_.label == "app:youtube.com").get
         } yield assertTrue(yt.usedMins == 40) && // both devices summed
           assertTrue(yt.limitMins == 30) &&
           assertTrue(yt.remainingMins == 0) &&   // clamped to 0
@@ -1093,7 +1093,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1118,7 +1118,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1127,7 +1127,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1157,7 +1157,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1188,7 +1188,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1197,7 +1197,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1229,7 +1229,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1261,7 +1261,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1270,7 +1270,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1313,7 +1313,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1369,7 +1369,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1378,7 +1378,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1415,7 +1415,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1442,7 +1442,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1451,7 +1451,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1483,7 +1483,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1508,7 +1508,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1517,7 +1517,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1546,7 +1546,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1573,7 +1573,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             schedRepo,
             hsRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             blocklistRepo,
             trafficRepo,
@@ -1596,7 +1596,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1655,7 +1655,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1664,7 +1664,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1698,7 +1698,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1743,7 +1743,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1752,7 +1752,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1788,7 +1788,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1810,7 +1810,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1819,7 +1819,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1851,7 +1851,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1875,7 +1875,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1884,7 +1884,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1925,7 +1925,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -1958,7 +1958,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -1967,7 +1967,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -1996,7 +1996,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2024,7 +2024,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2033,7 +2033,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2064,7 +2064,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2084,7 +2084,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2093,7 +2093,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2138,7 +2138,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2159,7 +2159,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2168,7 +2168,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2213,7 +2213,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
           extRepo         <- ZIO.service[TimeExtensionRepo]
@@ -2226,7 +2226,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2235,7 +2235,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2260,7 +2260,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2287,7 +2287,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2296,7 +2296,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2334,7 +2334,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           profileRepo     <- ZIO.service[ProfileRepo]
           schedRepo       <- ZIO.service[ScheduleRepo]
           tlRepo          <- ZIO.service[TimeLimitRepo]
-          stlRepo         <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo         <- ZIO.service[AppTimeLimitRepo]
           deviceRepo      <- ZIO.service[DeviceRepo]
           trafficRepo     <- ZIO.service[TrafficReportRepo]
           extRepo         <- ZIO.service[TimeExtensionRepo]
@@ -2347,7 +2347,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2356,7 +2356,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2386,7 +2386,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2422,7 +2422,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2431,7 +2431,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,
@@ -2462,7 +2462,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
           tlRepo      <- ZIO.service[TimeLimitRepo]
-          stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+          atlRepo     <- ZIO.service[AppTimeLimitRepo]
           schedRepo   <- ZIO.service[ScheduleRepo]
           deviceRepo  <- ZIO.service[DeviceRepo]
           trafficRepo <- ZIO.service[TrafficReportRepo]
@@ -2494,7 +2494,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             profileRepo,
             schedRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             deviceRepo,
             trafficRepo,
             extRepo,
@@ -2503,7 +2503,7 @@ object TimeApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
             auth,
             deviceRepo,
             tlRepo,
-            stlRepo,
+            atlRepo,
             trafficRepo,
             extRepo,
             profileRepo,

--- a/api/test/src/feature/TimeStatusCacheSpec.scala
+++ b/api/test/src/feature/TimeStatusCacheSpec.scala
@@ -86,7 +86,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       auth        <- makeAuth
       deviceRepo  <- ZIO.service[DeviceRepo]
       tlRepo      <- ZIO.service[TimeLimitRepo]
-      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+      atlRepo     <- ZIO.service[AppTimeLimitRepo]
       trafficRepo <- ZIO.service[TrafficReportRepo]
       extRepo     <- ZIO.service[TimeExtensionRepo]
       profileRepo <- ZIO.service[ProfileRepo]
@@ -98,7 +98,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         profileRepo,
         schedRepo,
         tlRepo,
-        stlRepo,
+        atlRepo,
         deviceRepo,
         trafficRepo,
         extRepo,
@@ -107,7 +107,7 @@ object TimeStatusCacheSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       auth,
       deviceRepo,
       tlRepo,
-      stlRepo,
+      atlRepo,
       trafficRepo,
       extRepo,
       profileRepo,

--- a/api/test/src/feature/TimeStatusServiceSpec.scala
+++ b/api/test/src/feature/TimeStatusServiceSpec.scala
@@ -23,8 +23,8 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
   private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeService: ZIO[
-    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo,
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
+      TimeExtensionRepo,
     Nothing,
     TimeStatusService,
   ] =
@@ -32,11 +32,11 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       pr   <- ZIO.service[ProfileRepo]
       sr   <- ZIO.service[ScheduleRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       trr  <- ZIO.service[TrafficReportRepo]
       er   <- ZIO.service[TimeExtensionRepo]
-    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er)
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er)
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-tss", Sha256Hex.unsafe("t" * 64)))
@@ -281,7 +281,7 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         stOpt <- svc.todaysState(now, s, kid)
       } yield assertTrue(stOpt.exists(_.usedMinutes == 10)) &&
         assertTrue(
-          stOpt.exists(_.perSite.exists(p => p.domainPattern == "khan.org" && p.exemptFromDaily)),
+          stOpt.exists(_.perApp.exists(p => p.domainPattern == "khan.org" && p.exemptFromDaily)),
         )
     },
     test("#1504: per-site usage counts engaged minutes, blocking at the true cap not bucket-max") {
@@ -320,12 +320,12 @@ object TimeStatusServiceSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         stOpt <- svc.todaysState(now, s, kid)
       } yield assertTrue(
         stOpt.exists(
-          _.perSite.exists(p => p.domainPattern == "mathacademy.com" && p.usedMinutes == 30),
+          _.perApp.exists(p => p.domainPattern == "mathacademy.com" && p.usedMinutes == 30),
         ),
       ) &&
         assertTrue(
           stOpt.exists(
-            _.perSite.exists(p =>
+            _.perApp.exists(p =>
               p.domainPattern == "mathacademy.com" && p.usedMinutes >= p.dailyLimitMinutes,
             ),
           ),

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -27,8 +27,8 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
   private val cleanDb = TestDatabase.cleanAndMigrate
 
   private def makeService: ZIO[
-    ProfileRepo & ScheduleRepo & TimeLimitRepo & SiteTimeLimitRepo & DeviceRepo &
-      TrafficReportRepo & TimeExtensionRepo & TimeUsedRollupRepo & HouseholdSettingsRepo,
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
+      TimeExtensionRepo & TimeUsedRollupRepo & HouseholdSettingsRepo,
     Nothing,
     TimeStatusService,
   ] =
@@ -36,12 +36,12 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
       pr   <- ZIO.service[ProfileRepo]
       sr   <- ZIO.service[ScheduleRepo]
       tlr  <- ZIO.service[TimeLimitRepo]
-      stlr <- ZIO.service[SiteTimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
       dr   <- ZIO.service[DeviceRepo]
       trr  <- ZIO.service[TrafficReportRepo]
       er   <- ZIO.service[TimeExtensionRepo]
       ru   <- ZIO.service[TimeUsedRollupRepo]
-    } yield new TimeStatusServiceLive(pr, sr, tlr, stlr, dr, trr, er, ru)
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er, ru)
 
   private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
     ZIO.serviceWithZIO[RouterRepo](_.create("gw-tur", Sha256Hex.unsafe("t" * 64)))
@@ -128,10 +128,10 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
             devices <- ZIO
               .serviceWithZIO[DeviceRepo](_.listAll)
               .map(_.filter(_.profileId.contains(kid)))
-            stls    <- ZIO.serviceWithZIO[SiteTimeLimitRepo](_.listForProfile(kid))
+            atls    <- ZIO.serviceWithZIO[AppTimeLimitRepo](_.listForProfile(kid))
             allPres <- trr.listPresenceRows(devices.map(_.mac), today)
             prefixP = allPres.filter(_.periodStart.isBefore(prefix))
-            secs    = TimeStatusService.usedSecondsForProfile(profile, devices, stls, prefixP, s)
+            secs    = TimeStatusService.usedSecondsForProfile(profile, devices, atls, prefixP, s)
           } yield secs
         }
         _        <- ru.upsertDay(kid, today, RolledDay(rolledA, watermark))
@@ -151,7 +151,7 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         aru <- ZIO.service[AppUsedRollupRepo]
         ar  <- ZIO.service[AppRepo]
         trr <- ZIO.service[TrafficReportRepo]
-        stl <- ZIO.service[SiteTimeLimitRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
         s   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:20", "kid-a", kid)
@@ -239,7 +239,7 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         aru <- ZIO.service[AppUsedRollupRepo]
         ar  <- ZIO.service[AppRepo]
         trr <- ZIO.service[TrafficReportRepo]
-        stl <- ZIO.service[SiteTimeLimitRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
         _   <- setTz(hsr, "UTC")
         kid <- TestLayers.seedKidsProfile(pr, sr)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:50", "kid", kid)

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -91,7 +91,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[wifihaven.api.db.RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
-      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      atlRepo         <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -104,7 +104,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         appRepo,
         rollupRepo,
         hsRepo,
-        stlRepo,
+        atlRepo,
         clock,
       ),
       auth,
@@ -112,7 +112,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
 
   // #1517 — the numbers along the per-app reconciliation chain for a single time-limited app, read
   // the way an operator would: the #1510 rollup accessor, the per-app cap aggregate
-  // (`SiteDayState.usedMinutes`), the per-app graph series (`/usage/series?groupBy=app`), the profile
+  // (`AppDayState.usedMinutes`), the per-app graph series (`/usage/series?groupBy=app`), the profile
   // headline total, the legacy per-host proportional sum (what the un-bridged series plotted), and
   // the app's per-hour series minutes.
   private case class AppReco(
@@ -144,7 +144,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       trafficRepo <- ZIO.service[TrafficReportRepo]
       appRepo     <- ZIO.service[AppRepo]
       timeLimRepo <- ZIO.service[TimeLimitRepo]
-      stlRepo     <- ZIO.service[SiteTimeLimitRepo]
+      atlRepo     <- ZIO.service[AppTimeLimitRepo]
       extRepo     <- ZIO.service[TimeExtensionRepo]
       ruRepo      <- ZIO.service[TimeUsedRollupRepo]
       aruRepo     <- ZIO.service[AppUsedRollupRepo]
@@ -170,7 +170,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         aruRepo,
         profileRepo,
         deviceRepo,
-        stlRepo,
+        atlRepo,
         appRepo,
         trafficRepo,
         hsr,
@@ -179,25 +179,25 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
       reader = new AppUsedRollupServiceLive(
         profileRepo,
         deviceRepo,
-        stlRepo,
+        atlRepo,
         appRepo,
         trafficRepo,
         aruRepo,
       )
       rollup <- reader.appEngagedMinutes(now, today, settings, kidsId)
-      // Per-app cap aggregate (SiteDayState.usedMinutes).
+      // Per-app cap aggregate (AppDayState.usedMinutes).
       tsvc = new TimeStatusServiceLive(
         profileRepo,
         schedRepo,
         timeLimRepo,
-        stlRepo,
+        atlRepo,
         deviceRepo,
         trafficRepo,
         extRepo,
         ruRepo,
       )
       state <- tsvc.dayStateLive(now, today, settings, kidsId)
-      capMin = state.flatMap(_.perSite.find(_.label == s"app:$appSlug").map(_.usedMinutes))
+      capMin = state.flatMap(_.perApp.find(_.label == s"app:$appSlug").map(_.usedMinutes))
       // The legacy per-host proportional sum (what the un-bridged series plotted).
       rows <- trafficRepo.listPresenceRows(List(MacAddress.unsafe(testMac)), today)
       perHostPropMins = (wifihaven.api.presence.Presence
@@ -1481,11 +1481,12 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           body <- resp.body.asString
           out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
           yt = out.aggregateRows.find(_.groups.getOrElse("app", "") == "youtube").get
-          ot = out.aggregateRows.find(_.groups.getOrElse("app", "") == "__other__").get
+          // #1526: google.com → its own single-host app keyed by the host.
+          ot = out.aggregateRows.find(_.groups.getOrElse("app", "") == "google.com").get
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(out.groupBy == List("app")) &&
           assertTrue(out.aggregateRows.length == 2) &&
-          // Bytes invariant: app + __other__ together cover everything that was inserted.
+          // Bytes invariant: app + single-host-app row together cover everything that was inserted.
           assertTrue(
             out.aggregateRows.map(_.totalBytesIn).sum == 1600L,
           ) &&
@@ -1498,7 +1499,7 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           assertTrue(yt.appIcon.contains("📺")) &&
           assertTrue(yt.appId.isDefined) &&
           assertTrue(ot.totalBytesIn == 100L) &&
-          assertTrue(ot.appName.contains("Other")) &&
+          assertTrue(ot.appName.contains("google.com")) &&
           assertTrue(ot.appId.isEmpty)
       },
       test("#769: groupBy=app fans a multi-app host into one row per app") {
@@ -1572,7 +1573,8 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           routerId    <- seedRouter
           // App "YouTube" owns apex youtube.com + ytimg.com; traffic arrives
           // on FQDN subdomains (www.youtube.com, i.ytimg.com) — must still
-          // attribute to YouTube, not __other__.
+          // attribute to YouTube. #1526: api.mcsrvstat.us has no apex match, so
+          // it becomes its own single-host app keyed by the host.
           ytId        <- appRepo.create("YouTube", "youtube", None, Some("📺"))
           _           <- appRepo.setHosts(
             ytId,
@@ -1638,16 +1640,18 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
           body <- resp.body.asString
           out  <- ZIO.fromEither(body.fromJson[TrafficUsageResponse])
           yt = out.aggregateRows.find(_.groups.getOrElse("app", "") == "youtube").get
-          ot = out.aggregateRows.find(_.groups.getOrElse("app", "") == "__other__").get
+          // #1526: api.mcsrvstat.us → its own single-host app keyed by the host.
+          ot = out.aggregateRows.find(_.groups.getOrElse("app", "") == "api.mcsrvstat.us").get
         } yield assertTrue(resp.status == Status.Ok) &&
           assertTrue(out.aggregateRows.length == 2) &&
           // www.youtube.com + i.ytimg.com both roll up to YouTube.
           assertTrue(yt.totalBytesIn == 1500L) &&
           assertTrue(yt.totalBytesOut == 3500L) &&
           assertTrue(yt.appName.contains("YouTube")) &&
-          // Only api.mcsrvstat.us (no apex match) lands in Other.
+          // api.mcsrvstat.us (no apex match) is its own single-host app row.
           assertTrue(ot.totalBytesIn == 100L) &&
           assertTrue(ot.totalBytesOut == 100L) &&
+          assertTrue(ot.appName.contains("api.mcsrvstat.us")) &&
           assertTrue(ot.appId.isEmpty)
       },
       // #769: groupBy=app is now implemented; the apex case still rejects.

--- a/api/test/src/feature/UsageRoutingSpec.scala
+++ b/api/test/src/feature/UsageRoutingSpec.scala
@@ -56,7 +56,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
-      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      atlRepo         <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- buildAuth
     } yield (
@@ -69,7 +69,7 @@ object UsageRoutingSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         appRepo,
         rollupRepo,
         hsRepo,
-        stlRepo,
+        atlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/feature/UsageSeriesPerfSpec.scala
+++ b/api/test/src/feature/UsageSeriesPerfSpec.scala
@@ -91,7 +91,7 @@ object UsageSeriesPerfSpec
       appRepo         <- ZIO.service[AppRepo]
       rollupRepo      <- ZIO.service[RollupRepo]
       hsRepo          <- ZIO.service[wifihaven.api.db.HouseholdSettingsRepo]
-      stlRepo         <- ZIO.service[wifihaven.api.db.SiteTimeLimitRepo]
+      atlRepo         <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
       clock           <- ZIO.service[Clock]
       auth            <- makeAuth
     } yield (
@@ -104,7 +104,7 @@ object UsageSeriesPerfSpec
         appRepo,
         rollupRepo,
         hsRepo,
-        stlRepo,
+        atlRepo,
         clock,
       ),
       auth,

--- a/api/test/src/unit/PerAppScheduleSpec.scala
+++ b/api/test/src/unit/PerAppScheduleSpec.scala
@@ -246,7 +246,7 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
           blocked = true,
           blockReason =
             Some(MacBlockReason.Schedule), // higher-precedence reason; gate must ignore it
-          perSite = Nil,
+          perApp = Nil,
         )
         assertTrue(PolicyService.dailyCapExhausted(st))
       },
@@ -260,7 +260,7 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
           remainingMinutes = Some(5),
           blocked = false,
           blockReason = None,
-          perSite = Nil,
+          perApp = Nil,
         )
         assertTrue(!PolicyService.dailyCapExhausted(st))
       },
@@ -274,7 +274,7 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
           remainingMinutes = None,
           blocked = false,
           blockReason = None,
-          perSite = Nil,
+          perApp = Nil,
         )
         assertTrue(!PolicyService.dailyCapExhausted(st))
       },

--- a/api/test/src/unit/UsageTrafficSpec.scala
+++ b/api/test/src/unit/UsageTrafficSpec.scala
@@ -90,6 +90,33 @@ object UsageTrafficSpec extends ZIOSpecDefault {
       assertTrue(out.head.windowStart == base.toString) &&
       assertTrue(out.head.windowEnd == base.plusSeconds(600L).toString)
     },
+    test("#1526: unmatched hosts each become their own single-host app (no 'Other' bucket)") {
+      // Two distinct hosts, neither in any registered app. Under the old model
+      // both rows would collapse into one synthetic `__other__` row; under the
+      // app-focused model each unmatched host is its own single-host app, so
+      // grouping by app must produce two distinct rows keyed by host.
+      val hostA = HostId.Fqdn(Hostname.unsafe("example-a.com"))
+      val hostB = HostId.Fqdn(Hostname.unsafe("example-b.com"))
+      val rows  = List(
+        TrafficUsageDbRow(mac1, hostA, base, base.plusSeconds(300), 60, 1000L, 200L),
+        TrafficUsageDbRow(mac1, hostB, base, base.plusSeconds(300), 60, 1000L, 200L),
+      )
+      val out   = UsageTraffic.buildAggregate(
+        rows = rows,
+        bucket = UsageTraffic.Bucket.TenMin,
+        zone = UTC,
+        groupBy = Set(UsageTraffic.GroupBy.App),
+        deviceByMac = Map.empty,
+        profileNameById = Map.empty,
+        appsByHost = Map.empty, // no apps registered
+      )
+      val appSlugs = out.flatMap(_.groups.get("app")).toSet
+      // Two unmatched hosts → two single-host apps, NOT one shared bucket.
+      assertTrue(out.length == 2) &&
+      assertTrue(appSlugs.size == 2) &&
+      assertTrue(!appSlugs.contains("__other__")) &&
+      assertTrue(appSlugs == Set(hostA.value, hostB.value))
+    },
     test("floorTo and stepOf agree for each sub-day bucket (no 2× stride anywhere)") {
       // For every sub-day bucket: flooring an instant inside the bucket should
       // never produce a window wider than `stepOf(bucket)` — i.e. `start +

--- a/api/test/src/unit/UsageTrafficSpec.scala
+++ b/api/test/src/unit/UsageTrafficSpec.scala
@@ -95,13 +95,13 @@ object UsageTrafficSpec extends ZIOSpecDefault {
       // both rows would collapse into one synthetic `__other__` row; under the
       // app-focused model each unmatched host is its own single-host app, so
       // grouping by app must produce two distinct rows keyed by host.
-      val hostA = HostId.Fqdn(Hostname.unsafe("example-a.com"))
-      val hostB = HostId.Fqdn(Hostname.unsafe("example-b.com"))
-      val rows  = List(
+      val hostA    = HostId.Fqdn(Hostname.unsafe("example-a.com"))
+      val hostB    = HostId.Fqdn(Hostname.unsafe("example-b.com"))
+      val rows     = List(
         TrafficUsageDbRow(mac1, hostA, base, base.plusSeconds(300), 60, 1000L, 200L),
         TrafficUsageDbRow(mac1, hostB, base, base.plusSeconds(300), 60, 1000L, 200L),
       )
-      val out   = UsageTraffic.buildAggregate(
+      val out      = UsageTraffic.buildAggregate(
         rows = rows,
         bucket = UsageTraffic.Bucket.TenMin,
         zone = UTC,

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -255,8 +255,8 @@ case class TimeLimit(
     dailyMinutes: Int,
 ) derives JsonCodec
 
-case class SiteTimeLimit(
-    id: SiteTimeLimitId,
+case class AppTimeLimit(
+    id: AppTimeLimitId,
     profileId: ProfileId,
     domainPattern: String,
     dailyMinutes: Int,
@@ -825,7 +825,7 @@ case class ConnectionEventAggRow(
     appIcon: Option[String] = None,
 ) derives JsonCodec
 
-case class SiteUsage(
+case class AppUsage(
     label: String,
     domainPattern: String,
     limitMins: Int,
@@ -843,7 +843,7 @@ case class DeviceTimeStatus(
     usedMins: Int,
     extensionMins: Int,
     remainingMins: Option[Int],
-    siteUsage: List[SiteUsage],
+    appUsage: List[AppUsage],
 ) derives JsonCodec
 
 case class DeviceUsageSummary(
@@ -903,7 +903,7 @@ case class ProfileTimeStatus(
     usedMins: Int,
     extensionMins: Int,
     remainingMins: Option[Int],
-    siteUsage: List[SiteUsage],
+    appUsage: List[AppUsage],
     devices: List[DeviceUsageSummary],
     hostUsage: List[HostUsage],
 ) derives JsonCodec
@@ -1645,15 +1645,15 @@ object MacBlockReason {
 // the event-table form without re-encoding (their wire form is unchanged in
 // the snapshot JSON — only the event-DB encoding becomes kind-tagged).
 object BlockReason {
-  case object Allow                       extends BlockReason
-  case object Blocked                     extends BlockReason
-  case object ExtraAllowed                extends BlockReason
-  case object ExtraBlocked                extends BlockReason
-  case object NoProfile                   extends BlockReason
-  case class Category(slug: BlocklistId)  extends BlockReason
-  case class SiteTimeLimit(label: String) extends BlockReason
-  case class AppBlocked(appId: String)    extends BlockReason
-  case class Unknown(raw: String)         extends BlockReason
+  case object Allow                      extends BlockReason
+  case object Blocked                    extends BlockReason
+  case object ExtraAllowed               extends BlockReason
+  case object ExtraBlocked               extends BlockReason
+  case object NoProfile                  extends BlockReason
+  case class Category(slug: BlocklistId) extends BlockReason
+  case class AppTimeLimit(label: String) extends BlockReason
+  case class AppBlocked(appId: String)   extends BlockReason
+  case class Unknown(raw: String)        extends BlockReason
 
   /**
    * Parse a router / PolicyService wire-format reason string. Unknown values fall through to
@@ -1677,8 +1677,11 @@ object BlockReason {
         .parse(s.stripPrefix("category:"))
         .map(Category(_))
         .getOrElse(Unknown(s))
-    case s if s.startsWith("site_time_limit:")                 =>
-      SiteTimeLimit(s.stripPrefix("site_time_limit:"))
+    case s
+        if s.startsWith(
+          "site_time_limit:",
+        ) => // FROZEN wire token (#376): keep literal until wire versioning
+      AppTimeLimit(s.stripPrefix("site_time_limit:"))
     case s if s.startsWith("app:")                             =>
       AppBlocked(s.stripPrefix("app:"))
     case other                                                 => Unknown(other)
@@ -1710,7 +1713,8 @@ object BlockReason {
     case MacBlockReason.Unmanaged   => "unmanaged_mac"
     case MacBlockReason.DefaultDeny => "default_deny"
     case Category(slug)             => s"category:${slug.value}"
-    case SiteTimeLimit(label)       => s"site_time_limit:$label"
+    case AppTimeLimit(label)        =>
+      s"site_time_limit:$label" // FROZEN wire token (#376): keep literal until wire versioning
     case AppBlocked(appId)          => s"app:$appId"
     case Unknown(raw)               => raw
   }
@@ -1732,8 +1736,11 @@ object BlockReason {
     case MacBlockReason.DefaultDeny => Json.Obj("kind" -> Json.Str("defaultDeny"))
     case Category(slug)             =>
       Json.Obj("kind" -> Json.Str("category"), "slug" -> Json.Str(slug.value))
-    case SiteTimeLimit(label)       =>
-      Json.Obj("kind" -> Json.Str("siteTimeLimit"), "label" -> Json.Str(label))
+    case AppTimeLimit(label)        =>
+      Json.Obj(
+        "kind"  -> Json.Str("siteTimeLimit"),
+        "label" -> Json.Str(label),
+      ) // FROZEN wire token (#376): keep literal until wire versioning
     case AppBlocked(appId)          =>
       Json.Obj("kind" -> Json.Str("appBlocked"), "appId" -> Json.Str(appId))
     case Unknown(raw)               =>
@@ -1764,7 +1771,10 @@ object BlockReason {
           field("slug").flatMap(s =>
             BlocklistId.parse(s).map(Category(_)).left.map(_ => s"invalid category slug: $s"),
           )
-        case "siteTimeLimit" => field("label").map(SiteTimeLimit(_))
+        case "siteTimeLimit" =>
+          field("label").map(
+            AppTimeLimit(_),
+          ) // FROZEN wire token (#376): keep literal until wire versioning
         case "appBlocked"    => field("appId").map(AppBlocked(_))
         case "unknown"       => field("raw").map(Unknown(_))
         case other           => Left(s"BlockReason: unknown kind '$other'")

--- a/shared/src/types/Ids.scala
+++ b/shared/src/types/Ids.scala
@@ -14,7 +14,7 @@ opaque type ProfileId             = Long
 opaque type DeviceId              = Long
 opaque type ScheduleId            = Long
 opaque type TimeLimitId           = Long
-opaque type SiteTimeLimitId       = Long
+opaque type AppTimeLimitId        = Long
 opaque type TimeExtensionId       = Long
 opaque type UserId                = Long
 opaque type BlockEventId          = Long
@@ -59,10 +59,10 @@ object TimeLimitId {
   given JsonCodec[TimeLimitId]               = JsonCodec.long
 }
 
-object SiteTimeLimitId {
-  def apply(l: Long): SiteTimeLimitId            = l
-  extension (s: SiteTimeLimitId) def value: Long = s
-  given JsonCodec[SiteTimeLimitId]               = JsonCodec.long
+object AppTimeLimitId {
+  def apply(l: Long): AppTimeLimitId            = l
+  extension (s: AppTimeLimitId) def value: Long = s
+  given JsonCodec[AppTimeLimitId]               = JsonCodec.long
 }
 
 object TimeExtensionId {

--- a/shared/test/src/types/BlockReasonSpec.scala
+++ b/shared/test/src/types/BlockReasonSpec.scala
@@ -62,8 +62,8 @@ object BlockReasonSpec extends ZIOSpecDefault {
         assertTrue(r.toJson == "{\"kind\":\"category\",\"slug\":\"ads\"}") &&
         assertTrue(r.toJson.fromJson[BlockReason].contains(r))
       },
-      test("SiteTimeLimit carries label") {
-        val r: BlockReason = BlockReason.SiteTimeLimit("youtube")
+      test("AppTimeLimit carries label") {
+        val r: BlockReason = BlockReason.AppTimeLimit("youtube")
         assertTrue(r.toJson.fromJson[BlockReason].contains(r))
       },
       test("Unknown preserves raw text") {
@@ -114,7 +114,7 @@ object BlockReasonSpec extends ZIOSpecDefault {
       },
       test("site_time_limit:<label>") {
         assertTrue(
-          BlockReason.fromWire("site_time_limit:youtube") == BlockReason.SiteTimeLimit("youtube"),
+          BlockReason.fromWire("site_time_limit:youtube") == BlockReason.AppTimeLimit("youtube"),
         )
       },
       test("unknown form falls back to Unknown(raw)") {
@@ -138,7 +138,7 @@ object BlockReasonSpec extends ZIOSpecDefault {
           BlockReason.ExtraBlocked,
           MacBlockReason.TimeLimit,
           BlockReason.Category(ads),
-          BlockReason.SiteTimeLimit("youtube"),
+          BlockReason.AppTimeLimit("youtube"),
         )
         emitted.foldLeft(assertTrue(true)) { (acc, r) =>
           acc && assertTrue(BlockReason.fromWire(BlockReason.asWire(r)) == r)

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -413,8 +413,9 @@ function NonGroupedCell({
 }
 
 // #769: app-column cell. When grouped, renders the app's icon + display name
-// (or "Other" for the synthetic `__other__` bucket). When not grouped, falls
-// back to the same sole / distinct-count behaviour as the other columns.
+// (or the host itself for a #1526 single-host app — unmatched hosts have
+// appId=null). When not grouped, falls back to the same sole / distinct-count
+// behaviour as the other columns.
 function AppCell({
   active,
   appName,
@@ -508,9 +509,10 @@ function AggregatedEventsView({
 
   if (error) return <ErrorBanner message={error} />
 
-  // #769: drilled into "App" but the household has no apps yet — the rows
-  // would all collapse to a single `__other__` bucket. Point the operator
-  // at the apps screen instead.
+  // #769: drilled into "App" but the household has no apps yet. #1526:
+  // without registered apps the per-host single-host-app grouping is
+  // identical to grouping by Domain — point the operator at the apps screen
+  // to set up real app aggregations.
   const showAppEmpty = groupBy.includes('app') && appCount === 0
   if (showAppEmpty) {
     return (

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -623,7 +623,7 @@ describe('ProfilesPage — create (inline name-only, #978)', () => {
 //                      subsection lands; the column default
 //                      (`last-known-good`) is pinned by the create body
 //                      assertion above.
-// Post-#764 the legacy extraBlocked/extraAllowed/siteTimeLimits fields are
+// Post-#764 the legacy extraBlocked/extraAllowed/appTimeLimits fields are
 // gone — per-host policy lives in apps, exercised by the apps subsection.
 
 describe('ProfilesPage — inline time-limit subsection (#975)', () => {

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -518,9 +518,9 @@ interface AggProps extends FilterHeaderProps {
 }
 
 // #769: app-column cell. When grouped, renders the app's icon + display
-// name (or "Other" for the synthetic `__other__` bucket). When not grouped,
-// falls back to the same sole / distinct-count behaviour as the other
-// columns.
+// name (or the host itself for a #1526 single-host app — unmatched hosts
+// have appId=null). When not grouped, falls back to the same sole /
+// distinct-count behaviour as the other columns.
 function AppCell({
   active,
   appName,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -104,7 +104,7 @@ export interface TimeLimit {
   dailyMinutes: number
 }
 
-export interface SiteTimeLimit {
+export interface AppTimeLimit {
   id: number
   profileId: number
   domainPattern: string
@@ -206,7 +206,7 @@ export type BlockReason =
   | { kind: 'timeLimit' }
   | { kind: 'manual' }
   | { kind: 'category'; slug: string }
-  | { kind: 'siteTimeLimit'; label: string }
+  | { kind: 'siteTimeLimit'; label: string } // FROZEN wire token (#376): keep literal until wire versioning
   | { kind: 'appBlocked'; appId: string }
   | { kind: 'unknown'; raw: string }
 
@@ -303,7 +303,7 @@ export interface DeviceStats {
   blocked: number
 }
 
-export interface SiteUsage {
+export interface AppUsage {
   label: string
   domainPattern: string
   limitMins: number
@@ -321,7 +321,7 @@ export interface DeviceTimeStatus {
   usedMins: number
   extensionMins: number
   remainingMins?: number | null
-  siteUsage: SiteUsage[]
+  appUsage: AppUsage[]
 }
 
 export interface DeviceUsageSummary {
@@ -377,7 +377,7 @@ export interface ProfileTimeStatus {
   usedMins: number
   extensionMins: number
   remainingMins?: number | null
-  siteUsage: SiteUsage[]
+  appUsage: AppUsage[]
   devices: DeviceUsageSummary[]
   hostUsage: HostUsage[]
 }
@@ -542,7 +542,8 @@ export interface UsageSeriesBatchResponse {
 export type TrafficUsageBucket = 'raw' | '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
 // #846: groupBy is composable. Apex is deferred to #856 (needs PSL). #769
 // turned `app` on — it now resolves to a server-side join through
-// `app_hosts`. The empty/synthetic bucket is keyed `__other__`.
+// `app_hosts`. #1526: a host with no registered app is its own single-host
+// app, keyed by the host itself (no shared "Other" bucket).
 export type TrafficUsageGroupBy = 'domain' | 'device' | 'profile' | 'apex' | 'app'
 
 export interface TrafficUsageRawRow {
@@ -579,7 +580,8 @@ export interface TrafficUsageAggregateRow {
   soleDomain?: string | null
   soleApp?: string | null
   // #769: present when `app` is in groupBy. The slug lives in `groups.app`;
-  // these carry the display metadata. `__other__` rows emit appName="Other".
+  // these carry the display metadata. #1526: host-keyed single-host apps
+  // (unmatched hosts) emit appName=<host> and appId=null.
   appId?: number | null
   appName?: string | null
   appIcon?: string | null

--- a/web/src/types/blockReason.ts
+++ b/web/src/types/blockReason.ts
@@ -21,7 +21,7 @@ export function blockReasonText(r: BlockReason): string {
     case 'timeLimit':     return 'daily limit reached'
     case 'manual':        return 'blocked by parent'
     case 'category':      return `category: ${r.slug}`
-    case 'siteTimeLimit': return `site limit: ${r.label}`
+    case 'siteTimeLimit': return `site limit: ${r.label}` // FROZEN wire token (#376): keep literal until wire versioning
     case 'appBlocked':    return `app blocked: ${r.appId}`
     case 'unknown':       return r.raw || 'unknown'
   }


### PR DESCRIPTION
Closes #1526.

## Summary

Two changes, in two commits over a red-green test pair:

1. **Behavior — drop the semantic `__other__` bucket.** A host with no registered app is now its own **single-host app** keyed by the host itself, in both the Scala `UsageTraffic.buildAggregate` and the connection-events series SQL. Two unmatched hosts produce two distinct app rows instead of one shared "Other" bucket. "Other" remains a presentation-only top-N rollup applied AFTER attribution.

2. **Rename — internal `Site*` identifiers → `App*`.** Per the issue: `SiteTimeLimit` / `Repo` / `Id`, `SiteDayState`, `SiteUsage` (+ `siteUsage` field), `perSite`, `siteLimits`, plus the `BlockReason.SiteTimeLimit` case and short locals (`stls`/`stlMap`/`stlRepo`/...). 57 files touched.

## Frozen wire/persisted tokens (gated on #376)

The strings `"site_time_limit:"` (wire reason prefix), `"siteTimeLimit"` (jsonb `kind`), and `"site_time_limit"` (BlockedRoutes tuple, SQL CASE) stay literal. Every preserved literal carries an inline `FROZEN wire token (#376)` comment so a future reader knows why the rename stopped at that line.

## Test plan

- [x] Red commit: new unit test `UsageTrafficSpec` "#1526: unmatched hosts each become their own single-host app" — two unmatched hosts produce two distinct app slugs keyed by host, no `__other__` sentinel.
- [x] Green commit: synthetic per-host `AppMembership` in `UsageTraffic.membershipsFor` + SQL `COALESCE(am.slug, <domain>)` in `connection_events` querySeries.
- [x] `mill __.test` — full suite green.
- [x] `scalafmt --check` — clean.
- [x] `npm run type-check && npm run lint && npm test -- --run` — all green (392 vitest tests pass).
- [x] No `Site*`/`perSite`/`siteUsage` identifier residues in `api/src`, `shared/src`, `web/src`; only frozen wire tokens remain, each commented.