### PR TITLE
fix(#1717): single-source openwrt package DEPENDS (restores v4-TCP SNI attribution)

### DIFF
--- a/openwrt/build-apk.sh
+++ b/openwrt/build-apk.sh
@@ -25,6 +25,10 @@ PKG_VERSION="${PKG_VERSION:-$(grep '^PKG_VERSION:=' "$SCRIPT_DIR/Makefile" | cut
 PKG_RELEASE="${PKG_RELEASE:-$(grep '^PKG_RELEASE:=' "$SCRIPT_DIR/Makefile" | cut -d= -f2)}"
 OUT_APK="$SCRIPT_DIR/wifihaven_${PKG_VERSION}-${PKG_RELEASE}_all.apk"
 
+# Derive the apk depends list from the canonical openwrt/Makefile DEPENDS line
+# via the shared helper (single-source-of-truth, #1717). See build-ipk.sh.
+DEPENDS_LIST=$("$SCRIPT_DIR/depends-list.sh" apk)
+
 APK_TOOLS_REPO="${APK_TOOLS_REPO:-https://gitlab.alpinelinux.org/alpine/apk-tools.git}"
 APK_TOOLS_REF="${APK_TOOLS_REF:-v3.0.6}"
 APK_TOOLS_PREFIX="${APK_TOOLS_PREFIX:-$HOME/.cache/wifihaven-apk-tools}"
@@ -146,7 +150,7 @@ rm -f "$OUT_APK"
     --info "license:MIT" \
     --info "url:https://github.com/wifihaven/wifihaven" \
     --info "maintainer:WifiHaven <noreply@example.com>" \
-    --info "depends:lua libuci-lua luci-lib-jsonc conntrack curl uhttpd-mod-lua kmod-nf-log kmod-nf-log6 libustream-mbedtls openssl-util tcpdump-mini" \
+    --info "depends:${DEPENDS_LIST}" \
     --script "post-install:$WORK/post-install" \
     --script "trigger:$WORK/trigger" \
     --trigger "/etc/crontabs" \

--- a/openwrt/build-ipk.sh
+++ b/openwrt/build-ipk.sh
@@ -13,6 +13,13 @@ PKG_VERSION="${PKG_VERSION:-$(grep '^PKG_VERSION:=' "$SCRIPT_DIR/Makefile" | cut
 PKG_RELEASE="${PKG_RELEASE:-$(grep '^PKG_RELEASE:=' "$SCRIPT_DIR/Makefile" | cut -d= -f2)}"
 OUT_IPK="$SCRIPT_DIR/wifihaven_${PKG_VERSION}-${PKG_RELEASE}_all.ipk"
 
+# Derive the package Depends list from the canonical openwrt/Makefile DEPENDS
+# line via the shared helper (single-source-of-truth, #1717). A hard-coded
+# copy here drifted from the Makefile when #1702 added lua-openssl, shipping
+# an .ipk that crash-looped sni-tail's require('openssl') in production.
+# build_depends_sync_spec.test.sh pins the equivalence in CI.
+DEPENDS_LIST=$("$SCRIPT_DIR/depends-list.sh" ipk)
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -25,7 +32,7 @@ mkdir "$WORK/ctrl"
 cat > "$WORK/ctrl/control" <<EOF
 Package: wifihaven
 Version: ${PKG_VERSION}-${PKG_RELEASE}
-Depends: lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6, libustream-mbedtls, openssl-util, tcpdump-mini
+Depends: ${DEPENDS_LIST}
 Architecture: all
 Maintainer: WifiHaven <noreply@example.com>
 Description: Agent daemon for WifiHaven. Enforces per-device DNS filtering

--- a/openwrt/depends-list.sh
+++ b/openwrt/depends-list.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Single source of truth for the wifihaven package's runtime DEPENDS list
+# (#1717, AGENTS.md §single-source-of-truth). Parses the canonical +-prefixed
+# OpenWRT Makefile DEPENDS line (openwrt/Makefile, sibling of this script)
+# and emits the list in the format the named packaging tool expects:
+#
+#   ./depends-list.sh ipk    →  "pkg1, pkg2, pkg3"   (Debian control "Depends:")
+#   ./depends-list.sh apk    →  "pkg1 pkg2 pkg3"     (apk mkpkg --info depends:)
+#   ./depends-list.sh lines  →  one package per line  (test diffs, ad-hoc)
+#
+# Invoked from openwrt/build-ipk.sh and openwrt/build-apk.sh so adding a
+# runtime dependency only requires editing openwrt/Makefile;
+# openwrt/test/build_depends_sync_spec.test.sh pins the equivalence in CI.
+#
+# The Makefile path is the file named "Makefile" in the same directory as
+# this script. Set WH_DEPENDS_MAKEFILE=/path/to/Makefile to override (tests).
+
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+MAKEFILE="${WH_DEPENDS_MAKEFILE:-$SCRIPT_DIR/Makefile}"
+
+if [ ! -f "$MAKEFILE" ]; then
+    echo "depends-list.sh: cannot find Makefile at $MAKEFILE" >&2
+    exit 1
+fi
+
+emit_lines() {
+    grep -E '^[[:space:]]*DEPENDS:=' "$MAKEFILE" \
+        | head -n1 \
+        | sed -E 's/^[[:space:]]*DEPENDS:=//' \
+        | tr ' \t' '\n' \
+        | sed -E 's/^\+//' \
+        | grep -v '^$'
+}
+
+case "${1:-lines}" in
+    lines) emit_lines ;;
+    ipk)   emit_lines | paste -sd ',' - | sed 's/,/, /g' ;;
+    apk)   emit_lines | paste -sd ' ' - ;;
+    *)
+        echo "depends-list.sh: unknown format '$1' (want: lines|ipk|apk)" >&2
+        exit 2
+        ;;
+esac

--- a/openwrt/depends-list.sh
+++ b/openwrt/depends-list.sh
@@ -14,6 +14,10 @@
 #
 # The Makefile path is the file named "Makefile" in the same directory as
 # this script. Set WH_DEPENDS_MAKEFILE=/path/to/Makefile to override (tests).
+#
+# Execute, do not source: the script resolves its directory from $0 so sourcing
+# from another shell would silently misbehave. Callers invoke it as
+# `"$SCRIPT_DIR/depends-list.sh" ipk`.
 
 set -eu
 
@@ -26,8 +30,15 @@ if [ ! -f "$MAKEFILE" ]; then
 fi
 
 emit_lines() {
+    # Bail loud if the Makefile grows a second DEPENDS:= line — silently
+    # taking the first match would let a future luci subpackage's DEPENDS
+    # accidentally take precedence over the wifihaven package's.
+    n=$(grep -cE '^[[:space:]]*DEPENDS:=' "$MAKEFILE" || true)
+    if [ "$n" -ne 1 ]; then
+        echo "depends-list.sh: expected exactly one DEPENDS:= line in $MAKEFILE, found $n" >&2
+        exit 1
+    fi
     grep -E '^[[:space:]]*DEPENDS:=' "$MAKEFILE" \
-        | head -n1 \
         | sed -E 's/^[[:space:]]*DEPENDS:=//' \
         | tr ' \t' '\n' \
         | sed -E 's/^\+//' \

--- a/openwrt/test/build_depends_sync_spec.test.sh
+++ b/openwrt/test/build_depends_sync_spec.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Asserts that the package DEPENDS list is single-sourced from openwrt/Makefile
+# and reproduced identically in the local builder scripts that produce the
+# shipped .ipk and .apk (#1717).
+#
+# Why: build-ipk.sh and build-apk.sh wrote a hard-coded Depends string of their
+# own that drifted from Makefile DEPENDS. When #1702 added lua-openssl to the
+# Makefile DEPENDS for the SNI sidecar's QUIC path, neither script picked it
+# up — the shipped .ipk was missing lua-openssl, the on-router sni-tail's
+# `require("openssl")` crashed the sidecar in a procd respawn loop, and the
+# Gate 2 v4-TCP SNI attribution test timed out waiting for a dns-cache row.
+# The runtime symptom traced back to a duplicated decision (the DEPENDS list)
+# living in three places. This pins the equivalence so the next addition can't
+# regress the same way.
+
+set -euo pipefail
+OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Parse the +-prefixed DEPENDS line from the OpenWRT Makefile into a sorted,
+# normalized package list (one per line, no leading +).
+parse_makefile_depends() {
+    grep -E '^[[:space:]]*DEPENDS:=' "$OPENWRT_DIR/Makefile" \
+        | head -n1 \
+        | sed -E 's/^[[:space:]]*DEPENDS:=//' \
+        | tr ' \t' '\n' \
+        | sed -E 's/^\+//' \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u
+}
+
+# Pull the Depends string out of build-ipk.sh's control-file heredoc and
+# normalize it the same way.
+parse_ipk_depends() {
+    grep -E '^Depends:' "$OPENWRT_DIR/build-ipk.sh" \
+        | head -n1 \
+        | sed -E 's/^Depends:[[:space:]]*//' \
+        | tr ',' '\n' \
+        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u
+}
+
+# Pull the apk depends list out of build-apk.sh's --info line.
+parse_apk_depends() {
+    grep -E '^[[:space:]]*--info "depends:' "$OPENWRT_DIR/build-apk.sh" \
+        | head -n1 \
+        | sed -E 's/.*--info "depends://; s/"[[:space:]]*\\?$//' \
+        | tr ' ' '\n' \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u
+}
+
+makefile=$(parse_makefile_depends)
+ipk=$(parse_ipk_depends)
+apk=$(parse_apk_depends)
+
+fail=0
+
+if [ "$makefile" != "$ipk" ]; then
+    echo "FAIL: build-ipk.sh Depends drift from openwrt/Makefile DEPENDS" >&2
+    (diff <(echo "$makefile") <(echo "$ipk") | sed 's/^/  /' >&2) || true
+    fail=1
+fi
+
+if [ "$makefile" != "$apk" ]; then
+    echo "FAIL: build-apk.sh --info depends drift from openwrt/Makefile DEPENDS" >&2
+    (diff <(echo "$makefile") <(echo "$apk") | sed 's/^/  /' >&2) || true
+    fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+    echo "ok: openwrt/Makefile DEPENDS == build-ipk.sh Depends == build-apk.sh --info depends"
+fi
+exit "$fail"

--- a/openwrt/test/build_depends_sync_spec.test.sh
+++ b/openwrt/test/build_depends_sync_spec.test.sh
@@ -1,74 +1,79 @@
 #!/usr/bin/env bash
-# Asserts that the package DEPENDS list is single-sourced from openwrt/Makefile
-# and reproduced identically in the local builder scripts that produce the
-# shipped .ipk and .apk (#1717).
+# Asserts the wifihaven package DEPENDS list is single-sourced from
+# openwrt/Makefile and that the local builder scripts that ship the .ipk
+# / .apk use the shared helper rather than a hard-coded copy (#1717).
 #
-# Why: build-ipk.sh and build-apk.sh wrote a hard-coded Depends string of their
-# own that drifted from Makefile DEPENDS. When #1702 added lua-openssl to the
-# Makefile DEPENDS for the SNI sidecar's QUIC path, neither script picked it
-# up — the shipped .ipk was missing lua-openssl, the on-router sni-tail's
-# `require("openssl")` crashed the sidecar in a procd respawn loop, and the
-# Gate 2 v4-TCP SNI attribution test timed out waiting for a dns-cache row.
-# The runtime symptom traced back to a duplicated decision (the DEPENDS list)
-# living in three places. This pins the equivalence so the next addition can't
-# regress the same way.
+# Why: build-ipk.sh and build-apk.sh used to embed a literal Depends string
+# of their own. When #1702 added lua-openssl to openwrt/Makefile for the SNI
+# sidecar's QUIC path, neither script picked it up — the shipped .ipk was
+# missing lua-openssl, the on-router sni-tail's `require("openssl")` crashed
+# the sidecar in a procd respawn loop, and the Gate 2 v4-TCP SNI attribution
+# test timed out (master-router-cd red for two days; prod router.lan stuck on
+# 24-day-old code per #1716 because no openwrt-latest could publish).
+#
+# Gate: fail if either builder script
+#   (a) stops calling openwrt/depends-list.sh, OR
+#   (b) re-introduces a literal hard-coded Depends list, OR
+#   (c) the helper itself loses one of the regression-pinned packages.
 
 set -euo pipefail
 OPENWRT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$OPENWRT_DIR/depends-list.sh"
 
-# Parse the +-prefixed DEPENDS line from the OpenWRT Makefile into a sorted,
-# normalized package list (one per line, no leading +).
-parse_makefile_depends() {
-    grep -E '^[[:space:]]*DEPENDS:=' "$OPENWRT_DIR/Makefile" \
-        | head -n1 \
-        | sed -E 's/^[[:space:]]*DEPENDS:=//' \
-        | tr ' \t' '\n' \
-        | sed -E 's/^\+//' \
-        | grep -v '^$' \
-        | LC_ALL=C sort -u
-}
+if [ ! -x "$HELPER" ]; then
+    echo "FAIL: $HELPER missing or not executable (single source for wifihaven DEPENDS)" >&2
+    exit 1
+fi
 
-# Pull the Depends string out of build-ipk.sh's control-file heredoc and
-# normalize it the same way.
-parse_ipk_depends() {
-    grep -E '^Depends:' "$OPENWRT_DIR/build-ipk.sh" \
-        | head -n1 \
-        | sed -E 's/^Depends:[[:space:]]*//' \
-        | tr ',' '\n' \
-        | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
-        | grep -v '^$' \
-        | LC_ALL=C sort -u
-}
-
-# Pull the apk depends list out of build-apk.sh's --info line.
-parse_apk_depends() {
-    grep -E '^[[:space:]]*--info "depends:' "$OPENWRT_DIR/build-apk.sh" \
-        | head -n1 \
-        | sed -E 's/.*--info "depends://; s/"[[:space:]]*\\?$//' \
-        | tr ' ' '\n' \
-        | grep -v '^$' \
-        | LC_ALL=C sort -u
-}
-
-makefile=$(parse_makefile_depends)
-ipk=$(parse_ipk_depends)
-apk=$(parse_apk_depends)
+# (c) Regression pins. lua-openssl was the live #1717 miss; kmod-nf-conntrack6
+# was its #1690 sibling that also escaped the stale builders.
+lines=$("$HELPER" lines || true)
+if [ -z "$lines" ]; then
+    echo "FAIL: depends-list.sh emitted nothing — openwrt/Makefile DEPENDS unparsable?" >&2
+    exit 1
+fi
+for required in lua-openssl kmod-nf-conntrack6 tcpdump-mini; do
+    if ! printf '%s\n' "$lines" | grep -qx "$required"; then
+        echo "FAIL: canonical DEPENDS missing $required (regression-pinned by #1717)" >&2
+        echo "  current list:" >&2
+        printf '%s\n' "$lines" | sed 's/^/    /' >&2
+        exit 1
+    fi
+done
 
 fail=0
 
-if [ "$makefile" != "$ipk" ]; then
-    echo "FAIL: build-ipk.sh Depends drift from openwrt/Makefile DEPENDS" >&2
-    (diff <(echo "$makefile") <(echo "$ipk") | sed 's/^/  /' >&2) || true
-    fail=1
-fi
+# (a) + (b): each builder script must call depends-list.sh AND have its
+# control line reference ${DEPENDS_LIST}; a literal `Depends: lua, libuci-lua…`
+# / `--info "depends:lua libuci-lua…"` line is forbidden because that is
+# the failure mode this rule guards.
+check_builder() {
+    label="$1"; script="$2"; helper_arg="$3"; control_pattern="$4"
+    if ! grep -qE "DEPENDS_LIST=.*depends-list\\.sh.* ${helper_arg}" "$script"; then
+        echo "FAIL: $label does not assign DEPENDS_LIST=\$(.../depends-list.sh ${helper_arg})" >&2
+        return 1
+    fi
+    if ! grep -qE -- "$control_pattern" "$script"; then
+        echo "FAIL: $label control line does not expand \${DEPENDS_LIST} (re-hardcoded?)" >&2
+        return 1
+    fi
+    # Reject any literal Depends/--info depends: line whose value is a real
+    # package name rather than the ${DEPENDS_LIST} reference.
+    if grep -nE '^(Depends:|[[:space:]]*--info "depends:)[[:space:]]*[a-z]' "$script" \
+        | grep -vF '${DEPENDS_LIST}' >/dev/null; then
+        echo "FAIL: $label contains a literal Depends list (must reference \${DEPENDS_LIST})" >&2
+        grep -nE '^(Depends:|[[:space:]]*--info "depends:)[[:space:]]*[a-z]' "$script" >&2
+        return 1
+    fi
+}
 
-if [ "$makefile" != "$apk" ]; then
-    echo "FAIL: build-apk.sh --info depends drift from openwrt/Makefile DEPENDS" >&2
-    (diff <(echo "$makefile") <(echo "$apk") | sed 's/^/  /' >&2) || true
-    fail=1
-fi
+check_builder "build-ipk.sh" "$OPENWRT_DIR/build-ipk.sh" \
+    ipk 'Depends: \$\{DEPENDS_LIST\}' || fail=1
+
+check_builder "build-apk.sh" "$OPENWRT_DIR/build-apk.sh" \
+    apk '--info "depends:\$\{DEPENDS_LIST\}"' || fail=1
 
 if [ "$fail" = 0 ]; then
-    echo "ok: openwrt/Makefile DEPENDS == build-ipk.sh Depends == build-apk.sh --info depends"
+    echo "ok: openwrt/Makefile DEPENDS is the single source for build-ipk.sh and build-apk.sh"
 fi
 exit "$fail"

--- a/openwrt/test/build_depends_sync_spec.test.sh
+++ b/openwrt/test/build_depends_sync_spec.test.sh
@@ -32,7 +32,7 @@ if [ -z "$lines" ]; then
     echo "FAIL: depends-list.sh emitted nothing — openwrt/Makefile DEPENDS unparsable?" >&2
     exit 1
 fi
-for required in lua-openssl kmod-nf-conntrack6 tcpdump-mini; do
+for required in lua-openssl kmod-nf-conntrack6 tcpdump-mini kmod-nf-log kmod-nf-log6; do
     if ! printf '%s\n' "$lines" | grep -qx "$required"; then
         echo "FAIL: canonical DEPENDS missing $required (regression-pinned by #1717)" >&2
         echo "  current list:" >&2

--- a/openwrt/test/install_spec.sh
+++ b/openwrt/test/install_spec.sh
@@ -214,22 +214,23 @@ grep -q "95-wifihaven-uhttpd" "$ROOT/Makefile" \
   || check "legacy static index.html has been removed" \
            "openwrt/files/www/wifihaven/index.html still present"
 
-# #528: build-ipk.sh and build-apk.sh both hardcode the package's depends
-# line (the OpenWRT Image Builder reads the package metadata, not the
-# Makefile, when assembling the router image). Both must include
+# #528 (post-#1717 collapse): the wifihaven package's DEPENDS must include
 # uhttpd-mod-lua so the lua_handler wired in just above actually runs —
 # without the module uhttpd silently ignores lua_handler, falls back to
 # static-file serving, and 404s every request (the legacy index.html was
 # removed alongside the handler).
-grep -q "uhttpd-mod-lua" "$ROOT/build-ipk.sh" \
-  && check "build-ipk.sh Depends pulls in uhttpd-mod-lua" ok \
-  || check "build-ipk.sh Depends pulls in uhttpd-mod-lua" \
-           "missing uhttpd-mod-lua dep in build-ipk.sh"
-
-grep -q "uhttpd-mod-lua" "$ROOT/build-apk.sh" \
-  && check "build-apk.sh depends pulls in uhttpd-mod-lua" ok \
-  || check "build-apk.sh depends pulls in uhttpd-mod-lua" \
-           "missing uhttpd-mod-lua dep in build-apk.sh"
+#
+# Pre-#1717 this was checked by grepping uhttpd-mod-lua out of build-ipk.sh
+# and build-apk.sh, which kept their own hard-coded Depends strings. #1717
+# collapsed that drift: the canonical DEPENDS lives in openwrt/Makefile and
+# both builders derive their control-file Depends from it via
+# openwrt/depends-list.sh (pinned by build_depends_sync_spec.test.sh). So
+# checking openwrt/Makefile is the right place to enforce the
+# uhttpd-mod-lua invariant — both .ipk and .apk inherit it automatically.
+grep -q '^[[:space:]]*DEPENDS:=.*+uhttpd-mod-lua\b' "$ROOT/Makefile" \
+  && check "Makefile DEPENDS pulls in uhttpd-mod-lua" ok \
+  || check "Makefile DEPENDS pulls in uhttpd-mod-lua" \
+           "missing +uhttpd-mod-lua in openwrt/Makefile DEPENDS"
 
 # #1278: luci-app-wifihaven is a classic Lua/CBI LuCI app. On modern OpenWRT
 # (23.05+, apk-based 24.10) luci-base is the ucode/JS framework; the server-


### PR DESCRIPTION
Closes #1717. Unblocks Master Router CD; new openwrt-latest will publish after merge.

## Root cause

`openwrt/build-ipk.sh` line 28 and `openwrt/build-apk.sh` line 149 each hard-coded their own `Depends:` / `--info depends:` string for the wifihaven router-agent package, in addition to the canonical `DEPENDS:=…` in `openwrt/Makefile`. When [#1702](https://github.com/wifihaven/wifihaven/pull/1702) added `lua-openssl` to the Makefile so the SNI sidecar could parse QUIC v1 Initial packets, the two builder scripts never picked it up. Every shipped router .ipk therefore omitted `lua-openssl`, and the very first line of `wifihaven-sni-tail` — `require("openssl")` — crashed the sidecar at startup. procd respawned it 5× in ~25s and gave up, so `/tmp/wifihaven-sni.log` stayed empty fleet-wide and the Gate 2 v4-TCP attribution test timed out waiting for its dns-cache row.

The same drift had already silently hidden `kmod-nf-conntrack6` (added in [#1690](https://github.com/wifihaven/wifihaven/pull/1690) for v6 attribution); v6 tests passed only because something in the stock 23.05 image happened to load the v6 conntrack hooks anyway.

The runtime symptom traced back to a **single-source-of-truth violation** per `AGENTS.md`: the DEPENDS list was a decision duplicated in three files. Fix is to **collapse**, not to add a third stale copy.

## Fix

A tiny helper `openwrt/depends-list.sh` parses the canonical `DEPENDS:=` line in `openwrt/Makefile` once and emits it in the format each packaging tool expects:
- `./depends-list.sh ipk` → `"pkg1, pkg2, pkg3"` (Debian control `Depends:`)
- `./depends-list.sh apk` → `"pkg1 pkg2 pkg3"` (`apk mkpkg --info depends:`)

`build-ipk.sh` and `build-apk.sh` both invoke the helper instead of hard-coding. Adding a runtime dependency now requires editing only the Makefile.

## Tests

New shell test `openwrt/test/build_depends_sync_spec.test.sh` (auto-discovered by the CI `*.test.sh` job in `ci.yml`) RED-pinned the drift in commit 1, GREEN in commit 2. It guards three things going forward:
1. Each builder script calls `depends-list.sh ipk`/`apk`.
2. Each builder's control line references `${DEPENDS_LIST}` rather than a literal package list (re-hardcoding is rejected).
3. The helper's output still contains the regression-pinned packages (`lua-openssl`, `kmod-nf-conntrack6`, `kmod-nf-log`, `kmod-nf-log6`, `tcpdump-mini`) so a future Makefile edit that loses one of them is caught.

## Verification (local Gate 2 on plex)

**Before** (commit `8dc4974e`, current main):
- `.ipk` Depends has no `lua-openssl` / `kmod-nf-conntrack6`
- `logread` on booted router: `wifihaven-sni-tail: module 'openssl' not found` (×5 then procd gives up)
- `test_sni_only_hostname_attribution`: `FAILED` (TimeoutError waiting for dns-cache row)

**After** (this PR):
- `.ipk` Depends: `lua, libuci-lua, luci-lib-jsonc, conntrack, curl, uhttpd-mod-lua, kmod-nf-log, kmod-nf-log6, kmod-nf-conntrack6, libustream-mbedtls, openssl-util, tcpdump-mini, lua-openssl`
- `test_sni_only_hostname_attribution`: `SKIPPED` (the expected outcome — primary dns-cache assertion lands, the secondary connection_event assertion is intentionally skipped per [#1360](https://github.com/wifihaven/wifihaven/issues/1360))

## Downstream

- Master Router CD goes green → openwrt-latest publishes.
- On the next auto-update cycle, prod router.lan picks up current code; [#1716](https://github.com/wifihaven/wifihaven/issues/1716) may resolve as a side effect.