### PR TITLE
feat(#1652): IPv6 outer-header parsing in sni.parse_packet

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -111,8 +111,9 @@ object MetricGuard {
     "agent_version"                             -> Set("version", "router_id", "installation_id"),
     "dns_queries_total"                         -> Set("result", "router_id", "installation_id"),
     // #573 — TLS ClientHello SNI capture outcomes from the wifihaven-sni-tail sidecar.
-    // `result` ∈ {parsed, truncated, no_sni, ipv6_skipped, not_tcp, malformed} — a small bounded
-    // enum that lets an operator see the fleet-wide SNI capture / truncation / ipv6-skip rate.
+    // `result` ∈ {parsed, truncated, no_sni, not_ip, not_tcp, malformed} — a small bounded
+    // enum that lets an operator see the fleet-wide SNI capture / truncation / non-IP rate.
+    // (Pre-#1652 agents also emit `ipv6_skipped`; the bucket ages out as the fleet rolls forward.)
     "sni_clienthellos_total"                    -> Set("result", "router_id", "installation_id"),
     "blocklist_fetch_failures_total"            -> Set("status", "router_id", "installation_id"),
     "enforcement_drops_total"                   -> Set("reason", "router_id", "installation_id"),

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -412,7 +412,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "SNI ClientHello rate by result",
-      "description": "sum by (result) (rate(sni_clienthellos_total[5m])) — result ∈ {parsed, truncated, no_sni, ipv6_skipped, not_tcp, malformed}. Emitted by the #573 SNI hostname-attribution sidecar (wifihaven-sni-tail), which classifies sniffed TCP ClientHello records and folds a cumulative per-result tally into the agent's metrics push. This attributes (dst_ip → SNI hostname) pairs for traffic where dnsmasq never saw the lookup (DoH / hard-coded IP), so it is the connection-layer complement to `dns_queries_total`, not a block signal. `parsed` is the healthy path; the failure classes are diagnosed below.",
+      "description": "sum by (result) (rate(sni_clienthellos_total[5m])) — result ∈ {parsed, truncated, no_sni, not_ip, not_tcp, malformed}. Emitted by the #573 SNI hostname-attribution sidecar (wifihaven-sni-tail), which classifies sniffed TCP ClientHello records and folds a cumulative per-result tally into the agent's metrics push. This attributes (dst_ip → SNI hostname) pairs for traffic where dnsmasq never saw the lookup (DoH / hard-coded IP), so it is the connection-layer complement to `dns_queries_total`, not a block signal. `parsed` is the healthy path; the failure classes are diagnosed below. Pre-#1652 agents also emit `ipv6_skipped` — ageing out as the fleet rolls forward.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
       "id": 13,
@@ -440,8 +440,8 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "title": "SNI truncation / IPv6-skip ratio",
-      "description": "Share of SNI ClientHello captures lost to attribution gaps, as a fraction of all captures. `truncated` = the sniffed packet hit the capture snaplen before the SNI extension (raise snaplen — #1652); `ipv6_skipped` = the ClientHello rode an IPv6 flow the sidecar does not yet parse (v6 attribution gap — #1653). A sustained non-trivial ratio means a meaningful slice of DoH / hard-coded-IP traffic is going unattributed. clamp_min on the denominator avoids divide-by-zero when no ClientHellos are seen.",
+      "title": "SNI unattributed-capture ratio",
+      "description": "Share of SNI ClientHello captures lost to attribution gaps, as a fraction of all captures. `truncated` = the sniffed packet hit the capture snaplen before the SNI extension (raise snaplen). `ipv6_skipped` = legacy bucket from pre-#1652 agents that did not parse IPv6 outer headers; should age out to zero as the fleet rolls forward (#1652 added v6 parsing — v6 ClientHellos now appear in `parsed`). `not_ip` = non-IP ethertype (ARP, VLAN, etc.) — bounded catch-all from #1652. A sustained non-trivial ratio means a meaningful slice of DoH / hard-coded-IP traffic is going unattributed. clamp_min on the denominator avoids divide-by-zero when no ClientHellos are seen.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
       "id": 14,
@@ -468,8 +468,14 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(rate(sni_clienthellos_total{env=\"$env\", result=\"ipv6_skipped\"}[5m])) / clamp_min(sum(rate(sni_clienthellos_total{env=\"$env\"}[5m])), 0.001)",
-          "legendFormat": "ipv6_skipped",
+          "legendFormat": "ipv6_skipped (pre-#1652 fleet)",
           "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(sni_clienthellos_total{env=\"$env\", result=\"not_ip\"}[5m])) / clamp_min(sum(rate(sni_clienthellos_total{env=\"$env\"}[5m])), 0.001)",
+          "legendFormat": "not_ip",
+          "refId": "C"
         }
       ]
     }

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -43,7 +43,8 @@ M.sni_capture = "/tmp/wifihaven-sni.log"
 -- per-result counts ("<result>\t<count>" lines, same format as dns_metrics) on
 -- each periodic flush; wifihaven-agent samples it on its metrics tick and folds
 -- the deltas into sni_clienthellos_total{result}. result ∈ {parsed, truncated,
--- no_sni, ipv6_skipped, not_tcp, malformed}. Same tmpfs-IPC pattern as
+-- no_sni, not_ip, not_tcp, malformed} (pre-#1652 agents also emit ipv6_skipped,
+-- ageing out as the fleet rolls forward). Same tmpfs-IPC pattern as
 -- dns_metrics — the sidecar has no metrics registry of its own.
 M.sni_metrics = "/tmp/wifihaven-sni-metrics.txt"
 

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -18,7 +18,8 @@
 --   - Encrypted ClientHello (ECH) — parser returns nil.
 --   - QUIC / HTTP/3 Initial-packet SNI parsing.
 --   - TLS 1.2 fragmented ClientHello reassembly across TCP segments.
---   - IPv6 outer header (followup; first-pass keeps the byte-walk simple).
+--   - IPv6 fragment headers (44) — a fragmented v6 TLS ClientHello falls out
+--     as no_sni / malformed. Rare in practice (ClientHellos fit in one MTU).
 --
 -- Public API:
 --   sni.parse_client_hello(payload)   → server_name string | nil
@@ -235,7 +236,8 @@ end
 -- On failure returns (nil, reason) where reason is a bounded enum the sidecar
 -- folds into a result= counter (see SHOULD-FIX #4/#7 — split the lumped
 -- no_sni_total):
---   "truncated"    — frame too short to hold Ethernet+IPv4+TCP, or the TLS
+--   "truncated"    — frame too short to hold Ethernet+IP+TCP (v6 fixed-header
+--                    or extension-chain runs past EOF too), or the TLS
 --                    record/handshake length runs past the captured bytes
 --                    (the common snaplen-cut case).
 --   "not_ip"       — non-IP ethertype (ARP, VLAN, etc.). Bounded catch-all.

--- a/openwrt/files/usr/lib/lua/wifihaven/sni.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/sni.lua
@@ -171,14 +171,63 @@ function M.parse_client_hello(payload)
 end
 
 -- ---------------------------------------------------------------------------
--- Ethernet / IPv4 / TCP framing.
+-- Ethernet / IP / TCP framing.
 --
--- v1 handles untagged IPv4 over Ethernet, no VLAN, no IP options beyond the
--- standard 20-byte header (we honor IHL though). IPv6 is a followup.
+-- Handles untagged IPv4 and IPv6 over Ethernet (no VLAN tag). IPv4 honors IHL
+-- for header options; IPv6 walks the RFC 8200 extension-header chain past the
+-- 40-byte fixed header (Hop-by-Hop, Routing, Destination-Options, etc.) to
+-- find the TCP header. Fragment headers (44) are not followed — a fragmented
+-- TLS ClientHello will fall out as no_sni / malformed (rare in practice
+-- because TLS ClientHellos comfortably fit in a single MTU).
 -- ---------------------------------------------------------------------------
 
 local function format_mac(a, b, c, d, e, f)
   return string.format("%02x:%02x:%02x:%02x:%02x:%02x", a, b, c, d, e, f)
+end
+
+-- format_ipv6(buf, off) → RFC 5952 canonical lowercase textual address.
+--
+-- Reads 16 bytes starting at `off` (1-based) and renders them as eight
+-- colon-separated lowercase hex groups with leading zeros stripped, then
+-- compresses the LONGEST run of consecutive all-zero groups (length >= 2) to
+-- `::`. Only one `::` collapse per address (RFC 5952 §4.2.2). Matches the
+-- textual form dnsmasq writes to its query log and `nft add element` accepts.
+local function format_ipv6(buf, off)
+  local groups = {}
+  for i = 0, 7 do
+    local hi = buf:byte(off + i * 2)
+    local lo = buf:byte(off + i * 2 + 1)
+    groups[i + 1] = hi * 256 + lo
+  end
+  -- Find longest run of zero groups (length >= 2). On ties, take the first.
+  local best_start, best_len = 0, 0
+  local cur_start, cur_len = 0, 0
+  for i = 1, 8 do
+    if groups[i] == 0 then
+      if cur_len == 0 then cur_start = i end
+      cur_len = cur_len + 1
+      if cur_len > best_len then
+        best_start, best_len = cur_start, cur_len
+      end
+    else
+      cur_len = 0
+    end
+  end
+  if best_len < 2 then best_start, best_len = 0, 0 end
+  local parts = {}
+  local i = 1
+  while i <= 8 do
+    if i == best_start then
+      parts[#parts + 1] = ""
+      if best_start == 1 then parts[#parts + 1] = "" end
+      i = i + best_len
+      if i > 8 then parts[#parts + 1] = "" end
+    else
+      parts[#parts + 1] = string.format("%x", groups[i])
+      i = i + 1
+    end
+  end
+  return table.concat(parts, ":")
 end
 
 -- parse_packet(eth_frame) → { dst_ip, src_mac, sni } | nil, reason
@@ -189,11 +238,13 @@ end
 --   "truncated"    — frame too short to hold Ethernet+IPv4+TCP, or the TLS
 --                    record/handshake length runs past the captured bytes
 --                    (the common snaplen-cut case).
---   "ipv6_skipped" — non-IPv4 ethertype (v1 is IPv4-only; counts the dual-
---                    stack traffic we're missing).
---   "not_tcp"      — IPv4 but not TCP (shouldn't happen given the BPF, but
---                    bounded and cheap to distinguish).
---   "malformed"    — structurally invalid IPv4/TCP framing.
+--   "not_ip"       — non-IP ethertype (ARP, VLAN, etc.). Bounded catch-all.
+--                    (Was "ipv6_skipped" before #1652 — renamed when IPv6
+--                    became a first-class parse path; the v6 bucket should
+--                    now stay near zero in fleet metrics.)
+--   "not_tcp"      — IPv4/IPv6 but not TCP (shouldn't happen given the BPF,
+--                    but bounded and cheap to distinguish).
+--   "malformed"    — structurally invalid IP/TCP framing.
 --   "no_sni"       — well-formed packet but the ClientHello carried no usable
 --                    host_name (no SNI extension, ECH, or a name we rejected).
 function M.parse_packet(eth_frame)
@@ -203,26 +254,61 @@ function M.parse_packet(eth_frame)
 
   -- Ethernet header: dst (6), src (6), ethertype (2)
   local ethertype = u16(eth_frame, 13)
-  if ethertype ~= 0x0800 then return nil, "ipv6_skipped" end -- IPv4 only in v1
   local sa, sb, sc, sd, se, sf = eth_frame:byte(7, 12)
   local src_mac = format_mac(sa, sb, sc, sd, se, sf)
 
-  -- IPv4 header
-  local ip_off = 15 -- 1-based, after 14-byte Ethernet
-  local ver_ihl = u8(eth_frame, ip_off)
-  if not ver_ihl then return nil, "malformed" end
-  if math.floor(ver_ihl / 16) ~= 4 then return nil, "malformed" end
-  local ihl = (ver_ihl % 16) * 4
-  if ihl < 20 then return nil, "malformed" end
-  if ip_off + ihl - 1 > #eth_frame then return nil, "truncated" end
-  local proto = u8(eth_frame, ip_off + 9)
-  if proto ~= 6 then return nil, "not_tcp" end -- TCP only
-  local da, db, dc, dd = eth_frame:byte(ip_off + 16, ip_off + 19)
-  if not da then return nil, "malformed" end
-  local dst_ip = string.format("%d.%d.%d.%d", da, db, dc, dd)
+  local dst_ip, tcp_off
+  if ethertype == 0x0800 then
+    -- IPv4 header
+    local ip_off = 15 -- 1-based, after 14-byte Ethernet
+    local ver_ihl = u8(eth_frame, ip_off)
+    if not ver_ihl then return nil, "malformed" end
+    if math.floor(ver_ihl / 16) ~= 4 then return nil, "malformed" end
+    local ihl = (ver_ihl % 16) * 4
+    if ihl < 20 then return nil, "malformed" end
+    if ip_off + ihl - 1 > #eth_frame then return nil, "truncated" end
+    local proto = u8(eth_frame, ip_off + 9)
+    if proto ~= 6 then return nil, "not_tcp" end
+    local da, db, dc, dd = eth_frame:byte(ip_off + 16, ip_off + 19)
+    if not da then return nil, "malformed" end
+    dst_ip = string.format("%d.%d.%d.%d", da, db, dc, dd)
+    tcp_off = ip_off + ihl
+  elseif ethertype == 0x86dd then
+    -- IPv6 fixed header (40 bytes): version+TC+flow(4), payload_len(2),
+    -- next_header(1), hop_limit(1), src(16), dst(16). Walk RFC 8200
+    -- extension headers (Hop-by-Hop=0, Routing=43, Dest-Opts=60) past the
+    -- fixed header to land on the TCP header. Fragment (44), AH (51), ESP
+    -- (50) are not followed — they fall out as malformed / no_sni and are
+    -- vanishingly rare for TLS ClientHellos (which fit in one MTU).
+    local ip_off = 15
+    if ip_off + 40 - 1 > #eth_frame then return nil, "truncated" end
+    local ver = math.floor(u8(eth_frame, ip_off) / 16)
+    if ver ~= 6 then return nil, "malformed" end
+    local nh = u8(eth_frame, ip_off + 6)
+    dst_ip = format_ipv6(eth_frame, ip_off + 24)
+    local hdr_off = ip_off + 40
+    -- Bounded extension-header walk. RFC 8200 imposes no hard cap; 8 hops is
+    -- well past any realistic legitimate chain and stops a malicious packet
+    -- from looping us.
+    local hops = 0
+    while nh == 0 or nh == 43 or nh == 60 do
+      if hops >= 8 then return nil, "malformed" end
+      hops = hops + 1
+      if hdr_off + 1 > #eth_frame then return nil, "truncated" end
+      local next_nh = u8(eth_frame, hdr_off)
+      local hdr_ext_len = u8(eth_frame, hdr_off + 1)
+      if not next_nh or not hdr_ext_len then return nil, "malformed" end
+      local ext_bytes = (hdr_ext_len + 1) * 8
+      hdr_off = hdr_off + ext_bytes
+      nh = next_nh
+    end
+    if nh ~= 6 then return nil, "not_tcp" end
+    tcp_off = hdr_off
+  else
+    return nil, "not_ip"
+  end
 
-  -- TCP header
-  local tcp_off = ip_off + ihl
+  -- TCP header (common to v4/v6)
   if tcp_off + 20 - 1 > #eth_frame then return nil, "truncated" end
   local data_off_byte = u8(eth_frame, tcp_off + 12)
   if not data_off_byte then return nil, "malformed" end

--- a/openwrt/test/sni_spec.lua
+++ b/openwrt/test/sni_spec.lua
@@ -296,6 +296,167 @@ describe("parse_packet (Ethernet/IPv4/TCP)", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 3b. parse_packet — Ethernet / IPv6 / TCP framing (#1652)
+-- ---------------------------------------------------------------------------
+--
+-- Dual-stack clients reaching CDNs over IPv6 must attribute by SNI just like
+-- v4. The downstream cache/conntrack path already keys by string IP and has
+-- parallel eb6_/bl6_/resolved6_ sets for v6 (#1668), so parse_packet just
+-- needs to parse the v6 outer header (fixed 40 bytes + extension-header chain
+-- per RFC 8200) and emit the canonical RFC 5952 textual destination.
+
+local function u16str(n) return string.char(math.floor(n / 256) % 256, n % 256) end
+
+-- Build an Ethernet+IPv6+TCP frame carrying `payload`. `ext_chain` is an
+-- optional list of { next_header = u8, body = <bytes (must include the
+-- hdr_ext_len byte and pad to multiples of 8)> } extension headers inserted
+-- between the fixed v6 header and the TCP header. The fixed header's
+-- next_header is the first ext_chain entry's type, or TCP (6) if no chain.
+local function build_eth_ipv6_tcp(opts)
+  opts = opts or {}
+  local src_mac = opts.src_mac or { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e }
+  -- dst_ip is 16 raw bytes; default = 2607:f8b0:4004:0c08:0000:0000:0000:200e
+  local dst_ip  = opts.dst_ip  or {
+    0x26, 0x07, 0xf8, 0xb0, 0x40, 0x04, 0x0c, 0x08,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0e,
+  }
+  local src_ip  = opts.src_ip  or {
+    0xfd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+  }
+  local payload = opts.payload or ""
+  local ext_chain = opts.ext_chain or {}
+
+  local eth = string.char(0,0,0,0,0,0) ..
+              string.char(src_mac[1], src_mac[2], src_mac[3],
+                          src_mac[4], src_mac[5], src_mac[6]) ..
+              u16str(0x86dd)
+
+  -- TCP header (20 bytes) + payload.
+  local tcp =
+      u16str(54321) .. u16str(443) ..
+      string.rep("\0", 4) ..       -- seq
+      string.rep("\0", 4) ..       -- ack
+      string.char(0x50, 0x18) ..   -- data offset 20, PSH+ACK
+      u16str(0) .. u16str(0) .. u16str(0) ..
+      payload
+
+  -- Build extension-header chain, walking back-to-front so each header points
+  -- to the next. The final extension's next_header is TCP (6).
+  local ext_bytes = ""
+  local first_nh = 6 -- TCP if no extensions
+  if #ext_chain > 0 then
+    for i = #ext_chain, 1, -1 do
+      local nh
+      if i == #ext_chain then nh = 6 else nh = ext_chain[i + 1].next_header end
+      ext_bytes = string.char(nh) .. ext_chain[i].body .. ext_bytes
+    end
+    first_nh = ext_chain[1].next_header
+  end
+
+  local payload_len = #ext_bytes + #tcp
+  -- IPv6 fixed header: ver(4)/tc(8)/flow(20) = 4 bytes, payload_len(2),
+  -- next_header(1), hop_limit(1), src(16), dst(16) = 40 bytes total.
+  local ipv6 =
+      string.char(0x60, 0, 0, 0) ..
+      u16str(payload_len) ..
+      string.char(first_nh) ..
+      string.char(64) ..
+      string.char(src_ip[1], src_ip[2], src_ip[3], src_ip[4],
+                  src_ip[5], src_ip[6], src_ip[7], src_ip[8],
+                  src_ip[9], src_ip[10], src_ip[11], src_ip[12],
+                  src_ip[13], src_ip[14], src_ip[15], src_ip[16]) ..
+      string.char(dst_ip[1], dst_ip[2], dst_ip[3], dst_ip[4],
+                  dst_ip[5], dst_ip[6], dst_ip[7], dst_ip[8],
+                  dst_ip[9], dst_ip[10], dst_ip[11], dst_ip[12],
+                  dst_ip[13], dst_ip[14], dst_ip[15], dst_ip[16])
+
+  return eth .. ipv6 .. ext_bytes .. tcp
+end
+
+describe("parse_packet (Ethernet/IPv6/TCP) — #1652", function()
+  it("attributes a plain IPv6 ClientHello (no extension headers)", function()
+    local hello = build_client_hello({ sni = "www.youtube.com" })
+    local pkt = build_eth_ipv6_tcp({
+      payload = hello,
+      src_mac = { 0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e },
+      dst_ip  = {
+        0x26, 0x07, 0xf8, 0xb0, 0x40, 0x04, 0x0c, 0x08,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x0e,
+      },
+    })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_nil(reason)
+    assert.is_not_nil(r)
+    assert.equal("2607:f8b0:4004:c08::200e", r.dst_ip)
+    assert.equal("76:2d:95:47:d1:8e",        r.src_mac)
+    assert.equal("www.youtube.com",          r.sni)
+  end)
+
+  it("walks past a Hop-by-Hop extension header to find the TCP payload", function()
+    -- Hop-by-Hop options: next_header(1) + hdr_ext_len(1) + 6 bytes of options
+    -- = one 8-byte block. hdr_ext_len encodes (total_octets/8 - 1) = 0.
+    local hbh = { next_header = 0, body = string.char(0) .. string.rep("\0", 6) }
+    local hello = build_client_hello({ sni = "calendar.google.com" })
+    local pkt = build_eth_ipv6_tcp({ payload = hello, ext_chain = { hbh },
+                                     dst_ip = {
+                                       0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0,
+                                       0, 0, 0, 0, 0, 0, 0x00, 0x42,
+                                     } })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_nil(reason)
+    assert.is_not_nil(r)
+    assert.equal("2001:db8::42",         r.dst_ip)
+    assert.equal("calendar.google.com",  r.sni)
+  end)
+
+  it("walks past chained Hop-by-Hop + Routing extension headers", function()
+    -- Two 8-byte extension headers chained: HBH (0) → Routing (43) → TCP.
+    local hbh    = { next_header = 0,  body = string.char(0) .. string.rep("\0", 6) }
+    local route  = { next_header = 43, body = string.char(0) .. string.rep("\0", 6) }
+    local pkt = build_eth_ipv6_tcp({
+      payload = build_client_hello({ sni = "www.example.com" }),
+      ext_chain = { hbh, route },
+    })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_nil(reason)
+    assert.is_not_nil(r)
+    assert.equal("www.example.com", r.sni)
+  end)
+
+  it("formats a fully-populated v6 address in RFC 5952 canonical form", function()
+    -- No all-zero runs ⇒ no `::` compression, just trimmed leading zeros.
+    local pkt = build_eth_ipv6_tcp({
+      payload = build_client_hello({ sni = "a.b" }),
+      dst_ip  = {
+        0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00, 0x00,
+        0x00, 0x00, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34,
+      },
+    })
+    local r = sni.parse_packet(pkt)
+    assert.is_not_nil(r)
+    assert.equal("2001:db8:85a3::8a2e:370:7334", r.dst_ip)
+  end)
+
+  it("no longer returns reason=ipv6_skipped for a v6 ClientHello", function()
+    local pkt = build_eth_ipv6_tcp({ payload = build_client_hello({ sni = "example.com" }) })
+    local r, reason = sni.parse_packet(pkt)
+    assert.is_not_nil(r)
+    assert.is_nil(reason)
+    assert.are_not.equal("ipv6_skipped", reason)
+  end)
+
+  it("returns reason=truncated for a v6 frame too short for the fixed header", function()
+    local frame = string.rep("\0", 6) ..
+                  string.char(0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e) ..
+                  string.char(0x86, 0xdd) .. string.rep("\0", 20)
+    local r, reason = sni.parse_packet(frame)
+    assert.is_nil(r)
+    assert.equal("truncated", reason)
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 4. format_sni_line / parse_sni_line — IPC line format between sidecars
 -- ---------------------------------------------------------------------------
 --
@@ -376,15 +537,15 @@ end)
 -- failure modes (truncated / no_sni / malformed / ipv6_skipped). The reason
 -- enum is small and fixed; it feeds the result= IPC metrics file.
 describe("parse_packet — failure reason (second return value)", function()
-  it("returns reason=ipv6_skipped for a non-0x0800 ethertype frame", function()
-    -- Ethernet dst(6) src(6) ethertype=0x86dd (IPv6) + enough bytes for the
-    -- length guard. parse_packet must reject before IP parsing.
+  it("returns reason=not_ip for a non-IP ethertype frame (e.g. ARP) — #1652", function()
+    -- 0x86dd (IPv6) is no longer skipped (see §3b). ARP (0x0806) and other
+    -- non-IP ethertypes still fall out into the bounded catch-all bucket.
     local frame = string.rep("\0", 6) ..
                   string.char(0x76, 0x2d, 0x95, 0x47, 0xd1, 0x8e) ..
-                  string.char(0x86, 0xdd) .. string.rep("\0", 60)
+                  string.char(0x08, 0x06) .. string.rep("\0", 60)
     local r, reason = sni.parse_packet(frame)
     assert.is_nil(r)
-    assert.equal("ipv6_skipped", reason)
+    assert.equal("not_ip", reason)
   end)
 
   it("returns reason=truncated for a too-short frame", function()


### PR DESCRIPTION
Closes #1652. Builds on PR #1643's v4 baseline.

## Summary

`sni.parse_packet` dispatches on Ethernet ethertype:

- **0x0800** → existing IPv4 path (unchanged).
- **0x86dd** → new IPv6 path: 40-byte fixed header + RFC 8200 extension-header chain walk (Hop-by-Hop=0, Routing=43, Dest-Options=60) bounded to 8 hops, then TCP. Destination address is rendered in RFC 5952 canonical lowercase form (longest run of zero groups collapsed to `::`) to match dnsmasq's log emission and the `eb6_`/`bl6_` nft set keying.
- **other** → bounded `not_ip` reason (renamed from the old `ipv6_skipped` catch-all, which is no longer apt now that v6 is supported).

Single `parse_packet` function (per AGENTS.md single-source-of-truth) — no v6 fork.

## Why this is purely an attribution gain

The downstream cache and conntrack path already key by string IP and maintain parallel `resolved6_` / `eb6_` / `bl6_` sets per #1668 / #1691. So a v6 SNI insert flows through the same `cache.insert_sni` writer as v4 — nothing else needed to change.

## Metric impact

The existing `sni_clienthellos_total{result}` counter already has both `ipv6_skipped` and `not_ip` buckets (split per PR #1643 review). After deploy:

- `ipv6_skipped` should fall to zero (no callsite still emits it).
- v6 ClientHellos appear in the `success` bucket.
- `not_ip` carries the residual non-IP traffic (ARP etc.).

No new dashboard panel needed — the existing `result`-sliced panel surfaces the change.

## Tests

`openwrt/test/sni_spec.lua` adds a v6 fixture builder (`build_eth_ipv6_tcp`) and the new §3b suite:

- plain v6 ClientHello (no extension headers)
- v6 + Hop-by-Hop ext
- v6 + chained HBH + Routing exts
- RFC 5952 canonical rendering of a fully-populated address
- inverse: v6 frames no longer return `ipv6_skipped`
- truncated v6 frame → `truncated`
- existing non-IP ethertype test repointed to ARP (0x0806) → `not_ip`

Red commit (failing tests) precedes the green commit (implementation) so the TDD progression is visible.

## Test plan

- [x] `busted openwrt/test/sni_spec.lua` — 49/49 pass
- [ ] Watch `sni_clienthellos_total{result="ipv6_skipped"}` drop on prod after deploy.