### PR TITLE
docs(#1661): codify shared-pool host-set authoring principle + template audit

### DIFF
--- a/api/resources/app_templates/_README.yml
+++ b/api/resources/app_templates/_README.yml
@@ -67,7 +67,7 @@
 #     is NEAR-CERTAIN. STRIP THESE — they never carry app-specific bytes worth
 #     blocking; the dedicated-bytes host already does. Audit found exactly one
 #     across all 15 templates: `youtubei.googleapis.com` in youtube.yml,
-#     removed in Phase 0 (#1660).
+#     being removed in Phase 0 (#1660).
 #
 #   Class 2 — third-party cloud-CDN edge (branded per-app asset domains that
 #     happen to sit behind a multi-tenant CDN): `discordapp.net` (Cloudflare),

--- a/api/resources/app_templates/_README.yml
+++ b/api/resources/app_templates/_README.yml
@@ -38,6 +38,49 @@
 #              app's own dependency domains and are distinct from the
 #              device-level infra-allow list (#1337/#1411).
 #
+# ──────────────────────────────────────────────────────────────────────────
+# SHARED-POOL COLLATERAL — don't block a host you don't own the IPs of
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Enforcement is IP-layer, not DNS (see AGENTS.md / docs/architecture.md §0.2).
+# A blocked host's *resolved IPs* go into a per-(MAC, host) `eb_<host>` nftables
+# drop set; the kernel then drops every flow to those dst_ips. So a host whose
+# IPs are SHARED with traffic we never meant to block drags that other traffic
+# into the drop. This was the root cause of #1636 (kids' iPads couldn't sign
+# into Google Drive when YouTube was blocked): `youtubei.googleapis.com`
+# resolves to the same Google GFE anycast pool as Drive/OAuth/Calendar, so the
+# YouTube `eb_` rule dropped every Google product API on that pool.
+#
+# THE RULE: Don't put a shared vendor-API / multi-tenant-CDN host into a block
+# host-set when a DEDICATED-BYTES host already carries the meaningful block.
+# Prefer the app's dedicated-bytes host — `googlevideo.com` for YouTube,
+# `nflxvideo.net` for Netflix — that's where the attention-heavy traffic lives
+# and it carries no collateral. `imessage.yml` is the worked example of a
+# collateral-aware host-set: it deliberately EXCLUDES the shared APNs push
+# channel and targets only the iMessage-specific `ess.apple.com` edge; read
+# its inline comments before authoring a new host-set on shared infra.
+#
+# Two classes of shared-pool host (from the #1648 audit):
+#
+#   Class 1 — vendor-API anycast pools (Google GFE `*.googleapis.com`, and any
+#     host that fronts a whole vendor's product APIs on one IP pool). Collision
+#     is NEAR-CERTAIN. STRIP THESE — they never carry app-specific bytes worth
+#     blocking; the dedicated-bytes host already does. Audit found exactly one
+#     across all 15 templates: `youtubei.googleapis.com` in youtube.yml,
+#     removed in Phase 0 (#1660).
+#
+#   Class 2 — third-party cloud-CDN edge (branded per-app asset domains that
+#     happen to sit behind a multi-tenant CDN): `discordapp.net` (Cloudflare),
+#     `rbxcdn.com`, `tiktokcdn.com`, `sc-cdn.net`, `jtvnw.net` / `ttvnw.net`,
+#     `kastatic.org`, and similar across the set. These are LATENT risk only —
+#     they ARE where the app's own bytes live, so stripping them defeats the
+#     block. DO NOT mass-strip Class 2. They are a watch-list for the deferred
+#     Phase 3 evidence loop (#1663): only remove one if real traffic evidence
+#     shows it actually shares IPs with collateral we care about.
+#
+# When in doubt: block the dedicated-bytes host, leave the shared edge alone,
+# and file against #1663 rather than editing blind.
+#
 # File names beginning with `_` are reserved for documentation (this file) and
 # the manifest (`_index.yml`) and are ignored by the template loader.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,7 @@ for usage attribution (§7.2). It is **never** the enforcement plane.
 > [#1648](https://github.com/wifihaven/wifihaven/issues/1648) audit split
 > shared-pool hosts into **Class 1** (vendor-API anycast pools like Google GFE
 > `*.googleapis.com` — collision near-certain, strip; only
-> `youtubei.googleapis.com` qualified, removed in Phase 0
+> `youtubei.googleapis.com` qualified, being removed in Phase 0
 > [#1660](https://github.com/wifihaven/wifihaven/issues/1660)) and **Class 2**
 > (branded per-app CDN edges like `discordapp.net`, `rbxcdn.com`,
 > `tiktokcdn.com`, `sc-cdn.net`, `jtvnw.net` / `ttvnw.net`, `kastatic.org` —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,32 @@ dnsmasq's role is exclusively: forward DNS upstream, populate per-host
 nftables ipsets via `--ipset=`, and write a query log that `dns-tail` reads
 for usage attribution (§7.2). It is **never** the enforcement plane.
 
+> **Shared-pool collateral — `extraBlocked` host-sets must own their IPs.**
+> Because `extraBlocked` drops on the resolved `dst_ip`, a blocked host whose
+> IPs are *shared* with traffic we never meant to block drags that other
+> traffic into the drop. This was the root cause of
+> [#1636](https://github.com/wifihaven/wifihaven/issues/1636): kids' iPads
+> couldn't sign into Google Drive when YouTube was blocked because
+> `youtubei.googleapis.com` resolves to the same Google GFE anycast pool as
+> Drive / OAuth / Calendar, so the YouTube `eb_` rule dropped every Google
+> product API on that pool. The fix is an **authoring** rule, not a new
+> enforcement mechanism: prefer the app's **dedicated-bytes** host
+> (`googlevideo.com` for YouTube, `nflxvideo.net` for Netflix) — that's where
+> the attention-heavy traffic lives and it carries no collateral — and keep
+> shared vendor-API / multi-tenant-CDN hosts out of block host-sets. The
+> [#1648](https://github.com/wifihaven/wifihaven/issues/1648) audit split
+> shared-pool hosts into **Class 1** (vendor-API anycast pools like Google GFE
+> `*.googleapis.com` — collision near-certain, strip; only
+> `youtubei.googleapis.com` qualified, removed in Phase 0
+> [#1660](https://github.com/wifihaven/wifihaven/issues/1660)) and **Class 2**
+> (branded per-app CDN edges like `discordapp.net`, `rbxcdn.com`,
+> `tiktokcdn.com`, `sc-cdn.net`, `jtvnw.net` / `ttvnw.net`, `kastatic.org` —
+> latent risk only, **do not strip**, watch-list for the deferred Phase 3
+> evidence loop [#1663](https://github.com/wifihaven/wifihaven/issues/1663)).
+> The full authoring rule and worked example (`imessage.yml`) live next to the
+> templates in
+> [`api/resources/app_templates/_README.yml`](../api/resources/app_templates/_README.yml).
+
 ### 0.3 The global policy layer (#1308)
 
 Fleet-wide policy is carried **once** in `snapshot.global`, not copied into


### PR DESCRIPTION
Phase 1 of #1648. Makes the #1636 lesson durable: the root cause was **authoring a shared-pool host into a block-set**, not a missing enforcement mechanism. IP-layer enforcement drops on `dst_ip`, so a host on a shared anycast pool (Google GFE `*.googleapis.com`) or a multi-tenant cloud-CDN edge drags other tenants' IPs into the `eb_` drop set.

This is **docs + template-comment only** — no code, schema, or tests.

### What changed
- **`api/resources/app_templates/_README.yml`** — added a "SHARED-POOL COLLATERAL" section to the host-set authoring guidance:
  - The principle: prefer the app's **dedicated-bytes** host (`googlevideo.com` for YouTube, `nflxvideo.net` for Netflix); keep shared vendor-API / multi-tenant-CDN hosts out of block host-sets.
  - The #1648 **two-class taxonomy** (Class 1 vendor-API anycast pools → strip; Class 2 branded CDN edges → latent, do NOT strip).
  - Cites `imessage.yml` as the worked example of a collateral-aware host-set.
- **`docs/architecture.md`** — matching callout after the `extraBlocked` enforcement-plane table, linking back to the README for the full rule.

### Template audit (all 15, against the Class-1 rule)
Only **`youtubei.googleapis.com`** (in `youtube.yml`) qualifies as Class 1 — handled in Phase 0 #1660 (in flight). No template `hosts:` lists were edited here (out of scope).

**Class-2 watch-list** recorded as "do NOT strip; candidates for Phase 3 #1663": `discordapp.net`, `rbxcdn.com`, `tiktokcdn.com`, `sc-cdn.net`, `jtvnw.net`/`ttvnw.net`, `kastatic.org`, and similar branded CDN asset domains across the set.

Closes #1661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)