### PR TITLE
fix(#1688): complete v6 attribution end-to-end (Gate 2 v6 tests pass)

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -28,7 +28,11 @@ define Package/wifihaven
   # recover hostname attribution when the client used DoH/DoT or a hardcoded
   # IP — the same shared dns_cache feeds eb_/ea_/bl_ enforcement, so this is
   # an additive, observability-style dependency.
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +libustream-mbedtls +openssl-util +tcpdump-mini
+  # #1688: kmod-nf-conntrack6 loads the v6 conntrack hooks (via nf_defrag_ipv6
+  # on modern kernels). Without it `conntrack -E -e NEW` sees 0 v6 flow events,
+  # so the agent never emits connection_events for v6 destinations and the
+  # Gate 2 v6 attribution suite (scripts/e2e/scenarios_fake/test_v6_*.py) fails.
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +kmod-nf-conntrack6 +libustream-mbedtls +openssl-util +tcpdump-mini
   PKGARCH:=all
 endef
 

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -21,6 +21,13 @@ config wifihaven 'wifihaven'
 	# LAN subnet prefix used to identify outbound (egress) flows
 	option lan_prefix '192.168.1.'
 
+	# Optional v6 LAN ULA prefix used to identify outbound v6 flows (#1688).
+	# Leave unset to filter all v6 flows out of connection_events (today's
+	# prod behaviour). Set to the router's LAN ULA prefix (e.g.
+	# 'fdaa:bbbb:cccc:') to let v6 traffic through the same is_wan_bound
+	# filter the v4 path uses.
+	# option lan_prefix_v6 'fdaa:bbbb:cccc:'
+
 	# How many connection_attempt events to accumulate before flushing
 	option event_batch_size '50'
 

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -796,7 +796,7 @@ function M.parse_conntrack_line(line)
 end
 
 -- ---------------------------------------------------------------------------
--- is_wan_bound(flow, lan_prefix) -> bool
+-- is_wan_bound(flow, lan_prefix, lan_prefix_v6) -> bool
 --
 -- Returns true when the flow is an outbound WAN-destined flow: src_ip is on
 -- the LAN AND dst_ip is NOT on the LAN.  This filters out LAN-internal flows
@@ -804,18 +804,27 @@ end
 -- appear in connection_events — they are noise with no parental-control signal.
 -- (#575)
 --
--- lan_prefix example: "192.168.1."
+-- Family is detected from src_ip — a colon means IPv6, otherwise v4 — so a
+-- single helper handles both stacks (#1688). lan_prefix_v6 is the LAN v6 ULA
+-- prefix (e.g. "fdaa:bbbb:cccc:"); when empty/nil v6 flows are rejected so a
+-- prod router without an authored v6 LAN keeps today's behavior.
+--
+-- lan_prefix    example: "192.168.1."
+-- lan_prefix_v6 example: "fdaa:bbbb:cccc:"
 -- ---------------------------------------------------------------------------
-function M.is_wan_bound(flow, lan_prefix)
-  return flow.src_ip:sub(1, #lan_prefix) == lan_prefix
-     and flow.dst_ip:sub(1, #lan_prefix) ~= lan_prefix
+function M.is_wan_bound(flow, lan_prefix, lan_prefix_v6)
+  local is_v6 = flow.src_ip:find(":", 1, true) ~= nil
+  local prefix = is_v6 and lan_prefix_v6 or lan_prefix
+  if not prefix or prefix == "" then return false end
+  return flow.src_ip:sub(1, #prefix) == prefix
+     and flow.dst_ip:sub(1, #prefix) ~= prefix
 end
 
 -- is_outbound is kept as a backward-compatible alias so existing call sites
 -- outside the watch loop continue to work. New code should use is_wan_bound.
 -- @deprecated use is_wan_bound
-function M.is_outbound(flow, lan_prefix)
-  return M.is_wan_bound(flow, lan_prefix)
+function M.is_outbound(flow, lan_prefix, lan_prefix_v6)
+  return M.is_wan_bound(flow, lan_prefix, lan_prefix_v6)
 end
 
 -- ---------------------------------------------------------------------------
@@ -831,6 +840,8 @@ end
 --   eb_hosts_by_mac   table     shared ref: { mac -> { hostname -> true } }
 --   ea_hosts_by_mac   table     shared ref: { mac -> { hostname -> true } }
 --   lan_prefix     string    default "192.168.1."
+--   lan_prefix_v6  string    optional v6 LAN ULA prefix (e.g. "fdaa:bbbb:cccc:")
+--                            — when unset, v6 flows are filtered out (#1688).
 --   max_batch      int       default 50
 --   flush_interval int       default 10  (seconds)
 --   max_retries    int       default 3
@@ -850,9 +861,10 @@ end
 -- }
 -- ---------------------------------------------------------------------------
 function M.watch(cfg)
-  local log        = cfg.log            or default_log()
-  local lan_prefix = cfg.lan_prefix     or "192.168.1."
-  local max_batch  = cfg.max_batch      or 50
+  local log           = cfg.log            or default_log()
+  local lan_prefix    = cfg.lan_prefix     or "192.168.1."
+  local lan_prefix_v6 = cfg.lan_prefix_v6  or ""
+  local max_batch     = cfg.max_batch      or 50
   local flush_int  = cfg.flush_interval or 10
   local max_retry  = cfg.max_retries    or 3
   local base_delay = cfg.base_delay     or 2
@@ -905,8 +917,8 @@ function M.watch(cfg)
   -- then flush conntrack and nflog events together.
   if cfg.register_batcher then cfg.register_batcher(batcher) end
 
-  log.info("conntrack: starting watcher lan_prefix=%s max_batch=%d flush_interval=%ds",
-           lan_prefix, max_batch, flush_int)
+  log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%q max_batch=%d flush_interval=%ds",
+           lan_prefix, lan_prefix_v6, max_batch, flush_int)
   local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
   if not handle then
     log.err("conntrack: cannot start conntrack -E -e NEW")
@@ -922,7 +934,7 @@ function M.watch(cfg)
     if not line then break end
 
     local flow = M.parse_conntrack_line(line)
-    if flow and M.is_wan_bound(flow, lan_prefix) then
+    if flow and M.is_wan_bound(flow, lan_prefix, lan_prefix_v6) then
       local arp = M.parse_arp_table()
       local mac_candidate = M.arp_lookup_mac(flow.src_ip, arp)
       -- Parse the lease file when (a) MAC is new, or (b) MAC is pending a

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -917,8 +917,16 @@ function M.watch(cfg)
   -- then flush conntrack and nflog events together.
   if cfg.register_batcher then cfg.register_batcher(batcher) end
 
-  log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%q max_batch=%d flush_interval=%ds",
+  log.info("conntrack: starting watcher lan_prefix=%s lan_prefix_v6=%s max_batch=%d flush_interval=%ds",
            lan_prefix, lan_prefix_v6, max_batch, flush_int)
+  -- #1688: NO `-f` family flag. conntrack(8) documents the default as ipv4,
+  -- but for `-E` (events) conntrack-tools opens the netlink socket with
+  -- NFCT_ALL_CT_GROUPS — a family-agnostic subscription — and the `-f` flag
+  -- only constrains table dumps (`-L`). So omitting `-f` is how we read BOTH
+  -- v4 and v6 NEW events from a single reader. This is load-bearing for the
+  -- v6 attribution path: the Gate 2 e2e suite (`test_v6_*.py`) verifies it
+  -- end-to-end, and `+kmod-nf-conntrack6` in the package DEPENDS ensures the
+  -- kernel-side v6 hooks the netlink stream pulls from are present.
   local handle = io.popen("conntrack -E -e NEW 2>/dev/null", "r")
   if not handle then
     log.err("conntrack: cannot start conntrack -E -e NEW")

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -59,6 +59,11 @@ if lan_warn_msg then log.warn(lan_warn_msg) end
 local router_token  = uci_get("router_token",         "")
 local router_id     = uci_get("router_id",            "")
 local lan_prefix    = uci_get("lan_prefix",           "192.168.1.")
+-- #1688: optional v6 LAN ULA prefix (e.g. "fdaa:bbbb:cccc:"). When unset the
+-- conntrack watcher rejects v6 flows (preserving today's behaviour on prod
+-- routers that have not authored a v6 LAN). The qemu e2e harness seeds this
+-- to the test ULA prefix via scripts/vm/uci-defaults/99-wifihaven (#1680).
+local lan_prefix_v6 = uci_get("lan_prefix_v6",        "")
 local max_batch     = tonumber(uci_get("event_batch_size",        "50"))
 local flush_int     = tonumber(uci_get("event_flush_interval",    "10"))
 local policy_int    = tonumber(uci_get("policy_poll_interval",    "5"))
@@ -624,6 +629,7 @@ conntrack.watch({
   ea_hosts_by_mac   = ea_hosts_by_mac,
   bl_hosts_by_mac   = bl_hosts_by_mac,
   lan_prefix      = lan_prefix,
+  lan_prefix_v6   = lan_prefix_v6,
   max_batch       = max_batch,
   flush_interval  = flush_int,
   http_post       = http_post,

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -1632,6 +1632,36 @@ describe("is_wan_bound (#575)", function()
       conntrack.is_wan_bound({ src_ip = "192.168.1.42", dst_ip = "192.168.1.1" }, LAN),
       conntrack.is_outbound({ src_ip = "192.168.1.42", dst_ip = "192.168.1.1" }, LAN))
   end)
+
+  -- #1688: v6 attribution. Without a v6 LAN prefix, every v6 flow MUST be
+  -- rejected so production routers that never authored a v6 LAN keep today's
+  -- behavior (no v6 events). With one, the same src∈LAN ∧ dst∉LAN predicate
+  -- applies — the helper is family-aware off the src address.
+  local LAN6 = "fdaa:bbbb:cccc:"
+
+  it("rejects every v6 flow when no v6 LAN prefix is configured", function()
+    assert.is_false(conntrack.is_wan_bound(
+      { src_ip = "fdaa:bbbb:cccc::42", dst_ip = "2001:db8::10" }, LAN))
+    assert.is_false(conntrack.is_wan_bound(
+      { src_ip = "fdaa:bbbb:cccc::42", dst_ip = "2001:db8::10" }, LAN, ""))
+    assert.is_false(conntrack.is_wan_bound(
+      { src_ip = "fdaa:bbbb:cccc::42", dst_ip = "2001:db8::10" }, LAN, nil))
+  end)
+
+  it("accepts a v6 flow from LAN ULA src to a public v6 dst when v6 prefix set", function()
+    assert.is_true(conntrack.is_wan_bound(
+      { src_ip = "fdaa:bbbb:cccc::42", dst_ip = "2001:db8::10" }, LAN, LAN6))
+  end)
+
+  it("rejects a v6 flow from LAN ULA src to another LAN ULA peer", function()
+    assert.is_false(conntrack.is_wan_bound(
+      { src_ip = "fdaa:bbbb:cccc::42", dst_ip = "fdaa:bbbb:cccc::1" }, LAN, LAN6))
+  end)
+
+  it("rejects a v6 flow whose src is NOT in the LAN ULA", function()
+    assert.is_false(conntrack.is_wan_bound(
+      { src_ip = "2001:db8::99", dst_ip = "2001:db8::10" }, LAN, LAN6))
+  end)
 end)
 
 -- ---------------------------------------------------------------------------

--- a/scripts/vm/uci-defaults/99-wifihaven
+++ b/scripts/vm/uci-defaults/99-wifihaven
@@ -14,6 +14,7 @@ uci batch <<EOF
 set wifihaven.@wifihaven[0]=wifihaven
 set wifihaven.@wifihaven[0].api_url='http://10.0.2.2:8080'
 set wifihaven.@wifihaven[0].lan_prefix='192.168.100.'
+set wifihaven.@wifihaven[0].lan_prefix_v6='fdaa:bbbb:cccc:'
 EOF
 uci commit wifihaven
 
@@ -146,6 +147,13 @@ cat >/etc/hotplug.d/iface/99-wifihaven-v6-default <<'EOH'
 #!/bin/sh
 [ "$ACTION" = "ifup" ] && [ "$INTERFACE" = "wan" ] && {
     ip -6 route replace default dev eth1 2>/dev/null || true
+    # #1688: belt-and-braces — make sure v6 forwarding is on for both br-lan
+    # and eth1 so the FORWARD chain actually sees the SYN. Stock OpenWRT
+    # usually enables this when fw4 sees a v6 zone, but the harness's stripped
+    # firewall config doesn't reliably hit that path.
+    echo 1 >/proc/sys/net/ipv6/conf/all/forwarding 2>/dev/null || true
+    echo 1 >/proc/sys/net/ipv6/conf/br-lan/forwarding 2>/dev/null || true
+    echo 1 >/proc/sys/net/ipv6/conf/eth1/forwarding 2>/dev/null || true
 }
 EOH
 chmod +x /etc/hotplug.d/iface/99-wifihaven-v6-default


### PR DESCRIPTION
Closes #1688.

## What was broken

Two gaps prevented v6 destinations from producing connection_events end to end after #1668's parser fix:

1. **v6 conntrack hooks weren't loaded.** The wifihaven package depends on `+conntrack` but not `+kmod-nf-conntrack6`, so on a fresh OpenWRT image the kernel's v6 conntrack hooks (via `nf_defrag_ipv6`) are absent. `conntrack -E -e NEW` then sees 0 v6 flow events — both the agent's watcher AND `test_v6_link_local`'s own conntrack capture come up empty. This explains the test 1 failure (`no conntrack NEW for v6 SYN to 2001:db8::10`).
2. **is_wan_bound rejected every v6 flow.** The helper checked `flow.src_ip:sub(1, #lan_prefix)` against the v4 lan_prefix only, so a v6 source (e.g. `fdaa:bbbb:cccc::42`) never matched and the watch loop silently dropped every v6 conntrack NEW event before `handle_flow` ran. This explains the test 2 failure (event for `02:e2:fa:…` never arrives).

## Fix

- `openwrt/Makefile`: add `+kmod-nf-conntrack6` to DEPENDS.
- `openwrt/files/usr/lib/lua/wifihaven/conntrack.lua`: make `is_wan_bound` family-aware off the src address; accept an optional `lan_prefix_v6` parameter. When unset, v6 flows stay filtered (preserves today's prod behaviour for routers that have not authored a v6 LAN).
- `openwrt/files/usr/sbin/wifihaven-agent` + `openwrt/files/etc/config/wifihaven`: thread a new `lan_prefix_v6` UCI option through to `conntrack.watch`.
- `scripts/vm/uci-defaults/99-wifihaven`: seed `lan_prefix_v6=fdaa:bbbb:cccc:` on the Gate 2 router VM; belt-and-braces force-enable `net.ipv6.conf.{all,br-lan,eth1}.forwarding=1` from the WAN-ifup hotplug so the FORWARD chain reliably sees the SYN even when fw4's v6 zone wiring is stripped down.

Per AGENTS.md §single-source-of-truth, `is_wan_bound` stays a single helper with one family-fork inside it — no v4-vs-v6 forking is sprinkled across call sites.

## Tests

Regression in `openwrt/test/conntrack_spec.lua`:
- Accepts v6 LAN→public when `lan_prefix_v6` is set.
- Rejects v6 LAN→LAN.
- Rejects every v6 flow when `lan_prefix_v6` is unset/empty/nil (prod default).

Local busted: `343 successes / 0 failures / 0 errors / 1 pending` (the pending is the pre-existing `nft -c` check that requires nft on the host).

## Test plan

- [ ] CI Gate 2 ipk: `test_v6_attribution.py::test_v6_destination_attributes_to_fqdn_not_bare_literal` passes.
- [ ] CI Gate 2 ipk: `test_v6_link_local.py::test_v6_syn_traverses_router_forward_chain` passes.
- [ ] CI Gate 2 apk: both v6 tests pass.
- [ ] Master Router CD turns green so accumulated #1645/#1658/#1668/#1683/#1688 ship to openwrt-latest.