### PR TITLE
fix(#1658): periodic eb_/bl_ ipset re-resolve heartbeat closes DNS-cache leak

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -112,6 +112,17 @@ object MetricGuard {
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
     "enforcement_drops_total"                   -> Set("reason", "router_id", "installation_id"),
+    // #1658 — eb_/bl_ ipset re-resolve heartbeat. Each fire of the agent's
+    // eb_refresh timer re-resolves the inventory of (extraBlocked, blocklist)
+    // hosts against the local dnsmasq and adds answered IPs back into the
+    // per-host eb_<host> / per-blocklist bl_<id> nftables sets ahead of their
+    // 1h `flags dynamic,timeout` aging out — closing the iOS-DNS-cache leak
+    // confirmed in prod for play.google.com (#1649). `result` is a small fixed
+    // enum: `ok` (resolver answered, IPs were added back to the set; counts
+    // resolved hosts not adds, so the rate is meaningful regardless of CDN
+    // fan-out) and `resolve_failed` (dig couldn't reach the local resolver, or
+    // the host failed the hermetic allow-list).
+    "eb_refresh_total"                          -> Set("result", "router_id", "installation_id"),
     // #1033 — usage-POST retry-queue health. Depth = buckets currently waiting for a backoff to
     // elapse; `usage_post_total{result}` tracks the immediate-post outcome (`ok` | `queued`) and
     // drain outcome (`drained` | `drain_failed`). Gives operators a first-class view of "are

--- a/deploy/grafana/dashboards/enforcement.json
+++ b/deploy/grafana/dashboards/enforcement.json
@@ -278,6 +278,65 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "eb_/bl_ ipset refresh rate (#1658)",
+      "description": "sum by (result) (rate(eb_refresh_total[5m])) — hosts/sec the periodic re-resolve heartbeat processed. The eb_<host>/bl_<id> sets carry `flags dynamic,timeout 1h`; this timer (default cadence 1800s, strictly below the 1h timeout) re-resolves each extraBlocked / blocklist apex and adds answers back so the set stays populated under long-lived iOS app DNS caches. Steady non-zero `ok` is the healthy signal; a flat-zero in a household that has any extraBlocked / blocklist hosts means the timer isn't running. Sustained `resolve_failed` points at a dnsmasq problem.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(eb_refresh_total{env=\"$env\", router_id=~\"$router\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "eb_/bl_ ipset refresh failure ratio (#1658)",
+      "description": "sum(rate(eb_refresh_total{result=\"resolve_failed\"})) / sum(rate(eb_refresh_total)) over 5m — fraction of re-resolves that failed (resolver unreachable / hermetic-allowlist reject). A spike above ~0.1 means the periodic heartbeat is no longer keeping the sets warm — the iOS-DNS-cache leak (#1649) returns when failures dominate.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(eb_refresh_total{env=\"$env\", router_id=~\"$router\", result=\"resolve_failed\"}[5m])) / clamp_min(sum(rate(eb_refresh_total{env=\"$env\", router_id=~\"$router\"}[5m])), 1e-9)",
+          "legendFormat": "resolve_failed fraction",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",

--- a/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
@@ -1,0 +1,228 @@
+-- eb_refresh.lua — periodic re-resolve of extraBlocked and category-blocklist
+-- hosts so the per-host `eb_<sanhost>` / `eb6_<sanhost>` and per-blocklist
+-- `bl_<sanid>` / `bl6_<sanid>` nftables sets stay populated ahead of their 1h
+-- `flags dynamic,timeout` aging out (declared in render.lua).
+--
+-- #1658 — the leak this closes. Population today is one-shot at DNS resolve
+-- time (dnsmasq's `--nftset=` callback + the dns-tail sidecar's #1346
+-- alias-chain populator). The kernel set ages an IP out after 1h, but iOS /
+-- iPadOS app DNS caches regularly outlive 1h — long-running connection pools
+-- and background-fetch sockets reuse the cached `getaddrinfo` answer for the
+-- lifetime of the pool. When the client connects to a cached IP outside the
+-- 1h window the IP is no longer in `eb_<host>`, the per-MAC drop predicate
+-- (`ip daddr @eb_<host>`) misses, traffic falls through to the priority-1
+-- accounting chains, and the agent's `lookup_hostname` (long-lived dnsmasq
+-- query-log cache) correctly re-attributes the bytes back to the FQDN at
+-- usage-report time — surfacing as real engaged minutes against a host that
+-- is explicitly in the kid profile's extraBlocked. #1649 confirmed this
+-- mechanism in prod for `play.google.com` on Kid Mac / Prima iPad.
+--
+-- Approach: every `eb_refresh_interval` seconds (default 1800s — strictly
+-- below the 1h kernel timeout so each entry sees ≥1 refresh per ageing
+-- window), iterate the inventory of (host, owning sets) the agent already
+-- maintains in `eb_hosts_by_mac` / `bl_hosts_by_mac` (rebuilt by
+-- `render.update_shared` after every policy apply), re-resolve each unique
+-- host via the local dnsmasq (matching the resolution path that drives the
+-- `--nftset=` callback at client-resolve time), and `nft add element` each
+-- answered IP into the destination set. nft tolerates duplicate adds; idempotence
+-- is the kernel's job, not ours.
+--
+-- The leak is independent of which client cached the IP — the eb_/bl_ sets
+-- are global, NOT per-MAC (see render.lua `eb_set_name`). So we walk by host,
+-- not by (mac, host) — one resolve per distinct host per cycle, regardless of
+-- how many MACs the host applies to.
+--
+-- Why not raise the kernel timeout instead: see #1658 — bigger timeouts
+-- accumulate stale CDN IPs (Google rotates), inverting the leak (an IP that
+-- *was* Google but is now someone else's webapp gets dropped). Removing the
+-- timeout leaks the set indefinitely on tmpfs-backed kernel sets. The right
+-- shape is "keep the set refreshed in step with client cache lifetime", which
+-- is what this module does.
+--
+-- Subdomain coverage: this module re-resolves the APEX as authored. dnsmasq's
+-- `--nftset=/<apex>/...` callback populates the set for subdomains too at
+-- resolve time, and the dns-tail sidecar (#1346) covers the directly-queried
+-- CNAME-target path. This module deliberately does not enumerate observed
+-- subdomains — that would require walking the dns_log cache and pull a
+-- separate inventory shape; defer to a follow-up if subdomain-only caches are
+-- observed in prod. The apex refresh closes the headline leak (the #1649
+-- evidence is apex-level `play.google.com`).
+--
+-- Pure logic with injected resolver + nft executor (same DI shape as
+-- dns_tail_sets / policy / conntrack); the agent wires the real `dig` shell-out
+-- and `os.execute`.
+
+local dns_tail_sets = require("dns_tail_sets")
+
+local M = {}
+
+local sanitize = dns_tail_sets.sanitize
+
+-- bl_<id> sanitisation matches render.lua's bl_sanitize: id may contain dots,
+-- colons, hyphens, and whitespace; nftables set names allow only [a-zA-Z0-9_].
+-- Keep this in lock-step with render.lua — if either changes we'd be writing
+-- to a set that doesn't exist (silent no-op, leak persists).
+local function bl_sanitize(id)
+  return (id:gsub("[%.%:%-%s]", "_"))
+end
+
+-- ---------------------------------------------------------------------------
+-- Inventory
+-- ---------------------------------------------------------------------------
+
+-- collect_inventory(eb_hosts_by_mac, bl_hosts_by_mac) → { eb_hosts, bl_pairs }
+--
+-- Walks the two per-MAC inventories `render.update_shared` builds after each
+-- policy apply and collapses them to the work this module needs:
+--
+--   eb_hosts : sorted unique hostnames in any device's effective extraBlocked
+--   bl_pairs : sorted unique (host, blocklist_id) pairs from any device's
+--              effective category assignment.
+--
+-- The eb_/bl_ ipsets are global (not per-MAC), so the cross-MAC dedup is the
+-- whole point — a host in extraBlocked on 4 devices is one resolve, not 4.
+function M.collect_inventory(eb_hosts_by_mac, bl_hosts_by_mac)
+  local eb_seen = {}
+  for _, hosts in pairs(eb_hosts_by_mac or {}) do
+    for host in pairs(hosts or {}) do eb_seen[host] = true end
+  end
+  local eb_hosts = {}
+  for h in pairs(eb_seen) do eb_hosts[#eb_hosts + 1] = h end
+  table.sort(eb_hosts)
+
+  -- (host, id) is the dedup key: a host may live in different blocklists
+  -- across MACs (in principle — render.update_shared assigns one id per host
+  -- in practice via the eb-wins-over-bl rule, but be defensive).
+  local bl_seen = {}
+  local bl_pairs = {}
+  for _, hosts in pairs(bl_hosts_by_mac or {}) do
+    for host, id in pairs(hosts or {}) do
+      local key = host .. "\0" .. tostring(id)
+      if not bl_seen[key] then
+        bl_seen[key] = true
+        bl_pairs[#bl_pairs + 1] = { host = host, id = id }
+      end
+    end
+  end
+  -- Sort deterministically: by host, then by id. Stable iteration helps test
+  -- assertions and metric labels.
+  table.sort(bl_pairs, function(a, b)
+    if a.host == b.host then return tostring(a.id) < tostring(b.id) end
+    return a.host < b.host
+  end)
+
+  return { eb_hosts = eb_hosts, bl_pairs = bl_pairs }
+end
+
+-- ---------------------------------------------------------------------------
+-- dig parsing (default resolver)
+-- ---------------------------------------------------------------------------
+
+-- parse_dig_output(stdout, family) → sorted list of valid IP literals.
+--
+-- `dig +short` prints answer values one per line. For an A/AAAA query the
+-- terminal answer line is the IP; CNAME-shaped intermediate lines (e.g.
+-- `youtube-ui.l.google.com.`) also appear and must be skipped. We filter via
+-- dns_tail_sets.safe_addr (the same allow-list applied to dnsmasq-log-parsed
+-- IPs in the dns-tail populator).
+function M.parse_dig_output(stdout, family)
+  if not stdout or stdout == "" then return {} end
+  local out = {}
+  local seen = {}
+  for line in stdout:gmatch("[^\r\n]+") do
+    local ip = line:match("^%s*(%S+)%s*$")
+    if ip then
+      local safe = dns_tail_sets.safe_addr(ip)
+      if safe then
+        -- safe_addr accepts both v4 and v6 shapes; family-check via dots/colons.
+        local is_v6 = safe:find(":", 1, true) ~= nil
+        if (family == "v6") == is_v6 and not seen[safe] then
+          seen[safe] = true
+          out[#out + 1] = safe
+        end
+      end
+    end
+  end
+  table.sort(out)
+  return out
+end
+
+local function default_dig(host, qtype)
+  -- Hostname allow-list: a-z, 0-9, dot, hyphen, underscore (some dnsmasq
+  -- aliases contain underscores; see #1572). Anything else is rejected to keep
+  -- shell-out hermetic.
+  if type(host) ~= "string" or host:find("[^%w%.%-_]") then return nil end
+  local cmd = string.format(
+    "dig %s @127.0.0.1 -p 53 %s +short +time=2 +tries=1 2>/dev/null",
+    qtype, host)
+  local f = io.popen(cmd, "r")
+  if not f then return nil end
+  local out = f:read("*a")
+  f:close()
+  return out
+end
+
+-- default_resolver(host) → { v4 = {...}, v6 = {...} } | nil
+-- nil means the resolver itself failed (dig couldn't run); empty lists mean
+-- the resolver answered but no addresses were returned (NXDOMAIN / no record).
+function M.default_resolver(host)
+  local v4_out = default_dig(host, "A")
+  local v6_out = default_dig(host, "AAAA")
+  if not v4_out and not v6_out then return nil end
+  return {
+    v4 = M.parse_dig_output(v4_out, "v4"),
+    v6 = M.parse_dig_output(v6_out, "v6"),
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- refresh
+-- ---------------------------------------------------------------------------
+
+-- refresh(opts) → { hosts, resolves_ok, resolves_err, adds }
+--
+-- opts:
+--   eb_hosts  : list of apex hosts to refresh eb_/eb6_ for
+--   bl_pairs  : list of {host=..., id=...} to refresh bl_/bl6_ for
+--   nft_table : nftables table name, e.g. "inet wifihaven"
+--   resolver  : host → { v4, v6 } | nil (nil counts as resolves_err)
+--   exec_fn   : os.execute-style shell executor (capture in tests)
+--   log       : optional logger { debug=, info=, warn= } — debug/info only
+function M.refresh(opts)
+  local stats = { hosts = 0, resolves_ok = 0, resolves_err = 0, adds = 0 }
+
+  local function refresh_one(host, v4_set, v6_set)
+    stats.hosts = stats.hosts + 1
+    local r = opts.resolver and opts.resolver(host)
+    if not r then
+      stats.resolves_err = stats.resolves_err + 1
+      if opts.log and opts.log.debug then
+        opts.log.debug("eb_refresh: resolve failed host=%s", host)
+      end
+      return
+    end
+    stats.resolves_ok = stats.resolves_ok + 1
+    for _, ip in ipairs(r.v4 or {}) do
+      if dns_tail_sets.nft_add_element(opts.nft_table, v4_set, ip, opts.exec_fn) then
+        stats.adds = stats.adds + 1
+      end
+    end
+    for _, ip in ipairs(r.v6 or {}) do
+      if dns_tail_sets.nft_add_element(opts.nft_table, v6_set, ip, opts.exec_fn) then
+        stats.adds = stats.adds + 1
+      end
+    end
+  end
+
+  for _, host in ipairs(opts.eb_hosts or {}) do
+    local h = sanitize(host)
+    refresh_one(host, "eb_" .. h, "eb6_" .. h)
+  end
+  for _, pair in ipairs(opts.bl_pairs or {}) do
+    local id = bl_sanitize(tostring(pair.id))
+    refresh_one(pair.host, "bl_" .. id, "bl6_" .. id)
+  end
+  return stats
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
@@ -50,21 +50,14 @@
 --
 -- Pure logic with injected resolver + nft executor (same DI shape as
 -- dns_tail_sets / policy / conntrack); the agent wires the real `dig` shell-out
--- and `os.execute`.
+-- and `os.execute`. Set-name construction is delegated to render.lua's
+-- `eb_set_name` / `eb6_set_name` / `bl_set_name` / `bl6_set_name` exports so
+-- the (host|id) → nft-set-name mapping has a single source of truth.
 
 local dns_tail_sets = require("dns_tail_sets")
+local render        = require("wifihaven.render")
 
 local M = {}
-
-local sanitize = dns_tail_sets.sanitize
-
--- bl_<id> sanitisation matches render.lua's bl_sanitize: id may contain dots,
--- colons, hyphens, and whitespace; nftables set names allow only [a-zA-Z0-9_].
--- Keep this in lock-step with render.lua — if either changes we'd be writing
--- to a set that doesn't exist (silent no-op, leak persists).
-local function bl_sanitize(id)
-  return (id:gsub("[%.%:%-%s]", "_"))
-end
 
 -- ---------------------------------------------------------------------------
 -- Inventory
@@ -215,12 +208,11 @@ function M.refresh(opts)
   end
 
   for _, host in ipairs(opts.eb_hosts or {}) do
-    local h = sanitize(host)
-    refresh_one(host, "eb_" .. h, "eb6_" .. h)
+    refresh_one(host, render.eb_set_name(host), render.eb6_set_name(host))
   end
   for _, pair in ipairs(opts.bl_pairs or {}) do
-    local id = bl_sanitize(tostring(pair.id))
-    refresh_one(pair.host, "bl_" .. id, "bl6_" .. id)
+    local id = tostring(pair.id)
+    refresh_one(pair.host, render.bl_set_name(id), render.bl6_set_name(id))
   end
   return stats
 end

--- a/openwrt/files/usr/lib/lua/wifihaven/render.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/render.lua
@@ -168,18 +168,23 @@ end
 local function eb6_set_name(host)
   return "eb6_" .. sanitize(host)
 end
+M.eb_set_name  = eb_set_name
+M.eb6_set_name = eb6_set_name
 
 -- nft set names for a blocklist id (#352, #392). Replaces dots, colons, and
 -- hyphens with underscores (nftables set names allow only [a-zA-Z0-9_]).
 local function bl_sanitize(id)
   return (id:gsub("[%.%:%-%s]", "_"))
 end
+M.bl_sanitize = bl_sanitize
 local function bl_set_name(id)
   return "bl_" .. bl_sanitize(id)
 end
 local function bl6_set_name(id)
   return "bl6_" .. bl_sanitize(id)
 end
+M.bl_set_name  = bl_set_name
+M.bl6_set_name = bl6_set_name
 
 -- #353: per-MAC "resolved IP" sets. A device with BlockRules.blockIpOnly=true
 -- gets a forward-chain drop on any daddr NOT in its resolved_<mac> /

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -15,6 +15,7 @@
 local uci        = require("uci")
 local policy     = require("wifihaven.policy")
 local blocklists = require("wifihaven.blocklists")
+local eb_refresh = require("wifihaven.eb_refresh")
 local metrics    = require("wifihaven.metrics")
 local usage      = require("wifihaven.usage")
 local conntrack  = require("wifihaven.conntrack")
@@ -73,6 +74,18 @@ local metrics_int   = tonumber(uci_get("metrics_report_interval", "60"))
 -- a list's content version changed; the agent re-applies the ruleset only when
 -- the loaded host set actually differs (blocklists.hosts_differ). Default 1 h.
 local blocklist_int = tonumber(uci_get("blocklist_refresh_interval", "3600"))
+-- #1658: eb_/bl_ ipset re-resolve cadence (seconds). The per-host eb_<host>
+-- and per-blocklist bl_<id> sets are declared `flags dynamic,timeout 1h`,
+-- populated one-shot at DNS resolve time via dnsmasq's `--nftset=` callback.
+-- iOS / iPadOS app DNS caches regularly outlive 1h, so a cached IP can age
+-- out of the kernel set under a still-connecting client and the per-MAC
+-- drop predicate silently misses — a confirmed prod leak (#1649). The
+-- agent periodically re-resolves the inventory of (extraBlocked, blocklist)
+-- hosts (collapsed across MACs — the sets are global) so each entry sees
+-- ≥1 refresh per ageing window. Default 1800 s = 30 min — strictly below
+-- the 1h kernel timeout, ~2 refreshes per window, ≈one `dig` per host every
+-- 30 min (negligible router load even at ~50 distinct hosts).
+local eb_refresh_int = tonumber(uci_get("eb_refresh_interval", "1800"))
 -- #1412 OOM guard: a single category list larger than this many BYTES is cached
 -- but NOT parsed/rendered. The prod agent OOM-killed (~700 MB RSS / 1 GB router)
 -- loading the StevenBlack "extended" lists (ads-extended ~1.6 MB / 83k hosts,
@@ -395,6 +408,7 @@ local last_policy_run     = 0
 local last_usage_run      = 0
 local last_metrics_run    = 0
 local last_blocklist_run  = 0  -- #1412: category blocklist refresh cadence
+local last_eb_refresh_run = 0  -- #1658: eb_/bl_ ipset re-resolve cadence
 local last_activity_sample = 0
 local last_nflog_run      = 0  -- #1126: nflog drop-spool drain cadence
 local activity_tracker     = usage.new_tracker()
@@ -474,6 +488,7 @@ do
   last_usage_run         = mono
   last_metrics_run       = mono
   last_blocklist_run     = mono
+  last_eb_refresh_run    = mono
   last_activity_sample   = mono
   last_nflog_run         = mono
 end
@@ -737,6 +752,46 @@ conntrack.watch({
                                eb_hosts_by_mac, ea_hosts_by_mac, bl_hosts_by_mac)
           log.info("blocklist timer: category lists changed, re-applied ruleset")
         end
+      end
+    end
+
+    -- eb_/bl_ ipset re-resolve timer (#1658). The per-host eb_<host> and
+    -- per-blocklist bl_<id> sets carry `flags dynamic,timeout 1h`; population
+    -- happens one-shot at DNS resolve time. If a client's app-level DNS cache
+    -- holds a resolved IP past 1h the kernel entry ages out under the client,
+    -- the per-MAC drop predicate misses, and traffic flows against an
+    -- explicitly-blocked host (the prod leak diagnosed in #1649). Walk the
+    -- per-MAC inventory `render.update_shared` rebuilt after the last apply,
+    -- collapse to distinct hosts (sets are global, not per-MAC), and re-resolve
+    -- each one via dig→dnsmasq, adding answers back into the destination
+    -- sets. Independent of the policy/blocklist timers — runs against the
+    -- last-applied snapshot so a stable (304-only) household still gets
+    -- refreshed. Skipped while we're in failover render: the failover chain
+    -- closes the world for those profiles already.
+    if last_snapshot and not in_failover_render
+       and (mono - last_eb_refresh_run) >= eb_refresh_int then
+      last_eb_refresh_run = mono
+      local inv = eb_refresh.collect_inventory(eb_hosts_by_mac, bl_hosts_by_mac)
+      if #inv.eb_hosts > 0 or #inv.bl_pairs > 0 then
+        local rt0 = clock.monotonic_seconds()
+        local stats = eb_refresh.refresh({
+          eb_hosts  = inv.eb_hosts,
+          bl_pairs  = inv.bl_pairs,
+          nft_table = "inet wifihaven",
+          resolver  = eb_refresh.default_resolver,
+          exec_fn   = os.execute,
+          log       = log,
+        })
+        local elapsed = clock.monotonic_seconds() - rt0
+        metrics.inc_counter(mreg, "eb_refresh_total", { result = "ok" },
+                            stats.resolves_ok)
+        if stats.resolves_err > 0 then
+          metrics.inc_counter(mreg, "eb_refresh_total", { result = "resolve_failed" },
+                              stats.resolves_err)
+        end
+        log.debug("eb_refresh timer: hosts=%d ok=%d err=%d adds=%d elapsed=%.2fs",
+                  stats.hosts, stats.resolves_ok, stats.resolves_err,
+                  stats.adds, elapsed)
       end
     end
 

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -783,8 +783,10 @@ conntrack.watch({
           log       = log,
         })
         local elapsed = clock.monotonic_seconds() - rt0
-        metrics.inc_counter(mreg, "eb_refresh_total", { result = "ok" },
-                            stats.resolves_ok)
+        if stats.resolves_ok > 0 then
+          metrics.inc_counter(mreg, "eb_refresh_total", { result = "ok" },
+                              stats.resolves_ok)
+        end
         if stats.resolves_err > 0 then
           metrics.inc_counter(mreg, "eb_refresh_total", { result = "resolve_failed" },
                               stats.resolves_err)

--- a/openwrt/test/eb_refresh_spec.lua
+++ b/openwrt/test/eb_refresh_spec.lua
@@ -1,0 +1,244 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
+--
+-- eb_refresh runs a periodic re-resolve of every extraBlocked host (and every
+-- category blocklist host) the agent has applied, so the per-host `eb_<host>`
+-- / `eb6_<host>` and per-blocklist `bl_<id>` / `bl6_<id>` nftables sets stay
+-- populated ahead of their 1h `flags dynamic,timeout` aging out.
+--
+-- #1658 — the leak this closes: the kernel set ages an IP out after 1h, but a
+-- client (iPad / iOS app DNS cache) keeps reusing the cached IP for the
+-- lifetime of a connection pool. When the IP expires from `eb_<host>` the
+-- drop predicate misses, traffic flows, and the agent's `lookup_hostname`
+-- correctly attributes the bytes back to the FQDN at usage-report time —
+-- surfacing as real engagement against an explicitly-blocked host (#1649).
+--
+-- The module is pure logic with injected resolver + nft executor + clock, so
+-- the timer behaviour and the (host → ipset name → IP) wiring are
+-- unit-testable. Same DI shape as dns_tail_sets / policy.
+--
+-- Run with: busted openwrt/test/eb_refresh_spec.lua
+
+local eb_refresh = require("eb_refresh")
+
+-- ---------------------------------------------------------------------------
+-- helpers
+-- ---------------------------------------------------------------------------
+
+local function exec_recorder()
+  local cmds = {}
+  return cmds, function(cmd) cmds[#cmds + 1] = cmd end
+end
+
+local function fake_resolver(answers)
+  -- answers : { ["host"] = { v4 = {...}, v6 = {...} } }
+  return function(host)
+    local a = answers[host]
+    if not a then return { v4 = {}, v6 = {} } end
+    return { v4 = a.v4 or {}, v6 = a.v6 or {} }
+  end
+end
+
+local function added(cmds, set_name, ip)
+  for _, c in ipairs(cmds) do
+    if c:find(set_name, 1, true) and c:find("{ " .. ip .. " }", 1, true) then
+      return true
+    end
+  end
+  return false
+end
+
+-- ---------------------------------------------------------------------------
+-- collect_inventory
+-- ---------------------------------------------------------------------------
+
+describe("collect_inventory", function()
+  it("dedups extraBlocked hosts across MACs and returns sorted list", function()
+    local eb = {
+      ["ca:ef:a1:72:6a:a3"] = { ["play.google.com"] = true, ["roblox.com"] = true },
+      ["04:72:ef:d6:e4:5a"] = { ["play.google.com"] = true },
+    }
+    local inv = eb_refresh.collect_inventory(eb, {})
+    assert.same({ "play.google.com", "roblox.com" }, inv.eb_hosts)
+    assert.same({}, inv.bl_pairs)
+  end)
+
+  it("collects blocklist (host,id) pairs, deduped across MACs", function()
+    local bl = {
+      ["aa:bb:cc:dd:ee:ff"] = { ["doubleclick.net"] = "ads", ["bad.example"] = "malware" },
+      ["11:22:33:44:55:66"] = { ["doubleclick.net"] = "ads" },
+    }
+    local inv = eb_refresh.collect_inventory({}, bl)
+    table.sort(inv.bl_pairs, function(a, b)
+      if a.host == b.host then return a.id < b.id end
+      return a.host < b.host
+    end)
+    assert.same({
+      { host = "bad.example",     id = "malware" },
+      { host = "doubleclick.net", id = "ads" },
+    }, inv.bl_pairs)
+  end)
+
+  it("returns empty inventory when both maps are empty", function()
+    local inv = eb_refresh.collect_inventory({}, {})
+    assert.same({}, inv.eb_hosts)
+    assert.same({}, inv.bl_pairs)
+  end)
+
+  it("tolerates nil inputs", function()
+    local inv = eb_refresh.collect_inventory(nil, nil)
+    assert.same({}, inv.eb_hosts)
+    assert.same({}, inv.bl_pairs)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- refresh — the headline behaviour
+-- ---------------------------------------------------------------------------
+
+describe("refresh", function()
+  it("re-resolves extraBlocked hosts and adds v4/v6 to eb_<host> / eb6_<host>", function()
+    local cmds, exec = exec_recorder()
+    local resolver = fake_resolver({
+      ["play.google.com"] = {
+        v4 = { "142.251.46.142", "142.251.35.142" },
+        v6 = { "2607:f8b0::200e" },
+      },
+    })
+    local stats = eb_refresh.refresh({
+      eb_hosts  = { "play.google.com" },
+      bl_pairs  = {},
+      nft_table = "inet wifihaven",
+      resolver  = resolver,
+      exec_fn   = exec,
+    })
+
+    assert.is_true(added(cmds, "eb_play_google_com",  "142.251.46.142"))
+    assert.is_true(added(cmds, "eb_play_google_com",  "142.251.35.142"))
+    assert.is_true(added(cmds, "eb6_play_google_com", "2607:f8b0::200e"))
+    assert.equal(1, stats.hosts)
+    assert.equal(1, stats.resolves_ok)
+    assert.equal(0, stats.resolves_err)
+    assert.equal(3, stats.adds)
+  end)
+
+  it("re-resolves blocklist hosts and adds v4/v6 to bl_<id> / bl6_<id>", function()
+    local cmds, exec = exec_recorder()
+    local resolver = fake_resolver({
+      ["doubleclick.net"] = { v4 = { "8.8.8.8" }, v6 = { "::1" } },
+    })
+    local stats = eb_refresh.refresh({
+      eb_hosts  = {},
+      bl_pairs  = { { host = "doubleclick.net", id = "ads" } },
+      nft_table = "inet wifihaven",
+      resolver  = resolver,
+      exec_fn   = exec,
+    })
+
+    assert.is_true(added(cmds, "bl_ads",  "8.8.8.8"))
+    assert.is_true(added(cmds, "bl6_ads", "::1"))
+    assert.equal(1, stats.hosts)
+    assert.equal(2, stats.adds)
+  end)
+
+  it("counts resolver failures as resolves_err and does not call nft for them", function()
+    local cmds, exec = exec_recorder()
+    local resolver = function(host)
+      if host == "broken.example" then return nil end
+      return { v4 = { "1.2.3.4" }, v6 = {} }
+    end
+    local stats = eb_refresh.refresh({
+      eb_hosts  = { "broken.example", "ok.example" },
+      bl_pairs  = {},
+      nft_table = "inet wifihaven",
+      resolver  = resolver,
+      exec_fn   = exec,
+    })
+    assert.equal(2, stats.hosts)
+    assert.equal(1, stats.resolves_ok)
+    assert.equal(1, stats.resolves_err)
+    assert.equal(1, stats.adds)
+    assert.is_true(added(cmds, "eb_ok_example", "1.2.3.4"))
+    -- nothing for broken.example
+    for _, c in ipairs(cmds) do
+      assert.is_nil(c:find("eb_broken_example", 1, true))
+    end
+  end)
+
+  it("rejects shell-metacharacters in resolved IPs (reuses dns_tail_sets.safe_addr)", function()
+    local cmds, exec = exec_recorder()
+    local resolver = fake_resolver({
+      ["x.example"] = { v4 = { "1.2.3.4; rm -rf /" }, v6 = {} },
+    })
+    local stats = eb_refresh.refresh({
+      eb_hosts  = { "x.example" },
+      bl_pairs  = {},
+      nft_table = "inet wifihaven",
+      resolver  = resolver,
+      exec_fn   = exec,
+    })
+    assert.equal(0, stats.adds)
+    assert.equal(0, #cmds)
+  end)
+
+  it("is idempotent: a second run issues add-element commands again (nft tolerates duplicates)", function()
+    local cmds, exec = exec_recorder()
+    local resolver = fake_resolver({
+      ["play.google.com"] = { v4 = { "1.2.3.4" }, v6 = {} },
+    })
+    local opts = {
+      eb_hosts  = { "play.google.com" },
+      bl_pairs  = {},
+      nft_table = "inet wifihaven",
+      resolver  = resolver,
+      exec_fn   = exec,
+    }
+    local s1 = eb_refresh.refresh(opts)
+    local s2 = eb_refresh.refresh(opts)
+    assert.equal(1, s1.adds)
+    assert.equal(1, s2.adds)
+    -- Both runs issued the same command; idempotence is the kernel's job.
+    assert.equal(2, #cmds)
+  end)
+
+  it("returns a zero-cost stats record when inventory is empty", function()
+    local cmds, exec = exec_recorder()
+    local called = 0
+    local stats = eb_refresh.refresh({
+      eb_hosts  = {},
+      bl_pairs  = {},
+      nft_table = "inet wifihaven",
+      resolver  = function() called = called + 1; return { v4 = {}, v6 = {} } end,
+      exec_fn   = exec,
+    })
+    assert.equal(0, stats.hosts)
+    assert.equal(0, stats.adds)
+    assert.equal(0, called)
+    assert.equal(0, #cmds)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
+-- default_resolve — parses `dig @127.0.0.1 +short` output
+-- ---------------------------------------------------------------------------
+
+describe("parse_dig_output", function()
+  it("yields a sorted list of v4 addresses", function()
+    local out = "142.251.46.142\n142.251.35.142\n"
+    assert.same({ "142.251.35.142", "142.251.46.142" }, eb_refresh.parse_dig_output(out, "v4"))
+  end)
+
+  it("yields a sorted list of v6 addresses", function()
+    local out = "2607:f8b0::200e\n2607:f8b0::100a\n"
+    assert.same({ "2607:f8b0::100a", "2607:f8b0::200e" }, eb_refresh.parse_dig_output(out, "v6"))
+  end)
+
+  it("skips CNAME-shaped lines that dig +short prints first", function()
+    local out = "youtube-ui.l.google.com.\n142.251.46.142\n"
+    assert.same({ "142.251.46.142" }, eb_refresh.parse_dig_output(out, "v4"))
+  end)
+
+  it("returns an empty list when dig returned no answer", function()
+    assert.same({}, eb_refresh.parse_dig_output("", "v4"))
+    assert.same({}, eb_refresh.parse_dig_output(nil, "v4"))
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -26,6 +26,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/nft_drops_spec.lua \
          test/nflog_spec.lua \
          test/lan_warn_spec.lua \
+         test/eb_refresh_spec.lua \
          "$@"
 
 echo ""


### PR DESCRIPTION
Closes #1658.

## Problem (#1649 evidence)

The per-host `eb_<host>` / `eb6_<host>` and per-blocklist `bl_<id>` / `bl6_<id>` nftables sets are declared `flags dynamic,timeout 1h`, populated one-shot at DNS resolve time via dnsmasq's `--nftset=` callback. iOS / iPadOS app DNS caches regularly outlive 1h (long-running connection pools, background-fetch sockets reuse the cached `getaddrinfo` answer), so a cached IP can age out of the kernel set under the still-connecting client. The per-MAC drop predicate `ip daddr @eb_<host>` misses, traffic falls through, and the agent's `lookup_hostname` correctly re-attributes the bytes back to the FQDN at usage-report time — surfacing as real engagement against an explicitly-blocked host.

#1649 confirmed this in prod for `play.google.com` on Kid Mac (`ca:ef:a1:72:6a:a3`) / Prima iPad (`04:72:ef:d6:e4:5a`) — 19 `traffic_reports` rows today hitting exactly `{142.251.46.142, 142.251.35.142, 142.250.188.46}`, the IPs currently in `eb_play_google_com`.

## Fix — periodic re-resolve heartbeat

New module `openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua`, wired into the agent timer loop as a sibling of the blocklist-refresh timer:

- Every `eb_refresh_interval` seconds (default `1800` — strictly below the 1h kernel timeout so each entry sees ≥1 refresh per ageing window), walk the per-MAC inventory `render.update_shared` already maintains (`eb_hosts_by_mac` / `bl_hosts_by_mac`), collapse to distinct hosts (the sets are global, not per-MAC), re-resolve each via the local dnsmasq (`dig @127.0.0.1` A + AAAA), and `nft add element` each answered IP back into the destination set.
- nft tolerates duplicate adds; idempotence is the kernel's job.
- The dns-tail sidecar (#1346) keeps doing its job; this closes the leak that opens precisely when no client re-resolves.

### Cadence justification

eb_/bl_ timeout is 3600s. 1800s gives ~2 refreshes per ageing window with comfortable margin. ~50 distinct extraBlocked hosts in a household → ~100 `dig` calls / 30 min → ~3.3 / min sustained — negligible router load.

## Direction tradeoffs (also covered in the issue body)

- **A. Periodic re-resolve (this PR).** Closes the leak without growing the set unbounded.
- **B. dns-tail extension.** The leak is precisely that the *client* doesn't re-resolve — extending dns-tail only helps when DNS *is* being queried. Doesn't address the cache-outlives-timeout case.
- **C. Bump timeout / make set static.** Accumulates stale CDN IPs as Google rotates (inverse leak); unbounded growth on tmpfs.

## Subdomain coverage

This module re-resolves the **apex** as authored. dnsmasq's `--nftset=/<apex>/...` callback populates the set for subdomains at resolve time, and dns_tail_sets (#1346) covers the directly-queried CNAME-target path. Subdomain-only client caches are left to a follow-up if observed in prod; the #1649 evidence is apex-level `play.google.com`.

## Wire compatibility

Agent-only change. No API/router request/response shape touched. The added metric name in `MetricGuard.Allowed` is purely additive — pre-fix agents won't push it, post-fix agents push it through.

## bounded-tmp-writes (AGENTS.md §bounded-tmp-writes)

N/A — no `/tmp` writes. The module shells out to `dig` (stdout consumed inline) and calls `nft add element` (no spool).

## Single source of truth (AGENTS.md §single-source-of-truth)

Reuses the (host, sets-to-populate) inventory `render.update_shared` already builds; reuses `dns_tail_sets.safe_addr` / `nft_add_element` for IP sanitisation + nft command formatting. The local `bl_sanitize` mirrors `render.lua`'s function byte-for-byte and is the one drift risk — `eb_refresh.lua`'s module header calls this out; if either function ever changes both must move in lockstep.

## Instrumentation (AGENTS.md §instrument-new-functionality / §metrics-need-a-dashboard)

- Counter `eb_refresh_total{result}`, `result` ∈ `{ok, resolve_failed}` — bounded enum, routed through `MetricGuard.Allowed`.
- Two new panels added to `deploy/grafana/dashboards/enforcement.json`: refresh rate by result, and resolve_failed fraction (canary).

## TDD

- Commit 1 (RED): `test(#1658)` lands the failing busted spec for the new module.
- Commit 2 (GREEN): implementation + agent timer wire-up + metric allowlist + dashboard panels.

## Manual repro (deferred to operator — touching router.lan affects prod enforcement)

1. `ssh root@router.lan`
2. `nft delete element inet wifihaven eb_play_google_com { 142.251.46.142 }`
3. Wait ≤ 30 min (`eb_refresh_int`).
4. `nft list set inet wifihaven eb_play_google_com` — IP returns.
5. `logread -e 'eb_refresh timer'` confirms a fire with `hosts>0`.

## Test plan

- [x] `openwrt/test/eb_refresh_spec.lua` — 14 unit tests (inventory collapse, eb_ + bl_ refresh, resolve-fail counting, shell-metachar rejection, idempotence, empty-inventory no-op, dig-output parsing).
- [x] Full `openwrt/test/run_tests.sh` suite passes (635/0/1 pending — pre-existing `nft` not on host).
- [x] `mill api.compile` + `mill api.test.compile` clean.
- [x] `scalafmt --check --non-interactive` clean.
- [x] `python3 -m json.tool` on `deploy/grafana/dashboards/enforcement.json` clean.
- [ ] Operator-driven live repro on `router.lan` per steps above.