### PR TITLE
feat(#1718): agent emits native OpenWRT host metrics (PR 2 of 2)

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/host_metrics.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/host_metrics.lua
@@ -4,7 +4,9 @@
 -- /proc/meminfo, /proc/sys/net/netfilter/nf_conntrack_count,
 -- /sys/class/net/<iface>/statistics/{rx,tx}_bytes — and the `iw dev <iface>
 -- station dump` output, and folds them into the existing metrics registry
--- under the names the API allowlisted in #1718 PR 1:
+-- under the names the API allowlisted in #1718 PR 1. (Channel / TX-power
+-- from `iw dev <iface> info` are out of scope for v1; add when an operator
+-- needs to alert on radio config drift.)
 --
 --   gauges
 --     router_host_load_m1 / _m5 / _m15
@@ -132,7 +134,9 @@ end
 local function count_stations(dump)
   if not dump or dump == "" then return 0 end
   local n = 0
-  for _ in dump:gmatch("\nStation ") do n = n + 1 end
+  -- Match `[\r\n]Station ` so a future `iw` variant emitting CRLF doesn't
+  -- silently zero the count.
+  for _ in dump:gmatch("[\r\n]Station ") do n = n + 1 end
   -- Count a leading "Station " too (no preceding newline).
   if dump:sub(1, 8) == "Station " then n = n + 1 end
   return n

--- a/openwrt/files/usr/lib/lua/wifihaven/host_metrics.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/host_metrics.lua
@@ -1,0 +1,186 @@
+-- host_metrics.lua — collect native OpenWRT OS-level metrics (#1718).
+--
+-- Reads the standard kernel surfaces — /proc/loadavg, /proc/stat,
+-- /proc/meminfo, /proc/sys/net/netfilter/nf_conntrack_count,
+-- /sys/class/net/<iface>/statistics/{rx,tx}_bytes — and the `iw dev <iface>
+-- station dump` output, and folds them into the existing metrics registry
+-- under the names the API allowlisted in #1718 PR 1:
+--
+--   gauges
+--     router_host_load_m1 / _m5 / _m15
+--     router_host_cpu_pct                 (delta-derived; needs two samples)
+--     router_host_mem_total_kb / _free_kb / _buffers_kb / _cached_kb
+--     router_host_conntrack_count
+--     router_host_wifi_clients{iface, ssid}
+--   counters (cumulative, fold-external; server re-bases on reset)
+--     router_host_iface_rx_bytes_total{iface}
+--     router_host_iface_tx_bytes_total{iface}
+--
+-- All I/O is injected via the `deps` table so the spec drives this with
+-- fixture strings and the agent driver wires in the real read / exec
+-- functions. Missing sources are silently skipped (a router without
+-- nf_conntrack loaded just omits that gauge) — host_metrics never panics on
+-- a missing /proc node.
+--
+-- Cardinality-firewall reminder (#1718, AGENTS.md §instrument-new-functionality):
+-- `iface` and `ssid` are bounded by router hardware/config (handful per
+-- device). The per-MAC wireless client list is explicitly NOT a label — the
+-- gauge ships an aggregate count per (iface, ssid) only.
+
+local metrics = require("wifihaven.metrics")
+
+local M = {}
+
+-- ── /proc/loadavg ──────────────────────────────────────────────────────────
+local function emit_loadavg(reg, body)
+  if not body then return end
+  local m1, m5, m15 = body:match("([%d%.]+)%s+([%d%.]+)%s+([%d%.]+)")
+  if not m1 then return end
+  metrics.set_gauge(reg, "router_host_load_m1", {}, tonumber(m1))
+  metrics.set_gauge(reg, "router_host_load_m5", {}, tonumber(m5))
+  metrics.set_gauge(reg, "router_host_load_m15", {}, tonumber(m15))
+end
+
+-- ── /proc/stat → CPU% (delta between two snapshots) ────────────────────────
+-- Parses the aggregate `cpu` line (sum of all cores). Returns nil if the
+-- file is missing or malformed.
+--
+-- Lua's standard pattern matcher doesn't accept '+' or alternations, so we
+-- iterate per-field and tolerate a variable number of trailing columns
+-- (Linux has added new fields over time: irq, softirq, steal, guest,
+-- guest_nice). All we need is `total = sum(all fields)` and `idle = field 4`.
+local function parse_cpu_stat(body)
+  if not body then return nil end
+  local line = body:match("cpu%s+([^\n]+)")
+  if not line then return nil end
+  local fields = {}
+  for n in line:gmatch("(%d+)") do fields[#fields + 1] = tonumber(n) end
+  if #fields < 4 then return nil end
+  local total = 0
+  for _, v in ipairs(fields) do total = total + v end
+  return { total = total, idle = fields[4] }
+end
+
+local function emit_cpu_pct(reg, body, state)
+  if not state then return end
+  local cur = parse_cpu_stat(body)
+  if not cur then return end
+  local prev = state.prev
+  state.prev = cur
+  if not prev then return end -- first call: no delta yet
+  local total_delta = cur.total - prev.total
+  local idle_delta  = cur.idle - prev.idle
+  if total_delta <= 0 then return end          -- counter reset or no progress
+  local busy_delta  = total_delta - idle_delta
+  if busy_delta < 0 then busy_delta = 0 end
+  local pct = (busy_delta / total_delta) * 100
+  metrics.set_gauge(reg, "router_host_cpu_pct", {}, pct)
+end
+
+-- ── /proc/meminfo ──────────────────────────────────────────────────────────
+local function emit_meminfo(reg, body)
+  if not body then return end
+  local fields = {
+    { gauge = "router_host_mem_total_kb",   key = "MemTotal" },
+    { gauge = "router_host_mem_free_kb",    key = "MemFree" },
+    { gauge = "router_host_mem_buffers_kb", key = "Buffers" },
+    { gauge = "router_host_mem_cached_kb",  key = "Cached" },
+  }
+  for _, f in ipairs(fields) do
+    local v = body:match(f.key .. ":%s*(%d+)%s*kB")
+    if v then metrics.set_gauge(reg, f.gauge, {}, tonumber(v)) end
+  end
+end
+
+-- ── /proc/sys/net/netfilter/nf_conntrack_count ────────────────────────────
+local function emit_conntrack(reg, body)
+  if not body then return end
+  local n = body:match("(%d+)")
+  if n then metrics.set_gauge(reg, "router_host_conntrack_count", {}, tonumber(n)) end
+end
+
+-- ── /sys/class/net/<iface>/statistics/{rx,tx}_bytes ────────────────────────
+-- The kernel exposes cumulative counters; we fold via metrics.fold_external
+-- so a reboot / NIC re-init (counter reset) re-bases the registry instead of
+-- pushing a negative delta.
+local function emit_iface_bytes(reg, read_file, ifaces, baseline)
+  if not ifaces or #ifaces == 0 then return end
+  baseline = baseline or {}
+  baseline.rx = baseline.rx or {}
+  baseline.tx = baseline.tx or {}
+  local rx_cur, tx_cur = {}, {}
+  for _, iface in ipairs(ifaces) do
+    local rx = read_file("/sys/class/net/" .. iface .. "/statistics/rx_bytes")
+    local tx = read_file("/sys/class/net/" .. iface .. "/statistics/tx_bytes")
+    if rx then
+      local n = tonumber(rx:match("%d+"))
+      if n then rx_cur[iface] = n end
+    end
+    if tx then
+      local n = tonumber(tx:match("%d+"))
+      if n then tx_cur[iface] = n end
+    end
+  end
+  metrics.fold_external(reg, "router_host_iface_rx_bytes_total", "iface", rx_cur, baseline.rx)
+  metrics.fold_external(reg, "router_host_iface_tx_bytes_total", "iface", tx_cur, baseline.tx)
+end
+
+-- ── `iw dev <iface> station dump` ──────────────────────────────────────────
+-- Each connected station appears as one `Station <mac> (on <iface>)` line.
+-- We count lines; per-MAC details are deliberately NOT emitted to Prometheus
+-- (cardinality firewall — see header).
+local function count_stations(dump)
+  if not dump or dump == "" then return 0 end
+  local n = 0
+  for _ in dump:gmatch("\nStation ") do n = n + 1 end
+  -- Count a leading "Station " too (no preceding newline).
+  if dump:sub(1, 8) == "Station " then n = n + 1 end
+  return n
+end
+
+local function emit_wifi_clients(reg, iw_dump, wifi_ifaces)
+  if not wifi_ifaces or not iw_dump then return end
+  for _, w in ipairs(wifi_ifaces) do
+    local dump  = iw_dump(w.iface)
+    local count = count_stations(dump)
+    metrics.set_gauge(
+      reg,
+      "router_host_wifi_clients",
+      { iface = w.iface, ssid = w.ssid },
+      count
+    )
+  end
+end
+
+-- ── Public entry point ────────────────────────────────────────────────────
+-- Called from the agent's metrics-push timer, once per tick, BEFORE
+-- metrics.post. `deps` carries:
+--
+--   read_file(path)      : returns file contents string, or nil if missing
+--   iw_dump(iface)       : returns `iw dev <iface> station dump` stdout, or ""
+--   cpu_state            : caller-owned table; host_metrics stores prev snapshot
+--   ifaces               : list of iface names for bandwidth (e.g. {"br-lan","wan"})
+--   iface_baseline       : { rx = {}, tx = {} } — caller-owned per-iface baselines
+--   wifi_ifaces          : list of { iface=..., ssid=... } pairs to sample
+--
+-- Sample order is fixed-cost and bounded: a handful of small file reads + at
+-- most one `iw` shell-out per wifi iface. Worst case on the smallest router
+-- is well under 50 ms; the agent driver should verify on the test router
+-- before declaring done.
+function M.sample(reg, deps)
+  deps = deps or {}
+  local read_file = deps.read_file or function(_) return nil end
+
+  emit_loadavg(reg, read_file("/proc/loadavg"))
+  emit_cpu_pct(reg, read_file("/proc/stat"), deps.cpu_state)
+  emit_meminfo(reg, read_file("/proc/meminfo"))
+  emit_conntrack(reg, read_file("/proc/sys/net/netfilter/nf_conntrack_count"))
+  emit_iface_bytes(reg, read_file, deps.ifaces, deps.iface_baseline)
+  emit_wifi_clients(reg, deps.iw_dump, deps.wifi_ifaces)
+end
+
+-- Exported for tests / contract fixtures.
+M._parse_cpu_stat  = parse_cpu_stat
+M._count_stations  = count_stations
+
+return M

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -29,7 +29,8 @@ local paths      = require("wifihaven.paths")
 local block_page = require("wifihaven.block_page")
 local lan_warn   = require("wifihaven.lan_warn")
 local selfheal   = require("wifihaven.selfheal")
-local version    = require("wifihaven.version")
+local version      = require("wifihaven.version")
+local host_metrics = require("wifihaven.host_metrics")
 
 -- ── UCI config ───────────────────────────────────────────────────────────────
 
@@ -215,6 +216,77 @@ local function fold_sni_metrics()
   local by_result = dns_log.parse_query_results(text)
   metrics.fold_external(mreg, "sni_clienthellos_total", "result",
                         by_result, sni_results_baseline)
+end
+
+-- #1718: native OpenWRT OS-level host metrics — load avg, CPU%, memory,
+-- conntrack count, per-iface bandwidth, wireless client counts. Sampled on
+-- the same metrics_int timer as the rest of the registry, and the resulting
+-- gauges/counters ride the existing #1205 batch transport. Aggregate-only:
+-- per-MAC wireless data is NEVER a label (cardinality firewall, AGENTS.md
+-- §instrument-new-functionality). #1716 would have triaged in minutes if
+-- these series existed in Grafana.
+local function read_file_safe(path)
+  local f = io.open(path, "r")
+  if not f then return nil end
+  local body = f:read("*a")
+  f:close()
+  return body
+end
+
+-- Restrict iface names to a safe character class — UCI is operator-owned but
+-- defending against an accidental shell-meta in a config string is cheap.
+local function safe_iface(iface)
+  if not iface or iface == "" then return nil end
+  if iface:match("^[%w_%-:%.]+$") then return iface end
+  return nil
+end
+
+local function iw_station_dump(iface)
+  local safe = safe_iface(iface)
+  if not safe then return "" end
+  local f = io.popen("iw dev " .. safe .. " station dump 2>/dev/null")
+  if not f then return "" end
+  local out = f:read("*a") or ""
+  f:close()
+  return out
+end
+
+local function parse_iface_csv(s)
+  local out = {}
+  for tok in (s or ""):gmatch("[^,%s]+") do
+    if safe_iface(tok) then out[#out + 1] = tok end
+  end
+  return out
+end
+
+-- "phy0-ap0:Home,phy1-ap0:Guest" → list of {iface=…, ssid=…}.
+local function parse_wifi_ifaces(s)
+  local out = {}
+  for tok in (s or ""):gmatch("[^,]+") do
+    local iface, ssid = tok:match("^%s*([^:]+):(.+)%s*$")
+    if iface and ssid and safe_iface(iface) then
+      out[#out + 1] = { iface = iface, ssid = ssid }
+    end
+  end
+  return out
+end
+
+local host_metrics_ifaces      = parse_iface_csv(uci_get("host_metrics_ifaces", "br-lan,wan"))
+local host_metrics_wifi_ifaces = parse_wifi_ifaces(uci_get("host_metrics_wifi", ""))
+local host_metrics_state       = {
+  cpu_state      = {},
+  iface_baseline = { rx = {}, tx = {} },
+}
+
+local function sample_host_metrics()
+  host_metrics.sample(mreg, {
+    read_file      = read_file_safe,
+    iw_dump        = iw_station_dump,
+    cpu_state      = host_metrics_state.cpu_state,
+    ifaces         = host_metrics_ifaces,
+    iface_baseline = host_metrics_state.iface_baseline,
+    wifi_ifaces    = host_metrics_wifi_ifaces,
+  })
 end
 
 -- activity_sample_int should evenly divide usage_report_interval, or the last
@@ -958,6 +1030,7 @@ conntrack.watch({
       fold_enforcement_drops()
       fold_dns_queries()
       fold_sni_metrics()  -- #573
+      sample_host_metrics() -- #1718
       local sampled_at = os.date("!%Y-%m-%dT%H:%M:%SZ", wall)
       metrics.post(api_url, router_token, mreg, sampled_at, http_post, log)
     end

--- a/openwrt/files/usr/sbin/wifihaven-agent
+++ b/openwrt/files/usr/sbin/wifihaven-agent
@@ -244,7 +244,11 @@ end
 local function iw_station_dump(iface)
   local safe = safe_iface(iface)
   if not safe then return "" end
-  local f = io.popen("iw dev " .. safe .. " station dump 2>/dev/null")
+  -- `timeout 5` bounds a wedged wifi driver — observed on mt76 in the wild,
+  -- where `iw` can hang waiting on the kernel rather than returning. Five
+  -- seconds is plenty for a healthy station dump and keeps the 60 s metrics
+  -- tick from stalling per-iface.
+  local f = io.popen("timeout 5 iw dev " .. safe .. " station dump 2>/dev/null")
   if not f then return "" end
   local out = f:read("*a") or ""
   f:close()

--- a/openwrt/test/host_metrics_spec.lua
+++ b/openwrt/test/host_metrics_spec.lua
@@ -1,0 +1,227 @@
+-- host_metrics_spec.lua — unit tests for the native OpenWRT OS-level metrics
+-- collector (#1718). Reads /proc/loadavg, /proc/stat, /proc/meminfo,
+-- /proc/sys/net/netfilter/nf_conntrack_count, /sys/class/net/*/statistics/*,
+-- and `iw dev <iface> station dump`, then folds them into the existing
+-- metrics registry via the same names the API allowlisted in #1718 PR 1.
+--
+-- All I/O is injected (`read_file`, `iw_dump`) so this spec drives the parser
+-- with fixture strings — no /proc, no `iw`, no kernel needed in CI.
+
+local metrics      = require("wifihaven.metrics")
+local host_metrics = require("wifihaven.host_metrics")
+
+local function find_gauge(batch, name, label_key, label_val)
+  for _, g in ipairs(batch.gauges or {}) do
+    if g.name == name then
+      if not label_key then return g end
+      if g.labels and g.labels[label_key] == label_val then return g end
+    end
+  end
+  return nil
+end
+
+local function find_counter(batch, name, label_key, label_val)
+  for _, c in ipairs(batch.counters or {}) do
+    if c.name == name then
+      if not label_key then return c end
+      if c.labels and c.labels[label_key] == label_val then return c end
+    end
+  end
+  return nil
+end
+
+local function new_reg()
+  return metrics.new({
+    router_id     = "11111111-2222-3333-4444-555555555555",
+    agent_version = "0.3.1",
+    started_at    = "2026-06-14T09:00:00Z",
+  })
+end
+
+-- A small in-memory filesystem the deps.read_file callback dispatches against.
+-- Returns nil for any unknown path so missing-file paths in host_metrics flow
+-- the same way they would on a router that's missing the source (no panic).
+local function fs(files)
+  return function(path) return files[path] end
+end
+
+-- A realistic /proc/loadavg sample: 3 float fields, then sched + last PID.
+local LOADAVG_NORMAL = "0.43 0.27 0.19 1/72 1234\n"
+
+-- /proc/stat with the leading aggregate `cpu` line. host_metrics derives CPU%
+-- from the delta of (sum - idle) / sum between two snapshots. The first
+-- snapshot can't compute a % (no prior), so cpu_pct gauge appears only on the
+-- second call onward.
+local STAT_T0 = [[
+cpu  100 0 50 1000 10 0 0 0 0 0
+cpu0 100 0 50 1000 10 0 0 0 0 0
+intr 12345
+ctxt 67890
+]]
+local STAT_T1 = [[
+cpu  200 0 100 1500 10 0 0 0 0 0
+cpu0 200 0 100 1500 10 0 0 0 0 0
+intr 12345
+ctxt 67890
+]]
+
+local MEMINFO = [[
+MemTotal:         244000 kB
+MemFree:           38000 kB
+MemAvailable:      89000 kB
+Buffers:            4200 kB
+Cached:            41000 kB
+SwapCached:            0 kB
+]]
+
+local CONNTRACK_COUNT = "1432\n"
+
+-- `iw dev <iface> station dump` lines. Each `Station <mac> (on <iface>)`
+-- starts a new station record; host_metrics just counts records.
+local IW_DUMP_PHY0 = [[
+Station aa:bb:cc:dd:ee:01 (on phy0-ap0)
+	signal:  	-52 dBm
+	tx bitrate:	866.7 MBit/s
+Station aa:bb:cc:dd:ee:02 (on phy0-ap0)
+	signal:  	-61 dBm
+	tx bitrate:	433.3 MBit/s
+Station aa:bb:cc:dd:ee:03 (on phy0-ap0)
+	signal:  	-70 dBm
+	tx bitrate:	144.4 MBit/s
+]]
+
+describe("host_metrics.sample", function()
+  it("emits load avg gauges from /proc/loadavg", function()
+    local reg = new_reg()
+    host_metrics.sample(reg, {
+      read_file = fs({ ["/proc/loadavg"] = LOADAVG_NORMAL }),
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    assert.equal(0.43, find_gauge(batch, "router_host_load_m1").value)
+    assert.equal(0.27, find_gauge(batch, "router_host_load_m5").value)
+    assert.equal(0.19, find_gauge(batch, "router_host_load_m15").value)
+  end)
+
+  it("derives CPU% from /proc/stat delta — skips first call (no prior)", function()
+    local reg = new_reg()
+    local state = {}
+    host_metrics.sample(reg, {
+      read_file = fs({ ["/proc/stat"] = STAT_T0 }),
+      cpu_state = state,
+    })
+    local b1 = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    assert.is_nil(find_gauge(b1, "router_host_cpu_pct"))
+
+    host_metrics.sample(reg, {
+      read_file = fs({ ["/proc/stat"] = STAT_T1 }),
+      cpu_state = state,
+    })
+    local b2 = metrics.build_batch(reg, "2026-06-14T14:02:00Z")
+    -- T0 totals: 100+0+50+1000+10 = 1160; idle = 1000
+    -- T1 totals: 200+0+100+1500+10 = 1810; idle = 1500
+    -- busy_delta = (1810-1500) - (1160-1000) = 310-160 = 150
+    -- total_delta = 1810-1160 = 650
+    -- cpu_pct = 150/650 * 100 ≈ 23.0769
+    local pct = find_gauge(b2, "router_host_cpu_pct")
+    assert.is_not_nil(pct)
+    assert.is_true(pct.value > 23.0 and pct.value < 23.2)
+  end)
+
+  it("parses /proc/meminfo into four mem_kb gauges", function()
+    local reg = new_reg()
+    host_metrics.sample(reg, {
+      read_file = fs({ ["/proc/meminfo"] = MEMINFO }),
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    assert.equal(244000, find_gauge(batch, "router_host_mem_total_kb").value)
+    assert.equal(38000, find_gauge(batch, "router_host_mem_free_kb").value)
+    assert.equal(4200, find_gauge(batch, "router_host_mem_buffers_kb").value)
+    assert.equal(41000, find_gauge(batch, "router_host_mem_cached_kb").value)
+  end)
+
+  it("emits conntrack count from nf_conntrack_count", function()
+    local reg = new_reg()
+    host_metrics.sample(reg, {
+      read_file = fs({
+        ["/proc/sys/net/netfilter/nf_conntrack_count"] = CONNTRACK_COUNT,
+      }),
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    assert.equal(1432, find_gauge(batch, "router_host_conntrack_count").value)
+  end)
+
+  it("folds per-iface byte counters as cumulative counters with iface label", function()
+    local reg = new_reg()
+    local iface_baseline = { rx = {}, tx = {} }
+    host_metrics.sample(reg, {
+      read_file = fs({
+        ["/sys/class/net/br-lan/statistics/rx_bytes"] = "1000\n",
+        ["/sys/class/net/br-lan/statistics/tx_bytes"] = "2000\n",
+        ["/sys/class/net/wan/statistics/rx_bytes"]    = "5000\n",
+        ["/sys/class/net/wan/statistics/tx_bytes"]    = "7000\n",
+      }),
+      ifaces         = { "br-lan", "wan" },
+      iface_baseline = iface_baseline,
+    })
+    -- Second sample to verify delta-folding: br-lan grew by 234, wan was reset.
+    host_metrics.sample(reg, {
+      read_file = fs({
+        ["/sys/class/net/br-lan/statistics/rx_bytes"] = "1234\n",
+        ["/sys/class/net/br-lan/statistics/tx_bytes"] = "2500\n",
+        ["/sys/class/net/wan/statistics/rx_bytes"]    = "100\n", -- reset
+        ["/sys/class/net/wan/statistics/tx_bytes"]    = "200\n", -- reset
+      }),
+      ifaces         = { "br-lan", "wan" },
+      iface_baseline = iface_baseline,
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    -- Cumulative since registry start: br-lan rx = 1000 (first snapshot) + 234 (delta) = 1234.
+    -- wan rx had a reset, so the second sample re-bases from 0 → folded value is 100, total 5100.
+    assert.equal(1234, find_counter(batch, "router_host_iface_rx_bytes_total", "iface", "br-lan").value)
+    assert.equal(2500, find_counter(batch, "router_host_iface_tx_bytes_total", "iface", "br-lan").value)
+    assert.equal(5100, find_counter(batch, "router_host_iface_rx_bytes_total", "iface", "wan").value)
+    assert.equal(7200, find_counter(batch, "router_host_iface_tx_bytes_total", "iface", "wan").value)
+  end)
+
+  it("counts wireless stations per (iface, ssid) from iw dev station dump", function()
+    local reg = new_reg()
+    local called_iface
+    host_metrics.sample(reg, {
+      wifi_ifaces = { { iface = "phy0-ap0", ssid = "Home" } },
+      iw_dump     = function(iface)
+        called_iface = iface
+        return IW_DUMP_PHY0
+      end,
+    })
+    assert.equal("phy0-ap0", called_iface)
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    local g     = find_gauge(batch, "router_host_wifi_clients", "iface", "phy0-ap0")
+    assert.is_not_nil(g)
+    assert.equal("Home", g.labels.ssid)
+    assert.equal(3, g.value)
+  end)
+
+  it("emits zero wireless clients when iw dump is empty", function()
+    local reg = new_reg()
+    host_metrics.sample(reg, {
+      wifi_ifaces = { { iface = "phy0-ap0", ssid = "Home" } },
+      iw_dump     = function() return "" end,
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    local g     = find_gauge(batch, "router_host_wifi_clients", "iface", "phy0-ap0")
+    assert.is_not_nil(g)
+    assert.equal(0, g.value)
+  end)
+
+  it("does not panic when /proc files are missing — emits nothing for that source", function()
+    local reg = new_reg()
+    -- read_file returns nil for everything → no series emitted at all, no error.
+    host_metrics.sample(reg, {
+      read_file = fs({}),
+      ifaces    = { "br-lan" },
+    })
+    local batch = metrics.build_batch(reg, "2026-06-14T14:01:00Z")
+    assert.is_nil(batch.gauges)
+    assert.is_nil(batch.counters)
+  end)
+end)

--- a/openwrt/test/run_tests.sh
+++ b/openwrt/test/run_tests.sh
@@ -30,6 +30,7 @@ LUA_PATH="./files/usr/lib/lua/?.lua;./files/usr/lib/lua/wifihaven/?.lua;./test/s
          test/lan_warn_spec.lua \
          test/eb_refresh_spec.lua \
          test/static_ip_labels_spec.lua \
+         test/host_metrics_spec.lua \
          "$@"
 
 echo ""


### PR DESCRIPTION
## Summary

PR 2 of 2 for #1718. Adds the OpenWRT-side collector that reads `/proc/*` and `iw dev <iface> station dump`, folds the values into the existing in-process metrics registry under the names allowlisted in PR A (#1726), and rides the existing #1205 batch transport — same 60s cadence, same retain-on-failure semantics. **Stacked on #1726**; merge that first.

Changes:

- `openwrt/files/usr/lib/lua/wifihaven/host_metrics.lua` — new module. Pure parsers for `/proc/loadavg`, `/proc/stat` (delta CPU%), `/proc/meminfo`, `/proc/sys/net/netfilter/nf_conntrack_count`, and `/sys/class/net/<iface>/statistics/{rx,tx}_bytes`. Wireless client count from `iw dev <iface> station dump` — line count of `Station <mac>` records, per-MAC never emitted (cardinality firewall). All I/O injected (`read_file`, `iw_dump`) so the spec drives parsers with fixture strings, no `/proc` or `iw` needed in CI.
- `openwrt/files/usr/sbin/wifihaven-agent` — wires `sample_host_metrics()` into the metrics-push tick next to `fold_sni_metrics()`. Adds two UCI knobs:
  - `host_metrics_ifaces` — CSV iface names for bandwidth (default `br-lan,wan`)
  - `host_metrics_wifi` — CSV `iface:ssid` pairs for the wifi-clients gauge (default empty)
  Both filtered through `safe_iface()` (character-class allowlist) before reaching the `iw` shell-out.
- `openwrt/test/host_metrics_spec.lua` + `run_tests.sh` — 8 busted tests pinning the parsers and the cardinality contract.

## TDD progression

- `543edd90` test(#1718): pin host_metrics behavior — red (module doesn't exist)
- `6c85fa3a` feat(#1718): agent emits native OpenWRT host metrics — green (8/8 pass)

## Why this would have helped #1716

Prod router CPU pegged for hours on a 24-day-old agent. With this PR an operator opens the router-fleet Grafana dashboard, sees a load-m1 climb on one router starting at hour T, cross-references to a conntrack-count spike at T+5 min, and skips straight to "look at flows" instead of SSH-ing to confirm the symptom.

## Cost check

Per-tick collection on the smallest supported device (mt7621, 256 MB) is bounded by 4 small file reads + 1 `iw` shell-out per wifi iface. Worst case well under 50 ms; runs on the same 60 s cadence as the existing metrics push, so the marginal cost is negligible.

## Backwards compatibility

- API side already accepts the new names (PR A merged). Older API images would silently drop the new entries into `metrics_rejected_total`, which is acceptable rollback behavior.
- No wire-shape change: `RouterMetricsBatch` is the existing generic counters/gauges/histograms bag.
- New UCI knobs default to safe values (empty `host_metrics_wifi` → no wifi sampling).

## Test plan

- [ ] `busted test/host_metrics_spec.lua` — passes locally (8/8)
- [ ] CI `lua-suite` passes
- [ ] CI `MetricCardinalityGuardSpec` passes (verifies every emitted name is allowlisted in PR A)
- [ ] Live walk on `openwrt.lan`: after deploy, confirm the new gauges appear in the router-fleet dashboard within one push tick