### PR TITLE
feat(#1485): drop legacy schedules table (Phase 3, destructive — soak passed)

### DIFF
--- a/api/resources/db/migration/V57__drop_legacy_schedules.sql
+++ b/api/resources/db/migration/V57__drop_legacy_schedules.sql
@@ -1,0 +1,24 @@
+-- #1485 Phase 3 (destructive): drop the legacy per-profile `schedules` table.
+--
+-- Background:
+--   * #1482 / #1490 (merged 2026-06-05) cut the policy READ path over to
+--     `named_schedules` + `profile_schedule_rules`. The legacy table has not
+--     been an enforcement source since.
+--   * #1494 / #1495 / #1500 stopped writes from the profile/schedule editors.
+--   * #1602 / #1603 disabled `ScheduleSeeder.seedAndMigrate` so the legacy
+--     rows could no longer be resurrected on boot.
+--   * #1709 / PR #1714 (merged 2026-06-14) removed the residual
+--     `trait ScheduleRepo`, `ScheduleRepoLive`, wiring, and the
+--     `TestDatabase` fixture writes — so nothing in the codebase reads or
+--     writes the table anymore.
+--   * Soak in prod from 2026-06-05 → 2026-06-14 (9 days) past the ~1-week
+--     gate in the issue body.
+--
+-- Runtime: `schedules` is a small per-profile table (rows on the order of
+-- one per profile per window — dozens at most in prod). `DROP TABLE` is
+-- sub-second at this scale, so this is safe to run on the startup
+-- critical path despite the §migrations-prod-data-volume caution.
+--
+-- Irreversibility: this is destructive. Operator pre-flight must confirm a
+-- recent prod DB snapshot exists before merge; rollback is restore-only.
+DROP TABLE IF EXISTS schedules;


### PR DESCRIPTION
Closes #1485.

> **⚠️ OPERATOR PRE-FLIGHT BEFORE MERGE:**
> - Confirm a recent prod DB snapshot exists (Render Postgres, or wherever prod DB lives).
> - `DROP TABLE` is irreversible without restore.
> - After merge + deploy, confirm prod schedule enforcement still works (no kid suddenly sees their bedtime block disappear). The named-schedule path has been live since 2026-06-05 so this is expected to be a no-op behaviorally, but worth one eyeball pass.

## Preconditions (all hold as of 2026-06-14)

- ✅ **#1482 PR 2 (`a25ae618`, PR #1490) merged + deployed.** Cut the policy READ path to `named_schedules` / `profile_schedule_rules`. Shipped to prod via master-api-ui CD on 2026-06-05.
- ✅ **~1 week soak passed.** 2026-06-05 → 2026-06-14 = 9 days, past the issue's target.
- ✅ **Zero code references to the legacy table.** Verified via grep: no live `SELECT/INSERT/UPDATE/DELETE` on `schedules` in `api/src`, `shared/src`, `openwrt/files`, `web/src`, or `api/test`. The residual `trait ScheduleRepo` + `ScheduleRepoLive` + wiring + `TestDatabase` fixture writes were removed in #1709 (PR #1714, merged 2026-06-14). Remaining string hits are just URL paths (`/api/schedules` — NamedScheduleRepo-backed), `schedules: []` in JSON-tolerated input (per `Models.scala`), or doc/code-deleted comments.
- ✅ **Past the rollback window.** 120+ commits to main since #1482; rolling back to a pre-#1482 image is not a recovery goal.

## Change

One SQL file: `api/resources/db/migration/V57__drop_legacy_schedules.sql`:

```sql
DROP TABLE IF EXISTS schedules;
```

No code changes — migration-isolation rule compliant.

## Runtime expectation at prod scale

`schedules` is a small per-profile table (rows = per-profile bedtime/etc. windows; dozens at most in prod). `DROP TABLE` is sub-second at this scale, so this migration is safe to run on the API startup critical path. Not on the §migrations-prod-data-volume worry list.

## Test plan

- [x] `mill api.test` GREEN locally (192 tests across the suite). The embedded Postgres applies V57 along with every other Flyway migration before fixtures run; if any code path still touched the legacy table this would have failed at fixture setup, which is the back-compat gate per AGENTS.md §migrations-back-compat.
- [ ] Operator confirms prod DB snapshot before merge.
- [ ] Post-deploy: verify schedule enforcement still active on prod profiles.