### PR TITLE
audit(#1532): sweep N — source BlockedRoutes reasonClass from BlockReason.wireKind; file follow-ups

### DIFF
--- a/api/src/routes/BlockedRoutes.scala
+++ b/api/src/routes/BlockedRoutes.scala
@@ -133,20 +133,29 @@ object BlockedRoutes {
       reason: String,
       blocklistRepo: BlocklistRepo,
   ): Task[(String, Option[String])] = BlockReason.fromWire(reason) match {
-    case MacBlockReason.Paused         => ZIO.succeed(("paused", None))
-    case MacBlockReason.Schedule       => ZIO.succeed(("schedule", None))
-    case MacBlockReason.TimeLimit      => ZIO.succeed(("time_limit", None))
-    case BlockReason.ExtraBlocked      => ZIO.succeed(("extra_blocked", None))
-    case BlockReason.ExtraBlockedBy(_) => ZIO.succeed(("extra_blocked", None)) // #1645
-    case BlockReason.AppTimeLimit(_)   =>
-      // #1518: rename `site_time_limit` → `app_time_limit`. SPA-API surface,
-      // updated atomically with the SPA in the same PR.
-      ZIO.succeed(("app_time_limit", None))
-    case BlockReason.Category(id)      =>
+    // #1532: reasonClass strings are sourced from each case's `wireKind` rather
+    // than hand-written parallel literals. The block page's reason taxonomy and
+    // the BlockReason wire taxonomy are intentionally aligned; reading the value
+    // from `wireKind` keeps them aligned through future renames instead of
+    // leaving it to a "must mirror" comment.
+    case r @ MacBlockReason.Paused     => ZIO.succeed((r.wireKind, None))
+    case r @ MacBlockReason.Schedule   => ZIO.succeed((r.wireKind, None))
+    case r @ MacBlockReason.TimeLimit  => ZIO.succeed((r.wireKind, None))
+    case r @ BlockReason.ExtraBlocked  => ZIO.succeed((r.wireKind, None))
+    case BlockReason.ExtraBlockedBy(_) =>
+      // #1645: a per-flow host block from another path still renders as the
+      // generic "extra_blocked" class — the block page does not distinguish
+      // ExtraBlocked vs ExtraBlockedBy(host).
+      ZIO.succeed((BlockReason.ExtraBlocked.wireKind, None))
+    case r: BlockReason.AppTimeLimit   =>
+      // #1518 rename (`site_time_limit` → `app_time_limit`); `r.wireKind` is the
+      // SPA-API surface string, updated atomically with the SPA in the same PR.
+      ZIO.succeed((r.wireKind, None))
+    case r @ BlockReason.Category(id)  =>
       blocklistRepo
         .findMeta(id)
-        .map(meta => ("category", meta.map(_.name)))
-        .catchAll(_ => ZIO.succeed(("category", None)))
+        .map(meta => (r.wireKind, meta.map(_.name)))
+        .catchAll(_ => ZIO.succeed((r.wireKind, None)))
     // Generic / unrecognized blocks. `decide()` only reaches mapReason on a Block decision, so the
     // allow-side cases (Allow/ExtraAllowed/NoProfile) are defensive; Manual/Unmanaged/DefaultDeny/
     // AppBlocked and any Unknown(raw) wire string render the neutral block copy rather than being

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -267,22 +267,24 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
           .AppTimeLimit("YouTube")
           .wireKind,
       )
-      ZIO
-        .foreach(cases) { case (wire, expected) =>
-          for {
-            _   <- cleanDb
-            pr  <- ZIO.service[ProfileRepo]
-            dr  <- ZIO.service[DeviceRepo]
-            blr <- ZIO.service[BlocklistRepo]
-            tss <- makeTimeStatus
-            hsr <- ZIO.service[HouseholdSettingsRepo]
-            clk <- ZIO.service[Clock]
-            routes = BlockedRoutes.routes(stub(wire), dr, pr, blr, tss, hsr, clk)
-            info <- callBlocked(routes, "aa:bb:cc:dd:ee:ff", "example.com")
-          } yield assertTrue(info.blocked) &&
-            assertTrue(info.reasonClass.contains(expected))
+      // The stub PolicyService short-circuits before any repo read, so a single
+      // cleanDb + shared service binding is sufficient for all cases — no need to
+      // pay the embedded-Postgres reset per case.
+      for {
+        _       <- cleanDb
+        pr      <- ZIO.service[ProfileRepo]
+        dr      <- ZIO.service[DeviceRepo]
+        blr     <- ZIO.service[BlocklistRepo]
+        tss     <- makeTimeStatus
+        hsr     <- ZIO.service[HouseholdSettingsRepo]
+        clk     <- ZIO.service[Clock]
+        results <- ZIO.foreach(cases) { case (wire, expected) =>
+          val routes = BlockedRoutes.routes(stub(wire), dr, pr, blr, tss, hsr, clk)
+          callBlocked(routes, "aa:bb:cc:dd:ee:ff", "example.com").map { info =>
+            assertTrue(info.blocked) && assertTrue(info.reasonClass.contains(expected))
+          }
         }
-        .map(_.reduce(_ && _))
+      } yield results.reduce(_ && _)
     },
     // #335: kid-side block page must show today's usage so a restricted kid can see
     // *why* their time is gone, not just that it is. The fields are populated for any

--- a/api/test/src/feature/BlockedApiSpec.scala
+++ b/api/test/src/feature/BlockedApiSpec.scala
@@ -235,6 +235,55 @@ object BlockedApiSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres &
         assertTrue(info.reasonClass.contains("blocked")) &&
         assertTrue(info.categoryName.isEmpty)
     },
+    // #1532: pins the reasonClass invariant — for every BlockReason case that
+    // BlockedRoutes.mapReason recognizes, the reasonClass it emits MUST equal that
+    // case's wireKind (or the documented generic "blocked" fallthrough for the
+    // unrecognized-on-the-block-page bucket). This is the test-pin behind the
+    // collapse that sources reasonClass strings from `wireKind` instead of
+    // hand-written literals — the test holds both before and after.
+    test("reasonClass strings track BlockReason.wireKind for every recognized case") {
+      def stub(wire: String): PolicyService = new PolicyService {
+        def snapshot: Task[PolicySnapshot]                                      =
+          ZIO.dieMessage("snapshot unused in this test")
+        def renderBlocklist(id: BlocklistId): Task[Option[(ETag, String)]]      =
+          ZIO.dieMessage("renderBlocklist unused in this test")
+        def decide(mac: String, hostname: String): Task[RouterDecisionResponse] =
+          ZIO.succeed(RouterDecisionResponse(ConnectionDecision.Block, wire, None))
+      }
+      // Each entry is (wire reason string emitted by decide(), expected reasonClass).
+      // The expected value is taken directly from the case's `wireKind` — if a
+      // wireKind is renamed in shared/Models the same value flows through here.
+      val cases: List[(String, String)]     = List(
+        BlockReason.asWire(MacBlockReason.Paused)    -> MacBlockReason.Paused.wireKind,
+        BlockReason.asWire(MacBlockReason.Schedule)  -> MacBlockReason.Schedule.wireKind,
+        BlockReason.asWire(MacBlockReason.TimeLimit) -> MacBlockReason.TimeLimit.wireKind,
+        BlockReason.asWire(BlockReason.ExtraBlocked) -> BlockReason.ExtraBlocked.wireKind,
+        BlockReason.asWire(
+          BlockReason.ExtraBlockedBy(
+            Hostname.unsafe("example.com"),
+          ),
+        )                                            -> BlockReason.ExtraBlocked.wireKind,
+        BlockReason.asWire(BlockReason.AppTimeLimit("YouTube")) -> BlockReason
+          .AppTimeLimit("YouTube")
+          .wireKind,
+      )
+      ZIO
+        .foreach(cases) { case (wire, expected) =>
+          for {
+            _   <- cleanDb
+            pr  <- ZIO.service[ProfileRepo]
+            dr  <- ZIO.service[DeviceRepo]
+            blr <- ZIO.service[BlocklistRepo]
+            tss <- makeTimeStatus
+            hsr <- ZIO.service[HouseholdSettingsRepo]
+            clk <- ZIO.service[Clock]
+            routes = BlockedRoutes.routes(stub(wire), dr, pr, blr, tss, hsr, clk)
+            info <- callBlocked(routes, "aa:bb:cc:dd:ee:ff", "example.com")
+          } yield assertTrue(info.blocked) &&
+            assertTrue(info.reasonClass.contains(expected))
+        }
+        .map(_.reduce(_ && _))
+    },
     // #335: kid-side block page must show today's usage so a restricted kid can see
     // *why* their time is gone, not just that it is. The fields are populated for any
     // enrolled MAC (blocked or not) so the page can render usage on a non-blocked


### PR DESCRIPTION
Sweep N of the #1532 duplicated-decision audit. This PR ships **only the trivial collapse** found in the sweep; the medium-risk findings are filed as separate sub-issues per the audit-PR convention.

## What changed in this PR

\`api/src/routes/BlockedRoutes.scala\` — the block-page \`mapReason\` previously emitted \`reasonClass\` strings as hand-written literals (\`"paused"\`, \`"schedule"\`, \`"time_limit"\`, \`"app_time_limit"\`, \`"extra_blocked"\`, \`"category"\`) that just happened to equal each \`BlockReason\` case's \`.wireKind\`. A future \`wireKind\` rename would have silently drifted the block page. The literals are now read off the bound case's \`.wireKind\`, so the compiler keeps the alignment by construction.

\`api/test/src/feature/BlockedApiSpec.scala\` — a parameterised feature test pins the invariant for every recognised case. Committed first as a separate red-pin commit; the test holds before AND after the collapse.

The pre-existing generic-block fallthrough (\`"blocked"\` for \`Allow\` / \`Blocked\` / \`ExtraAllowed\` / \`NoProfile\` / \`AppBlocked\` / \`Unknown\` / \`Manual\` / \`Unmanaged\` / \`DefaultDeny\`) is unchanged — that bucket isn't aligned with any single \`wireKind\` and is intentionally generic per #1545.

## Sweep findings — full classification

| # | Finding | Classification | Disposition |
|---|---------|----------------|-------------|
| 1 | \`Routes.scala:1325\` \`windowTier\`/\`rank\` duplicates \`UsageRoutes.windowTier\` | MEDIUM | Filed #1744 (blocked on open PR #1732 in same file) |
| 2 | \`web/retentionGating.ts\` retention day constants hard-coded vs \`RetentionSweepJob\` | MEDIUM | Filed #1740 |
| 3 | LATERAL FQDN-resolve CTE duplicated across \`RollupRepo\` + 6 sites in \`Repos.scala\` | MEDIUM | Filed #1741 |
| 4 | \`PolicyService.isScheduleBlock\` re-derived in snapshot vs live-decide paths | MEDIUM | Filed #1742 |
| 5 | \`BlockedRoutes.mapReason\` reasonClass literals parallel to \`wireKind\` | **TRIVIAL** | **Collapsed in this PR** |
| 6 | Web \`BUCKET_TIER\` mirrors shared \`BucketPolicy.grainForBucket\` | MEDIUM | Filed #1743 (likely lands with #1740) |
| 7 | Stale \`// must mirror\` comment in \`Routes.scala:1382\` (already collapsed) | TRIVIAL (comment) | Rolled into #1744 (same-file PR conflict) |

No LARGE / RISKY findings.
No new WIRE-SHAPE-CARVE-OUT violations spotted (infra-allow copy, profiles map, #1718 host block are all intentional per AGENTS.md and not flagged).

## Out of scope

Findings 1 and 7 are deferred to #1744 because PR #1732 is actively touching \`Routes.scala\`; collapsing here would conflict. #1744 is gated on #1732 merging.

## Test plan

- [x] \`mill api.test.testOnly wifihaven.api.feature.BlockedApiSpec\` passes pre-collapse (test-pin commit, 9/9)
- [x] Same suite passes post-collapse (9/9)
- [x] \`scalafmt --check --non-interactive\` clean
- [ ] CI green
- [ ] Independent /pr-review pass posted

Refs #1532 (umbrella — do not close).