### PR TITLE
fix(#1607): bump default JWT user-token expiry 24h → 30d

### DIFF
--- a/api/test/src/unit/ConfigSpec.scala
+++ b/api/test/src/unit/ConfigSpec.scala
@@ -6,6 +6,8 @@ import zio.config.magnolia.*
 import zio.config.typesafe.*
 import zio.test.*
 
+import java.nio.file.{Files, Paths}
+
 /**
  * #1221: `db.poolSize` must be configurable per deployment. In prod the value arrives as the
  * `WIFIHAVEN_DB_POOL_SIZE` env var, which `docker/entrypoint.sh` substitutes into the rendered
@@ -49,6 +51,27 @@ object ConfigSpec extends ZIOSpecDefault {
     test("local-dev default (5) parses when no override is supplied") {
       for cfg <- load("5")
       yield assertTrue(cfg.db.poolSize == 5)
+    },
+    // #1607: pin the user-token JWT expiry default. The operator was hitting
+    // the re-login flow ~daily; this asserts the in-repo default minted into
+    // a fresh self-hosted install is 30 days, not 24 hours. Per-deploy
+    // override flows through WIFIHAVEN_JWT_HOURS via docker/entrypoint.sh.
+    test("config/application.conf.example default for jwt.expiryHours is 720 (30 days)") {
+      // Walk up from cwd to find the repo root containing config/application.conf.example.
+      // Mill's cwd at test time is not the repo root.
+      def findExample(p: java.nio.file.Path): java.nio.file.Path =
+        if (Files.exists(p.resolve("config/application.conf.example")))
+          p.resolve("config/application.conf.example")
+        else if (p.getParent != null) findExample(p.getParent)
+        else throw new RuntimeException("could not find config/application.conf.example")
+      val text = new String(Files.readAllBytes(findExample(Paths.get(".").toAbsolutePath)))
+      for cfg <-
+          read(
+            deriveConfig[AppConfig]
+              .nested("wifihaven")
+              .from(TypesafeConfigProvider.fromHoconString(text)),
+          )
+      yield assertTrue(cfg.jwt.expiryHours == 720)
     },
   )
 }

--- a/config/application.conf.example
+++ b/config/application.conf.example
@@ -38,7 +38,12 @@ wifihaven {
 
   jwt {
     secret      = "change-this-to-a-random-32-char-secret!!"
-    expiryHours = 24
+    # #1607: 30 days. The operator hits re-login ~daily on a 24h default,
+    # and this is a self-hosted home tool used from trusted devices.
+    # Per-deploy override: set WIFIHAVEN_JWT_HOURS (entrypoint.sh).
+    # Security trade-off: longer-lived JWTs widen blast radius on token
+    # leak; bcrypt + JWT secret rotation unchanged, role claims unchanged.
+    expiryHours = 720
   }
 
   cors {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 : "${WIFIHAVEN_STATIC_DIR:=/app/web}"
 : "${WIFIHAVEN_SERVE_SPA:=true}"
 : "${WIFIHAVEN_JWT_SECRET:=staging-jwt-secret-do-not-use-in-prod-32ch}"
-: "${WIFIHAVEN_JWT_HOURS:=24}"
+: "${WIFIHAVEN_JWT_HOURS:=720}"  # #1607: 30d default; see application.conf.example
 : "${WIFIHAVEN_LOG_LEVEL:=INFO}"
 : "${WIFIHAVEN_DEBUG:=}"
 : "${WIFIHAVEN_ALLOWED_ORIGINS:=}"


### PR DESCRIPTION
Closes #1607.

## Summary
- Bumps default `jwt.expiryHours` from `24` to `720` (30 days) so the operator stops getting kicked back to the login screen daily on a self-hosted home tool used from trusted devices.
- Two defaults updated in lockstep so both deploy paths get the new value:
  - `config/application.conf.example` — self-hosted / local-dev default.
  - `docker/entrypoint.sh`'s `WIFIHAVEN_JWT_HOURS` default — containerized deploys (entrypoint renders `application.conf` from env).
- Already-issued tokens keep their existing TTL; only tokens minted after the deploy lands carry the new 30-day expiry.

## Per-deploy override path (verified)
The override env var was already wired before this PR:

```
WIFIHAVEN_JWT_HOURS → docker/entrypoint.sh → rendered application.conf → JwtConfig.expiryHours
```

So an operator can pin a different value on the Render service (or a docker-compose env) without changing the in-repo default — no new env-var plumbing needed in `render.yaml`. The prod/staging entries don't set it explicitly, which means they pick up the entrypoint default (now 720); set the env var on the service if a tighter value is ever wanted.

## Not a wire change
The JWT shape is unchanged — only the distribution of `exp` claim values shifts forward. Per-AGENTS.md "Backwards compatibility": new tokens go further out, old tokens continue to validate until their original expiry. The router↔API wire contract is untouched.

## Security trade-off
Longer-lived JWTs widen the blast radius on token leak. Mitigations:
- bcrypt password store (cost 12) — unchanged.
- JWT secret rotation story — unchanged.
- Role claims (admin / readonly / child) — unchanged; nothing scoped tighter changes.
- 30 days is a common "remember me" duration, not infinite.
- A future refresh-token / "remember me" flow could split into short-lived access + long-lived refresh tokens; that's the structurally correct fix and is explicitly out of scope here.

## TDD trail
- `1a31d8da` — test pinning the example default to 720 (RED on `24`).
- `dc97b194` — defaults bumped (GREEN).

## Test plan
- [x] `mill api.test.testOnly wifihaven.api.unit.ConfigSpec` — new assertion passes on 720, would fail on 24.
- [x] `mill api.test` — full feature suite green (no AuthApiSpec / RouterApiSpec / etc. regression from the default bump; those specs construct `JwtConfig` explicitly with `expiryHours = 1`).
- [x] `scalafmt --check` clean.
- [ ] After deploy: log in fresh, decode the new token's `exp` and confirm ~30d out.

## Out of scope (file follow-ups if wanted)
- Refresh-token / "remember me" UI toggle.
- SPA-side token-expiry UX improvements (already shows re-login prompt on 401).
- Short-lived access token + long-lived refresh token split.