### PR TITLE
feat(#1655): static IP-range → label map for hardcoded-IP services (last-resort attribution)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -877,14 +877,18 @@ in zero drop or carve-out predicates: enforcement is the per-MAC
 an enforcement input requires explicit operator approval and a tracking
 issue. The header comment in `static_ip_labels.lua` repeats this.
 
-Note that the *produced label* is emitted as a `HostId` with
-`type = "fqdn"` and therefore flows through downstream
-`HostMatch.matchesAny` / app-host-set membership exactly like a real
-DNS/SNI-derived hostname — i.e. an operator who configures an app whose
-host-set includes the literal `apple-push` will see APNs flows attribute
-to that app, count against its quotas, and obey its allow/block policy.
-That's the intended way labels surface; what "labels only" rules out is
-the map *itself* gating a drop server-side.
+Note that the *produced label* is currently emitted as a `HostId` with
+`type = "fqdn"` (no distinct variant exists yet) and therefore flows
+through downstream `HostMatch.matchesAny` / app-host-set membership
+exactly like a real DNS/SNI-derived hostname — i.e. an operator who
+configures an app whose host-set includes the literal `apple-push` will
+see APNs flows attribute to that app, count against its quotas, and
+obey its allow/block policy. That's the intended way labels surface;
+what "labels only" rules out is the map *itself* gating a drop
+server-side. Distinguishing labels from real FQDNs at the wire level
+(adding a `HostId.Label` variant so downstream code can tell them apart)
+is tracked separately in
+[#1708](https://github.com/wifihaven/wifihaven/issues/1708).
 
 **Extending the map.** Add a `{ cidr, label }` row to `M._ranges` with a
 citation in the comment beside it, and a test in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -877,6 +877,15 @@ in zero drop or carve-out predicates: enforcement is the per-MAC
 an enforcement input requires explicit operator approval and a tracking
 issue. The header comment in `static_ip_labels.lua` repeats this.
 
+Note that the *produced label* is emitted as a `HostId` with
+`type = "fqdn"` and therefore flows through downstream
+`HostMatch.matchesAny` / app-host-set membership exactly like a real
+DNS/SNI-derived hostname — i.e. an operator who configures an app whose
+host-set includes the literal `apple-push` will see APNs flows attribute
+to that app, count against its quotas, and obey its allow/block policy.
+That's the intended way labels surface; what "labels only" rules out is
+the map *itself* gating a drop server-side.
+
 **Extending the map.** Add a `{ cidr, label }` row to `M._ranges` with a
 citation in the comment beside it, and a test in
 `openwrt/test/static_ip_labels_spec.lua`. Keep growth operator-curated:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -848,6 +848,41 @@ rather than smuggling an IP into a hostname field, so the type system
 prevents accidental pattern matches against `*.example.com` and the admin
 UI can render direct-IP rows distinguishably from named hosts.
 
+#### Static IP-range labels (#1655)
+
+Before falling through to the IP literal, the agent consults a small,
+in-repo **static IP-range → label map**
+(`openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua`) as a
+last-resort attribution source. Some traffic never presents an SNI *and*
+never resolves via dnsmasq — notably Apple push (APNs) on `17.0.0.0/8`,
+and apps that bypass the local resolver and hit public resolvers
+(`8.8.8.8`, `1.1.1.1`) directly. With the map, those flows show up in
+connection_events as `apple-push` / `google-dns` / `cloudflare-dns`
+instead of a bare IP.
+
+**Precedence in `handle_flow`:**
+
+1. `attribute_hostname` — dnsmasq query-log cache (the SNI/QUIC sidecars
+   also feed this primitive via `cache.insert_sni`, so SNI- and
+   QUIC-derived hostnames flow through the same path — #573, #1651).
+2. `ipset_lookup_hostname` — legacy `nft_sets` fallback for site_limits
+   domains.
+3. `static_ip_labels.lookup` — last-resort static map (this section).
+
+A real attribution always beats a static guess.
+
+**LABELS ONLY — never an enforcement input.** The static map participates
+in zero drop or carve-out predicates: enforcement is the per-MAC
+`BlockRules` / nftables pipeline (see §0.1 / §0.2). Promoting an entry to
+an enforcement input requires explicit operator approval and a tracking
+issue. The header comment in `static_ip_labels.lua` repeats this.
+
+**Extending the map.** Add a `{ cidr, label }` row to `M._ranges` with a
+citation in the comment beside it, and a test in
+`openwrt/test/static_ip_labels_spec.lua`. Keep growth operator-curated:
+entries should cover ranges with an unambiguous, well-known owner that
+prod evidence shows dominating the unattributed-IP tail.
+
 ### 7.3 Package layout
 
 ```

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -23,6 +23,8 @@
 
 local M = {}
 
+local static_ip_labels = require("wifihaven.static_ip_labels")
+
 -- ---------------------------------------------------------------------------
 -- eb_san(host) -> string
 --
@@ -655,6 +657,14 @@ function M.handle_flow(flow, ctx, batcher)
   local hname = M.attribute_hostname(flow.dst_ip, ctx.lookup_hostname, ctx.fqdn_retry_state)
   if not hname then
     hname = M.ipset_lookup_hostname(flow.dst_ip, ctx.nft_sets or {})
+  end
+  -- #1655: last-resort static IP-range → label fallback for flows with no SNI
+  -- and no DNS resolution (Apple APNs on 17.0.0.0/8, well-known public DNS
+  -- resolvers, etc.). LABELS ONLY — see static_ip_labels.lua header. The
+  -- precedence above (DNS > SNI-via-shared-cache > nft_sets > static map) is
+  -- intentional: a real attribution must always beat a static guess.
+  if not hname then
+    hname = static_ip_labels.lookup(flow.dst_ip)
   end
 
   -- Per-MAC block lookup (#297): pause and time-limit block every flow from

--- a/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
@@ -63,15 +63,17 @@ local function parse_cidr_v4(cidr)
 end
 
 -- Pre-compile the v4 ranges once at module load. We keep a parallel array
--- (not a map) so first-match-wins ordering is preserved.
+-- (not a map) so first-match-wins ordering is preserved. `blocksize` is
+-- `2^(32-prefix)` — pre-computed so the hot path in `lookup` is a single
+-- modulo + subtract per range, no per-call shift.
 local compiled_v4 = {}
 for _, entry in ipairs(M._ranges) do
   local parsed = parse_cidr_v4(entry.cidr)
   if parsed then
     compiled_v4[#compiled_v4 + 1] = {
-      network = parsed.network,
-      mask    = parsed.mask,
-      label   = entry.label,
+      network   = parsed.network,
+      blocksize = 0xFFFFFFFF - parsed.mask + 1,
+      label     = entry.label,
     }
   end
 end
@@ -92,8 +94,7 @@ function M.lookup(ip)
     -- Bitwise AND via float math: (n & mask) == network ⇔
     --   n - (n % blocksize) == network, where blocksize = 2^(32-prefix).
     -- Equivalent and avoids requiring bit32 on Lua 5.1.
-    local blocksize = 0xFFFFFFFF - range.mask + 1
-    if (n - (n % blocksize)) == range.network then
+    if (n - (n % range.blocksize)) == range.network then
       return range.label
     end
   end

--- a/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
@@ -1,0 +1,103 @@
+-- static_ip_labels.lua — last-resort IP-range → label map (#1655).
+--
+-- ATTRIBUTION ONLY. This map MUST NOT participate in any drop predicate or
+-- carve-out: enforcement lives entirely in the per-MAC BlockRules / nftables
+-- pipeline (see AGENTS.md "Architectural model"). The map exists so that
+-- connection_events for flows that have NO SNI and NO DNS resolution carry
+-- a meaningful label instead of a bare IP literal — Apple push (APNs) on
+-- 17.0.0.0/8 is the canonical case. Promotion to an enforcement input
+-- requires explicit operator approval and a tracking issue.
+--
+-- Precedence in conntrack.handle_flow:
+--   1. attribute_hostname (dnsmasq query-log cache, which SNI/QUIC sidecars
+--      also feed via cache.insert_sni — see #573 / #1651)
+--   2. ipset_lookup_hostname (legacy nft_sets fallback)
+--   3. static_ip_labels.lookup (THIS module — last resort)
+--
+-- Initial map is intentionally small (< 10 entries). Operators should extend
+-- it only with prod evidence that a range dominates the unattributed-IP tail
+-- AND has a well-known, unambiguous owner. Add an entry + a test in the same
+-- PR; cite the source in the comment beside the entry.
+
+local M = {}
+
+-- IPv4 ranges. Each entry: { cidr, label, why }.
+--
+-- 17.0.0.0/8         — Apple's RIR-allocated /8. APNs hosts and many Apple
+--                      infrastructure services live here; clients pin them
+--                      and bypass dnsmasq entirely.
+--                      <https://www.iana.org/assignments/ipv4-address-space>
+-- 8.8.8.8, 8.8.4.4   — Google Public DNS. Apps that bypass the local
+--                      resolver hit these directly.
+-- 1.1.1.1, 1.0.0.1   — Cloudflare Public DNS. Same pattern as Google DNS.
+--
+-- Time servers (pool.ntp.org and friends) are NOT included: there are too
+-- many rotating IPs to enumerate, and NTP volume is tiny.
+M._ranges = {
+  { cidr = "17.0.0.0/8",     label = "apple-push"     },
+  { cidr = "8.8.8.8/32",     label = "google-dns"     },
+  { cidr = "8.8.4.4/32",     label = "google-dns"     },
+  { cidr = "1.1.1.1/32",     label = "cloudflare-dns" },
+  { cidr = "1.0.0.1/32",     label = "cloudflare-dns" },
+}
+
+-- Parse "a.b.c.d" → 32-bit unsigned integer, or nil on malformed input.
+local function ipv4_to_uint(ip)
+  if type(ip) ~= "string" then return nil end
+  local a, b, c, d = ip:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then return nil end
+  a, b, c, d = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
+  if a > 255 or b > 255 or c > 255 or d > 255 then return nil end
+  return a * 16777216 + b * 65536 + c * 256 + d
+end
+
+-- Parse "a.b.c.d/N" → { network = uint, mask = uint }, or nil on malformed.
+local function parse_cidr_v4(cidr)
+  local addr, prefix = cidr:match("^([%d%.]+)/(%d+)$")
+  if not addr then return nil end
+  local ip = ipv4_to_uint(addr)
+  prefix = tonumber(prefix)
+  if not ip or not prefix or prefix < 0 or prefix > 32 then return nil end
+  local mask = (prefix == 0) and 0 or (0xFFFFFFFF - (2 ^ (32 - prefix) - 1))
+  return { network = ip - (ip % (2 ^ (32 - prefix))), mask = mask }
+end
+
+-- Pre-compile the v4 ranges once at module load. We keep a parallel array
+-- (not a map) so first-match-wins ordering is preserved.
+local compiled_v4 = {}
+for _, entry in ipairs(M._ranges) do
+  local parsed = parse_cidr_v4(entry.cidr)
+  if parsed then
+    compiled_v4[#compiled_v4 + 1] = {
+      network = parsed.network,
+      mask    = parsed.mask,
+      label   = entry.label,
+    }
+  end
+end
+
+-- lookup(ip) → label | nil
+--
+-- Returns the first label whose range contains ip, or nil. v4-only for now;
+-- v6 is parsed off (returns nil) so callers can wire it in safely. To add a
+-- v6 entry later, extend M._ranges with `family = "v6"` rows and add a
+-- ipv6_to_uint128 path here.
+function M.lookup(ip)
+  if type(ip) ~= "string" or ip == "" then return nil end
+  -- v6 literals always contain a colon; punt for now (returns nil).
+  if ip:find(":", 1, true) then return nil end
+  local n = ipv4_to_uint(ip)
+  if not n then return nil end
+  for _, range in ipairs(compiled_v4) do
+    -- Bitwise AND via float math: (n & mask) == network ⇔
+    --   n - (n % blocksize) == network, where blocksize = 2^(32-prefix).
+    -- Equivalent and avoids requiring bit32 on Lua 5.1.
+    local blocksize = 0xFFFFFFFF - range.mask + 1
+    if (n - (n % blocksize)) == range.network then
+      return range.label
+    end
+  end
+  return nil
+end
+
+return M

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -701,6 +701,58 @@ describe("handle_flow", function()
     assert.equal("legacy.example", b.events[2].host.value)
   end)
 
+  -- #1655: static IP-range → label map. When DNS and ipset attribution both
+  -- miss, attribute the flow via the in-repo static map (last-resort, labels
+  -- only — never an enforcement input).
+  it("#1655: falls back to static IP-range label when DNS and nft_sets both miss", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.188.166.41" }, ctx, b)
+    assert.equal("fqdn",       b.events[2].host.type)
+    assert.equal("apple-push", b.events[2].host.value)
+  end)
+
+  it("#1655: leaves host as IP literal when DNS, nft_sets, AND static map all miss", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "203.0.113.7" }, ctx, b)
+    assert.equal("ipv4",        b.events[2].host.type)
+    assert.equal("203.0.113.7", b.events[2].host.value)
+  end)
+
+  it("#1655: DNS attribution wins over the static map", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      -- dst_ip is in 17/8, but the DNS cache attributes it to a hostname.
+      lookup_hostname = function(ip)
+        if ip == "17.1.2.3" then return "icloud.com" end
+        return nil
+      end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.1.2.3" }, ctx, b)
+    assert.equal("fqdn",       b.events[2].host.type)
+    assert.equal("icloud.com", b.events[2].host.value)
+  end)
+
+  it("#1655: ipset (SNI/dns_log) attribution wins over the static map", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      nft_sets        = { ["push.apple.com"] = { ["17.1.2.3"] = true } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.1.2.3" }, ctx, b)
+    assert.equal("fqdn",           b.events[2].host.type)
+    assert.equal("push.apple.com", b.events[2].host.value)
+  end)
+
   -- #583: dns-tail race fix. When the first lookup misses but the reply is
   -- about to land, handle_flow should sleep briefly and retry the lookup
   -- before falling through to host.type=ipv4.

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -28,6 +28,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/nflog_spec.lua \
          test/lan_warn_spec.lua \
          test/eb_refresh_spec.lua \
+         test/static_ip_labels_spec.lua \
          "$@"
 
 echo ""

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -1,0 +1,45 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua  (#1655)
+-- Run with: busted openwrt/test/static_ip_labels_spec.lua
+
+local labels = require("static_ip_labels")
+
+describe("static_ip_labels.lookup", function()
+  it("returns the label for an IP inside Apple's 17.0.0.0/8", function()
+    assert.equal("apple-push", labels.lookup("17.0.0.1"))
+    assert.equal("apple-push", labels.lookup("17.255.255.254"))
+    assert.equal("apple-push", labels.lookup("17.188.166.41"))
+  end)
+
+  it("returns the well-known DNS labels", function()
+    assert.equal("google-dns",     labels.lookup("8.8.8.8"))
+    assert.equal("google-dns",     labels.lookup("8.8.4.4"))
+    assert.equal("cloudflare-dns", labels.lookup("1.1.1.1"))
+    assert.equal("cloudflare-dns", labels.lookup("1.0.0.1"))
+  end)
+
+  it("returns nil for an IP outside every range", function()
+    assert.is_nil(labels.lookup("18.0.0.1"))         -- just past 17/8
+    assert.is_nil(labels.lookup("16.255.255.255"))   -- just before 17/8
+    assert.is_nil(labels.lookup("9.9.9.9"))
+    assert.is_nil(labels.lookup("192.168.1.42"))
+  end)
+
+  it("returns nil for malformed or empty input", function()
+    assert.is_nil(labels.lookup(nil))
+    assert.is_nil(labels.lookup(""))
+    assert.is_nil(labels.lookup("not.an.ip"))
+    assert.is_nil(labels.lookup("17.0.0"))
+  end)
+
+  it("returns nil for IPv6 addresses (initial map is v4-only)", function()
+    assert.is_nil(labels.lookup("2001:db8::1"))
+    assert.is_nil(labels.lookup("::1"))
+  end)
+
+  it("keeps the initial map small (< 10 entries) so growth is operator-curated", function()
+    -- Belt-and-braces: the map is intentionally a starter. Future entries
+    -- should land with prod evidence; if this assertion ever needs raising,
+    -- re-justify in the PR.
+    assert.is_true(#labels._ranges < 10)
+  end)
+end)

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -37,9 +37,11 @@ describe("static_ip_labels.lookup", function()
   end)
 
   it("keeps the initial map small (< 10 entries) so growth is operator-curated", function()
-    -- Belt-and-braces: the map is intentionally a starter. Future entries
-    -- should land with prod evidence; if this assertion ever needs raising,
-    -- re-justify in the PR.
+    -- Tripwire: the map is intentionally a starter. Per the module header
+    -- + docs/architecture.md §7.2 ("Static IP-range labels"), new entries
+    -- must land with prod evidence that the range dominates the
+    -- unattributed-IP tail AND has an unambiguous well-known owner. If
+    -- this assertion ever needs raising, re-justify in the PR body.
     assert.is_true(#labels._ranges < 10)
   end)
 end)


### PR DESCRIPTION
Closes #1655.

## What

Adds a small in-repo **static IP-range → label** map consulted as the
last-resort attribution source in `conntrack.handle_flow`. Flows that
have no SNI and no dnsmasq resolution (Apple push on `17.0.0.0/8`, apps
that bypass the local resolver and hit `8.8.8.8` / `1.1.1.1` directly)
now surface as `apple-push` / `google-dns` / `cloudflare-dns` in
connection_events instead of bare IP literals.

## Initial map

| CIDR        | Label            | Why |
|-------------|------------------|-----|
| `17.0.0.0/8`  | `apple-push`     | Apple's IANA-allocated /8. APNs hosts and many Apple infra services pin into here and bypass dnsmasq. |
| `8.8.8.8/32`  | `google-dns`     | Google Public DNS. Apps that bypass the local resolver hit it directly. |
| `8.8.4.4/32`  | `google-dns`     | Google Public DNS (secondary). |
| `1.1.1.1/32`  | `cloudflare-dns` | Cloudflare Public DNS. |
| `1.0.0.1/32`  | `cloudflare-dns` | Cloudflare Public DNS (secondary). |

NTP isn't included — too many rotating pool IPs and volume is tiny.

## Architecture

**Precedence in `handle_flow`:**

1. `attribute_hostname` — dnsmasq query-log cache (SNI/QUIC sidecars feed
   this same primitive via `cache.insert_sni`, per #573 / #1651).
2. `ipset_lookup_hostname` — legacy `nft_sets` fallback for site_limits
   domains.
3. `static_ip_labels.lookup` — **new**, last resort.

A real attribution always wins over a static guess. The new map feeds
the **same** attribution primitive (per AGENTS.md single-source-of-truth
rule) — no parallel pipeline.

## LABELS ONLY — never an enforcement input

The static map participates in **zero** drop or carve-out predicates.
Enforcement remains the per-MAC `BlockRules` / nftables pipeline (AGENTS.md
§0.1, §0.2). The `static_ip_labels.lua` header repeats this and notes that
promoting an entry to an enforcement input requires explicit operator
approval and a tracking issue.

## Extending the map

Add a `{ cidr, label }` row to `M._ranges` with a citation in the comment
beside it, and add a test in `openwrt/test/static_ip_labels_spec.lua`.
Initial map is intentionally kept under 10 entries (pinned by a test);
growth should be operator-curated against prod evidence.

## Tests

- New `openwrt/test/static_ip_labels_spec.lua` — pure-function tests for
  the map: in-range hits, out-of-range misses, malformed input, v6 punt,
  size cap.
- New tests in `openwrt/test/conntrack_spec.lua` covering the precedence
  chain via the real `handle_flow`: DNS wins, ipset wins, static-map
  fallback fires only when both miss, and an unattributed flow that's
  *also* out-of-range stays as an `ipv4` HostId literal.

Red → green progression is visible in the commit history (`test(#1655): red`
→ `feat(#1655): ...`).

## Arc

Closes the final piece of the #573 SNI/QUIC attribution arc minus the
two siblings that are landing in parallel (#1650 + #1653).