### PR TITLE
feat(#1615): BlockedPage stops reading URL reason= param (API is canonical)

### DIFF
--- a/web/src/pages/BlockedPage.test.tsx
+++ b/web/src/pages/BlockedPage.test.tsx
@@ -14,75 +14,142 @@ function renderBlocked(params: Record<string, string>) {
   )
 }
 
-describe('BlockedPage — reason display', () => {
-  // Reason strings here mirror MacBlockReason wire format
-  // (shared/src/Models.scala: Paused / Schedule / TimeLimit / Manual).
-  it('shows paused-profile copy for reason=Paused (#437)', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'Paused' })
-    expect(screen.getByText(/profile is paused/i)).toBeInTheDocument()
+// After #1615 the API (GET /api/blocked) is the only source of body copy and
+// CTA kinds. The URL `?reason=` param is ignored. These tests mock the API
+// directly via global fetch (the api client wraps fetch).
+function mockBlockedInfo(body: object) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response)
+}
+
+function mockBlockedInfoReject() {
+  globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline'))
+}
+
+let originalFetch: typeof fetch
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+})
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('BlockedPage — API-driven reason copy (#1615)', () => {
+  it('renders paused copy when API returns reasonClass=paused', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'paused' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() => expect(screen.getByText(/profile is paused/i)).toBeInTheDocument())
   })
 
-  it('shows schedule end time for reason=Schedule with until param', () => {
-    renderBlocked({
-      mac: 'aa:bb:cc:11:22:33',
-      host: 'example.com',
-      reason: 'Schedule',
-      until: '07:00',
-    })
-    expect(screen.getByText(/07:00/)).toBeInTheDocument()
+  it('renders schedule copy when API returns reasonClass=schedule', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'schedule' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() => expect(screen.getByText(/outside allowed time/i)).toBeInTheDocument())
   })
 
-  // #959 Q4: don't leak minute counts — copy is just "out of time today".
-  it('shows out-of-time copy for reason=TimeLimit', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
-    expect(screen.getByText(/out of time today/i)).toBeInTheDocument()
+  it('renders out-of-time copy when API returns reasonClass=time_limit', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+    await waitFor(() => expect(screen.getByText(/out of time today/i)).toBeInTheDocument())
   })
 
-  it('shows manual-block copy for reason=Manual', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'Manual' })
-    expect(screen.getByText(/blocked by a parent/i)).toBeInTheDocument()
+  it('renders app-time-limit copy when API returns reasonClass=app_time_limit', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'app_time_limit' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+    await waitFor(() => expect(screen.getByText(/out of time on this app/i)).toBeInTheDocument())
   })
 
-  it('shows extra-blocked copy for reason=ExtraBlocked (#576)', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'ExtraBlocked' })
-    expect(screen.getByText(/blocked by the household/i)).toBeInTheDocument()
+  it('renders extra-blocked copy when API returns reasonClass=extra_blocked', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'extra_blocked' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() => expect(screen.getByText(/blocked by your parent/i)).toBeInTheDocument())
   })
 
-  it('shows category message for reason=category:ads', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'ads.example.com', reason: 'category:ads' })
-    expect(screen.getByText(/blocked category/i)).toBeInTheDocument()
+  it('renders category copy with category name from the API', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'category', categoryName: 'Ads' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'ads.example.com' })
+    await waitFor(() => expect(screen.getByText(/blocked category: ads/i)).toBeInTheDocument())
   })
 
-  it('shows a non-empty fallback for unknown reason instead of leaving it blank (#437)', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'whatever' })
-    expect(screen.getByText(/access blocked/i)).toBeInTheDocument()
+  it('renders the profile name when present in the payload', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'paused', profileName: 'Kids' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() => expect(screen.getByText(/for kids/i)).toBeInTheDocument())
   })
 
-  it('shows the blocked hostname prominently', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+  it('shows the blocked hostname prominently', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
     expect(screen.getByText('youtube.com')).toBeInTheDocument()
   })
 })
 
+describe('BlockedPage — URL reason param is ignored (#1615)', () => {
+  it('IGNORES URL ?reason=Paused when API returns reasonClass=category', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'category', categoryName: 'Ads' })
+    renderBlocked({
+      mac: 'aa:bb:cc:11:22:33',
+      host: 'ads.example.com',
+      reason: 'Paused',
+    })
+    await waitFor(() => expect(screen.getByText(/blocked category: ads/i)).toBeInTheDocument())
+    expect(screen.queryByText(/profile is paused/i)).not.toBeInTheDocument()
+  })
+
+  it('renders neutral copy on API error, NOT the URL-supplied reason text', async () => {
+    mockBlockedInfoReject()
+    renderBlocked({
+      mac: 'aa:bb:cc:11:22:33',
+      host: 'example.com',
+      reason: 'Paused',
+    })
+    await waitFor(() => expect(screen.getByText(/access blocked/i)).toBeInTheDocument())
+    expect(screen.queryByText(/profile is paused/i)).not.toBeInTheDocument()
+  })
+
+  it('schedule class never leaks an end time even if `until` is present in URL', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'schedule' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', until: '07:00' })
+    await waitFor(() => expect(screen.getByText(/outside allowed time/i)).toBeInTheDocument())
+    expect(screen.queryByText(/07:00/)).not.toBeInTheDocument()
+  })
+})
+
 describe('BlockedPage — ask-a-parent CTA (#960)', () => {
-  it('still has no parent-login dialog (no kid-side credentials)', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+  it('still has no parent-login dialog (no kid-side credentials)', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+    await waitFor(() => expect(screen.getByTestId('ask-parent')).toBeInTheDocument())
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('shows an extension CTA for TimeLimit blocks', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
-    expect(screen.getByTestId('ask-parent-extension')).toBeInTheDocument()
+  it('shows an extension CTA when API returns reasonClass=time_limit', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+    await waitFor(() =>
+      expect(screen.getByTestId('ask-parent-extension')).toBeInTheDocument(),
+    )
   })
 
-  it('shows an exemption CTA for ExtraBlocked / category blocks', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'foo.com', reason: 'ExtraBlocked' })
-    expect(screen.getByTestId('ask-parent-exemption')).toBeInTheDocument()
+  it('shows an exemption CTA when API returns reasonClass=extra_blocked', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'extra_blocked' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'foo.com' })
+    await waitFor(() =>
+      expect(screen.getByTestId('ask-parent-exemption')).toBeInTheDocument(),
+    )
   })
 
-  it('shows unpause + extension CTAs for Paused', () => {
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', reason: 'Paused' })
-    expect(screen.getByTestId('ask-parent-unpause')).toBeInTheDocument()
+  it('shows unpause + extension CTAs when API returns reasonClass=paused', async () => {
+    mockBlockedInfo({ blocked: true, reasonClass: 'paused' })
+    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
+    await waitFor(() => expect(screen.getByTestId('ask-parent-unpause')).toBeInTheDocument())
     expect(screen.getByTestId('ask-parent-extension')).toBeInTheDocument()
   })
 
@@ -90,19 +157,21 @@ describe('BlockedPage — ask-a-parent CTA (#960)', () => {
     // The block-page redirect always supplies mac=, but be tolerant: when it
     // is missing we cannot identify the kid's profile, so hide the CTA and
     // render the older static message instead of posting an anonymous row.
-    renderBlocked({ host: 'youtube.com', reason: 'TimeLimit' })
+    renderBlocked({ host: 'youtube.com' })
     expect(screen.queryByTestId('ask-parent')).not.toBeInTheDocument()
     expect(screen.getByText(/ask a parent/i)).toBeInTheDocument()
   })
 
   describe('posting the request', () => {
-    beforeEach(() => vi.restoreAllMocks())
-
     it('POSTs the kid-known (mac, host, kind) and shows a confirmation', async () => {
+      mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
       const create = vi
         .spyOn(api.alerts, 'createAccessRequest')
         .mockResolvedValue({} as never)
-      renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+      renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+      await waitFor(() =>
+        expect(screen.getByTestId('ask-parent-extension')).toBeInTheDocument(),
+      )
       fireEvent.click(screen.getByTestId('ask-parent-extension'))
       await waitFor(() => expect(create).toHaveBeenCalledTimes(1))
       expect(create).toHaveBeenCalledWith({
@@ -115,52 +184,14 @@ describe('BlockedPage — ask-a-parent CTA (#960)', () => {
     })
 
     it('surfaces a network error inline without leaving the CTA disabled forever', async () => {
+      mockBlockedInfo({ blocked: true, reasonClass: 'time_limit' })
       vi.spyOn(api.alerts, 'createAccessRequest').mockRejectedValue(new Error('offline'))
-      renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com', reason: 'TimeLimit' })
+      renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'youtube.com' })
+      await waitFor(() =>
+        expect(screen.getByTestId('ask-parent-extension')).toBeInTheDocument(),
+      )
       fireEvent.click(screen.getByTestId('ask-parent-extension'))
       expect(await screen.findByTestId('ask-parent-error')).toHaveTextContent('offline')
     })
-  })
-})
-
-// #959: API-driven path overrides the legacy `reason` query param when the
-// SPA can reach GET /api/blocked.
-describe('BlockedPage — API-driven reason (#959)', () => {
-  let originalFetch: typeof fetch
-
-  beforeEach(() => {
-    originalFetch = globalThis.fetch
-  })
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  function mockBlockedInfo(body: object) {
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: new Headers(),
-      json: () => Promise.resolve(body),
-      text: () => Promise.resolve(JSON.stringify(body)),
-    } as unknown as Response)
-  }
-
-  it('renders category name from the API payload', async () => {
-    mockBlockedInfo({ blocked: true, reasonClass: 'category', categoryName: 'Ads' })
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'ads.example.com' })
-    await waitFor(() => expect(screen.getByText(/blocked category: ads/i)).toBeInTheDocument())
-  })
-
-  it('renders the profile name when present in the payload', async () => {
-    mockBlockedInfo({ blocked: true, reasonClass: 'paused', profileName: 'Kids' })
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com' })
-    await waitFor(() => expect(screen.getByText(/for kids/i)).toBeInTheDocument())
-  })
-
-  it('schedule class never leaks an end time even if `until` is present in URL', async () => {
-    mockBlockedInfo({ blocked: true, reasonClass: 'schedule' })
-    renderBlocked({ mac: 'aa:bb:cc:11:22:33', host: 'example.com', until: '07:00' })
-    await waitFor(() => expect(screen.getByText(/outside allowed time/i)).toBeInTheDocument())
-    expect(screen.queryByText(/07:00/)).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/BlockedPage.tsx
+++ b/web/src/pages/BlockedPage.tsx
@@ -18,9 +18,9 @@ import type { AccessRequestKind, BlockedInfoResponse } from '@/types/api'
 //   - app_time_limit → "Out of time on this app"
 //   - extra_blocked → "Blocked by your parent"
 //
-// Fallback: if `reason` is supplied as a query param (older router serving the
-// MacBlockReason string directly, pre-API path), we still render the legacy
-// copy so a stale OpenWRT agent doesn't show a blank page during rollout.
+// #1615: the API is the only source of body copy and CTA kinds. The router
+// still appends `?reason=` to the redirect URL until PR2 (#1617), but the SPA
+// ignores it — it's kid-supplied input and the API is canonical.
 
 function copyFor(info: BlockedInfoResponse): string {
   if (!info.blocked) return 'This page is not blocked for this device.'
@@ -44,28 +44,10 @@ function copyFor(info: BlockedInfoResponse): string {
   }
 }
 
-function legacyCopy(reason: string, until?: string | null): string {
-  if (reason === 'Paused') return 'Your profile is paused.'
-  if (reason === 'Schedule') return until ? `This is scheduled quiet time until ${until}.` : 'Outside allowed time.'
-  if (reason === 'TimeLimit') return 'Out of time today.'
-  if (reason === 'Manual') return 'This device has been blocked by a parent.'
-  if (reason === 'ExtraBlocked') return 'This site is blocked by the household.'
-  // #961 — unmanaged-MAC fallthrough. Sent by the router when an HTTP/80
-  // request originates from a MAC not enrolled in any profile and the
-  // household policy is `block`.
-  if (reason === 'device_not_enrolled') return 'This device is not enrolled. Ask the household admin to add it.'
-  if (reason.startsWith('app_time_limit')) return 'Out of time on this app today.'
-  if (reason.startsWith('category:')) return `Blocked category: ${reason.slice('category:'.length)}.`
-  if (reason === 'extra_blocked') return 'Blocked by your parent.'
-  return 'Access blocked.'
-}
-
 export function BlockedPage() {
   const [params] = useSearchParams()
-  const host       = params.get('host') ?? ''
-  const mac        = params.get('mac') ?? ''
-  const legacyReason = params.get('reason') ?? ''
-  const legacyUntil  = params.get('until')
+  const host = params.get('host') ?? ''
+  const mac  = params.get('mac') ?? ''
 
   const [info, setInfo] = useState<BlockedInfoResponse | null>(null)
   const [error, setError] = useState<boolean>(false)
@@ -80,16 +62,11 @@ export function BlockedPage() {
     return () => { cancelled = true }
   }, [mac, host])
 
-  // Prefer the API result when it arrives. Until then (or on error), fall back
-  // to the legacy `reason` query param the router still sends so a stale
-  // router agent or a slow API doesn't show a blank page.
   const body =
-    info != null && info.blocked ? copyFor(info)
-    : legacyReason                ? legacyCopy(legacyReason, legacyUntil)
-    : info != null                ? copyFor(info) // info.blocked === false
-    : error                       ? 'Access blocked.'
-    : mac && host                 ? '…'
-    :                               'Access blocked.'
+    info != null   ? copyFor(info)
+    : error        ? 'Access blocked.'
+    : mac && host  ? '…'
+    :                'Access blocked.'
 
   const profileLine = info?.blocked && info.profileName
     ? `for ${info.profileName}`
@@ -105,7 +82,7 @@ export function BlockedPage() {
           {profileLine && <p className="text-brand-text-muted text-xs">{profileLine}</p>}
         </div>
         {mac && host
-          ? <AskParent mac={mac} host={host} info={info} legacyReason={legacyReason} />
+          ? <AskParent mac={mac} host={host} info={info} />
           : <p className="text-brand-text-muted text-sm">Ask a parent to adjust your settings.</p>
         }
       </div>
@@ -114,30 +91,21 @@ export function BlockedPage() {
 }
 
 /**
- * #960: kid-side CTA. Maps the block reason (API `reasonClass` first, legacy
- * `reason` query param as fallback) to the request kinds that make sense for
- * that reason — e.g. `time_limit` offers only "ask for more time", a category
- * block offers only "ask to unblock this site". POSTs to the public
- * `/api/access-requests` endpoint; no kid-side credentials.
+ * #960: kid-side CTA. Maps the API `reasonClass` to the request kinds that
+ * make sense for that reason — e.g. `time_limit` offers only "ask for more
+ * time", a category block offers only "ask to unblock this site". POSTs to
+ * the public `/api/access-requests` endpoint; no kid-side credentials.
  */
-function offeredKindsFor(info: BlockedInfoResponse | null, legacy: string): AccessRequestKind[] {
+function offeredKindsFor(info: BlockedInfoResponse | null): AccessRequestKind[] {
   const cls = info?.blocked ? info.reasonClass : null
   if (cls === 'paused')          return ['unpause', 'extension']
   if (cls === 'schedule')        return ['unpause', 'extension']
   if (cls === 'time_limit')      return ['extension']
-  if (cls === 'app_time_limit') return ['extension', 'exemption']
+  if (cls === 'app_time_limit')  return ['extension', 'exemption']
   if (cls === 'category')        return ['exemption']
   if (cls === 'extra_blocked')   return ['exemption']
-  // Fall back to the legacy reason string for stale router agents.
-  if (legacy === 'Paused')                 return ['unpause', 'extension']
-  if (legacy === 'Schedule')               return ['unpause', 'extension']
-  if (legacy === 'TimeLimit')              return ['extension']
-  if (legacy === 'ExtraBlocked')           return ['exemption']
-  if (legacy === 'Manual')                 return ['exemption']
-  if (legacy === 'extra_blocked')          return ['exemption']
-  if (legacy.startsWith('category:'))      return ['exemption']
-  if (legacy.startsWith('app_time_limit'))   return ['extension', 'exemption']
-  // Unknown reason — offer everything so the kid still has a way through.
+  // API in flight or unknown class — offer everything so the kid still has a
+  // way through.
   return ['extension', 'exemption', 'unpause']
 }
 
@@ -153,14 +121,12 @@ function AskParent({
   mac,
   host,
   info,
-  legacyReason,
 }: {
   mac: string
   host: string
   info: BlockedInfoResponse | null
-  legacyReason: string
 }) {
-  const kinds = offeredKindsFor(info, legacyReason)
+  const kinds = offeredKindsFor(info)
   const [note, setNote] = useState('')
   const [sending, setSending] = useState<AccessRequestKind | null>(null)
   const [sent, setSent] = useState(false)


### PR DESCRIPTION
Closes #1615.

## What

web/src/pages/BlockedPage.tsx no longer reads `?reason=` or `?until=` from the URL. The API (`GET /api/blocked` → `PolicyService.decide`) is the only source of body copy and offered access-request kinds. URL-supplied reasons are ignored.

## Why

PR1 of 4 in the #679 split. After PR2 (#1617) the router will stop including `?reason=` in the redirect URL; this PR makes the SPA stop trusting it ahead of that change so PR1 and PR2 ship independently.

## Test plan

- [x] Unit: BlockedPage renders correct copy + CTAs from API reasonClass for every block class.
- [x] Unit: URL `?reason=Paused` is ignored when API returns a different class.
- [x] Unit: API error renders neutral copy, not URL-supplied reason.
- [ ] Manual: visit `/blocked?mac=…&host=…&reason=Paused` on a SPA with the API mocked to return `reasonClass=category` — expect category copy, not paused copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)