### PR TITLE
feat(#1679 schema): add app_policy_assignments.allowed_during_schedule_block

### DIFF
--- a/api/resources/db/migration/V56__app_policy_assignments_allowed_during_schedule_block.sql
+++ b/api/resources/db/migration/V56__app_policy_assignments_allowed_during_schedule_block.sql
@@ -1,0 +1,22 @@
+-- #1679: Per-allowed-app toggle "allowed during schedule block".
+--
+-- Adds a per-(profile, app) flag to app_policy_assignments controlling
+-- whether the app's host-set remains in the snapshot's per-MAC extraAllowed
+-- set during a Schedule-reason block (blockReason = Schedule). Other block
+-- reasons (Paused / TimeLimit / Manual) ignore this toggle.
+--
+-- The wire shape is UNCHANGED: this is consumed entirely server-side in
+-- PolicyService snapshot assembly (per AGENTS.md "Express new policy via
+-- existing functional fields"). The router still sees extraAllowed; it just
+-- contains different hosts during a schedule window when this is false.
+--
+-- DEFAULT TRUE: existing assignments are preserved as "always allowed", which
+-- matches current behavior (extraAllowed beats @blocked_macs, see #421). The
+-- next image after this migration deploys is backward-compatible — code that
+-- doesn't read this column behaves exactly as before.
+--
+-- Schema-only per AGENTS.md §migrations-back-compat. Code adoption follows in
+-- a separate PR.
+
+ALTER TABLE app_policy_assignments
+  ADD COLUMN allowed_during_schedule_block BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
Phase 1 of #1679. Schema-only per AGENTS.md §migrations-back-compat.

Adds a per-(profile, app) boolean column `allowed_during_schedule_block` to `app_policy_assignments`, defaulting to `TRUE` — which preserves current behavior on rollout (an existing allowed-app assignment continues to override the per-MAC schedule drop, matching the documented `extraAllowed`-beats-`@blocked_macs` contract from #421).

Code adoption ships in PR 2 after this lands and deploys. In the meantime the column is dormant: server code doesn't read it yet, so behavior is unchanged.

Note on table name: #1679's sketch said `app_time_limits` with a caveat to confirm at design time. The per-(profile, app) assignment table is actually `app_policy_assignments` (V28); this PR adds the column there.

## Test plan
- [ ] CI green (the existing api.test suite is the migration-isolation gate; image-(N-1) code runs against DB-at-V56)