### PR TITLE
feat(#1585): write-time FQDN backfill for traffic_reports

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -86,6 +86,14 @@ object MetricGuard {
     // underscores, see #1572) is skipped + metered here instead of 400-ing the
     // whole batch. `reason` is a small fixed enum (currently just `decode_error`).
     "usage_records_rejected_total"              -> Set("reason"),
+    // #1585 — write-time FQDN backfill for traffic_reports. Counts each
+    // UsageRecord at ingest by what the backfill decided: `filled` (race-loser
+    // ipv4/ipv6 rewritten to a fqdn from a recent connection_event),
+    // `miss` (candidate had no matching fqdn in the window), or `skip` (record
+    // was already fqdn, or carried no dest_ip — not a candidate). `result` is
+    // a small fixed enum; bounded. Reuses the existing `result` label key
+    // rather than introducing `outcome` (#1210 keeps the vocabulary small).
+    "traffic_reports_backfill_total"            -> Set("result"),
     // #1318 — global-policy-layer visibility. `global_allow_hosts` is the size of the
     // security-sensitive fleet-wide always-reachable set (a host here bypasses every block);
     // `default_deny_profiles` counts profiles running the block-all baseline. Both are unlabelled
@@ -266,6 +274,16 @@ object AppMetrics {
   // ingest instead of failing the whole batch. A rising rate flags an agent/DNS
   // source emitting host values the API rejects (the #1572 CNAME-target case).
   // `reason` is a small fixed enum — only `decode_error` today.
+
+  // ── #1585: traffic_reports write-time FQDN backfill outcomes ───────────────
+  // Per-UsageRecord ingest decision: `filled` (race-loser ipv4/ipv6 rewritten
+  // to a fqdn from a recent connection_event), `miss` (candidate but no fqdn
+  // in the window — operator can rate-alert on a rising miss share to spot
+  // unattributable destinations), or `skip` (already fqdn, or no dest_ip).
+  // `result` is the small fixed enum.
+
+  def recordTrafficBackfill(result: String): UIO[Unit] =
+    MetricGuard.counter("traffic_reports_backfill_total", Map("result" -> result))
 
   def recordUsageRecordsRejected(count: Int, reason: String = "decode_error"): UIO[Unit] =
     ZIO

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -92,6 +92,7 @@ object RouterIngestRoutes {
               trafficRepo,
               timeUsageRepo,
               deviceRepo,
+              connEventRepo,
             )
             _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
           } yield Response.ok
@@ -175,6 +176,7 @@ object RouterIngestRoutes {
       trafficRepo: TrafficReportRepo,
       timeUsageRepo: TimeUsageRepo,
       deviceRepo: DeviceRepo,
+      connEventRepo: ConnectionEventRepo,
   ): IO[ApiError, Unit] = {
     // #1010: bucket usage by the household's logical "today" (TZ + non-midnight
     // reset_time), matching the read-side date used by PolicyService.snapshot.
@@ -185,36 +187,105 @@ object RouterIngestRoutes {
     // regression shows up as a rising rate rather than a per-request warn-log.
     val zeroByteRows =
       records.count(r => r.activeSeconds == 0L && r.bytesIn == 0L && r.bytesOut == 0L)
-    val inserts      = records.map(r =>
-      TrafficReportInsert(
-        routerId,
-        r.mac,
-        r.ip,
-        r.host,
-        date,
-        periodStart,
-        periodEnd,
-        r.activeSeconds.toInt,
-        r.bytesIn,
-        r.bytesOut,
-        // #730: pass through the per-record destination IP. INSERT ... ON
-        // CONFLICT DO NOTHING means colliding records on the existing
-        // (router_id, period_start, mac, host_type, host_value) key keep the
-        // first row's dest_ip — same byte/seconds behaviour as today; #730 just
-        // adds the column the follow-up write-time FQDN backfill will consume.
-        r.destIp,
-      ),
-    )
     for {
-      _        <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
+      _         <- AppMetrics.recordZeroByteFiltered(zeroByteRows)
+      // #1585: write-time FQDN backfill. The router's per-(mac, dst_ip)
+      // accumulator emits records whose host is the resolved fqdn when DNS
+      // attribution won the race, but ipv4/ipv6 when it lost (DoH, hard-coded
+      // IP, or just an ordering race). For each such race-loser we consult
+      // recent fqdn connection_events for the same (router_id, dest_ip) and
+      // rewrite the record to its resolved fqdn BEFORE inserting — so the
+      // traffic_reports row lands under the human-readable host and the
+      // read-side LATERAL join (#730 follow-up cleanup) can eventually go away.
+      rewritten <- ZIO.foreach(records)(r =>
+        backfillRecord(routerId, r, periodStart, connEventRepo),
+      )
+      // After rewrite, two distinct (mac, dst_ip) records can collapse to the
+      // same (mac, host) at the same period — the existing primary key
+      // (router_id, period_start, mac, host_type, host_value) makes the second
+      // INSERT a silent no-op under ON CONFLICT DO NOTHING and the row's bytes
+      // would be dropped. Aggregate (sum bytes; max activeSeconds — same merge
+      // applyDelta uses below) before INSERT.
+      aggregated = aggregateForInsert(rewritten)
+      inserts    = aggregated.map(r =>
+        TrafficReportInsert(
+          routerId,
+          r.mac,
+          r.ip,
+          r.host,
+          date,
+          periodStart,
+          periodEnd,
+          r.activeSeconds.toInt,
+          r.bytesIn,
+          r.bytesOut,
+          r.destIp,
+        ),
+      )
       // Idempotency: ON CONFLICT DO NOTHING returns the count of NEW rows.
       // Only those rows should drive time_usage / device updates; replays return 0.
       newCount <- trafficRepo.insertBatch(inserts).mapError(ApiError.Db(_))
+      // applyDelta groups by (mac, host); pass the rewritten records so the
+      // time_usage credit lands under the resolved fqdn too. Unaggregated is
+      // fine — applyDelta already collapses duplicates with the same merge.
       _        <- ZIO.when(newCount > 0)(
-        applyDelta(routerId, periodEnd, records, settings, timeUsageRepo, deviceRepo),
+        applyDelta(routerId, periodEnd, rewritten, settings, timeUsageRepo, deviceRepo),
       )
     } yield ()
   }
+
+  /**
+   * #1585: rewrite a race-loser ipv4/ipv6 UsageRecord to its resolved FQDN by consulting recent
+   * fqdn-typed connection_events for the same (router_id, dest_ip). Reuses [[fqdnBackfillWindow]]
+   * for symmetry with the events-side backfill (#720); five minutes covers conntrack/dns-tail
+   * jitter without inviting attribution across reused-IP cloud endpoints. Emits
+   * `traffic_reports_backfill_total{outcome}` per record: `skip` (not a candidate — already fqdn,
+   * or no dest_ip), `filled` (rewritten), or `miss` (candidate, no fqdn found).
+   */
+  private def backfillRecord(
+      routerId: RouterId,
+      record: UsageRecord,
+      periodStart: Instant,
+      connEventRepo: ConnectionEventRepo,
+  ): IO[ApiError, UsageRecord] =
+    (record.host, record.destIp) match {
+      case (HostId.IPv4(_) | HostId.IPv6(_), Some(destIp)) =>
+        connEventRepo
+          .findRecentFqdnFor(routerId, destIp, periodStart.minus(fqdnBackfillWindow))
+          .mapError(ApiError.Db(_))
+          .flatMap {
+            case Some(name) =>
+              AppMetrics.recordTrafficBackfill("filled").as(record.copy(host = HostId.Fqdn(name)))
+            case None       =>
+              AppMetrics.recordTrafficBackfill("miss").as(record)
+          }
+      case _                                               =>
+        AppMetrics.recordTrafficBackfill("skip").as(record)
+    }
+
+  /**
+   * #1585: collapse (mac, host) duplicates before INSERT so the traffic_reports primary key's `ON
+   * CONFLICT DO NOTHING` doesn't silently drop bytes from race-losers that the backfill just
+   * rewrote into a sibling record's bucket. Bytes sum; activeSeconds takes the max (the agent emits
+   * the bucket duration on every record, so summing would double-count the wall-clock); destIp / ip
+   * take the first non-null. Single-host batches (the common case) pass through unchanged.
+   */
+  private def aggregateForInsert(records: List[UsageRecord]): List[UsageRecord] =
+    records
+      .groupBy(r => (r.mac, r.host))
+      .view
+      .map { case (_, rs) =>
+        rs.reduce { (a, b) =>
+          a.copy(
+            ip = a.ip.orElse(b.ip),
+            activeSeconds = math.max(a.activeSeconds, b.activeSeconds),
+            bytesIn = a.bytesIn + b.bytesIn,
+            bytesOut = a.bytesOut + b.bytesOut,
+            destIp = a.destIp.orElse(b.destIp),
+          )
+        }
+      }
+      .toList
 
   /**
    * Apply seconds/byte deltas + device last_seen for a freshly-accepted batch. We only enter here

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -584,6 +584,180 @@ object RouterIngestSpec
       } yield assertTrue(resp.status == Status.Ok) && assertTrue(d.isEmpty)
     },
 
+    // ── #1585: write-time FQDN backfill for traffic_reports ──────────────────
+    test(
+      "usage: ipv4-typed UsageRecord with destIp matching a recent fqdn connection_event " +
+        "is persisted under the resolved FQDN",
+    ) {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        // Seed a fqdn-typed connection_event for (router, destIp) inside the
+        // backfill window so the ingest path can attribute the ipv4 row to the
+        // FQDN. We pin the event 1 minute before periodStart so the recency
+        // filter (since = periodStart - 5min) selects it.
+        _        <- cRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId = id,
+              mac = Some(MacAddress.unsafe(knownMac)),
+              host = HostId.Fqdn(Hostname.unsafe("neverssl.com")),
+              destIp = Some(IpAddress.unsafe("34.223.124.45")),
+              allowed = true,
+              reason = BlockReason.Allow,
+              ts = periodStart.minusSeconds(60),
+              eventId = Some(UUID.randomUUID()),
+            ),
+          ),
+        )
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          Some(IpAddress.unsafe("192.168.1.42")),
+          HostId.IPv4(IpAddress.unsafe("34.223.124.45")),
+          60L,
+          100L,
+          50L,
+          Some(IpAddress.unsafe("34.223.124.45")),
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        resp <- post(routes, "/api/router/usage", body, Some(tk))
+        rows <- sql"""SELECT host_type, host_value, dest_ip, bytes_in, bytes_out
+                       FROM traffic_reports
+                       WHERE router_id = $id
+                         AND mac = ${MacAddress.unsafe(knownMac)}"""
+          .query[(String, String, Option[String], Long, Long)]
+          .to[List]
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(rows.head._1 == "fqdn") &&
+        assertTrue(rows.head._2 == "neverssl.com") &&
+        assertTrue(rows.head._3.contains("34.223.124.45")) &&
+        assertTrue(rows.head._4 == 100L) &&
+        assertTrue(rows.head._5 == 50L)
+    },
+    test(
+      "usage: ipv4-typed UsageRecord with destIp but NO matching connection_event " +
+        "is persisted under the ipv4 literal (miss)",
+    ) {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        rec  = UsageRecord(
+          MacAddress.unsafe(knownMac),
+          Some(IpAddress.unsafe("192.168.1.42")),
+          HostId.IPv4(IpAddress.unsafe("203.0.113.7")),
+          60L,
+          100L,
+          50L,
+          Some(IpAddress.unsafe("203.0.113.7")),
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, List(rec)).toJson
+        resp <- post(routes, "/api/router/usage", body, Some(tk))
+        rows <- sql"""SELECT host_type, host_value
+                       FROM traffic_reports
+                       WHERE router_id = $id
+                         AND mac = ${MacAddress.unsafe(knownMac)}"""
+          .query[(String, String)]
+          .to[List]
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(rows.head._1 == "ipv4") &&
+        assertTrue(rows.head._2 == "203.0.113.7")
+    },
+    test(
+      "usage: two ipv4 UsageRecords whose destIps resolve to the same FQDN " +
+        "collapse to one traffic_reports row with summed bytes",
+    ) {
+      import doobie.implicits.*
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        xa       <- ZIO.service[Transactor[Task]]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        // Seed two fqdn events, one per destIp, both mapping to cdn.example.com.
+        _        <- cRepo.insertBatch(
+          List(
+            ConnectionEventInsert(
+              routerId = id,
+              mac = Some(MacAddress.unsafe(knownMac)),
+              host = HostId.Fqdn(Hostname.unsafe("cdn.example.com")),
+              destIp = Some(IpAddress.unsafe("198.51.100.10")),
+              allowed = true,
+              reason = BlockReason.Allow,
+              ts = periodStart.minusSeconds(60),
+              eventId = Some(UUID.randomUUID()),
+            ),
+            ConnectionEventInsert(
+              routerId = id,
+              mac = Some(MacAddress.unsafe(knownMac)),
+              host = HostId.Fqdn(Hostname.unsafe("cdn.example.com")),
+              destIp = Some(IpAddress.unsafe("198.51.100.11")),
+              allowed = true,
+              reason = BlockReason.Allow,
+              ts = periodStart.minusSeconds(60),
+              eventId = Some(UUID.randomUUID()),
+            ),
+          ),
+        )
+        recs = List(
+          UsageRecord(
+            MacAddress.unsafe(knownMac),
+            None,
+            HostId.IPv4(IpAddress.unsafe("198.51.100.10")),
+            60L,
+            100L,
+            50L,
+            Some(IpAddress.unsafe("198.51.100.10")),
+          ),
+          UsageRecord(
+            MacAddress.unsafe(knownMac),
+            None,
+            HostId.IPv4(IpAddress.unsafe("198.51.100.11")),
+            60L,
+            200L,
+            10L,
+            Some(IpAddress.unsafe("198.51.100.11")),
+          ),
+        )
+        body = UsageReport(id, periodStart.toString, periodEnd.toString, recs).toJson
+        resp <- post(routes, "/api/router/usage", body, Some(tk))
+        rows <- sql"""SELECT host_type, host_value, bytes_in, bytes_out
+                       FROM traffic_reports
+                       WHERE router_id = $id
+                         AND mac = ${MacAddress.unsafe(knownMac)}"""
+          .query[(String, String, Long, Long)]
+          .to[List]
+          .transact(xa)
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(rows.head._1 == "fqdn") &&
+        assertTrue(rows.head._2 == "cdn.example.com") &&
+        assertTrue(rows.head._3 == 300L) &&
+        assertTrue(rows.head._4 == 60L)
+    },
+
     // ── events ───────────────────────────────────────────────────────────────
     test("events: connection_attempt batch is recorded with allowed/reason") {
       for {

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -371,6 +371,77 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Traffic_reports write-time FQDN backfill (#1585)",
+      "description": "sum by (result) (rate(traffic_reports_backfill_total[5m])) — per-UsageRecord ingest decision from RouterIngestRoutes.backfillRecord. `filled` = ipv4/ipv6 race-loser rewritten to a fqdn from a recent connection_event (the desired outcome); `miss` = candidate but no fqdn in the 5-min window (host stays ipv4/ipv6 — a sustained high miss share means destinations the router can't attribute, e.g. DoH or hard-coded IPs); `skip` = already a fqdn or no dest_ip (the bulk of healthy traffic). `result` is a fixed enum. From AppMetrics.recordTrafficBackfill.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 40 },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(traffic_reports_backfill_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Backfill miss share (#1585)",
+      "description": "miss / (filled + miss) over 1h — share of attributable-candidate UsageRecords (ipv4/ipv6 + dest_ip) for which no fqdn could be found in the backfill window. A rising share means more destinations are landing in traffic_reports under their IP literal instead of a hostname; investigate DNS attribution (DoH on devices, agent dnsmasq health, conntrack/dns-tail race). `skip` is excluded from the denominator — it counts records that were never backfill candidates.",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.25 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(traffic_reports_backfill_total{env=\"$env\",result=\"miss\"}[1h])) / clamp_min(sum(rate(traffic_reports_backfill_total{env=\"$env\",result=~\"filled|miss\"}[1h])), 1e-9)",
+          "legendFormat": "miss share (1h)",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
Closes #1585.

## Summary

- When an ipv4/ipv6-typed `UsageRecord` arrives with a non-null `destIp` (the router-side per-(mac, dst_ip) accumulator's race-loser path), `RouterIngestRoutes.handleUsage` now consults recent fqdn `connection_events` for the same `(router_id, dest_ip)` and rewrites the record to its resolved FQDN **before** inserting into `traffic_reports`. The row lands under the human-readable host instead of the IP literal — what the read-side `LATERAL` join from #730 has been compensating for at every read path.
- Mirrors the events-side backfill (#720): reuses the existing 5-minute `fqdnBackfillWindow` constant and the same `ConnectionEventRepo.findRecentFqdnFor` query. The lookup is already served by `idx_conn_events_router_dest_ip_ts` (V42) `ON connection_events (router_id, dest_ip, ts DESC) WHERE dest_ip IS NOT NULL` — **no schema change required** (so no PR1 split per AGENTS.md migration-isolation).
- After the rewrite, `(mac, host)` duplicates are aggregated **before** `insertBatch`. Two race-loser records with different `destIp`s that both map to the same fqdn now collapse into one row with summed bytes; without the aggregation step the second `INSERT` would be silently dropped by the existing `(router_id, period_start, mac, host_type, host_value)` `ON CONFLICT DO NOTHING` and its bytes would vanish. Same `(max activeSeconds, sum bytes)` merge `applyDelta` uses below.
- `applyDelta` is fed the rewritten records too, so `time_usage` credit lands under the resolved fqdn (not the IP literal).

## Metric + dashboard

Per AGENTS.md §instrument-new-functionality / §metrics-need-a-dashboard, the new path ships with a counter and a panel in the same PR:

- `AppMetrics.recordTrafficBackfill(result)` → `traffic_reports_backfill_total{result}` where `result ∈ {filled, miss, skip}`. Reuses the existing bounded `result` label key — no new `KnownLabelKeys` entry needed (per #1210 \"keep the vocabulary small\").
- Two panels added to `deploy/grafana/dashboards/data-quality-ingest.json` (already registered in `infra/grafana/main.tf`):
  - per-`result` rate timeseries
  - `miss / (filled + miss)` 1h share stat (skip excluded from denominator — those records were never candidates)

## Scope

The issue's acceptance bullet 3 (retire 8 read-side `LATERAL` joins + drop V22 `idx_conn_events_mac_dest_resolved` + delete `TimeUsageBackfillSpec`) is **deferred to a follow-up**: V54 — the `traffic_reports.dest_ip` column that this PR's backfill writes — only landed yesterday (`ecb4781d` 2026-06-07), so pre-V54 ipv4 `time_usage` rows are still well within retention and the read-side join is still load-bearing. Removing the join now would silently lose attribution on those rows until they age out.

## Test plan

TDD red→green:

- `0d24fe2a` — three feature tests added to `RouterIngestSpec` against embedded Postgres (positive backfill, miss, two-IP collapse). Committed RED.
- `7c7927cc` — implementation. All three now pass; full `api.test` suite (852 tests) and `shared.test` (≥86 tests) green locally.

Verifications I ran:
- [x] `scalafmt --check --non-interactive` clean
- [x] `python3 -m json.tool` on the dashboard JSON
- [x] `terraform fmt -check` in `infra/grafana/`
- [x] `mill --jobs 4 api.test` — all suites pass
- [x] `mill shared.test` — all suites pass

### Query plan (AGENTS.md §query-explain-before-merge)

The new backfill lookup is `findRecentFqdnFor`, the **identical** query the #720 events-side backfill already runs on the same hot ingest path. It hits the partial index `idx_conn_events_router_dest_ip_ts (router_id, dest_ip, ts DESC) WHERE dest_ip IS NOT NULL` (V42) as a single index seek + `LIMIT 1`. No new query shape, no new index, no plan change vs. main.