### PR TITLE
fix(#1559): route dashboard now-widget host ranking through canonical app-aware suppression

### DIFF
--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -369,6 +369,7 @@ object Main extends ZIOAppDefault {
             deviceRepo,
             profileRepo,
             upRepo,
+            atlRepo,
             clock,
           ) ++
           BlocklistRoutes.routes(auth, blRepo, blCache, blFetcher2, bundledBlocklists) ++

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -354,8 +354,26 @@ object Presence {
       filter: HeartbeatFilter,
       appHostPatterns: List[String] = Nil,
   ): Boolean =
-    !isAppAttributed(row, appHostPatterns) &&
-      (isBackgroundHost(row) || (filter.enabled && row.bytes < filter.bytesThreshold))
+    suppressedAsBackground(row.host, appHostPatterns) ||
+      (!isAppAttributed(
+        row,
+        appHostPatterns,
+      ) && filter.enabled && row.bytes < filter.bytesThreshold)
+
+  /**
+   * #1559: host-keyed "drop unless app-attributed" predicate — the ranking-side analogue of
+   * [[isHeartbeat]]'s suppression branch, without the PresenceRow byte-floor. A host is suppressed
+   * as device-level background iff it is on the [[InfraHosts.isBackground]] list AND no active
+   * app's host-set claims it (attribution beats suppression, same #1506 contract every counting
+   * surface routes through). The SINGLE host-keyed entry point: `isHeartbeat` reuses this for its
+   * suppression branch and `DashboardNowRoutes.dropBackground` calls it directly, so the rule
+   * cannot diverge between counting and ranking (#1532).
+   *
+   * An empty `appHostPatterns` (no app context) reduces to plain `InfraHosts.isBackground` —
+   * preserves prior behavior for callers without app-attribution data.
+   */
+  def suppressedAsBackground(host: HostId, appHostPatterns: List[String]): Boolean =
+    InfraHosts.isBackground(host) && !HostMatch.matchesAny(host, appHostPatterns)
 
   /**
    * #1506: whether the row's FQDN is attributed to one of the active apps' host-sets — the
@@ -366,16 +384,6 @@ object Presence {
    */
   def isAppAttributed(row: PresenceRow, appHostPatterns: List[String]): Boolean =
     HostMatch.matchesAny(row.host, appHostPatterns)
-
-  /**
-   * #1503/#1525: whether the row's FQDN is device-level background infra
-   * ([[InfraHosts.isBackground]] \= allow+suppress canonical ∪ suppress-only). Keyed on host
-   * identity only — IP-literal hosts never match. #1560: thin alias for the canonical host-keyed
-   * predicate on [[InfraHosts]] — every presence/dashboard suppression call site routes through
-   * that one entry point so the rule cannot diverge between surfaces (#1532).
-   */
-  private def isBackgroundHost(row: PresenceRow): Boolean =
-    InfraHosts.isBackground(row.host)
 
   /**
    * #714: per-row heartbeat classification for the explain debug surface. Wraps each row with the

--- a/api/src/routes/DashboardNowRoutes.scala
+++ b/api/src/routes/DashboardNowRoutes.scala
@@ -2,6 +2,8 @@ package wifihaven.api.routes
 
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
+import wifihaven.api.policy.ProfileAppDispositions
+import wifihaven.api.presence.Presence
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
@@ -37,6 +39,7 @@ object DashboardNowRoutes {
       deviceRepo: DeviceRepo,
       profileRepo: ProfileRepo,
       userProfileRepo: UserProfileRepo,
+      appTimeLimitRepo: AppTimeLimitRepo,
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
@@ -58,8 +61,8 @@ object DashboardNowRoutes {
             // Both inputs in parallel.
             since       = now.minus(TopHostsWindow)
             connSince   = now.minus(RecentActivityWindow)
-            lastSeenF <- connRepo.lastSeenByMacSince(connSince).fork
-            rowsF     <- trafficRepo
+            lastSeenF  <- connRepo.lastSeenByMacSince(connSince).fork
+            rowsF      <- trafficRepo
               .listTrafficRollupRows(
                 TrafficRollupFilter(
                   macs = Some(visibleMacs),
@@ -69,14 +72,27 @@ object DashboardNowRoutes {
                 ),
               )
               .fork
-            lastSeen  <- lastSeenF.join.mapError(ApiError.Db(_))
-            rows      <- rowsF.join.mapError(ApiError.Db(_))
-            response = buildResponse(
+            // #1559: per-profile active-app host-set, fed into [[dropBackground]] so an
+            // app-attributed background-pattern host stays in the ranking (attribution beats
+            // suppression, same #1506 contract counting surfaces use). Read through the
+            // canonical [[ProfileAppDispositions]] fold so the dashboard cannot disagree
+            // with the counting paths on what "active app host" means (#1532 / #1560).
+            appLimitsF <- appTimeLimitRepo.listAll.fork
+            lastSeen   <- lastSeenF.join.mapError(ApiError.Db(_))
+            rows       <- rowsF.join.mapError(ApiError.Db(_))
+            appLimits  <- appLimitsF.join.mapError(ApiError.Db(_))
+            appHostPatternsByProfile = appLimits
+              .groupBy(_.profileId)
+              .view
+              .mapValues(ProfileAppDispositions.from(_).appHostPatterns)
+              .toMap
+            response                 = buildResponse(
               now = now,
               profiles = visibleProf,
               devices = visibleDevs,
               lastSeen = lastSeen,
               rows = rows,
+              appHostPatternsByProfile = appHostPatternsByProfile,
             )
           } yield Response.json(response.toJson)
           handle.mapError(ErrorMapper.errorToResponse)
@@ -99,6 +115,7 @@ object DashboardNowRoutes {
       devices: List[Device],
       lastSeen: Map[MacAddress, Instant],
       rows: List[TrafficRollupRow],
+      appHostPatternsByProfile: Map[ProfileId, List[String]] = Map.empty,
   ): DashboardNow = {
     val trafficCutoff                             = now.minus(TrafficActiveWindow)
     val rowsByMac                                 = rows.groupBy(_.mac)
@@ -108,8 +125,9 @@ object DashboardNowRoutes {
         .toMap
 
     val profile = profiles.sortBy(_.id).map { p =>
-      val devs   = devices.filter(_.profileId.contains(p.id))
-      val active = devs.flatMap { d =>
+      val devs            = devices.filter(_.profileId.contains(p.id))
+      val appHostPatterns = appHostPatternsByProfile.getOrElse(p.id, Nil)
+      val active          = devs.flatMap { d =>
         val connTs    = lastSeen.get(d.mac)
         val trafficTs = latestTrafficTs.get(d.mac).filter(_.isAfter(trafficCutoff))
         val activeTs  = (connTs, trafficTs) match {
@@ -124,8 +142,8 @@ object DashboardNowRoutes {
             name = d.name,
             mac = d.mac,
             lastSeenSeconds = lastSeenSeconds,
-            topHosts = topHostsFromRows(devRows),
-            nowActivity = nowActivityFromRows(devRows),
+            topHosts = topHostsFromRows(devRows, appHostPatterns),
+            nowActivity = nowActivityFromRows(devRows, appHostPatterns),
           )
         }
       }
@@ -145,8 +163,11 @@ object DashboardNowRoutes {
    * bucket and returns its top host. If earlier consecutive buckets share the same top host,
    * reports a `minutes` run (capped at 60); otherwise `minutes = None`. See #852.
    */
-  def nowActivityFromRows(rows: List[TrafficRollupRow]): Option[DashboardNowActivity] = {
-    val buckets = dropBackground(rows)
+  def nowActivityFromRows(
+      rows: List[TrafficRollupRow],
+      appHostPatterns: List[String] = Nil,
+  ): Option[DashboardNowActivity] = {
+    val buckets = dropBackground(rows, appHostPatterns)
       .groupBy(_.periodEnd)
       .toList
       .sortBy { case (end, _) => -end.getEpochSecond }
@@ -179,8 +200,11 @@ object DashboardNowRoutes {
       .headOption
       .map(_._1)
 
-  def topHostsFromRows(rows: List[TrafficRollupRow]): List[DashboardNowHost] =
-    dropBackground(rows)
+  def topHostsFromRows(
+      rows: List[TrafficRollupRow],
+      appHostPatterns: List[String] = Nil,
+  ): List[DashboardNowHost] =
+    dropBackground(rows, appHostPatterns)
       .groupBy(_.host)
       .view
       .mapValues(rs => rs.map(_.activeSeconds.toLong).sum)
@@ -196,7 +220,19 @@ object DashboardNowRoutes {
    * floor — so it cannot hide a genuine low-byte foreground request (the #1446 undercount
    * mechanism): a single chatty 60-byte keepalive looks identical to a real request-driven app at
    * the byte level, so only identity is safe here.
+   *
+   * #1559: ATTRIBUTION BEATS SUPPRESSION. `appHostPatterns` is the union of the profile's
+   * active-app host-sets (via [[ProfileAppDispositions.appHostPatterns]]). A row whose host matches
+   * an active app's host-set is attributed to that app and kept in the ranking — so an off-domain
+   * asset/CDN host an app genuinely depends on that also happens to be on the [[InfraHosts]]
+   * device-infra list (e.g. `beacons3.gvt2.com` when a "Google" app claims `gvt2.com`) surfaces in
+   * topHosts/nowActivity instead of being silently dropped. Routed through the single host-keyed
+   * [[Presence.suppressedAsBackground]] predicate — same rule the counting surfaces use, no second
+   * copy (#1532 / #1560).
    */
-  private def dropBackground(rows: List[TrafficRollupRow]): List[TrafficRollupRow] =
-    rows.filterNot(r => InfraHosts.isBackground(r.host))
+  private def dropBackground(
+      rows: List[TrafficRollupRow],
+      appHostPatterns: List[String],
+  ): List[TrafficRollupRow] =
+    rows.filterNot(r => Presence.suppressedAsBackground(r.host, appHostPatterns))
 }

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -279,6 +279,58 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         dev.nowActivity.exists(_.topHost == HostId.Fqdn(Hostname.unsafe("youtube.com"))),
       )
     },
+    test(
+      "#1559 a background-pattern host attributed to an active app is kept in the now-widget ranking",
+    ) {
+      // Attribution beats suppression on the ranking path (#1559), the same way #1506 made it
+      // beat suppression on the counting paths. An off-domain asset/CDN host an app genuinely
+      // depends on that also happens to match the unified InfraHosts device-infra list must stay
+      // in topHosts / nowActivity instead of being silently dropped. A device-infra host with no
+      // app behind it (ocsp.digicert.com here) stays dropped.
+      //
+      // The app's host-set is built via app_policy_assignments + app_hosts, the same
+      // attribution data `Presence.appHostPatterns` reads — i.e. routed through the single
+      // canonical predicate, not a parallel one (#1532 / #1560).
+      for {
+        _        <- cleanDb
+        _        <- clearSeededProfiles
+        routerId <- seedRouter()
+        dr       <- ZIO.service[DeviceRepo]
+        pr       <- ZIO.service[ProfileRepo]
+        ar       <- ZIO.service[AppRepo]
+        kid      <- pr.create("Kids", Nil)
+        _        <- TestLayers.seedDevice(dr, mac1, "iPad", kid)
+        // Synthetic time-limited app whose host-set claims `gvt2.com` — the apex sits on
+        // InfraHosts.canonical, so any subdomain (`beacons3.gvt2.com`) would otherwise be
+        // dropped as background. With the #1559 app-aware predicate it is attributed to the
+        // app and kept.
+        _        <- TestLayers.seedAppAssignment(
+          ar,
+          kid,
+          host = "gvt2.com",
+          mode = AppMode.TimeLimited,
+          dailyMinutes = Some(60),
+          exemptFromDaily = false,
+        )
+        now0     <- Clock.instant
+        t0 = now0.minusSeconds(10 * 60)
+        // App-attributed background host — stays in ranking after the fix.
+        _      <- insertReport(routerId, mac1, "beacons3.gvt2.com", t0, activeSeconds = 300)
+        // Device infra with no app behind it — still dropped.
+        _      <- insertReport(routerId, mac1, "ocsp.digicert.com", t0, activeSeconds = 300)
+        _      <- insertConn(routerId, mac1, now0.minusSeconds(15))
+        auth   <- makeAuth
+        token  <- auth.login("admin", "changeme").map(_.token)
+        routes <- buildRoutes(auth)
+        resp   <- getJson(routes, "/api/dashboard/now", token)
+        body   <- resp.body.asString
+        parsed <- ZIO.fromEither(body.fromJson[DashboardNow])
+        dev = parsed.profiles.find(_.id == kid).get.activeDevices.head
+      } yield assertTrue(
+        dev.topHosts.map(_.host) == List(HostId.Fqdn(Hostname.unsafe("beacons3.gvt2.com"))),
+        dev.nowActivity.exists(_.topHost == HostId.Fqdn(Hostname.unsafe("beacons3.gvt2.com"))),
+      )
+    },
     test("nowActivity: consistent top host across 3 buckets → topHost + accurate minutes") {
       for {
         _        <- cleanDb

--- a/api/test/src/feature/DashboardNowApiSpec.scala
+++ b/api/test/src/feature/DashboardNowApiSpec.scala
@@ -101,8 +101,9 @@ object DashboardNowApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
       dr     <- ZIO.service[DeviceRepo]
       pr     <- ZIO.service[ProfileRepo]
       upRepo <- ZIO.service[UserProfileRepo]
+      atl    <- ZIO.service[AppTimeLimitRepo]
       clock  <- ZIO.service[Clock]
-    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, clock)
+    } yield DashboardNowRoutes.routes(auth, tr, cr, dr, pr, upRepo, atl, clock)
 
   /**
    * V1__init seeds two profiles ("Kids" and "Adults"). Tests that need a clean slate clear them so


### PR DESCRIPTION
Closes #1559.

## Summary

`DashboardNowRoutes.dropBackground` was the last consumer that hadn't been
routed through #1506's app-aware predicate. It suppressed hosts purely on
`InfraHosts.isBackground` host identity, so an off-domain asset / CDN host an
app genuinely depends on — e.g. `beacons3.gvt2.com` when a Google app's
host-set claims `gvt2.com` — was silently dropped from `topHosts` /
`nowActivity` even while it correctly counted toward the app's time. The seam
#1506 closed for counting was still open for the live widget.

Collapse through a single host-keyed predicate:

```scala
// api/src/presence/Presence.scala
def suppressedAsBackground(host: HostId, appHostPatterns: List[String]): Boolean =
  InfraHosts.isBackground(host) && !HostMatch.matchesAny(host, appHostPatterns)
```

`Presence.isHeartbeat`'s suppression branch is rewritten to call it too, so the
ranking path (`DashboardNowRoutes.dropBackground`) and every counting path
share one rule. Same #1506 contract, no second copy (#1532 / #1560).

The dashboard loads the per-profile active-app host-set through the canonical
`ProfileAppDispositions.from(appLimits).appHostPatterns` fold — the same data
`TimeStatusService.appHostPatterns` feeds counting surfaces — so the dashboard
cannot disagree with them on "what's an active-app host".

## Before / after (now-widget for a Kids profile watching `beacons3.gvt2.com`, with a Google app whose host-set includes `gvt2.com`)

Before: `topHosts = []`, `nowActivity = None`. The dominant host is dropped as
"device infra" even though it's foreground traffic to a managed app — the
operator sees "no recent activity" while the kid is in fact watching their app.

After: `topHosts = [{host: beacons3.gvt2.com, activeSeconds: 300}]`,
`nowActivity = {topHost: beacons3.gvt2.com}`. Attribution wins; the operator
sees the actual host being used. Device infra with no app behind it
(`ocsp.digicert.com`) still drops, matching prior behavior.

## Lesson

Single source of truth (AGENTS.md §single-source-of-truth): #1506 centralized
the app-aware predicate for counting; #1560 collapsed the host-keyed plumbing.
Each follow-up that touches a new surface must route through those primitives
rather than re-derive the rule — otherwise the ranking and counting paths drift
again, the same class of bug the #1532 audit is closing. This PR routes the
last identified consumer (`DashboardNowRoutes.dropBackground`) through the
canonical predicate.

## Test plan
- [x] `mill api.test` (full api suite, 15-spec `DashboardNowApiSpec` includes the new pinning test)
- [x] New test: `#1559 a background-pattern host attributed to an active app is kept in the now-widget ranking`