### PR TITLE
feat(#1641): admin /api/admin/snapshot endpoint + snapshot_changed INFO logging

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -414,6 +414,7 @@ object Main extends ZIOAppDefault {
             clock,
           ) ++
           AppRoutes.routes(auth, appRepo, profileRepo, upRepo, templates) ++
+          AdminDebugRoutes.routes(auth, policy) ++
           DebugRoutes.routes(
             cfg.debugEnabled,
             deviceRepo,

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -6,9 +6,11 @@ import wifihaven.api.metrics.AppMetrics
 import wifihaven.shared.{Schedule as DbSchedule, *}
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
+import zio.json.*
 
 import java.security.MessageDigest
 import java.time.{DayOfWeek, Instant, LocalDate}
+import java.util.concurrent.atomic.AtomicReference
 
 trait PolicyService {
   def snapshot: Task[PolicySnapshot]
@@ -120,6 +122,16 @@ class PolicyServiceLive(
   // hosts when assembling the global section. (#1321 moved the curated
   // `infraAllowHosts` onto the same global path, retiring its per-profile copy.)
   private val uiGlobalAllow: List[Hostname] = uiAllowedHosts
+
+  // #1641: process-local last-seen-etag for snapshot-change INFO logging. On every `snapshot`
+  // call we atomically compare-and-set the latest etag here; only the winner of the swap emits
+  // the `event=snapshot_changed` INFO log carrying the full snapshot JSON. One line per ETag
+  // transition (NOT per poll) so volume is bounded by how often policy actually changes.
+  // Render retains stdout for ~7 days, giving roughly a week of snapshot history for free —
+  // long enough to investigate most incidents (the #1640 motivation). Not a metric (cardinality
+  // fence; snapshot JSON is not metric data).
+  private val lastSnapshotEtag: AtomicReference[Option[ETag]] =
+    new AtomicReference(Option.empty[ETag])
 
   // #1069/#1482: per-host /decision fallback must see the same schedule downtime as the snapshot —
   // the windows of every block-mode named schedule attached to the profile (as synthetic
@@ -267,8 +279,29 @@ class PolicyServiceLive(
       // #1318: surface the global-section size + default-deny profile count for operators.
       AppMetrics
         .setGlobalPolicy(snap.global.extraAllowed.size, defaultDenyProfiles)
+        .zipRight(logSnapshotChanged(snap))
         .as(snap)
     }
+
+  /**
+   * #1641: emit an INFO log line carrying the full snapshot JSON the first time we see a given ETag
+   * in this process. Atomic compare-and-set against `lastSnapshotEtag` — only the caller who
+   * swapped a new etag in logs, so concurrent pollers cannot duplicate the line. One line per ETag
+   * transition (not per poll), bounded by how often policy actually changes.
+   */
+  private def logSnapshotChanged(snap: PolicySnapshot): UIO[Unit] = ZIO.suspendSucceed {
+    val prev    = lastSnapshotEtag.get()
+    val changed = !prev.contains(snap.etag) && lastSnapshotEtag.compareAndSet(prev, Some(snap.etag))
+    if (!changed) ZIO.unit
+    else {
+      val json = snap.toJson
+      ZIO.logInfo(
+        s"event=snapshot_changed etag=${snap.etag.value} " +
+          s"prevEtag=${prev.map(_.value).getOrElse("none")} " +
+          s"bytes=${json.length} snapshot=$json",
+      )
+    }
+  }
 
   def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]] =
     for {

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -230,14 +230,12 @@ object AdminDebugRoutes {
               snap <- policy.snapshot.mapError(ApiError.Db(_))
             } yield Response
               .json(snap.toJson)
-              .addHeader(Header.ETag.Strong(stripQuotedEtag(snap.etag.value)))
+              // #1641: shared with the router's GET /api/router/policy via
+              // RouterRoutes.stripQuotes — collapsed into one helper rather than
+              // hand-mirrored here, so the ETag header emission cannot drift between
+              // the two routes (AGENTS.md §Single source of truth).
+              .addHeader(Header.ETag.Strong(RouterRoutes.stripQuotes(snap.etag.value)))
           handle.mapError(ErrorMapper.errorToResponse)
         },
     )
-
-  // Mirror of `RouterRoutes.stripQuotes` — `Header.ETag.Strong` wants the bare token without
-  // surrounding quotes (zio-http renders them back on the wire). The stored ETag value is the
-  // quoted form (sha256:..."), so trim the wrapping quotes before constructing the header.
-  private def stripQuotedEtag(s: String): String =
-    if s.startsWith("\"") && s.endsWith("\"") then s.drop(1).dropRight(1) else s
 }

--- a/api/src/routes/DebugRoutes.scala
+++ b/api/src/routes/DebugRoutes.scala
@@ -1,7 +1,9 @@
 package wifihaven.api.routes
 
+import wifihaven.api.auth.*
 import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
+import wifihaven.api.policy.PolicyService
 import wifihaven.shared.Clock
 import zio.{Clock as _, *}
 import zio.http.*
@@ -200,4 +202,42 @@ object DebugRoutes {
         s
     stripped == "localhost" || stripped == "127.0.0.1" || stripped == "::1"
   }
+}
+
+/**
+ * Admin-auth-gated debug surface (#1641). Distinct from [[DebugRoutes]]: that family is loopback-
+ * only and requires `WIFIHAVEN_DEBUG=1`, suitable only for on-host triage; this one is reachable
+ * from anywhere with an admin JWT, suitable for remote incident response on the cloud deploys.
+ *
+ * Current routes:
+ *   - `GET /api/admin/snapshot` — returns the same [[wifihaven.shared.PolicySnapshot]] JSON the
+ *     router fetches at `/api/router/policy`, with a strong ETag header matching. Reuses
+ *     `PolicyService.snapshot` (single-source-of-truth — no parallel resolver). Read-only: does NOT
+ *     call `routerRepo.touch`, so polling here doesn't move `last_etag` / `last_seen_at`.
+ */
+object AdminDebugRoutes {
+
+  def routes(
+      auth: AuthService,
+      policy: PolicyService,
+  ): Routes[Any, Response] =
+    Routes(
+      Method.GET / "api" / "admin" / "snapshot" ->
+        handler { (req: Request) =>
+          val handle: ZIO[Any, ApiError, Response] =
+            for {
+              _    <- requireAdmin(req, auth).mapError(ApiError.Wrapped(_))
+              snap <- policy.snapshot.mapError(ApiError.Db(_))
+            } yield Response
+              .json(snap.toJson)
+              .addHeader(Header.ETag.Strong(stripQuotedEtag(snap.etag.value)))
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
+    )
+
+  // Mirror of `RouterRoutes.stripQuotes` — `Header.ETag.Strong` wants the bare token without
+  // surrounding quotes (zio-http renders them back on the wire). The stored ETag value is the
+  // quoted form (sha256:..."), so trim the wrapping quotes before constructing the header.
+  private def stripQuotedEtag(s: String): String =
+    if s.startsWith("\"") && s.endsWith("\"") then s.drop(1).dropRight(1) else s
 }

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -165,7 +165,13 @@ object RouterRoutes {
         },
     )
 
-  private def stripQuotes(s: String): String =
+  // #1641: package-visible so [[AdminDebugRoutes]] (which emits the same router-shape ETag
+  // header on `GET /api/admin/snapshot`) can reuse this instead of hand-mirroring a copy.
+  // `Header.ETag.Strong` wants the bare token without surrounding quotes; our stored ETag
+  // value is the quoted form (`"sha256:..."`), so trim the wrapping quotes before constructing
+  // the header. Shared helper, not a "keep in sync" mirror (per AGENTS.md §Single source of
+  // truth).
+  private[routes] def stripQuotes(s: String): String =
     if s.startsWith("\"") && s.endsWith("\"") then s.drop(1).dropRight(1) else s
 
   // RFC 7232 §2.3.2: If-None-Match uses weak comparison; W/"x" matches "x".

--- a/api/test/src/feature/AdminSnapshotApiSpec.scala
+++ b/api/test/src/feature/AdminSnapshotApiSpec.scala
@@ -1,0 +1,159 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.policy.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+/**
+ * #1641 — admin /api/admin/snapshot endpoint and snapshot_changed INFO logging.
+ *
+ * Covers:
+ *   1. GET /api/admin/snapshot with admin token → 200, returns the same PolicySnapshot JSON the
+ *      router gets at /api/router/policy, with ETag header matching. 2. ReadOnly (child) token →
+ *      403. 3. No auth → 401. 4. PolicyService logs `event=snapshot_changed` exactly once per ETag
+ *      transition: first compute, no-op repeats (same etag → no log), and after a state mutation
+ *      that moves the etag (next call logs again).
+ */
+object AdminSnapshotApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def makePolicyService =
+    for {
+      pr     <- ZIO.service[ProfileRepo]
+      sr     <- ZIO.service[ScheduleRepo]
+      hsr    <- ZIO.service[HouseholdSettingsRepo]
+      tlr    <- ZIO.service[TimeLimitRepo]
+      atlr   <- ZIO.service[AppTimeLimitRepo]
+      dr     <- ZIO.service[DeviceRepo]
+      blr    <- ZIO.service[BlocklistRepo]
+      trRepo <- ZIO.service[TrafficReportRepo]
+      er     <- ZIO.service[TimeExtensionRepo]
+      ar     <- ZIO.service[AppRepo]
+      clock  <- ZIO.service[Clock]
+    } yield PolicyServiceLive(
+      pr,
+      sr,
+      hsr,
+      tlr,
+      atlr,
+      dr,
+      blr,
+      trRepo,
+      er,
+      ar,
+      clock,
+    ): PolicyService
+
+  private def snapshotChangedLines(logs: Chunk[ZTestLogger.LogEntry]): Int = {
+    val needle = "event=snapshot_changed"
+    logs.count(e => e.logLevel == LogLevel.Info && e.message().contains(needle))
+  }
+
+  def spec = suite("Admin snapshot API (#1641)")(
+    test("GET /api/admin/snapshot with admin token returns full PolicySnapshot + ETag header") {
+      for {
+        _          <- cleanDb
+        pr         <- ZIO.service[ProfileRepo]
+        sr         <- ZIO.service[ScheduleRepo]
+        dr         <- ZIO.service[DeviceRepo]
+        _          <- TestLayers.seedKidsProfile(pr, sr)
+        auth       <- makeAuth
+        ps         <- makePolicyService
+        adminLogin <- auth.login("admin", "changeme")
+        routes = AdminDebugRoutes.routes(auth, ps)
+        resp <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/admin/snapshot").toOption.get)
+            .addHeader(Header.Authorization.Bearer(adminLogin.token.value)),
+        )
+        body <- resp.body.asString
+        snap <- ZIO.fromEither(body.fromJson[PolicySnapshot])
+        // ETag header should be present and match snap.etag (modulo quote stripping).
+        etagHeader = resp.headers.get(Header.ETag).map(_.renderedValue).getOrElse("")
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(snap.profiles.nonEmpty) &&
+        assertTrue(etagHeader.nonEmpty) &&
+        // The router ships strong ETag headers without surrounding quotes in the typed form,
+        // but the rendered value contains quotes — the snap.etag has the quoted form, so
+        // we check the inner sha256 marker is present in both.
+        assertTrue(etagHeader.contains("sha256:")) &&
+        assertTrue(snap.etag.value.contains("sha256:"))
+    },
+    test("GET /api/admin/snapshot with child (non-admin) token → 403") {
+      for {
+        _          <- cleanDb
+        ur         <- ZIO.service[UserRepo]
+        auth       <- makeAuth
+        ps         <- makePolicyService
+        hash       <- auth.hashPassword("kidpass")
+        kidId      <- ur.create("kid", hash, "child")
+        // Child user defaults to must_change_password=true; clear it so we can authenticate.
+        _          <- ur.clearMustChangePassword(kidId)
+        childLogin <- auth.login("kid", "kidpass")
+        routes = AdminDebugRoutes.routes(auth, ps)
+        resp <- routes.runZIO(
+          Request
+            .get(URL.decode("/api/admin/snapshot").toOption.get)
+            .addHeader(Header.Authorization.Bearer(childLogin.token.value)),
+        )
+      } yield assertTrue(resp.status == Status.Forbidden)
+    },
+    test("GET /api/admin/snapshot without bearer token → 401") {
+      for {
+        _    <- cleanDb
+        auth <- makeAuth
+        ps   <- makePolicyService
+        routes = AdminDebugRoutes.routes(auth, ps)
+        resp <- routes.runZIO(Request.get(URL.decode("/api/admin/snapshot").toOption.get))
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+    test(
+      "PolicyService.snapshot emits exactly one snapshot_changed INFO log per ETag transition",
+    ) {
+      (for {
+        _    <- cleanDb
+        pr   <- ZIO.service[ProfileRepo]
+        sr   <- ZIO.service[ScheduleRepo]
+        kid  <- TestLayers.seedKidsProfile(pr, sr)
+        ps   <- makePolicyService
+        // First snapshot: should log once (None -> Some(etag1)).
+        s1   <- ps.snapshot
+        // Second snapshot with no DB change: same etag, should NOT log.
+        s2   <- ps.snapshot
+        // Mutate state: pause the kids profile. Should change the etag.
+        _    <- pr.setPaused(kid, true)
+        s3   <- ps.snapshot
+        // Final snapshot, same as s3: should not log again.
+        s4   <- ps.snapshot
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(s1.etag == s2.etag) &&
+        assertTrue(s1.etag != s3.etag) &&
+        assertTrue(s3.etag == s4.etag) &&
+        assertTrue(snapshotChangedLines(logs) == 2))
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/AdminSnapshotApiSpec.scala
+++ b/api/test/src/feature/AdminSnapshotApiSpec.scala
@@ -91,16 +91,16 @@ object AdminSnapshotApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPost
         )
         body <- resp.body.asString
         snap <- ZIO.fromEither(body.fromJson[PolicySnapshot])
-        // ETag header should be present and match snap.etag (modulo quote stripping).
+        // The handler emits a strong ETag header carrying `snap.etag` modulo the wrapping
+        // quotes (Header.ETag.Strong appends them on render). Assert the round-trip equals
+        // the body's etag exactly after one normalize step — this is what pins the
+        // header-emission contract (the previous "both contain sha256:" check would pass
+        // against a hard-coded sentinel value).
         etagHeader = resp.headers.get(Header.ETag).map(_.renderedValue).getOrElse("")
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(snap.profiles.nonEmpty) &&
         assertTrue(etagHeader.nonEmpty) &&
-        // The router ships strong ETag headers without surrounding quotes in the typed form,
-        // but the rendered value contains quotes — the snap.etag has the quoted form, so
-        // we check the inner sha256 marker is present in both.
-        assertTrue(etagHeader.contains("sha256:")) &&
-        assertTrue(snap.etag.value.contains("sha256:"))
+        assertTrue(etagHeader == snap.etag.value)
     },
     test("GET /api/admin/snapshot with child (non-admin) token → 403") {
       for {


### PR DESCRIPTION
Closes #1641.

cc @sameerparekh for review.

## Summary

Two deliverables, both reusing `PolicyService.snapshot` (single source of truth — no parallel resolver):

1. **`GET /api/admin/snapshot`** — admin-JWT-gated, read-only. Returns the same `PolicySnapshot` JSON the router consumes at `/api/router/policy`, with a strong `ETag` header matching `snap.etag`. No `routerRepo.touch` side effect.
2. **`event=snapshot_changed` INFO log line on every ETag transition** — process-local `AtomicReference[Option[ETag]]` in `PolicyServiceLive`; atomic compare-and-set on every `snapshot` call. Only the caller who actually swaps in a new etag emits the line, so concurrent pollers cannot duplicate it. One line per ETag change (not per poll).

Together these close the #1640 historical-snapshot gap: next time conntrack labels a host as `extraBlocked` that doesn't match the current snapshot, an operator opens Render logs at the incident timestamp, greps for `snapshot_changed`, and reads the exact `BlockRules` shape in force at that moment.

## Design

- **Where it lives.** `AdminDebugRoutes` is a new object in `api/src/routes/DebugRoutes.scala` — distinct from the existing `DebugRoutes` (which is loopback-only and gated by `WIFIHAVEN_DEBUG=1`). Mounted unconditionally in `Main.scala` alongside the other admin route families; auth gate is `requireAdmin`.
- **No re-derivation.** Handler is essentially `policy.snapshot.map(s => Response.json(s.toJson).addHeader(ETag.Strong(...)))`. Same JSON shape, same ETag.
- **No filter params.** `?profileId=` / `?mac=` skipped per the issue's "if trivial" note — default returns the full snapshot.
- **Logging atomicity.** `AtomicReference` (not `Ref[…]`) so construction stays synchronous — the existing 40+ direct test constructors of `PolicyServiceLive` stay arity-stable, no factory rewiring needed. `compareAndSet` guarantees exactly-one logger per transition under concurrent pollers.
- **Not a metric.** Per the issue note, snapshot JSON is not metric data — log line only. No dashboard panel.

## Sample log line (as actually emitted)

```
timestamp=2026-06-11T14:00:04.974Z level=INFO thread=#zio-fiber-221 message="event=snapshot_changed etag=\"sha256:e75d33c8709f508f9dafc0146dde2a6e291a3558f3fd5a4ca92d2355a56485cd\" prevEtag=\"sha256:6a46e6c07b093d8d1c408f0e343419eeb3caf84beb48fe6a30c95e2529981ccf\" bytes=1228 snapshot={\"etag\":\"\\\"sha256:e75d33c8709f508f9dafc0146dde2a6e291a3558f3fd5a4ca92d2355a56485cd\\\"\",\"generatedAt\":\"2025-01-06T14:00:00Z\",\"global\":{...},\"devices\":{...},\"profiles\":{\"3\":{\"name\":\"Kids\",\"rules\":{\"blocked\":true,\"blockReason\":\"Paused\",...}},...},\"blocklists\":{}}" location=wifihaven.api.policy.PolicyServiceLive.logSnapshotChanged file=PolicyService.scala line=302
```

First call after process start logs `prevEtag=none`; subsequent calls log only when `snap.etag` actually moves.

## Sample curl

```bash
$ curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" https://api.wifihaven.net/api/admin/snapshot | jq .
{
  "etag": "\"sha256:e75d33c8…\"",
  "generatedAt": "2026-06-11T14:00:00Z",
  "global": { "blocked": false, "extraAllowed": [...], ... },
  "devices": { ... },
  "profiles": { ... },
  "blocklists": { ... }
}
```

The response carries the same `ETag` header the router endpoint emits, so a client can use If-None-Match for cheap polling (the handler doesn't 304 itself today — that's out of scope).

## TDD red→green

Per AGENTS.md the red commit lands first, isolated:
- `8c1e3a49 test(#1641): failing spec for admin snapshot + snapshot_changed logging` — fails to compile (`AdminDebugRoutes` doesn't exist).
- `fecd5533 feat(#1641): admin snapshot endpoint + snapshot_changed INFO logging` — implementation; spec now passes.

## Test plan

- [x] Spec covers admin → 200 + ETag header, child → 403, no auth → 401, plus exactly-one-INFO-per-ETag-transition.
- [x] `mill api.test` — full suite green locally (no regressions in any of the existing policy/router specs).
- [x] `scalafmt --check` clean.
- [ ] Operator smoke-test on staging post-merge: `curl -sS -H "Authorization: Bearer …" https://staging.wifihaven.net/api/admin/snapshot`.
- [ ] Operator confirms the `snapshot_changed` line appears in Render logs on the next policy change post-deploy.

## Backwards compatibility

Purely additive: new endpoint, additive INFO log line. No wire shape changes, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)