### PR TITLE
refactor(#1743): SPA reads bucket→grain mapping from API

### DIFF
--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -39,6 +39,20 @@ object UsageRoutes {
       clock: Clock,
   ): Routes[Any, Response] =
     Routes(
+      // #1743: bucket → grain mapping the SPA reads at boot to gate its
+      // date-picker, sourced from `BucketPolicy.bucketTiers` so the SPA no
+      // longer hand-mirrors `grainForBucket` in retentionGating.ts. (Paired
+      // with #1740 — the same endpoint will grow a `horizons` field there.)
+      Method.GET / "api" / "usage" / "config"                                   ->
+        handler { (req: Request) =>
+          val handle: ZIO[Any, ApiError, Response] = for {
+            _ <- requireAuth(req, auth).mapError(ApiError.Wrapped(_))
+            cfg = UsageConfig(
+              bucketTiers = BucketPolicy.bucketTiers.view.mapValues(_.wire).toMap,
+            )
+          } yield Response.json(cfg.toJson)
+          handle.mapError(ErrorMapper.errorToResponse)
+        },
       Method.GET / "api" / "usage" / "traffic"                                  ->
         handler { (req: Request) =>
           trafficHandler(

--- a/api/src/routes/UsageRoutes.scala
+++ b/api/src/routes/UsageRoutes.scala
@@ -43,6 +43,9 @@ object UsageRoutes {
       // date-picker, sourced from `BucketPolicy.bucketTiers` so the SPA no
       // longer hand-mirrors `grainForBucket` in retentionGating.ts. (Paired
       // with #1740 — the same endpoint will grow a `horizons` field there.)
+      // No bespoke metric: the HTTP middleware already meters `route`,
+      // `status`, and duration for this path, and the response is a static
+      // constant with no failure modes beyond auth.
       Method.GET / "api" / "usage" / "config"                                   ->
         handler { (req: Request) =>
           val handle: ZIO[Any, ApiError, Response] = for {

--- a/api/test/src/feature/UsageConfigSpec.scala
+++ b/api/test/src/feature/UsageConfigSpec.scala
@@ -100,5 +100,5 @@ object UsageConfigSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres 
         resp <- routes.runZIO(Request.get(url))
       } yield assertTrue(resp.status == Status.Unauthorized)
     },
-  )
+  ) @@ TestAspect.sequential
 }

--- a/api/test/src/feature/UsageConfigSpec.scala
+++ b/api/test/src/feature/UsageConfigSpec.scala
@@ -1,0 +1,104 @@
+package wifihaven.api.feature
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import wifihaven.api.JwtConfig
+import wifihaven.api.auth.*
+import wifihaven.api.db.*
+import wifihaven.api.routes.UsageRoutes
+import wifihaven.shared.*
+import wifihaven.shared.Clock.TestClock
+import wifihaven.testinfra.*
+import zio.{Clock as _, *}
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+// #1743: GET /api/usage/config emits the bucket → grain mapping so the SPA
+// (web/src/components/usage/retentionGating.ts) reads it at runtime instead of
+// hand-maintaining a parallel literal that must mirror `BucketPolicy.grainForBucket`.
+object UsageConfigSpec extends ZIOSpec[TestDatabase.AllRepos & EmbeddedPostgres & Clock] {
+
+  override val bootstrap =
+    TestDatabase.layer ++ TestLayers.withClock(TestClock.schoolDayAfternoon)
+
+  private val cleanDb = TestDatabase.cleanAndMigrate
+
+  private val jwtCfg    = JwtConfig(secret = "test-secret-at-least-32-chars!!", expiryHours = 1)
+  private def buildAuth =
+    for {
+      ur    <- ZIO.service[UserRepo]
+      clock <- ZIO.service[Clock]
+    } yield AuthServiceLive(ur, jwtCfg, clock)
+
+  private def buildRoutes =
+    for {
+      deviceRepo      <- ZIO.service[DeviceRepo]
+      trafficRepo     <- ZIO.service[TrafficReportRepo]
+      userProfileRepo <- ZIO.service[UserProfileRepo]
+      profileRepo     <- ZIO.service[ProfileRepo]
+      appRepo         <- ZIO.service[AppRepo]
+      rollupRepo      <- ZIO.service[RollupRepo]
+      hsRepo          <- ZIO.service[HouseholdSettingsRepo]
+      atlRepo         <- ZIO.service[AppTimeLimitRepo]
+      aruRepo         <- ZIO.service[AppUsedRollupRepo]
+      clock           <- ZIO.service[Clock]
+      auth            <- buildAuth
+    } yield (
+      UsageRoutes.routes(
+        auth,
+        deviceRepo,
+        trafficRepo,
+        userProfileRepo,
+        profileRepo,
+        appRepo,
+        rollupRepo,
+        hsRepo,
+        atlRepo,
+        aruRepo,
+        clock,
+      ),
+      auth,
+    )
+
+  private def loginAdmin(auth: AuthService): Task[String] =
+    auth
+      .login("admin", "changeme")
+      .mapError(e => new RuntimeException(e.toString))
+      .map(_.token.value)
+
+  def spec = suite("GET /api/usage/config (#1743)")(
+    test("returns the canonical bucket → grain mapping from BucketPolicy") {
+      for {
+        _  <- cleanDb
+        rb <- buildRoutes
+        (routes, auth) = rb
+        token <- loginAdmin(auth)
+        url = URL.decode("/api/usage/config").toOption.get
+        resp <- routes.runZIO(Request.get(url).addHeader(Header.Authorization.Bearer(token)))
+        body <- resp.body.asString
+        out  <- ZIO.fromEither(body.fromJson[UsageConfig])
+        expected = BucketPolicy.bucketTiers.view.mapValues(_.wire).toMap
+      } yield assertTrue(
+        resp.status == Status.Ok,
+        out.bucketTiers == expected,
+        // Spot-checks so a future drop-the-test-and-just-pin-the-map regression
+        // doesn't silently green if BucketPolicy itself is broken.
+        out.bucketTiers("raw") == "raw",
+        out.bucketTiers("10m") == "raw",
+        out.bucketTiers("1h") == "hourly",
+        out.bucketTiers("12h") == "hourly",
+        out.bucketTiers("1d") == "daily",
+        out.bucketTiers("1w") == "daily",
+      )
+    },
+    test("requires auth") {
+      for {
+        _  <- cleanDb
+        rb <- buildRoutes
+        (routes, _) = rb
+        url         = URL.decode("/api/usage/config").toOption.get
+        resp <- routes.runZIO(Request.get(url))
+      } yield assertTrue(resp.status == Status.Unauthorized)
+    },
+  )
+}

--- a/shared/src/BucketPolicy.scala
+++ b/shared/src/BucketPolicy.scala
@@ -14,11 +14,23 @@ package wifihaven.shared
 // so the two can't disagree about which tier serves a width. This is the
 // single shared mapping that keeps them from drifting — and it is keyed on the
 // bucket, not the window.
-enum BucketGrain {
-  case Raw, Hourly, Daily
+enum BucketGrain(val wire: String) {
+  case Raw    extends BucketGrain("raw")
+  case Hourly extends BucketGrain("hourly")
+  case Daily  extends BucketGrain("daily")
+}
+
+object BucketGrain {
+  def fromWire(s: String): Option[BucketGrain] = values.find(_.wire == s)
 }
 
 object BucketPolicy {
+
+  /**
+   * Canonical list of bucket codes the API understands. Lives next to `grainForBucket` so the SPA
+   * can read both pieces from a single API surface (#1743) without re-listing buckets out-of-band.
+   */
+  val allBuckets: List[String] = List("raw", "1m", "10m", "1h", "12h", "1d", "1w")
 
   /**
    * Coarsest storage grain that can render `bucketCode` without losing resolution. Keyed on the
@@ -30,4 +42,11 @@ object BucketPolicy {
     case "1d" | "1w"  => BucketGrain.Daily
     case _            => BucketGrain.Raw
   }
+
+  /**
+   * Canonical bucket → grain mapping the API emits to the SPA (#1743). Built from `allBuckets` and
+   * `grainForBucket` so this stays the only place the classification is defined.
+   */
+  val bucketTiers: Map[String, BucketGrain] =
+    allBuckets.map(b => b -> grainForBucket(b)).toMap
 }

--- a/shared/src/Models.scala
+++ b/shared/src/Models.scala
@@ -1739,6 +1739,12 @@ object MacBlockReason {
   )
 }
 
+// #1743: client-facing usage config the SPA reads at boot. Today this is just
+// the bucket → grain mapping (so `retentionGating.ts` no longer hand-mirrors
+// `BucketPolicy.grainForBucket`); paired with #1740 it will also carry
+// retention horizons.
+case class UsageConfig(bucketTiers: Map[String, String]) derives JsonCodec
+
 // #962: typed reason for block_events / connection_events. Stored as JSONB
 // in Postgres tagged on `kind`. The router/PolicyService emit a free-form
 // wire string today; the API converts on ingest via `BlockReason.fromWire`.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,7 +8,7 @@ import type {
   PatchUserRequest, PatchAppRequest,
   NamedSchedule, NamedScheduleRequest,
   RecentApexesResponse, RouterSummary, SetUserProfilesRequest, TimeExtension,
-  TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse,
+  TrafficUsageBucket, TrafficUsageGroupBy, TrafficUsageResponse, UsageConfig,
   PatchDeviceRequest, PatchProfileRequest,
   UpsertAppAssignmentRequest, UpsertDeviceRequest, UpsertProfileRequest, GrantExtensionRequest,
   UsageSeriesBatchResponse, UsageSeriesResponse, User,
@@ -279,6 +279,10 @@ export const api = {
 
   // ── Usage (#716) ───────────────────────────────────────────────────────
   usage: {
+    // #1743: bucket → grain mapping (and, post-#1740, retention horizons).
+    // Sourced from `BucketPolicy.bucketTiers` on the API so the SPA stops
+    // hand-mirroring `grainForBucket` in retentionGating.ts.
+    config: () => req<UsageConfig>('GET', '/usage/config'),
     series: (params: {
       mac?: string
       profileId?: number

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -12,7 +12,7 @@ import type {
   ProfileTimeStatus,
   ProfileAppWeeklyUsage,
   ProfileTimeStatusWeek, ProfileTimeSummary, ProfileTimeSummaryWeek, ProfileUsageByApp,
-  QueryLog, UsageSeriesResponse,
+  QueryLog, UsageConfig, UsageSeriesResponse,
 } from '@/types/api'
 
 const MIN = 60_000
@@ -80,6 +80,19 @@ export function useProfiles(opts?: QueryOpts<ProfileDetail[]>) {
     queryKey: qk.profiles(),
     queryFn: () => api.profiles.list(),
     staleTime: STALE.profiles,
+    ...opts,
+  })
+}
+
+// #1743: bucket → grain mapping the API emits from BucketPolicy. Cached for an
+// hour because it's effectively a constant; the SPA falls back to the locally
+// shipped defaults when the fetch hasn't completed (or fails) so the
+// date-picker isn't blocked by network.
+export function useUsageConfig(opts?: QueryOpts<UsageConfig>) {
+  return useQuery({
+    queryKey: ['usage', 'config'] as const,
+    queryFn: () => api.usage.config(),
+    staleTime: 60 * MIN,
     ...opts,
   })
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -93,6 +93,8 @@ export function useUsageConfig(opts?: QueryOpts<UsageConfig>) {
     queryKey: ['usage', 'config'] as const,
     queryFn: () => api.usage.config(),
     staleTime: 60 * MIN,
+    // Effectively constant — survive page-mount churn without re-fetching.
+    gcTime: Infinity,
     ...opts,
   })
 }

--- a/web/src/components/usage/retentionGating.test.ts
+++ b/web/src/components/usage/retentionGating.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { TrafficUsageBucket } from '@/types/api'
 import {
+  DEFAULT_BUCKET_TIERS,
   DEFAULT_RETENTION_HORIZONS,
   bucketAvailability,
 } from './retentionGating'
@@ -79,5 +80,49 @@ describe('bucketAvailability — gate granularity on retention horizon', () => {
     expect(gates.raw.enabled).toBe(false)
     expect(gates['1h'].enabled).toBe(true)
     expect(gates['1d'].enabled).toBe(true)
+  })
+})
+
+// #1743: the bucket → grain mapping is API-driven (GET /api/usage/config); the
+// SPA falls back to DEFAULT_BUCKET_TIERS when the boot fetch hasn't returned.
+describe('bucketAvailability — API-driven bucket tiers (#1743)', () => {
+  it('falls back to DEFAULT_BUCKET_TIERS when no map is supplied', () => {
+    const gates = bucketAvailability(daysAgo(45), NOW, DEFAULT_RETENTION_HORIZONS)
+    // Defaults: raw goes through the raw tier, 1h through hourly.
+    expect(gates.raw.enabled).toBe(false)
+    expect(gates['1h'].enabled).toBe(true)
+  })
+
+  it('uses the supplied bucketTiers map to classify buckets', () => {
+    // Re-classify 1h as raw — at 45d it should now be gated out by the raw horizon.
+    const overridden = { ...DEFAULT_BUCKET_TIERS, '1h': 'raw' as const }
+    const gates = bucketAvailability(daysAgo(45), NOW, DEFAULT_RETENTION_HORIZONS, overridden)
+    expect(gates['1h'].enabled).toBe(false)
+    expect(gates['1h'].reason).toMatch(/30 days/)
+    // 1d is still daily-tier, still enabled.
+    expect(gates['1d'].enabled).toBe(true)
+  })
+
+  it('a bucket missing from the supplied map falls back to its default tier', () => {
+    // Partial map (older API image, or a smaller payload): only `raw` is listed.
+    const partial: Record<string, 'raw' | 'hourly' | 'daily'> = { raw: 'raw' }
+    const gates = bucketAvailability(daysAgo(120), NOW, DEFAULT_RETENTION_HORIZONS, partial)
+    // 1h should still be classified hourly via the default, and gated out at 120d.
+    expect(gates['1h'].enabled).toBe(false)
+    // 1d should still be classified daily via the default, and enabled at 120d.
+    expect(gates['1d'].enabled).toBe(true)
+  })
+
+  it('DEFAULT_BUCKET_TIERS mirrors BucketPolicy.grainForBucket', () => {
+    // Backstop sanity-check that the fallback agrees with the API's mapping.
+    expect(DEFAULT_BUCKET_TIERS).toEqual({
+      raw: 'raw',
+      '1m': 'raw',
+      '10m': 'raw',
+      '1h': 'hourly',
+      '12h': 'hourly',
+      '1d': 'daily',
+      '1w': 'daily',
+    })
   })
 })

--- a/web/src/components/usage/retentionGating.ts
+++ b/web/src/components/usage/retentionGating.ts
@@ -1,5 +1,13 @@
 import type { BucketGrain, TrafficUsageBucket } from '@/types/api'
 
+// Gating data for the usage date-picker: (a) retention horizons (still
+// hard-coded as defaults, paired with #1740 to move them API-side), and (b)
+// the bucket → grain mapping the API now emits via GET /api/usage/config
+// (#1743). `bucketAvailability` is the consumer; everything below is its
+// inputs. The bucket list this file iterates is intentionally SPA-known —
+// adding a new bucket code requires a SPA change in addition to the API
+// emitting it, since `TrafficUsageBucket` is a closed TS enum.
+//
 // Retention horizons, mirrored from the server. The sweep job
 // (api/src/usage/RetentionSweepJob.scala) drops raw rows after 30d, hourly
 // rollups after 90d, daily rollups after 180d. We hard-code the same values

--- a/web/src/components/usage/retentionGating.ts
+++ b/web/src/components/usage/retentionGating.ts
@@ -1,4 +1,4 @@
-import type { TrafficUsageBucket } from '@/types/api'
+import type { BucketGrain, TrafficUsageBucket } from '@/types/api'
 
 // Retention horizons, mirrored from the server. The sweep job
 // (api/src/usage/RetentionSweepJob.scala) drops raw rows after 30d, hourly
@@ -18,15 +18,14 @@ export const DEFAULT_RETENTION_HORIZONS: RetentionHorizons = {
   dailyDays: 180,
 }
 
-type SourceTier = 'raw' | 'hourly' | 'daily'
+type SourceTier = BucketGrain
 
-// Which source tier backs each display bucket — mirrors the bucket→tier
-// grouping in UsageRoutes.scala (minBucketFor / bucketRank): sub-hourly
-// buckets can only come from raw 5-min rows; 1h/12h come from the hourly
-// rollup (or finer); 1d/1w come from the daily rollup (or finer). A bucket is
-// retained as far back as the *coarsest* tier that can produce it, which is
-// exactly the tier named here.
-const BUCKET_TIER: Record<TrafficUsageBucket, SourceTier> = {
+// #1743: which source tier backs each display bucket. The API emits this from
+// `BucketPolicy.bucketTiers` (GET /api/usage/config), and the SPA reads it
+// via `useUsageConfig`. The defaults below are a fallback so the date-picker
+// works before the boot fetch completes (or when offline) and double as the
+// list of buckets the SPA renders.
+export const DEFAULT_BUCKET_TIERS: Record<TrafficUsageBucket, SourceTier> = {
   raw: 'raw',
   '1m': 'raw',
   '10m': 'raw',
@@ -69,15 +68,21 @@ function reasonFor(tier: SourceTier, h: RetentionHorizons): string {
 // return the enable/disable state for every granularity bucket. A bucket is
 // disabled when its newest visible point is already older than its source
 // tier's retention horizon — i.e. the whole window has been swept.
+//
+// `bucketTiers` is the API-emitted mapping (#1743); falls back to
+// `DEFAULT_BUCKET_TIERS` when the caller hasn't fetched it yet. A bucket not
+// present in the supplied map falls back to its default tier, so an older API
+// image missing a newer client-side bucket code does not break the UI.
 export function bucketAvailability(
   until: Date | null,
   now: Date,
   horizons: RetentionHorizons = DEFAULT_RETENTION_HORIZONS,
+  bucketTiers: Record<string, SourceTier> = DEFAULT_BUCKET_TIERS,
 ): Record<TrafficUsageBucket, BucketGate> {
   const daysAgo = until === null ? 0 : (now.getTime() - until.getTime()) / DAY_MS
   const gates = {} as Record<TrafficUsageBucket, BucketGate>
-  for (const bucket of Object.keys(BUCKET_TIER) as TrafficUsageBucket[]) {
-    const tier = BUCKET_TIER[bucket]
+  for (const bucket of Object.keys(DEFAULT_BUCKET_TIERS) as TrafficUsageBucket[]) {
+    const tier = bucketTiers[bucket] ?? DEFAULT_BUCKET_TIERS[bucket]
     const enabled = daysAgo <= horizonFor(tier, horizons)
     gates[bucket] = enabled ? { enabled } : { enabled, reason: reasonFor(tier, horizons) }
   }

--- a/web/src/pages/TrafficUsagePage.test.tsx
+++ b/web/src/pages/TrafficUsagePage.test.tsx
@@ -2,11 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { TrafficUsageResponse } from '@/types/api'
 
 vi.mock('@/api/client', () => ({
   api: {
-    usage:    { traffic: vi.fn() },
+    usage:    { traffic: vi.fn(), config: vi.fn().mockResolvedValue({ bucketTiers: {} }) },
     devices:  { list:    vi.fn() },
     profiles: { list:    vi.fn() },
     apps:     { list:    vi.fn() },
@@ -62,11 +63,19 @@ const aggResp: TrafficUsageResponse = {
   ],
 }
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+}
+
 function renderPage() {
   return render(
-    <MemoryRouter>
-      <TrafficUsagePage />
-    </MemoryRouter>,
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter>
+        <TrafficUsagePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
@@ -198,9 +207,11 @@ describe('TrafficUsagePage', () => {
     const trafficMock = api.usage.traffic as ReturnType<typeof vi.fn>
     trafficMock.mockResolvedValue(aggResp)
     render(
-      <MemoryRouter initialEntries={['/?groupBy=device&groupBy=domain']}>
-        <TrafficUsagePage />
-      </MemoryRouter>,
+      <QueryClientProvider client={makeQueryClient()}>
+        <MemoryRouter initialEntries={['/?groupBy=device&groupBy=domain']}>
+          <TrafficUsagePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     )
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
     // Default bucket is raw — switch to 1h to surface the groupBy in the call.
@@ -286,9 +297,11 @@ describe('TrafficUsagePage', () => {
     trafficMock.mockResolvedValue(rawResp)
     const seed = '2026-05-21T14:00:00.000Z'
     render(
-      <MemoryRouter initialEntries={[`/?until=${encodeURIComponent(seed)}`]}>
-        <TrafficUsagePage />
-      </MemoryRouter>,
+      <QueryClientProvider client={makeQueryClient()}>
+        <MemoryRouter initialEntries={[`/?until=${encodeURIComponent(seed)}`]}>
+          <TrafficUsagePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     )
     await waitFor(() => expect(api.usage.traffic).toHaveBeenCalledTimes(1))
     expect(trafficMock.mock.calls[0][0].to).toBe(seed)

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { api } from '@/api/client'
+import { useUsageConfig } from '@/api/queries'
 import type {
   Device,
   ProfileDetail,
@@ -26,7 +27,6 @@ import {
   localTime,
 } from '@/components/usage/usageHelpers'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
-import { useUsageConfig } from '@/api/queries'
 
 // #846 — Traffic Usage page. Raw + aggregated views over traffic_reports.
 // Column headers double as groupBy toggles (Host=domain, Device=device,

--- a/web/src/pages/TrafficUsagePage.tsx
+++ b/web/src/pages/TrafficUsagePage.tsx
@@ -26,6 +26,7 @@ import {
   localTime,
 } from '@/components/usage/usageHelpers'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll'
+import { useUsageConfig } from '@/api/queries'
 
 // #846 — Traffic Usage page. Raw + aggregated views over traffic_reports.
 // Column headers double as groupBy toggles (Host=domain, Device=device,
@@ -103,9 +104,13 @@ export function TrafficUsagePage() {
   // those buckets grey out (BucketSelector) and we auto-promote the current
   // selection to the finest still-available bucket so we never request a
   // swept tier.
+  // #1743: the bucket → grain mapping comes from the API; until the fetch
+  // returns we fall back to the shipped defaults so the picker still works.
+  const usageConfig = useUsageConfig()
+  const bucketTiers = usageConfig.data?.bucketTiers
   const bucketGates = useMemo<Record<TrafficUsageBucket, BucketGate>>(
-    () => bucketAvailability(until ? new Date(until) : null, new Date()),
-    [until],
+    () => bucketAvailability(until ? new Date(until) : null, new Date(), undefined, bucketTiers),
+    [until, bucketTiers],
   )
 
   useEffect(() => {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -572,6 +572,15 @@ export interface UsageSeriesBatchResponse {
 // inspection. 1m bucket and apex/app groupBy are reserved (router cadence /
 // PSL / apps track) — server returns 400 with a typed `error` code.
 export type TrafficUsageBucket = 'raw' | '1m' | '10m' | '1h' | '12h' | '1d' | '1w'
+
+// #1743: which storage grain backs each display bucket. Sourced from the API
+// (`BucketPolicy.bucketTiers`), not hand-mirrored — see `useUsageConfig` /
+// `retentionGating.ts`.
+export type BucketGrain = 'raw' | 'hourly' | 'daily'
+
+export interface UsageConfig {
+  bucketTiers: Record<string, BucketGrain>
+}
 // #846: groupBy is composable. Apex is deferred to #856 (needs PSL). #769
 // turned `app` on — it now resolves to a server-side join through
 // `app_hosts`. #1526: a host with no registered app is its own single-host


### PR DESCRIPTION
## Summary

Collapses the duplicated bucket → grain mapping between `BucketPolicy.grainForBucket` (Scala) and the hand-defined `BUCKET_TIER` in `web/src/components/usage/retentionGating.ts` per [Single source of truth](../blob/main/AGENTS.md#single-source-of-truth).

- New `GET /api/usage/config` emits `BucketPolicy.bucketTiers` on the wire (auth-gated, consistent with the rest of `/api/usage/*`).
- `BucketPolicy` now owns the canonical bucket list and the bucket → grain map; both are derived from `grainForBucket` so the classification stays single-source.
- The SPA fetches the mapping via `useUsageConfig` (1-hour cache). `bucketAvailability` takes the map as a new parameter and falls back to `DEFAULT_BUCKET_TIERS` for pre-fetch / offline / partial-payload cases — the constants live on so the date-picker still works before the boot fetch returns.

## Path note

#1740 (operator-tunable retention horizons on the same endpoint) is still open and unstarted, so this PR opens `GET /api/usage/config` here. When #1740 lands it just extends the existing response with a `horizons` field — the route comment and the shared model both flag the intent. No conflict expected.

## Test plan

- [x] Failing feature test committed first (red), then implementation (green): `wifihaven.api.feature.UsageConfigSpec` — asserts the wire payload equals `BucketPolicy.bucketTiers` plus spot-checks, and that the route is auth-gated.
- [x] `mill api.test` — full Scala test suite green.
- [x] `scalafmt --check` — formatted.
- [x] Vitest: extended `web/src/components/usage/retentionGating.test.ts` with fallback + injected-map + partial-map + default-mirror cases; full `npx vitest run` green (410 tests).
- [x] `web/` `npm run type-check` clean.

Refs #1532. Closes #1743.