### PR TITLE
feat(#1654): wifihaven.sni.enabled UCI toggle for SNI sidecar

### DIFF
--- a/docs/ops/hostname-attribution.md
+++ b/docs/ops/hostname-attribution.md
@@ -81,6 +81,19 @@ Mitigations: see [#572](https://github.com/wifihaven/wifihaven/issues/572)
 (block DoH/DoT egress) and [#573](https://github.com/wifihaven/wifihaven/issues/573)
 (recover hostname from TLS SNI).
 
+The SNI sidecar (`wifihaven-sni-tail`) can be disabled per-router on
+constrained or misconfigured hardware via the `wifihaven.sni.enabled`
+UCI option (default `1`):
+
+```
+uci set wifihaven.sni.enabled=0
+uci commit wifihaven
+/etc/init.d/wifihaven restart
+```
+
+This is local agent config, not a policy-snapshot field — the API and
+other routers are unaffected. ([#1654](https://github.com/wifihaven/wifihaven/issues/1654))
+
 ### 4. Connection-reuse / QUIC sessions
 
 HTTP/3 (QUIC) maintains a single UDP "connection" that the app reuses

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -52,3 +52,13 @@ config wifihaven 'wifihaven'
 	# buckets at report boundaries (e.g. 10 with usage_report_interval=60
 	# yields 6 samples per report). See docs/router-tuning.md.
 	option activity_sample_int '10'
+
+# SNI sidecar (wifihaven-sni-tail) toggle. The sidecar captures the first
+# packet of every outbound TCP/443 flow via tcpdump-mini to attribute
+# DoH / hard-coded-IP traffic to a hostname (#573). On constrained or
+# misconfigured hardware an operator can disable it per-router without
+# uninstalling: `uci set wifihaven.sni.enabled=0 && /etc/init.d/wifihaven
+# restart`. This is local agent config — NOT a policy-snapshot field.
+# (#1654)
+config sni 'sni'
+	option enabled '1'

--- a/openwrt/files/etc/config/wifihaven
+++ b/openwrt/files/etc/config/wifihaven
@@ -53,9 +53,12 @@ config wifihaven 'wifihaven'
 	# yields 6 samples per report). See docs/router-tuning.md.
 	option activity_sample_int '10'
 
-# SNI sidecar (wifihaven-sni-tail) toggle. The sidecar captures the first
-# packet of every outbound TCP/443 flow via tcpdump-mini to attribute
-# DoH / hard-coded-IP traffic to a hostname (#573). On constrained or
+# SNI sidecar (wifihaven-sni-tail) toggle. Lives in its own `config sni`
+# section, distinct from the `config wifihaven 'wifihaven'` anchor above —
+# the init script reads it as `wifihaven.sni.enabled` via
+# `config_get … sni enabled '1'`. The sidecar captures the first packet of
+# every outbound TCP/443 flow via tcpdump-mini to attribute DoH /
+# hard-coded-IP traffic to a hostname (#573). On constrained or
 # misconfigured hardware an operator can disable it per-router without
 # uninstalling: `uci set wifihaven.sni.enabled=0 && /etc/init.d/wifihaven
 # restart`. This is local agent config — NOT a policy-snapshot field.

--- a/openwrt/files/etc/init.d/wifihaven
+++ b/openwrt/files/etc/init.d/wifihaven
@@ -28,12 +28,23 @@ start_service() {
     # tails that spool alongside the dnsmasq log and routes SNI lines through
     # the shared (single-writer) dns_cache. Closes the DoH / hard-coded-IP
     # attribution gap (#573).
-    procd_open_instance "sni-tail"
-    procd_set_param command /usr/sbin/wifihaven-sni-tail
-    procd_set_param respawn 3600 5 5
-    procd_set_param stdout 1
-    procd_set_param stderr 1
-    procd_close_instance
+    #
+    # Gated on `wifihaven.sni.enabled` (default 1) so operators can disable it
+    # per-router on constrained or misconfigured hardware without uninstalling
+    # — local agent config, NOT a policy-snapshot field (#1654).
+    local sni_enabled
+    config_load wifihaven
+    config_get sni_enabled sni enabled '1'
+    if [ "$sni_enabled" = "1" ]; then
+        procd_open_instance "sni-tail"
+        procd_set_param command /usr/sbin/wifihaven-sni-tail
+        procd_set_param respawn 3600 5 5
+        procd_set_param stdout 1
+        procd_set_param stderr 1
+        procd_close_instance
+    else
+        logger -t wifihaven 'sni sidecar disabled via uci (wifihaven.sni.enabled=0)'
+    fi
 
     # nflog-tail sidecar: tails `logread -f` for the nft `log prefix "wh_drop:…"`
     # forward-drop records and spools them to /tmp/wifihaven-nflog.log so the

--- a/openwrt/test/init_sni_toggle_spec.sh
+++ b/openwrt/test/init_sni_toggle_spec.sh
@@ -97,10 +97,11 @@ else
   check "enabled=0: other sidecars still start" "missing=[$missing] OPENED=[$out]"
 fi
 
-# 4. Init script source must reference the toggle key so reviewers can grep it.
-grep -q 'sni.*enabled' "$INIT" \
-  && check "init script references wifihaven.sni.enabled" ok \
-  || check "init script references wifihaven.sni.enabled" "not found"
+# 4. Init script source must invoke the UCI read in the documented form so a
+# rename of the option key is caught by this test.
+grep -q 'config_get .* sni enabled' "$INIT" \
+  && check "init script reads wifihaven.sni.enabled via config_get" ok \
+  || check "init script reads wifihaven.sni.enabled via config_get" "not found"
 
 printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/openwrt/test/init_sni_toggle_spec.sh
+++ b/openwrt/test/init_sni_toggle_spec.sh
@@ -84,10 +84,18 @@ case " $out " in
   *" sni-tail "*) check "enabled=0: sni-tail skipped" "OPENED=[$out]" ;;
   *) check "enabled=0: sni-tail skipped" ok ;;
 esac
-case " $out " in
-  *" agent "*" dns-tail "*" nflog-tail "*) check "enabled=0: other sidecars still start" ok ;;
-  *) check "enabled=0: other sidecars still start" "OPENED=[$out]" ;;
-esac
+missing=""
+for inst in agent dns-tail nflog-tail; do
+  case " $out " in
+    *" $inst "*) : ;;
+    *) missing="$missing $inst" ;;
+  esac
+done
+if [ -z "$missing" ]; then
+  check "enabled=0: other sidecars still start" ok
+else
+  check "enabled=0: other sidecars still start" "missing=[$missing] OPENED=[$out]"
+fi
 
 # 4. Init script source must reference the toggle key so reviewers can grep it.
 grep -q 'sni.*enabled' "$INIT" \

--- a/openwrt/test/init_sni_toggle_spec.sh
+++ b/openwrt/test/init_sni_toggle_spec.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Functional test for #1654: wifihaven.sni.enabled UCI toggle gates the
+# sni-tail procd instance. We mock the procd / UCI shell helpers, source the
+# start_service body out of the init script, and assert sni-tail is or is not
+# opened based on the SNI_ENABLED_FIXTURE.
+set -e
+
+PASS=0; FAIL=0
+INIT="$(cd "$(dirname "$0")/.." && pwd)/files/etc/init.d/wifihaven"
+
+check() {
+  if [ "$2" = "ok" ]; then
+    printf "  PASS: %s\n" "$1"; PASS=$((PASS + 1))
+  else
+    printf "  FAIL: %s — %s\n" "$1" "$2"; FAIL=$((FAIL + 1))
+  fi
+}
+
+[ -f "$INIT" ] || { printf "MISSING: %s\n" "$INIT"; exit 1; }
+
+run_start_service() {
+  # $1 = fixture value for wifihaven.sni.enabled ("" means unset → default)
+  SNI_ENABLED_FIXTURE="$1"
+  OPENED=""
+  LOGGED=""
+
+  # shellcheck disable=SC2317
+  config_load() { :; }
+  # shellcheck disable=SC2317
+  config_get() {
+    # usage: config_get <var> <section> <option> <default>
+    local _var="$1" _opt="$3" _def="$4"
+    if [ "$_opt" = "enabled" ] && [ -n "$SNI_ENABLED_FIXTURE" ]; then
+      eval "$_var=\"\$SNI_ENABLED_FIXTURE\""
+    else
+      eval "$_var=\"\$_def\""
+    fi
+  }
+  # shellcheck disable=SC2317
+  procd_open_instance() { OPENED="$OPENED $1"; }
+  # shellcheck disable=SC2317
+  procd_set_param() { :; }
+  # shellcheck disable=SC2317
+  procd_close_instance() { :; }
+  # shellcheck disable=SC2317
+  procd_add_reload_trigger() { :; }
+  # shellcheck disable=SC2317
+  logger() {
+    # capture all args after option flags
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -*) shift ;;
+        *) LOGGED="$LOGGED $1"; shift ;;
+      esac
+    done
+  }
+
+  # Source ONLY the function definitions out of the init script (skip the
+  # shebang, which references /etc/rc.common — not present on macOS).
+  eval "$(sed -n '/^start_service()/,/^}/p; /^service_triggers()/,/^}/p' "$INIT")"
+
+  start_service
+  echo "$OPENED"
+}
+
+# 1. Default (option unset) → sni-tail starts (preserves existing behavior)
+out=$(run_start_service "")
+case " $out " in
+  *" sni-tail "*) check "default: sni-tail starts when enabled unset" ok ;;
+  *) check "default: sni-tail starts when enabled unset" "OPENED=[$out]" ;;
+esac
+
+# 2. enabled=1 → sni-tail starts
+out=$(run_start_service "1")
+case " $out " in
+  *" sni-tail "*) check "enabled=1: sni-tail starts" ok ;;
+  *) check "enabled=1: sni-tail starts" "OPENED=[$out]" ;;
+esac
+
+# 3. enabled=0 → sni-tail SKIPPED, other sidecars still start
+out=$(run_start_service "0")
+case " $out " in
+  *" sni-tail "*) check "enabled=0: sni-tail skipped" "OPENED=[$out]" ;;
+  *) check "enabled=0: sni-tail skipped" ok ;;
+esac
+case " $out " in
+  *" agent "*" dns-tail "*" nflog-tail "*) check "enabled=0: other sidecars still start" ok ;;
+  *) check "enabled=0: other sidecars still start" "OPENED=[$out]" ;;
+esac
+
+# 4. Init script source must reference the toggle key so reviewers can grep it.
+grep -q 'sni.*enabled' "$INIT" \
+  && check "init script references wifihaven.sni.enabled" ok \
+  || check "init script references wifihaven.sni.enabled" "not found"
+
+printf "\nResults: %d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -41,3 +41,4 @@ sh test/lua_module_paths_spec.sh
 sh test/nft_log_dep_spec.sh
 sh test/agent_spec.sh
 sh test/rotate_dnsmasq_log_spec.sh
+sh test/init_sni_toggle_spec.sh


### PR DESCRIPTION
Closes #1654.

The SNI sidecar (`wifihaven-sni-tail`, #573 / PR #1643) ships always-on.
On a misconfigured or constrained router an operator had no clean
escape hatch short of removing the file. This adds a UCI toggle:

```
uci set wifihaven.sni.enabled=0
uci commit wifihaven
/etc/init.d/wifihaven restart
```

- Default `1` — current behavior preserved.
- Gated in `start_service` so procd doesn't keep respawning nothing.
- Logs `sni sidecar disabled via uci (wifihaven.sni.enabled=0)` at
  startup when off, so ops can see why no SNI rows are flowing.
- Local agent config (UCI) — **NOT** added to the policy snapshot.
  Router stays a dumb applier per AGENTS.md §1.

## Test plan

- [x] `sh openwrt/test/init_sni_toggle_spec.sh` — RED→GREEN, covers
  default-unset / `enabled=1` / `enabled=0` cases plus
  "other sidecars unaffected"
- [x] `sh openwrt/test/init_spec.sh` — existing init contract still passes
- [ ] Manual on a live OpenWRT: `uci set wifihaven.sni.enabled=0 &&
  /etc/init.d/wifihaven restart && logread | grep sni` shows the
  disable line; `pgrep wifihaven-sni-tail` returns nothing