### PR TITLE
audit(#1532): sweep 3 — collapse aggGroupKey separator, file BlockReason kind-string follow-up

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -2560,7 +2560,12 @@ class ConnectionEventRepoLive(xa: Transactor[Task]) extends ConnectionEventRepo 
         ).flatten
         val groupKeyExpr  = groupKeyParts match {
           case Nil   => fr"''"
-          case parts => parts.reduce((a, b) => a ++ fr"|| chr(31) ||" ++ b)
+          case parts =>
+            // #1532: separator byte sourced from `LogAggGroupKey` so the SQL
+            // `chr(N) ||` concat and the Scala-side `Routes.aggGroupKey` cannot
+            // drift; both join with the same ASCII unit-separator.
+            val sepFrag = Fragment.const(s"|| chr(${LogAggGroupKey.SeparatorCode}) ||")
+            parts.reduce((a, b) => a ++ sepFrag ++ b)
         }
 
         // #857: resolved (fqdn → app) pairs as a VALUES table. Explicit casts on

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -1382,12 +1382,12 @@ object LogRoutes {
 
   // #862: must mirror the SQL's group_key concatenation order exactly
   // (domain, device, profile — only requested columns, US-separator).
-  private def aggGroupKey(r: ConnectionEventAggRow): String = {
-    val sep = ""
+  // Separator byte is sourced from `LogAggGroupKey` so the SQL `chr(N) ||`
+  // concat in `ConnectionEventRepo` and this builder cannot drift (#1532).
+  private def aggGroupKey(r: ConnectionEventAggRow): String =
     List("domain", "device", "profile").iterator
       .flatMap(k => r.groups.get(k))
-      .mkString(sep)
-  }
+      .mkString(LogAggGroupKey.Separator)
 
   def routes(
       auth: AuthService,

--- a/api/src/usage/UsageTraffic.scala
+++ b/api/src/usage/UsageTraffic.scala
@@ -94,10 +94,15 @@ object UsageTraffic {
     def parse(s: String): Option[GroupBy] = values.find(_.code == s)
   }
 
-  // #862: stable group key for keyset cursor on the aggregated path. Must
-  // mirror the order used by buildAggregate's row builder so the cursor
-  // compare is deterministic. Same separator as the SQL chr(31) || concat in
-  // ConnectionEventRepo.querySeries.
+  // #862: stable group key for keyset cursor on the aggregated path. The
+  // traffic-aggregation cursor is constructed and compared entirely in Scala
+  // (the SQL just returns raw `traffic_reports` rows; aggregation happens in
+  // `buildAggregate`), so the separator below is NOT coupled to the `chr(31)`
+  // used by `ConnectionEventRepo.querySeries` — both sides of the cursor
+  // compare run through this same function. Keeping the legacy empty
+  // separator preserves cursor compatibility for already-emitted cursors
+  // (#1532 audit confirmed the prior "same separator as the SQL" comment was
+  // misleading: that separator is `LogAggGroupKey.Separator`; this one isn't).
   def aggGroupKey(
       r: wifihaven.shared.TrafficUsageAggregateRow,
       effectiveGroupBy: Set[GroupBy],

--- a/shared/src/types/LogAggGroupKey.scala
+++ b/shared/src/types/LogAggGroupKey.scala
@@ -1,0 +1,29 @@
+package wifihaven.shared.types
+
+/**
+ * Single source of truth for the lexicographic group-key delimiter used by the #862
+ * connection-event aggregation cursor and the #846 traffic-aggregation cursor.
+ *
+ * The keyset cursor sorts on `(window_start DESC, group_key ASC)`, where `group_key` is the
+ * concatenation of the requested group values (`domain`, `device`, `profile`) joined by an ASCII
+ * unit separator (`U+001F`, code 31) — chosen because it cannot appear in hostnames, MAC strings,
+ * or profile names. The SQL `group_key` expression and the Scala-side per-row builders MUST agree
+ * on the delimiter byte; if they drift, the cursor's `(prevWs, prevKey) < (ws, key)` compare on the
+ * SQL side and the `aggGroupKey(row)` value on the Scala side will use different separators and
+ * pagination will silently skip or repeat rows at page boundaries.
+ *
+ * Before this object the byte was hard-coded as `chr(31)` in the SQL (`ConnectionEventRepo`), a
+ * literal one-character `` string in two Scala builders (`Routes.aggGroupKey`,
+ * `UsageTraffic.aggGroupKey`), and tracked only by "must mirror" / "Same separator as the SQL"
+ * comments. Audit umbrella #1532.
+ */
+object LogAggGroupKey {
+
+  /** The ASCII unit-separator code point. Stable wire/protocol constant — do not change. */
+  val SeparatorCode: Int = 31
+
+  /**
+   * The unit separator as a single-character string. Equivalent to `SeparatorCode.toChar.toString`.
+   */
+  val Separator: String = SeparatorCode.toChar.toString
+}

--- a/shared/test/src/types/LogAggGroupKeySpec.scala
+++ b/shared/test/src/types/LogAggGroupKeySpec.scala
@@ -1,0 +1,33 @@
+package wifihaven.shared.types
+
+import zio.test.*
+import zio.test.Assertion.*
+
+/**
+ * Pins the unit-separator byte used by the SQL `chr(N) ||` concat in `ConnectionEventRepo` and the
+ * Scala-side `aggGroupKey` builders in `Routes` and `UsageTraffic`. Audit umbrella #1532.
+ *
+ * If this constant ever changes, BOTH sides must change in lockstep — the SQL fragment is
+ * `Fragment.const(s"chr(${LogAggGroupKey.SeparatorCode})")`, and the Scala builders join with
+ * `LogAggGroupKey.Separator`. A drift between SQL and Scala silently corrupts the #862 keyset
+ * cursor at page boundaries.
+ */
+object LogAggGroupKeySpec extends ZIOSpecDefault {
+
+  def spec = suite("LogAggGroupKey")(
+    test("SeparatorCode is the ASCII unit separator (31, 0x1F)") {
+      assertTrue(LogAggGroupKey.SeparatorCode == 31)
+    },
+    test("Separator is a single-character string equal to U+001F") {
+      assertTrue(LogAggGroupKey.Separator == "") &&
+      assertTrue(LogAggGroupKey.Separator.length == 1) &&
+      assertTrue(LogAggGroupKey.Separator.head.toInt == LogAggGroupKey.SeparatorCode)
+    },
+    test("Separator does not collide with hostname, MAC, or profile-name characters") {
+      val sep = LogAggGroupKey.Separator
+      assertTrue(!"abc.example.com".contains(sep)) &&
+      assertTrue(!"aa:bb:cc:11:22:33".contains(sep)) &&
+      assertTrue(!"Kids".contains(sep))
+    },
+  )
+}


### PR DESCRIPTION
Refs #1532.

Third pass through the umbrella's "same logical quantity computed in two+ places" sweep. Prior passes shipped #1544 / #1545 / #1546 / #1547. This pass found one trivial, cross-language collapse (shipped inline with a pinning test) and one MEDIUM finding (filed as a sub-issue).

## TRIVIAL — collapsed inline

### `aggGroupKey` ASCII unit-separator: hand-spelled in three places

The lexicographic group-key delimiter used by the #862 keyset cursor was a literal `` byte in three independent spots, with no single source of truth — only "must mirror" / "Same separator as the SQL" comments tracking the contract.

| Site | Form |
|---|---|
| [api/src/db/Repos.scala:2563](api/src/db/Repos.scala) | SQL `\|\| chr(31) \|\|` |
| [api/src/routes/Routes.scala:1386](api/src/routes/Routes.scala) | Scala `val sep = ""` |
| [api/src/usage/UsageTraffic.scala:104](api/src/usage/UsageTraffic.scala) | Scala `val sep = ""` |

Audit revealed that the `UsageTraffic` site was the most dangerous of the three — its comment claimed *"Same separator as the SQL chr(31) || concat in ConnectionEventRepo"*, but the actual literal there is an **empty string**, and the path's aggregation/sort/cursor all run in Scala, so it has no SQL coupling at all. The misleading comment masked the true (Scala-only) contract.

Two-commit collapse:

1. **test-pin** (`91edea83`) — introduce `shared/src/types/LogAggGroupKey.scala` with `SeparatorCode = 31` / `Separator = ""`, plus `LogAggGroupKeySpec` pinning the byte and asserting it does not collide with hostname / MAC / profile-name characters. No call-site changes — the constant is unused.
2. **collapse** (`05c997b9`) — thread `LogAggGroupKey.SeparatorCode` through the SQL `chr(${SeparatorCode})` fragment and `Routes.aggGroupKey` `mkString`; fix the misleading `UsageTraffic.aggGroupKey` comment, documenting it as a Scala-only joiner whose empty separator is preserved for cursor compatibility.

`mill api.test wifihaven.api.feature.LogApiSpec` passes (65 tests, including the #862 keyset-cursor cases).

## MEDIUM — filed as #1605

### BlockReason kind strings spelled in five places

The `BlockReason` sealed trait's "kind" string is hand-spelled in:

- `BlockReason.asWire` ([shared/src/Models.scala:1741](shared/src/Models.scala)) — Reason → text (exhaustive match, compiler-checked)
- `JsonEncoder[BlockReason]` ([shared/src/Models.scala:1763](shared/src/Models.scala)) — Reason → JSON kind (exhaustive match, compiler-checked)
- `BlockReason.fromWire` ([shared/src/Models.scala:1697](shared/src/Models.scala)) — text → Reason (string match, NOT compiler-checked)
- `JsonDecoder[BlockReason]` ([shared/src/Models.scala:1789](shared/src/Models.scala)) — JSON kind → Reason (string match, NOT compiler-checked)
- `ReasonTextBackfill.asWireSql` ([api/src/ReasonTextBackfill.scala:36](api/src/ReasonTextBackfill.scala)) — JSON kind → text, in SQL (CASE expression, NOT compiler-checked)

A new `BlockReason` case forces the two encoders (compile error) but silently leaves the three string-parse paths broken. Same drift class as #1531/#1539. Filed as #1605 — needs design (lift "kind" to a `def kind: String` on each case and derive both encoders, plus a property-style exhaustiveness test that runs the live SQL fragment per case).

## LARGE — none this pass

## Verified-already-collapsed (not findings, just confirming the umbrella's invariants hold)

- Schedule evaluation flows through `PolicyService.scheduleActiveAt` only — `TimeStatusService` calls it, no rederivation.
- `PolicyService.infraAllowHosts` is the sole source for the curated infra allow list, sourced from `InfraHosts.canonical`.
- `HostMatch.matchesPattern` / `matchesApex` is the only hostname-pattern primitive; `Presence.matchesPattern` is a thin delegate.
- `TimeStatusService.usedSecondsByMac` / `usedSecondsForProfile` / `appSecondsByApp` and `Presence.appSecondsForProfile` are the only per-MAC / per-profile / per-app time roll-ups; no hand-rolled re-derivations in routes.
- `BlockReason.asWire` / `fromWire` are the only wire-format reason string handlers (collapsed by #1545); the remaining drift surface is the JSON / SQL kind set (filed as #1605).
- `TimeStatusService.groupAppLimits` / `PolicyService.appCapExhaustedHosts` are the only cap-evaluation primitives, threaded through the decide path and the time-status surfaces.

The intentional wire-shape redundancy carve-out (infra allow list copied into every profile's `extraAllowed`; profiles map as a wire dedup aid) was respected — not flagged.

## Test plan

- [x] `mill shared.test wifihaven.shared.types.LogAggGroupKeySpec` passes
- [x] `mill api.test wifihaven.api.feature.LogApiSpec` passes (65 tests)
- [x] `scalafmt --check` clean