### PR TITLE
fix(#623): /api/auth/change-password returns JSON body

### DIFF
--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -70,7 +70,7 @@ object AuthRoutes {
                 case _                            =>
                   ApiError.Wrapped(ErrorMapper.dbUnavailable("AuthError"))
               }
-          } yield Response.ok
+          } yield Response.json(ChangePasswordResponse(mustChangePassword = false).toJson)
           handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.GET / "api" / "me"                              ->

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -118,7 +118,7 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
         cpResp   <- ZIO.fromEither(respBody.fromJson[ChangePasswordResponse])
       } yield assertTrue(resp.status == Status.Ok) &&
         assertTrue(respBody.nonEmpty) &&
-        assertTrue(cpResp.mustChangePassword == false)
+        assertTrue(!cpResp.mustChangePassword)
     },
     test("POST /api/auth/login via HTTP handler") {
       for {

--- a/api/test/src/feature/AuthApiSpec.scala
+++ b/api/test/src/feature/AuthApiSpec.scala
@@ -100,6 +100,26 @@ object AuthApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Cl
       } yield assertTrue(bad.isFailure) &&
         assertTrue(good.isSuccess)
     },
+    test("POST /api/auth/change-password returns JSON body with mustChangePassword=false (#623)") {
+      for {
+        _               <- cleanDb
+        userRepo        <- ZIO.service[UserRepo]
+        auth            <- makeAuth
+        userProfileRepo <- ZIO.service[UserProfileRepo]
+        routes = AuthRoutes.routes(auth, userRepo, userProfileRepo)
+        token <- auth.login("admin", "changeme").map(_.token.value)
+        cpBody = ChangePasswordRequest("changeme", "newpassword123").toJson
+        cpReq  = Request
+          .post(URL.decode("/api/auth/change-password").toOption.get, Body.fromString(cpBody))
+          .addHeader(Header.Authorization.Bearer(token))
+          .addHeader(Header.ContentType(MediaType.application.json))
+        resp     <- routes.runZIO(cpReq)
+        respBody <- resp.body.asString
+        cpResp   <- ZIO.fromEither(respBody.fromJson[ChangePasswordResponse])
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(respBody.nonEmpty) &&
+        assertTrue(cpResp.mustChangePassword == false)
+    },
     test("POST /api/auth/login via HTTP handler") {
       for {
         _               <- cleanDb

--- a/docker/fake-router.py
+++ b/docker/fake-router.py
@@ -109,17 +109,11 @@ def _login(password: str) -> dict:
 
 
 def _change_password(token: str, current: str, new: str) -> None:
-    # The endpoint returns 200 with an empty body, so we can't go through
-    # _post (which always tries to json.loads the response).
-    data = json.dumps({"currentPassword": current, "newPassword": new}).encode()
-    req = urllib.request.Request(
-        f"{API_BASE}/api/auth/change-password",
-        data=data,
-        headers={"content-type": "application/json", "authorization": f"Bearer {token}"},
-        method="POST",
+    _post(
+        "/api/auth/change-password",
+        {"currentPassword": current, "newPassword": new},
+        token=token,
     )
-    with urllib.request.urlopen(req, timeout=10) as r:
-        r.read()
 
 
 def _bootstrap_admin_token() -> str:

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -623,6 +623,10 @@ case class LoginResponse(
     mustChangePassword: Boolean = false,
 ) derives JsonCodec
 case class ChangePasswordRequest(currentPassword: String, newPassword: String) derives JsonCodec
+// #623: change-password used to return an empty 200 body, which broke clients
+// that assume "200 ⇒ parseable JSON" (every other route returns JSON). Echo
+// back mustChangePassword=false so callers can refresh session state inline.
+case class ChangePasswordResponse(mustChangePassword: Boolean) derives JsonCodec
 case class CreateUserRequest(
     username: String,
     password: String,


### PR DESCRIPTION
## Summary

`POST /api/auth/change-password` previously returned `Response.ok` with an empty body, breaking any client that assumes "200 ⇒ parseable JSON" (every other endpoint on the API returns JSON). The fake-router bootstrap had to hand-roll a urllib call to avoid blowing up in `json.loads` (called out in #623).

This change returns `ChangePasswordResponse(mustChangePassword = false)`, lets `docker/fake-router.py::_change_password` go through the normal `_post` helper, and adds a feature test pinning the new shape.

## Backwards compat

This is technically a behavior change on the wire — empty body → `{"mustChangePassword":false}`. Surveyed callers:

- **SPA** (`web/src/api/client.ts`): types it as `req<void>`, and the request helper already short-circuits `204` / `content-length: 0` to `undefined`; a JSON body will parse and be discarded. No change needed.
- **`docker/fake-router.py`**: had a workaround for the empty body; switched to `_post` in this PR.
- **`deploy/install.sh`**: only inspects the HTTP status code (per #623); unaffected.

No client asserts on empty body.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.AuthApiSpec` — new test asserts 200 + JSON `{mustChangePassword:false}`, suite green.
- [x] Red-green progression visible across two commits (failing test → fix).

Closes #623.