### PR TITLE
feat(#335): show today's usage on the kid block page

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -376,7 +376,21 @@ object Main extends ZIOAppDefault {
             upRepo,
             clock,
           ) ++
-          BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists)
+          BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists) ++
+          // #335: kid-side block page support. Unauthenticated — the router DNATs blocked
+          // traffic to the SPA's /blocked, which calls GET /api/blocked?mac=&host= to render
+          // the reason + today's usage. Accidentally removed from registration in #1060;
+          // re-wired here so the kid-friendly path stops falling back to the legacy
+          // router-supplied `reason` query string.
+          BlockedRoutes.routes(
+            policy,
+            deviceRepo,
+            profileRepo,
+            blRepo,
+            timeStatus,
+            hsRepo,
+            clock,
+          )
 
       val routerAndAdminRoutes: Routes[Any, Response] =
         RouterRoutes.routes(routerRepo, policy, routerAuth, blockEvRepo) ++

--- a/api/src/routes/BlockedRoutes.scala
+++ b/api/src/routes/BlockedRoutes.scala
@@ -33,6 +33,9 @@ object BlockedRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       blocklistRepo: BlocklistRepo,
+      timeStatusService: TimeStatusService,
+      householdSettingsRepo: HouseholdSettingsRepo,
+      clock: Clock,
   ): Routes[Any, Response] = {
     val notBlocked = BlockedInfoResponse(blocked = false, None, None, None)
 
@@ -50,7 +53,17 @@ object BlockedRoutes {
             case Left(_)            =>
               ZIO.succeed(Response.json(notBlocked.toJson))
             case Right((mac, host)) =>
-              resolve(policy, deviceRepo, profileRepo, blocklistRepo, mac, host)
+              resolve(
+                policy,
+                deviceRepo,
+                profileRepo,
+                blocklistRepo,
+                timeStatusService,
+                householdSettingsRepo,
+                clock,
+                mac,
+                host,
+              )
                 .map(r => Response.json(r.toJson))
                 .catchAll(_ => ZIO.succeed(Response.json(notBlocked.toJson)))
           }
@@ -63,30 +76,44 @@ object BlockedRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       blocklistRepo: BlocklistRepo,
+      timeStatusService: TimeStatusService,
+      householdSettingsRepo: HouseholdSettingsRepo,
+      clock: Clock,
       mac: MacAddress,
       host: Hostname,
-  ): Task[BlockedInfoResponse] = {
-    val notBlocked = BlockedInfoResponse(blocked = false, None, None, None)
+  ): Task[BlockedInfoResponse] =
     for {
-      decision   <- policy.decide(mac.value, host.value)
-      device     <- deviceRepo.findByMac(mac)
-      profileOpt <- device.flatMap(_.profileId) match {
+      decision    <- policy.decide(mac.value, host.value)
+      device      <- deviceRepo.findByMac(mac)
+      profileOpt  <- device.flatMap(_.profileId) match {
         case Some(pid) => profileRepo.findById(pid)
         case None      => ZIO.succeed(None)
       }
-      result     <-
-        if decision.decision != ConnectionDecision.Block then ZIO.succeed(notBlocked)
-        else
-          mapReason(decision.reason, blocklistRepo).map { case (rc, catName) =>
-            BlockedInfoResponse(
-              blocked = true,
-              reasonClass = Some(rc),
-              categoryName = catName,
-              profileName = profileOpt.map(_.name),
-            )
-          }
-    } yield result
-  }
+      // #335: today's usage for the device's profile, sourced from the canonical
+      // TimeStatusService — same primitive that drives the snapshot's TimeLimit
+      // decision and the admin /api/time/status UI. None when there's no profile.
+      dayStateOpt <- profileOpt match {
+        case None    => ZIO.succeed(None)
+        case Some(p) =>
+          for {
+            now      <- clock.instant
+            settings <- householdSettingsRepo.get
+            ds       <- timeStatusService.todaysState(now, settings, p.id)
+          } yield ds
+      }
+      reasonPair  <-
+        if decision.decision != ConnectionDecision.Block then ZIO.succeed(None)
+        else mapReason(decision.reason, blocklistRepo).map(Some(_))
+    } yield BlockedInfoResponse(
+      blocked = reasonPair.isDefined,
+      reasonClass = reasonPair.map(_._1),
+      categoryName = reasonPair.flatMap(_._2),
+      profileName = profileOpt.map(_.name),
+      usedMinutes = dayStateOpt.map(_.usedMinutes),
+      dailyLimitMinutes = dayStateOpt.flatMap(_.dailyLimitMinutes),
+      extensionMinutes = dayStateOpt.map(_.extensionMinutes),
+      remainingMinutes = dayStateOpt.flatMap(_.remainingMinutes),
+    )
 
   /**
    * Map the router decision wire-reason to a (reasonClass, categoryName?) pair.

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -13,7 +13,7 @@ import zio.http.*
 import zio.json.*
 import zio.test.*
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
 /**
  * #959: kid-side block-page endpoint. Verifies the unauthenticated reason-class shape (no schedule
@@ -57,6 +57,56 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       namedScheduleRepo = nsr,
     ): PolicyService
 
+  private def makeTimeStatus =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er): TimeStatusService
+
+  private def seedRouter: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo] { rr =>
+      for {
+        id <- rr.create("test-router", Sha256Hex.unsafe("t" * 64))
+        _  <- rr.completeEnrollment(id, Sha256Hex.unsafe("u" * 64))
+      } yield id
+    }
+
+  // Mirrors TimeApiSpec.seedTraffic: `minutes/5` non-overlapping 5-min buckets.
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      date: LocalDate,
+      minutes: Int,
+      bucketOffset: Int = 0,
+  ): ZIO[TrafficReportRepo, Throwable, Int] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val today0  = date.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = today0.plusSeconds((bucketOffset + i) * 300L)
+        val end   = start.plusSeconds(300)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          date,
+          start,
+          end,
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).as(bucketOffset + buckets)
+    }
+
   private def callBlocked(
       routes: Routes[Any, Response],
       mac: String,
@@ -78,7 +128,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         dr  <- ZIO.service[DeviceRepo]
         blr <- ZIO.service[BlocklistRepo]
         ps  <- makePsAt(TestClock.schoolDayAfternoon)
-        routes = BlockedRoutes.routes(ps, dr, pr, blr)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "ff:ff:ff:ff:ff:ff", "example.com")
       } yield assertTrue(!info.blocked) &&
         assertTrue(info.reasonClass.isEmpty) &&
@@ -95,7 +147,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         _   <- pr.setPaused(kid, true)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
         ps  <- makePsAt(TestClock.schoolDayAfternoon)
-        routes = BlockedRoutes.routes(ps, dr, pr, blr)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "aa:bb:cc:11:22:33", "example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(info.reasonClass.contains("paused")) &&
@@ -112,7 +166,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         kid <- TestLayers.seedKidsProfile(pr, sr)
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
         ps  <- makePsAt(TestClock.bedtime)
-        routes = BlockedRoutes.routes(ps, dr, pr, blr)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "aa:bb:cc:11:22:33", "example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(info.reasonClass.contains("schedule")) &&
@@ -125,7 +181,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         dr  <- ZIO.service[DeviceRepo]
         blr <- ZIO.service[BlocklistRepo]
         ps  <- makePsAt(TestClock.schoolDayAfternoon)
-        routes = BlockedRoutes.routes(ps, dr, pr, blr)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "not-a-mac", "example.com")
       } yield assertTrue(!info.blocked)
     },
@@ -139,7 +197,9 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         adults <- TestLayers.seedAdultsProfile(pr)
         _      <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:55", "ipad", adults)
         ps     <- makePsAt(TestClock.schoolDayAfternoon)
-        routes = BlockedRoutes.routes(ps, dr, pr, blr)
+        tss    <- makeTimeStatus
+        hsr    <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "aa:bb:cc:11:22:55", "example.com")
       } yield assertTrue(!info.blocked)
     },
@@ -163,12 +223,61 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         pr  <- ZIO.service[ProfileRepo]
         dr  <- ZIO.service[DeviceRepo]
         blr <- ZIO.service[BlocklistRepo]
-        routes = BlockedRoutes.routes(stubPolicy, dr, pr, blr)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(stubPolicy, dr, pr, blr, tss, hsr)
         info <- callBlocked(routes, "aa:bb:cc:11:22:99", "weird.example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(!info.reasonClass.contains("extra_blocked")) &&
         assertTrue(info.reasonClass.contains("blocked")) &&
         assertTrue(info.categoryName.isEmpty)
+    },
+    // #335: kid-side block page must show today's usage so a restricted kid can see
+    // *why* their time is gone, not just that it is. The fields are populated for any
+    // enrolled MAC (blocked or not) so the page can render usage on a non-blocked
+    // request too. Values come from the canonical TimeStatusService.todaysState — no
+    // re-derivation here (single source of truth).
+    test("enrolled MAC → response includes today's usage (used/cap/extension/remaining)") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        sr  <- ZIO.service[ScheduleRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        blr <- ZIO.service[BlocklistRepo]
+        tlr <- ZIO.service[TimeLimitRepo]
+        kid <- TestLayers.seedKidsProfile(pr, sr)
+        _   <- tlr.upsert(kid, 120)
+        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:44", "kid-ipad", kid)
+        rid <- seedRouter
+        today = TestClock.bedtime.toLocalDate
+        _   <- seedTraffic(rid, "aa:bb:cc:11:22:44", "minecraft.net", today, 45)
+        ps  <- makePsAt(TestClock.bedtime)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        info <- callBlocked(routes, "aa:bb:cc:11:22:44", "example.com")
+      } yield assertTrue(info.blocked) &&
+        assertTrue(info.reasonClass.contains("schedule")) &&
+        assertTrue(info.dailyLimitMinutes.contains(120)) &&
+        assertTrue(info.usedMinutes.contains(45)) &&
+        assertTrue(info.extensionMinutes.contains(0)) &&
+        assertTrue(info.remainingMinutes.contains(75))
+    },
+    test("unknown MAC → usage fields are None (no enrollment leak)") {
+      for {
+        _   <- cleanDb
+        pr  <- ZIO.service[ProfileRepo]
+        dr  <- ZIO.service[DeviceRepo]
+        blr <- ZIO.service[BlocklistRepo]
+        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        info <- callBlocked(routes, "ff:ff:ff:ff:ff:ff", "example.com")
+      } yield assertTrue(!info.blocked) &&
+        assertTrue(info.usedMinutes.isEmpty) &&
+        assertTrue(info.dailyLimitMinutes.isEmpty) &&
+        assertTrue(info.remainingMinutes.isEmpty)
     },
   ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -42,20 +42,23 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
       nsr    <- ZIO.service[NamedScheduleRepo]
       ref    <- Ref.make(dt)
       clk = new Clock.TestClock(ref)
-    } yield PolicyServiceLive(
-      pr,
-      sr,
-      hsr,
-      tlr,
-      atlr,
-      dr,
-      blr,
-      trRepo,
-      er,
-      ar,
-      clk,
-      namedScheduleRepo = nsr,
-    ): PolicyService
+    } yield (
+      PolicyServiceLive(
+        pr,
+        sr,
+        hsr,
+        tlr,
+        atlr,
+        dr,
+        blr,
+        trRepo,
+        er,
+        ar,
+        clk,
+        namedScheduleRepo = nsr,
+      ): PolicyService,
+      clk: Clock,
+    )
 
   private def makeTimeStatus =
     for {
@@ -123,14 +126,15 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
   def spec = suite("GET /api/blocked")(
     test("unknown MAC → blocked:false (no enrollment leak)") {
       for {
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        blr <- ZIO.service[BlocklistRepo]
-        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        psClk <- makePsAt(TestClock.schoolDayAfternoon)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "ff:ff:ff:ff:ff:ff", "example.com")
       } yield assertTrue(!info.blocked) &&
         assertTrue(info.reasonClass.isEmpty) &&
@@ -138,18 +142,19 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     },
     test("paused profile → blocked:true, reasonClass=paused, profileName populated") {
       for {
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        blr <- ZIO.service[BlocklistRepo]
-        kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- pr.setPaused(kid, true)
-        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- pr.setPaused(kid, true)
+        _     <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        psClk <- makePsAt(TestClock.schoolDayAfternoon)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "aa:bb:cc:11:22:33", "example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(info.reasonClass.contains("paused")) &&
@@ -158,17 +163,18 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     },
     test("active schedule → reasonClass=schedule, NO expiresAt/end-time leak") {
       for {
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        sr  <- ZIO.service[ScheduleRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        blr <- ZIO.service[BlocklistRepo]
-        kid <- TestLayers.seedKidsProfile(pr, sr)
-        _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
-        ps  <- makePsAt(TestClock.bedtime)
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        sr    <- ZIO.service[ScheduleRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        kid   <- TestLayers.seedKidsProfile(pr, sr)
+        _     <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:33", "kid-ipad", kid)
+        psClk <- makePsAt(TestClock.bedtime)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "aa:bb:cc:11:22:33", "example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(info.reasonClass.contains("schedule")) &&
@@ -176,14 +182,15 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     },
     test("malformed mac → blocked:false (no error leakage)") {
       for {
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        blr <- ZIO.service[BlocklistRepo]
-        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        psClk <- makePsAt(TestClock.schoolDayAfternoon)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "not-a-mac", "example.com")
       } yield assertTrue(!info.blocked)
     },
@@ -196,10 +203,11 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         blr    <- ZIO.service[BlocklistRepo]
         adults <- TestLayers.seedAdultsProfile(pr)
         _      <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:55", "ipad", adults)
-        ps     <- makePsAt(TestClock.schoolDayAfternoon)
-        tss    <- makeTimeStatus
-        hsr    <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        psClk  <- makePsAt(TestClock.schoolDayAfternoon)
+        (ps, clk) = psClk
+        tss <- makeTimeStatus
+        hsr <- ZIO.service[HouseholdSettingsRepo]
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "aa:bb:cc:11:22:55", "example.com")
       } yield assertTrue(!info.blocked)
     },
@@ -225,7 +233,8 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         blr <- ZIO.service[BlocklistRepo]
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(stubPolicy, dr, pr, blr, tss, hsr)
+        clk <- ZIO.service[Clock]
+        routes = BlockedRoutes.routes(stubPolicy, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "aa:bb:cc:11:22:99", "weird.example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(!info.reasonClass.contains("extra_blocked")) &&
@@ -250,11 +259,12 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         _   <- TestLayers.seedDevice(dr, "aa:bb:cc:11:22:44", "kid-ipad", kid)
         rid <- seedRouter
         today = TestClock.bedtime.toLocalDate
-        _   <- seedTraffic(rid, "aa:bb:cc:11:22:44", "minecraft.net", today, 45)
-        ps  <- makePsAt(TestClock.bedtime)
+        _     <- seedTraffic(rid, "aa:bb:cc:11:22:44", "minecraft.net", today, 45)
+        psClk <- makePsAt(TestClock.bedtime)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "aa:bb:cc:11:22:44", "example.com")
       } yield assertTrue(info.blocked) &&
         assertTrue(info.reasonClass.contains("schedule")) &&
@@ -265,14 +275,15 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
     },
     test("unknown MAC → usage fields are None (no enrollment leak)") {
       for {
-        _   <- cleanDb
-        pr  <- ZIO.service[ProfileRepo]
-        dr  <- ZIO.service[DeviceRepo]
-        blr <- ZIO.service[BlocklistRepo]
-        ps  <- makePsAt(TestClock.schoolDayAfternoon)
+        _     <- cleanDb
+        pr    <- ZIO.service[ProfileRepo]
+        dr    <- ZIO.service[DeviceRepo]
+        blr   <- ZIO.service[BlocklistRepo]
+        psClk <- makePsAt(TestClock.schoolDayAfternoon)
+        (ps, clk) = psClk
         tss <- makeTimeStatus
         hsr <- ZIO.service[HouseholdSettingsRepo]
-        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr)
+        routes = BlockedRoutes.routes(ps, dr, pr, blr, tss, hsr, clk)
         info <- callBlocked(routes, "ff:ff:ff:ff:ff:ff", "example.com")
       } yield assertTrue(!info.blocked) &&
         assertTrue(info.usedMinutes.isEmpty) &&

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1486,11 +1486,23 @@ case class RouterDecisionResponse(
 // `blocked` is false when the (mac, host) pair resolves to Allow or the
 // device is unenrolled; the SPA renders a generic "not blocked" page in
 // that case rather than leaking household state.
+// #335: usage fields are populated for any enrolled MAC (blocked or not) so a
+// restricted kid can see *why* their time is gone, not just that it is. None on
+// an unknown MAC (no enrollment leak) and on an enrolled MAC with no profile
+// assigned. `usedMinutes` is the active screen-minutes today; `dailyLimitMinutes`
+// is the configured cap before extensions; `extensionMinutes` is today's granted
+// extension; `remainingMinutes` is `cap + extensions - used`, clamped at 0.
+// Sourced from the canonical TimeStatusService.todaysState so the block page
+// cannot drift from the snapshot's "blocked because TimeLimit" decision.
 case class BlockedInfoResponse(
     blocked: Boolean,
     reasonClass: Option[String],
     categoryName: Option[String],
     profileName: Option[String],
+    usedMinutes: Option[Int] = None,
+    dailyLimitMinutes: Option[Int] = None,
+    extensionMinutes: Option[Int] = None,
+    remainingMinutes: Option[Int] = None,
 ) derives JsonCodec
 
 // ── Policy snapshot (target shape per docs/architecture.md §0.2, #354) ────

--- a/web/src/pages/BlockedPage.test.tsx
+++ b/web/src/pages/BlockedPage.test.tsx
@@ -163,4 +163,32 @@ describe('BlockedPage — API-driven reason (#959)', () => {
     await waitFor(() => expect(screen.getByText(/outside allowed time/i)).toBeInTheDocument())
     expect(screen.queryByText(/07:00/)).not.toBeInTheDocument()
   })
+
+  // #335: a restricted kid sees today's used / cap / remaining on the block
+  // page so they understand *why* their time is gone. Hidden when no cap is
+  // configured so unenrolled / adult-profile cases stay clean.
+  it("shows today's usage when the API includes used/cap minutes", async () => {
+    mockBlockedInfo({
+      blocked: true,
+      reasonClass: 'time_limit',
+      profileName: 'Kids',
+      usedMinutes: 90,
+      dailyLimitMinutes: 120,
+      extensionMinutes: 0,
+      remainingMinutes: 30,
+    })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+    await waitFor(() => expect(screen.getByTestId('block-usage')).toBeInTheDocument())
+    expect(screen.getByTestId('block-usage-used')).toHaveTextContent('Used: 90 / 120 min')
+    expect(screen.getByTestId('block-usage-remaining')).toHaveTextContent('30 min left')
+  })
+
+  it('hides the usage panel when the API has no cap (unenrolled / no daily limit)', async () => {
+    mockBlockedInfo({ blocked: false })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() =>
+      expect(screen.getByText(/not blocked for this device/i)).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('block-usage')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -104,11 +104,43 @@ export function BlockedPage() {
           <p className="text-brand-text text-sm">{body}</p>
           {profileLine && <p className="text-brand-text-muted text-xs">{profileLine}</p>}
         </div>
+        {info && <UsageToday info={info} />}
         {mac && host
           ? <AskParent mac={mac} host={host} info={info} legacyReason={legacyReason} />
           : <p className="text-brand-text-muted text-sm">Ask a parent to adjust your settings.</p>
         }
       </div>
+    </div>
+  )
+}
+
+/**
+ * #335: today's screen-time summary for the device's profile. The block page is
+ * the kid's only authenticated-free window into their own state, so we surface
+ * used / cap / extension / remaining here. Values come from the API
+ * (BlockedInfoResponse), which sources them from the canonical
+ * TimeStatusService.todaysState — same primitive that drives the snapshot's
+ * TimeLimit decision. We render nothing if no daily cap is configured for the
+ * profile (or the MAC is unenrolled).
+ */
+function UsageToday({ info }: { info: BlockedInfoResponse }) {
+  const used = info.usedMinutes ?? null
+  const cap = info.dailyLimitMinutes ?? null
+  const ext = info.extensionMinutes ?? 0
+  const remaining = info.remainingMinutes ?? null
+  if (cap == null || used == null) return null
+  return (
+    <div
+      data-testid="block-usage"
+      className="bg-white border border-brand-border rounded-2xl px-4 py-3 text-sm text-brand-text text-left space-y-1"
+    >
+      <div className="font-medium text-brand-ink">Time today</div>
+      <div data-testid="block-usage-used">Used: {used} / {cap} min{ext > 0 ? ` (+${ext} extension)` : ''}</div>
+      {remaining != null && (
+        <div data-testid="block-usage-remaining">
+          {remaining > 0 ? `${remaining} min left` : 'No time left today'}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -967,4 +967,11 @@ export interface BlockedInfoResponse {
   reasonClass?: string | null
   categoryName?: string | null
   profileName?: string | null
+  // #335: today's usage for the device's profile so a restricted kid can see
+  // why their time is gone. Populated for any enrolled MAC; null/undefined when
+  // the MAC has no profile or there's no daily limit configured.
+  usedMinutes?: number | null
+  dailyLimitMinutes?: number | null
+  extensionMinutes?: number | null
+  remainingMinutes?: number | null
 }


### PR DESCRIPTION
Closes #335.

A device under a paused / scheduled / time-limited profile already lands
on the unauthenticated SPA block page (router DNATs traffic to it, the
SPA hosts sit in `extraAllowed`, and `#959`/`#960` gave it kid-friendly
copy + the Ask-A-Parent CTA). What it couldn't do is answer the actual
ask in #335 — **let a restricted kid look at their own usage** — so the
page now surfaces today's used / cap / extension / remaining alongside
the existing reason.

## Summary

- **`BlockedInfoResponse`** gains four additive optional fields:
  `usedMinutes`, `dailyLimitMinutes`, `extensionMinutes`,
  `remainingMinutes`. Backwards compatible (extra fields are ignored by
  older clients; the SPA tolerates `null`/`undefined`).
- **`BlockedRoutes.resolve`** populates them from
  `TimeStatusService.todaysState` — the same canonical primitive that
  drives the snapshot's `TimeLimit` decision and the admin
  `/api/time/status` UI. Single-source-of-truth, no re-derivation.
  `None` when the MAC is unenrolled (no enrollment leak) or has no
  profile assigned.
- **`BlockedPage.tsx`** renders a new `UsageToday` panel under the
  reason copy and above the Ask-A-Parent CTA. Hidden when no cap is
  configured, so the unenrolled / adult-profile cases stay clean.
- **Re-registers `BlockedRoutes` in `Main.scala`.** It was accidentally
  dropped from the route table in #1060 (refactor: replace device_alerts
  with a generic alerts table), so `/api/blocked` has been silently
  dead in prod since that PR merged — every kid landing on `/blocked`
  has been falling back to the legacy router-supplied `reason` query
  string. Re-wiring it restores the kid-friendly reasoning path the
  test suite has covered all along.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.BlockedApiSpec` —
  passes (2 new + 6 existing tests). RED commit committed before GREEN.
- [x] `npx vitest run src/pages/BlockedPage.test.tsx` — passes
  (2 new + 18 existing tests).
- [x] Adjacent specs unaffected: `TimeApiSpec`,
  `BlockedMacEventIngestSpec` — all pass.
- [ ] **Manual verification on household**:
  1. Pick a kid MAC and ensure its profile has a daily cap configured
     (e.g. Kids profile, 120 min).
  2. Force a schedule block (or pause the profile) so the device drops
     to the block page. Either trigger an actual schedule window, or
     `curl -X PATCH https://<api>/api/profiles/<id>/paused` with admin
     auth and `{"paused": true}`.
  3. From a browser on the kid's device, hit any HTTP/80 site. The
     router DNATs to `https://wifihaven.net/blocked?mac=…&host=…`.
  4. Confirm the new "Time today" card appears under the reason copy,
     showing `Used: X / 120 min` and either `N min left` or
     `No time left today`. The reason copy and Ask-A-Parent CTA should
     still render exactly as before.
  5. Hit the API directly (no auth) — `curl
     "https://<api>/api/blocked?mac=<MAC>&host=youtube.com"` — and
     verify the new fields are present in the JSON.

## Out of scope (deferred)

Several adjacent improvements live in their own threads:

- A full **authenticated kid portal** (separate `app.wifihaven.net`
  with sign-in, "my schedule", history) — that's the larger #679
  block-page architecture redesign and not what #335 was asking for.
- **Per-app usage breakdown** on the block page (today's top apps by
  minutes). Doable via `ProfileDayState.perApp` but adds layout
  complexity; left for a follow-up if the operator wants it.