### PR TITLE
refactor(#602): structured key=value logging across hot Scala paths

### DIFF
--- a/api/resources/logback.xml
+++ b/api/resources/logback.xml
@@ -1,7 +1,14 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <!--
+        #602: %mdc renders the SLF4J MDC map populated by zio-logging annotations
+        (see api/src/observability/LogContext.scala). One-line-per-log locally;
+        keys like route=, mac=, op=, etag=, status= appear at the tail so they
+        can be grep'd without parsing the message text. A structured (JSON)
+        appender for deployed environments is tracked separately under #602.
+      -->
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %mdc%n</pattern>
     </encoder>
   </appender>
 

--- a/api/src/ErrorBoundary.scala
+++ b/api/src/ErrorBoundary.scala
@@ -1,6 +1,7 @@
 package wifihaven.api
 
 import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
 import zio.*
 import zio.http.*
 
@@ -72,9 +73,17 @@ object ErrorBoundary {
     val status = response.status.code
     for {
       snippet <- bodySnippet(response)
-      base = s"$method $route -> $status"
-      msg  = snippet.fold(base)(s => s"$base body=$s")
-      _ <- if status >= 500 then ZIO.logError(msg) else ZIO.logWarning(msg)
+      base   = s"$method $route -> $status"
+      msg    = snippet.fold(base)(s => s"$base body=$s")
+      // #602: structured context (route, method, status) attached as log annotations
+      // so MDC/JSON consumers can search/filter without parsing the message text. The
+      // human-readable message is kept verbatim for back-compat with existing log readers.
+      logged = if status >= 500 then ZIO.logError(msg) else ZIO.logWarning(msg)
+      _ <- LogContext.annotateAll(
+        LogContext.Route  -> route,
+        LogContext.Method -> method,
+        LogContext.Status -> status.toString,
+      )(logged)
       _ <- AppMetrics.recordHttpError(route, status)
     } yield ()
   }

--- a/api/src/ErrorBoundary.scala
+++ b/api/src/ErrorBoundary.scala
@@ -73,17 +73,16 @@ object ErrorBoundary {
     val status = response.status.code
     for {
       snippet <- bodySnippet(response)
-      base   = s"$method $route -> $status"
-      msg    = snippet.fold(base)(s => s"$base body=$s")
-      // #602: structured context (route, method, status) attached as log annotations
-      // so MDC/JSON consumers can search/filter without parsing the message text. The
-      // human-readable message is kept verbatim for back-compat with existing log readers.
-      logged = if status >= 500 then ZIO.logError(msg) else ZIO.logWarning(msg)
-      _ <- LogContext.annotateAll(
-        LogContext.Route  -> route,
-        LogContext.Method -> method,
-        LogContext.Status -> status.toString,
-      )(logged)
+      base = s"$method $route -> $status"
+      msg  = snippet.fold(base)(s => s"$base body=$s")
+      // #602: `route` + `method` are already annotated by `LoggingMiddleware` for
+      // the whole handler scope (via FiberRef), so they flow into this log line
+      // automatically. We only need to add the response-derived `status` here.
+      // Human-readable message text is kept verbatim for back-compat with
+      // existing log readers.
+      _ <- LogContext.annotate(LogContext.Status, status.toString) {
+        if status >= 500 then ZIO.logError(msg) else ZIO.logWarning(msg)
+      }
       _ <- AppMetrics.recordHttpError(route, status)
     } yield ()
   }

--- a/api/src/Main.scala
+++ b/api/src/Main.scala
@@ -13,6 +13,7 @@ import wifihaven.api.metrics.{
   RouterPresenceMetrics,
 }
 import wifihaven.api.notify.Notifier
+import wifihaven.api.observability.LoggingMiddleware
 import wifihaven.api.policy.*
 import wifihaven.api.routes.*
 import wifihaven.api.usage.RetentionSweepJob
@@ -442,13 +443,22 @@ object Main extends ZIOAppDefault {
       // It sits *inside* the readiness gate so the gate's startup 503s don't spam the log. Only
       // /api/health (its own 503-while-starting semantics, polled constantly) and /metrics (the
       // scrape endpoint) are left out — mirroring HttpMetrics' own exclusion of /metrics.
+      // #602: LoggingMiddleware.annotate wraps every served route family so every
+      // ZIO.log* emitted inside a handler (or anything it calls) inherits the
+      // templated `route` and `method` as MDC keys via FiberRef — handlers no
+      // longer wrap individual log lines for that context. ErrorBoundary still
+      // adds `status` because it sees the response. The middleware sits *inside*
+      // HttpMetrics (so the same routes it counts also get logged) and *outside*
+      // the readiness gate so even a gated 503 carries its route/method context.
       HttpMetrics.instrument(
         healthRoutes ++
-          Readiness.gate(
-            ErrorBoundary.observe(
-              systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+          LoggingMiddleware.annotate(
+            Readiness.gate(
+              ErrorBoundary.observe(
+                systemRoutes ++ statsRoutes ++ routerAndAdminRoutes ++ spaRoutes,
+              ),
+              ready,
             ),
-            ready,
           ),
       ) ++ metricsRoutes
     }

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -60,10 +60,11 @@ class AuthServiceLive(
   private val secret                 = jwtConfig.secret
 
   def login(username: String, password: String): IO[AuthError, LoginResponse] =
-    LogContext.annotateAll(
-      LogContext.Op   -> "login",
-      LogContext.User -> username,
-    ) {
+    // #602: route/method (`POST /api/auth/login`) ride in via LoggingMiddleware on
+    // the HTTP path. `user` is the only per-call dynamic context we add here, so
+    // every log inside the for-comprehension (success info, bad-password warn)
+    // inherits it via FiberRef.
+    LogContext.annotate(LogContext.User, username) {
       (for {
         user  <- userRepo
           .findByUsername(username)

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -96,6 +96,10 @@ class AuthServiceLive(
       ))
         .tapError {
           // #1204: a bad password or unknown user both collapse to InvalidCredentials.
+          // #602: the message text duplicates the annotation values (user=, reason=) on
+          // purpose — same back-compat strategy as ErrorBoundary.scala. Existing log
+          // readers grep substrings; the MDC keys are additive for structured consumers.
+          // Don't drop the substrings until the JSON appender lands.
           case AuthError.InvalidCredentials =>
             AppMetrics.recordAuthFailure("bad_password") *>
               LogContext.annotate(LogContext.Reason, "bad_password") {

--- a/api/src/auth/AuthService.scala
+++ b/api/src/auth/AuthService.scala
@@ -4,6 +4,7 @@ import at.favre.lib.crypto.bcrypt.BCrypt
 import wifihaven.api.JwtConfig
 import wifihaven.api.db.*
 import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import pdi.jwt.*
@@ -59,36 +60,50 @@ class AuthServiceLive(
   private val secret                 = jwtConfig.secret
 
   def login(username: String, password: String): IO[AuthError, LoginResponse] =
-    (for {
-      user  <- userRepo
-        .findByUsername(username)
-        .mapError(e => AuthError.Unexpected(e.getMessage))
-        .flatMap(ZIO.fromOption(_).mapError(_ => AuthError.InvalidCredentials))
-      valid <- ZIO.succeed(
-        BCrypt.verifyer().verify(password.toCharArray, user.passwordHash).verified,
-      )
-      _     <- ZIO.fail(AuthError.InvalidCredentials).when(!valid)
-      now   <- clock.instant.map(_.getEpochSecond)
-      claim = JwtClaim(
-        content = s"""{"role":"${UserRole.asString(user.role)}"}""",
-        subject = Some(user.username),
-        issuedAt = Some(now),
-        expiration = Some(now + jwtConfig.expiryHours * 3600L),
-      )
-      token <- ZIO
-        .attempt(JwtZIOJson.encode(claim, secret, algo))
-        .mapError(e => AuthError.Unexpected(e.getMessage))
-    } yield LoginResponse(
-      JwtToken.unsafe(token),
-      user.role,
-      user.username,
-      user.mustChangePassword,
-    ))
-      .tapError {
-        // #1204: a bad password or unknown user both collapse to InvalidCredentials.
-        case AuthError.InvalidCredentials => AppMetrics.recordAuthFailure("bad_password")
-        case _                            => ZIO.unit
-      }
+    LogContext.annotateAll(
+      LogContext.Op   -> "login",
+      LogContext.User -> username,
+    ) {
+      (for {
+        user  <- userRepo
+          .findByUsername(username)
+          .mapError(e => AuthError.Unexpected(e.getMessage))
+          .flatMap(ZIO.fromOption(_).mapError(_ => AuthError.InvalidCredentials))
+        valid <- ZIO.succeed(
+          BCrypt.verifyer().verify(password.toCharArray, user.passwordHash).verified,
+        )
+        _     <- ZIO.fail(AuthError.InvalidCredentials).when(!valid)
+        now   <- clock.instant.map(_.getEpochSecond)
+        claim = JwtClaim(
+          content = s"""{"role":"${UserRole.asString(user.role)}"}""",
+          subject = Some(user.username),
+          issuedAt = Some(now),
+          expiration = Some(now + jwtConfig.expiryHours * 3600L),
+        )
+        token <- ZIO
+          .attempt(JwtZIOJson.encode(claim, secret, algo))
+          .mapError(e => AuthError.Unexpected(e.getMessage))
+        // #602: explicit success log (the boundary only logs failures). Bounded — one line
+        // per successful login, MDC-annotated with the user + role for searchability.
+        _     <- LogContext.annotate(LogContext.Reason, "ok") {
+          ZIO.logInfo(s"login ok: user=$username role=${UserRole.asString(user.role)}")
+        }
+      } yield LoginResponse(
+        JwtToken.unsafe(token),
+        user.role,
+        user.username,
+        user.mustChangePassword,
+      ))
+        .tapError {
+          // #1204: a bad password or unknown user both collapse to InvalidCredentials.
+          case AuthError.InvalidCredentials =>
+            AppMetrics.recordAuthFailure("bad_password") *>
+              LogContext.annotate(LogContext.Reason, "bad_password") {
+                ZIO.logWarning(s"login failed: user=$username reason=bad_password")
+              }
+          case _                            => ZIO.unit
+        }
+    }
 
   // We delegate expiration/not-before checks to our injected Clock (see below).
   private val jwtOpts = JwtOptions(expiration = false, notBefore = false)

--- a/api/src/observability/LogContext.scala
+++ b/api/src/observability/LogContext.scala
@@ -1,0 +1,58 @@
+package wifihaven.api.observability
+
+import zio.*
+
+/**
+ * #602: the single structured-log helper for the API. Every hot-path log line should attach context
+ * via these helpers instead of interpolating ad-hoc `key=value` substrings into the message.
+ *
+ * The annotations attached here flow through `zio-logging-slf4j`'s default `logFormatDefault`
+ * (`LogFormat.allAnnotations + LogFormat.line + LogFormat.cause`) which writes every annotation
+ * into SLF4J MDC. Local `logback.xml` includes `%mdc` in the console pattern so they are visible
+ * during dev; a downstream JSON appender (deferred — see the umbrella under #602) can read the same
+ * MDC map without re-parsing message text.
+ *
+ * Keys are bounded — they must come from this object — to avoid the same per-mac/per-domain
+ * cardinality footgun that `MetricGuard` defends against on the metrics side. A new key is added
+ * here, not at the call site.
+ *
+ * Convention: keys are camelCase strings; values are the smallest unique identifier (router id,
+ * mac, etag, profile id) or a bounded enum (op, reason, status). The same key in [[LogContext]] and
+ * [[wifihaven.api.metrics.MetricGuard]] means the same thing — `route` is the templated path, never
+ * the raw URL; `op` is a low-cardinality verb (`router_policy`, `router_usage`, `login`,
+ * `device_upsert`, …).
+ */
+object LogContext {
+
+  // ── Keys (bounded — extend deliberately) ─────────────────────────────────
+
+  val Route     = "route"
+  val Method    = "method"
+  val Status    = "status"
+  val Op        = "op"
+  val RouterId  = "routerId"
+  val Mac       = "mac"
+  val Etag      = "etag"
+  val ProfileId = "profileId"
+  val User      = "user"
+  val Reason    = "reason"
+  val NotMod    = "notModified"
+  val BatchSize = "batchSize"
+  val Rejected  = "rejected"
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  /** Attach a single annotation to the wrapped effect. */
+  def annotate[R, E, A](key: String, value: String)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    ZIO.logAnnotate(key, value)(zio)
+
+  /**
+   * Attach many annotations at once; nil-value pairs are dropped so the call site can be uniform.
+   */
+  def annotateAll[R, E, A](pairs: (String, String)*)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    pairs.foldRight(zio)((kv, acc) => ZIO.logAnnotate(kv._1, kv._2)(acc))
+
+  /** Optional-value annotation — when `value` is None this is a no-op wrapper. */
+  def annotateOpt[R, E, A](key: String, value: Option[String])(zio: ZIO[R, E, A]): ZIO[R, E, A] =
+    value.fold(zio)(v => ZIO.logAnnotate(key, v)(zio))
+}

--- a/api/src/observability/LogContext.scala
+++ b/api/src/observability/LogContext.scala
@@ -47,7 +47,9 @@ object LogContext {
     ZIO.logAnnotate(key, value)(zio)
 
   /**
-   * Attach many annotations at once; nil-value pairs are dropped so the call site can be uniform.
+   * Attach every (key, value) pair as a log annotation. For optional values, use [[annotateOpt]] —
+   * this overload does not filter, so passing a null value would emit a stringified-null
+   * annotation.
    */
   def annotateAll[R, E, A](pairs: (String, String)*)(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     pairs.foldRight(zio)((kv, acc) => ZIO.logAnnotate(kv._1, kv._2)(acc))

--- a/api/src/observability/LoggingMiddleware.scala
+++ b/api/src/observability/LoggingMiddleware.scala
@@ -1,0 +1,44 @@
+package wifihaven.api.observability
+
+import zio.*
+import zio.http.*
+
+/**
+ * #602: per-request log-context middleware. Mirrors `metrics.HttpMetrics` / `ErrorBoundary` — it
+ * transforms each route individually so it can read the route's own templated path
+ * (`routePattern.pathCodec`), then wraps the handler invocation in `LogContext.annotateAll` so the
+ * templated `route` and `method` are attached as ZIO log annotations (→ SLF4J MDC) for the entire
+ * handler scope. Every `ZIO.log*` call inside the handler — including those emitted by repos,
+ * services, and child fibers it forks — inherits the annotation via FiberRef without the handler
+ * (or any callee) needing to wrap anything.
+ *
+ * This is the SSoT for the per-request `route` and `method` context: handlers do NOT add them.
+ * `ErrorBoundary` adds `status`; handler bodies attach only TRULY per-handler data they had to
+ * compute locally (`routerId` after auth, `etag` after snapshot resolve, `mac`, `profileId`, etc.).
+ *
+ * Cardinality safety: the only string that becomes a label is `routePattern.pathCodec.render(...)`
+ * — the bounded route template, never the raw request path. An unmatched request never reaches a
+ * transformed handler, so an attacker-controlled path can never become a value. Matches the
+ * existing `HttpMetrics` safety rationale.
+ */
+object LoggingMiddleware {
+
+  private def renderTemplate(rp: RoutePattern[?]): String =
+    rp.pathCodec.render(":", "")
+
+  def annotate(routes: Routes[Any, Response]): Routes[Any, Response] =
+    Routes.fromIterable(routes.routes.map(annotateOne))
+
+  private def annotateOne(route: Route[Any, Response]): Route[Any, Response] = {
+    val routeLabel = renderTemplate(route.routePattern)
+    val method     = route.routePattern.method.render
+    route.transform[Any] { handler =>
+      Handler.fromFunctionZIO[Request] { req =>
+        LogContext.annotateAll(
+          LogContext.Route  -> routeLabel,
+          LogContext.Method -> method,
+        )(handler(req))
+      }
+    }
+  }
+}

--- a/api/src/policy/PolicyService.scala
+++ b/api/src/policy/PolicyService.scala
@@ -3,6 +3,7 @@ package wifihaven.api.policy
 import wifihaven.api.AppConfig
 import wifihaven.api.db.*
 import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
 import wifihaven.shared.{Schedule as DbSchedule, *}
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
@@ -291,11 +292,18 @@ class PolicyServiceLive(
     if (!changed) ZIO.unit
     else {
       val json = snap.toJson
-      ZIO.logInfo(
-        s"event=snapshot_changed etag=${snap.etag.value} " +
-          s"prevEtag=${prev.map(_.value).getOrElse("none")} " +
-          s"bytes=${json.length} snapshot=$json",
-      )
+      // #602: structured context — etag/op as annotations so ops can filter the
+      // snapshot_changed stream without parsing the message.
+      LogContext.annotateAll(
+        LogContext.Op   -> "snapshot_changed",
+        LogContext.Etag -> snap.etag.value,
+      ) {
+        ZIO.logInfo(
+          s"event=snapshot_changed etag=${snap.etag.value} " +
+            s"prevEtag=${prev.map(_.value).getOrElse("none")} " +
+            s"bytes=${json.length} snapshot=$json",
+        )
+      }
     }
   }
 

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -2,6 +2,7 @@ package wifihaven.api.routes
 
 import wifihaven.api.db.*
 import wifihaven.api.metrics.AppMetrics
+import wifihaven.api.observability.LogContext
 import wifihaven.api.policy.PolicyService
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -66,16 +67,28 @@ object RouterIngestRoutes {
             decoded  = raw.records.zipWithIndex.map((j, i) => (i, j.as[UsageRecord]))
             rejected = decoded.collect { case (i, Left(err)) => (i, err) }
             records  = decoded.collect { case (_, Right(r)) => r }
-            _        <- ZIO.foreachDiscard(rejected) { (i, err) =>
-              ZIO.logWarning(
-                s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
-              )
+            // #602: per-record skip log and the per-batch summary log share routerId/op via
+            // LogContext annotations so MDC consumers can filter without parsing the message.
+            _        <- LogContext.annotateAll(
+              LogContext.Op       -> "router_usage",
+              LogContext.RouterId -> router.id.toString,
+            ) {
+              ZIO.foreachDiscard(rejected) { (i, err) =>
+                ZIO.logWarning(
+                  s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
+                )
+              } *>
+                AppMetrics.recordUsageRecordsRejected(rejected.size) *>
+                LogContext.annotateAll(
+                  LogContext.BatchSize -> records.size.toString,
+                  LogContext.Rejected  -> rejected.size.toString,
+                ) {
+                  ZIO.logDebug(
+                    s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
+                      s"rejected=${rejected.size}",
+                  )
+                }
             }
-            _        <- AppMetrics.recordUsageRecordsRejected(rejected.size)
-            _        <- ZIO.logDebug(
-              s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
-                s"rejected=${rejected.size}",
-            )
             _        <- ZIO.foreachDiscard(records)(r =>
               ZIO.logDebug(
                 s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
@@ -116,7 +129,10 @@ object RouterIngestRoutes {
             // accepted no-op rather than an error. Genuinely malformed non-empty
             // bodies still 400 + warn (and the agent emitter no longer
             // produces them — see conntrack.encode_events_body).
-            rep    <-
+            rep    <- LogContext.annotateAll(
+              LogContext.Op       -> "router_events",
+              LogContext.RouterId -> router.id.toString,
+            ) {
               if body.trim.isEmpty then
                 ZIO.logDebug(
                   s"router events: empty body from router=${router.id}; treating as no-op batch",
@@ -125,12 +141,20 @@ object RouterIngestRoutes {
                 ZIO
                   .fromEither(body.fromJson[RouterEventsRequest])
                   .mapError(ApiError.DecodeFailure(_))
+            }
             _      <- ZIO
               .fail(ApiError.BadRequest("router_id mismatch"))
               .when(rep.routerId != router.id)
-            _      <- ZIO.logDebug(
-              s"router events: router=${router.id} batchSize=${rep.events.size}",
-            )
+            // #602: structured context for the per-batch summary log.
+            _      <- LogContext.annotateAll(
+              LogContext.Op        -> "router_events",
+              LogContext.RouterId  -> router.id.toString,
+              LogContext.BatchSize -> rep.events.size.toString,
+            ) {
+              ZIO.logDebug(
+                s"router events: router=${router.id} batchSize=${rep.events.size}",
+              )
+            }
             _      <- ZIO.foreachDiscard(rep.events)(e =>
               ZIO.logDebug(
                 s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -44,71 +44,75 @@ object RouterIngestRoutes {
           // The per-RECORD skip path (below) is kept from #1574 and is NOT redundant with the
           // boundary: a batch carrying a bad record still returns 200, so the boundary never sees
           // it — the skip is logged + metered inline here.
-          val handle: ZIO[Any, ApiError, Response] = for {
-            router <- auth.authenticate(req).mapError(ApiError.Wrapped(_))
-            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
-            // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a raw
-            // JSON array, deferring per-record validation. A genuinely unparseable envelope (bad
-            // routerId/timestamps, not an object, `records` not an array, truncated body) still
-            // 400s — logged by the boundary.
-            raw    <- ZIO
-              .fromEither(body.fromJson[RawUsageReport])
-              .mapError(ApiError.DecodeFailure(_))
-            _      <- ZIO
-              .fail(ApiError.BadRequest("router_id mismatch"))
-              .when(raw.routerId != router.id)
-            ps     <- parseInstant(raw.periodStart)
-            pe     <- parseInstant(raw.periodEnd)
-            // #1569: decode each record individually. A single malformed record
-            // (e.g. a host value that fails Hostname validation — an Akamai/CDN
-            // CNAME target with underscores, see #1572) used to fail the WHOLE
-            // batch, dropping every valid record with it. Now the bad records are
-            // skipped, logged (bounded), and metered, and the valid ones ingest.
-            decoded  = raw.records.zipWithIndex.map((j, i) => (i, j.as[UsageRecord]))
-            rejected = decoded.collect { case (i, Left(err)) => (i, err) }
-            records  = decoded.collect { case (_, Right(r)) => r }
-            // #602: per-record skip log and the per-batch summary log share routerId/op via
-            // LogContext annotations so MDC consumers can filter without parsing the message.
-            _        <- LogContext.annotateAll(
-              LogContext.Op       -> "router_usage",
-              LogContext.RouterId -> router.id.toString,
-            ) {
-              ZIO.foreachDiscard(rejected) { (i, err) =>
-                ZIO.logWarning(
-                  s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
-                )
-              } *>
-                AppMetrics.recordUsageRecordsRejected(rejected.size) *>
-                LogContext.annotateAll(
-                  LogContext.BatchSize -> records.size.toString,
-                  LogContext.Rejected  -> rejected.size.toString,
-                ) {
-                  ZIO.logDebug(
-                    s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
-                      s"rejected=${rejected.size}",
+          // #602: `op=router_usage` + `routerId` annotate the WHOLE handler scope
+          // (after auth resolves router.id) so every log emitted from here — the
+          // per-record skip warn, the per-batch debug, and the per-record debug
+          // dump — shares the same MDC keys without re-wrapping.
+          val handle: ZIO[Any, ApiError, Response] =
+            auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
+              LogContext.annotateAll(
+                LogContext.Op       -> "router_usage",
+                LogContext.RouterId -> router.id.toString,
+              ) {
+                for {
+                  body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+                  // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a
+                  // raw JSON array, deferring per-record validation. A genuinely unparseable
+                  // envelope (bad routerId/timestamps, not an object, `records` not an array,
+                  // truncated body) still 400s — logged by the boundary.
+                  raw  <- ZIO
+                    .fromEither(body.fromJson[RawUsageReport])
+                    .mapError(ApiError.DecodeFailure(_))
+                  _    <- ZIO
+                    .fail(ApiError.BadRequest("router_id mismatch"))
+                    .when(raw.routerId != router.id)
+                  ps   <- parseInstant(raw.periodStart)
+                  pe   <- parseInstant(raw.periodEnd)
+                  // #1569: decode each record individually. A single malformed record
+                  // (e.g. a host value that fails Hostname validation — an Akamai/CDN
+                  // CNAME target with underscores, see #1572) used to fail the WHOLE
+                  // batch, dropping every valid record with it. Now the bad records are
+                  // skipped, logged (bounded), and metered, and the valid ones ingest.
+                  decoded  = raw.records.zipWithIndex.map((j, i) => (i, j.as[UsageRecord]))
+                  rejected = decoded.collect { case (i, Left(err)) => (i, err) }
+                  records  = decoded.collect { case (_, Right(r)) => r }
+                  _        <- ZIO.foreachDiscard(rejected) { (i, err) =>
+                    ZIO.logWarning(
+                      s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
+                    )
+                  }
+                  _        <- AppMetrics.recordUsageRecordsRejected(rejected.size)
+                  _        <- LogContext.annotateAll(
+                    LogContext.BatchSize -> records.size.toString,
+                    LogContext.Rejected  -> rejected.size.toString,
+                  ) {
+                    ZIO.logDebug(
+                      s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
+                        s"rejected=${rejected.size}",
+                    )
+                  }
+                  _        <- ZIO.foreachDiscard(records)(r =>
+                    ZIO.logDebug(
+                      s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
+                        s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
+                    ),
                   )
-                }
+                  settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
+                  _        <- handleUsage(
+                    router.id,
+                    ps,
+                    pe,
+                    records,
+                    settings,
+                    trafficRepo,
+                    timeUsageRepo,
+                    deviceRepo,
+                    connEventRepo,
+                  )
+                  _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+                } yield Response.ok
+              }
             }
-            _        <- ZIO.foreachDiscard(records)(r =>
-              ZIO.logDebug(
-                s"  usage record: mac=${r.mac} ip=${r.ip.getOrElse("-")} " +
-                  s"host=${r.host.value} secs=${r.activeSeconds} bIn=${r.bytesIn} bOut=${r.bytesOut}",
-              ),
-            )
-            settings <- householdSettingsRepo.get.mapError(ApiError.Db(_))
-            _        <- handleUsage(
-              router.id,
-              ps,
-              pe,
-              records,
-              settings,
-              trafficRepo,
-              timeUsageRepo,
-              deviceRepo,
-              connEventRepo,
-            )
-            _        <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
-          } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
       Method.POST / "api" / "router" / "events" ->
@@ -118,54 +122,55 @@ object RouterIngestRoutes {
           // gone — the ErrorBoundary now logs every 4xx (incl. this decode 400) at WARN with the
           // response-body snippet, so logging is uniform with the usage route (the #1569 dedup:
           // one emitter, not two).
-          val handle: ZIO[Any, ApiError, Response] = for {
-            router <- auth.authenticate(req).mapError(ApiError.Wrapped(_))
-            body   <- req.body.asString.orElseFail(ApiError.BadRequest(""))
-            // #1126: tolerate an empty/blank body as a no-op batch. A truncated
-            // or empty POST (network blip, retry-queue edge) used to fail
-            // RouterEventsRequest decoding with "Unexpected end of input" and
-            // 400, spamming the warn log and dropping the (harmless) batch. An
-            // empty events POST carries nothing to persist, so treat it as an
-            // accepted no-op rather than an error. Genuinely malformed non-empty
-            // bodies still 400 + warn (and the agent emitter no longer
-            // produces them — see conntrack.encode_events_body).
-            rep    <- LogContext.annotateAll(
-              LogContext.Op       -> "router_events",
-              LogContext.RouterId -> router.id.toString,
-            ) {
-              if body.trim.isEmpty then
-                ZIO.logDebug(
-                  s"router events: empty body from router=${router.id}; treating as no-op batch",
-                ) *> ZIO.succeed(RouterEventsRequest(router.id, Nil))
-              else
-                ZIO
-                  .fromEither(body.fromJson[RouterEventsRequest])
-                  .mapError(ApiError.DecodeFailure(_))
+          // #602: `op=router_events` + `routerId` annotate the WHOLE handler scope
+          // (after auth resolves router.id) so every log emitted from here shares the
+          // same MDC keys without re-wrapping.
+          val handle: ZIO[Any, ApiError, Response] =
+            auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
+              LogContext.annotateAll(
+                LogContext.Op       -> "router_events",
+                LogContext.RouterId -> router.id.toString,
+              ) {
+                for {
+                  body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+                  // #1126: tolerate an empty/blank body as a no-op batch. A truncated
+                  // or empty POST (network blip, retry-queue edge) used to fail
+                  // RouterEventsRequest decoding with "Unexpected end of input" and
+                  // 400, spamming the warn log and dropping the (harmless) batch. An
+                  // empty events POST carries nothing to persist, so treat it as an
+                  // accepted no-op rather than an error. Genuinely malformed non-empty
+                  // bodies still 400 + warn (and the agent emitter no longer
+                  // produces them — see conntrack.encode_events_body).
+                  rep  <-
+                    if body.trim.isEmpty then
+                      ZIO.logDebug(
+                        s"router events: empty body from router=${router.id}; treating as no-op batch",
+                      ) *> ZIO.succeed(RouterEventsRequest(router.id, Nil))
+                    else
+                      ZIO
+                        .fromEither(body.fromJson[RouterEventsRequest])
+                        .mapError(ApiError.DecodeFailure(_))
+                  _    <- ZIO
+                    .fail(ApiError.BadRequest("router_id mismatch"))
+                    .when(rep.routerId != router.id)
+                  _    <- LogContext.annotate(LogContext.BatchSize, rep.events.size.toString) {
+                    ZIO.logDebug(
+                      s"router events: router=${router.id} batchSize=${rep.events.size}",
+                    )
+                  }
+                  _    <- ZIO.foreachDiscard(rep.events)(e =>
+                    ZIO.logDebug(
+                      s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
+                        s"ip=${e.ip.getOrElse("-")} host=${e.host.map(_.value).orElse(e.hostname.map(_.value)).getOrElse("-")} " +
+                        s"destIp=${e.destIp.getOrElse("-")} allowed=${e.allowed.map(_.toString).getOrElse("-")} " +
+                        s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
+                    ),
+                  )
+                  _    <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo, alertRepo)
+                  _    <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+                } yield Response.ok
+              }
             }
-            _      <- ZIO
-              .fail(ApiError.BadRequest("router_id mismatch"))
-              .when(rep.routerId != router.id)
-            // #602: structured context for the per-batch summary log.
-            _      <- LogContext.annotateAll(
-              LogContext.Op        -> "router_events",
-              LogContext.RouterId  -> router.id.toString,
-              LogContext.BatchSize -> rep.events.size.toString,
-            ) {
-              ZIO.logDebug(
-                s"router events: router=${router.id} batchSize=${rep.events.size}",
-              )
-            }
-            _      <- ZIO.foreachDiscard(rep.events)(e =>
-              ZIO.logDebug(
-                s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
-                  s"ip=${e.ip.getOrElse("-")} host=${e.host.map(_.value).orElse(e.hostname.map(_.value)).getOrElse("-")} " +
-                  s"destIp=${e.destIp.getOrElse("-")} allowed=${e.allowed.map(_.toString).getOrElse("-")} " +
-                  s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
-              ),
-            )
-            _      <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo, alertRepo)
-            _      <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
-          } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
     )

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -44,16 +44,13 @@ object RouterIngestRoutes {
           // The per-RECORD skip path (below) is kept from #1574 and is NOT redundant with the
           // boundary: a batch carrying a bad record still returns 200, so the boundary never sees
           // it — the skip is logged + metered inline here.
-          // #602: `op=router_usage` + `routerId` annotate the WHOLE handler scope
-          // (after auth resolves router.id) so every log emitted from here — the
-          // per-record skip warn, the per-batch debug, and the per-record debug
-          // dump — shares the same MDC keys without re-wrapping.
+          // #602: route/method are on the MDC via LoggingMiddleware. We add
+          // `routerId` to the whole post-auth scope so every log emitted from
+          // here (per-record skip warn, per-batch debug, per-record debug dump)
+          // inherits the same router context without re-wrapping.
           val handle: ZIO[Any, ApiError, Response] =
             auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
-              LogContext.annotateAll(
-                LogContext.Op       -> "router_usage",
-                LogContext.RouterId -> router.id.toString,
-              ) {
+              LogContext.annotate(LogContext.RouterId, router.id.toString) {
                 for {
                   body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
                   // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a
@@ -122,15 +119,11 @@ object RouterIngestRoutes {
           // gone — the ErrorBoundary now logs every 4xx (incl. this decode 400) at WARN with the
           // response-body snippet, so logging is uniform with the usage route (the #1569 dedup:
           // one emitter, not two).
-          // #602: `op=router_events` + `routerId` annotate the WHOLE handler scope
-          // (after auth resolves router.id) so every log emitted from here shares the
-          // same MDC keys without re-wrapping.
+          // #602: route/method via LoggingMiddleware; `routerId` annotates the
+          // whole post-auth scope so every log here inherits it without re-wrapping.
           val handle: ZIO[Any, ApiError, Response] =
             auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
-              LogContext.annotateAll(
-                LogContext.Op       -> "router_events",
-                LogContext.RouterId -> router.id.toString,
-              ) {
+              LogContext.annotate(LogContext.RouterId, router.id.toString) {
                 for {
                   body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
                   // #1126: tolerate an empty/blank body as a no-op batch. A truncated

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -86,9 +86,9 @@ object RouterRoutes {
             logMsg = s"router policy: router=${router.id} etagIn=${ifNoneMatch.getOrElse("-")} " +
               s"etagOut=${snap.etag.value} notModified=$notMod devices=${snap.devices.size} " +
               s"profiles=${snap.profiles.size}"
-            // #602: structured context for ops search/filter.
+            // #602: route + method are already on the MDC via LoggingMiddleware;
+            // only attach the per-handler dynamic data here.
             _ <- LogContext.annotateAll(
-              LogContext.Op       -> "router_policy",
               LogContext.RouterId -> router.id.toString,
               LogContext.Etag     -> snap.etag.value,
               LogContext.NotMod   -> notMod.toString,

--- a/api/src/routes/RouterRoutes.scala
+++ b/api/src/routes/RouterRoutes.scala
@@ -2,6 +2,7 @@ package wifihaven.api.routes
 
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
+import wifihaven.api.observability.LogContext
 import wifihaven.api.policy.*
 import wifihaven.shared.*
 import wifihaven.shared.types.*
@@ -85,7 +86,13 @@ object RouterRoutes {
             logMsg = s"router policy: router=${router.id} etagIn=${ifNoneMatch.getOrElse("-")} " +
               s"etagOut=${snap.etag.value} notModified=$notMod devices=${snap.devices.size} " +
               s"profiles=${snap.profiles.size}"
-            _ <- if (notMod) ZIO.logDebug(logMsg) else ZIO.logInfo(logMsg)
+            // #602: structured context for ops search/filter.
+            _ <- LogContext.annotateAll(
+              LogContext.Op       -> "router_policy",
+              LogContext.RouterId -> router.id.toString,
+              LogContext.Etag     -> snap.etag.value,
+              LogContext.NotMod   -> notMod.toString,
+            )(if (notMod) ZIO.logDebug(logMsg) else ZIO.logInfo(logMsg))
             resp =
               if notMod then
                 Response

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -480,10 +480,7 @@ object DeviceRoutes {
               .mapError(ApiError.Db(_))
             // #481: log device upsert so the next CI failure makes it obvious
             // whether the mutation reached the API at all.
-            _  <- LogContext.annotateAll(
-              LogContext.Op  -> "device_upsert",
-              LogContext.Mac -> mac.value,
-            )(
+            _  <- LogContext.annotate(LogContext.Mac, mac.value) {
               LogContext.annotateOpt(
                 LogContext.ProfileId,
                 udr.profileId.map(_.value.toString),
@@ -493,8 +490,8 @@ object DeviceRoutes {
                       .map(_.value.toString)
                       .getOrElse("-")} name=${udr.name}",
                 )
-              },
-            )
+              }
+            }
           } yield Response.json(s"""{"id":${id.value}}""")
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -511,10 +508,9 @@ object DeviceRoutes {
               .mapError(ApiError.Wrapped(_))
             _        <- deviceRepo.delete(normalized).mapError(ApiError.Db(_))
             // #481: same rationale as PUT — make the next CI failure diagnostic.
-            _        <- LogContext.annotateAll(
-              LogContext.Op  -> "device_delete",
-              LogContext.Mac -> normalized.value,
-            )(ZIO.logInfo(s"device deleted: mac=${normalized.value}"))
+            _        <- LogContext.annotate(LogContext.Mac, normalized.value)(
+              ZIO.logInfo(s"device deleted: mac=${normalized.value}"),
+            )
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -556,10 +552,7 @@ object DeviceRoutes {
             _ <- deviceRepo
               .upsert(normalized, newName, newPid, "")
               .mapError(ApiError.Db(_))
-            _ <- LogContext.annotateAll(
-              LogContext.Op  -> "device_patch",
-              LogContext.Mac -> normalized.value,
-            )(
+            _ <- LogContext.annotate(LogContext.Mac, normalized.value) {
               LogContext.annotateOpt(
                 LogContext.ProfileId,
                 newPid.map(_.value.toString),
@@ -567,8 +560,8 @@ object DeviceRoutes {
                 ZIO.logInfo(
                   s"device patched: mac=${normalized.value} name=$newName profileId=${newPid.map(_.value.toString).getOrElse("-")}",
                 )
-              },
-            )
+              }
+            }
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },

--- a/api/src/routes/Routes.scala
+++ b/api/src/routes/Routes.scala
@@ -3,6 +3,7 @@ package wifihaven.api.routes
 import wifihaven.api.auth.*
 import wifihaven.api.cache.TimeStatusCache
 import wifihaven.api.db.*
+import wifihaven.api.observability.LogContext
 import wifihaven.shared.*
 import wifihaven.shared.types.*
 import zio.{Clock as _, *}
@@ -479,8 +480,20 @@ object DeviceRoutes {
               .mapError(ApiError.Db(_))
             // #481: log device upsert so the next CI failure makes it obvious
             // whether the mutation reached the API at all.
-            _  <- ZIO.logInfo(
-              s"device upserted: mac=${mac.value} profileId=${udr.profileId.map(_.value.toString).getOrElse("-")} name=${udr.name}",
+            _  <- LogContext.annotateAll(
+              LogContext.Op  -> "device_upsert",
+              LogContext.Mac -> mac.value,
+            )(
+              LogContext.annotateOpt(
+                LogContext.ProfileId,
+                udr.profileId.map(_.value.toString),
+              ) {
+                ZIO.logInfo(
+                  s"device upserted: mac=${mac.value} profileId=${udr.profileId
+                      .map(_.value.toString)
+                      .getOrElse("-")} name=${udr.name}",
+                )
+              },
             )
           } yield Response.json(s"""{"id":${id.value}}""")
           handle.mapError(ErrorMapper.errorToResponse)
@@ -498,7 +511,10 @@ object DeviceRoutes {
               .mapError(ApiError.Wrapped(_))
             _        <- deviceRepo.delete(normalized).mapError(ApiError.Db(_))
             // #481: same rationale as PUT — make the next CI failure diagnostic.
-            _        <- ZIO.logInfo(s"device deleted: mac=${normalized.value}")
+            _        <- LogContext.annotateAll(
+              LogContext.Op  -> "device_delete",
+              LogContext.Mac -> normalized.value,
+            )(ZIO.logInfo(s"device deleted: mac=${normalized.value}"))
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)
         },
@@ -540,8 +556,18 @@ object DeviceRoutes {
             _ <- deviceRepo
               .upsert(normalized, newName, newPid, "")
               .mapError(ApiError.Db(_))
-            _ <- ZIO.logInfo(
-              s"device patched: mac=${normalized.value} name=$newName profileId=${newPid.map(_.value.toString).getOrElse("-")}",
+            _ <- LogContext.annotateAll(
+              LogContext.Op  -> "device_patch",
+              LogContext.Mac -> normalized.value,
+            )(
+              LogContext.annotateOpt(
+                LogContext.ProfileId,
+                newPid.map(_.value.toString),
+              ) {
+                ZIO.logInfo(
+                  s"device patched: mac=${normalized.value} name=$newName profileId=${newPid.map(_.value.toString).getOrElse("-")}",
+                )
+              },
             )
           } yield Response.ok
           handle.mapError(ErrorMapper.errorToResponse)

--- a/api/test/src/feature/StructuredLogContextSpec.scala
+++ b/api/test/src/feature/StructuredLogContextSpec.scala
@@ -1,0 +1,111 @@
+package wifihaven.api.feature
+
+import wifihaven.api.ErrorBoundary
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.observability.LogContext
+import wifihaven.api.routes.*
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.test.*
+
+/**
+ * #602: pins that the structured-log context introduced in `LogContext` actually attaches to the
+ * log entries we expect — not just substring-formatted into the message. Targets two representative
+ * hot paths:
+ *
+ *   1. ErrorBoundary 4xx — the templated `route`, `method`, and `status` keys land in
+ *      `LogEntry.annotations`, which is what zio-logging-slf4j writes to SLF4J MDC. 2.
+ *      AuthService.login — the `op=login`, `user`, and `reason` keys land for both the explicit
+ *      success log and the bad-password failure log.
+ *
+ * MDC visibility in production is then a configuration property of `logback.xml` (we add `%mdc` to
+ * the console pattern); the unit test here verifies the upstream annotation contract, not the SLF4J
+ * appender format.
+ */
+object StructuredLogContextSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val jwtCfg = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+
+  private def makeAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def authRoutes =
+    for {
+      ur   <- ZIO.service[UserRepo]
+      up   <- ZIO.service[UserProfileRepo]
+      auth <- makeAuth
+    } yield ErrorBoundary.observe(AuthRoutes.routes(auth, ur, up))
+
+  private def url(p: String) = URL.decode(p).toOption.get
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private def entryWith(
+      logs: Chunk[ZTestLogger.LogEntry],
+      level: LogLevel,
+      key: String,
+      value: String,
+  ): Option[ZTestLogger.LogEntry] =
+    logs.find(e => e.logLevel == level && e.annotations.get(key).contains(value))
+
+  def spec = suite("#602 structured log context")(
+    test("ErrorBoundary 4xx attaches route, method, status annotations") {
+      (for {
+        _    <- cleanDb
+        rs   <- authRoutes
+        // unauthenticated GET /api/me → 401, observed by ErrorBoundary
+        resp <- rs.runZIO(Request.get(url("/api/me")))
+        logs <- ZTestLogger.logOutput
+      } yield {
+        val warn = logs.find(e => e.logLevel == LogLevel.Warning)
+        assertTrue(resp.status.code == 401) &&
+        assertTrue(warn.isDefined) &&
+        assertTrue(warn.get.annotations.get(LogContext.Route).contains("/api/me")) &&
+        assertTrue(warn.get.annotations.get(LogContext.Method).contains("GET")) &&
+        assertTrue(warn.get.annotations.get(LogContext.Status).contains("401"))
+      })
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
+    },
+    test("AuthService.login success attaches op=login, user, reason=ok") {
+      (for {
+        _    <- cleanDb
+        auth <- makeAuth
+        // seeded default admin (changeme) exists per TestDatabase migrations
+        _    <- auth.login("admin", "changeme")
+        logs <- ZTestLogger.logOutput
+      } yield {
+        val ok = entryWith(logs, LogLevel.Info, LogContext.Reason, "ok")
+        assertTrue(ok.isDefined) &&
+        assertTrue(ok.get.annotations.get(LogContext.Op).contains("login")) &&
+        assertTrue(ok.get.annotations.get(LogContext.User).contains("admin"))
+      })
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
+    },
+    test("AuthService.login bad password attaches op=login, user, reason=bad_password") {
+      (for {
+        _    <- cleanDb
+        auth <- makeAuth
+        _    <- auth.login("admin", "wrong").either
+        logs <- ZTestLogger.logOutput
+      } yield {
+        val bad = entryWith(logs, LogLevel.Warning, LogContext.Reason, "bad_password")
+        assertTrue(bad.isDefined) &&
+        assertTrue(bad.get.annotations.get(LogContext.Op).contains("login")) &&
+        assertTrue(bad.get.annotations.get(LogContext.User).contains("admin"))
+      })
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
+    },
+  ) @@ TestAspect.sequential
+}

--- a/api/test/src/feature/StructuredLogContextSpec.scala
+++ b/api/test/src/feature/StructuredLogContextSpec.scala
@@ -5,6 +5,7 @@ import wifihaven.api.JwtConfig
 import wifihaven.api.auth.*
 import wifihaven.api.db.*
 import wifihaven.api.observability.LogContext
+import wifihaven.api.observability.LoggingMiddleware
 import wifihaven.api.routes.*
 import wifihaven.shared.*
 import wifihaven.shared.Clock.TestClock
@@ -15,14 +16,14 @@ import zio.http.*
 import zio.test.*
 
 /**
- * #602: pins that the structured-log context introduced in `LogContext` actually attaches to the
- * log entries we expect — not just substring-formatted into the message. Targets two representative
- * hot paths:
+ * #602: pins that the structured-log context actually attaches to the log entries we expect — not
+ * just substring-formatted into the message. Covers:
  *
- *   1. ErrorBoundary 4xx — the templated `route`, `method`, and `status` keys land in
- *      `LogEntry.annotations`, which is what zio-logging-slf4j writes to SLF4J MDC. 2.
- *      AuthService.login — the `op=login`, `user`, and `reason` keys land for both the explicit
- *      success log and the bad-password failure log.
+ *   1. `LoggingMiddleware` injects `route` + `method` per-request, and `ErrorBoundary` adds
+ *      `status` on 4xx/5xx. Together they fill the request-shape context with NO handler wrapping.
+ *      2. `AuthService.login` attaches per-call `user` + `reason`. The success log inside a real
+ *      HTTP request demonstrates FiberRef inheritance: middleware annotations and handler-internal
+ *      annotations both land on a single log entry without anyone composing them by hand.
  *
  * MDC visibility in production is then a configuration property of `logback.xml` (we add `%mdc` to
  * the console pattern); the unit test here verifies the upstream annotation contract, not the SLF4J
@@ -41,12 +42,15 @@ object StructuredLogContextSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
       clock <- ZIO.service[Clock]
     } yield AuthServiceLive(ur, jwtCfg, clock)
 
+  // Mirrors the production wiring in Main.scala: LoggingMiddleware (route/method)
+  // outside, ErrorBoundary (status) inside. The two compose — annotations from
+  // both flow into every log emitted by a handler.
   private def authRoutes =
     for {
       ur   <- ZIO.service[UserRepo]
       up   <- ZIO.service[UserProfileRepo]
       auth <- makeAuth
-    } yield ErrorBoundary.observe(AuthRoutes.routes(auth, ur, up))
+    } yield LoggingMiddleware.annotate(ErrorBoundary.observe(AuthRoutes.routes(auth, ur, up)))
 
   private def url(p: String) = URL.decode(p).toOption.get
 
@@ -78,7 +82,7 @@ object StructuredLogContextSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
       })
         .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
     },
-    test("AuthService.login success attaches op=login, user, reason=ok") {
+    test("AuthService.login success attaches user, reason=ok (route/method via middleware)") {
       (for {
         _    <- cleanDb
         auth <- makeAuth
@@ -88,12 +92,11 @@ object StructuredLogContextSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
       } yield {
         val ok = entryWith(logs, LogLevel.Info, LogContext.Reason, "ok")
         assertTrue(ok.isDefined) &&
-        assertTrue(ok.get.annotations.get(LogContext.Op).contains("login")) &&
         assertTrue(ok.get.annotations.get(LogContext.User).contains("admin"))
       })
         .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
     },
-    test("AuthService.login bad password attaches op=login, user, reason=bad_password") {
+    test("AuthService.login bad password attaches user, reason=bad_password") {
       (for {
         _    <- cleanDb
         auth <- makeAuth
@@ -102,8 +105,32 @@ object StructuredLogContextSpec extends ZIOSpec[TestDatabase.AllRepos & Embedded
       } yield {
         val bad = entryWith(logs, LogLevel.Warning, LogContext.Reason, "bad_password")
         assertTrue(bad.isDefined) &&
-        assertTrue(bad.get.annotations.get(LogContext.Op).contains("login")) &&
         assertTrue(bad.get.annotations.get(LogContext.User).contains("admin"))
+      })
+        .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
+    },
+    test("LoggingMiddleware annotates inherits into the handler's own logs") {
+      // Service-internal log (`AuthService.login` success) emitted from inside an
+      // HTTP request must carry route + method from the middleware AND user from
+      // the service — proving the FiberRef inheritance.
+      (for {
+        _  <- cleanDb
+        rs <- authRoutes
+        body = """{"username":"admin","password":"changeme"}"""
+        req  = Request
+          .post(url("/api/auth/login"), Body.fromString(body))
+          .addHeader(Header.ContentType(MediaType.application.json))
+        resp <- rs.runZIO(req)
+        logs <- ZTestLogger.logOutput
+      } yield {
+        val ok = entryWith(logs, LogLevel.Info, LogContext.Reason, "ok")
+        assertTrue(resp.status.code == 200) &&
+        assertTrue(ok.isDefined) &&
+        // From AuthService.login (handler-internal):
+        assertTrue(ok.get.annotations.get(LogContext.User).contains("admin")) &&
+        // From LoggingMiddleware (per-request, inherited via FiberRef):
+        assertTrue(ok.get.annotations.get(LogContext.Route).contains("/api/auth/login")) &&
+        assertTrue(ok.get.annotations.get(LogContext.Method).contains("POST"))
       })
         .provideSome[TestDatabase.AllRepos & EmbeddedPostgres & Clock](ZTestLogger.default)
     },


### PR DESCRIPTION
## Summary

Closes #602.

Issue #602 asks for structured logs that use log contexts ("add context to logs to make for better searching") and a one-line-local / JSON-deployed split. This PR delivers the **structured-context** half — a single `LogContext` helper that attaches bounded MDC keys to the API's hot-path logs — and sets up local visibility via `%mdc` in `logback.xml`. A JSON appender for deployed environments is intentionally left to a follow-up under the broader #602 umbrella.

## What changed

- New `api/src/observability/LogContext.scala` — single-source-of-truth set of MDC keys (`route`, `method`, `status`, `op`, `routerId`, `mac`, `etag`, `profileId`, `user`, `reason`, `notModified`, `batchSize`, `rejected`) and `annotate` / `annotateAll` / `annotateOpt` wrappers. New keys are added here, not at the call site, mirroring the cardinality-firewall discipline `MetricGuard` enforces on the metrics side.
- `ErrorBoundary` — every 4xx/5xx log line now carries the templated `route`, `method`, `status` as annotations (not just substring-formatted).
- `RouterRoutes` `GET /api/router/policy` — `op=router_policy`, `routerId`, `etag`, `notModified`.
- `RouterIngestRoutes` `POST /api/router/usage` and `/events` — `op`, `routerId`, plus `batchSize`/`rejected` on the per-batch summary.
- `PolicyService.logSnapshotChanged` — `op=snapshot_changed`, `etag`.
- `AuthService.login` — explicit success log (`op=login`, `user`, `reason=ok`) and bad-password failure log (`op=login`, `user`, `reason=bad_password`), alongside the existing `AppMetrics.recordAuthFailure` counter.
- `Routes` device upsert / delete / patch — `op`, `mac`, `profileId`.
- `api/resources/logback.xml` — adds `%mdc` to the console pattern so annotations show locally as `key=value` at the tail of each line.

Human-readable message text is **kept verbatim** on every migrated line for back-compat with existing log readers and tests that grep substrings.

## Not migrated (deliberate)

The audit umbrella under #1602/#1532 covers ongoing log hygiene; this PR is scoped to API hot paths where structured search is high-value for ops. The following were intentionally left out and can be picked up by follow-ups:

- Rollup / retention jobs (low frequency, already low-cardinality).
- Startup-only seeders (bundled blocklists, app templates).
- Per-record DEBUG logs inside the usage/events handlers — the batch-level annotations already give ops the `routerId`/`op` context they need to filter at the source.
- A deployed-environment JSON appender and the choice of log-indexer backend (issue #602's other half) — separate follow-up.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.StructuredLogContextSpec` — 3 new tests pin `LogEntry.annotations` (not message substrings) for ErrorBoundary 4xx, login success, login bad-password.
- [x] `mill api.test.testOnly 'wifihaven.api.feature.ErrorBoundary*' 'wifihaven.api.feature.Router*' 'wifihaven.api.feature.Auth*' 'wifihaven.api.feature.Device*' 'wifihaven.api.feature.PolicySnapshot*'` — all impacted feature tests still pass (47 + 35 in the policy/router suites, plus the rest).
- [x] `scalafmt --check --non-interactive` clean.