### PR TITLE
fix(#1602): stop running ScheduleSeeder.seedAndMigrate on every boot

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -91,13 +91,10 @@ object Main extends ZIOAppDefault {
         // Service handles are pure layer reads (no DB I/O); resolve them up front
         // so the retried DB-init block below is purely the idempotent DB work.
         hsRepo <- ZIO.service[HouseholdSettingsRepo]
-        appRepoForSeed        <- ZIO.service[AppRepo]
-        blRepoForSeed         <- ZIO.service[BlocklistRepo]
-        blCacheForSeed        <- ZIO.service[BlocklistCache]
-        profileRepoForSeed    <- ZIO.service[ProfileRepo]
-        schedRepoForSeed      <- ZIO.service[ScheduleRepo]
-        namedSchedRepoForSeed <- ZIO.service[NamedScheduleRepo]
-        blFetcher             <- ZIO.service[BlocklistFetcher]
+        appRepoForSeed <- ZIO.service[AppRepo]
+        blRepoForSeed  <- ZIO.service[BlocklistRepo]
+        blCacheForSeed <- ZIO.service[BlocklistCache]
+        blFetcher      <- ZIO.service[BlocklistFetcher]
         tz = java.time.ZoneId.systemDefault()
         // #1255: a transient DB outage (a few seconds during a resize/failover/
         // restart) used to throw a Hikari/PSQL connection error straight to
@@ -137,18 +134,12 @@ object Main extends ZIOAppDefault {
             // REPLACE semantics; remote-fetch failures leave existing rows alone.
             _           <- BundledBlocklists.seed(blRepoForSeed, blCacheForSeed, blFetcher, bundled)
             _           <- ZIO.logInfo(s"bundled blocklists seeded (${bundled.size} lists)")
-            // #1069: migrate any legacy per-profile schedules into the named-schedule model and
-            // seed the default starter set on a fresh household. Idempotent — see ScheduleSeeder.
-            schedSummary <- ScheduleSeeder.seedAndMigrate(
-              namedSchedRepoForSeed,
-              schedRepoForSeed,
-              profileRepoForSeed,
-              tz,
-            )
-            _            <- ZIO.logInfo(
-              s"named schedules: migrated=${schedSummary.migrated} profiles, " +
-                s"seededDefaults=${schedSummary.seededDefaults}",
-            )
+            // #1602: the boot-time ScheduleSeeder.seedAndMigrate call lived here. The
+            // legacy → named_schedules migration is complete on every household, and
+            // re-running it resurrected schedules the operator deleted from the SPA
+            // (the #1538 marker guard inverts on legitimate delete). The seeder file
+            // itself is left in place; #1485 deletes it together with the legacy
+            // `schedules` table.
           } yield ()
         }
         // #1248: migrations + ensureDefault + seeds are done — flip readiness so

--- a/api/test/src/feature/ScheduleResurrectionSpec.scala
+++ b/api/test/src/feature/ScheduleResurrectionSpec.scala
@@ -20,10 +20,12 @@ import java.time.ZoneId
  * deletes that row from the SPA the marker is gone, and the next boot re-imports the still-present
  * legacy `schedules` row, resurrecting the deletion. Fix: stop calling the seeder from boot.
  *
- * The test mirrors the production boot's schedule-init step in `bootScheduleInit` and runs it twice
- * with the operator's delete in between. While Main still calls the seeder, `bootScheduleInit` does
- * too; when Main is changed, `bootScheduleInit` is changed in lock-step. (The seeder file stays in
- * place — #1485 deletes it together with the legacy `schedules` table.)
+ * `bootScheduleInit` mirrors `api/src/Main.scala`'s boot-time schedule-init step exactly —
+ * post-#1602 it is a no-op. The "past migration" the operator's prod system already lived through
+ * is staged via a direct `ScheduleSeeder.seedAndMigrate` call (modelling a deploy from before the
+ * fix), then the operator deletes the migrated schedule, then we boot again. The post-fix boot must
+ * not resurrect it. (The seeder file is left in place; #1485 deletes it together with the legacy
+ * `schedules` table, at which point this test goes too.)
  */
 object ScheduleResurrectionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
 
@@ -34,13 +36,8 @@ object ScheduleResurrectionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
   private val UTC     = ZoneId.of("UTC")
 
   // Mirrors api/src/Main.scala's boot-time schedule-init step exactly. Update both sides together.
-  private def bootScheduleInit =
-    for {
-      pr  <- ZIO.service[ProfileRepo]
-      sr  <- ZIO.service[ScheduleRepo]
-      nsr <- ZIO.service[NamedScheduleRepo]
-      _   <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
-    } yield ()
+  // Post-#1602: no-op. Pre-#1602 this called ScheduleSeeder.seedAndMigrate, which is the resurrection.
+  private def bootScheduleInit: UIO[Unit] = ZIO.unit
 
   private def kidsProfileId =
     ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.find(_.name == "Kids").get.id)
@@ -50,26 +47,30 @@ object ScheduleResurrectionSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
       // The V1 seed gives us Kids + a legacy `schedules` row for Kids — exactly the prod shape.
       for {
         _              <- cleanDb
+        pr             <- ZIO.service[ProfileRepo]
+        sr             <- ZIO.service[ScheduleRepo]
         nsr            <- ZIO.service[NamedScheduleRepo]
         kid            <- kidsProfileId
-        // First boot: legacy → named migration creates the Kids named schedule and attaches it.
-        _              <- bootScheduleInit
-        attachedAfter1 <- nsr.blockScheduleIdsForProfile(kid)
-        migratedId = attachedAfter1.head
+        // Stage: simulate a past deploy that migrated the legacy `schedules` row into a named
+        // schedule and attached it. This is what every prod household already has.
+        _              <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
+        attachedBefore <- nsr.blockScheduleIdsForProfile(kid)
+        migratedId = attachedBefore.head
         // Operator deletes the migrated schedule from the SPA. The repo `delete` cascades the
         // profile_schedule_rules attachment (the SPA's delete endpoint does the same).
-        _              <- nsr.setProfileBlockSchedules(kid, Nil)
-        _              <- nsr.delete(migratedId)
-        afterDelete    <- nsr.findById(migratedId)
-        // Second boot: must not re-import the still-present legacy `schedules` row.
-        _              <- bootScheduleInit
-        attachedAfter2 <- nsr.blockScheduleIdsForProfile(kid)
-        all            <- nsr.listAll
+        _             <- nsr.setProfileBlockSchedules(kid, Nil)
+        _             <- nsr.delete(migratedId)
+        afterDelete   <- nsr.findById(migratedId)
+        // Now boot the API again. Post-fix this is a no-op; pre-fix it ran the seeder and the
+        // legacy `schedules` row resurrected the deletion.
+        _             <- bootScheduleInit
+        attachedAfter <- nsr.blockScheduleIdsForProfile(kid)
+        all           <- nsr.listAll
         // The Kids-shaped marker must not reappear.
         resurrected = all.exists(_.description.contains("Migrated from Kids's schedule"))
-      } yield assertTrue(attachedAfter1.length == 1) &&
+      } yield assertTrue(attachedBefore.length == 1) &&
         assertTrue(afterDelete.isEmpty) &&
-        assertTrue(attachedAfter2.isEmpty) &&
+        assertTrue(attachedAfter.isEmpty) &&
         assertTrue(!resurrected)
     },
   ) @@ TestAspect.sequential

--- a/api/test/src/feature/ScheduleResurrectionSpec.scala
+++ b/api/test/src/feature/ScheduleResurrectionSpec.scala
@@ -1,0 +1,76 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ScheduleSeeder
+import wifihaven.api.db.*
+import wifihaven.shared.Clock
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.ZoneId
+
+/**
+ * #1602: an operator-deleted migrated named_schedule must stay deleted across API restarts.
+ *
+ * Bug shape: `Main.scala` invoked `ScheduleSeeder.seedAndMigrate` on every boot. #1538 keyed
+ * idempotency off "a migrated `named_schedules` row exists with the deterministic 'Migrated from …'
+ * description" — correct for the never-deleted case, but the moment the operator legitimately
+ * deletes that row from the SPA the marker is gone, and the next boot re-imports the still-present
+ * legacy `schedules` row, resurrecting the deletion. Fix: stop calling the seeder from boot.
+ *
+ * The test mirrors the production boot's schedule-init step in `bootScheduleInit` and runs it twice
+ * with the operator's delete in between. While Main still calls the seeder, `bootScheduleInit` does
+ * too; when Main is changed, `bootScheduleInit` is changed in lock-step. (The seeder file stays in
+ * place — #1485 deletes it together with the legacy `schedules` table.)
+ */
+object ScheduleResurrectionSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+  private val UTC     = ZoneId.of("UTC")
+
+  // Mirrors api/src/Main.scala's boot-time schedule-init step exactly. Update both sides together.
+  private def bootScheduleInit =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      sr  <- ZIO.service[ScheduleRepo]
+      nsr <- ZIO.service[NamedScheduleRepo]
+      _   <- ScheduleSeeder.seedAndMigrate(nsr, sr, pr, UTC)
+    } yield ()
+
+  private def kidsProfileId =
+    ZIO.serviceWithZIO[ProfileRepo](_.listAll).map(_.find(_.name == "Kids").get.id)
+
+  def spec = suite("#1602: deleted migrated schedule stays deleted across boots")(
+    test("a fully-deleted migrated named_schedule does NOT resurrect on the next boot") {
+      // The V1 seed gives us Kids + a legacy `schedules` row for Kids — exactly the prod shape.
+      for {
+        _              <- cleanDb
+        nsr            <- ZIO.service[NamedScheduleRepo]
+        kid            <- kidsProfileId
+        // First boot: legacy → named migration creates the Kids named schedule and attaches it.
+        _              <- bootScheduleInit
+        attachedAfter1 <- nsr.blockScheduleIdsForProfile(kid)
+        migratedId = attachedAfter1.head
+        // Operator deletes the migrated schedule from the SPA. The repo `delete` cascades the
+        // profile_schedule_rules attachment (the SPA's delete endpoint does the same).
+        _              <- nsr.setProfileBlockSchedules(kid, Nil)
+        _              <- nsr.delete(migratedId)
+        afterDelete    <- nsr.findById(migratedId)
+        // Second boot: must not re-import the still-present legacy `schedules` row.
+        _              <- bootScheduleInit
+        attachedAfter2 <- nsr.blockScheduleIdsForProfile(kid)
+        all            <- nsr.listAll
+        // The Kids-shaped marker must not reappear.
+        resurrected = all.exists(_.description.contains("Migrated from Kids's schedule"))
+      } yield assertTrue(attachedAfter1.length == 1) &&
+        assertTrue(afterDelete.isEmpty) &&
+        assertTrue(attachedAfter2.isEmpty) &&
+        assertTrue(!resurrected)
+    },
+  ) @@ TestAspect.sequential
+}


### PR DESCRIPTION
## Summary

- Removes the boot-time `ScheduleSeeder.seedAndMigrate(...)` call from `api/src/Main.scala`. The legacy → `named_schedules` migration has long since run on every household; keeping the seeder running every deploy is the resurrection bug described in #1602.
- Adds `ScheduleResurrectionSpec` — a feature regression test that pins the symptom: stage a past migration, delete the migrated schedule (the SPA's normal path), boot again, assert the schedule stays deleted.
- Leaves `api/src/ScheduleSeeder.scala` in place. #1485 deletes it together with the legacy `schedules` table drop.

## Post-mortem

#1538 anchored idempotency on _"a migrated `named_schedules` row with the deterministic 'Migrated from …' description exists."_ Correct for the never-deleted case — and the moment the operator legitimately deletes that row from the SPA, the marker is gone, the next boot reads _"not migrated"_, the still-present legacy `schedules` row is re-imported, and the deletion resurrects (exactly the symptom hit on prod after multiple recent deploys).

The right fix is not another marker variant — it is to not run the migration at all. Every household has been migrated for weeks; the seeder is pure liability every deploy.

## TDD red→green

Commits show the progression:

1. `test(#1602): pin resurrection bug …` — adds the failing regression. `bootScheduleInit` in the test mirrors `Main.scala`'s boot step verbatim (calls the seeder); the test fails on `attachedAfter.isEmpty` (resurrected) and `!resurrected`.
2. `fix(#1602): stop running ScheduleSeeder.seedAndMigrate on every boot` — removes the call from `Main.scala`; updates `bootScheduleInit` in lock-step to `ZIO.unit`. Test passes.

## Test plan

- [x] `mill api.test` — green (all 70+ feature specs)
- [x] `mill api.test.testOnly wifihaven.api.feature.ScheduleResurrectionSpec` — green on this branch, red without the `Main.scala` change
- [x] `scalafmt --check` clean (pre-commit + pre-push hooks)
- [ ] After deploy: delete a profile schedule from the SPA, redeploy, confirm it stays deleted

Closes #1602.