### PR TITLE
fix(#1683): require wifihaven.dns_tail_sets, not bare dns_tail_sets — unbreaks Master Router CD

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/eb_refresh.lua
@@ -54,7 +54,7 @@
 -- `eb_set_name` / `eb6_set_name` / `bl_set_name` / `bl6_set_name` exports so
 -- the (host|id) → nft-set-name mapping has a single source of truth.
 
-local dns_tail_sets = require("dns_tail_sets")
+local dns_tail_sets = require("wifihaven.dns_tail_sets")
 local render        = require("wifihaven.render")
 
 local M = {}

--- a/openwrt/test/lua_module_paths_spec.sh
+++ b/openwrt/test/lua_module_paths_spec.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Verify every module under files/usr/lib/lua/wifihaven/ loads cleanly under
+# the LUA_PATH that exists on a real router — i.e., only the qualified
+# `wifihaven.X` form is reachable from /usr/lib/lua/, NOT the bare `X` form.
+#
+# The default test harness (test/run_tests.sh) sets LUA_PATH to include both
+# ./files/usr/lib/lua/?.lua AND ./files/usr/lib/lua/wifihaven/?.lua, so
+# require("dns_tail_sets") works alongside require("wifihaven.dns_tail_sets").
+# On the installed router, lua's default LUA_PATH is just /usr/share/lua/?.lua
+# and /usr/lib/lua/?.lua, so a bare require("dns_tail_sets") fails with
+# "module not found" and the wifihaven-agent crash-loops at startup.
+#
+# This caught #1683: PR #1659 (eb_refresh.lua, #1658) used
+# `require("dns_tail_sets")` instead of `require("wifihaven.dns_tail_sets")`,
+# which passed locally but broke every Gate 2 / Gate 3a run because the
+# agent could not load.
+set -e
+
+PASS=0; FAIL=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MOD_DIR="$ROOT/files/usr/lib/lua/wifihaven"
+
+[ -d "$MOD_DIR" ] || { printf "MISSING: %s\n" "$MOD_DIR"; exit 1; }
+
+# Mirror the production LUA_PATH: only the qualified `wifihaven.X` form is
+# reachable. Bare names must use require("wifihaven.X") to resolve.
+PROD_LUA_PATH="$ROOT/files/usr/lib/lua/?.lua;$ROOT/test/shim/?.lua;$ROOT/test/shim/?/init.lua;$(lua -e 'print(package.path)')"
+
+check() {
+  if [ "$2" = "ok" ]; then
+    printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "$1" "$2"; FAIL=$((FAIL + 1))
+  fi
+}
+
+for f in "$MOD_DIR"/*.lua; do
+  name="$(basename "$f" .lua)"
+  # `init` files under a subdir are loaded as the parent module name, skip.
+  case "$name" in
+    init) continue ;;
+  esac
+  err="$(LUA_PATH="$PROD_LUA_PATH" lua -e "require('wifihaven.$name')" 2>&1 || true)"
+  if [ -z "$err" ]; then
+    check "require('wifihaven.$name') loads under production LUA_PATH" ok
+  else
+    # Trim to the first line for readability.
+    first="$(printf "%s" "$err" | head -n1)"
+    check "require('wifihaven.$name') loads under production LUA_PATH" "$first"
+  fi
+done
+
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -37,6 +37,7 @@ sh test/boot_skeleton_spec.sh
 sh test/update_spec.sh
 sh test/update_multi_pkg_spec.sh
 sh test/install_spec.sh
+sh test/lua_module_paths_spec.sh
 sh test/nft_log_dep_spec.sh
 sh test/agent_spec.sh
 sh test/rotate_dnsmasq_log_spec.sh


### PR DESCRIPTION
Closes #1683.

## Symptom

Master Router CD has been red since PR #1659 (#1658) landed. All 4 e2e arms
(Gate 2 × {ipk,apk} + Gate 3a × {ipk,apk}) fail with:

```
TimeoutError: no policy fetch after id=0 in 180s
```

The fake API receives the router-token enrollment but the agent never polls
`/api/router/policy`. Latest failing run before this fix:
https://github.com/wifihaven/wifihaven/actions/runs/27434620060

## Root cause

Reproduced locally on plex by booting the freshly-built router image and
SSHing in:

```
logread | grep -i wifihaven | tail
…
daemon.err wifihaven-agent[2881]: /usr/bin/lua: /usr/lib/lua/wifihaven/eb_refresh.lua:57:
                                  module 'dns_tail_sets' not found:
…
daemon.info procd: Instance wifihaven::agent s in a crash loop 6 crashes, 0 seconds since last crash
```

PR #1659 introduced `eb_refresh.lua` with:

```lua
local dns_tail_sets = require("dns_tail_sets")        -- bare name
local render        = require("wifihaven.render")     -- qualified
```

The bare `require("dns_tail_sets")` works in `openwrt/test/run_tests.sh`,
which sets `LUA_PATH` to include **both** `./files/usr/lib/lua/?.lua` and
`./files/usr/lib/lua/wifihaven/?.lua`, so either spelling resolves. On a
real router lua's default `LUA_PATH` is only `/usr/share/lua/?.lua;
/usr/lib/lua/?.lua` — the bare form looks for `/usr/lib/lua/dns_tail_sets.lua`,
which doesn't exist (it lives at `/usr/lib/lua/wifihaven/dns_tail_sets.lua`).
The agent crashes at startup → procd respawns it 6× → procd marks it
crash-looped → no `/api/router/policy` poll ever happens → every Gate 2 /
Gate 3a scenario errors at fixture setup.

Top suspect from #1683 (#573 / `tcpdump-mini`) was a red herring — the SNI
dep was packaged correctly. The bisect target was the lower-risk #1659 change.

## Fix

Single character: `require("dns_tail_sets")` → `require("wifihaven.dns_tail_sets")`.

## Test

TDD red→green:

1. **Red commit** (`a7bd3c5`): adds `openwrt/test/lua_module_paths_spec.sh`
   which mirrors the production `LUA_PATH` (only `./files/usr/lib/lua/?.lua` —
   NOT the `wifihaven` subdir) and asserts every module under
   `files/usr/lib/lua/wifihaven/` resolves cleanly via
   `require('wifihaven.X')`. Wired into `run_tests.sh`. Before the fix it
   reports `FAIL: require('wifihaven.eb_refresh')` with the same "module
   not found" error the router crashed on. This pins the regression so any
   future bare `require` in a wifihaven module fails CI immediately, well
   before Gate 2's 3-minute timeout.
2. **Green commit** (`6522564`): applies the require fix; the spec turns
   green.

## Verified

Built `openwrt-wifihaven-ipk-23.05.img` on plex against this branch and ran
`scripts/e2e-vm.sh --mode=fake --only allowed-browsing`:

```
================= 1 passed, 44 deselected in 67.78s (0:01:07) ==================
```

Full Gate 2 fake suite running in parallel; will confirm before merge.