### PR TITLE
test(#1622): fix flaky cert_spec idempotency assertion (fingerprint, not mtime)

### DIFF
--- a/openwrt/test/cert_spec.test.sh
+++ b/openwrt/test/cert_spec.test.sh
@@ -63,20 +63,26 @@ else
   check "cert key length >= 2048 bits" "unable to confirm key length"
 fi
 
-# Idempotent: a second run must NOT overwrite either file.
-CRT_BEFORE="$(stat -f '%m' "${CRT}" 2>/dev/null || stat -c '%Y' "${CRT}")"
-KEY_BEFORE="$(stat -f '%m' "${KEY}" 2>/dev/null || stat -c '%Y' "${KEY}")"
-sleep 1
+# Idempotent: a second run must NOT rotate either file. Assert on cert/key
+# *identity* (cert SHA-256 fingerprint + key content hash), NOT mtime. mtime is
+# a fragile proxy that this assertion previously used: idempotent runs leave the
+# file untouched so the mtime is stable, but a same-second filesystem-timestamp
+# window (and the BSD/GNU `stat` fallback) raced it intermittently in CI. The
+# real invariant we care about is that the cert was not regenerated — a rotated
+# cert would churn the uhttpd TLS listener on every boot — and a fingerprint
+# comparison verifies exactly that, with no timing dependency.
+CRT_FP_BEFORE="$(openssl x509 -in "${CRT}" -noout -fingerprint -sha256 2>/dev/null)"
+KEY_HASH_BEFORE="$(openssl dgst -sha256 "${KEY}" 2>/dev/null)"
 WIFIHAVEN_BLOCK_PAGE_CRT="${CRT}" WIFIHAVEN_BLOCK_PAGE_KEY="${KEY}" \
   sh "${SCRIPT}" >/dev/null 2>&1
-CRT_AFTER="$(stat -f '%m' "${CRT}" 2>/dev/null || stat -c '%Y' "${CRT}")"
-KEY_AFTER="$(stat -f '%m' "${KEY}" 2>/dev/null || stat -c '%Y' "${KEY}")"
+CRT_FP_AFTER="$(openssl x509 -in "${CRT}" -noout -fingerprint -sha256 2>/dev/null)"
+KEY_HASH_AFTER="$(openssl dgst -sha256 "${KEY}" 2>/dev/null)"
 
-if [ "${CRT_BEFORE}" = "${CRT_AFTER}" ] && [ "${KEY_BEFORE}" = "${KEY_AFTER}" ]; then
-  check "second run is idempotent (mtimes unchanged)" ok
+if [ "${CRT_FP_BEFORE}" = "${CRT_FP_AFTER}" ] && [ "${KEY_HASH_BEFORE}" = "${KEY_HASH_AFTER}" ]; then
+  check "second run is idempotent (cert + key unchanged)" ok
 else
-  check "second run is idempotent (mtimes unchanged)" \
-    "cert ${CRT_BEFORE}→${CRT_AFTER}, key ${KEY_BEFORE}→${KEY_AFTER}"
+  check "second run is idempotent (cert + key unchanged)" \
+    "cert ${CRT_FP_BEFORE}→${CRT_FP_AFTER}, key ${KEY_HASH_BEFORE}→${KEY_HASH_AFTER}"
 fi
 
 printf "\n%d passed, %d failed\n" "${PASS}" "${FAIL}"


### PR DESCRIPTION
## Problem

`openwrt/test/cert_spec.test.sh`'s **"second run is idempotent"** assertion
compares the **mtime** of `block_page.crt` / `block_page.key` across two runs
of `generate-block-page-cert.sh`. It fails intermittently in CI (observed on
GitHub Actions run 27354778995, job *Shell Tests*) while passing reliably
locally.

## Root cause — the test, not the generator

The generator is **correctly idempotent**: it skips when both files already
exist and are non-empty (`[ -s "$CRT" ] && [ -s "$KEY" ]`), so a second run
never touches the files. Verified locally — second run logs `skipping` and
the cert fingerprint is byte-for-byte identical across runs.

So this is **case (a): the assertion is the fragile part.** mtime is only a
*proxy* for "the cert wasn't rotated", and the proxy races:

- the `sleep 1` + whole-second mtime comparison straddles the
  same-second filesystem-timestamp window, and
- the BSD/GNU `stat -f '%m' || stat -c '%Y'` fallback adds platform skew.

The generator itself needs no change.

## Fix

Assert on cert/key **identity** instead of mtime:

- cert **SHA-256 fingerprint** (`openssl x509 -fingerprint -sha256`)
- key **content hash** (`openssl dgst -sha256`)

This is **timing-independent** (the `sleep 1` is removed) and verifies the
invariant we actually care about: the cert was not regenerated. A rotated
cert would churn the uhttpd TLS listener on every boot — exactly the
regression worth catching — and a fingerprint comparison catches it
**deterministically** where mtime caught it only probabilistically.

## Validation

- New assertion runs **green deterministically** across repeated runs (no
  sleep, no timestamp dependency).
- **Red-test check:** temporarily neutering the generator's idempotency guard
  makes the new assertion **FAIL** with a clear cert/key fingerprint diff —
  confirming the assertion still catches genuine non-idempotency.
- Full shell suite green: `cert_spec` 6/6, `install_spec` 48/48,
  `update_multi_pkg_spec` 33/33.
- The lua suite was not runnable in this local env (missing `lua5.1` /
  `luci.jsonc`); no lua files are touched by this change, so CI exercises it
  unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)