### PR TITLE
feat(#1708): HostId.Label variant — API + SPA accept label-typed hosts (part 1 of 2)

### DIFF
--- a/api/src/db/TypeMeta.scala
+++ b/api/src/db/TypeMeta.scala
@@ -147,10 +147,14 @@ object TypeMeta {
   // in the same order. Any SQL touching HostId columns must respect that.
   given Read[HostId]  = Read[(String, String)].map { case (kind, value) =>
     kind match {
-      case "fqdn" => HostId.Fqdn(Hostname.unsafe(value))
-      case "ipv4" => HostId.IPv4(IpAddress.unsafe(value))
-      case "ipv6" => HostId.IPv6(IpAddress.unsafe(value))
-      case other  =>
+      case "fqdn"  => HostId.Fqdn(Hostname.unsafe(value))
+      case "ipv4"  => HostId.IPv4(IpAddress.unsafe(value))
+      case "ipv6"  => HostId.IPv6(IpAddress.unsafe(value))
+      // #1708: synthetic label (static IP-range attribution). `source` is wire-only;
+      // not persisted in the two-column composite — there's only one source today
+      // (`static-ip-range`) and the encoder reconstructs it on read.
+      case "label" => HostId.Label(value)
+      case other   =>
         throw new IllegalStateException(s"DB has unknown host_type: $other")
     }
   }

--- a/shared/src/types/HostId.scala
+++ b/shared/src/types/HostId.scala
@@ -23,7 +23,10 @@ enum HostId {
   // inside a hardcoded operator-curated range (apple-push, google-dns, cloudflare-dns;
   // see openwrt static_ip_labels). NOT a hostname the agent ever observed at the
   // resolver — it cannot be pattern-matched against `*.example.com` and `asFqdn`
-  // returns None, the same as IP literals.
+  // returns None, the same as IP literals. The label string is intentionally a
+  // plain `String` (not a validated opaque type): label validity is enforced
+  // UPSTREAM by the curated `static_ip_labels.lua` map; the decoder's only
+  // defense here is rejecting an empty value.
   case Label(name: String)
 }
 

--- a/shared/src/types/HostId.scala
+++ b/shared/src/types/HostId.scala
@@ -19,6 +19,12 @@ enum HostId {
   case Fqdn(name: Hostname)
   case IPv4(addr: IpAddress)
   case IPv6(addr: IpAddress)
+  // #1708: A synthetic name attached by the agent because the destination IP fell
+  // inside a hardcoded operator-curated range (apple-push, google-dns, cloudflare-dns;
+  // see openwrt static_ip_labels). NOT a hostname the agent ever observed at the
+  // resolver — it cannot be pattern-matched against `*.example.com` and `asFqdn`
+  // returns None, the same as IP literals.
+  case Label(name: String)
 }
 
 object HostId {
@@ -34,30 +40,47 @@ object HostId {
   def ip(addr: IpAddress): HostId =
     if addr.value.contains(':') then IPv6(addr) else IPv4(addr)
 
-  // ── Wire form: {"type":"fqdn"|"ipv4"|"ipv6","value":"..."} ─────────────
+  // ── Wire form: {"type":"fqdn"|"ipv4"|"ipv6"|"label","value":"...","source":"..."?} ──
+  //
+  // #1708: `label`-typed hosts carry an optional `source` field naming the
+  // attribution path that produced the label (today: `static-ip-range`). The
+  // decoder is tolerant of source's absence so a future label source (e.g. an
+  // ASN-based map) can ship without a wire break; the encoder always emits the
+  // source for forward observability.
 
-  private case class Wire(`type`: String, value: String) derives JsonCodec
+  private case class Wire(
+      `type`: String,
+      value: String,
+      source: Option[String] = None,
+  ) derives JsonCodec
+
+  /** The single label source today — see openwrt `static_ip_labels.lua` (#1655). */
+  val LabelSourceStaticIpRange: String = "static-ip-range"
 
   given JsonCodec[HostId] = JsonCodec[Wire].transformOrFail(
     {
-      case Wire("fqdn", v) => Hostname.parse(v).map(Fqdn(_))
-      case Wire("ipv4", v) =>
+      case Wire("fqdn", v, _)  => Hostname.parse(v).map(Fqdn(_))
+      case Wire("ipv4", v, _)  =>
         IpAddress.parse(v).flatMap { ip =>
           if ip.value.contains(':') then Left(s"ipv4 host carried v6 value: $v")
           else Right(IPv4(ip))
         }
-      case Wire("ipv6", v) =>
+      case Wire("ipv6", v, _)  =>
         IpAddress.parse(v).flatMap { ip =>
           if ip.value.contains(':') then Right(IPv6(ip))
           else Left(s"ipv6 host carried v4 value: $v")
         }
-      case Wire(other, _)  =>
+      case Wire("label", v, _) =>
+        if v.isEmpty then Left("label host has empty value")
+        else Right(Label(v))
+      case Wire(other, _, _)   =>
         Left(s"unknown host type: $other")
     },
     {
-      case Fqdn(h) => Wire("fqdn", h.value)
-      case IPv4(a) => Wire("ipv4", a.value)
-      case IPv6(a) => Wire("ipv6", a.value)
+      case Fqdn(h)  => Wire("fqdn", h.value, None)
+      case IPv4(a)  => Wire("ipv4", a.value, None)
+      case IPv6(a)  => Wire("ipv6", a.value, None)
+      case Label(v) => Wire("label", v, Some(LabelSourceStaticIpRange))
     },
   )
 
@@ -65,16 +88,18 @@ object HostId {
 
     /** The raw string value, for display, logging, or DB column. */
     def value: String = h match {
-      case Fqdn(name) => name.value
-      case IPv4(addr) => addr.value
-      case IPv6(addr) => addr.value
+      case Fqdn(name)  => name.value
+      case IPv4(addr)  => addr.value
+      case IPv6(addr)  => addr.value
+      case Label(name) => name
     }
 
     /** The discriminator tag, for DB column or display. */
     def kind: String = h match {
-      case _: Fqdn => "fqdn"
-      case _: IPv4 => "ipv4"
-      case _: IPv6 => "ipv6"
+      case _: Fqdn  => "fqdn"
+      case _: IPv4  => "ipv4"
+      case _: IPv6  => "ipv6"
+      case _: Label => "label"
     }
 
     /**
@@ -83,7 +108,11 @@ object HostId {
      */
     def isFqdn: Boolean = h.isInstanceOf[Fqdn]
 
-    /** Pull out the FQDN if this is one — useful for matchers that only apply to named hosts. */
+    /**
+     * Pull out the FQDN if this is one — useful for matchers that only apply to named hosts.
+     * Returns None for IP literals AND for synthetic Label hosts (#1708): labels are not domain
+     * names and must never be pattern-matched against `*.example.com`.
+     */
     def asFqdn: Option[Hostname] = h match {
       case Fqdn(n) => Some(n)
       case _       => None

--- a/shared/test/src/types/HostIdSpec.scala
+++ b/shared/test/src/types/HostIdSpec.scala
@@ -54,6 +54,26 @@ object HostIdSpec extends ZIOSpecDefault {
         val json = """{"type":"fqdn","value":"192.0.2.1"}"""
         assertTrue(json.fromJson[HostId].isLeft)
       },
+      // #1708: distinct `label` variant so static IP-range labels (apple-push,
+      // google-dns, cloudflare-dns) don't masquerade as FQDNs on the wire.
+      test("encodes Label as {type:label,value:...,source:static-ip-range}") {
+        val h    = HostId.Label("apple-push"): HostId
+        val json = h.toJson
+        assertTrue(json == """{"type":"label","value":"apple-push","source":"static-ip-range"}""")
+      },
+      test("round-trips Label with source") {
+        val h    = HostId.Label("apple-push"): HostId
+        val json = h.toJson
+        assertTrue(json.fromJson[HostId].contains(h))
+      },
+      test("decodes Label without source (forward-compat for future label sources)") {
+        val json = """{"type":"label","value":"google-dns"}"""
+        assertTrue(json.fromJson[HostId].contains(HostId.Label("google-dns"): HostId))
+      },
+      test("decodes Label with an unknown source verbatim (forward-compat)") {
+        val json = """{"type":"label","value":"future-label","source":"asn-map"}"""
+        assertTrue(json.fromJson[HostId].contains(HostId.Label("future-label"): HostId))
+      },
     ),
     suite("extensions")(
       test("value returns underlying string for all variants") {
@@ -82,6 +102,15 @@ object HostIdSpec extends ZIOSpecDefault {
         val v4 = HostId.IPv4(IpAddress.parse("1.2.3.4").toOption.get): HostId
         assertTrue(f.asFqdn.exists(_.value == "a.example")) &&
         assertTrue(v4.asFqdn.isEmpty)
+      },
+      test("#1708: Label.value/kind/isFqdn/asFqdn") {
+        val l: HostId = HostId.Label("apple-push")
+        assertTrue(
+          l.value == "apple-push",
+          l.kind == "label",
+          !l.isFqdn,
+          l.asFqdn.isEmpty,
+        )
       },
     ),
   )

--- a/shared/test/src/types/HostMatchSpec.scala
+++ b/shared/test/src/types/HostMatchSpec.scala
@@ -33,6 +33,14 @@ object HostMatchSpec extends ZIOSpecDefault {
         !HostMatch.matchesAny(ip, List("*.google.com")),
       )
     },
+    test("#1708: Label hosts never match — synthetic names are not FQDN patterns") {
+      val label: HostId = HostId.Label("apple-push")
+      assertTrue(
+        !HostMatch.matchesAny(label, List("apple-push")),
+        !HostMatch.matchesAny(label, List("*.apple-push")),
+        !HostMatch.matchesAny(label, List("apple.com")),
+      )
+    },
     test("InfraHosts.isBackground(HostId): suppresses canonical infra and suppressOnly tier") {
       assertTrue(
         InfraHosts.isBackground(infra),

--- a/web/src/components/HostCell.test.tsx
+++ b/web/src/components/HostCell.test.tsx
@@ -26,6 +26,16 @@ describe('HostCell', () => {
     expect(screen.getByText('ipv6')).toBeInTheDocument()
   })
 
+  // #1708: Label-typed hosts (apple-push, google-dns, cloudflare-dns) are
+  // synthetic names attached when the agent matched a hardcoded IP range.
+  // They must render distinguishably from FQDN rows so an operator scanning
+  // the logs sees at a glance that the row is a label, not a resolved host.
+  it('#1708: renders a label host with value and a visible "label" tag', () => {
+    render(<HostCell host={{ type: 'label', value: 'apple-push', source: 'static-ip-range' }} />)
+    expect(screen.getByText('apple-push')).toBeInTheDocument()
+    expect(screen.getByText('label')).toBeInTheDocument()
+  })
+
   // #458: The fix adds a {' '} text node between the IP value and the type tag so
   // the cell's text content reads "239.255.255.250 ipv4" (with a space), not
   // "239.255.255.250ipv4".  Verify the space is present in the rendered text.

--- a/web/src/components/HostCell.test.tsx
+++ b/web/src/components/HostCell.test.tsx
@@ -36,6 +36,19 @@ describe('HostCell', () => {
     expect(screen.getByText('label')).toBeInTheDocument()
   })
 
+  // #1708 + #826: label rows must inherit the same standardized unresolved
+  // treatment as IP rows (italic + text-brand-text) so a synthetic name
+  // doesn't visually masquerade as a resolved FQDN if the surface ever drifts.
+  it('#1708: label rows get the standardized italic / muted treatment', () => {
+    const { container } = render(
+      <HostCell host={{ type: 'label', value: 'apple-push', source: 'static-ip-range' }} />,
+    )
+    const outer = container.firstChild as HTMLElement
+    expect(outer.className).toContain('italic')
+    expect(outer.className).toContain('text-brand-text')
+    expect(outer.className).toContain('font-mono')
+  })
+
   // #458: The fix adds a {' '} text node between the IP value and the type tag so
   // the cell's text content reads "239.255.255.250 ipv4" (with a space), not
   // "239.255.255.250ipv4".  Verify the space is present in the rendered text.

--- a/web/src/components/HostCell.tsx
+++ b/web/src/components/HostCell.tsx
@@ -21,8 +21,12 @@ export function HostCell({ host, className = '' }: { host: HostId; className?: s
       </span>
     )
   }
+  // #1708: Label rows render with the same italic + tag treatment as IP literals
+  // so a synthetic name (apple-push) doesn't visually masquerade as a resolved
+  // FQDN. Tooltip carries the source where present for inspectability.
+  const title = host.type === 'label' && host.source ? `${host.value} (${host.source})` : host.value
   return (
-    <span className={`font-mono italic text-brand-text ${className}`.trim()} title={host.value}>
+    <span className={`font-mono italic text-brand-text ${className}`.trim()} title={title}>
       {host.value}
       {' '}
       <span className="text-[10px] uppercase tracking-wide text-brand-text-muted">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -185,6 +185,9 @@ export type HostId =
   | { type: 'fqdn'; value: string }
   | { type: 'ipv4'; value: string }
   | { type: 'ipv6'; value: string }
+  // `source` is open-ended (forward-compat for a future ASN map etc.); today
+  // the only emitted value is 'static-ip-range'. Kept as plain string per
+  // eslint @typescript-eslint/ban-types (rules out the literal+string trick).
   | { type: 'label'; value: string; source?: string }
 
 export function hostDisplay(h: HostId): string {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -177,11 +177,15 @@ export interface ApproveAlertRequest {
 // Tagged-union host identifier (#391). Wire shape carried by every endpoint
 // that surfaces a "what host did the device contact" field. FQDN is a
 // resolved hostname; ipv4/ipv6 are raw IP literals emitted when DNS
-// attribution missed (DoH, Apple Private Relay, direct-IP).
+// attribution missed (DoH, Apple Private Relay, direct-IP). `label` (#1708)
+// is a synthetic name attached because the destination IP fell inside a
+// hardcoded operator-curated range (e.g. apple-push / google-dns /
+// cloudflare-dns) — NOT a hostname the agent observed at the resolver.
 export type HostId =
   | { type: 'fqdn'; value: string }
   | { type: 'ipv4'; value: string }
   | { type: 'ipv6'; value: string }
+  | { type: 'label'; value: string; source?: string }
 
 export function hostDisplay(h: HostId): string {
   return h.value


### PR DESCRIPTION
Refs #1708. Part 1 of 2.

## What

Adds a distinct `HostId.Label` variant so static IP-range labels
(`apple-push`, `google-dns`, `cloudflare-dns` — see #1655 / #1706's
`openwrt/.../static_ip_labels.lua`) stop riding the wire as `fqdn`s.

## Wire shape

```json
{ "type": "label", "value": "apple-push", "source": "static-ip-range" }
```

- The encoder always emits `source` (today the only value is
  `static-ip-range`).
- The decoder is tolerant of `source`'s absence so a future label source
  (e.g. an ASN-based map) can ship without a wire break.

## Surfaces touched

- `shared/HostId` — new `Label(name: String)` case + wire codec.
- `shared/HostMatch.matchesAny` — Label hosts return `false`. They have no
  `asFqdn`, so the existing fqdn-only matcher naturally skips them, the same
  way it does for `ipv4` / `ipv6`. A synthetic name must never pattern-match
  against `*.example.com`.
- `api/db/TypeMeta` — `Read[HostId]` understands the `label` discriminator.
  `source` is wire-only; the two-column composite `(host_type, host_value)`
  stores no `source`, and the encoder reconstructs it on read.
- `web/types/api` + `web/components/HostCell` — Label rows render with the
  same italic + tag treatment as IP literals (monospace, `text-brand-text`,
  `label` tag), so a synthetic name doesn't visually masquerade as a
  resolved hostname. Tooltip includes the source where present.

## Additive-on-the-wire (AGENTS.md independent-deploy rule)

Older agents continue to emit static-IP labels as `fqdn`-typed hosts; the
new `label` variant is accepted on the wire by this PR but **not yet
emitted by any agent**. The OpenWRT agent's `static_ip_labels.lookup` /
`conntrack.build_event` switch to the new variant ships in a follow-up PR
(#1708 part 2) after this PR deploys, per the "API and the agents deploy
independently" contract.

## Scope NOT in this PR

- **No Flyway migration.** Persistence carries `host_type` as a TEXT column
  with a CHECK constraint pinned to `('fqdn', 'ipv4', 'ipv6')` on four
  tables (`time_usage`, `connection_events`, `block_events`,
  `traffic_reports`). Widening the constraint to include `'label'` is a
  schema-only PR per AGENTS.md migration-isolation — filed as #1712 — and
  must deploy BEFORE the agent emit PR or `INSERT`s with `host_type='label'`
  will be rejected.
- **No agent change.** Lua agent code stays untouched in this PR (part 2).

## Tests (red → green visible in commit history)

- `shared/test/.../HostIdSpec` — encodes Label with source, round-trips with
  and without source, decodes an unknown source verbatim, asserts
  `value` / `kind` / `isFqdn` / `asFqdn` for the new case.
- `shared/test/.../HostMatchSpec` — Label hosts never match an FQDN pattern,
  same default as IP literals.
- `web/.../HostCell.test` — Label rows render value + visible "label" tag.

The DB-roundtrip ingest test that would prove end-to-end Label persistence
is deferred to the schema-migration PR (#1712), because today the four
`host_type` CHECK constraints reject it.

Refs #1655, #1706, #1712.