### PR TITLE
fix(#1630): collapse per-app disposition readers into one fold

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -195,10 +195,18 @@ trait TimeLimitRepo {
 }
 
 /**
- * Post-#764 the `site_time_limits` table is dropped. This repo now synthesizes the legacy
- * `AppTimeLimit` shape from `app_policy_assignments` rows with mode='time_limited', emitting one
- * row per (assignment × host) — mirroring the snapshot expansion in `PolicyService`. Synthetic ids
- * are 0L; callers that need stable ids should switch to AppRepo directly.
+ * Post-#764 the `site_time_limits` table is dropped. This repo now synthesizes the `AppTimeLimit`
+ * shape from `app_policy_assignments` rows — emitting one row per (assignment × host) — that the
+ * [[wifihaven.api.policy.ProfileAppDispositions]] collapse folds into every downstream per-app
+ * projection. Synthetic `id` is `0L`; the canonical assignment identity is the `assignmentId`
+ * field, carried from `app_policy_assignments.id`.
+ *
+ * Post-#1630 the SQL filter is dropped: rows for EVERY mode (Allowed, Blocked, TimeLimited) are
+ * returned, with `mode` carried on the row. The single fold case-analyzes on `mode` to route each
+ * disposition to the right bucket. Before #1630 the repo filtered `WHERE mode='time_limited'`,
+ * which hid `mode=Allowed, exemptFromDaily=true` assignments from the daily-usage path and let
+ * their traffic count against the daily total even though the SPA contract was that "Khan doesn't
+ * count". The collapse removes that structural seam.
  */
 trait AppTimeLimitRepo {
   def listForProfile(pid: ProfileId): Task[List[AppTimeLimit]]
@@ -1099,20 +1107,34 @@ class TimeLimitRepoLive(xa: Transactor[Task]) extends TimeLimitRepo {
 }
 
 class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
-  // #1564: (profileId, host, dailyMinutes, slug, exemptFromDaily, appId) — the join already has
-  // `apps.id` in scope, so we carry it through as the canonical FK reference instead of throwing
-  // it away and re-resolving the slug downstream.
-  private type R = (ProfileId, String, Int, String, Boolean, AppId)
+  // #1564 + #1630: (profileId, host, dailyMinutes, slug, exemptFromDaily, appId, assignmentId,
+  // mode) — the join already has `apps.id` in scope, so we carry it through as the canonical FK
+  // reference instead of throwing it away and re-resolving the slug downstream. Post-#1630 the
+  // `apa.id` (assignmentId) and `apa.mode` are also carried so the `ProfileAppDispositions`
+  // collapse can route each (assignment × host) row to the right bucket without a second repo
+  // read. The Postgres enum `app_mode` round-trips via doobie's string type-class.
+  private type R = (ProfileId, String, Int, String, Boolean, AppId, AppPolicyAssignmentId, String)
   private def toS(r: R) =
-    AppTimeLimit(AppTimeLimitId(0L), r._1, r._2, r._3, s"app:${r._4}", r._5, r._6)
+    AppTimeLimit(
+      AppTimeLimitId(0L),
+      r._1,
+      r._2,
+      r._3,
+      s"app:${r._4}",
+      r._5,
+      r._6,
+      AppMode.parse(r._8).getOrElse(AppMode.TimeLimited),
+      r._7,
+    )
 
   def listForProfile(pid: ProfileId) =
     DbMetrics.timed("appTimeLimit.listForProfile")(
-      sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily, a.id
+      sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug,
+                   apa.exempt_from_daily, a.id, apa.id, apa.mode::text
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id
-           WHERE apa.profile_id = $pid AND apa.mode = 'time_limited'
+           WHERE apa.profile_id = $pid
            ORDER BY apa.id, ah.host"""
         .query[R]
         .map(toS)
@@ -1121,11 +1143,11 @@ class AppTimeLimitRepoLive(xa: Transactor[Task]) extends AppTimeLimitRepo {
     )
 
   def listAll =
-    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug, apa.exempt_from_daily, a.id
+    sql"""SELECT apa.profile_id, ah.host, COALESCE(apa.daily_minutes, 0), a.slug,
+                 apa.exempt_from_daily, a.id, apa.id, apa.mode::text
             FROM app_policy_assignments apa
             JOIN apps a       ON a.id = apa.app_id
             JOIN app_hosts ah ON ah.app_id = apa.app_id
-           WHERE apa.mode = 'time_limited'
            ORDER BY apa.id, ah.host"""
       .query[R]
       .map(toS)

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -91,7 +91,12 @@ class PolicyServiceLive(
     // remain injected to feed the companion `apply` factory's TimeStatusServiceLive and to keep the
     // constructor arity ~40 test constructions depend on; the class body no longer reads them.
     @scala.annotation.unused timeLimitRepo: TimeLimitRepo,
-    @scala.annotation.unused appTimeLimitRepo: AppTimeLimitRepo,
+    // #1630: post-collapse this repo IS read by `snapshot` and `decide` — it now returns rows for
+    // every mode (`mode=Allowed`, `Blocked`, `TimeLimited`) so the [[ProfileAppDispositions]]
+    // single fold drives both the per-app enforcement (extraAllowed/extraBlocked) and the
+    // structural projections (exempt host-set / active-app host-set / cap groups) without a
+    // separate read off `appRepo.listAssignmentsForProfile`.
+    appTimeLimitRepo: AppTimeLimitRepo,
     deviceRepo: DeviceRepo,
     blocklistRepo: BlocklistRepo,
     @scala.annotation.unused trafficRepo: TrafficReportRepo,
@@ -140,26 +145,27 @@ class PolicyServiceLive(
       today = PolicyService.householdLocalDate(now, settings)
       // #1104: today's cap/block state for every profile in one batched read. Same call the
       // /api/time/status/... endpoints use — keeps the snapshot and the UI in lockstep.
-      dayStates   <- timeStatusService.dayStateAll(now, today, settings)
-      profiles    <- profileRepo.listAll
-      devices     <- deviceRepo.listAll
-      cats        <- blocklistRepo.listCategories
-      catDomains  <- ZIO.foreach(cats)(c => blocklistRepo.loadCategory(c).map(c -> _))
-      // #763: load apps + per-app hosts + per-profile assignments so we can
-      // expand app modes into the per-profile BlockRules buckets below.
-      apps        <- appRepo.listAll
-      appHostsRaw <- ZIO.foreach(apps)(a => appRepo.getHosts(a.id).map(a.id -> _))
-      appAssigns  <- ZIO.foreach(profiles)(p =>
-        appRepo.listAssignmentsForProfile(p.id).map(p.id -> _),
+      dayStates          <- timeStatusService.dayStateAll(now, today, settings)
+      profiles           <- profileRepo.listAll
+      devices            <- deviceRepo.listAll
+      cats               <- blocklistRepo.listCategories
+      catDomains         <- ZIO.foreach(cats)(c => blocklistRepo.loadCategory(c).map(c -> _))
+      // #1630: every profile's per-app assignments — across all modes — as (assignment × host)
+      // rows. Replaces the prior `apps + appHostsRaw + appAssigns` fan-out: that path went
+      // through `appRepo.listAssignmentsForProfile` (all modes) AND `appTimeLimitRepo` (filtered
+      // to time_limited), so the two readers saw different rows and the projections drifted.
+      // Now both the per-app enforcement (extraAllowed/extraBlocked) and the structural
+      // projections downstream of `TimeStatusService` read the SAME rows through the same fold.
+      appLimitsByProfile <- ZIO.foreach(profiles)(p =>
+        appTimeLimitRepo.listForProfile(p.id).map(p.id -> _),
       )
       // #1379: per-app schedule rules, resolved to (mode, window) pairs per assignment.
       // Folded into the per-app effective disposition below, before app-mode bucketing.
-      appSched    <- ZIO.foreach(profiles)(p =>
+      appSched           <- ZIO.foreach(profiles)(p =>
         appRepo.appScheduleWindowsForProfile(p.id).map(p.id -> _),
       )
-      appHostsMap = appHostsRaw.toMap
-      appAssignsMap = appAssigns.toMap
-      appSchedMap   = appSched.toMap
+      appLimitsMap = appLimitsByProfile.toMap
+      appSchedMap = appSched.toMap
     } yield {
       val profilePolicies: Map[ProfileId, ProfilePolicy] = profiles.iterator.map { p =>
         // #1104: cap/block state comes from TimeStatusService — the same value the UI reads.
@@ -170,20 +176,18 @@ class PolicyServiceLive(
           ProfileDayState(p.id, today, None, 0, 0, None, blocked = false, None, Nil),
         )
 
-        // #763/#764/#1379: expand this profile's app assignments into wire-shape buckets.
-        // Each assignment's effective disposition at `now` folds its per-app schedule windows
-        // over its base mode (an active window overrides the base), then the AllowedDuring carve
-        // is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5). Post-#764,
-        // time_limited apps are surfaced via AppTimeLimitRepo, so they contribute nothing here.
-        val pAssigns                           = appAssignsMap.getOrElse(p.id, Nil)
-        val (appAllowedHosts, appBlockedHosts) =
-          PolicyService.expandAppDispositions(
-            assigns = pAssigns,
-            hostsByApp = appHostsMap,
-            schedWindows = appSchedMap.getOrElse(p.id, Map.empty),
-            capExhausted = PolicyService.dailyCapExhausted(state),
-            now = now,
-          )
+        // #763/#764/#1379/#1630: collapse this profile's app assignments into the per-MAC
+        // BlockRules buckets via the SINGLE fold `ProfileAppDispositions.enforcement`. Schedule
+        // windows fold over base mode (an active window overrides the base); the AllowedDuring
+        // carve is gated by the daily cap unless the app is exemptFromDaily (design §4.1, §5).
+        // `mode=TimeLimited` apps contribute nothing here — they surface via the per-app cap
+        // path (`appCapExhaustedHosts` reads `state.perApp`).
+        val dispositions = ProfileAppDispositions.from(appLimitsMap.getOrElse(p.id, Nil))
+        val (appAllowedHosts, appBlockedHosts) = dispositions.enforcement(
+          schedWindows = appSchedMap.getOrElse(p.id, Map.empty),
+          capExhausted = PolicyService.dailyCapExhausted(state),
+          now = now,
+        )
 
         val rules = PolicyService.computeBlockRules(
           profile = p,
@@ -322,14 +326,13 @@ class PolicyServiceLive(
             // `capExhausted` re-derivation) so the block-page reason and the snapshot's nftables
             // enforcement cannot drift. Only the genuinely per-HOST matching stays below.
             state           <- timeStatusService.todaysState(now, settings, pid)
-            // #764: post-migration, extraAllowed/extraBlocked are sourced
-            // exclusively from app_policy_assignments. Mirror the snapshot
-            // expansion (allowed/blocked modes) here so the per-host
-            // fallback agrees with the snapshot's precedence.
-            appAssigns      <- appRepo.listAssignmentsForProfile(pid)
-            appHostsByApp   <- ZIO
-              .foreach(appAssigns.map(_.appId).distinct)(aid => appRepo.getHosts(aid).map(aid -> _))
-              .map(_.toMap)
+            // #1630: read the unified `appTimeLimitRepo` rows (all modes) so the per-host
+            // /decision fallback shares the same fold as the snapshot via
+            // `ProfileAppDispositions.from`. Before #1630 this path fetched `appAssigns` +
+            // `appHostsByApp` and called the legacy `expandAppDispositions`, while
+            // `TimeStatusService` read a `mode='time_limited'`-filtered version of the same
+            // table — the divergence behind #1630.
+            appLimits       <- appTimeLimitRepo.listForProfile(pid)
             // #1379: per-app schedule windows for this profile's assignments, used to fold each
             // app's effective disposition + carve gate exactly as the snapshot does.
             appSchedWindows <- appRepo.appScheduleWindowsForProfile(pid)
@@ -358,17 +361,15 @@ class PolicyServiceLive(
                 // totals, so it agrees with the snapshot's gate by construction.
                 val capExhausted = PolicyService.dailyCapExhausted(dayState)
 
-                // #1379: fold each app's effective disposition (schedule windows over base mode) +
-                // the carve gate, exactly as the snapshot does. A non-exempt allowed_during app
-                // whose cap is exhausted is NOT carved, so it correctly falls through to the
-                // time_limit block below; an exempt one (or one under cap) is carved and beats it.
-                val (appAllowed, appBlocked) = PolicyService.expandAppDispositions(
-                  assigns = appAssigns,
-                  hostsByApp = appHostsByApp,
-                  schedWindows = appSchedWindows,
-                  capExhausted = capExhausted,
-                  now = now,
-                )
+                // #1379/#1630: fold each app's effective disposition (schedule windows over base
+                // mode) + the carve gate via the SINGLE fold `ProfileAppDispositions.enforcement`
+                // — exactly as the snapshot does. A non-exempt allowed_during app whose cap is
+                // exhausted is NOT carved, so it correctly falls through to the time_limit block
+                // below; an exempt one (or one under cap) is carved and beats it.
+                val (appAllowed, appBlocked) =
+                  ProfileAppDispositions
+                    .from(appLimits)
+                    .enforcement(appSchedWindows, capExhausted, now)
 
                 // #1515: the per-profile carve set the snapshot puts in `extraAllowed`, reproduced
                 // here so /decision agrees with what nftables enforces. It is the allowed/allowed_during
@@ -802,54 +803,14 @@ object PolicyService {
       now,
     )
 
-  /**
-   * #1379: collapse each app assignment into the `(extraAllowed, extraBlocked)` host buckets,
-   * folding its per-app schedule windows over its base mode (design §4.1):
-   *
-   *   - any `allowed_during` window active → AllowedDuring candidate (carve gate below);
-   *   - else any `blocked_during` window active → Blocked;
-   *   - else the assignment's base [[AppMode]].
-   *
-   * `allowed_during` beats `blocked_during` on simultaneous overlap (consistent with #421
-   * allow-beats-block). The AllowedDuring carve into `extraAllowed` is gated by the daily cap:
-   * `carve = NOT (capExhausted AND NOT exemptFromDaily)`. A non-exempt app whose cap is exhausted
-   * is therefore NOT carved — it stays subject to the whole-MAC block, so the daily limit still
-   * bites without any wire/router change (design §5 rows 9a–9c). An AllowedDuring candidate that
-   * fails the gate is added to neither bucket. `TimeLimited` base apps contribute nothing here
-   * (surfaced via the site-limit path, #764). Shared by `snapshot` and `decide` so they agree.
-   */
-  private[policy] def expandAppDispositions(
-      assigns: List[AppPolicyAssignment],
-      hostsByApp: Map[AppId, List[Hostname]],
-      schedWindows: Map[AppPolicyAssignmentId, List[(AppScheduleMode, ScheduleWindow)]],
-      capExhausted: Boolean,
-      now: Instant,
-  ): (List[Hostname], List[Hostname]) = {
-    val allowed = scala.collection.mutable.ListBuffer.empty[Hostname]
-    val blocked = scala.collection.mutable.ListBuffer.empty[Hostname]
-    assigns.foreach { a =>
-      val hosts         = hostsByApp.getOrElse(a.appId, Nil)
-      val pairs         = schedWindows.getOrElse(a.id, Nil)
-      val allowedActive = pairs.exists { case (m, w) =>
-        m == AppScheduleMode.AllowedDuring && windowActiveAt(w, now)
-      }
-      val blockedActive = pairs.exists { case (m, w) =>
-        m == AppScheduleMode.BlockedDuring && windowActiveAt(w, now)
-      }
-      if (allowedActive) {
-        // Carve gate: withhold the carve for a non-exempt app whose cap is exhausted.
-        if (!(capExhausted && !a.exemptFromDaily)) allowed ++= hosts
-      } else if (blockedActive) {
-        blocked ++= hosts
-      } else
-        a.mode match {
-          case AppMode.Allowed     => allowed ++= hosts
-          case AppMode.Blocked     => blocked ++= hosts
-          case AppMode.TimeLimited => () // site-limit path (#764)
-        }
-    }
-    (allowed.toList.distinct, blocked.toList.distinct)
-  }
+  // #1630: `expandAppDispositions` was deleted here. Its responsibility — collapsing each app
+  // assignment into the per-MAC `(extraAllowed, extraBlocked)` BlockRules buckets, with the
+  // AllowedDuring carve-gate and per-schedule overrides — moved into the single fold
+  // [[ProfileAppDispositions.enforcement]]. Production callers (`snapshot`, `decide`) build the
+  // fold off the unified `appTimeLimitRepo.listForProfile` read (now unfiltered: every mode
+  // round-trips with its `assignmentId`). The prior split — one fold here, another in
+  // `TimeStatusService.groupAppLimits` / `exemptPatterns` — was the structural seam that let
+  // `mode=Allowed, exemptFromDaily=true` apps reach `extraAllowed` but not `exemptPatterns`.
 
   // ── #334: timezone-aware time math ────────────────────────────────────────
   //

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -803,15 +803,6 @@ object PolicyService {
       now,
     )
 
-  // #1630: `expandAppDispositions` was deleted here. Its responsibility — collapsing each app
-  // assignment into the per-MAC `(extraAllowed, extraBlocked)` BlockRules buckets, with the
-  // AllowedDuring carve-gate and per-schedule overrides — moved into the single fold
-  // [[ProfileAppDispositions.enforcement]]. Production callers (`snapshot`, `decide`) build the
-  // fold off the unified `appTimeLimitRepo.listForProfile` read (now unfiltered: every mode
-  // round-trips with its `assignmentId`). The prior split — one fold here, another in
-  // `TimeStatusService.groupAppLimits` / `exemptPatterns` — was the structural seam that let
-  // `mode=Allowed, exemptFromDaily=true` apps reach `extraAllowed` but not `exemptPatterns`.
-
   // ── #334: timezone-aware time math ────────────────────────────────────────
   //
   // Schedules + daily-reset carry an IANA zone with the data. All evaluation

--- a/api/src/policy/ProfileAppDispositions.scala
+++ b/api/src/policy/ProfileAppDispositions.scala
@@ -149,13 +149,12 @@ object ProfileAppDispositions {
           appId = first.appId,
           assignmentId = assignmentId,
           mode = first.mode,
-          // `exemptFromDaily` is uniform across an assignment's synthesized rows by construction,
-          // but `exists` is the defensive choice — any synthetic row marked exempt makes the
-          // assignment exempt.
-          exemptFromDaily = rows.exists(_.exemptFromDaily),
-          // `dailyMinutes` is uniform per assignment; max is defensive — agrees with the prior
-          // `groupAppLimits` reduction.
-          dailyMinutes = rows.map(_.dailyMinutes).max,
+          // `exemptFromDaily` and `dailyMinutes` are uniform across an assignment's synthesized
+          // rows by construction (one assignment row × N host rows from the `app_hosts` join), so
+          // any row's value is the assignment's value. Reading off `first` makes that invariant
+          // explicit at the call site.
+          exemptFromDaily = first.exemptFromDaily,
+          dailyMinutes = first.dailyMinutes,
           label = first.label,
           hosts = rows.map(_.domainPattern).distinct,
         )

--- a/api/src/policy/ProfileAppDispositions.scala
+++ b/api/src/policy/ProfileAppDispositions.scala
@@ -1,0 +1,166 @@
+package wifihaven.api.policy
+
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+
+import java.time.Instant
+
+/**
+ * #1630: the SINGLE fold of a profile's per-app assignments into every downstream projection — the
+ * extraAllowed / extraBlocked carve sets (snapshot enforcement), the exempt host-set (excluded from
+ * the profile's daily total), the active-app host-set (attribution-beats-suppression in Presence),
+ * and the per-app cap groups (the TimeLimited-mode subset that the per-app daily caps key off).
+ *
+ * Before #1630 these projections were derived in two unrelated places. `expandAppDispositions`
+ * (PolicyService) read `List[AppPolicyAssignment]` and produced extraAllowed/extraBlocked, while
+ * `exemptPatterns` / `appHostPatterns` / `groupAppLimits` (TimeStatusService) read
+ * `List[AppTimeLimit]` — synthesized by a repo query that filtered `WHERE mode='time_limited'` —
+ * and produced everything else. That filter meant a `mode=Allowed, exemptFromDaily=true` app
+ * reached `extraAllowed` (visible to the snapshot) but never reached `exemptPatterns` (invisible to
+ * the daily-usage path), so its traffic was both permitted *and* counted against the daily cap —
+ * the user-visible contract was "Khan doesn't count". Collapsing to one fold means the structural
+ * seam through which that divergence appeared no longer exists: any reader of these projections
+ * goes through `ProfileAppDispositions.from`.
+ */
+final case class ProfileAppDispositions(
+    perApp: List[AppDisposition],
+) {
+
+  /**
+   * Hosts of every assignment with `exemptFromDaily=true`. Consumed by `TimeStatusService`'s daily
+   * total path to filter out exempt traffic before counting. Independent of `mode` and independent
+   * of any per-instant schedule state — the exempt flag is a structural property of the assignment,
+   * not a function of "what's active right now".
+   */
+  lazy val exemptPatterns: List[String] =
+    perApp.filter(_.exemptFromDaily).flatMap(_.hosts).distinct
+
+  /**
+   * Hosts of every assignment. Consumed by `Presence.isHeartbeat` for attribution-beats-
+   * suppression (#1506): a row whose host matches any of these patterns is never silently dropped
+   * as background infra. Mode-agnostic for the same reason as `exemptPatterns` — attribution is a
+   * structural relationship, not an enforcement one.
+   */
+  lazy val appHostPatterns: List[String] =
+    perApp.flatMap(_.hosts).distinct
+
+  /**
+   * The subset of `perApp` that participates in per-app daily caps — `mode=TimeLimited` only.
+   * `mode=Allowed` and `mode=Blocked` apps do not contribute, regardless of `dailyMinutes` (an
+   * Allowed app with no cap encodes the rule "no per-app limit", not "0-minute cap fires
+   * immediately"; see acceptance test 4 on #1630).
+   */
+  lazy val capGroups: List[AppDisposition] =
+    perApp.filter(_.mode == AppMode.TimeLimited)
+
+  /**
+   * The (label → hosts) pairs the Presence cap-aggregation primitive
+   * (`Presence.patternGroupMinutesForProfile` / `Presence.appSecondsForProfile`) expects. Stable
+   * order by label so the cap-group representation downstream consumers carry is deterministic.
+   */
+  def capGroupLabelHosts: List[(String, List[String])] =
+    capGroups.map(d => d.label -> d.hosts)
+
+  /**
+   * Snapshot enforcement: collapse every assignment into the per-MAC `(extraAllowed, extraBlocked)`
+   * BlockRules buckets the router applies, folding each assignment's per-app schedule windows over
+   * its base mode (design §4.1):
+   *
+   *   - any `AllowedDuring` window active → AllowedDuring candidate (carve gate below);
+   *   - else any `BlockedDuring` window active → Blocked;
+   *   - else the assignment's base [[AppMode]].
+   *
+   * `AllowedDuring` beats `BlockedDuring` on simultaneous overlap (consistent with #421
+   * allow-beats-block). The AllowedDuring carve into `extraAllowed` is gated by the daily cap: a
+   * non-exempt app whose cap is exhausted is NOT carved — it stays subject to the whole-MAC block,
+   * so the daily limit still bites without any wire/router change (design §5 rows 9a–9c).
+   * `TimeLimited` base apps contribute nothing here — they surface via the per-app cap path
+   * (`PolicyService.appCapExhaustedHosts`).
+   */
+  def enforcement(
+      schedWindows: Map[AppPolicyAssignmentId, List[(AppScheduleMode, ScheduleWindow)]],
+      capExhausted: Boolean,
+      now: Instant,
+  ): (List[Hostname], List[Hostname]) = {
+    val allowed = scala.collection.mutable.ListBuffer.empty[Hostname]
+    val blocked = scala.collection.mutable.ListBuffer.empty[Hostname]
+    perApp.foreach { d =>
+      val hosts         = d.hosts.map(Hostname.unsafe)
+      val pairs         = schedWindows.getOrElse(d.assignmentId, Nil)
+      val allowedActive = pairs.exists { case (m, w) =>
+        m == AppScheduleMode.AllowedDuring && PolicyService.windowActiveAt(w, now)
+      }
+      val blockedActive = pairs.exists { case (m, w) =>
+        m == AppScheduleMode.BlockedDuring && PolicyService.windowActiveAt(w, now)
+      }
+      if (allowedActive) {
+        if (!(capExhausted && !d.exemptFromDaily)) allowed ++= hosts
+      } else if (blockedActive) {
+        blocked ++= hosts
+      } else
+        d.mode match {
+          case AppMode.Allowed     => allowed ++= hosts
+          case AppMode.Blocked     => blocked ++= hosts
+          case AppMode.TimeLimited => () // surfaces via the per-app cap path
+        }
+    }
+    (allowed.toList.distinct, blocked.toList.distinct)
+  }
+}
+
+/**
+ * One row per assignment under a profile, collapsed from the per-(assignment × host) shape the repo
+ * emits. `hosts` carries every host attached to the underlying app at the time of the read. `label`
+ * is the app's `"app:<slug>"` cap-group key — the same value `Presence`'s per-app primitive uses as
+ * the group key.
+ */
+final case class AppDisposition(
+    appId: AppId,
+    assignmentId: AppPolicyAssignmentId,
+    mode: AppMode,
+    exemptFromDaily: Boolean,
+    dailyMinutes: Int,
+    label: String,
+    hosts: List[String],
+)
+
+object ProfileAppDispositions {
+
+  /** Empty (no assignments / no apps). */
+  val empty: ProfileAppDispositions = ProfileAppDispositions(Nil)
+
+  /**
+   * The fold. Takes `appLimits` — every (assignment × host) row the unfiltered
+   * [[wifihaven.api.db.AppTimeLimitRepo.listForProfile]] returns, across all modes — and emits the
+   * unified per-profile decomposition. Rows are grouped by `assignmentId` (the canonical
+   * per-assignment key, populated from `app_policy_assignments.id` in the repo SELECT); each
+   * assignment maps to exactly one [[AppDisposition]]. Stable order by `label`.
+   *
+   * If an assignment has no hosts the repo emits no rows for it — such an assignment contributes
+   * nothing to any projection, which is correct: there's nothing to allow, block, exempt, or
+   * attribute on.
+   */
+  def from(appLimits: List[wifihaven.shared.AppTimeLimit]): ProfileAppDispositions = {
+    val byAssignment = appLimits.groupBy(_.assignmentId).toList
+    val perApp       = byAssignment
+      .map { case (assignmentId, rows) =>
+        val first = rows.head
+        AppDisposition(
+          appId = first.appId,
+          assignmentId = assignmentId,
+          mode = first.mode,
+          // `exemptFromDaily` is uniform across an assignment's synthesized rows by construction,
+          // but `exists` is the defensive choice — any synthetic row marked exempt makes the
+          // assignment exempt.
+          exemptFromDaily = rows.exists(_.exemptFromDaily),
+          // `dailyMinutes` is uniform per assignment; max is defensive — agrees with the prior
+          // `groupAppLimits` reduction.
+          dailyMinutes = rows.map(_.dailyMinutes).max,
+          label = first.label,
+          hosts = rows.map(_.domainPattern).distinct,
+        )
+      }
+      .sortBy(_.label)
+    ProfileAppDispositions(perApp)
+  }
+}

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -411,27 +411,24 @@ object TimeStatusService {
   }
 
   /**
-   * #1505 + #1564: collapse the per-(assignment × host) [[AppTimeLimit]] rows into one group per
-   * app, keyed by the typed `apps.id` FK (the canonical identity carried straight from the repo
-   * join). `label` ("app:<slug>") stays alongside as display text for the SPA wire, but the cap /
-   * rollup surfaces compose on `appId`. `dailyMinutes` and `exemptFromDaily` are uniform across an
-   * app's synthesized rows, so we take them off any row. The representative `domainPattern` is the
-   * apex (shortest host) — used only for the wire/UI; the `hosts` list drives every per-app
-   * computation. Stable order (by label) for deterministic output.
+   * #1505 + #1564 + #1630: the per-app cap groups for this profile — one entry per
+   * `mode=TimeLimited` assignment, in the tuple shape downstream consumers still expect: `(appId,
+   * label, dailyMinutes, exemptFromDaily, hosts, representativeHost)`.
+   *
+   * Post-#1630 this is a thin adapter over the single fold [[ProfileAppDispositions.from]]: the
+   * case-on-mode that filters this list down to TimeLimited assignments lives in
+   * `ProfileAppDispositions.capGroups`. Keeping the tuple wrapper avoids churning every downstream
+   * callsite while removing the duplicated per-app collapse that — in its previous standalone form
+   * — drifted from `PolicyService.expandAppDispositions` (the defect behind #1630). Stable order by
+   * `label`.
    */
   private[policy] def groupAppLimits(
       appLimits: List[AppTimeLimit],
   ): List[(AppId, String, Int, Boolean, List[String], String)] =
-    appLimits
-      .groupBy(_.appId)
-      .toList
-      .map { case (appId, lims) =>
-        val label = lims.head.label
-        val hosts = lims.map(_.domainPattern).distinct
-        val rep   = hosts.minByOption(_.length).getOrElse(label)
-        (appId, label, lims.map(_.dailyMinutes).max, lims.exists(_.exemptFromDaily), hosts, rep)
-      }
-      .sortBy(_._2)
+    ProfileAppDispositions.from(appLimits).capGroups.map { d =>
+      val rep = d.hosts.minByOption(_.length).getOrElse(d.label)
+      (d.appId, d.label, d.dailyMinutes, d.exemptFromDaily, d.hosts, rep)
+    }
 
   /**
    * #1505 + #1504: per-app [[AppDayState]] list — one entry per app, with `usedMinutes` aggregated
@@ -546,20 +543,16 @@ object TimeStatusService {
    * tail stay exact across the watermark boundary.
    */
   /**
-   * #1531: the WHOLE host-set of every exempt-from-daily app — the patterns excluded from the daily
-   * total. Derived from the same per-app collapse (`groupAppLimits`) the per-app bars and
-   * `computeBlockRules` use, so the displayed `usedMinutes`, the snapshot's `blocked`, and the
-   * per-device summaries (#1546) all read ONE explicit host-set. The previous
-   * `appLimits.map(_.domainPattern)` happened to span the whole set only because `listForProfile`
-   * emits one row per host; reusing the collapse makes the whole-host-set exemption explicit rather
-   * than an implicit dependency on that row shape, which would silently regress to apex-only the
-   * moment those rows were ever de-duped upstream. Shared by [[usedSecondsForProfile]] and
-   * [[usedSecondsByMac]] so the two can never derive exempt patterns differently.
+   * #1531 + #1630: the WHOLE host-set of every `exemptFromDaily=true` assignment — the patterns
+   * excluded from the daily total. Post-#1630 this is a thin accessor on the single fold
+   * [[ProfileAppDispositions.from]]: the previous version filtered `groupAppLimits` for exempt
+   * rows, but `groupAppLimits` only saw `mode=TimeLimited` rows (the repo filter), so a
+   * `mode=Allowed, exemptFromDaily=true` assignment never reached this list and its traffic counted
+   * against the daily total. The collapse fixes that by making `ProfileAppDispositions` the single
+   * point of mode-case-analysis.
    */
   private[policy] def exemptPatterns(appLimits: List[AppTimeLimit]): List[String] =
-    groupAppLimits(appLimits).collect {
-      case (_, _, _, exempt, hosts, _) if exempt => hosts
-    }.flatten
+    ProfileAppDispositions.from(appLimits).exemptPatterns
 
   /**
    * #1516 + #1564: per-app engaged seconds for a profile, keyed by `apps.id`, derived from the
@@ -606,7 +599,7 @@ object TimeStatusService {
    * app's host is still excluded — it is simply no longer mis-classified as a heartbeat first.
    */
   private[policy] def appHostPatterns(appLimits: List[AppTimeLimit]): List[String] =
-    groupAppLimits(appLimits).flatMap(_._5)
+    ProfileAppDispositions.from(appLimits).appHostPatterns
 
   def usedSecondsForProfile(
       profile: Profile,

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -702,7 +702,11 @@ object UsageRoutes {
         .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
       all       <- deviceRepo.listAll.mapError(ApiError.Db(_))
       appLimits <- appTimeLimitRepo.listForProfile(pid).mapError(ApiError.Db(_))
-      exempt    = appLimits.filter(_.exemptFromDaily).map(_.domainPattern)
+      // #1630: read the canonical exempt-pattern primitive (`ProfileAppDispositions.exemptPatterns`)
+      // instead of re-deriving the filter inline — the same §single-source-of-truth shape the
+      // collapse exists to enforce. Both sides agree on the current input (the repo returns rows
+      // for every mode), so this is a structural cleanup rather than a behavior change.
+      exempt    = wifihaven.api.policy.ProfileAppDispositions.from(appLimits).exemptPatterns
       devices   = all.filter(_.profileId.contains(pid))
       macs      = devices.map(_.mac)
       nameByMac = devices.iterator.map(d => d.mac -> d.name).toMap

--- a/api/test/src/feature/AppDispositionCollapseSpec.scala
+++ b/api/test/src/feature/AppDispositionCollapseSpec.scala
@@ -1,0 +1,275 @@
+package wifihaven.api.feature
+
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.test.*
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+/**
+ * #1630: collapse the per-app disposition readers into one fold so the divergence between
+ * `expandAppDispositions` (read for snapshot extraAllowed/extraBlocked) and `exemptPatterns` (read
+ * for daily-total exclusion) can no longer recur.
+ *
+ * The symptom the collapse fixes: a `mode=Allowed, exemptFromDaily=true` app reaches `extraAllowed`
+ * (so traffic to it is permitted) but its hosts are NOT excluded from the daily total — because
+ * `AppTimeLimitRepo.listForProfile` filters `WHERE mode='time_limited'`, so the exempt flag is
+ * invisible to the daily-usage path.
+ */
+object AppDispositionCollapseSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres] {
+
+  override val bootstrap = TestDatabase.layer
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val today = LocalDate.of(2025, 1, 6) // Monday
+  private val noon  = LocalDateTime.of(2025, 1, 6, 12, 0, 0)
+
+  private val kidMac = "aa:bb:cc:11:22:33"
+
+  private def seedRouterRow: ZIO[RouterRepo, Throwable, RouterId] =
+    ZIO.serviceWithZIO[RouterRepo](_.create("gw-1630", Sha256Hex.unsafe("e" * 64)))
+
+  /** Seed `minutes` of traffic against `hostname` for `mac` on `today`. */
+  private def seedTraffic(
+      routerId: RouterId,
+      mac: String,
+      hostname: String,
+      minutes: Int,
+  ): ZIO[TrafficReportRepo, Throwable, Unit] =
+    ZIO.serviceWithZIO[TrafficReportRepo] { tr =>
+      val buckets = minutes / 5
+      val day0    = today.atStartOfDay(ZoneOffset.UTC).toInstant
+      val inserts = (0 until buckets).map { i =>
+        val start = day0.plusSeconds(i * 300L)
+        TrafficReportInsert(
+          routerId,
+          MacAddress.unsafe(mac),
+          None,
+          HostId.Fqdn(Hostname.unsafe(hostname)),
+          today,
+          start,
+          start.plusSeconds(300),
+          300,
+          500_000L,
+          500_000L,
+        )
+      }.toList
+      tr.insertBatch(inserts).unit
+    }
+
+  private def buildPs(
+      now: LocalDateTime,
+  ): ZIO[
+    ProfileRepo & ScheduleRepo & HouseholdSettingsRepo & TimeLimitRepo & AppTimeLimitRepo &
+      DeviceRepo & BlocklistRepo & TrafficReportRepo & TimeExtensionRepo & AppRepo &
+      NamedScheduleRepo,
+    Nothing,
+    PolicyService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      hsr  <- ZIO.service[HouseholdSettingsRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      blr  <- ZIO.service[BlocklistRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+      ar   <- ZIO.service[AppRepo]
+      nsr  <- ZIO.service[NamedScheduleRepo]
+      ref  <- Ref.make(now)
+      clk = new Clock.TestClock(ref)
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      atlr,
+      dr,
+      blr,
+      trr,
+      er,
+      ar,
+      clk,
+      Nil,
+      NoopGlobalPolicyRepo,
+      nsr,
+    )
+
+  private def buildTss: ZIO[
+    ProfileRepo & ScheduleRepo & TimeLimitRepo & AppTimeLimitRepo & DeviceRepo & TrafficReportRepo &
+      TimeExtensionRepo,
+    Nothing,
+    TimeStatusService,
+  ] =
+    for {
+      pr   <- ZIO.service[ProfileRepo]
+      sr   <- ZIO.service[ScheduleRepo]
+      tlr  <- ZIO.service[TimeLimitRepo]
+      atlr <- ZIO.service[AppTimeLimitRepo]
+      dr   <- ZIO.service[DeviceRepo]
+      trr  <- ZIO.service[TrafficReportRepo]
+      er   <- ZIO.service[TimeExtensionRepo]
+    } yield new TimeStatusServiceLive(pr, sr, tlr, atlr, dr, trr, er)
+
+  // Use the seeded Adults profile (no schedules, no blocklists) so the test isolates the per-app
+  // disposition behavior — the Kids profile carries a 21:00-07:00 schedule + blocklists that would
+  // perturb the assertions.
+  private def seedProfileAndDevice(
+      pr: ProfileRepo,
+      dr: DeviceRepo,
+  ): Task[(ProfileId, MacAddress)] =
+    for {
+      pid <- TestLayers.seedAdultsProfile(pr)
+      _   <- TestLayers.seedDevice(dr, kidMac, "ipad", pid)
+    } yield (pid, MacAddress.unsafe(kidMac))
+
+  private val nowInstant = noon.toInstant(ZoneOffset.UTC)
+
+  def spec = suite("AppDispositionCollapseSpec (#1630)")(
+    test("Allowed-mode exempt app does NOT contribute to usedSecondsForProfile") {
+      // mode=Allowed, exemptFromDaily=true, no per-app cap. Traffic against the app's host should
+      // be excluded from the daily total. Today this FAILS: AppTimeLimitRepo filters
+      // mode='time_limited' so the row is invisible to the exempt-pattern derivation, and the
+      // traffic counts.
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        ar       <- ZIO.service[AppRepo]
+        hsr      <- ZIO.service[HouseholdSettingsRepo]
+        (pid, _) <- seedProfileAndDevice(pr, dr)
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          pid,
+          "khanacademy.org",
+          AppMode.Allowed,
+          dailyMinutes = None,
+          exemptFromDaily = true,
+        )
+        rid      <- seedRouterRow
+        _        <- seedTraffic(rid, kidMac, "khanacademy.org", 20)
+        settings <- hsr.get
+        tss      <- buildTss
+        stOpt    <- tss.todaysState(nowInstant, settings, pid)
+        state = stOpt.get
+      } yield assertTrue(state.usedMinutes == 0)
+    },
+    test("Allowed-mode NON-exempt app DOES contribute to usedSecondsForProfile") {
+      // mode=Allowed, exemptFromDaily=false. Traffic counts toward the daily total.
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        ar       <- ZIO.service[AppRepo]
+        hsr      <- ZIO.service[HouseholdSettingsRepo]
+        (pid, _) <- seedProfileAndDevice(pr, dr)
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          pid,
+          "khanacademy.org",
+          AppMode.Allowed,
+          dailyMinutes = None,
+          exemptFromDaily = false,
+        )
+        rid      <- seedRouterRow
+        _        <- seedTraffic(rid, kidMac, "khanacademy.org", 20)
+        settings <- hsr.get
+        tss      <- buildTss
+        stOpt    <- tss.todaysState(nowInstant, settings, pid)
+        state = stOpt.get
+      } yield assertTrue(state.usedMinutes >= 15)
+    },
+    test("Allowed-mode exempt app still reaches the kid via extraAllowed") {
+      // Snapshot carve-out: the assignment's host appears in the profile's BlockRules.extraAllowed
+      // so the router carves it out of every drop. Passes today; verify it still does after the
+      // collapse.
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        ar       <- ZIO.service[AppRepo]
+        (pid, _) <- seedProfileAndDevice(pr, dr)
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          pid,
+          "khanacademy.org",
+          AppMode.Allowed,
+          dailyMinutes = None,
+          exemptFromDaily = true,
+        )
+        ps       <- buildPs(noon)
+        snap     <- ps.snapshot
+        rules = snap.profiles(pid).rules
+      } yield assertTrue(rules.extraAllowed.map(_.value).contains("khanacademy.org"))
+    },
+    test("Allowed-mode app with no cap does NOT fire a TimeLimit block") {
+      // The assignment has no daily_minutes set. Even with substantial usage, the profile should
+      // not be blocked under TimeLimit on account of this app. The Adults profile carries no
+      // profile-level daily limit either, so any block reason here would be wrong.
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        ar       <- ZIO.service[AppRepo]
+        hsr      <- ZIO.service[HouseholdSettingsRepo]
+        (pid, _) <- seedProfileAndDevice(pr, dr)
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          pid,
+          "khanacademy.org",
+          AppMode.Allowed,
+          dailyMinutes = None,
+          exemptFromDaily = false,
+        )
+        rid      <- seedRouterRow
+        _        <- seedTraffic(rid, kidMac, "khanacademy.org", 120)
+        settings <- hsr.get
+        tss      <- buildTss
+        stOpt    <- tss.todaysState(nowInstant, settings, pid)
+        state = stOpt.get
+      } yield assertTrue(
+        !state.blocked || state.blockReason != Some(MacBlockReason.TimeLimit),
+      )
+    },
+    test("TimeLimited-mode regression: cap still fires") {
+      // Existing time-limited behavior is unchanged: mode=TimeLimited with dailyMinutes=60,
+      // exemptFromDaily=false, and 60+ min of traffic ⇒ TimeLimit block.
+      for {
+        _        <- cleanDb
+        pr       <- ZIO.service[ProfileRepo]
+        dr       <- ZIO.service[DeviceRepo]
+        ar       <- ZIO.service[AppRepo]
+        hsr      <- ZIO.service[HouseholdSettingsRepo]
+        tlr      <- ZIO.service[TimeLimitRepo]
+        (pid, _) <- seedProfileAndDevice(pr, dr)
+        // A profile daily cap of 60 lets the test observe a TimeLimit block when usage >= 60.
+        _        <- tlr.upsert(pid, 60)
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          pid,
+          "youtube.com",
+          AppMode.TimeLimited,
+          dailyMinutes = Some(60),
+          exemptFromDaily = false,
+        )
+        rid      <- seedRouterRow
+        _        <- seedTraffic(rid, kidMac, "youtube.com", 65)
+        settings <- hsr.get
+        tss      <- buildTss
+        stOpt    <- tss.todaysState(nowInstant, settings, pid)
+        state = stOpt.get
+      } yield assertTrue(
+        state.blocked,
+        state.blockReason == Some(MacBlockReason.TimeLimit),
+      )
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/unit/PerAppScheduleSpec.scala
+++ b/api/test/src/unit/PerAppScheduleSpec.scala
@@ -7,13 +7,13 @@ import zio.test.*
 import java.time.{Instant, LocalTime, ZoneId, ZonedDateTime}
 
 /**
- * #1379: per-app schedule evaluation — the pure server-side collapse of an app's (schedule, mode)
- * rules into the existing `extraAllowed` / `extraBlocked` host buckets. These unit tests pin the
- * schedule-boundary behaviour ([[PolicyService.windowActiveAt]] reuses the DST-correct
+ * #1379/#1630: per-app schedule evaluation — the pure server-side collapse of an app's (schedule,
+ * mode) rules into the existing `extraAllowed` / `extraBlocked` host buckets. These unit tests pin
+ * the schedule-boundary behaviour ([[PolicyService.windowActiveAt]] reuses the DST-correct
  * [[PolicyService.scheduleActiveAt]]), the effective-disposition resolution
- * ([[PolicyService.expandAppDispositions]] — window overrides base mode, allowed beats blocked),
- * and the daily-cap carve gate ([[PolicyService.dailyCapExhausted]]). No wire shape is touched —
- * the only outputs are the two host lists.
+ * ([[ProfileAppDispositions.enforcement]] — window overrides base mode, allowed beats blocked), and
+ * the daily-cap carve gate ([[PolicyService.dailyCapExhausted]]). No wire shape is touched — the
+ * only outputs are the two host lists.
  */
 object PerAppScheduleSpec extends ZIOSpecDefault {
 
@@ -61,13 +61,17 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
       capExhausted: Boolean,
       now: Instant,
   ): (Set[String], Set[String]) = {
-    val (allowed, blocked) = PolicyService.expandAppDispositions(
-      assigns = List(a),
-      hostsByApp = hostsByApp,
-      schedWindows = Map(a.id -> rules),
-      capExhausted = capExhausted,
-      now = now,
+    val d                  = AppDisposition(
+      appId = a.appId,
+      assignmentId = a.id,
+      mode = a.mode,
+      exemptFromDaily = a.exemptFromDaily,
+      dailyMinutes = a.dailyMinutes.getOrElse(0),
+      label = s"app:${a.appId.value}",
+      hosts = hostsByApp.getOrElse(a.appId, Nil).map(_.value),
     )
+    val (allowed, blocked) =
+      ProfileAppDispositions(List(d)).enforcement(Map(a.id -> rules), capExhausted, now)
     (allowed.map(_.value).toSet, blocked.map(_.value).toSet)
   }
 
@@ -78,7 +82,80 @@ object PerAppScheduleSpec extends ZIOSpecDefault {
   // Wed 2026-05-13 12:00 UTC — outside bedtime.
   private val atNoon    = instantAt(2026, 5, 13, 12, 0, UTC)
 
+  // ── #1630: structural SSOT pin ─────────────────────────────────────────────
+  // The collapse's contract: the single fold consumes the same
+  // `List[AppPolicyAssignment]` -> ` ProfileAppDispositions` and every projection is read off
+  // that one value. The test below pins the invariant that fails the moment the
+  // `extraAllowed`/`extraBlocked` reader and the `exemptPatterns` reader diverge again — the
+  // exact shape of the #1630 defect.
+  private def disposition(
+      assignmentId: Long,
+      appId: Long,
+      mode: AppMode,
+      exempt: Boolean,
+      hosts: List[String],
+  ): AppDisposition =
+    AppDisposition(
+      appId = AppId(appId),
+      assignmentId = AppPolicyAssignmentId(assignmentId),
+      mode = mode,
+      exemptFromDaily = exempt,
+      dailyMinutes = 0,
+      label = s"app:$appId",
+      hosts = hosts,
+    )
+
   def spec = suite("per-app schedules (#1379)")(
+    suite("#1630 collapse — single fold structural invariants")(
+      test("every host on extraAllowed sourced from an exempt assignment is on exemptPatterns") {
+        val ds           = ProfileAppDispositions(
+          List(
+            disposition(1L, 100L, AppMode.Allowed, exempt = true, List("khan.org")),
+            disposition(2L, 200L, AppMode.Allowed, exempt = false, List("wikipedia.org")),
+            disposition(3L, 300L, AppMode.Blocked, exempt = true, List("badhost.com")),
+            disposition(4L, 400L, AppMode.TimeLimited, exempt = false, List("youtube.com")),
+          ),
+        )
+        val (allowed, _) = ds.enforcement(Map.empty, capExhausted = false, now = Instant.EPOCH)
+        val exemptHosts  = ds.exemptPatterns.toSet
+        // Every host whose owning assignment is exempt AND that landed in extraAllowed must also
+        // be on exemptPatterns. This is the structural agreement that #1630 was missing.
+        val exemptAllowedHosts = allowed
+          .map(_.value)
+          .toSet
+          .intersect(
+            ds.perApp.filter(_.exemptFromDaily).flatMap(_.hosts).toSet,
+          )
+        assertTrue(exemptAllowedHosts.subsetOf(exemptHosts))
+      },
+      test(
+        "cap groups contain only mode=TimeLimited assignments; structural projections include all modes",
+      ) {
+        val ds = ProfileAppDispositions(
+          List(
+            disposition(1L, 100L, AppMode.Allowed, exempt = true, List("khan.org")),
+            disposition(2L, 200L, AppMode.Blocked, exempt = false, List("badhost.com")),
+            disposition(3L, 300L, AppMode.TimeLimited, exempt = false, List("youtube.com")),
+          ),
+        )
+        // capGroups: TimeLimited only.
+        assertTrue(ds.capGroups.map(_.appId) == List(AppId(300L))) &&
+        // appHostPatterns: mode-agnostic. Attribution should beat suppression for any host an
+        // assigned app names, regardless of its mode.
+        assertTrue(ds.appHostPatterns.toSet == Set("khan.org", "badhost.com", "youtube.com")) &&
+        // exemptPatterns: mode-agnostic, only filters on the exempt flag.
+        assertTrue(ds.exemptPatterns.toSet == Set("khan.org"))
+      },
+      test("Allowed-mode exempt app's hosts reach BOTH extraAllowed AND exemptPatterns") {
+        // The #1630 acceptance shape at the structural level.
+        val ds           = ProfileAppDispositions(
+          List(disposition(1L, 100L, AppMode.Allowed, exempt = true, List("khan.org"))),
+        )
+        val (allowed, _) = ds.enforcement(Map.empty, capExhausted = false, Instant.EPOCH)
+        assertTrue(allowed.map(_.value) == List("khan.org")) &&
+        assertTrue(ds.exemptPatterns == List("khan.org"))
+      },
+    ),
     suite("windowActiveAt — boundaries reuse scheduleActiveAt")(
       test("exact start is inclusive (active)") {
         val w = win(LocalTime.of(9, 0), LocalTime.of(17, 0))

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -267,6 +267,14 @@ case class AppTimeLimit(
     // SPA-facing display text only. Defaults to AppId(0L) so seed/test constructions that don't
     // care about the FK still compile during the rollout.
     appId: AppId = AppId(0L),
+    // #1630: the assignment's mode and id, carried straight from the listForProfile join. Before
+    // the #1630 collapse the repo filtered `WHERE mode='time_limited'` and these were implicit
+    // (every row was TimeLimited, every assignment unique). Post-collapse the repo returns every
+    // assignment's rows across every mode, so the projection needs both fields to identify the
+    // owning assignment and decide which downstream bucket the row contributes to. Default
+    // values keep legacy hand-built test constructions (single-app TimeLimited rows) compiling.
+    mode: AppMode = AppMode.TimeLimited,
+    assignmentId: AppPolicyAssignmentId = AppPolicyAssignmentId(0L),
 ) derives JsonCodec
 
 // #761: app concept. An App is a household-scoped named bundle of host


### PR DESCRIPTION
## Summary

Two unrelated readers of the same `app_policy_assignments` table silently disagreed:

- `PolicyService.expandAppDispositions` read `List[AppPolicyAssignment]` (all modes) and emitted snapshot `extraAllowed` / `extraBlocked`.
- `TimeStatusService` (`groupAppLimits` / `exemptPatterns` / `appHostPatterns`) read `List[AppTimeLimit]` synthesized by a repo query filtered `WHERE mode='time_limited'` and emitted everything else — including the daily-total exempt host-set.

That seam let a `mode=Allowed, exemptFromDaily=true` app reach `extraAllowed` (snapshot allowed it) but never reach `exemptPatterns` (daily-usage path counted it) — exactly the §single-source-of-truth class the #1532 audit was supposed to catch.

The PR replaces both readers with the single fold `ProfileAppDispositions.from(appLimits)`. Every projection — `extraAllowed`, `extraBlocked`, `exemptPatterns`, `appHostPatterns`, `capGroups` — is read off that one value. After the collapse it is structurally impossible (not just patched) for two readers to disagree about whether a `mode=Allowed` exempt app counts toward the daily total.

## What changed

- **New** `api/src/policy/ProfileAppDispositions.scala` — the case class + `from` factory + `enforcement(schedWindows, capExhausted, now)` method. This is the ONE place mode case-analysis happens.
- **`AppTimeLimitRepoLive.listForProfile`** — drops the `WHERE mode='time_limited'` filter. Now returns rows for every mode. SELECT also carries `apa.id` (assignmentId) and `apa.mode` so the fold can route each row.
- **`AppTimeLimit`** — gains additive `mode: AppMode` + `assignmentId: AppPolicyAssignmentId` fields with defaults at the end (back-compat with hand-built test constructions).
- **`PolicyService.expandAppDispositions`** — deleted. `snapshot` and `decide` now build `ProfileAppDispositions.from(appLimits).enforcement(...)` directly, off the unified `appTimeLimitRepo.listForProfile` read. The prior `apps + appHostsRaw + appAssigns` fan-out in `snapshot` collapses into a single per-profile fetch.
- **`TimeStatusService.{groupAppLimits, exemptPatterns, appHostPatterns}`** — kept as `private[policy]` names but reduced to thin delegations to `ProfileAppDispositions.from(...)`'s accessors. Downstream consumers (`appDayStates`, `appDayStatesFromMinutes`, `appSecondsByApp`, `usedSecondsForProfile`, `usedSecondsByMac`) keep their existing signatures.

Resolves the symptom on #1628 and #1629 (those investigation issues stay open until the operator confirms in prod).

Closes #1630

## Test plan

- [x] **Allowed-mode exempt app does NOT contribute to `usedSecondsForProfile`** — committed first as RED (fails on `main`), green after collapse. Profile with `App(khanacademy.org, mode=Allowed, exemptFromDaily=true)`, 20 min of traffic → `state.usedMinutes == 0`.
- [x] **Allowed-mode NON-exempt app DOES contribute** — symmetric case, `state.usedMinutes >= 15`.
- [x] **Allowed-mode exempt app still reaches the kid via `extraAllowed`** — snapshot `BlockRules.extraAllowed` for the profile contains `khanacademy.org`.
- [x] **Allowed-mode app with no cap does NOT fire a TimeLimit block** — `state.blocked == false` or `blockReason != TimeLimit` with 120 min of traffic.
- [x] **TimeLimited-mode regression** — `dailyMinutes=60`, 65 min of traffic → blocked with `TimeLimit` reason. Unchanged.
- [x] **SSOT structural pin** (unit, `PerAppScheduleSpec`) — every host that lands on `extraAllowed` from an `exemptFromDaily=true` assignment is also on `exemptPatterns`; cap groups contain only `TimeLimited`; `appHostPatterns`/`exemptPatterns` are mode-agnostic. Fails the moment the readers diverge again.
- [x] Full Scala test suite (`mill __.test`) — green (no regressions across PolicySnapshot/Router/Time/Usage suites).
- [x] `scalafmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)