### PR TITLE
fix(#1678): drop 'router events' per-batch log to DEBUG (parity with router usage line)

### DIFF
--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -128,7 +128,7 @@ object RouterIngestRoutes {
             _      <- ZIO
               .fail(ApiError.BadRequest("router_id mismatch"))
               .when(rep.routerId != router.id)
-            _      <- ZIO.logInfo(
+            _      <- ZIO.logDebug(
               s"router events: router=${router.id} batchSize=${rep.events.size}",
             )
             _      <- ZIO.foreachDiscard(rep.events)(e =>


### PR DESCRIPTION
Closes #1678.

The per-batch line at `api/src/routes/RouterIngestRoutes.scala:131` was logging at INFO. Routers poll every 5-10s, so this floods prod logs with hundreds of lines per hour per router. The parallel `router usage:` line at :75 is already `logDebug`; this one was the outlier. Per-record events at :134 are already DEBUG too.

Counters/metrics already cover batch throughput, so the INFO line was purely informational. WARN/ERROR paths (malformed body, router-id mismatch) stay at their existing levels.

No test added — this is a one-line log-level change and the codebase doesn't have an existing log-level assertion pattern for this kind of line.