### PR TITLE
feat(#1628): blocked MAC produces zero usage records

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -54,7 +54,7 @@
 --
 --   usage.build_report(counters, nft_sets, period_start, period_end, router_id,
 --                      leases, lookup_hostname, tracker,
---                      sample_seconds, bucket_seconds)
+--                      sample_seconds, bucket_seconds, blocked_macs)
 --     → report table ready for JSON encoding and POST /api/router/usage
 --     nft_sets:        { hostname → { ip → true } }  (maintained by render.update_shared + dnsmasq)
 --     leases:          { mac → ip }  (optional; populates the ip field on each record)
@@ -318,12 +318,22 @@ end
 -- bucket_seconds.  A counter present in `counters` but missing from the
 -- tracker (e.g. set element first appeared after the last sample) falls back
 -- to one active sample when bytes > 0.
+-- #1628: blocked_macs (optional) is the shared `{ mac -> true }` table
+-- maintained by render.update_shared. When supplied, any counter whose mac is
+-- in the set is dropped before record emission so a blocked device produces
+-- zero traffic_reports rows — even for ea_ carve-out traffic (Khan / Math
+-- Academy / 1Password) that the kernel legitimately allows past the per-MAC
+-- forward-drop. The architectural contract is "blocked = no usage growth";
+-- the carve-out exists for functional access, not to credit minutes against
+-- the daily cap. With agent-side rows suppressed during the block window,
+-- Presence has nothing to stitch across the block boundary either.
 function M.build_report(counters, nft_sets, period_start, period_end, router_id,
                         leases, lookup_hostname, tracker,
-                        sample_seconds, bucket_seconds)
+                        sample_seconds, bucket_seconds, blocked_macs)
   local records = {}
 
   for _, c in ipairs(counters or {}) do
+    if not (blocked_macs and c.mac and blocked_macs[c.mac]) then
     local host    = host_for_ip(c.dst_ip, nft_sets, lookup_hostname)
     local samples = tracker.active_samples[tracker_key(c.mac, c.dst_ip)] or 0
     local active_seconds
@@ -362,6 +372,7 @@ function M.build_report(counters, nft_sets, period_start, period_end, router_id,
       end
       records[#records + 1] = rec
     end
+    end -- #1628 blocked_macs filter
   end
 
   return {

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -820,10 +820,15 @@ conntrack.watch({
         -- last activity_sample_int tick still get an active sample counted.
         usage.tracker_sample(activity_tracker, counters)
         last_activity_sample = mono
+        -- #1628: skip records for MACs currently blocked (TimeLimit / Schedule
+        -- / Paused / Manual) so a blocked device produces zero traffic_reports
+        -- row growth — even when ea_ carve-out traffic legitimately reaches
+        -- the priority-1 accounting chain. blocked_macs is the shared ref
+        -- render.update_shared rebuilds from each device's effective rules.
         local report = usage.build_report(
           counters, nft_sets, period_start, period_end, router_id,
           nil, lookup_hostname, activity_tracker,
-          activity_sample_int, usage_int)
+          activity_sample_int, usage_int, blocked_macs)
         log.debug("usage timer: %d counter(s), %d record(s) prepared",
                   #counters, report.records and #report.records or 0)
         -- Retry queue's next_attempt_at math runs on the monotonic clock so

--- a/openwrt/test/usage_spec.lua
+++ b/openwrt/test/usage_spec.lua
@@ -510,6 +510,35 @@ describe("usage.build_report", function()
     assert.equal(BUCKET_S,            r.records[1].activeSeconds)
   end)
 
+  -- #1628: a blocked MAC must produce zero new traffic_reports rows even when
+  -- ea_ carve-out traffic (Khan/Math Academy/1Password) legitimately flows
+  -- through the priority-1 accounting chain. Filtering at agent report time
+  -- guarantees the architectural contract — "blocked = no usage growth" — and
+  -- collapses any downstream Presence-stitch concern, because there is nothing
+  -- to stitch across the block window.
+  it("drops records for MACs in blocked_macs (#1628)", function()
+    local counters = {
+      -- Blocked MAC's ea_ carve-out to Khan Academy: bytes flowed, but the MAC
+      -- is blocked so this must NOT be reported.
+      { mac = "04:72:ef:d6:e4:5a", dst_ip = "1.2.3.4", bytes = 50000, packets = 100 },
+      -- Unblocked MAC: must still be reported.
+      { mac = "de:ad:be:ef:00:01", dst_ip = "8.8.8.8", bytes = 1024, packets = 20 },
+    }
+    local blocked_macs = { ["04:72:ef:d6:e4:5a"] = true }
+    local r = usage.build_report(counters, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, full_tracker(counters), SAMPLE_S, BUCKET_S,
+                                 blocked_macs)
+    assert.equal(1, #r.records)
+    assert.equal("de:ad:be:ef:00:01", r.records[1].mac)
+  end)
+
+  it("treats nil blocked_macs as no filter (back-compat)", function()
+    local r = usage.build_report(COUNTERS, NF_SETS, P_START, P_END, ROUTER,
+                                 nil, nil, full_tracker(COUNTERS), SAMPLE_S, BUCKET_S,
+                                 nil)
+    assert.equal(2, #r.records)
+  end)
+
   -- #1032 regression guard: a flow that appeared *after* the last sample tick
   -- has no tracker samples but bytes > 0 — the post-tick branch credits one
   -- sample of activeSeconds and must still emit a record.


### PR DESCRIPTION
Closes #1628.

## What

`usage.build_report` takes an optional `blocked_macs` table and drops any counter whose `mac` is in it; `wifihaven-agent` passes the shared `blocked_macs` ref (already maintained by `render.update_shared`) at every usage-timer tick.

## Why

The architectural contract from the issue is: **a `blocked=true` MAC produces zero new `traffic_reports` row growth and zero new `usedMinutes` accumulation**, regardless of `blockReason` (TimeLimit / Schedule / Paused / Manual).

Router-side investigation against live `openwrt.lan` (Prima `04:72:ef:d6:e4:5a`, `blocked=true, blockReason=TimeLimit`):

- `wifihaven_block` hooks `forward` at `priority filter` (0); `wifihaven_account_tx` / `wifihaven_account_rx` hook at `priority filter + 1`. `drop` at priority 0 terminates packet processing before the priority-1 accounting chains, so **dropped flows do NOT increment `mac_ip_tracking`** — confirmed by `nft list set inet wifihaven mac_ip_tracking` showing zero rows for the blocked MAC despite drop counters showing 3411 v4 / 2878 v6 packets dropped. Hypothesis 1's mechanism (drops inflating tx counter) does not occur.
- But the per-MAC drop rules carry `ip daddr != @ea_<mac>_<host>` carve-outs. **`ea_` carve-out traffic** (`1password.com`, `kasandbox.org`, `kastatic.org`, `khanacademy.org`, `mathacademy.com`) is legitimately allowed past the drop and DOES update the priority-1 counters. The agent ships those as `traffic_reports` rows for the blocked MAC; Presence stitches them (`continuationSeconds=120s`) into engaged-seconds against the daily cap — which is what the operator sees growing past the cap.

The `extraAllowed` carve-out exists for **functional access** (the kid can still hand in Khan / unlock 1Password after they've hit the daily limit), not to credit minutes against a daily limit they've already exhausted. Filtering at agent report time enforces the contract end-to-end: zero rows shipped, nothing for Presence to stitch across the block window, no need for any API-side display clamp or headline exclusion.

This also collapses the Hypothesis 2 concern (Presence stitching across the block window): with no agent-side rows during the block, there is nothing to bridge from.

## TDD

- **Red** (586285ff): `test/usage_spec.lua` adds a `build_report` case asserting that a counter for a MAC in `blocked_macs` is dropped while a counter for an unblocked MAC is still emitted, plus a back-compat check that `nil` blocked_macs is a no-op.
- **Green** (58e6b11c): `usage.build_report` and `wifihaven-agent` carry `blocked_macs` through.

## Tests

`sh openwrt/test/run_tests.sh` → 637 successes / 0 failures / 0 errors. No other module touched.

## Wire compatibility

Additive: `build_report` adds an optional 11th positional arg; `nil` is the old behavior. The API surface (`POST /api/router/usage`) is unchanged — this PR just emits fewer rows for blocked MACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)