### PR TITLE
fix(#1174): pin schedule-block + ui-allow carve-out, warn on LAN api_url misconfig

### DIFF
--- a/api/test/src/feature/PolicyScheduleGlobalAllowSpec.scala
+++ b/api/test/src/feature/PolicyScheduleGlobalAllowSpec.scala
@@ -1,0 +1,139 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDateTime, LocalTime, ZoneId}
+
+/**
+ * #1174 regression pin: a MAC blocked by a SCHEDULE downtime window — combined with deployment-
+ * configured `uiAllowedHosts` — must still let the SPA hosts through, because the kid sees the
+ * block page (and the request-an-extension flow) on the SPA. After #1318/#1319/#1321 the ui hosts
+ * ride in `snapshot.global.extraAllowed` (one fleet-wide @global_allow, carving every drop incl.
+ * @blocked_macs),
+ *   not per-profile `extraAllowed`. This spec pins both halves at the API layer:
+ *
+ *   - the schedule actually blocks the MAC (rules.blocked = true, blockReason = Schedule)
+ *   - global.extraAllowed contains every configured ui host so the router can carve them out
+ *
+ * Bug-class background: `PolicySnapshotGlobalAllowSpec` already covers paused-blocked + uiHosts;
+ * this file covers the schedule-block case specifically, which is the original #1174 reproducer.
+ */
+object PolicyScheduleGlobalAllowSpec
+    extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.bedtime)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val uiHosts: List[Hostname] =
+    List("wifihaven.net", "www.wifihaven.net", "api.wifihaven.net").map(Hostname.unsafe)
+
+  private def makePsAt(dt: LocalDateTime) =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      hsr  <- ZIO.service[HouseholdSettingsRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      blr  <- ZIO.service[BlocklistRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ar   <- ZIO.service[AppRepo]
+      ref  <- Ref.make(dt)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      atlr,
+      dr,
+      blr,
+      trr,
+      er,
+      ar,
+      clk,
+      uiHosts,
+      NoopGlobalPolicyRepo,
+      nsr,
+    ): PolicyService
+
+  // Attach a 21:00-07:00 bedtime named schedule to Kids and place the kid MAC in it.
+  private val kidMac            = "aa:bb:cc:11:22:33"
+  private def seedBedtimeAndKid =
+    for {
+      pr  <- ZIO.service[ProfileRepo]
+      nsr <- ZIO.service[NamedScheduleRepo]
+      dr  <- ZIO.service[DeviceRepo]
+      ps0 <- pr.listAll
+      kids = ps0.find(_.name == "Kids").get
+      sid <- nsr.create(
+        "Bedtime",
+        Some("overnight"),
+        List(
+          ScheduleWindow(
+            List("mon", "tue", "wed", "thu", "fri", "sat", "sun"),
+            LocalTime.of(21, 0),
+            LocalTime.of(7, 0),
+            ZoneId.of("UTC"),
+          ),
+        ),
+      )
+      _   <- nsr.setProfileBlockSchedules(kids.id, List(sid))
+      _   <- TestLayers.seedDevice(dr, kidMac, "kid-ipad", kids.id)
+    } yield kids.id
+
+  def spec = suite("policy snapshot — schedule block + global ui allow (#1174)")(
+    test(
+      "kid under bedtime schedule with uiAllowedHosts → blocked + ui hosts in global.extraAllowed",
+    ) {
+      for {
+        _    <- cleanDb
+        pid  <- seedBedtimeAndKid
+        svc  <- makePsAt(TestClock.bedtime)
+        snap <- svc.snapshot
+      } yield {
+        val kidsRules     = snap.profiles(pid).rules
+        val globalAllowed = snap.global.extraAllowed.map(_.value).toSet
+        val expected      = uiHosts.map(_.value).toSet
+        assertTrue(
+          // Schedule fold (#1069 / #1494) blocks the MAC with reason=Schedule.
+          kidsRules.blocked,
+          kidsRules.blockReason.contains(MacBlockReason.Schedule),
+          // Configured ui hosts are reachable via the fleet-wide global.extraAllowed
+          // (post-#1318/#1321 they no longer ride per-profile).
+          expected.subsetOf(globalAllowed),
+          // And not duplicated into the profile's own extraAllowed.
+          expected.intersect(kidsRules.extraAllowed.map(_.value).toSet).isEmpty,
+        )
+      }
+    },
+    test("outside the window → kid not blocked; ui hosts still in global.extraAllowed") {
+      for {
+        _    <- cleanDb
+        pid  <- seedBedtimeAndKid
+        svc  <- makePsAt(TestClock.schoolDayAfternoon)
+        snap <- svc.snapshot
+      } yield {
+        val kidsRules     = snap.profiles(pid).rules
+        val globalAllowed = snap.global.extraAllowed.map(_.value).toSet
+        val expected      = uiHosts.map(_.value).toSet
+        assertTrue(
+          !kidsRules.blocked,
+          expected.subsetOf(globalAllowed),
+        )
+      }
+    },
+  ) @@ TestAspect.sequential
+}

--- a/openwrt/files/usr/lib/lua/wifihaven/lan_warn.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/lan_warn.lua
@@ -1,0 +1,98 @@
+-- lan_warn.lua — agent-startup misconfiguration sniffer (#1174)
+--
+-- The original #1174 incident reproduced as: a prod router enrolled against a
+-- LAN-address API URL (e.g. http://api.lan:8080 / http://192.168.10.43:8080)
+-- with NO block_page_url set. resolve_base then falls the block-page redirect
+-- back to api_url, so the kid's blocked traffic gets a 302 to a LAN host the
+-- kid's browser can't reach (or shouldn't reach in a cloud deploy).
+--
+-- A self-hosted install legitimately enrols against api.lan and bundles the
+-- SPA into the API image, so we cannot HARD-fail this — that's a real shape we
+-- support. The cheapest defence is a clear startup log line the operator can
+-- spot in `logread` / on the install console.
+--
+-- Pure helper: `check(api_url, block_page_url) → message?`. Returns the
+-- warning string when the combination is suspicious, nil otherwise. The agent
+-- calls this once at startup and routes the message through log.info; the
+-- helper is pure so it can be busted-tested without UCI / logging stubs.
+
+local M = {}
+
+-- Strip the scheme + leading slashes, port, and trailing path so we're left
+-- with the bare host. Returns "" for unparsable input. Intentionally permissive
+-- — the agent already validates api_url before using it; we just want the host.
+local function host_of(url)
+  if type(url) ~= "string" or url == "" then return "" end
+  local h = url:gsub("^%s+", ""):gsub("%s+$", "")
+  h = h:gsub("^[%w%+%-%.]+://", "")
+  h = h:gsub("/.*$", "")
+  -- IPv6 literals are wrapped in [ ]; strip them before the port split.
+  if h:sub(1, 1) == "[" then
+    local close = h:find("]", 1, true)
+    if close then return h:sub(2, close - 1) end
+    return ""
+  end
+  h = h:gsub(":%d+$", "")
+  return h
+end
+M.host_of = host_of
+
+-- Return the four IPv4 octets as integers, or nil if `h` isn't a dotted-quad.
+local function ipv4_octets(h)
+  local a, b, c, d = h:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then return nil end
+  a, b, c, d = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
+  if not (a and b and c and d) then return nil end
+  if a > 255 or b > 255 or c > 255 or d > 255 then return nil end
+  return a, b, c, d
+end
+
+-- True iff `h` is an IPv4 address in RFC1918 private space:
+--   10.0.0.0/8 · 172.16.0.0/12 · 192.168.0.0/16
+local function is_private_ipv4(h)
+  local a, b = ipv4_octets(h)
+  if not a then return false end
+  if a == 10 then return true end
+  if a == 172 and b >= 16 and b <= 31 then return true end
+  if a == 192 and b == 168 then return true end
+  return false
+end
+M.is_private_ipv4 = is_private_ipv4
+
+-- True iff the host should be treated as LAN-only: a private IPv4 literal, or
+-- a multicast-DNS / OpenWRT-style local hostname (.lan / .local / localhost).
+-- We deliberately do NOT resolve DNS here — the agent runs this once at
+-- startup and a resolver lookup would pull in more failure modes than the
+-- warning is worth. The hostname suffixes catch the common shapes (api.lan,
+-- foo.local, localhost) without paying for resolution.
+local function is_lan_host(h)
+  if h == "" then return false end
+  if h == "localhost" then return true end
+  if is_private_ipv4(h) then return true end
+  local lower = h:lower()
+  if lower:sub(-4) == ".lan"   then return true end
+  if lower:sub(-6) == ".local" then return true end
+  return false
+end
+M.is_lan_host = is_lan_host
+
+-- check(api_url, block_page_url) → string | nil
+--
+-- Warning fires iff:
+--   1. api_url resolves (textually) to a LAN host, AND
+--   2. block_page_url is unset / empty.
+--
+-- (When block_page_url IS set, the operator has explicitly picked the
+-- redirect host, so the LAN api_url is fine: that's the self-hosted shape.)
+function M.check(api_url, block_page_url)
+  local h = host_of(api_url)
+  if not is_lan_host(h) then return nil end
+  if block_page_url and block_page_url ~= "" then return nil end
+  return string.format(
+    "wifihaven: api_url resolves to a LAN address (%s); the block-page redirect will point there. " ..
+    "If this router is intended for production, re-enroll against the public API URL and set " ..
+    "wifihaven.block_page_url.",
+    h)
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -26,6 +26,7 @@ local log        = require("wifihaven.log")
 local clock      = require("wifihaven.clock")
 local paths      = require("wifihaven.paths")
 local block_page = require("wifihaven.block_page")
+local lan_warn   = require("wifihaven.lan_warn")
 local selfheal   = require("wifihaven.selfheal")
 local version    = require("wifihaven.version")
 
@@ -44,7 +45,16 @@ local api_url       = uci_get("api_url",              "http://192.168.1.1:8080")
 -- self-hosted installs (SPA bundled into the API image, same host) and any
 -- router that never sets it keep today's behavior exactly. This is router-side
 -- deployment config (UCI), not policy, so it is not on the API↔router wire.
-local block_page_url = block_page.resolve_base(uci_get("block_page_url", ""), api_url)
+local raw_block_page_url = uci_get("block_page_url", "")
+local block_page_url = block_page.resolve_base(raw_block_page_url, api_url)
+-- #1174: noisy-but-informational startup check. If the router is enrolled
+-- against a LAN api_url AND block_page_url is unset, the kid's block-page
+-- redirect will fall back to api_url and point at a LAN host the kid's
+-- browser can't reach in a cloud deploy. Self-hosted installs legitimately
+-- pair a LAN api_url with the bundled-SPA shape, so this is NOT a hard
+-- refusal — just a logread-spottable warning the operator can grep for.
+local lan_warn_msg = lan_warn.check(api_url, raw_block_page_url)
+if lan_warn_msg then log.warn(lan_warn_msg) end
 local router_token  = uci_get("router_token",         "")
 local router_id     = uci_get("router_id",            "")
 local lan_prefix    = uci_get("lan_prefix",           "192.168.1.")

--- a/openwrt/test/lan_warn_spec.lua
+++ b/openwrt/test/lan_warn_spec.lua
@@ -1,0 +1,83 @@
+-- lan_warn_spec.lua — pin the agent-startup LAN-misconfig warning (#1174).
+--
+-- We don't care which logger the agent routes the message through; the helper
+-- is a pure (api_url, block_page_url) → string|nil classifier.
+
+local lan_warn = require("wifihaven.lan_warn")
+
+describe("lan_warn.host_of", function()
+  it("strips scheme, port, and path", function()
+    assert.equals("api.lan",          lan_warn.host_of("http://api.lan:8080"))
+    assert.equals("api.wifihaven.net", lan_warn.host_of("https://api.wifihaven.net"))
+    assert.equals("192.168.10.43",     lan_warn.host_of("http://192.168.10.43:8080/api/router/policy"))
+    assert.equals("",                  lan_warn.host_of(""))
+    assert.equals("",                  lan_warn.host_of(nil))
+  end)
+
+  it("handles IPv6 literals in brackets", function()
+    assert.equals("::1",          lan_warn.host_of("http://[::1]:8080"))
+    assert.equals("fe80::1234",   lan_warn.host_of("https://[fe80::1234]/x"))
+  end)
+end)
+
+describe("lan_warn.is_private_ipv4", function()
+  it("flags RFC1918 ranges", function()
+    assert.is_true(lan_warn.is_private_ipv4("10.0.0.1"))
+    assert.is_true(lan_warn.is_private_ipv4("10.255.255.255"))
+    assert.is_true(lan_warn.is_private_ipv4("192.168.10.43"))
+    assert.is_true(lan_warn.is_private_ipv4("172.16.0.1"))
+    assert.is_true(lan_warn.is_private_ipv4("172.31.255.254"))
+  end)
+
+  it("does NOT flag adjacent public ranges or non-IPv4 strings", function()
+    assert.is_false(lan_warn.is_private_ipv4("11.0.0.1"))
+    assert.is_false(lan_warn.is_private_ipv4("172.15.0.1"))
+    assert.is_false(lan_warn.is_private_ipv4("172.32.0.1"))
+    assert.is_false(lan_warn.is_private_ipv4("8.8.8.8"))
+    assert.is_false(lan_warn.is_private_ipv4("api.wifihaven.net"))
+    assert.is_false(lan_warn.is_private_ipv4("256.1.1.1"))
+    assert.is_false(lan_warn.is_private_ipv4(""))
+  end)
+end)
+
+describe("lan_warn.is_lan_host", function()
+  it("flags .lan / .local / localhost / private IPv4", function()
+    assert.is_true(lan_warn.is_lan_host("api.lan"))
+    assert.is_true(lan_warn.is_lan_host("router.LAN"))     -- case-insensitive
+    assert.is_true(lan_warn.is_lan_host("foo.local"))
+    assert.is_true(lan_warn.is_lan_host("localhost"))
+    assert.is_true(lan_warn.is_lan_host("192.168.10.43"))
+  end)
+
+  it("does NOT flag public DNS names or public IPs", function()
+    assert.is_false(lan_warn.is_lan_host("api.wifihaven.net"))
+    assert.is_false(lan_warn.is_lan_host("wifihaven.net"))
+    assert.is_false(lan_warn.is_lan_host("8.8.8.8"))
+    assert.is_false(lan_warn.is_lan_host(""))
+  end)
+end)
+
+describe("lan_warn.check — startup misconfig warning (#1174)", function()
+  it("warns when api_url is LAN AND block_page_url is unset", function()
+    local msg = lan_warn.check("http://api.lan:8080", "")
+    assert.is_string(msg)
+    assert.truthy(msg:find("api.lan",          1, true))
+    assert.truthy(msg:find("block_page_url",   1, true))
+  end)
+
+  it("warns for private IPv4 api_url with empty block_page_url (the #1174 prod shape)", function()
+    local msg = lan_warn.check("http://192.168.10.43:8080", nil)
+    assert.is_string(msg)
+    assert.truthy(msg:find("192.168.10.43", 1, true))
+  end)
+
+  it("does NOT warn when block_page_url is explicitly set (self-hosted is OK)", function()
+    assert.is_nil(lan_warn.check("http://api.lan:8080",      "https://wifihaven.net"))
+    assert.is_nil(lan_warn.check("http://192.168.10.43:8080", "http://192.168.10.43:8080"))
+  end)
+
+  it("does NOT warn for a public api_url (the cloud shape)", function()
+    assert.is_nil(lan_warn.check("https://api.wifihaven.net", ""))
+    assert.is_nil(lan_warn.check("https://api.wifihaven.net", "https://wifihaven.net"))
+  end)
+end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -2563,3 +2563,64 @@ describe("render.nft global composition — precedence compositions (#1322)", fu
       1, true))
   end)
 end)
+
+-- ── #1174 schedule-block + ui-host allow pin ──────────────────────────────
+--
+-- The original prod incident: a kid under a scheduled downtime window couldn't
+-- reach the block page (served from wifihaven.net), because the @blocked_macs
+-- drop had no carve-out for the SPA hosts. After #1318/#1319/#1321 the SPA
+-- hosts ride in @global_allow, so the per-MAC schedule drop must carry
+-- `ip daddr != @global_allow` (and the v6 sibling) for every configured ui host.
+describe("render.nft #1174 schedule-block + ui-host allow", function()
+  -- snap_global with the kid MAC blocked-by-Schedule and the canonical SPA
+  -- ui-host set parked in global.extraAllowed (mirrors the prod render.yaml
+  -- WIFIHAVEN_UI_ALLOWED_HOSTS value).
+  local function snap_174()
+    local s = snap_global()
+    s.global.extraAllowed = { "api.wifihaven.net", "wifihaven.net", "www.wifihaven.net" }
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    return s
+  end
+
+  it("schedule-blocked MAC's per-MAC drop carries `!= @global_allow` (v4 + v6)", function()
+    local nft = render.nft(snap_174())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr != @global_allow6 log prefix \"wh_drop:aa:bb:cc:11:22:33:Schedule \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:Schedule\"",
+      1, true))
+  end)
+
+  it("dnsmasq emits one merged nftset= per SPA host pointing at @global_allow / @global_allow6", function()
+    local conf = render.dnsmasq(snap_174())
+    for _, host in ipairs({ "wifihaven.net", "www.wifihaven.net", "api.wifihaven.net" }) do
+      assert.truthy(
+        conf:find("nftset=/" .. host .. "/4#inet#wifihaven#global_allow,6#inet#wifihaven#global_allow6",
+                  1, true),
+        "missing global_allow nftset directive for " .. host)
+    end
+  end)
+
+  it("no per-(MAC, ui-host) ea_ rule appears — ui hosts ride global only (#1321/#1489)", function()
+    -- The schedule-block drop must not be carved by ea_aa_bb_cc_..._wifihaven_net;
+    -- @global_allow is the sole carve-out path for ui hosts post-#1321, so any ea_
+    -- spec for them would be the pre-#1318 redundancy we explicitly retired.
+    local nft = render.nft(snap_174())
+    assert.is_nil(nft:find("ea_aa_bb_cc_11_22_33_wifihaven_net",     1, true))
+    assert.is_nil(nft:find("ea_aa_bb_cc_11_22_33_www_wifihaven_net", 1, true))
+    assert.is_nil(nft:find("ea_aa_bb_cc_11_22_33_api_wifihaven_net", 1, true))
+  end)
+
+  it("empty ui-host allow → no @global_allow carve in the schedule drop (no-op control)", function()
+    -- The control: with no ui hosts configured the schedule drop is family-
+    -- agnostic again (no `ip daddr` predicate), so the regression test above
+    -- only fires when global.extraAllowed is actually populated.
+    local s = snap_global()
+    s.profiles["3"].rules.blocked     = true
+    s.profiles["3"].rules.blockReason = "Schedule"
+    local nft = render.nft(s)
+    assert.is_nil(nft:find("!= @global_allow", 1, true))
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -25,6 +25,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/dns_log_spec.lua \
          test/nft_drops_spec.lua \
          test/nflog_spec.lua \
+         test/lan_warn_spec.lua \
          "$@"
 
 echo ""


### PR DESCRIPTION
Closes #1174.

## Diagnosis (prod router)

SSH'd `root@192.168.10.1` from the orchestration Mac. The diagnosis recipe in
the original issue comment is now stale (pre-#1318); the current prod router
state is **correctly configured**:

- `uci get wifihaven.@wifihaven[0].api_url` → `https://api.wifihaven.net` ✓
- `uci get wifihaven.@wifihaven[0].block_page_url` → `https://wifihaven.net` ✓
- `grep nftset=/wifihaven.net /tmp/dnsmasq.d/wifihaven.conf` → three `nftset=`
  directives pointing at `@global_allow` / `@global_allow6` (not per-MAC `ea_`
  sets — the post-#1318 architecture).
- `nft list set inet wifihaven global_allow` → currently populated with
  resolved IPs (Apple/Google/CDN entries actively timing out at 30-60m).

**The #1174 incident is already resolved by the global-allow layer landed in
#1318 / #1319 / #1321.** That work moved deployment-configured `uiAllowedHosts`
from per-profile `extraAllowed` copies into one fleet-wide
`snapshot.global.extraAllowed` (router: `@global_allow`), which carves out
EVERY drop including `@blocked_macs` — so a kid under a scheduled-downtime
block reaches `wifihaven.net` regardless. No further router-side or
operator-side action needed: prod is correct now.

What this PR adds is **defensive pins** so a future regression of the same
class is caught at PR time + at install time.

## Regression tests added

- **API**: [PolicyScheduleGlobalAllowSpec.scala](api/test/src/feature/PolicyScheduleGlobalAllowSpec.scala) — pins that a named-schedule downtime fold blocks the kid MAC with reason=Schedule AND uiAllowedHosts land in `snapshot.global.extraAllowed` (and explicitly NOT in any per-profile `extraAllowed`). Companion to `PolicySnapshotGlobalAllowSpec` which covered the paused case.
- **Router**: [render_spec.lua](openwrt/test/render_spec.lua) "#1174 schedule-block + ui-host allow" describe block — three pins:
  - per-MAC Schedule drop carries `ip daddr != @global_allow` (v4 + v6).
  - dnsmasq emits one merged `nftset=` per SPA host pointing at `@global_allow` / `@global_allow6`.
  - no per-(MAC, ui-host) `ea_` rule appears (#1321 redundancy stays retired).
  - control: empty `global.extraAllowed` → no `!= @global_allow` carve in the drop (proves the assertion only fires when populated).

## Startup misconfig warning (lan_warn)

New [lan_warn.lua](openwrt/files/usr/lib/lua/wifihaven/lan_warn.lua) helper +
busted spec, wired into `wifihaven-agent` startup. When the agent boots with
an `api_url` pointing at a LAN address (RFC1918 IPv4 / `.lan` / `.local` /
`localhost`) AND `block_page_url` is unset, the agent logs:

> `wifihaven: api_url resolves to a LAN address (api.lan); the block-page redirect will point there. If this router is intended for production, re-enroll against the public API URL and set wifihaven.block_page_url.`

Informational, not a hard refusal — self-hosted installs legitimately pair a
LAN `api_url` with the SPA bundled into the API image (block-page redirect
falls back to `api_url` correctly). The warning is `user.warning` priority so
`logread` greps it cleanly.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.PolicyScheduleGlobalAllowSpec` — 2/2 green
- [x] `busted test/lan_warn_spec.lua test/render_spec.lua` — 190/0, 1 pending (the pre-existing `nft -c` syntax check that needs nftables installed)
- [x] `scalafmt --check` — clean