### PR TITLE
refactor(#1741): extract shared LATERAL FQDN-resolve CTE fragment

### DIFF
--- a/api/src/db/Repos.scala
+++ b/api/src/db/Repos.scala
@@ -1890,16 +1890,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                  tr.date::TEXT, tr.period_start::TEXT, tr.period_end::TEXT,
                  tr.active_seconds, tr.bytes_in, tr.bytes_out
           FROM traffic_reports tr
-          LEFT JOIN LATERAL (
-            SELECT resolved_host_value
-            FROM connection_events
-            WHERE mac          = tr.mac
-              AND dest_ip      = tr.host_value
-              AND resolved_host_value IS NOT NULL
-              AND ts >= tr.date::TIMESTAMPTZ
-              AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-            ORDER BY ts DESC LIMIT 1
-          ) ce ON tr.host_type IN ('ipv4','ipv6')
+          ${SqlFragments.resolvedHostLateral}
           WHERE tr.router_id = $routerId
           ORDER BY tr.period_start DESC LIMIT $limit"""
       .query[R]
@@ -1939,16 +1930,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                                tr.host_value),
                       tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end
                FROM traffic_reports tr
-               LEFT JOIN LATERAL (
-                 SELECT resolved_host_value
-                 FROM connection_events
-                 WHERE mac          = tr.mac
-                   AND dest_ip      = tr.host_value
-                   AND resolved_host_value IS NOT NULL
-                   AND ts >= tr.date::TIMESTAMPTZ
-                   AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-                 ORDER BY ts DESC LIMIT 1
-               ) ce ON tr.host_type IN ('ipv4','ipv6')
+               ${SqlFragments.resolvedHostLateral}
                WHERE tr.period_start >= $fromInstant AND tr.period_start < $toInstant
                  AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
                  AND """ ++ Fragments.in(fr"tr.mac", nel)
@@ -1986,16 +1968,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                                tr.host_value),
                       tr.active_seconds, tr.bytes_in, tr.bytes_out, tr.period_start, tr.period_end
                FROM traffic_reports tr
-               LEFT JOIN LATERAL (
-                 SELECT resolved_host_value
-                 FROM connection_events
-                 WHERE mac          = tr.mac
-                   AND dest_ip      = tr.host_value
-                   AND resolved_host_value IS NOT NULL
-                   AND ts >= tr.date::TIMESTAMPTZ
-                   AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-                 ORDER BY ts DESC LIMIT 1
-               ) ce ON tr.host_type IN ('ipv4','ipv6')
+               ${SqlFragments.resolvedHostLateral}
                WHERE tr.date BETWEEN $from AND $to
                  AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
                  AND """ ++ Fragments.in(fr"tr.mac", nel) ++
@@ -2033,16 +2006,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                   tr.period_start, tr.period_end,
                   tr.active_seconds, tr.bytes_in, tr.bytes_out
            FROM traffic_reports tr
-           LEFT JOIN LATERAL (
-             SELECT resolved_host_value
-             FROM connection_events
-             WHERE mac          = tr.mac
-               AND dest_ip      = tr.host_value
-               AND resolved_host_value IS NOT NULL
-               AND ts >= tr.date::TIMESTAMPTZ
-               AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-             ORDER BY ts DESC LIMIT 1
-           ) ce ON tr.host_type IN ('ipv4','ipv6')
+           ${SqlFragments.resolvedHostLateral}
            WHERE tr.period_start >= $fromInstant AND tr.period_start < $toInstant
              AND (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0) """
     val macFilter  = macs match {
@@ -2097,16 +2061,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                    ) AS host,
                    (tr.bytes_in + tr.bytes_out) AS bytes
             FROM traffic_reports tr
-            LEFT JOIN LATERAL (
-              SELECT resolved_host_value
-              FROM connection_events
-              WHERE mac          = tr.mac
-                AND dest_ip      = tr.host_value
-                AND resolved_host_value IS NOT NULL
-                AND ts >= tr.date::TIMESTAMPTZ
-                AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-              ORDER BY ts DESC LIMIT 1
-            ) ce ON tr.host_type IN ('ipv4','ipv6')
+            ${SqlFragments.resolvedHostLateral}
             WHERE tr.mac = $mac
               AND tr.period_start >= $fromInstant
               AND tr.period_start <  $toInstant
@@ -2135,16 +2090,7 @@ class TrafficReportRepoLive(xa: Transactor[Task]) extends TrafficReportRepo {
                   tr.date, tr.period_start, tr.period_end,
                   tr.active_seconds, tr.bytes_in, tr.bytes_out
            FROM traffic_reports tr
-           LEFT JOIN LATERAL (
-             SELECT resolved_host_value
-             FROM connection_events
-             WHERE mac          = tr.mac
-               AND dest_ip      = tr.host_value
-               AND resolved_host_value IS NOT NULL
-               AND ts >= tr.date::TIMESTAMPTZ
-               AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-             ORDER BY ts DESC LIMIT 1
-           ) ce ON tr.host_type IN ('ipv4','ipv6')
+           ${SqlFragments.resolvedHostLateral}
            WHERE 1=1"""
     val byMacs  = f.macs match {
       case None      => fr""

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -202,7 +202,7 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
           tr.bytes_in,
           tr.bytes_out
         FROM traffic_reports tr
-        """ ++ SqlFragments.resolvedHostLateral ++ fr"""
+        ${SqlFragments.resolvedHostLateral}
         WHERE (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
       """
 

--- a/api/src/db/RollupRepo.scala
+++ b/api/src/db/RollupRepo.scala
@@ -184,9 +184,8 @@ trait RollupRepo {
 
 class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
 
-  // The LATERAL FQDN-resolve mirrors TrafficReportRepoLive — keep them in
-  // lockstep. If the read-time resolve in traffic_reports queries ever
-  // changes, this CTE must change too.
+  // The FQDN-resolve LATERAL is centralised in SqlFragments so this CTE and
+  // every TrafficReportRepoLive read use the same join shape (#1741).
   private val resolvedCte =
     fr"""
       WITH resolved AS (
@@ -203,16 +202,7 @@ class RollupRepoLive(xa: Transactor[Task]) extends RollupRepo {
           tr.bytes_in,
           tr.bytes_out
         FROM traffic_reports tr
-        LEFT JOIN LATERAL (
-          SELECT resolved_host_value
-          FROM connection_events
-          WHERE mac                 = tr.mac
-            AND dest_ip             = tr.host_value
-            AND resolved_host_value IS NOT NULL
-            AND ts >= tr.date::TIMESTAMPTZ
-            AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
-          ORDER BY ts DESC LIMIT 1
-        ) ce ON tr.host_type IN ('ipv4','ipv6')
+        """ ++ SqlFragments.resolvedHostLateral ++ fr"""
         WHERE (tr.active_seconds > 0 OR tr.bytes_in > 0 OR tr.bytes_out > 0)
       """
 

--- a/api/src/db/SqlFragments.scala
+++ b/api/src/db/SqlFragments.scala
@@ -1,0 +1,31 @@
+package wifihaven.api.db
+
+import doobie.*
+import doobie.implicits.*
+
+// Shared SQL fragments used across repos to keep duplicated read-side joins
+// in one place (#1532 SSOT audit, #1741).
+object SqlFragments {
+
+  // Promotes ipv4/ipv6-typed `traffic_reports` rows to their resolved fqdn by
+  // looking up the most recent `connection_events` row for the same
+  // (mac, dest_ip) that has a resolved_host_value, within the row's own day.
+  // The partial index added in V22 (idx_conn_events_mac_dest_resolved) —
+  // tightened in V34 after the #1240 / #1254 prod outage — is what keeps the
+  // join cheap; any change to this join's columns or bounds must keep that
+  // index covering it. Expects the outer query to alias `traffic_reports`
+  // as `tr`; binds the result as `ce`.
+  // TODO(#730): remove once usage records carry dest_ip directly and the
+  // read-side resolve is no longer needed.
+  val resolvedHostLateral: Fragment =
+    fr"""LEFT JOIN LATERAL (
+           SELECT resolved_host_value
+           FROM connection_events
+           WHERE mac          = tr.mac
+             AND dest_ip      = tr.host_value
+             AND resolved_host_value IS NOT NULL
+             AND ts >= tr.date::TIMESTAMPTZ
+             AND ts <  (tr.date + INTERVAL '1 day')::TIMESTAMPTZ
+           ORDER BY ts DESC LIMIT 1
+         ) ce ON tr.host_type IN ('ipv4','ipv6')"""
+}


### PR DESCRIPTION
## Summary

The hand-rolled `LEFT JOIN LATERAL` that promotes ipv4/ipv6-typed `traffic_reports` rows to their resolved fqdn (via the most recent matching `connection_events.resolved_host_value` within the row's day) was duplicated across **six** `TrafficReportRepoLive` read paths plus the `resolvedCte` in `RollupRepoLive`. Every copy was byte-identical, and the comment on the rollup copy openly admitted the keep-in-sync coupling — exactly the §single-source-of-truth anti-pattern #1532 is sweeping. The blast radius is non-theoretical: this is the LATERAL whose missing supporting index caused the #1240 / #1254 prod outage.

Pull the join into `wifihaven.api.db.SqlFragments.resolvedHostLateral` and interpolate it at every identical site. The supporting-index pointer (V22 / V34 partial index on `(mac, dest_ip, ts) WHERE resolved_host_value IS NOT NULL`) and the `TODO(#730)` lives anchored to that one fragment now.

Sites collapsed (alias `tr` for `traffic_reports`, day-bound from `tr.date`):

- `api/src/db/RollupRepo.scala` — `resolvedCte` (the comment that flagged the drift)
- `api/src/db/Repos.scala` — `listForRouter`, `listPresenceRowsInWindow`, `listPresenceRowsBetween`, `listRawInRange`, `listFqdnHostAggregatesForDevice`, `listTrafficRollupRows`

Intentionally **left alone** (to keep this a pure extract per the §1741 charter — the prompt forbids semantic changes):

- `TrafficReportRepoLive.listForDevice` — binds the day with a `$date` parameter rather than `tr.date`. Semantically equivalent under the outer `WHERE tr.date = $date`, but lexically different. Tracked as a follow-up sweep on #1532.
- `TimeUsageRepoLive.listForDevice` / `listForDeviceMacs` / `snapshotAll` — different table (`time_usage tu`), different mac column (`tu.device_mac`), parameterised day. Could share a parameterised variant later, but not part of this collapse.
- The two `RollupRepoLive.aggregateByApp{Hourly,Daily}` LATERALs — different shape entirely (`traffic_{hourly,daily}_apps` lookups), not FQDN-resolve.

## Plan / behaviour

Pure refactor. Emitted SQL differs only in interior whitespace; the join's column set, predicates, day bounds, ORDER BY, and `ON tr.host_type IN ('ipv4','ipv6')` clause are all unchanged. The query plan is therefore unchanged and still backed by the V22 / V34 supporting index that closed #1254 / #1256.

## §query-explain-before-merge

This PR introduces no new query and no changed plan — the canonical fragment expands to byte-identical-modulo-whitespace SQL at every site, and Postgres normalises whitespace before planning. The on-prod `EXPLAIN (ANALYZE, BUFFERS)` that backs the V22 / V34 partial index (run during #1254 / #1256 mitigation) still applies. The full `mill api.test` suite — which runs every Flyway migration on classpath against the same embedded Postgres these queries hit in prod — passes (192/192 modules; the suite executes the LATERAL via `listForRouter`, the rollup CTE via `RollupRepoSpec` / `AppUsedRollupSpec`, and the presence-row paths via `PresenceDefaultsPinSpec` / `TimeUsedRollupSpec`).

If the operator wants the on-prod `EXPLAIN` re-confirmed before merge, the read-only DSN in 1Password ("WifiHaven — Prod RO Postgres URL") is the route; happy to paste the plan summary when supplied — it needs an interactive step this session can't take.

## Test plan

- [x] `mill api.compile`
- [x] `mill api.test` — 192/192 modules pass
- [x] `mill api.checkFormatAll`
- [x] Pre-push hooks (scalafmt, migration-isolation) clean
- [ ] (Optional) on-prod `EXPLAIN (ANALYZE, BUFFERS)` re-run on `listRawInRange` to confirm the partial index is still used

Closes #1741. Refs #1532.