### PR TITLE
feat(#573): SNI-based hostname attribution (v1: libpcap-userspace, TLS-only)

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -70,7 +70,14 @@ jobs:
     # api.lan now eats most of the headroom, so 30m no longer covers the
     # tail. 40m re-establishes the safety margin without masking a real
     # regression in the scenario pack itself.
-    timeout-minutes: 40
+    #
+    # Bumped 40→50m after #573 added the test_sni_attribution scenario: each
+    # VM scenario carries a fixed ~2m snapshot-restore + boot cost, so the
+    # 45th scenario pushed the slower apk arm to 40m23s — over the 40m cap —
+    # while the ipk arm passed at 32m30s. The pack itself is healthy (per-step
+    # times unchanged); the cap just needs to grow with the scenario count.
+    # 50m restores ~10m headroom on the slow arm without masking a regression.
+    timeout-minutes: 50
     # #685: matrix over ipk-23.05 and apk-25.12 router images. fail-fast=false
     # so a regression in one flavor still reports the other arm's status
     # (needed to surface apk-only regressions like the #531 history case).

--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -110,6 +110,10 @@ object MetricGuard {
     "agent_uptime_seconds"                      -> Set("router_id", "installation_id"),
     "agent_version"                             -> Set("version", "router_id", "installation_id"),
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
+    // #573 — TLS ClientHello SNI capture outcomes from the wifihaven-sni-tail sidecar.
+    // `result` ∈ {parsed, truncated, no_sni, ipv6_skipped, not_tcp, malformed} — a small bounded
+    // enum that lets an operator see the fleet-wide SNI capture / truncation / ipv6-skip rate.
+    "sni_clienthellos_total"                    -> Set("result", "router_id", "installation_id"),
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
     "enforcement_drops_total"                   -> Set("reason", "router_id", "installation_id"),
     // #1033 — usage-POST retry-queue health. Depth = buckets currently waiting for a backoff to

--- a/api/test/src/feature/RouterMetricsIngestSpec.scala
+++ b/api/test/src/feature/RouterMetricsIngestSpec.scala
@@ -212,6 +212,10 @@ object RouterMetricsIngestSpec
             MetricCounter("blocklist_fetch_failures_total", Map("status" -> "5xx"), 4),
             MetricCounter("enforcement_drops_total", Map("reason" -> "whole_mac"), 1820),
             MetricCounter("enforcement_drops_total", Map("reason" -> "category_block"), 12990),
+            // #573 SNI sidecar result counters — must be allowlisted and
+            // re-exposed under router_id like the other agent-sourced series.
+            MetricCounter("sni_clienthellos_total", Map("result" -> "parsed"), 8421),
+            MetricCounter("sni_clienthellos_total", Map("result" -> "truncated"), 37),
           ),
         )
         resp <- post(routes, tok, body)
@@ -239,6 +243,14 @@ object RouterMetricsIngestSpec
             s"""router_id="$ridStr"""",
             "category_block",
           ).contains(12990.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "sni_clienthellos_total", s"""router_id="$ridStr"""", "parsed")
+            .contains(8421.0),
+        ) &&
+        assertTrue(
+          seriesValue(scraped, "sni_clienthellos_total", s"""router_id="$ridStr"""", "truncated")
+            .contains(37.0),
         )
       }
     },

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -23,7 +23,12 @@ define Package/wifihaven
   # listen_https block-page sibling on :8443; openssl-util provides
   # /usr/bin/openssl for the self-signed cert generator that ships at
   # /usr/lib/wifihaven/generate-block-page-cert.sh.
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +libustream-mbedtls +openssl-util
+  # #573: tcpdump-mini provides libpcap-userspace capture for the SNI sidecar
+  # (wifihaven-sni-tail). It parses the TLS ClientHello off the LAN bridge to
+  # recover hostname attribution when the client used DoH/DoT or a hardcoded
+  # IP — the same shared dns_cache feeds eb_/ea_/bl_ enforcement, so this is
+  # an additive, observability-style dependency.
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +libustream-mbedtls +openssl-util +tcpdump-mini
   PKGARCH:=all
 endef
 
@@ -44,6 +49,7 @@ define Package/wifihaven/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-agent $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-dns-tail $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-nflog-tail $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-sni-tail $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-update $(1)/usr/sbin/
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/usr/sbin/wifihaven-rotate-dnsmasq-log $(1)/usr/sbin/
 

--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -146,7 +146,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/wifihaven/wifihaven" \
     --info "maintainer:WifiHaven <noreply@example.com>" \
-    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua kmod-nf-log kmod-nf-log6 libustream-mbedtls openssl-util" \
+    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua kmod-nf-log kmod-nf-log6 libustream-mbedtls openssl-util tcpdump-mini" \
     --script "post-install:$WORK/post-install" \
     --script "trigger:$WORK/trigger" \
     --trigger "/etc/crontabs" \

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -25,7 +25,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: wifihaven
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6, libustream-mbedtls, openssl-util
+Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6, libustream-mbedtls, openssl-util, tcpdump-mini
 Architecture: all
 Maintainer: WifiHaven <noreply@example.com>
 Description: Agent daemon for WifiHaven. Enforces per-device DNS filtering

--- a/openwrt/files/etc/init.d/wifihaven
+++ b/openwrt/files/etc/init.d/wifihaven
@@ -22,6 +22,19 @@ start_service() {
     procd_set_param stderr 1
     procd_close_instance
 
+    # sni-tail sidecar: captures the first packet of every outbound TCP/443 flow
+    # via tcpdump-mini, extracts the TLS ClientHello SNI, and appends parsed
+    # (dst_ip, src_mac, sni) lines to /tmp/wifihaven-sni.log. wifihaven-dns-tail
+    # tails that spool alongside the dnsmasq log and routes SNI lines through
+    # the shared (single-writer) dns_cache. Closes the DoH / hard-coded-IP
+    # attribution gap (#573).
+    procd_open_instance "sni-tail"
+    procd_set_param command /usr/sbin/wifihaven-sni-tail
+    procd_set_param respawn 3600 5 5
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+
     # nflog-tail sidecar: tails `logread -f` for the nft `log prefix "wh_drop:…"`
     # forward-drop records and spools them to /tmp/wifihaven-nflog.log so the
     # agent can synthesize connection_attempt events for blocked flows (#1126).

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -401,6 +401,23 @@ function M.new(opts)
     return resolve_head(name)
   end
 
+  -- insert_sni(dst_ip, server_name, now) — record an (ip → hostname) mapping
+  -- learned from a TLS ClientHello SNI extension (#573). The wifihaven-sni-tail
+  -- sidecar feeds these in via the same line stream as dnsmasq replies; this
+  -- helper runs the server_name through the SAME CNAME-alias map (resolve_head)
+  -- DNS ingest uses, so an SNI to a CDN leaf target attributes back to the
+  -- branded chain head we already learned from the DNS path (#1344). A
+  -- subsequent cache.lookup(dst_ip) then matches the same eb_/ea_/bl_ suffix
+  -- walks the DNS-derived entries do — no router code is aware of the SNI
+  -- origin. nil-safe.
+  function self.insert_sni(dst_ip, server_name, now)
+    if type(dst_ip) ~= "string" or dst_ip == "" then return end
+    if type(server_name) ~= "string" or server_name == "" then return end
+    now = now or now_fn()
+    local head = resolve_head(server_name)
+    store(dst_ip, head, now)
+  end
+
   -- Serialise the live cache to a single newline-delimited string.
   -- Format: "<ip>\t<hostname>\t<ts>\n" per non-expired entry.
   function self.dump_text()

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -32,9 +32,20 @@ M.bl_member_index = "/tmp/wifihaven-bl-members.txt"
 -- and appends one "SNI\t<dst_ip>\t<src_mac>\t<server_name>" line per capture to
 -- this tmpfs file. wifihaven-dns-tail tails it alongside the dnsmasq query log
 -- and routes SNI-prefixed lines through cache.insert_sni, so the shared
--- ip→hostname cache (paths.dns_cache) stays single-writer (dns-tail) and the
--- downstream eb_/ea_/bl_ populators see SNI-derived hostnames transparently.
+-- ip→hostname cache (paths.dns_cache) stays single-writer (dns-tail). This
+-- improves connection-event fqdn ATTRIBUTION only (cache.lookup); it does NOT
+-- feed the eb_/ea_/bl_ nft drop-set populators, which fire solely on dnsmasq
+-- `reply <name> is <ip>` lines — SNI is observed after the flow's first packet,
+-- too late to populate a drop set for that flow.
 M.sni_capture = "/tmp/wifihaven-sni.log"
+
+-- SNI capture result tally (#573): wifihaven-sni-tail writes cumulative
+-- per-result counts ("<result>\t<count>" lines, same format as dns_metrics) on
+-- each periodic flush; wifihaven-agent samples it on its metrics tick and folds
+-- the deltas into sni_clienthellos_total{result}. result ∈ {parsed, truncated,
+-- no_sni, ipv6_skipped, not_tcp, malformed}. Same tmpfs-IPC pattern as
+-- dns_metrics — the sidecar has no metrics registry of its own.
+M.sni_metrics = "/tmp/wifihaven-sni-metrics.txt"
 
 -- nflog drop spool (#1126): wifihaven-nflog-tail tails `logread -f`, greps the
 -- nft `log prefix "wh_drop:…"` forward-drop records, and appends them here; the

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -27,6 +27,15 @@ M.dns_metrics = "/tmp/wifihaven-dns-metrics.txt"
 -- wifihaven-dns-tail bl_ populator reads it on its set-refresh cadence.
 M.bl_member_index = "/tmp/wifihaven-bl-members.txt"
 
+-- SNI capture spool (#573): wifihaven-sni-tail parses the first packet of every
+-- outbound TCP/443 flow off the LAN bridge, extracts the TLS ClientHello SNI,
+-- and appends one "SNI\t<dst_ip>\t<src_mac>\t<server_name>" line per capture to
+-- this tmpfs file. wifihaven-dns-tail tails it alongside the dnsmasq query log
+-- and routes SNI-prefixed lines through cache.insert_sni, so the shared
+-- ip→hostname cache (paths.dns_cache) stays single-writer (dns-tail) and the
+-- downstream eb_/ea_/bl_ populators see SNI-derived hostnames transparently.
+M.sni_capture = "/tmp/wifihaven-sni.log"
+
 -- nflog drop spool (#1126): wifihaven-nflog-tail tails `logread -f`, greps the
 -- nft `log prefix "wh_drop:…"` forward-drop records, and appends them here; the
 -- main agent drains new complete lines from this tmpfs spool on its cooperative

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -80,14 +80,22 @@ function M.parse_client_hello(payload)
   if content_type ~= 0x16 then return nil end -- not handshake
   local record_len = u16(payload, 4)
   if not record_len then return nil end
-  if 5 + record_len > #payload + 1 then return nil end -- truncated record
+  -- NB: we deliberately do NOT reject when the declared record length exceeds
+  -- the captured buffer. Real OpenSSL/curl TLS 1.3 ClientHellos are padded past
+  -- ~512 bytes, so under the capture snaplen the tail (large key_share /
+  -- padding extensions) is clipped — but the server_name extension sits near
+  -- the FRONT and is therefore fully present in the captured prefix. Rejecting
+  -- the whole record on declared-vs-captured length was the bug the Gate 2 e2e
+  -- caught (every real ClientHello fell out as "no_sni"). The extension walk
+  -- below is bounded by the actual buffer via the per-field u8/u16/slice reads
+  -- (each returns nil past end-of-buffer), so a SNI beyond the captured bytes
+  -- still yields nil — we just no longer discard one that IS present.
 
   -- Handshake header (inside the record)
   local hs_type = u8(payload, 6)
   if hs_type ~= 0x01 then return nil end -- not ClientHello
   local hs_len = u24(payload, 7)
   if not hs_len then return nil end
-  if 10 + hs_len > #payload + 1 then return nil end -- truncated handshake
 
   -- ClientHello body starts at offset 10
   local off = 10

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -25,6 +25,9 @@
 --   sni.parse_packet(eth_frame_bytes) → { dst_ip, src_mac, sni } | nil
 --   sni.format_sni_line(ip, mac, sni) → "SNI\t<ip>\t<mac>\t<sni>\n"
 --   sni.parse_sni_line(line)          → { dst_ip, src_mac, sni } | nil
+--   sni.read_global_header(read_fn)   → { swapped } | nil   (pcap stream)
+--   sni.read_record(read_fn, swapped) → { data } | nil      (pcap stream)
+--   sni.iter_pcap(read_fn)            → iterator of packet bytes
 --
 -- Defensive style: every length field is checked against the remaining
 -- payload before being trusted. A malformed record returns nil; it never
@@ -274,6 +277,87 @@ function M.route_line(line, deps)
   if not sn then return false end                   -- dnsmasq line: fall through
   deps.insert_fn(sn.dst_ip, sn.sni)
   return true
+end
+
+-- ---------------------------------------------------------------------------
+-- pcap stream reader (#573).
+--
+-- The wifihaven-sni-tail sidecar reads tcpdump's `-w -` output: a 24-byte
+-- global header (magic 0xa1b2c3d4 / 0xd4c3b2a1 for the two byte orders)
+-- followed by a sequence of 16-byte record headers each framing incl_len
+-- captured packet bytes. This reader used to live as inline local functions in
+-- the sidecar and was never executed by a test. It now lives here as pure,
+-- injectable functions: a `read_fn(n)` returns up to n bytes or nil at EOF, so
+-- the sidecar backs it with the io.popen handle and tests back it with an
+-- in-memory string cursor — single source of truth for the framing logic.
+-- ---------------------------------------------------------------------------
+
+-- read_exact(read_fn, n) → exactly n bytes, or nil if EOF/short read.
+-- read_fn(k) returns up to k bytes (or nil/"" at EOF); we loop until we have n.
+local function read_exact(read_fn, n)
+  if n <= 0 then return "" end
+  local out = {}
+  local got = 0
+  while got < n do
+    local chunk = read_fn(n - got)
+    if not chunk or #chunk == 0 then return nil end
+    out[#out + 1] = chunk
+    got = got + #chunk
+  end
+  return table.concat(out)
+end
+
+-- read_global_header(read_fn) → { swapped = bool } | nil
+--
+-- Consumes the 24-byte pcap global header. The magic's first byte distinguishes
+-- the two byte orders: native 0xa1b2c3d4 starts 0xa1; swapped 0xd4c3b2a1 starts
+-- 0xd4. Returns nil if the stream is too short to hold a header (e.g. tcpdump
+-- never produced a pcap stream — wrong interface / rejected BPF).
+function M.read_global_header(read_fn)
+  local hdr = read_exact(read_fn, 24)
+  if not hdr or #hdr < 4 then return nil end
+  local b1 = hdr:byte(1)
+  local swapped = (b1 == 0xd4)
+  return { swapped = swapped }
+end
+
+-- read_record(read_fn, swapped) → { data = <packet bytes> } | nil
+--
+-- Reads one 16-byte record header (ts_sec, ts_usec, incl_len, orig_len),
+-- honoring `swapped` for the little/big-endian incl_len, then reads incl_len
+-- captured bytes. Returns nil at clean EOF, on a truncated record header, or
+-- when incl_len overruns the available bytes (snaplen-cut tail / pipe close) —
+-- never raises.
+function M.read_record(read_fn, swapped)
+  local rec = read_exact(read_fn, 16)
+  if not rec then return nil end
+  local function u32(off)
+    local a, b, c, d = rec:byte(off, off + 3)
+    if swapped then a, b, c, d = d, c, b, a end
+    return ((a * 256 + b) * 256 + c) * 256 + d
+  end
+  local incl_len = u32(9)
+  local data = read_exact(read_fn, incl_len)
+  if not data then return nil end
+  return { data = data }
+end
+
+-- iter_pcap(read_fn) → function() → packet bytes | nil
+--
+-- Consumes the global header once, then returns an iterator that yields each
+-- record's captured packet bytes in turn and nil at EOF (or on a truncated
+-- trailing record, which terminates the iteration cleanly). If the global
+-- header is absent/short the iterator yields nothing — the sidecar treats a
+-- nil header as "tcpdump produced no pcap stream" and exits. Usable directly in
+-- a `for pkt in sni.iter_pcap(read_fn) do ... end` loop.
+function M.iter_pcap(read_fn)
+  local gh = M.read_global_header(read_fn)
+  return function()
+    if not gh then return nil end
+    local rec = M.read_record(read_fn, gh.swapped)
+    if not rec then return nil end
+    return rec.data
+  end
 end
 
 -- lan_device(cursor) → string   (#573 SHOULD-FIX #3)

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -142,7 +142,10 @@ function M.parse_client_hello(payload)
         if sn_off + sn_len > list_end then return nil end
         if name_type == 0x00 then -- host_name
           local sn = slice(payload, sn_off, sn_len)
-          if sn and sn ~= "" then return sn end
+          -- A real SNI is a domain; the shortest plausible one is "a.b" (3
+          -- chars). Anything shorter is malformed — reject it (the value is
+          -- only ever used as a cache key, but we don't want junk keys).
+          if sn and #sn >= 3 then return sn end
           return nil
         end
         list_off = sn_off + sn_len
@@ -167,43 +170,59 @@ local function format_mac(a, b, c, d, e, f)
   return string.format("%02x:%02x:%02x:%02x:%02x:%02x", a, b, c, d, e, f)
 end
 
--- parse_packet(eth_frame) → { dst_ip, src_mac, sni } | nil
+-- parse_packet(eth_frame) → { dst_ip, src_mac, sni } | nil, reason
+--
+-- On failure returns (nil, reason) where reason is a bounded enum the sidecar
+-- folds into a result= counter (see SHOULD-FIX #4/#7 — split the lumped
+-- no_sni_total):
+--   "truncated"    — frame too short to hold Ethernet+IPv4+TCP, or the TLS
+--                    record/handshake length runs past the captured bytes
+--                    (the common snaplen-cut case).
+--   "ipv6_skipped" — non-IPv4 ethertype (v1 is IPv4-only; counts the dual-
+--                    stack traffic we're missing).
+--   "not_tcp"      — IPv4 but not TCP (shouldn't happen given the BPF, but
+--                    bounded and cheap to distinguish).
+--   "malformed"    — structurally invalid IPv4/TCP framing.
+--   "no_sni"       — well-formed packet but the ClientHello carried no usable
+--                    host_name (no SNI extension, ECH, or a name we rejected).
 function M.parse_packet(eth_frame)
-  if type(eth_frame) ~= "string" or #eth_frame < 14 + 20 + 20 then return nil end
+  if type(eth_frame) ~= "string" or #eth_frame < 14 + 20 + 20 then
+    return nil, "truncated"
+  end
 
   -- Ethernet header: dst (6), src (6), ethertype (2)
   local ethertype = u16(eth_frame, 13)
-  if ethertype ~= 0x0800 then return nil end -- IPv4 only in v1
+  if ethertype ~= 0x0800 then return nil, "ipv6_skipped" end -- IPv4 only in v1
   local sa, sb, sc, sd, se, sf = eth_frame:byte(7, 12)
   local src_mac = format_mac(sa, sb, sc, sd, se, sf)
 
   -- IPv4 header
   local ip_off = 15 -- 1-based, after 14-byte Ethernet
   local ver_ihl = u8(eth_frame, ip_off)
-  if not ver_ihl then return nil end
-  if math.floor(ver_ihl / 16) ~= 4 then return nil end
+  if not ver_ihl then return nil, "malformed" end
+  if math.floor(ver_ihl / 16) ~= 4 then return nil, "malformed" end
   local ihl = (ver_ihl % 16) * 4
-  if ihl < 20 then return nil end
-  if ip_off + ihl - 1 > #eth_frame then return nil end
+  if ihl < 20 then return nil, "malformed" end
+  if ip_off + ihl - 1 > #eth_frame then return nil, "truncated" end
   local proto = u8(eth_frame, ip_off + 9)
-  if proto ~= 6 then return nil end -- TCP only
+  if proto ~= 6 then return nil, "not_tcp" end -- TCP only
   local da, db, dc, dd = eth_frame:byte(ip_off + 16, ip_off + 19)
-  if not da then return nil end
+  if not da then return nil, "malformed" end
   local dst_ip = string.format("%d.%d.%d.%d", da, db, dc, dd)
 
   -- TCP header
   local tcp_off = ip_off + ihl
-  if tcp_off + 20 - 1 > #eth_frame then return nil end
+  if tcp_off + 20 - 1 > #eth_frame then return nil, "truncated" end
   local data_off_byte = u8(eth_frame, tcp_off + 12)
-  if not data_off_byte then return nil end
+  if not data_off_byte then return nil, "malformed" end
   local data_off = math.floor(data_off_byte / 16) * 4
-  if data_off < 20 then return nil end
+  if data_off < 20 then return nil, "malformed" end
   local payload_off = tcp_off + data_off
-  if payload_off > #eth_frame then return nil end
+  if payload_off > #eth_frame then return nil, "truncated" end
   local payload = eth_frame:sub(payload_off)
 
   local sni = M.parse_client_hello(payload)
-  if not sni then return nil end
+  if not sni then return nil, "no_sni" end
   return { dst_ip = dst_ip, src_mac = src_mac, sni = sni }
 end
 
@@ -226,6 +245,52 @@ function M.parse_sni_line(line)
   local ip, mac, sn = line:match("^SNI\t(%S+)\t(%S+)\t(%S+)%s*$")
   if not ip then return nil end
   return { dst_ip = ip, src_mac = mac, sni = sn }
+end
+
+-- route_line(line, deps) → handled (boolean)   (#573 SHOULD-FIX #1)
+--
+-- The wifihaven-dns-tail sidecar tails the dnsmasq query log AND the SNI
+-- capture spool together (`tail -F dnsmasq.log sni.log`). This is the single
+-- routing decision for each line, extracted from the sidecar's main loop so it
+-- can be unit-tested in isolation:
+--
+--   * `tail -F` emits a "==> <file> <==" banner whenever it switches between
+--     the two followed files — those are not dnsmasq lines and must never
+--     reach the dnsmasq parsers, so they are consumed (handled = true) without
+--     any side effect.
+--   * "SNI\t<ip>\t<mac>\t<host>" rows from sni-tail are routed to the injected
+--     insert_fn (cache.insert_sni), which is the SAME shared dns_cache writer
+--     primitive DNS replies use — so dns-tail stays the sole writer of
+--     paths.dns_cache (single-writer invariant preserved).
+--   * Everything else (dnsmasq reply/query lines) returns handled = false so
+--     the caller's existing dnsmasq handlers run.
+--
+-- deps.insert_fn(ip, host) is required; the routing is otherwise pure, so the
+-- function never touches the cache, the spool, or flush bookkeeping itself.
+function M.route_line(line, deps)
+  if type(line) ~= "string" or line == "" then return false end
+  if line:sub(1, 4) == "==> " then return true end -- tail -F switch banner
+  local sn = M.parse_sni_line(line)
+  if not sn then return false end                   -- dnsmasq line: fall through
+  deps.insert_fn(sn.dst_ip, sn.sni)
+  return true
+end
+
+-- lan_device(cursor) → string   (#573 SHOULD-FIX #3)
+--
+-- Probe the LAN bridge name from UCI (network.lan.device) so the sidecar
+-- captures off the actual bridge instead of a hardcoded br-lan — routers using
+-- a custom bridge name (br0, multi-WAN configs) otherwise produce no SNI rows
+-- silently. Falls back to "br-lan" when the option (or the cursor) is absent.
+-- The cursor is injected so this is unit-testable without a live UCI.
+function M.lan_device(cursor)
+  if cursor then
+    local ok, dev = pcall(function()
+      return cursor:get("network", "lan", "device")
+    end)
+    if ok and dev and dev ~= "" then return dev end
+  end
+  return "br-lan"
 end
 
 return M

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -1,0 +1,231 @@
+-- sni.lua — TLS ClientHello SNI parser + Ethernet/IPv4/TCP framing helper.
+--
+-- The wifihaven-sni-tail sidecar captures the first packet of every outbound
+-- TCP/443 flow off the LAN bridge and parses the TLS ClientHello to extract
+-- the SNI server_name (#573). This recovers the hostname an app actually
+-- contacted even when the client used DoH/DoT to resolve the name (so dnsmasq
+-- never saw the query) or hard-coded the IP. The resulting (dst_ip, sni) pair
+-- is fed back into the same dns_log cache the agent already reads for flow
+-- attribution, so downstream eb_/ea_/bl_ matching, event labeling, and
+-- conntrack-event fqdn emission all flow through unchanged.
+--
+-- v1 scope (#573):
+--   - TLS 1.2 and TLS 1.3 ClientHello, single TCP segment (BPF snaplen=600).
+--   - Single Ethernet+IPv4+TCP packet (no IPv4 options, no VLAN tag, no IPv6).
+--   - server_name extension type 0x0000, name_type 0x00 (host_name).
+--
+-- Explicitly out of scope (followups, see #573 PR body):
+--   - Encrypted ClientHello (ECH) — parser returns nil.
+--   - QUIC / HTTP/3 Initial-packet SNI parsing.
+--   - TLS 1.2 fragmented ClientHello reassembly across TCP segments.
+--   - IPv6 outer header (followup; first-pass keeps the byte-walk simple).
+--
+-- Public API:
+--   sni.parse_client_hello(payload)   → server_name string | nil
+--   sni.parse_packet(eth_frame_bytes) → { dst_ip, src_mac, sni } | nil
+--   sni.format_sni_line(ip, mac, sni) → "SNI\t<ip>\t<mac>\t<sni>\n"
+--   sni.parse_sni_line(line)          → { dst_ip, src_mac, sni } | nil
+--
+-- Defensive style: every length field is checked against the remaining
+-- payload before being trusted. A malformed record returns nil; it never
+-- raises a Lua error (the sidecar must keep running through any payload).
+
+local M = {}
+
+-- ---------------------------------------------------------------------------
+-- Byte helpers — Lua 5.1-safe (no string.unpack).
+-- ---------------------------------------------------------------------------
+
+local function u8(buf, off)
+  if off < 1 or off > #buf then return nil end
+  return buf:byte(off)
+end
+
+local function u16(buf, off)
+  if off < 1 or off + 1 > #buf then return nil end
+  local a, b = buf:byte(off, off + 1)
+  return a * 256 + b
+end
+
+local function u24(buf, off)
+  if off < 1 or off + 2 > #buf then return nil end
+  local a, b, c = buf:byte(off, off + 2)
+  return a * 65536 + b * 256 + c
+end
+
+-- Bounds-checked substring: returns nil if [off, off+len-1] is out of range.
+local function slice(buf, off, len)
+  if off < 1 or len < 0 or (off + len - 1) > #buf then return nil end
+  return buf:sub(off, off + len - 1)
+end
+
+-- ---------------------------------------------------------------------------
+-- TLS ClientHello parser.
+-- ---------------------------------------------------------------------------
+
+-- parse_client_hello(payload) → server_name string | nil
+--
+-- payload is the raw bytes of the TCP segment starting at the TLS record.
+-- Returns the server_name from the SNI extension when present, or nil for
+-- any of: non-handshake content type, non-ClientHello handshake, no SNI
+-- extension, malformed/truncated record, name_type != host_name (0x00).
+function M.parse_client_hello(payload)
+  if type(payload) ~= "string" or #payload < 5 then return nil end
+
+  -- TLS record header
+  local content_type = u8(payload, 1)
+  if content_type ~= 0x16 then return nil end -- not handshake
+  local record_len = u16(payload, 4)
+  if not record_len then return nil end
+  if 5 + record_len > #payload + 1 then return nil end -- truncated record
+
+  -- Handshake header (inside the record)
+  local hs_type = u8(payload, 6)
+  if hs_type ~= 0x01 then return nil end -- not ClientHello
+  local hs_len = u24(payload, 7)
+  if not hs_len then return nil end
+  if 10 + hs_len > #payload + 1 then return nil end -- truncated handshake
+
+  -- ClientHello body starts at offset 10
+  local off = 10
+  local end_off = 10 + hs_len -- one past last byte of body
+
+  -- legacy_version (2) + random (32) = 34 bytes
+  off = off + 34
+  if off > end_off then return nil end
+
+  -- legacy_session_id: u8 length + bytes
+  local sid_len = u8(payload, off); if not sid_len then return nil end
+  off = off + 1 + sid_len
+  if off > end_off then return nil end
+
+  -- cipher_suites: u16 length + bytes
+  local cs_len = u16(payload, off); if not cs_len then return nil end
+  off = off + 2 + cs_len
+  if off > end_off then return nil end
+
+  -- compression_methods: u8 length + bytes
+  local cm_len = u8(payload, off); if not cm_len then return nil end
+  off = off + 1 + cm_len
+  if off > end_off then return nil end
+
+  -- extensions: u16 total length + extension records
+  local ext_total = u16(payload, off); if not ext_total then return nil end
+  off = off + 2
+  local ext_end = off + ext_total
+  if ext_end > end_off then return nil end
+
+  -- Walk extension records
+  while off + 4 <= ext_end do
+    local ext_type = u16(payload, off);     if not ext_type then return nil end
+    local ext_len  = u16(payload, off + 2); if not ext_len  then return nil end
+    local ext_body_off = off + 4
+    local ext_body_end = ext_body_off + ext_len
+    if ext_body_end > ext_end then return nil end
+
+    if ext_type == 0x0000 then -- server_name
+      -- ServerNameList: u16 list length + entries
+      if ext_body_off + 2 > ext_body_end then return nil end
+      local sn_list_len = u16(payload, ext_body_off)
+      if not sn_list_len then return nil end
+      local list_off = ext_body_off + 2
+      local list_end = list_off + sn_list_len
+      if list_end > ext_body_end then return nil end
+
+      -- First entry only — RFC 6066 §3 says list MAY contain multiple but
+      -- in practice it's always one host_name. We'll take the first
+      -- host_name entry we find.
+      while list_off + 3 <= list_end do
+        local name_type = u8(payload, list_off);     if not name_type then return nil end
+        local sn_len    = u16(payload, list_off + 1); if not sn_len    then return nil end
+        local sn_off    = list_off + 3
+        if sn_off + sn_len > list_end then return nil end
+        if name_type == 0x00 then -- host_name
+          local sn = slice(payload, sn_off, sn_len)
+          if sn and sn ~= "" then return sn end
+          return nil
+        end
+        list_off = sn_off + sn_len
+      end
+      return nil -- SNI extension present but no host_name entry
+    end
+
+    off = ext_body_end
+  end
+
+  return nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Ethernet / IPv4 / TCP framing.
+--
+-- v1 handles untagged IPv4 over Ethernet, no VLAN, no IP options beyond the
+-- standard 20-byte header (we honor IHL though). IPv6 is a followup.
+-- ---------------------------------------------------------------------------
+
+local function format_mac(a, b, c, d, e, f)
+  return string.format("%02x:%02x:%02x:%02x:%02x:%02x", a, b, c, d, e, f)
+end
+
+-- parse_packet(eth_frame) → { dst_ip, src_mac, sni } | nil
+function M.parse_packet(eth_frame)
+  if type(eth_frame) ~= "string" or #eth_frame < 14 + 20 + 20 then return nil end
+
+  -- Ethernet header: dst (6), src (6), ethertype (2)
+  local ethertype = u16(eth_frame, 13)
+  if ethertype ~= 0x0800 then return nil end -- IPv4 only in v1
+  local sa, sb, sc, sd, se, sf = eth_frame:byte(7, 12)
+  local src_mac = format_mac(sa, sb, sc, sd, se, sf)
+
+  -- IPv4 header
+  local ip_off = 15 -- 1-based, after 14-byte Ethernet
+  local ver_ihl = u8(eth_frame, ip_off)
+  if not ver_ihl then return nil end
+  if math.floor(ver_ihl / 16) ~= 4 then return nil end
+  local ihl = (ver_ihl % 16) * 4
+  if ihl < 20 then return nil end
+  if ip_off + ihl - 1 > #eth_frame then return nil end
+  local proto = u8(eth_frame, ip_off + 9)
+  if proto ~= 6 then return nil end -- TCP only
+  local da, db, dc, dd = eth_frame:byte(ip_off + 16, ip_off + 19)
+  if not da then return nil end
+  local dst_ip = string.format("%d.%d.%d.%d", da, db, dc, dd)
+
+  -- TCP header
+  local tcp_off = ip_off + ihl
+  if tcp_off + 20 - 1 > #eth_frame then return nil end
+  local data_off_byte = u8(eth_frame, tcp_off + 12)
+  if not data_off_byte then return nil end
+  local data_off = math.floor(data_off_byte / 16) * 4
+  if data_off < 20 then return nil end
+  local payload_off = tcp_off + data_off
+  if payload_off > #eth_frame then return nil end
+  local payload = eth_frame:sub(payload_off)
+
+  local sni = M.parse_client_hello(payload)
+  if not sni then return nil end
+  return { dst_ip = dst_ip, src_mac = src_mac, sni = sni }
+end
+
+-- ---------------------------------------------------------------------------
+-- IPC line format between wifihaven-sni-tail and wifihaven-dns-tail.
+--
+-- The two sidecars share the existing dns_cache writer (dns-tail), so SNI
+-- captures must reach dns-tail as a line stream. sni-tail appends one TSV row
+-- per ClientHello to /tmp/wifihaven-sni.log; dns-tail tails it alongside the
+-- dnsmasq log and routes rows by the "SNI\t" prefix.
+-- ---------------------------------------------------------------------------
+
+function M.format_sni_line(dst_ip, src_mac, server_name)
+  return string.format("SNI\t%s\t%s\t%s\n",
+                       dst_ip or "", src_mac or "", server_name or "")
+end
+
+function M.parse_sni_line(line)
+  if type(line) ~= "string" or line == "" then return nil end
+  local ip, mac, sn = line:match("^SNI\t(%S+)\t(%S+)\t(%S+)%s*$")
+  if not ip then return nil end
+  return { dst_ip = ip, src_mac = mac, sni = sn }
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -180,6 +180,23 @@ local function fold_dns_queries()
                         by_result, dns_results_baseline)
 end
 
+-- #573: SNI ClientHello result counters. The wifihaven-sni-tail sidecar writes
+-- a cumulative per-result tally (same <result>\t<count> format as dns_metrics)
+-- to paths.sni_metrics; sample + fold the deltas into
+-- sni_clienthellos_total{result}. result ∈ {parsed, truncated, no_sni,
+-- ipv6_skipped, not_tcp, malformed}. A sidecar restart re-bases from 0, which
+-- fold_external treats as a reset.
+local sni_results_baseline = {}
+local function fold_sni_metrics()
+  local f = io.open(paths.sni_metrics, "r")
+  if not f then return end
+  local text = f:read("*a") or ""
+  f:close()
+  local by_result = dns_log.parse_query_results(text)
+  metrics.fold_external(mreg, "sni_clienthellos_total", "result",
+                        by_result, sni_results_baseline)
+end
+
 -- activity_sample_int should evenly divide usage_report_interval, or the last
 -- partial bucket at report flush time is shorter than the others. Warn and
 -- continue — a misconfig here degrades activeSeconds accuracy slightly but
@@ -852,6 +869,7 @@ conntrack.watch({
       -- before the push so the batch carries their latest deltas.
       fold_enforcement_drops()
       fold_dns_queries()
+      fold_sni_metrics()  -- #573
       local sampled_at = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
       metrics.post(api_url, router_token, mreg, sampled_at, http_post, log)
     end

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -267,18 +267,20 @@ local dns_results      = {}
 
 local sni_inserts = 0
 
--- handle_sni_line(line) → true iff `line` was an SNI capture line from the
--- wifihaven-sni-tail sidecar and was routed into cache.insert_sni. Returns
--- false for dnsmasq log lines (those flow through the existing handlers
--- below). Also returns true for `tail -F` switch banners ("==> file <=="),
--- which are not dnsmasq lines and must not reach the dnsmasq parsers.
-local function handle_sni_or_skip(line)
-  if line:sub(1, 4) == "==> " then return true end
-  local sn = sni.parse_sni_line(line)
-  if not sn then return false end
-  cache.insert_sni(sn.dst_ip, sn.sni)
-  sni_inserts = sni_inserts + 1
-  return true
+-- #573: SNI capture lines from the wifihaven-sni-tail sidecar are tailed in the
+-- same `tail -F` stream as the dnsmasq log. sni.route_line is the single
+-- routing decision (extracted + unit-tested in sni_spec.lua): it consumes
+-- "SNI\t..." lines into cache.insert_sni (the SAME shared dns_cache writer DNS
+-- replies use, so dns-tail stays the sole writer) and `tail -F` "==> file <=="
+-- switch banners, returning true; dnsmasq lines return false and fall through
+-- to the parsers/populators below.
+local function route_sni(line)
+  return sni.route_line(line, {
+    insert_fn = function(ip, host)
+      cache.insert_sni(ip, host)
+      sni_inserts = sni_inserts + 1
+    end,
+  })
 end
 
 while true do
@@ -288,10 +290,7 @@ while true do
     break
   end
 
-  -- #573: SNI lines from the wifihaven-sni-tail sidecar land in the same
-  -- shared dns_cache as dnsmasq replies. Route them first, then short-circuit
-  -- past the dnsmasq-log parsers / populators below.
-  if handle_sni_or_skip(line) then
+  if route_sni(line) then
     -- Update the shared flush bookkeeping so the next tick still writes the
     -- cache file even on a long stretch of SNI-only traffic.
     since_flush      = since_flush + 1
@@ -305,82 +304,82 @@ while true do
       last_tick   = now
     end
   else
-  cache.ingest_line(line)
-  since_flush      = since_flush + 1
-  lines_ingested   = lines_ingested + 1
-  lines_since_stat = lines_since_stat + 1
+    cache.ingest_line(line)
+    since_flush      = since_flush + 1
+    lines_ingested   = lines_ingested + 1
+    lines_since_stat = lines_since_stat + 1
 
-  -- #1302: classify this line's DNS outcome (resolved / nxdomain / servfail /
-  -- refused / nodata) and bump the cumulative tally. nil for query lines and
-  -- non-terminal CNAME hops.
-  local dns_result = dns_log.classify_query_result(line)
-  if dns_result then
-    dns_results[dns_result] = (dns_results[dns_result] or 0) + 1
-  end
+    -- #1302: classify this line's DNS outcome (resolved / nxdomain / servfail /
+    -- refused / nodata) and bump the cumulative tally. nil for query lines and
+    -- non-terminal CNAME hops.
+    local dns_result = dns_log.classify_query_result(line)
+    if dns_result then
+      dns_results[dns_result] = (dns_results[dns_result] or 0) + 1
+    end
 
-  local now = os.time()
+    local now = os.time()
 
-  -- #505: populate per-MAC blockIpOnly resolved sets in lockstep with the
-  -- hostname cache. This must be inline (not batched) for the same reason
-  -- as the hostname flush: conntrack -E NEW lands milliseconds after the
-  -- dnsmasq reply, and any delay here means the first packet of a newly
-  -- resolved flow hits an empty set and gets dropped (#472 / blockIpOnly
-  -- defeats user-visible connectivity).
-  maybe_populate_bio(line, now)
+    -- #505: populate per-MAC blockIpOnly resolved sets in lockstep with the
+    -- hostname cache. This must be inline (not batched) for the same reason
+    -- as the hostname flush: conntrack -E NEW lands milliseconds after the
+    -- dnsmasq reply, and any delay here means the first packet of a newly
+    -- resolved flow hits an empty set and gets dropped (#472 / blockIpOnly
+    -- defeats user-visible connectivity).
+    maybe_populate_bio(line, now)
 
-  -- #515: same lockstep argument as bio — the per-host extraBlocked drop
-  -- rule fires on the first packet of the flow, so any delay between the
-  -- dnsmasq reply and the eb_<sanhost> element add lets the first SYN
-  -- through.
-  maybe_populate_eb(line)
+    -- #515: same lockstep argument as bio — the per-host extraBlocked drop
+    -- rule fires on the first packet of the flow, so any delay between the
+    -- dnsmasq reply and the eb_<sanhost> element add lets the first SYN
+    -- through.
+    maybe_populate_eb(line)
 
-  -- #1346: per-(MAC, host) extraAllowed carve-out, same first-SYN-race
-  -- argument — if the resolved IP isn't in the ea_<mac>_<host> set before the
-  -- flow's first packet, a whole-MAC block drops an explicitly-allowed app.
-  maybe_populate_ea(line)
+    -- #1346: per-(MAC, host) extraAllowed carve-out, same first-SYN-race
+    -- argument — if the resolved IP isn't in the ea_<mac>_<host> set before the
+    -- flow's first packet, a whole-MAC block drops an explicitly-allowed app.
+    maybe_populate_ea(line)
 
-  -- #1348: same lockstep argument — close the category-blocklist bypass for
-  -- directly-queried CNAME targets by adding the resolved IP to the member's
-  -- bl_ set when the answered name attributes (via the alias map) to a member.
-  maybe_populate_bl(line)
+    -- #1348: same lockstep argument — close the category-blocklist bypass for
+    -- directly-queried CNAME targets by adding the resolved IP to the member's
+    -- bl_ set when the answered name attributes (via the alias map) to a member.
+    maybe_populate_bl(line)
 
-  if since_flush >= flush_every or (now - last_tick) >= 30 then
-    cache.tick(now)
-    atomic_write(cache_path, cache.dump_text())
-    -- #1302: publish the cumulative query-result tally alongside the cache so
-    -- the agent's next metrics tick can fold the deltas.
-    atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))
-    log.debug("dns-tail: flushed cache size=%d", cache.size())
-    since_flush = 0
-    last_tick   = now
-  end
+    if since_flush >= flush_every or (now - last_tick) >= 30 then
+      cache.tick(now)
+      atomic_write(cache_path, cache.dump_text())
+      -- #1302: publish the cumulative query-result tally alongside the cache so
+      -- the agent's next metrics tick can fold the deltas.
+      atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))
+      log.debug("dns-tail: flushed cache size=%d", cache.size())
+      since_flush = 0
+      last_tick   = now
+    end
 
-  -- Refresh per-MAC blockIpOnly state (lease table + which sets exist).
-  -- We do this on the tail loop rather than a timer so we don't need
-  -- non-blocking IO; periodic policy changes from the agent + DHCP renewals
-  -- are slow relative to log line throughput.
-  if (now - last_lease_refresh) >= lease_refresh_seconds then
-    ip_to_mac = refresh_ip_to_mac()
-    last_lease_refresh = now
-  end
-  if (now - last_bio_refresh) >= bio_refresh_seconds then
-    nft_sets = refresh_nft_sets()
-    bl_member_index = refresh_bl_member_index()  -- #1348
-    last_bio_refresh = now
-  end
+    -- Refresh per-MAC blockIpOnly state (lease table + which sets exist).
+    -- We do this on the tail loop rather than a timer so we don't need
+    -- non-blocking IO; periodic policy changes from the agent + DHCP renewals
+    -- are slow relative to log line throughput.
+    if (now - last_lease_refresh) >= lease_refresh_seconds then
+      ip_to_mac = refresh_ip_to_mac()
+      last_lease_refresh = now
+    end
+    if (now - last_bio_refresh) >= bio_refresh_seconds then
+      nft_sets = refresh_nft_sets()
+      bl_member_index = refresh_bl_member_index()  -- #1348
+      last_bio_refresh = now
+    end
 
-  -- One-line info heartbeat so silent failures (dnsmasq not logging, tail
-  -- dropping the pipe, regex never matching) are diagnosable from logread
-  -- alone without on-VM access (#480).
-  if (now - last_stats_log) >= 60 then
-    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d bl_adds=%d sni_inserts=%d",
-             lines_ingested, lines_since_stat, now - last_stats_log,
-             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total,
-             bl_adds_total, sni_inserts)
-    last_stats_log   = now
-    lines_since_stat = 0
-  end
-  end -- else branch of handle_sni_or_skip
+    -- One-line info heartbeat so silent failures (dnsmasq not logging, tail
+    -- dropping the pipe, regex never matching) are diagnosable from logread
+    -- alone without on-VM access (#480).
+    if (now - last_stats_log) >= 60 then
+      log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d bl_adds=%d sni_inserts=%d",
+               lines_ingested, lines_since_stat, now - last_stats_log,
+               cache.size(), bio_adds_total, eb_adds_total, ea_adds_total,
+               bl_adds_total, sni_inserts)
+      last_stats_log   = now
+      lines_since_stat = 0
+    end
+  end -- else branch of route_sni
 end
 
 handle:close()

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -12,6 +12,7 @@ local dns_sets  = require("wifihaven.dns_tail_sets")
 local conntrack = require("wifihaven.conntrack")
 local log       = require("wifihaven.log")
 local paths     = require("wifihaven.paths")
+local sni       = require("wifihaven.sni")
 
 local cursor = uci.cursor()
 local function uci_get(opt, default)
@@ -52,10 +53,20 @@ local cache = dns_log.new({ ttl_seconds = 3600 })
 
 -- tail -F follows the log across rotations (dnsmasq SIGHUP, file replaced).
 -- -n 0 skips replay of the historical log so we don't burn CPU at boot.
+--
+-- #573: also tail the SNI capture spool the wifihaven-sni-tail sidecar writes,
+-- so SNI-derived hostname attributions land in the SAME shared dns_cache as
+-- DNS-derived attributions. Using `tail -F a b` produces "==> file <==" header
+-- lines on switches that we filter out below; the SNI lines are themselves
+-- "SNI\t..." prefixed so a routing match on the line content suffices. busybox
+-- tail -F handles multiple files. We `touch` the SNI spool first so tail does
+-- not warn when sni-tail hasn't created it yet.
+os.execute(string.format("touch %q 2>/dev/null", paths.sni_capture))
 local handle = io.popen(string.format(
-  "tail -n 0 -F %q 2>/dev/null", source_path), "r")
+  "tail -n 0 -F %q %q 2>/dev/null", source_path, paths.sni_capture), "r")
 if not handle then
-  log.err("dns-tail: cannot start tail on %s", source_path)
+  log.err("dns-tail: cannot start tail on %s, %s",
+          source_path, paths.sni_capture)
   os.exit(1)
 end
 
@@ -254,12 +265,46 @@ local lines_since_stat = 0
 -- without double-counting.
 local dns_results      = {}
 
+local sni_inserts = 0
+
+-- handle_sni_line(line) → true iff `line` was an SNI capture line from the
+-- wifihaven-sni-tail sidecar and was routed into cache.insert_sni. Returns
+-- false for dnsmasq log lines (those flow through the existing handlers
+-- below). Also returns true for `tail -F` switch banners ("==> file <=="),
+-- which are not dnsmasq lines and must not reach the dnsmasq parsers.
+local function handle_sni_or_skip(line)
+  if line:sub(1, 4) == "==> " then return true end
+  local sn = sni.parse_sni_line(line)
+  if not sn then return false end
+  cache.insert_sni(sn.dst_ip, sn.sni)
+  sni_inserts = sni_inserts + 1
+  return true
+end
+
 while true do
   local line = handle:read("*l")
   if not line then
     log.warn("dns-tail: tail pipe closed; exiting (procd will respawn)")
     break
   end
+
+  -- #573: SNI lines from the wifihaven-sni-tail sidecar land in the same
+  -- shared dns_cache as dnsmasq replies. Route them first, then short-circuit
+  -- past the dnsmasq-log parsers / populators below.
+  if handle_sni_or_skip(line) then
+    -- Update the shared flush bookkeeping so the next tick still writes the
+    -- cache file even on a long stretch of SNI-only traffic.
+    since_flush      = since_flush + 1
+    lines_since_stat = lines_since_stat + 1
+    local now = os.time()
+    if since_flush >= flush_every or (now - last_tick) >= 30 then
+      cache.tick(now)
+      atomic_write(cache_path, cache.dump_text())
+      atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))
+      since_flush = 0
+      last_tick   = now
+    end
+  else
   cache.ingest_line(line)
   since_flush      = since_flush + 1
   lines_ingested   = lines_ingested + 1
@@ -328,12 +373,14 @@ while true do
   -- dropping the pipe, regex never matching) are diagnosable from logread
   -- alone without on-VM access (#480).
   if (now - last_stats_log) >= 60 then
-    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d bl_adds=%d",
+    log.info("dns-tail: ingested=%d (+%d in last %ds) cache_size=%d bio_adds=%d eb_adds=%d ea_adds=%d bl_adds=%d sni_inserts=%d",
              lines_ingested, lines_since_stat, now - last_stats_log,
-             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total, bl_adds_total)
+             cache.size(), bio_adds_total, eb_adds_total, ea_adds_total,
+             bl_adds_total, sni_inserts)
     last_stats_log   = now
     lines_since_stat = 0
   end
+  end -- else branch of handle_sni_or_skip
 end
 
 handle:close()

--- a/openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log
+++ b/openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log
@@ -1,36 +1,42 @@
 #!/bin/sh
-# wifihaven-rotate-dnsmasq-log — cap /tmp/wifihaven-dnsmasq.log at 20 MB.
+# wifihaven-rotate-dnsmasq-log — cap the agent's tmpfs spool files at 20 MB.
 #
-# Run from cron every 10 minutes. When the log exceeds MAX_BYTES, it is
-# rotated in place: the previous rotation is discarded, the current file is
-# copied to *.1, and the original is truncated to zero.
+# Run from cron every 10 minutes. For each spooled log, when it exceeds
+# MAX_BYTES it is rotated in place: the previous rotation is discarded, the
+# current file is copied to *.1, and the original is truncated to zero.
+#
+# Files rotated:
+#   /tmp/wifihaven-dnsmasq.log  — dnsmasq query log (the writer is dnsmasq).
+#   /tmp/wifihaven-sni.log      — SNI capture spool (#573; writer is
+#                                 wifihaven-sni-tail, follower is dns-tail).
 #
 # Truncating the original (rather than renaming it) is the "copytruncate"
-# pattern. dnsmasq holds the log fd open for the lifetime of the process and
-# does not reopen it on SIGHUP when logfacility is a file path — so a rename
-# would leave dnsmasq writing to an invisible, unrotated inode. Truncating
-# leaves dnsmasq on the same inode; it continues writing from offset 0.
+# pattern. dnsmasq / sni-tail hold the log fd open for the lifetime of the
+# process and do not reopen it — so a rename would leave the writer writing to
+# an invisible, unrotated inode. Truncating leaves the writer on the same
+# inode; it continues writing from offset 0.
 #
 # wifihaven-dns-tail runs `tail -n 0 -F` (follow by name). BusyBox tail -F
 # polls the file by name and detects the truncation within its next stat
 # interval; it reseeks to the beginning and resumes from there. Lines written
-# by dnsmasq between the copy and the truncate are present in *.1 and will be
-# missed by the tailer — this is acceptable and bounded: at 10-minute cron
-# cadence, the window is tiny and the tailer's hostname cache fills back up
-# within seconds of the next resolved query.
+# between the copy and the truncate are present in *.1 and will be missed by
+# the tailer — this is acceptable and bounded: at 10-minute cron cadence, the
+# window is tiny and the tailer's hostname cache fills back up within seconds.
 
 set -eu
 
-LOG=/tmp/wifihaven-dnsmasq.log
-LOG_PREV="${LOG}.1"
 # 20 MB in bytes — two rotations consume at most ~40 MB + the live file's
-# headroom before the next rotation, so worst-case /tmp usage is ~60 MB.
+# headroom before the next rotation, so worst-case /tmp usage is ~60 MB/file.
 MAX_BYTES=20971520
 
-[ -f "$LOG" ] || exit 0
+rotate_if_big() {
+  log="$1"
+  [ -f "$log" ] || return 0
+  size=$(wc -c < "$log" 2>/dev/null) || return 0
+  [ "$size" -ge "$MAX_BYTES" ] || return 0
+  cp -f "$log" "${log}.1"
+  : > "$log"
+}
 
-size=$(wc -c < "$LOG" 2>/dev/null) || exit 0
-[ "$size" -ge "$MAX_BYTES" ] || exit 0
-
-cp -f "$LOG" "$LOG_PREV"
-: > "$LOG"
+rotate_if_big /tmp/wifihaven-dnsmasq.log
+rotate_if_big /tmp/wifihaven-sni.log

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -64,9 +64,11 @@ log.info("sni-tail: starting iface=%s snaplen=%d spool=%s",
 
 -- ---------------------------------------------------------------------------
 -- pcap stream reader. tcpdump -w - emits a global pcap file header (24 bytes)
--- followed by record headers (16 bytes) + captured packet bytes. We read the
--- stream as a byte buffer, peel records off the front, and feed each captured
--- packet to sni.parse_packet.
+-- followed by record headers (16 bytes) + captured packet bytes. The framing
+-- logic lives in sni.lua (sni.read_global_header / sni.read_record /
+-- sni.iter_pcap) so it is exercised by the unit + integration suite; this
+-- sidecar is a thin driver that backs the reader's read_fn with the io.popen
+-- handle and feeds each captured packet to sni.parse_packet.
 -- ---------------------------------------------------------------------------
 
 local h = io.popen(CAPTURE_CMD, "r")
@@ -75,43 +77,16 @@ if not h then
   os.exit(1)
 end
 
-local function read_n(handle, n)
-  local out = {}
-  local got = 0
-  while got < n do
-    local chunk = handle:read(n - got)
-    if not chunk or #chunk == 0 then return nil end
-    out[#out + 1] = chunk
-    got = got + #chunk
-  end
-  return table.concat(out)
+-- read_fn(n) → up to n bytes from the tcpdump pipe, nil at EOF. The pcap reader
+-- reassembles short reads into exact-length record/header reads internally.
+local function read_fn(n)
+  return h:read(n)
 end
 
--- Global pcap header: magic (4), version_major (2), version_minor (2),
--- thiszone (4), sigfigs (4), snaplen (4), network (4) = 24 bytes.
-local function read_global_header(handle)
-  local hdr = read_n(handle, 24)
-  if not hdr or #hdr < 4 then return nil end
-  -- magic byte order: 0xa1b2c3d4 (us) / 0xd4c3b2a1 (other endian) — we trust
-  -- the local tcpdump's byte order, so byte 1 distinguishes them.
-  local b1 = hdr:byte(1)
-  local swapped = (b1 == 0xd4)
-  return { swapped = swapped }
-end
-
--- Per-record header: ts_sec (4), ts_usec (4), incl_len (4), orig_len (4)
-local function read_record_header(handle, swapped)
-  local rec = read_n(handle, 16)
-  if not rec then return nil end
-  local function u32(off)
-    local a, b, c, d = rec:byte(off, off + 3)
-    if swapped then a, b, c, d = d, c, b, a end
-    return ((a * 256 + b) * 256 + c) * 256 + d
-  end
-  return { incl_len = u32(9) }
-end
-
-local gh = read_global_header(h)
+-- Consume the global header first so we can emit a clear diagnostic when
+-- tcpdump produced no pcap stream at all (the per-record loop below then reads
+-- successive packets against the detected byte order).
+local gh = sni.read_global_header(read_fn)
 if not gh then
   log.err("sni-tail: tcpdump produced no pcap stream on iface=%s — is the " ..
           "interface up and is the BPF filter accepted? (a wrong LAN bridge " ..
@@ -155,16 +130,12 @@ local function flush_metrics()
 end
 
 while true do
-  local rh = read_record_header(h, gh.swapped)
-  if not rh then
-    log.warn("sni-tail: pcap pipe closed; exiting (procd will respawn)")
+  local rec = sni.read_record(read_fn, gh.swapped)
+  if not rec then
+    log.warn("sni-tail: pcap pipe closed or short read; exiting (procd will respawn)")
     break
   end
-  local pkt = read_n(h, rh.incl_len)
-  if not pkt then
-    log.warn("sni-tail: short packet read (incl_len=%d); exiting", rh.incl_len)
-    break
-  end
+  local pkt = rec.data
 
   local r, reason = sni.parse_packet(pkt)
   if r then

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -6,11 +6,14 @@
 -- file alongside the dnsmasq query log and calls cache.insert_sni so the
 -- shared ip→hostname cache (paths.dns_cache) stays single-writer.
 --
--- This closes the DoH / hard-coded-IP attribution gap (#573): a client that
+-- This closes the DoH / hard-coded-IP ATTRIBUTION gap (#573): a client that
 -- bypasses the on-router DNS resolver still ends up with its destination IP
 -- mapped back to the branded hostname in the agent's flow-attribution cache,
--- so downstream eb_/ea_/bl_ matching, conntrack-event fqdn emission, and
--- (#1636/#1640) per-MAC drop-set populators all work transparently.
+-- so connection-event fqdn emission and cache.lookup-based labeling work even
+-- when dnsmasq never saw the query. It does NOT close the ENFORCEMENT gap: the
+-- eb_/ea_/bl_ nft drop-set populators fire only on dnsmasq `reply` lines, and
+-- SNI is seen after the flow's first packet — too late to populate a drop set
+-- for that flow. Enforcement on hard-coded-IP traffic remains blockIpOnly's job.
 --
 -- v1 scope:
 --   - Single-segment TLS 1.2 / TLS 1.3 ClientHello on TCP/443.
@@ -23,9 +26,11 @@
 -- that adds an external dependency. Output is raw pcap on stdout (-w -),
 -- parsed inline by sni.parse_packet, which accepts Ethernet/IPv4/TCP frames.
 
-local sni    = require("wifihaven.sni")
-local log    = require("wifihaven.log")
-local paths  = require("wifihaven.paths")
+local uci     = require("uci")
+local sni     = require("wifihaven.sni")
+local log     = require("wifihaven.log")
+local paths   = require("wifihaven.paths")
+local dns_log = require("wifihaven.dns_log")
 
 -- BPF filter: TCP to dst port 443, ACK set, PSH set, payload starts with the
 -- TLS handshake/ClientHello signature 0x16 ... 0x01. This restricts capture to
@@ -39,9 +44,10 @@ local BPF_FILTER = "tcp dst port 443 and " ..
   "(tcp[((tcp[12]&0xf0)>>2)] = 0x16) and " ..
   "(tcp[((tcp[12]&0xf0)>>2)+5] = 0x01)"
 
--- Capture interface defaults to br-lan, the standard LAN bridge on OpenWRT.
--- A future UCI toggle can override this; v1 hardcodes the convention.
-local IFACE       = "br-lan"
+-- Capture interface: probe the actual LAN bridge from UCI (network.lan.device)
+-- so routers using a non-default bridge name (br0, multi-WAN) still get
+-- captured; falls back to br-lan. (#573 SHOULD-FIX #3.)
+local IFACE       = sni.lan_device(uci.cursor())
 -- snaplen 600 covers the TLS record header (5) + handshake header (4) +
 -- ClientHello header (38) + a typical SNI extension well within the bound.
 -- Larger ClientHellos with long key_share / cipher lists may be truncated; the
@@ -107,7 +113,9 @@ end
 
 local gh = read_global_header(h)
 if not gh then
-  log.err("sni-tail: tcpdump produced no pcap stream — interface up? bpf accepted?")
+  log.err("sni-tail: tcpdump produced no pcap stream on iface=%s — is the " ..
+          "interface up and is the BPF filter accepted? (a wrong LAN bridge " ..
+          "name is the usual cause; set network.lan.device)", IFACE)
   os.exit(1)
 end
 
@@ -118,10 +126,33 @@ if not spool then
   os.exit(1)
 end
 
+-- #573: cumulative per-result tally. result ∈ {parsed, truncated, no_sni,
+-- ipv6_skipped, not_tcp, malformed} — a small bounded enum. We mirror the
+-- #1302 dns_metrics IPC: reuse dns_log.format_query_results to serialise the
+-- tally to paths.sni_metrics on each flush, and the agent's metrics tick folds
+-- the deltas into sni_clienthellos_total{result}. The split also feeds the
+-- periodic log line so a fleet-wide truncation/ipv6-skip rate is visible from
+-- logread alone (was lumped into a single no_sni_total — SHOULD-FIX #4/#7).
+local results           = {}
 local parsed_total      = 0
-local no_sni_total      = 0
-local last_stats_log    = os.time()
 local since_stat_parsed = 0
+local last_stats_log    = os.time()
+local last_metrics_flush = os.time()
+
+local function bump(result)
+  results[result] = (results[result] or 0) + 1
+end
+
+-- Atomic publish of the result tally (per-path .tmp sibling + rename) so the
+-- agent never reads a half-written file.
+local function flush_metrics()
+  local tmp = paths.sni_metrics .. ".tmp"
+  local f = io.open(tmp, "w")
+  if not f then return end
+  f:write(dns_log.format_query_results(results))
+  f:close()
+  os.rename(tmp, paths.sni_metrics)
+end
 
 while true do
   local rh = read_record_header(h, gh.swapped)
@@ -135,24 +166,36 @@ while true do
     break
   end
 
-  local r = sni.parse_packet(pkt)
+  local r, reason = sni.parse_packet(pkt)
   if r then
     spool:write(sni.format_sni_line(r.dst_ip, r.src_mac, r.sni))
     spool:flush()
     parsed_total      = parsed_total + 1
     since_stat_parsed = since_stat_parsed + 1
+    bump("parsed")
   else
-    no_sni_total = no_sni_total + 1
+    bump(reason or "no_sni")
   end
 
   local now = os.time()
+  -- Publish the result tally on the same cadence as the heartbeat. Cheap
+  -- (a few-row tmpfs write) and bounded by the result enum.
+  if (now - last_metrics_flush) >= 30 then
+    flush_metrics()
+    last_metrics_flush = now
+  end
   if (now - last_stats_log) >= 60 then
-    log.info("sni-tail: parsed=%d (+%d in last %ds) no_sni=%d",
-             parsed_total, since_stat_parsed, now - last_stats_log, no_sni_total)
+    log.info("sni-tail: parsed=%d (+%d in last %ds) truncated=%d no_sni=%d ipv6_skipped=%d not_tcp=%d malformed=%d",
+             parsed_total, since_stat_parsed, now - last_stats_log,
+             results.truncated or 0, results.no_sni or 0,
+             results.ipv6_skipped or 0, results.not_tcp or 0,
+             results.malformed or 0)
+    flush_metrics()
     last_stats_log    = now
     since_stat_parsed = 0
   end
 end
 
+flush_metrics()
 spool:close()
 h:close()

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -1,0 +1,158 @@
+#!/usr/bin/lua
+-- wifihaven-sni-tail — sidecar daemon that captures the first packet of every
+-- outbound TCP/443 flow off the LAN bridge and extracts the TLS ClientHello
+-- SNI server_name. The (dst_ip, src_mac, sni) tuple is appended as a single
+-- TSV line to paths.sni_capture; the wifihaven-dns-tail sidecar tails that
+-- file alongside the dnsmasq query log and calls cache.insert_sni so the
+-- shared ip→hostname cache (paths.dns_cache) stays single-writer.
+--
+-- This closes the DoH / hard-coded-IP attribution gap (#573): a client that
+-- bypasses the on-router DNS resolver still ends up with its destination IP
+-- mapped back to the branded hostname in the agent's flow-attribution cache,
+-- so downstream eb_/ea_/bl_ matching, conntrack-event fqdn emission, and
+-- (#1636/#1640) per-MAC drop-set populators all work transparently.
+--
+-- v1 scope:
+--   - Single-segment TLS 1.2 / TLS 1.3 ClientHello on TCP/443.
+--   - Always-on (no UCI toggle).
+--   - IPv4 only (followup for IPv6).
+--   - ECH ClientHellos → nil SNI → silently skipped (followup).
+--
+-- We rely on tcpdump-mini (libpcap-userspace) to provide the capture: it
+-- already ships in OpenWRT's default feed and is the only piece of the design
+-- that adds an external dependency. Output is raw pcap on stdout (-w -),
+-- parsed inline by sni.parse_packet, which accepts Ethernet/IPv4/TCP frames.
+
+local sni    = require("wifihaven.sni")
+local log    = require("wifihaven.log")
+local paths  = require("wifihaven.paths")
+
+-- BPF filter: TCP to dst port 443, ACK set, PSH set, payload starts with the
+-- TLS handshake/ClientHello signature 0x16 ... 0x01. This restricts capture to
+-- the first packet of new TLS flows so the sidecar's per-packet cost stays
+-- ~one parse per new flow rather than every TLS data segment. The byte-offset
+-- expression follows the libpcap convention used in countless tcpdump recipes
+-- (tcp[((tcp[12]&0xf0)>>2)] = 0x16 — first byte of TCP payload is handshake);
+-- if the on-router libpcap rejects the expression (per the #573 abort list)
+-- we'd fall back to the looser `tcp dst port 443` and live with ~10x packets.
+local BPF_FILTER = "tcp dst port 443 and " ..
+  "(tcp[((tcp[12]&0xf0)>>2)] = 0x16) and " ..
+  "(tcp[((tcp[12]&0xf0)>>2)+5] = 0x01)"
+
+-- Capture interface defaults to br-lan, the standard LAN bridge on OpenWRT.
+-- A future UCI toggle can override this; v1 hardcodes the convention.
+local IFACE       = "br-lan"
+-- snaplen 600 covers the TLS record header (5) + handshake header (4) +
+-- ClientHello header (38) + a typical SNI extension well within the bound.
+-- Larger ClientHellos with long key_share / cipher lists may be truncated; the
+-- parser returns nil on truncation and the flow is silently skipped (acceptable
+-- for v1 — the dnsmasq path still covers the resolved case).
+local SNAPLEN     = 600
+local CAPTURE_CMD = string.format(
+  "tcpdump -i %s -s %d -U -w - -B 1024 -n %q 2>/dev/null",
+  IFACE, SNAPLEN, BPF_FILTER)
+
+log.init({ debug = "0" })
+log.info("sni-tail: starting iface=%s snaplen=%d spool=%s",
+         IFACE, SNAPLEN, paths.sni_capture)
+
+-- ---------------------------------------------------------------------------
+-- pcap stream reader. tcpdump -w - emits a global pcap file header (24 bytes)
+-- followed by record headers (16 bytes) + captured packet bytes. We read the
+-- stream as a byte buffer, peel records off the front, and feed each captured
+-- packet to sni.parse_packet.
+-- ---------------------------------------------------------------------------
+
+local h = io.popen(CAPTURE_CMD, "r")
+if not h then
+  log.err("sni-tail: cannot start tcpdump (%s)", CAPTURE_CMD)
+  os.exit(1)
+end
+
+local function read_n(handle, n)
+  local out = {}
+  local got = 0
+  while got < n do
+    local chunk = handle:read(n - got)
+    if not chunk or #chunk == 0 then return nil end
+    out[#out + 1] = chunk
+    got = got + #chunk
+  end
+  return table.concat(out)
+end
+
+-- Global pcap header: magic (4), version_major (2), version_minor (2),
+-- thiszone (4), sigfigs (4), snaplen (4), network (4) = 24 bytes.
+local function read_global_header(handle)
+  local hdr = read_n(handle, 24)
+  if not hdr or #hdr < 4 then return nil end
+  -- magic byte order: 0xa1b2c3d4 (us) / 0xd4c3b2a1 (other endian) — we trust
+  -- the local tcpdump's byte order, so byte 1 distinguishes them.
+  local b1 = hdr:byte(1)
+  local swapped = (b1 == 0xd4)
+  return { swapped = swapped }
+end
+
+-- Per-record header: ts_sec (4), ts_usec (4), incl_len (4), orig_len (4)
+local function read_record_header(handle, swapped)
+  local rec = read_n(handle, 16)
+  if not rec then return nil end
+  local function u32(off)
+    local a, b, c, d = rec:byte(off, off + 3)
+    if swapped then a, b, c, d = d, c, b, a end
+    return ((a * 256 + b) * 256 + c) * 256 + d
+  end
+  return { incl_len = u32(9) }
+end
+
+local gh = read_global_header(h)
+if not gh then
+  log.err("sni-tail: tcpdump produced no pcap stream — interface up? bpf accepted?")
+  os.exit(1)
+end
+
+-- Open the spool in append mode. Each ClientHello → one fwrite + flush.
+local spool, err = io.open(paths.sni_capture, "a")
+if not spool then
+  log.err("sni-tail: open %s failed: %s", paths.sni_capture, tostring(err))
+  os.exit(1)
+end
+
+local parsed_total      = 0
+local no_sni_total      = 0
+local last_stats_log    = os.time()
+local since_stat_parsed = 0
+
+while true do
+  local rh = read_record_header(h, gh.swapped)
+  if not rh then
+    log.warn("sni-tail: pcap pipe closed; exiting (procd will respawn)")
+    break
+  end
+  local pkt = read_n(h, rh.incl_len)
+  if not pkt then
+    log.warn("sni-tail: short packet read (incl_len=%d); exiting", rh.incl_len)
+    break
+  end
+
+  local r = sni.parse_packet(pkt)
+  if r then
+    spool:write(sni.format_sni_line(r.dst_ip, r.src_mac, r.sni))
+    spool:flush()
+    parsed_total      = parsed_total + 1
+    since_stat_parsed = since_stat_parsed + 1
+  else
+    no_sni_total = no_sni_total + 1
+  end
+
+  local now = os.time()
+  if (now - last_stats_log) >= 60 then
+    log.info("sni-tail: parsed=%d (+%d in last %ds) no_sni=%d",
+             parsed_total, since_stat_parsed, now - last_stats_log, no_sni_total)
+    last_stats_log    = now
+    since_stat_parsed = 0
+  end
+end
+
+spool:close()
+h:close()

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -48,12 +48,18 @@ local BPF_FILTER = "tcp dst port 443 and " ..
 -- so routers using a non-default bridge name (br0, multi-WAN) still get
 -- captured; falls back to br-lan. (#573 SHOULD-FIX #3.)
 local IFACE       = sni.lan_device(uci.cursor())
--- snaplen 600 covers the TLS record header (5) + handshake header (4) +
--- ClientHello header (38) + a typical SNI extension well within the bound.
--- Larger ClientHellos with long key_share / cipher lists may be truncated; the
--- parser returns nil on truncation and the flow is silently skipped (acceptable
--- for v1 — the dnsmasq path still covers the resolved case).
-local SNAPLEN     = 600
+-- snaplen sized to capture a full single-segment ClientHello. Real
+-- OpenSSL/curl TLS 1.3 ClientHellos are padded past ~512 bytes and grow with
+-- key_share / ALPN / supported_groups, routinely landing in the 512-1500B
+-- range — 600 truncated nearly all of them, so the parser saw a record whose
+-- declared length exceeded the captured bytes (the Gate 2 e2e caught this:
+-- every real ClientHello fell out as no_sni). 2048 comfortably covers a full
+-- single-TCP-segment ClientHello (bounded by the path MSS, typ. ~1460B) plus
+-- IP/TCP option headroom. The parser is also truncation-tolerant now (it finds
+-- the front-placed server_name extension even when the tail is clipped), so
+-- this bound is defense-in-depth rather than the sole guard. Multi-segment
+-- ClientHello reassembly remains out of v1 scope (#1653).
+local SNAPLEN     = 2048
 local CAPTURE_CMD = string.format(
   "tcpdump -i %s -s %d -U -w - -B 1024 -n %q 2>/dev/null",
   IFACE, SNAPLEN, BPF_FILTER)

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -789,13 +789,15 @@ end)
 
 describe("cache:insert_sni (#573)", function()
   it("stores (ip → sni) so lookup returns the SNI hostname", function()
-    local c = dns_log.new()
-    c.insert_sni("1.2.3.4", "example.com", 1000)
+    local t = 1000
+    local c = dns_log.new({ now_fn = function() return t end })
+    c.insert_sni("1.2.3.4", "example.com", t)
     assert.equal("example.com", c.lookup("1.2.3.4"))
   end)
 
   it("runs the SNI through the CNAME-alias map (resolve_head)", function()
-    local c = dns_log.new()
+    local t = 1000
+    local c = dns_log.new({ now_fn = function() return t end })
     -- Seed alias edge via a normal DNS reply chain:
     --   query[A] cdn.kastatic.org
     --   reply    cdn.kastatic.org is <CNAME>
@@ -809,7 +811,7 @@ describe("cache:insert_sni (#573)", function()
     c.ingest_line(
       "1 192.168.1.42/54321 reply prod.khan.map.fastly.net is 1.2.3.4")
     -- An SNI to the leaf CDN target attributes back to the branded head.
-    c.insert_sni("5.6.7.8", "prod.khan.map.fastly.net", 2000)
+    c.insert_sni("5.6.7.8", "prod.khan.map.fastly.net", t)
     assert.equal("cdn.kastatic.org", c.lookup("5.6.7.8"))
   end)
 

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -776,3 +776,48 @@ describe("format_query_results / parse_query_results (#1302)", function()
     assert.same({}, dns_log.parse_query_results(nil))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- 5. cache:insert_sni (#573) — SNI-derived hostname injection.
+--
+-- The wifihaven-sni-tail sidecar parses TLS ClientHellos off the LAN bridge
+-- and the dns-tail loop calls cache.insert_sni(dst_ip, sni, now). insert_sni
+-- runs the SNI through the same resolve_head alias map dns ingest uses, then
+-- stores (ip → head) so cache.lookup attributes the flow back to the branded
+-- host. This closes the DoH/hard-coded-IP attribution gap (#573).
+-- ---------------------------------------------------------------------------
+
+describe("cache:insert_sni (#573)", function()
+  it("stores (ip → sni) so lookup returns the SNI hostname", function()
+    local c = dns_log.new()
+    c.insert_sni("1.2.3.4", "example.com", 1000)
+    assert.equal("example.com", c.lookup("1.2.3.4"))
+  end)
+
+  it("runs the SNI through the CNAME-alias map (resolve_head)", function()
+    local c = dns_log.new()
+    -- Seed alias edge via a normal DNS reply chain:
+    --   query[A] cdn.kastatic.org
+    --   reply    cdn.kastatic.org is <CNAME>
+    --   reply    prod.khan.map.fastly.net is 1.2.3.4
+    -- (#1344) — after which prod.khan.map.fastly.net is known to alias back to
+    -- cdn.kastatic.org.
+    c.ingest_line(
+      "1 192.168.1.42/54321 query[A] cdn.kastatic.org from 192.168.1.42")
+    c.ingest_line(
+      "1 192.168.1.42/54321 reply cdn.kastatic.org is <CNAME>")
+    c.ingest_line(
+      "1 192.168.1.42/54321 reply prod.khan.map.fastly.net is 1.2.3.4")
+    -- An SNI to the leaf CDN target attributes back to the branded head.
+    c.insert_sni("5.6.7.8", "prod.khan.map.fastly.net", 2000)
+    assert.equal("cdn.kastatic.org", c.lookup("5.6.7.8"))
+  end)
+
+  it("is a no-op on nil/empty input", function()
+    local c = dns_log.new()
+    c.insert_sni(nil, "example.com", 1000)
+    c.insert_sni("1.2.3.4", nil, 1000)
+    c.insert_sni("", "", 1000)
+    assert.equal(0, c.size())
+  end)
+end)

--- a/openwrt/test/init_spec.sh
+++ b/openwrt/test/init_spec.sh
@@ -51,6 +51,11 @@ grep -q 'wifihaven-nflog-tail' "$INIT" \
   && check "starts wifihaven-nflog-tail sidecar" ok \
   || check "starts wifihaven-nflog-tail sidecar" "not found"
 
+# 5d. sni-tail sidecar must also be started (#573 — SNI hostname attribution)
+grep -q 'wifihaven-sni-tail' "$INIT" \
+  && check "starts wifihaven-sni-tail sidecar" ok \
+  || check "starts wifihaven-sni-tail sidecar" "not found"
+
 # 6. Must configure procd_set_param respawn (auto-restart on crash)
 grep -q 'procd_set_param respawn' "$INIT" \
   && check "sets procd_set_param respawn" ok \

--- a/openwrt/test/rotate_dnsmasq_log_spec.sh
+++ b/openwrt/test/rotate_dnsmasq_log_spec.sh
@@ -108,9 +108,11 @@ trap 'rm -rf "$TESTDIR"' EXIT
 FAKE_LOG="$TESTDIR/wifihaven-dnsmasq.log"
 FAKE_LOG_PREV="${FAKE_LOG}.1"
 
-# Rewrite the LOG variable in a copy of the script so it targets our tmpdir.
+# Rewrite the dnsmasq log path in a copy of the script so it targets our
+# tmpdir. Point the SNI path at a non-existent file so it is a no-op here.
 PATCHED="$TESTDIR/wifihaven-rotate-dnsmasq-log"
-sed "s|^LOG=/tmp/wifihaven-dnsmasq.log|LOG=$FAKE_LOG|" "$SCRIPT" > "$PATCHED"
+sed -e "s|/tmp/wifihaven-dnsmasq.log|$FAKE_LOG|g" \
+    -e "s|/tmp/wifihaven-sni.log|$TESTDIR/_absent-sni.log|g" "$SCRIPT" > "$PATCHED"
 chmod +x "$PATCHED"
 
 # Case A: file absent — script exits 0, no .1 created.

--- a/openwrt/test/rotate_dnsmasq_log_spec.sh
+++ b/openwrt/test/rotate_dnsmasq_log_spec.sh
@@ -33,6 +33,13 @@ grep -q '/tmp/wifihaven-dnsmasq.log' "$SCRIPT" \
   && check "rotation script targets /tmp/wifihaven-dnsmasq.log" ok \
   || check "rotation script targets /tmp/wifihaven-dnsmasq.log" "wrong log path"
 
+# #573: the SNI capture spool grows unbounded otherwise; it must be bounded by
+# the same rotation cron.
+grep -q '/tmp/wifihaven-sni.log' "$SCRIPT" \
+  && check "rotation script also targets /tmp/wifihaven-sni.log (#573)" ok \
+  || check "rotation script also targets /tmp/wifihaven-sni.log (#573)" \
+           "SNI spool not bounded by rotation"
+
 # Must use in-place truncation (: > "$LOG") so dnsmasq's open fd stays on the
 # same inode. A rename would send dnsmasq's writes to an invisible inode.
 grep -q ': > ' "$SCRIPT" \
@@ -186,6 +193,36 @@ print('B' if sample == b'BBBB' else 'other')
   && check "[second rotation] .1 overwritten with latest rotation" ok \
   || check "[second rotation] .1 overwritten with latest rotation" \
            "expected B content in .1, got: $old_prev"
+
+# ---------------------------------------------------------------------------
+# 4. Behavioural simulation for the SNI spool (#573)
+# ---------------------------------------------------------------------------
+# Patch BOTH log paths to the tmpdir and confirm the SNI spool is rotated by
+# the same script when it crosses the cap.
+FAKE_SNI="$TESTDIR/wifihaven-sni.log"
+FAKE_SNI_PREV="${FAKE_SNI}.1"
+PATCHED2="$TESTDIR/wifihaven-rotate-both"
+sed -e "s|/tmp/wifihaven-dnsmasq.log|$FAKE_LOG|g" \
+    -e "s|/tmp/wifihaven-sni.log|$FAKE_SNI|g" "$SCRIPT" > "$PATCHED2"
+chmod +x "$PATCHED2"
+
+python3 -c "
+import sys
+with open(sys.argv[1], 'wb') as f:
+    f.write(b'S' * (20 * 1024 * 1024 + 1))
+" "$FAKE_SNI"
+: > "$FAKE_LOG"   # keep dnsmasq log small so only SNI rotates
+"$PATCHED2"
+
+[ -f "$FAKE_SNI_PREV" ] \
+  && check "[sni spool] .1 backup created when SNI spool exceeds cap" ok \
+  || check "[sni spool] .1 backup created when SNI spool exceeds cap" ".1 not created"
+
+sni_size=$(wc -c < "$FAKE_SNI" 2>/dev/null)
+[ "$sni_size" -eq 0 ] \
+  && check "[sni spool] original truncated to zero after rotation" ok \
+  || check "[sni spool] original truncated to zero after rotation" \
+           "expected 0 bytes, got $sni_size"
 
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -23,6 +23,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/update_spec.lua \
          test/metrics_spec.lua \
          test/dns_log_spec.lua \
+         test/sni_spec.lua \
          test/nft_drops_spec.lua \
          test/nflog_spec.lua \
          test/lan_warn_spec.lua \

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -469,30 +469,35 @@ local function u32be(n)
                      n % 256)
 end
 
--- Build a 24-byte pcap global header. swapped=false → native magic
--- 0xa1b2c3d4 written little-endian (byte 1 = 0xd4); swapped=true → the
--- other-endian magic 0xd4c3b2a1 written little-endian (byte 1 = 0xa1).
--- (We mirror tcpdump's on-the-wire convention: the magic is written in the
--- writer's native byte order, so the first byte tells the reader the order.)
+-- Build a 24-byte pcap global header for a given on-wire byte order.
+--
+-- The reader (sni.read_global_header) keys off the magic's first byte:
+--   byte1 = 0xa1  (magic bytes a1 b2 c3 d4)  → swapped=false → BIG-endian fields
+--   byte1 = 0xd4  (magic bytes d4 c3 b2 a1)  → swapped=true  → LITTLE-endian fields
+-- i.e. the magic 0xa1b2c3d4 laid down big-endian, or laid down little-endian.
+-- The header/record length fields must therefore use the matching encoder.
 local function pcap_global_header(swapped)
-  local magic
+  local enc, magic
   if swapped then
-    magic = string.char(0xd4, 0xc3, 0xb2, 0xa1) -- reader sees swapped byte order
+    magic = string.char(0xd4, 0xc3, 0xb2, 0xa1) -- little-endian on the wire
+    enc = u32le
   else
-    magic = string.char(0xa1, 0xb2, 0xc3, 0xd4) -- reader sees native byte order
+    magic = string.char(0xa1, 0xb2, 0xc3, 0xd4) -- big-endian on the wire
+    enc = u32be
   end
   -- version_major(2) version_minor(2) thiszone(4) sigfigs(4) snaplen(4) net(4)
-  local rest = string.char(2, 0) .. string.char(4, 0) ..
+  -- (the reader only inspects the magic; the rest just has to be 24 bytes.)
+  local rest = string.char(0, 2) .. string.char(0, 4) ..
                string.rep("\0", 4) .. string.rep("\0", 4) ..
-               (swapped and u32be(600) or u32le(600)) ..
-               (swapped and u32be(1)   or u32le(1))     -- LINKTYPE_ETHERNET
+               enc(600) ..
+               enc(1)                                   -- LINKTYPE_ETHERNET
   return magic .. rest
 end
 
 -- Build a 16-byte pcap record header framing a packet of incl_len bytes, in
--- the chosen byte order, followed by the packet bytes themselves.
+-- the matching byte order, followed by the packet bytes themselves.
 local function pcap_record(packet, swapped)
-  local enc = swapped and u32be or u32le
+  local enc = swapped and u32le or u32be
   local ts_sec, ts_usec = 0, 0
   local incl_len = #packet
   local orig_len = #packet
@@ -573,7 +578,8 @@ describe("read_record — per-record framing", function()
 
   it("returns nil when incl_len overruns the available bytes", function()
     -- 16-byte header claiming incl_len=100, but only 4 packet bytes follow.
-    local hdr = u32le(0) .. u32le(0) .. u32le(100) .. u32le(100)
+    -- swapped=false → big-endian fields (see pcap_global_header).
+    local hdr = u32be(0) .. u32be(0) .. u32be(100) .. u32be(100)
     assert.is_nil(sni.read_record(string_reader(hdr .. "abcd"), false))
   end)
 end)

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -293,3 +293,133 @@ describe("format_sni_line / parse_sni_line", function()
     assert.is_nil(sni.parse_sni_line(nil))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- 5. route_line — the dns-tail SNI/dnsmasq routing seam (#573 SHOULD-FIX #1)
+-- ---------------------------------------------------------------------------
+--
+-- wifihaven-dns-tail tails the dnsmasq log AND the SNI capture spool together
+-- via `tail -F a b`. Each line is classified by sni.route_line, which:
+--   (a) routes "SNI\t..." lines to the injected insert_fn (cache.insert_sni)
+--   (b) skips "==> file <==" tail-banner lines emitted on file switch
+--   (c) returns false for dnsmasq reply lines so they fall through to the
+--       existing dnsmasq handlers (the single dns_cache writer stays dns-tail).
+describe("route_line — dns-tail SNI routing seam", function()
+  it("routes an SNI line to insert_fn and returns true", function()
+    local seen = {}
+    local handled = sni.route_line(
+      sni.format_sni_line("142.250.80.46", "76:2d:95:47:d1:8e", "example.com"),
+      { insert_fn = function(ip, host) seen = { ip = ip, host = host } end })
+    assert.is_true(handled)
+    assert.equal("142.250.80.46", seen.ip)
+    assert.equal("example.com",   seen.host)
+  end)
+
+  it("skips a `tail -F` switch-banner line without calling insert_fn", function()
+    local calls = 0
+    local handled = sni.route_line(
+      "==> /tmp/wifihaven-sni.log <==",
+      { insert_fn = function() calls = calls + 1 end })
+    assert.is_true(handled)        -- consumed (not a dnsmasq line)
+    assert.equal(0, calls)         -- but no cache insert
+  end)
+
+  it("returns false for a dnsmasq reply line (falls through to dns handlers)", function()
+    local calls = 0
+    local handled = sni.route_line(
+      "Nov 12 10:00:01 dnsmasq[1234]: reply youtube.com is 142.250.80.46",
+      { insert_fn = function() calls = calls + 1 end })
+    assert.is_false(handled)
+    assert.equal(0, calls)
+  end)
+
+  it("returns false for an empty / nil line", function()
+    assert.is_false(sni.route_line("", { insert_fn = function() end }))
+    assert.is_false(sni.route_line(nil, { insert_fn = function() end }))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 6. parse_packet failure-reason categorization (#573 SHOULD-FIX #4/#7)
+-- ---------------------------------------------------------------------------
+--
+-- On a nil result, parse_packet returns a bounded reason string as its second
+-- value so the sidecar can split the lumped no_sni_total counter into distinct
+-- failure modes (truncated / no_sni / malformed / ipv6_skipped). The reason
+-- enum is small and fixed; it feeds the result= IPC metrics file.
+describe("parse_packet — failure reason (second return value)", function()
+  it("returns reason=ipv6_skipped for a non-0x0800 ethertype frame", function()
+    -- Ethernet dst(6) src(6) ethertype=0x86dd (IPv6) + enough bytes for the
+    -- length guard. parse_packet must reject before IP parsing.
+    local frame = string.rep("\0", 6) ..
+                  string.char(0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e) ..
+                  string.char(0x86, 0xdd) .. string.rep("\0", 60)
+    local r, reason = sni.parse_packet(frame)
+    assert.is_nil(r)
+    assert.equal("ipv6_skipped", reason)
+  end)
+
+  it("returns reason=truncated for a too-short frame", function()
+    local r, reason = sni.parse_packet(string.rep("\0", 20))
+    assert.is_nil(r)
+    assert.equal("truncated", reason)
+  end)
+
+  it("returns reason=no_sni for a valid IPv4/TCP packet whose payload has no SNI", function()
+    local hello = build_client_hello({ sni = "x", omit_sni_ext = true,
+                                       extra_exts = build_key_share_ext(20) })
+    local pkt = build_eth_ipv4_tcp({ payload = hello })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_nil(r)
+    assert.equal("no_sni", reason)
+  end)
+
+  it("returns a parsed result with no reason for a good ClientHello", function()
+    local pkt = build_eth_ipv4_tcp({ payload = build_client_hello({ sni = "example.com" }) })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_not_nil(r)
+    assert.equal("example.com", r.sni)
+    assert.is_nil(reason)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 7. lan_device — probe the LAN bridge from UCI (#573 SHOULD-FIX #3)
+-- ---------------------------------------------------------------------------
+--
+-- The sidecar must not hardcode br-lan. sni.lan_device reads network.lan.device
+-- from an injected UCI cursor and falls back to br-lan when unset, so a router
+-- whose LAN bridge is named br0 still gets captured.
+describe("lan_device — UCI LAN-bridge probe", function()
+  local function fake_cursor(dev)
+    return { get = function(_, pkg, sec, opt)
+      if pkg == "network" and sec == "lan" and opt == "device" then return dev end
+      return nil
+    end }
+  end
+
+  it("returns network.lan.device when set", function()
+    assert.equal("br0", sni.lan_device(fake_cursor("br0")))
+  end)
+
+  it("falls back to br-lan when network.lan.device is unset", function()
+    assert.equal("br-lan", sni.lan_device(fake_cursor(nil)))
+  end)
+
+  it("falls back to br-lan when no cursor is available", function()
+    assert.equal("br-lan", sni.lan_device(nil))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 8. <3-char SNI rejected (#573 NIT #3)
+-- ---------------------------------------------------------------------------
+describe("parse_client_hello — minimum SNI length", function()
+  it("rejects a 1-char SNI (no real domain is shorter than a.b)", function()
+    assert.is_nil(sni.parse_client_hello(build_client_hello({ sni = "x" })))
+  end)
+
+  it("accepts a 3-char SNI (a.b)", function()
+    assert.equal("a.b", sni.parse_client_hello(build_client_hello({ sni = "a.b" })))
+  end)
+end)

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -120,6 +120,34 @@ describe("parse_client_hello", function()
                                      sni = "calendar.google.com" })
     assert.equal("calendar.google.com", sni.parse_client_hello(rec))
   end)
+
+  it("extracts SNI from a snaplen-clipped ClientHello when the server_name ext is in the captured prefix (#573)", function()
+    -- Regression for the prod-equivalent bug the Gate 2 e2e caught: real
+    -- OpenSSL/curl TLS 1.3 ClientHellos are padded past ~512 bytes, so under
+    -- the capture snaplen the tail (large key_share / padding) is clipped. The
+    -- server_name extension sits near the FRONT, so it is fully present in the
+    -- captured prefix — the parser must still return it instead of rejecting
+    -- the whole record because its declared length exceeds the buffer.
+    local sni_str = "example.com"
+    local entry   = u8(0) .. u16(#sni_str) .. sni_str
+    local list    = u16(#entry) .. entry
+    local sni_ext = u16(0x0000) .. u16(#list) .. list
+    -- SNI FIRST, then a large trailing extension that the snaplen clip removes.
+    local big_ext = u16(0x0033) .. u16(800) .. string.rep("\0", 800)
+    local exts    = sni_ext .. big_ext
+    local body =
+      u16(0x0303) .. string.rep("\0", 32) ..   -- legacy_version + random
+      u8(0) ..                                 -- empty session id
+      u16(2) .. bytes(0x13, 0x01) ..           -- one cipher suite
+      u8(1) .. u8(0) ..                        -- null compression
+      u16(#exts) .. exts                       -- extensions (declared full size)
+    local handshake = u8(0x01) .. u24(#body) .. body
+    local rec       = u8(0x16) .. u16(0x0303) .. u16(#handshake) .. handshake
+    -- Clip well past the SNI ext (~byte 80) but far short of the declared
+    -- ~880-byte record, exactly as a small snaplen would.
+    local clipped = rec:sub(1, 130)
+    assert.equal("example.com", sni.parse_client_hello(clipped))
+  end)
 end)
 
 -- ---------------------------------------------------------------------------

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -423,3 +423,234 @@ describe("parse_client_hello — minimum SNI length", function()
     assert.equal("a.b", sni.parse_client_hello(build_client_hello({ sni = "a.b" })))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- 9. pcap stream reader + full pcap→cache integration (#573)
+-- ---------------------------------------------------------------------------
+--
+-- The wifihaven-sni-tail sidecar reads tcpdump's `-w -` pcap stream: a 24-byte
+-- global header (magic 0xa1b2c3d4 / 0xd4c3b2a1 for the two byte orders) then a
+-- sequence of 16-byte record headers each followed by incl_len packet bytes.
+-- That stream reader used to live as inline local functions in the sidecar and
+-- was never exercised by a test. It now lives in sni.lua as injectable, pure
+-- functions backed by a read_fn(n) → bytes|nil cursor, so the assembled
+-- pipeline (pcap bytes → packets → parse_packet → SNI line → route_line →
+-- cache) can be driven in-process with zero router/tcpdump involvement.
+--
+--   sni.read_global_header(read_fn) → { swapped = bool } | nil
+--   sni.read_record(read_fn, swapped) → { data = <packet bytes> } | nil (EOF)
+--   sni.iter_pcap(read_fn) → function() returning successive packet payloads
+--                            (nil at EOF), after consuming the global header.
+
+-- A read_fn over an in-memory byte string: returns up to n bytes per call and
+-- nil at EOF, mirroring the io.popen handle:read(n) contract the sidecar uses.
+local function string_reader(s)
+  local pos = 1
+  return function(n)
+    if pos > #s then return nil end
+    local chunk = s:sub(pos, pos + n - 1)
+    pos = pos + #chunk
+    if #chunk == 0 then return nil end
+    return chunk
+  end
+end
+
+-- 32-bit little/big-endian encoders for pcap header fields.
+local function u32le(n)
+  return string.char(n % 256,
+                     math.floor(n / 256) % 256,
+                     math.floor(n / 65536) % 256,
+                     math.floor(n / 16777216) % 256)
+end
+local function u32be(n)
+  return string.char(math.floor(n / 16777216) % 256,
+                     math.floor(n / 65536) % 256,
+                     math.floor(n / 256) % 256,
+                     n % 256)
+end
+
+-- Build a 24-byte pcap global header. swapped=false → native magic
+-- 0xa1b2c3d4 written little-endian (byte 1 = 0xd4); swapped=true → the
+-- other-endian magic 0xd4c3b2a1 written little-endian (byte 1 = 0xa1).
+-- (We mirror tcpdump's on-the-wire convention: the magic is written in the
+-- writer's native byte order, so the first byte tells the reader the order.)
+local function pcap_global_header(swapped)
+  local magic
+  if swapped then
+    magic = string.char(0xd4, 0xc3, 0xb2, 0xa1) -- reader sees swapped byte order
+  else
+    magic = string.char(0xa1, 0xb2, 0xc3, 0xd4) -- reader sees native byte order
+  end
+  -- version_major(2) version_minor(2) thiszone(4) sigfigs(4) snaplen(4) net(4)
+  local rest = string.char(2, 0) .. string.char(4, 0) ..
+               string.rep("\0", 4) .. string.rep("\0", 4) ..
+               (swapped and u32be(600) or u32le(600)) ..
+               (swapped and u32be(1)   or u32le(1))     -- LINKTYPE_ETHERNET
+  return magic .. rest
+end
+
+-- Build a 16-byte pcap record header framing a packet of incl_len bytes, in
+-- the chosen byte order, followed by the packet bytes themselves.
+local function pcap_record(packet, swapped)
+  local enc = swapped and u32be or u32le
+  local ts_sec, ts_usec = 0, 0
+  local incl_len = #packet
+  local orig_len = #packet
+  local hdr = enc(ts_sec) .. enc(ts_usec) .. enc(incl_len) .. enc(orig_len)
+  return hdr .. packet
+end
+
+-- Assemble a full pcap stream from a list of Ethernet frames.
+local function pcap_stream(frames, swapped)
+  local parts = { pcap_global_header(swapped) }
+  for _, f in ipairs(frames) do
+    parts[#parts + 1] = pcap_record(f, swapped)
+  end
+  return table.concat(parts)
+end
+
+-- Drive the full pipeline assembled from the extracted module functions:
+--   read_fn → iter_pcap → parse_packet → format_sni_line → route_line → cache
+-- Returns the fake cache (ip→host) plus the count of records iterated.
+local function run_pipeline(stream)
+  local cache = {}
+  local insert_fn = function(ip, host) cache[ip] = host end
+  local next_pkt = sni.iter_pcap(string_reader(stream))
+  local records = 0
+  for pkt in next_pkt do
+    records = records + 1
+    local r = sni.parse_packet(pkt)
+    if r then
+      local line = sni.format_sni_line(r.dst_ip, r.src_mac, r.sni)
+      sni.route_line(line, { insert_fn = insert_fn })
+    end
+  end
+  return cache, records
+end
+
+describe("read_global_header — pcap magic / byte order", function()
+  it("detects the native (little-endian magic) byte order", function()
+    local gh = sni.read_global_header(string_reader(pcap_global_header(false)))
+    assert.is_not_nil(gh)
+    assert.is_false(gh.swapped)
+  end)
+
+  it("detects the swapped byte order", function()
+    local gh = sni.read_global_header(string_reader(pcap_global_header(true)))
+    assert.is_not_nil(gh)
+    assert.is_true(gh.swapped)
+  end)
+
+  it("returns nil when the stream is too short to hold a global header", function()
+    assert.is_nil(sni.read_global_header(string_reader("\xa1\xb2")))
+  end)
+end)
+
+describe("read_record — per-record framing", function()
+  it("reads incl_len bytes after the 16-byte header (native order)", function()
+    local packet = string.rep("P", 42)
+    local stream = pcap_record(packet, false)
+    local rec = sni.read_record(string_reader(stream), false)
+    assert.is_not_nil(rec)
+    assert.equal(packet, rec.data)
+  end)
+
+  it("honors the swapped byte order for incl_len", function()
+    local packet = string.rep("Q", 17)
+    local stream = pcap_record(packet, true)
+    local rec = sni.read_record(string_reader(stream), true)
+    assert.is_not_nil(rec)
+    assert.equal(packet, rec.data)
+  end)
+
+  it("returns nil at clean EOF (no record header present)", function()
+    assert.is_nil(sni.read_record(string_reader(""), false))
+  end)
+
+  it("returns nil on a truncated record header (partial 16-byte header)", function()
+    assert.is_nil(sni.read_record(string_reader(string.rep("\0", 8)), false))
+  end)
+
+  it("returns nil when incl_len overruns the available bytes", function()
+    -- 16-byte header claiming incl_len=100, but only 4 packet bytes follow.
+    local hdr = u32le(0) .. u32le(0) .. u32le(100) .. u32le(100)
+    assert.is_nil(sni.read_record(string_reader(hdr .. "abcd"), false))
+  end)
+end)
+
+describe("iter_pcap → parse_packet → route_line → cache (full pipeline)", function()
+  local function hello_packet(host, mac, ip)
+    return build_eth_ipv4_tcp({
+      payload = build_client_hello({ sni = host }),
+      src_mac = mac,
+      dst_ip  = ip,
+    })
+  end
+
+  it("attributes a single ClientHello's dst_ip to its SNI host (native order)", function()
+    local stream = pcap_stream({
+      hello_packet("calendar.google.com",
+                   { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }, { 142, 250, 80, 46 }),
+    }, false)
+    local cache, records = run_pipeline(stream)
+    assert.equal(1, records)
+    assert.equal("calendar.google.com", cache["142.250.80.46"])
+  end)
+
+  it("attributes multiple ClientHellos across records", function()
+    local stream = pcap_stream({
+      hello_packet("calendar.google.com",
+                   { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }, { 142, 250, 80, 46 }),
+      hello_packet("www.youtube.com",
+                   { 0xfa, 0x10, 0xcd, 0x84, 0x78, 0x22 }, { 142, 250, 72, 14 }),
+    }, false)
+    local cache = run_pipeline(stream)
+    assert.equal("calendar.google.com", cache["142.250.80.46"])
+    assert.equal("www.youtube.com",     cache["142.250.72.14"])
+  end)
+
+  it("parses identically under the swapped pcap byte order", function()
+    local frames = {
+      hello_packet("calendar.google.com",
+                   { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }, { 142, 250, 80, 46 }),
+      hello_packet("www.youtube.com",
+                   { 0xfa, 0x10, 0xcd, 0x84, 0x78, 0x22 }, { 142, 250, 72, 14 }),
+    }
+    local native  = run_pipeline(pcap_stream(frames, false))
+    local swapped = run_pipeline(pcap_stream(frames, true))
+    assert.same(native, swapped)
+    assert.equal("calendar.google.com", swapped["142.250.80.46"])
+    assert.equal("www.youtube.com",     swapped["142.250.72.14"])
+  end)
+
+  it("skips a non-TLS packet without polluting the cache, still draining the stream", function()
+    local stream = pcap_stream({
+      build_eth_ipv4_tcp({ payload = string.rep("X", 64),       -- not a ClientHello
+                           dst_ip = { 10, 0, 0, 9 } }),
+      hello_packet("www.youtube.com",
+                   { 0xfa, 0x10, 0xcd, 0x84, 0x78, 0x22 }, { 142, 250, 72, 14 }),
+    }, false)
+    local cache, records = run_pipeline(stream)
+    assert.equal(2, records)                       -- both records iterated
+    assert.is_nil(cache["10.0.0.9"])               -- non-TLS not attributed
+    assert.equal("www.youtube.com", cache["142.250.72.14"])
+  end)
+
+  it("terminates cleanly on a truncated trailing record header (no Lua error)", function()
+    local good = pcap_stream({
+      hello_packet("calendar.google.com",
+                   { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }, { 142, 250, 80, 46 }),
+    }, false)
+    -- Append a partial (8-byte) record header that snaplen/pipe-close could cut.
+    local stream = good .. string.rep("\0", 8)
+    local cache, records = run_pipeline(stream)
+    assert.equal(1, records)                       -- only the complete record
+    assert.equal("calendar.google.com", cache["142.250.80.46"])
+  end)
+
+  it("returns nil iterator state when the global header is absent/short", function()
+    -- iter_pcap with a stream too short for a global header yields nothing.
+    local next_pkt = sni.iter_pcap(string_reader("\xa1\xb2"))
+    assert.is_nil(next_pkt())
+  end)
+end)

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -1,0 +1,295 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/sni.lua
+--
+-- sni.lua parses TLS ClientHello records and extracts the SNI server_name
+-- extension. v1 covers single-segment TLS 1.2 and TLS 1.3 ClientHellos on
+-- TCP dst port 443 (#573). The parser is pure Lua, operates on a raw byte
+-- string, and is unit-testable via busted with hand-rolled binary fixtures.
+--
+-- Run with: busted openwrt/test/sni_spec.lua
+
+local sni = require("sni")
+
+-- ---------------------------------------------------------------------------
+-- Binary fixture helpers — keep test fixtures readable and easy to truncate.
+-- ---------------------------------------------------------------------------
+
+local function bytes(...)
+  local t = { ... }
+  local s = {}
+  for i, b in ipairs(t) do s[i] = string.char(b) end
+  return table.concat(s)
+end
+
+local function u8(n) return string.char(n) end
+local function u16(n) return string.char(math.floor(n / 256) % 256, n % 256) end
+local function u24(n)
+  return string.char(math.floor(n / 65536) % 256,
+                     math.floor(n / 256) % 256,
+                     n % 256)
+end
+
+-- Build a TLS ClientHello "record" containing only a server_name extension.
+--
+-- Layout (RFC 5246 / RFC 8446):
+--   TLSPlaintext
+--     ContentType        u8   = 0x16 (handshake)
+--     ProtocolVersion    u16  = 0x0301..0x0303
+--     Length             u16  = (rest of record)
+--   Handshake
+--     HandshakeType      u8   = 0x01 (client_hello)
+--     Length             u24
+--   ClientHello
+--     legacy_version     u16
+--     random             32 bytes
+--     legacy_session_id  u8 length + bytes
+--     cipher_suites      u16 length + bytes
+--     compression_methods u8 length + bytes
+--     extensions         u16 length + bytes
+--
+-- A single server_name extension has the shape:
+--   extension_type    u16  = 0x0000
+--   extension_data_len u16
+--   server_name_list_len u16
+--   name_type         u8   = 0x00 (host_name)
+--   server_name_len   u16
+--   server_name       bytes
+local function build_client_hello(opts)
+  opts = opts or {}
+  local tls_version  = opts.tls_version or 0x0303      -- record-layer version
+  local legacy_ver   = opts.legacy_version or 0x0303   -- ClientHello.legacy_version
+  local sni          = opts.sni                        -- server_name string, or nil
+  local extra_exts   = opts.extra_exts or ""           -- raw bytes prepended before SNI ext
+  local omit_sni_ext = opts.omit_sni_ext or false
+  local handshake_type = opts.handshake_type or 0x01   -- override to test ServerHello (0x02)
+
+  -- random: 32 bytes of zeros (content irrelevant)
+  local random = string.rep("\0", 32)
+  local session_id = u8(0) -- empty session id
+  local cipher_suites = u16(2) .. bytes(0x13, 0x01) -- one suite TLS_AES_128_GCM_SHA256
+  local compression = u8(1) .. u8(0) -- null compression
+
+  -- Build server_name extension
+  local sni_ext = ""
+  if not omit_sni_ext and sni then
+    local server_name_entry = u8(0) .. u16(#sni) .. sni
+    local server_name_list  = u16(#server_name_entry) .. server_name_entry
+    sni_ext = u16(0x0000) .. u16(#server_name_list) .. server_name_list
+  end
+
+  local extensions = extra_exts .. sni_ext
+  local ext_block  = u16(#extensions) .. extensions
+
+  local client_hello_body =
+      u16(legacy_ver) .. random .. session_id ..
+      cipher_suites .. compression .. ext_block
+
+  local handshake = u8(handshake_type) .. u24(#client_hello_body) .. client_hello_body
+  local record    = u8(0x16) .. u16(tls_version) .. u16(#handshake) .. handshake
+  return record
+end
+
+-- A key_share extension (TLS 1.3) — type 0x0033, opaque payload. Used to test
+-- that the parser walks past non-SNI extensions and still finds server_name.
+local function build_key_share_ext(payload_len)
+  payload_len = payload_len or 38
+  return u16(0x0033) .. u16(payload_len) .. string.rep("\0", payload_len)
+end
+
+-- ---------------------------------------------------------------------------
+-- 1. parse_client_hello — happy paths
+-- ---------------------------------------------------------------------------
+
+describe("parse_client_hello", function()
+  it("extracts SNI from a TLS 1.2 ClientHello with only the server_name extension", function()
+    local rec = build_client_hello({ tls_version = 0x0303, legacy_version = 0x0303,
+                                     sni = "example.com" })
+    assert.equal("example.com", sni.parse_client_hello(rec))
+  end)
+
+  it("extracts SNI from a TLS 1.3 ClientHello where key_share precedes server_name", function()
+    local rec = build_client_hello({
+      tls_version = 0x0303, legacy_version = 0x0303,
+      sni = "www.youtube.com",
+      extra_exts = build_key_share_ext(40),
+    })
+    assert.equal("www.youtube.com", sni.parse_client_hello(rec))
+  end)
+
+  it("extracts SNI when record-layer version is 0x0301 (TLS 1.0 record framing, real ClientHellos do this)", function()
+    local rec = build_client_hello({ tls_version = 0x0301, legacy_version = 0x0303,
+                                     sni = "calendar.google.com" })
+    assert.equal("calendar.google.com", sni.parse_client_hello(rec))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 2. parse_client_hello — graceful nil paths (no Lua errors)
+-- ---------------------------------------------------------------------------
+
+describe("parse_client_hello — nil-returning paths", function()
+  it("returns nil when there is no server_name extension", function()
+    local rec = build_client_hello({ sni = "example.com", omit_sni_ext = true,
+                                     extra_exts = build_key_share_ext(20) })
+    assert.is_nil(sni.parse_client_hello(rec))
+  end)
+
+  it("returns nil for a truncated record (record header says more than is present)", function()
+    local rec = build_client_hello({ sni = "example.com" })
+    local truncated = rec:sub(1, 50) -- way short of declared length
+    assert.is_nil(sni.parse_client_hello(truncated))
+  end)
+
+  it("returns nil for a malformed server_name extension (length overruns)", function()
+    -- Hand-build a record whose server_name extension claims length 9999 but
+    -- the extension block ends much sooner.
+    local random = string.rep("\0", 32)
+    local body =
+      u16(0x0303) .. random ..
+      u8(0) ..             -- empty session id
+      u16(2) .. bytes(0x13, 0x01) ..
+      u8(1) .. u8(0) ..
+      u16(8) ..            -- extensions total length = 8
+      u16(0x0000) ..       -- ext type = SNI
+      u16(9999) ..         -- ext data length = lie
+      u16(9997) ..         -- server_name_list_len = lie
+      u8(0) ..             -- name_type host_name
+      u16(9994) ..         -- server_name_len = lie
+      "x"                  -- only one body byte
+    local handshake = u8(0x01) .. u24(#body) .. body
+    local rec = u8(0x16) .. u16(0x0303) .. u16(#handshake) .. handshake
+    assert.is_nil(sni.parse_client_hello(rec))
+  end)
+
+  it("returns nil for a non-ClientHello handshake (ServerHello)", function()
+    local rec = build_client_hello({ sni = "example.com", handshake_type = 0x02 })
+    assert.is_nil(sni.parse_client_hello(rec))
+  end)
+
+  it("returns nil for non-TLS payload (random bytes starting with 0x17 application_data)", function()
+    local payload = u8(0x17) .. u16(0x0303) .. u16(16) .. string.rep("X", 16)
+    assert.is_nil(sni.parse_client_hello(payload))
+  end)
+
+  it("returns nil for an empty / non-string input", function()
+    assert.is_nil(sni.parse_client_hello(""))
+    assert.is_nil(sni.parse_client_hello(nil))
+    assert.is_nil(sni.parse_client_hello(42))
+  end)
+
+  it("returns nil for a server_name extension with name_type != host_name", function()
+    -- Hand-build: name_type = 0xff (unknown). RFC 6066: parser must skip.
+    local random = string.rep("\0", 32)
+    local snlen = 11
+    local server_name_entry = u8(0xff) .. u16(snlen) .. "example.com"
+    local server_name_list  = u16(#server_name_entry) .. server_name_entry
+    local sni_ext = u16(0x0000) .. u16(#server_name_list) .. server_name_list
+    local body =
+      u16(0x0303) .. random ..
+      u8(0) ..
+      u16(2) .. bytes(0x13, 0x01) ..
+      u8(1) .. u8(0) ..
+      u16(#sni_ext) .. sni_ext
+    local handshake = u8(0x01) .. u24(#body) .. body
+    local rec = u8(0x16) .. u16(0x0303) .. u16(#handshake) .. handshake
+    assert.is_nil(sni.parse_client_hello(rec))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 3. parse_packet — Ethernet / IP / TCP framing
+-- ---------------------------------------------------------------------------
+--
+-- The sni-tail sidecar feeds raw packets from `tcpdump -i br-lan -w -` (pcap
+-- format), each link-layer record is an Ethernet frame:
+--   Ethernet  (14 bytes; src MAC at offset 6..11)
+--   IPv4      (variable, 20+ bytes; dst IP at IHL offset 16..19, proto at 9)
+--   TCP       (variable, 20+ bytes; data offset in upper nibble of byte 12)
+--   Payload   ← TLS record starts here
+
+local function build_eth_ipv4_tcp(opts)
+  opts = opts or {}
+  local src_mac = opts.src_mac or { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }
+  local dst_ip  = opts.dst_ip  or { 142, 250, 80, 46 }
+  local payload = opts.payload or ""
+
+  -- Ethernet: dst (6), src (6), ethertype (2 = 0x0800 IPv4)
+  local eth = string.char(0,0,0,0,0,0) ..
+              string.char(src_mac[1], src_mac[2], src_mac[3],
+                          src_mac[4], src_mac[5], src_mac[6]) ..
+              u16(0x0800)
+
+  -- TCP: src port, dst port, seq, ack, data-offset+flags, window, checksum, urg
+  local tcp =
+      u16(54321) .. u16(443) ..
+      string.rep("\0", 4) ..       -- seq
+      string.rep("\0", 4) ..       -- ack
+      string.char(0x50, 0x18) ..   -- data offset 5*4=20 bytes, PSH+ACK
+      u16(0) .. u16(0) .. u16(0) ..
+      payload
+
+  -- IPv4: VER+IHL, DSCP, total length, ident, flags+frag, TTL, proto=6 TCP,
+  --       checksum, src ip, dst ip
+  local total_len = 20 + #tcp
+  local ip =
+      string.char(0x45) .. string.char(0) .. u16(total_len) ..
+      u16(0) .. u16(0) .. string.char(64) .. string.char(6) ..
+      u16(0) ..
+      string.char(192, 168, 1, 100) ..
+      string.char(dst_ip[1], dst_ip[2], dst_ip[3], dst_ip[4])
+
+  return eth .. ip .. tcp
+end
+
+describe("parse_packet (Ethernet/IPv4/TCP)", function()
+  it("returns dst_ip, src_mac, sni for a single-segment ClientHello", function()
+    local hello = build_client_hello({ sni = "example.com" })
+    local pkt = build_eth_ipv4_tcp({
+      payload = hello,
+      src_mac = { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e },
+      dst_ip  = { 142, 250, 80, 46 },
+    })
+    local r = sni.parse_packet(pkt)
+    assert.is_not_nil(r)
+    assert.equal("142.250.80.46",    r.dst_ip)
+    assert.equal("76:2d:95:47:d1:8e", r.src_mac)
+    assert.equal("example.com",      r.sni)
+  end)
+
+  it("returns nil when the TCP payload is not a TLS ClientHello", function()
+    local pkt = build_eth_ipv4_tcp({ payload = string.rep("X", 64) })
+    assert.is_nil(sni.parse_packet(pkt))
+  end)
+
+  it("returns nil for a short / truncated packet", function()
+    assert.is_nil(sni.parse_packet(""))
+    assert.is_nil(sni.parse_packet(string.rep("\0", 30)))
+    assert.is_nil(sni.parse_packet(nil))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- 4. format_sni_line / parse_sni_line — IPC line format between sidecars
+-- ---------------------------------------------------------------------------
+--
+-- wifihaven-sni-tail emits lines into /tmp/wifihaven-sni.log; dns-tail tails
+-- that file alongside the dnsmasq log and routes SNI-prefixed lines through
+-- cache.insert_sni. The line format is a single TSV row prefixed with "SNI\t"
+-- so dns-tail can disambiguate cheaply.
+describe("format_sni_line / parse_sni_line", function()
+  it("round-trips a (dst_ip, src_mac, sni) triple", function()
+    local line = sni.format_sni_line("142.250.80.46", "76:2d:95:47:d1:8e", "example.com")
+    assert.matches("^SNI\t", line)
+    local r = sni.parse_sni_line(line)
+    assert.is_not_nil(r)
+    assert.equal("142.250.80.46",     r.dst_ip)
+    assert.equal("76:2d:95:47:d1:8e", r.src_mac)
+    assert.equal("example.com",        r.sni)
+  end)
+
+  it("returns nil for non-SNI lines (e.g. a dnsmasq log line)", function()
+    assert.is_nil(sni.parse_sni_line(
+      "Nov 12 10:00:01 dnsmasq[1234]: 7 192.168.1.42/54321 query[A] youtube.com from 192.168.1.42"))
+    assert.is_nil(sni.parse_sni_line(""))
+    assert.is_nil(sni.parse_sni_line(nil))
+  end)
+end)

--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -107,10 +107,12 @@ case "${ONLY}" in
                 MARK="unknown_device" ;;
   install-health|install_health)
                 MARK="install_health" ;;
+  sni-attribution|sni_attribution)
+                MARK="sni_attribution" ;;
   *) echo "unknown --only: ${ONLY}" >&2
      echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page," >&2
      echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device," >&2
-     echo "       install-health" >&2
+     echo "       install-health, sni-attribution" >&2
      exit 2 ;;
 esac
 

--- a/scripts/e2e/lib/traffic.py
+++ b/scripts/e2e/lib/traffic.py
@@ -64,6 +64,33 @@ def dns_query(client: Client, host: str, *, timeout_s: int = 5) -> Result:
     )
 
 
+def tls_clienthello(client: Client, sni: str, ip: str, *, timeout_s: int = 5) -> Result:
+    """Emit a TLS ClientHello carrying `sni` to `ip:443` from the client — WITHOUT
+    a DNS lookup for `sni` (#573).
+
+    `curl --resolve <sni>:443:<ip>` pins the connection to `ip` so curl never
+    queries dnsmasq for `sni`; the ClientHello with `server_name=sni` is sent on
+    br-lan immediately after the TCP handshake completes. `-k` ignores the bogus
+    cert and `--max-time` bounds the (expected-to-fail) request. The HTTPS request
+    will not return a real body — `ip` is a throwaway listener — but that does not
+    matter: the proof is that the ClientHello crossed br-lan, where the SNI sidecar
+    captures it. Success is NOT required; emission is. Returns the raw Result for
+    diagnostics.
+    """
+    url = f"https://{sni}/"
+    return client_exec(
+        client,
+        [
+            "sh", "-c",
+            f"curl -k -s --max-time {timeout_s} "
+            f"--resolve {shell_quote(f'{sni}:443:{ip}')} "
+            f"-o /dev/null {shell_quote(url)} || true",
+        ],
+        timeout=timeout_s + 10,
+        check=False,
+    )
+
+
 def shell_quote(s: str) -> str:
     import shlex
     return shlex.quote(s)

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -18,6 +18,7 @@ markers =
     install_health: post-install router health asserts (#922 — cron, etc.)
     nflog: #1122 — forward-drop visibility via nflog (per-MAC drop comment + agent emission)
     cname_direct_requery: suite G (#1351) — ea_/eb_ population for directly-queried CNAME targets
+    sni_attribution: suite I (#573) — SNI-only hostname attribution via the wifihaven-sni-tail sidecar
     global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true

--- a/scripts/e2e/scenarios_fake/_observers.py
+++ b/scripts/e2e/scenarios_fake/_observers.py
@@ -277,6 +277,88 @@ def wait_ea_set_populated(mac: str, host: str, *, timeout_s: float = 90) -> list
     )
 
 
+def sni_cache_rows() -> list[tuple[str, str]]:
+    """Return (ip, hostname) rows from the router's shared dns→host cache.
+
+    The cache file (paths.dns_cache = /tmp/wifihaven-dns-cache.txt) is written
+    by wifihaven-dns-tail in the format `<ip>\\t<hostname>\\t<ts>` per entry. For
+    SNI-derived attribution (#573) the sidecar feeds `(dst_ip, sni)` tuples
+    through cache.insert_sni → the SAME single-writer cache, so an SNI-only
+    hostname (one never DNS-resolved) appears here exactly as a DNS-derived one
+    would. Ignores the trailing timestamp column.
+    """
+    res = router_ssh(
+        "cat /tmp/wifihaven-dns-cache.txt 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    rows: list[tuple[str, str]] = []
+    for line in (res.stdout or "").splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].strip() and parts[1].strip():
+            rows.append((parts[0].strip(), parts[1].strip()))
+    return rows
+
+
+def sni_spool_lines() -> list[str]:
+    """Return raw lines from the router's SNI capture spool.
+
+    paths.sni_capture = /tmp/wifihaven-sni.log — the wifihaven-sni-tail sidecar
+    appends one `SNI\\t<dst_ip>\\t<src_mac>\\t<server_name>` line per parsed
+    ClientHello. Used as a secondary diagnostic: if a row is in the spool but
+    not yet in the dns-cache, the failure is in dns-tail's SNI ingest, not in
+    the sidecar's capture/parse.
+    """
+    res = router_ssh(
+        "cat /tmp/wifihaven-sni.log 2>/dev/null || true",
+        check=False, timeout=10,
+    )
+    return [l for l in (res.stdout or "").splitlines() if l.strip()]
+
+
+def wait_sni_attributed(ip: str, host: str, *, timeout_s: float = 120) -> tuple[str, str]:
+    """Block until the router's shared dns→host cache maps `ip → host` (#573).
+
+    This is THE proof that SNI is the sole attribution source: `host` is a name
+    the client never DNS-resolves, so the only way it can reach the router's
+    attribution cache is via the TLS ClientHello captured by wifihaven-sni-tail,
+    parsed in sni.lua, and routed through cache.insert_sni by wifihaven-dns-tail.
+    A DNS-derived entry for `host` is impossible because no `reply <host> is <ip>`
+    line ever existed.
+
+    Returns the matched (ip, hostname) cache row. Raises TimeoutError (surfacing
+    the current cache rows + SNI spool tail) if the mapping never appears.
+    """
+    want_ip = ip.strip()
+    want_host = host.strip().lower()
+
+    def probe():
+        for cip, chost in sni_cache_rows():
+            if cip == want_ip and chost.lower() == want_host:
+                return (cip, chost)
+        return None
+
+    try:
+        return wait_until(
+            probe, timeout_s=timeout_s, interval_s=3,
+            description=(
+                f"dns-cache row {want_ip} -> {host} attributed via SNI "
+                f"(host never DNS-resolved, so SNI is the only possible source)"
+            ),
+        )
+    except TimeoutError:
+        # Secondary diagnostic: did the sidecar capture the ClientHello at all?
+        spool = sni_spool_lines()
+        rows = sni_cache_rows()
+        raise TimeoutError(
+            f"SNI attribution {want_ip} -> {host} never landed in the dns-cache "
+            f"within {timeout_s}s.\n"
+            f"  dns-cache rows ({len(rows)}): {rows!r}\n"
+            f"  sni spool lines ({len(spool)}): {spool[-10:]!r}\n"
+            f"  (spool non-empty + cache miss => dns-tail SNI ingest broke; "
+            f"spool empty => sidecar capture/parse broke or no ClientHello crossed br-lan)"
+        )
+
+
 def wait_event_with_host_attribution(
     fake_api,
     mac: str,

--- a/scripts/e2e/scenarios_fake/test_sni_attribution.py
+++ b/scripts/e2e/scenarios_fake/test_sni_attribution.py
@@ -1,0 +1,225 @@
+"""Suite I — SNI-only hostname attribution on a real router VM (#573).
+
+PR #1643 adds a `wifihaven-sni-tail` procd sidecar that captures the first
+packet of every outbound TCP/443 flow on br-lan via tcpdump-mini, parses the
+TLS ClientHello SNI in `sni.lua`, and feeds `(dst_ip, server_name)` tuples
+through `cache.insert_sni` into the SHARED dns→host attribution cache
+(paths.dns_cache = /tmp/wifihaven-dns-cache.txt) — the same single-writer cache
+the dnsmasq query log populates. The Lua busted suite (openwrt/test/sni_spec.lua,
+dns_log_spec.lua) covers the parser + cache helper in isolation, and the
+in-process integration test wires pcap → cache; THIS suite proves the FULL
+pipeline on a real router VM driving real br-lan traffic:
+
+    client → TLS ClientHello (curl --resolve, no DNS lookup)
+           → br-lan
+           → wifihaven-sni-tail (tcpdump-mini capture + sni.lua parse)
+           → /tmp/wifihaven-sni.log spool
+           → wifihaven-dns-tail (cache.insert_sni)
+           → /tmp/wifihaven-dns-cache.txt  (dst_ip → server_name)
+
+Failure mode this guards (the IP-vs-hostname collateral class, #1636 / #1640,
+sibling to the CNAME-direct-requery attribution bugs #1348/#1344): when a client
+bypasses the on-router DNS resolver (DoH) or hard-codes a destination IP, the
+DNS attribution path never sees the queried hostname, so connection_event
+labeling and per-host classification fall back to the raw IP — mis-attributing
+the flow (and, for a shared CDN IP, mislabeling collateral hosts). SNI v1 closes
+that gap for TLS/443 by recovering the hostname off the ClientHello.
+
+ISOLATION — why SNI is provably the SOLE attribution source here:
+  SNI_HOST is `e2e-sni.wifihaven.net`, a name the client NEVER `dig`s. dnsmasq
+  therefore logs zero `reply e2e-sni.wifihaven.net is <ip>` lines for it, so the
+  DNS attribution path CANNOT know it and no DNS-derived dns-cache row for it can
+  ever exist. The only way that name reaches the router's attribution cache is
+  the captured ClientHello. So a dns-cache row `<router-lan-ip> → e2e-sni…` is
+  an unambiguous proof of the SNI pipeline — there is no DNS confound.
+
+CAPTURABLE-CLIENTHELLO REQUIREMENT — why we dial the router's OWN LAN IP:
+  The TLS ClientHello is sent immediately AFTER the TCP handshake completes. An
+  unroutable / unreachable dst never completes the handshake, so no ClientHello
+  is ever emitted and nothing is captured (this is exactly why the Suite G
+  CNAME allow-path xfails against the RFC 5737 TEST-NET leaf — see
+  test_cname_direct_requery._xfail_if_leaf_unreachable / #1360). To guarantee a
+  real handshake on br-lan WITHOUT depending on any external origin, we stand up
+  a throwaway TCP listener on 443 on the ROUTER ITSELF (its br-lan IP) and pin
+  the client's connection there with `curl --resolve`. The TLS handshake need
+  not succeed — the listener speaks no TLS — but the ClientHello has already
+  left the client and crossed br-lan, which is all the sidecar needs.
+
+ASSERTIONS:
+  Primary (hard, deterministic, origin-independent): the router's shared
+  dns-cache maps <ROUTER_LAN_IP> → SNI_HOST. This needs only that the
+  ClientHello crossed br-lan — no reachable forwarded ORIGIN, no successful
+  TLS — so it stays HARD-gating even though the listener answers no TLS.
+
+  Secondary (best-effort, xfail-guarded per the #1360 harness gap): the
+  forwarded connection_event attribution (wait_event_with_host_attribution)
+  would prove conntrack.lua labels the flow with the SNI-derived host. But the
+  fake harness has NO forwarded reachable 443 origin to drive a labeled
+  connection_event for this synthetic name (the same missing-reachable-origin
+  gap #1360 documents for the CNAME allow-path), and the flow here targets the
+  router's own LAN IP (not a forwarded destination), so this path is NOT
+  exercised. It is intentionally skipped, not red-gated — see the inline note.
+"""
+from __future__ import annotations
+
+import pytest
+
+from ._observers import (
+    sni_cache_rows,
+    sni_spool_lines,
+    wait_sni_attributed,
+)
+from .snapshot_builder import SnapshotBuilder
+from lib.traffic import tls_clienthello
+from lib.vm import router_ssh
+from lib.wait import wait_until
+
+pytestmark = pytest.mark.sni_attribution
+
+# A name the client NEVER resolves — guarantees DNS cannot be the attribution
+# source, so a dns-cache row for it isolates the SNI pipeline (see module docstring).
+SNI_HOST = "e2e-sni.wifihaven.net"
+
+# Default router br-lan IP (scripts/vm/config.sh WH_LAN_ROUTER_IP /
+# uci-defaults/99-wifihaven network.lan.ipaddr). Resolved live from the router
+# at test time via uci, falling back to this constant.
+_DEFAULT_ROUTER_LAN_IP = "192.168.100.1"
+
+PID = 730
+
+
+def _router_lan_ip() -> str:
+    """The router's br-lan IP — the client's gateway, reachable on br-lan so the
+    TLS handshake completes and the ClientHello is emitted + captured."""
+    res = router_ssh("uci -q get network.lan.ipaddr || true", check=False, timeout=10)
+    ip = (res.stdout or "").strip()
+    return ip or _DEFAULT_ROUTER_LAN_IP
+
+
+def _start_router_tcp443_listener():
+    """Stand up a throwaway TCP/443 listener on the router so the client's TLS
+    handshake to <ROUTER_LAN_IP>:443 completes and the ClientHello is emitted.
+
+    The listener speaks no TLS — it only needs to ACCEPT the TCP connection so
+    the handshake finishes and curl proceeds to send the ClientHello. We use
+    busybox `nc`; `-ll` keeps it listening across connections where supported,
+    falling back to a re-accepting shell loop. Best-effort: we don't fail the
+    test on listener-start quirks because the PRIMARY proof only needs the
+    ClientHello to cross br-lan, and even a single accept suffices.
+    """
+    # Probe what this image's nc supports (busybox nc flags vary).
+    router_ssh("which nc || true; nc --help 2>&1 | head -3 || true",
+               check=False, timeout=10)
+    # Re-accepting loop in the background, surviving each closed connection.
+    # `setsid` detaches it from the SSH session so it isn't reaped on logout.
+    router_ssh(
+        "setsid sh -c 'while true; do nc -l -p 443 >/dev/null 2>&1 || "
+        "nc -l 443 >/dev/null 2>&1 || sleep 1; done' >/dev/null 2>&1 &",
+        check=False, timeout=10,
+    )
+
+
+def _stop_router_tcp443_listener():
+    """Tear down the throwaway listener + its re-accept loop so it doesn't leak
+    into the next scenario (the function-scoped `router` fixture restores the VM
+    snapshot, but the listener is started post-restore in-test, so clean it up
+    explicitly)."""
+    router_ssh(
+        "kill $(pgrep -f 'nc -l') 2>/dev/null; "
+        "kill $(pgrep -f 'while true; do nc -l') 2>/dev/null; true",
+        check=False, timeout=10,
+    )
+
+
+def test_sni_only_hostname_attribution(router, client, fake_api):
+    """I1: a TLS ClientHello for a name the client never DNS-resolves is captured
+    by the sni-tail sidecar and attributed in the shared dns-cache.
+
+    Primary assertion (hard, origin-independent): the router's dns→host cache
+    maps <ROUTER_LAN_IP> → e2e-sni.wifihaven.net. Because e2e-sni.wifihaven.net
+    is never `dig`'d, no DNS-derived row for it can exist — so this row proves
+    the SNI pipeline end-to-end (client ClientHello → br-lan → tcpdump-mini →
+    sni.lua → cache.insert_sni → dns-cache). A failure here means either the
+    sidecar didn't capture/parse the ClientHello or dns-tail didn't ingest the
+    SNI spool line; the observer's TimeoutError prints both the cache rows and
+    the SNI spool tail to localize which.
+    """
+    # A plain profile + this device. SNI attribution needs no DNS/blocklist/block
+    # state — it is attribution-only (PR #1643 review SHOULD-FIX #2: SNI improves
+    # cache.lookup / connection_event labeling; it does NOT add IPs to eb_/bl_
+    # drop sets), so we deliberately exercise it with nothing else in the way.
+    snap = (
+        SnapshotBuilder()
+        .add_profile(id=PID, name="e2e-sni-attr")
+        .add_device(mac=client.mac, name="e2e-sni-attr-dev", profile_id=PID)
+        .build(etag='"sha256:sni-attr-v1"')
+    )
+    etag = fake_api.serve_snapshot(snap)
+    fake_api.wait_for_etag_served(etag=etag, timeout_s=240)
+
+    router_lan_ip = _router_lan_ip()
+
+    # Sanity precondition: e2e-sni.wifihaven.net must NOT already be in the
+    # dns-cache before we emit the ClientHello. If it were, the isolation
+    # premise is broken and the primary assertion would be meaningless.
+    pre_rows = sni_cache_rows()
+    assert not any(
+        h.lower() == SNI_HOST.lower() for _ip, h in pre_rows
+    ), (
+        f"{SNI_HOST} unexpectedly already present in the dns-cache before any "
+        f"ClientHello — isolation premise broken (it must never be DNS-resolved). "
+        f"rows={pre_rows!r}"
+    )
+
+    _start_router_tcp443_listener()
+    try:
+        # Emit the ClientHello WITHOUT a DNS lookup for SNI_HOST, pinned to the
+        # router's own LAN IP so the TCP handshake completes on br-lan and the
+        # ClientHello is captured. Fire it a few times: the sidecar's BPF only
+        # captures the first packet of a NEW flow, and a single curl could race
+        # the sidecar's tcpdump warm-up on a freshly-restored VM.
+        for _ in range(3):
+            tls_clienthello(client, SNI_HOST, router_lan_ip, timeout_s=5)
+
+        # Keep emitting in the background while we poll, so the attribution has
+        # multiple chances to be captured even if tcpdump warmed up late.
+        def _attributed():
+            try:
+                return wait_sni_attributed(router_lan_ip, SNI_HOST, timeout_s=15)
+            except TimeoutError:
+                tls_clienthello(client, SNI_HOST, router_lan_ip, timeout_s=5)
+                return None
+
+        row = wait_until(
+            _attributed,
+            timeout_s=150,
+            interval_s=1,
+            description=(
+                f"dns-cache row {router_lan_ip} -> {SNI_HOST} attributed via SNI "
+                f"(host never DNS-resolved => SNI is the only possible source)"
+            ),
+        )
+        assert row == (router_lan_ip, SNI_HOST) or row[1].lower() == SNI_HOST.lower(), (
+            f"expected dns-cache attribution {router_lan_ip} -> {SNI_HOST}, "
+            f"got {row!r}. SNI spool tail: {sni_spool_lines()[-10:]!r}"
+        )
+    finally:
+        _stop_router_tcp443_listener()
+
+    # Secondary / best-effort (NOT exercised here; intentionally skipped, not
+    # red-gated). Proving conntrack.lua emits a connection_event whose host is
+    # the SNI-derived name would require a FORWARDED reachable TCP/443 origin so
+    # a labeled forwarded flow exists — the fake harness has none (the same
+    # missing-reachable-origin gap #1360 documents for the Suite G CNAME
+    # allow-path), and this scenario deliberately targets the router's OWN LAN
+    # IP (not a forwarded destination) to guarantee a capturable ClientHello.
+    # The primary dns-cache assertion above already proves the SNI pipeline
+    # populates the attribution cache; the connection_event consumer reading
+    # that cache is covered by the conntrack/dns_log unit + the existing
+    # CNAME-attribution Gate 2 scenario (G3). A future harness-served forwarded
+    # 443 origin (the #1360 follow-up) would let this run for real.
+    pytest.skip(
+        "forwarded connection_event SNI labeling needs a reachable forwarded "
+        "443 origin the fake harness lacks (#1360); primary dns-cache "
+        "attribution above is the hard proof of the SNI pipeline."
+    )

--- a/scripts/e2e/scenarios_fake/test_sni_attribution.py
+++ b/scripts/e2e/scenarios_fake/test_sni_attribution.py
@@ -96,37 +96,60 @@ def _router_lan_ip() -> str:
     return ip or _DEFAULT_ROUTER_LAN_IP
 
 
+# Exact arg string used to launch the throwaway responder, so teardown can
+# pgrep it precisely without matching the block-page uhttpd instance.
+_LISTENER_CMD = "uhttpd -h /tmp -p 0.0.0.0:443"
+
+
+def _port_443_listening() -> bool:
+    """True iff something now accepts TCP connections on the router's :443."""
+    res = router_ssh(
+        "netstat -tln 2>/dev/null | grep -q ':443 ' && echo yes || true",
+        check=False, timeout=10,
+    )
+    return "yes" in (res.stdout or "")
+
+
 def _start_router_tcp443_listener():
-    """Stand up a throwaway TCP/443 listener on the router so the client's TLS
+    """Stand up a throwaway TCP/443 responder on the router so the client's TLS
     handshake to <ROUTER_LAN_IP>:443 completes and the ClientHello is emitted.
 
-    The listener speaks no TLS — it only needs to ACCEPT the TCP connection so
-    the handshake finishes and curl proceeds to send the ClientHello. We use
-    busybox `nc`; `-ll` keeps it listening across connections where supported,
-    falling back to a re-accepting shell loop. Best-effort: we don't fail the
-    test on listener-start quirks because the PRIMARY proof only needs the
-    ClientHello to cross br-lan, and even a single accept suffices.
+    The responder need not speak TLS — it only has to ACCEPT the TCP connection
+    so the client proceeds to send the ClientHello (the first application-data
+    packet after the TCP handshake), which is what sni-tail captures on br-lan.
+
+    Why uhttpd and not nc: OpenWRT's busybox `nc` is the CLIENT-ONLY applet
+    (`Usage: nc [IPADDR PORT]` — no `-l`/server mode compiled in), so an
+    `nc -l -p 443` listener never binds. With no other 443 responder in the
+    minimal image (uhttpd hosts the block page on loopback:8081 only), the
+    client's SYN is refused, no ClientHello is ever emitted, and the sidecar
+    correctly captures nothing — which is exactly how this scenario first went
+    red. `uhttpd` IS in the image (it is the block-page dependency) and does
+    listen, so we run a throwaway standalone instance on 0.0.0.0:443. It speaks
+    plain HTTP, not TLS, but that is irrelevant here: accepting the TCP
+    connection is all that is needed for the ClientHello to cross br-lan.
     """
-    # Probe what this image's nc supports (busybox nc flags vary).
-    router_ssh("which nc || true; nc --help 2>&1 | head -3 || true",
-               check=False, timeout=10)
-    # Re-accepting loop in the background, surviving each closed connection.
-    # `setsid` detaches it from the SSH session so it isn't reaped on logout.
-    router_ssh(
-        "setsid sh -c 'while true; do nc -l -p 443 >/dev/null 2>&1 || "
-        "nc -l 443 >/dev/null 2>&1 || sleep 1; done' >/dev/null 2>&1 &",
-        check=False, timeout=10,
+    router_ssh(f"{_LISTENER_CMD} >/dev/null 2>&1 &", check=False, timeout=10)
+    # Surface a listener-start failure HERE (clear message) rather than letting
+    # it masquerade as a downstream attribution timeout.
+    wait_until(
+        lambda: True if _port_443_listening() else None,
+        timeout_s=20,
+        interval_s=2,
+        description=(
+            "a TCP/443 responder (throwaway uhttpd) to bind on the router so "
+            "the client's TLS ClientHello is actually emitted onto br-lan"
+        ),
     )
 
 
 def _stop_router_tcp443_listener():
-    """Tear down the throwaway listener + its re-accept loop so it doesn't leak
-    into the next scenario (the function-scoped `router` fixture restores the VM
-    snapshot, but the listener is started post-restore in-test, so clean it up
-    explicitly)."""
+    """Tear down the throwaway responder so it doesn't leak into the next
+    scenario (the function-scoped `router` fixture restores the VM snapshot, but
+    the responder is started post-restore in-test, so clean it up explicitly).
+    Targets only our instance's arg string, never the block-page uhttpd."""
     router_ssh(
-        "kill $(pgrep -f 'nc -l') 2>/dev/null; "
-        "kill $(pgrep -f 'while true; do nc -l') 2>/dev/null; true",
+        f"kill $(pgrep -f '{_LISTENER_CMD}') 2>/dev/null; true",
         check=False, timeout=10,
     )
 


### PR DESCRIPTION
## Summary

Adds v1 of the SNI-based hostname **attribution** sidecar (#573).

A new `wifihaven-sni-tail` procd sidecar captures the first packet of every outbound TCP/443 flow on the LAN bridge (probed from `network.lan.device`, default `br-lan`) via `tcpdump-mini`, parses the TLS ClientHello, and emits `SNI\t<dst_ip>\t<src_mac>\t<server_name>` lines into `/tmp/wifihaven-sni.log`. `wifihaven-dns-tail` tails that spool alongside the dnsmasq query log and routes SNI rows through `sni.route_line` → `cache.insert_sni`. The shared `paths.dns_cache` therefore stays **single-writer** (dns-tail) — no agent / router / wire changes.

**What this closes — attribution only.** SNI improves the agent's flow-attribution cache (`cache.lookup`), so `connection_attempt` / conntrack events get the branded `fqdn` even when the client used DoH/DoT or a hard-coded IP and dnsmasq never saw a query. It does **not** feed the `eb_` / `ea_` / `bl_` nftables drop-set populators: those fire solely on dnsmasq `reply <name> is <ip>` lines, and SNI is observed *after* the flow's first packet — too late to populate a drop set for that flow. So this PR closes the DoH/hard-coded-IP **attribution** gap behind the #1636 / #1640 class of *mislabeled* events; **enforcement** on hard-coded-IP traffic remains `blockIpOnly`'s job, and DoH/DoT egress blocking is the separate #572.

## Design choice

| Path | Verdict |
|---|---|
| **libpcap-userspace (tcpdump-mini)** | **chosen.** Slots into the existing sidecar-on-tmpfs pattern, no new kernel-side toolchain. Single OpenWRT package add. CPU is ~1 parse per new TLS flow — fine on the slowest supported router. |
| nft-ingress-eBPF | Ruled out — would introduce a brand-new libbpf + clang cross-compile dependency surface for a feature whose CPU budget does not require kernel-side parsing. |
| tc-bpf | Ruled out — same dependency-surface problem, plus bypasses the nft pipeline that all other enforcement flows through. |

## What is in v1

- TLS 1.2 / TLS 1.3 single-segment ClientHello SNI parsing on TCP dst port 443
- BPF capture filter restricting work to first-packet-of-flow ClientHellos (`tcp[((tcp[12]&0xf0)>>2)] = 0x16` AND the handshake byte is `0x01`)
- LAN bridge probed from UCI (`sni.lan_device` → `network.lan.device`, fallback `br-lan`); the "no pcap stream" error names the interface so a wrong bridge is diagnosable
- `sni.route_line(line, {insert_fn})` — the single dns-tail routing decision (SNI → `cache.insert_sni`, `tail -F` `==> file <==` banners skipped, dnsmasq lines fall through), extracted so the integration seam is unit-tested
- `cache.insert_sni(dst_ip, server_name[, now])` runs the SNI through the existing `resolve_head` CNAME-alias map (#1344) before `store()` — same primitive DNS ingest uses
- `sni.parse_packet` returns a bounded failure **reason** (`truncated` / `ipv6_skipped` / `not_tcp` / `malformed` / `no_sni`); the sidecar splits the formerly-lumped `no_sni` counter and surfaces each category in its periodic log line
- **Metrics:** sni-tail writes a cumulative per-result tally to `paths.sni_metrics` (same tmpfs-IPC + `format_query_results` shape as #1302's `dns_metrics`); the agent folds it into `sni_clienthellos_total{result}` on its metrics tick, and the metric is allowlisted in `MetricGuard.Allowed`
- `/tmp/wifihaven-sni.log` bounded by the existing 10-min `wifihaven-rotate-dnsmasq-log` cron
- New pure-Lua TLS parser module `openwrt/files/usr/lib/lua/wifihaven/sni.lua`, busted-tested
- `+tcpdump-mini` added to the OpenWRT package manifest (Makefile + build-ipk.sh + build-apk.sh)
- procd `sni-tail` instance in `/etc/init.d/wifihaven`, asserted by `init_spec.sh`

## What is explicitly out of scope (followups under #573)

- ECH (Encrypted ClientHello) — parser returns `nil`, counted as `no_sni`
- QUIC / HTTP/3 (UDP 443) Initial-packet SNI parsing
- IPv6 outer header (counted as `ipv6_skipped`)
- TLS 1.2 fragmented ClientHello reassembly across TCP segments
- UCI toggle to disable the sidecar per-router
- Static label map for hardcoded IP ranges (Apple APNs 17.0.0.0/8 etc.)
- **Grafana dashboard panel** for `sni_clienthellos_total{result}` (the metric itself ships in this PR; the panel + any agent-fold polish is the deferred follow-up)
- #572 DoH/DoT egress blocking (complementary, not blocking)

## Tests

`openwrt/test/sni_spec.lua` (42 specs) covers the TLS/Ethernet/IPv4/TCP parser, the `format_sni_line`/`parse_sni_line` round-trip, and the review-driven additions:

- `route_line`: SNI lines → `insert_fn`, `tail -F` switch banners skipped, dnsmasq lines fall through, empty/nil → not handled
- `parse_packet` failure reason second return value (`ipv6_skipped` / `truncated` / `no_sni`)
- `lan_device`: probes an injected UCI cursor, falls back to `br-lan`
- `parse_client_hello` rejects <3-char SNI, accepts `a.b`

**In-process pcap → cache integration (`sni_spec.lua` §9).** The
`wifihaven-sni-tail` pcap-stream reader is no longer untested inline
sidecar code: the byte-order-detecting global-header read, the
endianness-honoring 16-byte record framing, and the read loop are
extracted into `sni.lua` as pure, injectable functions
(`sni.read_global_header` / `sni.read_record` / `sni.iter_pcap`, backed
by a `read_fn(n)→bytes|nil` cursor), and the sidecar is now a thin
driver around them (single source of truth — one tested copy of the
framing logic, not a parallel inline one). A new integration block
assembles a synthetic pcap stream (24-byte global header + record
headers framing real Ethernet/IPv4/TCP packets carrying known-SNI
ClientHello fixtures) and drives the **full assembled pipeline**
in-process with no router or tcpdump: `iter_pcap → parse_packet →
format_sni_line → route_line → fake cache`, asserting the known
`dst_ip → SNI host` attribution lands in the cache. It also pins:
**both pcap byte orders** parse identically (covers review NIT #4 —
pcap header endianness, previously "verify by walkthrough" only); a
**truncated trailing record header** terminates the iterator cleanly
with no Lua error; and a **non-TLS packet** is skipped without
polluting the cache. This is the automated coverage of the assembled
reader + `route_line→cache` seam that previously existed only as
on-router manual steps.

`openwrt/test/dns_log_spec.lua` — `cache:insert_sni` stores so `cache.lookup` returns the SNI hostname, runs it through the CNAME-alias map, and is a no-op on nil/empty.

`openwrt/test/rotate_dnsmasq_log_spec.sh` — asserts the SNI spool is bounded by the rotation cron.

`api/test/src/feature/RouterMetricsIngestSpec.scala` — `sni_clienthellos_total{result}` re-exposes under `router_id` (additive `MetricGuard.Allowed` entry, no migration).

`openwrt/test/init_spec.sh` — the `wifihaven-sni-tail` procd instance is wired.

**VM e2e (Gate 2)** — `scripts/e2e/scenarios_fake/test_sni_attribution.py` (marker `sni_attribution`): a REAL router-VM end-to-end test of the sidecar, run automatically by the `e2e-vm-fake.yml` gate (pytest `testpaths` auto-collects the whole `scenarios_fake/` dir; both the ipk and apk router images bake `tcpdump-mini` + the `wifihaven-sni-tail` binary, so the scenario runs with no workflow change). It isolates SNI as the SOLE attribution source: the client emits a TLS ClientHello (`curl --resolve`, no DNS lookup) for `e2e-sni.wifihaven.net` — a name it never `dig`s — pinned to the router's own br-lan IP (a throwaway TCP/443 listener stood up on the router so the handshake completes and the ClientHello crosses br-lan). The hard, origin-independent assertion polls the router's shared dns→host cache (`/tmp/wifihaven-dns-cache.txt`) until it maps `<router-lan-ip> → e2e-sni.wifihaven.net` — unambiguous proof of the full pipeline (`ClientHello → br-lan → tcpdump-mini → sni.lua → cache.insert_sni → dns-cache`), since that name has no DNS-derived row. The forwarded `connection_event` SNI-labeling path is skipped (not red-gated): it needs a forwarded reachable 443 origin the fake harness lacks (the same #1360 missing-origin gap the Suite G CNAME allow-path xfails on).

## Field validation (operator, on `openwrt.lan`)

The assembled pcap → cache pipeline is now covered automatically by the
in-process integration test above; the steps below remain as on-router
**field validation** against a live tcpdump / dnsmasq / conntrack stack
(real capture, real interface, real flow attribution) — they are no
longer the only e2e coverage.

1. After upgrading the agent, `logread | grep sni-tail` should show `sni-tail: starting iface=<lan-bridge> snaplen=600 spool=/tmp/wifihaven-sni.log`.
2. To prove SNI is the source of attribution (rather than the dnsmasq path), temporarily set `uci set dhcp.@dnsmasq[0].logqueries=0` and restart dnsmasq.
3. From a LAN device (e.g. the Kids-profile iPad), `curl -v https://calendar.google.com`. Within 2 s expect `/tmp/wifihaven-sni.log` to contain a row mapping the resolved IP to `calendar.google.com`, and `/tmp/wifihaven-dns-cache.txt` to mirror it.
4. Generate a new conntrack flow to the same IP and confirm the resulting `connection_event` POST carries `fqdn=calendar.google.com`.
5. Re-enable `logqueries=extra` and run mixed `curl` traffic for 60 s while tailing the cache file — verify no torn or malformed lines (single-writer invariant preserved). The dns-tail 60-s heartbeat should report `sni_inserts=N`, and the sni-tail line should report `parsed/truncated/no_sni/ipv6_skipped/...`.

## Follow-ups to file as separate issues

- ECH (Encrypted ClientHello) detection and graceful degradation
- QUIC / HTTP/3 Initial-packet SNI parsing (UDP 443)
- IPv6 outer-header support in `sni.parse_packet`
- TLS 1.2 fragmented ClientHello reassembly
- UCI toggle to disable the SNI sidecar per-router
- Static label map for hardcoded IP ranges (Apple APNs 17.0.0.0/8)
- Grafana panel for `sni_clienthellos_total{result}`
- #572 DoH/DoT egress blocking (complementary, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


