### PR TITLE
fix(#1761): strip :port from host on agent emitters + tolerant API decoder

### DIFF
--- a/api/test/src/feature/RouterIngestSpec.scala
+++ b/api/test/src/feature/RouterIngestSpec.scala
@@ -1595,6 +1595,58 @@ object RouterIngestSpec
         // exactly the one malformed record was metered as rejected
         assertTrue(after.count - before.count == 1.0)
     },
+    // ── #1761: tolerant decode of `host:port` fqdn values ───────────────────
+    test("usage: an fqdn host with a trailing :port is accepted (port stripped)") {
+      // Prod incident #1761: an attribution path (SNI / Host-header capture)
+      // bleeds the destination port into the wire `host` field, so values like
+      // `ws.nas.native-cloud.com:443` arrived verbatim. Hostname validation
+      // rejected them as "invalid hostname label 'com:443'" and the record
+      // was metered as a decode failure. The tolerant decoder strips a
+      // trailing `:<digits>` from fqdn values before parsing, so the record
+      // ingests normally and the rejection counter does NOT advance.
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        tu       <- ZIO.service[TimeUsageRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        before   <- rejectedCounter.value
+        rec  =
+          s"""{"mac":"$knownMac","host":{"type":"fqdn","value":"ws.nas.native-cloud.com:443"},"activeSeconds":60,"bytesIn":100,"bytesOut":50}"""
+        body =
+          s"""{"routerId":"$id","periodStart":"${periodStart.toString}","periodEnd":"${periodEnd.toString}","records":[$rec]}"""
+        resp  <- post(routes, "/api/router/usage", body, Some(tk))
+        sb    <- tu.getSecondsAndBytes(
+          MacAddress.unsafe(knownMac),
+          HostId.Fqdn(Hostname.unsafe("ws.nas.native-cloud.com")),
+          testDate,
+        )
+        after <- rejectedCounter.value
+      } yield assertTrue(resp.status == Status.Ok) &&
+        // persisted under the port-free hostname
+        assertTrue(sb == ((60L, 100L, 50L))) &&
+        // and the rejection counter did NOT advance
+        assertTrue(after.count - before.count == 0.0)
+    },
+    test("events: an fqdn host with a trailing :port ingests (port stripped)") {
+      for {
+        _        <- cleanDb
+        rRepo    <- ZIO.service[RouterRepo]
+        pRepo    <- ZIO.service[ProfileRepo]
+        dRepo    <- ZIO.service[DeviceRepo]
+        routes   <- buildRoutes
+        _        <- seedKnownDevice(dRepo, pRepo)
+        (id, tk) <- seedRouter(rRepo)
+        ev   =
+          s"""{"type":"connection_attempt","mac":"$knownMac","host":{"type":"fqdn","value":"ws.nas.native-cloud.com:443"},"destIp":"1.2.3.4","allowed":false,"reason":"category:adult","ts":"2026-05-07T14:01:14Z"}"""
+        body =
+          s"""{"routerId":"$id","events":[$ev]}"""
+        resp <- post(routes, "/api/router/events", body, Some(tk))
+      } yield assertTrue(resp.status == Status.Ok)
+    },
     test("usage: a batch of ONLY malformed records is accepted (200) and meters them all") {
       // No valid records to ingest, but the envelope is well-formed — so this is
       // a 200 no-op-ingest, NOT a 400. The bad records are all metered.

--- a/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/conntrack.lua
@@ -24,6 +24,7 @@
 local M = {}
 
 local static_ip_labels = require("wifihaven.static_ip_labels")
+local host_norm        = require("wifihaven.host_norm")
 
 -- ---------------------------------------------------------------------------
 -- eb_san(host) -> string
@@ -469,7 +470,9 @@ function M.build_event(opts)
   if opts.host_label_source and opts.hostname then
     host = { type = "label", value = opts.hostname, source = opts.host_label_source }
   elseif opts.hostname then
-    host = { type = "fqdn", value = opts.hostname }
+    -- #1761: strip a trailing :<port> so the API's Hostname validation
+    -- doesn't reject the record. Single-source via host_norm.
+    host = { type = "fqdn", value = host_norm.strip_port_suffix(opts.hostname) }
   else
     local kind = (opts.dest_ip and opts.dest_ip:find(":", 1, true)) and "ipv6" or "ipv4"
     host = { type = kind, value = opts.dest_ip }

--- a/openwrt/files/usr/lib/lua/wifihaven/host_norm.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/host_norm.lua
@@ -1,0 +1,47 @@
+-- host_norm.lua — single-source wire-host normalization (#1761).
+--
+-- A handful of attribution paths (SNI / Host-header capture, future plumbing
+-- that interns "fqdn:port" pairs) can hand the wire emitters a hostname whose
+-- value carries a trailing `:<port>` suffix. The API's Hostname validation
+-- treats the port digits as part of the last label and rejects the record
+-- ("invalid hostname label 'com:443'"), so the bad value 4xxs at ingest and
+-- shows up on the prod data-quality-ingest dashboard.
+--
+-- The fix is to normalize at every wire-emit site (the three places that
+-- construct `{type = "fqdn", value = h}` — conntrack.build_event,
+-- nflog.build_event, usage.host_for_ip). All three call strip_port_suffix
+-- so the helper, not a pattern, is the single source of truth.
+--
+-- This is the agent half of the back-compat pair: the API also accepts a
+-- "fqdn:port" value and strips it server-side, so a fleet of pre-fix agents
+-- ingests cleanly while the fleet rolls forward.
+
+local M = {}
+
+-- strip_port_suffix(host) -> host
+--
+-- Returns `host` with a trailing `:<digits>` suffix removed, idempotent on
+-- already-clean values. Defends against IPv6 literals that contain colons:
+-- a bare IPv6 ("::1", "fe80::1234") is left alone (it would never reach this
+-- helper because v6 destinations are emitted as type="ipv6", but the helper
+-- has to be safe regardless). A bracketed IPv6 ("[::1]:443") IS recognized
+-- and stripped because the closing bracket disambiguates the port boundary.
+--
+-- Nil / empty pass through unchanged so the helper composes with the existing
+-- nil-tolerant emitter branches without needing extra guards at every call
+-- site.
+function M.strip_port_suffix(host)
+  if host == nil or host == "" then return host end
+  -- Bracketed IPv6: "[v6]:port" -> "[v6]"
+  if host:sub(1, 1) == "[" then
+    return (host:gsub("(%])%:%d+$", "%1"))
+  end
+  -- Bare IPv6 contains at least two colons; treat as already-port-free.
+  -- (A trailing `:%d+` on a v6 literal is ambiguous and we'd rather leave
+  -- the value intact than guess wrong.)
+  local _, ncolons = host:gsub(":", ":")
+  if ncolons > 1 then return host end
+  return (host:gsub(":%d+$", ""))
+end
+
+return M

--- a/openwrt/files/usr/lib/lua/wifihaven/nflog.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/nflog.lua
@@ -44,6 +44,8 @@
 
 local M = {}
 
+local host_norm = require("wifihaven.host_norm")
+
 -- Defer to conntrack.gen_event_id for the idempotency-key generator so the
 -- nflog path stamps event ids in exactly the same way (and tests can stub it
 -- via the same package.loaded indirection conntrack uses).
@@ -93,7 +95,8 @@ end
 function M.build_event(opts)
   local host
   if opts.hostname then
-    host = { type = "fqdn", value = opts.hostname }
+    -- #1761: strip a trailing :<port> — see host_norm.lua.
+    host = { type = "fqdn", value = host_norm.strip_port_suffix(opts.hostname) }
   else
     local kind = (opts.dst_ip and opts.dst_ip:find(":", 1, true)) and "ipv6" or "ipv4"
     host = { type = kind, value = opts.dst_ip }

--- a/openwrt/files/usr/lib/lua/wifihaven/usage.lua
+++ b/openwrt/files/usr/lib/lua/wifihaven/usage.lua
@@ -75,6 +75,8 @@
 --     → bool
 --     post_fn(url, body, headers) → status_code, body_str
 
+local host_norm = require("wifihaven.host_norm")
+
 local M = {}
 
 -- log is injectable; default to the real logger wrapper, fall back to stderr.
@@ -252,10 +254,13 @@ end
 local function host_for_ip(dst_ip, nft_sets, lookup_hostname)
   if lookup_hostname then
     local h = lookup_hostname(dst_ip)
-    if h then return { type = "fqdn", value = h } end
+    -- #1761: strip a trailing :<port> — see host_norm.lua.
+    if h then return { type = "fqdn", value = host_norm.strip_port_suffix(h) } end
   end
   for hostname, ips in pairs(nft_sets or {}) do
-    if ips[dst_ip] then return { type = "fqdn", value = hostname } end
+    if ips[dst_ip] then
+      return { type = "fqdn", value = host_norm.strip_port_suffix(hostname) }
+    end
   end
   local kind = (dst_ip and dst_ip:find(":", 1, true)) and "ipv6" or "ipv4"
   return { type = kind, value = dst_ip }

--- a/openwrt/test/conntrack_spec.lua
+++ b/openwrt/test/conntrack_spec.lua
@@ -211,6 +211,23 @@ describe("build_event", function()
     assert.equal("2026-05-07T14:01:14Z", ev.ts)
   end)
 
+  it("strips a :port suffix from a fqdn hostname (#1761)", function()
+    -- An attribution path (SNI/Host-header capture) can hand us a hostname
+    -- with a trailing ":443". Wire-emit must normalize it BEFORE it reaches
+    -- the API, where Hostname validation rejects "com:443" as an invalid
+    -- label and 4xxs the record.
+    local ev = conntrack.build_event({
+      mac      = "aa:bb:cc:11:22:33",
+      hostname = "ws.nas.native-cloud.com:443",
+      dest_ip  = "1.2.3.4",
+      allowed  = false,
+      reason   = "category:adult",
+      ts       = "2026-05-07T14:01:14Z",
+    })
+    assert.equal("fqdn",                     ev.host.type)
+    assert.equal("ws.nas.native-cloud.com",  ev.host.value)
+  end)
+
   it("uses dest_ip as host fallback (type='ipv4') when hostname is nil", function()
     local ev = conntrack.build_event({
       mac      = "aa:bb:cc:11:22:33",

--- a/openwrt/test/host_norm_spec.lua
+++ b/openwrt/test/host_norm_spec.lua
@@ -1,0 +1,43 @@
+-- host_norm_spec.lua — pin the wire-host normalization helper (#1761).
+--
+-- A handful of attribution paths (notably SNI / Host-header capture) feed the
+-- ip→hostname cache with values that include a `:port` suffix. The API's
+-- Hostname validation rejects those as "invalid hostname label 'com:443'", so
+-- usage records and connection events that carry them 4xx at ingest. The
+-- single-source fix is to strip a trailing `:<digits>` BEFORE the value
+-- reaches the wire — every FQDN emit site routes its `value` through
+-- host_norm.strip_port_suffix.
+
+local host_norm = require("wifihaven.host_norm")
+
+describe("host_norm.strip_port_suffix", function()
+  it("strips a trailing :<port>", function()
+    assert.equals("foo.example.com",            host_norm.strip_port_suffix("foo.example.com:443"))
+    assert.equals("ws.nas.native-cloud.com",    host_norm.strip_port_suffix("ws.nas.native-cloud.com:443"))
+    assert.equals("foo.example.com",            host_norm.strip_port_suffix("foo.example.com:8080"))
+  end)
+
+  it("is idempotent on a clean hostname", function()
+    assert.equals("foo.example.com",            host_norm.strip_port_suffix("foo.example.com"))
+    assert.equals("a",                          host_norm.strip_port_suffix("a"))
+  end)
+
+  it("leaves nil / empty alone", function()
+    assert.is_nil(host_norm.strip_port_suffix(nil))
+    assert.equals("",                           host_norm.strip_port_suffix(""))
+  end)
+
+  it("does NOT touch a bare IPv6 literal (multiple colons, no bracket form)", function()
+    -- Bare IPv6 hostnames shouldn't reach this helper (they're emitted as
+    -- type="ipv6"), but if one does, the heuristic must not strip the last
+    -- group as if it were a port: "::1" -> "::1", not ":".
+    assert.equals("::1",                        host_norm.strip_port_suffix("::1"))
+    assert.equals("fe80::1234",                 host_norm.strip_port_suffix("fe80::1234"))
+    assert.equals("2001:db8::beef",             host_norm.strip_port_suffix("2001:db8::beef"))
+  end)
+
+  it("strips port from a bracketed IPv6 host", function()
+    -- "[::1]:443" -> "[::1]" (defensive — bracketed form is unambiguous).
+    assert.equals("[::1]",                      host_norm.strip_port_suffix("[::1]:443"))
+  end)
+end)

--- a/shared/src/types/HostId.scala
+++ b/shared/src/types/HostId.scala
@@ -60,9 +60,25 @@ object HostId {
   /** The single label source today — see openwrt `static_ip_labels.lua` (#1655). */
   val LabelSourceStaticIpRange: String = "static-ip-range"
 
+  // #1761: tolerantly strip a trailing `:<port>` from an fqdn wire value.
+  // Older agents (and any future emitter that interns an SNI/Host-header value
+  // verbatim) can ship `ws.nas.native-cloud.com:443`; without this strip the
+  // decoder rejects "com:443" as an invalid Hostname label and the record is
+  // metered as a decode failure. Defense-in-depth: agent emitters also strip
+  // at the wire (openwrt host_norm.lua), so newer fleets never produce the
+  // suffix — this branch keeps the API tolerant of legacy / re-introduced
+  // emitters. Bare IPv6 literals contain colons too; they're emitted as
+  // type="ipv6" so they don't take this path, but as a guard we only strip
+  // when exactly one colon is present (a plain `host:port`).
+  private val FqdnPortSuffix                       = "^([^:\\[\\]]+):\\d+$".r
+  private def stripPortFromFqdn(v: String): String = v match {
+    case FqdnPortSuffix(host) => host
+    case _                    => v
+  }
+
   given JsonCodec[HostId] = JsonCodec[Wire].transformOrFail(
     {
-      case Wire("fqdn", v, _)  => Hostname.parse(v).map(Fqdn(_))
+      case Wire("fqdn", v, _)  => Hostname.parse(stripPortFromFqdn(v)).map(Fqdn(_))
       case Wire("ipv4", v, _)  =>
         IpAddress.parse(v).flatMap { ip =>
           if ip.value.contains(':') then Left(s"ipv4 host carried v6 value: $v")

--- a/shared/src/types/HostId.scala
+++ b/shared/src/types/HostId.scala
@@ -67,13 +67,20 @@ object HostId {
   // metered as a decode failure. Defense-in-depth: agent emitters also strip
   // at the wire (openwrt host_norm.lua), so newer fleets never produce the
   // suffix — this branch keeps the API tolerant of legacy / re-introduced
-  // emitters. Bare IPv6 literals contain colons too; they're emitted as
-  // type="ipv6" so they don't take this path, but as a guard we only strip
-  // when exactly one colon is present (a plain `host:port`).
+  // emitters.
+  //
+  // Symmetry with the Lua half (host_norm.lua):
+  //   - a plain `host:port`               → `host`        (one colon allowed)
+  //   - a bracketed v6 literal `[v6]:port`→ `[v6]`        (brackets disambiguate)
+  //   - a bare v6 literal (multiple ':')  → unchanged     (ambiguous, leave alone)
+  // In practice a bracketed v6 host arrives as type="ipv6" and never reaches
+  // this branch — the bracket case is parity with Lua, not load-bearing.
   private val FqdnPortSuffix                       = "^([^:\\[\\]]+):\\d+$".r
+  private val BracketedV6PortSuffix                = "^(\\[[^\\[\\]]*\\]):\\d+$".r
   private def stripPortFromFqdn(v: String): String = v match {
-    case FqdnPortSuffix(host) => host
-    case _                    => v
+    case FqdnPortSuffix(host)        => host
+    case BracketedV6PortSuffix(host) => host
+    case _                           => v
   }
 
   given JsonCodec[HostId] = JsonCodec[Wire].transformOrFail(

--- a/shared/test/src/types/HostIdSpec.scala
+++ b/shared/test/src/types/HostIdSpec.scala
@@ -112,6 +112,38 @@ object HostIdSpec extends ZIOSpecDefault {
           l.asFqdn.isEmpty,
         )
       },
+      test("#1761: decoder strips a trailing :<port> from an fqdn wire value") {
+        // Older agents (and any future emitter that interns an SNI/Host-header
+        // value verbatim) ship `foo.com:443`; without the tolerant strip the
+        // record is rejected as "invalid hostname label 'com:443'". Symmetric
+        // with the Lua agent helper (host_norm.lua):
+        //  - plain `host:port`        → `host`
+        //  - bracketed v6 `[v6]:port` → `[v6]` (parity; v6 doesn't take this branch in practice)
+        //  - bare v6 (multi-colon)    → unchanged (ambiguous)
+        val stripped =
+          """{"type":"fqdn","value":"ws.nas.native-cloud.com:443"}"""
+            .fromJson[HostId]
+            .toOption
+            .flatMap(_.asFqdn)
+            .map(_.value)
+        val clean    =
+          """{"type":"fqdn","value":"foo.example.com"}"""
+            .fromJson[HostId]
+            .toOption
+            .flatMap(_.asFqdn)
+            .map(_.value)
+        assertTrue(stripped.contains("ws.nas.native-cloud.com")) &&
+        assertTrue(clean.contains("foo.example.com"))
+      },
+      test("#1761: decoder rejects fqdn values that are still invalid after strip") {
+        // `:443` alone strips to empty → Hostname.parse fails. A bare v6
+        // literal stays as-is (multi-colon, ambiguous) and Hostname.parse
+        // rejects it because Hostname is not an IP literal type.
+        val badEmpty = """{"type":"fqdn","value":":443"}"""
+        val badV6    = """{"type":"fqdn","value":"::1"}"""
+        assertTrue(badEmpty.fromJson[HostId].isLeft) &&
+        assertTrue(badV6.fromJson[HostId].isLeft)
+      },
     ),
   )
 }


### PR DESCRIPTION
## Summary

Closes #1761.

Both ends of the router↔API wire now normalize an fqdn host that carries a
trailing `:port` (e.g. `ws.nas.native-cloud.com:443`). Before this change
such a value reached the API verbatim, where `Hostname.parse` rejected
`com:443` as an invalid hostname label and the record was metered as a
decode failure — the prod symptom on the data-quality-ingest dashboard
panel id 9 from 2026-06-13 20:00 onward.

## Root cause

Some attribution path (the prime suspect is the recent SNI / Host-header
work — #573 / #1707 / #1711 / #1731 landed in the onset window) is
interning a `host:port` string into the ip→hostname cache, so the wire
emitters in `conntrack.lua`, `nflog.lua`, and `usage.lua` all pass it
through verbatim. Rather than chase the single producer (any future
emitter could re-introduce the same suffix), the fix normalizes at every
wire-emit site and the API tolerates the legacy shape too.

## Fix shape

**Agent side (root-cause normalization).** New
`openwrt/.../host_norm.lua` exports a single `strip_port_suffix(host)`
helper. The three wire-emit sites that construct `{type="fqdn", value=…}`
— `conntrack.build_event`, `nflog.build_event`, and
`usage.host_for_ip` — all route the value through the helper, so the
normalization is a single source of truth per AGENTS.md
§single-source-of-truth. The helper is conservative around bare and
bracketed IPv6 literals (a bare IPv6 isn't expected to reach this path
since v6 destinations are emitted as `type="ipv6"`, but the helper is
safe regardless).

**API side (defense in depth, back-compat).** `HostId`'s JSON codec
strips a trailing `:<digits>` from an fqdn wire value before calling
`Hostname.parse`. This keeps the API tolerant of pre-fix agents
already in the field (additive per the AGENTS.md wire back-compat
policy) and of any future emitter that re-introduces the suffix.

## Tests

Two failing tests landed first in a separate RED commit, then the fix
makes them green:

- `openwrt/test/host_norm_spec.lua` — `strip_port_suffix` itself
  (idempotent, IPv6-safe).
- `openwrt/test/conntrack_spec.lua` — `build_event` strips `:port`
  before emitting.
- `api/test/src/feature/RouterIngestSpec.scala` — `/api/router/usage`
  and `/api/router/events` accept a record with
  `host = ws.nas.native-cloud.com:443`, persist under the port-free
  hostname, and the `usage_records_rejected_total` counter does NOT
  advance.

Red→green is visible in the commit history (test commit precedes fix).

## Verification plan

- `mill api.test.testOnly wifihaven.api.feature.RouterIngestSpec` — 50/50 pass locally.
- `mill shared.test` — pass.
- `openwrt/test/run_tests.sh` — host_norm_spec / conntrack_spec / nflog_spec / usage_spec pass. (Existing nft_log_dep_spec failures are unrelated to this PR — pre-existing build-script kmod-nf-log deps.)
- `mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll` — clean.
- Post-deploy: watch the data-quality-ingest dashboard's
  `usage_records_rejected_total{reason="decode_error"}` series return
  to baseline; ditto the equivalent on `/events` once #1759 also lands.

## Scope-out

This PR keeps the port data discarded (consistent with the issue
acceptance). Capturing port end-to-end (UI surface, allow/block on
host:port) is #296 and will be tackled separately to avoid bundling a
migration on the growth tables with a live prod hotfix.

## Test plan

- [x] Lua specs pass (`host_norm_spec`, `conntrack_spec` `build_event`).
- [x] Scala specs pass (`RouterIngestSpec` usage + events).
- [x] `scalafmt` clean.
- [ ] Post-deploy: `usage_records_rejected_total{reason="decode_error"}` returns to pre-2026-06-13 baseline.