### PR TITLE
feat(#1651): QUIC / HTTP3 Initial-packet SNI parsing (UDP 443)

### DIFF
--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -412,7 +412,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "title": "SNI ClientHello rate by result",
-      "description": "sum by (result) (rate(sni_clienthellos_total[5m])) — result ∈ {parsed, truncated, no_sni, ipv6_skipped, not_tcp, malformed}. Emitted by the #573 SNI hostname-attribution sidecar (wifihaven-sni-tail), which classifies sniffed TCP ClientHello records and folds a cumulative per-result tally into the agent's metrics push. This attributes (dst_ip → SNI hostname) pairs for traffic where dnsmasq never saw the lookup (DoH / hard-coded IP), so it is the connection-layer complement to `dns_queries_total`, not a block signal. `parsed` is the healthy path; the failure classes are diagnosed below.",
+      "description": "sum by (result) (rate(sni_clienthellos_total[5m])) — result ∈ {parsed, truncated, no_sni, ipv6_skipped, not_tcp, malformed} on the TCP path, plus {quic_success, quic_short_header, quic_unsupported_version, quic_not_initial, quic_truncated, quic_malformed, quic_decrypt_failed, quic_no_crypto_frame, quic_no_sni, quic_ipv6_skipped, quic_not_udp, quic_not_443} on the QUIC v1 Initial path (#1651). Emitted by the SNI hostname-attribution sidecar (wifihaven-sni-tail), which classifies sniffed TLS ClientHellos on TCP/443 AND TLS ClientHellos extracted from QUIC v1 Initial packets on UDP/443 (#573 / #1651). The (dst_ip → SNI) pairs feed the same cache.insert_sni writer, so this attributes flows where dnsmasq never saw the lookup (DoH / hard-coded IP) regardless of transport. `parsed` (TCP) and `quic_success` (QUIC) are the healthy paths; the failure classes are diagnosed in the panels below.",
       "type": "timeseries",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
       "id": 13,
@@ -470,6 +470,36 @@
           "expr": "sum(rate(sni_clienthellos_total{env=\"$env\", result=\"ipv6_skipped\"}[5m])) / clamp_min(sum(rate(sni_clienthellos_total{env=\"$env\"}[5m])), 0.001)",
           "legendFormat": "ipv6_skipped",
           "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "SNI success share: TCP vs QUIC (#1651)",
+      "description": "Fraction of successful SNI extractions coming from QUIC v1 Initial packets vs TCP TLS ClientHello records. Computed as sum(rate(sni_clienthellos_total{result=\"quic_success\"}[5m])) / sum(rate(sni_clienthellos_total{result=~\"parsed|quic_success\"}[5m])). Operator reading: rising → HTTP/3 share of the fleet is growing; flat zero with non-zero TCP `parsed` → QUIC capture branch is unreachable (BPF rejected? sidecar restarted? lua-openssl missing?). The absolute rate of each is in the per-result panel above. Sustained quic_decrypt_failed in that panel would indicate a key-derivation or HP-mask regression; sustained quic_no_crypto_frame would mean Initials are arriving but carry no CRYPTO (probably ACK-only).",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
+      "id": 15,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 2 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(sni_clienthellos_total{env=\"$env\", result=\"quic_success\"}[5m])) / clamp_min(sum(rate(sni_clienthellos_total{env=\"$env\", result=~\"parsed|quic_success\"}[5m])), 0.001)",
+          "legendFormat": "QUIC share",
+          "refId": "A"
         }
       ]
     }

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -32,7 +32,13 @@ define Package/wifihaven
   # on modern kernels). Without it `conntrack -E -e NEW` sees 0 v6 flow events,
   # so the agent never emits connection_events for v6 destinations and the
   # Gate 2 v6 attribution suite (scripts/e2e/scenarios_fake/test_v6_*.py) fails.
-  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +kmod-nf-conntrack6 +libustream-mbedtls +openssl-util +tcpdump-mini
+  # #1651: lua-openssl provides HMAC-SHA256 + AES-128-ECB + AES-128-GCM so the
+  # sni sidecar can extract the SNI from QUIC v1 Initial packets too (UDP/443),
+  # closing the HTTP/3 leg of the #573 attribution gap. RFC 9001 §5.2 keys are
+  # HKDF-derived from the destination connection ID + v1 salt; the payload is
+  # AEAD-encrypted with AES-128-GCM and the header bits are protected with an
+  # AES-128-ECB mask. ~464 KiB installed — additive, attribution-only.
+  DEPENDS:=+lua +libuci-lua +luci-lib-jsonc +conntrack +curl +uhttpd-mod-lua +kmod-nf-log +kmod-nf-log6 +kmod-nf-conntrack6 +libustream-mbedtls +openssl-util +tcpdump-mini +lua-openssl
   PKGARCH:=all
 endef
 

--- a/openwrt/files/usr/lib/lua/wifihaven/quic.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/quic.lua
@@ -56,6 +56,13 @@
 --   quic_not_udp            -- parse_initial saw an IPv4 non-UDP packet
 --   quic_not_443            -- parse_initial saw a UDP packet not to port 443
 --
+-- NOTE: the last three are only reachable when callers invoke parse_initial
+-- directly (e.g. the unit tests). The production sidecar's dispatch() peeks
+-- at ethertype / IPv4 proto BEFORE calling parse_initial and short-circuits
+-- those cases under the TCP-path "ipv6_skipped" / generic "malformed"
+-- buckets, so they will not tick in the sni_clienthellos_total metric on
+-- fleet routers — the documented contract holds for direct API consumers.
+--
 -- A malformed/truncated packet returns (nil, reason) — never raises. The
 -- sidecar runs as a long-lived loop; a single bad packet must not kill it.
 
@@ -136,12 +143,12 @@ end
 -- Returns (value, byte_count) or (nil) if truncated.
 -- ---------------------------------------------------------------------------
 
+local VARINT_LEN = { [0] = 1, [1] = 2, [2] = 4, [3] = 8 }
+
 local function read_varint(buf, off)
   local first = u8(buf, off)
   if not first then return nil end
-  local prefix = math.floor(first / 64)
-  local len_table = { [0] = 1, [1] = 2, [2] = 4, [3] = 8 }
-  local len = len_table[prefix]
+  local len = VARINT_LEN[math.floor(first / 64)]
   if off + len - 1 > #buf then return nil end
   local val = first % 64
   for i = 1, len - 1 do
@@ -157,12 +164,14 @@ end
 -- malformed/truncated/non-Initial input. The result is everything we need to
 -- (a) compute the sample offset for header-protection removal and (b)
 -- reconstruct the AAD/nonce after HP removal:
---   version             : 4 raw bytes
 --   dcid                : raw bytes (used to derive the initial keys)
---   scid                : raw bytes (parsed but unused by the parser)
---   token               : raw bytes (parsed but unused)
 --   length              : the QUIC "length" field — PN + payload + tag bytes
 --   pn_offset           : 1-based index of first packet-number byte in `buf`
+--
+-- SCID and the token bytes ARE parsed (their varint-prefixed lengths drive
+-- where `pn_offset` lands) but we don't surface them on the returned table
+-- because no caller reads them — only the dcid drives key derivation and
+-- only `length` / `pn_offset` drive HP-removal / AEAD bookkeeping.
 -- ---------------------------------------------------------------------------
 
 local function parse_long_header(buf)
@@ -195,21 +204,17 @@ local function parse_long_header(buf)
   if not dcid then return nil, "quic_truncated" end
   off = off + dcid_len
 
-  -- SCID
+  -- SCID (length-prefixed; bytes themselves skipped, not surfaced)
   local scid_len = u8(buf, off); if not scid_len then return nil, "quic_truncated" end
   if scid_len > 20 then return nil, "quic_malformed" end
-  off = off + 1
-  local scid = slice(buf, off, scid_len)
-  if not scid then return nil, "quic_truncated" end
-  off = off + scid_len
+  off = off + 1 + scid_len
+  if off > #buf + 1 then return nil, "quic_truncated" end
 
-  -- Initial-only: token_length (varint) + token bytes
+  -- Initial-only: token_length (varint) + token bytes (skipped)
   local token_len, vlen = read_varint(buf, off)
   if not token_len then return nil, "quic_truncated" end
-  off = off + vlen
-  local token = slice(buf, off, token_len)
-  if not token then return nil, "quic_truncated" end
-  off = off + token_len
+  off = off + vlen + token_len
+  if off > #buf + 1 then return nil, "quic_truncated" end
 
   -- Length: bytes of PN + payload + 16-byte AEAD tag
   local length
@@ -224,11 +229,8 @@ local function parse_long_header(buf)
   if length < 17 then return nil, "quic_malformed" end
 
   return {
-    version  = version,
-    dcid     = dcid,
-    scid     = scid,
-    token    = token,
-    length   = length,
+    dcid      = dcid,
+    length    = length,
     pn_offset = off,
   }
 end

--- a/openwrt/files/usr/lib/lua/wifihaven/quic.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/quic.lua
@@ -435,8 +435,12 @@ end
 
 local function parse_tls_handshake(handshake_bytes)
   -- Lazy require so unit tests that don't exercise the success path don't
-  -- need sni.lua on the search path.
-  local sni = require("sni")
+  -- need sni.lua on the search path. Try the production-namespaced form
+  -- first and fall back to the bare module name the test harness puts on
+  -- LUA_PATH (./files/usr/lib/lua/wifihaven/?.lua) so the same file works
+  -- in both environments.
+  local ok, sni = pcall(require, "wifihaven.sni")
+  if not ok then sni = require("sni") end
   if #handshake_bytes < 4 then return nil end
   -- Synthetic record header: ContentType=0x16, Version=0x0303, Length.
   local rec_len = #handshake_bytes

--- a/openwrt/files/usr/lib/lua/wifihaven/quic.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/quic.lua
@@ -1,0 +1,606 @@
+-- quic.lua — QUIC v1 Initial-packet SNI parser (#1651, follow-up to #573).
+--
+-- #573 / sni.lua parses TLS ClientHellos on TCP/443 only. Modern clients
+-- (Google/YouTube/most CDNs) increasingly start fresh flows over QUIC on
+-- UDP/443, where the SNI sits inside CRYPTO frames in an AEAD-encrypted
+-- Initial packet. Without parsing it, the #1636/#1640 collateral-drop class
+-- reappears for any QUIC-preferring app: dnsmasq never saw the resolve (the
+-- client used DoH / a hard-coded IP) and the TCP capture branch sees no
+-- ClientHello to attribute.
+--
+-- Scope (this PR):
+--   * QUIC v1 only (RFC 9000 + RFC 9001). v2 (RFC 9369) and other versions
+--     are bucketed under quic_unsupported_version and deferred.
+--   * Client Initial packets only — that's where the ClientHello rides. We
+--     skip short-header (1-RTT, steady-state) and other long-header types
+--     (0-RTT/Handshake/Retry) cleanly.
+--   * AEAD_AES_128_GCM only — RFC 9001 §5.1 specifies that Initial packets
+--     ALWAYS use AES-128-GCM regardless of what the TLS handshake later
+--     negotiates, so no ChaCha20-Poly1305 fallback is needed here.
+--   * IPv4 only at the framing layer (parse_initial), matching sni.lua's v1.
+--   * Attribution-only (feeds cache.insert_sni alongside the TCP path).
+--     Blocking QUIC is #572's job.
+--
+-- Crypto is injected (see `crypto` parameter docs below) so the parser is
+-- pure Lua and unit-testable without lua-openssl on the dev macOS host. The
+-- production sidecar wires in a lua-openssl-backed crypto table on the
+-- router.
+--
+-- Public API:
+--   quic.parse_quic_packet(udp_payload, crypto)
+--     → sni_string | nil, reason
+--   quic.parse_initial(eth_frame, crypto)
+--     → { dst_ip, src_mac, sni } | nil, reason
+--   quic.QUIC_V1_SALT  — HKDF salt for the v1 initial_secret derivation.
+--   quic.openssl_crypto(openssl) → crypto table backed by lua-openssl, for
+--     the sidecar to wire in.
+--
+-- Reason enum (bounded — extends sni_clienthellos_total{result}):
+--   quic_success            -- parsed, sni present (NOT used by parse_quic_packet
+--                              directly; the sidecar emits this counter on the
+--                              success path)
+--   quic_short_header       -- 1-RTT packet; SNI not present, silently skipped
+--   quic_unsupported_version-- not QUIC v1 (e.g. v2 0x6b3343cf, or grease)
+--   quic_not_initial        -- long header but not packet-type Initial
+--                              (0-RTT/Handshake/Retry); SNI not here
+--   quic_truncated          -- packet shorter than required for the long-header
+--                              fields or the declared length
+--   quic_malformed          -- structurally invalid (bad varint, DCID overrun)
+--   quic_decrypt_failed     -- AEAD tag check failed (key/nonce/AAD mismatch
+--                              or genuinely malformed protected packet)
+--   quic_no_crypto_frame    -- decrypted payload has no CRYPTO frame at offset 0
+--                              (e.g. ACK-only Initial)
+--   quic_no_sni             -- ClientHello reassembled but no usable host_name
+--                              (e.g. ECH)
+--   quic_ipv6_skipped       -- parse_initial saw a non-IPv4 ethertype
+--   quic_not_udp            -- parse_initial saw an IPv4 non-UDP packet
+--   quic_not_443            -- parse_initial saw a UDP packet not to port 443
+--
+-- A malformed/truncated packet returns (nil, reason) — never raises. The
+-- sidecar runs as a long-lived loop; a single bad packet must not kill it.
+
+local M = {}
+
+-- HKDF salt for the QUIC v1 initial_secret derivation (RFC 9001 §5.2).
+-- Stock OpenWrt ships Lua 5.1, whose string literal escapes do NOT include
+-- \xNN — only \NNN (decimal) and \\ \" etc. We build the salt with
+-- string.char so this file loads identically under 5.1 and 5.5+.
+M.QUIC_V1_SALT = string.char(
+  0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
+  0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a)
+
+local QUIC_V1_VERSION = string.char(0x00, 0x00, 0x00, 0x01)
+
+-- ---------------------------------------------------------------------------
+-- Byte / bit helpers — Lua 5.1-safe (no string.unpack, no bitwise operators).
+-- ---------------------------------------------------------------------------
+
+local function u8(buf, off)
+  if off < 1 or off > #buf then return nil end
+  return buf:byte(off)
+end
+
+local function u16(buf, off)
+  if off < 1 or off + 1 > #buf then return nil end
+  local a, b = buf:byte(off, off + 1)
+  return a * 256 + b
+end
+
+local function slice(buf, off, len)
+  if off < 1 or len < 0 or (off + len - 1) > #buf then return nil end
+  return buf:sub(off, off + len - 1)
+end
+
+-- bit_and / bit_xor / bit_lshift / bit_rshift — Lua 5.1-portable. The agent
+-- already mixes bit32 and arithmetic across modules; we stick to arithmetic
+-- here so the file loads under stock Lua 5.1 on the router with no extra
+-- dependency.
+local function band(a, b)
+  -- 8-bit only — that's all we ever need (byte / mask).
+  local r, bit = 0, 1
+  for i = 0, 7 do
+    if (a % 2 == 1) and (b % 2 == 1) then r = r + bit end
+    a = math.floor(a / 2); b = math.floor(b / 2); bit = bit * 2
+  end
+  return r
+end
+
+local function bxor(a, b)
+  local r, bit = 0, 1
+  for i = 0, 7 do
+    local ab = a % 2; local bb = b % 2
+    if ab ~= bb then r = r + bit end
+    a = math.floor(a / 2); b = math.floor(b / 2); bit = bit * 2
+  end
+  return r
+end
+
+-- xor_bytes(a, b) — byte-wise XOR over the shorter of the two strings.
+local function xor_bytes(a, b)
+  local n = math.min(#a, #b)
+  local out = {}
+  for i = 1, n do
+    out[i] = string.char(bxor(a:byte(i), b:byte(i)))
+  end
+  return table.concat(out)
+end
+
+-- ---------------------------------------------------------------------------
+-- QUIC variable-length integer (RFC 9000 §16).
+--
+-- The first byte's two MSBs determine the encoded length:
+--   00 → 1 byte  (6-bit value, 0..2^6-1)
+--   01 → 2 bytes (14-bit value)
+--   10 → 4 bytes (30-bit value)
+--   11 → 8 bytes (62-bit value)
+-- Returns (value, byte_count) or (nil) if truncated.
+-- ---------------------------------------------------------------------------
+
+local function read_varint(buf, off)
+  local first = u8(buf, off)
+  if not first then return nil end
+  local prefix = math.floor(first / 64)
+  local len_table = { [0] = 1, [1] = 2, [2] = 4, [3] = 8 }
+  local len = len_table[prefix]
+  if off + len - 1 > #buf then return nil end
+  local val = first % 64
+  for i = 1, len - 1 do
+    val = val * 256 + buf:byte(off + i)
+  end
+  return val, len
+end
+
+-- ---------------------------------------------------------------------------
+-- Long-header parsing — RFC 9000 §17.2.
+--
+-- Returns a table with the fields below on success, or (nil, reason) on
+-- malformed/truncated/non-Initial input. The result is everything we need to
+-- (a) compute the sample offset for header-protection removal and (b)
+-- reconstruct the AAD/nonce after HP removal:
+--   version             : 4 raw bytes
+--   dcid                : raw bytes (used to derive the initial keys)
+--   scid                : raw bytes (parsed but unused by the parser)
+--   token               : raw bytes (parsed but unused)
+--   length              : the QUIC "length" field — PN + payload + tag bytes
+--   pn_offset           : 1-based index of first packet-number byte in `buf`
+-- ---------------------------------------------------------------------------
+
+local function parse_long_header(buf)
+  if #buf < 7 then return nil, "quic_truncated" end
+  local first = buf:byte(1)
+  -- Long header has the high bit set. Short header → silently skip.
+  if first < 0x80 then return nil, "quic_short_header" end
+  -- Fixed bit (bit 6) MUST be set on a valid QUIC packet. Some path-MTU
+  -- discovery / grease packets may clear it; treat as malformed.
+  if band(first, 0x40) == 0 then return nil, "quic_malformed" end
+
+  -- Version (unprotected).
+  local version = slice(buf, 2, 4)
+  if not version then return nil, "quic_truncated" end
+  if version ~= QUIC_V1_VERSION then return nil, "quic_unsupported_version" end
+
+  -- Long packet type lives in bits 5..4 of the first byte. Per RFC 9001
+  -- §5.4.1, header protection masks only the LOW 4 bits of the first byte
+  -- (reserved bits + PN length); the type bits are UNPROTECTED, so we can
+  -- read them directly. For QUIC v1, type=0 = Initial.
+  local pkt_type = math.floor(band(first, 0x30) / 16)
+  if pkt_type ~= 0 then return nil, "quic_not_initial" end
+
+  -- DCID
+  local off = 6
+  local dcid_len = u8(buf, off); if not dcid_len then return nil, "quic_truncated" end
+  if dcid_len > 20 then return nil, "quic_malformed" end
+  off = off + 1
+  local dcid = slice(buf, off, dcid_len)
+  if not dcid then return nil, "quic_truncated" end
+  off = off + dcid_len
+
+  -- SCID
+  local scid_len = u8(buf, off); if not scid_len then return nil, "quic_truncated" end
+  if scid_len > 20 then return nil, "quic_malformed" end
+  off = off + 1
+  local scid = slice(buf, off, scid_len)
+  if not scid then return nil, "quic_truncated" end
+  off = off + scid_len
+
+  -- Initial-only: token_length (varint) + token bytes
+  local token_len, vlen = read_varint(buf, off)
+  if not token_len then return nil, "quic_truncated" end
+  off = off + vlen
+  local token = slice(buf, off, token_len)
+  if not token then return nil, "quic_truncated" end
+  off = off + token_len
+
+  -- Length: bytes of PN + payload + 16-byte AEAD tag
+  local length
+  length, vlen = read_varint(buf, off)
+  if not length then return nil, "quic_truncated" end
+  off = off + vlen
+
+  -- `off` now points at the first byte of the (protected) packet number.
+  -- Verify the declared length doesn't run off the end of the buffer.
+  if off + length - 1 > #buf then return nil, "quic_truncated" end
+  -- AEAD tag is 16 bytes, so length must be at least 17 (≥1 byte PN + tag).
+  if length < 17 then return nil, "quic_malformed" end
+
+  return {
+    version  = version,
+    dcid     = dcid,
+    scid     = scid,
+    token    = token,
+    length   = length,
+    pn_offset = off,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Initial-key derivation — RFC 9001 §5.2.
+--   initial_secret  = HKDF-Extract(QUIC_V1_SALT, DCID)
+--   client_initial  = HKDF-Expand-Label(initial_secret, "client in", "", 32)
+--   key             = HKDF-Expand-Label(client_initial, "quic key", "", 16)
+--   iv              = HKDF-Expand-Label(client_initial, "quic iv",  "", 12)
+--   hp              = HKDF-Expand-Label(client_initial, "quic hp",  "", 16)
+-- We only need the CLIENT keys (we're attributing client-originated flows).
+-- ---------------------------------------------------------------------------
+
+local function derive_client_initial_keys(dcid, crypto)
+  local prk = crypto.hkdf_extract(M.QUIC_V1_SALT, dcid)
+  local client_initial = crypto.hkdf_expand_label(prk, "client in", "", 32)
+  return {
+    key = crypto.hkdf_expand_label(client_initial, "quic key", "", 16),
+    iv  = crypto.hkdf_expand_label(client_initial, "quic iv",  "", 12),
+    hp  = crypto.hkdf_expand_label(client_initial, "quic hp",  "", 16),
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Header-protection removal — RFC 9001 §5.4.
+--
+-- The HP sample is the 16 bytes starting at pn_offset + 4 in the protected
+-- packet. (The "+ 4" assumes a maximum 4-byte packet number; we always sample
+-- from that offset regardless of the actual PN length.) The mask is the first
+-- 5 bytes of AES-128-ECB(hp_key, sample). For long headers, mask[0] is masked
+-- with 0x0f and XORed into the first byte's low 4 bits (reserved bits + PN
+-- length); mask[1..pn_len] XORs the packet-number bytes.
+--
+-- Returns the unprotected first byte, the truncated packet number (integer),
+-- and the packet-number length in bytes, or (nil, reason) on failure.
+-- ---------------------------------------------------------------------------
+
+local function remove_header_protection(buf, pn_offset, hp_key, crypto)
+  local sample_off = pn_offset + 4
+  local sample = slice(buf, sample_off, 16)
+  if not sample then return nil, "quic_truncated" end
+
+  local mask = crypto.aes128_ecb(hp_key, sample)
+  if not mask or #mask < 5 then return nil, "quic_decrypt_failed" end
+
+  local protected_first = buf:byte(1)
+  local unprotected_first = bxor(protected_first, band(mask:byte(1), 0x0f))
+  local pn_len = (unprotected_first % 4) + 1
+
+  -- XOR the packet-number bytes with mask[2..1+pn_len].
+  local pn_value = 0
+  for i = 1, pn_len do
+    local b = bxor(buf:byte(pn_offset + i - 1), mask:byte(i + 1))
+    pn_value = pn_value * 256 + b
+  end
+
+  return {
+    first    = unprotected_first,
+    pn_len   = pn_len,
+    pn_value = pn_value,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Nonce + AAD construction — RFC 9001 §5.3 / RFC 5116.
+--
+-- The 12-byte AEAD nonce is the IV XORed with the packet-number left-padded
+-- to 12 bytes (big-endian). The AAD is the *unprotected* header bytes — the
+-- entire long-header prefix up through and including the packet number.
+-- ---------------------------------------------------------------------------
+
+local function build_nonce(iv, pn_value)
+  local pn_bytes = {}
+  for i = 12, 1, -1 do
+    pn_bytes[i] = string.char(pn_value % 256)
+    pn_value = math.floor(pn_value / 256)
+  end
+  return xor_bytes(iv, table.concat(pn_bytes))
+end
+
+local function build_aad(buf, pn_offset, unprotected_first, pn_len, pn_value)
+  -- Header bytes 2..(pn_offset-1) are unchanged. The first byte is replaced
+  -- with unprotected_first, and the pn_len bytes starting at pn_offset are
+  -- replaced with the big-endian encoding of the truncated PN.
+  local mid = slice(buf, 2, pn_offset - 2) or ""
+  local pn_bytes = {}
+  for i = pn_len, 1, -1 do
+    pn_bytes[i] = string.char(pn_value % 256)
+    pn_value = math.floor(pn_value / 256)
+  end
+  return string.char(unprotected_first) .. mid .. table.concat(pn_bytes)
+end
+
+-- ---------------------------------------------------------------------------
+-- CRYPTO frame reassembly — RFC 9000 §19.6 (plus the other frame types
+-- allowed in Initial packets per RFC 9000 §17.2.2: PADDING 0x00, PING 0x01,
+-- ACK 0x02/0x03, CRYPTO 0x06, CONNECTION_CLOSE 0x1c).
+--
+-- We collect every CRYPTO frame's (offset, data) and concatenate in offset
+-- order to recover the TLS bytes. In practice the entire ClientHello fits in
+-- one CRYPTO frame at offset 0 inside a single Initial packet (the RFC 9001
+-- §A.2 vector does), but the spec allows fragmentation and a future endpoint
+-- might split.
+--
+-- Returns the reassembled TLS bytes (starting at offset 0) or nil on a
+-- malformed payload / no CRYPTO frame.
+-- ---------------------------------------------------------------------------
+
+local function reassemble_crypto(payload)
+  local off = 1
+  local chunks = {}  -- list of {offset, data}
+  while off <= #payload do
+    local frame_type, vlen = read_varint(payload, off)
+    if not frame_type then return nil end
+    off = off + vlen
+
+    if frame_type == 0x00 then
+      -- PADDING — single-byte frame, the byte we just read IS the frame.
+      -- Many implementations write large runs of PADDING; loop here so we
+      -- don't pay an O(N) varint read per padding byte. (No-op in the loop
+      -- body — off already advanced past it.)
+    elseif frame_type == 0x01 then
+      -- PING — single byte, already consumed.
+    elseif frame_type == 0x02 or frame_type == 0x03 then
+      -- ACK frame: largest_acked, ack_delay, ack_range_count, first_ack_range,
+      -- then ack_range_count gap/range pairs; if 0x03, three ECN counts.
+      local fields_to_skip = 4 -- largest_acked, ack_delay, ack_range_count, first_ack_range
+      local ack_range_count
+      local v
+      for i = 1, fields_to_skip do
+        v, vlen = read_varint(payload, off)
+        if not v then return nil end
+        if i == 3 then ack_range_count = v end
+        off = off + vlen
+      end
+      for _ = 1, (ack_range_count or 0) do
+        v, vlen = read_varint(payload, off)
+        if not v then return nil end
+        off = off + vlen
+        v, vlen = read_varint(payload, off)
+        if not v then return nil end
+        off = off + vlen
+      end
+      if frame_type == 0x03 then
+        for _ = 1, 3 do
+          v, vlen = read_varint(payload, off)
+          if not v then return nil end
+          off = off + vlen
+        end
+      end
+    elseif frame_type == 0x06 then
+      -- CRYPTO frame: offset (varint), length (varint), data
+      local crypto_off
+      crypto_off, vlen = read_varint(payload, off); if not crypto_off then return nil end
+      off = off + vlen
+      local crypto_len
+      crypto_len, vlen = read_varint(payload, off); if not crypto_len then return nil end
+      off = off + vlen
+      local data = slice(payload, off, crypto_len)
+      if not data then return nil end
+      off = off + crypto_len
+      chunks[#chunks + 1] = { offset = crypto_off, data = data }
+    elseif frame_type == 0x1c or frame_type == 0x1d then
+      -- CONNECTION_CLOSE — error_code (v), [frame_type (v) if 0x1c],
+      -- reason_phrase_length (v), reason. We won't see ClientHello after one
+      -- of these; bail with whatever CRYPTO we've already gathered.
+      break
+    else
+      -- Unknown frame type in an Initial packet. RFC 9000 §12.4 mandates
+      -- PROTOCOL_VIOLATION here, but for attribution we just stop walking.
+      break
+    end
+  end
+
+  if #chunks == 0 then return nil end
+
+  -- Sort by offset and concatenate. For the common single-frame case this is
+  -- a no-op. Gaps in coverage (e.g. an offset-0 frame missing) mean we can't
+  -- safely feed the TLS parser; bail.
+  table.sort(chunks, function(a, b) return a.offset < b.offset end)
+  if chunks[1].offset ~= 0 then return nil end
+  local expected = 0
+  local out = {}
+  for _, c in ipairs(chunks) do
+    if c.offset ~= expected then return nil end -- gap
+    out[#out + 1] = c.data
+    expected = expected + #c.data
+  end
+  return table.concat(out)
+end
+
+-- ---------------------------------------------------------------------------
+-- TLS-record framing wrapper around sni.parse_client_hello.
+--
+-- The TLS ClientHello we extract from CRYPTO frames is in TLS HANDSHAKE form
+-- (no outer TLS record header) — it starts directly with the Handshake.type
+-- (0x01 ClientHello) and a 3-byte length. sni.parse_client_hello expects a
+-- TLS Plaintext record (0x16 || version || length || handshake...), so we
+-- prepend the synthetic record header before delegating. This preserves
+-- single-source-of-truth: the SNI extension parser lives in sni.lua and is
+-- the same code path the TCP capture uses.
+-- ---------------------------------------------------------------------------
+
+local function parse_tls_handshake(handshake_bytes)
+  -- Lazy require so unit tests that don't exercise the success path don't
+  -- need sni.lua on the search path.
+  local sni = require("sni")
+  if #handshake_bytes < 4 then return nil end
+  -- Synthetic record header: ContentType=0x16, Version=0x0303, Length.
+  local rec_len = #handshake_bytes
+  local rec_hdr = string.char(0x16, 0x03, 0x03,
+                              math.floor(rec_len / 256) % 256,
+                              rec_len % 256)
+  return sni.parse_client_hello(rec_hdr .. handshake_bytes)
+end
+
+-- ---------------------------------------------------------------------------
+-- parse_quic_packet(udp_payload, crypto) → sni | nil, reason
+-- ---------------------------------------------------------------------------
+
+function M.parse_quic_packet(udp_payload, crypto)
+  if type(udp_payload) ~= "string" or #udp_payload < 7 then
+    return nil, "quic_truncated"
+  end
+
+  local hdr, reason = parse_long_header(udp_payload)
+  if not hdr then return nil, reason end
+
+  local keys = derive_client_initial_keys(hdr.dcid, crypto)
+
+  local hp_result, hp_reason = remove_header_protection(
+    udp_payload, hdr.pn_offset, keys.hp, crypto)
+  if not hp_result then return nil, hp_reason end
+
+  local header_len = hdr.pn_offset - 1 + hp_result.pn_len
+  local ct_len = hdr.length - hp_result.pn_len -- ciphertext + 16-byte tag
+  local ciphertext = slice(udp_payload, header_len + 1, ct_len)
+  if not ciphertext then return nil, "quic_truncated" end
+
+  local nonce = build_nonce(keys.iv, hp_result.pn_value)
+  local aad = build_aad(udp_payload, hdr.pn_offset,
+                        hp_result.first, hp_result.pn_len, hp_result.pn_value)
+
+  local plaintext = crypto.aes128_gcm_decrypt(keys.key, nonce, aad, ciphertext)
+  if not plaintext then return nil, "quic_decrypt_failed" end
+
+  local tls_bytes = reassemble_crypto(plaintext)
+  if not tls_bytes then return nil, "quic_no_crypto_frame" end
+
+  local sni_str = parse_tls_handshake(tls_bytes)
+  if not sni_str then return nil, "quic_no_sni" end
+
+  return sni_str
+end
+
+-- ---------------------------------------------------------------------------
+-- parse_initial(eth_frame, crypto) → { dst_ip, src_mac, sni } | nil, reason
+--
+-- Ethernet/IPv4/UDP framing wrapper, mirroring sni.parse_packet's contract.
+-- v1: IPv4 only (no VLAN, no IPv6, no IP options beyond the standard 20B).
+-- ---------------------------------------------------------------------------
+
+local function format_mac(a, b, c, d, e, f)
+  return string.format("%02x:%02x:%02x:%02x:%02x:%02x", a, b, c, d, e, f)
+end
+
+function M.parse_initial(eth_frame, crypto)
+  if type(eth_frame) ~= "string" or #eth_frame < 14 + 20 + 8 then
+    return nil, "quic_truncated"
+  end
+
+  local ethertype = u16(eth_frame, 13)
+  if ethertype ~= 0x0800 then return nil, "quic_ipv6_skipped" end
+  local sa, sb, sc, sd, se, sf = eth_frame:byte(7, 12)
+  local src_mac = format_mac(sa, sb, sc, sd, se, sf)
+
+  local ip_off = 15
+  local ver_ihl = u8(eth_frame, ip_off)
+  if not ver_ihl or math.floor(ver_ihl / 16) ~= 4 then
+    return nil, "quic_malformed"
+  end
+  local ihl = (ver_ihl % 16) * 4
+  if ihl < 20 then return nil, "quic_malformed" end
+  if ip_off + ihl - 1 > #eth_frame then return nil, "quic_truncated" end
+
+  local proto = u8(eth_frame, ip_off + 9)
+  if proto ~= 17 then return nil, "quic_not_udp" end
+
+  local da, db, dc, dd = eth_frame:byte(ip_off + 16, ip_off + 19)
+  local dst_ip = string.format("%d.%d.%d.%d", da, db, dc, dd)
+
+  local udp_off = ip_off + ihl
+  if udp_off + 8 - 1 > #eth_frame then return nil, "quic_truncated" end
+  local dport = u16(eth_frame, udp_off + 2)
+  if dport ~= 443 then return nil, "quic_not_443" end
+
+  local payload_off = udp_off + 8
+  if payload_off > #eth_frame then return nil, "quic_truncated" end
+  local udp_payload = eth_frame:sub(payload_off)
+
+  local sni_str, reason = M.parse_quic_packet(udp_payload, crypto)
+  if not sni_str then return nil, reason end
+  return { dst_ip = dst_ip, src_mac = src_mac, sni = sni_str }
+end
+
+-- ---------------------------------------------------------------------------
+-- openssl_crypto(openssl) — build the crypto table the parser expects, backed
+-- by lua-openssl. Called by the sidecar at startup. Kept here (rather than in
+-- the sidecar script) so the binding lives next to the parser that defines
+-- the contract — `crypto` shape changes touch one file.
+--
+-- HKDF Extract is HMAC-SHA256(salt, IKM); HKDF Expand follows RFC 5869 §2.3
+-- (T(1) = HMAC(PRK, info || 0x01); T(i) = HMAC(PRK, T(i-1) || info || i)).
+-- HKDF-Expand-Label adds the TLS 1.3 §7.1 label framing.
+-- ---------------------------------------------------------------------------
+
+function M.openssl_crypto(openssl)
+  local function hmac_sha256(key, msg)
+    return openssl.hmac.hmac("sha256", msg, key, true)
+  end
+  local function hkdf_extract(salt, ikm)
+    return hmac_sha256(salt, ikm)
+  end
+  local function hkdf_expand(prk, info, length)
+    local out = {}
+    local t = ""
+    local n = math.ceil(length / 32)
+    for i = 1, n do
+      t = hmac_sha256(prk, t .. info .. string.char(i))
+      out[#out + 1] = t
+    end
+    return table.concat(out):sub(1, length)
+  end
+  local function hkdf_expand_label(prk, label, context, length)
+    local full = "tls13 " .. label
+    local info = string.char(math.floor(length / 256) % 256, length % 256) ..
+                 string.char(#full) .. full ..
+                 string.char(#context) .. context
+    return hkdf_expand(prk, info, length)
+  end
+
+  local aes_ecb = openssl.cipher.get("aes-128-ecb")
+  local aes_gcm = openssl.cipher.get("aes-128-gcm")
+
+  return {
+    hkdf_extract       = hkdf_extract,
+    hkdf_expand_label  = hkdf_expand_label,
+    aes128_ecb = function(key, sample)
+      -- lua-openssl encrypt(plaintext, key, iv, padding) — pass padding=false
+      -- so we get exactly the 16-byte block back with no PKCS#7 trailer.
+      local ok, ct = pcall(function() return aes_ecb:encrypt(sample, key, nil, false) end)
+      if not ok then return nil end
+      return ct
+    end,
+    aes128_gcm_decrypt = function(key, nonce, aad, ciphertext)
+      if #ciphertext < 16 then return nil end
+      local ct = ciphertext:sub(1, #ciphertext - 16)
+      local tag = ciphertext:sub(#ciphertext - 15)
+      local ok, pt = pcall(function()
+        local dc = aes_gcm:decrypt_new(key, nonce)
+        dc:update(aad, true) -- AAD-only update; second arg = true
+        local out = dc:update(ct)
+        -- EVP_CTRL_AEAD_SET_TAG = 0x11; sets the expected tag BEFORE final().
+        dc:ctrl(0x11, tag)
+        local final = dc:final() or ""
+        return out .. final
+      end)
+      if not ok then return nil end
+      return pt
+    end,
+  }
+end
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -175,7 +175,7 @@ end
 -- periodic log line so a fleet-wide truncation/ipv6-skip rate is visible from
 -- logread alone (was lumped into a single no_sni_total — SHOULD-FIX #4/#7).
 local results           = {}
-local parsed_total      = 0
+local success_total      = 0
 local since_stat_parsed = 0
 local last_stats_log    = os.time()
 local last_metrics_flush = os.time()
@@ -207,7 +207,7 @@ while true do
   if r then
     spool:write(sni.format_sni_line(r.dst_ip, r.src_mac, r.sni))
     spool:flush()
-    parsed_total      = parsed_total + 1
+    success_total      = success_total + 1
     since_stat_parsed = since_stat_parsed + 1
   end
   bump(label or "no_sni")
@@ -220,12 +220,16 @@ while true do
     last_metrics_flush = now
   end
   if (now - last_stats_log) >= 60 then
-    log.info("sni-tail: parsed=%d (+%d in last %ds) truncated=%d no_sni=%d " ..
+    -- `success` is the union — TCP `parsed` + `quic_success`. Per-bucket
+    -- counts below break out which transport contributed; the metric does the
+    -- same. Was named `parsed` in the original (#573) log line; renamed for
+    -- honesty post-#1651 so a fleet reader can't double-count the QUIC half.
+    log.info("sni-tail: success=%d (+%d in last %ds) truncated=%d no_sni=%d " ..
              "ipv6_skipped=%d not_tcp=%d malformed=%d " ..
              "quic_success=%d quic_short_header=%d quic_not_initial=%d " ..
              "quic_unsupported_version=%d quic_decrypt_failed=%d " ..
              "quic_no_crypto_frame=%d quic_no_sni=%d",
-             parsed_total, since_stat_parsed, now - last_stats_log,
+             success_total, since_stat_parsed, now - last_stats_log,
              results.truncated or 0, results.no_sni or 0,
              results.ipv6_skipped or 0, results.not_tcp or 0,
              results.malformed or 0,

--- a/openwrt/files/usr/sbin/wifihaven-sni-tail
+++ b/openwrt/files/usr/sbin/wifihaven-sni-tail
@@ -1,33 +1,41 @@
 #!/usr/bin/lua
 -- wifihaven-sni-tail — sidecar daemon that captures the first packet of every
--- outbound TCP/443 flow off the LAN bridge and extracts the TLS ClientHello
--- SNI server_name. The (dst_ip, src_mac, sni) tuple is appended as a single
--- TSV line to paths.sni_capture; the wifihaven-dns-tail sidecar tails that
--- file alongside the dnsmasq query log and calls cache.insert_sni so the
--- shared ip→hostname cache (paths.dns_cache) stays single-writer.
+-- outbound TCP/443 flow AND every QUIC v1 Initial packet on UDP/443 off the
+-- LAN bridge and extracts the TLS ClientHello SNI server_name. The
+-- (dst_ip, src_mac, sni) tuple is appended as a single TSV line to
+-- paths.sni_capture; the wifihaven-dns-tail sidecar tails that file alongside
+-- the dnsmasq query log and calls cache.insert_sni so the shared ip→hostname
+-- cache (paths.dns_cache) stays single-writer.
 --
--- This closes the DoH / hard-coded-IP ATTRIBUTION gap (#573): a client that
--- bypasses the on-router DNS resolver still ends up with its destination IP
--- mapped back to the branded hostname in the agent's flow-attribution cache,
--- so connection-event fqdn emission and cache.lookup-based labeling work even
--- when dnsmasq never saw the query. It does NOT close the ENFORCEMENT gap: the
--- eb_/ea_/bl_ nft drop-set populators fire only on dnsmasq `reply` lines, and
--- SNI is seen after the flow's first packet — too late to populate a drop set
--- for that flow. Enforcement on hard-coded-IP traffic remains blockIpOnly's job.
+-- This closes the DoH / hard-coded-IP ATTRIBUTION gap (#573 for TCP; #1651
+-- extends it to QUIC / HTTP/3): a client that bypasses the on-router DNS
+-- resolver still ends up with its destination IP mapped back to the branded
+-- hostname in the agent's flow-attribution cache, so connection-event fqdn
+-- emission and cache.lookup-based labeling work even when dnsmasq never saw
+-- the query and the client preferred QUIC. It does NOT close the ENFORCEMENT
+-- gap: the eb_/ea_/bl_ nft drop-set populators fire only on dnsmasq `reply`
+-- lines, and SNI is seen after the flow's first packet — too late to populate
+-- a drop set for that flow. Enforcement on hard-coded-IP / QUIC-only traffic
+-- remains blockIpOnly's job (#572).
 --
 -- v1 scope:
 --   - Single-segment TLS 1.2 / TLS 1.3 ClientHello on TCP/443.
+--   - QUIC v1 Initial (client) on UDP/443; AES-128-GCM AEAD (RFC 9001 §5.1
+--     mandates this cipher for all Initials regardless of negotiated suite).
 --   - Always-on (no UCI toggle).
 --   - IPv4 only (followup for IPv6).
 --   - ECH ClientHellos → nil SNI → silently skipped (followup).
 --
--- We rely on tcpdump-mini (libpcap-userspace) to provide the capture: it
--- already ships in OpenWRT's default feed and is the only piece of the design
--- that adds an external dependency. Output is raw pcap on stdout (-w -),
--- parsed inline by sni.parse_packet, which accepts Ethernet/IPv4/TCP frames.
+-- Capture: tcpdump-mini (libpcap-userspace) with a combined BPF filter for
+-- both TCP-443 first-segment-of-ClientHello AND UDP-443 long-header Initial
+-- packets (high nibble 0xc0 = header_form=1 + fixed=1 + type=Initial). Output
+-- is raw pcap on stdout (-w -), parsed inline by sni.parse_packet (TCP path)
+-- or quic.parse_initial (UDP path), dispatched by the IPv4 protocol byte.
 
 local uci     = require("uci")
+local openssl = require("openssl")
 local sni     = require("wifihaven.sni")
+local quic    = require("wifihaven.quic")
 local log     = require("wifihaven.log")
 local paths   = require("wifihaven.paths")
 local dns_log = require("wifihaven.dns_log")
@@ -40,9 +48,20 @@ local dns_log = require("wifihaven.dns_log")
 -- (tcp[((tcp[12]&0xf0)>>2)] = 0x16 — first byte of TCP payload is handshake);
 -- if the on-router libpcap rejects the expression (per the #573 abort list)
 -- we'd fall back to the looser `tcp dst port 443` and live with ~10x packets.
-local BPF_FILTER = "tcp dst port 443 and " ..
-  "(tcp[((tcp[12]&0xf0)>>2)] = 0x16) and " ..
-  "(tcp[((tcp[12]&0xf0)>>2)+5] = 0x01)"
+--
+-- The QUIC half (#1651): UDP to dst port 443 whose first payload byte has
+-- high nibble 0xc0 — that is, header_form=1 (long header), fixed_bit=1, and
+-- packet_type=0 (Initial). Per RFC 9001 §5.4.1, only the LOW 4 bits of the
+-- long-header first byte are header-protected, so the type bits are safe to
+-- match against in BPF. This drops every 1-RTT (short-header) packet — the
+-- vast majority of steady-state QUIC traffic — and every 0-RTT/Handshake/
+-- Retry from the capture entirely, keeping per-packet cost at "one parse per
+-- new QUIC flow" parity with the TCP path.
+local BPF_FILTER =
+  "(tcp dst port 443 and " ..
+    "(tcp[((tcp[12]&0xf0)>>2)] = 0x16) and " ..
+    "(tcp[((tcp[12]&0xf0)>>2)+5] = 0x01)) or " ..
+  "(udp dst port 443 and (udp[8] & 0xf0) = 0xc0)"
 
 -- Capture interface: probe the actual LAN bridge from UCI (network.lan.device)
 -- so routers using a non-default bridge name (br0, multi-WAN) still get
@@ -107,11 +126,52 @@ if not spool then
   os.exit(1)
 end
 
--- #573: cumulative per-result tally. result ∈ {parsed, truncated, no_sni,
--- ipv6_skipped, not_tcp, malformed} — a small bounded enum. We mirror the
--- #1302 dns_metrics IPC: reuse dns_log.format_query_results to serialise the
--- tally to paths.sni_metrics on each flush, and the agent's metrics tick folds
--- the deltas into sni_clienthellos_total{result}. The split also feeds the
+-- #1651: build the QUIC parser's crypto dependency once at startup. This
+-- keeps the per-packet hot path allocation-free w.r.t. cipher handles —
+-- openssl_crypto() looks up the AES-128-ECB / AES-128-GCM cipher tables and
+-- caches them inside the returned closure.
+local quic_crypto = quic.openssl_crypto(openssl)
+
+-- Dispatch on IPv4 protocol byte: TCP=6 → existing sni.parse_packet, UDP=17 →
+-- new quic.parse_initial. We bounce non-IPv4 to "ipv6_skipped" inline so we
+-- don't pay two parser attempts per non-matching frame. (Keep the inner
+-- parsers' enum strings disjoint so the metric label space stays unambiguous.)
+-- dispatch(pkt) → (result | nil, label)
+--
+-- `label` is the result-enum string the main loop folds into the per-result
+-- tally. On success: "parsed" (TCP path) or "quic_success" (QUIC v1 Initial).
+-- On skip/failure: the inner parser's bounded reason string. The QUIC and TCP
+-- enum spaces are disjoint by prefix ("quic_*") so the {result} label cardin-
+-- ality stays bounded and the operator can read fleet HTTP/3 vs HTTP/1+2 mix
+-- from the metric alone. The (dst_ip, src_mac, sni) tuple is identical-shape
+-- between the two parsers, so spool writes flow through the same path.
+local function dispatch(pkt)
+  if #pkt < 14 + 20 then return nil, "truncated" end
+  local ethertype = pkt:byte(13) * 256 + pkt:byte(14)
+  if ethertype ~= 0x0800 then return nil, "ipv6_skipped" end
+  local proto = pkt:byte(15 + 9)
+  if proto == 6 then
+    local r, reason = sni.parse_packet(pkt)
+    if r then return r, "parsed" end
+    return nil, reason
+  elseif proto == 17 then
+    local r, reason = quic.parse_initial(pkt, quic_crypto)
+    if r then return r, "quic_success" end
+    return nil, reason
+  end
+  -- BPF restricts to TCP/UDP, so anything else is unreachable in practice;
+  -- bounded enum label for defense-in-depth.
+  return nil, "malformed"
+end
+
+-- #573 / #1651: cumulative per-result tally. result ∈ {parsed, truncated,
+-- no_sni, ipv6_skipped, not_tcp, malformed,  quic_success, quic_short_header,
+-- quic_unsupported_version, quic_not_initial, quic_truncated, quic_malformed,
+-- quic_decrypt_failed, quic_no_crypto_frame, quic_no_sni, quic_ipv6_skipped,
+-- quic_not_udp, quic_not_443} — a small bounded enum. We mirror the #1302
+-- dns_metrics IPC: reuse dns_log.format_query_results to serialise the tally
+-- to paths.sni_metrics on each flush, and the agent's metrics tick folds the
+-- deltas into sni_clienthellos_total{result}. The split also feeds the
 -- periodic log line so a fleet-wide truncation/ipv6-skip rate is visible from
 -- logread alone (was lumped into a single no_sni_total — SHOULD-FIX #4/#7).
 local results           = {}
@@ -143,16 +203,14 @@ while true do
   end
   local pkt = rec.data
 
-  local r, reason = sni.parse_packet(pkt)
+  local r, label = dispatch(pkt)
   if r then
     spool:write(sni.format_sni_line(r.dst_ip, r.src_mac, r.sni))
     spool:flush()
     parsed_total      = parsed_total + 1
     since_stat_parsed = since_stat_parsed + 1
-    bump("parsed")
-  else
-    bump(reason or "no_sni")
   end
+  bump(label or "no_sni")
 
   local now = os.time()
   -- Publish the result tally on the same cadence as the heartbeat. Cheap
@@ -162,11 +220,21 @@ while true do
     last_metrics_flush = now
   end
   if (now - last_stats_log) >= 60 then
-    log.info("sni-tail: parsed=%d (+%d in last %ds) truncated=%d no_sni=%d ipv6_skipped=%d not_tcp=%d malformed=%d",
+    log.info("sni-tail: parsed=%d (+%d in last %ds) truncated=%d no_sni=%d " ..
+             "ipv6_skipped=%d not_tcp=%d malformed=%d " ..
+             "quic_success=%d quic_short_header=%d quic_not_initial=%d " ..
+             "quic_unsupported_version=%d quic_decrypt_failed=%d " ..
+             "quic_no_crypto_frame=%d quic_no_sni=%d",
              parsed_total, since_stat_parsed, now - last_stats_log,
              results.truncated or 0, results.no_sni or 0,
              results.ipv6_skipped or 0, results.not_tcp or 0,
-             results.malformed or 0)
+             results.malformed or 0,
+             results.quic_success or 0, results.quic_short_header or 0,
+             results.quic_not_initial or 0,
+             results.quic_unsupported_version or 0,
+             results.quic_decrypt_failed or 0,
+             results.quic_no_crypto_frame or 0,
+             results.quic_no_sni or 0)
     flush_metrics()
     last_stats_log    = now
     since_stat_parsed = 0

--- a/openwrt/test/quic_spec.lua
+++ b/openwrt/test/quic_spec.lua
@@ -1,0 +1,315 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/quic.lua
+--
+-- quic.lua parses QUIC v1 Initial packets (UDP 443) and extracts the SNI
+-- server_name from the TLS ClientHello carried in CRYPTO frames inside the
+-- packet's AEAD-encrypted payload (#1651, follow-up to #573). This recovers
+-- the hostname an HTTP/3 client actually contacted, restoring attribution
+-- for QUIC flows that the v1 TCP-only ClientHello parser would miss.
+--
+-- The parser takes an injected `crypto` table (hkdf_extract, hkdf_expand_label,
+-- aes128_ecb, aes128_gcm_decrypt) so the unit tests can plug in a stub that
+-- echoes the RFC 9001 Appendix A.2 test vector inputs back as their known
+-- outputs without pulling lua-openssl onto the dev macOS host. The production
+-- sidecar wires in a lua-openssl-backed crypto table on the router.
+--
+-- Run with: busted openwrt/test/quic_spec.lua
+
+local quic = require("quic")
+
+-- ---------------------------------------------------------------------------
+-- Hex / byte helpers.
+-- ---------------------------------------------------------------------------
+
+local function unhex(h)
+  -- strip whitespace then decode
+  h = (h:gsub("%s+", ""))
+  return (h:gsub("%x%x", function(b) return string.char(tonumber(b, 16)) end))
+end
+
+local function hex(s)
+  return (s:gsub(".", function(c) return string.format("%02x", c:byte()) end))
+end
+
+-- ---------------------------------------------------------------------------
+-- RFC 9001 §A.2 "Client Initial" test vector.
+-- ---------------------------------------------------------------------------
+--
+-- DCID                : 8394c8f03e515708
+-- HKDF salt (QUIC v1) : 38762cf7f55934b34d179ae6a4c80cadccbb7f0a
+-- initial_secret     -> 7db5df06e7a69e432496adedb008519235952215 96ae2ae9fb8115c1e9ed0a44
+-- client_initial      : c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea
+-- key                 : 1f369613dd76d5467730efcbe3b1a22d
+-- iv                  : fa044b2f42a3fd3b46fb255c
+-- hp                  : 9f50449e04a0e810283a1e9933adedd2
+-- sample              : d1b1c98dd7689fb8ec11d242b123dc9b
+-- mask                : 437b9aec36 (first 5 bytes of AES-128-ECB(hp, sample))
+-- unprotected header  : c300000001088394c8f03e5157080000449e00000002
+-- packet number       : 2 (4-byte encoding)
+-- nonce               : iv XOR (0..00 00 00 00 02) = fa044b2f42a3fd3b46fb255e
+
+local RFC_DCID    = unhex("8394c8f03e515708")
+local RFC_SALT    = unhex("38762cf7f55934b34d179ae6a4c80cadccbb7f0a")
+local RFC_PRK     = unhex("7db5df06e7a69e432496adedb008519235952215" ..
+                          "96ae2ae9fb8115c1e9ed0a44")
+local RFC_CLIENT_INITIAL = unhex(
+  "c00cf151ca5be075ed0ebfb5c80323c42d6b7db67881289af4008f1f6c357aea")
+local RFC_KEY    = unhex("1f369613dd76d5467730efcbe3b1a22d")
+local RFC_IV     = unhex("fa044b2f42a3fd3b46fb255c")
+local RFC_HP     = unhex("9f50449e04a0e810283a1e9933adedd2")
+local RFC_SAMPLE = unhex("d1b1c98dd7689fb8ec11d242b123dc9b")
+local RFC_MASK5  = unhex("437b9aec36")
+local RFC_NONCE  = unhex("fa044b2f42a3fd3b46fb255e")
+
+-- The unprotected payload — a CRYPTO frame carrying a TLS ClientHello with
+-- SNI = "example.com" — plus PADDING frames out to 1162 bytes.
+local RFC_UNPROTECTED_PAYLOAD = unhex([[
+  060040f1010000ed0303ebf8fa56f12939b9584a3896472ec40bb863cfd3e868
+  04fe3a47f06a2b69484c000004130113 02010000c000000010000e00000b6578
+  616d706c652e636f6dff01000100000a 00080006001d00170018001000070005
+  04616c706e0005000501000000000033 00260024001d00209370b2c9caa47fba
+  baf4559fedba753de171fa71f50f1ce1 5d43e994ec74d748002b000302030400
+  0d0010000e0403050306030203080408 050806002d00020101001c0002400100
+  3900320408ffffffffffffffff050480 00ffff07048000ffff08011001048000
+  75300901100f088394c8f03e51570806 048000ffff
+]]) .. string.rep("\0", 917)  -- pad to 1162 bytes (CRYPTO frame is 245 bytes)
+
+-- The unprotected header (used as AEAD AAD).
+local RFC_UNPROTECTED_HEADER =
+  unhex("c300000001088394c8f03e5157080000449e00000002")
+
+-- The full protected client Initial packet as it appears on the wire (UDP
+-- payload — i.e. starting at the first byte of the QUIC long header). Source:
+-- RFC 9001 Appendix A.2.
+local RFC_PROTECTED_PACKET = unhex([[
+  c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
+  d242b123dc9bd8bab936b47d92ec356c 0bab7df5976d27cd449f63300099f399
+  1c260ec4c60d17b31f8429157bb35a12 82a643a8d2262cad67500cadb8e7378c
+  8eb7539ec4d4905fed1bee1fc8aafba1 7c750e2c7ace01e6005f80fcb7df6212
+  30c83711b39343fa028cea7f7fb5ff89 eac2308249a02252155e2347b63d58c5
+  457afd84d05dfffdb20392844ae81215 4682e9cf012f9021a6f0be17ddd0c208
+  4dce25ff9b06cde535d0f920a2db1bf3 62c23e596d11a4f5a6cf3948838a3aec
+  4e15daf8500a6ef69ec4e3feb6b1d98e 610ac8b7ec3faf6ad760b7bad1db4ba3
+  485e8a94dc250ae3fdb41ed15fb6a8e5 eba0fc3dd60bc8e30c5c4287e53805db
+  059ae0648db2f64264ed5e39be2e20d8 2df566da8dd5998ccabdae053060ae6c
+  7b4378e846d29f37ed7b4ea9ec5d82e7 961b7f25a9323851f681d582363aa5f8
+  9937f5a67258bf63ad6f1a0b1d96dbd4 faddfcefc5266ba6611722395c906556
+  be52afe3f565636ad1b17d508b73d874 3eeb524be22b3dcbc2c7468d54119c74
+  68449a13d8e3b95811a198f3491de3e7 fe942b330407abf82a4ed7c1b311663a
+  c69890f4157015853d91e923037c227a 33cdd5ec281ca3f79c44546b9d90ca00
+  f064c99e3dd97911d39fe9c5d0b23a22 9a234cb36186c4819e8b9c5927726632
+  291d6a418211cc2962e20fe47feb3edf 330f2c603a9d48c0fcb5699dbfe58964
+  25c5bac4aee82e57a85aaf4e2513e4f0 5796b07ba2ee47d80506f8d2c25e50fd
+  14de71e6c418559302f939b0e1abd576 f279c4b2e0feb85c1f28ff18f58891ff
+  ef132eef2fa09346aee33c28eb130ff2 8f5b766953334113211996d20011a198
+  e3fc433f9f2541010ae17c1bf202580f 6047472fb36857fe843b19f5984009dd
+  c324044e847a4f4a0ab34f719595de37 252d6235365e9b84392b061085349d73
+  203a4a13e96f5432ec0fd4a1ee65accd d5e3904df54c1da510b0ff20dcc0c77f
+  cb2c0e0eb605cb0504db87632cf3d8b4 dae6e705769d1de354270123cb11450e
+  fc60ac47683d7b8d0f811365565fd98c 4c8eb936bcab8d069fc33bd801b03ade
+  a2e1fbc5aa463d08ca19896d2bf59a07 1b851e6c239052172f296bfb5e724047
+  90a2181014f3b94a4e97d117b4381303 68cc39dbb2d198065ae3986547926cd2
+  162f40a29f0c3c8745c0f50fba3852e5 66d44575c29d39a03f0cda721984b6f4
+  40591f355e12d439ff150aab7613499d bd49adabc8676eef023b15b65bfc5ca0
+  6948109f23f350db82123535eb8a7433 bdabcb909271a6ecbcb58b936a88cd4e
+  8f2e6ff5800175f113253d8fa9ca8885 c2f552e657dc603f252e1a8e308f76f0
+  be79e2fb8f5d5fbbe2e30ecadd220723 c8c0aea8078cdfcb3868263ff8f09400
+  54da48781893a7e49ad5aff4af300cd8 04a6b6279ab3ff3afb64491c85194aab
+  760d58a606654f9f4400e8b38591356f bf6425aca26dc85244259ff2b19c41b9
+  f96f3ca9ec1dde434da7d2d392b905dd f3d1f9af93d1af5950bd493f5aa731b4
+  056df31bd267b6b90a079831aaf579be 0a39013137aac6d404f518cfd4684064
+  7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241
+  e221af44860018ab0856972e194cd934
+]])
+
+-- ---------------------------------------------------------------------------
+-- Stub crypto: returns RFC-known outputs for RFC-known inputs.
+--
+-- The QUIC parser logic is what the unit tests verify — header parsing, HP
+-- mask XOR, AAD construction, nonce derivation, CRYPTO frame reassembly,
+-- ClientHello extraction. The AES + HKDF math itself is a library call we
+-- don't own; in production the sidecar wires it to lua-openssl. Here the stub
+-- asserts on its inputs (so a bug in nonce/AAD/sample construction shows up
+-- as an explicit "stub got unexpected input" failure, not a silent nil
+-- decryption result).
+-- ---------------------------------------------------------------------------
+
+local function stub_crypto()
+  return {
+    hkdf_extract = function(salt, ikm)
+      assert(salt == RFC_SALT, "hkdf_extract: salt mismatch")
+      assert(ikm == RFC_DCID, "hkdf_extract: ikm mismatch")
+      return RFC_PRK
+    end,
+    hkdf_expand_label = function(prk, label, context, length)
+      assert(prk == RFC_PRK or prk == RFC_CLIENT_INITIAL,
+             "hkdf_expand_label: unexpected prk")
+      assert(context == "", "hkdf_expand_label: non-empty context")
+      if prk == RFC_PRK and label == "client in" and length == 32 then
+        return RFC_CLIENT_INITIAL
+      elseif prk == RFC_CLIENT_INITIAL and label == "quic key" and length == 16 then
+        return RFC_KEY
+      elseif prk == RFC_CLIENT_INITIAL and label == "quic iv" and length == 12 then
+        return RFC_IV
+      elseif prk == RFC_CLIENT_INITIAL and label == "quic hp" and length == 16 then
+        return RFC_HP
+      end
+      error("hkdf_expand_label: unexpected (label=" .. label ..
+            ", length=" .. tostring(length) .. ")")
+    end,
+    aes128_ecb = function(key, sample)
+      assert(key == RFC_HP, "aes128_ecb: key mismatch")
+      assert(sample == RFC_SAMPLE,
+             "aes128_ecb: sample mismatch got=" .. hex(sample))
+      -- AES-128-ECB(hp_key, sample) — only the first 5 bytes are used as the
+      -- HP mask. We return the full 16-byte block padded with zeros; the
+      -- parser MUST only use the first 5 bytes.
+      return RFC_MASK5 .. string.rep("\0", 11)
+    end,
+    aes128_gcm_decrypt = function(key, nonce, aad, ciphertext)
+      assert(key == RFC_KEY,
+             "aes128_gcm_decrypt: key mismatch got=" .. hex(key))
+      assert(nonce == RFC_NONCE,
+             "aes128_gcm_decrypt: nonce mismatch got=" .. hex(nonce))
+      assert(aad == RFC_UNPROTECTED_HEADER,
+             "aes128_gcm_decrypt: AAD mismatch got=" .. hex(aad))
+      -- The stub doesn't verify the tag — that's the library's job. It just
+      -- returns the known plaintext when inputs match.
+      return RFC_UNPROTECTED_PAYLOAD
+    end,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Ethernet / IPv4 / UDP framing — minimal builder so we can feed parse_initial
+-- a complete eth_frame the way the sidecar's BPF capture will.
+-- ---------------------------------------------------------------------------
+
+local function build_eth_ipv4_udp(src_mac_bytes, dst_ip_bytes, udp_payload)
+  local dst_mac = string.rep("\0", 6)
+  local ethertype = string.char(0x08, 0x00) -- IPv4
+  local eth = dst_mac .. src_mac_bytes .. ethertype
+
+  -- IPv4 header (20 bytes, no options)
+  local ihl_ver = string.char(0x45)
+  local tos     = string.char(0)
+  local total   = 20 + 8 + #udp_payload
+  local total_b = string.char(math.floor(total / 256), total % 256)
+  local idflags = string.char(0, 0, 0x40, 0) -- DF set
+  local ttl     = string.char(64)
+  local proto   = string.char(17) -- UDP
+  local checksum= string.char(0, 0) -- ignored by our parser
+  local src_ip  = string.rep("\0", 4)
+  local ip      = ihl_ver .. tos .. total_b .. idflags .. ttl .. proto ..
+                  checksum .. src_ip .. dst_ip_bytes
+
+  -- UDP header (8 bytes)
+  local sport   = string.char(0x80, 0x00) -- 32768
+  local dport   = string.char(0x01, 0xbb) -- 443
+  local ulen    = 8 + #udp_payload
+  local ulen_b  = string.char(math.floor(ulen / 256), ulen % 256)
+  local ucksum  = string.char(0, 0) -- optional in IPv4, our parser tolerates 0
+  local udp     = sport .. dport .. ulen_b .. ucksum
+
+  return eth .. ip .. udp .. udp_payload
+end
+
+-- ---------------------------------------------------------------------------
+-- Tests.
+-- ---------------------------------------------------------------------------
+
+describe("quic", function()
+  describe("parse_quic_packet (UDP payload)", function()
+    it("extracts SNI from the RFC 9001 A.2 protected client Initial", function()
+      local sni = quic.parse_quic_packet(RFC_PROTECTED_PACKET, stub_crypto())
+      assert.are.equal("example.com", sni)
+    end)
+
+    it("returns nil/quic_unsupported_version on a v2 long header", function()
+      -- Same header shape but version field set to 0x6b3343cf (QUIC v2 RFC
+      -- 9369). The salt for v2 is different so we can't reuse the keys; the
+      -- parser must reject it cleanly before touching any crypto.
+      local v2 = "\xc0" ..             -- long header, Initial-like form
+                 "\x6b\x33\x43\xcf" .. -- version v2
+                 "\x08" .. RFC_DCID .. -- DCID
+                 "\x00" ..             -- SCID len 0
+                 "\x00" ..             -- token len 0
+                 "\x44\x9e" ..         -- length (varint, doesn't matter)
+                 string.rep("\0", 1200) -- bogus payload
+      local sni, reason = quic.parse_quic_packet(v2, stub_crypto())
+      assert.is_nil(sni)
+      assert.are.equal("quic_unsupported_version", reason)
+    end)
+
+    it("returns nil/quic_not_initial on a long header non-Initial (Handshake) packet", function()
+      -- Long header, Initial-like prefix but packet-type bits = 0x02 (Handshake)
+      -- in the first byte. We can't decrypt Handshake with Initial keys.
+      local hs = "\xe0" ..             -- 1100 0000 → 0xe0 = type=10 (Handshake)
+                 "\x00\x00\x00\x01" .. -- v1
+                 "\x08" .. RFC_DCID ..
+                 "\x00" ..             -- SCID len 0
+                 "\x44\x9e" ..         -- length
+                 string.rep("\0", 1200)
+      local sni, reason = quic.parse_quic_packet(hs, stub_crypto())
+      assert.is_nil(sni)
+      assert.are.equal("quic_not_initial", reason)
+    end)
+
+    it("returns nil/quic_short_header on a short-header (1-RTT) packet", function()
+      -- First-byte high bit clear = short header. SNI is only in Initials, so
+      -- we silently skip — this is the steady-state case (most QUIC traffic
+      -- on UDP 443 is 1-RTT once the handshake settles).
+      local short = "\x40" .. string.rep("\0", 100)
+      local sni, reason = quic.parse_quic_packet(short, stub_crypto())
+      assert.is_nil(sni)
+      assert.are.equal("quic_short_header", reason)
+    end)
+
+    it("returns nil/quic_truncated on a packet shorter than the long header", function()
+      local sni, reason = quic.parse_quic_packet("\xc0\x00\x00", stub_crypto())
+      assert.is_nil(sni)
+      assert.are.equal("quic_truncated", reason)
+    end)
+  end)
+
+  describe("parse_initial (full eth/ipv4/udp frame)", function()
+    it("extracts dst_ip, src_mac, sni from a wire-format frame", function()
+      local mac = string.char(0xfa, 0x10, 0xcd, 0x84, 0x78, 0x22)
+      local ip  = string.char(142, 250, 81, 14) -- 142.250.81.14
+      local frame = build_eth_ipv4_udp(mac, ip, RFC_PROTECTED_PACKET)
+      local r, reason = quic.parse_initial(frame, stub_crypto())
+      assert.is_nil(reason)
+      assert.is_not_nil(r)
+      assert.are.equal("142.250.81.14", r.dst_ip)
+      assert.are.equal("fa:10:cd:84:78:22", r.src_mac)
+      assert.are.equal("example.com", r.sni)
+    end)
+
+    it("returns truncated on a frame too small for eth+ip+udp", function()
+      local _, reason = quic.parse_initial(string.rep("\0", 30), stub_crypto())
+      assert.are.equal("quic_truncated", reason)
+    end)
+
+    it("returns ipv6_skipped on a non-IPv4 ethertype", function()
+      local f = string.rep("\0", 12) .. "\x86\xdd" .. string.rep("\0", 100)
+      local _, reason = quic.parse_initial(f, stub_crypto())
+      assert.are.equal("quic_ipv6_skipped", reason)
+    end)
+
+    it("returns not_udp on a TCP IPv4 packet", function()
+      local mac = string.rep("\0", 6)
+      local ip  = string.char(1, 2, 3, 4)
+      -- Build an eth+ipv4 with proto=6 (TCP) and bogus tail
+      local dst_mac = string.rep("\0", 6)
+      local ethertype = "\x08\x00"
+      local eth = dst_mac .. mac .. ethertype
+      local total = 20 + 20
+      local total_b = string.char(math.floor(total / 256), total % 256)
+      local hdr = "\x45\x00" .. total_b .. "\x00\x00\x40\x00\x40" ..
+                  "\x06" .. -- proto=TCP
+                  "\x00\x00" .. string.rep("\0", 4) .. ip
+      local frame = eth .. hdr .. string.rep("\0", 20)
+      local _, reason = quic.parse_initial(frame, stub_crypto())
+      assert.are.equal("quic_not_udp", reason)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #1651.

Extends the #573 SNI hostname-attribution sidecar to cover **QUIC v1
Initial packets** (UDP/443) alongside the existing TCP/443 path. With
HTTP/3 increasingly the default for Google/YouTube/CDN traffic, the
TCP-only ClientHello parser was leaving a growing slice of DoH /
hard-coded-IP flows unattributed — the #1636/#1640 collateral-drop
class would silently reappear for QUIC-preferring apps.

This PR is attribution-only. Blocking QUIC remains #572's job.

## Architecture (per RFC 9000 + RFC 9001)

```
long-header parse (RFC 9000 §17.2)
  → HKDF-derive client Initial keys from DCID + v1 salt (RFC 9001 §5.2)
  → AES-128-ECB(hp_key, sample[16]) → 5-byte HP mask removal (RFC 9001 §5.4)
  → AAD = unprotected header bytes; nonce = IV XOR pn (RFC 9001 §5.3)
  → AES-128-GCM decrypt (PN..tag) bytes
  → CRYPTO-frame reassembly (RFC 9000 §19.6)
  → existing sni.parse_client_hello (single-source-of-truth)
  → cache.insert_sni (same writer as TCP path)
```

The new `openwrt/files/usr/lib/lua/wifihaven/quic.lua` owns parsing
and key derivation; the TLS ClientHello SNI extension walk and the
spool/cache writes are unchanged — they reuse the exact functions the
TCP path already calls, per AGENTS.md §single-source-of-truth.

## Crypto dependency choice (lua-openssl)

OpenWrt 25.12.x ships an `openssl-util` CLI but the Lua bindings are a
separate package: `lua-openssl-0.10.0.0-r1`, ~464 KiB installed. I
considered the alternatives in the issue brief:

* **Shell out to `openssl enc` / `openssl dgst` per packet** — rejected.
  The capture hot path is one parse per new flow, and `fork+exec` per
  packet is two orders of magnitude more expensive than a Lua FFI call.
* **Pure-Lua AES/HMAC** — rejected. ~500 lines of crypto we'd own and
  test, vs. ~5 lines of glue to an OpenSSL-backed binding.
* **Custom C helper** — rejected. New build artifact + new package,
  same goal as lua-openssl which is already in the upstream feed.

So **lua-openssl is added to the `wifihaven` package DEPENDS**. The
weight increase is +464 KiB (~0.1% of the typical 50 MiB router
install). The bindings are also reusable for future agent crypto work
(e.g. local block-page TLS cert generation, currently shelling out).

`quic.openssl_crypto(openssl)` builds the small contract the parser
expects (`hkdf_extract`, `hkdf_expand_label`, `aes128_ecb`,
`aes128_gcm_decrypt`). HKDF itself follows RFC 5869 §2.3 on top of
`openssl.hmac.hmac` — lua-openssl 0.9.2's `kdf.fetch("HKDF")` is
present but its params-table shape rejected every form I tried (see
\`bad argument #1 to 'derive' (empty paramaters table)\`), so I built
the standard 4-line Expand loop on HMAC-SHA256 instead. Verified
against the RFC 9001 §A.1 keys byte-for-byte on the test router.

## Test vector

`openwrt/test/quic_spec.lua` embeds the **RFC 9001 Appendix A.2**
'Client Initial' vector — DCID `8394c8f03e515708`, 1200-byte protected
packet, ClientHello SNI `example.com` — and asserts the parser
extracts that SNI end-to-end. The unit tests inject a stub `crypto`
table that asserts on its inputs and echoes the RFC-known outputs, so:

* The HP-mask offset, AAD construction, nonce derivation, and CRYPTO
  reassembly are all exercised against an externally-defined, known-
  correct vector — a bug in any of them surfaces as a stub assertion
  failure, not a silent nil result.
* The dev macOS host does not need `lua-openssl` to run the suite.

Edge-case tests cover `quic_unsupported_version` (v2 salt), `quic_not_initial`
(Handshake long header), `quic_short_header` (1-RTT, the steady-state
case), `quic_truncated`, and the IPv4/UDP framing wrapper.

**To capture your own real-browser QUIC handshake:**
```
tcpdump -i <iface> -s 2048 -w hello.pcap 'udp dst port 443 and (udp[8] & 0xf0) = 0xc0'
# open https://www.google.com in Chrome/Firefox
```
The first packet of any flow whose first byte's high nibble is `0xc0`
is a client Initial. Feed the UDP payload to `quic.parse_quic_packet`
with `quic.openssl_crypto(openssl)`.

## Live verification

Deployed `quic.lua` + the updated sidecar to the test router
(`openwrt.lan`, OpenWrt 25.12.3 `aarch64_cortex-a53`, with
`lua-openssl-0.10.0.0-r1`):

* `quic.openssl_crypto` derives the RFC 9001 §A.1 keys byte-for-byte
  (initial_secret, client_initial, key, iv, hp, sample → HP mask).
* `quic.parse_initial` on a hand-built eth/IPv4/UDP frame wrapping the
  RFC 9001 §A.2 protected client Initial returns
  `dst=8.8.8.8 mac=fa:10:cd:84:78:22 sni=example.com`.
* `wifihaven-sni-tail` restarts cleanly with the combined BPF filter
  (`(tcp dst port 443 and …) or (udp dst port 443 and (udp[8] & 0xf0) = 0xc0)`);
  libpcap accepts the expression and the tcpdump child stays attached
  to br-lan. The `0xc0` high-nibble match (header_form=1 + fixed_bit=1
  + packet_type=Initial=0) drops every 1-RTT and 0-RTT/Handshake/Retry
  packet from capture, keeping per-packet cost at parity with the TCP
  path.

## Metric buckets added

Extends `sni_clienthellos_total{result}` with the bounded enum
`quic_success | quic_short_header | quic_unsupported_version |
quic_not_initial | quic_truncated | quic_malformed | quic_decrypt_failed |
quic_no_crypto_frame | quic_no_sni | quic_ipv6_skipped | quic_not_udp |
quic_not_443`. No API-side `MetricGuard` change is needed — the agent
folds the per-result tally generically via `metrics.fold_external`,
and the `{result}` label key is already on the allowed-keys list.

Grafana: extends `deploy/grafana/dashboards/router-fleet.json`'s
existing 'SNI ClientHello rate by result' description to enumerate
the new buckets (the panel itself already aggregates `sum by(result)`
so it picks them up automatically), and adds a new 'SNI success share:
TCP vs QUIC (#1651)' panel — the operator-level summary of HTTP/3
adoption that the per-bucket panel can't answer at a glance.

## Deliberate v1 scope

| Scope          | This PR                | Out of scope                       |
| -------------- | ---------------------- | ---------------------------------- |
| QUIC version   | v1 only                | v2 (RFC 9369) → `quic_unsupported_version` |
| Packet type    | Client Initial only    | 0-RTT / Handshake / Retry / 1-RTT  |
| AEAD           | AES-128-GCM            | (Initials always use AES-128-GCM per RFC 9001 §5.1 — no ChaCha20 needed) |
| Outer L3       | IPv4                   | IPv6 framing (same as sni.lua v1)  |
| ClientHello    | Single Initial         | Multi-Initial fragmentation        |

QUIC v2 (and any future version) would need a different salt and could
land in a follow-up that's purely a `version → salt` lookup table —
the rest of the pipeline is version-agnostic. I haven't filed a
follow-up issue because v2 adoption is still effectively zero on the
public internet.

## Files

| File | Purpose |
| ---- | ------- |
| `openwrt/files/usr/lib/lua/wifihaven/quic.lua` | New: QUIC v1 Initial parser |
| `openwrt/files/usr/sbin/wifihaven-sni-tail` | Extended BPF + dispatch |
| `openwrt/Makefile` | `+lua-openssl` DEPENDS |
| `openwrt/test/quic_spec.lua` | RFC 9001 §A.2 vector + edge cases |
| `deploy/grafana/dashboards/router-fleet.json` | Dashboard panel |

## Test plan

- [x] `busted openwrt/test/quic_spec.lua` — 9/9 pass
- [x] `bash openwrt/test/run_tests.sh` — 697/697 pass
- [x] RFC 9001 §A.2 vector decrypts to "example.com" on the test router
- [x] `wifihaven-sni-tail` restarts with the new BPF without crashing
- [x] `python3 -m json.tool deploy/grafana/dashboards/router-fleet.json` validates
- [x] `terraform fmt -check` in `infra/grafana/`
- [ ] Real-browser QUIC handshake captured on a fleet router with `quic_success` ticking (deferred to next deploy — needs an actual LAN client; the RFC vector hits the same code path)