### PR TITLE
feat(#1617): router redirect URL drops reason= param (handler stops resolving block-page reasons)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
@@ -93,17 +93,17 @@ function M.resolve_base(block_page_url, api_url)
   return api_url
 end
 
--- Build the destination URL on the block-page host. Reason and mac are passed
--- through as-is; the SPA's React BlockedPage matches against the wire-format
--- MacBlockReason strings ("Paused", "Schedule", "TimeLimit", "Manual").
--- `base_url` is the resolved block-page host (see resolve_base), not
--- necessarily the API URL. (#1174)
-function M.build_dest_url(base_url, host, mac, reason)
+-- Build the destination URL on the block-page host. Only host and mac are
+-- carried — the SPA's React BlockedPage derives the canonical reason
+-- server-side from GET /api/blocked (PolicyService.decide), so the router no
+-- longer needs to pass it through the URL (#679 / #1617). `base_url` is the
+-- resolved block-page host (see resolve_base), not necessarily the API URL.
+-- (#1174)
+function M.build_dest_url(base_url, host, mac)
   if not base_url or base_url == "" then return nil end
   return base_url .. "/blocked"
-      .. "?host="   .. url_encode(host)
-      .. "&reason=" .. url_encode(reason or "")
-      .. "&mac="    .. url_encode(mac or "")
+      .. "?host=" .. url_encode(host)
+      .. "&mac="  .. url_encode(mac or "")
 end
 
 -- Inline copy used when API_URL is not (yet) configured. Mirrors the
@@ -130,11 +130,13 @@ end
 
 -- Render the HTML body for the block page. If base_url is set, returns a tiny
 -- redirect document (meta refresh + JS for compatibility). Otherwise returns a
--- self-contained page with inline copy keyed on `reason`. `base_url` is the
--- resolved block-page host (see resolve_base), not necessarily the API URL.
-function M.render_html(base_url, host, mac, reason)
-  local dest = M.build_dest_url(base_url, host, mac, reason)
-  local copy = M.inline_copy_for(reason)
+-- self-contained page with neutral block copy. The reason-specific copy moved
+-- API-side: the SPA reads GET /api/blocked and renders the canonical message
+-- there (#679 / #1617). `base_url` is the resolved block-page host (see
+-- resolve_base), not necessarily the API URL.
+function M.render_html(base_url, host, mac)
+  local dest = M.build_dest_url(base_url, host, mac)
+  local copy = "This site is blocked."
   local site_line = (host and host ~= "")
     and ("Site: " .. html_escape(host)) or ""
   -- Shared inline style used by both paths so the page is always visible.

--- a/openwrt/files/www/wifihaven/handler.lua
+++ b/openwrt/files/www/wifihaven/handler.lua
@@ -27,29 +27,14 @@ function handle_request(env)
   local arp = read_file("/proc/net/arp")
   local mac = block_page.parse_arp(arp, remote)
 
-  local reasons = read_file(paths.block_page_reasons)
-  local reason  = mac and block_page.parse_reasons(reasons, mac) or nil
-  -- No MAC-wide reason means the DNAT was triggered by a per-(MAC, host) drop,
-  -- not a whole-MAC block. Look up the host in the per-MAC classifier file to
-  -- distinguish extraBlocked from category-blocklist hits (#594). Falls back
-  -- to "ExtraBlocked" if the classifier file is missing or the lookup misses
-  -- (#576 default).
-  if mac and not reason then
-    local hosts_content = read_file(paths.block_page_hosts)
-    local source = block_page.parse_blocked_hosts(hosts_content, mac, host)
-    if source == "extra_blocked" then
-      reason = "ExtraBlocked"
-    elseif source then
-      reason = source  -- e.g. "category:ads"
-    else
-      reason = "ExtraBlocked"
-    end
-  end
+  -- #679 / #1617: the redirect URL no longer carries reason=. The SPA derives
+  -- the canonical block reason server-side via GET /api/blocked
+  -- (PolicyService.decide), so there is nothing for this handler to look up.
 
   local api_url = read_file(paths.block_page_api_url)
   if api_url then api_url = api_url:gsub("%s+$", "") end
 
-  local body = block_page.render_html(api_url, host, mac, reason)
+  local body = block_page.render_html(api_url, host, mac)
 
   uhttpd.send("Status: 200 OK\r\n")
   uhttpd.send("Content-Type: text/html; charset=utf-8\r\n")

--- a/openwrt/test/block_page_spec.lua
+++ b/openwrt/test/block_page_spec.lua
@@ -130,58 +130,64 @@ describe("block_page.resolve_base (#1174)", function()
   end)
 end)
 
-describe("block_page.build_dest_url", function()
-  it("emits a fully-formed /blocked URL with host, reason, and mac", function()
+describe("block_page.build_dest_url (#679/#1617: no reason= param)", function()
+  it("emits a fully-formed /blocked URL with host and mac only", function()
     local u = bp.build_dest_url(
-      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33", "Paused")
+      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(u:find("http://api.example.com/blocked", 1, true))
     assert.truthy(u:find("host=youtube.com", 1, true))
-    assert.truthy(u:find("reason=Paused", 1, true))
     assert.truthy(u:find("mac=aa%3Abb%3Acc%3A11%3A22%3A33", 1, true))
+    -- Reason is derived API-side from GET /api/blocked (PR1 / #1615); the
+    -- router no longer sends it on the redirect URL.
+    assert.is_nil(u:find("reason=", 1, true))
   end)
 
   -- #1174: when the block-page base is the public SPA host (not api_url), the
   -- redirect targets the SPA, not the API host.
   it("targets the SPA host when given the block-page base (#1174)", function()
     local base = bp.resolve_base("https://wifihaven.net", "https://api.wifihaven.net")
-    local u = bp.build_dest_url(base, "youtube.com", "aa:bb:cc:11:22:33", "Schedule")
+    local u = bp.build_dest_url(base, "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(u:find("https://wifihaven.net/blocked", 1, true))
     assert.is_nil(u:find("api.wifihaven.net", 1, true))
+    assert.is_nil(u:find("reason=", 1, true))
   end)
 
   it("returns nil when api_url is not configured", function()
-    assert.is_nil(bp.build_dest_url(nil, "x.com", "aa:bb:cc:11:22:33", "Paused"))
-    assert.is_nil(bp.build_dest_url("", "x.com", "aa:bb:cc:11:22:33", "Paused"))
+    assert.is_nil(bp.build_dest_url(nil, "x.com", "aa:bb:cc:11:22:33"))
+    assert.is_nil(bp.build_dest_url("", "x.com", "aa:bb:cc:11:22:33"))
   end)
 
-  it("tolerates a missing mac/reason (still emits a valid URL for fallback display)", function()
-    local u = bp.build_dest_url("http://api.example.com", "x.com", nil, nil)
+  it("tolerates a missing mac (still emits a valid URL for fallback display)", function()
+    local u = bp.build_dest_url("http://api.example.com", "x.com", nil)
     assert.truthy(u:find("mac=", 1, true))
-    assert.truthy(u:find("reason=", 1, true))
+    assert.is_nil(u:find("reason=", 1, true))
   end)
 end)
 
-describe("block_page.render_html", function()
+describe("block_page.render_html (#679/#1617: no reason= param)", function()
   it("emits a redirect document containing the dest URL when api_url is set", function()
     local html = bp.render_html(
-      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33", "Paused")
+      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(html:find("window.location.replace", 1, true))
-    assert.truthy(html:find("reason=Paused", 1, true))
     assert.truthy(html:find("http://api.example.com/blocked", 1, true))
+    -- Redirect URL must NOT carry a reason= param — SPA derives the reason
+    -- from GET /api/blocked (PR1 / #1615).
+    assert.is_nil(html:find("reason=", 1, true))
   end)
 
-  -- #580: redirect page must carry a viewport meta and show inline copy so
-  -- iOS Safari users see content even if the cross-origin redirect is blocked.
-  it("redirect page includes viewport meta and visible block reason (#580)", function()
+  -- #580: redirect page must carry a viewport meta and show neutral inline
+  -- copy so iOS Safari users see content even if the cross-origin redirect is
+  -- blocked. Post-#1617 the inline copy is no longer reason-keyed.
+  it("redirect page includes viewport meta and neutral inline copy (#580)", function()
     local html = bp.render_html(
-      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33", "TimeLimit")
+      "http://api.example.com", "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(html:find('name="viewport"', 1, true))
-    assert.truthy(html:find("Daily screen time limit reached.", 1, true))
+    assert.truthy(html:find("This site is blocked.", 1, true))
   end)
 
   -- #580: inline fallback (no api_url) must also carry viewport meta.
   it("inline fallback includes viewport meta (#580)", function()
-    local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33", "Paused")
+    local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(html:find('name="viewport"', 1, true))
   end)
 
@@ -189,18 +195,22 @@ describe("block_page.render_html", function()
   -- host as base, the redirect document points at the SPA, not the API host.
   it("redirect document points at the block-page base, not api_url (#1174)", function()
     local base = bp.resolve_base("https://wifihaven.net", "https://api.wifihaven.net")
-    local html = bp.render_html(base, "youtube.com", "aa:bb:cc:11:22:33", "Schedule")
+    local html = bp.render_html(base, "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(html:find("https://wifihaven.net/blocked", 1, true))
     assert.is_nil(html:find("api.wifihaven.net", 1, true))
+    assert.is_nil(html:find("reason=", 1, true))
   end)
 
-  it("falls back to inline copy when api_url is missing", function()
-    local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33", "Paused")
-    assert.truthy(html:find("This profile is paused.", 1, true))
+  it("falls back to neutral inline copy when api_url is missing", function()
+    local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33")
+    assert.truthy(html:find("This site is blocked.", 1, true))
     assert.is_nil(html:find("window.location.replace", 1, true))
   end)
 
-  it("inline copy covers every MacBlockReason, ExtraBlocked, and a fallback", function()
+  -- inline_copy_for + parse_reasons + parse_blocked_hosts are no longer called
+  -- by the handler (#1617). They remain in the module for now and get deleted
+  -- in PR3 (#1618) along with the agent-side reason-file writes.
+  it("inline copy still resolves MacBlockReason / ExtraBlocked / fallback (kept for PR3)", function()
     assert.equals("This profile is paused.",                  bp.inline_copy_for("Paused"))
     assert.equals("This is scheduled quiet time.",            bp.inline_copy_for("Schedule"))
     assert.equals("Daily screen time limit reached.",         bp.inline_copy_for("TimeLimit"))
@@ -210,13 +220,13 @@ describe("block_page.render_html", function()
     assert.equals("This site is blocked.",                    bp.inline_copy_for(nil))
   end)
 
-  it("inline copy names the blocklist for a category:<id> reason (#594)", function()
+  it("inline copy names the blocklist for a category:<id> reason (#594, kept for PR3)", function()
     assert.equals("Blocked category: ads.",   bp.inline_copy_for("category:ads"))
     assert.equals("Blocked category: adult.", bp.inline_copy_for("category:adult"))
   end)
 
   it("escapes the host in the inline page so it can't break out of HTML", function()
-    local html = bp.render_html(nil, "<script>alert(1)</script>", nil, "Paused")
+    local html = bp.render_html(nil, "<script>alert(1)</script>", nil)
     assert.is_nil(html:find("<script>alert(1)</script>", 1, true))
     assert.truthy(html:find("&lt;script&gt;", 1, true))
   end)


### PR DESCRIPTION
Closes #1617.

## What

The block-page uhttpd handler emits a redirect to the SPA's `/blocked` carrying only `?mac=` and `?host=`. The handler no longer reads `/var/run/wifihaven/blocked_reasons` or `/var/run/wifihaven/blocked_hosts`; the SPA derives the canonical reason from `GET /api/blocked` (`PolicyService.decide`) — that path was made authoritative in #1615 (PR1, merged).

`block_page.build_dest_url` and `render_html` lose their reason argument. The inline-fallback page (shown when api_url isn't yet configured) shows neutral "This site is blocked." copy.

## Explicitly NOT in this PR

- Agent still writes the reason files. Those become unread no-ops here; PR3 (#1618) removes the writers and the now-dead `parse_reasons` / `parse_blocked_hosts` / `inline_copy_for` from block_page.lua.
- Snapshot wire `blockReason` field stays — it feeds the in-memory `blocked_reason` map that `conntrack.lua` uses for per-MAC connection_event labels. PR4 was closed won't-do.
- No SPA / API / agent / render / paths changes.

## Test plan

- [x] busted: build_dest_url + render_html drop the reason arg; URL and HTML carry no `reason=`.
- [x] Existing parse_reasons / parse_blocked_hosts / inline_copy_for tests still pass (functions unchanged for PR2; PR3 deletes them).
- [ ] Manual on router.lan: visit a blocked site, observe redirect URL is `…?host=…&mac=…` only; SPA renders the API-derived copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)