### PR TITLE
feat(#1645): label extraBlocked events with the matched eb_<host> rule

### DIFF
--- a/api/src/routes/BlockedRoutes.scala
+++ b/api/src/routes/BlockedRoutes.scala
@@ -133,15 +133,16 @@ object BlockedRoutes {
       reason: String,
       blocklistRepo: BlocklistRepo,
   ): Task[(String, Option[String])] = BlockReason.fromWire(reason) match {
-    case MacBlockReason.Paused       => ZIO.succeed(("paused", None))
-    case MacBlockReason.Schedule     => ZIO.succeed(("schedule", None))
-    case MacBlockReason.TimeLimit    => ZIO.succeed(("time_limit", None))
-    case BlockReason.ExtraBlocked    => ZIO.succeed(("extra_blocked", None))
-    case BlockReason.AppTimeLimit(_) =>
+    case MacBlockReason.Paused         => ZIO.succeed(("paused", None))
+    case MacBlockReason.Schedule       => ZIO.succeed(("schedule", None))
+    case MacBlockReason.TimeLimit      => ZIO.succeed(("time_limit", None))
+    case BlockReason.ExtraBlocked      => ZIO.succeed(("extra_blocked", None))
+    case BlockReason.ExtraBlockedBy(_) => ZIO.succeed(("extra_blocked", None)) // #1645
+    case BlockReason.AppTimeLimit(_)   =>
       // #1518: rename `site_time_limit` → `app_time_limit`. SPA-API surface,
       // updated atomically with the SPA in the same PR.
       ZIO.succeed(("app_time_limit", None))
-    case BlockReason.Category(id)    =>
+    case BlockReason.Category(id)      =>
       blocklistRepo
         .findMeta(id)
         .map(meta => ("category", meta.map(_.name)))

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -711,7 +711,11 @@ function M.handle_flow(flow, ctx, batcher)
       end
       if eb_hit and not check_ea_carveout(eb_hit_host) then
         allowed = false
-        reason  = "host"
+        -- #1645: name the matched eb_<host> rule so triage can see which
+        -- extraBlocked entry fired (otherwise an IP-anycast overlap on a
+        -- shared CDN looks like an opaque "host" block). Symmetric with
+        -- the `category:<id>` reason for the bl_ path below.
+        reason  = "host:" .. eb_hit_host
       end
     end
   end

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -715,6 +715,14 @@ function M.handle_flow(flow, ctx, batcher)
         -- extraBlocked entry fired (otherwise an IP-anycast overlap on a
         -- shared CDN looks like an opaque "host" block). Symmetric with
         -- the `category:<id>` reason for the bl_ path below.
+        --
+        -- When `eb_hosts` for this MAC contains more than one host whose
+        -- ipset covers the same `dst_ip` (rare overlap, e.g. same anycast
+        -- IP resolved for two different extraBlocked apex domains), the
+        -- labeled `eb_hit_host` reflects whichever `pairs(eb_hosts)`
+        -- iteration order surfaced first — non-deterministic per Lua
+        -- semantics. The drop itself is unaffected (the kernel already
+        -- matched at least one eb_ set); only the debug label can vary.
         reason  = "host:" .. eb_hit_host
       end
     end

--- a/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/nft_drops.lua
@@ -50,7 +50,11 @@ local WHOLE_MAC_REASONS = {
 -- comment_reason is the `<reason>` portion of `wh_drop:<mac>:<reason>`.
 function M.classify_reason(comment_reason)
   if type(comment_reason) ~= "string" then return "whole_mac" end
-  if comment_reason == "host" then
+  -- #1645: post-rollout per-host drops carry `host:<host>` so the matched
+  -- eb_<host> rule is named in events; the bare `host` legacy form (pre-
+  -- rollout routers) still folds into the same bounded bucket. The host
+  -- name itself never becomes a label — §4 cardinality firewall.
+  if comment_reason == "host" or comment_reason:match("^host:") then
     return "host_block"
   elseif comment_reason == "ip_only" then
     return "ip_only"

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1046,12 +1046,12 @@ function M.nft(snapshot, opts)
   for _, p in ipairs(eb_pairs) do
     ind2(string.format("ether saddr %s ip daddr @%s%s%s%s",
                        p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"),
-                       ga_suffix("ip"), drop_suffix(p.mac, "host")))
+                       ga_suffix("ip"), drop_suffix(p.mac, "host:" .. p.host)))
   end
   for _, p in ipairs(eb_pairs) do
     ind2(string.format("ether saddr %s ip6 daddr @%s%s%s%s",
                        p.mac, eb6_set_name(p.host), ea_suffix(p.mac, "ip6"),
-                       ga_suffix("ip6"), drop_suffix(p.mac, "host")))
+                       ga_suffix("ip6"), drop_suffix(p.mac, "host:" .. p.host)))
   end
   for _, p in ipairs(bl_pairs) do
     ind2(string.format("ether saddr %s ip daddr @%s%s%s%s",

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -1043,6 +1043,15 @@ function M.nft(snapshot, opts)
   -- so behaviour for those is unchanged.
   -- #1319: ga_suffix appended after the per-MAC ea exception, so an allowed
   -- host (per-MAC or global) suppresses the per-host / per-category drop.
+  -- #1645: `host:<host>` names the matched eb_<host> rule in the kernel
+  -- log line and the nft comment. Kernel `log prefix` is bounded by
+  -- NF_LOG_PREFIXLEN=128; with `wh_drop:<mac>:host:<host> ` the fixed
+  -- envelope is 31 chars, leaving 96 chars of headroom — comfortably above
+  -- any realistic hostname (RFC 1035 caps a single label at 63 chars and
+  -- typical extraBlocked apex hosts are < 30). If a pathologically long
+  -- CNAME ever surfaces, the kernel truncates silently and the nflog
+  -- parser sees a partial host; for now we accept that gracefully (the
+  -- drop still fires correctly — only the label is lossy).
   for _, p in ipairs(eb_pairs) do
     ind2(string.format("ether saddr %s ip daddr @%s%s%s%s",
                        p.mac, eb_set_name(p.host), ea_suffix(p.mac, "ip"),

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -685,7 +685,7 @@ describe("handle_flow", function()
   -- so decisions are driven off hname matching eb_hosts_by_mac — NOT off
   -- nft_sets[host][dst_ip].
 
-  it("labels connection_attempt as blocked (reason=host) when hname exactly matches an eb_ host for the MAC", function()
+  it("labels connection_attempt as blocked (reason=host:<host>) when hname exactly matches an eb_ host for the MAC (#1645)", function()
     local b = collecting_batcher()
     local ctx = ctx_with({
       reported_macs   = { [MAC] = true },
@@ -699,7 +699,7 @@ describe("handle_flow", function()
     local ev = b.events[#b.events]
     assert.equal("connection_attempt", ev["type"])
     assert.equal(false,  ev.allowed)
-    assert.equal("host", ev.reason)
+    assert.equal("host:example.com", ev.reason)
   end)
 
   it("labels connection_attempt as blocked when hname is a subdomain of an eb_ host (suffix-match)", function()
@@ -716,7 +716,9 @@ describe("handle_flow", function()
     conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
     local ev = b.events[#b.events]
     assert.equal(false,  ev.allowed)
-    assert.equal("host", ev.reason)
+    -- #1645: reason carries the matched eb_ host even for the subdomain
+    -- suffix-match case; the matched rule's host name is what gets logged.
+    assert.equal("host:example.com", ev.reason)
   end)
 
   it("does NOT block when hname does not match any eb_ host for the MAC", function()
@@ -829,7 +831,7 @@ describe("handle_flow", function()
     conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
     local ev = b.events[#b.events]
     assert.equal(false,  ev.allowed)
-    assert.equal("host", ev.reason)
+    assert.equal("host:shared.example", ev.reason)
   end)
 
   it("does NOT block when eb_hosts_by_mac is absent from ctx", function()
@@ -872,7 +874,9 @@ describe("handle_flow", function()
     conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
     local ev = b.events[#b.events]
     assert.equal(false,  ev.allowed, "extraBlocked IP with no DNS attribution must be logged as blocked")
-    assert.equal("host", ev.reason)
+    -- #1645: even in the no-hname fallback the reason names which eb_ rule
+    -- matched, so triage can see the specific eb_<host> that fired.
+    assert.equal("host:example.com", ev.reason)
     assert.is_true(#exec_calls >= 1, "exec_fn must have been called for the nft lookup")
   end)
 

--- a/openwrt/test/failover_spec.lua
+++ b/openwrt/test/failover_spec.lua
@@ -166,11 +166,11 @@ describe("render.nft — #385/#422 three-mode failover", function()
     s.profiles["3"].rules.extraBlocked = { "tiktok.com" }
     local nft_no_signal = render.nft(s)
     assert.truthy(nft_no_signal:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host\"", 1, true),
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
       "AllowAll must enforce normally when no failover signal is present")
     local nft_ok = render.nft(s, { poll_failed = false })
     assert.truthy(nft_ok:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host\"", 1, true),
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_tiktok_com log prefix \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:tiktok.com\"", 1, true),
       "AllowAll must enforce normally when the most-recent poll succeeded")
   end)
 
@@ -184,15 +184,15 @@ describe("render.nft — #385/#422 three-mode failover", function()
     local nft = render.nft(s, { poll_failed = true })
     -- Block-all kid keeps its extraBlocked drop.
     assert.truthy(nft:find(
-      "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example log prefix \"wh_drop:aa:aa:aa:00:00:01:host \" counter drop comment \"wh_drop:aa:aa:aa:00:00:01:host\"",
+      "ether saddr aa:aa:aa:00:00:01 ip daddr @eb_kidblocked_example log prefix \"wh_drop:aa:aa:aa:00:00:01:host:kidblocked.example \" counter drop comment \"wh_drop:aa:aa:aa:00:00:01:host:kidblocked.example\"",
       1, true))
     -- LastKnownGood adult keeps its extraBlocked drop.
     assert.truthy(nft:find(
-      "ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example log prefix \"wh_drop:bb:bb:bb:00:00:02:host \" counter drop comment \"wh_drop:bb:bb:bb:00:00:02:host\"",
+      "ether saddr bb:bb:bb:00:00:02 ip daddr @eb_adultblocked_example log prefix \"wh_drop:bb:bb:bb:00:00:02:host:adultblocked.example \" counter drop comment \"wh_drop:bb:bb:bb:00:00:02:host:adultblocked.example\"",
       1, true))
     -- AllowAll guest does NOT have its extraBlocked drop.
     assert.is_nil(nft:find(
-      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_guestblocked_example log prefix \"wh_drop:cc:cc:cc:00:00:03:host \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host\"",
+      "ether saddr cc:cc:cc:00:00:03 ip daddr @eb_guestblocked_example log prefix \"wh_drop:cc:cc:cc:00:00:03:host:guestblocked.example \" counter drop comment \"wh_drop:cc:cc:cc:00:00:03:host:guestblocked.example\"",
       1, true))
   end)
 

--- a/openwrt/test/nflog_spec.lua
+++ b/openwrt/test/nflog_spec.lua
@@ -49,6 +49,18 @@ describe("nflog.parse_line", function()
     assert.equal("host", ev.reason)
   end)
 
+  -- #1645: post-rollout render.lua emits `wh_drop:<mac>:host:<host>` so the
+  -- nflog parser pulls the matched eb_<host> rule's host straight through
+  -- as reason=`host:<host>`. Same `(%S+)` capture as `category:<id>`; no
+  -- prefix translation step.
+  it("parses the per-host eb_ drop reason `host:<host>` (#1645)", function()
+    local line = "wh_drop:aa:bb:cc:11:22:33:host:youtubei.googleapis.com " ..
+                 "SRC=192.168.1.42 DST=1.2.3.4 PROTO=TCP DPT=443"
+    local ev = nflog.parse_line(line)
+    assert.is_not_nil(ev)
+    assert.equal("host:youtubei.googleapis.com", ev.reason)
+  end)
+
   it("parses the per-category (bl_) drop reason `category:<id>`", function()
     local line = "wh_drop:aa:bb:cc:11:22:33:category:ads " ..
                  "SRC=192.168.1.42 DST=1.2.3.4 PROTO=TCP DPT=443"

--- a/openwrt/test/nft_drops_spec.lua
+++ b/openwrt/test/nft_drops_spec.lua
@@ -7,6 +7,16 @@ describe("nft_drops.classify_reason", function()
     assert.equal("host_block", nft_drops.classify_reason("host"))
   end)
 
+  -- #1645: post-rollout the per-host drop comment is `host:<host>` so the
+  -- matched eb_<host> rule can be named. Both the legacy bare `host` and
+  -- the new `host:<host>` form fold into the same bounded `host_block`
+  -- metrics bucket — the host name itself is forbidden as a label per the
+  -- §4 cardinality firewall.
+  it("collapses host:<host> into host_block (#1645)", function()
+    assert.equal("host_block", nft_drops.classify_reason("host:youtubei.googleapis.com"))
+    assert.equal("host_block", nft_drops.classify_reason("host:tiktok.com"))
+  end)
+
   it("maps the blockIpOnly drop to ip_only", function()
     assert.equal("ip_only", nft_drops.classify_reason("ip_only"))
   end)

--- a/openwrt/test/render_spec.lua
+++ b/openwrt/test/render_spec.lua
@@ -414,7 +414,7 @@ describe("render.nft extraBlocked enforcement", function()
   it("emits a drop rule `ether saddr <mac> ip daddr @eb_<host> drop` for each (mac, host) pair", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   -- #392: v6 drop rule mirrors the v4 one. Without it a dual-stack host
@@ -422,7 +422,7 @@ describe("render.nft extraBlocked enforcement", function()
   it("emits a v6 drop rule `ether saddr <mac> ip6 daddr @eb6_<host> drop` (#392)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   it("does NOT drop traffic from MACs in OTHER profiles (no global leakage — the bug #351 fixes)", function()
@@ -440,10 +440,10 @@ describe("render.nft extraBlocked enforcement", function()
     local nft = render.nft(s)
     -- Kids MAC still has the drop.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     -- Adults MAC must NOT appear paired with eb_tiktok_com.
     assert.is_nil(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host\"", 1, true))
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
   end)
 
   it("two MACs sharing the same extraBlocked host produce ONE ipset and TWO MAC-scoped drops", function()
@@ -462,9 +462,9 @@ describe("render.nft extraBlocked enforcement", function()
     local _, set_count = nft:gsub("set eb_tiktok_com {", "")
     assert.equal(1, set_count)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     assert.truthy(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr @eb_tiktok_com log prefix \"wh_drop:11:22:33:44:55:66:host \" counter drop comment \"wh_drop:11:22:33:44:55:66:host\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_tiktok_com log prefix \"wh_drop:11:22:33:44:55:66:host:tiktok.com \" counter drop comment \"wh_drop:11:22:33:44:55:66:host:tiktok.com\"", 1, true))
   end)
 
   it("emits no extraBlocked sets or drop rules when no device has extraBlocked", function()
@@ -501,10 +501,10 @@ describe("render.nft extraBlocked enforcement", function()
     }
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_override_example log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_override_example log prefix \"wh_drop:aa:bb:cc:11:22:33:host:override.example \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:override.example\"", 1, true))
     -- Sibling under the same profile must NOT inherit the override.
     assert.is_nil(nft:find(
-      "ether saddr 11:22:33:44:55:66 ip daddr @eb_override_example log prefix \"wh_drop:11:22:33:44:55:66:host \" counter drop comment \"wh_drop:11:22:33:44:55:66:host\"", 1, true))
+      "ether saddr 11:22:33:44:55:66 ip daddr @eb_override_example log prefix \"wh_drop:11:22:33:44:55:66:host:override.example \" counter drop comment \"wh_drop:11:22:33:44:55:66:host:override.example\"", 1, true))
   end)
 
 end)
@@ -759,10 +759,10 @@ describe("render.nft drop rules carry log prefix + counter + comment (#1122/#112
     end
   end)
 
-  it("eb_ drop comment is wh_drop:<mac>:host", function()
+  it("eb_ drop comment is wh_drop:<mac>:host:<host> (#1645)", function()
     local nft = render.nft(snap_one())
     assert.truthy(nft:find(
-      "ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -1534,7 +1534,7 @@ describe("render blockIpOnly enforcement (#353)", function()
     -- rules, so a packet matching the eb_ rule is dropped regardless of the
     -- blockIpOnly rule's predicate.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
     assert.truthy(nft:find(
       "ether saddr aa:bb:cc:11:22:33 ip daddr != @resolved_aa_bb_cc_11_22_33 log prefix \"wh_drop:aa:bb:cc:11:22:33:ip_only \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:ip_only\"",
       1, true))
@@ -1697,14 +1697,14 @@ describe("render extraAllowed enforcement (#421)", function()
   it("appends `ip daddr != @ea_<m>_<a>` to the eb_<host> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
   it("appends `ip6 daddr != @ea6_<m>_<a>` to the eb6_<host> drop for MAC m", function()
     local nft = render.nft(snap_ea())
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ether saddr aa:bb:cc:11:22:33 ip6 daddr @eb6_tiktok_com ip6 daddr != @ea6_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -1728,7 +1728,7 @@ describe("render extraAllowed enforcement (#421)", function()
     local nft = render.nft(s)
     -- Both clauses present in the same eb_ drop rule, in sorted order.
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_khanacademy_org ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 
@@ -1738,7 +1738,7 @@ describe("render extraAllowed enforcement (#421)", function()
     -- Adult MAC has the same eb_tiktok_com drop but extraAllowed={}, so no
     -- ea_ suffix on its rule.
     assert.truthy(nft:find(
-      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host\"", 1, true))
+      "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com log prefix \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com \" counter drop comment \"wh_drop:de:ad:be:ef:00:01:host:tiktok.com\"", 1, true))
     -- And specifically not carrying the kid's ea set.
     assert.is_nil(nft:find(
       "ether saddr de:ad:be:ef:00:01 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com",
@@ -1750,7 +1750,7 @@ describe("render extraAllowed enforcement (#421)", function()
     s.profiles["3"].rules.extraAllowed = {}
     local nft = render.nft(s)
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"", 1, true))
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"", 1, true))
   end)
 
   -- ── DNAT chain: same suffix applied ─────────────────────────────────────
@@ -1803,7 +1803,7 @@ describe("render extraAllowed enforcement (#421)", function()
     local nft = render.nft(s)
     -- eb drop has ea suffix:
     assert.truthy(nft:find(
-      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ether saddr aa:bb:cc:11:22:33 ip daddr @eb_tiktok_com ip daddr != @ea_aa_bb_cc_11_22_33_music_tiktok_com log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
     -- bio drop has no ea suffix:
     assert.truthy(nft:find(
@@ -2291,7 +2291,7 @@ describe("render.nft global composition (#1319)", function()
     s.global.extraAllowed = { "wifihaven.local" }
     local nft = render.nft(s) -- snap_one has extraBlocked = { "tiktok.com" }
     assert.truthy(nft:find(
-      "ip daddr @eb_tiktok_com ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:host \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host\"",
+      "ip daddr @eb_tiktok_com ip daddr != @global_allow log prefix \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com \" counter drop comment \"wh_drop:aa:bb:cc:11:22:33:host:tiktok.com\"",
       1, true))
   end)
 

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1756,6 +1756,14 @@ object BlockReason {
   // `host:<host>`; the legacy bare `host` alias below still parses as the
   // anonymous `ExtraBlocked` for pre-rollout routers.
   case class ExtraBlockedBy(host: Hostname) extends BlockReason {
+    // `wireKind` here is the prefix-form sentinel (trailing `:` implied) —
+    // same convention as `Category("category")`, `AppTimeLimit("app_time_limit")`,
+    // `AppBlocked("app")`. The actual wire string is assembled in `asWire`
+    // (`"host:" + h.value`) and parsed via the `startsWith("host:")` arm in
+    // `fromWire`. The bare `"host"` string still maps to anonymous
+    // `ExtraBlocked` via `LegacyWireAliases`; the overlap is harmless because
+    // `byWireKind` is built only from `NullaryCases`, which does NOT include
+    // this parameterised case.
     val jsonKind = "extraBlockedBy"; val wireKind = "host"
   }
   case class Unknown(raw: String)           extends BlockReason {

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1725,33 +1725,40 @@ object MacBlockReason {
 // the event-table form without re-encoding (their wire form is unchanged in
 // the snapshot JSON — only the event-DB encoding becomes kind-tagged).
 object BlockReason {
-  case object Allow                      extends BlockReason {
+  case object Allow                         extends BlockReason {
     val jsonKind = "allow"; val wireKind = "allow"
   }
-  case object Blocked                    extends BlockReason {
+  case object Blocked                       extends BlockReason {
     val jsonKind = "blocked"; val wireKind = "blocked"
   }
-  case object ExtraAllowed               extends BlockReason {
+  case object ExtraAllowed                  extends BlockReason {
     val jsonKind = "extraAllowed"; val wireKind = "extra_allowed"
   }
-  case object ExtraBlocked               extends BlockReason {
+  case object ExtraBlocked                  extends BlockReason {
     val jsonKind = "extraBlocked"; val wireKind = "extra_blocked"
   }
-  case object NoProfile                  extends BlockReason {
+  case object NoProfile                     extends BlockReason {
     val jsonKind = "noProfile"; val wireKind = "no_profile"
   }
-  case class Category(slug: BlocklistId) extends BlockReason {
+  case class Category(slug: BlocklistId)    extends BlockReason {
     val jsonKind = "category"; val wireKind = "category"
   }
-  case class AppTimeLimit(label: String) extends BlockReason {
+  case class AppTimeLimit(label: String)    extends BlockReason {
     // #1518 rename; the legacy `siteTimeLimit` jsonKind is still ACCEPTED by
     // the decoder below for V40-migrated DB rows, but never emitted.
     val jsonKind = "appTimeLimit"; val wireKind = "app_time_limit"
   }
-  case class AppBlocked(appId: String)   extends BlockReason {
+  case class AppBlocked(appId: String)      extends BlockReason {
     val jsonKind = "appBlocked"; val wireKind = "app"
   }
-  case class Unknown(raw: String)        extends BlockReason {
+  // #1645: labels a per-host extraBlocked drop with the matched eb_<host>
+  // rule so triage can see *which* extraBlocked entry fired. Wire form is
+  // `host:<host>`; the legacy bare `host` alias below still parses as the
+  // anonymous `ExtraBlocked` for pre-rollout routers.
+  case class ExtraBlockedBy(host: Hostname) extends BlockReason {
+    val jsonKind = "extraBlockedBy"; val wireKind = "host"
+  }
+  case class Unknown(raw: String)           extends BlockReason {
     // `wireKind` here is informational only; `asWire(Unknown(raw))` emits
     // `raw` verbatim, not via this field, so a non-categorizable wire string
     // round-trips through `fromWire`.
@@ -1827,6 +1834,14 @@ object BlockReason {
         AppTimeLimit(s.stripPrefix("app_time_limit:"))
       else if (s.startsWith("app:"))
         AppBlocked(s.stripPrefix("app:"))
+      else if (s.startsWith("host:"))
+        // #1645: `host:<host>` names the matched eb_<host> rule. Bare `host`
+        // (no colon) is still handled by the LegacyWireAliases lookup above
+        // and resolves to the anonymous ExtraBlocked.
+        Hostname
+          .parse(s.stripPrefix("host:"))
+          .map(ExtraBlockedBy(_))
+          .getOrElse(Unknown(s))
       else
         Unknown(s)
     }
@@ -1852,6 +1867,7 @@ object BlockReason {
     case AppTimeLimit(label) =>
       s"app_time_limit:$label" // #1518 rename; routers echo back what they receive, no legacy parse needed
     case AppBlocked(appId)   => s"app:$appId"
+    case ExtraBlockedBy(h)   => s"host:${h.value}" // #1645
     case Unknown(raw)        => raw
     case r                   => r.wireKind
   }
@@ -1871,6 +1887,8 @@ object BlockReason {
     // for V40-migrated DB rows and any older SPA build that pattern-matches on it.
     case AppBlocked(appId)   =>
       Json.Obj("kind" -> Json.Str("appBlocked"), "appId" -> Json.Str(appId))
+    case ExtraBlockedBy(h)   =>
+      Json.Obj("kind" -> Json.Str("extraBlockedBy"), "host" -> Json.Str(h.value))
     case Unknown(raw)        =>
       Json.Obj("kind" -> Json.Str("unknown"), "raw" -> Json.Str(raw))
     case r                   =>
@@ -1907,6 +1925,11 @@ object BlockReason {
                 // (written before that PR) still decode.
                 field("label").map(AppTimeLimit(_))
               case "appBlocked"                     => field("appId").map(AppBlocked(_))
+              case "extraBlockedBy"                 =>
+                // #1645
+                field("host").flatMap(s =>
+                  Hostname.parse(s).left.map(e => s"invalid host: $e").map(ExtraBlockedBy(_)),
+                )
               case "unknown"                        => field("raw").map(Unknown(_))
               case other                            => Left(s"BlockReason: unknown kind '$other'")
             }

--- a/shared/test/src/types/BlockReasonSpec.scala
+++ b/shared/test/src/types/BlockReasonSpec.scala
@@ -138,6 +138,49 @@ object BlockReasonSpec extends ZIOSpecDefault {
           BlockReason.fromWire("category:UPPER!!!") == BlockReason.Unknown("category:UPPER!!!"),
         )
       },
+      // #1645: routers (post-rollout) emit `host:<host>` so a dropped eb_<host>
+      // flow names the matched rule. The legacy bare `host` alias above must
+      // still resolve to `ExtraBlocked` for pre-rollout routers.
+      test("host:<host> parses as ExtraBlockedBy and round-trips") {
+        val youtube = Hostname.parse("youtubei.googleapis.com").toOption.get
+        assertTrue(
+          BlockReason.fromWire("host:youtubei.googleapis.com") ==
+            BlockReason.ExtraBlockedBy(youtube),
+        ) &&
+        assertTrue(
+          BlockReason.asWire(BlockReason.ExtraBlockedBy(youtube)) ==
+            "host:youtubei.googleapis.com",
+        ) &&
+        assertTrue(
+          BlockReason.fromWire(
+            BlockReason.asWire(BlockReason.ExtraBlockedBy(youtube)),
+          ) == BlockReason.ExtraBlockedBy(youtube),
+        )
+      },
+      test("host:<host> with invalid hostname falls back to Unknown") {
+        assertTrue(
+          BlockReason.fromWire("host:NOT A HOST") == BlockReason.Unknown("host:NOT A HOST"),
+        )
+      },
+      test("legacy bare `host` still parses as ExtraBlocked (#1645 back-compat)") {
+        assertTrue(BlockReason.fromWire("host") == BlockReason.ExtraBlocked)
+      },
+      test("ExtraBlockedBy JSON round-trips with host field") {
+        val h: Hostname    = Hostname.parse("youtubei.googleapis.com").toOption.get
+        val r: BlockReason = BlockReason.ExtraBlockedBy(h)
+        assertTrue(
+          r.toJson ==
+            "{\"kind\":\"extraBlockedBy\",\"host\":\"youtubei.googleapis.com\"}",
+        ) &&
+        assertTrue(r.toJson.fromJson[BlockReason].contains(r))
+      },
+      test("legacy {kind:extraBlocked} JSON still decodes to ExtraBlocked (#1645)") {
+        assertTrue(
+          "{\"kind\":\"extraBlocked\"}"
+            .fromJson[BlockReason]
+            .contains(BlockReason.ExtraBlocked),
+        )
+      },
       // #1545: pin that every reason `PolicyService.decide` can emit survives a
       // `fromWire(asWire(r))` round-trip, so routing the emitter and the block-page
       // re-parser through the typed `BlockReason` cannot silently drop a case.
@@ -168,21 +211,22 @@ object BlockReasonSpec extends ZIOSpecDefault {
     // compile error, which is the operator's signal to also extend `allCases`.
     suite("BlockReason exhaustiveness (#1605)")({
       def shapeCheck(r: BlockReason): Unit = r match {
-        case BlockReason.Allow           => ()
-        case BlockReason.Blocked         => ()
-        case BlockReason.ExtraAllowed    => ()
-        case BlockReason.ExtraBlocked    => ()
-        case BlockReason.NoProfile       => ()
-        case MacBlockReason.Paused       => ()
-        case MacBlockReason.Schedule     => ()
-        case MacBlockReason.TimeLimit    => ()
-        case MacBlockReason.Manual       => ()
-        case MacBlockReason.Unmanaged    => ()
-        case MacBlockReason.DefaultDeny  => ()
-        case _: BlockReason.Category     => ()
-        case _: BlockReason.AppTimeLimit => ()
-        case _: BlockReason.AppBlocked   => ()
-        case _: BlockReason.Unknown      => ()
+        case BlockReason.Allow             => ()
+        case BlockReason.Blocked           => ()
+        case BlockReason.ExtraAllowed      => ()
+        case BlockReason.ExtraBlocked      => ()
+        case BlockReason.NoProfile         => ()
+        case MacBlockReason.Paused         => ()
+        case MacBlockReason.Schedule       => ()
+        case MacBlockReason.TimeLimit      => ()
+        case MacBlockReason.Manual         => ()
+        case MacBlockReason.Unmanaged      => ()
+        case MacBlockReason.DefaultDeny    => ()
+        case _: BlockReason.Category       => ()
+        case _: BlockReason.AppTimeLimit   => ()
+        case _: BlockReason.AppBlocked     => ()
+        case _: BlockReason.ExtraBlockedBy => ()
+        case _: BlockReason.Unknown        => ()
       }
       val allCases: List[BlockReason]      = List(
         BlockReason.Allow,
@@ -199,6 +243,7 @@ object BlockReasonSpec extends ZIOSpecDefault {
         BlockReason.Category(ads),
         BlockReason.AppTimeLimit("youtube"),
         BlockReason.AppBlocked("netflix"),
+        BlockReason.ExtraBlockedBy(Hostname.parse("youtubei.googleapis.com").toOption.get),
         BlockReason.Unknown("some-raw"),
       )
       // The shape-check is satisfied by `allCases` covering every variant;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -198,6 +198,7 @@ export type BlockReason =
   | { kind: 'blocked' }
   | { kind: 'extraAllowed' }
   | { kind: 'extraBlocked' }
+  | { kind: 'extraBlockedBy'; host: string } // #1645: names the matched eb_<host> rule
   | { kind: 'noProfile' }
   | { kind: 'unmanaged' }
   | { kind: 'paused' }

--- a/web/src/types/blockReason.test.ts
+++ b/web/src/types/blockReason.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { blockReasonText } from './blockReason'
+
+describe('blockReasonText', () => {
+  it('renders extraBlocked as the generic household label', () => {
+    expect(blockReasonText({ kind: 'extraBlocked' })).toBe('blocked (household)')
+  })
+
+  // #1645: post-rollout the router emits the matched eb_<host> rule's host
+  // on per-host drops; the SPA names the matched host so triage can see it
+  // at a glance (eb_youtubei_googleapis_com matched, not just "blocked").
+  it('renders extraBlockedBy with the matched host (#1645)', () => {
+    expect(
+      blockReasonText({ kind: 'extraBlockedBy', host: 'youtubei.googleapis.com' }),
+    ).toBe('blocked: matched youtubei.googleapis.com')
+  })
+})

--- a/web/src/types/blockReason.ts
+++ b/web/src/types/blockReason.ts
@@ -14,6 +14,7 @@ export function blockReasonText(r: BlockReason): string {
     case 'blocked':       return 'blocked'
     case 'extraAllowed':  return 'allowed (household)'
     case 'extraBlocked':  return 'blocked (household)'
+    case 'extraBlockedBy': return `blocked: matched ${r.host}` // #1645
     case 'noProfile':     return 'no profile'
     case 'unmanaged':     return 'unmanaged device'
     case 'paused':        return 'profile paused'


### PR DESCRIPTION
## Summary

Closes #1645 — purely a debugging-aid label, NOT a fix for the underlying
GFE/anycast false-positive in #1636.

When an `eb_<host>` rule drops a flow, the connection event now ships
`reason = "host:<host>"` instead of bare `"host"`, so the SPA can name
*which* extraBlocked entry fired. The matched host renders as
"blocked: matched youtubei.googleapis.com" rather than the generic
"blocked (household)" that masked the YouTube/oauthmanager anycast
overlap during the #1640 triage.

Symmetric with the existing `category:<id>` precedent for `bl_` drops —
no new wire vocabulary, no new metrics label, no router policy logic.

## Wire compatibility (per AGENTS.md "Backwards compatibility")

Pure additive. API and routers deploy independently.

| Direction | Old → New | Behaviour |
|---|---|---|
| Old router → new API | `reason="host"` | Still parses as `ExtraBlocked` (legacy `LegacyWireAliases` entry preserved). |
| New router → old API | `reason="host:youtubei.googleapis.com"` | Parses as `Unknown("host:youtubei.googleapis.com")` — acceptable bridge state, no row drop. |
| Historical DB rows | `{kind:"extraBlocked"}` JSONB | Still decodes — `extraBlocked` arm preserved. |
| Historical text rows | `reason_text="host"` | Still parses via the same `LegacyWireAliases` entry. |

No deprecation window needed — `ExtraBlocked` remains valid as the
anonymous shape for any producer that doesn't know the matched host.

## TDD progression (visible in commit history)

1. `84a107bd` — **test (red):** wire round-trip + legacy alias for `ExtraBlockedBy`.
2. `1556a706` — **feat (green):** API parses `host:<host>` as `ExtraBlockedBy`.
3. `8ebf0868` — **test (red):** router emits `wh_drop:<mac>:host:<host>`.
4. `0fb74d31` — **feat (green):** render.lua / conntrack.lua / nft_drops.lua updated.
5. `ba09063a` — **feat:** SPA renders `extraBlockedBy` with the matched host (+ vitest).

## Out of scope

The actual anycast-shared-GFE false-positive (#1636) — this PR just
makes that class of incident legible in the SPA.

## Test plan

- [x] `mill shared.test`
- [x] `mill api.test`
- [x] `cd openwrt && sh test/run_tests.sh`
- [x] `cd web && npx vitest run src/types/blockReason.test.ts`
- [x] `npm run -s type-check`
- [x] scalafmt + eslint clean (pre-push hooks)
- [ ] @sameerparekh — independent /pr-review pass clears, then merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>