### PR TITLE
docs(#1758): chips monitor PRs to MERGED, not just queued (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -908,14 +908,33 @@ the chip watches the merge queue and iterates without waiting for an operator
 prompt:
 
 - **Queue CI fails** (Gate 2 port collision from a sibling chip,
-  infrastructure flake, etc.) → diagnose, push a fix or re-queue, iterate.
+  infrastructure flake, etc.) → diagnose, push a fix, iterate.
 - **Conflict appears** with another PR that landed first → rebase on
-  `origin/main`, resolve, push, re-queue.
+  `origin/main`, resolve, push.
 - **Re-review needed** because new commits got pushed → re-run `/pr-review`,
   address BLOCKERs, push. (This pairs with the re-run-on-push behavior in the
   *Posting & re-runs* section of [`docs/pr-review-checklist.md`](docs/pr-review-checklist.md),
   which covers the REVIEWER side; this rule covers the AUTHOR side of the
   same lifecycle.)
+
+**The chip NEVER queues a PR for merge itself, and NEVER re-arms
+merge-when-ready unless the operator had already armed it.** The
+merge-when-ready click is the operator's explicit approval to ship — it is
+**required** so the operator approves every change, and a chip running
+`gh pr merge … --auto` (or any equivalent) bypasses that approval and is
+forbidden. Concretely:
+
+- **First time the PR is ready** → the chip reports "review APPROVE, ready
+  for merge-when-ready," and stops. The operator clicks merge-when-ready.
+- **After a rebase or queue-CI fix push**, the chip may re-arm
+  merge-when-ready (`gh pr merge <n> --auto …`) **only if** the operator had
+  already armed it before the push — i.e. `gh pr view <n> --json
+  autoMergeRequest` returned a non-null `autoMergeRequest` immediately
+  before the push knocked it off. Check that field; if it is null, do
+  nothing and report state.
+- **If the operator explicitly unqueued the PR** (the chip should treat
+  any transition from armed → null as "operator unqueued" unless the chip
+  itself just force-pushed), the chip does NOT re-arm. Report and stop.
 
 A chip replies "done" only when `gh pr view <n> --json state` returns
 `MERGED`. Polling cadence is ~5–10 minutes — use `ScheduleWakeup` for long

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -899,11 +899,13 @@ ADDRESSED *and* no new BLOCKER was introduced; any open BLOCKER stays
 merge-gating. See the *Posting & re-runs* section of the checklist for the full
 algorithm.
 
-**Spawned chips monitor PRs through to MERGED, not just to queued.**
-{#monitor-to-merged} The independent review pass is the gate for ENTERING the
-merge queue, but the author chip's job isn't done until the PR's state is
-`MERGED`. Once queued, the chip watches the merge queue and iterates without
-waiting for an operator prompt:
+### Monitor PRs through to MERGED, not just queued {#monitor-to-merged}
+
+**Spawned chips monitor PRs through to MERGED, not just to queued.** The
+independent review pass is the gate for ENTERING the merge queue, but the
+author chip's job isn't done until the PR's state is `MERGED`. Once queued,
+the chip watches the merge queue and iterates without waiting for an operator
+prompt:
 
 - **Queue CI fails** (Gate 2 port collision from a sibling chip,
   infrastructure flake, etc.) → diagnose, push a fix or re-queue, iterate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -899,6 +899,26 @@ ADDRESSED *and* no new BLOCKER was introduced; any open BLOCKER stays
 merge-gating. See the *Posting & re-runs* section of the checklist for the full
 algorithm.
 
+**Spawned chips monitor PRs through to MERGED, not just to queued.**
+{#monitor-to-merged} The independent review pass is the gate for ENTERING the
+merge queue, but the author chip's job isn't done until the PR's state is
+`MERGED`. Once queued, the chip watches the merge queue and iterates without
+waiting for an operator prompt:
+
+- **Queue CI fails** (Gate 2 port collision from a sibling chip,
+  infrastructure flake, etc.) → diagnose, push a fix or re-queue, iterate.
+- **Conflict appears** with another PR that landed first → rebase on
+  `origin/main`, resolve, push, re-queue.
+- **Re-review needed** because new commits got pushed → re-run `/pr-review`,
+  address BLOCKERs, push. (This pairs with the re-run-on-push behavior in the
+  *Posting & re-runs* section of [`docs/pr-review-checklist.md`](docs/pr-review-checklist.md),
+  which covers the REVIEWER side; this rule covers the AUTHOR side of the
+  same lifecycle.)
+
+A chip replies "done" only when `gh pr view <n> --json state` returns
+`MERGED`. Polling cadence is ~5–10 minutes — use `ScheduleWakeup` for long
+waits, don't busy-poll.
+
 ## Testing philosophy
 
 ### Feature tests first, unit tests for edge cases only


### PR DESCRIPTION
Closes #1758.

Extends AGENTS.md §independent-pr-review with a new {#monitor-to-merged} subsection codifying the author-side lifecycle rule: chips iterate on queue CI failures, rebase conflicts, and re-reviews without operator prompts, and reply done only when `gh pr view <n> --json state` returns MERGED.

Note: there is no top-of-file standing-rules summary list in AGENTS.md to add a one-liner to (the doc launches straight into the Architectural model), so only the §independent-pr-review extension is included.