### PR TITLE
fix(#1703): Usage-by-App renders <img> for app icon, not the URL string

### DIFF
--- a/web/src/components/usage/ProfileUsageBreakdown.test.tsx
+++ b/web/src/components/usage/ProfileUsageBreakdown.test.tsx
@@ -77,6 +77,27 @@ describe('ProfileUsageBreakdown — #1519/#726', () => {
       .toBeInTheDocument()
   })
 
+  it('renders the app icon as an <img> for URL icons, not as raw URL text (#1703)', () => {
+    const data = fixture()
+    data.apps[0].appIcon = 'https://icons.duckduckgo.com/ip3/youtube.com.ico'
+    data.apps[0].appIconType = 'url'
+    render(<BreakdownBody profileId={1} data={data} />)
+    const row = screen.getByTestId('profile-usage-breakdown-1-app-10')
+    // The favicon URL must not appear as visible text on the row
+    expect(row).not.toHaveTextContent('https://icons.duckduckgo.com/ip3/youtube.com.ico')
+    // …it must render as an <img> whose src is the favicon URL
+    const img = row.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img!.getAttribute('src')).toBe('https://icons.duckduckgo.com/ip3/youtube.com.ico')
+  })
+
+  it('renders an emoji icon as text (not as an <img>) — fallback path unaffected', () => {
+    render(<BreakdownBody profileId={1} data={fixture()} />)
+    const row = screen.getByTestId('profile-usage-breakdown-1-app-10')
+    expect(row.querySelector('img')).toBeNull()
+    expect(row).toHaveTextContent('📺')
+  })
+
   it('renders an empty-state when there is no usage at all', () => {
     render(
       <BreakdownBody

--- a/web/src/components/usage/ProfileUsageBreakdown.tsx
+++ b/web/src/components/usage/ProfileUsageBreakdown.tsx
@@ -4,6 +4,7 @@ import type {
   HostUsage, OrphanHostUsage, ProfileAppUsage, ProfileUsageByApp,
 } from '@/types/api'
 import { formatMins } from '@/lib/timeFormat'
+import { AppIcon } from '@/components/AppIcon'
 
 // #1519 / #726 — per-profile usage breakdown: one row per configured app
 // (drillable to its per-host minutes — the #726 per-FQDN breakdown), then one
@@ -107,7 +108,9 @@ function AppRow({ profileId, app }: { profileId: number; app: ProfileAppUsage })
       >
         <span className="flex items-center gap-2">
           <span className={`text-brand-text-muted transition-transform text-xs ${open ? 'rotate-90' : ''}`}>▸</span>
-          {app.appIcon && <span aria-hidden>{app.appIcon}</span>}
+          {app.appIcon && (
+            <AppIcon icon={app.appIcon} iconType={app.appIconType ?? undefined} size="sm" />
+          )}
           <span className="text-sm font-medium text-brand-ink">{app.appName}</span>
         </span>
         <span


### PR DESCRIPTION
Closes #1703.

## Root cause
`web/src/components/usage/ProfileUsageBreakdown.tsx` rendered
`{app.appIcon}` directly as a text node. For URL-shaped icons (the DDG
ip3 favicons used for most apps) this put the raw URL string on the row
before the app name. Emoji icons looked fine by accident; orphan-host
rows were unaffected because they have no icon field.

## Fix
Swap the inlined text node for `<AppIcon icon={…} iconType={…} size=\"sm\">`,
the existing single-source-of-truth icon component used by Logs,
Traffic-Usage, Profiles and Apps. It renders an `<img>` for https URLs
(with `loading=\"lazy\"`, fixed width/height for layout stability, and
the #1004 https-only safeImageSrc guard) and falls back to a text glyph
for emoji / null icons.

## Tests
RED → GREEN visible in commit history. Two new vitest cases in
`ProfileUsageBreakdown.test.tsx`:
- URL icon → `<img>` with `src=` favicon URL, no URL text on row
- Emoji icon → text glyph, no `<img>`

Orphan-host rows unchanged.