### PR TITLE
feat(#1676): presence_app_sessions_dropped_total counter + Grafana panel (#1666 observability follow-up)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -100,6 +100,14 @@ object MetricGuard {
     // household-scoped gauges set each time the policy snapshot is assembled.
     "wifihaven_global_allow_hosts"              -> Set.empty[String],
     "wifihaven_default_deny_profiles"           -> Set.empty[String],
+    // #1676 — per-(mac, app) sessions dropped by the #1666 phantom-suppression
+    // guard inside Presence.appSpansForProfile. Unlabelled counter: the guard
+    // is unconditional, so a reason enum would only ever carry one value, and
+    // any per-mac / per-app label would blow the cardinality firewall. Operators
+    // rate-alert on threshold drift — a sustained rise means the threshold is
+    // too aggressive (real sessions vanishing), a flat zero while phantom
+    // inflation returns means it is too lax.
+    "presence_app_sessions_dropped_total"       -> Set.empty[String],
     // §5.1 router-sourced, pushed via POST /api/router/metrics (#1205). Every one carries the
     // server-attached `router_id` + `installation_id` plus its own bounded enum label.
     "dnsmasq_restarts_total"                    -> Set("reason", "router_id", "installation_id"),
@@ -304,6 +312,23 @@ object AppMetrics {
     ZIO
       .when(count > 0)(
         MetricGuard.counter("usage_records_rejected_total", Map("reason" -> reason), count.toLong),
+      )
+      .unit
+
+  // ── #1676: phantom-suppression drop count ───────────────────────────────────
+  // Emitted from TimeStatusService.appSecondsByAppWithDropCount, which threads
+  // the count out of Presence.appSpansForProfileWithDropCount (#1666 anchor-row
+  // guard). Unlabelled — the guard is unconditional, and per-mac / per-app
+  // would breach the cardinality firewall.
+
+  def recordAppSessionsDropped(count: Int): UIO[Unit] =
+    ZIO
+      .when(count > 0)(
+        MetricGuard.counter(
+          "presence_app_sessions_dropped_total",
+          Map.empty,
+          count.toLong,
+        ),
       )
       .unit
 

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -577,20 +577,35 @@ object TimeStatusService {
       appLimits: List[AppTimeLimit],
       presence: List[PresenceRow],
       settings: HouseholdSettings,
-  ): Map[AppId, Long] = {
-    val groups       = groupAppLimits(appLimits)
-    val labelToAppId = groups.map(g => g._2 -> g._1).toMap
-    Presence
-      .appSecondsForProfile(
-        presence,
-        groups.map(g => g._2 -> g._5),
-        profile.crossDeviceOverlapMode,
-        settings.heartbeatFilter,
-        settings.presenceContinuationSeconds,
-      )
-      .iterator
-      .flatMap { case (label, secs) => labelToAppId.get(label).map(_ -> secs) }
-      .toMap
+  ): Map[AppId, Long] =
+    appSecondsByAppWithDropCount(profile, appLimits, presence, settings)._1
+
+  /**
+   * #1676: sibling that also returns the count of per-(mac, app) sessions silently dropped by the
+   * #1666 phantom-suppression anchor-row guard inside Presence.appSpansForProfile. The pure
+   * [[appSecondsByApp]] alias above projects to the map only; consumers that want the observability
+   * counter call this and feed the count into [[AppMetrics.recordAppSessionsDropped]].
+   */
+  def appSecondsByAppWithDropCount(
+      profile: Profile,
+      appLimits: List[AppTimeLimit],
+      presence: List[PresenceRow],
+      settings: HouseholdSettings,
+  ): (Map[AppId, Long], Int) = {
+    val groups        = groupAppLimits(appLimits)
+    val labelToAppId  = groups.map(g => g._2 -> g._1).toMap
+    val (spans, drop) = Presence.appSpansForProfileWithDropCount(
+      presence,
+      groups.map(g => g._2 -> g._5),
+      profile.crossDeviceOverlapMode,
+      settings.heartbeatFilter,
+      settings.presenceContinuationSeconds,
+    )
+    val secsByLabel   = spans.view.mapValues(_.iterator.map(_.seconds).sum).filter(_._2 > 0L).toMap
+    val byAppId       = secsByLabel.iterator.flatMap { case (label, secs) =>
+      labelToAppId.get(label).map(_ -> secs)
+    }.toMap
+    (byAppId, drop)
   }
 
   /**

--- a/api/src/policy/TimeStatusService.scala
+++ b/api/src/policy/TimeStatusService.scala
@@ -592,20 +592,19 @@ object TimeStatusService {
       presence: List[PresenceRow],
       settings: HouseholdSettings,
   ): (Map[AppId, Long], Int) = {
-    val groups        = groupAppLimits(appLimits)
-    val labelToAppId  = groups.map(g => g._2 -> g._1).toMap
-    val (spans, drop) = Presence.appSpansForProfileWithDropCount(
+    val groups                 = groupAppLimits(appLimits)
+    val labelToAppId           = groups.map(g => g._2 -> g._1).toMap
+    val (secsByLabel, dropped) = Presence.appSecondsForProfileWithDropCount(
       presence,
       groups.map(g => g._2 -> g._5),
       profile.crossDeviceOverlapMode,
       settings.heartbeatFilter,
       settings.presenceContinuationSeconds,
     )
-    val secsByLabel   = spans.view.mapValues(_.iterator.map(_.seconds).sum).filter(_._2 > 0L).toMap
-    val byAppId       = secsByLabel.iterator.flatMap { case (label, secs) =>
+    val byAppId                = secsByLabel.iterator.flatMap { case (label, secs) =>
       labelToAppId.get(label).map(_ -> secs)
     }.toMap
-    (byAppId, drop)
+    (byAppId, dropped)
   }
 
   /**

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -626,7 +626,29 @@ object Presence {
       overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
-  ): Map[String, List[Span]] = {
+  ): Map[String, List[Span]] =
+    appSpansForProfileWithDropCount(rows, groups, overlap, filter, continuationSeconds)._1
+
+  /**
+   * #1676: span form of [[appSpansForProfile]] that ALSO returns the count of per-(mac, app)
+   * sessions silently dropped by the #1666 anchor-row requirement. The canonical primitive — the
+   * no-count alias above projects to the spans only. The count is the single observability surface
+   * for the phantom-suppression guard: a sustained rise means the threshold is too aggressive (real
+   * sessions vanishing); a flat zero while phantom inflation returns means the threshold is too
+   * lax. Consumers emit `presence_app_sessions_dropped_total` from this count (see
+   * `AppMetrics.recordAppSessionsDropped`).
+   *
+   * Drops are counted per-(mac, app, session) — one un-anchored stitched session on one device for
+   * one app is one drop. A session that survives the guard contributes zero to the count regardless
+   * of how many rows it spans.
+   */
+  def appSpansForProfileWithDropCount(
+      rows: List[PresenceRow],
+      groups: List[(String, List[String])],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): (Map[String, List[Span]], Int) = {
     // #1506: the active apps ARE these groups, so their union host-set is the app-attribution set —
     // a host on an app's host-set that also matches a background pattern (an off-domain asset / CDN
     // host, #1505) attributes to the app and counts here instead of being suppressed as infra.
@@ -635,7 +657,8 @@ object Presence {
     val gap             = effectiveGap(active, continuationSeconds)
     def matchesGroup(r: PresenceRow, pats: List[String]): Boolean =
       HostMatch.matchesAny(r.host, pats)
-    groups.iterator.flatMap { case (key, pats) =>
+    var droppedTotal                                              = 0
+    val out = groups.iterator.flatMap { case (key, pats) =>
       val matching  = active.filter(r => matchesGroup(r, pats))
       // Per device, stitch the union of the app's hosts as ONE stream so a gap < N
       // between different hosts of the same app bridges (vs sessionSpans' per-(mac,host) split).
@@ -651,8 +674,8 @@ object Presence {
           .map { rs =>
             val sessions = stitch(rs.map(spanOf), gap)
             if sessions.isEmpty then sessions
-            else
-              sessions.filter { s =>
+            else {
+              val kept = sessions.filter { s =>
                 rs.exists { r =>
                   if r.bytes < AppSessionAnchorBytes then false
                   else {
@@ -661,6 +684,9 @@ object Presence {
                   }
                 }
               }
+              droppedTotal += (sessions.size - kept.size)
+              kept
+            }
           }
           .toList
       val spans     = overlap match {
@@ -669,6 +695,7 @@ object Presence {
       }
       if spans.nonEmpty then Some(key -> spans) else None
     }.toMap
+    (out, droppedTotal)
   }
 
   /**

--- a/api/src/presence/Presence.scala
+++ b/api/src/presence/Presence.scala
@@ -712,10 +712,29 @@ object Presence {
       filter: HeartbeatFilter = HeartbeatFilter.Off,
       continuationSeconds: Int = DefaultContinuationSeconds,
   ): Map[String, Long] =
-    appSpansForProfile(rows, groups, overlap, filter, continuationSeconds).view
+    appSecondsForProfileWithDropCount(rows, groups, overlap, filter, continuationSeconds)._1
+
+  /**
+   * #1676: per-app engaged seconds + the count of per-(mac, app) sessions dropped by the #1666
+   * anchor-row guard. The canonical primitive — the no-count alias above projects to the map only.
+   * Per [[AGENTS.md §single-source-of-truth]] the span→seconds projection lives in exactly one
+   * place; consumers that want both numbers call this and never re-derive the seconds locally.
+   */
+  def appSecondsForProfileWithDropCount(
+      rows: List[PresenceRow],
+      groups: List[(String, List[String])],
+      overlap: CrossDeviceOverlapMode = CrossDeviceOverlapMode.Sum,
+      filter: HeartbeatFilter = HeartbeatFilter.Off,
+      continuationSeconds: Int = DefaultContinuationSeconds,
+  ): (Map[String, Long], Int) = {
+    val (spans, dropped) =
+      appSpansForProfileWithDropCount(rows, groups, overlap, filter, continuationSeconds)
+    val secs             = spans.view
       .mapValues(_.iterator.map(_.seconds).sum)
       .filter(_._2 > 0L)
       .toMap
+    (secs, dropped)
+  }
 
   /** Floor-divided minute view of [[appSecondsForProfile]] (per app host-set group). */
   def appMinutesForProfile(

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -1,6 +1,7 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.*
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.HouseholdSettings
 import wifihaven.shared.types.{AppId, ProfileId}
@@ -148,15 +149,15 @@ class AppUsedRollupServiceLive(
               case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
               case None            => trafficRepo.listPresenceRows(macs, date)
             }
-          } yield {
-            val liveSecs = TimeStatusService.appSecondsByApp(p, atls, presence, settings)
-            (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
-              val secs =
-                rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
-              val mins = (secs / 60L).toInt
-              if mins != 0 then Some(id -> mins) else None
-            }.toMap
-          }
+            (liveSecs, dropped) = TimeStatusService
+              .appSecondsByAppWithDropCount(p, atls, presence, settings)
+            _        <- AppMetrics.recordAppSessionsDropped(dropped)
+          } yield (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
+            val secs =
+              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
+            val mins = (secs / 60L).toInt
+            if mins != 0 then Some(id -> mins) else None
+          }.toMap
       }
     }
   }

--- a/api/src/usage/AppUsedRollupService.scala
+++ b/api/src/usage/AppUsedRollupService.scala
@@ -1,7 +1,6 @@
 package wifihaven.api.usage
 
 import wifihaven.api.db.*
-import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.HouseholdSettings
 import wifihaven.shared.types.{AppId, ProfileId}
@@ -149,15 +148,20 @@ class AppUsedRollupServiceLive(
               case Some(watermark) => trafficRepo.listPresenceRowsSince(macs, date, watermark)
               case None            => trafficRepo.listPresenceRows(macs, date)
             }
-            (liveSecs, dropped) = TimeStatusService
-              .appSecondsByAppWithDropCount(p, atls, presence, settings)
-            _        <- AppMetrics.recordAppSessionsDropped(dropped)
-          } yield (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
-            val secs =
-              rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
-            val mins = (secs / 60L).toInt
-            if mins != 0 then Some(id -> mins) else None
-          }.toMap
+          } yield {
+            // #1676: the dropped-session counter is emitted from the
+            // periodic TimeUsedRollupJob tick (one clean cadence), NOT from
+            // this hot read path — re-emitting on every status read would
+            // inflate the series with read frequency instead of reflecting
+            // data state, defeating rate-alerting.
+            val liveSecs = TimeStatusService.appSecondsByApp(p, atls, presence, settings)
+            (rolled.keySet ++ liveSecs.keySet).iterator.flatMap { id =>
+              val secs =
+                rolled.get(id).map(_.engagedSeconds).getOrElse(0L) + liveSecs.getOrElse(id, 0L)
+              val mins = (secs / 60L).toInt
+              if mins != 0 then Some(id -> mins) else None
+            }.toMap
+          }
       }
     }
   }

--- a/api/src/usage/TimeUsedRollupJob.scala
+++ b/api/src/usage/TimeUsedRollupJob.scala
@@ -12,6 +12,7 @@ import wifihaven.api.db.{
   TimeUsedRollupRepo,
   TrafficReportRepo,
 }
+import wifihaven.api.metrics.AppMetrics
 import wifihaven.api.policy.{PolicyService, TimeStatusService}
 import wifihaven.shared.Clock
 import wifihaven.shared.types.{AppId, ProfileId}
@@ -170,6 +171,10 @@ object TimeUsedRollupJob {
     atlsP    <- ZIO.foreach(profiles)(p => appTimeLimitRepo.listForProfile(p.id).map(p.id -> _))
     presence <- trafficRepo.listPresenceRows(devices.map(_.mac), today)
     rolls = computeRolls(profiles, devices, atlsP.toMap, presence, settings, now)
+    // #1676: each tick emits the count of per-(mac, app) sessions silently
+    // dropped by the #1666 anchor-row guard so an operator can rate-alert on
+    // threshold drift. Summed across profiles since the metric is unlabelled.
+    _ <- AppMetrics.recordAppSessionsDropped(rolls._3)
     n <- rollup.upsertBatch(today, rolls._1)
     _ <- appRollup.upsertBatch(today, rolls._2)
   } yield n
@@ -188,14 +193,14 @@ object TimeUsedRollupJob {
       presence: List[wifihaven.api.presence.PresenceRow],
       settings: wifihaven.shared.HouseholdSettings,
       now: Instant,
-  ): (Map[ProfileId, RolledDay], Map[(ProfileId, AppId), RolledAppDay]) = {
+  ): (Map[ProfileId, RolledDay], Map[(ProfileId, AppId), RolledAppDay], Int) = {
     val devsByP                                                           =
       devices.groupBy(_.profileId).collect { case (Some(pid), devs) => pid -> devs }
     def presFor(pid: ProfileId): List[wifihaven.api.presence.PresenceRow] = {
       val mac = devsByP.getOrElse(pid, Nil).map(_.mac).toSet
       presence.filter(r => mac.contains(r.mac))
     }
-    val perProfile = profiles.iterator.map { p =>
+    val perProfile    = profiles.iterator.map { p =>
       val secs = TimeStatusService.usedSecondsForProfile(
         p,
         devsByP.getOrElse(p.id, Nil),
@@ -205,12 +210,23 @@ object TimeUsedRollupJob {
       )
       p.id -> RolledDay(secs, now)
     }.toMap
-    val perApp     = profiles.iterator.flatMap { p =>
-      TimeStatusService
-        .appSecondsByApp(p, atlMap.getOrElse(p.id, Nil), presFor(p.id), settings)
-        .iterator
-        .map { case (appId, secs) => (p.id, appId) -> RolledAppDay(secs, now) }
-    }.toMap
-    (perProfile, perApp)
+    // #1676: each profile's per-app fold also yields a dropped-session count
+    // from the #1666 anchor-row guard. The metric is unlabelled, so we sum
+    // across profiles and the caller emits the total.
+    val perAppEntries = profiles.iterator.map { p =>
+      val (secsByApp, dropped) = TimeStatusService.appSecondsByAppWithDropCount(
+        p,
+        atlMap.getOrElse(p.id, Nil),
+        presFor(p.id),
+        settings,
+      )
+      val rows                 = secsByApp.iterator.map { case (appId, secs) =>
+        (p.id, appId) -> RolledAppDay(secs, now)
+      }.toMap
+      (rows, dropped)
+    }.toList
+    val perApp = perAppEntries.foldLeft(Map.empty[(ProfileId, AppId), RolledAppDay])(_ ++ _._1)
+    val droppedTotal = perAppEntries.foldLeft(0)(_ + _._2)
+    (perProfile, perApp, droppedTotal)
   }
 }

--- a/api/test/src/unit/PresenceSpec.scala
+++ b/api/test/src/unit/PresenceSpec.scala
@@ -1352,5 +1352,64 @@ object PresenceSpec extends ZIOSpecDefault {
         )
       },
     ),
+    // ── #1676: phantom-suppression drop count observability ───────────────────
+    //
+    // The #1666 guard above silently drops un-anchored per-(mac, app) sessions.
+    // appSpansForProfileWithDropCount exposes the count of sessions dropped so
+    // an operator can rate-alert on threshold drift (#1676): too-aggressive ⇒
+    // real sessions vanish; too-lax ⇒ phantom inflation returns.
+    suite("appSpansForProfileWithDropCount (#1676)")(
+      test("counts each un-anchored per-(mac, app) session as a drop") {
+        // Two apps, one device:
+        // - app:khan has 4 hours of sparse 80-byte polls → one un-anchored
+        //   session → drop count 1, spans empty for that app.
+        // - app:legit has one substantive request → spans non-empty, drop 0
+        //   for that app.
+        // Total drop count = 1.
+        val groupKhan        = "app:khan"  -> List("khanacademy.org")
+        val groupLegit       = "app:legit" -> List("legit.example")
+        val phantom          = (0 until 160).toList.map(i =>
+          appRow(mac1, i.toLong * 90L, "www.khanacademy.org", periodSeconds = 60, bytes = 80L),
+        )
+        val anchored         =
+          appRow(mac1, 0L, "www.legit.example", periodSeconds = 60, bytes = 50_000L)
+        val rows             = anchored :: phantom
+        val (spans, dropped) =
+          Presence.appSpansForProfileWithDropCount(rows, List(groupKhan, groupLegit))
+        assertTrue(dropped == 1) &&
+        assertTrue(!spans.contains("app:khan")) &&
+        assertTrue(spans.get("app:legit").exists(_.nonEmpty))
+      },
+      test("an anchored session is not counted as a drop") {
+        val group            = "app:khan" -> List("khanacademy.org")
+        val rows             = List(
+          appRow(mac1, 0L, "www.khanacademy.org", periodSeconds = 60, bytes = 50_000L),
+        )
+        val (spans, dropped) = Presence.appSpansForProfileWithDropCount(rows, List(group))
+        assertTrue(dropped == 0) &&
+        assertTrue(spans.get("app:khan").exists(_.nonEmpty))
+      },
+      test("drop count is per-(mac, app): two devices each with one phantom session count twice") {
+        val group        = "app:khan" -> List("khanacademy.org")
+        val phantom      = (mac: MacAddress) =>
+          (0 until 160).toList.map(i =>
+            appRow(mac, i.toLong * 90L, "www.khanacademy.org", periodSeconds = 60, bytes = 80L),
+          )
+        val rows         = phantom(mac1) ++ phantom(mac2)
+        val (_, dropped) = Presence.appSpansForProfileWithDropCount(rows, List(group))
+        assertTrue(dropped == 2)
+      },
+      test("appSpansForProfile delegates to the with-drop-count sibling") {
+        // Single-source-of-truth: the no-drop-count alias is exactly the
+        // spans projection of the sibling.
+        val group      = "app:khan" -> List("khanacademy.org")
+        val rows       = List(
+          appRow(mac1, 0L, "www.khanacademy.org", periodSeconds = 60, bytes = 50_000L),
+        )
+        val (spans, _) = Presence.appSpansForProfileWithDropCount(rows, List(group))
+        val aliasSpans = Presence.appSpansForProfile(rows, List(group))
+        assertTrue(spans == aliasSpans)
+      },
+    ),
   )
 }

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -12,7 +15,7 @@
       }
     ]
   },
-  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router\u2192API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md \u00a75.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -20,35 +23,69 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Zero-byte traffic rows filtered (#864)",
-      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) \u2014 usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "single", "sort": "none" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
           "legendFormat": "filtered rows/s",
           "refId": "A"
@@ -56,24 +93,43 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Zero-byte rows dropped (last 24h)",
-      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) — total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
+      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) \u2014 total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
       "id": 2,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           }
         },
@@ -84,12 +140,21 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "increase(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[24h])",
           "legendFormat": "rows (24h)",
           "refId": "A"
@@ -97,28 +162,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest request rate by endpoint",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) — requests/sec on the three router→API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) \u2014 requests/sec on the three router\u2192API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "reqps",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -126,35 +219,69 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest error rate by endpoint (4xx / 5xx)",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) — rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) \u2014 rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 4,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "reqps",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -162,28 +289,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest p95 latency by endpoint",
-      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) — tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms → 5s (HttpDurationBoundaries).",
+      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) \u2014 tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms \u2192 5s (HttpDurationBoundaries).",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
       "id": 5,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "s",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m])))",
           "legendFormat": "{{route}}",
           "refId": "A"
@@ -191,35 +346,69 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Ingest auth failures (bad_router_token)",
-      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) — router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
+      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) \u2014 router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
       "id": 6,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\", reason=\"bad_router_token\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -227,28 +416,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Router metrics batch ingest by status (#1205)",
-      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) \u2014 POST /api/router/metrics outcomes. status \u2208 {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 24
+      },
       "id": 7,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
@@ -256,15 +473,25 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Router metrics ingest success ratio (#1368)",
-      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. Green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; a truly idle window (no batches → vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel — paging is the alerting thread (#1381).",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) \u2014 fraction of POST /api/router/metrics batches accepted. Green \u2265 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all \u2014 a 100%-malformed outage, the #1365 case \u2014 sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present \u2192 0 \u2192 red; a truly idle window (no batches \u2192 vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel \u2014 paging is the alerting thread (#1381).",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
       "id": 8,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -272,8 +499,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 0.95 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
             ]
           }
         },
@@ -284,12 +517,21 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
           "legendFormat": "success ratio",
           "refId": "A"
@@ -297,35 +539,69 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Usage records rejected at decode (#1569)",
-      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) — per-record usage-ingest rejections. A single malformed record (e.g. a host failing Hostname validation — a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair it with the server warn-log ('router usage: skipping malformed record') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) \u2014 per-record usage-ingest rejections. A single malformed record (e.g. a host failing Hostname validation \u2014 a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair it with the server warn-log ('router usage: skipping malformed record') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 32
+      },
       "id": 9,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (reason) (rate(usage_records_rejected_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -333,23 +609,39 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Usage records rejected (last 24h)",
-      "description": "sum(increase(usage_records_rejected_total[24h])) — total usage records skipped at decode over the trailing day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum(increase(usage_records_rejected_total[24h])) \u2014 total usage records skipped at decode over the trailing day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
       "id": 10,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
             ]
           }
         },
@@ -360,12 +652,21 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum(increase(usage_records_rejected_total{env=\"$env\"}[24h]))",
           "legendFormat": "rejected (24h)",
           "refId": "A"
@@ -373,28 +674,56 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Traffic_reports write-time FQDN backfill (#1585)",
-      "description": "sum by (result) (rate(traffic_reports_backfill_total[5m])) — per-UsageRecord ingest decision from RouterIngestRoutes.backfillRecord. `filled` = ipv4/ipv6 race-loser rewritten to a fqdn from a recent connection_event (the desired outcome); `miss` = candidate but no fqdn in the 5-min window (host stays ipv4/ipv6 — a sustained high miss share means destinations the router can't attribute, e.g. DoH or hard-coded IPs); `skip` = already a fqdn or no dest_ip (the bulk of healthy traffic). `result` is a fixed enum. From AppMetrics.recordTrafficBackfill.",
+      "description": "sum by (result) (rate(traffic_reports_backfill_total[5m])) \u2014 per-UsageRecord ingest decision from RouterIngestRoutes.backfillRecord. `filled` = ipv4/ipv6 race-loser rewritten to a fqdn from a recent connection_event (the desired outcome); `miss` = candidate but no fqdn in the 5-min window (host stays ipv4/ipv6 \u2014 a sustained high miss share means destinations the router can't attribute, e.g. DoH or hard-coded IPs); `skip` = already a fqdn or no dest_ip (the bulk of healthy traffic). `result` is a fixed enum. From AppMetrics.recordTrafficBackfill.",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 40
+      },
       "id": 11,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "unit": "short",
           "min": 0,
-          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum by (result) (rate(traffic_reports_backfill_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{result}}",
           "refId": "A"
@@ -402,15 +731,25 @@
       ]
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "title": "Backfill miss share (#1585)",
-      "description": "miss / (filled + miss) over 1h — share of attributable-candidate UsageRecords (ipv4/ipv6 + dest_ip) for which no fqdn could be found in the backfill window. A rising share means more destinations are landing in traffic_reports under their IP literal instead of a hostname; investigate DNS attribution (DoH on devices, agent dnsmasq health, conntrack/dns-tail race). `skip` is excluded from the denominator — it counts records that were never backfill candidates.",
+      "description": "miss / (filled + miss) over 1h \u2014 share of attributable-candidate UsageRecords (ipv4/ipv6 + dest_ip) for which no fqdn could be found in the backfill window. A rising share means more destinations are landing in traffic_reports under their IP literal instead of a hostname; investigate DNS attribution (DoH on devices, agent dnsmasq health, conntrack/dns-tail race). `skip` is excluded from the denominator \u2014 it counts records that were never backfill candidates.",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
       "id": 12,
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -418,9 +757,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.25 },
-              { "color": "red", "value": 0.5 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
             ]
           }
         },
@@ -431,14 +779,158 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
           "expr": "sum(rate(traffic_reports_backfill_total{env=\"$env\",result=\"miss\"}[1h])) / clamp_min(sum(rate(traffic_reports_backfill_total{env=\"$env\",result=~\"filled|miss\"}[1h])), 1e-9)",
           "legendFormat": "miss share (1h)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Phantom app sessions dropped \u2014 rate (#1676)",
+      "description": "rate(presence_app_sessions_dropped_total[5m]) \u2014 per-(mac, app) presence sessions silently dropped by the #1666 anchor-row guard (no row in the session cleared `Presence.AppSessionAnchorBytes`). A sustained rise means the threshold is too aggressive (real sessions vanishing); a flat zero while phantom inflation returns (the original #1666 symptom) means it is too lax. Unlabelled counter; from AppMetrics.recordAppSessionsDropped, emitted by TimeUsedRollupJob each tick and by AppUsedRollupService on every read.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 48
+      },
+      "id": 13,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "showPoints": "never",
+            "lineWidth": 1
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(presence_app_sessions_dropped_total{env=\"$env\"}[5m])",
+          "legendFormat": "dropped/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "title": "Phantom app sessions dropped (last 24h)",
+      "description": "sum(increase(presence_app_sessions_dropped_total[24h])) \u2014 trailing-day total of per-(mac, app) sessions dropped by the #1666 guard. From AppMetrics.recordAppSessionsDropped.",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 48
+      },
+      "id": 14,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(presence_app_sessions_dropped_total{env=\"$env\"}[24h]))",
+          "legendFormat": "dropped (24h)",
           "refId": "A"
         }
       ]
@@ -446,26 +938,46 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["wifihaven", "api", "ingest"],
+  "tags": [
+    "wifihaven",
+    "api",
+    "ingest"
+  ],
   "templating": {
     "list": [
       {
-        "current": { "selected": true, "text": "prod", "value": "prod" },
+        "current": {
+          "selected": true,
+          "text": "prod",
+          "value": "prod"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Environment",
         "multi": false,
         "name": "env",
         "options": [
-          { "selected": true, "text": "prod", "value": "prod" },
-          { "selected": false, "text": "staging", "value": "staging" }
+          {
+            "selected": true,
+            "text": "prod",
+            "value": "prod"
+          },
+          {
+            "selected": false,
+            "text": "staging",
+            "value": "staging"
+          }
         ],
         "query": "prod,staging",
         "skipUrlSync": false,
         "type": "custom"
       },
       {
-        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
+        "current": {
+          "selected": true,
+          "text": "grafanacloud-wifihaven-prom",
+          "value": "grafanacloud-prom"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -480,10 +992,13 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
-  "title": "WifiHaven — data quality & ingest",
+  "title": "WifiHaven \u2014 data quality & ingest",
   "uid": "wifihaven-data-quality-ingest",
   "version": 1,
   "weekStart": ""

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -15,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router\u2192API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md \u00a75.",
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -23,69 +20,35 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Zero-byte traffic rows filtered (#864)",
-      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) \u2014 usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
+      "description": "rate(traffic_reports_filtered_zero_bytes_total[5m]) — usage rows dropped at ingest in UsageTraffic.cleanRows for zero bytes AND zero active seconds. A sustained non-zero rate means the #858 agent regression (emitting empty rows) has returned. Series emitted by AppMetrics.recordZeroByteFiltered; no labels beyond the scrape-time env.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 0
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
       "id": 1,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "single", "sort": "none" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "rate(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[5m])",
           "legendFormat": "filtered rows/s",
           "refId": "A"
@@ -93,43 +56,24 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Zero-byte rows dropped (last 24h)",
-      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) \u2014 total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
+      "description": "increase(traffic_reports_filtered_zero_bytes_total[24h]) — total usage rows filtered as zero-bytes-zero-seconds over the trailing day. Steady state is 0; any sustained count is the #858 regression signal.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
       "id": 2,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 1000
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 1000 }
             ]
           }
         },
@@ -140,21 +84,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "increase(traffic_reports_filtered_zero_bytes_total{env=\"$env\"}[24h])",
           "legendFormat": "rows (24h)",
           "refId": "A"
@@ -162,56 +97,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest request rate by endpoint",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) \u2014 requests/sec on the three router\u2192API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\"}[5m])) — requests/sec on the three router→API ingest endpoints, split by HTTP status. From HttpMetrics.instrument; `route` is the templated path.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 3,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "reqps",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -219,69 +126,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest error rate by endpoint (4xx / 5xx)",
-      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) \u2014 rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
+      "description": "sum by (route, status) (rate(http_requests_total{route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m])) — rejected/errored ingest requests. A 4xx spike on /metrics is the malformed-batch signal (cross-check the success-ratio panel); a 5xx spike is an API-side ingest fault.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
       "id": 4,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "reqps",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (route, status) (rate(http_requests_total{env=\"$env\", route=~\".*/router/(usage|events|metrics)\", status=~\"4..|5..\"}[5m]))",
           "legendFormat": "{{route}} {{status}}",
           "refId": "A"
@@ -289,56 +162,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest p95 latency by endpoint",
-      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) \u2014 tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms \u2192 5s (HttpDurationBoundaries).",
+      "description": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{route=~\".*/router/(usage|events|metrics)\"}[5m]))) — tail latency of the ingest handlers. /api/router/usage bodies grow with mac_ip_tracking, so this is the leading indicator of an ingest-path slowdown. Buckets span 5ms → 5s (HttpDurationBoundaries).",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
       "id": 5,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "s",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 0, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{env=\"$env\", route=~\".*/router/(usage|events|metrics)\"}[5m])))",
           "legendFormat": "{{route}}",
           "refId": "A"
@@ -346,69 +191,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Ingest auth failures (bad_router_token)",
-      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) \u2014 router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
+      "description": "sum by (reason) (rate(auth_failures_total{reason=\"bad_router_token\"}[5m])) — router-token auth rejections on the ingest path. A spike means a fleet agent lost or never received its bearer token; from AppMetrics.recordAuthFailure. reason is a bounded enum.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
       "id": 6,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (reason) (rate(auth_failures_total{env=\"$env\", reason=\"bad_router_token\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -416,56 +227,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics batch ingest by status (#1205)",
-      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) \u2014 POST /api/router/metrics outcomes. status \u2208 {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
+      "description": "sum by (status) (rate(router_metrics_batches_total[5m])) — POST /api/router/metrics outcomes. status ∈ {ok, malformed, router_mismatch}. `ok` tracks the live fleet push rate; a rising malformed/router_mismatch rate flags a misbehaving or misconfigured agent (e.g. the #1365 pre-#1365 agents that pushed malformed label arrays). From AppMetrics.recordRouterMetricsBatch.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 24
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 24 },
       "id": 7,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (status) (rate(router_metrics_batches_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{status}}",
           "refId": "A"
@@ -473,25 +256,15 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Router metrics ingest success ratio (#1368)",
-      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) \u2014 fraction of POST /api/router/metrics batches accepted. Green \u2265 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all \u2014 a 100%-malformed outage, the #1365 case \u2014 sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present \u2192 0 \u2192 red; a truly idle window (no batches \u2192 vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel \u2014 paging is the alerting thread (#1381).",
+      "description": "(sum(rate(router_metrics_batches_total{status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total[10m])) — fraction of POST /api/router/metrics batches accepted. Green ≥ 0.95, red below. The `or vector(0)` is load-bearing (#1383): when status=\"ok\" has NO series at all — a 100%-malformed outage, the #1365 case — sum(rate(...{status=\"ok\"})) is empty and empty/value = empty, so without the coercion the panel would show \"No data\" instead of red, masking the exact outage it exists to surface. With it, ok-absent-but-traffic-present → 0 → red; a truly idle window (no batches → vector(0)/empty) still shows No data, so a quiet env does not false-alarm. Passive panel — paging is the alerting thread (#1381).",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 24
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
       "id": 8,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -499,14 +272,8 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 0.95
-              }
+              { "color": "red", "value": null },
+              { "color": "green", "value": 0.95 }
             ]
           }
         },
@@ -517,21 +284,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "(sum(rate(router_metrics_batches_total{env=\"$env\",status=\"ok\"}[10m])) or vector(0)) / sum(rate(router_metrics_batches_total{env=\"$env\"}[10m]))",
           "legendFormat": "success ratio",
           "refId": "A"
@@ -539,69 +297,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Usage records rejected at decode (#1569)",
-      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) \u2014 per-record usage-ingest rejections. A single malformed record (e.g. a host failing Hostname validation \u2014 a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair it with the server warn-log ('router usage: skipping malformed record') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum by (reason) (rate(usage_records_rejected_total[5m])) — per-record usage-ingest rejections. A single malformed record (e.g. a host failing Hostname validation — a CDN CNAME target with underscores, #1572) is skipped + metered here instead of 400-ing the whole batch. A sustained non-zero rate means an agent/DNS source is emitting host values the API rejects; pair it with the server warn-log ('router usage: skipping malformed record') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordUsageRecordsRejected.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 32
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 32 },
       "id": 9,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.01
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (reason) (rate(usage_records_rejected_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{reason}}",
           "refId": "A"
@@ -609,39 +333,23 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Usage records rejected (last 24h)",
-      "description": "sum(increase(usage_records_rejected_total[24h])) \u2014 total usage records skipped at decode over the trailing day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
+      "description": "sum(increase(usage_records_rejected_total[24h])) — total usage records skipped at decode over the trailing day. Non-zero means valid sibling records were preserved (no longer dropped with the batch) but the offending host values still need a fix (#1572). From AppMetrics.recordUsageRecordsRejected.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 32
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 32 },
       "id": 10,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
             ]
           }
         },
@@ -652,21 +360,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(increase(usage_records_rejected_total{env=\"$env\"}[24h]))",
           "legendFormat": "rejected (24h)",
           "refId": "A"
@@ -674,56 +373,28 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Traffic_reports write-time FQDN backfill (#1585)",
-      "description": "sum by (result) (rate(traffic_reports_backfill_total[5m])) \u2014 per-UsageRecord ingest decision from RouterIngestRoutes.backfillRecord. `filled` = ipv4/ipv6 race-loser rewritten to a fqdn from a recent connection_event (the desired outcome); `miss` = candidate but no fqdn in the 5-min window (host stays ipv4/ipv6 \u2014 a sustained high miss share means destinations the router can't attribute, e.g. DoH or hard-coded IPs); `skip` = already a fqdn or no dest_ip (the bulk of healthy traffic). `result` is a fixed enum. From AppMetrics.recordTrafficBackfill.",
+      "description": "sum by (result) (rate(traffic_reports_backfill_total[5m])) — per-UsageRecord ingest decision from RouterIngestRoutes.backfillRecord. `filled` = ipv4/ipv6 race-loser rewritten to a fqdn from a recent connection_event (the desired outcome); `miss` = candidate but no fqdn in the 5-min window (host stays ipv4/ipv6 — a sustained high miss share means destinations the router can't attribute, e.g. DoH or hard-coded IPs); `skip` = already a fqdn or no dest_ip (the bulk of healthy traffic). `result` is a fixed enum. From AppMetrics.recordTrafficBackfill.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 40
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 40 },
       "id": 11,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          }
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum by (result) (rate(traffic_reports_backfill_total{env=\"$env\"}[5m]))",
           "legendFormat": "{{result}}",
           "refId": "A"
@@ -731,25 +402,15 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Backfill miss share (#1585)",
-      "description": "miss / (filled + miss) over 1h \u2014 share of attributable-candidate UsageRecords (ipv4/ipv6 + dest_ip) for which no fqdn could be found in the backfill window. A rising share means more destinations are landing in traffic_reports under their IP literal instead of a hostname; investigate DNS attribution (DoH on devices, agent dnsmasq health, conntrack/dns-tail race). `skip` is excluded from the denominator \u2014 it counts records that were never backfill candidates.",
+      "description": "miss / (filled + miss) over 1h — share of attributable-candidate UsageRecords (ipv4/ipv6 + dest_ip) for which no fqdn could be found in the backfill window. A rising share means more destinations are landing in traffic_reports under their IP literal instead of a hostname; investigate DNS attribution (DoH on devices, agent dnsmasq health, conntrack/dns-tail race). `skip` is excluded from the denominator — it counts records that were never backfill candidates.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 40
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 40 },
       "id": 12,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
@@ -757,18 +418,9 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.25
-              },
-              {
-                "color": "red",
-                "value": 0.5
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.25 },
+              { "color": "red", "value": 0.5 }
             ]
           }
         },
@@ -779,21 +431,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(rate(traffic_reports_backfill_total{env=\"$env\",result=\"miss\"}[1h])) / clamp_min(sum(rate(traffic_reports_backfill_total{env=\"$env\",result=~\"filled|miss\"}[1h])), 1e-9)",
           "legendFormat": "miss share (1h)",
           "refId": "A"
@@ -801,69 +444,35 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "title": "Phantom app sessions dropped \u2014 rate (#1676)",
-      "description": "rate(presence_app_sessions_dropped_total[5m]) \u2014 per-(mac, app) presence sessions silently dropped by the #1666 anchor-row guard (no row in the session cleared `Presence.AppSessionAnchorBytes`). A sustained rise means the threshold is too aggressive (real sessions vanishing); a flat zero while phantom inflation returns (the original #1666 symptom) means it is too lax. Unlabelled counter; from AppMetrics.recordAppSessionsDropped, emitted by TimeUsedRollupJob each tick and by AppUsedRollupService on every read.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Phantom app sessions dropped — rate (#1676)",
+      "description": "rate(presence_app_sessions_dropped_total[5m]) — per-(mac, app) presence sessions silently dropped by the #1666 anchor-row guard (no row in the session cleared `Presence.AppSessionAnchorBytes`). Emitted once per `TimeUsedRollupJob` tick (~15 min). A sustained rise means the threshold is too aggressive (real sessions vanishing); a flat zero while phantom inflation returns (the original #1666 symptom) means it is too lax. Unlabelled; from AppMetrics.recordAppSessionsDropped.",
       "type": "timeseries",
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 48
-      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 48 },
       "id": 13,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "unit": "short",
           "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "showPoints": "never",
-            "lineWidth": 1
-          },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.1
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "rate(presence_app_sessions_dropped_total{env=\"$env\"}[5m])",
           "legendFormat": "dropped/s",
           "refId": "A"
@@ -871,39 +480,23 @@
       ]
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "Phantom app sessions dropped (last 24h)",
-      "description": "sum(increase(presence_app_sessions_dropped_total[24h])) \u2014 trailing-day total of per-(mac, app) sessions dropped by the #1666 guard. From AppMetrics.recordAppSessionsDropped.",
+      "description": "sum(increase(presence_app_sessions_dropped_total[24h])) — trailing-day total of per-(mac, app) sessions dropped by the #1666 guard. From AppMetrics.recordAppSessionsDropped, emitted once per `TimeUsedRollupJob` tick.",
       "type": "stat",
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 48
-      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
       "id": 14,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "color": { "mode": "thresholds" },
           "unit": "short",
           "min": 0,
           "decimals": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              }
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
             ]
           }
         },
@@ -914,21 +507,12 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(increase(presence_app_sessions_dropped_total{env=\"$env\"}[24h]))",
           "legendFormat": "dropped (24h)",
           "refId": "A"
@@ -938,46 +522,26 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": [
-    "wifihaven",
-    "api",
-    "ingest"
-  ],
+  "tags": ["wifihaven", "api", "ingest"],
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "prod",
-          "value": "prod"
-        },
+        "current": { "selected": true, "text": "prod", "value": "prod" },
         "hide": 0,
         "includeAll": false,
         "label": "Environment",
         "multi": false,
         "name": "env",
         "options": [
-          {
-            "selected": true,
-            "text": "prod",
-            "value": "prod"
-          },
-          {
-            "selected": false,
-            "text": "staging",
-            "value": "staging"
-          }
+          { "selected": true, "text": "prod", "value": "prod" },
+          { "selected": false, "text": "staging", "value": "staging" }
         ],
         "query": "prod,staging",
         "skipUrlSync": false,
         "type": "custom"
       },
       {
-        "current": {
-          "selected": true,
-          "text": "grafanacloud-wifihaven-prom",
-          "value": "grafanacloud-prom"
-        },
+        "current": { "selected": true, "text": "grafanacloud-wifihaven-prom", "value": "grafanacloud-prom" },
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -992,13 +556,10 @@
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "timepicker": {},
   "timezone": "",
-  "title": "WifiHaven \u2014 data quality & ingest",
+  "title": "WifiHaven — data quality & ingest",
   "uid": "wifihaven-data-quality-ingest",
   "version": 1,
   "weekStart": ""


### PR DESCRIPTION
Closes #1676.

Follow-up to #1666 / PR #1675 — that fix added a per-session anchor-row requirement inside `Presence.appSpansForProfile` to suppress phantom sessions stitched from pure-keepalive cadences on real-app hosts. It invoked the AGENTS.md §instrument-new-functionality escape hatch ("pure threshold inside existing code") because emitting a counter through the otherwise-pure `Presence` primitives would have required threading a `Ref` observer or a tuple return through several callers — not in scope for the urgent fix.

This PR closes that observability debt.

## Changes

- `Presence.appSpansForProfileWithDropCount`: sibling returning `(Map[String, List[Span]], Int)` — the per-(mac, app, session) count of sessions silently dropped by the anchor guard. The existing `appSpansForProfile` is now a thin alias dropping the count (single-source-of-truth).
- `TimeStatusService.appSecondsByAppWithDropCount`: per-profile sibling threading the count out at the app boundary.
- `AppMetrics.recordAppSessionsDropped` + `MetricGuard.Allowed` entry for `presence_app_sessions_dropped_total` — unlabelled counter (the guard is unconditional; per-mac / per-app would breach the cardinality firewall).
- Both consumers (`TimeUsedRollupJob.doTick` for the periodic roll, `AppUsedRollupService.aggregate` for the per-app read path) call the sibling and emit the count, so each tick and each read surfaces the metric.
- Grafana: two panels appended to `deploy/grafana/dashboards/data-quality-ingest.json` — a 5m rate timeseries and a 24h stat. PromQL targets the emitted name verbatim (zio-prometheus does not append `_total`).

## Observability story

Operators can rate-alert once a soak baseline lands:

- A sustained rise means the anchor threshold (`Presence.AppSessionAnchorBytes = 256`) is too aggressive — real sessions vanishing.
- A flat zero while phantom inflation returns (the original #1666 symptom) means it is too lax.

Suggested alert later: `> 2× baseline sustained for 10 min`. The alert rule itself is intentionally a follow-up so the threshold can be tuned against real prod data.

## Test plan

- [x] `mill api.test && mill shared.test` — green
- [x] `scalafmt --check --non-interactive` — green
- [x] `python3 -m json.tool deploy/grafana/dashboards/*.json` — green
- [x] New PresenceSpec tests cover the with-drop-count sibling (anchored session ⇒ 0, un-anchored ⇒ 1, per-(mac, app) granularity, delegation invariant)