### PR TITLE
feat(#1572): best-effort CNAME alias recovery — persist alias map across dns-tail restarts

### DIFF
--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -424,6 +424,47 @@ function M.new(opts)
     store(dst_ip, head, now)
   end
 
+  -- Serialise the live CNAME-alias map to a single newline-delimited string
+  -- (#1572). Format: "<target>\t<head>\t<ts>\n" per non-expired alias edge.
+  -- Persisted alongside dump_text() so a wifihaven-dns-tail restart can reseed
+  -- the alias map and recover the queried brand for a directly-queried CDN
+  -- target whose branded chain was last observed before the restart — the
+  -- failure mode that left ~33 traffic_reports / time_usage rows attributed
+  -- to opaque CDN edge names in #1572's recon.
+  function self.dump_aliases_text()
+    local now = now_fn()
+    local lines = {}
+    for target, a in pairs(aliases) do
+      if (now - a.ts) <= ttl then
+        lines[#lines + 1] = string.format("%s\t%s\t%d", target, a.head, a.ts)
+      end
+    end
+    return table.concat(lines, "\n") .. (#lines > 0 and "\n" or "")
+  end
+
+  -- seed_aliases(tbl, now) — pre-load `target → head` edges learned by a
+  -- previous wifihaven-dns-tail process (#1572). `tbl` is a plain
+  -- `{[target]=head}` table (the output of dns_log.load_aliases_table). Each
+  -- edge is inserted with the given timestamp (default: now) so it ages out
+  -- under the same TTL the in-process learned edges do. Existing edges are not
+  -- overwritten by a stale seed, so a sidecar that has already relearned the
+  -- chain wins over its own old snapshot.
+  function self.seed_aliases(tbl, now)
+    if type(tbl) ~= "table" then return end
+    now = now or now_fn()
+    for target, head in pairs(tbl) do
+      if type(target) == "string" and type(head) == "string"
+         and target ~= "" and head ~= "" and target ~= head
+         and aliases[target] == nil then
+        if alias_count >= max_aliases then
+          evict_oldest_alias()
+        end
+        alias_count = alias_count + 1
+        aliases[target] = { head = head, ts = now, seq = next_seq() }
+      end
+    end
+  end
+
   -- Serialise the live cache to a single newline-delimited string.
   -- Format: "<ip>\t<hostname>\t<ts>\n" per non-expired entry.
   function self.dump_text()
@@ -510,6 +551,26 @@ function M.populate_bl(reply, member_index, resolve_head_fn, add_fn)
     name = name:sub(dot + 1)
   end
   return matched
+end
+
+-- Parses the output of an instance's `dump_aliases_text()` and returns a
+-- plain `{target → head}` table with edges older than `ttl_seconds` (relative
+-- to `now`) filtered out (#1572). Inverse of dump_aliases_text; the
+-- wifihaven-dns-tail sidecar reads this snapshot on startup and hands it to
+-- cache.seed_aliases() so the in-memory CNAME-alias map survives a restart.
+function M.load_aliases_table(text, ttl_seconds, now)
+  local out = {}
+  if type(text) ~= "string" or text == "" then return out end
+  for line in text:gmatch("[^\n]+") do
+    local target, head, ts = line:match("^(%S+)\t(%S+)\t(%d+)$")
+    if target and head and ts then
+      local ts_n = tonumber(ts)
+      if ts_n and (now - ts_n) <= ttl_seconds then
+        out[target] = head
+      end
+    end
+  end
+  return out
 end
 
 -- Parses the output of an instance's `dump_text()` and returns a plain

--- a/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/dns_log.lua
@@ -448,7 +448,9 @@ function M.new(opts)
   -- edge is inserted with the given timestamp (default: now) so it ages out
   -- under the same TTL the in-process learned edges do. Existing edges are not
   -- overwritten by a stale seed, so a sidecar that has already relearned the
-  -- chain wins over its own old snapshot.
+  -- chain wins over its own old snapshot. If the seed exceeds max_aliases the
+  -- LRU evicts as we insert, so which edges survive is iteration-order
+  -- dependent — acceptable for best-effort recovery (#1572).
   function self.seed_aliases(tbl, now)
     if type(tbl) ~= "table" then return end
     now = now or now_fn()

--- a/openwrt/files/usr/lib/lua/wifihaven/paths.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/paths.lua
@@ -14,6 +14,14 @@ M.block_page_api_url  = "/var/run/wifihaven/api_url"
 -- ip → hostname cache (#259): wifihaven-dns-tail writes, wifihaven-agent reads.
 M.dns_cache = "/tmp/wifihaven-dns-cache.txt"
 
+-- CNAME-alias map snapshot (#1572): wifihaven-dns-tail writes in lockstep with
+-- dns_cache and reloads it on startup via cache.seed_aliases. Persists the
+-- target→branded-head edges learned from observed CNAME chains so a sidecar
+-- restart does not lose the ability to attribute a directly-queried CDN edge
+-- name back to the brand the client originally typed. Same atomic-write/
+-- tmpfs-IPC pattern as dns_cache; the agent does not read this file.
+M.dns_aliases = "/tmp/wifihaven-dns-aliases.txt"
+
 -- DNS query-result tally (#1302): wifihaven-dns-tail writes cumulative
 -- per-result counts ("<result>\t<count>" lines) on each flush; wifihaven-agent
 -- samples it on its metrics tick and folds the deltas into

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -22,6 +22,10 @@ end
 local debug_opt   = uci_get("debug", "0")
 local source_path = "/tmp/wifihaven-dnsmasq.log"
 local cache_path  = paths.dns_cache
+-- #1572: persisted CNAME-alias map snapshot path. Written in lockstep with the
+-- ip→hostname cache; reloaded on startup so the brand attribution chain
+-- learned before the last restart survives.
+local aliases_path = paths.dns_aliases
 -- #1302: cumulative per-result DNS query tally, written for the agent to fold
 -- into dns_queries_total{result}. Flushed in lockstep with the hostname cache.
 local dns_metrics_path = paths.dns_metrics
@@ -50,6 +54,25 @@ log.init({ debug = debug_opt })
 log.info("dns-tail: starting source=%s cache=%s", source_path, cache_path)
 
 local cache = dns_log.new({ ttl_seconds = 3600 })
+
+-- #1572: reseed the CNAME-alias map from the on-disk snapshot, if one is
+-- present from a previous run. Without this the alias map starts cold on every
+-- restart, so a client that queries a CDN edge name DIRECTLY before its
+-- branded chain is re-observed is attributed to the opaque CDN target
+-- (~33 such entries observed on prod in the #1572 recon). Best-effort:
+-- silently skips when the file is missing / corrupted.
+do
+  local f = io.open(aliases_path, "r")
+  if f then
+    local text = f:read("*a")
+    f:close()
+    local seeded = dns_log.load_aliases_table(text or "", 3600, os.time())
+    cache.seed_aliases(seeded, os.time())
+    local n = 0
+    for _ in pairs(seeded) do n = n + 1 end
+    log.info("dns-tail: reseeded %d CNAME-alias edge(s) from %s", n, aliases_path)
+  end
+end
 
 -- tail -F follows the log across rotations (dnsmasq SIGHUP, file replaced).
 -- -n 0 skips replay of the historical log so we don't burn CPU at boot.
@@ -299,6 +322,9 @@ while true do
     if since_flush >= flush_every or (now - last_tick) >= 30 then
       cache.tick(now)
       atomic_write(cache_path, cache.dump_text())
+      -- #1572: persist the learned CNAME-alias edges in lockstep so a restart
+      -- can reseed them and recover the brand for a directly-queried CDN target.
+      atomic_write(aliases_path, cache.dump_aliases_text())
       atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))
       since_flush = 0
       last_tick   = now

--- a/openwrt/files/usr/sbin/wifihaven-dns-tail
+++ b/openwrt/files/usr/sbin/wifihaven-dns-tail
@@ -372,6 +372,12 @@ while true do
     if since_flush >= flush_every or (now - last_tick) >= 30 then
       cache.tick(now)
       atomic_write(cache_path, cache.dump_text())
+      -- #1572: persist the learned CNAME-alias edges in lockstep so a restart
+      -- can reseed them and recover the brand for a directly-queried CDN target.
+      -- Mirrored in the SNI-routed flush block above — both flush sites must
+      -- write the alias snapshot for the on-disk file to track the in-memory
+      -- map under both line types.
+      atomic_write(aliases_path, cache.dump_aliases_text())
       -- #1302: publish the cumulative query-result tally alongside the cache so
       -- the agent's next metrics tick can fold the deltas.
       atomic_write(dns_metrics_path, dns_log.format_query_results(dns_results))

--- a/openwrt/test/dns_log_spec.lua
+++ b/openwrt/test/dns_log_spec.lua
@@ -553,6 +553,85 @@ describe("dump_text + load_table", function()
 end)
 
 -- ---------------------------------------------------------------------------
+-- 4b. CNAME-alias persistence across restarts (#1572)
+--
+-- #1344's CNAME→brand alias map is in-memory only, so any restart of
+-- wifihaven-dns-tail loses every learned edge. If a client then queries the
+-- CDN target DIRECTLY before the branded chain is re-observed (the common
+-- Apple-device pattern), resolve_head returns the opaque CDN name verbatim
+-- and traffic/usage records are attributed to the CDN target instead of the
+-- queried brand — the very pollution #1344 set out to fix.
+--
+-- The "best-effort alias recovery" is to dump the alias map to /tmp on each
+-- cache flush and reload it on startup, mirroring the existing
+-- dump_text/load_table pattern for entries.
+-- ---------------------------------------------------------------------------
+
+describe("alias-map persistence (#1572)", function()
+  local function fake_clock()
+    local t = 1000000
+    return { now = function() return t end, advance = function(s) t = t + s end }
+  end
+
+  it("dumps learned aliases as <target>\\t<head>\\t<ts> lines", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("1 192.168.1.10/100 query[A] brand.com from 192.168.1.10")
+    c.ingest_line("1 192.168.1.10/100 reply brand.com is <CNAME>")
+    c.ingest_line("1 192.168.1.10/100 reply edge.akamai.net is 1.2.3.4")
+
+    local text = c.dump_aliases_text()
+    assert.truthy(text:find("edge.akamai.net\tbrand.com\t1000000", 1, true))
+  end)
+
+  it("seed_aliases restores the alias map so a later direct query attributes to the brand", function()
+    local clk = fake_clock()
+
+    -- Process A: learns brand.com -> CNAME edge.akamai.net -> 1.2.3.4
+    local a = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    a.ingest_line("1 192.168.1.10/100 query[A] brand.com from 192.168.1.10")
+    a.ingest_line("1 192.168.1.10/100 reply brand.com is <CNAME>")
+    a.ingest_line("1 192.168.1.10/100 reply edge.akamai.net is 1.2.3.4")
+    local alias_dump = a.dump_aliases_text()
+
+    -- Process B: a fresh sidecar instance (post-restart). Without seeding,
+    -- a DIRECT query for the CDN target attributes to the CDN target itself.
+    clk.advance(60)
+    local b = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    b.seed_aliases(dns_log.load_aliases_table(alias_dump, 3600, clk.now()))
+    b.ingest_line("2 192.168.1.10/200 query[A] edge.akamai.net from 192.168.1.10")
+    b.ingest_line("2 192.168.1.10/200 reply edge.akamai.net is 5.6.7.8")
+
+    -- With seeded aliases, the direct-query IP attributes back to brand.com.
+    assert.equal("brand.com", b.lookup("5.6.7.8"))
+    -- resolve_head() also recovers the brand directly.
+    assert.equal("brand.com", b.resolve_head("edge.akamai.net"))
+  end)
+
+  it("load_aliases_table skips expired alias edges", function()
+    local clk = fake_clock()
+    local c = dns_log.new({ ttl_seconds = 3600, now_fn = clk.now })
+    c.ingest_line("1 1.1.1.1/1 query[A] brand.com from 1.1.1.1")
+    c.ingest_line("1 1.1.1.1/1 reply brand.com is <CNAME>")
+    c.ingest_line("1 1.1.1.1/1 reply edge.akamai.net is 1.2.3.4")
+    clk.advance(7200)  -- past ttl
+    c.ingest_line("2 1.1.1.1/2 query[A] fresh.example from 1.1.1.1")
+    c.ingest_line("2 1.1.1.1/2 reply fresh.example is <CNAME>")
+    c.ingest_line("2 1.1.1.1/2 reply other.cdn.example is 2.2.2.2")
+
+    local table_out = dns_log.load_aliases_table(c.dump_aliases_text(), 3600, clk.now())
+    assert.is_nil(table_out["edge.akamai.net"])
+    assert.equal("fresh.example", table_out["other.cdn.example"])
+  end)
+
+  it("load_aliases_table tolerates nil / empty / malformed input", function()
+    assert.same({}, dns_log.load_aliases_table(nil, 3600, 0))
+    assert.same({}, dns_log.load_aliases_table("", 3600, 0))
+    assert.same({}, dns_log.load_aliases_table("garbage\nnot a real edge\n", 3600, 0))
+  end)
+end)
+
+-- ---------------------------------------------------------------------------
 -- 2c. resolve_head public accessor (#1346/#1348)
 --
 -- The CNAME-alias resolution (#1344) was previously an internal closure used


### PR DESCRIPTION
Closes #1572.

## Problem

The CNAME→brand alias map #1344 introduced lives in memory only. On every `wifihaven-dns-tail` restart it starts cold, so a client that queries a CDN edge name **directly** (the Apple re-query pattern #1346 describes) before its branded chain is re-observed gets attributed to the opaque CDN target. The recon in #1572 found ~33 such polluted entries on prod (`dn0qt3r0xannq.cloudfront.net`, `media.amazon.map.fastly.net`, …) — the exact failure mode #1344 set out to fix.

## Fix

Persist the alias map alongside the existing ip→hostname cache, mirroring the `dump_text` / `load_table` pattern already used for entries:

- `dump_aliases_text()` — instance serializer (`<target>\t<head>\t<ts>\n` per non-expired edge)
- `load_aliases_table(text, ttl, now)` — inverse, drops expired edges
- `seed_aliases(tbl, now)` — pre-loads `target → head` edges on startup; existing in-process edges win over stale snapshot rows
- `paths.dns_aliases = /tmp/wifihaven-dns-aliases.txt`
- `wifihaven-dns-tail`: reads the snapshot on startup, writes it on every cache flush

The snapshot is bounded by the existing `max_aliases` (10 000) cap — it's a full-file atomic snapshot, not an append-grow spool, so per AGENTS.md "bounded /tmp writes" it does not need a rotation entry.

## Before / after

Sequence (before this PR):

```
t0  query[A]  brand.com
t0  reply     brand.com CNAME edge.akamai.net
t0  reply     edge.akamai.net is 1.2.3.4         ← cache.lookup(1.2.3.4) = brand.com ✓
*** dns-tail restart (in-memory alias map lost) ***
t1  query[A]  edge.akamai.net                    (Apple re-query, direct)
t1  reply     edge.akamai.net is 5.6.7.8         ← cache.lookup(5.6.7.8) = edge.akamai.net ✗
```

After: `dns-tail` reseeds the alias map from `/tmp/wifihaven-dns-aliases.txt` at startup; the `t1` lookup attributes back to `brand.com`.

## Wire shape

No wire changes — the snapshot is a router-internal IPC file. `connection_events` / `traffic_reports` shapes are unchanged.

## Test plan

- [x] `busted openwrt/test/dns_log_spec.lua` — 64 successes (4 new persistence cases under "alias-map persistence (#1572)")
- [x] Red → green commits visible: `040d0c5b test(#1572): RED — …` then `c534593c feat(#1572): …`
- [x] Full `openwrt/test/run_tests.sh` — only the pre-existing nft_log_dep_spec failures, unrelated to this PR