### PR TITLE
fix(#1716): sweep orphan conntrack -E subscribers at agent startup

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -114,7 +114,10 @@ function M.kill_orphan_watchers(opts)
   opts = opts or {}
   local list = opts.list_procs_fn or default_list_procs
   local kill = opts.kill_fn or function(pid)
-    return os.execute("kill " .. tostring(pid) .. " 2>/dev/null") == 0
+    -- os.execute return shape varies by Lua version: int exit-code on 5.1/5.2,
+    -- boolean true on 5.3+ for a clean exit. Mirror nft_eb_hit's normalisation.
+    local ret = os.execute("kill " .. tostring(pid) .. " 2>/dev/null")
+    return ret == 0 or ret == true
   end
   local killed = 0
   for _, p in ipairs(list()) do

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -37,6 +37,96 @@ function M.eb_san(host)
 end
 
 -- ---------------------------------------------------------------------------
+-- list_procs() -> { { pid, ppid, cmdline }, ... }   (default scanner)
+--
+-- Enumerates the live process table by reading /proc/<pid>/status (for PPid)
+-- and /proc/<pid>/cmdline (NUL-separated argv joined with spaces). Used by
+-- kill_orphan_watchers; injectable as opts.list_procs_fn for tests.
+-- ---------------------------------------------------------------------------
+local function default_list_procs()
+  local out = {}
+  local p = io.popen("ls /proc 2>/dev/null", "r")
+  if not p then return out end
+  for name in p:lines() do
+    local pid = tonumber(name)
+    if pid then
+      local sf = io.open("/proc/" .. pid .. "/status", "r")
+      local ppid
+      if sf then
+        for line in sf:lines() do
+          local v = line:match("^PPid:%s*(%d+)")
+          if v then ppid = tonumber(v); break end
+        end
+        sf:close()
+      end
+      local cf = io.open("/proc/" .. pid .. "/cmdline", "r")
+      local cmdline = ""
+      if cf then
+        local raw = cf:read("*a") or ""
+        cf:close()
+        -- argv is NUL-separated with a trailing NUL; replace NUL with space
+        -- and strip the trailing whitespace so it matches a plain command line.
+        cmdline = raw:gsub("%z", " "):gsub("%s+$", "")
+      end
+      if ppid then
+        out[#out + 1] = { pid = pid, ppid = ppid, cmdline = cmdline }
+      end
+    end
+  end
+  p:close()
+  return out
+end
+
+-- ---------------------------------------------------------------------------
+-- kill_orphan_watchers(opts) -> int (orphans killed)  -- #1716
+--
+-- Scan /proc for `conntrack -E -e NEW` processes that have been reparented to
+-- init (PPID = 1) — those are leftover children of a prior wifihaven-agent
+-- instance. SIGTERM each one before opening this agent's own conntrack
+-- subscription.
+--
+-- Why this is needed: conntrack subscribes to NFCT_ALL_CT_GROUPS on its
+-- netlink socket, idles waiting for events, and only ever writes to stdout
+-- when an event arrives. When the agent that opened it via io.popen() is
+-- replaced (procd restart, CD reinstall, upgrade), the child is reparented
+-- to init. SIGPIPE fires only on write, so an idle orphan with no events
+-- never gets SIGPIPE and never dies. Across many restarts the orphans
+-- accumulate, every netfilter event wakes all subscribers, and CPU + load
+-- climb. Prod #1716: 24-day uptime → 16 orphans → agent CPU 22-24% / load
+-- 3.2; SIGTERMing the orphans dropped agent CPU to 0%.
+--
+-- opts:
+--   list_procs_fn  function() -> { {pid, ppid, cmdline}, ... }   injectable
+--                  process scanner; defaults to default_list_procs above
+--                  (reads /proc). Tests pass a closure over a canned list.
+--   kill_fn        function(pid) -> bool                          injectable;
+--                  defaults to `kill <pid>` via os.execute. Returns true on
+--                  successful signal delivery (best-effort).
+--
+-- Matching is intentionally narrow: we only sweep processes whose cmdline is
+-- EXACTLY `conntrack -E -e NEW` (the agent's invocation) — not `conntrack -L`,
+-- `conntrack -F`, `conntrack -E -e NEW -p tcp`, etc. — so an operator's
+-- transient conntrack tool isn't stomped.
+-- ---------------------------------------------------------------------------
+local AGENT_CONNTRACK_CMDLINE = "conntrack -E -e NEW"
+
+function M.kill_orphan_watchers(opts)
+  opts = opts or {}
+  local list = opts.list_procs_fn or default_list_procs
+  local kill = opts.kill_fn or function(pid)
+    return os.execute("kill " .. tostring(pid) .. " 2>/dev/null") == 0
+  end
+  local killed = 0
+  for _, p in ipairs(list()) do
+    if p.ppid == 1 and p.cmdline == AGENT_CONNTRACK_CMDLINE then
+      kill(p.pid)
+      killed = killed + 1
+    end
+  end
+  return killed
+end
+
+-- ---------------------------------------------------------------------------
 -- nft_eb_hit(dst_ip, eb_host, exec_fn) -> bool
 --
 -- Returns true when dst_ip is a current member of the nftables set

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -436,6 +436,22 @@ local last_nflog_run      = 0  -- #1126: nflog drop-spool drain cadence
 local activity_tracker     = usage.new_tracker()
 local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs (#309)
 
+-- ── Sweep orphan conntrack subscribers (#1716) ──────────────────────────────
+-- conntrack -E -e NEW is opened via io.popen() below. When this agent process
+-- is replaced (procd restart, CD reinstall, upgrade), the child is reparented
+-- to init and idles on netlink with no reader for its stdout. SIGPIPE only
+-- fires on write, and an idle conntrack with no events never writes — so the
+-- orphan never dies. Across many restarts the orphans accumulate, every
+-- netfilter event wakes all subscribers, and CPU + load climb. Prod #1716:
+-- 24-day uptime → 16 orphans → agent CPU 22-24%, load 3.2; SIGTERMing them
+-- dropped agent CPU to 0%. Sweep before spawning our own.
+do
+  local killed = conntrack.kill_orphan_watchers()
+  if killed > 0 then
+    log.info("startup: swept %d orphan conntrack -E -e NEW subscriber(s) (#1716)", killed)
+  end
+end
+
 -- ── Initial policy fetch at startup ──────────────────────────────────────────
 
 -- Load cached policy from flash BEFORE the first network poll (#309). If the

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -445,6 +445,13 @@ local usage_queue          = usage.new_queue()  -- retry queue for failed POSTs 
 -- netfilter event wakes all subscribers, and CPU + load climb. Prod #1716:
 -- 24-day uptime → 16 orphans → agent CPU 22-24%, load 3.2; SIGTERMing them
 -- dropped agent CPU to 0%. Sweep before spawning our own.
+--
+-- Startup sweep bounds the orphan count at ~1 per restart cycle but doesn't
+-- prevent the orphan from being created in the first place. The proper
+-- complement — an explicit SIGTERM handler that kills the conntrack child on
+-- agent shutdown — is tracked in #1723. Fleet-level metric tracking (so an
+-- operator can see if any router is still spawning orphans after this fix
+-- ships) is tracked in #1722.
 do
   local killed = conntrack.kill_orphan_watchers()
   if killed > 0 then

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -1898,7 +1898,9 @@ describe("kill_orphan_watchers (#1716)", function()
   it("ignores processes whose cmdline does not match the agent's conntrack invocation", function()
     -- Avoid stomping unrelated `conntrack -L`, `conntrack -F`, etc. running
     -- under cron or a transient operator shell. We match the exact agent
-    -- invocation only.
+    -- invocation only — also rejecting whitespace variants so a future
+    -- agent that opens conntrack differently can't be silently swept by this
+    -- one (would be a different invocation, deserves its own sweeper).
     local killed = {}
     conntrack.kill_orphan_watchers({
       list_procs_fn = fake_list_procs({
@@ -1906,6 +1908,7 @@ describe("kill_orphan_watchers (#1716)", function()
         { pid = 101, ppid = 1, cmdline = "conntrack -F" },
         { pid = 102, ppid = 1, cmdline = "conntrack -E -e NEW -p tcp" }, -- different flags
         { pid = 103, ppid = 1, cmdline = "grep conntrack -E -e NEW" },
+        { pid = 105, ppid = 1, cmdline = "conntrack  -E -e NEW" },        -- extra-whitespace
         { pid = 104, ppid = 1, cmdline = "conntrack -E -e NEW" },         -- match
       }),
       kill_fn = function(pid) killed[#killed + 1] = pid; return true end,

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -1844,3 +1844,82 @@ describe("encode_events_body (#1126 ingest reliability)", function()
     assert.truthy(body:find('"events":[', 1, true))
   end)
 end)
+
+-- ---------------------------------------------------------------------------
+-- kill_orphan_watchers — #1716
+--
+-- conntrack -E -e NEW is opened via io.popen() in watch(). If the agent
+-- process is replaced (procd restart, CD wave reinstall, upgrade), the child
+-- conntrack process is reparented to init (PPID 1) and idles on netlink with
+-- no reader for its stdout. SIGPIPE only fires on write, and an idle conntrack
+-- never writes when there are no events — so the orphan never dies, and each
+-- subsequent agent restart leaves another orphan behind. Prod evidence (#1716,
+-- 24-day uptime): 16 orphans accumulated, every netfilter event woke all 17
+-- subscribers, agent ran at 22-24% CPU sustained with vol_ctxt_switches ≈
+-- 2600/sec. After SIGTERMing the 16 orphans, agent CPU dropped to 0%.
+--
+-- At startup the agent calls kill_orphan_watchers to sweep any prior orphans
+-- before opening its own conntrack subscription.
+-- ---------------------------------------------------------------------------
+describe("kill_orphan_watchers (#1716)", function()
+  -- Builds a fake /proc scanner: returns the supplied {pid=, ppid=, cmdline=}
+  -- records, in order, when list_procs_fn() is called.
+  local function fake_list_procs(records)
+    return function() return records end
+  end
+
+  it("kills conntrack -E -e NEW processes whose PPID is 1 (init-reparented)", function()
+    local killed = {}
+    local n = conntrack.kill_orphan_watchers({
+      list_procs_fn = fake_list_procs({
+        { pid = 685,   ppid = 1,     cmdline = "conntrack -E -e NEW" },
+        { pid = 4233,  ppid = 1,     cmdline = "conntrack -E -e NEW" },
+        { pid = 15829, ppid = 1,     cmdline = "conntrack -E -e NEW" },
+      }),
+      kill_fn = function(pid) killed[#killed + 1] = pid; return true end,
+    })
+    assert.equal(3, n)
+    assert.same({ 685, 4233, 15829 }, killed)
+  end)
+
+  it("does NOT kill the live agent's own conntrack child (PPID = current agent)", function()
+    local killed = {}
+    local n = conntrack.kill_orphan_watchers({
+      list_procs_fn = fake_list_procs({
+        { pid = 14665, ppid = 14449, cmdline = "conntrack -E -e NEW" }, -- our child
+        { pid = 685,   ppid = 1,     cmdline = "conntrack -E -e NEW" }, -- orphan
+      }),
+      kill_fn = function(pid) killed[#killed + 1] = pid; return true end,
+    })
+    assert.equal(1, n)
+    assert.same({ 685 }, killed)
+  end)
+
+  it("ignores processes whose cmdline does not match the agent's conntrack invocation", function()
+    -- Avoid stomping unrelated `conntrack -L`, `conntrack -F`, etc. running
+    -- under cron or a transient operator shell. We match the exact agent
+    -- invocation only.
+    local killed = {}
+    conntrack.kill_orphan_watchers({
+      list_procs_fn = fake_list_procs({
+        { pid = 100, ppid = 1, cmdline = "conntrack -L" },
+        { pid = 101, ppid = 1, cmdline = "conntrack -F" },
+        { pid = 102, ppid = 1, cmdline = "conntrack -E -e NEW -p tcp" }, -- different flags
+        { pid = 103, ppid = 1, cmdline = "grep conntrack -E -e NEW" },
+        { pid = 104, ppid = 1, cmdline = "conntrack -E -e NEW" },         -- match
+      }),
+      kill_fn = function(pid) killed[#killed + 1] = pid; return true end,
+    })
+    assert.same({ 104 }, killed)
+  end)
+
+  it("returns 0 and calls kill 0 times when there are no orphans", function()
+    local killed = {}
+    local n = conntrack.kill_orphan_watchers({
+      list_procs_fn = fake_list_procs({}),
+      kill_fn = function(pid) killed[#killed + 1] = pid; return true end,
+    })
+    assert.equal(0, n)
+    assert.same({}, killed)
+  end)
+end)


### PR DESCRIPTION
Closes #1716.

## Pinned root cause

**16 orphan `conntrack -E -e NEW` processes (PPID=1)** had accumulated on prod router.lan over a 24-day uptime. All were subscribed to `NFCT_ALL_CT_GROUPS`. Every netfilter event woke all 17 subscribers (16 orphans + the live agent's child) — kernel context-switch and softirq overhead pegged the CPU.

Manually SIGTERMing the 16 orphans on prod dropped agent CPU from **22-24% → 0%** immediately (top sample captured at the time):

```
=== BEFORE (16 orphans alive) ===
14449  root R    22%  /usr/bin/lua /usr/sbin/wifihaven-agent
14450  root R     0%  /usr/bin/lua /usr/sbin/wifihaven-dns-tail
Load average: 3.33 3.35 3.22

=== AFTER orphan sweep ===
14449  root S     0%  /usr/bin/lua /usr/sbin/wifihaven-agent
Load average: 2.63 3.13 3.15
```

Agent voluntary context switches dropped from ~2600/sec historic to ~50/sec post-sweep.

## Why orphans accumulate

`conntrack.watch` opens the subscriber via `io.popen("conntrack -E -e NEW")`. When the agent process is replaced (procd restart, CD reinstall, upgrade) the child is reparented to init. `SIGPIPE` only fires on a write; an idle conntrack with no events never writes, so the orphan never dies. Across many restarts (≈ one per day under CD) the count grows monotonically.

## Fix

At agent startup, before opening the agent's own conntrack subscription, scan `/proc` for `conntrack -E -e NEW` processes whose PPID is 1 and SIGTERM each. Matching is intentionally narrow (exact agent invocation, PPID=1 only) so an operator's transient `conntrack -L`/`-F` and the live agent's own child are never stomped.

Lives in `conntrack.lua` as `kill_orphan_watchers({list_procs_fn, kill_fn})` with both seams injected for tests; wired into [wifihaven-agent startup](openwrt/files/usr/sbin/wifihaven-agent) right before the initial policy fetch.

## Tests

Four busted cases in `conntrack_spec.lua` using fake `list_procs_fn` / `kill_fn`:
- kills PPID=1 matches
- spares the live agent's own child (PPID = current agent)
- ignores `conntrack -L`, `-F`, and `conntrack -E -e NEW -p tcp`
- no-op when no orphans

Red-green progression preserved in two commits.

## Out of scope / follow-ups

- `wifihaven-dns-tail` still burst-spikes to ~27% on prod under a high-rate DNS log stream (per-line `atomic_write` of the full ~133KB cache file is O(N) per line). Separate hot path, not this PR. The dominant baseline CPU traced to this fix; dns-tail spikes are correlated with a storming TimeLimit-blocked device retrying TCP/443 SYNs at ~40/sec and warrant a separate investigation.

## Test plan

- [x] `busted test/conntrack_spec.lua` — 121 successes / 0 failures
- [x] Full openwrt suite (conntrack, policy, render) — 352 successes / 0 failures / 1 pending (`nft` binary not on macOS)
- [ ] Operator: after merge & router update, verify `pgrep -af "conntrack -E -e NEW"` returns exactly one (the agent's child) and agent CPU is < 5% sustained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)