### PR TITLE
feat(#1564): thread typed AppId FK through the per-app cap/rollup surface

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -190,7 +190,6 @@ object Main extends ZIOAppDefault {
         profileRepoForJ   <- ZIO.service[wifihaven.api.db.ProfileRepo]
         deviceRepoForJ    <- ZIO.service[wifihaven.api.db.DeviceRepo]
         stlRepoForJ       <- ZIO.service[wifihaven.api.db.AppTimeLimitRepo]
-        appRepoForJ       <- ZIO.service[AppRepo]
         trafficRepoForJ   <- ZIO.service[wifihaven.api.db.TrafficReportRepo]
         _                 <- TimeUsedRollupJob
           .loop(
@@ -200,7 +199,6 @@ object Main extends ZIOAppDefault {
             profileRepoForJ,
             deviceRepoForJ,
             stlRepoForJ,
-            appRepoForJ,
             trafficRepoForJ,
             hsRepo,
             clockForJobs,

--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1089,14 +1089,16 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
 }
 
 class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
-  // (profileId, host, dailyMinutes, slug, exemptFromDaily)
-  private type R = (ProfileId, String, Int, String, Boolean)
+  // #1564: (profileId, host, dailyMinutes, slug, exemptFromDaily, appId) — the join already has
+  // `apps.id` in scope, so we carry it through as the canonical FK reference instead of throwing
+  // it away and re-resolving the slug downstream.
+  private type R = (ProfileId, String, Int, String, Boolean, AppId)
   private def toS(r: R) =
-    AppTimeLimit(AppTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5)
+    AppTimeLimit(AppTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5, r._6)
 
   def listForProfile(pid: ProfileId) =
     DbMetrics.timed("appTimeLimit.listForProfile")(
-      sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
+      sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily, a.id
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id
@@ -1109,7 +1111,7 @@ class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
     )
 
   def listAll =
-    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily
+    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily, a.id
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -46,6 +46,10 @@ final case class AppDayState(
     // every host so off-domain asset/CDN traffic ticks the *same* app limit and is exempted from the
     // daily total just like the apex. For a single-host app this is `List(domainPattern)`.
     hosts: List[String] = Nil,
+    // #1564: the typed FK to apps(id) the cap/rollup surface keys on internally. `label` and
+    // `domainPattern` stay as display text; `appId` is the canonical identity that joins to
+    // `app_used_daily.app_id` directly — no slug round-trip.
+    appId: AppId = AppId(0L),
 )
 
 trait TimeStatusService {
@@ -276,7 +280,7 @@ class TimeStatusServiceLive(
           extMins    <- extRepo.getProfileTotalExtension(profileId, date)
           // #1515: per-app cap usage from the #1510 per-app rollup + live tail, so the per-app cap
           // enforces on the rollup path identically to the all-live path.
-          perAppMins <- appUsedRollupService.appCapMinutesByLabel(now, date, settings, profileId)
+          perAppMins <- appUsedRollupService.appCapMinutesByAppId(now, date, settings, profileId)
         } yield {
           val tailSeconds =
             TimeStatusService.usedSecondsForProfile(p, devices, atls, tail, settings)
@@ -335,7 +339,7 @@ class TimeStatusServiceLive(
       // `app:<slug>` cap-group label so it joins to each profile's per-app cap groups below.
       perAppMins <- ZIO
         .foreach(profiles)(p =>
-          appUsedRollupService.appCapMinutesByLabel(now, date, settings, p.id).map(p.id -> _),
+          appUsedRollupService.appCapMinutesByAppId(now, date, settings, p.id).map(p.id -> _),
         )
         .map(_.toMap)
     } yield {
@@ -407,25 +411,27 @@ object TimeStatusService {
   }
 
   /**
-   * #1505: collapse the per-(assignment × host) [[AppTimeLimit]] rows into one group per app (keyed
-   * by `label`, which is `app:<slug>`), carrying the app's full host-set. `dailyMinutes` and
-   * `exemptFromDaily` are uniform across an app's synthesized rows, so we take them off any row.
-   * The representative `domainPattern` is the apex (shortest host) — used only for the wire/UI; the
-   * `hosts` list drives every per-app computation. Stable order (by label) for deterministic
-   * output.
+   * #1505 + #1564: collapse the per-(assignment × host) [[AppTimeLimit]] rows into one group per
+   * app, keyed by the typed `apps.id` FK (the canonical identity carried straight from the repo
+   * join). `label` ("app:<slug>") stays alongside as display text for the SPA wire, but the cap /
+   * rollup surfaces compose on `appId`. `dailyMinutes` and `exemptFromDaily` are uniform across an
+   * app's synthesized rows, so we take them off any row. The representative `domainPattern` is the
+   * apex (shortest host) — used only for the wire/UI; the `hosts` list drives every per-app
+   * computation. Stable order (by label) for deterministic output.
    */
   private[policy] def groupSiteLimits(
       appLimits: List[AppTimeLimit],
-  ): List[(String, Int, Boolean, List[String], String)] =
+  ): List[(AppId, String, Int, Boolean, List[String], String)] =
     appLimits
-      .groupBy(_.label)
+      .groupBy(_.appId)
       .toList
-      .sortBy(_._1)
-      .map { case (label, lims) =>
+      .map { case (appId, lims) =>
+        val label = lims.head.label
         val hosts = lims.map(_.domainPattern).distinct
         val rep   = hosts.minByOption(_.length).getOrElse(label)
-        (label, lims.map(_.dailyMinutes).max, lims.exists(_.exemptFromDaily), hosts, rep)
+        (appId, label, lims.map(_.dailyMinutes).max, lims.exists(_.exemptFromDaily), hosts, rep)
       }
+      .sortBy(_._2)
 
   /**
    * #1505 + #1504: per-app [[AppDayState]] list — one entry per app, with `usedMinutes` aggregated
@@ -440,14 +446,22 @@ object TimeStatusService {
       filter: HeartbeatFilter,
       continuationSeconds: Int,
   ): List[AppDayState] = {
-    val perGroup = Presence.patternGroupMinutesForProfile(
+    // #1564: feed Presence the cap-group label as its String key so the underlying span/union math
+    // is unchanged, then re-key the result by appId via the (label -> appId) map groupSiteLimits
+    // emits directly. One canonical conversion, no slug parsing.
+    val groups       = groupSiteLimits(appLimits)
+    val labelToAppId = groups.map(g => g._2 -> g._1).toMap
+    val perLabel     = Presence.patternGroupMinutesForProfile(
       presence,
-      groupSiteLimits(appLimits).map(g => g._1 -> g._4),
+      groups.map(g => g._2 -> g._5),
       overlap,
       filter,
       continuationSeconds,
     )
-    appDayStatesFromMinutes(appLimits, perGroup)
+    val perAppId     = perLabel.iterator.flatMap { case (label, m) =>
+      labelToAppId.get(label).map(_ -> m)
+    }.toMap
+    appDayStatesFromMinutes(appLimits, perAppId)
   }
 
   /**
@@ -456,22 +470,23 @@ object TimeStatusService {
    * groups (label / host-set / limit / exempt) are zipped with their used-minutes, regardless of
    * where the minutes come from: the live presence aggregation ([[appDayStates]]), the rollup +
    * live-tail read path ([[TimeStatusServiceLive]], via
-   * [[wifihaven.api.usage.AppUsedRollupService.appCapMinutesByLabel]]), or the zero-usage default
+   * [[wifihaven.api.usage.AppUsedRollupService.appCapMinutesByAppId]]), or the zero-usage default
    * in [[assemble]]. Keeping one zip means the cap groups can't be shaped differently across those
    * paths (#1532). A label absent from the map contributes zero minutes.
    */
   private[policy] def appDayStatesFromMinutes(
       appLimits: List[AppTimeLimit],
-      minutesByLabel: Map[String, Int],
+      minutesByAppId: Map[AppId, Int],
   ): List[AppDayState] =
-    groupSiteLimits(appLimits).map { case (label, daily, exempt, hosts, rep) =>
+    groupSiteLimits(appLimits).map { case (appId, label, daily, exempt, hosts, rep) =>
       AppDayState(
         label = label,
         domainPattern = rep,
         dailyLimitMinutes = daily,
-        usedMinutes = minutesByLabel.getOrElse(label, 0),
+        usedMinutes = minutesByAppId.getOrElse(appId, 0),
         exemptFromDaily = exempt,
         hosts = hosts,
+        appId = appId,
       )
     }
 
@@ -543,52 +558,40 @@ object TimeStatusService {
    */
   private[policy] def exemptPatterns(appLimits: List[AppTimeLimit]): List[String] =
     groupSiteLimits(appLimits).collect {
-      case (_, _, exempt, hosts, _) if exempt => hosts
+      case (_, _, _, exempt, hosts, _) if exempt => hosts
     }.flatten
 
   /**
-   * #1516: per-app engaged seconds for a profile, keyed by `app_id`, derived from the SINGLE
-   * per-app presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same
+   * #1516 + #1564: per-app engaged seconds for a profile, keyed by `apps.id`, derived from the
+   * SINGLE per-app presence primitive [[Presence.appSecondsForProfile]] (#1514/#1532) — the same
    * gap-bridged, cross-host union the per-app cap ([[appDayStates]] /
-   * [[Presence.patternGroupMinutesForProfile]]) ticks on. This is the value the `app_used_daily`
-   * rollup persists and the per-app series reads, so the rollup ⇄ cap ⇄ series identities hold by
-   * construction (there is exactly one per-app time computation). `slugToAppId` resolves each
-   * `app:<slug>` group key (from [[groupSiteLimits]]) to its registered `apps.id`; an app whose
-   * slug is absent is dropped (defensive — post-V35 every cap entry is a real registered app, so
-   * this never fires in practice). `presence` must already be scoped to the profile's devices.
-   * Seconds (not minutes) so the rolled + tail decomposition stays exact across the watermark
-   * boundary; floor-to-minutes happens once at read time.
+   * [[Presence.patternGroupMinutesForProfile]]) ticks on. The cap-group label ([[groupSiteLimits]])
+   * is used as Presence's group key; the (label -> appId) map emitted by the same call re-keys the
+   * result back to the typed FK — no slug parsing, no slugToAppId lookup table. This is the value
+   * the `app_used_daily` rollup persists and the per-app series reads, so the rollup ⇄ cap ⇄ series
+   * identities hold by construction (there is exactly one per-app time computation). `presence`
+   * must already be scoped to the profile's devices. Seconds (not minutes) so the rolled + tail
+   * decomposition stays exact across the watermark boundary; floor-to-minutes happens once at read
+   * time.
    */
-  /**
-   * The `apps.slug` ⇄ `apps.id` resolution shared by the per-app rollup writer
-   * ([[wifihaven.api.usage.TimeUsedRollupJob]]) and reader
-   * ([[wifihaven.api.usage.AppUsedRollupService]]), so both resolve an `app:<slug>` cap group key
-   * to the same registered app identity. Centralized here next to [[appSecondsByApp]] (its
-   * consumer) so the keying convention can't drift between the two sides.
-   */
-  def slugToAppId(apps: List[App]): Map[String, AppId] =
-    apps.iterator.map(a => a.slug -> a.id).toMap
-
   def appSecondsByApp(
       profile: Profile,
       appLimits: List[AppTimeLimit],
-      slugToAppId: Map[String, AppId],
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): Map[AppId, Long] = {
-    val groups = groupSiteLimits(appLimits).map(g => g._1 -> g._4)
+    val groups       = groupSiteLimits(appLimits)
+    val labelToAppId = groups.map(g => g._2 -> g._1).toMap
     Presence
       .appSecondsForProfile(
         presence,
-        groups,
+        groups.map(g => g._2 -> g._5),
         profile.crossDeviceOverlapMode,
         settings.heartbeatFilter,
         settings.presenceContinuationSeconds,
       )
       .iterator
-      .flatMap { case (label, secs) =>
-        slugToAppId.get(label.stripPrefix("app:")).map(_ -> secs)
-      }
+      .flatMap { case (label, secs) => labelToAppId.get(label).map(_ -> secs) }
       .toMap
   }
 
@@ -603,7 +606,7 @@ object TimeStatusService {
    * app's host is still excluded — it is simply no longer mis-classified as a heartbeat first.
    */
   private[policy] def appHostPatterns(appLimits: List[AppTimeLimit]): List[String] =
-    groupSiteLimits(appLimits).flatMap(_._4)
+    groupSiteLimits(appLimits).flatMap(_._5)
 
   def usedSecondsForProfile(
       profile: Profile,

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -56,20 +56,21 @@ trait AppUsedRollupService {
   ): Task[Map[AppId, Int]]
 
   /**
-   * #1515: the same per-app engaged minutes as [[appEngagedMinutes]], re-keyed by the cap group
-   * label `app:<slug>` (the key [[wifihaven.api.policy.TimeStatusService.groupSiteLimits]] emits).
-   * This is what the snapshot's / `/decision`'s per-app cap reads through `perApp` on the rollup
-   * read path: [[wifihaven.api.policy.TimeStatusServiceLive]] joins it to the profile's per-app cap
-   * groups to fill `AppDayState.usedMinutes`, so a profile that has rolled (the prod steady state)
-   * still caps on the real per-app aggregate instead of zero. Same rolled + live-tail figure, so
-   * the rollup read and the all-live read agree by construction (#1532).
+   * #1515 + #1564: the same per-app engaged minutes as [[appEngagedMinutes]], surfaced for the cap
+   * read path. Keyed by the typed `apps.id` FK — the same key `app_used_daily` stores, the same key
+   * the cap-group ([[wifihaven.api.policy.TimeStatusService.groupSiteLimits]]) emits, and the same
+   * key [[wifihaven.api.policy.TimeStatusService.appDayStatesFromMinutes]] joins on. The snapshot's
+   * / `/decision`'s per-app cap reads through `perApp` on the rollup read path so a profile that
+   * has rolled (the prod steady state) still caps on the real per-app aggregate instead of zero.
+   * Same rolled + live-tail figure, so the rollup read and the all-live read agree by construction
+   * (#1532).
    */
-  def appCapMinutesByLabel(
+  def appCapMinutesByAppId(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-  ): Task[Map[String, Int]]
+  ): Task[Map[AppId, Int]]
 }
 
 /**
@@ -85,19 +86,18 @@ object NoopAppUsedRollupService extends AppUsedRollupService {
       settings: HouseholdSettings,
       profileId: ProfileId,
   ): Task[Map[AppId, Int]] = ZIO.succeed(Map.empty)
-  def appCapMinutesByLabel(
+  def appCapMinutesByAppId(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-  ): Task[Map[String, Int]] = ZIO.succeed(Map.empty)
+  ): Task[Map[AppId, Int]] = ZIO.succeed(Map.empty)
 }
 
 class AppUsedRollupServiceLive(
     profileRepo: ProfileRepo,
     deviceRepo: DeviceRepo,
     appTimeLimitRepo: AppTimeLimitRepo,
-    appRepo: AppRepo,
     trafficRepo: TrafficReportRepo,
     rollupRepo: AppUsedRollupRepo,
 ) extends AppUsedRollupService {
@@ -108,74 +108,54 @@ class AppUsedRollupServiceLive(
       settings: HouseholdSettings,
       profileId: ProfileId,
   ): Task[Map[AppId, Int]] =
-    aggregate(now, date, settings, profileId).map(_._1)
+    aggregate(now, date, settings, profileId)
 
-  def appCapMinutesByLabel(
+  def appCapMinutesByAppId(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-  ): Task[Map[String, Int]] =
-    aggregate(now, date, settings, profileId).map(_._2)
+  ): Task[Map[AppId, Int]] =
+    aggregate(now, date, settings, profileId)
 
-  // Single read path for both keyings. When the per-app rollup is non-empty, add its engaged seconds
-  // to a live aggregation of the TAIL past the shared watermark (period_start >= rolled_through).
-  // When it is empty (cache miss / past date), the watermark is absent so the whole day is aggregated
-  // live and the rolled contribution is zero — i.e. the all-live path. Either way the floor-of-sum to
-  // minutes happens once at the end, so the result is byte-identical to a full live aggregation (the
-  // watermark lands in an idle gap, so no engaged span straddles it — same exactness argument as
-  // `time_used_daily`). Returns the minutes keyed both by `apps.id` (the per-app series) and by the
-  // `app:<slug>` cap-group label (the per-app cap), computed once.
+  // Single read path keyed on apps.id end-to-end (#1564). When the per-app rollup is non-empty,
+  // add its engaged seconds to a live aggregation of the TAIL past the shared watermark
+  // (period_start >= rolled_through). When it is empty (cache miss / past date), the watermark is
+  // absent so the whole day is aggregated live and the rolled contribution is zero — i.e. the
+  // all-live path. Either way the floor-of-sum to minutes happens once at the end, so the result is
+  // byte-identical to a full live aggregation (the watermark lands in an idle gap, so no engaged
+  // span straddles it — same exactness argument as `time_used_daily`). The cap and series consumers
+  // both read this AppId-keyed map directly; no slug round-trip.
   private def aggregate(
       now: Instant,
       date: LocalDate,
       settings: HouseholdSettings,
       profileId: ProfileId,
-  ): Task[(Map[AppId, Int], Map[String, Int])] = {
+  ): Task[Map[AppId, Int]] = {
     val today   = PolicyService.householdLocalDate(now, settings)
-    // Only today reads the rollup; past dates ignore it (rollup is today-only, like
-    // `time_used_daily`). An empty rolled map — cache miss, or a past date — collapses to a full-day
-    // all-live computation.
     val rolledZ =
       if (date == today) rollupRepo.getDayForProfile(profileId, date)
       else ZIO.succeed(Map.empty[AppId, RolledAppDay])
     rolledZ.flatMap { rolled =>
       profileRepo.findById(profileId).flatMap {
-        case None    => ZIO.succeed((Map.empty[AppId, Int], Map.empty[String, Int]))
+        case None    => ZIO.succeed(Map.empty[AppId, Int])
         case Some(p) =>
           for {
             atls    <- appTimeLimitRepo.listForProfile(profileId)
             devices <- deviceRepo.listAll.map(_.filter(_.profileId.contains(profileId)))
-            apps    <- appRepo.listAll
             macs = devices.map(_.mac)
             presence <- rolled.values.iterator.map(_.rolledThrough).minOption match {
               case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
               case None            => trafficRepo.listPresenceRows(macs, date)
             }
           } yield {
-            val liveSecs                  =
-              TimeStatusService.appSecondsByApp(
-                p,
-                atls,
-                TimeStatusService.slugToAppId(apps),
-                presence,
-                settings,
-              )
-            val byApp: Map[AppId, Int]    =
-              (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
-                val secs =
-                  rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
-                val mins = (secs / 60L).toInt
-                if mins != 0 then Some(id -> mins) else None
-              }.toMap
-            // Re-key to the `app:<slug>` cap-group label via the inverse of `slugToAppId` — the same
-            // labelling `groupSiteLimits` uses — so the per-app cap can join by label.
-            val idToSlug                  = TimeStatusService.slugToAppId(apps).map(_.swap)
-            val byLabel: Map[String, Int] =
-              byApp.iterator.flatMap { case (id, mins) =>
-                idToSlug.get(id).map(slug => s"app:$slug" -> mins)
-              }.toMap
-            (byApp, byLabel)
+            val liveSecs = TimeStatusService.appSecondsByApp(p, atls, presence, settings)
+            (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
+              val secs =
+                rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
+              val mins = (secs / 60L).toInt
+              if mins != 0 then Some(id -> mins) else None
+            }.toMap
           }
       }
     }
@@ -184,8 +164,8 @@ class AppUsedRollupServiceLive(
 
 object AppUsedRollupService {
   val layer: ZLayer[
-    ProfileRepo & DeviceRepo & AppTimeLimitRepo & AppRepo & TrafficReportRepo & AppUsedRollupRepo,
+    ProfileRepo & DeviceRepo & AppTimeLimitRepo & TrafficReportRepo & AppUsedRollupRepo,
     Nothing,
     AppUsedRollupService,
-  ] = ZLayer.fromFunction(AppUsedRollupServiceLive(_, _, _, _, _, _))
+  ] = ZLayer.fromFunction(AppUsedRollupServiceLive(_, _, _, _, _))
 }

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -1,7 +1,6 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.{
-  AppRepo,
   AppTimeLimitRepo,
   AppUsedRollupRepo,
   DeviceRepo,
@@ -63,7 +62,6 @@ object TimeUsedRollupJob {
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
-      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       clock: Clock,
@@ -78,7 +76,6 @@ object TimeUsedRollupJob {
           profileRepo,
           deviceRepo,
           appTimeLimitRepo,
-          appRepo,
           trafficRepo,
           hs,
           now,
@@ -98,7 +95,6 @@ object TimeUsedRollupJob {
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
-      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
@@ -109,7 +105,6 @@ object TimeUsedRollupJob {
       profileRepo,
       deviceRepo,
       appTimeLimitRepo,
-      appRepo,
       trafficRepo,
       hs,
       now,
@@ -164,7 +159,6 @@ object TimeUsedRollupJob {
       profileRepo: ProfileRepo,
       deviceRepo: DeviceRepo,
       appTimeLimitRepo: AppTimeLimitRepo,
-      appRepo: AppRepo,
       trafficRepo: TrafficReportRepo,
       hs: HouseholdSettingsRepo,
       now: Instant,
@@ -173,10 +167,9 @@ object TimeUsedRollupJob {
     today = PolicyService.householdLocalDate(now, settings)
     profiles <- profileRepo.listAll
     devices  <- deviceRepo.listAll
-    apps     <- appRepo.listAll
     atlsP    <- ZIO.foreach(profiles)(p => appTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
     presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
-    rolls = computeRolls(profiles, devices, apps, atlsP.toMap, presence, settings, now)
+    rolls = computeRolls(profiles, devices, atlsP.toMap, presence, settings, now)
     n <- rollup.upsertBatch(today, rolls._1)
     _ <- appRollup.upsertBatch(today, rolls._2)
   } yield n
@@ -184,21 +177,20 @@ object TimeUsedRollupJob {
   // Pure: collapse one presence batch into both the per-profile total roll (`time_used_daily`) and
   // the per-(profile, app) engaged roll (`app_used_daily`), stamped with the same `now` watermark so
   // the two compose identically (rolled + tail). The per-app figure derives from the SINGLE per-app
-  // primitive (`TimeStatusService.appSecondsByApp` → `Presence.appSecondsForProfile`), so the rollup
-  // reconciles exactly with the per-app cap and the per-app series. Only apps with engaged activity
-  // get a row (zero-activity apps are absent).
+  // primitive (`TimeStatusService.appSecondsByApp` → `Presence.appSecondsForProfile`), keyed on the
+  // typed `apps.id` FK [[wifihaven.shared.AppTimeLimit.appId]] carried straight from the repo join
+  // (#1564) — no slugToAppId lookup. Only apps with engaged activity get a row (zero-activity apps
+  // are absent).
   private def computeRolls(
       profiles: List[wifihaven.shared.Profile],
       devices: List[wifihaven.shared.Device],
-      apps: List[wifihaven.shared.App],
       atlMap: Map[ProfileId, List[wifihaven.shared.AppTimeLimit]],
       presence: List[wifihaven.api.presence.PresenceRow],
       settings: wifihaven.shared.HouseholdSettings,
       now: Instant,
   ): (Map[ProfileId, RolledDay], Map[(ProfileId, AppId), RolledAppDay]) = {
-    val devsByP     =
+    val devsByP                                                           =
       devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
-    val slugToAppId = TimeStatusService.slugToAppId(apps)
     def presFor(pid: ProfileId): List[wifihaven.api.presence.PresenceRow] = {
       val mac = devsByP.getOrElse(pid, Nil).map(_.mac).toSet
       presence.filter(r => mac.contains(r.mac))
@@ -215,7 +207,7 @@ object TimeUsedRollupJob {
     }.toMap
     val perApp     = profiles.iterator.flatMap { p =>
       TimeStatusService
-        .appSecondsByApp(p, atlMap.getOrElse(p.id, Nil), slugToAppId, presFor(p.id), settings)
+        .appSecondsByApp(p, atlMap.getOrElse(p.id, Nil), presFor(p.id), settings)
         .iterator
         .map { case (appId, secs) => (p.id, appId) -> RolledAppDay(secs, now) }
     }.toMap

--- a/api/test/src/feature/AppUsedRollupSpec.scala
+++ b/api/test/src/feature/AppUsedRollupSpec.scala
@@ -44,7 +44,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
       ar  <- ZIO.service[AppRepo]
       trr <- ZIO.service[TrafficReportRepo]
       aru <- ZIO.service[AppUsedRollupRepo]
-    } yield new AppUsedRollupServiceLive(pr, dr, stl, ar, trr, aru)
+    } yield new AppUsedRollupServiceLive(pr, dr, stl, trr, aru)
 
   private def makeTimeService: ZIO[
     ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
@@ -152,7 +152,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:60", "social.com", today, 5, 8 * 60)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:60", "cdn.social.net", today, 5, 8 * 60 + 10)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         reader <- makeReader
         perApp <- reader.appEngagedMinutes(now, today, s, kid)
         // The per-app cap aggregate (AppDayState.usedMinutes) for the same app.
@@ -218,7 +218,7 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "a.com", today, 10, 8 * 60)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:62", "b.com", today, 15, 9 * 60)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _       <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _       <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         timeRow <- ru.getDayForProfile(kid, today)
         appRows <- aru.getDayForProfile(kid, today)
         appSum = appRows.values.map(_.engagedSeconds).sum
@@ -281,9 +281,9 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         today = LocalDate.of(2025, 1, 6)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:63", "youtube.com", today, 20, 8 * 60)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         first  <- aru.getDayForProfile(kid, today)
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         second <- aru.getDayForProfile(kid, today)
       } yield assertTrue(first.nonEmpty) && assertTrue(first == second)
     },

--- a/api/test/src/feature/AppUsedRollupSpec.scala
+++ b/api/test/src/feature/AppUsedRollupSpec.scala
@@ -226,6 +226,41 @@ object AppUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgre
         assertTrue(appSum == 1500L) &&
         assertTrue(appRows.size == 2)
     },
+    test(
+      "#1564: AppTimeLimit + AppDayState carry the FK appId, not just the `app:<slug>` label",
+    ) {
+      // The cap surface keys on `apps.id` end-to-end so consumers no longer have to parse
+      // `label.stripPrefix(\"app:\")` and re-resolve a slug. The repo carries `a.id` straight
+      // through from the join (it was already in scope), and the per-app DayState exposes it
+      // alongside the slug-derived label (the label stays for SPA back-compat).
+      for {
+        _   <- cleanDb
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        ar  <- ZIO.service[AppRepo]
+        stl <- ZIO.service[AppTimeLimitRepo]
+        trr <- ZIO.service[TrafficReportRepo]
+        s   <- setTz(hsr, "UTC")
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:dd:ee:64", "kid", kid)
+        app <- seedApp(ar, kid, "fkapp", List("fkapp.com"), 60)
+        rid <- seedRouterRow
+        today = LocalDate.of(2025, 1, 6)
+        _    <- seedTraffic(rid, "aa:bb:cc:dd:ee:64", "fkapp.com", today, 10, 8 * 60)
+        atls <- stl.listForProfile(kid)
+        // Every emitted AppTimeLimit row carries the registered apps.id directly.
+        _   = atls
+        now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
+        tsvc  <- makeTimeService
+        state <- tsvc.dayStateLive(now, today, s, kid)
+        perApp = state.map(_.perApp).getOrElse(Nil)
+      } yield assertTrue(atls.nonEmpty) &&
+        assertTrue(atls.forall(_.appId == app)) &&
+        assertTrue(perApp.exists(_.appId == app)) &&
+        assertTrue(perApp.find(_.appId == app).map(_.usedMinutes).contains(10))
+    },
     test("re-running the aggregation tick is idempotent") {
       for {
         _   <- cleanDb

--- a/api/test/src/feature/MetricsExportSpec.scala
+++ b/api/test/src/feature/MetricsExportSpec.scala
@@ -98,7 +98,6 @@ object MetricsExportSpec
             profileRepo,
             deviceRepo,
             atlRepo,
-            appRepo,
             trafficRepo,
             hsRepo,
             clock,

--- a/api/test/src/feature/PolicySnapshotAppsSpec.scala
+++ b/api/test/src/feature/PolicySnapshotAppsSpec.scala
@@ -101,7 +101,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
       ru   <- ZIO.service[TimeUsedRollupRepo]
       aru  <- ZIO.service[AppUsedRollupRepo]
       clk  <- ZIO.service[Clock]
-      aus = new AppUsedRollupServiceLive(pr, dr, atlr, ar, trr, aru)
+      aus = new AppUsedRollupServiceLive(pr, dr, atlr, trr, aru)
       tss = new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er, ru, nsr, aus)
     } yield new PolicyServiceLive(
       pr,
@@ -315,7 +315,7 @@ object PolicySnapshotAppsSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPo
         aru    <- ZIO.service[AppUsedRollupRepo]
         clk    <- ZIO.service[Clock]
         now    <- clk.instant
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, atlr, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, atlr, trr, hsr, now)
         // Proves the rollup branch is exercised: the per-app rollup row exists for this profile.
         rolled <- aru.getDayForProfile(kids, today)
         svc    <- makePsRollup

--- a/api/test/src/feature/TimeUsedRollupSpec.scala
+++ b/api/test/src/feature/TimeUsedRollupSpec.scala
@@ -161,7 +161,7 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
         svc    <- makeService
         live   <- svc.dayStateAllLive(now, today, s)
-        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _      <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         cached <- svc.dayStateAll(now, today, s)
       } yield assertTrue(cached(kid).usedMinutes == live(kid).usedMinutes) &&
         assertTrue(live(kid).usedMinutes == 40)
@@ -253,12 +253,12 @@ object TimeUsedRollupSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgr
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 0)
         _ <- seedTraffic(rid, "aa:bb:cc:dd:ee:50", "mathacademy.com", today, 5, 20)
         now = LocalDateTime.of(2025, 1, 6, 12, 0).toInstant(ZoneOffset.UTC)
-        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         before      <- ru.getDayForProfile(kid, today)
         cur         <- hsr.get
         _           <- hsr.update(cur.copy(presenceContinuationSeconds = 900))
         invalidated <- ru.getDayForProfile(kid, today)
-        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, ar, trr, hsr, now)
+        _           <- TimeUsedRollupJob.oneTickForTest(ru, aru, pr, dr, stl, trr, hsr, now)
         after       <- ru.getDayForProfile(kid, today)
       } yield assertTrue(before.exists(_.usedSeconds == 600L)) &&
         assertTrue(invalidated.isEmpty) &&

--- a/api/test/src/feature/UsageApiSpec.scala
+++ b/api/test/src/feature/UsageApiSpec.scala
@@ -173,7 +173,6 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         profileRepo,
         deviceRepo,
         atlRepo,
-        appRepo,
         trafficRepo,
         hsr,
         now,
@@ -182,7 +181,6 @@ object UsageApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & C
         profileRepo,
         deviceRepo,
         atlRepo,
-        appRepo,
         trafficRepo,
         aruRepo,
       )

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -262,6 +262,11 @@ case class AppTimeLimit(
     dailyMinutes: Int,
     label: String,
     exemptFromDaily: Boolean = true,
+    // #1564: typed FK to apps(id), carried straight from the listForProfile join. This is the
+    // canonical app identity the cap/rollup surface keys on; `label` ("app:<slug>") stays as
+    // SPA-facing display text only. Defaults to AppId(0L) so seed/test constructions that don't
+    // care about the FK still compile during the rollout.
+    appId: AppId = AppId(0L),
 ) derives JsonCodec
 
 // #761: app concept. An App is a household-scoped named bundle of host


### PR DESCRIPTION
## Summary

Closes #1564.

The per-app cap/rollup surface used to identify a registered app by a
synthetic `"app:<slug>"` string label, even though `apps.id` was already in
hand at every step:

- `AppTimeLimitRepoLive.listForProfile` joined `apps a` (which has `a.id`
  right there) but built `label = s"app:${a.slug}"` and **discarded `a.id`**.
- `TimeStatusService.appSecondsByApp` had to parse it back: `label.stripPrefix("app:")` → slug → `slugToAppId` lookup → `apps.id`.
- `AppUsedRollupService.aggregate` then computed the **inverse** map (`idToSlug`) to re-key the result back to `app:<slug>` for the cap consumer.

A full slug round-trip that recovered exactly the id the source query already
had — and a drift risk every time a new path needed to reach the same app
identity. This PR removes the round-trip.

### What changes (additive on the wire)

- `AppTimeLimit` gains `appId: AppId`, carried straight from the repo join.
- `AppDayState` gains `appId: AppId` alongside `label` (additive).
- `TimeStatusService.groupSiteLimits` keys on `appId`; `appDayStatesFromMinutes` consumes `Map[AppId, Int]` and joins on `appId` directly.
- `TimeStatusService.appSecondsByApp` builds the `(label -> appId)` map alongside the cap groups and re-keys Presence's per-label result on `appId` — no `slugToAppId`, no slug parsing.
- `TimeStatusService.slugToAppId` is deleted; so is the inverse `idToSlug` round-trip in `AppUsedRollupService`.
- `AppUsedRollupService.appCapMinutesByLabel` → `appCapMinutesByAppId` returning `Map[AppId, Int]` — the same key `app_used_daily.app_id` already stores.
- `AppRepo` drops from `AppUsedRollupServiceLive` and `TimeUsedRollupJob` (slug lookup was the only reader).

### Back-compat / wire shape

- `label` stays on `AppTimeLimit`/`AppDayState` for the SPA. `appId` is added with default `AppId(0L)` so seed/test constructions that don't care about the FK still compile.
- The frozen `site_time_limit:` wire reason token (`BlockReason.AppTimeLimit`) is untouched — that's #376 territory.
- `app_used_daily` schema is unchanged — V53 already keyed on `app_id BIGINT REFERENCES apps(id)`. The original task plan called for a PR1 schema migration, but the column was already there; nothing to migrate.

### Single source of truth (AGENTS.md §single-source-of-truth)

The (label → appId) map is built **once** inside `groupSiteLimits`' consumers. There is no longer any ad-hoc slug↔id lookup in the cap or rollup paths.

## Test plan

- [x] Existing per-app cap / rollup / time-status tests pass (`api.test`, 82 specs).
- [x] New red→green feature test pinning the FK shape: `#1564: AppTimeLimit + AppDayState carry the FK appId, not just the \`app:<slug>\` label` in [AppUsedRollupSpec](api/test/src/feature/AppUsedRollupSpec.scala).
- [x] Reconciliation invariants from #1516 still hold (multi-host bridge, rolled+tail vs all-live, per-app sum == profile total in the restricted case, idempotent tick) — same suite.
- [x] `scalafmt --check` on the diff is clean.