### PR TITLE
fix(#1680): bring up IPv6 across the Gate 2 qemu LAN bridge

### DIFF
--- a/scripts/e2e-vm.sh
+++ b/scripts/e2e-vm.sh
@@ -109,10 +109,12 @@ case "${ONLY}" in
                 MARK="install_health" ;;
   sni-attribution|sni_attribution)
                 MARK="sni_attribution" ;;
+  v6-link-local|v6_link_local)
+                MARK="v6_link_local" ;;
   *) echo "unknown --only: ${ONLY}" >&2
      echo "valid: enrollment, allowed-browsing, blocked-domain, daily-limit, usage, blocked-page," >&2
      echo "       pause, extra-blocked, schedule, time-limit, reassignment, unknown-device," >&2
-     echo "       install-health, sni-attribution" >&2
+     echo "       install-health, sni-attribution, v6-link-local" >&2
      exit 2 ;;
 esac
 

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -299,10 +299,51 @@ def _wait_for_client_lan(client: Client, *, timeout_s: float = 60, interval_s: f
             _time.sleep(interval_s)
             continue
         if res.returncode == 0:
+            _assert_v6_link_local_ready(client)
             return
         last = (res.stderr or res.stdout or "").strip()
         _time.sleep(interval_s)
     log.warning("client %s LAN/DNS not ready after %ss (last: %r)", client.name, timeout_s, last)
+
+
+# Router ULA, kept in sync with scripts/vm/uci-defaults/99-wifihaven (#1680).
+ROUTER_ULA_PREFIX = "fdaa:bbbb:cccc"
+
+
+def _assert_v6_link_local_ready(client: Client, *, timeout_s: float = 30, interval_s: float = 2.0) -> None:
+    """Regression gate (#1680): once the LAN is up, the client must also have
+    a v6 default route and a global-scope ULA address.
+
+    If a future change strips RA/SLAAC (e.g. odhcpd disabled, ULA prefix
+    cleared, accept_ra=0 on the client base), every Gate 2 scenario gets a
+    clear, early failure here rather than a confusing late timeout in the
+    v6 attribution suite (#1677)."""
+    import time as _time
+    deadline = _time.monotonic() + timeout_s
+    probe_cmd = [
+        "sh", "-c",
+        "ip -6 route show default 2>/dev/null | grep -q 'dev eth0' && "
+        f"ip -6 addr show eth0 scope global 2>/dev/null | grep -q '{ROUTER_ULA_PREFIX}'",
+    ]
+    last_v6_state = ""
+    while _time.monotonic() < deadline:
+        res = client_exec(client, probe_cmd, timeout=10, check=False)
+        if res.returncode == 0:
+            return
+        diag = client_exec(
+            client,
+            ["sh", "-c", "ip -6 route; echo ---; ip -6 addr show eth0"],
+            timeout=10, check=False,
+        )
+        last_v6_state = (diag.stdout or "").strip()
+        _time.sleep(interval_s)
+    raise RuntimeError(
+        f"client {client.name} missing IPv6 default route or ULA address "
+        f"in {ROUTER_ULA_PREFIX}::/48 after {timeout_s}s. The qemu LAN bridge "
+        f"is not carrying RA/SLAAC — see scripts/vm/uci-defaults/99-wifihaven "
+        f"and #1680.\n"
+        f"--- client ip -6 addr/route ---\n{last_v6_state}"
+    )
 
 
 def client_down(name: str = "client1") -> Result:

--- a/scripts/e2e/pytest.ini
+++ b/scripts/e2e/pytest.ini
@@ -19,6 +19,7 @@ markers =
     nflog: #1122 — forward-drop visibility via nflog (per-MAC drop comment + agent emission)
     cname_direct_requery: suite G (#1351) — ea_/eb_ population for directly-queried CNAME targets
     sni_attribution: suite I (#573) — SNI-only hostname attribution via the wifihaven-sni-tail sidecar
+    v6_link_local: #1680 — IPv6 LAN bring-up (ULA SLAAC + v6 FORWARD path), prep for #1677
     global_policy: suite H (#1460) — @global_allow / @global_block fleet-wide enforcement (gate for #1321)
     smoke: fast subset across suites (one short case each) for PR gating
 log_cli = true

--- a/scripts/e2e/scenarios_fake/test_v6_link_local.py
+++ b/scripts/e2e/scenarios_fake/test_v6_link_local.py
@@ -1,12 +1,12 @@
 """Gate 2 v6 link-local bring-up (#1680, prep for #1677).
 
-Confirms the qemu LAN bridge carries IPv6 between the client and router VMs:
-
-- Router LAN advertises a ULA prefix via odhcpd RAs.
-- Client picks up SLAAC + a v6 default route via the router's link-local.
-- A v6 SYN from client to a documentation address traverses the router's
-  FORWARD chain and fires a conntrack NEW event (the prerequisite for v6
-  hostname attribution in #1677).
+Confirms the qemu LAN bridge carries IPv6 between the client and router VMs
+all the way through the router's FORWARD chain. The `client` fixture's
+`_assert_v6_link_local_ready` (scripts/e2e/lib/vm.py) already gates that
+SLAAC + a v6 default route landed on the client; the test below covers
+what the fixture can't — that a v6 SYN from the client actually transits
+the router's FORWARD chain and fires conntrack NEW, which is the
+prerequisite for v6 hostname attribution in #1677.
 
 The router can't actually forward the packet anywhere — qemu SLIRP is
 v4-only — but the FORWARD-chain transit alone is what #1677 needs.
@@ -15,65 +15,35 @@ from __future__ import annotations
 
 import pytest
 
-from lib.vm import client_exec, router_ssh
+from lib.vm import ROUTER_ULA_PREFIX, client_exec, router_ssh
 
 pytestmark = pytest.mark.v6_link_local
 
-# Must match the ULA in scripts/vm/uci-defaults/99-wifihaven.
-ROUTER_ULA_PREFIX = "fdaa:bbbb:cccc"
-
-
-def test_client_has_v6_default_route(client):
-    """Client kernel must accept the router's RA and install a default route."""
-    res = client_exec(
-        client,
-        ["sh", "-c", "ip -6 route show default"],
-        check=False,
-        timeout=10,
-    )
-    assert res.returncode == 0, (
-        f"`ip -6 route show default` failed: rc={res.returncode} "
-        f"stdout={res.stdout!r} stderr={res.stderr!r}"
-    )
-    out = (res.stdout or "").strip()
-    assert out, (
-        "no IPv6 default route on client eth0 — RA from router did not "
-        f"install one. `ip -6 route show default` returned empty.\n"
-        f"full `ip -6 route`:\n"
-        f"{client_exec(client, ['sh', '-c', 'ip -6 route'], check=False, timeout=10).stdout}"
-    )
-    # Default route must be via a link-local on eth0 (the LAN-side NIC).
-    assert "dev eth0" in out, f"v6 default route not on eth0: {out!r}"
-
-
-def test_client_has_ula_global_address(client):
-    """Client must SLAAC-derive a global-scope address from the router's ULA."""
-    res = client_exec(
-        client,
-        ["sh", "-c", "ip -6 addr show eth0 scope global"],
-        check=False,
-        timeout=10,
-    )
-    out = res.stdout or ""
-    assert ROUTER_ULA_PREFIX in out, (
-        f"client eth0 has no address in router ULA prefix "
-        f"{ROUTER_ULA_PREFIX}::/48 — SLAAC failed.\n"
-        f"`ip -6 addr show eth0 scope global` stdout:\n{out!r}"
-    )
+assert ROUTER_ULA_PREFIX  # silence unused-import lints; documents the contract
 
 
 def test_v6_syn_traverses_router_forward_chain(client):
     """A v6 SYN to an RFC 3849 doc-space address must fire conntrack NEW
     on the router. We don't care that SLIRP drops it on the WAN side; the
     FORWARD-chain transit is what #1677 attribution depends on."""
-    # Start a `conntrack -E -f ipv6 -e NEW` capture on the router in the
-    # background, fire the v6 SYN, then check the capture.
-    router_ssh(
-        "rm -f /tmp/ct6.log; "
-        "(conntrack -E -f ipv6 -e NEW -o timestamp >/tmp/ct6.log 2>&1 &) ; "
-        "echo $!",
+    # Start `conntrack -E -f ipv6 -e NEW` in the background and capture its
+    # PID so we can kill it by PID later — avoids relying on busybox
+    # `pkill -f` matching full argv (which varies across busybox builds).
+    #
+    # The conntrack process MUST be daemonized in its own router_ssh call:
+    # if a future cleanup pass folds the start/probe into one SSH session,
+    # the backgrounded conntrack dies with the session and the capture
+    # never sees the SYN.
+    start = router_ssh(
+        "rm -f /tmp/ct6.log /tmp/ct6.pid; "
+        "( conntrack -E -f ipv6 -e NEW -o timestamp >/tmp/ct6.log 2>&1 & "
+        "  echo $! >/tmp/ct6.pid ); "
+        "cat /tmp/ct6.pid",
         timeout=10,
     )
+    ct_pid = (start.stdout or "").strip().splitlines()[-1]
+    assert ct_pid.isdigit(), f"failed to capture conntrack pid: {start.stdout!r}"
+
     # nc returns immediately on SYN_SENT timeout. Doc-space 2001:db8::10
     # is unreachable, which is the point — the SYN crossed FORWARD.
     client_exec(
@@ -84,7 +54,7 @@ def test_v6_syn_traverses_router_forward_chain(client):
     )
     # Give conntrack a moment, then sample.
     res = router_ssh(
-        "sleep 2; pkill -f 'conntrack -E -f ipv6' 2>/dev/null; "
+        f"sleep 2; kill {ct_pid} 2>/dev/null; "
         "grep -c '\\[NEW\\].*2001:db8::10' /tmp/ct6.log || echo 0",
         check=False,
         timeout=15,

--- a/scripts/e2e/scenarios_fake/test_v6_link_local.py
+++ b/scripts/e2e/scenarios_fake/test_v6_link_local.py
@@ -1,0 +1,107 @@
+"""Gate 2 v6 link-local bring-up (#1680, prep for #1677).
+
+Confirms the qemu LAN bridge carries IPv6 between the client and router VMs:
+
+- Router LAN advertises a ULA prefix via odhcpd RAs.
+- Client picks up SLAAC + a v6 default route via the router's link-local.
+- A v6 SYN from client to a documentation address traverses the router's
+  FORWARD chain and fires a conntrack NEW event (the prerequisite for v6
+  hostname attribution in #1677).
+
+The router can't actually forward the packet anywhere — qemu SLIRP is
+v4-only — but the FORWARD-chain transit alone is what #1677 needs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lib.vm import client_exec, router_ssh
+
+pytestmark = pytest.mark.v6_link_local
+
+# Must match the ULA in scripts/vm/uci-defaults/99-wifihaven.
+ROUTER_ULA_PREFIX = "fdaa:bbbb:cccc"
+
+
+def test_client_has_v6_default_route(client):
+    """Client kernel must accept the router's RA and install a default route."""
+    res = client_exec(
+        client,
+        ["sh", "-c", "ip -6 route show default"],
+        check=False,
+        timeout=10,
+    )
+    assert res.returncode == 0, (
+        f"`ip -6 route show default` failed: rc={res.returncode} "
+        f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    )
+    out = (res.stdout or "").strip()
+    assert out, (
+        "no IPv6 default route on client eth0 — RA from router did not "
+        f"install one. `ip -6 route show default` returned empty.\n"
+        f"full `ip -6 route`:\n"
+        f"{client_exec(client, ['sh', '-c', 'ip -6 route'], check=False, timeout=10).stdout}"
+    )
+    # Default route must be via a link-local on eth0 (the LAN-side NIC).
+    assert "dev eth0" in out, f"v6 default route not on eth0: {out!r}"
+
+
+def test_client_has_ula_global_address(client):
+    """Client must SLAAC-derive a global-scope address from the router's ULA."""
+    res = client_exec(
+        client,
+        ["sh", "-c", "ip -6 addr show eth0 scope global"],
+        check=False,
+        timeout=10,
+    )
+    out = res.stdout or ""
+    assert ROUTER_ULA_PREFIX in out, (
+        f"client eth0 has no address in router ULA prefix "
+        f"{ROUTER_ULA_PREFIX}::/48 — SLAAC failed.\n"
+        f"`ip -6 addr show eth0 scope global` stdout:\n{out!r}"
+    )
+
+
+def test_v6_syn_traverses_router_forward_chain(client):
+    """A v6 SYN to an RFC 3849 doc-space address must fire conntrack NEW
+    on the router. We don't care that SLIRP drops it on the WAN side; the
+    FORWARD-chain transit is what #1677 attribution depends on."""
+    # Start a `conntrack -E -f ipv6 -e NEW` capture on the router in the
+    # background, fire the v6 SYN, then check the capture.
+    router_ssh(
+        "rm -f /tmp/ct6.log; "
+        "(conntrack -E -f ipv6 -e NEW -o timestamp >/tmp/ct6.log 2>&1 &) ; "
+        "echo $!",
+        timeout=10,
+    )
+    # nc returns immediately on SYN_SENT timeout. Doc-space 2001:db8::10
+    # is unreachable, which is the point — the SYN crossed FORWARD.
+    client_exec(
+        client,
+        ["sh", "-c", "nc -6 -w 2 2001:db8::10 80 >/dev/null 2>&1; true"],
+        check=False,
+        timeout=10,
+    )
+    # Give conntrack a moment, then sample.
+    res = router_ssh(
+        "sleep 2; pkill -f 'conntrack -E -f ipv6' 2>/dev/null; "
+        "grep -c '\\[NEW\\].*2001:db8::10' /tmp/ct6.log || echo 0",
+        check=False,
+        timeout=15,
+    )
+    count_line = (res.stdout or "0").strip().splitlines()[-1]
+    try:
+        n = int(count_line)
+    except ValueError:
+        n = 0
+    if n == 0:
+        # If conntrack didn't fire we want full diagnostics in the failure.
+        ct_dump = router_ssh(
+            "cat /tmp/ct6.log 2>/dev/null; echo '---'; "
+            "ip -6 route; echo '---'; nft list chain inet wifihaven forward 2>&1 | head -20",
+            check=False, timeout=10,
+        )
+        pytest.fail(
+            f"no conntrack NEW for v6 SYN to 2001:db8::10 "
+            f"(grep returned {count_line!r}).\n{ct_dump.stdout}"
+        )

--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -103,4 +103,49 @@ uci commit uhttpd
 # times out (HTTPCODE:000) instead of receiving the page.
 [ -x /etc/init.d/uhttpd ] && /etc/init.d/uhttpd enable
 
+# ── IPv6 LAN bring-up (#1680, prep for #1677) ────────────────────────────
+# Bring up dual-stack on the qemu LAN bridge so the v6 attribution
+# scenario (#1677, the CD-tier follow-up to #1673/#1668) can fire a v6
+# SYN from the client and exercise the same conntrack→dns_log→snapshot
+# pipeline as v4. The qemu SLIRP WAN is v4-only, so upstream v6 is not
+# in scope — only LAN connectivity and a FORWARD-chain-traversing v6 SYN.
+#
+# - ula_prefix:   deterministic so the orchestrator and tests can hard-code
+#                 the prefix. Anything in fd00::/8 is valid; this value
+#                 collides with nothing in the harness.
+# - ip6assign:    LAN takes the first /60 of the ULA, which gives the
+#                 router fdaa:bbbb:cccc::1/60 and clients SLAAC into the
+#                 same /64 (default eui64 or stable-privacy).
+# - dhcp.lan.ra / dhcpv6: enable odhcpd RAs + DHCPv6 on LAN. ra_default=1
+#                 makes the router advertise itself as the v6 default
+#                 even though it has no v6 upstream — required so the
+#                 client installs a default route via the router's LL.
+# The existing block-dns-leak fw rule omits `family`, which under fw4
+# means both ipv4 and ipv6 — no v6 sibling needed.
+uci set network.globals=globals
+uci set network.globals.ula_prefix='fdaa:bbbb:cccc::/48'
+uci set network.lan.ip6assign='60'
+uci commit network
+
+uci set dhcp.lan.ra='server'
+uci set dhcp.lan.dhcpv6='server'
+uci set dhcp.lan.ra_default='1'
+uci commit dhcp
+
+# Give the router a v6 default route on the WAN side so client→public-v6
+# SYNs cross the FORWARD chain (where conntrack NEW fires and where the
+# wifihaven nft drops live) before the kernel discovers the packet is
+# unroutable beyond SLIRP. The next-hop need not exist — the routing
+# decision picks this entry, the packet enters FORWARD, conntrack
+# emits a NEW event, and ND/NS for the bogus next-hop fails silently.
+#
+# Wired through hotplug because uci-defaults runs before WAN comes up.
+cat >/etc/hotplug.d/iface/99-wifihaven-v6-default <<'EOH'
+#!/bin/sh
+[ "$ACTION" = "ifup" ] && [ "$INTERFACE" = "wan" ] && {
+    ip -6 route replace default dev eth1 2>/dev/null || true
+}
+EOH
+chmod +x /etc/hotplug.d/iface/99-wifihaven-v6-default
+
 exit 0

--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -112,7 +112,9 @@ uci commit uhttpd
 #
 # - ula_prefix:   deterministic so the orchestrator and tests can hard-code
 #                 the prefix. Anything in fd00::/8 is valid; this value
-#                 collides with nothing in the harness.
+#                 collides with nothing in the harness. The Python-side
+#                 mirror lives at scripts/e2e/lib/vm.py:ROUTER_ULA_PREFIX —
+#                 keep both in sync when changing the prefix.
 # - ip6assign:    LAN takes the first /60 of the ULA, which gives the
 #                 router fdaa:bbbb:cccc::1/60 and clients SLAAC into the
 #                 same /64 (default eui64 or stable-privacy).


### PR DESCRIPTION
## Summary

Wires IPv6 across the Gate 2 qemu harness so the client VM can originate routable v6 flows toward the router VM — preparatory work for the v6 attribution scenario in #1677 (CD-tier follow-up to PR #1673 / issue #1668).

Out of scope: upstream v6 reachability (qemu SLIRP WAN is v4-only). The attribution path only needs the conntrack \`NEW\` event, which fires as soon as the SYN crosses the router's FORWARD chain.

## Changes

**Router** (\`scripts/vm/uci-defaults/99-wifihaven\`):
- \`network.globals.ula_prefix='fdaa:bbbb:cccc::/48'\` — deterministic ULA so tests and orchestrator can pin it.
- \`network.lan.ip6assign='60'\` — LAN takes the first /60 of the ULA.
- \`dhcp.lan.ra='server'\` / \`dhcpv6='server'\` / \`ra_default='1'\` — odhcpd advertises the prefix and the router as v6 default. \`ra_default=1\` is required because the router has no v6 upstream; without it odhcpd suppresses the RA's Router Lifetime and the client never installs a v6 default route.
- New hotplug script \`/etc/hotplug.d/iface/99-wifihaven-v6-default\` does \`ip -6 route replace default dev eth1\` on WAN ifup. The next-hop is bogus on purpose — the routing decision picks it, the packet enters FORWARD (conntrack \`NEW\` fires), and ND fails silently. That's the FORWARD-chain transit #1677 needs.

Stock OpenWRT fw4 generates v4+v6 nft rules for any user rule that omits \`family\`, so the existing \`block-dns-leak\` rule covers v6 unchanged — no v6 sibling needed.

**Client side**: no change required. Alpine's default \`net.ipv6.conf.eth0.accept_ra=1\` picks up the RA and installs the default route; SLAAC produces the global ULA address. The cloud-init \`eth0 inet dhcp\` stanza is v4-only and does not disable v6.

**Orchestrator** (\`scripts/e2e/lib/vm.py\`):
- \`_wait_for_client_lan\` now chains into \`_assert_v6_link_local_ready\`, which fails loudly with \`ip -6 addr/route\` diagnostics if the client lacks a v6 default route or a \`fdaa:bbbb:cccc\` address. Regression gate: any future change that strips RA/SLAAC fails every Gate 2 scenario early with a clear message rather than confusing late timeouts in #1677.

**Scenario** (\`scripts/e2e/scenarios_fake/test_v6_link_local.py\`):
1. Client has a v6 default route on \`eth0\`.
2. Client has a SLAAC global address in \`fdaa:bbbb:cccc::/48\`.
3. A v6 SYN from client to \`2001:db8::10\` fires conntrack \`NEW\` on the router (proves the FORWARD chain executes for v6).

Marker + \`--only v6-link-local\` switch registered.

## TDD

Two commits: a RED commit with the test only against current main (the router image had zero v6 config, so all three asserts fail at \`Network unreachable\` before any v6 packet is emitted), then the GREEN commit with the uci-defaults and orchestrator wiring. KVM not available in the authoring env, so the green run happens on the self-hosted KVM runner via \`e2e-vm-fake.yml\`.

## Acceptance (from #1680)

From the running client VM, after this PR:

\`\`\`
ip -6 route | grep '^default'         # router LL via eth0 — covered by test 1
ping6 -c1 fdaa:bbbb:cccc::1            # router LAN ULA — covered by SLAAC + default route
nc -6 -w 2 2001:db8::10 80             # conntrack -E NEW fires on router — covered by test 3
\`\`\`

## Test plan

- [ ] CI \`e2e-vm-fake\` passes (\`test_v6_link_local\` runs and goes green on the self-hosted KVM runner).
- [ ] No regression on the other Gate 2 scenarios — \`_assert_v6_link_local_ready\` adds a new precondition; if the v6 bring-up is racy in practice, expect to see it surface in any scenario that uses the \`client\` fixture.

Closes #1680. Unblocks #1677.