### PR TITLE
feat(#1712): widen host_type CHECK to accept 'label' (schema for #1708 part 2)

### DIFF
--- a/api/resources/db/migration/V58__widen_host_type_label.sql
+++ b/api/resources/db/migration/V58__widen_host_type_label.sql
@@ -1,0 +1,53 @@
+-- V58__widen_host_type_label.sql
+-- Widen the `host_type` CHECK constraint on every table that carries a
+-- `HostId` discriminator so the new `label` variant (#1708) can be
+-- inserted. This is the prerequisite schema PR for the OpenWRT agent's
+-- switch from `fqdn`-typed static-IP-range labels to a distinct
+-- `label`-typed HostId.
+--
+-- Tables touched (constraint definitions originally in V13; redefined on
+-- the partitioned parents in V41/V42):
+--   * time_usage             (V13)
+--   * block_events           (V13)
+--   * traffic_reports        (V41, partitioned parent)
+--   * connection_events      (V42, partitioned parent)
+--
+-- Why NOT VALID + (no VALIDATE):
+--
+-- The new value set is a strict superset of the old, so every existing
+-- row is already valid by construction. A plain ADD CONSTRAINT would
+-- take AccessExclusiveLock and full-scan each partition to re-prove
+-- something we already know — at prod scale (the unbounded-growth tables
+-- `traffic_reports` and `connection_events`) that scan can run past the
+-- 15-minute Render port-bind timeout (see AGENTS.md
+-- migrations-prod-data-volume; cf. #1197). ADD CONSTRAINT ... NOT VALID
+-- is an O(1) catalog change that takes a brief lock and starts enforcing
+-- on new INSERTs/UPDATEs immediately, which is the only thing we need.
+--
+-- Existing data is provably valid (subset relation), so VALIDATE
+-- CONSTRAINT is left for a later operator-applied step if desired; it is
+-- not required for correctness.
+
+ALTER TABLE time_usage
+  DROP CONSTRAINT time_usage_host_type_check;
+ALTER TABLE time_usage
+  ADD CONSTRAINT time_usage_host_type_check
+  CHECK (host_type IN ('fqdn','ipv4','ipv6','label')) NOT VALID;
+
+ALTER TABLE block_events
+  DROP CONSTRAINT block_events_host_type_check;
+ALTER TABLE block_events
+  ADD CONSTRAINT block_events_host_type_check
+  CHECK (host_type IN ('fqdn','ipv4','ipv6','label')) NOT VALID;
+
+ALTER TABLE traffic_reports
+  DROP CONSTRAINT traffic_reports_host_type_check;
+ALTER TABLE traffic_reports
+  ADD CONSTRAINT traffic_reports_host_type_check
+  CHECK (host_type IN ('fqdn','ipv4','ipv6','label')) NOT VALID;
+
+ALTER TABLE connection_events
+  DROP CONSTRAINT connection_events_host_type_check;
+ALTER TABLE connection_events
+  ADD CONSTRAINT connection_events_host_type_check
+  CHECK (host_type IN ('fqdn','ipv4','ipv6','label')) NOT VALID;


### PR DESCRIPTION
Closes #1712. Schema-only prerequisite for the #1708 part 2 (OpenWRT
agent emit) PR — must merge + deploy before the agent starts producing
`host_type='label'` rows.

> **Updated 2026-06-14**: renumbered from V57 → V58 after main advanced
> with V57 (#1719 `drop_legacy_schedules`). No semantic change.

## What

PR #1713 added the `HostId.Label` wire variant and the API decoder /
SPA renderer, but it explicitly deferred the matching DB constraint
widening to this PR (see #1713 body, "Scope NOT in this PR"). Today
the four host_type CHECK constraints — on `time_usage`, `block_events`,
`traffic_reports`, `connection_events` — are pinned to
`('fqdn','ipv4','ipv6')` (V13; partition parents redefined in V41/V42).
Any INSERT with `host_type='label'` is rejected at write time.

This migration drops and re-adds each constraint with `'label'`
added to the value set.

## Lock / scan profile

`ADD CONSTRAINT ... NOT VALID` is used on all four tables. The new set
is a strict superset of the old, so every existing row is valid by
construction; the regular ADD CONSTRAINT path's full-table verification
scan would buy nothing and (per AGENTS.md §migrations-prod-data-volume)
the two unbounded-growth tables — `traffic_reports`, `connection_events`
— would risk a multi-minute scan past the Render 15-minute port-bind
timeout (cf. #1197). NOT VALID is an O(1) catalog change; enforcement on
new INSERTs/UPDATEs is immediate. VALIDATE can be run out-of-band later
as hygiene, but is not required for correctness.

## Migration-isolation

Only the SQL file. No source, no test, no CI change — gated by
`check-migration-isolation.sh`.

## Deploy ordering

1. Merge this PR → auto-deploys to staging → prod.
2. After prod is on V58, open the agent PR (#1708 part 2 = #1727) that
   switches `openwrt/.../conntrack.lua` to emit `host_type='label'` for
   static-IP attributions.

Refs #1708, #1713.