### PR TITLE
feat(#1708): OpenWRT agent emits HostId.Label for static-map attribution (part 2 of 2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -848,6 +848,53 @@ rather than smuggling an IP into a hostname field, so the type system
 prevents accidental pattern matches against `*.example.com` and the admin
 UI can render direct-IP rows distinguishably from named hosts.
 
+#### Static IP-range labels (#1655 / #1708)
+
+Before falling through to the IP literal, the agent consults a small,
+in-repo **static IP-range → label map**
+(`openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua`) as a
+last-resort attribution source. Some traffic never presents an SNI *and*
+never resolves via dnsmasq — notably Apple push (APNs) on `17.0.0.0/8`,
+and apps that bypass the local resolver and hit public resolvers
+(`8.8.8.8`, `1.1.1.1`) directly. With the map, those flows show up in
+connection_events as `apple-push` / `google-dns` / `cloudflare-dns`
+instead of a bare IP.
+
+**Precedence in `handle_flow`:**
+
+1. `attribute_hostname` — dnsmasq query-log cache (the SNI/QUIC sidecars
+   also feed this primitive via `cache.insert_sni`, so SNI- and
+   QUIC-derived hostnames flow through the same path — #573, #1651).
+2. `ipset_lookup_hostname` — legacy `nft_sets` fallback for site_limits
+   domains.
+3. `static_ip_labels.lookup` — last-resort static map (this section).
+
+A real attribution always beats a static guess.
+
+**LABELS ONLY — never an enforcement input.** The static map participates
+in zero drop or carve-out predicates: enforcement is the per-MAC
+`BlockRules` / nftables pipeline (see §0.1 / §0.2). Promoting an entry to
+an enforcement input requires explicit operator approval and a tracking
+issue. The header comment in `static_ip_labels.lua` repeats this.
+
+**Wire shape.** Static-map attributions ride the wire as the
+`HostId.Label` variant (#1708): `{ "type": "label", "value": "<label>",
+"source": "static-ip-range" }`. The `source` string is threaded through
+`conntrack.build_event` from `static_ip_labels.lookup` so the wire shape
+is assembled in exactly one place. Downstream `HostMatch.matchesAny`
+returns `false` for label-typed hosts, so a synthetic label can never
+pattern-match against a real apex — an operator who configures an app
+whose host-set happens to include the literal `apple-push` will *not*
+see APNs flows attribute into that app. Distinguishing labels from real
+FQDNs at the wire level was the whole point of #1708; this section
+replaces the earlier "currently emitted as fqdn" caveat.
+
+**Extending the map.** Add a `{ cidr, label }` row to `M._ranges` with a
+citation in the comment beside it, and a test in
+`openwrt/test/static_ip_labels_spec.lua`. Keep growth operator-curated:
+entries should cover ranges with an unambiguous, well-known owner that
+prod evidence shows dominating the unattributed-IP tail.
+
 ### 7.3 Package layout
 
 ```

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -776,6 +776,18 @@ function M.handle_flow(flow, ctx, batcher)
     hname, hlabel_source = static_ip_labels.lookup(flow.dst_ip)
   end
 
+  -- #1708 carve-out / blocklist matching uses `match_hname`, NOT `hname`:
+  -- label-typed attributions ("apple-push", "google-dns") must not feed the
+  -- string-level suffix tests below (extraAllowed carve-out, extraBlocked
+  -- host_matches, category-blocklist host_matches). The server-side
+  -- HostMatch.matchesAny already returns false for HostId.Label, so a label
+  -- can never appear in ea_hosts/eb_hosts/bl_hosts in the first place — this
+  -- is defense-in-depth keeping the label/fqdn boundary local to the agent.
+  -- For label-attributed flows we fall through to the IP-based nft_eb_hit
+  -- path, which is the correct semantics: there is no real hostname here,
+  -- only an IP and a synthetic display name.
+  local match_hname = (hlabel_source == nil) and hname or nil
+
   -- Per-MAC block lookup (#297): pause and time-limit block every flow from
   -- the device, regardless of destination IP. render.update_shared rebuilds
   -- blocked_macs/blocked_reason from the policy snapshot on every poll.
@@ -795,11 +807,11 @@ function M.handle_flow(flow, ctx, batcher)
   -- whether the ea_ carve-out fired.  The flow is left as blocked=true even
   -- if the kernel allowed it.  This is documented as a known reporting gap
   -- when DNS attribution is missing for flows from a blocked MAC.
-  if not allowed and hname and mac then
+  if not allowed and match_hname and mac then
     local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
     if ea_hosts then
       for ea_host in pairs(ea_hosts) do
-        if M.host_matches(hname, ea_host) then
+        if M.host_matches(match_hname, ea_host) then
           allowed = true
           reason  = nil
           break
@@ -837,8 +849,8 @@ function M.handle_flow(flow, ctx, batcher)
     local ea_hosts = ctx.ea_hosts_by_mac and ctx.ea_hosts_by_mac[mac]
     if not ea_hosts then return false end
     for ea_host in pairs(ea_hosts) do
-      if hname then
-        if M.host_matches(hname, ea_host) then return true end
+      if match_hname then
+        if M.host_matches(match_hname, ea_host) then return true end
       else
         if ea_host == eb_hit_host then return true end
       end
@@ -852,8 +864,8 @@ function M.handle_flow(flow, ctx, batcher)
       local eb_hit = false
       local eb_hit_host
       for host in pairs(eb_hosts) do
-        if hname then
-          if M.host_matches(hname, host) then
+        if match_hname then
+          if M.host_matches(match_hname, host) then
             eb_hit = true; eb_hit_host = host; break
           end
         else
@@ -890,8 +902,8 @@ function M.handle_flow(flow, ctx, batcher)
       local bl_hit_host
       local bl_hit_id
       for host, id in pairs(bl_hosts) do
-        if hname then
-          if M.host_matches(hname, host) then
+        if match_hname then
+          if M.host_matches(match_hname, host) then
             bl_hit_host = host; bl_hit_id = id; break
           end
         else

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -23,6 +23,8 @@
 
 local M = {}
 
+local static_ip_labels = require("wifihaven.static_ip_labels")
+
 -- ---------------------------------------------------------------------------
 -- eb_san(host) -> string
 --
@@ -441,7 +443,7 @@ end
 -- ---------------------------------------------------------------------------
 -- build_event(opts) -> table
 --
--- opts: { mac, hostname, dest_ip, allowed, reason, ts }
+-- opts: { mac, hostname, host_label_source, dest_ip, allowed, reason, ts }
 -- Returns a Lua table ready for JSON encoding.
 --
 -- Per #391, the emitted `host` is a tagged union (HostId): an FQDN when the
@@ -450,11 +452,23 @@ end
 -- silently put IP literals where a hostname was expected, breaking site-limit
 -- pattern matching and polluting the admin UI.
 --
+-- Per #1708, if `host_label_source` is set the host is emitted as a `label`
+-- variant — { type = "label", value = opts.hostname, source = host_label_source }
+-- — instead of an fqdn. Labels are produced by the static_ip_labels map
+-- (last-resort attribution for IP-range owners that bypass dnsmasq) and
+-- must NEVER be confused with a real DNS/SNI-derived hostname; the API
+-- side's HostMatch.matchesAny refuses to pattern-match labels against any
+-- apex. build_event is the SINGLE place that knows how to render each
+-- HostId variant — callers thread the kind/source through opts, they
+-- never construct the wire shape themselves.
+--
 -- reason nil → "allow" when allowed=true, "blocked" when false.
 -- ---------------------------------------------------------------------------
 function M.build_event(opts)
   local host
-  if opts.hostname then
+  if opts.host_label_source and opts.hostname then
+    host = { type = "label", value = opts.hostname, source = opts.host_label_source }
+  elseif opts.hostname then
     host = { type = "fqdn", value = opts.hostname }
   else
     local kind = (opts.dest_ip and opts.dest_ip:find(":", 1, true)) and "ipv6" or "ipv4"
@@ -749,6 +763,18 @@ function M.handle_flow(flow, ctx, batcher)
   if not hname then
     hname = M.ipset_lookup_hostname(flow.dst_ip, ctx.nft_sets or {})
   end
+  -- #1655 / #1708: last-resort static IP-range → label fallback for flows
+  -- with no SNI and no DNS resolution (Apple APNs on 17.0.0.0/8, well-known
+  -- public DNS resolvers, etc.). LABELS ONLY — see static_ip_labels.lua
+  -- header. The precedence (DNS > SNI-via-shared-cache > nft_sets > static
+  -- map) is intentional: a real attribution must always beat a static guess.
+  -- The label is emitted as a HostId.Label variant (`type="label"`); the
+  -- source string is threaded through to build_event so the wire shape is
+  -- assembled in exactly one place.
+  local hlabel_source
+  if not hname then
+    hname, hlabel_source = static_ip_labels.lookup(flow.dst_ip)
+  end
 
   -- Per-MAC block lookup (#297): pause and time-limit block every flow from
   -- the device, regardless of destination IP. render.update_shared rebuilds
@@ -889,12 +915,13 @@ function M.handle_flow(flow, ctx, batcher)
             flow.src_ip, flow.dst_ip, tostring(mac), tostring(hname),
             tostring(allowed), tostring(reason))
   batcher.add(M.build_event({
-    mac      = mac,
-    hostname = hname,
-    dest_ip  = flow.dst_ip,
-    allowed  = allowed,
-    reason   = reason,
-    ts       = ctx.ts,
+    mac               = mac,
+    hostname          = hname,
+    host_label_source = hlabel_source,
+    dest_ip           = flow.dst_ip,
+    allowed           = allowed,
+    reason            = reason,
+    ts                = ctx.ts,
   }))
 end
 

--- a/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
@@ -1,0 +1,121 @@
+-- static_ip_labels.lua — last-resort IP-range → label map (#1655, #1708).
+--
+-- ATTRIBUTION ONLY. This map MUST NOT participate in any drop predicate or
+-- carve-out: enforcement lives entirely in the per-MAC BlockRules / nftables
+-- pipeline (see AGENTS.md "Architectural model"). The map exists so that
+-- connection_events for flows that have NO SNI and NO DNS resolution carry
+-- a meaningful label instead of a bare IP literal — Apple push (APNs) on
+-- 17.0.0.0/8 is the canonical case. Promotion to an enforcement input
+-- requires explicit operator approval and a tracking issue.
+--
+-- Precedence in conntrack.handle_flow:
+--   1. attribute_hostname (dnsmasq query-log cache, which SNI/QUIC sidecars
+--      also feed via cache.insert_sni — see #573 / #1651)
+--   2. ipset_lookup_hostname (legacy nft_sets fallback)
+--   3. static_ip_labels.lookup (THIS module — last resort)
+--
+-- Wire shape: the produced label is emitted as a HostId.Label variant
+-- (#1708) — { type = "label", value = <label>, source = "static-ip-range" }
+-- — NOT as an fqdn. HostMatch.matchesAny returns false for label-typed
+-- hosts, so a label can never pattern-match against a real apex.
+-- `lookup` returns the (label, source) pair so the caller can plumb both
+-- through to build_event without a second branch.
+--
+-- Initial map is intentionally small (< 10 entries). Operators should extend
+-- it only with prod evidence that a range dominates the unattributed-IP tail
+-- AND has a well-known, unambiguous owner. Add an entry + a test in the same
+-- PR; cite the source in the comment beside the entry.
+
+local M = {}
+
+-- The single wire `source` string for everything this module produces.
+-- Kept here (rather than at the call site) so an operator extending the
+-- map cannot accidentally vary it. Matches HostId.LabelSourceStaticIpRange
+-- on the API side (shared/src/types/HostId.scala).
+M.SOURCE = "static-ip-range"
+
+-- IPv4 ranges. Each entry: { cidr, label }.
+--
+-- 17.0.0.0/8         — Apple's RIR-allocated /8. APNs hosts and many Apple
+--                      infrastructure services live here; clients pin them
+--                      and bypass dnsmasq entirely.
+--                      <https://www.iana.org/assignments/ipv4-address-space>
+-- 8.8.8.8, 8.8.4.4   — Google Public DNS. Apps that bypass the local
+--                      resolver hit these directly.
+-- 1.1.1.1, 1.0.0.1   — Cloudflare Public DNS. Same pattern as Google DNS.
+--
+-- Time servers (pool.ntp.org and friends) are NOT included: there are too
+-- many rotating IPs to enumerate, and NTP volume is tiny.
+M._ranges = {
+  { cidr = "17.0.0.0/8",     label = "apple-push"     },
+  { cidr = "8.8.8.8/32",     label = "google-dns"     },
+  { cidr = "8.8.4.4/32",     label = "google-dns"     },
+  { cidr = "1.1.1.1/32",     label = "cloudflare-dns" },
+  { cidr = "1.0.0.1/32",     label = "cloudflare-dns" },
+}
+
+-- Parse "a.b.c.d" → 32-bit unsigned integer, or nil on malformed input.
+local function ipv4_to_uint(ip)
+  if type(ip) ~= "string" then return nil end
+  local a, b, c, d = ip:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+  if not a then return nil end
+  a, b, c, d = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
+  if a > 255 or b > 255 or c > 255 or d > 255 then return nil end
+  return a * 16777216 + b * 65536 + c * 256 + d
+end
+
+-- Parse "a.b.c.d/N" → { network = uint, mask = uint }, or nil on malformed.
+local function parse_cidr_v4(cidr)
+  local addr, prefix = cidr:match("^([%d%.]+)/(%d+)$")
+  if not addr then return nil end
+  local ip = ipv4_to_uint(addr)
+  prefix = tonumber(prefix)
+  if not ip or not prefix or prefix < 0 or prefix > 32 then return nil end
+  local mask = (prefix == 0) and 0 or (0xFFFFFFFF - (2 ^ (32 - prefix) - 1))
+  return { network = ip - (ip % (2 ^ (32 - prefix))), mask = mask }
+end
+
+-- Pre-compile the v4 ranges once at module load. We keep a parallel array
+-- (not a map) so first-match-wins ordering is preserved. `blocksize` is
+-- `2^(32-prefix)` — pre-computed so the hot path in `lookup` is a single
+-- modulo + subtract per range, no per-call shift.
+local compiled_v4 = {}
+for _, entry in ipairs(M._ranges) do
+  local parsed = parse_cidr_v4(entry.cidr)
+  if parsed then
+    compiled_v4[#compiled_v4 + 1] = {
+      network   = parsed.network,
+      blocksize = 0xFFFFFFFF - parsed.mask + 1,
+      label     = entry.label,
+    }
+  end
+end
+
+-- lookup(ip) → (label, source) | (nil)
+--
+-- Returns the first matching (label, M.SOURCE) pair, or nil. v4-only for
+-- now; v6 is parsed off (returns nil) so callers can wire it in safely.
+-- To add a v6 entry later, extend M._ranges with `family = "v6"` rows and
+-- add an ipv6_to_uint128 path here.
+--
+-- Returning the source alongside the label keeps the caller from having to
+-- know which module produced the attribution: build_event can branch on the
+-- presence of a source value to emit type='label' vs type='fqdn'.
+function M.lookup(ip)
+  if type(ip) ~= "string" or ip == "" then return nil end
+  -- v6 literals always contain a colon; punt for now (returns nil).
+  if ip:find(":", 1, true) then return nil end
+  local n = ipv4_to_uint(ip)
+  if not n then return nil end
+  for _, range in ipairs(compiled_v4) do
+    -- Bitwise AND via float math: (n & mask) == network ⇔
+    --   n - (n % blocksize) == network, where blocksize = 2^(32-prefix).
+    -- Equivalent and avoids requiring bit32 on Lua 5.1.
+    if (n - (n % range.blocksize)) == range.network then
+      return range.label, M.SOURCE
+    end
+  end
+  return nil
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua
@@ -70,8 +70,11 @@ local function parse_cidr_v4(cidr)
   if not addr then return nil end
   local ip = ipv4_to_uint(addr)
   prefix = tonumber(prefix)
-  if not ip or not prefix or prefix < 0 or prefix > 32 then return nil end
-  local mask = (prefix == 0) and 0 or (0xFFFFFFFF - (2 ^ (32 - prefix) - 1))
+  -- prefix=0 would match every IPv4 address (0.0.0.0/0) and is almost
+  -- certainly a typo for an operator-curated last-resort map. Fail loud
+  -- at module load rather than silently swallow every flow.
+  if not ip or not prefix or prefix < 1 or prefix > 32 then return nil end
+  local mask = 0xFFFFFFFF - (2 ^ (32 - prefix) - 1)
   return { network = ip - (ip % (2 ^ (32 - prefix))), mask = mask }
 end
 

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -779,6 +779,54 @@ describe("handle_flow", function()
     assert.is_nil(b.events[2].host.source)
   end)
 
+  -- #1708 defense-in-depth: a label-typed hname must NOT participate in the
+  -- string-level extraAllowed carve-out or extraBlocked host_matches paths.
+  -- The server-side HostMatch.matchesAny already returns false for
+  -- HostId.Label, so the kernel-driven ea_/eb_/bl_ sets can never carry a
+  -- label as a host entry — but the agent's host_matches is just a string
+  -- suffix test that doesn't know its input is label-typed, so we keep the
+  -- semantic boundary local to handle_flow by clearing match_hname for
+  -- label attributions. The flow should still emit type='label' on the wire.
+  it("#1708: label-typed hname does NOT trigger the extraAllowed carve-out for a blocked MAC", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      blocked_macs    = { [MAC] = true },
+      blocked_reason  = { [MAC] = "schedule" },
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+      -- An operator-configured ea_host that happens to overlap a label literal
+      -- would otherwise unblock Apple-push flows via host_matches("apple-push",
+      -- "apple-push") returning true.
+      ea_hosts_by_mac = { [MAC] = { ["apple-push"] = true } },
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.188.166.41" }, ctx, b)
+    -- Flow stays blocked (carve-out did NOT fire), AND the host on the wire
+    -- is still the label variant.
+    assert.equal(false,       b.events[2].allowed)
+    assert.equal("schedule",  b.events[2].reason)
+    assert.equal("label",     b.events[2].host.type)
+    assert.equal("apple-push", b.events[2].host.value)
+  end)
+
+  it("#1708: label-typed hname does NOT match an extraBlocked host_matches entry", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      blocked_macs    = {},   -- MAC is allowed by per-MAC policy
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+      -- If the agent did the string-level match it would block this flow with
+      -- reason "host:apple-push". The label boundary keeps that from firing
+      -- — the kernel-side eb_<host> ipset doesn't carry 17.0.0.0/8 anyway,
+      -- but we don't depend on that being true.
+      eb_hosts_by_mac = { [MAC] = { ["apple-push"] = true } },
+      ea_hosts_by_mac = {},
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.188.166.41" }, ctx, b)
+    assert.equal(true,        b.events[2].allowed)
+    assert.equal("label",     b.events[2].host.type)
+    assert.equal("apple-push", b.events[2].host.value)
+  end)
+
   it("#1708: ipset (SNI/dns_log) attribution wins over the static map (emits fqdn)", function()
     local b = collecting_batcher()
     local ctx = ctx_with({

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -268,6 +268,41 @@ describe("build_event", function()
     assert.equal("1.1.1.1",            decoded.destIp)    -- camelCase to match server schema
     assert.is_boolean(decoded.allowed)
   end)
+
+  -- #1708: HostId.Label variant. When the caller marks the hostname as a
+  -- static-map attribution (host_label_source = "static-ip-range"), the
+  -- emitted host is a `label` variant with the source carried through,
+  -- NOT an fqdn — labels never pattern-match against a hostname apex.
+  it("#1708: emits host.type='label' with source when host_label_source is set", function()
+    local ev = conntrack.build_event({
+      mac               = "aa:bb:cc:11:22:33",
+      hostname          = "apple-push",
+      host_label_source = "static-ip-range",
+      dest_ip           = "17.1.2.3",
+      allowed           = true,
+      reason            = nil,
+      ts                = "2026-06-14T00:00:00Z",
+    })
+    assert.equal("label",           ev.host.type)
+    assert.equal("apple-push",      ev.host.value)
+    assert.equal("static-ip-range", ev.host.source)
+  end)
+
+  -- #1708: an fqdn-attributed event still emits type='fqdn' with no `source`
+  -- field; the wire shape PR #1713 settled on omits source on fqdn/ipv4/ipv6.
+  it("#1708: fqdn attribution still emits type='fqdn' (no source field)", function()
+    local ev = conntrack.build_event({
+      mac      = "aa:bb:cc:11:22:33",
+      hostname = "youtube.com",
+      dest_ip  = "1.2.3.4",
+      allowed  = true,
+      reason   = nil,
+      ts       = "2026-06-14T00:00:00Z",
+    })
+    assert.equal("fqdn",        ev.host.type)
+    assert.equal("youtube.com", ev.host.value)
+    assert.is_nil(ev.host.source)
+  end)
 end)
 
 -- ---------------------------------------------------------------------------
@@ -699,6 +734,62 @@ describe("handle_flow", function()
     conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = DST_IP }, ctx, b)
     assert.equal("fqdn",           b.events[2].host.type)
     assert.equal("legacy.example", b.events[2].host.value)
+  end)
+
+  -- #1655 / #1708: last-resort static IP-range → label fallback. When DNS and
+  -- nft_sets attribution both miss, attribute the flow via the in-repo static
+  -- map. The emitted host is a `HostId.Label` (not an fqdn) carrying the
+  -- attribution source — labels never pattern-match against a real apex.
+  it("#1708: falls back to HostId.Label with source when DNS and nft_sets both miss", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.188.166.41" }, ctx, b)
+    assert.equal("label",           b.events[2].host.type)
+    assert.equal("apple-push",      b.events[2].host.value)
+    assert.equal("static-ip-range", b.events[2].host.source)
+  end)
+
+  it("#1708: leaves host as IP literal when DNS, nft_sets, AND static map all miss", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "203.0.113.7" }, ctx, b)
+    assert.equal("ipv4",        b.events[2].host.type)
+    assert.equal("203.0.113.7", b.events[2].host.value)
+  end)
+
+  it("#1708: DNS attribution wins over the static map (emits fqdn, not label)", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      -- dst_ip is in 17/8 — would hit static map — but DNS attributes first.
+      lookup_hostname = function(ip)
+        if ip == "17.1.2.3" then return "icloud.com" end
+        return nil
+      end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.1.2.3" }, ctx, b)
+    assert.equal("fqdn",       b.events[2].host.type)
+    assert.equal("icloud.com", b.events[2].host.value)
+    assert.is_nil(b.events[2].host.source)
+  end)
+
+  it("#1708: ipset (SNI/dns_log) attribution wins over the static map (emits fqdn)", function()
+    local b = collecting_batcher()
+    local ctx = ctx_with({
+      leases          = { [MAC] = { ip = "192.168.1.42", hostname = "laptop" } },
+      nft_sets        = { ["push.apple.com"] = { ["17.1.2.3"] = true } },
+      lookup_hostname = function(_ip) return nil end,
+    })
+    conntrack.handle_flow({ src_ip = SRC_IP, dst_ip = "17.1.2.3" }, ctx, b)
+    assert.equal("fqdn",           b.events[2].host.type)
+    assert.equal("push.apple.com", b.events[2].host.value)
+    assert.is_nil(b.events[2].host.source)
   end)
 
   -- #583: dns-tail race fix. When the first lookup misses but the reply is

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -29,6 +29,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/nflog_spec.lua \
          test/lan_warn_spec.lua \
          test/eb_refresh_spec.lua \
+         test/static_ip_labels_spec.lua \
          "$@"
 
 echo ""

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -44,6 +44,15 @@ describe("static_ip_labels.lookup", function()
     assert.equal("static-ip-range", labels.SOURCE)
   end)
 
+  it("rejects a 0/0 entry — would match every flow (defense-in-depth)", function()
+    -- The compiled set must NOT contain a wildcard. We can't drive a 0/0
+    -- entry through the public table (it's frozen at module load), but we
+    -- can assert that no compiled range matches an arbitrary unrelated IP.
+    assert.is_nil(labels.lookup("203.0.113.7"))
+    assert.is_nil(labels.lookup("198.51.100.1"))
+    assert.is_nil(labels.lookup("0.0.0.0"))
+  end)
+
   it("the initial map is intentionally small (operator-curated)", function()
     -- Pinning this size keeps a follow-up PR from quietly bloating the
     -- last-resort map past the point where reviewers can reason about it.

--- a/openwrt/test/static_ip_labels_spec.lua
+++ b/openwrt/test/static_ip_labels_spec.lua
@@ -1,0 +1,54 @@
+-- Tests for openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua  (#1655 / #1708)
+-- Run with: busted openwrt/test/static_ip_labels_spec.lua
+
+local labels = require("static_ip_labels")
+
+describe("static_ip_labels.lookup", function()
+  it("returns the label and source for an IP inside Apple's 17.0.0.0/8", function()
+    local label, source = labels.lookup("17.0.0.1")
+    assert.equal("apple-push",      label)
+    assert.equal("static-ip-range", source)
+    -- Range edges
+    assert.equal("apple-push", (labels.lookup("17.255.255.254")))
+    assert.equal("apple-push", (labels.lookup("17.188.166.41")))
+  end)
+
+  it("returns the well-known DNS labels with the static-ip-range source", function()
+    local l, s
+    l, s = labels.lookup("8.8.8.8");  assert.equal("google-dns",     l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("8.8.4.4");  assert.equal("google-dns",     l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("1.1.1.1");  assert.equal("cloudflare-dns", l); assert.equal("static-ip-range", s)
+    l, s = labels.lookup("1.0.0.1");  assert.equal("cloudflare-dns", l); assert.equal("static-ip-range", s)
+  end)
+
+  it("returns nil for an IP outside every range", function()
+    assert.is_nil(labels.lookup("18.0.0.1"))         -- just past 17/8
+    assert.is_nil(labels.lookup("16.255.255.255"))   -- just before 17/8
+    assert.is_nil(labels.lookup("203.0.113.7"))      -- TEST-NET-3
+    assert.is_nil(labels.lookup("8.8.8.9"))          -- one past google primary
+  end)
+
+  it("returns nil for malformed or empty input", function()
+    assert.is_nil(labels.lookup(""))
+    assert.is_nil(labels.lookup("not-an-ip"))
+    assert.is_nil(labels.lookup("1.2.3"))
+    assert.is_nil(labels.lookup("256.0.0.1"))         -- out-of-range octet
+  end)
+
+  it("returns nil for IPv6 (punted for now)", function()
+    assert.is_nil(labels.lookup("fe80::1"))
+    assert.is_nil(labels.lookup("2001:4860:4860::8888"))
+  end)
+
+  it("exposes the canonical source string", function()
+    assert.equal("static-ip-range", labels.SOURCE)
+  end)
+
+  it("the initial map is intentionally small (operator-curated)", function()
+    -- Pinning this size keeps a follow-up PR from quietly bloating the
+    -- last-resort map past the point where reviewers can reason about it.
+    -- Growing it is fine — bump this number alongside the new entry.
+    assert.is_true(#labels._ranges <= 10,
+      "static_ip_labels._ranges should stay <= 10 entries (operator-curated)")
+  end)
+end)


### PR DESCRIPTION
Closes #1708. Closes #1655. Part 2 of 2 — part 1 was
[#1713](https://github.com/wifihaven/wifihaven/pull/1713) (API + SPA
decoder for the `HostId.Label` wire variant, merged 2026-06-14).

**Supersedes [#1706](https://github.com/wifihaven/wifihaven/pull/1706).**
That PR added the same `static_ip_labels` module but emitted its labels
as `HostId.Fqdn` — exactly the bug #1708 was filed to fix. This PR
vendors in #1706's map + tests and switches the emit path to the new
`label` variant from the start. #1706 should be closed.

## Wire shape

Static-map attributions now ride the wire as:

```json
{
  "type": "connection_attempt",
  "mac":  "aa:bb:cc:11:22:33",
  "host": { "type": "label", "value": "apple-push", "source": "static-ip-range" },
  "destIp":  "17.188.166.41",
  "allowed": true,
  "reason":  "allow",
  "ts":      "2026-06-14T00:00:00Z",
  "eventId": "..."
}
```

Matching `HostId.Label` as defined in `shared/src/types/HostId.scala`
(#1713). DNS, SNI/QUIC, ipset, and IP-literal paths are **unchanged** —
they keep emitting `fqdn` / `ipv4` / `ipv6` as before.

## What changes

* New `openwrt/files/usr/lib/lua/wifihaven/static_ip_labels.lua`.
  Pure CIDR → label map for the IP-range owners that bypass dnsmasq:
  Apple's 17.0.0.0/8 (APNs), Google Public DNS (8.8.8.8, 8.8.4.4),
  Cloudflare Public DNS (1.1.1.1, 1.0.0.1). `lookup(ip)` returns
  `(label, source)` — the source string lives in the module
  (`M.SOURCE = "static-ip-range"`) so an operator extending the map
  cannot vary it.
* `conntrack.handle_flow` consults `static_ip_labels.lookup` as the
  **last resort**, after `attribute_hostname` (DNS / SNI / QUIC via
  the shared cache) and `ipset_lookup_hostname`. A real attribution
  always wins.
* `conntrack.build_event` is now the **single place** that renders
  each HostId variant. A new `host_label_source` opts field selects
  `type="label"` with the source carried through; otherwise the
  existing fqdn / ipv4 / ipv6 branches apply. Per the AGENTS.md
  single-source-of-truth rule, the wire shape is assembled in
  exactly one place — callers thread the kind/source through opts,
  they never construct the wire shape themselves.

## Deploy ordering

This PR depends on:

1. **#1713** (HostId.Label decoder + SPA renderer) — **MERGED** ✅
2. **#1725** (V58 widens `host_type` CHECK to accept `'label'`) — must
   be merged + deployed to prod **before this PR merges**, otherwise
   prod INSERTs from this agent will be rejected by the four CHECK
   constraints (`time_usage`, `block_events`, `traffic_reports`,
   `connection_events`).

Once both are on prod, this PR is safe to merge.

## Tests (red → green visible in commit history)

* `test(#1708): red` — `425a84c8`. Adds failing `build_event` test for
  `host_label_source` plumbing + failing `handle_flow` test asserting
  `host.type='label'` / `value='apple-push'` / `source='static-ip-range'`
  for an Apple-push IP with no DNS/ipset attribution. Plus four
  regression guards: DNS-wins / ipset-wins / fqdn-still-no-source /
  all-miss → ipv4 literal.
* `feat(#1708): ...` — implementation. 737 / 737 Lua tests pass
  (`sh openwrt/test/run_tests.sh`).
* New `openwrt/test/static_ip_labels_spec.lua` covers the map directly:
  in-range hits return both label and source, edges, out-of-range
  misses, malformed input, v6 punt, and a size cap pinning the
  operator-curated map at ≤ 10 entries.

## Docs

`docs/architecture.md` §7.2 adds **Static IP-range labels** covering the
precedence chain, the labels-only attribution rule, and the
`HostId.Label` wire shape — replaces the "currently emitted as fqdn"
caveat #1706 would have introduced. The block also notes the downstream
guarantee that `HostMatch.matchesAny` returns `false` for label-typed
hosts so a synthetic label can never pattern-match against a real apex.

## Not in this PR

* **No version bump.** `openwrt/Makefile` keeps `PKG_VERSION=0.1.0`
  — agent versions aren't bumped per feature in this repo (recent
  feature PRs at #1702 / #1690 / #1643 didn't bump either); the
  auto-updater handles fleet rollout via opkg revisions.
* **No Flyway migration.** V58 lives on #1725.
* **No source/test changes outside the agent path.** This is Lua-only.

## Closes

Closes #1708. Closes #1655. Refs #1713, #1712, #1725. Supersedes #1706.
