### PR TITLE
feat(#1718): allowlist + Grafana for native router host metrics (PR 1 of 2)

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -59,6 +59,12 @@ object MetricGuard {
       "rollup_job",
       "router_id",
       "installation_id",
+      // #1718 — bounded per-router dimensions for native OS-level metrics. `iface` is the
+      // network-interface name (handful per router: br-lan, wan, phyN-apM, …). `ssid` is the
+      // wireless SSID (a handful per router). Both are bounded by router hardware/config, not
+      // by user/device/flow growth, so they're firewall-safe.
+      "iface",
+      "ssid",
     )
 
   /**
@@ -147,18 +153,38 @@ object MetricGuard {
     "usage_post_total"                          -> Set("result", "router_id", "installation_id"),
     // Server-side ingest health for POST /api/router/metrics (#1205). Concrete, emitted now.
     "router_metrics_batches_total"              -> Set("status"),
+    // #1718 — native OpenWRT OS-level metrics the agent collects from /proc/* and `iw dev`
+    // and pushes through the existing #1205 batch transport. Gives operators the LuCI-style
+    // view of router health (load / cpu / mem / bandwidth / conntrack / wifi clients) in
+    // Grafana, so incidents like #1716 (prod router CPU pegged) show as a visible climb
+    // rather than requiring an SSH session. Per the §4 cardinality firewall the per-MAC
+    // wireless client list is NEVER a Prometheus dimension — only the aggregate
+    // count-per-(iface,ssid) ships as a labeled series. Per-client drill-in would need a
+    // separate DB-backed surface.
+    "router_host_load_m1"                       -> Set("router_id", "installation_id"),
+    "router_host_load_m5"                       -> Set("router_id", "installation_id"),
+    "router_host_load_m15"                      -> Set("router_id", "installation_id"),
+    "router_host_cpu_pct"                       -> Set("router_id", "installation_id"),
+    "router_host_mem_total_kb"                  -> Set("router_id", "installation_id"),
+    "router_host_mem_free_kb"                   -> Set("router_id", "installation_id"),
+    "router_host_mem_buffers_kb"                -> Set("router_id", "installation_id"),
+    "router_host_mem_cached_kb"                 -> Set("router_id", "installation_id"),
+    "router_host_conntrack_count"               -> Set("router_id", "installation_id"),
+    "router_host_iface_rx_bytes_total"          -> Set("iface", "router_id", "installation_id"),
+    "router_host_iface_tx_bytes_total"          -> Set("iface", "router_id", "installation_id"),
+    "router_host_wifi_clients"             -> Set("iface", "ssid", "router_id", "installation_id"),
     // #1243 rollup health — `rollup_job` is a handful of hand-named jobs (traffic_hourly,
     // traffic_daily, time_used_daily), `status` ∈ {ok, error}. Bounded; routed through the guard.
-    "wifihaven_rollup_runs_total"               -> Set("rollup_job", "status"),
-    "wifihaven_rollup_duration_seconds"         -> Set("rollup_job"),
-    "wifihaven_rollup_rows_upserted"            -> Set("rollup_job"),
+    "wifihaven_rollup_runs_total"          -> Set("rollup_job", "status"),
+    "wifihaven_rollup_duration_seconds"    -> Set("rollup_job"),
+    "wifihaven_rollup_rows_upserted"       -> Set("rollup_job"),
     // #1069 named-schedule CRUD — `op` ∈ {create, update, delete}, a fixed enum. Lets an operator
     // see schedule edits land (and rate-alert on a runaway delete loop) without grepping logs.
-    "wifihaven_schedule_mutations_total"        -> Set("op"),
+    "wifihaven_schedule_mutations_total"   -> Set("op"),
     // #1243/#1221 HikariCP pool gauges — no labels.
-    "wifihaven_db_pool_active_connections"      -> Set.empty[String],
-    "wifihaven_db_pool_idle_connections"        -> Set.empty[String],
-    "wifihaven_db_pool_total_connections"       -> Set.empty[String],
+    "wifihaven_db_pool_active_connections" -> Set.empty[String],
+    "wifihaven_db_pool_idle_connections"   -> Set.empty[String],
+    "wifihaven_db_pool_total_connections"  -> Set.empty[String],
     "wifihaven_db_pool_threads_awaiting_connection" -> Set.empty[String],
     "wifihaven_db_pool_max_size"                    -> Set.empty[String],
   )

--- a/api/test/src/feature/RouterHostMetricsAllowlistSpec.scala
+++ b/api/test/src/feature/RouterHostMetricsAllowlistSpec.scala
@@ -1,0 +1,97 @@
+package wifihaven.api.feature
+
+import wifihaven.api.metrics.MetricGuard
+import zio.*
+import zio.metrics.*
+import zio.test.*
+
+/**
+ * #1718: the router agent will start pushing native OpenWRT OS-level metrics (load / cpu / mem /
+ * iface bandwidth / conntrack / wifi clients) through the existing #1205 batch transport. The
+ * agent-side emit lands in a follow-up PR; this PR is the API-side allowlist + Grafana panels.
+ *
+ * The link between the two PRs is the cardinality firewall: when the agent (follow-up) names a
+ * series, the server-side guard MUST already permit it or the entire push gets rejected and
+ * silently lands in `metrics_rejected_total`. So we pin the `(name, labels)` contract for each new
+ * series here, in the PR that ships the allowlist — that way the follow-up agent PR can rely on
+ * these names without re-coordinating, and any accidental rename / label drop on this side fails
+ * loudly at CI rather than silently on prod.
+ *
+ * Cardinality firewall reminder (AGENTS.md §instrument-new-functionality + the §4 firewall):
+ * `router_id` / `installation_id` are bounded fleet dimensions the server attaches itself; `iface`
+ * and `ssid` are bounded by router hardware/config (handful per device). Per-MAC wireless client
+ * data is explicitly NOT a Prometheus dimension — only the aggregate `router_host_wifi_clients`
+ * count per (iface, ssid) ships as a labeled series. Any per-client drill-in is out of scope here.
+ */
+object RouterHostMetricsAllowlistSpec extends ZIOSpecDefault {
+
+  private val ServerAttached: Set[String] = Set("router_id", "installation_id")
+
+  private def hasEntry(name: String, expectedExtra: Set[String]): TestResult =
+    assertTrue(
+      MetricGuard.Allowed.get(name).contains(ServerAttached ++ expectedExtra),
+    )
+
+  def spec = suite("RouterHostMetricsAllowlistSpec")(
+    test("load avg gauges are allowlisted (router_id + installation_id, no other labels)") {
+      hasEntry("router_host_load_m1", Set.empty) &&
+      hasEntry("router_host_load_m5", Set.empty) &&
+      hasEntry("router_host_load_m15", Set.empty)
+    },
+    test("cpu percent gauge is allowlisted") {
+      hasEntry("router_host_cpu_pct", Set.empty)
+    },
+    test("memory gauges are allowlisted") {
+      hasEntry("router_host_mem_total_kb", Set.empty) &&
+      hasEntry("router_host_mem_free_kb", Set.empty) &&
+      hasEntry("router_host_mem_buffers_kb", Set.empty) &&
+      hasEntry("router_host_mem_cached_kb", Set.empty)
+    },
+    test("conntrack count gauge is allowlisted") {
+      hasEntry("router_host_conntrack_count", Set.empty)
+    },
+    test("per-iface bandwidth counters carry `iface` and only `iface`") {
+      hasEntry("router_host_iface_rx_bytes_total", Set("iface")) &&
+      hasEntry("router_host_iface_tx_bytes_total", Set("iface"))
+    },
+    test("wifi clients gauge carries `iface` and `ssid` — NEVER `mac` (cardinality firewall)") {
+      hasEntry("router_host_wifi_clients", Set("iface", "ssid"))
+    },
+    test("a forbidden per-MAC label on the wifi-clients gauge is rejected") {
+      val rejected = Metric.counter("metrics_rejected_total").tagged("reason", "forbidden_label")
+      for {
+        before <- rejected.value
+        _      <- MetricGuard.gauge(
+          "router_host_wifi_clients",
+          Map("mac" -> "aa:bb:cc:dd:ee:ff"),
+          1.0,
+        )
+        after  <- rejected.value
+      } yield assertTrue(after.count - before.count >= 1.0)
+    },
+    test("a permitted (iface, ssid) labelling on the wifi-clients gauge is accepted") {
+      // The reject counter is a global registry series that concurrent specs also touch, so
+      // we cannot use a no-drift assertion safely. Verify acceptance by reading the gauge value
+      // back — if MetricGuard had rejected the call it would stay at its pre-emit value.
+      val gauge = Metric
+        .gauge("router_host_wifi_clients")
+        .tagged("iface", "phy0-ap0")
+        .tagged("ssid", "AcceptedTestSsid")
+        .tagged("router_id", "r1")
+        .tagged("installation_id", "i1")
+      for {
+        _   <- MetricGuard.gauge(
+          "router_host_wifi_clients",
+          Map(
+            "iface"           -> "phy0-ap0",
+            "ssid"            -> "AcceptedTestSsid",
+            "router_id"       -> "r1",
+            "installation_id" -> "i1",
+          ),
+          3.0,
+        )
+        got <- gauge.value
+      } yield assertTrue(got.value == 3.0)
+    },
+  )
+}

--- a/api/test/src/feature/RouterHostMetricsAllowlistSpec.scala
+++ b/api/test/src/feature/RouterHostMetricsAllowlistSpec.scala
@@ -70,7 +70,8 @@ object RouterHostMetricsAllowlistSpec extends ZIOSpecDefault {
       } yield assertTrue(after.count - before.count >= 1.0)
     },
     test("a permitted (iface, ssid) labelling on the wifi-clients gauge is accepted") {
-      // The reject counter is a global registry series that concurrent specs also touch, so
+      // The reject counter is a global registry series that concurrent specs also touch (see
+      // MetricCardinalityGuardSpec, which only asserts `>= 1.0` on it for the same reason), so
       // we cannot use a no-drift assertion safely. Verify acceptance by reading the gauge value
       // back — if MetricGuard had rejected the call it would stay at its pre-emit value.
       val gauge = Metric

--- a/deploy/grafana/dashboards/router-fleet.json
+++ b/deploy/grafana/dashboards/router-fleet.json
@@ -508,6 +508,211 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Load avg (1m) per router (#1718)",
+      "description": "Per-router load average from /proc/loadavg. #1716 would have shown as a load-m1 climb on the affected router minutes before the operator noticed; this panel is the first-look for 'is any router CPU-pegged right now?'. router_id is server-attached; labels stay router_id-only.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (router_id) (router_host_load_m1{env=\"$env\"})",
+          "legendFormat": "{{router_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "CPU% per router (#1718)",
+      "description": "Per-router CPU utilization (delta-of-/proc/stat between agent ticks). Pairs with load-m1 above: load > 1 with cpu_pct near 100 is CPU saturation; load > 1 with cpu_pct low is I/O wait. Either way the panel shows it in one glance.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 64 },
+      "id": 17,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (router_id) (router_host_cpu_pct{env=\"$env\"})",
+          "legendFormat": "{{router_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Memory used% per router (#1718)",
+      "description": "(total - free - buffers - cached) / total — the LuCI 'available' definition. A climb here on a small router (~256 MB) is the early warning for the OOM/wedge cluster we've seen historically.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 64 },
+      "id": 18,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (router_id) ((router_host_mem_total_kb{env=\"$env\"} - router_host_mem_free_kb{env=\"$env\"} - router_host_mem_buffers_kb{env=\"$env\"} - router_host_mem_cached_kb{env=\"$env\"}) / clamp_min(router_host_mem_total_kb{env=\"$env\"}, 1))",
+          "legendFormat": "{{router_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Per-iface bandwidth — RX (#1718)",
+      "description": "rate(router_host_iface_rx_bytes_total[5m]) by (router_id, iface). iface is bounded (br-lan, wan, phyN-apM…) — handful per router, firewall-safe. Counter, not gauge; cumulative, server re-bases on agent restart via the #1205 counter-reset sentinel.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
+      "id": 19,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (router_id, iface) (rate(router_host_iface_rx_bytes_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{router_id}} / {{iface}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Per-iface bandwidth — TX (#1718)",
+      "description": "rate(router_host_iface_tx_bytes_total[5m]) by (router_id, iface). Symmetric to RX above; usually a household's TX on the WAN iface tracks the uplink.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 72 },
+      "id": 20,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (router_id, iface) (rate(router_host_iface_tx_bytes_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{router_id}} / {{iface}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Conntrack table size per router (#1718)",
+      "description": "/proc/sys/net/netfilter/nf_conntrack_count. Routers wedge when this gets near nf_conntrack_max (typically 16k on the budget hardware). A sustained climb is the first sign of a torrent/scan-style flow explosion or a leaking conntrack timer.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 80 },
+      "id": 21,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (router_id) (router_host_conntrack_count{env=\"$env\"})",
+          "legendFormat": "{{router_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Wireless clients connected per (router, iface, ssid) (#1718)",
+      "description": "Aggregate count of associated stations per AP (from `iw dev <iface> station dump | wc -l`). Per-MAC drill-in is deliberately NOT a Prometheus label — the cardinality firewall forbids `mac` as a label, and per-client surfaces belong in a separate DB-backed view. Useful for spotting an AP that drops to 0 connected clients (radio crash) or jumps to an unexpectedly high count.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 80 },
+      "id": 22,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never", "lineWidth": 1 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (router_id, iface, ssid) (router_host_wifi_clients{env=\"$env\"})",
+          "legendFormat": "{{router_id}} / {{ssid}} ({{iface}})",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

PR 1 of 2 for #1718 (router agent publishes native OS metrics — load / bandwidth / wireless / connections). This PR is API + Grafana only; the follow-up PR wires the OpenWRT agent to emit through the existing #1205 batch transport.

**No new DB tables, no wire-shape change.** `RouterMetricsBatch` is already a generic `counters` / `gauges` / `histograms` bag and the server already attaches `router_id`. So the API side is just allowlist + dashboard, and the agent side will just push new entries through the same path.

Changes:

- `api/src/metrics/Metrics.scala` — add `iface` and `ssid` to `MetricGuard.KnownLabelKeys` (both bounded by router hardware/config, firewall-safe), register `router_host_load_m{1,5,15}`, `router_host_cpu_pct`, `router_host_mem_{total,free,buffers,cached}_kb`, `router_host_conntrack_count`, `router_host_iface_{rx,tx}_bytes_total{iface}`, `router_host_wifi_clients{iface, ssid}` in `MetricGuard.Allowed`.
- `api/test/src/feature/RouterHostMetricsAllowlistSpec.scala` — new spec pins the `(name, labels)` contract and proves the cardinality firewall rejects a per-MAC label on the wifi-clients gauge while accepting `(iface, ssid)`.
- `deploy/grafana/dashboards/router-fleet.json` — seven new panels: load avg (1m), CPU%, memory used %, per-iface RX/TX bandwidth, conntrack count, wireless clients per (router, iface, ssid).

Per-MAC wireless drill-in is deliberately out of scope here per AGENTS.md §instrument-new-functionality (cardinality firewall) — the aggregate count-per-AP is the labeled series; a per-client surface would need a separate API endpoint.

## TDD progression

- `322477a7` test(#1718): pin (name, labels) contract — red (Allowed doesn't carry the new names)
- `e053c9f4` feat(#1718): allowlist native router-host metrics — green
- `5491efd7` feat(#1718): Grafana panels

## Why this would have helped #1716

The motivating incident: prod router CPU pegged for hours on a 24-day-old agent. With the load-m1 panel an operator would have seen the climb start exactly when, without SSH; with the conntrack and memory panels it would have triaged the cause faster. The CPU panel sits right next to it.

## Follow-up — PR 2 of 2

Agent emit: read `/proc/{loadavg,stat,meminfo,sys/net/netfilter/nf_conntrack_count}`, parse `iw dev <iface> station dump`, append the new entries to the existing batch payload. Lands once this PR ships.

## Test plan

- [ ] CI `api.test` passes (new spec + MetricCardinalityGuardSpec)
- [ ] CI `grafana-terraform` passes (terraform fmt/validate + json.tool on the dashboard)
- [ ] PR 2 agent emit lands once this is merged