### PR TITLE
ci(#1590): fail PRs whose base is not main

### DIFF
--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,56 @@
+name: PR Base Guard
+
+# Fail any PR whose base branch is not in the allowlist.
+#
+# Motivation — https://github.com/wifihaven/wifihaven/issues/1590:
+# When a chip opens a "wire" PR stacked on a not-yet-merged "schema" PR, it
+# correctly sets the base to the schema branch. If the schema PR merges
+# first, GitHub usually auto-retargets the stacked PR's base to `main` — but
+# the retarget can lag, or the stacked PR can be merged before retarget
+# happens. Result: a PR merged into a branch that is itself already merged,
+# leaving the code on a soon-to-be-deleted dead branch (#1586, #1271, #1168).
+#
+# This check fails fast on any PR whose base is not `main` so a mistargeted
+# PR can never reach the merge queue. Extend ALLOWED_BASES if a real release
+# branch is ever introduced — declarative config in-repo per AGENTS.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  check-base:
+    name: PR base must be main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify base ref
+        env:
+          ALLOWED_BASES: "main"
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "merge_group event — the queue only runs after a PR was merged into main; skipping."
+            exit 0
+          fi
+          if [ -z "${PR_BASE}" ]; then
+            echo "::error::No base ref on pull_request payload"
+            exit 1
+          fi
+          ok=0
+          for allowed in ${ALLOWED_BASES}; do
+            if [ "${PR_BASE}" = "${allowed}" ]; then
+              ok=1
+              break
+            fi
+          done
+          if [ "${ok}" != "1" ]; then
+            echo "::error title=PR base is not main::PR #${PR_NUMBER} targets '${PR_BASE}' — only ${ALLOWED_BASES} allowed. Retarget to main (Edit → base). See https://github.com/wifihaven/wifihaven/issues/1590."
+            exit 1
+          fi
+          echo "OK: PR base '${PR_BASE}' is in allowlist '${ALLOWED_BASES}'."

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -30,27 +30,44 @@ jobs:
       - name: Verify base ref
         env:
           ALLOWED_BASES: "main"
+          EVENT_NAME: ${{ github.event_name }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # merge_group payload carries the target branch as base_ref
+          # (a fully-qualified refs/heads/<name>). We strip the prefix
+          # below. This re-runs the check at merge-queue time, closing
+          # the race where GitHub's async auto-retarget hasn't fired yet
+          # when a stacked PR enters the queue (see #1590).
+          MG_BASE_REF: ${{ github.event.merge_group.base_ref }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            echo "merge_group event — the queue only runs after a PR was merged into main; skipping."
-            exit 0
-          fi
-          if [ -z "${PR_BASE}" ]; then
-            echo "::error::No base ref on pull_request payload"
+          case "${EVENT_NAME}" in
+            pull_request)
+              base="${PR_BASE}"
+              ctx="PR #${PR_NUMBER}"
+              ;;
+            merge_group)
+              base="${MG_BASE_REF#refs/heads/}"
+              ctx="merge_group"
+              ;;
+            *)
+              echo "Unsupported event '${EVENT_NAME}'."
+              exit 1
+              ;;
+          esac
+          if [ -z "${base}" ]; then
+            echo "::error::No base ref resolved from ${EVENT_NAME} payload"
             exit 1
           fi
           ok=0
           for allowed in ${ALLOWED_BASES}; do
-            if [ "${PR_BASE}" = "${allowed}" ]; then
+            if [ "${base}" = "${allowed}" ]; then
               ok=1
               break
             fi
           done
           if [ "${ok}" != "1" ]; then
-            echo "::error title=PR base is not main::PR #${PR_NUMBER} targets '${PR_BASE}' — only ${ALLOWED_BASES} allowed. Retarget to main (Edit → base). See https://github.com/wifihaven/wifihaven/issues/1590."
+            echo "::error title=Base is not main::${ctx} targets '${base}' — only ${ALLOWED_BASES} allowed. Retarget to main (Edit → base). See https://github.com/wifihaven/wifihaven/issues/1590."
             exit 1
           fi
-          echo "OK: PR base '${PR_BASE}' is in allowlist '${ALLOWED_BASES}'."
+          echo "OK: ${ctx} base '${base}' is in allowlist '${ALLOWED_BASES}'."


### PR DESCRIPTION
Closes #1590.

## Summary

Adds `.github/workflows/pr-base-guard.yml` — a small `pull_request` check that fails any PR whose `base.ref` is not in the allowlist (`main`). Catches the [#1586](https://github.com/wifihaven/wifihaven/pull/1586) incident class.

## Incident recap

[#1586](https://github.com/wifihaven/wifihaven/pull/1586) merged on 2026-06-08 with `baseRefName = claude/730-schema-dest-ip` instead of `main`. The merge commit `feae0e26` lives only on that already-dead branch — the wire code never reached `main`, but GitHub marked the PR MERGED, prematurely closed [#730](https://github.com/wifihaven/wifihaven/issues/730), and master-router CD didn't fire. Root cause: GitHub usually auto-retargets a stacked PR's base to `main` when the parent merges, but the retarget can lag, or the stacked PR can be merged before retarget happens. The migration-isolation rule (AGENTS.md) mandates split schema+code PRs, so the pattern will recur.

## Audit findings (last ~200 merged PRs)

Three merged PRs had `baseRefName != main`. **All three merge commits are missing from `origin/main`** (`git branch -r --contains <sha> | grep origin/main` is empty for each):

| PR | Merged | Base | Merge SHA | On main? |
|----|--------|------|-----------|----------|
| [#1586](https://github.com/wifihaven/wifihaven/pull/1586) | 2026-06-08 | `claude/730-schema-dest-ip` | `feae0e26` | ❌ |
| [#1271](https://github.com/wifihaven/wifihaven/pull/1271) | 2026-06-01 | `claude/fix-1265-ce-rollups` | `61bfe10f` | ❌ |
| [#1168](https://github.com/wifihaven/wifihaven/pull/1168) | 2026-05-30 | `perf/1160-timeused-rollup` | `7d1a00b8` | ❌ |

Two follow-up issues filed for #1271 and #1168 to investigate whether the work was reapplied or genuinely stranded (per the scope-limit in #1590, this PR does NOT recover those):
- [#1591](https://github.com/wifihaven/wifihaven/issues/1591) — investigate PR #1271
- [#1592](https://github.com/wifihaven/wifihaven/issues/1592) — investigate PR #1168

## How the check works

- Triggers on `pull_request` (`opened`, `synchronize`, `reopened`, `edited`) so a base-change via the GitHub UI re-evaluates.
- Reads `${{ github.event.pull_request.base.ref }}` and fails with `::error::` if it's not in `ALLOWED_BASES="main"`. Extend the env var here when a real release branch is introduced (declarative config per AGENTS.md).
- `merge_group` is a no-op (the queue only runs after the PR was already merged into main, so the base is implicit).

## Make it a required check (operator action)

Per AGENTS.md "Prefer declarative config over dashboard toggles", here is the snippet to mark the new check required on `main`. **Apply after this PR merges and one run of the new workflow has reported a status to the API**, otherwise the protection API rejects the unknown context name.

```bash
# Pull current protection, add the new context, push back.
gh api repos/wifihaven/wifihaven/branches/main/protection \
  > /tmp/main-protection.json
jq '.required_status_checks.contexts += ["PR base must be main"] |
    .required_status_checks.contexts |= unique' \
  /tmp/main-protection.json > /tmp/main-protection-new.json
gh api -X PUT repos/wifihaven/wifihaven/branches/main/protection \
  --input /tmp/main-protection-new.json
```

(The context name comes from the job's `name:` — "PR base must be main".)

## Test plan

- [ ] CI passes on this PR (its own base is `main`).
- [ ] Operator marks `PR base must be main` as a required status check on `main` after merge.
- [ ] Next mistargeted PR fails fast at this check instead of reaching the merge queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>