### PR TITLE
feat(#1525): drop household_settings.heartbeat_host_patterns column (schema-only)

### DIFF
--- a/api/resources/db/migration/V55__drop_heartbeat_host_patterns.sql
+++ b/api/resources/db/migration/V55__drop_heartbeat_host_patterns.sql
@@ -1,0 +1,25 @@
+-- V55__drop_heartbeat_host_patterns.sql
+--
+-- #1525: drop the retired `household_settings.heartbeat_host_patterns` column.
+--
+-- Host-identity heartbeat suppression has lived in the canonical
+-- `shared.types.InfraHosts` code constant since #1503/#1525 — the V24 seed was
+-- folded in as the suppress-only tier. The companion code-only PR (#1595)
+-- already stopped reading and writing this column, so the deployed image no
+-- longer touches it. This migration is the schema-only follow-up that finishes
+-- the retirement.
+--
+-- Prerequisites (must be true before this migration runs in prod):
+--   1. #1595 has merged AND been deployed for at least one full deploy cycle.
+--      The previously-deployed (N-1) image after THAT roll-forward must not
+--      SELECT or UPDATE this column — which is what #1595 guarantees.
+--   2. `household_settings` is a singleton row (id=1), so this DROP is fast at
+--      prod scale (AGENTS.md §migrations-prod-data-volume — schema metadata
+--      change on a tiny table).
+--
+-- The wire field `HeartbeatFilter.heartbeatHostPatterns` stays on the Scala
+-- model for back-compat input tolerance and continues to serialize as `[]`
+-- on output; removal of the wire field is gated separately on the wire-
+-- versioning work (#376) per AGENTS.md §Backwards compatibility.
+ALTER TABLE household_settings
+  DROP COLUMN heartbeat_host_patterns;


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until PR1 has shipped to prod

PR1 (the code-only retirement): #1595

This PR must NOT merge until **all** of the following are true:

1. PR1 has merged into \`main\`.
2. The resulting image has been deployed to prod for at least one full deploy cycle.
3. After that deploy, the previously-running (N-1) image — which still SELECTs \`heartbeat_host_patterns\` — is no longer in service anywhere.

Dropping the column while an older image is still running would crash \`HouseholdSettingsRepo.get\` (column missing). Once PR1 is shipped, the deployed image no longer references the column and this DROP is safe.

This branch is opened *off the PR1 branch* so CI passes against the post-PR1 code. **Once PR1 merges into main, rebase this PR onto \`main\` before merging.**

## Summary

Schema-only follow-up to PR1 (#1595). Drops the retired \`household_settings.heartbeat_host_patterns\` column.

Host-identity heartbeat suppression has lived in the canonical \`shared.types.InfraHosts\` code constant since #1503/#1525 — the V24 seed was folded in as the suppress-only tier. PR1 already stopped reading and writing the column. This finishes the retirement.

## Why split

\`AGENTS.md §migrations-back-compat\`: a Flyway migration ships in its own PR, no source/test/CI changes alongside. The companion code change is PR1. (\`check-migration-isolation.sh\` enforces this.)

\`AGENTS.md §migrations-prod-data-volume\`: \`household_settings\` is a singleton row, so \`ALTER TABLE … DROP COLUMN\` is a fast schema-metadata change — safe to run on the startup path.

## Wire contract

The Scala model field \`HeartbeatFilter.heartbeatHostPatterns\` stays on the wire for back-compat input tolerance (older SPA still sends it; we accept-and-ignore per PR1). The model field can be removed later under wire-versioning (#376).

## Test plan

- [x] V55 migration applies cleanly under the embedded Postgres \`TestDatabase\` (the full \`mill api.test\` suite — gated by \`AGENTS.md §migrations-back-compat\` — proves the post-PR1 code survives the column drop).
- [ ] **Pre-merge gate:** verify PR1 has shipped to prod for ≥1 full deploy cycle before merging this PR.

Closes #1525.