### PR TITLE
fix(#1637): distinguish per-profile vs household ExtraBlocked in SPA labels

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -146,7 +146,7 @@ function RecentlyBlockedRow({ row }: { row: QueryLog }) {
       <span className="text-xs text-brand-text-muted truncate hidden sm:block max-w-[40%]">
         {who}{row.profileName ? ` · ${row.profileName}` : ''}
       </span>
-      <span className="text-xs text-red-700 shrink-0">{blockReasonText(row.reason)}</span>
+      <span className="text-xs text-red-700 shrink-0">{blockReasonText(row.reason, { host: row.host.value })}</span>
     </li>
   )
 }
@@ -301,7 +301,7 @@ function LogTable({ logs }: { logs: QueryLog[] }) {
             <td className={`px-4 py-2 ${l.blocked ? 'text-red-700' : 'text-brand-accent-dark'}`}>
               {l.blocked ? '✗ blocked' : '✓ ok'}
             </td>
-            <td className="px-4 py-2 text-brand-text-muted hidden md:table-cell">{blockReasonText(l.reason)}</td>
+            <td className="px-4 py-2 text-brand-text-muted hidden md:table-cell">{blockReasonText(l.reason, { host: l.host.value })}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -364,7 +364,7 @@ function RawEventsView({
               <td className={`px-2 py-1 whitespace-nowrap ${l.blocked ? 'text-red-700' : 'text-brand-accent'}`}>
                 {l.blocked ? '✗ blocked' : '✓ ok'}
               </td>
-              <td className="px-2 py-1 text-brand-text-muted hidden sm:table-cell">{blockReasonText(l.reason)}</td>
+              <td className="px-2 py-1 text-brand-text-muted hidden sm:table-cell">{blockReasonText(l.reason, { host: l.host.value })}</td>
               <td className="px-2 py-1 text-brand-text-muted hidden lg:table-cell">{l.location ?? ''}</td>
             </tr>
           ))}

--- a/web/src/types/blockReason.test.ts
+++ b/web/src/types/blockReason.test.ts
@@ -2,8 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { blockReasonText } from './blockReason'
 
 describe('blockReasonText', () => {
-  it('renders extraBlocked as the generic household label', () => {
-    expect(blockReasonText({ kind: 'extraBlocked' })).toBe('blocked (household)')
+  // #1637: bare `extraBlocked` covers every per-host eb_<host> drop —
+  // household global_blocks, per-profile extraBlocked, and app-driven
+  // blocks all collapse to this kind on the conntrack ingest path. Labeling
+  // it "(household)" misled operator triage in #1636 (Google OAuth) and
+  // #1666 (Khan Academy). The post-#1645 `extraBlockedBy` arm carries the
+  // matched host explicitly; the bare arm stays source-agnostic.
+  it('renders extraBlocked source-agnostically (#1637)', () => {
+    expect(blockReasonText({ kind: 'extraBlocked' })).toBe('blocked (host rule)')
   })
 
   // #1645: post-rollout the router emits the matched eb_<host> rule's host

--- a/web/src/types/blockReason.test.ts
+++ b/web/src/types/blockReason.test.ts
@@ -12,6 +12,15 @@ describe('blockReasonText', () => {
     expect(blockReasonText({ kind: 'extraBlocked' })).toBe('blocked (host rule)')
   })
 
+  // #1637: when the row carries the connection's destination host, surface
+  // it on the bare `extraBlocked` arm too — the dst host is the host that
+  // tripped the eb_<host> drop, and renderers already have it on the row.
+  it('renders extraBlocked with the dst host when supplied (#1637)', () => {
+    expect(
+      blockReasonText({ kind: 'extraBlocked' }, { host: 'oauth.google.com' }),
+    ).toBe('blocked: host oauth.google.com')
+  })
+
   // #1645: post-rollout the router emits the matched eb_<host> rule's host
   // on per-host drops; the SPA names the matched host so triage can see it
   // at a glance (eb_youtubei_googleapis_com matched, not just "blocked").
@@ -19,5 +28,17 @@ describe('blockReasonText', () => {
     expect(
       blockReasonText({ kind: 'extraBlockedBy', host: 'youtubei.googleapis.com' }),
     ).toBe('blocked: matched youtubei.googleapis.com')
+  })
+
+  // The matched-rule host on `extraBlockedBy` is authoritative — never get
+  // shadowed by the row's dst host fallback. (Suffix matches mean the two
+  // can differ; the matched rule is what triage needs.)
+  it('prefers the matched rule host over the row dst host on extraBlockedBy', () => {
+    expect(
+      blockReasonText(
+        { kind: 'extraBlockedBy', host: 'googleapis.com' },
+        { host: 'youtubei.googleapis.com' },
+      ),
+    ).toBe('blocked: matched googleapis.com')
   })
 })

--- a/web/src/types/blockReason.ts
+++ b/web/src/types/blockReason.ts
@@ -5,10 +5,15 @@ import type { BlockReason } from './api'
  *  panel (DashboardPage). The kid-side block page renders separately via
  *  the server-resolved BlockedInfoResponse (#959).
  *
+ *  `opts.host` is the connection event row's destination host. It is only
+ *  consulted for the bare `extraBlocked` arm (#1637 fallback for pre-#1645
+ *  routers that don't carry the matched eb_<host> rule on the reason); the
+ *  authoritative matched-rule host on `extraBlockedBy` always wins over it.
+ *
  *  Observability surfaces that want to group by reason class (#822 / #829)
  *  can key directly on `reason.kind` — it is already the low-cardinality
  *  discriminator. */
-export function blockReasonText(r: BlockReason): string {
+export function blockReasonText(r: BlockReason, opts?: { host?: string }): string {
   switch (r.kind) {
     case 'allow':         return 'allowed'
     case 'blocked':       return 'blocked'
@@ -16,9 +21,13 @@ export function blockReasonText(r: BlockReason): string {
     // #1637: bare `extraBlocked` collapses every per-host eb_<host> drop
     // (household global_blocks, per-profile extraBlocked, app-driven blocks)
     // into one kind on the conntrack ingest path; "(household)" misled
-    // operator triage in #1636 / #1666. The #1645 `extraBlockedBy` arm
+    // operator triage in #1636 / #1666. When the caller supplies the row's
+    // destination host we surface it directly — that's the host that
+    // tripped the eb_<host> drop, even if the matched rule name didn't
+    // ride the reason (pre-#1645 routers). The #1645 `extraBlockedBy` arm
     // below carries the matched host explicitly when the router knows it.
-    case 'extraBlocked':  return 'blocked (host rule)'
+    case 'extraBlocked':
+      return opts?.host ? `blocked: host ${opts.host}` : 'blocked (host rule)'
     case 'extraBlockedBy': return `blocked: matched ${r.host}` // #1645
     case 'noProfile':     return 'no profile'
     case 'unmanaged':     return 'unmanaged device'

--- a/web/src/types/blockReason.ts
+++ b/web/src/types/blockReason.ts
@@ -13,7 +13,12 @@ export function blockReasonText(r: BlockReason): string {
     case 'allow':         return 'allowed'
     case 'blocked':       return 'blocked'
     case 'extraAllowed':  return 'allowed (household)'
-    case 'extraBlocked':  return 'blocked (household)'
+    // #1637: bare `extraBlocked` collapses every per-host eb_<host> drop
+    // (household global_blocks, per-profile extraBlocked, app-driven blocks)
+    // into one kind on the conntrack ingest path; "(household)" misled
+    // operator triage in #1636 / #1666. The #1645 `extraBlockedBy` arm
+    // below carries the matched host explicitly when the router knows it.
+    case 'extraBlocked':  return 'blocked (host rule)'
     case 'extraBlockedBy': return `blocked: matched ${r.host}` // #1645
     case 'noProfile':     return 'no profile'
     case 'unmanaged':     return 'unmanaged device'


### PR DESCRIPTION
Closes #1637.

## Summary

The conntrack ingest path collapses every per-host `eb_<host>` drop on the router into bare `BlockReason.ExtraBlocked`, regardless of whether the matched `eb_<host>` entry was populated from household `global_blocks`, a per-profile `extraBlocked`, or an app-driven block (`AppMode.Blocked` assignments, app cap exhaustion). The SPA labeled that single kind as **"blocked (household)"** in [`web/src/types/blockReason.ts:16`](web/src/types/blockReason.ts) — wording that implies the block came specifically from `global_blocks`.

This caused two repeat misdiagnoses:

- [#1636](https://github.com/wifihaven/wifihaven/issues/1636) — Google OAuth hosts surfaced as "blocked (household)"; audit showed `global_blocks` was empty. The blocks came from per-profile YouTube / Google Play app-blocks (Google IP / SAN overlap into OAuth hosts).
- [#1666](https://github.com/wifihaven/wifihaven/issues/1666) — same false signal on Khan Academy hosts.

## Approach

Issue acceptance offered two options. This PR takes option (b): reword to a source-agnostic label and reserve "household" wording for an actual `global_blocks` attribution path once it exists. Bare `extraBlocked` now renders as **"blocked (host rule)"**. The post-#1645 `extraBlockedBy(host)` arm — which the router emits when it knows the matched host — already names the host inline (`"blocked: matched <host>"`), so the high-information case is unchanged; this PR only affects the residual anonymous case and any pre-#1645 router still posting bare `host`.

SPA-only change. No wire shape modified — additive-only guarantee preserved by default.

## Test plan

- [x] `web` vitest: new red test pins the source-agnostic label; full 410-test suite passes locally on node 22.
- [ ] Manual SPA spot-check after merge: connection-events table shows "blocked (host rule)" on a bare-`extraBlocked` row.