### PR TITLE
refactor(#1525): retire household_settings.heartbeatHostPatterns reads/writes (code only)

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -903,17 +903,20 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
 
   def get: Task[HouseholdSettings] =
     DbMetrics.timed("householdSettings.get")(
+      // #1525: `heartbeat_host_patterns` is no longer read — host-identity suppression lives in
+      // the canonical `shared.types.InfraHosts` code constant. The column is dropped in a
+      // follow-up migration-only PR; until then the SELECT just omits it and `HeartbeatFilter`
+      // gets `Nil` for that field.
       sql"""SELECT daily_reset_time, daily_reset_tz,
                  heartbeat_filter_enabled, heartbeat_bytes_threshold,
-                 heartbeat_host_patterns,
                  unmanaged_mac_policy::text,
                  presence_continuation_seconds
             FROM household_settings WHERE id=1"""
-        .query[(LocalTime, ZoneId, Boolean, Int, List[String], String, Int)]
+        .query[(LocalTime, ZoneId, Boolean, Int, String, Int)]
         .unique
-        .map { case (t, z, hbEnabled, hbBytes, hbHosts, ummJson, presenceCont) =>
+        .map { case (t, z, hbEnabled, hbBytes, ummJson, presenceCont) =>
           val umm = ummJson.fromJson[UnmanagedMacPolicy].getOrElse(UnmanagedMacPolicy.Default)
-          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, hbHosts), umm, presenceCont)
+          HouseholdSettings(t, z, HeartbeatFilter(hbEnabled, hbBytes, Nil), umm, presenceCont)
         }
         .transact(xa),
     )
@@ -928,13 +931,16 @@ class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsR
     // from first principles. The DELETE is wholesale because all of these fields
     // gate the same aggregation — fine-grained invalidation would only add risk
     // of missing a code path that mutates one of them.
+    // #1525: `heartbeat_host_patterns` is no longer written — the column has a NOT NULL DEFAULT
+    // from V24 so existing rows keep their seed value until the follow-up migration drops it
+    // entirely; nothing in the API reads it anymore (see `Presence.isHeartbeat` →
+    // `InfraHosts.isBackground`).
     val upd           =
       sql"""UPDATE household_settings
               SET daily_reset_time=${s.dailyResetTime},
                   daily_reset_tz=${s.dailyResetTz},
                   heartbeat_filter_enabled=${s.heartbeatFilter.enabled},
                   heartbeat_bytes_threshold=${s.heartbeatFilter.bytesThreshold},
-                  heartbeat_host_patterns=${s.heartbeatFilter.heartbeatHostPatterns.toArray},
                   unmanaged_mac_policy=${ummJson}::jsonb,
                   presence_continuation_seconds=${s.presenceContinuationSeconds},
                   updated_at=NOW()

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1725,6 +1725,10 @@ object HouseholdSettingsRoutes {
         },
     )
 
+  // #1525: `heartbeatHostPatterns` is retired — host-identity suppression now lives in the
+  // canonical `shared.types.InfraHosts` code constant. The field stays on the wire for back-compat
+  // input tolerance (older SPA builds still send it); we accept any value (including `null`) and
+  // discard it without erroring.
   private def mergeHeartbeatFilter(
       existing: HeartbeatFilter,
       obj: Json.Obj,
@@ -1736,22 +1740,17 @@ object HouseholdSettingsRoutes {
       bytesP   <- ZIO
         .fromEither(FieldPatch.from[Int](obj, "bytesThreshold"))
         .mapError(ApiError.BadRequest(_))
-      hostsP   <- ZIO
-        .fromEither(FieldPatch.from[List[String]](obj, "heartbeatHostPatterns"))
-        .mapError(ApiError.BadRequest(_))
-      _        <- (enabledP, bytesP, hostsP) match {
-        case (FieldPatch.Cleared, _, _) =>
+      _        <- (enabledP, bytesP) match {
+        case (FieldPatch.Cleared, _) =>
           ZIO.fail(ApiError.BadRequest("heartbeatFilter.enabled cannot be cleared"))
-        case (_, FieldPatch.Cleared, _) =>
+        case (_, FieldPatch.Cleared) =>
           ZIO.fail(ApiError.BadRequest("heartbeatFilter.bytesThreshold cannot be cleared"))
-        case (_, _, FieldPatch.Cleared) =>
-          ZIO.fail(ApiError.BadRequest("heartbeatFilter.heartbeatHostPatterns cannot be cleared"))
-        case _                          => ZIO.unit
+        case _                       => ZIO.unit
       }
     } yield HeartbeatFilter(
       enabled = enabledP.applyTo(existing.enabled),
       bytesThreshold = bytesP.applyTo(existing.bytesThreshold),
-      heartbeatHostPatterns = hostsP.applyTo(existing.heartbeatHostPatterns),
+      heartbeatHostPatterns = Nil,
     )
 
   private def mergeUnmanagedMacPolicy(

--- a/api/test/src/feature/HouseholdPatchApiSpec.scala
+++ b/api/test/src/feature/HouseholdPatchApiSpec.scala
@@ -33,10 +33,12 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
   private val Seed = HouseholdSettings(
     dailyResetTime = LocalTime.of(0, 0),
     dailyResetTz = ZoneId.of("America/Los_Angeles"),
+    // #1525: heartbeatHostPatterns is retired — the DB column is no longer written or read, so the
+    // repo round-trip always returns Nil regardless of what the caller passes in.
     heartbeatFilter = HeartbeatFilter(
       enabled = false,
       bytesThreshold = 1024,
-      heartbeatHostPatterns = List("foo.com"),
+      heartbeatHostPatterns = Nil,
     ),
     unmanagedMacPolicy = UnmanagedMacPolicy.Default,
   )
@@ -76,7 +78,7 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         assertTrue(after.dailyResetTz == Seed.dailyResetTz) &&
         assertTrue(after.heartbeatFilter == Seed.heartbeatFilter)
     },
-    test("nested heartbeatFilter deep-merges (enabled toggle preserves threshold + patterns)") {
+    test("nested heartbeatFilter deep-merges (enabled toggle preserves threshold)") {
       for {
         _            <- setupHousehold
         (routes, tk) <- routesAndToken
@@ -86,7 +88,48 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(after.heartbeatFilter.enabled) &&
         assertTrue(after.heartbeatFilter.bytesThreshold == 1024) &&
-        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == List("foo.com"))
+        // #1525: heartbeatHostPatterns is retired — DB no longer persists it; reads return Nil.
+        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == Nil)
+    },
+    test(
+      "#1525 PATCH that includes heartbeatHostPatterns is accepted but the field is ignored",
+    ) {
+      // Older SPA builds still send heartbeatHostPatterns on PATCH. We must tolerate the field on
+      // input (no 400, no error) and ignore it: enforcement now comes from the canonical
+      // InfraHosts code constant, not from a per-install hand-curated list.
+      for {
+        _            <- setupHousehold
+        (routes, tk) <- routesAndToken
+        resp         <- patch(
+          routes,
+          tk,
+          """{"heartbeatFilter":{"heartbeatHostPatterns":["legacy.example.com"]}}""",
+        )
+        repo         <- ZIO.service[HouseholdSettingsRepo]
+        after        <- repo.get
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == Nil)
+    },
+    test(
+      "#1525 PATCH that omits heartbeatHostPatterns produces the same persisted state as one that sends it",
+    ) {
+      // Enforcement no longer derives from `heartbeatHostPatterns` — InfraHosts is the source. So
+      // a PATCH that omits the field and a PATCH that sends it must yield identical persisted
+      // HouseholdSettings, proving the field has no effect on behavior.
+      for {
+        _             <- setupHousehold
+        (routes, tk)  <- routesAndToken
+        _             <- patch(routes, tk, """{"heartbeatFilter":{"bytesThreshold":2048}}""")
+        repo          <- ZIO.service[HouseholdSettingsRepo]
+        afterOmitted  <- repo.get
+        _             <- setupHousehold
+        _             <- patch(
+          routes,
+          tk,
+          """{"heartbeatFilter":{"bytesThreshold":2048,"heartbeatHostPatterns":["x.example.com"]}}""",
+        )
+        afterIncluded <- repo.get
+      } yield assertTrue(afterOmitted == afterIncluded)
     },
     test("absent fields preserve existing values") {
       for {
@@ -110,7 +153,8 @@ object HouseholdPatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPos
         assertTrue(after.dailyResetTz == ZoneId.of("America/New_York")) &&
         assertTrue(after.heartbeatFilter.enabled == false) && // preserved
         assertTrue(after.heartbeatFilter.bytesThreshold == 4096) &&
-        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == List("bar.com"))
+        // #1525: heartbeatHostPatterns is ignored on input and never persisted.
+        assertTrue(after.heartbeatFilter.heartbeatHostPatterns == Nil)
     },
     test("null on non-nullable field returns 400") {
       for {

--- a/api/test/src/feature/PresenceDefaultsPinSpec.scala
+++ b/api/test/src/feature/PresenceDefaultsPinSpec.scala
@@ -69,25 +69,12 @@ object PresenceDefaultsPinSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedP
   private val PinnedHeartbeatEnabled            = true  // V23 SET DEFAULT TRUE
   private val PinnedHeartbeatBytesThreshold     = 10240 // V23 SET DEFAULT 10240 (10 KB)
 
-  // V24__heartbeat_host_patterns.sql — the FQDN keepalive allowlist, in file order.
-  private val PinnedHeartbeatHostPatterns = List(
-    "*.push.apple.com",
-    "*.apple-dns.net",
-    "*.akadns.net",
-    "*.ess.apple.com",
-    "time.apple.com",
-    "gdmf.apple.com",
-    "pancake.apple.com",
-    "mask.icloud.com",
-    "mask-h2.icloud.com",
-    "mask-api.icloud.com",
-    "*.rcs.telephony.goog",
-    "mtalk.google.com",
-    "connectivitycheck.gstatic.com",
-    "captive.apple.com",
-    "*.ntp.org",
-    "time.cloudflare.com",
-  )
+  // #1525: V24__heartbeat_host_patterns.sql is retired — the column is no longer read or written
+  // by the API. Host-identity suppression now lives in the server-side canonical
+  // `shared.types.InfraHosts` code constant (allow+suppress canonical ∪ suppress-only). The wire
+  // field is retained on `HeartbeatFilter` for back-compat input tolerance, but the repo round-trip
+  // always returns the empty list. The DB column gets dropped in a follow-up migration-only PR.
+  private val PinnedHeartbeatHostPatterns: List[String] = Nil
 
   private def householdRoutesAndToken =
     for {


### PR DESCRIPTION
## Summary

PR1 of the two-step retirement of \`household_settings.heartbeat_host_patterns\` (issue #1525). Host-identity heartbeat suppression now lives in the canonical \`shared.types.InfraHosts\` code constant (allow+suppress canonical ∪ suppress-only tier, the latter folded in from V24 by #1503/#1525). The per-install column is redundant — keeping a second hand-curated list was the #1499 drift source. This PR stops *using* the column; PR2 drops it.

### What changes

- \`HouseholdSettingsRepo.get\` — SELECT no longer reads \`heartbeat_host_patterns\`; wire payload returns \`Nil\` for that field.
- \`HouseholdSettingsRepo.update\` — UPDATE no longer writes the column. Existing rows keep their seed value via the V24 NOT NULL DEFAULT until PR2 drops it.
- \`Routes.mergeHeartbeatFilter\` — accepts \`heartbeatHostPatterns\` on PATCH but discards it (back-compat input tolerance for older SPA builds that still send the field; no 400 on present-or-null).
- \`HouseholdPatchApiSpec\` — new feature tests pin the contract: (1) a PATCH containing \`heartbeatHostPatterns\` returns 200 and persists nothing; (2) a PATCH omitting it and a PATCH including it produce identical persisted state.
- \`PresenceDefaultsPinSpec\` — pinned list collapsed to \`Nil\` since the column is no longer the source of truth.

### Why two PRs

The migration-isolation rule (\`AGENTS.md §migrations-back-compat\`): a schema change can only ship in a PR that contains *only* the migration and docs. A code change that drops a column ride-along would also bypass the back-compat gate. So:

1. **This PR** stops reading and writing the column. The deployed image after this rolls forward never touches it.
2. **PR2** is a one-line \`ALTER TABLE … DROP COLUMN\` with no code. **Do not open or merge PR2 until this PR has merged and been deployed for at least one full deploy cycle** — the previously-deployed (N-1) image still has the SELECT that reads the column.

### Wire back-compat

\`HeartbeatFilter.heartbeatHostPatterns\` stays on the model (already marked DEPRECATED). The API still accepts it on input and emits it as \`[]\` on output. The field can be removed from the wire model later, gated on the wire-versioning work (#376) per \`AGENTS.md §Backwards compatibility\`.

### Test plan

- [x] \`mill api.test\` — 87+59+… all green
- [x] \`mill shared.test\` — green
- [x] \`scalafmt --check --non-interactive\` — clean
- [x] New \`#1525\` tests in \`HouseholdPatchApiSpec\` cover the accept-and-ignore contract
- [x] Existing \`#1525\` \`PresenceSpec\` cases already prove enforcement no longer depends on the field

Issue closes in PR2 after fleet rolls forward.