### PR TITLE
fix(#1629): suppress Apple/iCloud OS background tail from kid phantom engagement

### DIFF
--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -109,6 +109,71 @@ object InfraHosts {
     "mtalk.google.com",    // GCM/FCM push
     "ntp.org",             // NTP time sync (was *.ntp.org)
     "time.cloudflare.com", // Cloudflare NTP
+    // ── #1629 Apple OS-services tail (suppress-only). Captured from
+    //    /api/profiles/<id>/usage-by-app on kid profiles 2026-06-10..2026-06-11 during
+    //    operator-pinned away+bedtime windows: device-level Apple background services
+    //    (App Store/iTunes background polls, Apple search-backend beacons, push
+    //    channels, location daemons, software-update metadata, analytics, Safe
+    //    Browsing edge, asset/media CDNs) that the kids were not interacting with.
+    //    Aggregated ~45–95 minutes of phantom orphan presence per kid per day, the
+    //    single largest contributor to the #1629 widened-scope inflation.
+    //
+    // App Store / iTunes Store background. Apex form matches all observed
+    // subdomains (p9-buy / p11-buy / p35-buy / init / ts / fpinit / auth /
+    // apps / configuration etc.). iMessage uses the distinct `ess.apple.com`
+    // apex, so this does not shadow it.
+    "itunes.apple.com",
+    // Apple search backend (Spotlight / Siri suggestions). `smoot.apple.com`
+    // apex matches `api-glb-*.smoot.apple.com` / `fbs.smoot.apple.com`.
+    "gsa.apple.com",
+    "gsas.apple.com",
+    "smoot.apple.com",
+    // Push channels / system management
+    "xp.apple.com",        // Apple Experience Push
+    "smp-device-content.apple.com", // System Management Push content
+    "humb.apple.com",               // background metrics
+    // Apple analytics (not user-initiated)
+    "swallow.apple.com",
+    "odin-signals.apple.com",
+    // Device configuration / software-update metadata. `mesu.apple.com` is the
+    // update-metadata feed; `gdmf-ados.apple.com` is a separate metadata host
+    // from `gdmf.apple.com` (already listed above) — both are background
+    // metadata fetches, not user actions.
+    "configuration.apple.com",
+    "mesu.apple.com",
+    "gdmf-ados.apple.com",
+    // Location daemon / CDN
+    "iphone-ld.apple.com",
+    "lcdn-locator.apple.com",
+    // Asset / media CDNs
+    "publicassets.cdn-apple.com",
+    "cabana-server.cdn-apple.com",
+    // Apple Safe Browsing edge (the sibling of `safebrowsing.google.com`
+    // already on canonical). gTLD `.apple` — exact-host match.
+    "proxy.safebrowsing.apple",
+    // ── #1629 iCloud background sync / Find My / Keychain Escrow. Same suppress-only
+    //    reasoning as the existing `mask*.icloud.com` (Private Relay) entries above:
+    //    count nothing toward engagement, but DO NOT allow-carve under a block.
+    //
+    //    Apex `icloud.com` form is required because iCloud hosts the operator's kids
+    //    actually contact are sharded with a per-region prefix (`p157-fmip.icloud.com`,
+    //    `p192-fmf.icloud.com`, `p108-escrowproxy.icloud.com` — the shard ID drifts
+    //    over time). Apex match catches all shards in one entry and also subsumes
+    //    `gateway.icloud.com` and any future similarly-sharded background services.
+    //
+    //    Safe because no `app_templates/*.yml` references `icloud.com`: today the
+    //    iCloud surfaces (Drive, Photos, Keychain, Backup) are not modelled as apps;
+    //    when they are, #1506 makes app attribution win over suppression here, the
+    //    same way `ess.apple.com` already coexists between this list and the iMessage
+    //    template. (The narrower existing `mask.icloud.com` / `mask-h2.icloud.com`
+    //    / `mask-api.icloud.com` entries above become redundant under this apex but
+    //    are retained for the load-bearing Private-Relay rationale documented inline.)
+    "icloud.com",
+    // ── #1629 iCloud Private Relay second hop. The first hop (`mask*.icloud.com`) is
+    //    already suppressed above; the second hop runs on Cloudflare under
+    //    `apple-relay.cloudflare.com`. Same anti-filtering-tunnel reasoning —
+    //    suppress, never allow-carve.
+    "apple-relay.cloudflare.com",
   )
 
   /** All hosts suppressed from presence counting: allow+suppress plus suppress-only (#1525). */

--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -102,9 +102,6 @@ object InfraHosts {
     "time.apple.com",      // Apple time sync
     "gdmf.apple.com",      // Apple software-update metadata
     "pancake.apple.com",   // Apple Maps/infra
-    "mask.icloud.com",     // iCloud Private Relay — suppress, never allow (bypass)
-    "mask-h2.icloud.com",  // iCloud Private Relay (HTTP/2)
-    "mask-api.icloud.com", // iCloud Private Relay (API)
     "rcs.telephony.goog",  // RCS messaging infra (was *.rcs.telephony.goog)
     "mtalk.google.com",    // GCM/FCM push
     "ntp.org",             // NTP time sync (was *.ntp.org)
@@ -119,9 +116,11 @@ object InfraHosts {
     //    single largest contributor to the #1629 widened-scope inflation.
     //
     // App Store / iTunes Store background. Apex form matches all observed
-    // subdomains (p9-buy / p11-buy / p35-buy / init / ts / fpinit / auth /
-    // apps / configuration etc.). iMessage uses the distinct `ess.apple.com`
-    // apex, so this does not shadow it.
+    // subdomains (p9-buy / p11-buy / p35-buy / init / ts / fpinit / auth on
+    // `*.itunes.apple.com`). iMessage uses the distinct `ess.apple.com` apex,
+    // so this does not shadow it. Sibling apple.com namespaces like the
+    // device-config feed are listed separately below — they don't sit under
+    // `itunes.apple.com`.
     "itunes.apple.com",
     // Apple search backend (Spotlight / Siri suggestions). `smoot.apple.com`
     // apex matches `api-glb-*.smoot.apple.com` / `fbs.smoot.apple.com`.
@@ -151,26 +150,31 @@ object InfraHosts {
     // Apple Safe Browsing edge (the sibling of `safebrowsing.google.com`
     // already on canonical). gTLD `.apple` — exact-host match.
     "proxy.safebrowsing.apple",
-    // ── #1629 iCloud background sync / Find My / Keychain Escrow. Same suppress-only
-    //    reasoning as the existing `mask*.icloud.com` (Private Relay) entries above:
-    //    count nothing toward engagement, but DO NOT allow-carve under a block.
+    // ── #1629 iCloud — apex covers iCloud Private Relay first hop
+    //    (`mask*.icloud.com`), background sync / Find My / Keychain Escrow
+    //    (`p157-fmip.icloud.com`, `p192-fmf.icloud.com`,
+    //    `p108-escrowproxy.icloud.com` — the shard prefix drifts per region),
+    //    `gateway.icloud.com`, and any future similarly-sharded iCloud
+    //    background service in one entry. (Pre-#1629 we listed three narrower
+    //    `mask*.icloud.com` entries for Private Relay alone; this apex subsumes
+    //    those and the granular Find-My / Escrow / gateway hosts.)
     //
-    //    Apex `icloud.com` form is required because iCloud hosts the operator's kids
-    //    actually contact are sharded with a per-region prefix (`p157-fmip.icloud.com`,
-    //    `p192-fmf.icloud.com`, `p108-escrowproxy.icloud.com` — the shard ID drifts
-    //    over time). Apex match catches all shards in one entry and also subsumes
-    //    `gateway.icloud.com` and any future similarly-sharded background services.
+    //    SUPPRESS-ONLY, NEVER ALLOW-CARVE. This is the load-bearing reason
+    //    `mask*.icloud.com` lived in this tier from the start: iCloud Private
+    //    Relay is an encrypted relay tunnel — allow-carving it would punch an
+    //    anti-filtering bypass through every block. Same reasoning applies to
+    //    any other iCloud service: count nothing toward engagement, but do not
+    //    make iCloud reachable under a block.
     //
-    //    Safe because no `app_templates/*.yml` references `icloud.com`: today the
-    //    iCloud surfaces (Drive, Photos, Keychain, Backup) are not modelled as apps;
-    //    when they are, #1506 makes app attribution win over suppression here, the
-    //    same way `ess.apple.com` already coexists between this list and the iMessage
-    //    template. (The narrower existing `mask.icloud.com` / `mask-h2.icloud.com`
-    //    / `mask-api.icloud.com` entries above become redundant under this apex but
-    //    are retained for the load-bearing Private-Relay rationale documented inline.)
+    //    Apex-form trade-off: this also matches user-facing iCloud surfaces
+    //    that today aren't modelled as apps (`www.icloud.com` webmail,
+    //    `beta.icloud.com`, etc.). Pinned as accepted collateral in the spec.
+    //    When an iCloud-anything template lands, #1506 makes app attribution
+    //    win over suppression here — same way `ess.apple.com` already coexists
+    //    between this list and the iMessage template.
     "icloud.com",
-    // ── #1629 iCloud Private Relay second hop. The first hop (`mask*.icloud.com`) is
-    //    already suppressed above; the second hop runs on Cloudflare under
+    // ── #1629 iCloud Private Relay second hop. The first hop is the `icloud.com`
+    //    apex above; the second hop runs on Cloudflare under
     //    `apple-relay.cloudflare.com`. Same anti-filtering-tunnel reasoning —
     //    suppress, never allow-carve.
     "apple-relay.cloudflare.com",

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -196,6 +196,29 @@ object InfraHostsSpec extends ZIOSpecDefault {
         iCloudTail.forall(h => !InfraHosts.isInfra(h)),
       )
     },
+    test(
+      "#1629 icloud.com apex collateral: user-facing iCloud surfaces are also suppressed today",
+    ) {
+      // The `icloud.com` apex is intentionally broad — necessary because the kid hosts
+      // are per-region-sharded (`p157-fmip` / `p192-fmf` / `p108-escrowproxy`) and the
+      // matcher has no `*-` infix wildcards. Pin the accepted trade-off explicitly so
+      // it's visible to whoever later adds an iCloud-anything app template: today
+      // these user-facing iCloud surfaces ARE suppressed from presence counting, and
+      // that's the trade-off — when an app template lands, #1506
+      // (`Presence.isAppAttributed`) makes app attribution win over suppression for
+      // hosts the template claims, identical to how `ess.apple.com` already coexists
+      // between this list and the iMessage template.
+      val collateral = List(
+        "www.icloud.com",  // iCloud webmail
+        "beta.icloud.com", // iCloud beta surfaces
+        "setup.icloud.com",// device setup flow
+      )
+      assertTrue(
+        collateral.forall(InfraHosts.isBackground),
+        // BOUNDARY still holds: collateral is suppress-only, never allow-carved.
+        collateral.forall(h => !InfraHosts.isInfra(h)),
+      )
+    },
     test("#1629 iCloud Private Relay second hop (apple-relay.cloudflare.com) is suppressed") {
       // The mask.icloud.com entry covers the first hop; the second hop is served from
       // Cloudflare under apple-relay.cloudflare.com. Same anti-filtering-tunnel reasoning

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -126,5 +126,102 @@ object InfraHostsSpec extends ZIOSpecDefault {
         InfraHosts.suppressOnly.forall(h => !h.startsWith("*.")),
       )
     },
+    test("#1629 Apple OS-services tail observed in prod orphan presence is suppressed") {
+      // Captured from `GET /api/profiles/<id>/usage-by-app` on 2026-06-10..2026-06-11 across
+      // kid profiles (Prima/Quintus/Kids) during operator-pinned away+bedtime windows. These
+      // are device-level Apple OS background services (App Store/iTunes background polls,
+      // Apple search-backend beacons, push channels, location daemons, software-update
+      // metadata, analytics, Safe Browsing edge) that the kids were not interacting with —
+      // they belong on the suppress side of the InfraHosts boundary, same tier as the
+      // existing Apple entries (`g.aaplimg.com`, `netcts.cdn-apple.com`, `ls.apple.com`,
+      // `ess.apple.com`, `gdmf.apple.com`, …). Suppress, not allow-carve: these don't
+      // need to be reachable under a block.
+      val appleTail = List(
+        // App Store / iTunes Store background polling (covers p9-buy / p11-buy / p35-buy /
+        // auth / init / ts / fpinit subdomains observed in prod)
+        "init.itunes.apple.com",
+        "ts.itunes.apple.com",
+        "auth.itunes.apple.com",
+        "fpinit.itunes.apple.com",
+        "p9-buy.itunes.apple.com",
+        "p11-buy.itunes.apple.com",
+        "p35-buy.itunes.apple.com",
+        // Apple search backend
+        "gsa.apple.com",
+        "gsas.apple.com",
+        "api-glb-ausw2c.smoot.apple.com",
+        "fbs.smoot.apple.com",
+        // Push channels / system management
+        "xp.apple.com",
+        "smp-device-content.apple.com",
+        "humb.apple.com",
+        // Apple analytics
+        "swallow.apple.com",
+        "odin-signals.apple.com",
+        // Device configuration / software update metadata
+        "configuration.apple.com",
+        "mesu.apple.com",
+        "gdmf-ados.apple.com",
+        // Location daemon / CDN
+        "iphone-ld.apple.com",
+        "lcdn-locator.apple.com",
+        // Asset / media CDN
+        "publicassets.cdn-apple.com",
+        "cabana-server.cdn-apple.com",
+        // Apple Safe Browsing edge (sibling of the canonical Google entries)
+        "proxy.safebrowsing.apple",
+      )
+      assertTrue(
+        appleTail.forall(InfraHosts.isBackground),
+        // BOUNDARY: this is a suppress-only addition, not an allow-carve. None of these
+        // should land on the canonical (`isInfra`) list — they have no app-allowlist
+        // carve-out role.
+        appleTail.forall(h => !InfraHosts.isInfra(h)),
+      )
+    },
+    test("#1629 iCloud background services observed in prod orphan presence are suppressed") {
+      // Same provenance as the Apple tail above — iCloud sync / Find-My / Keychain Escrow
+      // background that runs without user initiation. Suppress-only, same reasoning as
+      // mask.icloud.com: making these reachable under a block is not the goal; they
+      // simply shouldn't count as engagement.
+      val iCloudTail = List(
+        "p157-fmip.icloud.com",        // Find My iPhone
+        "p192-fmf.icloud.com",         // Find My Friends
+        "p157-fmfmobile.icloud.com",   // Find My Friends Mobile
+        "p108-escrowproxy.icloud.com", // iCloud Keychain Escrow
+        "gateway.icloud.com",          // iCloud gateway
+      )
+      assertTrue(
+        iCloudTail.forall(InfraHosts.isBackground),
+        iCloudTail.forall(h => !InfraHosts.isInfra(h)),
+      )
+    },
+    test("#1629 iCloud Private Relay second hop (apple-relay.cloudflare.com) is suppressed") {
+      // The mask.icloud.com entry covers the first hop; the second hop is served from
+      // Cloudflare under apple-relay.cloudflare.com. Same anti-filtering-tunnel reasoning
+      // as the first hop — suppress (don't count as engagement) but NEVER allow-carve.
+      assertTrue(
+        InfraHosts.isBackground("apple-relay.cloudflare.com"),
+        InfraHosts.isBackground("ingress.apple-relay.cloudflare.com"),
+        !InfraHosts.isInfra("apple-relay.cloudflare.com"),
+      )
+    },
+    test("#1629 additions do not shadow non-Apple app template host-sets") {
+      // Defensive: none of the patterns added for #1629 should accidentally suppress
+      // a real-app host on an unrelated apex (Khan, Math, etc. — their apexes don't
+      // overlap with Apple/iCloud at all). The `ess.apple.com` co-listing with the
+      // iMessage template is intentional and predates this change: #1506
+      // (`Presence.isAppAttributed`) lets app attribution win over suppression at
+      // runtime, so iMessage traffic keeps counting for profiles that have the
+      // iMessage app configured — this PR's additions are no different in shape.
+      val unrelatedAppHosts = List(
+        "khanacademy.org", // Khan Academy template
+        "kastatic.org",
+        "kasandbox.org",
+        "mathacademy.com", // Math Academy template
+        "www.mathacademy.com",
+      )
+      assertTrue(unrelatedAppHosts.forall(h => !InfraHosts.isBackground(h)))
+    },
   )
 }


### PR DESCRIPTION
Closes #1629.

## Symptom (operator, 2026-06-11 → 2026-06-12)

> kids were gone from 10–4 today, they sleep (and are bedtime restricted) from 730–630, so they shouldn't show any usage in those windows at an absolute minimum

> Prima used Math Academy today but only touched Khan Academy briefly — Khan Academy showed a lot more usage than expected

Per #1629's 2026-06-12 widened scope: the centralized presence predicate (#1503 / #1506 / #1560) is correct — its **inputs** miss a whole tier of Apple OS background services. Kids' iPads on the LAN keep polling Apple/iCloud edges while the kids are physically absent, and that traffic shows up as "engaged minutes."

## Evidence (read-only, prod)

Captured into [`evidence/`](evidence/EVIDENCE.md) from `GET /api/profiles/<id>/usage-by-app` on kid profiles 2026-06-10 → 2026-06-11:

| Pattern (apex/exact) | Profile 6 (Prima) | Profile 5 (Quintus) | Profile 1 (Kids) |
|---|---:|---:|---:|
| `itunes.apple.com` (p9/p11/p35-buy, auth/init/ts/fpinit) | 1543 s | 602 s | 828 s |
| `gsa.apple.com` / `gsas.apple.com` / `smoot.apple.com` | 1391 s | 772 s | — |
| `mesu.apple.com` (software-update metadata) | 183 s | 278 s | 797 s |
| `swallow.apple.com` / `odin-signals.apple.com` (analytics) | 862 s | — | — |
| `proxy.safebrowsing.apple` | 377 s | — | 445 s |
| `xp.apple.com` (push) | 347 s | — | 315 s |
| `configuration.apple.com` | — | 329 s | low |
| iCloud (`icloud.com` apex: fmip / fmf / fmfmobile / escrowproxy / gateway) | 243 s | 715 s | — |
| `apple-relay.cloudflare.com` (Private Relay 2nd hop) | 84 s | — | — |
| (plus smaller smp / humb / gdmf-ados / iphone-ld / lcdn / publicassets / cabana entries) | ~500 s | — | — |
| **TOTAL Apple/iCloud orphan presence** | **~5750 s (~95 min)** | **~2700 s (~45 min)** | **~2740 s (~45 min)** |

None of these hosts are in any current `app_templates/*.yml` host-set. All are device-level OS background services per the existing InfraHosts boundary — same tier as the canonical `g.aaplimg.com` / `netcts.cdn-apple.com` / `ls.apple.com` entries and the suppress-only `ess.apple.com` / `gdmf.apple.com` / `mask*.icloud.com` entries.

## Fix

Extend `InfraHosts.suppressOnly` (`shared/src/types/InfraHosts.scala`) with the prod-observed Apple OS tail (App Store/iTunes background, Apple search/push/analytics/config/software-update/location/CDN/Safe-Browsing-edge), `icloud.com` apex (covers per-region-sharded Find-My / Keychain Escrow / gateway), and `apple-relay.cloudflare.com` (Private Relay second hop).

That's the **whole** code change. The presence/aggregation pipeline (`Presence.isHeartbeat` → `InfraHosts.isBackground` → `Presence.proportionalHostSeconds` / `totalSecondsByMac` / `hostMinutes`) is reused unchanged — this is a single-source-of-truth tuning of the inputs.

## TDD

- **Commit 1 (RED)** adds four new cases in `InfraHostsSpec`: the Apple tail, the iCloud sharded tail, the Private Relay 2nd hop, and a BOUNDARY check that none of these patterns land on canonical. Verified red before fix.
- **Commit 2 (GREEN)** adds the patterns. All four new cases pass; `mill shared.test` + `mill api.test` clean (no PolicyService / Presence / usage-by-app regressions).

## Single source of truth / wire / backwards-compat

- Per AGENTS.md [§single-source-of-truth](../blob/main/CLAUDE.md#single-source-of-truth): change is *exclusively* to the inputs of the centralized predicate. No new code paths, no parallel suppression branch. Same shape as #1503 / #1525 / #1540.
- Per AGENTS.md "Backwards compatibility": no wire change. Snapshot uses canonical only (allow-carve), not suppressOnly. Router has no awareness of this list.
- Per #1506: where `ess.apple.com` already co-lists between suppressOnly and the iMessage template, `Presence.isAppAttributed` keeps app attribution winning at runtime. None of the patterns added here conflict with an existing app template host-set.

## Out of scope (follow-ups)

- **Bucket B — session-stitch tightening for Khan / Math** (operator's "Khan briefly touched → 7 min" observation). Even after this PR's Apple tail is removed, Khan Academy shows `proportionalSeconds=455` / `presenceSeconds=80` on 2026-06-11 — a ~6× stitch-inflation across sparse polling buckets. Per-host session-stitch behaviour belongs in its own change with a deliberate `presence_continuation_seconds` re-tune; will file under Tuning.
- **Other orphan classes** observed: Google background (`ssl.gstatic.com`, `clients4.google.com`, `android.clients.google.com`), Brave telemetry (`*.bsg.brave.com`), ad-network polling (`oa.openxcdn.net`, `ep2.adtrafficquality.google`, Unity3D mediation). Each needs per-source review on the OS-infra-vs-app-surface distinction.

## Test plan
- [x] `mill shared.test` — 14 InfraHostsSpec cases, 4 new ones GREEN; full shared suite clean
- [x] `mill api.test` — 176 tests across feature + unit suites, all GREEN (Presence / TimeStatusService / UsageRoutes paths unaffected since the predicate body didn't change)
- [ ] Post-merge: re-pull the same `usage-by-app` endpoint on Prima/Quintus/Kids for tomorrow's window; the Apple/iCloud orphan tail should drop ~80%+ in `orphanHosts` and the per-profile daily total should fall correspondingly.