### PR TITLE
fix(#1687): Gate 3b accepts any fc00::/7 ULA (drops hardcoded prefix from #1680)

### DIFF
--- a/scripts/e2e/lib/test_v6_ula.py
+++ b/scripts/e2e/lib/test_v6_ula.py
@@ -1,0 +1,72 @@
+"""Unit cover for the #1687 fix: the Gate 3b client-v6 check must accept
+ANY ULA (fc00::/7 per RFC 4193), not a hardcoded prefix.
+
+Before #1687, the harness asserted the client landed in `fdaa:bbbb:cccc::/48`
+(the prefix `/etc/uci-defaults/99-wifihaven` writes on a freshly built
+router). That broke Gate 3b, which boots the last-published router image —
+older builds use OpenWRT's auto-generated random ULA, so the check failed
+even though v6 was fully plumbed end-to-end.
+
+The check's real intent (from #1680) is "client got a v6 ULA from the
+router via RA/SLAAC" — any ULA satisfies that. Run standalone:
+
+    python3 -m pytest scripts/e2e/lib/test_v6_ula.py
+"""
+from __future__ import annotations
+
+from v6_ula import client_has_ula_address
+
+
+# Real `ip -6 addr show eth0` output shape, abridged.
+def _addr_output(*global_addrs: str) -> str:
+    lines = [
+        "2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000",
+        "    inet6 fe80::5054:ff:fe12:3456/64 scope link",
+        "       valid_lft forever preferred_lft forever",
+    ]
+    for a in global_addrs:
+        lines.append(f"    inet6 {a} scope global dynamic")
+        lines.append("       valid_lft 1800sec preferred_lft 1800sec")
+    return "\n".join(lines)
+
+
+def test_accepts_deterministic_ula_from_99_wifihaven():
+    """The Gate 2 case: new router image, deterministic prefix from
+    scripts/vm/uci-defaults/99-wifihaven."""
+    out = _addr_output("fdaa:bbbb:cccc::1/64")
+    assert client_has_ula_address(out) is True
+
+
+def test_accepts_random_ula_from_last_published_router():
+    """The Gate 3b case (#1687): older router image, OpenWRT-generated
+    random ULA. Must still pass — any ULA is fine."""
+    out = _addr_output("fdf8:cd30:bf17::1/64")
+    assert client_has_ula_address(out) is True
+
+
+def test_accepts_fc00_half_of_the_range():
+    """fc00::/7 is fc00::/8 plus fd00::/8. The fd00 half is the only one
+    in practical use today, but the check must not reject fc00 either."""
+    out = _addr_output("fc12:3456:7890::1/64")
+    assert client_has_ula_address(out) is True
+
+
+def test_rejects_no_v6_at_all():
+    """Preserve #1680's intent: a client with no v6 ULA must still fail
+    the check (catches a genuine RA/SLAAC regression)."""
+    out = "2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP>\n    inet6 fe80::1/64 scope link"
+    assert client_has_ula_address(out) is False
+
+
+def test_rejects_only_link_local():
+    """Link-local fe80::/10 is not a ULA — must not satisfy the check."""
+    out = _addr_output()  # only the link-local line
+    assert client_has_ula_address(out) is False
+
+
+def test_rejects_only_gua():
+    """A global unicast (2000::/3) is not a ULA — must not satisfy.
+    (In practice the qemu LAN bridge never sees a GUA, but the check
+    should reject it cleanly rather than spuriously pass.)"""
+    out = _addr_output("2001:db8::1/64")
+    assert client_has_ula_address(out) is False

--- a/scripts/e2e/lib/test_v6_ula.py
+++ b/scripts/e2e/lib/test_v6_ula.py
@@ -34,34 +34,34 @@ def test_accepts_deterministic_ula_from_99_wifihaven():
     """The Gate 2 case: new router image, deterministic prefix from
     scripts/vm/uci-defaults/99-wifihaven."""
     out = _addr_output("fdaa:bbbb:cccc::1/64")
-    assert client_has_ula_address(out) is True
+    assert client_has_ula_address(out)
 
 
 def test_accepts_random_ula_from_last_published_router():
     """The Gate 3b case (#1687): older router image, OpenWRT-generated
     random ULA. Must still pass — any ULA is fine."""
     out = _addr_output("fdf8:cd30:bf17::1/64")
-    assert client_has_ula_address(out) is True
+    assert client_has_ula_address(out)
 
 
 def test_accepts_fc00_half_of_the_range():
     """fc00::/7 is fc00::/8 plus fd00::/8. The fd00 half is the only one
     in practical use today, but the check must not reject fc00 either."""
     out = _addr_output("fc12:3456:7890::1/64")
-    assert client_has_ula_address(out) is True
+    assert client_has_ula_address(out)
 
 
 def test_rejects_no_v6_at_all():
     """Preserve #1680's intent: a client with no v6 ULA must still fail
     the check (catches a genuine RA/SLAAC regression)."""
     out = "2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP>\n    inet6 fe80::1/64 scope link"
-    assert client_has_ula_address(out) is False
+    assert not client_has_ula_address(out)
 
 
 def test_rejects_only_link_local():
     """Link-local fe80::/10 is not a ULA — must not satisfy the check."""
     out = _addr_output()  # only the link-local line
-    assert client_has_ula_address(out) is False
+    assert not client_has_ula_address(out)
 
 
 def test_rejects_only_gua():
@@ -69,4 +69,4 @@ def test_rejects_only_gua():
     (In practice the qemu LAN bridge never sees a GUA, but the check
     should reject it cleanly rather than spuriously pass.)"""
     out = _addr_output("2001:db8::1/64")
-    assert client_has_ula_address(out) is False
+    assert not client_has_ula_address(out)

--- a/scripts/e2e/lib/v6_ula.py
+++ b/scripts/e2e/lib/v6_ula.py
@@ -1,0 +1,43 @@
+"""Client-side ULA detection for the Gate 2/3b v6 link-local check (#1680/#1687).
+
+Lives in its own module so it stays a pure function the unit tests can
+exercise without spinning up VMs. vm.py's `_assert_v6_link_local_ready`
+calls into here once it has the client's `ip -6 addr show eth0` output.
+
+The check accepts ANY ULA in fc00::/7 (RFC 4193). Earlier revisions of
+the harness hardcoded the deterministic prefix
+`scripts/vm/uci-defaults/99-wifihaven` writes on freshly built routers,
+which broke Gate 3b — that gate boots the last-published router image,
+which predates the uci-default and falls back to OpenWRT's auto-generated
+random ULA. The functional intent of #1680 is "client got a v6 ULA from
+the router via RA/SLAAC," and any ULA satisfies that. See #1687.
+"""
+from __future__ import annotations
+
+import ipaddress
+
+_ULA_NET = ipaddress.IPv6Network("fc00::/7")
+
+
+def client_has_ula_address(ip6_addr_output: str) -> bool:
+    """Return True iff `ip -6 addr show <iface>` output contains at least
+    one IPv6 address inside fc00::/7.
+
+    Link-local (fe80::/10) and global-unicast (2000::/3) addresses are
+    explicitly rejected — only an actual ULA proves the router's RA/SLAAC
+    is reaching the client.
+    """
+    for raw in ip6_addr_output.splitlines():
+        line = raw.strip()
+        if not line.startswith("inet6 "):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        try:
+            addr = ipaddress.IPv6Interface(parts[1]).ip
+        except ValueError:
+            continue
+        if addr in _ULA_NET:
+            return True
+    return False

--- a/scripts/e2e/lib/vm.py
+++ b/scripts/e2e/lib/vm.py
@@ -306,42 +306,57 @@ def _wait_for_client_lan(client: Client, *, timeout_s: float = 60, interval_s: f
     log.warning("client %s LAN/DNS not ready after %ss (last: %r)", client.name, timeout_s, last)
 
 
-# Router ULA, kept in sync with scripts/vm/uci-defaults/99-wifihaven (#1680).
-ROUTER_ULA_PREFIX = "fdaa:bbbb:cccc"
+# Harness assumptions about router state must be derived from the live
+# router or kept as broad as the functional requirement — never hardcoded
+# to a specific value the router happens to ship today. An earlier rev of
+# this check pinned the deterministic prefix from
+# scripts/vm/uci-defaults/99-wifihaven, which broke Gate 3b (last-published
+# router image, predates the uci-default, falls back to OpenWRT's random
+# ULA). See #1687.
+from .v6_ula import client_has_ula_address
 
 
 def _assert_v6_link_local_ready(client: Client, *, timeout_s: float = 30, interval_s: float = 2.0) -> None:
     """Regression gate (#1680): once the LAN is up, the client must also have
-    a v6 default route and a global-scope ULA address.
+    a v6 default route via eth0 AND at least one global-scope ULA address
+    (fc00::/7 per RFC 4193).
 
     If a future change strips RA/SLAAC (e.g. odhcpd disabled, ULA prefix
     cleared, accept_ra=0 on the client base), every Gate 2 scenario gets a
     clear, early failure here rather than a confusing late timeout in the
-    v6 attribution suite (#1677)."""
+    v6 attribution suite (#1677).
+
+    The ULA prefix is intentionally NOT pinned to a specific value — Gate 3b
+    boots the last-published router image, which uses OpenWRT's auto-generated
+    random ULA rather than the deterministic prefix newer images write via
+    scripts/vm/uci-defaults/99-wifihaven (#1687)."""
     import time as _time
     deadline = _time.monotonic() + timeout_s
-    probe_cmd = [
-        "sh", "-c",
-        "ip -6 route show default 2>/dev/null | grep -q 'dev eth0' && "
-        f"ip -6 addr show eth0 scope global 2>/dev/null | grep -q '{ROUTER_ULA_PREFIX}'",
-    ]
     last_v6_state = ""
     while _time.monotonic() < deadline:
-        res = client_exec(client, probe_cmd, timeout=10, check=False)
-        if res.returncode == 0:
-            return
-        diag = client_exec(
+        route_res = client_exec(
             client,
-            ["sh", "-c", "ip -6 route; echo ---; ip -6 addr show eth0"],
+            ["sh", "-c", "ip -6 route show default 2>/dev/null"],
             timeout=10, check=False,
         )
-        last_v6_state = (diag.stdout or "").strip()
+        addr_res = client_exec(
+            client,
+            ["sh", "-c", "ip -6 addr show eth0 2>/dev/null"],
+            timeout=10, check=False,
+        )
+        route_out = (route_res.stdout or "")
+        addr_out = (addr_res.stdout or "")
+        has_default = "dev eth0" in route_out
+        has_ula = client_has_ula_address(addr_out)
+        if has_default and has_ula:
+            return
+        last_v6_state = f"{addr_out}\n---\n{route_out}".strip()
         _time.sleep(interval_s)
     raise RuntimeError(
-        f"client {client.name} missing IPv6 default route or ULA address "
-        f"in {ROUTER_ULA_PREFIX}::/48 after {timeout_s}s. The qemu LAN bridge "
+        f"client {client.name} missing IPv6 default route or any ULA "
+        f"(fc00::/7) address after {timeout_s}s. The qemu LAN bridge "
         f"is not carrying RA/SLAAC — see scripts/vm/uci-defaults/99-wifihaven "
-        f"and #1680.\n"
+        f"and #1680/#1687.\n"
         f"--- client ip -6 addr/route ---\n{last_v6_state}"
     )
 

--- a/scripts/e2e/scenarios_fake/test_v6_link_local.py
+++ b/scripts/e2e/scenarios_fake/test_v6_link_local.py
@@ -15,11 +15,9 @@ from __future__ import annotations
 
 import pytest
 
-from lib.vm import ROUTER_ULA_PREFIX, client_exec, router_ssh
+from lib.vm import client_exec, router_ssh
 
 pytestmark = pytest.mark.v6_link_local
-
-assert ROUTER_ULA_PREFIX  # silence unused-import lints; documents the contract
 
 
 def test_v6_syn_traverses_router_forward_chain(client):

--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -110,11 +110,13 @@ uci commit uhttpd
 # pipeline as v4. The qemu SLIRP WAN is v4-only, so upstream v6 is not
 # in scope — only LAN connectivity and a FORWARD-chain-traversing v6 SYN.
 #
-# - ula_prefix:   deterministic so the orchestrator and tests can hard-code
-#                 the prefix. Anything in fd00::/8 is valid; this value
-#                 collides with nothing in the harness. The Python-side
-#                 mirror lives at scripts/e2e/lib/vm.py:ROUTER_ULA_PREFIX —
-#                 keep both in sync when changing the prefix.
+# - ula_prefix:   deterministic for reproducibility, but the harness no
+#                 longer pins this specific value — it accepts ANY ULA in
+#                 fc00::/7 (RFC 4193). Anything in fd00::/8 is valid; this
+#                 value collides with nothing in the harness. See #1687:
+#                 hardcoding the prefix in two places (here AND vm.py) broke
+#                 Gate 3b, which boots last-published router images that
+#                 predate this uci-default and use OpenWRT's random ULA.
 # - ip6assign:    LAN takes the first /60 of the ULA, which gives the
 #                 router fdaa:bbbb:cccc::1/60 and clients SLAAC into the
 #                 same /64 (default eui64 or stable-privacy).


### PR DESCRIPTION
Closes #1687.

## Root cause

PR #1682 (closing #1680) added `/etc/uci-defaults/99-wifihaven` to write a deterministic ULA prefix `fdaa:bbbb:cccc::/48` on freshly built routers AND hardcoded that same prefix in `scripts/e2e/lib/vm.py:ROUTER_ULA_PREFIX` so the Gate 2 client-v6 assertion could pin it. Gate 3b explicitly boots the **last-published** router image (asymmetric-deploy test) — that image was built before #1682 merged, so its uci-defaults never write the deterministic prefix and OpenWRT falls back to a per-build random ULA (`fdf8:cd30:bf17::/48` in the failing run). v6 IS plumbed end-to-end; the harness was checking the wrong invariant.

The fix: drop the hardcoded prefix and accept any ULA in `fc00::/7` (RFC 4193) — that's what "client got a v6 ULA from the router" actually means. The new pure function `v6_ula.client_has_ula_address` is unit-covered (`scripts/e2e/lib/test_v6_ula.py`); `_assert_v6_link_local_ready` now AND-gates a `dev eth0` default route with the loosened ULA check.

## Compounding with #1683

Master Router CD is also red (#1683 — unblocked by 7db78029, still rolling out). Without this PR, Gate 3b would stay red until a new openwrt-latest with the deterministic ULA publishes; with it, API/UI CD recovers immediately without waiting on the router CD lane.

## #1680's regression catch is preserved

The original purpose of the assertion — "client got a v6 default route AND a global-scope ULA from the router via RA/SLAAC" — is still pinned, just by membership in fc00::/7 instead of by string match. The unit suite has explicit cases for:

- accepts deterministic prefix (Gate 2)
- accepts random ULA (Gate 3b)
- rejects no v6 at all (the #1680 regression shape)
- rejects link-local only
- rejects GUA only

## §single-source-of-truth note

The earlier hardcoded prefix lived in two places: `scripts/vm/uci-defaults/99-wifihaven` and `scripts/e2e/lib/vm.py`. The fix collapses them — neither side needs to know the literal value any more, because the assertion describes the functional property (any ULA) rather than mirroring a config value. Updated the uci-defaults comment to match.

## Test plan

- [x] `python3 -m pytest scripts/e2e/lib/test_v6_ula.py` — 6 passed (deterministic, random, fc00 half, no-v6, link-local-only, GUA-only)
- [ ] Master API/UI CD passes Gate 3b on the next run against this branch's merge
- [ ] Gate 2 still green (new routers — deterministic prefix is still a ULA, so the loosened check passes)