### PR TITLE
fix(#1660): drop youtubei.googleapis.com from YouTube template (shared GFE pool collateral)

### DIFF
--- a/api/resources/app_templates/youtube.yml
+++ b/api/resources/app_templates/youtube.yml
@@ -3,9 +3,16 @@ name: YouTube
 # Emoji fallback: 📺
 icon: "https://icons.duckduckgo.com/ip3/youtube.com.ico"
 icon_type: url
+# youtubei.googleapis.com is deliberately EXCLUDED from this set. It rides
+# Google's shared *.googleapis.com GFE anycast pool (216.239.32-38.223) — the
+# SAME front-end IPs that serve oauthaccountmanager.googleapis.com and the
+# Drive / Calendar / Docs APIs. Because the block enforces at the IP layer
+# (nftables drop on dst_ip ∈ eb_<host>), blocking youtubei poisons that shared
+# pool and collateral-drops Google sign-in / Drive on the device (#1636).
+# googlevideo.com below is YouTube's dedicated video-bytes pool, so keeping it
+# in the set preserves the meaningful block (no video) without the collateral.
 hosts:
   - youtube.com
   - youtu.be
   - ytimg.com
   - googlevideo.com
-  - youtubei.googleapis.com

--- a/api/test/src/feature/AppTemplatesSpec.scala
+++ b/api/test/src/feature/AppTemplatesSpec.scala
@@ -189,6 +189,23 @@ object AppTemplatesSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres
         assertTrue(hosts.forall(h => !h.contains("courier")))
       }
     },
+    test("youtube template keeps googlevideo but excludes the shared-pool youtubei host (#1636)") {
+      // youtubei.googleapis.com rides Google's shared *.googleapis.com GFE
+      // anycast pool — the same front-end IPs that serve OAuth / Drive / Docs.
+      // Because the block enforces at the IP layer, including it collateral-drops
+      // Google sign-in / Drive on the device (#1636). googlevideo.com is the
+      // dedicated video-bytes pool, so keeping it preserves the real block.
+      for {
+        templates <- AppTemplates.loadAll()
+      } yield {
+        val youtube = templates.find(_.slug == AppTemplateId.unsafe("youtube")).get
+        val hosts   = youtube.hosts.map(_.value).toSet
+        assertTrue(youtube.name == "YouTube") &&
+        assertTrue(hosts.contains("googlevideo.com")) &&
+        assertTrue(hosts.contains("youtube.com")) &&
+        assertTrue(hosts.forall(h => !h.contains("googleapis.com")))
+      }
+    },
     test("each template's hosts parse as apex hostnames") {
       for {
         templates <- AppTemplates.loadAll()


### PR DESCRIPTION
**Phase 0 of #1648. Closes #1660.** Fixes the root cause of #1636.

## Problem

The YouTube app block enforces at the IP layer (nftables drop on `dst_ip ∈ eb_<host>` ipsets). `youtubei.googleapis.com` resolves onto Google's **shared** `*.googleapis.com` GFE anycast pool (`216.239.32-38.223`) — the *same* front-end IPs that serve `oauthaccountmanager.googleapis.com` and the Drive / Calendar / Docs APIs.

So blocking YouTube poisoned that shared pool and collateral-dropped **Google sign-in / Drive** on kids' iPads — the live #1636 symptom.

## Change (intentionally tiny — template content only)

- Remove the `youtubei.googleapis.com` host line from `api/resources/app_templates/youtube.yml`.
- Add an `imessage.yml`-style explanatory comment above `hosts:` documenting *why* it's omitted.
- `googlevideo.com` (YouTube's **dedicated** video-bytes pool) stays in the set, so the meaningful block — no video — is preserved without the shared-pool collateral.
- Add a regression-pinning test in `AppTemplatesSpec` mirroring the existing imessage collateral-aware spec.

## Out of scope (deliberately)

- No Scala seeder / backfill / Flyway migration. Existing live `apps` rows are backfilled **manually** by the operator.
- No SNI/DPI, no new wire fields, no router/Lua changes.

## Verification

`mill api.test.testOnly …AppTemplatesSpec` → 26 passed (YouTube template now loads `hosts=4`, down from 5). `scalafmt` check clean.