### PR TITLE
docs: require bounded rotation for router-agent /tmp writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -791,6 +791,44 @@ In the same PR:
    `terraform fmt -check`, `terraform validate`, and `python3 -m json.tool`
    on every dashboard. Run all three locally before pushing.
 
+## Every router-agent write to `/tmp` must be bounded {#bounded-tmp-writes}
+
+**On the OpenWRT target `/tmp` is `tmpfs` — RAM, not disk.** A log, spool, or
+cache the agent appends to without a cap grows until it exhausts router memory,
+at which point allocations start failing fleet-wide: dnsmasq, the agent, and
+the kernel all compete for a few hundred MB of RAM on the smallest supported
+device. An unbounded `/tmp` writer is therefore not a disk-hygiene nicety —
+it is a latent **router-wedge / OOM** bug. (This rule comes out of the #573
+SNI sidecar, whose first cut appended to `/tmp/wifihaven-sni.log` forever.)
+
+So: **any agent file under `/tmp` that grows with traffic, time, or event
+volume must ship with a rotation/truncation path in the SAME change that
+introduces it.** Concretely:
+
+- **Add it to the existing rotation cron, don't invent a parallel one.**
+  [`wifihaven-rotate-dnsmasq-log`](openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log)
+  runs every 10 minutes and is the canonical place — it caps each file at a
+  fixed `MAX_BYTES` using the **copytruncate** pattern (`cp` to `*.1`, then
+  `: > file`). New spools join its file list; they do not get a second cron
+  job or a bespoke shell script.
+- **Copytruncate, never rename**, for any file a long-lived process holds an
+  open fd on (dnsmasq, or a `tail -F` follower like `wifihaven-dns-tail`). A
+  rename leaves the writer appending to an invisible, unrotated inode and the
+  follower stranded; truncation keeps both on the same inode. The follower's
+  brief reseek window is acceptable and bounded — see the header comment in
+  the rotate script for the full rationale.
+- **A bounded in-memory ring that is only ever *snapshotted* to `/tmp`
+  (atomic write + rename of a whole file, like `paths.dns_cache`) is already
+  bounded** — its size is the cache size, not cumulative. Those don't need
+  cron rotation. The rule targets **append/grow** writers (logs, spools,
+  metrics journals), not fixed-size snapshots.
+- **State the cap and worst-case `/tmp` footprint** in the script/header so a
+  reviewer can sanity-check it against the smallest device's RAM.
+
+The same reasoning applies to anything else the agent persists under `/tmp`
+(JSON spools, NDJSON event journals, debug dumps). If it can grow, it gets a
+bound — in the same PR.
+
 ## Branch-diff checks (CI + pre-push)
 
 CI checks and pre-push checks that compare a branch against `main` MUST diff against the **merge base** with `origin/main`, not `origin/main` directly. Use three-dot syntax (`origin/main...HEAD`) or an explicit `git merge-base origin/main HEAD`. Two-dot (`origin/main..HEAD`) over-reports when `main` has advanced since the branch diverged, producing spurious failures and noise.

--- a/docs/pr-review-checklist.md
+++ b/docs/pr-review-checklist.md
@@ -114,6 +114,15 @@ in [#1561](https://github.com/wifihaven/wifihaven/issues/1561).
 - **`Clock` injected** — no direct `java.time` `now`. **ZIO effects** — no
   `throw`; typed sealed errors, not strings. **Config via `zio-config`** — no
   `sys.env` or hardcoded values.
+- **Every new router-agent write under `/tmp` is bounded.** `/tmp` is `tmpfs`
+  (RAM) on OpenWRT, so an unbounded append-writer is an OOM / router-wedge bug.
+  Any new log / spool / journal that grows with traffic, time, or events must
+  ship rotation in the SAME PR — joined to the existing
+  `wifihaven-rotate-dnsmasq-log` cron, using **copytruncate** (not rename) when
+  a long-lived process or `tail -F` follower holds the fd. Fixed-size snapshots
+  (atomic whole-file rewrite, e.g. `paths.dns_cache`) are already bounded and
+  exempt. BLOCKER if a grow-writer ships with no cap. See AGENTS.md
+  [§bounded-tmp-writes](../AGENTS.md#bounded-tmp-writes).
 
 ## 4. Backwards compatibility / wire contract
 


### PR DESCRIPTION
## Summary

Codifies a rule that came directly out of the #573 SNI sidecar review (PR #1643, SHOULD-FIX #6): **every new router-agent file under `/tmp` that grows with traffic/time/events must ship a rotation or truncation path in the same change.**

`/tmp` on the OpenWRT target is `tmpfs` — RAM, not disk. An unbounded append-writer therefore isn't a disk-hygiene nicety; it grows until the router OOMs and allocations start failing fleet-wide (dnsmasq, the agent, and the kernel all share a few hundred MB on the smallest device). It's a latent **router-wedge** bug.

## What changed (docs only)

- **`AGENTS.md` → new section `## Every router-agent write to /tmp must be bounded` (`#bounded-tmp-writes`).** States the stakes, points new spools at the existing [`wifihaven-rotate-dnsmasq-log`](../openwrt/files/usr/sbin/wifihaven-rotate-dnsmasq-log) 10-minute cron (don't invent a parallel one), mandates **copytruncate** (not rename) for files a long-lived process / `tail -F` follower holds an fd on, and exempts fixed-size snapshots (atomic whole-file rewrite, e.g. `paths.dns_cache`) since those are already bounded by cache size, not cumulative.
- **`docs/pr-review-checklist.md` → bullet under §3 Architectural invariants.** Makes an unbounded grow-writer a **BLOCKER**, cross-linked to the AGENTS.md section, so the independent review gate catches it.

No code, no migration — `CLAUDE.md` is a symlink to `AGENTS.md`, so the one edit covers both.

## Why a rule and not just a one-off fix

The unbounded-spool mistake is easy to repeat every time someone adds a new agent observability path (JSON spools, NDJSON event journals, debug dumps). Pinning it in both the authoring guide and the review checklist makes it a standing gate rather than a lesson each new sidecar relearns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)