### PR TITLE
refactor(#1547): remove dead legacy ProfileDetail.schedules field

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -229,10 +229,14 @@ object ProfileRoutes {
             details     <- ZIO
               .foreach(visible) { p =>
                 for {
-                  scheds  <- scheduleRepo.listForProfile(p.id)
+                  // #1547 PR2 — stop populating the dead legacy `schedules`
+                  // field. Enforcement reads named_schedules/profile_schedule_rules
+                  // (#1482/#1490); the upsert no longer writes the V1 table
+                  // (#1494). Emit `Nil` so a stale legacy row can't ride the
+                  // wire. Field stays on the model until #1485 drops it.
                   tl      <- timeLimitRepo.findForProfile(p.id)
                   schedId <- namedScheduleRepo.blockScheduleIdsForProfile(p.id)
-                } yield ProfileDetail(p, scheds, tl, schedId)
+                } yield ProfileDetail(p, Nil, tl, schedId)
               }
               .mapError(ApiError.Db(_))
           } yield Response.json(details.toJson)
@@ -249,12 +253,13 @@ object ProfileRoutes {
               .findById(pid)
               .mapError(ApiError.Db(_))
               .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
-            scheds  <- scheduleRepo.listForProfile(pid).mapError(ApiError.Db(_))
+            // #1547 PR2 — see GET /api/profiles above; legacy `schedules`
+            // field is emitted as Nil pending #1485 removal.
             tl      <- timeLimitRepo.findForProfile(pid).mapError(ApiError.Db(_))
             schedId <- namedScheduleRepo
               .blockScheduleIdsForProfile(pid)
               .mapError(ApiError.Db(_))
-          } yield Response.json(ProfileDetail(p, scheds, tl, schedId).toJson)
+          } yield Response.json(ProfileDetail(p, Nil, tl, schedId).toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1069: replace the set of named schedules attached to this profile as BLOCK schedules

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -229,14 +229,9 @@ object ProfileRoutes {
             details     <- ZIO
               .foreach(visible) { p =>
                 for {
-                  // #1547 PR2 — stop populating the dead legacy `schedules`
-                  // field. Enforcement reads named_schedules/profile_schedule_rules
-                  // (#1482/#1490); the upsert no longer writes the V1 table
-                  // (#1494). Emit `Nil` so a stale legacy row can't ride the
-                  // wire. Field stays on the model until #1485 drops it.
                   tl      <- timeLimitRepo.findForProfile(p.id)
                   schedId <- namedScheduleRepo.blockScheduleIdsForProfile(p.id)
-                } yield ProfileDetail(p, Nil, tl, schedId)
+                } yield ProfileDetail(p, tl, schedId)
               }
               .mapError(ApiError.Db(_))
           } yield Response.json(details.toJson)
@@ -253,13 +248,11 @@ object ProfileRoutes {
               .findById(pid)
               .mapError(ApiError.Db(_))
               .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
-            // #1547 PR2 — see GET /api/profiles above; legacy `schedules`
-            // field is emitted as Nil pending #1485 removal.
             tl      <- timeLimitRepo.findForProfile(pid).mapError(ApiError.Db(_))
             schedId <- namedScheduleRepo
               .blockScheduleIdsForProfile(pid)
               .mapError(ApiError.Db(_))
-          } yield Response.json(ProfileDetail(p, Nil, tl, schedId).toJson)
+          } yield Response.json(ProfileDetail(p, tl, schedId).toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
       // #1069: replace the set of named schedules attached to this profile as BLOCK schedules

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -78,14 +78,13 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.Unauthorized)
       },
-      // #1547 — PR2 of the deprecation sequence: the legacy `schedules` field
-      // is dead weight on the wire. Enforcement now reads named_schedules /
-      // profile_schedule_rules (#1482/#1490) and the upsert no longer writes
-      // the V1 table (#1494). Stop populating the field server-side so a
-      // stale legacy row (left over from before #1494) cannot ride out on the
-      // wire and lure a future SPA surface into reading it. The field stays
-      // on the wire model until the #1485 deprecation window allows removal.
-      test("GET /api/profiles emits empty `schedules` even when legacy rows exist (#1547)") {
+      // #1547 — the legacy `schedules` field is removed from ProfileDetail.
+      // Enforcement reads named_schedules / profile_schedule_rules
+      // (#1482/#1490), the upsert no longer writes the V1 table (#1494), and
+      // no client surface reads `pd.schedules`. Assert the JSON body omits
+      // the key entirely even when a stale legacy row exists — a regression
+      // that re-adds the field will fail this raw-string check.
+      test("GET /api/profiles JSON omits the legacy `schedules` key (#1547)") {
         for {
           _           <- cleanDb
           profileRepo <- ZIO.service[ProfileRepo]
@@ -106,24 +105,24 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           )
           (auth, routes) <- mkRoutes
           token          <- auth.login("admin", "changeme").map(_.token.value)
-          req = Request
-            .get(URL.decode("/api/profiles").toOption.get)
-            .addHeader(Header.Authorization.Bearer(token))
-          resp    <- routes.runZIO(req)
-          body    <- resp.body.asString
-          details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
-          kidsDetail = details.find(_.profile.name == "Kids").get
-          single       <- routes.runZIO(
+          listResp       <- routes.runZIO(
+            Request
+              .get(URL.decode("/api/profiles").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          listBody       <- listResp.body.asString
+          singleResp     <- routes.runZIO(
             Request
               .get(URL.decode(s"/api/profiles/${kids.id.value}").toOption.get)
               .addHeader(Header.Authorization.Bearer(token)),
           )
-          singleBody   <- single.body.asString
-          singleDetail <- ZIO.fromEither(singleBody.fromJson[ProfileDetail])
-        } yield assertTrue(resp.status == Status.Ok) &&
-          assertTrue(kidsDetail.schedules.isEmpty) &&
-          assertTrue(single.status == Status.Ok) &&
-          assertTrue(singleDetail.schedules.isEmpty)
+          singleBody     <- singleResp.body.asString
+        } yield assertTrue(listResp.status == Status.Ok) &&
+          assertTrue(!listBody.contains("\"schedules\"")) &&
+          assertTrue(!listBody.contains("stale-legacy")) &&
+          assertTrue(singleResp.status == Status.Ok) &&
+          assertTrue(!singleBody.contains("\"schedules\"")) &&
+          assertTrue(!singleBody.contains("stale-legacy"))
       },
     ),
     suite("POST /api/profiles")(

--- a/api/test/src/feature/ProfileApiSpec.scala
+++ b/api/test/src/feature/ProfileApiSpec.scala
@@ -14,6 +14,7 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 import zio.test.Assertion.*
+import java.time.{LocalTime, ZoneId}
 
 /**
  * Feature tests for the Profile API.
@@ -76,6 +77,53 @@ object ProfileApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           req = Request.get(URL.decode("/api/profiles").toOption.get)
           resp <- routes.runZIO(req)
         } yield assertTrue(resp.status == Status.Unauthorized)
+      },
+      // #1547 — PR2 of the deprecation sequence: the legacy `schedules` field
+      // is dead weight on the wire. Enforcement now reads named_schedules /
+      // profile_schedule_rules (#1482/#1490) and the upsert no longer writes
+      // the V1 table (#1494). Stop populating the field server-side so a
+      // stale legacy row (left over from before #1494) cannot ride out on the
+      // wire and lure a future SPA surface into reading it. The field stays
+      // on the wire model until the #1485 deprecation window allows removal.
+      test("GET /api/profiles emits empty `schedules` even when legacy rows exist (#1547)") {
+        for {
+          _           <- cleanDb
+          profileRepo <- ZIO.service[ProfileRepo]
+          schedRepo   <- ZIO.service[ScheduleRepo]
+          profiles    <- profileRepo.listAll
+          kids = profiles.find(_.name == "Kids").get
+          _              <- schedRepo.replaceForProfile(
+            kids.id,
+            List(
+              ScheduleRequest(
+                name = "stale-legacy",
+                days = List("mon", "tue"),
+                startLocal = LocalTime.of(21, 0),
+                endLocal = LocalTime.of(7, 0),
+                tz = ZoneId.of("UTC"),
+              ),
+            ),
+          )
+          (auth, routes) <- mkRoutes
+          token          <- auth.login("admin", "changeme").map(_.token.value)
+          req = Request
+            .get(URL.decode("/api/profiles").toOption.get)
+            .addHeader(Header.Authorization.Bearer(token))
+          resp    <- routes.runZIO(req)
+          body    <- resp.body.asString
+          details <- ZIO.fromEither(body.fromJson[List[ProfileDetail]])
+          kidsDetail = details.find(_.profile.name == "Kids").get
+          single       <- routes.runZIO(
+            Request
+              .get(URL.decode(s"/api/profiles/${kids.id.value}").toOption.get)
+              .addHeader(Header.Authorization.Bearer(token)),
+          )
+          singleBody   <- single.body.asString
+          singleDetail <- ZIO.fromEither(singleBody.fromJson[ProfileDetail])
+        } yield assertTrue(resp.status == Status.Ok) &&
+          assertTrue(kidsDetail.schedules.isEmpty) &&
+          assertTrue(single.status == Status.Ok) &&
+          assertTrue(singleDetail.schedules.isEmpty)
       },
     ),
     suite("POST /api/profiles")(

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -968,7 +968,6 @@ case class DeviceTimeStatusWeek(
 
 case class ProfileDetail(
     profile: Profile,
-    schedules: List[Schedule],
     timeLimit: Option[TimeLimit],
     // #1069: ids of the named schedules attached to this profile as block
     // schedules (downtime while active). Empty until the operator attaches one.

--- a/web/src/api/queries.test.tsx
+++ b/web/src/api/queries.test.tsx
@@ -90,7 +90,7 @@ describe('SWR caching (#803)', () => {
     const qc = freshClient(0)
     const wrapper = makeWrapper(qc)
     ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all' as const, crossDeviceOverlapMode: 'sum' as const }, schedules: [], timeLimit: null },
+      { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all' as const, crossDeviceOverlapMode: 'sum' as const }, timeLimit: null },
     ])
     const hook = renderHook(() => useProfiles(), { wrapper })
     await waitFor(() => expect(hook.result.current.isSuccess).toBe(true))

--- a/web/src/pages/AppsPage.test.tsx
+++ b/web/src/pages/AppsPage.test.tsx
@@ -36,7 +36,6 @@ function makeProfile(id: number, name: string): ProfileDetail {
       pauseMode: 'soft',
       defaultDeny: false,
     },
-    schedules: [],
     timeLimit: null,
   }
 }

--- a/web/src/pages/DevicesPage.test.tsx
+++ b/web/src/pages/DevicesPage.test.tsx
@@ -58,11 +58,11 @@ const laptop: Device = {
 
 const kidsProfile: ProfileDetail = {
   profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false },
-  schedules: [], timeLimit: null,
+  timeLimit: null,
 }
 const adultsProfile: ProfileDetail = {
   profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false, failureMode: 'last-known-good', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false },
-  schedules: [], timeLimit: null,
+  timeLimit: null,
 }
 
 beforeEach(() => {

--- a/web/src/pages/LogsPage.test.tsx
+++ b/web/src/pages/LogsPage.test.tsx
@@ -39,7 +39,7 @@ const devices: Device[] = [
   { id: 10, mac: 'aa:bb:cc:dd:ee:01', name: "Kid's iPad", profileId: 1, profileName: 'Kids', lastSeenIp: null, lastSeenAt: null },
 ]
 const profileDetails: ProfileDetail[] = [
-  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false }, schedules: [], timeLimit: null },
+  { profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false, failureMode: 'block-all', crossDeviceOverlapMode: 'sum', pauseMode: 'soft', defaultDeny: false }, timeLimit: null },
 ]
 
 // Surfaces the current URL search string so tests can assert query-param

--- a/web/src/pages/ProfilesPage.test.tsx
+++ b/web/src/pages/ProfilesPage.test.tsx
@@ -101,7 +101,6 @@ const kidsProfile: ProfileDetail = {
   // #1494: the legacy inline `schedules` read field is now always empty (the
   // upsert no longer writes the V1 table). A profile's block schedules are the
   // attached #1069 named-schedule ids.
-  schedules: [],
   scheduleIds: [10],
   timeLimit: { id: 5, profileId: 1, dailyMinutes: 120 },
 }
@@ -117,7 +116,6 @@ const adultsProfile: ProfileDetail = {
     pauseMode: 'soft',
     defaultDeny: false,
   },
-  schedules: [],
   scheduleIds: [],
   timeLimit: null,
 }
@@ -225,7 +223,7 @@ describe('ProfilesPage — list (collapse-by-default shell, #972)', () => {
     // override the Kids profile to drop the schedule so the "active" chip
     // assertion is independent of when the test happens to run.
     (api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([
-      { ...kidsProfile, schedules: [] },
+      { ...kidsProfile },
       adultsProfile,
     ])
     renderPage()
@@ -1825,15 +1823,11 @@ describe('ProfilesPage — per-profile default-deny toggle (#1320)', () => {
   })
 })
 
-// #1539 — the "Paused (schedule)" chip must reflect the schedules that actually
-// ENFORCE (the household named schedules attached via `scheduleIds`), not the
-// dead legacy `pd.schedules` field. Enforcement (PolicyService) folds the named
-// schedules' windows into the per-MAC `blocked` flag; #1482/#1494 left the V1
-// `schedules` table out of enforcement and the upsert no longer writes it. The
-// chip used to read `pd.schedules`, so two profiles sharing the SAME named
-// schedules could show divergent chips (one "Paused (schedule)", one "Active")
-// purely from stale/per-profile legacy rows — the prod symptom in #1539.
-describe('ProfilesPage — schedule chip reads named schedules, not legacy (#1539)', () => {
+// #1539 — the "Paused (schedule)" chip reflects the household named schedules
+// attached via `scheduleIds`. Pre-#1547 the chip used to read a `pd.schedules`
+// field that has since been removed from the wire model; only the positive
+// case (identical named attachments → identical chips) remains pinnable.
+describe('ProfilesPage — schedule chip reads named schedules (#1539)', () => {
   // Two windows whose union covers the whole local day on every weekday, so the
   // chip is "active now" regardless of when the test runs (no wall-clock flake).
   const alwaysActive: NamedSchedule = {
@@ -1846,18 +1840,16 @@ describe('ProfilesPage — schedule chip reads named schedules, not legacy (#153
     ],
   }
 
-  it('identical named-schedule attachments yield identical chips (legacy rows empty)', async () => {
-    // Both profiles attach the SAME named schedule (id 10), both with an EMPTY
-    // legacy `schedules` array — proving the chip comes from the named source.
+  it('identical named-schedule attachments yield identical chips', async () => {
     const p1: ProfileDetail = {
       ...kidsProfile,
       profile: { ...kidsProfile.profile, id: 1, name: 'Kids', paused: false },
-      schedules: [], scheduleIds: [10], timeLimit: null,
+      scheduleIds: [10], timeLimit: null,
     }
     const p2: ProfileDetail = {
       ...kidsProfile,
       profile: { ...kidsProfile.profile, id: 2, name: 'Teens', paused: false },
-      schedules: [], scheduleIds: [10], timeLimit: null,
+      scheduleIds: [10], timeLimit: null,
     }
     ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([p1, p2])
     ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([alwaysActive])
@@ -1868,28 +1860,5 @@ describe('ProfilesPage — schedule chip reads named schedules, not legacy (#153
     const c2 = await screen.findByTestId('profile-pause-chip-2')
     expect(c1).toHaveAttribute('data-chip', 'paused-schedule')
     expect(c2).toHaveAttribute('data-chip', 'paused-schedule')
-  })
-
-  it('ignores the dead legacy `schedules` field (active legacy row, no named attachment → Active)', async () => {
-    // A profile with an active-now LEGACY schedule but NO named attachment must
-    // read "Active" — the legacy table is not an enforcement source (#1482), so
-    // the chip must not be driven by it.
-    const legacyOnly: ProfileDetail = {
-      ...kidsProfile,
-      profile: { ...kidsProfile.profile, id: 1, name: 'Kids', paused: false },
-      schedules: [
-        { id: 1, profileId: 1, name: 'legacy-am', days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '00:00', endLocal: '12:00', tz: 'UTC' },
-        { id: 2, profileId: 1, name: 'legacy-pm', days: ['mon','tue','wed','thu','fri','sat','sun'], startLocal: '12:00', endLocal: '00:00', tz: 'UTC' },
-      ],
-      scheduleIds: [],
-      timeLimit: null,
-    }
-    ;(api.profiles.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([legacyOnly])
-    ;(api.schedules.list as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
-    ;(api.time.summaryAll as unknown as ReturnType<typeof vi.fn>).mockResolvedValue([])
-
-    renderPage()
-    const chip = await screen.findByTestId('profile-pause-chip-1')
-    expect(chip).toHaveAttribute('data-chip', 'active')
   })
 })

--- a/web/src/pages/SchedulesPage.test.tsx
+++ b/web/src/pages/SchedulesPage.test.tsx
@@ -33,11 +33,11 @@ const school: NamedSchedule = {
 // Kids references Bedtime (id 1); Adults references nothing.
 const kids = {
   profile: { id: 10, name: 'Kids', blockedCategories: [], paused: false },
-  schedules: [], timeLimit: null, scheduleIds: [1],
+  timeLimit: null, scheduleIds: [1],
 } as unknown as ProfileDetail
 const adults = {
   profile: { id: 11, name: 'Adults', blockedCategories: [], paused: false },
-  schedules: [], timeLimit: null, scheduleIds: [],
+  timeLimit: null, scheduleIds: [],
 } as unknown as ProfileDetail
 
 const fn = (f: unknown) => f as unknown as ReturnType<typeof vi.fn>

--- a/web/src/pages/UsersPage.test.tsx
+++ b/web/src/pages/UsersPage.test.tsx
@@ -23,12 +23,12 @@ import { UsersPage } from './UsersPage'
 
 const kidsProfile = {
   profile: { id: 1, name: 'Kids', blockedCategories: [], paused: false },
-  schedules: [], timeLimit: null,
+  timeLimit: null,
 } as unknown as ProfileDetail
 
 const adultsProfile = {
   profile: { id: 2, name: 'Adults', blockedCategories: [], paused: false },
-  schedules: [], timeLimit: null,
+  timeLimit: null,
 } as unknown as ProfileDetail
 
 const aliceUser: User = { id: 10, username: 'alice', role: 'admin', profileIds: [] }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -115,7 +115,6 @@ export interface AppTimeLimit {
 
 export interface ProfileDetail {
   profile: Profile
-  schedules: Schedule[]
   timeLimit: TimeLimit | null
   // #1069 — ids of the household named schedules attached to this profile as
   // block schedules (downtime while active). Empty until the operator attaches


### PR DESCRIPTION
Closes #1547.

Removes the dead legacy `schedules` field from `ProfileDetail` on both wire ends — Scala case class (`shared/src/Models.scala`), API serialization (`api/src/routes/Routes.scala`), TypeScript interface (`web/src/types/api.ts`), and every SPA test fixture that carried `schedules: []` to satisfy the type.

## Why removing the field outright is safe
- **Enforcement** reads `named_schedules` / `profile_schedule_rules` (#1482/#1490); the V1 `schedules` table is never consulted.
- **Upsert** stopped writing the V1 table in #1494, so the only `schedules` rows in prod are stale leftovers.
- **Router agent** doesn't fetch this endpoint (router reads `/api/router/policy`).
- **SPA** has no surface reading `pd.schedules` — grep `web/src` confirms only comments mentioned it, and the chip path was migrated in #1542.
- **Wire-shape removal** is invisible at SPA runtime: TS types are erased and nothing reads the key, so a missing key in the JSON response has no behavioral effect even for an older SPA bundle.
- **#1485 is still the V1 table drop** (destructive migration, ~2026-06-12); this PR is wire-model only.

## Test plan
- [x] RED commit (1d86ddb3): new ProfileApiSpec test seeds a stale legacy row via `ScheduleRepo.replaceForProfile`, asserts both `GET /api/profiles` and `GET /api/profiles/:id` responses contain neither `"schedules"` nor `stale-legacy`. Failed before code change.
- [x] GREEN commit (4862b14a): field removed; new test passes; `mill api.test.testOnly` for Profile/GlobalPolicy/RoleAccess/Schedules specs green.
- [x] Full SPA suite: 394/394 green (`npx vitest run`).
- [x] SPA type-check: `npx tsc --noEmit` clean.
- [x] `scalafmt --check` clean.

Supersedes #1598 (the test-pin stopgap is no longer needed — there is no field left to read).