### PR TITLE
fix(#1667): pre-job port killer in router CD — prevents stale fake_api from blocking Gate 2 / Gate 3a

### DIFF
--- a/.github/workflows/e2e-vm-fake.yml
+++ b/.github/workflows/e2e-vm-fake.yml
@@ -184,6 +184,15 @@ jobs:
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
 
+      # #1667: free this arm's deterministic test ports before the fake_api
+      # fixture tries to bind. router-down.sh / client-down.sh only catch
+      # qemu via pidfile + name-scoped pkill — they do not catch a leaked
+      # in-process fake_api python listener from a cancelled prior run, which
+      # holds WH_PORT_BASE+1000 and crashes scenarios_fake/conftest.py at
+      # _start_async with OSError(EADDRINUSE).
+      - name: Free leaked test ports for this WH_PORT_BASE
+        run: scripts/vm/lib/free-test-ports.sh --from-port-base
+
       # Fake mode runs the API as an in-process asyncio app inside pytest
       # (scripts/e2e/scenarios_fake/conftest.py), so no docker-compose
       # stack bring-up / teardown / log capture is needed here.

--- a/.github/workflows/e2e-vm-gate3a.yml
+++ b/.github/workflows/e2e-vm-gate3a.yml
@@ -161,6 +161,14 @@ jobs:
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
 
+      # #1667: free this arm's deterministic test ports. Gate 3a does not
+      # spin up the fake API, but a leaked qemu from a prior cancelled run
+      # at the same WH_PORT_BASE would still hold the router-ssh /
+      # router-http / client-ssh host-forward ports — the existing
+      # router-down.sh / client-down.sh only touch *this* run's pidfile.
+      - name: Free leaked test ports for this WH_PORT_BASE
+        run: scripts/vm/lib/free-test-ports.sh --from-port-base
+
       - name: Run Gate 3a smoke against staging
         env:
           WH_ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}

--- a/.github/workflows/e2e-vm-gate3b.yml
+++ b/.github/workflows/e2e-vm-gate3b.yml
@@ -157,6 +157,14 @@ jobs:
           scripts/vm/router-down.sh || true
           scripts/vm/client-down.sh || true
 
+      # #1667: free this arm's deterministic test ports. Gate 3b does not
+      # spin up the fake API, but a leaked qemu from a prior cancelled run
+      # at the same WH_PORT_BASE would still hold the router-ssh /
+      # router-http / client-ssh host-forward ports — the existing
+      # router-down.sh / client-down.sh only touch *this* run's pidfile.
+      - name: Free leaked test ports for this WH_PORT_BASE
+        run: scripts/vm/lib/free-test-ports.sh --from-port-base
+
       - name: Run Gate 3b smoke against freshly-deployed staging
         env:
           WH_ADMIN_PASS: ${{ secrets.WH_STAGING_ADMIN_PASS }}

--- a/scripts/vm/lib/free-test-ports.sh
+++ b/scripts/vm/lib/free-test-ports.sh
@@ -1,7 +1,95 @@
 #!/usr/bin/env bash
-# Stub — RED commit for #1667.
+# Free leaked TCP loopback listeners on a run's per-arm test ports (#1667).
 #
-# Intentionally a no-op so the test in this same commit fails on Linux. The
-# real implementation lands in the next commit.
+# Why this exists
+# ---------------
+# The self-hosted KVM runner (api.lan) runs concurrent Master Router CD arms
+# that all bind deterministic per-arm host ports derived from $WH_PORT_BASE:
+#   router-ssh   = WH_PORT_BASE
+#   router-http  = WH_PORT_BASE + 1
+#   client-ssh   = WH_PORT_BASE + 2
+#   fake-api     = WH_PORT_BASE + 1000   (scripts/e2e-vm.sh, #907)
+# When a prior run is cancelled / SIGKILL'd / OOM'd, the in-process
+# fake_api python listener can leak: subsequent runs of the same matrix arm
+# bind the same WH_PORT_BASE and crash at conftest._start_async with
+# `OSError: [Errno 98] address already in use`, taking out Gate 2 fake-mode
+# and Gate 3a (#1667). The existing workflow pre-flight kills qemu by name
+# scoped to *this* run's WH_RUN_ID, which does not catch the leaked python.
+#
+# Scope (safety): only TCP LISTEN sockets on 127.0.0.1:<port> are touched.
+# The production wifihaven-api docker container does not listen on those
+# loopback ports, so this script cannot affect production. We resolve the
+# owning pid via `ss -lntpH "sport = :<port>"` and SIGTERM, then SIGKILL as
+# a backstop if the port is still bound a few seconds later.
+#
+# Usage
+# -----
+#   scripts/vm/lib/free-test-ports.sh <port> [<port>...]
+#   scripts/vm/lib/free-test-ports.sh --from-port-base   # uses $WH_PORT_BASE
+#
+# Linux-only (uses ss(8)). Idempotent. Echoes each kill so the kill record
+# appears in the workflow log (operator-visible signal per AGENTS.md
+# §instrument-new-functionality — a CI script's operator surface is the log).
 set -euo pipefail
-exit 0
+
+log() { printf '[free-test-ports] %s\n' "$*" >&2; }
+
+pids_on_port() {
+  local port="$1"
+  ss -lntpH "sport = :${port}" 2>/dev/null \
+    | grep -oE 'pid=[0-9]+' \
+    | awk -F= '{print $2}' \
+    | sort -u
+}
+
+free_one_port() {
+  local port="$1"
+  local pids
+  pids="$(pids_on_port "${port}" || true)"
+  if [[ -z "${pids}" ]]; then
+    return 0
+  fi
+  for pid in ${pids}; do
+    log "SIGTERM pid=${pid} on tcp:${port}"
+    kill -TERM "${pid}" 2>/dev/null || true
+  done
+  local waited
+  for waited in 1 2 3 4 5 6; do
+    sleep 0.5
+    local still
+    still="$(pids_on_port "${port}" || true)"
+    if [[ -z "${still}" ]]; then
+      return 0
+    fi
+  done
+  # Backstop: SIGKILL anything still holding the port.
+  local still
+  still="$(pids_on_port "${port}" || true)"
+  for pid in ${still}; do
+    log "SIGKILL pid=${pid} on tcp:${port} (TERM did not clear in ~3s)"
+    kill -KILL "${pid}" 2>/dev/null || true
+  done
+}
+
+PORTS=()
+if [[ "${1:-}" == "--from-port-base" ]]; then
+  if [[ -z "${WH_PORT_BASE:-}" ]]; then
+    echo "free-test-ports.sh: --from-port-base requires WH_PORT_BASE" >&2
+    exit 2
+  fi
+  PORTS=(
+    "${WH_PORT_BASE}"
+    "$((WH_PORT_BASE + 1))"
+    "$((WH_PORT_BASE + 2))"
+    "$((WH_PORT_BASE + 1000))"
+  )
+elif [[ "$#" -eq 0 ]]; then
+  echo "usage: free-test-ports.sh <port> [<port>...] | --from-port-base" >&2
+  exit 2
+else
+  PORTS=( "$@" )
+fi
+
+for p in "${PORTS[@]}"; do
+  free_one_port "${p}"
+done

--- a/scripts/vm/lib/free-test-ports.sh
+++ b/scripts/vm/lib/free-test-ports.sh
@@ -16,11 +16,14 @@
 # and Gate 3a (#1667). The existing workflow pre-flight kills qemu by name
 # scoped to *this* run's WH_RUN_ID, which does not catch the leaked python.
 #
-# Scope (safety): only TCP LISTEN sockets on 127.0.0.1:<port> are touched.
-# The production wifihaven-api docker container does not listen on those
-# loopback ports, so this script cannot affect production. We resolve the
-# owning pid via `ss -lntpH "sport = :<port>"` and SIGTERM, then SIGKILL as
-# a backstop if the port is still bound a few seconds later.
+# Scope (safety): only TCP LISTEN sockets on 127.0.0.1:<port> or ::1:<port>
+# are touched. The production wifihaven-api docker container does not listen
+# on those loopback ports, so this script cannot affect production — and we
+# *enforce* that scope in the ss filter (`src 127.0.0.1` / `src [::1]`)
+# rather than relying on it as a coincidence of the port ranges we currently
+# allocate. We resolve the owning pid via `ss -lntpH "sport = :<port> and
+# ( src 127.0.0.1 or src [::1] )"` and SIGTERM, then SIGKILL as a backstop
+# if the port is still bound a few seconds later.
 #
 # Usage
 # -----
@@ -36,7 +39,10 @@ log() { printf '[free-test-ports] %s\n' "$*" >&2; }
 
 pids_on_port() {
   local port="$1"
-  ss -lntpH "sport = :${port}" 2>/dev/null \
+  # Constrain to loopback (v4 + v6) so we cannot match a non-loopback
+  # listener that happens to share the port number — the docstring's
+  # "this cannot affect production" safety claim relies on this filter.
+  ss -lntpH "sport = :${port} and ( src 127.0.0.1 or src [::1] )" 2>/dev/null \
     | grep -oE 'pid=[0-9]+' \
     | awk -F= '{print $2}' \
     | sort -u
@@ -53,8 +59,7 @@ free_one_port() {
     log "SIGTERM pid=${pid} on tcp:${port}"
     kill -TERM "${pid}" 2>/dev/null || true
   done
-  local waited
-  for waited in 1 2 3 4 5 6; do
+  for _ in 1 2 3 4 5 6; do
     sleep 0.5
     local still
     still="$(pids_on_port "${port}" || true)"

--- a/scripts/vm/lib/free-test-ports.sh
+++ b/scripts/vm/lib/free-test-ports.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Stub — RED commit for #1667.
+#
+# Intentionally a no-op so the test in this same commit fails on Linux. The
+# real implementation lands in the next commit.
+set -euo pipefail
+exit 0

--- a/scripts/vm/lib/free-test-ports.test.sh
+++ b/scripts/vm/lib/free-test-ports.test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Test scripts/vm/lib/free-test-ports.sh (#1667).
+#
+# The script frees TCP loopback listeners on the deterministic per-run
+# ports a previously-cancelled Master Router CD arm can leak (qemu
+# host-forward ports + the in-process fake_api at WH_PORT_BASE+1000).
+# It must:
+#   1. SIGTERM (then SIGKILL backstop) any process holding a LISTEN
+#      socket on 127.0.0.1:<port> for each port passed in.
+#   2. Be a no-op when the port is already free (idempotent across
+#      back-to-back invocations).
+#   3. Derive the four per-run ports from $WH_PORT_BASE when called
+#      with --from-port-base.
+#
+# Linux-only (uses ss). Runs in CI's "Shell Tests" ubuntu-latest job.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="${HERE}/free-test-ports.sh"
+
+[[ -x "${SCRIPT}" ]] || chmod +x "${SCRIPT}"
+
+if ! command -v ss >/dev/null 2>&1; then
+  echo "skip: ss(8) not available (non-Linux); free-test-ports.sh is Linux-only"
+  exit 0
+fi
+
+PASS=0
+FAIL=0
+
+cleanup_pids=()
+cleanup() {
+  for pid in "${cleanup_pids[@]:-}"; do
+    [[ -n "${pid}" ]] && kill -KILL "${pid}" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+assert_free() {
+  local name="$1" port="$2"
+  if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+    echo "  FAIL: ${name} — port ${port} still bound"
+    FAIL=$((FAIL+1))
+  else
+    echo "  ok: ${name}"
+    PASS=$((PASS+1))
+  fi
+}
+
+assert_bound() {
+  local name="$1" port="$2"
+  if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+    echo "  ok: ${name}"
+    PASS=$((PASS+1))
+  else
+    echo "  FAIL: ${name} — port ${port} not bound"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+start_listener() {
+  # $1 = port. Echoes the listener pid.
+  local port="$1"
+  python3 -c "
+import socket, time
+s = socket.socket()
+s.bind(('127.0.0.1', ${port}))
+s.listen(1)
+time.sleep(120)
+" </dev/null >/dev/null 2>&1 &
+  local pid=$!
+  cleanup_pids+=("${pid}")
+  # Give the bind a moment to land in the kernel's listen list.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+      echo "${pid}"
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "listener never bound on ${port}" >&2
+  return 1
+}
+
+alloc_free_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); p=s.getsockname()[1]; s.close(); print(p)'
+}
+
+echo "── case 1: kills a held loopback listener ─────────────────────────────"
+PORT1=$(alloc_free_port)
+P1=$(start_listener "${PORT1}")
+assert_bound "listener started on ${PORT1}" "${PORT1}"
+"${SCRIPT}" "${PORT1}"
+assert_free "port ${PORT1} freed after script" "${PORT1}"
+
+echo "── case 2: no-op when port already free ───────────────────────────────"
+"${SCRIPT}" "${PORT1}"
+assert_free "port ${PORT1} still free after idempotent run" "${PORT1}"
+
+echo "── case 3: --from-port-base derives WH_PORT_BASE+1000 (fake-api) ──────"
+# Pick a base such that base+1000 is allocatable. Re-roll if any of the
+# four derived ports collides.
+for _ in 1 2 3 4 5 6 7 8; do
+  BASE=$(alloc_free_port)
+  P_FAKE=$((BASE+1000))
+  # Confirm the fake-api port is actually free before we try to bind it.
+  if ! ss -lntH "sport = :${P_FAKE}" 2>/dev/null | grep -q ":${P_FAKE}"; then
+    break
+  fi
+done
+P3=$(start_listener "${P_FAKE}")
+assert_bound "listener started on derived fake-api port ${P_FAKE}" "${P_FAKE}"
+WH_PORT_BASE="${BASE}" "${SCRIPT}" --from-port-base
+assert_free "derived fake-api port ${P_FAKE} freed via --from-port-base" "${P_FAKE}"
+
+echo "── case 4: --from-port-base errors out without WH_PORT_BASE ───────────"
+if "${SCRIPT}" --from-port-base 2>/dev/null; then
+  echo "  FAIL: expected non-zero exit when WH_PORT_BASE unset"
+  FAIL=$((FAIL+1))
+else
+  echo "  ok: refused to run without WH_PORT_BASE"
+  PASS=$((PASS+1))
+fi
+
+echo
+echo "── summary ────────────────────────────────────────────────────────────"
+echo "passed: ${PASS}, failed: ${FAIL}"
+if [[ "${FAIL}" -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/vm/lib/free-test-ports.test.sh
+++ b/scripts/vm/lib/free-test-ports.test.sh
@@ -38,7 +38,7 @@ trap cleanup EXIT
 
 assert_free() {
   local name="$1" port="$2"
-  if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+  if ss -lntH "sport = :${port}" 2>/dev/null | grep -qE ":${port}([^0-9]|$)"; then
     echo "  FAIL: ${name} — port ${port} still bound"
     FAIL=$((FAIL+1))
   else
@@ -49,7 +49,7 @@ assert_free() {
 
 assert_bound() {
   local name="$1" port="$2"
-  if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+  if ss -lntH "sport = :${port}" 2>/dev/null | grep -qE ":${port}([^0-9]|$)"; then
     echo "  ok: ${name}"
     PASS=$((PASS+1))
   else
@@ -72,7 +72,7 @@ time.sleep(120)
   cleanup_pids+=("${pid}")
   # Give the bind a moment to land in the kernel's listen list.
   for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if ss -lntH "sport = :${port}" 2>/dev/null | grep -q ":${port}"; then
+    if ss -lntH "sport = :${port}" 2>/dev/null | grep -qE ":${port}([^0-9]|$)"; then
       echo "${pid}"
       return 0
     fi


### PR DESCRIPTION
Closes #1667.

## Phase 1 (ops, no PR)

Verified on plex (`ssh api.lan`) at 2026-06-12 ~16:30 UTC: **all per-arm test
ports (2222–2224, 3222, 2322–2324, 3322) are already free** — no
`fake_api` / `scenarios_fake` python and no `qemu-system-x86_64` process is
running. The leaked listener from run
[27377547076](https://github.com/wifihaven/wifihaven/actions/runs/27377547076)
appears to have already exited (likely the python `_FakeServer`'s ~120s
session-fixture lifetime, or a runner restart).

Retriggering CD via `workflow_dispatch` was attempted
([run 27429831405](https://github.com/wifihaven/wifihaven/actions/runs/27429831405))
but failed at the unrelated `CI / Migrations Immutability Check` step —
`check-migrations.sh` requires a `<base-ref>` arg that is unset for
`workflow_dispatch` triggers (`BASE_SHA:` is empty). That gate fires before
the e2e jobs, so a dispatch never reaches Gate 2 / Gate 3a regardless of the
port-leak state. **This means the right way to verify Phase 1 is the
push-to-main triggered by merging this PR** — that path supplies BASE_SHA
from the push event and the e2e gates run.

I noted the `workflow_dispatch` BASE_SHA bug in passing — separate issue,
not this fix.

## Phase 2 (this PR)

A leaked `fake_api` python listener (or a leaked qemu) is bound to a
deterministic per-arm port derived from `WH_PORT_BASE`. The existing
pre-flight `pkill` only matches `qemu-system-x86_64.*-name wh-.*-${WH_RUN_ID}`,
so it cannot catch a python process or qemu from a sibling/prior cancelled
run. Subsequent matrix arms at the same `WH_PORT_BASE` then crash at
`scenarios_fake/conftest.py:_start_async` with
`OSError: [Errno 98] address already in use` on port `${WH_PORT_BASE}+1000`.

This PR adds `scripts/vm/lib/free-test-ports.sh` — a small helper that
finds the owning pid of any TCP LISTEN socket on `127.0.0.1:<port>` via
`ss -lntpH "sport = :<port>"`, SIGTERMs it, waits ~3s, then SIGKILLs any
holdouts. It is scoped to **loopback LISTEN sockets only on the per-arm
ports we allocate**, so it cannot affect production wifihaven-api (which
listens on the docker bridge, not loopback). Each kill is logged to stderr
and surfaces in the workflow log — that is the operator-visible signal for
future leaks (per AGENTS.md §instrument-new-functionality; a CI script's
operator surface is the log line, not a Grafana series).

Two entry shapes:

```sh
scripts/vm/lib/free-test-ports.sh <port> [<port>...]
scripts/vm/lib/free-test-ports.sh --from-port-base   # derives base+0/1/2/1000
```

Wired into the pre-flight step of all three VM e2e workflows (Gate 2, Gate
3a, Gate 3b) right after the existing `Pre-flight kill of stale wh VMs`
step.

### Option A vs Option B

The issue suggested two shapes:

* **Option A — pre-job port killer.** Minimal scope, runs on the runner
  where the leak happens. Picked.
* **Option B — conftest-side retry / ephemeral port.** Cleaner, but
  reshapes a fixture that's already exercising a `--from-port-base` /
  `+1000` contract documented in three other places (`scripts/e2e-vm.sh`,
  `scripts/vm/README.md`, the workflow YAML). Punts on the actual cause
  (the leak) and would still leave the runner accumulating zombie listeners
  until OOM.

### TDD progression

* **Commit 1** (RED): `scripts/vm/lib/free-test-ports.test.sh` lands with
  a stub `free-test-ports.sh` that is a no-op. The test asserts case 1
  (kills a held listener), case 2 (idempotent), case 3 (`--from-port-base`
  derives base+1000), case 4 (refuses to run without `WH_PORT_BASE`). The
  stub fails case 1.
* **Commit 2** (GREEN): real `free-test-ports.sh` — all four cases pass.
* **Commit 3**: workflow wiring.

The test cleanly skips on non-Linux (`ss` unavailable); it runs in the
ubuntu-latest `CI / Shell Tests` job, which discovers `*.test.sh`
automatically.

## Test plan

- [x] On plex (Linux) — `free-test-ports.test.sh` PASS after the
  GREEN commit (6/6 cases).
- [x] On macOS dev box — test skips cleanly (no `ss`).
- [ ] After merge, the push-to-main triggers Master Router CD; Gate 2 and
  Gate 3a both go green, openwrt-latest publishes the #1656 labeling fix
  on top of recent main commits.
- [ ] Operator confirms no spurious kills in the workflow log on a clean
  run (the new step should emit nothing when no leak exists).