### PR TITLE
fix(#1691): use curl -6 not nc -6 in Gate 2 v6 tests (BusyBox nc lacks -6)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -214,25 +214,51 @@ end
 -- ---------------------------------------------------------------------------
 -- parse_arp_table() -> { ip -> mac }
 --
--- Reads /proc/net/arp at call time.  Called per-event so the MAC table stays
--- fresh without a background refresh loop.
+-- Reads /proc/net/arp at call time (v4) AND `ip -6 neigh` (v6 NDP cache).
+-- The kernel exposes the v4 ARP table as a proc file but the v6 NDP cache
+-- only over netlink, so we shell out for the v6 half. Called per-event so
+-- the MAC table stays fresh without a background refresh loop.
+--
+-- v6 is load-bearing here: without it, the watch loop reaches a v6 conntrack
+-- NEW with `src=<lan-ula>`, asks parse_arp_table for the MAC of that v6
+-- src_ip, gets nil, and emits a connection_attempt event whose `mac` field
+-- is nil. The fake-API Gate 2 attribution suite (#1677) asserts on
+-- `mac == client.mac AND host.value contains LEAF_HOST` — a nil mac fails
+-- the assert and is_wan_bound's #1690 family-fork looks like it didn't
+-- close the loop. (#1691.)
 -- ---------------------------------------------------------------------------
 function M.parse_arp_table()
   local result = {}
+  -- /proc/net/arp columns: IP, HWtype, Flags, HWaddr, Mask, Device
   local f = io.open("/proc/net/arp", "r")
-  if not f then return result end
-  f:read("*l")  -- skip header
-  for line in f:lines() do
-    local ip, _, _, mac = line:match("^(%S+)%s+%S+%s+%S+%s+(%S+)%s+")
-    -- mac field is 4th column; re-match properly
-    local parts = {}
-    for w in line:gmatch("%S+") do parts[#parts + 1] = w end
-    -- /proc/net/arp columns: IP, HWtype, Flags, HWaddr, Mask, Device
-    if #parts >= 4 and parts[4] ~= "00:00:00:00:00:00" then
-      result[parts[1]] = parts[4]
+  if f then
+    f:read("*l")  -- skip header
+    for line in f:lines() do
+      local parts = {}
+      for w in line:gmatch("%S+") do parts[#parts + 1] = w end
+      if #parts >= 4 and parts[4] ~= "00:00:00:00:00:00" then
+        result[parts[1]] = parts[4]
+      end
     end
+    f:close()
   end
-  f:close()
+  -- v6 NDP cache. Format examples:
+  --   `2001:db8::1 dev br-lan lladdr 02:e2:fa:11:22:33 router REACHABLE`
+  --   `fdaa:bbbb:cccc::147 dev br-lan lladdr 02:e2:fa:8e:c2:ce STALE`
+  --   `fe80::2 dev eth1  used 0/0/0 probes 6 FAILED`   (no lladdr — skip)
+  -- The `lladdr <mac>` token is the load-bearing piece; entries in FAILED
+  -- state have no lladdr and we skip them naturally.
+  local pf = io.popen("ip -6 neigh show 2>/dev/null")
+  if pf then
+    for line in pf:lines() do
+      local ip = line:match("^(%S+)")
+      local mac = line:match("lladdr%s+(%S+)")
+      if ip and mac and mac ~= "00:00:00:00:00:00" then
+        result[ip] = mac
+      end
+    end
+    pf:close()
+  end
   return result
 end
 

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -81,6 +81,112 @@ describe("arp_lookup_mac", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 2b. parse_arp_table: combines /proc/net/arp (v4) AND `ip -6 neigh` (v6 NDP)
+--
+-- Regression for #1691 Bucket G: pre-fix, parse_arp_table only read
+-- /proc/net/arp (v4), so a v6 conntrack NEW with src=<lan-ula> resolved to
+-- mac=nil at handle_flow time, the emitted connection_attempt had a nil
+-- `mac` field, and the Gate 2 attribution suite (which asserts on
+-- mac == client.mac + host contains LEAF_HOST) timed out. The dns-cache
+-- lookup was fine; only the MAC half was missing.
+-- ---------------------------------------------------------------------------
+describe("parse_arp_table", function()
+  -- Helper to stub io.open + io.popen with canned line streams.
+  local function with_stubs(arp_lines, neigh_lines, body)
+    local function reader(lines)
+      local i = 0
+      return {
+        read = function(_, fmt)
+          if fmt == "*l" then i = i + 1; return lines[i] end
+          return nil
+        end,
+        lines = function()
+          return function()
+            i = i + 1
+            return lines[i]
+          end
+        end,
+        close = function() end,
+      }
+    end
+    local saved_open, saved_popen = io.open, io.popen
+    io.open = function(path, _)
+      if path == "/proc/net/arp" and arp_lines then return reader(arp_lines) end
+      return nil
+    end
+    io.popen = function(cmd)
+      if cmd:match("ip %-6 neigh") and neigh_lines then return reader(neigh_lines) end
+      return nil
+    end
+    local ok, err = pcall(body)
+    io.open, io.popen = saved_open, saved_popen
+    assert(ok, err)
+  end
+
+  it("populates v4 entries from /proc/net/arp", function()
+    with_stubs({
+      "IP address       HW type     Flags       HW address            Mask     Device",
+      "192.168.100.42   0x1         0x2         aa:bb:cc:11:22:33     *        br-lan",
+    }, {}, function()
+      local t = conntrack.parse_arp_table()
+      assert.equal("aa:bb:cc:11:22:33", t["192.168.100.42"])
+    end)
+  end)
+
+  it("populates v6 entries from `ip -6 neigh` lladdr tokens", function()
+    with_stubs({
+      "IP address       HW type     Flags       HW address            Mask     Device",
+    }, {
+      "fdaa:bbbb:cccc::147 dev br-lan lladdr 02:e2:fa:8e:c2:ce STALE",
+      "2001:db8::abcd dev br-lan lladdr aa:bb:cc:dd:ee:ff REACHABLE",
+    }, function()
+      local t = conntrack.parse_arp_table()
+      assert.equal("02:e2:fa:8e:c2:ce", t["fdaa:bbbb:cccc::147"])
+      assert.equal("aa:bb:cc:dd:ee:ff", t["2001:db8::abcd"])
+    end)
+  end)
+
+  it("skips v6 NDP entries in FAILED state (no lladdr token)", function()
+    with_stubs({
+      "IP address       HW type     Flags       HW address            Mask     Device",
+    }, {
+      "fe80::2 dev eth1  used 0/0/0 probes 6 FAILED",
+      "2001:db8::10 dev eth1 used 0/0/0 probes 6 FAILED",
+    }, function()
+      local t = conntrack.parse_arp_table()
+      assert.is_nil(t["fe80::2"])
+      assert.is_nil(t["2001:db8::10"])
+    end)
+  end)
+
+  it("merges v4 and v6 in a single lookup table (#1691)", function()
+    with_stubs({
+      "IP address       HW type     Flags       HW address            Mask     Device",
+      "192.168.100.42   0x1         0x2         02:e2:fa:8e:c2:ce     *        br-lan",
+    }, {
+      "fdaa:bbbb:cccc::147 dev br-lan lladdr 02:e2:fa:8e:c2:ce STALE",
+    }, function()
+      local t = conntrack.parse_arp_table()
+      assert.equal("02:e2:fa:8e:c2:ce", t["192.168.100.42"])
+      assert.equal("02:e2:fa:8e:c2:ce", t["fdaa:bbbb:cccc::147"])
+      -- arp_lookup_mac is unchanged — same call site finds either family.
+      assert.equal("02:e2:fa:8e:c2:ce",
+        conntrack.arp_lookup_mac("fdaa:bbbb:cccc::147", t))
+    end)
+  end)
+
+  it("tolerates the v6-neigh popen returning nothing", function()
+    with_stubs({
+      "IP address       HW type     Flags       HW address            Mask     Device",
+      "192.168.100.42   0x1         0x2         aa:bb:cc:11:22:33     *        br-lan",
+    }, nil, function()  -- io.popen returns nil
+      local t = conntrack.parse_arp_table()
+      assert.equal("aa:bb:cc:11:22:33", t["192.168.100.42"])
+    end)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 3. Event serialization
 -- ---------------------------------------------------------------------------
 

--- a/scripts/e2e/scenarios_fake/test_v6_attribution.py
+++ b/scripts/e2e/scenarios_fake/test_v6_attribution.py
@@ -90,14 +90,20 @@ def _fire_v6_syn(client) -> None:
     The destination is RFC 3849 doc-space so the SYN will RST or timeout on
     the WAN side — that does not matter. The conntrack NEW event on the
     router fires as the packet crosses the FORWARD chain, which is what
-    `handle_flow` consumes to emit the connection_event. `nc -6 -w 2` does
-    a SYN-then-bail with a 2-second timeout, returning immediately. Tail
-    `|| true` so a non-zero exit (the expected timeout) doesn't fail the
-    client_exec call.
+    `handle_flow` consumes to emit the connection_event.
+
+    NB: do NOT use `nc -6` here — the Alpine client's nc is BusyBox, which
+    does not implement `-6` (the option is rejected with "unrecognized
+    option: 6" and zero packets leave the client, so this whole test was a
+    silent no-op pre-#1691). curl is in the client base image's package
+    list (see scripts/vm/build-client-base.sh) and supports -6 natively;
+    `-s -m 2` does a SYN-then-bail with a 2-second timeout, returning
+    immediately. `|| true` swallows the expected connect-timeout (curl
+    exit 28) so client_exec doesn't fail.
     """
     client_exec(
         client,
-        ["sh", "-c", f"nc -6 -w 2 {LEAF_HOST} 80 >/dev/null 2>&1; true"],
+        ["sh", "-c", f"curl -6 -s -m 2 -o /dev/null http://[{LEAF_HOST}]/ ; true"],
         check=False,
         timeout=10,
     )

--- a/scripts/e2e/scenarios_fake/test_v6_attribution.py
+++ b/scripts/e2e/scenarios_fake/test_v6_attribution.py
@@ -103,7 +103,7 @@ def _fire_v6_syn(client) -> None:
     """
     client_exec(
         client,
-        ["sh", "-c", f"curl -6 -s -m 2 -o /dev/null http://[{LEAF_HOST}]/ ; true"],
+        ["sh", "-c", f"curl -6 -s -m 2 -o /dev/null http://{LEAF_HOST}/ ; true"],
         check=False,
         timeout=10,
     )

--- a/scripts/e2e/scenarios_fake/test_v6_link_local.py
+++ b/scripts/e2e/scenarios_fake/test_v6_link_local.py
@@ -42,11 +42,17 @@ def test_v6_syn_traverses_router_forward_chain(client):
     ct_pid = (start.stdout or "").strip().splitlines()[-1]
     assert ct_pid.isdigit(), f"failed to capture conntrack pid: {start.stdout!r}"
 
-    # nc returns immediately on SYN_SENT timeout. Doc-space 2001:db8::10
-    # is unreachable, which is the point — the SYN crossed FORWARD.
+    # curl -6 returns curl exit 28 on connect-timeout (RFC 3849 doc-space
+    # 2001:db8::10 is unreachable — the point is the SYN crossed FORWARD).
+    # NB: do NOT use `nc -6` here — the Alpine client's nc is BusyBox, which
+    # does not implement `-6` (the option is rejected with "unrecognized
+    # option: 6" and zero packets are emitted, so conntrack sees nothing and
+    # this whole test was a silent no-op pre-#1691). curl is in the client
+    # base image's package list (see scripts/vm/build-client-base.sh) and
+    # supports -6 natively.
     client_exec(
         client,
-        ["sh", "-c", "nc -6 -w 2 2001:db8::10 80 >/dev/null 2>&1; true"],
+        ["sh", "-c", "curl -6 -s -m 2 -o /dev/null http://[2001:db8::10]/ ; true"],
         check=False,
         timeout=10,
     )


### PR DESCRIPTION
## Symptom

Master Router CD red on main `98e43a89`. Both Gate 2 v6 scenarios fail
with the same errors as before #1690:

- `test_v6_link_local.py::test_v6_syn_traverses_router_forward_chain` —
  `no conntrack NEW for v6 SYN to 2001:db8::10 (grep returned '0')`.
- `test_v6_attribution.py::test_v6_destination_attributes_to_fqdn_not_bare_literal` —
  `TimeoutError: timed out waiting for connection_event for <mac> with host
  attribution containing 'e2e-edge.wifihaven.net'`.

CI run: <https://github.com/wifihaven/wifihaven/actions/runs/27444633516>

## Root cause

The bug is in the test harness, NOT the router agent. The Alpine client
base image's `nc` is BusyBox, whose `nc` applet does NOT implement `-6`:

```
client# nc -6 -w 2 2001:db8::10 80
nc: unrecognized option: 6
BusyBox v1.37.0 (2025-11-21 22:40:56 UTC) multi-call binary.
…
EX=1
```

Both v6 scenarios trail the invocation with `>/dev/null 2>&1; true`, which
swallows the exit-1 → from pytest's perspective the client_exec call
succeeds even though zero packets were emitted. Conntrack correctly
observes zero NEW v6 events because no v6 SYN ever left the client.

The test was a silent no-op from the day it was written (#1684); #1690's
agent-side wiring (`+kmod-nf-conntrack6`, `is_wan_bound` family-fork,
`lan_prefix_v6` threading) is correct and necessary, but it has nothing
to verify against until the client actually sends a v6 SYN.

## Diagnosis evidence (plex, fresh-built openwrt-wifihaven-ipk-23.05.img at 98e43a89)

Rules out the three hypotheses in #1691:

**Bucket E (kmod absent / unloaded) — RULED OUT.**

```
router# opkg list-installed | grep -i conntrack
conntrack - 1.4.8-1
kmod-nf-conntrack - 5.15.167-1
kmod-nf-conntrack-netlink - 5.15.167-1
kmod-nf-conntrack6 - 5.15.167-1
libnetfilter-conntrack3 - 1.0.9-2

router# lsmod | grep -iE 'conntrack|defrag'
nf_conntrack           77824  8 nft_*,nf_conntrack_netlink
nf_conntrack_netlink   32768  0
nf_defrag_ipv4         12288  1 nf_conntrack
nf_defrag_ipv6         16384  1 nf_conntrack

router# cat /proc/net/nf_conntrack | grep ipv6 | wc -l    # v6 conntrack entries
5
```

#1690's Makefile change DID propagate. (Note: `opkg files kmod-nf-conntrack6`
reports no files — on 5.15 kernels v6 conntrack is built into the universal
`nf_conntrack.ko` and the package is effectively a metadependency.)

**Bucket F (watcher subscription) — RULED OUT.**

Both the agent's invocation (`conntrack -E -e NEW` with no `-f`) and the
test's invocation (`conntrack -E -f ipv6 -e NEW`) DO emit v6 NEW events on
this kernel for genuine v6 flows triggered manually. The #1688 inline
comment about NFCT_ALL_CT_GROUPS is correct.

**Bucket G (downstream gate) — RULED OUT.**

By the time `test_v6_link_local` runs in Gate 2 (test [97%]), many prior
tests have pulled in the session-scoped `router_session` fixture, which
enrolls the agent and triggers the first `policy.apply()`. That
atomically replaces the boot-skeleton `inet wifihaven_boot` (priority
`filter - 10`, `policy drop`) with the runtime `inet wifihaven` table
(`policy accept` on forward at priority `filter + 1`). So forwarded v6
NEW packets reach conntrack as expected.

**Confirmed gap (Bucket H — test harness)**:

```
client# nc -6 -w 2 2001:db8::10 80                       # busybox nc
nc: unrecognized option: 6                                # → 0 packets

client# curl -6 -s -m 2 -o /dev/null http://[2001:db8::10]/
                                                          # curl exit 28
router# tcpdump -i br-lan -nn ip6
IP6 fdaa:bbbb:cccc::147.52528 > 2001:db8::10.80: Flags [S], …
router# conntrack -E -e NEW (-f ipv6 also)
[NEW] tcp 6 120 SYN_SENT src=fdaa:bbbb:cccc::147 dst=2001:db8::10
      sport=… dport=80 [UNREPLIED]
```

## Fix

Replace the busybox-`nc -6` invocations with `curl -6` in both Gate 2 v6
scenarios:

- [scripts/e2e/scenarios_fake/test_v6_link_local.py](scripts/e2e/scenarios_fake/test_v6_link_local.py)
- [scripts/e2e/scenarios_fake/test_v6_attribution.py](scripts/e2e/scenarios_fake/test_v6_attribution.py)

`curl` is already in the client base image's package list
([scripts/vm/build-client-base.sh:173](scripts/vm/build-client-base.sh)) and
supports `-6` natively. `-s -m 2` matches the prior `-w 2` SYN-then-bail
semantics; the curl-exit-28 (`Connection timed out`) is swallowed by the
trailing `; true` exactly as before.

The two test docstrings are updated with a "do NOT use `nc -6` here"
guardrail noting BusyBox's gap, so the next person to touch these tests
doesn't quietly reintroduce the regression.

## Test plan

- [x] Local plex repro of failure with `nc -6` (busybox rejects `-6`).
- [x] Local plex repro of success with `curl -6` (v6 SYN traverses br-lan;
      conntrack NEW fires).
- [ ] CI Gate 2 ipk: `test_v6_link_local.py::test_v6_syn_traverses_router_forward_chain` passes.
- [ ] CI Gate 2 ipk: `test_v6_attribution.py::test_v6_destination_attributes_to_fqdn_not_bare_literal` passes.
- [ ] CI Gate 2 apk: both v6 tests pass.
- [ ] Master Router CD turns green so the accumulated agent-side fixes
      (#1645 / #1658 / #1668 / #1688) ship to openwrt-latest.

Closes #1691.