### PR TITLE
feat(#1618): drop block-page reason writers and unused parsers

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/block_page.lua
@@ -3,9 +3,11 @@
 -- The static index.html previously served at /www/wifihaven/index.html cannot
 -- know which device requested it (the nft DNAT rewrites the destination only;
 -- the original URL is whatever the client typed). This module looks up the
--- client MAC from /proc/net/arp using REMOTE_ADDR and the policy reason from
--- the agent-written reasons file, then renders an HTML page that redirects to
--- the API's /blocked page with mac and reason populated.
+-- client MAC from /proc/net/arp using REMOTE_ADDR and renders an HTML page
+-- that redirects to the SPA's /blocked page carrying only mac and host — the
+-- SPA derives the canonical reason server-side from GET /api/blocked
+-- (PolicyService.decide), so the router no longer ships a reason through
+-- this path (#1615/#1617/#1618).
 
 local M = {}
 
@@ -23,41 +25,6 @@ function M.parse_arp(arp_content, ip)
        and fields[4]:match("^%x%x:%x%x:%x%x:%x%x:%x%x:%x%x$")
        and fields[4] ~= "00:00:00:00:00:00" then
       return fields[4]:lower()
-    end
-  end
-  return nil
-end
-
--- Parse the reasons file (lines of "<mac>\t<reason>") and return the reason
--- for `mac`, or nil. Mac comparison is case-insensitive.
-function M.parse_reasons(content, mac)
-  if not content or not mac then return nil end
-  local target = mac:lower()
-  for line in content:gmatch("[^\n]+") do
-    local m, r = line:match("^(%S+)%s+(%S+)$")
-    if m and m:lower() == target then return r end
-  end
-  return nil
-end
-
--- Parse the per-(MAC, host) classifier file (lines of "<mac>\t<host>\t<source>")
--- and return the source string for (mac, host), or nil. <source> is
--- "extra_blocked" or "category:<id>". Lookup uses dnsmasq nftset suffix-match
--- semantics: the file entry matches when host equals the request host or the
--- request host is a subdomain of the entry. MAC comparison is
--- case-insensitive; host comparison is lower-case. (#594)
-function M.parse_blocked_hosts(content, mac, host)
-  if not content or not mac or not host or host == "" then return nil end
-  local mac_target  = mac:lower()
-  local host_target = host:lower()
-  for line in content:gmatch("[^\n]+") do
-    local m, h, s = line:match("^(%S+)\t(%S+)\t(%S+)$")
-    if m and m:lower() == mac_target then
-      local h_lower = h:lower()
-      if host_target == h_lower
-         or host_target:sub(-(#h_lower + 1)) == "." .. h_lower then
-        return s
-      end
     end
   end
   return nil
@@ -104,28 +71,6 @@ function M.build_dest_url(base_url, host, mac)
   return base_url .. "/blocked"
       .. "?host=" .. url_encode(host)
       .. "&mac="  .. url_encode(mac or "")
-end
-
--- Inline copy used when API_URL is not (yet) configured. Mirrors the
--- BlockedPage.tsx mapping so the local fallback page still communicates the
--- reason instead of generic "blocked".
-local INLINE_COPY = {
-  Paused       = "This profile is paused.",
-  Schedule     = "This is scheduled quiet time.",
-  TimeLimit    = "Daily screen time limit reached.",
-  Manual       = "This device has been blocked by a parent.",
-  ExtraBlocked = "This site is blocked by the household.",
-}
-
-function M.inline_copy_for(reason)
-  reason = reason or ""
-  -- #594: category-blocklist hits arrive as "category:<id>"; surface the id in
-  -- the inline copy so the user can see which list matched.
-  local cat_id = reason:match("^category:(.+)$")
-  if cat_id then
-    return "Blocked category: " .. cat_id .. "."
-  end
-  return INLINE_COPY[reason] or "This site is blocked."
 end
 
 -- Render the HTML body for the block page. If base_url is set, returns a tiny

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -4,11 +4,12 @@
 -- /www and is easy to miss.
 local M = {}
 
--- Block-page IPC (#437, #594): the agent writes after every policy apply,
--- the uhttpd lua handler reads on each request.
+-- Block-page IPC: the agent writes the API URL after every policy apply,
+-- the uhttpd lua handler reads it on each request. The per-MAC reason and
+-- per-(MAC, host) classifier files (#437 / #594) were removed in #1618 —
+-- post-#1615/#1617 the SPA derives the canonical reason from
+-- GET /api/blocked, so the on-disk IPC has no readers left.
 M.block_page_api_url  = "/var/run/wifihaven/api_url"
-M.block_page_reasons  = "/var/run/wifihaven/blocked_reasons"
-M.block_page_hosts    = "/var/run/wifihaven/blocked_hosts"
 
 -- ip → hostname cache (#259): wifihaven-dns-tail writes, wifihaven-agent reads.
 M.dns_cache = "/tmp/wifihaven-dns-cache.txt"

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1374,66 +1374,12 @@ function M.update_shared(snapshot, nft_sets, blocked_macs, blocked_reason,
   end
 end
 
--- render.write_blocked_reasons(blocked_reason, path) → ok, err
---
--- Persist the in-memory { mac → reason_string } map (built by
--- update_shared above) to a file the block-page uhttpd handler can read.
--- Format: one "<mac>\t<reason>\n" per blocked MAC, sorted by MAC for
--- deterministic output. Written atomically via tmp+rename so the handler
--- never sees a partial write.
---
--- The block page handler (#437) looks the requesting device's MAC up in
--- this file to render reason-specific copy ("This profile is paused.",
--- etc.) instead of the generic "blocked" fallback.
-function M.write_blocked_reasons(blocked_reason, path)
-  local lines = {}
-  for mac, reason in pairs(blocked_reason or {}) do
-    table.insert(lines, mac .. "\t" .. tostring(reason))
-  end
-  table.sort(lines)
-  local body = table.concat(lines, "\n")
-  if #lines > 0 then body = body .. "\n" end
-  local tmp = path .. ".tmp"
-  local f, err = io.open(tmp, "w")
-  if not f then return nil, err end
-  f:write(body)
-  f:close()
-  local ok, rerr = os.rename(tmp, path)
-  if not ok then return nil, rerr end
-  return true
-end
-
--- render.write_blocked_hosts(eb_hosts_by_mac, bl_hosts_by_mac, path) → ok, err
---
--- Persist the per-(MAC, host) block source classification so the block-page
--- handler can distinguish an extraBlocked hit from a category-blocklist hit
--- (#594). Format: one "<mac>\t<host>\t<source>\n" per (mac, host) entry,
--- sorted for deterministic output. <source> is "extra_blocked" for an
--- extraBlocked hit or "category:<blocklist_id>" for a category-blocklist hit.
--- Written atomically via tmp+rename so the handler never sees a partial file.
-function M.write_blocked_hosts(eb_hosts_by_mac, bl_hosts_by_mac, path)
-  local lines = {}
-  for mac, hosts in pairs(eb_hosts_by_mac or {}) do
-    for host in pairs(hosts) do
-      table.insert(lines, mac .. "\t" .. host .. "\textra_blocked")
-    end
-  end
-  for mac, hosts in pairs(bl_hosts_by_mac or {}) do
-    for host, id in pairs(hosts) do
-      table.insert(lines, mac .. "\t" .. host .. "\tcategory:" .. tostring(id))
-    end
-  end
-  table.sort(lines)
-  local body = table.concat(lines, "\n")
-  if #lines > 0 then body = body .. "\n" end
-  local tmp = path .. ".tmp"
-  local f, err = io.open(tmp, "w")
-  if not f then return nil, err end
-  f:write(body)
-  f:close()
-  local ok, rerr = os.rename(tmp, path)
-  if not ok then return nil, rerr end
-  return true
-end
+-- (#1618) write_blocked_reasons / write_blocked_hosts were removed: the
+-- block-page handler stopped reading their on-disk output in #1615/#1617
+-- (the SPA derives the canonical reason from GET /api/blocked). The in-memory
+-- `blocked_reason` / `eb_hosts_by_mac` / `ea_hosts_by_mac` / `bl_hosts_by_mac`
+-- maps populated by `update_shared` above stay — they feed conntrack.lua's
+-- per-MAC connection_event labels on POST /api/router/events, which is a
+-- separate path.
 
 return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -361,12 +361,12 @@ end
 
 os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifihaven")
 
--- ── Block-page runtime config (#437) ─────────────────────────────────────────
+-- ── Block-page runtime config ────────────────────────────────────────────────
 -- The block-page uhttpd handler (/www/wifihaven/handler.lua, served via
 -- uhttpd-mod-lua) reads /var/run/wifihaven/api_url to know where to redirect
--- blocked clients, and /var/run/wifihaven/blocked_reasons (written below by
--- render.write_blocked_reasons after every snapshot apply) to look up the
--- per-MAC reason for the current device.
+-- blocked clients. Post-#1615/#1617/#1618 it does NOT read any per-MAC reason
+-- or per-(MAC, host) classifier file — the SPA derives the canonical reason
+-- from GET /api/blocked, so the agent no longer writes those files.
 --
 -- #1174: the value written here is the resolved block-page base
 -- (block_page_url), which is api_url for self-hosted installs but the public
@@ -374,28 +374,10 @@ os.execute("mkdir -p /tmp/dnsmasq.d /tmp/nftables.d /etc/wifihaven /var/run/wifi
 -- api_url for back-compat with an already-installed handler.lua.
 
 local BLOCK_PAGE_API_URL_PATH  = paths.block_page_api_url
-local BLOCK_PAGE_REASONS_PATH  = paths.block_page_reasons
-local BLOCK_PAGE_HOSTS_PATH    = paths.block_page_hosts  -- #594
 
 do
   local f = io.open(BLOCK_PAGE_API_URL_PATH, "w")
   if f then f:write(block_page_url); f:close() end
-end
-
--- Persist the per-MAC block reasons for the block-page handler. Called after
--- every render.update_shared so the file mirrors the live in-memory map.
-local function persist_blocked_reasons()
-  local ok, err = render.write_blocked_reasons(blocked_reason, BLOCK_PAGE_REASONS_PATH)
-  if not ok then
-    log.debug("could not write %s: %s", BLOCK_PAGE_REASONS_PATH, tostring(err))
-  end
-  -- #594: also persist the per-(MAC, host) classification so the block-page
-  -- handler can distinguish extraBlocked from category-blocklist hits.
-  local ok2, err2 = render.write_blocked_hosts(
-    eb_hosts_by_mac, bl_hosts_by_mac, BLOCK_PAGE_HOSTS_PATH)
-  if not ok2 then
-    log.debug("could not write %s: %s", BLOCK_PAGE_HOSTS_PATH, tostring(err2))
-  end
 end
 
 -- ── Timer state ───────────────────────────────────────────────────────────────
@@ -435,7 +417,6 @@ do
                     clock.monotonic_seconds() - t0)
     if applied then
       render.update_shared(cached, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
-      persist_blocked_reasons()
       last_snapshot = cached
       log.info("startup: applied cached policy from /etc/wifihaven/policy.json")
     else
@@ -474,7 +455,6 @@ do
                     clock.monotonic_seconds() - at0)
     if applied then
       render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
-      persist_blocked_reasons()
       current_etag = etag
       last_snapshot = snap
       policy.mark_poll_success(os.time())
@@ -660,7 +640,6 @@ conntrack.watch({
                         clock.monotonic_seconds() - at0)
         if applied then
           render.update_shared(snap, nft_sets, blocked_macs, blocked_reason, eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
-          persist_blocked_reasons()
           current_etag = etag
           last_snapshot = snap
           policy.mark_poll_success(wall)

--- a/openwrt/test/block_page_spec.lua
+++ b/openwrt/test/block_page_spec.lua
@@ -34,75 +34,15 @@ describe("block_page.parse_arp", function()
   end)
 end)
 
-describe("block_page.parse_reasons", function()
-  local content = table.concat({
-    "aa:bb:cc:11:22:33\tPaused",
-    "de:ad:be:ef:00:01\tTimeLimit",
-  }, "\n") .. "\n"
-
-  it("returns the reason for a known MAC", function()
-    assert.equals("Paused",    bp.parse_reasons(content, "aa:bb:cc:11:22:33"))
-    assert.equals("TimeLimit", bp.parse_reasons(content, "de:ad:be:ef:00:01"))
-  end)
-
-  it("is case-insensitive on the MAC lookup", function()
-    assert.equals("Paused", bp.parse_reasons(content, "AA:BB:CC:11:22:33"))
-  end)
-
-  it("returns nil for an unknown MAC", function()
-    assert.is_nil(bp.parse_reasons(content, "ff:ff:ff:ff:ff:ff"))
-  end)
-
-  it("returns nil on nil content (reasons file missing)", function()
-    assert.is_nil(bp.parse_reasons(nil, "aa:bb:cc:11:22:33"))
-  end)
-end)
-
-describe("block_page.parse_blocked_hosts (#594)", function()
-  local content = table.concat({
-    "aa:bb:cc:11:22:33\ttiktok.com\textra_blocked",
-    "aa:bb:cc:11:22:33\tad.doubleclick.net\tcategory:ads",
-    "de:ad:be:ef:00:01\tpornhub.com\tcategory:adult",
-  }, "\n") .. "\n"
-
-  it("returns 'extra_blocked' for a per-MAC extraBlocked entry", function()
-    assert.equals("extra_blocked",
-      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "tiktok.com"))
-  end)
-
-  it("returns 'category:<id>' for a per-MAC blocklist entry", function()
-    assert.equals("category:ads",
-      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "ad.doubleclick.net"))
-    assert.equals("category:adult",
-      bp.parse_blocked_hosts(content, "de:ad:be:ef:00:01", "pornhub.com"))
-  end)
-
-  it("matches subdomains via dnsmasq nftset suffix semantics", function()
-    -- entry: tiktok.com → matches m.tiktok.com
-    assert.equals("extra_blocked",
-      bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", "m.tiktok.com"))
-  end)
-
-  it("does NOT cross-match between MACs", function()
-    assert.is_nil(bp.parse_blocked_hosts(content, "de:ad:be:ef:00:01", "tiktok.com"))
-  end)
-
-  it("does NOT match unrelated hosts (no false-positive suffix match)", function()
-    -- "notexample.com" must not match an entry for "example.com"
-    local c = "aa:bb:cc:11:22:33\texample.com\textra_blocked\n"
-    assert.is_nil(bp.parse_blocked_hosts(c, "aa:bb:cc:11:22:33", "notexample.com"))
-  end)
-
-  it("returns nil on nil/empty inputs", function()
-    assert.is_nil(bp.parse_blocked_hosts(nil, "aa:bb:cc:11:22:33", "tiktok.com"))
-    assert.is_nil(bp.parse_blocked_hosts(content, nil, "tiktok.com"))
-    assert.is_nil(bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", nil))
-    assert.is_nil(bp.parse_blocked_hosts(content, "aa:bb:cc:11:22:33", ""))
-  end)
-
-  it("is case-insensitive on MAC and host", function()
-    assert.equals("extra_blocked",
-      bp.parse_blocked_hosts(content, "AA:BB:CC:11:22:33", "TikTok.com"))
+describe("block_page module surface (#1618)", function()
+  -- After #1615/#1617 the handler stopped reading the agent's on-disk reason /
+  -- blocked-host files; the SPA derives the canonical reason from
+  -- GET /api/blocked. The now-unused parse_reasons / parse_blocked_hosts /
+  -- inline_copy_for helpers are gone.
+  it("no longer exposes parse_reasons / parse_blocked_hosts / inline_copy_for", function()
+    assert.is_nil(bp.parse_reasons)
+    assert.is_nil(bp.parse_blocked_hosts)
+    assert.is_nil(bp.inline_copy_for)
   end)
 end)
 
@@ -205,24 +145,6 @@ describe("block_page.render_html (#679/#1617: no reason= param)", function()
     local html = bp.render_html(nil, "youtube.com", "aa:bb:cc:11:22:33")
     assert.truthy(html:find("This site is blocked.", 1, true))
     assert.is_nil(html:find("window.location.replace", 1, true))
-  end)
-
-  -- inline_copy_for + parse_reasons + parse_blocked_hosts are no longer called
-  -- by the handler (#1617). They remain in the module for now and get deleted
-  -- in PR3 (#1618) along with the agent-side reason-file writes.
-  it("inline copy still resolves MacBlockReason / ExtraBlocked / fallback (kept for PR3)", function()
-    assert.equals("This profile is paused.",                  bp.inline_copy_for("Paused"))
-    assert.equals("This is scheduled quiet time.",            bp.inline_copy_for("Schedule"))
-    assert.equals("Daily screen time limit reached.",         bp.inline_copy_for("TimeLimit"))
-    assert.equals("This device has been blocked by a parent.",bp.inline_copy_for("Manual"))
-    assert.equals("This site is blocked by the household.",   bp.inline_copy_for("ExtraBlocked"))
-    assert.equals("This site is blocked.",                    bp.inline_copy_for("Bogus"))
-    assert.equals("This site is blocked.",                    bp.inline_copy_for(nil))
-  end)
-
-  it("inline copy names the blocklist for a category:<id> reason (#594, kept for PR3)", function()
-    assert.equals("Blocked category: ads.",   bp.inline_copy_for("category:ads"))
-    assert.equals("Blocked category: adult.", bp.inline_copy_for("category:adult"))
   end)
 
   it("escapes the host in the inline page so it can't break out of HTML", function()

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -1969,98 +1969,17 @@ describe("render extraAllowed enforcement (#421)", function()
 
 end)
 
--- ── render.write_blocked_reasons (#437) ──────────────────────────────────────
+-- ── render (#1618) — block-page reason IPC removed ──────────────────────────
 --
--- The agent calls this after every render.update_shared so the block-page
--- uhttpd handler can map REMOTE_ADDR → MAC → reason instead of falling back
--- to generic "blocked" copy.
-describe("render.write_blocked_reasons", function()
-  local function tmp_path()
-    local p = os.tmpname()
-    os.remove(p)  -- only want the path; we'll write to it
-    return p
-  end
-
-  local function read_all(path)
-    local f = io.open(path, "r")
-    if not f then return nil end
-    local c = f:read("*a"); f:close(); return c
-  end
-
-  it("writes one '<mac>\\t<reason>' line per blocked MAC, sorted", function()
-    local p = tmp_path()
-    local ok = render.write_blocked_reasons({
-      ["de:ad:be:ef:00:01"] = "TimeLimit",
-      ["aa:bb:cc:11:22:33"] = "Paused",
-    }, p)
-    assert.is_true(ok)
-    assert.equals(
-      "aa:bb:cc:11:22:33\tPaused\nde:ad:be:ef:00:01\tTimeLimit\n",
-      read_all(p))
-    os.remove(p)
+-- The block-page handler (#1615) no longer reads on-disk reason / blocked-host
+-- files; the SPA derives the canonical reason from GET /api/blocked. The
+-- writers were unused after #1617 and are gone.
+describe("render (#1618) — block-page reason IPC removed", function()
+  it("does not expose write_blocked_reasons", function()
+    assert.is_nil(render.write_blocked_reasons)
   end)
-
-  it("writes an empty file when nothing is blocked", function()
-    local p = tmp_path()
-    local ok = render.write_blocked_reasons({}, p)
-    assert.is_true(ok)
-    assert.equals("", read_all(p))
-    os.remove(p)
-  end)
-
-  it("treats a nil map as empty (no crash, empty output)", function()
-    local p = tmp_path()
-    local ok = render.write_blocked_reasons(nil, p)
-    assert.is_true(ok)
-    assert.equals("", read_all(p))
-    os.remove(p)
-  end)
-end)
-
--- ── render.write_blocked_hosts (#594) ────────────────────────────────────────
---
--- Persists per-(MAC, host) block source so the block-page handler can name a
--- category-blocklist hit instead of mis-labelling it as ExtraBlocked.
-describe("render.write_blocked_hosts", function()
-  local function tmp_path()
-    local p = os.tmpname(); os.remove(p); return p
-  end
-  local function read_all(path)
-    local f = io.open(path, "r"); if not f then return nil end
-    local c = f:read("*a"); f:close(); return c
-  end
-
-  it("writes one '<mac>\\t<host>\\t<source>' line per entry, sorted", function()
-    local p = tmp_path()
-    local eb = { ["aa:bb:cc:11:22:33"] = { ["tiktok.com"] = true } }
-    local bl = {
-      ["aa:bb:cc:11:22:33"] = { ["ad.doubleclick.net"] = "ads" },
-      ["de:ad:be:ef:00:01"] = { ["pornhub.com"] = "adult" },
-    }
-    local ok = render.write_blocked_hosts(eb, bl, p)
-    assert.is_true(ok)
-    assert.equals(
-      "aa:bb:cc:11:22:33\tad.doubleclick.net\tcategory:ads\n"
-      .. "aa:bb:cc:11:22:33\ttiktok.com\textra_blocked\n"
-      .. "de:ad:be:ef:00:01\tpornhub.com\tcategory:adult\n",
-      read_all(p))
-    os.remove(p)
-  end)
-
-  it("writes an empty file when nothing is blocked", function()
-    local p = tmp_path()
-    local ok = render.write_blocked_hosts({}, {}, p)
-    assert.is_true(ok)
-    assert.equals("", read_all(p))
-    os.remove(p)
-  end)
-
-  it("treats nil tables as empty", function()
-    local p = tmp_path()
-    local ok = render.write_blocked_hosts(nil, nil, p)
-    assert.is_true(ok)
-    assert.equals("", read_all(p))
-    os.remove(p)
+  it("does not expose write_blocked_hosts", function()
+    assert.is_nil(render.write_blocked_hosts)
   end)
 end)
 


### PR DESCRIPTION
Closes #1618.

## What

After #1615 (SPA) and #1617 (router redirect URL) shipped, the agent's on-disk reason IPC (`/var/run/wifihaven/blocked_reasons`, `/var/run/wifihaven/blocked_hosts`) had no readers left. This PR deletes the dead writers and helpers:

- wifihaven-agent: `persist_blocked_reasons()` and its three call sites; `BLOCK_PAGE_REASONS_PATH` / `BLOCK_PAGE_HOSTS_PATH` constants.
- render.lua: `write_blocked_reasons` / `write_blocked_hosts` exports.
- block_page.lua: `parse_reasons` / `parse_blocked_hosts` / `inline_copy_for` / `INLINE_COPY` table.
- paths.lua: `block_page_reasons` / `block_page_hosts` entries.

## What stays

- In-memory `blocked_reason` / `eb_hosts_by_mac` / `ea_hosts_by_mac` / `bl_hosts_by_mac` maps and `render.update_shared`'s population of them. These feed `conntrack.lua`'s per-flow reason labels on `POST /api/router/events` — that's a separate path from the block page and stays unchanged.
- Snapshot wire `blockReason` field. It's the wire-vocabulary primitive that lets the API tell the router how to label per-MAC connection_event drops (Paused / Schedule / TimeLimit / Manual). #1619 (PR4) was closed won't-do; see #1623 for the AGENTS.md doc correction.

## Test plan

- [x] busted: render no longer exposes write_blocked_reasons / write_blocked_hosts; block_page no longer exposes parse_reasons / parse_blocked_hosts / inline_copy_for.
- [x] Full lua suite green (conntrack_spec unaffected — the in-memory maps it depends on are untouched).
- [ ] Manual on router.lan after deploy: existing \`/var/run/wifihaven/blocked_reasons\` and \`blocked_hosts\` files become stale (no readers anyway); next reboot clears them. No need to manually rm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)