### PR TITLE
feat(#842): router-side foreground-host heuristic for per-FQDN time-on-site

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -281,26 +281,50 @@ function M.new_tracker()
   return { last = {}, active_samples = {} }
 end
 
--- Compare each counter to its previous byte total; an increase counts as one
--- active sample.  A counter that went DOWN is treated as a fresh start
--- (element expired and reappeared, or counters reset out-of-band); we still
--- count it as an active sample if the new value is > 0.
+-- Per sample tick, only the foreground (mac, dst_ip) — the one with the
+-- largest byte delta since the previous tick — earns an active sample for
+-- each MAC (#842 / #715 Path 1). Background flows that get a small slice of
+-- every sample no longer inflate per-host time-on-site; bytes accounting
+-- (build_report.bytesIn/bytesOut) is unchanged.
+--
+-- A counter that went DOWN is treated as a fresh start (element expired and
+-- reappeared, or counters reset out-of-band); its effective delta for the
+-- foreground contest is the new total.
+--
+-- Ties break on lexically smallest dst_ip so the choice is deterministic.
 function M.tracker_sample(tracker, counters)
+  local winner_key   = {}  -- mac → tracker_key of largest-delta flow
+  local winner_delta = {}  -- mac → delta of current winner
+  local winner_dst   = {}  -- mac → dst_ip of current winner (for tie-break)
+
   for _, c in ipairs(counters or {}) do
     local key   = tracker_key(c.mac, c.dst_ip)
     local prev  = tracker.last[key] or 0
     -- Counter total spans both directions (#717) — growth in either bytes
     -- (device→remote) or bytes_out (remote→device) marks an active sample.
     local total = (c.bytes or 0) + (c.bytes_out or 0)
+    local delta = nil
     if total > prev then
-      tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
+      delta = total - prev
       tracker.last[key] = total
     elseif total < prev then
-      if total > 0 then
-        tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
-      end
+      if total > 0 then delta = total end
       tracker.last[key] = total
     end
+    if delta then
+      local best = winner_delta[c.mac]
+      if best == nil
+         or delta > best
+         or (delta == best and c.dst_ip < winner_dst[c.mac]) then
+        winner_key[c.mac]   = key
+        winner_delta[c.mac] = delta
+        winner_dst[c.mac]   = c.dst_ip
+      end
+    end
+  end
+
+  for _, key in pairs(winner_key) do
+    tracker.active_samples[key] = (tracker.active_samples[key] or 0) + 1
   end
 end
 

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -603,18 +603,50 @@ describe("usage.tracker", function()
     assert.equal(2, t.active_samples["de:ad:be:ef:00:01|8.8.8.8"])
   end)
 
-  it("tracks each dst_ip independently for the same mac", function()
+  -- #842 (foreground-host heuristic): within a single sample tick, only the
+  -- (mac, dst_ip) with the largest delta — per MAC — gets credited as the
+  -- active sample. Background flows that get a slice of every sample no
+  -- longer inflate time-on-site.
+  it("credits only the largest-delta dst_ip per MAC per sample (#842)", function()
+    local t = usage.new_tracker()
+    -- Sample 1: A is the larger flow (200 > 100 from baseline 0).
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),  -- delta 100 (B)
+      s("aa:bb:cc:11:22:33", "5.6.7.8", 200),  -- delta 200 (A) — winner
+    })
+    -- Sample 2: A wins again (delta 600 vs 0).
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),  -- no growth
+      s("aa:bb:cc:11:22:33", "5.6.7.8", 800),  -- delta 600 — winner
+    })
+    assert.equal(0, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"] or 0)
+    assert.equal(2, t.active_samples["aa:bb:cc:11:22:33|5.6.7.8"])
+  end)
+
+  -- Foreground heuristic is per-MAC: two devices each get their own winner
+  -- in the same sample tick.
+  it("picks the foreground dst_ip independently per MAC (#842)", function()
     local t = usage.new_tracker()
     usage.tracker_sample(t, {
-      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
-      s("aa:bb:cc:11:22:33", "5.6.7.8", 200),
-    })
-    usage.tracker_sample(t, {
-      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),
-      s("aa:bb:cc:11:22:33", "5.6.7.8", 800),
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 100),   -- mac1 only flow → winner
+      s("de:ad:be:ef:00:01", "8.8.8.8",  50),   -- mac2 small flow
+      s("de:ad:be:ef:00:01", "9.9.9.9", 900),   -- mac2 winner
     })
     assert.equal(1, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
-    assert.equal(2, t.active_samples["aa:bb:cc:11:22:33|5.6.7.8"])
+    assert.equal(0, t.active_samples["de:ad:be:ef:00:01|8.8.8.8"] or 0)
+    assert.equal(1, t.active_samples["de:ad:be:ef:00:01|9.9.9.9"])
+  end)
+
+  -- Tie-break: lexically smallest dst_ip wins. Deterministic so the choice
+  -- is reproducible in the wire output.
+  it("breaks ties on equal delta by lexically smallest dst_ip (#842)", function()
+    local t = usage.new_tracker()
+    usage.tracker_sample(t, {
+      s("aa:bb:cc:11:22:33", "5.6.7.8", 500),
+      s("aa:bb:cc:11:22:33", "1.2.3.4", 500),
+    })
+    assert.equal(1, t.active_samples["aa:bb:cc:11:22:33|1.2.3.4"])
+    assert.equal(0, t.active_samples["aa:bb:cc:11:22:33|5.6.7.8"] or 0)
   end)
 
   -- #717: counter total is bytes + bytes_out, so a download-only flow still


### PR DESCRIPTION
Closes #842.

## What changes

Within each 10s sample tick in `usage.tracker_sample`, only the foreground (mac, dst_ip) — the flow with the largest byte delta for that MAC — earns the active-sample credit. Background flows that previously got a slice of every sample no longer inflate per-host time-on-site.

- Per-MAC: each device picks its own foreground dst_ip in the same tick.
- Tie-break: lexically smallest dst_ip wins (deterministic).
- Bytes accounting (`bytesIn` / `bytesOut`) is unchanged — only the seconds-attribution shifts.

The heuristic lives in one place inside `usage.lua` (per AGENTS.md §single-source-of-truth).

## Behavior change callout

This is a usage-attribution behavior change in the router agent. Already-stored historical `traffic_reports` rows are unaffected; only NEW samples shift. The change pairs naturally with the server-side `proportionalMins` shipped by #715 Path 2 — after a soak window in prod, operator may want to compare both metrics to decide which one becomes the canonical display surface.

## Validation

Ran the Lua busted suite on Mac:

```
$ LUA_PATH=… busted test/conntrack_spec.lua test/render_spec.lua test/policy_spec.lua test/usage_spec.lua …
636 successes / 0 failures / 0 errors / 1 pending
```

The pending case is `nft -c -f -` which needs the `nft` binary (not present on macOS).

**End-to-end validation needs the KVM runner.** Operator may want to run the Linux Gate-1/Gate-2 e2e suite manually before promoting to prod, or wait for the master-router CD to do it on merge — the unit-test coverage of the heuristic is solid but the wire shape was not exercised against a live router image here.

## Test plan
- [x] RED commit: three new busted cases describing the heuristic (largest-delta-per-MAC, per-MAC independence, deterministic tie-break)
- [x] GREEN commit: `tracker_sample` rewritten as per-MAC argmax-delta selection
- [x] Full Lua suite passes (636/0/0/1-pending)
- [ ] Linux Gate-1/Gate-2 e2e (operator / CD)