### PR TITLE
feat(#423): PATCH /api/profiles/:id for partial updates

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -104,7 +104,22 @@ trait ProfileRepo {
   def create(name: String, cats: List[BlocklistId]): Task[ProfileId]
   def update(p: Profile): Task[Unit]
   def delete(id: ProfileId): Task[Unit]
+
+  // #423: per-field setters for the PATCH handler so concurrent PATCHes
+  // touching disjoint fields don't race via a full-row rewrite. Each method
+  // issues a targeted `UPDATE profiles SET <col>=? WHERE id=?` — the absent
+  // fields aren't touched by the SQL, so a "tab A patches paused, tab B
+  // patches name" interleaving preserves both edits. The full-shape
+  // [[update]] above stays for the legacy PUT route, which is documented as
+  // a full-replace.
+  def setName(id: ProfileId, name: String): Task[Unit]
+  def setBlockedCategories(id: ProfileId, cats: List[BlocklistId]): Task[Unit]
   def setPaused(id: ProfileId, paused: Boolean): Task[Unit]
+  def setFailureMode(id: ProfileId, mode: FailureMode): Task[Unit]
+  def setBlockIpOnly(id: ProfileId, v: Boolean): Task[Unit]
+  def setCrossDeviceOverlapMode(id: ProfileId, mode: CrossDeviceOverlapMode): Task[Unit]
+  def setPauseMode(id: ProfileId, mode: PauseMode): Task[Unit]
+  def setDefaultDeny(id: ProfileId, v: Boolean): Task[Unit]
 }
 
 /**
@@ -872,8 +887,34 @@ class ProfileRepoLive(xa: Transactor[Task]) extends ProfileRepo {
       .transact(xa)
       .unit
   def delete(id: ProfileId) = sql"DELETE FROM profiles WHERE id=$id".update.run.transact(xa).unit
-  def setPaused(id: ProfileId, p: Boolean) =
+
+  // #423: targeted per-column setters for the PATCH handler. Each runs an
+  // UPDATE that touches exactly one column, so concurrent PATCHes on
+  // disjoint fields no longer race through a full-row rewrite.
+  def setName(id: ProfileId, name: String)                                   =
+    sql"UPDATE profiles SET name=$name WHERE id=$id".update.run.transact(xa).unit
+  def setBlockedCategories(id: ProfileId, cats: List[BlocklistId])           =
+    sql"UPDATE profiles SET blocked_categories=${cats.map(_.value).toArray} WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def setPaused(id: ProfileId, p: Boolean)                                   =
     sql"UPDATE profiles SET paused=$p WHERE id=$id".update.run.transact(xa).unit
+  def setFailureMode(id: ProfileId, mode: FailureMode)                       =
+    sql"UPDATE profiles SET failure_mode=${FailureMode.asString(mode)} WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def setBlockIpOnly(id: ProfileId, v: Boolean)                              =
+    sql"UPDATE profiles SET block_ip_only=$v WHERE id=$id".update.run.transact(xa).unit
+  def setCrossDeviceOverlapMode(id: ProfileId, mode: CrossDeviceOverlapMode) =
+    sql"UPDATE profiles SET cross_device_overlap_mode=${CrossDeviceOverlapMode.asString(mode)} WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def setPauseMode(id: ProfileId, mode: PauseMode)                           =
+    sql"UPDATE profiles SET pause_mode=${PauseMode.asString(mode)} WHERE id=$id".update.run
+      .transact(xa)
+      .unit
+  def setDefaultDeny(id: ProfileId, v: Boolean)                              =
+    sql"UPDATE profiles SET default_deny=$v WHERE id=$id".update.run.transact(xa).unit
 }
 
 class HouseholdSettingsRepoLive(xa: Transactor[Task]) extends HouseholdSettingsRepo {

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -205,6 +205,24 @@ object AuthRoutes {
 // ── Profile routes ─────────────────────────────────────────────────────────
 
 object ProfileRoutes {
+  // #423 — the set of writable Profile fields the PATCH handler recognizes.
+  // Kept as a single named source so the PATCH log message can filter to
+  // recognized keys, AND so the test pin in ProfilePatchApiSpec can assert
+  // it covers every field on the underlying `Profile` case class minus `id`.
+  // If you add a writable field to `Profile`, update this set and PATCH's
+  // `p.copy(...)` together — the test pin will fail loudly otherwise.
+  val PatchableKeys: Set[String] = Set(
+    "name",
+    "blockedCategories",
+    "paused",
+    "failureMode",
+    "blockIpOnly",
+    "crossDeviceOverlapMode",
+    "pauseMode",
+    "defaultDeny",
+    "timeLimit",
+  )
+
   def routes(
       auth: AuthService,
       profileRepo: ProfileRepo,
@@ -486,13 +504,20 @@ object ProfileRoutes {
             }
             // #1538: paused / timeLimit changes affect ProfileTimeStatus, so
             // bust the per-profile cache the same way schedule attach/detach
-            // and /api/time/extend do — otherwise a freshly-patched pause
-            // wouldn't reach the dashboard until the today-TTL expired.
-            _                       <- ZIO.when(
-              pausedPatch != FieldPatch.Absent || timeLimitPatch != FieldPatch.Absent,
-            )(cache.invalidateProfile(pid))
-            _                       <- ZIO.logInfo(
-              s"profile patched: id=${pid.value} keys=${obj.fields.map(_._1).mkString(",")}",
+            // and /api/time/extend do. Guard on a real value change — not
+            // mere field presence — so a no-op `{"paused": false}` on an
+            // already-unpaused profile doesn't churn the cache.
+            pausedChanged = pausedPatch match {
+              case FieldPatch.Set(v) => v != p.paused
+              case _                 => false
+            }
+            timeLimitChanged = timeLimitPatch != FieldPatch.Absent
+            _ <- ZIO.when(pausedChanged || timeLimitChanged)(cache.invalidateProfile(pid))
+            // Log only recognized keys; unknown keys are ignored per the
+            // backwards-compat rule and would mislead ops triage if echoed.
+            recognizedKeys = obj.fields.map(_._1).filter(ProfileRoutes.PatchableKeys.contains)
+            _ <- ZIO.logInfo(
+              s"profile patched: id=${pid.value} keys=${recognizedKeys.mkString(",")}",
             )
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -400,6 +400,103 @@ object ProfileRoutes {
               ZIO.succeed(Response.ok)
           handle.mapError(ErrorMapper.errorToResponse)
         },
+      // #423: field-scoped partial update. Body is a subset of the writable
+      // Profile shape — every field optional, omitted fields preserve their
+      // current value. `timeLimit` is the only nullable field and accepts
+      // explicit null to clear; non-nullable fields reject null with 400.
+      // Race-safe vs the PUT clobber pattern that motivated #423 — the SPA
+      // can post `{"paused":true}` without first reading and re-shipping the
+      // rest of the profile. Schedules / users still live on their own
+      // sub-routes by design (#1494, #406) and are not patchable here.
+      Method.PATCH / "api" / "profiles" / long("id")             ->
+        handler { (id: Long, req: Request) =>
+          val pid                                  = ProfileId(id)
+          val handle: ZIO[Any, ApiError, Response] = for {
+            claims    <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
+            _         <- requireProfileAccess(claims, pid, userProfileRepo)
+              .mapError(ApiError.Wrapped(_))
+            body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(ApiError.BadRequest(_))
+            p         <- profileRepo
+              .findById(pid)
+              .mapError(ApiError.Db(_))
+              .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
+            namePatch <- ZIO
+              .fromEither(FieldPatch.from[String](obj, "name"))
+              .mapError(ApiError.BadRequest(_))
+            blockedCategoriesPatch  <- ZIO
+              .fromEither(FieldPatch.from[List[BlocklistId]](obj, "blockedCategories"))
+              .mapError(ApiError.BadRequest(_))
+            pausedPatch             <- ZIO
+              .fromEither(FieldPatch.from[Boolean](obj, "paused"))
+              .mapError(ApiError.BadRequest(_))
+            failureModePatch        <- ZIO
+              .fromEither(FieldPatch.from[FailureMode](obj, "failureMode"))
+              .mapError(ApiError.BadRequest(_))
+            blockIpOnlyPatch        <- ZIO
+              .fromEither(FieldPatch.from[Boolean](obj, "blockIpOnly"))
+              .mapError(ApiError.BadRequest(_))
+            crossDeviceOverlapPatch <- ZIO
+              .fromEither(FieldPatch.from[CrossDeviceOverlapMode](obj, "crossDeviceOverlapMode"))
+              .mapError(ApiError.BadRequest(_))
+            pauseModePatch          <- ZIO
+              .fromEither(FieldPatch.from[PauseMode](obj, "pauseMode"))
+              .mapError(ApiError.BadRequest(_))
+            defaultDenyPatch        <- ZIO
+              .fromEither(FieldPatch.from[Boolean](obj, "defaultDeny"))
+              .mapError(ApiError.BadRequest(_))
+            timeLimitPatch          <- ZIO
+              .fromEither(FieldPatch.from[Int](obj, "timeLimit"))
+              .mapError(ApiError.BadRequest(_))
+            // Reject `field: null` for non-nullable fields — only `timeLimit`
+            // accepts an explicit clear. Mirrors the device PATCH convention.
+            _                       <- ZIO
+              .foreachDiscard(
+                List(
+                  "name"                   -> namePatch,
+                  "blockedCategories"      -> blockedCategoriesPatch,
+                  "paused"                 -> pausedPatch,
+                  "failureMode"            -> failureModePatch,
+                  "blockIpOnly"            -> blockIpOnlyPatch,
+                  "crossDeviceOverlapMode" -> crossDeviceOverlapPatch,
+                  "pauseMode"              -> pauseModePatch,
+                  "defaultDeny"            -> defaultDenyPatch,
+                ),
+              ) { case (k, fp) =>
+                fp match {
+                  case FieldPatch.Cleared => ZIO.fail(ApiError.BadRequest(s"$k cannot be cleared"))
+                  case _                  => ZIO.unit
+                }
+              }
+            updated = p.copy(
+              name = namePatch.applyTo(p.name),
+              blockedCategories = blockedCategoriesPatch.applyTo(p.blockedCategories),
+              paused = pausedPatch.applyTo(p.paused),
+              failureMode = failureModePatch.applyTo(p.failureMode),
+              blockIpOnly = blockIpOnlyPatch.applyTo(p.blockIpOnly),
+              crossDeviceOverlapMode = crossDeviceOverlapPatch.applyTo(p.crossDeviceOverlapMode),
+              pauseMode = pauseModePatch.applyTo(p.pauseMode),
+              defaultDeny = defaultDenyPatch.applyTo(p.defaultDeny),
+            )
+            _                       <- profileRepo.update(updated).mapError(ApiError.Db(_))
+            _                       <- timeLimitPatch match {
+              case FieldPatch.Absent  => ZIO.unit
+              case FieldPatch.Cleared => timeLimitRepo.delete(pid).mapError(ApiError.Db(_))
+              case FieldPatch.Set(m)  => timeLimitRepo.upsert(pid, m).mapError(ApiError.Db(_))
+            }
+            // #1538: paused / timeLimit changes affect ProfileTimeStatus, so
+            // bust the per-profile cache the same way schedule attach/detach
+            // and /api/time/extend do — otherwise a freshly-patched pause
+            // wouldn't reach the dashboard until the today-TTL expired.
+            _                       <- ZIO.when(
+              pausedPatch != FieldPatch.Absent || timeLimitPatch != FieldPatch.Absent,
+            )(cache.invalidateProfile(pid))
+            _                       <- ZIO.logInfo(
+              s"profile patched: id=${pid.value} keys=${obj.fields.map(_._1).mkString(",")}",
+            )
+          } yield Response.ok
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
       Method.GET / "api" / "profiles" / long("id") / "users"     ->
         handler { (id: Long, req: Request) =>
           val pid                                  = ProfileId(id)

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -422,10 +422,18 @@ object ProfileRoutes {
       // Profile shape — every field optional, omitted fields preserve their
       // current value. `timeLimit` is the only nullable field and accepts
       // explicit null to clear; non-nullable fields reject null with 400.
-      // Race-safe vs the PUT clobber pattern that motivated #423 — the SPA
-      // can post `{"paused":true}` without first reading and re-shipping the
-      // rest of the profile. Schedules / users still live on their own
-      // sub-routes by design (#1494, #406) and are not patchable here.
+      //
+      // PER-FIELD RACE SAFETY — the whole point of #423. Each present field
+      // dispatches to a *targeted* repo setter (`profileRepo.setName`,
+      // `setPaused`, …) — NOT a full-row `profileRepo.update(p.copy(...))`.
+      // Two concurrent PATCHes touching disjoint fields therefore preserve
+      // both edits instead of the second-writer clobbering the first via a
+      // load → modify → write-all-columns trip. The Users PATCH already
+      // uses this dispatch shape; the Devices/Apps PATCHes still do not and
+      // have the same regression — tracked in follow-up issues.
+      //
+      // Schedules / users still live on their own sub-routes by design
+      // (#1494, #406) and are not patchable here.
       Method.PATCH / "api" / "profiles" / long("id")             ->
         handler { (id: Long, req: Request) =>
           val pid                                  = ProfileId(id)
@@ -433,12 +441,16 @@ object ProfileRoutes {
             claims    <- requireWriter(req, auth).mapError(ApiError.Wrapped(_))
             _         <- requireProfileAccess(claims, pid, userProfileRepo)
               .mapError(ApiError.Wrapped(_))
-            body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
-            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(ApiError.BadRequest(_))
-            p         <- profileRepo
+            // Existence check up front so a missing row 404s instead of
+            // letting per-field UPDATEs silently no-op. We deliberately do
+            // NOT carry the loaded row into the writes below: every SET is
+            // column-scoped, so there's no full-row copy to drift.
+            _         <- profileRepo
               .findById(pid)
               .mapError(ApiError.Db(_))
               .flatMap(ZIO.fromOption(_).orElseFail(ApiError.NotFound("Profile not found")))
+            body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+            obj       <- ZIO.fromEither(FieldPatch.parseObj(body)).mapError(ApiError.BadRequest(_))
             namePatch <- ZIO
               .fromEither(FieldPatch.from[String](obj, "name"))
               .mapError(ApiError.BadRequest(_))
@@ -486,17 +498,43 @@ object ProfileRoutes {
                   case _                  => ZIO.unit
                 }
               }
-            updated = p.copy(
-              name = namePatch.applyTo(p.name),
-              blockedCategories = blockedCategoriesPatch.applyTo(p.blockedCategories),
-              paused = pausedPatch.applyTo(p.paused),
-              failureMode = failureModePatch.applyTo(p.failureMode),
-              blockIpOnly = blockIpOnlyPatch.applyTo(p.blockIpOnly),
-              crossDeviceOverlapMode = crossDeviceOverlapPatch.applyTo(p.crossDeviceOverlapMode),
-              pauseMode = pauseModePatch.applyTo(p.pauseMode),
-              defaultDeny = defaultDenyPatch.applyTo(p.defaultDeny),
-            )
-            _                       <- profileRepo.update(updated).mapError(ApiError.Db(_))
+            // Per-field dispatch: Absent ⇒ no SQL; Set(v) ⇒ targeted SET.
+            // No load-then-write-all-columns step ⇒ disjoint-field PATCH
+            // races preserve both writers' edits.
+            _                       <- namePatch match {
+              case FieldPatch.Set(v) => profileRepo.setName(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- blockedCategoriesPatch match {
+              case FieldPatch.Set(v) =>
+                profileRepo.setBlockedCategories(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- pausedPatch match {
+              case FieldPatch.Set(v) => profileRepo.setPaused(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- failureModePatch match {
+              case FieldPatch.Set(v) => profileRepo.setFailureMode(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- blockIpOnlyPatch match {
+              case FieldPatch.Set(v) => profileRepo.setBlockIpOnly(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- crossDeviceOverlapPatch match {
+              case FieldPatch.Set(v) =>
+                profileRepo.setCrossDeviceOverlapMode(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- pauseModePatch match {
+              case FieldPatch.Set(v) => profileRepo.setPauseMode(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
+            _                       <- defaultDenyPatch match {
+              case FieldPatch.Set(v) => profileRepo.setDefaultDeny(pid, v).mapError(ApiError.Db(_))
+              case _                 => ZIO.unit
+            }
             _                       <- timeLimitPatch match {
               case FieldPatch.Absent  => ZIO.unit
               case FieldPatch.Cleared => timeLimitRepo.delete(pid).mapError(ApiError.Db(_))
@@ -504,15 +542,14 @@ object ProfileRoutes {
             }
             // #1538: paused / timeLimit changes affect ProfileTimeStatus, so
             // bust the per-profile cache the same way schedule attach/detach
-            // and /api/time/extend do. Guard on a real value change — not
-            // mere field presence — so a no-op `{"paused": false}` on an
-            // already-unpaused profile doesn't churn the cache.
-            pausedChanged = pausedPatch match {
-              case FieldPatch.Set(v) => v != p.paused
-              case _                 => false
-            }
-            timeLimitChanged = timeLimitPatch != FieldPatch.Absent
-            _ <- ZIO.when(pausedChanged || timeLimitChanged)(cache.invalidateProfile(pid))
+            // and /api/time/extend do. Trigger on any presence — a strict
+            // "value actually changed" check would require reading the row
+            // again post-write to compare, which would reintroduce the
+            // load-then-act window this handler exists to avoid. An
+            // over-invalidation just refills the cache: cheap and safe.
+            _                       <- ZIO.when(
+              pausedPatch != FieldPatch.Absent || timeLimitPatch != FieldPatch.Absent,
+            )(cache.invalidateProfile(pid))
             // Log only recognized keys; unknown keys are ignored per the
             // backwards-compat rule and would mislead ops triage if echoed.
             recognizedKeys = obj.fields.map(_._1).filter(ProfileRoutes.PatchableKeys.contains)

--- a/api/test/src/feature/ProfilePatchApiSpec.scala
+++ b/api/test/src/feature/ProfilePatchApiSpec.scala
@@ -192,6 +192,26 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         resp         <- patch(routes, tk, ProfileId(99999), """{"paused":true}""")
       } yield assertTrue(resp.status == Status.NotFound)
     },
+    // Drift pin (#423): if `Profile` gains a writable field, this test fails
+    // until the new field is added to `ProfileRoutes.PatchableKeys` AND the
+    // PATCH handler's `p.copy(...)` fold. `id` is the only intentional
+    // exclusion (immutable identity); `timeLimit` is a sibling table not on
+    // `Profile` but still patchable, so it's added to the expected set.
+    test("PatchableKeys covers every writable Profile field (drift pin)") {
+      // `getDeclaredFields` returns synthetic compiler fields too (e.g.
+      // `OFFSET$_m_0` from lazy-val codegen, anything containing `$`), so
+      // filter those out and keep only the case-class parameter names.
+      val profileFields  = classOf[Profile].getDeclaredFields
+        .map(_.getName)
+        .filterNot(_.contains("$"))
+        .toSet
+      val writableFields = profileFields - "id"
+      val expected       = writableFields + "timeLimit"
+      assertTrue(
+        ProfileRoutes.PatchableKeys == expected,
+        ProfileRoutes.PatchableKeys.contains("paused"),
+      )
+    },
     test("401 without token") {
       for {
         kids   <- setupKids()

--- a/api/test/src/feature/ProfilePatchApiSpec.scala
+++ b/api/test/src/feature/ProfilePatchApiSpec.scala
@@ -1,0 +1,203 @@
+package wifihaven.api.feature
+
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.types.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+// #423: PATCH /api/profiles/:id — partial, field-scoped updates so the SPA
+// can issue per-field writes (e.g. a paused toggle, an autosave on name) and
+// avoid the read-then-write clobber that today's PUT requires.
+//
+// Tri-state JSON semantics via FieldPatch:
+//   - field absent  → preserve existing value
+//   - field == null → clear (only legal on nullable fields, currently `timeLimit`)
+//   - field == v    → assign v
+object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg   = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+  private val cleanDb  = TestDatabase.cleanAndMigrate
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private def setupKids(timeLimit: Option[Int] = Some(120)) =
+    for {
+      _           <- cleanDb
+      profileRepo <- ZIO.service[ProfileRepo]
+      tlRepo      <- ZIO.service[TimeLimitRepo]
+      profiles    <- profileRepo.listAll
+      kids = profiles.find(_.name == "Kids").get
+      _ <- timeLimit match {
+        case Some(m) => tlRepo.upsert(kids.id, m)
+        case None    => tlRepo.delete(kids.id)
+      }
+    } yield kids
+
+  private def routesAndToken =
+    for {
+      auth            <- makeAuth
+      profileRepo     <- ZIO.service[ProfileRepo]
+      tlRepo          <- ZIO.service[TimeLimitRepo]
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      userRepo        <- ZIO.service[UserRepo]
+      token           <- auth.login("admin", "changeme").map(_.token.value)
+    } yield (
+      ProfileRoutes.routes(auth, profileRepo, tlRepo, userProfileRepo, userRepo),
+      token,
+    )
+
+  private def patch(routes: Routes[Any, Response], token: String, pid: ProfileId, body: String) =
+    routes.runZIO(
+      Request
+        .patch(url(s"/api/profiles/${pid.value}"), Body.fromString(body))
+        .addHeader(Header.Authorization.Bearer(token))
+        .addHeader(Header.ContentType(MediaType.application.json)),
+    )
+
+  def spec = suite("PATCH /api/profiles/:id (#423)")(
+    test("single-field patch updates only `paused`; all other fields unchanged") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        profileRepo  <- ZIO.service[ProfileRepo]
+        tlRepo       <- ZIO.service[TimeLimitRepo]
+        before       <- profileRepo.findById(kids.id).someOrFailException
+        beforeTl     <- tlRepo.findForProfile(kids.id)
+        resp         <- patch(routes, tk, kids.id, """{"paused":true}""")
+        after        <- profileRepo.findById(kids.id).someOrFailException
+        afterTl      <- tlRepo.findForProfile(kids.id)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after.paused, // newly true
+        !before.paused,
+        after.name == before.name,
+        after.blockedCategories == before.blockedCategories,
+        after.failureMode == before.failureMode,
+        after.blockIpOnly == before.blockIpOnly,
+        after.crossDeviceOverlapMode == before.crossDeviceOverlapMode,
+        after.pauseMode == before.pauseMode,
+        after.defaultDeny == before.defaultDeny,
+        afterTl == beforeTl,
+      )
+    },
+    test("single-field patch updates only `name`") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        profileRepo  <- ZIO.service[ProfileRepo]
+        resp         <- patch(routes, tk, kids.id, """{"name":"Littles"}""")
+        after        <- profileRepo.findById(kids.id).someOrFailException
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after.name == "Littles",
+        after.paused == kids.paused,
+      )
+    },
+    test("multi-field patch updates each supplied field") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        profileRepo  <- ZIO.service[ProfileRepo]
+        tlRepo       <- ZIO.service[TimeLimitRepo]
+        resp         <- patch(
+          routes,
+          tk,
+          kids.id,
+          """{"paused":true,"blockIpOnly":true,"defaultDeny":true,"timeLimit":45}""",
+        )
+        after        <- profileRepo.findById(kids.id).someOrFailException
+        afterTl      <- tlRepo.findForProfile(kids.id)
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after.paused,
+        after.blockIpOnly,
+        after.defaultDeny,
+        afterTl.contains(45),
+      )
+    },
+    test("empty patch preserves every field") {
+      for {
+        kids         <- setupKids(timeLimit = Some(90))
+        (routes, tk) <- routesAndToken
+        profileRepo  <- ZIO.service[ProfileRepo]
+        tlRepo       <- ZIO.service[TimeLimitRepo]
+        resp         <- patch(routes, tk, kids.id, "{}")
+        after        <- profileRepo.findById(kids.id).someOrFailException
+        afterTl      <- tlRepo.findForProfile(kids.id)
+      } yield assertTrue(resp.status == Status.Ok, after == kids, afterTl.contains(90))
+    },
+    test("null on nullable `timeLimit` clears the row") {
+      for {
+        kids         <- setupKids(timeLimit = Some(60))
+        (routes, tk) <- routesAndToken
+        tlRepo       <- ZIO.service[TimeLimitRepo]
+        resp         <- patch(routes, tk, kids.id, """{"timeLimit":null}""")
+        afterTl      <- tlRepo.findForProfile(kids.id)
+      } yield assertTrue(resp.status == Status.Ok, afterTl.isEmpty)
+    },
+    test("setting `timeLimit` upserts the row when none existed") {
+      for {
+        kids         <- setupKids(timeLimit = None)
+        (routes, tk) <- routesAndToken
+        tlRepo       <- ZIO.service[TimeLimitRepo]
+        resp         <- patch(routes, tk, kids.id, """{"timeLimit":75}""")
+        afterTl      <- tlRepo.findForProfile(kids.id)
+      } yield assertTrue(resp.status == Status.Ok, afterTl.contains(75))
+    },
+    test("null on non-nullable `name` returns 400") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, kids.id, """{"name":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("null on non-nullable `paused` returns 400") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, kids.id, """{"paused":null}""")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("invalid JSON body returns 400") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, kids.id, "not json")
+      } yield assertTrue(resp.status == Status.BadRequest)
+    },
+    test("404 when profile is missing") {
+      for {
+        _            <- cleanDb
+        (routes, tk) <- routesAndToken
+        resp         <- patch(routes, tk, ProfileId(99999), """{"paused":true}""")
+      } yield assertTrue(resp.status == Status.NotFound)
+    },
+    test("401 without token") {
+      for {
+        kids   <- setupKids()
+        routes <- routesAndToken.map(_._1)
+        resp   <- routes.runZIO(
+          Request
+            .patch(url(s"/api/profiles/${kids.id.value}"), Body.fromString("""{"paused":true}"""))
+            .addHeader(Header.ContentType(MediaType.application.json)),
+        )
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/ProfilePatchApiSpec.scala
+++ b/api/test/src/feature/ProfilePatchApiSpec.scala
@@ -128,7 +128,7 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         after.paused,
         after.blockIpOnly,
         after.defaultDeny,
-        afterTl.contains(45),
+        afterTl.map(_.dailyMinutes).contains(45),
       )
     },
     test("empty patch preserves every field") {
@@ -140,7 +140,11 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         resp         <- patch(routes, tk, kids.id, "{}")
         after        <- profileRepo.findById(kids.id).someOrFailException
         afterTl      <- tlRepo.findForProfile(kids.id)
-      } yield assertTrue(resp.status == Status.Ok, after == kids, afterTl.contains(90))
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        after == kids,
+        afterTl.map(_.dailyMinutes).contains(90),
+      )
     },
     test("null on nullable `timeLimit` clears the row") {
       for {
@@ -158,7 +162,7 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         tlRepo       <- ZIO.service[TimeLimitRepo]
         resp         <- patch(routes, tk, kids.id, """{"timeLimit":75}""")
         afterTl      <- tlRepo.findForProfile(kids.id)
-      } yield assertTrue(resp.status == Status.Ok, afterTl.contains(75))
+      } yield assertTrue(resp.status == Status.Ok, afterTl.map(_.dailyMinutes).contains(75))
     },
     test("null on non-nullable `name` returns 400") {
       for {

--- a/api/test/src/feature/ProfilePatchApiSpec.scala
+++ b/api/test/src/feature/ProfilePatchApiSpec.scala
@@ -212,6 +212,39 @@ object ProfilePatchApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostg
         ProfileRoutes.PatchableKeys.contains("paused"),
       )
     },
+    // #423 — the bug the route exists to fix. Two concurrent PATCHes
+    // touching DISJOINT fields must both survive. Implemented today by
+    // routing each present field to its own targeted SET (no load-then-
+    // write-all-columns trip) — if a future change reintroduces the
+    // full-row rewrite, the loser's edit will silently disappear and this
+    // test will fail. Compares against the deterministic interleaving:
+    // both writes complete, both columns reflect their PATCH.
+    test("concurrent PATCHes on disjoint fields don't clobber each other") {
+      for {
+        kids         <- setupKids()
+        (routes, tk) <- routesAndToken
+        profileRepo  <- ZIO.service[ProfileRepo]
+        // Run the two PATCHes in parallel via the same routes value (one
+        // shared embedded Postgres + connection pool — true concurrent
+        // executions, the same way two browser tabs would race).
+        respPair     <- patch(routes, tk, kids.id, """{"paused":true}""")
+          .zipPar(patch(routes, tk, kids.id, """{"name":"Littles"}"""))
+        (rA, rB) = respPair
+        after <- profileRepo.findById(kids.id).someOrFailException
+      } yield assertTrue(
+        rA.status == Status.Ok,
+        rB.status == Status.Ok,
+        after.paused,            // tab A's edit survived
+        after.name == "Littles", // tab B's edit survived
+        // every other field still matches the pre-patch row
+        after.blockedCategories == kids.blockedCategories,
+        after.failureMode == kids.failureMode,
+        after.blockIpOnly == kids.blockIpOnly,
+        after.crossDeviceOverlapMode == kids.crossDeviceOverlapMode,
+        after.pauseMode == kids.pauseMode,
+        after.defaultDeny == kids.defaultDeny,
+      )
+    },
     test("401 without token") {
       for {
         kids   <- setupKids()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,7 +9,7 @@ import type {
   NamedSchedule, NamedScheduleRequest,
   RecentApexesResponse, RouterSummary, SetUserProfilesRequest, TimeExtension,
   TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
-  PatchDeviceRequest,
+  PatchDeviceRequest, PatchProfileRequest,
   UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesBatchResponse, UsageSeriesResponse, User,
 } from '@/types/api'
@@ -153,6 +153,12 @@ export const api = {
       req<{ id: number }>('POST', '/profiles', data),
     update: (id: number, data: UpsertProfileRequest) =>
       req<void>('PUT', `/profiles/${id}`, data),
+    // #423 / #995 — field-scoped partial update. Race-safe alternative to
+    // `update`: only the supplied fields change. `timeLimit: null` clears the
+    // daily limit; non-nullable fields cannot be null. PUT stays for callers
+    // that want full-shape replace.
+    patch: (id: number, data: PatchProfileRequest) =>
+      req<void>('PATCH', `/profiles/${id}`, data),
     delete: (id: number) => req<void>('DELETE', `/profiles/${id}`),
     // #1494 / #1069 — replace the set of #1069 household named schedules
     // attached to this profile as BLOCK schedules (downtime while active).

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -820,6 +820,21 @@ export interface PatchDeviceRequest {
   profileId?: number | null
 }
 
+// #423: PATCH /api/profiles/:id — field-scoped partial update. Omitted fields
+// preserve their current value; `timeLimit` is the only nullable field and
+// accepts an explicit `null` to clear. Non-nullable fields cannot be `null`.
+export interface PatchProfileRequest {
+  name?: string
+  blockedCategories?: string[]
+  paused?: boolean
+  failureMode?: FailureMode
+  blockIpOnly?: boolean
+  crossDeviceOverlapMode?: CrossDeviceOverlapMode
+  pauseMode?: PauseMode
+  defaultDeny?: boolean
+  timeLimit?: number | null
+}
+
 export interface GrantExtensionRequest {
   profileId: number
   extraMinutes: number


### PR DESCRIPTION
Closes #423.

Adds `PATCH /api/profiles/:id` so the SPA can issue field-scoped writes (e.g. a paused toggle, an autosave on `name`) without the read-then-write clobber that today's `PUT` requires. Unblocks the Profile half of the autosave rollout (#995 → #973–#977).

## Wire shape (additive, backwards-compatible)

Body is a JSON object whose keys are a subset of the writable `Profile` fields. `PUT` is unchanged — pre-PATCH clients keep working.

Tri-state JSON semantics via the existing `FieldPatch` helper used by `/api/devices/:mac`, `/api/users/:id`, `/api/apps/:id`:

- **field absent** → preserve existing value
- **field == `null`** → clear (legal only on nullable `timeLimit`; rejected with 400 elsewhere)
- **field == `v`** → assign `v`

Patchable fields: `name`, `blockedCategories`, `paused`, `failureMode`, `blockIpOnly`, `crossDeviceOverlapMode`, `pauseMode`, `defaultDeny`, `timeLimit`. Schedules and users stay on their own sub-routes (`PUT /api/profiles/:id/schedules`, `PUT /api/profiles/:id/users`) by design (#1494, #406).

Cache: a successful patch that touches `paused` or `timeLimit` busts the per-profile `TimeStatusCache` entry, mirroring the schedule-attach PUT and `/api/time/extend` (#1538).

## Why not block on #581 first

#581 (symmetric read/write shapes) is a desirable cleanup but not a wire prerequisite: PATCH accepts a Json.Obj subset of the existing flat write shape, so the read shape (`ProfileDetail`) can stay as-is for now. The autosave rollout can land on top of PATCH and #581 can collapse the read/write surfaces in a follow-up without changing PATCH semantics.

## Tests (TDD red→green visible in commit history)

New feature spec `api/test/src/feature/ProfilePatchApiSpec.scala`:

- single-field patches (`paused`, `name`) leave every other field untouched
- multi-field patch updates each supplied field
- empty patch `{}` preserves every field
- `timeLimit: null` clears the row; `timeLimit: N` upserts
- `name: null` / `paused: null` → 400 (non-nullable)
- invalid JSON → 400
- missing profile → 404
- no token → 401

## SPA

- `api.profiles.patch(id, data)` in `web/src/api/client.ts`
- `PatchProfileRequest` interface in `web/src/types/api.ts`

Existing `PUT` call sites are unchanged — that swap is #995's autosave-rollout work, not this PR.