### PR TITLE
refactor(#1560): centralize host suppression / pattern-match predicates

### DIFF
--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -172,8 +172,7 @@ object Presence {
       filter: HeartbeatFilter,
       appHostPatterns: List[String] = Nil,
   ): List[PresenceRow] = {
-    def isExempt(h: HostId) =
-      h.asFqdn.exists(fqdn => exemptPatterns.exists(p => matchesPattern(fqdn.value, p)))
+    def isExempt(h: HostId) = HostMatch.matchesAny(h, exemptPatterns)
     // #1506: app attribution beats background/byte suppression; exempt-from-daily filtering is a
     // separate concern and still applies afterward (an exempt app's host is still excluded from the
     // daily total even though it is no longer suppressed as a heartbeat).
@@ -366,16 +365,17 @@ object Presence {
    * is never attributed.
    */
   def isAppAttributed(row: PresenceRow, appHostPatterns: List[String]): Boolean =
-    appHostPatterns.nonEmpty &&
-      row.host.asFqdn.exists(fqdn => appHostPatterns.exists(p => matchesPattern(fqdn.value, p)))
+    HostMatch.matchesAny(row.host, appHostPatterns)
 
   /**
    * #1503/#1525: whether the row's FQDN is device-level background infra
    * ([[InfraHosts.isBackground]] \= allow+suppress canonical ∪ suppress-only). Keyed on host
-   * identity only — IP-literal hosts never match.
+   * identity only — IP-literal hosts never match. #1560: thin alias for the canonical host-keyed
+   * predicate on [[InfraHosts]] — every presence/dashboard suppression call site routes through
+   * that one entry point so the rule cannot diverge between surfaces (#1532).
    */
   private def isBackgroundHost(row: PresenceRow): Boolean =
-    row.host.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value))
+    InfraHosts.isBackground(row.host)
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the
@@ -413,7 +413,7 @@ object Presence {
       .groupBy(_.host)
       .iterator
       .map { case (h, rs) =>
-        val isInfra = h.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value))
+        val isInfra = InfraHosts.isBackground(h)
         val reason  = if (isInfra) "infra" else "bytes-below-threshold"
         SuppressedHostRow(h, rs.iterator.map(_.bytes).sum, rs.size, reason)
       }
@@ -459,7 +459,7 @@ object Presence {
     val accum  = scala.collection.mutable.Map.empty[(MacAddress, String), Long]
     for {
       pat <- patterns
-      matching = active.filter(r => r.host.asFqdn.exists(fqdn => matchesPattern(fqdn.value, pat)))
+      matching = active.filter(r => HostMatch.matchesAny(r.host, List(pat)))
       (mac, macRows) <- matching.groupBy(_.mac)
       secs = unionSeconds(sessionSpans(macRows, gap))
       if secs > 0L
@@ -505,7 +505,7 @@ object Presence {
         val gap    = effectiveGap(active, continuationSeconds)
         patterns.iterator.flatMap { pat =>
           val matching =
-            active.filter(r => r.host.asFqdn.exists(fqdn => matchesPattern(fqdn.value, pat)))
+            active.filter(r => HostMatch.matchesAny(r.host, List(pat)))
           val secs     = unionSeconds(sessionSpans(matching, gap))
           if secs > 0L then Some(pat -> secs) else None
         }.toMap
@@ -612,7 +612,7 @@ object Presence {
     val active          = rows.filterNot(r => isHeartbeat(r, filter, appHostPatterns))
     val gap             = effectiveGap(active, continuationSeconds)
     def matchesGroup(r: PresenceRow, pats: List[String]): Boolean =
-      r.host.asFqdn.exists(fqdn => pats.exists(p => matchesPattern(fqdn.value, p)))
+      HostMatch.matchesAny(r.host, pats)
     groups.iterator.flatMap { case (key, pats) =>
       val matching  = active.filter(r => matchesGroup(r, pats))
       // Per device, stitch the union of the app's hosts as ONE stream so a gap < N

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -198,5 +198,5 @@ object DashboardNowRoutes {
    * the byte level, so only identity is safe here.
    */
   private def dropBackground(rows: List[TrafficRollupRow]): List[TrafficRollupRow] =
-    rows.filterNot(r => r.host.asFqdn.exists(fqdn => InfraHosts.isBackground(fqdn.value)))
+    rows.filterNot(r => InfraHosts.isBackground(r.host))
 }

--- a/shared/src/types/HostMatch.scala
+++ b/shared/src/types/HostMatch.scala
@@ -53,6 +53,21 @@ object HostMatch {
     loop(host, maxHops)
   }
 
+  /**
+   * #1560: `host` matches at least one pattern in `patterns` under [[matchesPattern]] semantics.
+   * The single host-keyed entry point every "does this host belong to any of these patterns"
+   * predicate routes through (`Presence.isExempt`, `isAppAttributed`, per-site / per-app pattern
+   * filters, the dashboard's app-aware branch in #1559) — so a pattern-match cannot drift between
+   * surfaces (the #1532 single-source-of-truth lesson).
+   *
+   * IP-literal hosts never match: patterns are FQDN-shaped (apex / `*.apex`) and `HostId.asFqdn`
+   * returns `None` for IPv4/IPv6 hosts. An empty `patterns` returns `false`.
+   */
+  def matchesAny(host: HostId, patterns: List[String]): Boolean =
+    patterns.nonEmpty && host.asFqdn.exists(fqdn =>
+      patterns.exists(p => matchesPattern(fqdn.value, p)),
+    )
+
   /** Boolean variant of [[lookupApex]] over a set of apexes. */
   def hasApexMatch(host: String, apexes: Set[String], maxHops: Int = 5): Boolean = {
     @annotation.tailrec

--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -131,4 +131,13 @@ object InfraHosts {
    * Whether `fqdn` is device-level background infra — the presence/dashboard suppression predicate.
    */
   def isBackground(fqdn: String): Boolean = matchedBackgroundPattern(fqdn).isDefined
+
+  /**
+   * #1560: host-keyed background-infra predicate. The SOLE entry point every presence/dashboard
+   * suppression call site routes through — `Presence.isBackgroundHost`,
+   * `Presence.suppressedHostUsage`, and `DashboardNowRoutes.dropBackground` all delegate here so
+   * the rule cannot diverge between surfaces (the #1532 single-source-of-truth lesson). IP-literal
+   * hosts never match (the suppression list keys on FQDN identity).
+   */
+  def isBackground(host: HostId): Boolean = host.asFqdn.exists(fqdn => isBackground(fqdn.value))
 }

--- a/shared/test/src/types/HostMatchSpec.scala
+++ b/shared/test/src/types/HostMatchSpec.scala
@@ -1,0 +1,67 @@
+package wifihaven.shared.types
+
+import zio.test.*
+
+/**
+ * #1560: pin the centralized host-suppression / pattern-matching predicates that replace the per-
+ * call-site copies in `DashboardNowRoutes` and `Presence`. The whole point of the collapse is that
+ * the dashboard and presence agree on which hosts are device-level infra and on the "host matches
+ * any of these patterns" shape — these tests fail if a future change makes one side drift.
+ */
+object HostMatchSpec extends ZIOSpecDefault {
+
+  private val infra: HostId = HostId.fqdn(Hostname.unsafe("r3---sn-abc.gvt2.com"))
+  private val app: HostId   = HostId.fqdn(Hostname.unsafe("www.youtube.com"))
+  private val cdn: HostId   = HostId.fqdn(Hostname.unsafe("a1.akamai.net"))
+  private val privateRelay  = HostId.fqdn(Hostname.unsafe("mask.icloud.com"))
+  private val ip            = HostId.ip(IpAddress.unsafe("8.8.8.8"))
+
+  def spec = suite("HostMatch / InfraHosts host-keyed entry points (#1560)")(
+    test("HostMatch.matchesAny: subdomain matches apex pattern, non-match returns false") {
+      assertTrue(
+        HostMatch.matchesAny(app, List("youtube.com")),
+        HostMatch.matchesAny(app, List("www.youtube.com")),
+        HostMatch.matchesAny(app, List("*.youtube.com")),
+        !HostMatch.matchesAny(app, List("notyoutube.com")),
+        !HostMatch.matchesAny(app, Nil),
+        !HostMatch.matchesAny(cdn, List("youtube.com")),
+      )
+    },
+    test("HostMatch.matchesAny: IP-literal hosts never match (FQDN-only by contract)") {
+      assertTrue(
+        !HostMatch.matchesAny(ip, List("8.8.8.8")),
+        !HostMatch.matchesAny(ip, List("*.google.com")),
+      )
+    },
+    test("InfraHosts.isBackground(HostId): suppresses canonical infra and suppressOnly tier") {
+      assertTrue(
+        InfraHosts.isBackground(infra),
+        InfraHosts.isBackground(privateRelay),
+        !InfraHosts.isBackground(app),
+        !InfraHosts.isBackground(cdn),
+        // IP-literal hosts never match (patterns key on FQDN identity).
+        !InfraHosts.isBackground(ip),
+      )
+    },
+    test(
+      "InfraHosts.isBackground(HostId) agrees with InfraHosts.isBackground(String) on the FQDN — " +
+        "no per-call-site copy can drift from the string predicate (#1560 / #1532)",
+    ) {
+      val hosts = List(
+        "r3---sn-abc.gvt2.com",
+        "mask.icloud.com",
+        "www.youtube.com",
+        "a1.akamai.net",
+        "connectivitycheck.gstatic.com",
+        "ocsp.digicert.com",
+        "firestore.googleapis.com",
+      )
+      assertTrue(
+        hosts.forall { h =>
+          val id = HostId.fqdn(Hostname.unsafe(h))
+          InfraHosts.isBackground(id) == InfraHosts.isBackground(h)
+        },
+      )
+    },
+  )
+}


### PR DESCRIPTION
Closes #1560.

## Summary

The dashboard and `Presence` were re-rolling the same `host → FQDN → pattern-match` plumbing at six call sites. The #1532 dedup audit consolidated the suppression **data** (one `InfraHosts` list, one `Presence.isHeartbeat`), but the **predicate plumbing** was never centralized — `Presence.isBackgroundHost` was `private`, so `DashboardNowRoutes.dropBackground` re-rolled it by hand, and the "host matches any of these patterns" shape appeared inline five times in `Presence`. Exactly the divergence class #1532 collapses.

## Canonical entry points (host-keyed)

Both live in `shared/src/types/` so policy/presence/dashboard/wire all share them:

- `HostMatch.matchesAny(host: HostId, patterns: List[String]): Boolean` — replaces the inline `asFqdn.exists(fqdn => patterns.exists(p => matchesPattern(fqdn.value, p)))` shape. IP-literal hosts never match; empty patterns returns `false`.
- `InfraHosts.isBackground(host: HostId): Boolean` — the SOLE entry point every presence/dashboard suppression call site routes through. Thin wrapper around the existing `String` predicate; pinned to agree with it.

## Sites collapsed

| File | Method | New call |
|---|---|---|
| `api/src/routes/DashboardNowRoutes.scala:201` | `dropBackground` | `InfraHosts.isBackground(r.host)` |
| `api/src/presence/Presence.scala:176` | `isExempt` | `HostMatch.matchesAny` |
| `api/src/presence/Presence.scala:370` | `isAppAttributed` | `HostMatch.matchesAny` |
| `api/src/presence/Presence.scala:378` | `isBackgroundHost` (private) | `InfraHosts.isBackground` |
| `api/src/presence/Presence.scala:416` | `suppressedHostUsage` | `InfraHosts.isBackground` |
| `api/src/presence/Presence.scala:462` | `patternSecondsByMac` | `HostMatch.matchesAny` |
| `api/src/presence/Presence.scala:508` | `patternSecondsForProfile` (Dedup) | `HostMatch.matchesAny` |
| `api/src/presence/Presence.scala:615` | `appSpansForProfile/matchesGroup` | `HostMatch.matchesAny` |

The private `Presence.isBackgroundHost` stays as a single-line alias for clarity (it adapts `PresenceRow → HostId`); every other call sites was either deleted or rewritten to call the canonical predicate directly.

## TDD

Commit 1 (red): `shared/test/src/types/HostMatchSpec.scala` pins both entry points (compile fails, since neither exists).
Commit 2 (green): implements the entry points + migrates every call site.

The pin includes an agreement test: `InfraHosts.isBackground(HostId)` must equal `InfraHosts.isBackground(String)` on every FQDN, so a future divergence between the two surfaces breaks the build instead of silently drifting (#1532 invariant, structurally enforced).

## Test plan

- [x] `mill shared.test` — green (new `HostMatchSpec` passes)
- [x] `mill api.test` — green (192 tasks, including all PresenceSpec / DashboardNow / #1506 / #1532 regression coverage)
- [x] `scalafmt --check` — clean

## Deferred follow-ups

- A grep-based CI guard rejecting new occurrences of `InfraHosts.isBackground(.*\.value)` outside the canonical file — keep predicate re-rolling structurally impossible. Small follow-up; not in scope here.
- #1559 (dashboard now-widget app-aware) now consumes these centralized predicates rather than adding a third copy of the suppression rule.