### PR TITLE
fix(#1672): suppress orphan-tail background hosts in InfraHosts (Brave/Google Play/ad-mediation/asset-CDN)

### DIFF
--- a/shared/src/types/InfraHosts.scala
+++ b/shared/src/types/InfraHosts.scala
@@ -178,6 +178,41 @@ object InfraHosts {
     //    `apple-relay.cloudflare.com`. Same anti-filtering-tunnel reasoning —
     //    suppress, never allow-carve.
     "apple-relay.cloudflare.com",
+    // ── #1672 Bucket A residual after #1669 — non-Apple orphan tail captured
+    //    from `/api/profiles/<id>/usage-by-app` on kid profiles 1 (Kids), 5
+    //    (Quintus), 6 in the 2026-06-10..06-11 prod orphan window. Each
+    //    sub-section is suppress-only (no allow-carve role); specific
+    //    subdomains rather than apexes where the apex would absorb legitimate
+    //    per-app traffic on sibling subdomains. Per #1506 `Presence.isAppAttributed`,
+    //    if a future app template claims one of these hosts, app attribution wins
+    //    over suppression — the entries are a fallback.
+    //
+    // Brave browser telemetry (profile 1): Shields telemetry collector + STAR
+    // randomness service. Background, not user-initiated.
+    "collector.bsg.brave.com",
+    "star-randsrv.bsg.brave.com",
+    // Google Play / client-services background polling (profile 1, profile 5).
+    // Specific hosts — the `google.com` and `googleusercontent.com` apexes are
+    // deliberately NOT swept in (same seam as the existing
+    // `clientservices.googleapis.com` vs. the broader `googleapis.com` apex).
+    "clients4.google.com",
+    "android.clients.google.com",
+    "clients2.googleusercontent.com",
+    // Ad-mediation / ad-quality signals (profile 5, profile 6). Mediation
+    // traffic is not user engagement; if an ad-supported app page is in scope,
+    // its template attributes the visible activity, not these background calls.
+    "oa.openxcdn.net",
+    "ep2.adtrafficquality.google",
+    "a-adq.mediation.unity3d.com",
+    // Asset CDNs whose attribution follows the embedding page — if the page is
+    // an orphan, the asset fetch is too. Specific subdomains so real apps that
+    // use sibling subdomains of `gstatic.com` / `googleusercontent.com` keep
+    // attributing. (The `ssl.gstatic.com` host is deliberately NOT added: the
+    // gstatic apex is too broad and `ssl.gstatic.com` itself fans out across
+    // many app surfaces — flagged in the PR body for operator decision.)
+    "use.fontawesome.com",
+    "encrypted-tbn0.gstatic.com",
+    "ci3.googleusercontent.com",
   )
 
   /** All hosts suppressed from presence counting: allow+suppress plus suppress-only (#1525). */

--- a/shared/test/src/types/InfraHostsSpec.scala
+++ b/shared/test/src/types/InfraHostsSpec.scala
@@ -229,6 +229,105 @@ object InfraHostsSpec extends ZIOSpecDefault {
         !InfraHosts.isInfra("apple-relay.cloudflare.com"),
       )
     },
+    test("#1672 Brave browser telemetry background hosts are suppressed") {
+      // Brave Shields telemetry / STAR randomness — clearly device-level telemetry,
+      // not user-initiated. Captured on profile 1 (Kids) in 2026-06-10..06-11 prod
+      // orphan tail at ~1491s + ~555s propSec. Suppress-only (no allow-carve role).
+      val brave = List(
+        "collector.bsg.brave.com",
+        "star-randsrv.bsg.brave.com",
+      )
+      assertTrue(
+        brave.forall(InfraHosts.isBackground),
+        brave.forall(h => !InfraHosts.isInfra(h)),
+      )
+    },
+    test("#1672 Google Play / client-services background hosts are suppressed") {
+      // Android Play Services / Google clients background polling captured on
+      // profile 1 (Kids) + profile 5 (Quintus) in 2026-06-10..06-11 prod orphan
+      // tail. Specific subdomains, NOT the `google.com` or `googleusercontent.com`
+      // apex — keeps real-app traffic on sibling subdomains attributing and counting
+      // (same seam as the existing `clientservices.googleapis.com` rather than the
+      // `googleapis.com` apex). Suppress-only.
+      val googleBg = List(
+        "clients4.google.com",
+        "android.clients.google.com",
+        "clients2.googleusercontent.com",
+      )
+      assertTrue(
+        googleBg.forall(InfraHosts.isBackground),
+        googleBg.forall(h => !InfraHosts.isInfra(h)),
+        // BOUNDARY: the apex must NOT be swept in. Sibling Google domains must
+        // still attribute to their real apps.
+        !InfraHosts.isBackground("www.google.com"),
+        !InfraHosts.isBackground("mail.google.com"),
+        !InfraHosts.isBackground("docs.google.com"),
+        !InfraHosts.isBackground("photos.googleusercontent.com"),
+        !InfraHosts.isBackground("lh3.googleusercontent.com"),
+      )
+    },
+    test("#1672 ad-mediation / ad-quality background hosts are suppressed") {
+      // OpenX / Unity / Google ad-quality mediation — these run in the background
+      // of ad-supported pages. The mediation traffic itself is not user-interactive
+      // engagement; the embedding page (if any) would attribute via its own app
+      // template. Captured on profile 5 + profile 6 in the 2026-06-10 orphan tail.
+      // Suppress-only.
+      val adMediation = List(
+        "oa.openxcdn.net",
+        "ep2.adtrafficquality.google",
+        "a-adq.mediation.unity3d.com",
+      )
+      assertTrue(
+        adMediation.forall(InfraHosts.isBackground),
+        adMediation.forall(h => !InfraHosts.isInfra(h)),
+        // BOUNDARY: don't sweep the apex. unity3d.com hosts a wide surface beyond
+        // the ad-mediation subdomain.
+        !InfraHosts.isBackground("unity3d.com"),
+        !InfraHosts.isBackground("www.unity3d.com"),
+      )
+    },
+    test("#1672 asset CDNs used by orphan pages are suppressed") {
+      // Webfont / image-thumbnail / user-content CDNs whose attribution "follows the
+      // embedding page" — if the embedding page is orphan, the CDN traffic is too.
+      // Specific subdomains (not apex `gstatic.com` / `googleusercontent.com`) so
+      // real apps that use sibling subdomains keep attributing.
+      //
+      // Safety w.r.t. real apps: #1506 (`Presence.isAppAttributed`) makes app
+      // attribution win over suppression — when an active app template claims
+      // one of these hosts, it counts toward the app, not the suppression list.
+      // These are suppress-only and never allow-carved.
+      val assetCdns = List(
+        "use.fontawesome.com",
+        "encrypted-tbn0.gstatic.com",
+        "ci3.googleusercontent.com",
+      )
+      assertTrue(
+        assetCdns.forall(InfraHosts.isBackground),
+        assetCdns.forall(h => !InfraHosts.isInfra(h)),
+        // BOUNDARY: the apex must NOT be on the list. The existing
+        // `connectivitycheck.gstatic.com` is the only `gstatic.com` entry — and
+        // adding `ssl.gstatic.com` / the `gstatic.com` apex is deliberately deferred
+        // (too broad — would absorb per-app static assets).
+        !InfraHosts.isBackground("ssl.gstatic.com"),
+        !InfraHosts.isBackground("fonts.gstatic.com"),
+        !InfraHosts.isBackground("gstatic.com"),
+        !InfraHosts.isBackground("googleusercontent.com"),
+      )
+    },
+    test("#1672 additions do not shadow non-Apple app template host-sets") {
+      // Defensive: the new hosts must not accidentally suppress real-app surfaces
+      // on neighbouring apexes (Google search/mail, YouTube, etc.).
+      val unrelated = List(
+        "www.google.com",
+        "mail.google.com",
+        "docs.google.com",
+        "www.youtube.com",
+        "khanacademy.org",
+        "www.mathacademy.com",
+        "firestore.googleapis.com",
+      )
+      assertTrue(unrelated.forall(h => !InfraHosts.isBackground(h)))
+    },
     test("#1629 additions do not shadow non-Apple app template host-sets") {
       // Defensive: none of the patterns added for #1629 should accidentally suppress
       // a real-app host on an unrelated apex (Khan, Math, etc. — their apexes don't


### PR DESCRIPTION
Closes #1672.

## Summary

Bucket A residual after #1629/#1669: adds 11 non-Apple orphan-tail hosts to `InfraHosts.suppressOnly`, captured from `/api/profiles/<id>/usage-by-app` on kid profiles 1 (Kids), 5 (Quintus), 6 in 2026-06-10..06-11 prod orphan windows. All are suppress-only (no allow-carve role).

## Host classification

### Added (suppress-only)

| Class | Host | Evidence (propSec) | Rationale |
|---|---|---:|---|
| Brave telemetry | `collector.bsg.brave.com` | ~1491 | Shields telemetry — clearly background |
| Brave telemetry | `star-randsrv.bsg.brave.com` | ~555 | STAR randomness service — background |
| Google Play | `clients4.google.com` | ~1115 | Google services background poll |
| Google Play | `android.clients.google.com` | ~1089 | Android Play Services background |
| Google Play | `clients2.googleusercontent.com` | (low) | Google services background |
| Ad-mediation | `oa.openxcdn.net` | ~70-200 | OpenX ad mediation |
| Ad-mediation | `ep2.adtrafficquality.google` | ~70 | Google Ad-quality background |
| Ad-mediation | `a-adq.mediation.unity3d.com` | ~209 | Unity3D ad mediation |
| Asset CDN | `use.fontawesome.com` | ~70 | Webfont; follows embedding page |
| Asset CDN | `encrypted-tbn0.gstatic.com` | ~70 | Google image thumbnails |
| Asset CDN | `ci3.googleusercontent.com` | ~74 | Google user-content CDN |

All entries are specific subdomains, **not** apex — the apexes (`google.com`, `googleusercontent.com`, `gstatic.com`, `unity3d.com`) would absorb legitimate per-app traffic on sibling subdomains. This mirrors the existing seam where `clientservices.googleapis.com` is listed but the `googleapis.com` apex is not.

Per AGENTS.md §single-source-of-truth: hosts go into the canonical `InfraHosts.suppressOnly` list rather than a parallel suppression path. Per #1506, if a future app template claims one of these hosts, `Presence.isAppAttributed` makes app attribution win over suppression — so asset CDNs are safe to suppress as a fallback when no app claims them.

### Deferred — operator decision required

| Host | Reason for deferral |
|---|---|
| `ssl.gstatic.com` | Used by many apps; ssl.gstatic.com itself fans out across multiple app surfaces. **Recommend: defer until evidence shows specific per-app surfaces use a different subdomain.** |
| `c.apple.news` | propSec ~545 on profile 1 — user-facing if kids actually read Apple News. **Operator decision: do the kids open News, or is this purely background widget polling?** |
| `news-edge.apple.com` | Same as `c.apple.news` |

## Replay-harness note

The harness at `scripts/analysis/presence_replay.py` (#1467) validates the *generic* presence-tuning gate (session-stitch / heartbeat-bytes), not per-host suppression deltas. The per-host evidence for this PR comes directly from `/api/profiles/<id>/usage-by-app` orphan-tail captures referenced in #1672's body (same provenance as #1669's `evidence/profile-{1,5,6}.json`). The unit tests pin the expected boundary behavior (no apex sweep, no shadow of unrelated app hosts).

## Tests

- RED commit: 4 new test cases fail without the InfraHosts additions.
- GREEN commit: `mill shared.test` (36 tests pass) and `mill api.test` (full suite passes) clean.

## Test plan
- [x] `mill shared.test` passes
- [x] `mill api.test` passes
- [x] RED→GREEN visible in commit history
- [ ] Independent `/pr-review` pass
