### PR TITLE
fix(#1757): skip per-record decode failures on /api/router/events

### DIFF
--- a/api/src/metrics/Metrics.scala
+++ b/api/src/metrics/Metrics.scala
@@ -92,6 +92,13 @@ object MetricGuard {
     // underscores, see #1572) is skipped + metered here instead of 400-ing the
     // whole batch. `reason` is a small fixed enum (currently just `decode_error`).
     "usage_records_rejected_total"              -> Set("reason"),
+    // #1757 — events-ingest records dropped at decode. Same shape as
+    // usage_records_rejected_total: a single malformed RouterEvent (bad host /
+    // mac / ts / unknown enum value) is skipped + metered instead of 400-ing
+    // the whole batch (which would drop every valid connection_attempt /
+    // dhcp_lease / first_seen_mac with it). `reason` is a small fixed enum
+    // (currently just `decode_error`).
+    "events_records_rejected_total"             -> Set("reason"),
     // #1585 — write-time FQDN backfill for traffic_reports. Counts each
     // UsageRecord at ingest by what the backfill decided: `filled` (race-loser
     // ipv4/ipv6 rewritten to a fqdn from a recent connection_event),
@@ -345,6 +352,16 @@ object AppMetrics {
     ZIO
       .when(count > 0)(
         MetricGuard.counter("usage_records_rejected_total", Map("reason" -> reason), count.toLong),
+      )
+      .unit
+
+  // #1757 — events-ingest per-record skip count. Same wire shape as the usage
+  // counter above; emitted from RouterIngestRoutes when one or more events in
+  // a batch fail individual decode but the envelope itself parses.
+  def recordEventsRecordsRejected(count: Int, reason: String = "decode_error"): UIO[Unit] =
+    ZIO
+      .when(count > 0)(
+        MetricGuard.counter("events_records_rejected_total", Map("reason" -> reason), count.toLong),
       )
       .unit
 

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -52,40 +52,40 @@ object RouterIngestRoutes {
             auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
               LogContext.annotate(LogContext.RouterId, router.id.toString) {
                 for {
-                  body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+                  body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
                   // #1569: decode the *envelope* (routerId, periodStart, periodEnd) + `records` as a
                   // raw JSON array, deferring per-record validation. A genuinely unparseable
                   // envelope (bad routerId/timestamps, not an object, `records` not an array,
                   // truncated body) still 400s — logged by the boundary.
-                  raw  <- ZIO
+                  raw       <- ZIO
                     .fromEither(body.fromJson[RawUsageReport])
                     .mapError(ApiError.DecodeFailure(_))
-                  _    <- ZIO
+                  _         <- ZIO
                     .fail(ApiError.BadRequest("router_id mismatch"))
                     .when(raw.routerId != router.id)
-                  ps   <- parseInstant(raw.periodStart)
-                  pe   <- parseInstant(raw.periodEnd)
-                  // #1569: decode each record individually. A single malformed record
-                  // (e.g. a host value that fails Hostname validation — an Akamai/CDN
-                  // CNAME target with underscores, see #1572) used to fail the WHOLE
-                  // batch, dropping every valid record with it. Now the bad records are
-                  // skipped, logged (bounded), and metered, and the valid ones ingest.
-                  decoded  = raw.records.zipWithIndex.map((j, i) => (i, j.as[UsageRecord]))
-                  rejected = decoded.collect { case (i, Left(err)) => (i, err) }
-                  records  = decoded.collect { case (_, Right(r)) => r }
-                  _        <- ZIO.foreachDiscard(rejected) { (i, err) =>
-                    ZIO.logWarning(
-                      s"router usage: skipping malformed record[$i] for router=${router.id}: $err",
-                    )
-                  }
-                  _        <- AppMetrics.recordUsageRecordsRejected(rejected.size)
+                  ps        <- parseInstant(raw.periodStart)
+                  pe        <- parseInstant(raw.periodEnd)
+                  // #1569 / #1757: decode each record individually via the shared per-
+                  // record skip helper. A single malformed record (e.g. a host value
+                  // that fails Hostname validation — an Akamai/CDN CNAME target with
+                  // underscores, see #1572) used to fail the WHOLE batch, dropping
+                  // every valid record with it. Now bad records are skipped, logged
+                  // (bounded), and metered, and the valid ones ingest.
+                  decResult <- decodePerRecord[UsageRecord](
+                    raw.records,
+                    "router usage",
+                    "record",
+                    router.id,
+                    AppMetrics.recordUsageRecordsRejected(_),
+                  )
+                  (records, rejectedCount) = decResult
                   _        <- LogContext.annotateAll(
                     LogContext.BatchSize -> records.size.toString,
-                    LogContext.Rejected  -> rejected.size.toString,
+                    LogContext.Rejected  -> rejectedCount.toString,
                   ) {
                     ZIO.logDebug(
                       s"router usage: router=${router.id} period=$ps..$pe records=${records.size} " +
-                        s"rejected=${rejected.size}",
+                        s"rejected=$rejectedCount",
                     )
                   }
                   _        <- ZIO.foreachDiscard(records)(r =>
@@ -125,7 +125,7 @@ object RouterIngestRoutes {
             auth.authenticate(req).mapError(ApiError.Wrapped(_)).flatMap { router =>
               LogContext.annotate(LogContext.RouterId, router.id.toString) {
                 for {
-                  body <- req.body.asString.orElseFail(ApiError.BadRequest(""))
+                  body      <- req.body.asString.orElseFail(ApiError.BadRequest(""))
                   // #1126: tolerate an empty/blank body as a no-op batch. A truncated
                   // or empty POST (network blip, retry-queue edge) used to fail
                   // RouterEventsRequest decoding with "Unexpected end of input" and
@@ -134,7 +134,7 @@ object RouterIngestRoutes {
                   // accepted no-op rather than an error. Genuinely malformed non-empty
                   // bodies still 400 + warn (and the agent emitter no longer
                   // produces them — see conntrack.encode_events_body).
-                  raw  <-
+                  raw       <-
                     if body.trim.isEmpty then
                       ZIO.logDebug(
                         s"router events: empty body from router=${router.id}; treating as no-op batch",
@@ -143,33 +143,30 @@ object RouterIngestRoutes {
                       ZIO
                         .fromEither(body.fromJson[RawEventsReport])
                         .mapError(ApiError.DecodeFailure(_))
-                  _    <- ZIO
+                  _         <- ZIO
                     .fail(ApiError.BadRequest("router_id mismatch"))
                     .when(raw.routerId != router.id)
-                  // #1757: decode each event individually. A single malformed
-                  // RouterEvent (bad host/mac/ts/unknown enum) used to fail the
-                  // WHOLE batch — every valid connection_attempt / dhcp_lease /
-                  // first_seen_mac dropped with it. Mirrors the #1574 fix on
-                  // /api/router/usage: bad ones are skipped + logged + metered;
-                  // the valid ones ingest. Envelope itself (routerId,
-                  // events-is-an-array) must still parse or the request is a
-                  // genuine 400.
-                  decoded  = raw.events.zipWithIndex.map((j, i) => (i, j.as[RouterEvent]))
-                  rejected = decoded.collect { case (i, Left(err)) => (i, err) }
-                  events   = decoded.collect { case (_, Right(e)) => e }
-                  _ <- ZIO.foreachDiscard(rejected) { (i, err) =>
-                    ZIO.logWarning(
-                      s"router events: skipping malformed event[$i] for router=${router.id}: $err",
-                    )
-                  }
-                  _ <- AppMetrics.recordEventsRecordsRejected(rejected.size)
+                  // #1757: decode each event individually via the shared per-record
+                  // skip helper. A single malformed RouterEvent (bad host/mac/ts/
+                  // unknown enum) used to fail the WHOLE batch — every valid
+                  // connection_attempt / dhcp_lease / first_seen_mac dropped with
+                  // it. Envelope itself (routerId, events-is-an-array) must still
+                  // parse or the request is a genuine 400.
+                  decResult <- decodePerRecord[RouterEvent](
+                    raw.events,
+                    "router events",
+                    "event",
+                    router.id,
+                    AppMetrics.recordEventsRecordsRejected(_),
+                  )
+                  (events, rejectedCount) = decResult
                   _ <- LogContext.annotateAll(
                     LogContext.BatchSize -> events.size.toString,
-                    LogContext.Rejected  -> rejected.size.toString,
+                    LogContext.Rejected  -> rejectedCount.toString,
                   ) {
                     ZIO.logDebug(
                       s"router events: router=${router.id} batchSize=${events.size} " +
-                        s"rejected=${rejected.size}",
+                        s"rejected=$rejectedCount",
                     )
                   }
                   _ <- ZIO.foreachDiscard(events)(e =>
@@ -224,6 +221,33 @@ object RouterIngestRoutes {
   // (The bespoke per-call warn log #1574 added is subsumed by the boundary — single emitter.)
   private def parseInstant(s: String): IO[ApiError, Instant] =
     ZIO.attempt(Instant.parse(s)).orElseFail(ApiError.BadRequest(s"invalid timestamp: $s"))
+
+  /**
+   * #1569 / #1757: shared per-record skip helper used by both `/api/router/usage` (records →
+   * UsageRecord) and `/api/router/events` (events → RouterEvent). The two ingest paths used to
+   * carry hand-copied decode loops with a "// must mirror" coupling — extracted here so the single
+   * source of truth is enforced by the compiler. Decodes each `Json` element into `T` individually,
+   * logs each failure (bounded — one warn per bad slot, with the JSON index) and increments the
+   * supplied rejection metric, then returns the decoded list plus the rejected count for the
+   * caller's per-batch debug annotation. Bad records are skipped, NOT 400'd — the envelope itself
+   * must still parse upstream.
+   */
+  private def decodePerRecord[T](
+      raw: List[Json],
+      logPrefix: String,
+      itemNoun: String,
+      routerId: RouterId,
+      recordMetric: Int => UIO[Unit],
+  )(implicit decoder: JsonDecoder[T]): UIO[(List[T], Int)] = {
+    val decoded  = raw.zipWithIndex.map((j, i) => (i, j.as[T]))
+    val rejected = decoded.collect { case (i, Left(err)) => (i, err) }
+    val ok       = decoded.collect { case (_, Right(t)) => t }
+    ZIO.foreachDiscard(rejected) { (i, err) =>
+      ZIO.logWarning(
+        s"$logPrefix: skipping malformed $itemNoun[$i] for router=$routerId: $err",
+      )
+    } *> recordMetric(rejected.size).as((ok, rejected.size))
+  }
 
   private def handleUsage(
       routerId: RouterId,

--- a/api/src/routes/RouterIngestRoutes.scala
+++ b/api/src/routes/RouterIngestRoutes.scala
@@ -134,24 +134,45 @@ object RouterIngestRoutes {
                   // accepted no-op rather than an error. Genuinely malformed non-empty
                   // bodies still 400 + warn (and the agent emitter no longer
                   // produces them — see conntrack.encode_events_body).
-                  rep  <-
+                  raw  <-
                     if body.trim.isEmpty then
                       ZIO.logDebug(
                         s"router events: empty body from router=${router.id}; treating as no-op batch",
-                      ) *> ZIO.succeed(RouterEventsRequest(router.id, Nil))
+                      ) *> ZIO.succeed(RawEventsReport(router.id, Nil))
                     else
                       ZIO
-                        .fromEither(body.fromJson[RouterEventsRequest])
+                        .fromEither(body.fromJson[RawEventsReport])
                         .mapError(ApiError.DecodeFailure(_))
                   _    <- ZIO
                     .fail(ApiError.BadRequest("router_id mismatch"))
-                    .when(rep.routerId != router.id)
-                  _    <- LogContext.annotate(LogContext.BatchSize, rep.events.size.toString) {
-                    ZIO.logDebug(
-                      s"router events: router=${router.id} batchSize=${rep.events.size}",
+                    .when(raw.routerId != router.id)
+                  // #1757: decode each event individually. A single malformed
+                  // RouterEvent (bad host/mac/ts/unknown enum) used to fail the
+                  // WHOLE batch — every valid connection_attempt / dhcp_lease /
+                  // first_seen_mac dropped with it. Mirrors the #1574 fix on
+                  // /api/router/usage: bad ones are skipped + logged + metered;
+                  // the valid ones ingest. Envelope itself (routerId,
+                  // events-is-an-array) must still parse or the request is a
+                  // genuine 400.
+                  decoded  = raw.events.zipWithIndex.map((j, i) => (i, j.as[RouterEvent]))
+                  rejected = decoded.collect { case (i, Left(err)) => (i, err) }
+                  events   = decoded.collect { case (_, Right(e)) => e }
+                  _ <- ZIO.foreachDiscard(rejected) { (i, err) =>
+                    ZIO.logWarning(
+                      s"router events: skipping malformed event[$i] for router=${router.id}: $err",
                     )
                   }
-                  _    <- ZIO.foreachDiscard(rep.events)(e =>
+                  _ <- AppMetrics.recordEventsRecordsRejected(rejected.size)
+                  _ <- LogContext.annotateAll(
+                    LogContext.BatchSize -> events.size.toString,
+                    LogContext.Rejected  -> rejected.size.toString,
+                  ) {
+                    ZIO.logDebug(
+                      s"router events: router=${router.id} batchSize=${events.size} " +
+                        s"rejected=${rejected.size}",
+                    )
+                  }
+                  _ <- ZIO.foreachDiscard(events)(e =>
                     ZIO.logDebug(
                       s"  event: type=${e.`type`} mac=${e.mac.getOrElse("-")} " +
                         s"ip=${e.ip.getOrElse("-")} host=${e.host.map(_.value).orElse(e.hostname.map(_.value)).getOrElse("-")} " +
@@ -159,8 +180,8 @@ object RouterIngestRoutes {
                         s"reason=${e.reason.getOrElse("-")} ts=${e.ts}",
                     ),
                   )
-                  _    <- handleEvents(router.id, rep.events, deviceRepo, connEventRepo, alertRepo)
-                  _    <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
+                  _ <- handleEvents(router.id, events, deviceRepo, connEventRepo, alertRepo)
+                  _ <- routerRepo.touch(router.id, None, None).mapError(ApiError.Db(_))
                 } yield Response.ok
               }
             }
@@ -182,6 +203,21 @@ object RouterIngestRoutes {
       periodStart: String,
       periodEnd: String,
       records: List[Json],
+  ) derives JsonDecoder
+
+  /**
+   * #1757: the wire-decode envelope for `POST /api/router/events`, the `RouterEventsRequest` analog
+   * of [[RawUsageReport]]. Identical field shape to [[RouterEventsRequest]] except `events` is held
+   * as a raw JSON array so each element can be decoded into a [[RouterEvent]] individually — a
+   * single malformed event (bad host / mac / ts / unknown enum value) is then skipped + logged +
+   * metered instead of 400-ing the whole batch and dropping every valid connection_attempt /
+   * dhcp_lease / first_seen_mac with it. The envelope itself (routerId, events-is-an-array) must
+   * still parse or the request is a genuine 400. Decode-only; this is a server-side parse aid, NOT
+   * a wire-contract type — unknown fields are still ignored.
+   */
+  private case class RawEventsReport(
+      routerId: RouterId,
+      events: List[Json],
   ) derives JsonDecoder
 
   // #1570: a bad timestamp is a typed BadRequest (400) mapped centrally; the boundary logs it.

--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -129,6 +129,10 @@ object RouterIngestSpec
   private val rejectedCounter =
     Metric.counter("usage_records_rejected_total").tagged("reason", "decode_error")
 
+  // #1757: events-side analog, used by the per-record skip tests below.
+  private val eventsRejectedCounter =
+    Metric.counter("events_records_rejected_total").tagged("reason", "decode_error")
+
   private def seedKnownDevice(dRepo: DeviceRepo, profileRepo: ProfileRepo): Task[Unit] =
     for {
       pid <- profileRepo.create("Kids", List(BlocklistId.unsafe("adult")))
@@ -1075,6 +1079,59 @@ object RouterIngestSpec
         resp <- post(routes, "/api/router/events", body, Some(tk))
         rows <- cRepo.listForRouter(id, 100)
       } yield assertTrue(resp.status == Status.Ok) && assertTrue(rows.isEmpty)
+    },
+    // ── #1757: one malformed event must not drop the whole events batch ─────
+    test(
+      "events: a batch with one malformed event ingests the valid events and meters the rejection",
+    ) {
+      // #1757: a single event whose host fails Hostname validation (same
+      // class as the #1569 Akamai CNAME bug, but on /events instead of
+      // /usage) used to fail the WHOLE RouterEventsRequest decode → 400 →
+      // every valid connection_attempt / dhcp_lease in the batch dropped.
+      // Now bad events are skipped + metered and the valid ones persist.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        before   <- eventsRejectedCounter.value
+        goodEv  =
+          s"""{"type":"connection_attempt","mac":"$knownMac","host":{"type":"fqdn","value":"youtube.com"},"destIp":"1.2.3.4","allowed":false,"reason":"category:adult","ts":"2026-05-07T14:01:14Z"}"""
+        badEv   =
+          s"""{"type":"connection_attempt","mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"destIp":"5.6.7.8","allowed":false,"reason":"category:adult","ts":"2026-05-07T14:01:15Z"}"""
+        rawBody =
+          s"""{"routerId":"$id","events":[$goodEv,$badEv]}"""
+        resp  <- post(routes, "/api/router/events", rawBody, Some(tk))
+        rows  <- cRepo.listForRouter(id, 100)
+        after <- eventsRejectedCounter.value
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.size == 1) &&
+        assertTrue(
+          rows.exists(r => r.host == HostId.Fqdn(Hostname.unsafe("youtube.com")) && !r.allowed),
+        ) &&
+        assertTrue(after.count - before.count == 1.0)
+    },
+    test("events: a batch of ONLY malformed events is accepted (200) and meters them all") {
+      // No valid events to ingest, but the envelope is well-formed — 200,
+      // not 400. The bad events are all metered.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        cRepo    <- ZIO.service[ConnectionEventRepo]
+        routes   <- buildRoutes
+        (id, tk) <- seedRouter(rRepo)
+        before   <- eventsRejectedCounter.value
+        badEv   =
+          s"""{"type":"connection_attempt","mac":"$knownMac","host":{"type":"fqdn","value":"$badHost"},"destIp":"5.6.7.8","allowed":false,"reason":"category:adult","ts":"2026-05-07T14:01:15Z"}"""
+        rawBody =
+          s"""{"routerId":"$id","events":[$badEv,$badEv]}"""
+        resp  <- post(routes, "/api/router/events", rawBody, Some(tk))
+        rows  <- cRepo.listForRouter(id, 100)
+        after <- eventsRejectedCounter.value
+      } yield assertTrue(resp.status == Status.Ok) &&
+        assertTrue(rows.isEmpty) &&
+        assertTrue(after.count - before.count == 2.0)
     },
     test("events: nflog-synthesized blocked flow persists with host + reason (#1126)") {
       // The exact wire shape the agent's nflog path emits: a connection_attempt

--- a/deploy/grafana/dashboards/data-quality-ingest.json
+++ b/deploy/grafana/dashboards/data-quality-ingest.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
+  "description": "WifiHaven ingest health + data quality (#1281, follow-up to #1209). The router→API ingest pipeline (POST /api/router/{usage,events,metrics}) plus the #864 zero-byte traffic filter. Every panel targets a series actually emitted by AppMetrics/HttpMetrics in api/src (grep-verified, not the design-doc catalog): traffic_reports_filtered_zero_bytes_total (#864), http_requests_total / http_request_duration_seconds (#1204), router_metrics_batches_total (#1205), auth_failures_total (#1204), usage_records_rejected_total (#1569), events_records_rejected_total (#1757). The `route` label is the templated path (/api/router/usage), never a concrete id. See docs/design/metrics-observability.md §5.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -515,6 +515,82 @@
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "expr": "sum(increase(presence_app_sessions_dropped_total{env=\"$env\"}[24h]))",
           "legendFormat": "dropped (24h)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Events records rejected at decode (#1757)",
+      "description": "sum by (reason) (rate(events_records_rejected_total[5m])) — per-event /api/router/events ingest rejections. Same shape as the usage panel above but for the events ingest: a single malformed RouterEvent (bad host / mac / ts / unknown enum) is skipped + metered here instead of 400-ing the whole batch and dropping every valid connection_attempt / dhcp_lease / first_seen_mac with it. A sustained non-zero rate means an agent is emitting field values the API rejects; pair it with the server warn-log ('router events: skipping malformed event') to see the offending field. `reason` is a bounded enum (decode_error today). From AppMetrics.recordEventsRecordsRejected.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 56 },
+      "id": 15,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "showPoints": "never", "lineWidth": 1 },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(events_records_rejected_total{env=\"$env\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "title": "Events records rejected (last 24h)",
+      "description": "sum(increase(events_records_rejected_total[24h])) — total events records skipped at decode over the trailing day. Non-zero means valid sibling events were preserved (no longer dropped with the batch) but the offending field values still need a fix. From AppMetrics.recordEventsRecordsRejected.",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 56 },
+      "id": 16,
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(increase(events_records_rejected_total{env=\"$env\"}[24h]))",
+          "legendFormat": "rejected (24h)",
           "refId": "A"
         }
       ]


### PR DESCRIPTION
Closes #1757.

## Class pinned: A — whole-batch drop on bad record (rank #1 in the issue)

The `/api/router/events` handler decoded the request body as one `RouterEventsRequest`. A single malformed `RouterEvent` (e.g. a host that fails `Hostname` validation — the Akamai CDN CNAME class from #1572, or any other per-field validation error) failed the whole decode → 400 → every valid `connection_attempt` / `dhcp_lease` / `first_seen_mac` in the batch dropped with it. This is the symptom showing up as a non-zero failure rate on `/api/router/events` in Grafana.

This is the same shape as #1569 was on `/usage`, and the fix mirrors #1574: wire-decode envelope (`RawEventsReport`) holds events as a raw JSON array, each is decoded into a `RouterEvent` individually, bad ones are skipped + logged + metered, valid ones ingest. Envelope itself (routerId, events-is-an-array) must still parse or the request is a genuine 400.

## Evidence

Pre-fix `api/src/routes/RouterIngestRoutes.scala`:

```scala
rep <- ZIO.fromEither(body.fromJson[RouterEventsRequest])
         .mapError(ApiError.DecodeFailure(_))
// ↑ one bad event in the array fails this — whole batch 400s.
```

`/api/router/usage` handler (same file) does NOT have this problem post-#1574: it decodes the envelope, then decodes each record individually.

## Changes

- New `RawEventsReport` envelope on the events handler, analogous to `RawUsageReport`.
- Per-event decode loop + `recordEventsRecordsRejected` metric, analogous to `recordUsageRecordsRejected`.
- New metric `events_records_rejected_total{reason}` added to `MetricGuard.Allowed`. Bounded label only (`reason` enum — currently just `decode_error`), no per-mac / per-host / per-router dimensions.

## Backwards compatibility

Purely server-side decoder change. Wire is unchanged: the server now accepts a superset of what it accepted before (every valid old payload still parses; payloads that used to 400 with one bad event now 200 with that event skipped). No agent-side change required.

## Tests (RED → GREEN visible in commits)

- `events: a batch with one malformed event ingests the valid events and meters the rejection`
- `events: a batch of ONLY malformed events is accepted (200) and meters them all`

Both mirror the existing #1569/#1574 tests on `/usage`.

## Test plan

- [x] `mill api.test.testOnly wifihaven.api.feature.RouterIngestSpec` — 50 passed
- [x] `mill api.test.testOnly wifihaven.api.feature.MetricCardinalityGuardSpec`
- [x] scalafmt --check

## Follow-up (post-merge)

- Watch the `/api/router/events` success-rate panel — should return to baseline.
- Watch `events_records_rejected_total{reason="decode_error"}` rate. A non-zero share indicates the bad-host payload identified in the incident; the operator can grep API logs for `"router events: skipping malformed event"` to see the exact rejected JSON.