### PR TITLE
feat(#383): HTTPS block-page variant via uhttpd TLS + self-signed cert

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -903,10 +903,55 @@ overshoot is one usage-report interval (~60 s) plus one policy-poll interval
 
 ### 7.6 Block-page redirect
 
-nftables `dnat` on TCP/80 to `127.0.0.1:8081` (uhttpd). A tiny CGI script
-reads the original destination from conntrack and 302s to
-`http://<api>/blocked?mac=…&host=…&reason=…`. Blocked HTTPS times out (no
-MITM without a CA install — same behavior as commercial parental-control boxes).
+nftables `dnat` on TCP/80 to `127.0.0.1:8081` (uhttpd) AND on TCP/443 to
+`127.0.0.1:8443` (uhttpd with a self-signed cert). The lua handler at
+`/www/wifihaven/handler.lua` reads the requested host from the
+`HTTP_HOST` env, the client MAC from the kernel ARP table keyed by
+`REMOTE_ADDR`, and the per-MAC reason from the agent-written IPC files
+under `/var/run/wifihaven/`. It renders the block page directly — no
+external 302 — so it works when the API is unreachable.
+
+#### HTTPS variant (#383)
+
+Up through Gate 2, blocked HTTPS sites timed out silently — the kid hit
+"this site can't be reached" and had no clue WiFi was filtering. As the
+web HTTPSifies, that gap degrades the UX by year and teaches the wrong
+lesson ("the wifi is broken; find a workaround") instead of the right
+one ("this is blocked; ask a parent").
+
+We now DNAT TCP/443 too, to a sibling uhttpd listener on
+`127.0.0.1:8443` (and `[::1]:8443`) that terminates TLS with a
+self-signed cert. Trade we accept:
+
+- The browser shows a cert warning. The user clicks through (in modern
+  Chrome / Safari / Firefox: "Advanced" → "Proceed anyway") and lands
+  on the same block page as the HTTP path.
+- The cert warning **is** the design. It is honest: the block page IS
+  a non-standard interception of the requested host.
+
+What we explicitly do NOT do:
+
+- **No CA installed on managed devices.** That would be invasive (per-
+  device setup), would escalate the trust model (we'd be sitting in
+  every TLS handshake the device makes), and is not necessary for the
+  block-page UX.
+
+Cert generation lives in
+`/usr/lib/wifihaven/generate-block-page-cert.sh` and is invoked by
+`setup-uhttpd-block-page.sh` before the TLS listener binds. CN is
+`block.wifihaven.local` (a hint — not a real DNS name); RSA-2048; valid
+for 10 years; **idempotent**: subsequent agent restarts reuse the
+existing cert and never rotate it. Keys live at
+`/etc/wifihaven/block_page.crt` and `/etc/wifihaven/block_page.key`.
+
+The DNAT pairing is emitted by a single `dnat4`/`dnat6` helper in
+`render.lua` — every block predicate (whole-MAC, per-(MAC, host),
+per-(MAC, blocklistId), `blockIpOnly`, global block, global lockdown,
+v4 + v6) lands BOTH a TCP/80 → 8081 rule and a TCP/443 → 8443 rule. No
+predicate can drift between the two ports.
+
+Still traffic-layer enforcement — DNS resolves normally; the redirect
+happens at nftables prerouting, exactly the same as HTTP/80.
 
 ## 8. OpnSense agent design  *(pending #94)*
 

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -19,7 +19,11 @@ define Package/wifihaven
   # table without them — silently dropping all enforcement, including the
   # block-page DNAT (#1144). kmod-nfnetlink-log is the NFLOG backend;
   # kmod-nf-log{,6} provide the netfilter log framework for each family.
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6
+  # #383: libustream-mbedtls supplies the TLS backend uhttpd uses for the
+  # listen_https block-page sibling on :8443; openssl-util provides
+  # /usr/bin/openssl for the self-signed cert generator that ships at
+  # /usr/lib/wifihaven/generate-block-page-cert.sh.
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +libustream-mbedtls +openssl-util
   PKGARCH:=all
 endef
 
@@ -64,6 +68,9 @@ define Package/wifihaven/install
 
 	$(INSTALL_DIR) $(1)/usr/lib/wifihaven
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh $(1)/usr/lib/wifihaven/
+	# #383: cert generator for the TLS block-page listener (CN=block.wifihaven.local,
+	# self-signed, RSA-2048). Idempotent; invoked from setup-uhttpd-block-page.sh.
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/lib/wifihaven/generate-block-page-cert.sh $(1)/usr/lib/wifihaven/
 	# #771: bake PKG_VERSION into a file the lua agent reads at startup so it
 	# can report itself to the API on every checkin (X-WifiHaven-Agent-Version).
 	echo $(PKG_VERSION) > $(1)/usr/lib/wifihaven/VERSION

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -146,7 +146,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/wifihaven/wifihaven" \
     --info "maintainer:WifiHaven <noreply@example.com>" \
-    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua kmod-nf-log kmod-nf-log6" \
+    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua kmod-nf-log kmod-nf-log6 libustream-mbedtls openssl-util" \
     --script "post-install:$WORK/post-install" \
     --script "trigger:$WORK/trigger" \
     --trigger "/etc/crontabs" \

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -25,7 +25,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: wifihaven
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6
+Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6, libustream-mbedtls, openssl-util
 Architecture: all
 Maintainer: WifiHaven <noreply@example.com>
 Description: Agent daemon for WifiHaven. Enforces per-device DNS filtering

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1126,73 +1126,78 @@ function M.nft(snapshot, opts)
       or has_global_block or g_blocked then
     ind("chain wifihaven_block_nat {")
     ind2("type nat hook prerouting priority dstnat; policy accept;")
+    -- #383: every block-page DNAT predicate emits a pair of rules — TCP/80 →
+    -- the HTTP uhttpd listener AND TCP/443 → the parallel TLS uhttpd listener
+    -- (self-signed cert, CN block.wifihaven.local). HTTPS used to time out
+    -- silently; now the user sees a cert warning and, after clicking through,
+    -- the same block page. The cert warning IS the design — we do NOT install
+    -- a CA on managed devices. The pair is emitted via the dnat4 / dnat6
+    -- helpers below so the predicate construction is single-source-of-truth.
+    local function dnat4(predicate)
+      ind2(predicate .. " tcp dport 80 dnat ip to 127.0.0.1:8081")
+      ind2(predicate .. " tcp dport 443 dnat ip to 127.0.0.1:8443")
+    end
+    local function dnat6(predicate)
+      ind2(predicate .. " tcp dport 80 dnat ip6 to ::1:8081")
+      ind2(predicate .. " tcp dport 443 dnat ip6 to ::1:8443")
+    end
     if #blocked_macs_list > 0 then
-      ind2("ether saddr @blocked_macs tcp dport 80 dnat ip to 127.0.0.1:8081")
+      dnat4("ether saddr @blocked_macs")
     end
     -- #421: blocked + extraAllowed → per-MAC v4 DNAT with ea exception.
     -- #1319: ga_suffix adds the @global_allow carve-out so an allowed host is
     -- never redirected to the block page.
     for _, mac in ipairs(blocked_ea_macs) do
-      ind2(string.format(
-        "ether saddr %s%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+      dnat4(string.format("ether saddr %s%s%s",
         mac, ea_suffix(mac, "ip"), ga_suffix("ip")))
     end
     for _, p in ipairs(eb_pairs) do
-      ind2(string.format(
-        "ether saddr %s ip daddr @%s%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+      dnat4(string.format("ether saddr %s ip daddr @%s%s%s",
         p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"), ga_suffix("ip")))
     end
     for _, p in ipairs(bl_pairs) do
-      ind2(string.format(
-        "ether saddr %s ip daddr @%s%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+      dnat4(string.format("ether saddr %s ip daddr @%s%s%s",
         p.mac, bl_set_name(p.id), ea_suffix(p.mac, "ip"), ga_suffix("ip")))
     end
     -- #1319: global block / lockdown v4 DNAT → block page. Carved out only by
     -- @global_allow (per-MAC ea does not save a global block).
     if has_global_block then
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format(
-          "ether saddr %s ip daddr @%s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+        dnat4(string.format("ether saddr %s ip daddr @%s%s",
           mac, GLOBAL_BLOCK4, ga_suffix("ip")))
       end
     end
     if g_blocked then
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format(
-          "ether saddr %s%s tcp dport 80 dnat ip to 127.0.0.1:8081",
-          mac, ga_suffix("ip")))
+        dnat4(string.format("ether saddr %s%s", mac, ga_suffix("ip")))
       end
     end
     -- #353: blockIpOnly v4 DNAT. Same predicate as the forward-chain drop;
     -- the DNAT fires *before* the drop (prerouting < forward), so the
     -- device sees the block page instead of a silent timeout.
     for _, mac in ipairs(bio_macs) do
-      ind2(string.format(
-        "ether saddr %s ip daddr != @%s tcp dport 80 dnat ip to 127.0.0.1:8081",
+      dnat4(string.format("ether saddr %s ip daddr != @%s",
         mac, resolved_set_name(mac)))
     end
-    -- #411: v6 siblings. uhttpd also binds [::1]:8081 (see install.sh).
+    -- #411: v6 siblings. uhttpd also binds [::1]:8081 + [::1]:8443.
     -- `ip6 daddr != ::1` guards against self-DNAT recursion if the block
     -- page itself ever issues an outbound v6 request.
     if #blocked_macs_list > 0 then
-      ind2("ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 80 dnat ip6 to ::1:8081")
+      dnat6("ether saddr @blocked_macs ip6 daddr != ::1")
     end
     -- #421: blocked + extraAllowed → per-MAC v6 DNAT with ea6 exception.
     -- `ip6 daddr != ::1` guards against self-DNAT (same as the @blocked_macs
     -- v6 line above).
     for _, mac in ipairs(blocked_ea_macs) do
-      ind2(string.format(
-        "ether saddr %s ip6 daddr != ::1%s%s tcp dport 80 dnat ip6 to ::1:8081",
+      dnat6(string.format("ether saddr %s ip6 daddr != ::1%s%s",
         mac, ea_suffix(mac, "ip6"), ga_suffix("ip6")))
     end
     for _, p in ipairs(eb_pairs) do
-      ind2(string.format(
-        "ether saddr %s ip6 daddr @%s%s%s tcp dport 80 dnat ip6 to ::1:8081",
+      dnat6(string.format("ether saddr %s ip6 daddr @%s%s%s",
         p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6"), ga_suffix("ip6")))
     end
     for _, p in ipairs(bl_pairs) do
-      ind2(string.format(
-        "ether saddr %s ip6 daddr @%s%s%s tcp dport 80 dnat ip6 to ::1:8081",
+      dnat6(string.format("ether saddr %s ip6 daddr @%s%s%s",
         p.mac, bl6_set_name(p.id), ea_suffix(p.mac, "ip6"), ga_suffix("ip6")))
     end
     -- #1319: global block / lockdown v6 DNAT → block page. The @global_block6
@@ -1201,15 +1206,13 @@ function M.nft(snapshot, opts)
     -- unconditional, so it carries `ip6 daddr != ::1`.
     if has_global_block then
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format(
-          "ether saddr %s ip6 daddr @%s%s tcp dport 80 dnat ip6 to ::1:8081",
+        dnat6(string.format("ether saddr %s ip6 daddr @%s%s",
           mac, GLOBAL_BLOCK6, ga_suffix("ip6")))
       end
     end
     if g_blocked then
       for _, mac in ipairs(managed_macs) do
-        ind2(string.format(
-          "ether saddr %s ip6 daddr != ::1%s tcp dport 80 dnat ip6 to ::1:8081",
+        dnat6(string.format("ether saddr %s ip6 daddr != ::1%s",
           mac, ga_suffix("ip6")))
       end
     end
@@ -1217,8 +1220,7 @@ function M.nft(snapshot, opts)
     -- self-redirect (the uhttpd listener at ::1 is "not in resolved set"
     -- by definition and we must not DNAT its own responses).
     for _, mac in ipairs(bio_macs) do
-      ind2(string.format(
-        "ether saddr %s ip6 daddr != ::1 ip6 daddr != @%s tcp dport 80 dnat ip6 to ::1:8081",
+      dnat6(string.format("ether saddr %s ip6 daddr != ::1 ip6 daddr != @%s",
         mac, resolved6_set_name(mac)))
     end
     ind("}")

--- a/openwrt/files/usr/lib/wifihaven/generate-block-page-cert.sh
+++ b/openwrt/files/usr/lib/wifihaven/generate-block-page-cert.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# #383: generate the self-signed cert + key used by the uhttpd TLS block-page
+# listener on 127.0.0.1:8443 / [::1]:8443.
+#
+# Called from:
+#   - setup-uhttpd-block-page.sh (before reloading uhttpd so the TLS listener
+#     binds on first install)
+#
+# Idempotent: if both files already exist and are non-empty, exits 0 without
+# touching them. Re-running on a deployed router never rotates the cert.
+#
+# Trust model — see docs/architecture.md §7.6 and issue #383: we do NOT
+# install a CA on managed devices. The browser cert warning IS the design;
+# the user clicks through and lands on the block page. CN block.wifihaven.local
+# is a hint, not a real DNS name.
+#
+# Paths are overridable for the test harness (openwrt/test/cert_spec.test.sh).
+set -eu
+
+CRT="${WIFIHAVEN_BLOCK_PAGE_CRT:-/etc/wifihaven/block_page.crt}"
+KEY="${WIFIHAVEN_BLOCK_PAGE_KEY:-/etc/wifihaven/block_page.key}"
+CN="${WIFIHAVEN_BLOCK_PAGE_CN:-block.wifihaven.local}"
+DAYS="${WIFIHAVEN_BLOCK_PAGE_DAYS:-3650}"
+
+log() { printf '[generate-block-page-cert] %s\n' "$1" >&2; }
+
+if [ -s "$CRT" ] && [ -s "$KEY" ]; then
+  log "cert + key already present at $CRT / $KEY — skipping"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$CRT")" "$(dirname "$KEY")"
+
+log "generating self-signed cert (CN=$CN, RSA-2048, ${DAYS} days)"
+umask 077
+openssl req -x509 \
+  -newkey rsa:2048 -nodes \
+  -keyout "$KEY" \
+  -out "$CRT" \
+  -days "$DAYS" \
+  -subj "/CN=$CN" \
+  >/dev/null 2>&1
+
+chmod 600 "$KEY"
+chmod 644 "$CRT"
+log "wrote $CRT and $KEY"

--- a/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
+++ b/openwrt/files/usr/lib/wifihaven/setup-uhttpd-block-page.sh
@@ -16,6 +16,17 @@ set -eu
 
 log() { printf '[setup-uhttpd-block-page] %s\n' "$1" >&2; }
 
+# #383: generate the TLS cert before reloading uhttpd, otherwise the
+# listen_https socket fails to bind on a clean install and the HTTPS DNAT
+# from render.lua's wifihaven_block_nat chain has nowhere to land. Helper
+# is idempotent so re-runs on an already-provisioned router are no-ops.
+CERT_GEN="/usr/lib/wifihaven/generate-block-page-cert.sh"
+if [ -x "$CERT_GEN" ] || [ -f "$CERT_GEN" ]; then
+  sh "$CERT_GEN" || log "WARN: cert generator failed; TLS listener will not bind"
+fi
+BLOCK_PAGE_CRT="/etc/wifihaven/block_page.crt"
+BLOCK_PAGE_KEY="/etc/wifihaven/block_page.key"
+
 uhttpd_section=$(uci show uhttpd 2>/dev/null \
   | awk -F'[.=]' "/^uhttpd\\.[^.]+\\.listen_http=.*'127\\.0\\.0\\.1:8081'/{print \$2; exit}")
 uhttpd_changed=0
@@ -40,6 +51,34 @@ if ! uci -q get "uhttpd.${uhttpd_section}.listen_http" \
     | tr ' ' '\n' | grep -qx '\[::1\]:8081'; then
   log "adding v6 block-page uhttpd listener on [::1]:8081"
   uci add_list "uhttpd.${uhttpd_section}.listen_http=[::1]:8081"
+  uhttpd_changed=1
+fi
+
+# #383: TLS sibling listeners on 127.0.0.1:8443 + [::1]:8443. render.lua's
+# wifihaven_block_nat chain DNATs blocked TCP/443 here, the self-signed cert
+# at /etc/wifihaven/block_page.* terminates TLS, and the same lua_handler
+# below serves the block page (uhttpd-mod-lua sees the request after TLS
+# termination — handler.lua doesn't care which listener fired).
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_https" \
+    | tr ' ' '\n' | grep -qx '127.0.0.1:8443'; then
+  log "adding v4 TLS block-page uhttpd listener on 127.0.0.1:8443"
+  uci add_list "uhttpd.${uhttpd_section}.listen_https=127.0.0.1:8443"
+  uhttpd_changed=1
+fi
+if ! uci -q get "uhttpd.${uhttpd_section}.listen_https" \
+    | tr ' ' '\n' | grep -qx '\[::1\]:8443'; then
+  log "adding v6 TLS block-page uhttpd listener on [::1]:8443"
+  uci add_list "uhttpd.${uhttpd_section}.listen_https=[::1]:8443"
+  uhttpd_changed=1
+fi
+current_cert=$(uci -q get "uhttpd.${uhttpd_section}.cert" || echo "")
+current_key=$(uci -q get "uhttpd.${uhttpd_section}.key"  || echo "")
+if [ "$current_cert" != "$BLOCK_PAGE_CRT" ]; then
+  uci set "uhttpd.${uhttpd_section}.cert=$BLOCK_PAGE_CRT"
+  uhttpd_changed=1
+fi
+if [ "$current_key" != "$BLOCK_PAGE_KEY" ]; then
+  uci set "uhttpd.${uhttpd_section}.key=$BLOCK_PAGE_KEY"
   uhttpd_changed=1
 fi
 

--- a/openwrt/test/cert_spec.test.sh
+++ b/openwrt/test/cert_spec.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# #383: tests for openwrt/files/usr/lib/wifihaven/generate-block-page-cert.sh.
+#
+# The script generates a self-signed cert + key for the uhttpd TLS block-page
+# listener (127.0.0.1:8443 / [::1]:8443). The cert warning IS the design — see
+# docs/architecture.md §7.6.
+#
+# Auto-discovered by CI via the *.test.sh pattern.
+set -euo pipefail
+
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${OPENWRT_DIR}/files/usr/lib/wifihaven/generate-block-page-cert.sh"
+
+PASS=0; FAIL=0
+check() {
+  if [ "${2}" = "ok" ]; then
+    printf "  PASS: %s\n" "${1}"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "${1}" "${2}"; FAIL=$((FAIL + 1))
+  fi
+}
+
+if [ ! -x "${SCRIPT}" ] && [ ! -f "${SCRIPT}" ]; then
+  printf "MISSING: %s\n" "${SCRIPT}"
+  exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  printf "SKIP: openssl not available in test env\n"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+CRT="${TMP}/block_page.crt"
+KEY="${TMP}/block_page.key"
+
+# First invocation must create both files.
+WIFIHAVEN_BLOCK_PAGE_CRT="${CRT}" WIFIHAVEN_BLOCK_PAGE_KEY="${KEY}" \
+  sh "${SCRIPT}" >/dev/null 2>&1 \
+  && check "first run exits 0" ok \
+  || check "first run exits 0" "script failed"
+
+[ -s "${CRT}" ] && check "cert file present and non-empty" ok \
+  || check "cert file present and non-empty" "missing ${CRT}"
+[ -s "${KEY}" ] && check "key file present and non-empty" ok \
+  || check "key file present and non-empty" "missing ${KEY}"
+
+# Cert must be a valid PEM x509 with the expected CN.
+if openssl x509 -in "${CRT}" -noout -subject 2>/dev/null | grep -q "CN.*block.wifihaven.local"; then
+  check "cert CN is block.wifihaven.local" ok
+else
+  check "cert CN is block.wifihaven.local" \
+    "subject was: $(openssl x509 -in "${CRT}" -noout -subject 2>/dev/null || echo 'unparseable')"
+fi
+
+# Cert must be at least 2048-bit RSA so modern browsers don't reject outright.
+if openssl x509 -in "${CRT}" -noout -text 2>/dev/null \
+    | grep -E "(Public-Key.*204[89]|Public-Key.*4096|RSA Public-Key.*204[89])" >/dev/null; then
+  check "cert key length >= 2048 bits" ok
+else
+  check "cert key length >= 2048 bits" "unable to confirm key length"
+fi
+
+# Idempotent: a second run must NOT overwrite either file.
+CRT_BEFORE="$(stat -f '%m' "${CRT}" 2>/dev/null || stat -c '%Y' "${CRT}")"
+KEY_BEFORE="$(stat -f '%m' "${KEY}" 2>/dev/null || stat -c '%Y' "${KEY}")"
+sleep 1
+WIFIHAVEN_BLOCK_PAGE_CRT="${CRT}" WIFIHAVEN_BLOCK_PAGE_KEY="${KEY}" \
+  sh "${SCRIPT}" >/dev/null 2>&1
+CRT_AFTER="$(stat -f '%m' "${CRT}" 2>/dev/null || stat -c '%Y' "${CRT}")"
+KEY_AFTER="$(stat -f '%m' "${KEY}" 2>/dev/null || stat -c '%Y' "${KEY}")"
+
+if [ "${CRT_BEFORE}" = "${CRT_AFTER}" ] && [ "${KEY_BEFORE}" = "${KEY_AFTER}" ]; then
+  check "second run is idempotent (mtimes unchanged)" ok
+else
+  check "second run is idempotent (mtimes unchanged)" \
+    "cert ${CRT_BEFORE}→${CRT_AFTER}, key ${KEY_BEFORE}→${KEY_AFTER}"
+fi
+
+printf "\n%d passed, %d failed\n" "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -124,6 +124,61 @@ grep -q "/www/wifihaven/handler.lua" "$UHTTPD_HELPER" \
   || check "helper configures lua_handler pointing at handler.lua" \
            "missing lua_handler wiring"
 
+# #383: TLS sibling listener on 127.0.0.1:8443 / [::1]:8443 so HTTPS DNAT
+# lands somewhere instead of failing with a connection reset. Same lua
+# handler — uhttpd terminates TLS before the handler runs.
+grep -q "listen_https=127.0.0.1:8443" "$UHTTPD_HELPER" \
+  && check "#383 helper configures TLS listener on 127.0.0.1:8443" ok \
+  || check "#383 helper configures TLS listener on 127.0.0.1:8443" \
+           "missing listen_https=127.0.0.1:8443 wiring"
+
+grep -q "listen_https=\[::1\]:8443" "$UHTTPD_HELPER" \
+  && check "#383 helper configures TLS listener on [::1]:8443" ok \
+  || check "#383 helper configures TLS listener on [::1]:8443" \
+           "missing listen_https=[::1]:8443 wiring"
+
+grep -q "/etc/wifihaven/block_page.crt" "$UHTTPD_HELPER" \
+  && check "#383 helper wires cert=/etc/wifihaven/block_page.crt" ok \
+  || check "#383 helper wires cert=/etc/wifihaven/block_page.crt" \
+           "missing cert path wiring"
+
+grep -q "/etc/wifihaven/block_page.key" "$UHTTPD_HELPER" \
+  && check "#383 helper wires key=/etc/wifihaven/block_page.key" ok \
+  || check "#383 helper wires key=/etc/wifihaven/block_page.key" \
+           "missing key path wiring"
+
+# #383: helper must generate the self-signed cert before reloading uhttpd,
+# otherwise the TLS listener fails to bind on first install.
+grep -q "generate-block-page-cert.sh" "$UHTTPD_HELPER" \
+  && check "#383 helper invokes generate-block-page-cert.sh" ok \
+  || check "#383 helper invokes generate-block-page-cert.sh" \
+           "missing cert generation step"
+
+# #383: ship the cert generator + Makefile must install it under /usr/lib/wifihaven.
+CERT_GEN="$ROOT/files/usr/lib/wifihaven/generate-block-page-cert.sh"
+[ -f "$CERT_GEN" ] \
+  && check "#383 generate-block-page-cert.sh shipped in package" ok \
+  || check "#383 generate-block-page-cert.sh shipped in package" \
+           "missing files/usr/lib/wifihaven/generate-block-page-cert.sh"
+
+grep -q "generate-block-page-cert.sh" "$ROOT/Makefile" \
+  && check "#383 Makefile installs generate-block-page-cert.sh" ok \
+  || check "#383 Makefile installs generate-block-page-cert.sh" \
+           "Package/wifihaven/install doesn't ship the cert generator"
+
+# #383: package depends must pull in TLS support for uhttpd. libustream-mbedtls
+# is the default OpenWRT TLS backend and what uhttpd's listen_https expects.
+# openssl-util provides /usr/bin/openssl for the cert generator.
+grep -Eq "libustream-(mbedtls|openssl|wolfssl)" "$ROOT/Makefile" \
+  && check "#383 Makefile DEPENDS includes libustream-* for uhttpd TLS" ok \
+  || check "#383 Makefile DEPENDS includes libustream-* for uhttpd TLS" \
+           "missing libustream-mbedtls dep"
+
+grep -q "openssl-util" "$ROOT/Makefile" \
+  && check "#383 Makefile DEPENDS includes openssl-util for cert generation" ok \
+  || check "#383 Makefile DEPENDS includes openssl-util for cert generation" \
+           "missing openssl-util dep"
+
 # #542: the uci-defaults stub runs the helper at first boot. uci-defaults
 # is the right idiom for postinst-style work that needs the live system
 # (procd, running uhttpd, mounted /etc/config) — postinst itself fires at

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -616,16 +616,34 @@ describe("render.nft nat chain", function()
       1, true))
   end)
 
-  -- HTTPS (port 443) is explicitly NOT redirected in either family — DNATing
-  -- TLS to a local listener would produce certificate errors, not a block
-  -- page. The filter chain drops it; the user sees a fast connection error,
-  -- same UX as v4.
-  it("does NOT emit a DNAT rule for HTTPS/443 in either family (#411)", function()
+  -- #383: HTTPS/443 is now redirected to a local TLS listener (uhttpd
+  -- listen_https on 127.0.0.1:8443 / [::1]:8443) presenting a self-signed
+  -- cert. The browser shows a cert warning; the user clicks through and
+  -- lands on the same block page as the HTTP path. The cert warning IS the
+  -- design — same behavior model as commercial parental-control filters
+  -- without a per-device CA install. Each TCP/80 DNAT rule must have a
+  -- parallel TCP/443 sibling with the same predicate.
+  it("emits a parallel HTTPS/443 DNAT for @blocked_macs (v4 + v6) (#383)", function()
     local s = snap_one()
     s.profiles["3"].rules.blocked = true
     s.profiles["3"].rules.blockReason = "Paused"
     local nft = render.nft(s)
-    assert.is_nil(nft:find("dport 443", 1, true))
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs tcp dport 443 dnat ip to 127.0.0.1:8443",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr @blocked_macs ip6 daddr != ::1 tcp dport 443 dnat ip6 to ::1:8443",
+      1, true))
+  end)
+
+  it("emits a parallel HTTPS/443 DNAT for per-MAC extraBlocked (#383)", function()
+    local nft = render.nft(snap_one())
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com tcp dport 443 dnat ip to 127.0.0.1:8443",
+      1, true))
+    assert.truthy(nft:find(
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com tcp dport 443 dnat ip6 to ::1:8443",
+      1, true))
   end)
 
 end)


### PR DESCRIPTION
Closes #383.

## Design

Until now, a blocked HTTPS site timed out silently — kid sees a generic "this site can't be reached" and has no clue WiFi is filtering. As the web HTTPSifies the gap widens by year and teaches the wrong lesson (the wifi is broken; route around it) instead of the right one (this is blocked; ask a parent).

This change DNATs blocked TCP/443 to a parallel uhttpd TLS listener on `127.0.0.1:8443` / `[::1]:8443` presenting a self-signed cert (`CN=block.wifihaven.local`, RSA-2048, 10y). The browser shows a cert warning; the user clicks through (Advanced → Proceed) and lands on the same block page as the HTTP path. The cert warning **is** the design — it is honest about the interception, and we explicitly do NOT install a CA on managed devices.

Single source of truth: every block predicate (whole-MAC, per-(MAC, host), per-(MAC, blocklistId), `blockIpOnly`, global block, global lockdown, v4 + v6) now lands BOTH a TCP/80 → 8081 rule and a TCP/443 → 8443 rule, emitted by a shared `dnat4`/`dnat6` helper in `render.lua`. The pair can't drift.

Cert generation lives in `/usr/lib/wifihaven/generate-block-page-cert.sh`. Idempotent: subsequent agent boots reuse the existing cert and never rotate it. Keys at `/etc/wifihaven/block_page.{crt,key}`.

## Compat

Router-only change. No API wire-contract impact — the agent renders both DNAT rules from the same snapshot the API already ships. Adds `libustream-mbedtls` + `openssl-util` to package deps; both ship in the standard OpenWRT 23.05 apk repos.

## Test plan

- [x] Lua unit tests: `render_spec.lua` pins the new TCP/443 DNAT pair for `@blocked_macs` and per-MAC extraBlocked (v4 + v6).
- [x] Shell test: `cert_spec.test.sh` exercises the generator — CN matches, ≥2048-bit RSA, second invocation is a no-op (mtimes unchanged).
- [x] Shell test: `install_spec.sh` pins the helper's `listen_https` + cert/key UCI wiring, package DEPENDS, and Makefile install.
- [ ] Manual validation on `router.lan`:
  ```sh
  ls -la /etc/wifihaven/block_page.{crt,key}        # cert present
  netstat -lnp | grep -E ':(8081|8443) '            # both ports listening
  nft list chain inet wifihaven wifihaven_block_nat \
    | grep -E 'dport (80|443)'                      # both DNAT rules present
  # On a kid device whose profile is blocked / has extraBlocked:
  curl -kv https://example.com/                     # cert warning → block-page HTML
  ```
- [ ] Operator may want to run the Linux Gate 2 e2e on KVM before promoting (this PR's CI exercised unit tests on macOS; the full e2e is router-side).